### PR TITLE
fix(docs): relative internal links for subpath deployment

### DIFF
--- a/docs/apps.mdx
+++ b/docs/apps.mdx
@@ -159,7 +159,7 @@ traversal-shaped "prompt id" must never reach the URL builder even if a caller
 bypasses the schema.
 
 For the generated per-tool schema reference, see
-[Apps tools](/tools/apps).
+[Apps tools](./tools/apps).
 
 ### Importing from the registry
 
@@ -231,8 +231,8 @@ workflow, with real inputs, without a canvas anywhere in sight.
 
 ## See also
 
-- [Apps tools](/tools/apps) — the generated per-tool schema reference
-- [Sidebar Panel](/panel) — where apps are converted, published, and explored
-- [Mobile app](/mobile) — the Apps tab in context
-- [RunPod pods](/tools/runpod) — the pod the "Run on RunPod" path targets
-- [Roadmap](/roadmap)
+- [Apps tools](./tools/apps) — the generated per-tool schema reference
+- [Sidebar Panel](./panel) — where apps are converted, published, and explored
+- [Mobile app](./mobile) — the Apps tab in context
+- [RunPod pods](./tools/runpod) — the pod the "Run on RunPod" path targets
+- [Roadmap](./roadmap)

--- a/docs/arena.mdx
+++ b/docs/arena.mdx
@@ -8,7 +8,7 @@ The **ComfyUI LLM Arena** answers one question honestly: *can this model
 actually drive ComfyUI?* Not "does it sound confident" — every scenario's
 outcome is **verified against the ComfyUI server itself** (job history,
 executed graph parameters, real output files and their pixel sizes). It runs
-over the same [compact tool-router](/local-llms) the panel and MCP clients
+over the same [compact tool-router](./local-llms) the panel and MCP clients
 use, so an arena score predicts real agent behavior.
 
 ```bash
@@ -68,8 +68,8 @@ once, and either Ollama or an API key.
 
 ## Current leaderboard
 
-<img className="block dark:hidden" src="/images/arena-leaderboard-light.svg" alt="ComfyUI LLM Arena leaderboard" />
-<img className="hidden dark:block" src="/images/arena-leaderboard-dark.svg" alt="ComfyUI LLM Arena leaderboard" />
+<img className="block dark:hidden" src="./images/arena-leaderboard-light.svg" alt="ComfyUI LLM Arena leaderboard" />
+<img className="hidden dark:block" src="./images/arena-leaderboard-dark.svg" alt="ComfyUI LLM Arena leaderboard" />
 
 14 models, best-of-3 on the top cluster. The headline findings:
 

--- a/docs/backends.mdx
+++ b/docs/backends.mdx
@@ -4,7 +4,7 @@ description: "The panel agent runs on ANY LLM: Claude, ChatGPT, Gemini, Grok, Ki
 icon: "shuffle"
 ---
 
-The [sidebar panel](/panel) agent is **provider-agnostic**. Pick **Claude**,
+The [sidebar panel](./panel) agent is **provider-agnostic**. Pick **Claude**,
 **ChatGPT**, **Gemini**, or **Ollama (local)** and the matching agent runs in
 the background — subscriptions need no API key, and local models need no
 account at all. The Ollama backend also speaks **any OpenAI-compatible
@@ -12,7 +12,7 @@ endpoint** (OpenRouter, DeepSeek, GLM, MiMo, vLLM, LM Studio), so "bring your
 own model" covers everything from a free 4B on your own GPU to the frontier.
 All providers share the same live-canvas tools, the same model knowledge, the
 same one-shot workflow loads, the same cost guardrail. The
-[LLM Arena](/arena) scores any of them on real ComfyUI tasks.
+[LLM Arena](./arena) scores any of them on real ComfyUI tasks.
 
 ```
 panel (pick a provider) ⇄ loopback bridge ⇄ orchestrator (Claude · ChatGPT · Gemini · any LLM) ⇄ your graph
@@ -98,7 +98,7 @@ placeholder follows the active backend ("Ask Claude…" / "Ask Ollama…").
   `/v1` (vLLM, DeepSeek, Together, Azure, a remote llama-server) in Settings →
   Custom endpoint; add an API key there if the server needs one (masked input,
   stored 0600 by the orchestrator). See
-  [Local LLMs → Custom endpoint](/local-llms#custom-endpoint-any-openai-compatible-server).
+  [Local LLMs → Custom endpoint](./local-llms#custom-endpoint-any-openai-compatible-server).
 
 ### Connect-time readiness & onboarding
 
@@ -130,7 +130,7 @@ The orchestrator depends on a provider-neutral **`AgentBackend`** port
 |---|---|---|---|---|
 | Driver | Claude Agent SDK — persistent streaming session | `codex app-server` JSON-RPC | `gemini --acp` (Agent Client Protocol) | direct HTTP — Ollama `/api/chat` or any OpenAI-compatible `/v1/chat/completions`; the backend owns the whole agentic loop |
 | Auth | claude.ai OAuth | ChatGPT login | Google login | none (local) / bearer key (hosted) |
-| Live-canvas tools | in-process SDK MCP server | loopback streamable-HTTP MCP | loopback streamable-HTTP MCP | the [6-tool router](/local-llms) over the same loopback MCP |
+| Live-canvas tools | in-process SDK MCP server | loopback streamable-HTTP MCP | loopback streamable-HTTP MCP | the [6-tool router](./local-llms) over the same loopback MCP |
 | Headless `comfyui` MCP | in-process | config-declared stdio | config-declared stdio | compact-mode stdio subprocess behind the router |
 
 The `panel_*` tool definitions live in **one shared list**, registered onto
@@ -138,7 +138,7 @@ every path, so the live-canvas surface (including the destructive-confirm
 gating for `panel_clear` / `panel_restart_comfyui`) is identical across
 providers. Parity is automatic — no path reimplements a tool. The Ollama/any-LLM
 backend additionally wraps both tool surfaces behind six router tools so
-small models aren't drowned in schemas — see [Local LLMs & other agents](/local-llms).
+small models aren't drowned in schemas — see [Local LLMs & other agents](./local-llms).
 
 ## Capability matrix
 
@@ -177,12 +177,12 @@ Because only Claude can load native skills, the bundled expertise is
 published as MCP tools any backend can call — `list_skills`, `read_skill`,
 `list_packs`, `read_pack_workflow`, `list_workflow_templates` — plus the
 local-GPU-vs-paid-API guardrail (`check_workflow_runtime`) and one-shot
-`panel_load_workflow`. See [Skills, Packs & Runtime Cost](/tools/skills-knowledge).
+`panel_load_workflow`. See [Skills, Packs & Runtime Cost](./tools/skills-knowledge).
 
 ## See also
 
-- [Sidebar Panel](/panel) — the full panel UX
-- [Local LLMs & other agents](/local-llms) — the 6-tool router, model requirements, Hermes/OpenClaw/Copilot setup
-- [LLM Arena](/arena) — score YOUR model on real ComfyUI tasks
-- [Skills, Packs & Runtime Cost](/tools/skills-knowledge) — the parity + cost tools
+- [Sidebar Panel](./panel) — the full panel UX
+- [Local LLMs & other agents](./local-llms) — the 6-tool router, model requirements, Hermes/OpenClaw/Copilot setup
+- [LLM Arena](./arena) — score YOUR model on real ComfyUI tasks
+- [Skills, Packs & Runtime Cost](./tools/skills-knowledge) — the parity + cost tools
 - Design doc: [`docs/design/agent-backend-injection.md`](https://github.com/artokun/comfyui-mcp/blob/main/docs/design/agent-backend-injection.md)

--- a/docs/blog/anima-comfyui.mdx
+++ b/docs/blog/anima-comfyui.mdx
@@ -27,7 +27,7 @@ inpainting and ControlNet workflow, how to **train your own anime LoRA** on a
 6 GB card, how it stacks up against the SDXL-lineage giants, and the fastest path
 to running it — a one-command install with
 [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the
-[sidebar Panel](/panel), instead of hand-downloading a dozen files into five
+[sidebar Panel](../panel), instead of hand-downloading a dozen files into five
 folders.
 
 > **TL;DR — one-command setup.** Install comfyui-mcp, apply the `anima` pack
@@ -96,8 +96,8 @@ text encoder that understands sentences. If your bottleneck is a 6–8 GB card, 
 you want to fine-tune without renting a GPU, ANIMA is the easy call.
 
 For non-anime work, this series covers the other specialists: the open-weight
-text-and-layout champion in [our Ideogram 4 post](/blog/ideogram-4-comfyui), and
-the speed/low-VRAM generalist in [our Z-Image post](/blog/z-image-comfyui).
+text-and-layout champion in [our Ideogram 4 post](./ideogram-4-comfyui), and
+the speed/low-VRAM generalist in [our Z-Image post](./z-image-comfyui).
 
 ## System & VRAM requirements
 
@@ -148,12 +148,12 @@ apply_manifest --path packs/anima/manifest.yaml
 
 Run the generated installer from your **ComfyUI root** (the folder containing
 `custom_nodes/` and `models/`), restart ComfyUI, and load
-`packs/anima/workflow.json`. Because the pack ships with the [plugin](/plugin),
+`packs/anima/workflow.json`. Because the pack ships with the [plugin](../plugin),
 your **own Claude session can drive the live graph through the
-[Panel](/panel)** — add/wire nodes, set widgets, swap LoRAs, and iterate on
+[Panel](../panel)** — add/wire nodes, set widgets, swap LoRAs, and iterate on
 prompts conversationally, with full undo and no API keys. Every model URL in the
 pack is CI-validated for reachability and size, so a link never quietly rots
-([here's why that matters](/blog/installer-packs-that-cant-rot)).
+([here's why that matters](./installer-packs-that-cant-rot)).
 
 ## Anime inpainting (the Anima-LLLite workflow)
 
@@ -318,13 +318,13 @@ isn't tuned for photorealistic output.
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](../panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **`anima` pack** — nodes + every model land in the right folders,
    CI-validated, with the Anima-LLLite inpainting node included.
-3. Open the [Panel](/panel) and let the panel's agent wire the graph, swap
+3. Open the [Panel](../panel) and let the panel's agent wire the graph, swap
    LoRAs, and iterate on tag-plus-prose prompts for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **Next in the series:**
-[LTX-2.3](/blog/ltx-2.3-comfyui) — the fast GGUF video model with synchronized
+[LTX-2.3](./ltx-2.3-comfyui) — the fast GGUF video model with synchronized
 audio and the LTX Director timeline.

--- a/docs/blog/blind-mode-privacy.mdx
+++ b/docs/blog/blind-mode-privacy.mdx
@@ -14,7 +14,7 @@ keywords:
 
 _by [artokun](https://github.com/artokun) · July 20, 2026 · privacy · blind mode · security_
 
-The [Panel](/panel)'s **Blind** toggle has a tooltip that makes a hard promise:
+The [Panel](../panel)'s **Blind** toggle has a tooltip that makes a hard promise:
 
 > "the agent still gets text notifications about renders and results, but
 > **NEVER receives the image pixels**."
@@ -190,5 +190,5 @@ it. That's exactly the kind of user a project earns by being fixable in public.
 
 Run an autonomous ComfyUI agent whose privacy toggles are enforced in code, not
 prompts: install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) (v0.42.0+)
-and add the [Panel](/panel) (0.9.8+). Star the repo or file an idea at
+and add the [Panel](../panel) (0.9.8+). Star the repo or file an idea at
 [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/blog/civitai-in-comfyui.mdx
+++ b/docs/blog/civitai-in-comfyui.mdx
@@ -163,5 +163,5 @@ tell the agent to match the picture — and the queue is already yours.
 ---
 
 Grab [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the
-[Panel](/panel) to try it, or tell us what the browser should do next at
+[Panel](../panel) to try it, or tell us what the browser should do next at
 [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/blog/comfyui-agent-claude-or-chatgpt.mdx
+++ b/docs/blog/comfyui-agent-claude-or-chatgpt.mdx
@@ -15,7 +15,7 @@ keywords:
 
 _by [artokun](https://github.com/artokun) · June 25, 2026 · AgentBackend · provider parity · architecture_
 
-The [Agent Panel](/panel) is an autonomous AI agent embedded in ComfyUI's
+The [Agent Panel](../panel) is an autonomous AI agent embedded in ComfyUI's
 sidebar. You type a request — "add a KSampler and wire it to my checkpoint",
 "build a Flux txt2img graph and run it" — and the agent edits the graph you're
 looking at, runs it, and replies right there next to your canvas. It runs **in
@@ -172,6 +172,6 @@ keys, no per-token billing, no juggling ports. Just a provider chip and Connect.
 
 Drive ComfyUI from an autonomous agent on your own Claude **or** ChatGPT
 subscription: install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and
-add the [Agent Panel](/panel) — see [Backends / providers](/backends) for the
+add the [Agent Panel](../panel) — see [Backends / providers](../backends) for the
 full capability matrix. Star the repo or file an idea at
 [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/blog/comfyui-mcp-tdqs-case-study.mdx
+++ b/docs/blog/comfyui-mcp-tdqs-case-study.mdx
@@ -102,4 +102,4 @@ With the 60/40 split, that pulls the server out of B and into A on the next re-i
 ---
 
 comfyui-mcp is open source on [GitHub](https://github.com/artokun/comfyui-mcp) — browse the full,
-schema-generated [tool reference](/tools/image-generation).
+schema-generated [tool reference](../tools/image-generation).

--- a/docs/blog/comfyui-mobile-app.mdx
+++ b/docs/blog/comfyui-mobile-app.mdx
@@ -23,9 +23,9 @@ another room. Did it finish? Did it OOM at 90%? Did the agent install the
 missing node and retry, and is it now waiting on a question you can't see? The
 desktop is doing fine. **You're the disconnected part.**
 
-The [ComfyUI-MCP mobile app](/mobile) closes that loop. It's a phone-native
+The [ComfyUI-MCP mobile app](../mobile) closes that loop. It's a phone-native
 front end — Flutter, shipping on **iOS and Android** in closed beta — to the
-same agent that powers the [Sidebar Panel](/panel). Not a dashboard, not a
+same agent that powers the [Sidebar Panel](../panel). Not a dashboard, not a
 read-only queue viewer: the actual agent, on the actual bridge, with your
 desktop's GPU doing the work.
 
@@ -163,8 +163,8 @@ the other hand.
 
 Put your ComfyUI agent in your pocket: install
 [comfyui-mcp](https://github.com/artokun/comfyui-mcp) with the
-[Agent Panel](/panel), then join the beta — the **iOS TestFlight** and
+[Agent Panel](../panel), then join the beta — the **iOS TestFlight** and
 **Android Firebase App Distribution** invites are right in the Panel's
-Settings, or on the [mobile page](/mobile). Scan the QR, and you're paired.
+Settings, or on the [mobile page](../mobile). Scan the QR, and you're paired.
 Star the repo or file an idea at
 [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/blog/ernie-image-comfyui.mdx
+++ b/docs/blog/ernie-image-comfyui.mdx
@@ -25,7 +25,7 @@ per-image fee, no non-commercial clause hanging over your head.
 Below: what ERNIE-Image actually is (and the one thing people keep getting wrong
 about it), how it stacks up against Ideogram 4 and Z-Image, the VRAM you need, and
 the fastest way to get it running — a one-command install with
-[comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [sidebar Panel](/panel),
+[comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [sidebar Panel](../panel),
 instead of hand-downloading GGUFs and untangling a contaminated installer.
 
 > **TL;DR — one-command setup.** Install comfyui-mcp, apply the `ernie` pack
@@ -43,7 +43,7 @@ prompts into richer descriptions. ComfyUI added **day-0 support** in April 2026.
 
 **The license is the headline — and it's genuinely permissive.** ERNIE-Image ships
 under **Apache-2.0**, which allows commercial use, modification, and redistribution,
-full stop. That's a real difference from [Ideogram 4](/blog/ideogram-4-comfyui),
+full stop. That's a real difference from [Ideogram 4](./ideogram-4-comfyui),
 which is open *weight* but under a **Non-Commercial** agreement (commercial use
 needs a paid license). With ERNIE you can put it in a product on day one. No gated
 download drama, no "for research only" footnote.
@@ -62,11 +62,11 @@ There's no single "best" — pick by the job:
 | **ERNIE-Image** | **Truly permissive (Apache-2.0)** commercial use, **multilingual EN/CN/JP text**, posters/signage/manga layouts, runs **under 8 GB** |
 | **Ideogram 4** | **Area-prompting** with structured JSON bounding boxes, fine-grained poster/logo **layout control**, brand-color accuracy |
 | **Z-Image Turbo** | **Raw speed + low VRAM** general-purpose ideation (~2.5s), LoRA-training stability on the base |
-| **Qwen-Image** | A larger, popular dev model also strong on long text — see our [Qwen-Image post](/blog/qwen-image-comfyui) |
+| **Qwen-Image** | A larger, popular dev model also strong on long text — see our [Qwen-Image post](./qwen-image-comfyui) |
 
-Where rivals win: **[Ideogram 4](/blog/ideogram-4-comfyui)** gives you explicit
+Where rivals win: **[Ideogram 4](./ideogram-4-comfyui)** gives you explicit
 spatial control — draw bounding boxes, place text and objects by region — which
-ERNIE doesn't expose (you steer ERNIE with descriptive prose). **[Z-Image](/blog/z-image-comfyui)**
+ERNIE doesn't expose (you steer ERNIE with descriptive prose). **[Z-Image](./z-image-comfyui)**
 is the speed king for fast general ideation. But ERNIE wins decisively on the two
 axes that matter for production text work: a **permissive license** and **clean
 multilingual typography**. Each of those models gets its own post in this series —
@@ -134,11 +134,11 @@ packs/ernie/install-runpod.sh        # RunPod / Linux
 ```
 
 Then load `packs/ernie/workflow.json`. Because the pack ships with the
-[plugin](/plugin), your **own Claude session can drive the live graph through the
-[Panel](/panel)** — add/wire nodes, set widgets, and iterate on prompts
+[plugin](../plugin), your **own Claude session can drive the live graph through the
+[Panel](../panel)** — add/wire nodes, set widgets, and iterate on prompts
 conversationally, with full Ctrl+Z undo and no extra API keys. Every model URL in
 the pack is CI-validated for reachability and size, so a link never quietly rots
-([here's why that matters](/blog/installer-packs-that-cant-rot)).
+([here's why that matters](./installer-packs-that-cant-rot)).
 
 ## Why text and layout are its superpower
 
@@ -255,7 +255,7 @@ with a Ministral-3-3B text encoder and the Flux 2 VAE.
 **English, Chinese, and Japanese** cleanly thanks to a character-aware encoder
 trained on a large CJK corpus.
 
-**ERNIE-Image vs Z-Image — which should I use?** [Z-Image](/blog/z-image-comfyui)
+**ERNIE-Image vs Z-Image — which should I use?** [Z-Image](./z-image-comfyui)
 for the fastest general-purpose ideation; **ERNIE** when you need a permissive
 license plus precise multilingual text and structured layouts.
 
@@ -267,11 +267,11 @@ designed for layout-sensitive, multilingual text rendering, not as an afterthoug
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](../panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **`ernie` pack** — nodes + ERNIE-only models land in the right folders, validated, with the Z-Image cruft stripped out.
-3. Open the [Panel](/panel) and let the panel's agent write multilingual prompts and wire the graph for you.
+3. Open the [Panel](../panel) and let the panel's agent write multilingual prompts and wire the graph for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **Next in the series:**
-[ANIMA 1.0](/blog/anima-comfyui) — the tiny anime model that generates and trains
+[ANIMA 1.0](./anima-comfyui) — the tiny anime model that generates and trains
 LoRAs under 6 GB.

--- a/docs/blog/flatten-workflows.mdx
+++ b/docs/blog/flatten-workflows.mdx
@@ -28,7 +28,7 @@ opaque. Ask "what feeds this sampler's model input?" and the honest answer is: a
 `Get_MODEL` node, which matches a `Set_MODEL` node by string, which is fed by a
 Reroute, which… The graph you can *see* is not the graph that *runs*.
 
-The [Panel](/panel) agent kept hitting this wall. It can read the canvas, edit
+The [Panel](../panel) agent kept hitting this wall. It can read the canvas, edit
 nodes, run workflows — but reading an expert workflow meant re-implementing three
 custom-node packs' resolution rules in its head, every time, per input. So we
 built the resolution once, as tools. This post is the dev-log: three tools, one
@@ -191,6 +191,6 @@ spaghetti untangles itself — and it doesn't move your nodes doing it.
 ---
 
 Try it on the gnarliest workflow in your collection: install
-[comfyui-mcp](https://github.com/artokun/comfyui-mcp), add the [Panel](/panel),
+[comfyui-mcp](https://github.com/artokun/comfyui-mcp), add the [Panel](../panel),
 and ask the agent to flatten what's on your canvas. Star the repo or file an
 idea at [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/blog/gemma4-fine-tune-arena.mdx
+++ b/docs/blog/gemma4-fine-tune-arena.mdx
@@ -28,7 +28,7 @@ model.** Here's both stories.
 
 ## Why fine-tune at all
 
-The [Agent Panel](/panel) runs on frontier models beautifully — Claude,
+The [Agent Panel](../panel) runs on frontier models beautifully — Claude,
 ChatGPT, Gemini all clear the hardest tasks. But a lot of people running
 ComfyUI have exactly one GPU, and it's busy rendering. The pitch of a **local**
 agent backend is: no account, no API key, no per-token cost, nothing leaves
@@ -60,7 +60,7 @@ you're about to read was cheap enough to actually run.
 ## The Arena: a judge that can't be charmed
 
 A fine-tune claim needs a measurement you'd trust from a stranger. The
-[LLM Arena](/arena) is a **10-scenario ladder** run over the same compact
+[LLM Arena](../arena) is a **10-scenario ladder** run over the same compact
 tool-router the panel and MCP clients use, so a score predicts real agent
 behavior. Every scenario is a real ComfyUI task, and every outcome is
 **verified against the ComfyUI server itself** — job history, the parameters
@@ -74,7 +74,7 @@ executed graph, a deliberate break-and-recover, provenance via `regenerate`),
 and a crucible of raw graph composition no template covers. PASS is 2,
 PARTIAL is 1, FAIL is 0, max **20**; ties break on nudges, then tool rounds,
 then wall time — a model that nails a task first-try outranks one that flailed
-to the same score. See the [Arena page](/arena) for the full task table, the
+to the same score. See the [Arena page](../arena) for the full task table, the
 all-tier leaderboard, and how to run *your* model through it with one command.
 
 Best-of-3 on an RTX 4090, here's where the ladder landed:
@@ -174,7 +174,7 @@ hosted market. Results land in `arena-results/` as JSON, full per-scenario
 transcripts, and a share-ready `arena-report.md`. If you run a model we
 haven't covered, post the report in a
 [GitHub discussion](https://github.com/artokun/comfyui-mcp/discussions) with
-your GPU and model tags — the leaderboard on the [Arena page](/arena) is
+your GPU and model tags — the leaderboard on the [Arena page](../arena) is
 built from exactly these runs.
 
 ## What the two builds bought each other
@@ -199,6 +199,6 @@ runs free, offline, on a model that has actually met your tools before.
 
 Run the ComfyUI agent on a free local model: install
 [comfyui-mcp](https://github.com/artokun/comfyui-mcp), pull
-`artokun/gemma4-comfyui-mcp:e4b`, and see [Local LLMs](/local-llms) for setup —
-or benchmark your own model on the [Arena](/arena). Star the repo or file an
+`artokun/gemma4-comfyui-mcp:e4b`, and see [Local LLMs](../local-llms) for setup —
+or benchmark your own model on the [Arena](../arena). Star the repo or file an
 idea at [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/blog/gpt-5-6-comfyui.mdx
+++ b/docs/blog/gpt-5-6-comfyui.mdx
@@ -13,8 +13,8 @@ keywords:
 
 _by [artokun](https://github.com/artokun) · July 20, 2026 · Codex · GPT-5.6 · provider tracking_
 
-Back in June, we wrote that the [Agent Panel](/panel) lets you [pick a provider,
-not a port](/blog/comfyui-agent-claude-or-chatgpt): the same canvas-driving agent
+Back in June, we wrote that the [Agent Panel](../panel) lets you [pick a provider,
+not a port](./comfyui-agent-claude-or-chatgpt): the same canvas-driving agent
 runs on either Claude or ChatGPT, on your own subscription, no API keys. The
 promise implicit in that design is that when a provider ships a new frontier
 family, you shouldn't have to do anything — the same panel just offers the new
@@ -146,6 +146,6 @@ picked a provider; the port kept up.
 
 Drive ComfyUI from an autonomous agent on your own Claude **or** ChatGPT
 subscription: install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and
-add the [Agent Panel](/panel) — see [Backends / providers](/backends) for the
+add the [Agent Panel](../panel) — see [Backends / providers](../backends) for the
 full capability matrix. Star the repo or file an idea at
 [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/blog/ideogram-4-comfyui.mdx
+++ b/docs/blog/ideogram-4-comfyui.mdx
@@ -24,7 +24,7 @@ self-host today for **text-in-image and graphic-design layout**.
 Below: what it's genuinely best at (with receipts), how it stacks up against Flux
 / Qwen / Z-Image / ERNIE, the VRAM you need, and the fastest way to get it running
 — a one-command install with [comfyui-mcp](https://github.com/artokun/comfyui-mcp)
-and the [sidebar Panel](/panel), instead of hand-downloading ~50 GB of weights and
+and the [sidebar Panel](../panel), instead of hand-downloading ~50 GB of weights and
 hand-typing JSON coordinates.
 
 > **TL;DR — one-command setup.** Install comfyui-mcp, apply the `ideogram` pack
@@ -130,11 +130,11 @@ packs/ideogram/install-runpod.sh        # RunPod / Linux
 ```
 
 Then load `packs/ideogram/workflow.json`. Because the pack ships with the
-[plugin](/plugin), your **own Claude session can drive the live graph through the
-[Panel](/panel)** — add/wire nodes, set widgets, and iterate on prompts
+[plugin](../plugin), your **own Claude session can drive the live graph through the
+[Panel](../panel)** — add/wire nodes, set widgets, and iterate on prompts
 conversationally, with full Ctrl+Z undo and no extra API keys. Every model URL in
 the pack is CI-validated for reachability and size, so a link never quietly rots
-([here's why that matters](/blog/installer-packs-that-cant-rot)).
+([here's why that matters](./installer-packs-that-cant-rot)).
 
 ## Structured JSON prompting (the part that sets Ideogram apart)
 
@@ -248,12 +248,12 @@ model's core design goal, not an afterthought.
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](../panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **`ideogram` pack** — nodes + ~50 GB of models land in the right folders, validated.
-3. Open the [Panel](/panel) and let the panel's agent build area-prompts and wire the graph for you.
+3. Open the [Panel](../panel) and let the panel's agent build area-prompts and wire the graph for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **That wraps the
 model-highlight series** — nine local ComfyUI setups, each one command away. Browse
-them all on the [blog index](/blog), or start from the top with
-[WAN 2.2 in ComfyUI](/blog/wan-2.2-comfyui).
+them all on the [blog index](./), or start from the top with
+[WAN 2.2 in ComfyUI](./wan-2.2-comfyui).

--- a/docs/blog/index.mdx
+++ b/docs/blog/index.mdx
@@ -10,56 +10,56 @@ quality, and what we learn shipping an MCP server people actually use.
 
 A chronological tour of the open image & video models you can run locally in
 ComfyUI — what each is best at, and how to set it up in one command with a
-comfyui-mcp pack and the [Panel](/panel). Oldest first, ending on the current
+comfyui-mcp pack and the [Panel](../panel). Oldest first, ending on the current
 open-weight champ, Ideogram 4.
 
 <CardGroup cols={2}>
 
-<Card title="WAN 2.2" href="/blog/wan-2.2-comfyui">
+<Card title="WAN 2.2" href="./wan-2.2-comfyui">
   The open-source video king — how the high/low-noise experts actually work,
   I2V/T2V, GGUF tiers, and longer videos.
 </Card>
 
-<Card title="Qwen-Image & Qwen-Image-Edit" href="/blog/qwen-image-comfyui">
+<Card title="Qwen-Image & Qwen-Image-Edit" href="./qwen-image-comfyui">
   20B text-to-image plus instruction editing and manual-mask inpainting, with a
   WAN 2.2 refine combo.
 </Card>
 
-<Card title="WAN Animate 2.2" href="/blog/wan-animate-comfyui">
+<Card title="WAN Animate 2.2" href="./wan-animate-comfyui">
   Drive a character with a reference video — v2v character & motion replace from
   a single image.
 </Card>
 
-<Card title="WAN Transparent Expressions" href="/blog/wan-transparent-comfyui">
+<Card title="WAN Transparent Expressions" href="./wan-transparent-comfyui">
   Alpha-channel character expression sprites (looping WebP/GIF) for SillyTavern
   and VTuber overlays.
 </Card>
 
-<Card title="Z-Image (Turbo & Base)" href="/blog/z-image-comfyui">
+<Card title="Z-Image (Turbo & Base)" href="./z-image-comfyui">
   6B, runs under 8 GB — the low-VRAM speed king. Turbo vs Base, ControlNet, and
   your own LoRAs.
 </Card>
 
-<Card title="ERNIE-Image" href="/blog/ernie-image-comfyui">
+<Card title="ERNIE-Image" href="./ernie-image-comfyui">
   Apache-2.0 text-to-image with razor-sharp multilingual text rendering, under
   8 GB VRAM.
 </Card>
 
-<Card title="ANIMA 1.0" href="/blog/anima-comfyui">
+<Card title="ANIMA 1.0" href="./anima-comfyui">
   A ~2B anime model that generates and trains under 6 GB — Danbooru tags plus
   natural language.
 </Card>
 
-<Card title="LTX-2.3" href="/blog/ltx-2.3-comfyui">
+<Card title="LTX-2.3" href="./ltx-2.3-comfyui">
   Fast GGUF video (T2V/I2V) and the LTX Director timeline editor inside ComfyUI.
 </Card>
 
-<Card title="Krea 2 Turbo" href="/blog/krea2-comfyui">
+<Card title="Krea 2 Turbo" href="./krea2-comfyui">
   Krea.ai's 12B open-weight text-to-image — 8-step turbo speed, Qwen3-VL
   prompting, and JSON area prompts.
 </Card>
 
-<Card title="Ideogram 4 — the finale" href="/blog/ideogram-4-comfyui">
+<Card title="Ideogram 4 — the finale" href="./ideogram-4-comfyui">
   The 9.3B open-weight king of readable in-image text and design layout, with
   JSON area prompting.
 </Card>
@@ -70,12 +70,12 @@ open-weight champ, Ideogram 4.
 
 <CardGroup cols={2}>
 
-<Card title="Upscaling video in ComfyUI" href="/blog/video-upscale-comfyui">
+<Card title="Upscaling video in ComfyUI" href="./video-upscale-comfyui">
   SeedVR2 & FlashVSR temporal restore, the downscale-first trick, the quick
   per-frame ESRGAN path, and RIFE/FILM interpolation (built into ComfyUI 0.26).
 </Card>
 
-<Card title="Extending video with Pusa" href="/blog/video-extend-pusa-comfyui">
+<Card title="Extending video with Pusa" href="./video-extend-pusa-comfyui">
   Pusa 2.2 temporal flowmatching on the WAN 2.2 stack — continue a clip instead
   of regenerating it, chain extensions, all on your own GPU.
 </Card>
@@ -86,7 +86,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="ComfyUI on RunPod: rent a cloud GPU"
-  href="/blog/runpod-comfyui"
+  href="./runpod-comfyui"
 >
   A first-party RunPod connector: one-tap deploy of a pod that runs YOUR exact
   custom nodes and models, an honest local⇄pod host pill, live GPU/cost status,
@@ -96,7 +96,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="Train a FLUX LoRA in the cloud on RunPod"
-  href="/blog/train-lora-runpod"
+  href="./train-lora-runpod"
 >
   No 24 GB card? Rent one. The LoRA trainer's new SSH transport stands ai-toolkit
   up on a RunPod pod and runs the same train_* flow on rented hardware — dataset
@@ -105,7 +105,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="Train a character LoRA by asking"
-  href="/blog/lora-trainer-p1"
+  href="./lora-trainer-p1"
 >
   The panel agent drives ostris's ai-toolkit end to end through train_* tools —
   preflight, dataset staging, streamed progress, honest cancel — verified with a
@@ -114,7 +114,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="Blind mode: a privacy promise the agent can't break"
-  href="/blog/blind-mode-privacy"
+  href="./blind-mode-privacy"
 >
   A user proved our "the agent never sees the image" toggle was leaky. The fix:
   enforcement at the tool-server boundary — one wrapper that withholds pixels
@@ -124,7 +124,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="GPT-5.6 Sol, Terra, and Luna land in the ComfyUI panel"
-  href="/blog/gpt-5-6-comfyui"
+  href="./gpt-5-6-comfyui"
 >
   The new frontier family on your ChatGPT subscription — max and ultra efforts
   with per-model ceilings from the live catalog, account-aware deprecation that
@@ -134,7 +134,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="Kimi K3: the biggest open-weight model ever now drives your ComfyUI canvas"
-  href="/blog/kimi-k3-comfyui"
+  href="./kimi-k3-comfyui"
 >
   Moonshot's 2.8T-parameter K3 — third on the intelligence boards, first on
   Frontend Code Arena, weights landing July 27 — became a first-class provider
@@ -144,7 +144,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="The 405 that wasn't: three dialects of ComfyUI-Manager"
-  href="/blog/manager-405-dialects"
+  href="./manager-405-dialects"
 >
   A debugging war story in three acts: per-operation routes vs task envelopes vs
   a legacy UI hiding under /v2 — and the frontend catchall that turns every wrong
@@ -153,7 +153,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="Your conversation now survives workflow switching"
-  href="/blog/panel-owned-sessions"
+  href="./panel-owned-sessions"
 >
   The conversation is the unit of continuity; the workflow is just the canvas
   target. How the orchestrator rebinds a live agent across workflow tabs — no
@@ -162,7 +162,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="CivitAI inside ComfyUI: browse, like, and run without a download folder"
-  href="/blog/civitai-in-comfyui"
+  href="./civitai-in-comfyui"
 >
   A full CivitAI browser in the sidebar — lightbox with generation details,
   like/unlike with a synced likes collection, @creator search qualifiers, and
@@ -171,7 +171,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="The render finished while you were making coffee: ComfyUI on your phone"
-  href="/blog/comfyui-mobile-app"
+  href="./comfyui-mobile-app"
 >
   The mobile companion (iOS + Android beta): same agent, same providers, CivitAI
   parity, one multi-purpose QR to pair — and tab-mirror remote control that lets
@@ -180,7 +180,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="Flatten the spaghetti: making expert workflows readable"
-  href="/blog/flatten-workflows"
+  href="./flatten-workflows"
 >
   Get/Set buses, Reroutes, and use-everywhere broadcasts resolved to direct
   links IN PLACE — layout, groups, and widgets preserved — plus the
@@ -189,7 +189,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="The orchestrator that never goes stale"
-  href="/blog/self-updating-orchestrator"
+  href="./self-updating-orchestrator"
 >
   Hourly npm self-update and dev-build self-restart, coalesced to fire only when
   every agent is idle and nothing is rendering — infrastructure that updates like
@@ -198,7 +198,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="We fine-tuned Gemma 4 to drive ComfyUI — and built an arena to prove it"
-  href="/blog/gemma4-fine-tune-arena"
+  href="./gemma4-fine-tune-arena"
 >
   A gemma4 ladder (e2b/e4b/12b) trained on server-verified trajectories, scored
   by a best-of-3 arena of real ComfyUI tasks — including the regression we
@@ -208,7 +208,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="Giving every backend eyes — and honesty when a model doesn't have them"
-  href="/blog/vision-per-model"
+  href="./vision-per-model"
 >
   Vision is a property of the model, not the provider. Always attempt image
   delivery, strip-and-retry once on rejection, and leave an in-history note so
@@ -217,7 +217,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="Bring any LLM: free local models now drive ComfyUI"
-  href="/blog/local-llms-comfyui"
+  href="./local-llms-comfyui"
 >
   Ollama, LM Studio, llama.cpp, or any OpenAI-compatible endpoint — no account,
   no API key, fully offline. The compact tool router that makes ~200 tools fit a
@@ -227,7 +227,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="Two brains, one canvas: ComfyUI on Claude or ChatGPT"
-  href="/blog/comfyui-agent-claude-or-chatgpt"
+  href="./comfyui-agent-claude-or-chatgpt"
 >
   The ComfyUI sidebar agent now runs on EITHER your Claude or your ChatGPT
   subscription — pick a provider, no API keys, full canvas-driving parity. How we
@@ -237,7 +237,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="The self-healing ComfyUI agent: it fixes the node that crashed it"
-  href="/blog/self-healing-comfyui-agent"
+  href="./self-healing-comfyui-agent"
 >
   A Wan2.2 render hard-crashes ComfyUI at 99% with a native access violation. The
   agent reads the crash dump on reload, names the culprit node, and escalates —
@@ -247,7 +247,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="The panel that talks back: an autonomous agent on your Claude subscription"
-  href="/blog/panel-agent-subscription"
+  href="./panel-agent-subscription"
 >
   Three tries to get the ComfyUI panel driven by a real background agent: channel
   pushes can't wake an idle session, the `--sdk-url` transport that did everything
@@ -258,7 +258,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="Installer packs that can't rot: one manifest, every install"
-  href="/blog/installer-packs-that-cant-rot"
+  href="./installer-packs-that-cant-rot"
 >
   The community "1-click installer" .bat is great UX and a maintenance trap —
   Windows-only, duplicated in a separate .sh, full of model URLs that rot
@@ -269,7 +269,7 @@ open-weight champ, Ideogram 4.
 
 <Card
   title="From B to A: sharpening 70+ tool descriptions with TDQS"
-  href="/blog/comfyui-mcp-tdqs-case-study"
+  href="./comfyui-mcp-tdqs-case-study"
 >
   A case study using Glama's Tool Definition Quality Score to find and fix the one weak tool that
   was capping our whole server — plus five rules any MCP author can steal. _May 25, 2026_

--- a/docs/blog/kimi-k3-comfyui.mdx
+++ b/docs/blog/kimi-k3-comfyui.mdx
@@ -21,7 +21,7 @@ it the largest open-weight model ever shipped, with the full weights promised
 on Hugging Face by **July 27** and a technical report alongside them.
 
 Two days later, K3 became a first-class provider in the [Agent
-Panel](/panel). Pick the **Kimi K3** chip, paste one API key, and the model
+Panel](../panel). Pick the **Kimi K3** chip, paste one API key, and the model
 that's currently sitting at the top of the open-weight world is editing the
 graph you're looking at.
 
@@ -130,7 +130,7 @@ that to one table entry — the next K3-shaped release wires in faster than this
 one did.
 
 Vision works the way it works everywhere in comfyui-mcp: capability is judged
-[per model, not per provider](/blog/vision-per-model), so K3's native visual
+[per model, not per provider](./vision-per-model), so K3's native visual
 understanding means it can actually look at your renders when you ask "why is
 the face melted?" — delivery is attempted, and honesty is enforced if a model
 can't see.
@@ -138,9 +138,9 @@ can't see.
 ## Where it fits in your lineup
 
 The panel's whole thesis is [pick a provider, not a
-port](/blog/comfyui-agent-claude-or-chatgpt), and K3 slots into a real niche
+port](./comfyui-agent-claude-or-chatgpt), and K3 slots into a real niche
 in that lineup. For quick widget nudges, a [free local
-model](/blog/local-llms-comfyui) on your own GPU is still the right tool — K3's
+model](./local-llms-comfyui) on your own GPU is still the right tool — K3's
 always-max thinking is overkill you pay for by the token. For the absolute
 ceiling, Claude and GPT-5.6 still hold the top two slots on most boards. K3's
 lane is the long, gnarly middle: a 128-node workflow autopsy, a
@@ -154,7 +154,7 @@ nine days until the weights. The chip is already in your sidebar.
 ---
 
 *Try it: [install comfyui-mcp](https://github.com/artokun/comfyui-mcp) and add
-the [Panel](/panel) to ComfyUI, grab a key at
+the [Panel](../panel) to ComfyUI, grab a key at
 [platform.kimi.ai](https://platform.kimi.ai), and pick the Kimi K3 chip. If
 you get K3 doing something great on your canvas — or something hilariously
 overeager — [file an issue or share

--- a/docs/blog/krea2-comfyui.mdx
+++ b/docs/blog/krea2-comfyui.mdx
@@ -81,7 +81,7 @@ Three files are needed (the installer fetches them):
 
 ### The fast way — comfyui-mcp + the Panel
 
-From a Claude Code session with the [comfyui-mcp](/) plugin installed:
+From a Claude Code session with the [comfyui-mcp](../) plugin installed:
 
 ```
 Install the krea2-txt2img-manual pack
@@ -169,7 +169,7 @@ the Qwen image VAE, both included in the pack.
 
 ## Get it running in one command
 
-Install the [comfyui-mcp](/) plugin, then ask your agent to install the
+Install the [comfyui-mcp](../) plugin, then ask your agent to install the
 `krea2-txt2img-manual`, `krea2-txt2img-json`, or `krea2-combo` pack — nodes,
 models, and a first render, hands-free.
 

--- a/docs/blog/local-llms-comfyui.mdx
+++ b/docs/blog/local-llms-comfyui.mdx
@@ -14,7 +14,7 @@ keywords:
 
 _by [artokun](https://github.com/artokun) · July 14, 2026 · local llms · tool router · reliability_
 
-The [Panel](/panel) agent — the autonomous assistant in ComfyUI's sidebar that
+The [Panel](../panel) agent — the autonomous assistant in ComfyUI's sidebar that
 adds nodes, wires graphs, installs packs, and runs renders — started life on
 Claude and ChatGPT subscriptions. That's still the strongest way to run it. But
 a lot of people running ComfyUI locally have exactly one question: *can I do
@@ -154,7 +154,7 @@ per-provider — delivery is always attempted, and an endpoint that rejects imag
 input triggers one graceful strip-and-retry with an honest 📎 note. (A sibling
 post covers that machinery.)
 
-Which model should you actually run? The [Arena](/arena) page exists for
+Which model should you actually run? The [Arena](../arena) page exists for
 exactly that question — a repeatable ten-scenario, 20-point benchmark across
 local and hosted models, where our `artokun/gemma4-comfyui-mcp` fine-tunes currently lead the
 local field. (Also its own post.)
@@ -179,7 +179,7 @@ those came out of a live failure, and every one is code you can read.
 
 Drive ComfyUI with a free local model — no account, no API key, fully offline:
 install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and add the
-[Panel](/panel), then pick Ollama, LM Studio, or llama.cpp in the backend
-picker — see [Local & self-hosted LLMs](/local-llms) for setup. Star the repo
+[Panel](../panel), then pick Ollama, LM Studio, or llama.cpp in the backend
+picker — see [Local & self-hosted LLMs](../local-llms) for setup. Star the repo
 or file an idea at
 [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/blog/lora-trainer-p1.mdx
+++ b/docs/blog/lora-trainer-p1.mdx
@@ -173,7 +173,7 @@ underneath it are already the real, E2E-proven thing.
 
 And if 24 GB isn't your reality *today*: LoRA training on genuinely small cards
 already exists in the pack shelf — [ANIMA trains character and style LoRAs on
-~6 GB](/blog/anima-comfyui), via its own trainer skill. Different base model,
+~6 GB](./anima-comfyui), via its own trainer skill. Different base model,
 same idea: your character, your GPU.
 
 ---
@@ -181,7 +181,7 @@ same idea: your character, your GPU.
 ## Train one tonight
 
 1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the
-   [Panel](/panel) — the panel auto-starts a background agent on your Claude
+   [Panel](../panel) — the panel auto-starts a background agent on your Claude
    subscription (no API keys; sign in with `claude` once).
 2. Have Docker + the NVIDIA Container Toolkit installed, and an `HF_TOKEN` with
    FLUX.1-dev access in the MCP server env.

--- a/docs/blog/ltx-2.3-comfyui.mdx
+++ b/docs/blog/ltx-2.3-comfyui.mdx
@@ -31,7 +31,7 @@ it, and the one import bug everyone hits.
 > `ltx-2.3-txt2vid` / `ltx-2.3-img2vid` pack (run the generated
 > `install-windows.bat` / `install-runpod.sh`, or
 > `apply_manifest --path packs/ltx-2.3-txt2vid/manifest.yaml`), then drive the
-> graph from your own Claude session via the [Panel](/panel).
+> graph from your own Claude session via the [Panel](../panel).
 > Jump to [Install](#install-ltx-2-3-in-comfyui).
 
 > **Update (June 19, 2026) — the render-verified sharp setup.** After actually
@@ -129,7 +129,7 @@ version:
 
 LTX-2.3's pitch is throughput and the audio track; WAN 2.2's is raw quality from its
 two-expert design. WAN 2.2 gets its own deep-dive on how the high/low-noise experts
-actually work — see [the WAN 2.2 post](/blog/wan-2.2-comfyui). For now: if you want
+actually work — see [the WAN 2.2 post](./wan-2.2-comfyui). For now: if you want
 fast local clips with sound, LTX-2.3; if you want to push motion quality and don't
 mind the cost, WAN 2.2.
 
@@ -193,9 +193,9 @@ Both packs ship a **render-verified `workflow.json`** built on the official
 two-stage template, so there's nothing to import — load it and generate. The
 installer clones each custom node **and resolves its `requirements.txt`** into the
 **ComfyUI venv** (the fix that ended a long tail of "node installed but doesn't
-load" failures — [details](/blog/installer-packs-that-cant-rot)). Because the pack
-ships with the [plugin](/plugin), your **own Claude session can drive the live
-graph through the [Panel](/panel)** — tweak prompts, swap the first-frame image,
+load" failures — [details](./installer-packs-that-cant-rot)). Because the pack
+ships with the [plugin](../plugin), your **own Claude session can drive the live
+graph through the [Panel](../panel)** — tweak prompts, swap the first-frame image,
 flip T2V↔I2V, and iterate conversationally with full undo and no extra API keys.
 Every model URL is CI-validated for reachability and size, so a link never quietly
 rots.
@@ -356,13 +356,13 @@ and the "sulphur" finetune is a separate third-party project with its own licens
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](../panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **`ltx-2.3` pack** — GGUF UNet, both VAEs, the Gemma encoder, text
    projection, upscaler, and LoRAs land in the right folders, validated.
-3. Run the bundled **kornia fix**, restart, then open the [Panel](/panel) and let
+3. Run the bundled **kornia fix**, restart, then open the [Panel](../panel) and let
    the panel's agent wire the GGUF graph and build prompts for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **Next in the series:**
-[Ideogram 4](/blog/ideogram-4-comfyui) — the open-weight text-and-layout king, and
+[Ideogram 4](./ideogram-4-comfyui) — the open-weight text-and-layout king, and
 the finale of the model-highlight run.

--- a/docs/blog/micro-apps.mdx
+++ b/docs/blog/micro-apps.mdx
@@ -192,6 +192,6 @@ still the source of truth. It's just no longer the interface.
 ---
 
 Convert your first workflow from the Apps button in the
-[Agent Panel](/panel) toolbar, or ask the agent what's installed with
+[Agent Panel](../panel) toolbar, or ask the agent what's installed with
 `apps` (`action:"list"`). Issues and ideas:
 [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/blog/panel-agent-subscription.mdx
+++ b/docs/blog/panel-agent-subscription.mdx
@@ -5,7 +5,7 @@ description: "Getting the ComfyUI sidebar panel driven by a real background agen
 
 _by [artokun](https://github.com/artokun) · June 16, 2026 · Claude Agent SDK · background agents · architecture_
 
-The [Panel](/panel) is comfyui-mcp's sidebar inside ComfyUI: you type a request,
+The [Panel](../panel) is comfyui-mcp's sidebar inside ComfyUI: you type a request,
 and an agent builds the graph, runs it, and replies — right there next to your
 canvas. The dream was always that this agent runs **in the background**, on its
 own, the way the Linear app quietly works a ticket while you do something else.
@@ -172,5 +172,5 @@ the panel runs on.
 
 Drive ComfyUI from a background agent on your own subscription: install
 [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and add the
-[Panel](/panel). Star the repo or file an idea at
+[Panel](../panel). Star the repo or file an idea at
 [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/blog/panel-owned-sessions.mdx
+++ b/docs/blog/panel-owned-sessions.mdx
@@ -145,5 +145,5 @@ which canvas it's driving now.
 
 Run an agent that survives your tab habits: install
 [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and add the
-[Panel](/panel). Star the repo or file an idea at
+[Panel](../panel). Star the repo or file an idea at
 [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/blog/panel-workflow-layout.mdx
+++ b/docs/blog/panel-workflow-layout.mdx
@@ -14,7 +14,7 @@ keywords:
 
 _by [artokun](https://github.com/artokun) · June 19, 2026 · panel · agent · layout · dev-log_
 
-The [Panel](/panel) agent could already build ComfyUI graphs — add nodes, wire
+The [Panel](../panel) agent could already build ComfyUI graphs — add nodes, wire
 them, set widgets, run them. But it built them **blind**. It could move a node to
 `[x, y]`, yet the graph read didn't return node **sizes**, so it stacked tall
 nodes (a `WanVideo Sampler` is ~900px) on a fixed 320px pitch and they overlapped.
@@ -132,5 +132,5 @@ algorithm every time instead of improvising:
 
 Small primitives, one skill, and — crucially — a way for the agent to look at what
 it made. If you're driving ComfyUI from your own Claude session through the
-[Panel](/panel), it can now hand you a workflow that's actually laid out, not just
+[Panel](../panel), it can now hand you a workflow that's actually laid out, not just
 wired. Grab [comfyui-mcp](https://github.com/artokun/comfyui-mcp) to try it.

--- a/docs/blog/qwen-image-comfyui.mdx
+++ b/docs/blog/qwen-image-comfyui.mdx
@@ -28,7 +28,7 @@ model, the instruction editor, the mask-based inpainter, and the
 Below: what each genuinely does best, how it stacks up against Flux and Ideogram,
 the VRAM you need, and the fastest way to get it running — a one-command install
 with [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the
-[sidebar Panel](/panel), instead of hand-downloading 40+ GB of weights and
+[sidebar Panel](../panel), instead of hand-downloading 40+ GB of weights and
 juggling two text encoders.
 
 > **TL;DR — one-command setup.** Install comfyui-mcp, apply the `qwen-image` pack
@@ -66,13 +66,13 @@ There's no single "best" — pick by the job:
 | Pick… | When you need… |
 |-------|----------------|
 | **Qwen-Image** | Multilingual **text rendering** (EN/中文/日本語/한국어), paragraph-level layouts, **instruction editing + inpainting**, Apache-2.0 commercial use, the WAN refine combo |
-| **Ideogram 4** | The best open-weight **typography + design layout** with structured JSON area-prompting (posters, logos, packaging) — see our [Ideogram 4 post](/blog/ideogram-4-comfyui) |
+| **Ideogram 4** | The best open-weight **typography + design layout** with structured JSON area-prompting (posters, logos, packaging) — see our [Ideogram 4 post](./ideogram-4-comfyui) |
 | **FLUX.2 / Kontext** | **Photorealism** as a mature default, and precise edits when you write very explicit prompts |
-| **ERNIE-Image** | Another Apache-2.0 option with strong CN/JP/EN text — see our [ERNIE-Image post](/blog/ernie-image-comfyui) |
+| **ERNIE-Image** | Another Apache-2.0 option with strong CN/JP/EN text — see our [ERNIE-Image post](./ernie-image-comfyui) |
 
 Where rivals win: **Ideogram 4** edges Qwen on pure typography and spatial layout
 control (it's purpose-built for it, and its English OCR accuracy leads the
-open-weight pack — details in [its post](/blog/ideogram-4-comfyui)); **Flux**
+open-weight pack — details in [its post](./ideogram-4-comfyui)); **Flux**
 remains the go-to for photoreal portraits and is the lighter download. Qwen's
 trump cards are **editing**, **multilingual text**, and a **truly permissive
 license**. Each of those models gets its own model-highlight post — Qwen earns
@@ -134,12 +134,12 @@ Then load the workflow:
 - **`qwen-image-edit`** ships `workflow.json` (instruction editing) and
   `workflow-inpainting.json` (manual-mask inpainting) — load whichever fits.
 
-Because both packs ship with the [plugin](/plugin), your **own Claude session can
-drive the live graph through the [Panel](/panel)** — load images, paint masks,
+Because both packs ship with the [plugin](../plugin), your **own Claude session can
+drive the live graph through the [Panel](../panel)** — load images, paint masks,
 wire nodes, tweak the edit instruction, and iterate conversationally, with full
 Ctrl+Z undo and no extra API keys. Every model URL in the packs is CI-validated
 for reachability and size, so a link never quietly rots
-([why that matters](/blog/installer-packs-that-cant-rot)).
+([why that matters](./installer-packs-that-cant-rot)).
 
 ## Qwen-Image-Edit: instruction editing that listens
 
@@ -304,14 +304,14 @@ English layouts.
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](../panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **[`qwen-image`](https://github.com/artokun/comfyui-mcp)** pack (20B
    T2I + WAN combo) and/or **`qwen-image-edit`** (instruction editing + mask
    inpainting) — nodes and models land in the right folders, validated.
-3. Open the [Panel](/panel) and let the panel's agent load images, paint masks,
+3. Open the [Panel](../panel) and let the panel's agent load images, paint masks,
    and wire the graph for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **Next in the series:**
-[WAN Animate 2.2](/blog/wan-animate-comfyui) — replace or drive a character from a
+[WAN Animate 2.2](./wan-animate-comfyui) — replace or drive a character from a
 single reference image.

--- a/docs/blog/runpod-comfyui.mdx
+++ b/docs/blog/runpod-comfyui.mdx
@@ -18,7 +18,7 @@ _July 21, 2026_
 
 Want to run ComfyUI on a cloud GPU without touching a terminal? With
 comfyui-mcp's **first-party RunPod connector** (≥ v0.44.0) you rent a GPU pod by
-the hour and drive it in natural language from the same [Agent Panel](/panel) you
+the hour and drive it in natural language from the same [Agent Panel](../panel) you
 already use locally. Ask the agent to deploy a pod, it boots **your** ComfyUI
 environment — your custom nodes, your LoRAs, your models — and you render on it.
 One tap flips back to your local rig when you're done. This guide covers the full
@@ -27,7 +27,7 @@ loop: deploy, manage, render, and stop without leaving the panel or your phone.
 ## Why rent a GPU for ComfyUI?
 
 Not everyone has a 24 GB card. Even if you do, some jobs want more: a WAN 2.2
-video batch, a big Flux upscale, or [a LoRA train](/blog/train-lora-runpod) that
+video batch, a big Flux upscale, or [a LoRA train](./train-lora-runpod) that
 would tie up your desktop for an hour. Renting a cloud GPU on
 [RunPod](https://runpod.io) gives you an RTX 5090 (or bigger) on demand, billed
 per hour, and hands it back when you stop.
@@ -72,7 +72,7 @@ The result is that the workflow you were editing locally renders **the same** on
 the pod. For the full picture of what persists across pod restarts (models,
 custom nodes, user settings all live on the network volume) and how the topology
 keeps your Claude/ChatGPT login on your own machine, see
-[Cloud deployment](/cloud-deployment).
+[Cloud deployment](../cloud-deployment).
 
 ## Honest host switching — you always know where a render runs
 
@@ -89,7 +89,7 @@ one-tap **Local ⇄ Pod** switch (`runpod_use_local`) moves you between them
 instantly. Point the pod at your canvas for the heavy job, flip back to local for
 quick iteration, and the pill tells you the truth the whole time. It's the same
 honest-target philosophy behind
-[panel-owned sessions](/blog/panel-owned-sessions) — the canvas target is explicit,
+[panel-owned sessions](./panel-owned-sessions) — the canvas target is explicit,
 never guessed.
 
 ## Cost control and idle auto-stop
@@ -118,12 +118,12 @@ Everything above works from a **panel control modal** on the desktop and a
 
 <CardGroup cols={2}>
 
-<Card title="Desktop panel modal" href="/panel">
+<Card title="Desktop panel modal" href="../panel">
   Host banner, live status card, pod dropdown by name, and Connect / Start / Stop
   / Use-Local buttons plus a confirm-armed Deploy — right in the ComfyUI sidebar.
 </Card>
 
-<Card title="Mobile control sheet" href="/mobile">
+<Card title="Mobile control sheet" href="../mobile">
   The same host banner, status card, pod picker, and one-tap controls in the
   companion app — kick off a cloud render from your couch, watch the meter, stop
   the pod when it's done.
@@ -155,7 +155,7 @@ you still get a working pod.
 
 ## How to run ComfyUI on RunPod
 
-1. **Install the [comfyui-mcp](/) plugin** and open the Agent Panel in ComfyUI.
+1. **Install the [comfyui-mcp](../) plugin** and open the Agent Panel in ComfyUI.
 2. **Set `RUNPOD_API_KEY` once** via the panel's **API-Keys card** — no CLI, no
    WSL fiddling. Secrets are stored server-side in `~/.comfyui-mcp/.env`.
 3. **(Optional) Set `RUNPOD_IDLE_STOP_MINUTES`** to your comfort window for the
@@ -178,7 +178,7 @@ environment, an honest pill that tells you where every render lands, and idle
 auto-stop so a forgotten pod doesn't drain your wallet. Set your
 `RUNPOD_API_KEY` once, then rent a GPU the same way you talk to your local one.
 
-Related reading: [Cloud deployment](/cloud-deployment) for the pod image and
-persistence model, [Remote / hosted connector](/remote-connector) for exposing
+Related reading: [Cloud deployment](../cloud-deployment) for the pod image and
+persistence model, [Remote / hosted connector](../remote-connector) for exposing
 comfyui-mcp itself to remote clients, and
-[ComfyUI on your phone](/blog/comfyui-mobile-app) for the mobile companion.
+[ComfyUI on your phone](./comfyui-mobile-app) for the mobile companion.

--- a/docs/blog/self-healing-comfyui-agent.mdx
+++ b/docs/blog/self-healing-comfyui-agent.mdx
@@ -28,7 +28,7 @@ catch it; the interpreter is already a corpse by the time anything is written to
 disk. The culprit, buried in ComfyUI's on-disk log, was an fp8 `merge_loras` path
 inside **ComfyUI-WanVideoWrapper**: `apply_lora` at `utils.py:338`.
 
-Here's the part that matters. The [Panel](/panel) agent — the autonomous
+Here's the part that matters. The [Panel](../panel) agent — the autonomous
 assistant living in the ComfyUI sidebar — **did not** shrug and say "ComfyUI
 restarted, want me to run it again?" It read the corpse, named the killer, and
 fixed it. This post is how that loop works, end to end, because every piece of it
@@ -211,5 +211,5 @@ were getting coffee the whole time.
 
 Run an autonomous agent that recovers from its own crashes: install
 [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and add the
-[Panel](/panel). Star the repo or file an idea at
+[Panel](../panel). Star the repo or file an idea at
 [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/blog/self-updating-orchestrator.mdx
+++ b/docs/blog/self-updating-orchestrator.mdx
@@ -14,7 +14,7 @@ keywords:
 
 _by [artokun](https://github.com/artokun) · July 14, 2026 · autonomous agents · self-updating · architecture_
 
-In [the last post](/blog/self-healing-comfyui-agent), the panel agent learned to
+In [the last post](./self-healing-comfyui-agent), the panel agent learned to
 read ComfyUI's corpse after a native crash, name the custom node that killed it,
 and patch the file. It can heal everything around it. There was one thing it
 couldn't heal: **itself**.
@@ -174,5 +174,5 @@ itself while you were getting coffee.
 
 Run an orchestrator that keeps itself current: install
 [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and add the
-[Panel](/panel). Star the repo or file an idea at
+[Panel](../panel). Star the repo or file an idea at
 [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/blog/train-lora-runpod.mdx
+++ b/docs/blog/train-lora-runpod.mdx
@@ -20,14 +20,14 @@ Short answer to the question everyone asks: **no, you don't need a 24GB card to
 train a FLUX LoRA anymore.** You rent one for the hour or two the run takes,
 train on it by asking the agent, and get the `.safetensors` back on your own
 machine. This is P4 — the cloud sequel to
-[the local LoRA trainer (P1)](/blog/lora-trainer-p1) — and it runs the exact same
+[the local LoRA trainer (P1)](./lora-trainer-p1) — and it runs the exact same
 `train_*` tools, just pointed at rented hardware.
 
 ## How much VRAM does FLUX LoRA training need?
 
 FLUX.1-dev LoRA training is greedy. Even with quantization on, a real character
 run wants roughly **24 GB of VRAM** — RTX 4090 class. That's the wall a lot of
-people hit the moment they read [P1](/blog/lora-trainer-p1): the flow is a
+people hit the moment they read [P1](./lora-trainer-p1): the flow is a
 conversation, the trainer is proven, the handoff is honest… and their local card
 is a 12 GB laptop GPU that can't fit the model. Training simply doesn't start.
 
@@ -44,8 +44,8 @@ sitting in `models/loras/` that loads on any GPU big enough to *infer* with it
 (far less than training needs).
 
 comfyui-mcp already knows how to talk to RunPod: it's the same pods the
-[RunPod connector](/blog/runpod-comfyui) uses for remote rendering, and the same
-`RUNPOD_API_KEY` you set once in the [panel](/panel)'s API-Keys card.
+[RunPod connector](./runpod-comfyui) uses for remote rendering, and the same
+`RUNPOD_API_KEY` you set once in the [panel](../panel)'s API-Keys card.
 P4 teaches the trainer to borrow that hardware for a training run.
 
 ## How the pod bootstrap works
@@ -122,13 +122,13 @@ The honest notes, because rented GPUs come with real trade-offs:
   it *finished*.
 - **Your dataset leaves your machine.** It goes up to the pod over rsync/ssh.
   That's inherent to renting someone else's GPU; if that's a dealbreaker for a
-  given dataset, [train it locally](/blog/lora-trainer-p1) instead.
+  given dataset, [train it locally](./lora-trainer-p1) instead.
 
 ## RunPod FLUX LoRA training setup
 
 1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the
-   [Panel](/panel). Set your `RUNPOD_API_KEY` **once** in the panel's API-Keys
-   card — the same key the [RunPod connector](/blog/runpod-comfyui) already uses.
+   [Panel](../panel). Set your `RUNPOD_API_KEY` **once** in the panel's API-Keys
+   card — the same key the [RunPod connector](./runpod-comfyui) already uses.
 2. Make sure an `HF_TOKEN` with FLUX.1-dev access is in the MCP server env
    (FLUX.1-dev is gated; the pod downloads it on the first run).
 3. Ask: *"train a character LoRA from these photos on a RunPod pod."* The agent
@@ -138,7 +138,7 @@ The honest notes, because rented GPUs come with real trade-offs:
    `models/loras/`.
 
 That's the whole pitch of P4: the local trainer from
-[P1](/blog/lora-trainer-p1) proved the flow; the cloud transport removes the one
+[P1](./lora-trainer-p1) proved the flow; the cloud transport removes the one
 requirement not everyone can meet. You no longer need to *own* a 24GB GPU to
 train a FLUX LoRA — you just need to borrow one for an hour.
 

--- a/docs/blog/video-extend-pusa-comfyui.mdx
+++ b/docs/blog/video-extend-pusa-comfyui.mdx
@@ -22,7 +22,7 @@ existing clip rather than regenerating it from scratch — by riding on the
 that holds your existing footage clean while it flow-matches new frames onto the
 end.
 
-This is the practical companion to the [WAN 2.2 deep-dive](/blog/wan-2.2-comfyui):
+This is the practical companion to the [WAN 2.2 deep-dive](./wan-2.2-comfyui):
 that post covers the base model and the hi/lo expert split; this one covers how to
 take a clip you've already made and **keep it going** without ghosting at the seam.
 Below: what temporal flowmatching actually is, the node graph, the models and LoRAs
@@ -344,15 +344,15 @@ A14B models that the **[`wan-longer-videos` pack](https://github.com/artokun/com
 already installs. So the path is:
 
 1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the
-   [Panel](/panel), and apply the `wan-longer-videos` pack — that lands the nodes
+   [Panel](../panel), and apply the `wan-longer-videos` pack — that lands the nodes
    and the shared T2V A14B stack. **Don't re-download the big models.**
 2. Grab the **two Pusa V1 LoRAs** from `Kijai/WanVideo_comfy/Pusa/` into
    `models/loras/`.
-3. Open the [Panel](/panel) and let the panel's agent load kijai's extension graph,
+3. Open the [Panel](../panel) and let the panel's agent load kijai's extension graph,
    re-point the model/VAE/LoRA dropdowns, set `merge_loras=false`, and tune the
    noise ramp for you — conversationally, with full undo and no extra API keys.
 
 That's the whole point of the project: expert ComfyUI setups that drive themselves
 from your own agent session. For the model underneath this whole pipeline, read the
-[WAN 2.2 deep-dive](/blog/wan-2.2-comfyui); for the natural next step, **extend
+[WAN 2.2 deep-dive](./wan-2.2-comfyui); for the natural next step, **extend
 first, then upscale**.

--- a/docs/blog/video-upscale-comfyui.mdx
+++ b/docs/blog/video-upscale-comfyui.mdx
@@ -258,14 +258,14 @@ during the download.
 
 Cloning the SeedVR2 / FlashVSR / interpolation nodes and wiring a correct
 downscale → restore → interpolate → encode graph is exactly the busywork
-[comfyui-mcp](/) removes. From a Claude Code session with the plugin installed, ask
+[comfyui-mcp](../) removes. From a Claude Code session with the plugin installed, ask
 your agent to build the video-upscale pipeline — it installs the nodes
 (`ComfyUI-SeedVR2_VideoUpscaler`, `ComfyUI-Frame-Interpolation`,
 `ComfyUI-VideoHelperSuite`, optionally `ComfyUI-FlashVSR`), drops the right
 interpolation weights in place, and wires the graph in the correct order. SeedVR2 and
 FlashVSR weights auto-download on first run, so there's little to pre-fetch.
 
-Then drive the live graph from your own session via the [Panel](/panel) — downscale
+Then drive the live graph from your own session via the [Panel](../panel) — downscale
 factor, target resolution, batch size, and RIFE multiplier, tuned conversationally
 with no extra API keys.
 

--- a/docs/blog/vision-per-model.mdx
+++ b/docs/blog/vision-per-model.mdx
@@ -14,7 +14,7 @@ keywords:
 
 _by [artokun](https://github.com/artokun) · July 14, 2026 · vision · backends · honesty_
 
-The [Agent Panel](/panel) drives an image generator. That sentence carries an
+The [Agent Panel](../panel) drives an image generator. That sentence carries an
 obligation most agent stacks quietly dodge: an agent that *makes* images had
 better be able to *look* at them. You paste a screenshot of a broken graph, or a
 render finishes on your canvas — and the agent should see it, the actual pixels,
@@ -164,6 +164,6 @@ image nobody ever looked at.
 
 Run an agent that actually looks at what it generates: install
 [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and add the
-[Agent Panel](/panel) — see [Backends / providers](/backends) for the
+[Agent Panel](../panel) — see [Backends / providers](../backends) for the
 capability matrix. Star the repo or file an idea at
 [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/blog/wan-2.2-comfyui.mdx
+++ b/docs/blog/wan-2.2-comfyui.mdx
@@ -19,14 +19,14 @@ actually afford. **WAN 2.2** refuses the trade. It's the Apache-2.0 model that
 brought a **Mixture-of-Experts** design to video diffusion — two 14B experts that
 hand off mid-denoise — and it runs **locally in ComfyUI**, no API key, no
 per-second cloud fee. This is the next entry in our model-highlight series after
-[Ideogram 4](/blog/ideogram-4-comfyui), and it earns its own spotlight: by most
+[Ideogram 4](./ideogram-4-comfyui), and it earns its own spotlight: by most
 open-weight measures, WAN 2.2 is the cinematic-motion king you can self-host today.
 
 Below: how the high-noise and low-noise experts actually work (the part everyone
 gets wrong), I2V vs T2V vs longer-video stitching, how it stacks up against
 LTX-2.3, the VRAM tiers from a 24 GB 4090 down to under 12 GB, and the fastest way
 to run it — a one-command install with
-[comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [sidebar Panel](/panel),
+[comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [sidebar Panel](../panel),
 instead of hand-downloading dozens of GB of GGUFs and wiring two samplers by hand.
 
 > **TL;DR — one-command setup.** Install comfyui-mcp, apply the
@@ -77,7 +77,7 @@ audio; WAN 2.2 wins cinematic motion and image-to-video fidelity**, and its MoE 
 FP8/GGUF path fits 16 GB cards where a dense model can't. ([WaveSpeed: LTX-2.3 vs WAN 2.2](https://wavespeed.ai/blog/posts/ltx-2-3-vs-wan-2-2-comparison-2026/), [Thunder Compute: WAN 2.2 in ComfyUI](https://www.thundercompute.com/blog/wan-2-2-comfyui-ai-video-model)) Treat the "18x faster" style figures as
 **vendor/blog benchmarks, not independently audited** — they vary wildly with
 resolution, steps, and hardware. Each rival gets its own post:
-[LTX-2.3](/blog/ltx-2.3-comfyui) and [WAN Animate](/blog/wan-animate-comfyui) are
+[LTX-2.3](./ltx-2.3-comfyui) and [WAN Animate](./wan-animate-comfyui) are
 elsewhere in the series.
 
 ## System & VRAM requirements
@@ -139,11 +139,11 @@ WAN2_2-ULTRA-MODELS-NODES_INSTALL.bat
 
 Then restart ComfyUI and load `packs/wan-longer-videos/workflow.json` (the first
 RIFE run auto-downloads `rife49.pth`). Because the pack ships with the
-[plugin](/plugin), your **own Claude session can drive the live graph through the
-[Panel](/panel)** — add/wire nodes, set the hi/lo split, swap LoRAs, and iterate on
+[plugin](../plugin), your **own Claude session can drive the live graph through the
+[Panel](../panel)** — add/wire nodes, set the hi/lo split, swap LoRAs, and iterate on
 prompts conversationally, with full Ctrl+Z undo and no extra API keys. Every model
 URL in the pack is CI-validated for reachability and size, so a link never quietly
-rots ([here's why that matters](/blog/installer-packs-that-cant-rot)).
+rots ([here's why that matters](./installer-packs-that-cant-rot)).
 
 ## How the high-noise and low-noise experts work
 
@@ -323,11 +323,11 @@ vendor/blog benchmarks, not independently audited.)
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](../panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **[`wan-longer-videos` pack](https://github.com/artokun/comfyui-mcp/tree/main/packs/wan-longer-videos)** — nodes + the four hi/lo GGUFs, encoder, VAE, LoRAs, and upscaler land in the right folders, validated. Pick your quant tier.
-3. Open the [Panel](/panel) and let the panel's agent set the hi/lo split, swap LoRAs, and stitch longer clips for you.
+3. Open the [Panel](../panel) and let the panel's agent set the hi/lo split, swap LoRAs, and stitch longer clips for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **Next in the series:**
-[Qwen-Image & Qwen-Image-Edit](/blog/qwen-image-comfyui) — the local edit-anything
+[Qwen-Image & Qwen-Image-Edit](./qwen-image-comfyui) — the local edit-anything
 model, and the T2I base that powers WAN's refine combo.

--- a/docs/blog/wan-animate-comfyui.mdx
+++ b/docs/blog/wan-animate-comfyui.mdx
@@ -25,7 +25,7 @@ the whole thing **locally in ComfyUI**, no API, no per-second render fee.
 Below: what it's genuinely best at (with the paper's receipts), how it works under
 the hood, where it sits relative to **WAN VACE** and the rest of the WAN stack, the
 VRAM you need, and the fastest way to get it running — a one-command install with
-[comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [sidebar Panel](/panel),
+[comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [sidebar Panel](../panel),
 instead of hand-cloning six custom-node repos and chasing dtype errors.
 
 > **TL;DR — one-command setup.** Install comfyui-mcp, apply the `wan-animate` pack
@@ -82,8 +82,8 @@ There's no single "best" — pick by the job:
 |-------|----------------|
 | **WAN Animate 2.2** | **Character replace** in existing footage, or **motion/expression transfer** to a still — best identity + scene blending, Apache 2.0 |
 | **WAN VACE** | A **general** video edit framework — inpaint/outpaint/extend/reference, mix-and-match tasks |
-| **WAN 2.2 T2V** | Original video **from text** (dual hi/lo experts, lightning LoRAs) — see [the WAN 2.2 post](/blog/wan-2.2-comfyui) |
-| **LTX-2.3** | Fast, real-time-ish generation on lower VRAM — see [the LTX-2.3 post](/blog/ltx-2.3-comfyui) |
+| **WAN 2.2 T2V** | Original video **from text** (dual hi/lo experts, lightning LoRAs) — see [the WAN 2.2 post](./wan-2.2-comfyui) |
+| **LTX-2.3** | Fast, real-time-ish generation on lower VRAM — see [the LTX-2.3 post](./ltx-2.3-comfyui) |
 
 Where rivals win: VACE for breadth of edit types, T2V for from-scratch creation,
 LTX for raw speed. WAN Animate earns the spotlight for the one thing it's built
@@ -134,12 +134,12 @@ apply_manifest --path packs/wan-animate/manifest.yaml
 > woct0rdho SageAttention wheel, and drops the Python include/libs zip so Triton can
 > compile. Restart ComfyUI afterward, then load `workflow.json`.
 
-Because the pack ships with the [plugin](/plugin), your **own Claude session can
-drive the live graph through the [Panel](/panel)** — load the reference image,
+Because the pack ships with the [plugin](../plugin), your **own Claude session can
+drive the live graph through the [Panel](../panel)** — load the reference image,
 point at the driving video, pick the SeC vs. auto-mask path, set widgets, and
 iterate conversationally, with full Ctrl+Z undo and no extra API keys. Every model
 URL in the pack is CI-validated for reachability and size, so a link never quietly
-rots ([here's why that matters](/blog/installer-packs-that-cant-rot)).
+rots ([here's why that matters](./installer-packs-that-cant-rot)).
 
 ## How WAN Animate works
 
@@ -193,7 +193,7 @@ paper explicitly calls out VACE's instability on character tasks. So:
 
 If you're already running our WAN stack, note that the WAN 2.2 T2V pack also ships
 **VACE modules** for reference/pose/depth conditioning on text-to-video — see the
-[WAN 2.2 post](/blog/wan-2.2-comfyui) for that side.
+[WAN 2.2 post](./wan-2.2-comfyui) for that side.
 
 ## What to make with it
 
@@ -236,7 +236,7 @@ lighting and camera.
 
 **Do I need a reference video?** Yes — Animate is **video-to-video**. You bring a
 reference image (the character) *and* a driving video (the performance/footage).
-For text-to-video from scratch, use the [WAN 2.2 T2V](/blog/wan-2.2-comfyui) stack
+For text-to-video from scratch, use the [WAN 2.2 T2V](./wan-2.2-comfyui) stack
 instead.
 
 **Is it free / commercial-use OK?** Yes. The weights are **Apache 2.0** — the most
@@ -262,12 +262,12 @@ not a universal benchmark.
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](../panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **`wan-animate` pack** — nodes + models land in the right folders, validated.
 3. Run `install_triton_and_sageattention_auto.bat`, restart, and load `workflow.json`.
-4. Open the [Panel](/panel) and let the panel's agent load the image, point at the driving video, and iterate.
+4. Open the [Panel](../panel) and let the panel's agent load the image, point at the driving video, and iterate.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **Next in the series:**
-[WAN Transparent Expressions](/blog/wan-transparent-comfyui) — looping,
+[WAN Transparent Expressions](./wan-transparent-comfyui) — looping,
 alpha-channel character sprites from WAN 2.2 I2V.

--- a/docs/blog/wan-transparent-comfyui.mdx
+++ b/docs/blog/wan-transparent-comfyui.mdx
@@ -27,7 +27,7 @@ great one. Below: what it produces and why it's worth the trouble, the exact
 node pipeline (WAN 2.2 I2V GGUF → per-frame matting with BiRefNet → RGBA
 WebP/GIF), the VRAM you need, and the fastest way to get it running — a
 one-command [comfyui-mcp](https://github.com/artokun/comfyui-mcp) install plus
-the [sidebar Panel](/panel), instead of hand-wiring a GGUF video graph and a
+the [sidebar Panel](../panel), instead of hand-wiring a GGUF video graph and a
 background-removal chain.
 
 > **TL;DR — one-command setup.** Install comfyui-mcp, apply the
@@ -62,8 +62,8 @@ correct lossless export + the right filenames. Wire it once and you've got a
 repeatable little factory for living character sprites.
 
 > New to the WAN stack? Start with the base
-> [WAN 2.2 in ComfyUI](/blog/wan-2.2-comfyui) post for how the high/low-noise
-> experts work, and see [WAN Animate](/blog/wan-animate-comfyui) for
+> [WAN 2.2 in ComfyUI](./wan-2.2-comfyui) post for how the high/low-noise
+> experts work, and see [WAN Animate](./wan-animate-comfyui) for
 > motion-transfer character animation.
 
 ## System & VRAM requirements
@@ -123,12 +123,12 @@ Then load `packs/wan-transparent/workflow.json`. On first run, the
 generating, run `expression-renamer.bat` in your output folder to normalize the
 sprite names for SillyTavern.
 
-Because the pack ships with the [plugin](/plugin), your **own Claude session can
-drive the live graph through the [Panel](/panel)** — swap the input image, edit
+Because the pack ships with the [plugin](../plugin), your **own Claude session can
+drive the live graph through the [Panel](../panel)** — swap the input image, edit
 the motion prompt, set frame count, and re-run conversationally, with full undo
 and no API keys. Every model URL in the pack is CI-validated for reachability
 and size, so links don't quietly rot
-([why that matters](/blog/installer-packs-that-cant-rot)).
+([why that matters](./installer-packs-that-cant-rot)).
 
 ## How it works (the pipeline)
 
@@ -255,11 +255,11 @@ use the output. SillyTavern is just the cleanest fit.
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](../panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **`wan-transparent` pack** — custom nodes + the WAN 2.2 I2V subset + the BiRefNet matting model land in the right folders, validated.
-3. Open the [Panel](/panel) and let the panel's agent swap input images, tweak motion prompts, and batch out a full expression set for you.
+3. Open the [Panel](../panel) and let the panel's agent swap input images, tweak motion prompts, and batch out a full expression set for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **Next in the series:**
-[Z-Image](/blog/z-image-comfyui) — the low-VRAM speed king that does photoreal
+[Z-Image](./z-image-comfyui) — the low-VRAM speed king that does photoreal
 1024px under 8 GB.

--- a/docs/blog/z-image-comfyui.mdx
+++ b/docs/blog/z-image-comfyui.mdx
@@ -26,14 +26,14 @@ the V2 ULTRA workflow extras (ControlNet, Detail Daemon, an 8-step LoRA, and the
 fix for Z-Image's infamous "same seed, same image" problem), how to **train your
 own Z-Image LoRAs**, where it beats — and loses to — the alternatives, and the
 fastest way to get it running: a one-command install with
-[comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel),
+[comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](../panel),
 instead of hand-downloading GGUFs into the right folders.
 
 > **TL;DR — one-command setup.** Install comfyui-mcp, apply the
 > [`z-image-turbo`](/packs/z-image-turbo) pack (fast) or
 > [`z-image-base`](/packs/z-image-base) pack (trainable) — nodes + GGUF models land
 > in the right folders, validated — and drive the graph from your own Claude session
-> through the [Panel](/panel). Jump to [Install](#install-z-image-in-comfyui).
+> through the [Panel](../panel). Jump to [Install](#install-z-image-in-comfyui).
 
 ## What is Z-Image?
 
@@ -54,7 +54,7 @@ scenes** — treat it as "punches well above its weight," not a universal SOTA c
 What makes it the **low-VRAM speed king**: as a GGUF quant the diffusion model fits
 in **under 8 GB**, and Turbo needs only ~8 steps. People are running it on
 6 GB cards. That's the pitch — flagship-ish quality on hardware that can't touch
-Flux.2 or a 9.3B [Ideogram 4](/blog/ideogram-4-comfyui).
+Flux.2 or a 9.3B [Ideogram 4](./ideogram-4-comfyui).
 
 ## Z-Image vs the alternatives
 
@@ -66,14 +66,14 @@ There's no single "best" — pick by the job:
 | **Z-Image Base** | **Trainable** photoreal base, diverse styles, LoRA finetuning |
 | **Ideogram 4** | Readable **in-image text**, posters, logos, layout control |
 | **Flux.2** | Top-tier **photorealism** and a mature production default |
-| **Qwen-Image** | Text + multilingual on a larger dev model — see our [Qwen-Image post](/blog/qwen-image-comfyui) |
+| **Qwen-Image** | Text + multilingual on a larger dev model — see our [Qwen-Image post](./qwen-image-comfyui) |
 
 Where Z-Image wins: **VRAM and speed**, full stop — nothing else here runs flagship-
 ish quality in 6–8 GB at this pace, and Base is genuinely cheap to finetune. Where
-it loses: in-image **typography and layout** go to [Ideogram 4](/blog/ideogram-4-comfyui)
+it loses: in-image **typography and layout** go to [Ideogram 4](./ideogram-4-comfyui)
 (a 9.3B model purpose-built for text), and the last 5% of large-scene
 **photorealism** still favors Flux.2. The text-and-layout deep-dive lives in the
-[Ideogram 4 post](/blog/ideogram-4-comfyui); Z-Image earns this spotlight for
+[Ideogram 4 post](./ideogram-4-comfyui); Z-Image earns this spotlight for
 flagship-ish output on hardware the others can't touch.
 
 ## System & VRAM requirements (GGUF)
@@ -128,12 +128,12 @@ your **ComfyUI root** (the folder containing `custom_nodes/` and `models/`), the
 restart ComfyUI (or use ComfyUI-Manager → *Install missing custom nodes*) and load
 `workflow.json`.
 
-Because the packs ship with the [plugin](/plugin), your **own Claude session can
-drive the live graph through the [Panel](/panel)** — swap quant tiers, wire the
+Because the packs ship with the [plugin](../plugin), your **own Claude session can
+drive the live graph through the [Panel](../panel)** — swap quant tiers, wire the
 ControlNet, toggle the Detail Daemon, and iterate on prompts conversationally, with
 full Ctrl+Z undo and no API keys. Every model URL is CI-validated for reachability
 and size, so a link never quietly rots
-([here's why that matters](/blog/installer-packs-that-cant-rot)).
+([here's why that matters](./installer-packs-that-cant-rot)).
 
 ## Turbo vs Base — pick by the job
 
@@ -192,7 +192,7 @@ Z-Image's low-VRAM advantage carries straight into **training**. Because it's a
 LoRA-training target in our stack — a 4090 is comfortable, and smaller cards work
 with float8 quantization at 512–768 resolution.
 
-Use the **[`ai-toolkit-trainer`](/plugin) skill** (ostris **AI-Toolkit**, MIT — a
+Use the **[`ai-toolkit-trainer`](../plugin) skill** (ostris **AI-Toolkit**, MIT — a
 standalone web-UI trainer, not a ComfyUI node) to train. Sensible starting points
 for Z-Image:
 
@@ -283,7 +283,7 @@ wants ~12–16 GB. People run it on 6 GB cards with low quants.
 on an RTX 4090; sub-second on data-center GPUs.
 
 **Can I train a Z-Image LoRA, and on which model?** Yes — train on **Base** with the
-[`ai-toolkit-trainer`](/plugin) skill; a Base-trained LoRA generally works in the
+[`ai-toolkit-trainer`](../plugin) skill; a Base-trained LoRA generally works in the
 Turbo workflow too.
 
 **Why don't negative prompts work in Turbo?** Turbo is DMD-distilled with CFG baked
@@ -297,14 +297,14 @@ published on the Aitrepreneur/FLX mirror — use Q5_K_S or Q8_0.
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](../panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the [`z-image-turbo`](/packs/z-image-turbo) pack (fast) or
    [`z-image-base`](/packs/z-image-base) pack (trainable) — nodes + GGUF models land
    in the right folders, validated.
-3. Open the [Panel](/panel) and let the panel's agent wire the ControlNet, swap
+3. Open the [Panel](../panel) and let the panel's agent wire the ControlNet, swap
    quant tiers, and iterate on prompts for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **Next in the series:**
-[ERNIE-Image](/blog/ernie-image-comfyui) — the Apache-2.0 text powerhouse with
+[ERNIE-Image](./ernie-image-comfyui) — the Apache-2.0 text powerhouse with
 clean multilingual EN/CN/JP type.

--- a/docs/changelog/2026-05-29.mdx
+++ b/docs/changelog/2026-05-29.mdx
@@ -18,7 +18,7 @@ with `@ref` pinning), and model downloads. Idempotent, with a per-item
 structured report so you can see exactly what was already installed, what
 just changed, and what failed.
 
-See [Install & environment tools](/tools/install-environment).
+See [Install & environment tools](../tools/install-environment).
 
 ### Custom-node authoring lifecycle
 
@@ -33,7 +33,7 @@ A complete write → test → publish loop, callable from your agent:
 - **`publish_custom_node`** — publish to the Comfy Registry via `comfy-cli`.
   Your `REGISTRY_ACCESS_TOKEN` is never logged.
 
-See [Custom-node tools](/tools/custom-nodes).
+See [Custom-node tools](../tools/custom-nodes).
 
 ### Cloud storage in and out
 
@@ -42,7 +42,7 @@ See [Custom-node tools](/tools/custom-nodes).
 - New **`upload_output`** pushes a generated image to S3, Azure, an HTTP
   endpoint, or Hugging Face and returns the URL(s).
 
-See [Models](/tools/models) and [Assets & images](/tools/assets-images).
+See [Models](../tools/models) and [Assets & images](../tools/assets-images).
 
 ### Server-side image conversion
 
@@ -51,7 +51,7 @@ output-dir path) to PNG, JPEG, or WebP via `sharp`. Returns inline base64
 plus an optional file write, and reports bytes saved — useful for trimming
 4 MB PNGs down to ~300 KB WebPs before they leave your machine.
 
-See [Assets & images](/tools/assets-images).
+See [Assets & images](../tools/assets-images).
 
 ### Node discovery agent
 
@@ -64,7 +64,7 @@ delegates deep dives to `comfy-explorer`.
 `source@version` (`COMFYUI_SKILL_CACHE_DIR`), so repeat analyses are
 instant. Pass `refresh` to bypass.
 
-See [Defaults, stats, and skills](/tools/defaults-stats-skills).
+See [Defaults, stats, and skills](../tools/defaults-stats-skills).
 
 ### Media uploads
 
@@ -72,7 +72,7 @@ See [Defaults, stats, and skills](/tools/defaults-stats-skills).
 ComfyUI's input directory so workflows can reference them as inputs —
 mirroring `upload_image` (closes #12).
 
-See [Assets & images](/tools/assets-images).
+See [Assets & images](../tools/assets-images).
 
 ### Hosted documentation
 
@@ -91,7 +91,7 @@ schema-generated from the source so it stays in lockstep with the server.
   (no more double-downloading the same checkpoint) and optional LRU eviction.
   Configure via `COMFYUI_DOWNLOAD_CACHE_DIR` and `COMFYUI_LRU_CACHE_SIZE_GB`.
 
-See [Models](/tools/models).
+See [Models](../tools/models).
 
 ### Custom-node install — pin to a ref
 
@@ -100,7 +100,7 @@ the URL (`https://github.com/user/repo@v1.2.0`), an explicit `ref` argument,
 or a `repo@ref` shorthand. Reproducible installs, no more "works on my
 machine" because `main` moved.
 
-See [Custom-node tools](/tools/custom-nodes).
+See [Custom-node tools](../tools/custom-nodes).
 
 ### Process supervision
 
@@ -112,7 +112,7 @@ See [Custom-node tools](/tools/custom-nodes).
   `COMFYUI_RESTART_WINDOW_S`) — recover from transient OOMs without spinning
   forever on a real bug.
 
-See [Process control](/tools/process-control).
+See [Process control](../tools/process-control).
 
 ### Better job error reporting
 
@@ -121,7 +121,7 @@ errors with the failing node ID and type, exception type/message, a
 truncated traceback, `current_inputs`, and an OOM flag — plus optional
 per-node and total execution timing. Fully additive.
 
-See [Workflow execution](/tools/workflow-execution).
+See [Workflow execution](../tools/workflow-execution).
 
 ### Plugin skills
 

--- a/docs/changelog/2026-06-05.mdx
+++ b/docs/changelog/2026-06-05.mdx
@@ -25,8 +25,8 @@ or Comfy Cloud — plus a v1 agent sidebar inside ComfyUI itself.
   silently.
 
 A new `COMFYUI_CLOUD_URL` env var lets you override the cloud endpoint.
-See [Configuration → Deployment modes](/configuration) and
-[Installation](/installation) for setup recipes per mode.
+See [Configuration → Deployment modes](../configuration) and
+[Installation](../installation) for setup recipes per mode.
 
 ### `health_check` tool
 
@@ -57,7 +57,7 @@ experimental — not part of default startup.
 local jobs return. Completed jobs are still enriched from history;
 failed jobs surface the cloud's error via `exception_message`.
 
-See [Workflow execution](/tools/workflow-execution).
+See [Workflow execution](../tools/workflow-execution).
 
 ### Slimmer default install
 
@@ -76,8 +76,8 @@ feature whose optional dep is missing surfaces the exact
 ### Repositioning vs. official Comfy Cloud MCP
 
 Comfy-Org announced an official Comfy Cloud MCP (closed beta). The
-README, [home page](/), [configuration](/configuration), and
-[installation](/installation) now frame `comfyui-mcp` as the community
+README, [home page](../), [configuration](../configuration), and
+[installation](../installation) now frame `comfyui-mcp` as the community
 MCP for **local + remote** ComfyUI, with cloud mode positioned as a
 complementary option when you want a single MCP across all three.
 

--- a/docs/changelog/2026-06-16.mdx
+++ b/docs/changelog/2026-06-16.mdx
@@ -30,8 +30,8 @@ you ⇄ Claude Code ⇄ comfyui-mcp (--channels) ⇄ ws://127.0.0.1:9101 ⇄ pan
 
 The plugin ships `--channels` **on by default**, so `/plugin install comfy`
 wires the bridge and `panel_*` tools automatically. See
-[Sidebar Panel](/panel) and
-[Channels mode configuration](/configuration#channels--drive-the-comfyui-sidebar-panel-from-your-own-agent-session).
+[Sidebar Panel](../panel) and
+[Channels mode configuration](../configuration#channels--drive-the-comfyui-sidebar-panel-from-your-own-agent-session).
 
 ### The panel grew up — and shipped to the Comfy Registry
 
@@ -110,7 +110,7 @@ A new **`model-registry`** skill consolidates download URLs + target
 `models/` subdirs for every model the skills reference (Flux, WAN, LTX, Qwen,
 Z-Image, shared VAEs/text-encoders). The README, npm description, keywords, and
 GitHub topics were corrected to the real asset counts (88 tools / 16 skills),
-and a new [`/plugin`](/plugin) docs page documents the full
+and a new [`/plugin`](../plugin) docs page documents the full
 skill/command/agent/hook surface.
 
 ## Fixes
@@ -121,7 +121,7 @@ skill/command/agent/hook surface.
   polling worked. It now declares the capability and sends
   `notifications/claude/channel` with the expected `{ content, meta }` shape.
   (The fuller story — and how the panel later moved to an autonomous background
-  agent — is in [this post](/blog/panel-agent-subscription).)
+  agent — is in [this post](../blog/panel-agent-subscription).)
 - **`list_local_models` sees `extra_model_paths.yaml` redirects** and works
   against remote/cloud ComfyUI — it now queries ComfyUI's `/models/<dir>` REST
   endpoint first instead of only scanning `${COMFYUI_PATH}/models/`.

--- a/docs/changelog/2026-06-17.mdx
+++ b/docs/changelog/2026-06-17.mdx
@@ -5,7 +5,7 @@ description: "The ComfyUI sidebar panel now runs an autonomous background agent 
 
 _June 17, 2026_
 
-**v0.14.0** turns the sidebar [Panel](/panel) into something that runs itself: an
+**v0.14.0** turns the sidebar [Panel](../panel) into something that runs itself: an
 autonomous background agent drives it, on your Claude subscription, with no API
 keys — and your interactive Claude session stays free.
 
@@ -23,7 +23,7 @@ to wake your interactive session, which can't happen while that session is idle;
 and the `--sdk-url` transport that *could* do it is guarded on current Claude
 Code (and we won't ship a patched binary). The Agent SDK's streaming-input mode
 gives the same persistent, injectable, interruptible session through a supported
-API. The full story is in [the blog](/blog/panel-agent-subscription).
+API. The full story is in [the blog](../blog/panel-agent-subscription).
 
 ### It just works
 

--- a/docs/changelog/2026-06-19.mdx
+++ b/docs/changelog/2026-06-19.mdx
@@ -5,7 +5,7 @@ description: "The ComfyUI Agent Panel gains live-streaming chat, SDK slash comma
 
 _June 19, 2026_
 
-**v0.15.0** is a big round on the [Agent Panel](/panel) — streaming, discoverable
+**v0.15.0** is a big round on the [Agent Panel](../panel) — streaming, discoverable
 commands, real recovery — plus converter and pack hardening underneath.
 
 ## The panel chat streams now
@@ -39,7 +39,7 @@ orchestrator — your unrelated shells and editors are never touched.
 
 The legacy interactive `--channels` mode (and the `panel_say` / `panel_inbox` /
 `panel_status` tools) is fully removed. The panel runs only on the autonomous
-[orchestrator](/configuration) on its dedicated bridge port **9180**, so nothing
+[orchestrator](../configuration) on its dedicated bridge port **9180**, so nothing
 can steal the panel's port anymore. The pack is now **ComfyUI Agent Panel**
 (`comfyui-agent-panel`) on the Comfy Registry.
 
@@ -63,7 +63,7 @@ can steal the panel's port anymore. The pack is now **ComfyUI Agent Panel**
   **LTX-2.3 rebuild**: `txt2vid` + `img2vid` now ship on the official Comfy-Org
   two-stage template (`LTXAVTextEncoderLoader` + gemma abliterated LoRA + dynamic
   distilled LoRA + ×2 upscale) — sharp 1280×704 with synced audio, replacing the
-  soft GGUF/DualCLIPLoader path. See the [LTX-2.3 post](/blog/ltx-2.3-comfyui).
+  soft GGUF/DualCLIPLoader path. See the [LTX-2.3 post](../blog/ltx-2.3-comfyui).
 - **Installers** now resolve each cloned node's **`requirements.txt`** into the
   **ComfyUI venv** (not system Python) — the root cause behind a long tail of
-  "installed but won't load" nodes. [Why it matters](/blog/installer-packs-that-cant-rot).
+  "installed but won't load" nodes. [Why it matters](../blog/installer-packs-that-cant-rot).

--- a/docs/changelog/2026-06-24.mdx
+++ b/docs/changelog/2026-06-24.mdx
@@ -5,7 +5,7 @@ description: "Day-one ComfyUI pack for Krea 2 Turbo — Krea.ai's new 12B open-w
 
 _June 24, 2026_
 
-[Krea 2](/blog/krea2-comfyui) shipped its open weights on June 23, and the krea2
+[Krea 2](../blog/krea2-comfyui) shipped its open weights on June 23, and the krea2
 txt2img packs land the next day.
 
 ## Krea 2 Turbo, packaged
@@ -25,4 +25,4 @@ txt2img packs land the next day.
 
 Released under the [Krea 2 Community License](https://www.krea.ai/krea-2-licensing)
 (free commercial use up to 50 seats). See the
-[Krea 2 in ComfyUI guide](/blog/krea2-comfyui).
+[Krea 2 in ComfyUI guide](../blog/krea2-comfyui).

--- a/docs/changelog/2026-06-25.mdx
+++ b/docs/changelog/2026-06-25.mdx
@@ -35,7 +35,7 @@ your live canvas at **full feature parity**.
   as local (free) or api/mixed/unknown (paid). Bundled packs are local/free; for ad-hoc
   graphs the agent **asks before spending paid API credits**.
 
-Read more: [Backends / providers](/backends) ·
-[Skills, Packs & Runtime Cost](/tools/skills-knowledge) ·
-[Sidebar Panel](/panel) ·
+Read more: [Backends / providers](../backends) ·
+[Skills, Packs & Runtime Cost](../tools/skills-knowledge) ·
+[Sidebar Panel](../panel) ·
 design doc [`agent-backend-injection.md`](https://github.com/artokun/comfyui-mcp/blob/main/docs/design/agent-backend-injection.md).

--- a/docs/changelog/2026-06-27.mdx
+++ b/docs/changelog/2026-06-27.mdx
@@ -29,7 +29,7 @@ it (if the watchdog WebSocket never opens, nothing changes):
   suggest `restart_comfyui` if it still won't die. A new **`clear_pending`** drops all
   pending jobs in the same call.
 
-See [How it works → the queue/render watchdog](/concepts#self-healing-the-queuerender-watchdog).
+See [How it works → the queue/render watchdog](../concepts#self-healing-the-queuerender-watchdog).
 
 ## `analyze_color` — color stats without a vision round-trip
 
@@ -83,7 +83,7 @@ reads those params from the query string, where they're now sent).
   a login on disk; macOS Keychain handled). An onboarding card shows only when neither
   provider is signed in; the panel auto-switches to a ready provider when the saved pick
   isn't usable (the saved preference is kept), and a not-ready row becomes a "set up"
-  action. See [Backends → readiness & onboarding](/backends#connect-time-readiness--onboarding).
+  action. See [Backends → readiness & onboarding](../backends#connect-time-readiness--onboarding).
 - **Rich media metadata in agent pushes.** A render's executed-event note (and a
   structured `metadata` field) now carry each output's path, file size, pixel dimensions,
   asset-set grouping ("output K of N from this run" + siblings, or "single output"),

--- a/docs/changelog/2026-07-08.mdx
+++ b/docs/changelog/2026-07-08.mdx
@@ -7,7 +7,7 @@ _July 8, 2026_
 
 The biggest release day yet: v0.23.0 → v0.27.0 (twenty-three MCP releases) plus panel
 0.6.6 → 0.6.8. Two headlines: **any LLM can now drive ComfyUI — including free local
-models** ([blog post](/blog/local-llms-comfyui)), and **remote ComfyUI became a
+models** ([blog post](../blog/local-llms-comfyui)), and **remote ComfyUI became a
 first-class citizen** — one command to connect, a custom RunPod image, and a secure
 tunnel bridge.
 

--- a/docs/changelog/2026-07-09.mdx
+++ b/docs/changelog/2026-07-09.mdx
@@ -7,7 +7,7 @@ _July 9, 2026_
 
 v0.28.0 → v0.30.0 plus panel 0.6.9 → 0.7.3. The local-LLM story from the day before
 rounds out to **every major local runtime**, the first **mobile** building blocks
-land, and the [gemma4 fine-tune ladder gets honest Arena numbers](/blog/gemma4-fine-tune-arena).
+land, and the [gemma4 fine-tune ladder gets honest Arena numbers](../blog/gemma4-fine-tune-arena).
 
 ## More local backends: LM Studio, llama.cpp, custom endpoints
 
@@ -35,7 +35,7 @@ Each ships with its own panel chip + setup card (panel 0.6.9 / 0.7.0).
 LLM Arena results for the `gemma4-comfyui-mcp` ladder: **`:e4b` 14/20** (best local
 model tested), `:12b` 13/20, and `:e2b` honestly flagged at 4/20 pending its v2
 training fix. Leaderboard SVGs + model-sizing guidance updated across the docs and
-the Ollama onboarding copy. [Full story on the blog](/blog/gemma4-fine-tune-arena).
+the Ollama onboarding copy. [Full story on the blog](../blog/gemma4-fine-tune-arena).
 
 ## Workflow intelligence + node development
 

--- a/docs/changelog/2026-07-14.mdx
+++ b/docs/changelog/2026-07-14.mdx
@@ -6,8 +6,8 @@ description: "The panel orchestrator now updates and restarts itself when every 
 _July 14, 2026_
 
 v0.31.1 → v0.34.0 plus panel 0.8.1 / 0.8.2. Two headliners:
-[the orchestrator that never goes stale](/blog/self-updating-orchestrator) and
-[giving every backend eyes](/blog/vision-per-model).
+[the orchestrator that never goes stale](../blog/self-updating-orchestrator) and
+[giving every backend eyes](../blog/vision-per-model).
 
 ## Self-updater + self-restarter
 

--- a/docs/changelog/2026-07-15.mdx
+++ b/docs/changelog/2026-07-15.mdx
@@ -6,7 +6,7 @@ description: "panel_flatten_workflow resolves Get/Set buses, Reroutes, and use-e
 _July 15, 2026_
 
 v0.35.0 and v0.36.0. The headline tool is
-[**`panel_flatten_workflow`**](/blog/flatten-workflows) — plus CivitAI creator
+[**`panel_flatten_workflow`**](../blog/flatten-workflows) — plus CivitAI creator
 discovery and remote control of a desktop session from the phone.
 
 ## `panel_flatten_workflow` — untangle without wrecking the layout
@@ -18,7 +18,7 @@ groups, positions, colors, and titles survive exactly, and one undo restores. UE
 broadcasts materialize from the pack's own computed `extra.ue_links`; real
 executable nodes (rgthree Context, Seed Everywhere) are kept. Where
 `strip_workflow` produces a clean copy for the agent to run,
-flatten fixes the graph you're looking at. [How it works](/blog/flatten-workflows).
+flatten fixes the graph you're looking at. [How it works](../blog/flatten-workflows).
 
 ## CivitAI creator discovery
 
@@ -38,7 +38,7 @@ Together: "show me top creators → their models → download" works end-to-end.
 The mobile app can **mirror and drive a desktop tab's session** (#227) — see the
 same conversation and send into it from the couch — alongside a fix for
 workflows-over-tunnel. More on the mobile app in
-[the mobile beta post](/blog/comfyui-mobile-app).
+[the mobile beta post](../blog/comfyui-mobile-app).
 
 ## Protocol polish
 

--- a/docs/changelog/2026-07-16.mdx
+++ b/docs/changelog/2026-07-16.mdx
@@ -15,7 +15,7 @@ riding the existing QueueMonitor watchdog so browser-queued jobs are covered too
 Change-only and capped at 1 frame/sec (an idle rig broadcasts nothing), and each tab
 is seeded with the current state on `hello`, so a client connecting mid-render sees
 the running job immediately. This powers the
-[mobile app's](/blog/comfyui-mobile-app) live queue monitor.
+[mobile app's](../blog/comfyui-mobile-app) live queue monitor.
 
 **`cancel_job` joins the mobile whitelist** for one-tap cancel of the running render
 from the phone — narrowly scoped: the client passes the `prompt_id` it observed,
@@ -38,5 +38,5 @@ URL change and stale-socket handlers can't null a new connection.
 
 ## Docs
 
-A **[mobile app (beta)](/mobile)** page: Android (Firebase App Distribution) and iOS
+A **[mobile app (beta)](../mobile)** page: Android (Firebase App Distribution) and iOS
 (TestFlight) beta-tester links plus the pairing walkthrough, wired into the nav.

--- a/docs/changelog/2026-07-17.mdx
+++ b/docs/changelog/2026-07-17.mdx
@@ -11,11 +11,11 @@ v0.38.0 plus the big panel 0.9.0.
 
 Moonshot's **Kimi K3** joins the provider roster (#233) — API-key based, alongside
 the existing Claude / ChatGPT / Gemini / Grok / GLM / Copilot / local lineup. Full
-story in [the Kimi K3 post](/blog/kimi-k3-comfyui).
+story in [the Kimi K3 post](../blog/kimi-k3-comfyui).
 
 ## CivitAI browser: browse, like, load, recreate
 
-Panel 0.9.0 makes the in-panel [CivitAI browser](/blog/civitai-in-comfyui) a full
+Panel 0.9.0 makes the in-panel [CivitAI browser](../blog/civitai-in-comfyui) a full
 loop:
 
 - **Load workflow onto canvas** (a Discord community request) — a lightbox post with
@@ -42,7 +42,7 @@ create workflows** — the agent is mechanically told which canvas it operates o
 the live agent instance is rebound across tab ids (no respawn), so even in-memory
 local backends keep their history. Settings → General → "Conversation follows the
 panel" restores the legacy per-workflow mode.
-[Why and how on the blog](/blog/panel-owned-sessions).
+[Why and how on the blog](../blog/panel-owned-sessions).
 
 ## Also in panel 0.9.0
 

--- a/docs/changelog/2026-07-18.mdx
+++ b/docs/changelog/2026-07-18.mdx
@@ -6,7 +6,7 @@ description: "Custom-node and model operations no longer 405 against a pip Comfy
 _July 18, 2026_
 
 v0.38.1 plus panel 0.9.1 — one deep compatibility fix, told in full in
-[the 405 that wasn't](/blog/manager-405-dialects).
+[the 405 that wasn't](../blog/manager-405-dialects).
 
 ## pip Manager's legacy-UI mode is a third API dialect
 

--- a/docs/changelog/2026-07-20.mdx
+++ b/docs/changelog/2026-07-20.mdx
@@ -14,7 +14,7 @@ The **GPT-5.6 family** lands for ChatGPT/Codex users with the extended effort sc
 0.145 alpha pairing, pre-5.6 models are deprecated (the picker hides them whenever
 the account has the 5.6 family), and the ChatGPT-direct default is now
 `gpt-5.6-luna`, successor to the retired `gpt-5.4-mini` (#241, #244; panel 0.9.7
-extends the effort slider). [Full rundown on the blog](/blog/gpt-5-6-comfyui).
+extends the effort slider). [Full rundown on the blog](../blog/gpt-5-6-comfyui).
 
 ## Train a character LoRA by asking
 
@@ -25,7 +25,7 @@ inside a headless GPU Docker image, so training character LoRAs on **FLUX.1-dev*
 is an agent-orchestrated flow — config generation, a crash-safe job registry, live
 step/loss/sample progress, and a handoff that drops the finished `.safetensors`
 into `models/loras/` and catalogs it. Ships the `train-character-lora` skill;
-end-to-end proven on a 4090. [The story](/blog/lora-trainer-p1).
+end-to-end proven on a 4090. [The story](../blog/lora-trainer-p1).
 
 ## Blind mode: from prompt to mechanism
 
@@ -34,7 +34,7 @@ Now it **mechanically gates every image-returning tool** (#245): blind tabs spaw
 their tool server with `COMFYUI_MCP_BLIND=1`, and a single registration-boundary
 wrapper replaces image blocks with an honest "withheld" note — on both the full MCP
 surface and the compact router. Toggling Blind live respawns the tab's tool server
-at idle. [The full confession](/blog/blind-mode-privacy).
+at idle. [The full confession](../blog/blind-mode-privacy).
 
 ## Gemini, revived
 

--- a/docs/changelog/2026-07-21.mdx
+++ b/docs/changelog/2026-07-21.mdx
@@ -26,17 +26,17 @@ a live card (GPU / VRAM / uptime / $·hr), and **idle auto-stop** shuts an idle 
 down for you — but only while you're actually rendering on it, so it never yanks a
 pod mid-session (`RUNPOD_IDLE_STOP_MINUTES`, default 15). RunPod serves ComfyUI on
 port 3000 by convention, and the connector targets 3000 for you.
-[The full walk-through](/blog/runpod-comfyui).
+[The full walk-through](../blog/runpod-comfyui).
 
 ## Train a LoRA on a rented GPU
 
-The [CLI LoRA trainer](/blog/lora-trainer-p1) gains a **dockerless native driver**
+The [CLI LoRA trainer](../blog/lora-trainer-p1) gains a **dockerless native driver**
 and an **SSH transport** that stands ai-toolkit up on a RunPod pod (#263): an
 idempotent bootstrap (clone@pin → venv → torch cu128 → requirements), a dataset
 rsynced up, live step/loss progress streamed back over ssh, and stop/liveness via
 pkill/pgrep — all behind the **same seven `train_*` tools and the same crash-safe
 job registry** as local training. FLUX.1-dev LoRA training no longer needs a
-24 GB card you own; borrow one for the hour the run takes. [The story](/blog/train-lora-runpod).
+24 GB card you own; borrow one for the hour the run takes. [The story](../blog/train-lora-runpod).
 
 ## Also new
 

--- a/docs/changelog/2026-07-28.mdx
+++ b/docs/changelog/2026-07-28.mdx
@@ -58,6 +58,6 @@ picker (#326). The list now serves the whole catalog.
 
 ## Docs
 
-- **[Hosting a third-party backend](/third-party-hosts)** — a new guide to the
+- **[Hosting a third-party backend](../third-party-hosts)** — a new guide to the
   panel↔backend protocol: how to register a host, the endpoints and handshake, and
   a copy-paste prompt for teaching an LLM to build an adapter (#327).

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -9,7 +9,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="July 28: a security patch, reconnect self-heal, and OpenRouter's full catalog"
-  href="/changelog/2026-07-28"
+  href="./2026-07-28"
 >
   **Path-traversal hardening** on the upload tools, a panel session that
   **self-heals** after a full reconnect/reload/workflow-switch instead of getting
@@ -19,7 +19,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="July 21: rent a GPU from the panel — RunPod connector and cloud LoRA training"
-  href="/changelog/2026-07-21"
+  href="./2026-07-21"
 >
   A **first-party RunPod connector** deploys and drives a cloud GPU pod from the
   panel and phone with an honest **local⇄pod host switch**, live cost/GPU status,
@@ -29,7 +29,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="July 20: GPT-5.6, the LoRA trainer lands, Blind mode gets mechanical"
-  href="/changelog/2026-07-20"
+  href="./2026-07-20"
 >
   The **GPT-5.6 family** (Sol / Terra / Luna) with the max/ultra effort scale,
   seven `train_*` tools that train character LoRAs on FLUX.1-dev from chat, a
@@ -39,7 +39,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="July 19: see what I see — viewport tools and one honest error surface"
-  href="/changelog/2026-07-19"
+  href="./2026-07-19"
 >
   `panel_view_selected` / `panel_view_nodes_in_viewport` let the agent read what
   you're looking at, and **`panel_get_errors`** becomes the single error surface —
@@ -49,7 +49,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="July 18: the 405 that wasn't — speaking pip Manager's legacy-UI dialect"
-  href="/changelog/2026-07-18"
+  href="./2026-07-18"
 >
   Custom-node and model operations no longer 405 against a pip ComfyUI-Manager in
   legacy-UI mode — comfyui-mcp detects the mode and speaks its `queue/batch`
@@ -58,7 +58,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="July 17: Kimi K3, the CivitAI browser grows up, panel-owned sessions"
-  href="/changelog/2026-07-17"
+  href="./2026-07-17"
 >
   Moonshot's **Kimi K3** joins the provider roster; the CivitAI browser gains
   likes, creator filters, and **load-workflow-onto-canvas** (zip wrappers
@@ -68,7 +68,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="July 16: live queue status everywhere, one-tap mobile cancel"
-  href="/changelog/2026-07-16"
+  href="./2026-07-16"
 >
   The orchestrator broadcasts ComfyUI's live render/queue state to every client
   (powering the mobile queue monitor), `cancel_job` goes mobile, and
@@ -77,7 +77,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="July 15: flatten workflows, CivitAI creator discovery, desktop-tab mirror"
-  href="/changelog/2026-07-15"
+  href="./2026-07-15"
 >
   **`panel_flatten_workflow`** resolves Get/Set buses, Reroutes, and
   use-everywhere links in place without moving a single kept node;
@@ -87,7 +87,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="July 14: the self-updating orchestrator, vision for every backend"
-  href="/changelog/2026-07-14"
+  href="./2026-07-14"
 >
   The orchestrator updates and restarts itself when every agent is idle — a
   running install never goes stale. Every Ollama-family backend and
@@ -97,7 +97,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="July 12: five new providers, A2UI chat cards, per-workflow sessions"
-  href="/changelog/2026-07-12"
+  href="./2026-07-12"
 >
   An OAuth engine brings **Grok, Kimi, GLM, ChatGPT-direct, and Copilot**;
   validated interactive A2UI cards render in chat; per-workflow agent sessions,
@@ -107,7 +107,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="July 9: LM Studio & llama.cpp backends, phone pairing, gemma4 Arena results"
-  href="/changelog/2026-07-09"
+  href="./2026-07-09"
 >
   LM Studio, llama.cpp, and custom OpenAI-compatible endpoints become
   first-class backends; token-gated phone pairing and the render mailbox land;
@@ -117,7 +117,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="July 8: local LLMs, remote pods, and the RunPod image — 20 releases in one day"
-  href="/changelog/2026-07-08"
+  href="./2026-07-08"
 >
   The agent goes all-LLM: an **Ollama backend** with a compact tool mode and our
   gemma4 fine-tune ladder as the local default. Plus one-command `connect` to a
@@ -127,7 +127,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="June 29: Comfy MCP parity, run-to-node, graph navigation"
-  href="/changelog/2026-06-29"
+  href="./2026-06-29"
 >
   Five one-call generation tools close the gap with Comfy's official cloud MCP
   (plus a token-gated tunnel connector), `panel_run` learns to render a single
@@ -137,7 +137,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="June 27: render-wedge watchdog, color analysis, provider onboarding"
-  href="/changelog/2026-06-27"
+  href="./2026-06-27"
 >
   A self-healing queue/render watchdog (backpressure + stall detection +
   escalating cancel), a new `analyze_color` tool, registry-first custom-node
@@ -147,7 +147,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="June 26: strip_workflow & slice_workflow — load any expert graph"
-  href="/changelog/2026-06-26"
+  href="./2026-06-26"
 >
   Two new workflow tools resolve GetNode/SetNode buses + Reroutes into real
   connections and un-chunk rgthree Fast-Groups-Bypass-toggled pipelines — clean,
@@ -156,7 +156,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="June 25: Multi-provider agent — Claude + ChatGPT"
-  href="/changelog/2026-06-25"
+  href="./2026-06-25"
 >
   The sidebar panel agent now runs on **either Claude or ChatGPT/Codex** at full
   feature parity — pick a provider, drive your live canvas, load packs in one shot
@@ -166,7 +166,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="June 24: Krea 2 Turbo pack"
-  href="/changelog/2026-06-24"
+  href="./2026-06-24"
 >
   Day-one ComfyUI pack for Krea 2 Turbo — Krea.ai's new 12B open-weight
   text-to-image model. 8-step turbo speed, Qwen3-VL prompting, JSON area
@@ -175,7 +175,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="June 19: v0.15.0 — streaming panel, SDK commands, one-click recovery"
-  href="/changelog/2026-06-19"
+  href="./2026-06-19"
 >
   The Agent Panel gains live-streaming chat, SDK slash commands (`/compact`,
   `/loop`, …), and one-click `/restart` recovery for a wedged agent — with
@@ -185,7 +185,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="June 17: v0.14.0 — the panel drives itself"
-  href="/changelog/2026-06-17"
+  href="./2026-06-17"
 >
   The sidebar panel now runs an autonomous background agent on your Claude
   subscription — no API keys, no interactive session needed. _June 17, 2026_
@@ -193,7 +193,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="Week of June 8: v0.9.5 → v0.13.0"
-  href="/changelog/2026-06-16"
+  href="./2026-06-16"
 >
   Eight releases: channels mode (drive ComfyUI from your own Claude session,
   no API keys), the sidebar panel live on the Comfy Registry, `generate_audio`,
@@ -202,7 +202,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="Week of June 1: v0.8.1 → v0.9.4"
-  href="/changelog/2026-06-05"
+  href="./2026-06-05"
 >
   Six releases: Comfy Cloud + explicit remote mode, an embedded agent
   sidebar inside ComfyUI, a new `health_check` tool, slimmer default
@@ -211,7 +211,7 @@ Weekly notes on what shipped in [comfyui-mcp](https://github.com/artokun/comfyui
 
 <Card
   title="Week of May 25: v0.6.0 → v0.8.0"
-  href="/changelog/2026-05-29"
+  href="./2026-05-29"
 >
   Four releases in one week: media uploads, hosted docs, model-download
   hardening, custom-node authoring + verification, declarative environment

--- a/docs/cloud-deployment.mdx
+++ b/docs/cloud-deployment.mdx
@@ -10,7 +10,7 @@ Don't have a local GPU — or want a bigger one on demand? Deploy ComfyUI to a
 
 <Note>
 The pod only serves **ComfyUI + Manager + the Agent Panel UI**. The agent's brain
-(the [panel orchestrator](/panel)) runs **locally on your machine** on your own
+(the [panel orchestrator](./panel)) runs **locally on your machine** on your own
 subscription — so a cloud pod never burns GPU-hours on the LLM, and no API key or
 agent login ever touches the box. See [Topology](#topology-where-the-agent-runs).
 </Note>
@@ -35,9 +35,9 @@ Then jump to [Connect from your machine](#connect-from-your-machine).
 ## Deploy & control it from the Agent Panel (v0.44+)
 
 Since **comfyui-mcp 0.44**, you don't have to touch the RunPod console or run a
-CLI command at all — the [Agent Panel](/panel) has a **RunPod control panel** that
+CLI command at all — the [Agent Panel](./panel) has a **RunPod control panel** that
 deploys, connects, monitors, and stops a pod for you, and the same control sheet
-ships in the [mobile app](/mobile).
+ships in the [mobile app](./mobile).
 
 1. **Set your key once.** In the panel's **API-Keys** card, paste your
    `RUNPOD_API_KEY`. It's stored server-side in `~/.comfyui-mcp/.env` — never in
@@ -78,7 +78,7 @@ template deploys (`RUNPOD_TEMPLATE_ID`) default it **off** — pass
 
 <Note>
 New to renting GPUs for ComfyUI? The blog walks the whole flow end to end:
-[Run ComfyUI on a rented cloud GPU](/blog/runpod-comfyui).
+[Run ComfyUI on a rented cloud GPU](./blog/runpod-comfyui).
 </Note>
 
 The rest of this page is the **manual / CLI path** — still fully supported, and
@@ -142,7 +142,7 @@ own path for the pod page to reach `ws://127.0.0.1:9180`).
 
 Want a **stable, self-hosted alternative** to the default Cloudflare quick tunnel
 — your own domain, no ephemeral hostname, full ownership of that hop — instead of
-either of the above? See [Self-hosted relay](/self-hosted-relay).
+either of the above? See [Self-hosted relay](./self-hosted-relay).
 
 ## Topology: where the agent runs
 
@@ -158,7 +158,7 @@ either of the above? See [Self-hosted relay](/self-hosted-relay).
 
 The pod deliberately ships **no Node.js agent, no Agent SDK, and no LLM client** —
 they'd burn GPU-hours for nothing. The reasoning loop lives on your machine; the
-pod is a pure ComfyUI backend. This is the same [remote-driving model](/panel) the
+pod is a pure ComfyUI backend. This is the same [remote-driving model](./panel) the
 local Agent Panel uses, just with ComfyUI on a cloud GPU instead of localhost.
 
 ## What persists (and what doesn't)
@@ -225,4 +225,4 @@ npx -y comfyui-mcp@latest connect https://your-comfyui.example.com
 ```
 
 For exposing **comfyui-mcp itself** as a hosted, authenticated MCP server (rather
-than deploying ComfyUI), see [Remote / hosted connector](/remote-connector).
+than deploying ComfyUI), see [Remote / hosted connector](./remote-connector).

--- a/docs/concepts.mdx
+++ b/docs/concepts.mdx
@@ -38,7 +38,7 @@ local, remote (`--comfyui-url`), or [Comfy Cloud](https://cloud.comfy.org) (`COM
 <Note>
   Rule of thumb: anything that **reads or runs** the connected server works in any mode;
   anything that **installs software or touches files on disk** needs a local install. The
-  full feature-parity matrix is in [Configuration → Deployment modes](/configuration#deployment-modes).
+  full feature-parity matrix is in [Configuration → Deployment modes](./configuration#deployment-modes).
 </Note>
 
 ## Self-healing: the queue/render watchdog
@@ -51,11 +51,11 @@ blindly re-queuing behind a stuck render:
   already running, so the agent doesn't stack behind it.
 - **Stall detection** — a passive WebSocket to ComfyUI tracks the running prompt / node /
   progress; a step that stops advancing past the threshold
-  ([`COMFYUI_MCP_STALL_S`](/configuration#panel-orchestrator--the-bridge), default 180s)
+  ([`COMFYUI_MCP_STALL_S`](./configuration#panel-orchestrator--the-bridge), default 180s)
   prepends a one-line STALL/BACKLOG note to the agent's next turn.
 - **Escalating cancel** — `queue` (action:"cancel") interrupts, **verifies** the job actually
   stopped
-  (within [`COMFYUI_MCP_INTERRUPT_S`](/configuration#job-watching), default 30s), then
+  (within [`COMFYUI_MCP_INTERRUPT_S`](./configuration#job-watching), default 30s), then
   escalates to `/free` and reports the render WEDGED (suggesting `restart_comfyui`) if it
   still won't die; `clear_pending` drops all pending jobs in the same call.
 
@@ -66,17 +66,17 @@ also reason about an image's colors without a vision round-trip via `analyze_col
 ## Tool categories
 
 <CardGroup cols={2}>
-  <Card title="Image Generation" icon="image" href="/tools/image-generation" />
-  <Card title="Workflow Execution" icon="play" href="/tools/workflow-execution" />
-  <Card title="Workflow Authoring" icon="pen-ruler" href="/tools/workflow-authoring" />
-  <Card title="Workflow Library" icon="folder-open" href="/tools/workflow-library" />
-  <Card title="Assets & Images" icon="images" href="/tools/assets-images" />
-  <Card title="Models" icon="box" href="/tools/models" />
-  <Card title="Custom Nodes" icon="puzzle" href="/tools/custom-nodes" />
-  <Card title="API Nodes" icon="cloud" href="/tools/api-nodes" />
-  <Card title="Install & Environment" icon="wrench" href="/tools/install-environment" />
-  <Card title="Process Control" icon="power" href="/tools/process-control" />
-  <Card title="Defaults, Stats & Skills" icon="sliders" href="/tools/defaults-stats-skills" />
+  <Card title="Image Generation" icon="image" href="./tools/image-generation" />
+  <Card title="Workflow Execution" icon="play" href="./tools/workflow-execution" />
+  <Card title="Workflow Authoring" icon="pen-ruler" href="./tools/workflow-authoring" />
+  <Card title="Workflow Library" icon="folder-open" href="./tools/workflow-library" />
+  <Card title="Assets & Images" icon="images" href="./tools/assets-images" />
+  <Card title="Models" icon="box" href="./tools/models" />
+  <Card title="Custom Nodes" icon="puzzle" href="./tools/custom-nodes" />
+  <Card title="API Nodes" icon="cloud" href="./tools/api-nodes" />
+  <Card title="Install & Environment" icon="wrench" href="./tools/install-environment" />
+  <Card title="Process Control" icon="power" href="./tools/process-control" />
+  <Card title="Defaults, Stats & Skills" icon="sliders" href="./tools/defaults-stats-skills" />
 </CardGroup>
 
 <Info>

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -100,7 +100,7 @@ error. Architecture and `cloud-client` dispatcher originally contributed by
 [@picoSols](https://github.com/picoSols).
 
 <Note>
-  **Comfy-Org ships [official agent tooling](https://docs.comfy.org/agent-tools)** — Comfy Cloud MCP (public beta) and the Comfy In-App Agent (private alpha), both maintained by the Comfy team and both running on Comfy Cloud. If you only target Comfy Cloud, that's likely the right choice; see [Local vs. Comfy Cloud](/local-vs-comfy-cloud). `comfyui-mcp`'s cloud-mode below is best when you want a single MCP across local / remote / cloud, or you need it today (it's MIT and shipping now).
+  **Comfy-Org ships [official agent tooling](https://docs.comfy.org/agent-tools)** — Comfy Cloud MCP (public beta) and the Comfy In-App Agent (private alpha), both maintained by the Comfy team and both running on Comfy Cloud. If you only target Comfy Cloud, that's likely the right choice; see [Local vs. Comfy Cloud](./local-vs-comfy-cloud). `comfyui-mcp`'s cloud-mode below is best when you want a single MCP across local / remote / cloud, or you need it today (it's MIT and shipping now).
 </Note>
 
 <ParamField path="COMFYUI_API_KEY" type="string">
@@ -189,7 +189,7 @@ driven by the **panel orchestrator** — a background process that owns a loopba
 WebSocket bridge and runs an autonomous Claude Agent SDK session per panel tab on
 your **Claude subscription** (no API keys). The panel pack auto-starts it on
 ComfyUI load, so you normally don't run anything by hand — see
-[Sidebar Panel](/panel). To run it yourself:
+[Sidebar Panel](./panel). To run it yourself:
 
 ```bash
 npx -y comfyui-mcp@latest connect
@@ -221,8 +221,8 @@ When `connect <url>` targets a **remote https** ComfyUI (e.g. a RunPod pod), the
 pod's HTTPS panel page can't open a plain `ws://127.0.0.1` socket to the bridge on
 your machine — browsers block it (mixed content / Private Network Access). The
 orchestrator automatically upgrades to a secure `wss://` tunnel so it works with
-no prompt, in any browser. See [Cloud deployment](/cloud-deployment) for the full
-walkthrough and [Self-hosted relay](/self-hosted-relay) for running your own
+no prompt, in any browser. See [Cloud deployment](./cloud-deployment) for the full
+walkthrough and [Self-hosted relay](./self-hosted-relay) for running your own
 tunnel infrastructure instead of the default cloudflared quick tunnel.
 
 <ParamField path="COMFYUI_MCP_INSECURE_BRIDGE" type="boolean" default="false">
@@ -234,7 +234,7 @@ tunnel infrastructure instead of the default cloudflared quick tunnel.
 <ParamField path="COMFYUI_MCP_TUNNEL_BACKEND" type="string" default="cloudflared">
   Which secure-bridge backend to use for a remote target: `cloudflared` (default
   — an ephemeral quick tunnel, zero setup) or `relay` (dial a
-  [self-hosted relay](/self-hosted-relay) you operate, for a stable domain and no
+  [self-hosted relay](./self-hosted-relay) you operate, for a stable domain and no
   third-party quick-tunnel dependency). Only takes effect when secure mode is
   active (remote https target, not `COMFYUI_MCP_INSECURE_BRIDGE`).
 </ParamField>

--- a/docs/docker.mdx
+++ b/docs/docker.mdx
@@ -28,7 +28,7 @@ wherever your MCP client runs, reaching ComfyUI over plain HTTP via
   <Card title="Local npx + local ComfyUI" icon="laptop">
     The default. ComfyUI runs directly on your machine; the MCP client spawns
     `npx -y comfyui-mcp@latest`, which auto-detects the local install and its
-    port. No config needed. See [Installation](/installation).
+    port. No config needed. See [Installation](./installation).
   </Card>
   <Card title="Local npx + dockerized / remote ComfyUI" icon="docker">
     ComfyUI runs in a container (or on another host); the MCP client still
@@ -104,9 +104,9 @@ yours per its own docs; the example compose file has a commented sketch.
   `devices: [/dev/kfd, /dev/dri]`, `group_add: [video]`,
   `security_opt: [seccomp:unconfined]`.
 - `comfyui-mcp` itself has **no GPU/CUDA dependency** — ROCm hosts are fully
-  supported. The [Agent Panel](/panel) is a **ComfyUI extension**, not a
+  supported. The [Agent Panel](./panel) is a **ComfyUI extension**, not a
   service, and is optional when an external front end is your surface.
 - [`docker/runpod/`](https://github.com/artokun/comfyui-mcp/tree/main/docker/runpod)
   in this repo is a **CUDA-oriented RunPod cloud image** (see
-  [Cloud deployment](/cloud-deployment)), not a general-purpose ComfyUI image —
+  [Cloud deployment](./cloud-deployment)), not a general-purpose ComfyUI image —
   AMD users should not start there.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -13,20 +13,20 @@ server, all in natural language. Not a thin prompt-to-image bridge — a full ag
 ComfyUI for you.
 
 <Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="ComfyUI MCP in action — screenshot coming soon" />
+  <img src="./images/placeholder.svg" alt="ComfyUI MCP in action — screenshot coming soon" />
 </Frame>
 
 <CardGroup cols={2}>
-  <Card title="Quickstart" icon="rocket" href="/quickstart">
+  <Card title="Quickstart" icon="rocket" href="./quickstart">
     Add the server to Claude Code and generate your first image in ~2 minutes.
   </Card>
-  <Card title="Tool Reference" icon="wrench" href="/tools/image-generation">
+  <Card title="Tool Reference" icon="wrench" href="./tools/image-generation">
     80+ tools, auto-documented from their live schemas.
   </Card>
-  <Card title="Installation" icon="download" href="/installation">
+  <Card title="Installation" icon="download" href="./installation">
     Install ComfyUI and wire up the MCP server (local or remote).
   </Card>
-  <Card title="Configuration" icon="gear" href="/configuration">
+  <Card title="Configuration" icon="gear" href="./configuration">
     Environment variables, transports, tokens, and remote targeting.
   </Card>
 </CardGroup>
@@ -65,7 +65,7 @@ ComfyUI for you.
 `comfyui-mcp` is the community MCP for **local** and **remote** ComfyUI — that's the primary
 target (Mac/Linux/Windows installs, RunPod, VPS, LAN, etc.).
 
-For **Comfy Cloud** users, Comfy-Org ships [official agent tooling](https://docs.comfy.org/agent-tools) — Comfy Cloud MCP (public beta) and the Comfy In-App Agent (private alpha) — maintained by the Comfy team and running on Comfy Cloud. If you have no GPU or want zero setup, use that ([side-by-side](/local-vs-comfy-cloud)). `comfyui-mcp` also includes a community cloud-mode (`COMFYUI_API_KEY`), so a single MCP can target all three deployment shapes from one config — pick whichever fits your workflow.
+For **Comfy Cloud** users, Comfy-Org ships [official agent tooling](https://docs.comfy.org/agent-tools) — Comfy Cloud MCP (public beta) and the Comfy In-App Agent (private alpha) — maintained by the Comfy team and running on Comfy Cloud. If you have no GPU or want zero setup, use that ([side-by-side](./local-vs-comfy-cloud)). `comfyui-mcp` also includes a community cloud-mode (`COMFYUI_API_KEY`), so a single MCP can target all three deployment shapes from one config — pick whichever fits your workflow.
 
 ---
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -11,7 +11,7 @@ icon: "download"
     The easiest way to get a managed install on macOS / Windows.
   </Card>
   <Card title="From source" icon="github" href="https://github.com/comfyanonymous/ComfyUI">
-    Clone and run manually — or use the [`install_comfyui`](/tools/install-environment) tool.
+    Clone and run manually — or use the [`install_comfyui`](./tools/install-environment) tool.
   </Card>
 </CardGroup>
 
@@ -54,7 +54,7 @@ ComfyUI MCP ships on npm as `comfyui-mcp` and runs via `npx` — no global insta
     <Note>
       Local-only tools (installing ComfyUI/custom nodes, removing model files, reading logs)
       need a local install path and will return a clear error in remote mode. See
-      [How it works](/concepts).
+      [How it works](./concepts).
     </Note>
   </Tab>
   <Tab title="Comfy Cloud">
@@ -80,11 +80,11 @@ ComfyUI MCP ships on npm as `comfyui-mcp` and runs via `npx` — no global insta
     <Note>
       Cloud mode skips local `COMFYUI_PATH` auto-detection and uses the cloud's own model
       library — `list_local_models`, `apply_manifest`, and other local-only tools throw
-      `CLOUD_UNSUPPORTED`. See the [Configuration](/configuration#deployment-modes) page
+      `CLOUD_UNSUPPORTED`. See the [Configuration](./configuration#deployment-modes) page
       for the full feature-parity matrix.
     </Note>
     <Note>
-      **Cloud-only?** [Comfy-Org's Comfy Cloud MCP](https://docs.comfy.org/agent-tools) (public beta) is the canonical choice — see [Local vs. Comfy Cloud](/local-vs-comfy-cloud). Use `comfyui-mcp`'s cloud-mode if you want a single MCP across local / remote / cloud, or you need cloud support today.
+      **Cloud-only?** [Comfy-Org's Comfy Cloud MCP](https://docs.comfy.org/agent-tools) (public beta) is the canonical choice — see [Local vs. Comfy Cloud](./local-vs-comfy-cloud). Use `comfyui-mcp`'s cloud-mode if you want a single MCP across local / remote / cloud, or you need cloud support today.
     </Note>
   </Tab>
 </Tabs>
@@ -93,7 +93,7 @@ Then run `/mcp` in Claude Code to connect.
 
 ## 3. (Optional) Tokens
 
-Some tools use API tokens. Set them in the server's `env` block (see [Configuration](/configuration)):
+Some tools use API tokens. Set them in the server's `env` block (see [Configuration](./configuration)):
 
 - `CIVITAI_API_TOKEN` — gated CivitAI downloads
 - `HUGGINGFACE_TOKEN` — higher HuggingFace rate limits

--- a/docs/local-llms.mdx
+++ b/docs/local-llms.mdx
@@ -179,7 +179,7 @@ ollama pull artokun/gemma4-comfyui-mcp:12b     # ~8 GB VRAM
 ollama pull artokun/gemma4-comfyui-mcp:e2b     # smallest — ~2 GB VRAM (see caveat)
 ```
 
-**Measured, not promised** — [LLM Arena](/arena) scores on the real 10-scenario
+**Measured, not promised** — [LLM Arena](./arena) scores on the real 10-scenario
 ladder (best of 3, every result verified against a live ComfyUI server, RTX 4090):
 
 | Tag | VRAM (q4) | Arena score | vs. stock |
@@ -277,7 +277,7 @@ of models through an identical task set against a *live* ComfyUI and verifies
 every outcome against the server, never the model's claims.
 
 Local-tier scores on the full 10-scenario ladder (RTX 4090, ComfyUI 0.27,
-temperature 0 — see the [Arena page](/arena) for the task ladder and the
+temperature 0 — see the [Arena page](./arena) for the task ladder and the
 all-tier leaderboard including frontier and hosted models):
 
 | Model | Size | Score /20 |
@@ -304,7 +304,7 @@ workflows yet can't visually critique results.
 
 ## The sidebar panel on a local model
 
-The [panel agent](/panel) gains an **Ollama backend** alongside Claude /
+The [panel agent](./panel) gains an **Ollama backend** alongside Claude /
 ChatGPT / Gemini: pick **Ollama (local)** in the backend picker and the
 orchestrator drives your live graph with a local model — no account, no API
 key, fully offline. The model sees the 6-tool router (the 3 compact comfyui
@@ -340,4 +340,4 @@ that agents without that knowledge layer can still find their way.
   not data — run the tool with call_tool").
 - **ComfyUI not reachable** — compact mode only changes tool *registration*;
   connection config is identical to every other setup (see
-  [Configuration](/configuration)).
+  [Configuration](./configuration)).

--- a/docs/local-vs-comfy-cloud.mdx
+++ b/docs/local-vs-comfy-cloud.mdx
@@ -87,13 +87,13 @@ These are good reasons. If several apply to you, stop reading and go use
 - **You want to use the LLM subscription you already have.** Your Claude or
   ChatGPT plan already covers the reasoning — no second meter for the agent.
 - **You want it free, or you want it offline.** Ollama, LM Studio, and llama.cpp
-  run with no account and no network. See [Local LLMs](/local-llms).
+  run with no account and no network. See [Local LLMs](./local-llms).
 - **Your install is the point.** Your custom nodes, your LoRAs, your checkpoint
-  collection. The agent [installs nodes and downloads models](/tools/models) into
+  collection. The agent [installs nodes and downloads models](./tools/models) into
   the install you actually use.
 - **You want to choose the model.** Different LLMs are better at different
-  things; the [LLM Arena](/arena) scores them on real ComfyUI tasks so you can
-  pick on evidence. See [Backends](/backends).
+  things; the [LLM Arena](./arena) scores them on real ComfyUI tasks so you can
+  pick on evidence. See [Backends](./backends).
 
 ## "Won't the official local MCP make this redundant?"
 
@@ -113,22 +113,22 @@ agent live inside ComfyUI and manage the install itself, that's the gap this
 project exists to fill.
 
 They also compose. This project can target Comfy Cloud too (set
-`COMFYUI_API_KEY` — see [Cloud deployment](/cloud-deployment)), so one config
+`COMFYUI_API_KEY` — see [Cloud deployment](./cloud-deployment)), so one config
 covers a local install, a LAN box, a VPS, and Comfy Cloud.
 
 ## Getting started
 
 <CardGroup cols={2}>
-  <Card title="Quickstart" icon="rocket" href="/quickstart">
+  <Card title="Quickstart" icon="rocket" href="./quickstart">
     MCP server running against your local ComfyUI in about a minute.
   </Card>
-  <Card title="Local LLMs" icon="microchip" href="/local-llms">
+  <Card title="Local LLMs" icon="microchip" href="./local-llms">
     Fully offline on Ollama, LM Studio, or llama.cpp — no account.
   </Card>
-  <Card title="Backends" icon="shuffle" href="/backends">
+  <Card title="Backends" icon="shuffle" href="./backends">
     Claude, ChatGPT, Gemini, Grok, Kimi, or any OpenAI-compatible endpoint.
   </Card>
-  <Card title="Agent Panel" icon="window" href="/panel">
+  <Card title="Agent Panel" icon="window" href="./panel">
     The sidebar agent that drives your live graph.
   </Card>
 </CardGroup>

--- a/docs/mobile.mdx
+++ b/docs/mobile.mdx
@@ -13,7 +13,7 @@ build for your platform:
 </Note>
 
 The mobile app is a phone-native front end to the same agent that powers the
-[Sidebar Panel](/panel). It connects to the panel orchestrator's bridge, so
+[Sidebar Panel](./panel). It connects to the panel orchestrator's bridge, so
 everything the panel can do — generate images, run and inspect workflows, switch
 models — is available from your phone, with your desktop's ComfyUI doing the
 work.
@@ -23,8 +23,8 @@ work.
 The app talks to the agent host over the panel bridge, so you pair once and
 you're in:
 
-1. Install and run [comfyui-mcp](/quickstart) with the
-   [Agent Panel](/panel) on your desktop.
+1. Install and run [comfyui-mcp](./quickstart) with the
+   [Agent Panel](./panel) on your desktop.
 2. Open the panel in ComfyUI and show the **pairing QR**.
 3. In the mobile app, tap **Scan QR from panel** — or paste the bridge URL
    (`ws://…?token=…`) by hand.
@@ -35,8 +35,8 @@ host and token never leave your devices. The app also registers the
 
 <Note>
 Phone and desktop need a network path between them — the same LAN in the
-simple case, or a [secure relay](/self-hosted-relay) /
-[cloud deployment](/cloud-deployment) when the host isn't directly reachable.
+simple case, or a [secure relay](./self-hosted-relay) /
+[cloud deployment](./cloud-deployment) when the host isn't directly reachable.
 </Note>
 
 ## What's in the app
@@ -57,6 +57,6 @@ Beta feedback and bug reports are welcome on
 
 ## See also
 
-- [Sidebar Panel](/panel) — the in-ComfyUI agent the app pairs with
-- [Cloud deployment](/cloud-deployment) — drive a remote ComfyUI pod
-- [Self-hosted relay](/self-hosted-relay) — own the secure bridge path
+- [Sidebar Panel](./panel) — the in-ComfyUI agent the app pairs with
+- [Cloud deployment](./cloud-deployment) — drive a remote ComfyUI pod
+- [Self-hosted relay](./self-hosted-relay) — own the secure bridge path

--- a/docs/panel.mdx
+++ b/docs/panel.mdx
@@ -16,8 +16,8 @@ change — it works against your ComfyUI and replies right there. Pick a provide
 **Claude**, **ChatGPT**, **Gemini**, or **Ollama (local)** — and the matching
 agent runs in the background: subscriptions with **no API key**, local models
 with **no account at all** (and the Ollama backend reaches any hosted
-OpenAI-compatible endpoint too). See [Backends](/backends) for the matrix and
-the [LLM Arena](/arena) for how each model class actually performs.
+OpenAI-compatible endpoint too). See [Backends](./backends) for the matrix and
+the [LLM Arena](./arena) for how each model class actually performs.
 
 ```
 you ⇄ panel (pick a provider) ⇄ loopback bridge ⇄ panel orchestrator ⇄ background agent: Claude · ChatGPT · Gemini · any LLM
@@ -32,7 +32,7 @@ panel executes a **fixed allowlist** of graph commands (no arbitrary
 JavaScript).
 
 <Note>
-  New here: [Backends / providers](/backends) explains the picker, the provider-neutral
+  New here: [Backends / providers](./backends) explains the picker, the provider-neutral
   `AgentBackend` port, and the capability matrix (what's identical across Claude and
   ChatGPT, and the few things that differ).
 </Note>
@@ -73,7 +73,7 @@ above still applies, but the orchestrator needs to run **on your own machine**,
 not the remote box — turn on **Settings → General → "Use external/local
 orchestrator (advanced)"**, then click Connect. `connect <remote-url>` on your
 laptop handles the rest, including a secure tunnel back to the pod's HTTPS page.
-See [Cloud deployment](/cloud-deployment) for the full walkthrough.
+See [Cloud deployment](./cloud-deployment) for the full walkthrough.
 </Note>
 
 <Note>
@@ -82,7 +82,7 @@ See [Cloud deployment](/cloud-deployment) for the full walkthrough.
   appears only when **neither** provider is signed in. If your saved pick isn't usable
   the panel **auto-switches to a ready provider** (your saved preference is kept), and a
   not-ready provider's row offers a **"set up"** action that seeds the one-time
-  `claude` / `codex login` step. See [Backends → readiness & onboarding](/backends#connect-time-readiness--onboarding).
+  `claude` / `codex login` step. See [Backends → readiness & onboarding](./backends#connect-time-readiness--onboarding).
 </Note>
 
 ## What it can do
@@ -90,7 +90,7 @@ See [Cloud deployment](/cloud-deployment) for the full walkthrough.
 The agent (Claude *or* ChatGPT) loads comfyui-mcp's model skills (IDEOGRAM, WAN,
 LTX, Qwen, and more), so it already knows the models you run — Claude natively, and
 ChatGPT via the same knowledge exposed as MCP tools
-([knowledge parity](/tools/skills-knowledge)). It can generate images, video and
+([knowledge parity](./tools/skills-knowledge)). It can generate images, video and
 audio, inspect and manage your ComfyUI, and reason about your setup — then reply in
 the panel chat.
 
@@ -98,7 +98,7 @@ It can also **load a whole workflow or installer pack in one shot**
 (`panel_load_workflow pack:<name>`) and is **cost-aware**: bundled packs are
 local-GPU / free, and for an ad-hoc graph the agent checks the runtime
 (`check_workflow_runtime`) and **asks before spending paid API credits**. See
-[Skills, Packs & Runtime Cost](/tools/skills-knowledge).
+[Skills, Packs & Runtime Cost](./tools/skills-knowledge).
 
 ## Driving the live graph
 
@@ -106,7 +106,7 @@ The autonomous agent works your live ComfyUI through a **fixed allowlist** of
 `panel_*` commands — no arbitrary JavaScript. Every graph mutation goes through
 LiteGraph's change tracking, so each is undoable with **Ctrl+Z**. The same
 `panel_*` surface is exposed identically to both backends (in-process for Claude,
-over a loopback HTTP MCP for ChatGPT/Codex), so [parity](/backends) is automatic.
+over a loopback HTTP MCP for ChatGPT/Codex), so [parity](./backends) is automatic.
 
 ### Read
 
@@ -179,7 +179,7 @@ straight in.
 
 The agent discovers bundled expertise and checks runtime cost before spending
 credits (same tools on both backends — see
-[Skills, Packs & Runtime Cost](/tools/skills-knowledge)):
+[Skills, Packs & Runtime Cost](./tools/skills-knowledge)):
 
 | Tool | Effect |
 |---|---|
@@ -245,7 +245,7 @@ Two shortcuts cover the common cases:
   orchestrator via per-turn snapshots. **Conversation** rollback (forking the chat
   back to a past turn) is currently **Claude-only**; the ChatGPT/Codex backend
   resumes whole threads only, so the panel gates that scope off for it. See the
-  [capability matrix](/backends#capability-matrix).
+  [capability matrix](./backends#capability-matrix).
 </Note>
 
 ## Pending-message tray
@@ -302,7 +302,7 @@ stops blindly stacking jobs behind a wedged one). The threshold is the
 **Render stall warning (seconds)** setting under **Settings → Comfy MCP Agent →
 General** (default 180s, range 15–3600). It's sent on Connect and pushed **live** —
 changing it applies without a reconnect. See
-[Configuration → `COMFYUI_MCP_STALL_S`](/configuration#panel-orchestrator--the-bridge).
+[Configuration → `COMFYUI_MCP_STALL_S`](./configuration#panel-orchestrator--the-bridge).
 
 ## Background-tab reliability
 
@@ -323,8 +323,8 @@ lists your pods **by name**, Connect / Start / Stop / **Use Local**, and a
 confirm-armed **Deploy**. Set `RUNPOD_API_KEY` once in the API-Keys card and you
 can deploy, monitor, switch local⇄pod, and stop a cloud GPU without touching the
 RunPod console — the host pill always tells you where the next render runs. See
-[Cloud deployment](/cloud-deployment) and the blog
-[Run ComfyUI on a rented cloud GPU](/blog/runpod-comfyui).
+[Cloud deployment](./cloud-deployment) and the blog
+[Run ComfyUI on a rented cloud GPU](./blog/runpod-comfyui).
 
 ## CivitAI browser
 
@@ -332,15 +332,15 @@ The **Civitai** toolbar button opens a full CivitAI browser — images, videos,
 checkpoints, LoRAs and workflows with search, filters, and a fullscreen viewer.
 Pick a result to **share it with the agent**, **download it to your machine**, or
 **save an embedded workflow** to the canvas. The story:
-[CivitAI inside ComfyUI](/blog/civitai-in-comfyui).
+[CivitAI inside ComfyUI](./blog/civitai-in-comfyui).
 
 ## See also
 
-- [Mobile app (beta)](/mobile) — pair your phone with the panel and chat with the agent on the go
-- [Backends / providers](/backends) — Claude vs ChatGPT, the picker, capability parity
-- [Skills, Packs & Runtime Cost](/tools/skills-knowledge) — knowledge parity + the cost guardrail
-- [Bridge configuration](/configuration)
-- [Cloud deployment](/cloud-deployment) — drive the panel against a remote ComfyUI pod (RunPod, etc.)
-- [Self-hosted relay](/self-hosted-relay) — run your own tunnel infrastructure for the bridge
-- [The Claude Code plugin](/plugin) — model skills, slash commands, agents
+- [Mobile app (beta)](./mobile) — pair your phone with the panel and chat with the agent on the go
+- [Backends / providers](./backends) — Claude vs ChatGPT, the picker, capability parity
+- [Skills, Packs & Runtime Cost](./tools/skills-knowledge) — knowledge parity + the cost guardrail
+- [Bridge configuration](./configuration)
+- [Cloud deployment](./cloud-deployment) — drive the panel against a remote ComfyUI pod (RunPod, etc.)
+- [Self-hosted relay](./self-hosted-relay) — run your own tunnel infrastructure for the bridge
+- [The Claude Code plugin](./plugin) — model skills, slash commands, agents
 - [comfyui-mcp on GitHub](https://github.com/artokun/comfyui-mcp) · [comfyui-mcp-panel on GitHub](https://github.com/artokun/comfyui-mcp-panel)

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -102,13 +102,13 @@ Mermaid), `/comfy:batch`, `/comfy:compare`, `/comfy:convert`, `/comfy:gallery`,
 <Note>
   The sidebar panel ships as its own pack. **🚧 It's in active development and
   temporarily off the Comfy Registry / ComfyUI-Manager — re-releasing soon.**
-  Install it from git for now (full guide: [Sidebar Panel](/panel)).
+  Install it from git for now (full guide: [Sidebar Panel](./panel)).
 </Note>
 
 The [comfyui-mcp-panel](https://github.com/artokun/comfyui-mcp-panel) sidebar runs
 an autonomous agent on your **Claude subscription** (no per-token API billing).
 Install the pack, open the Agent tab, and click **Connect** — it starts the
-[panel orchestrator](/configuration) on demand; ask it for an image, a workflow,
+[panel orchestrator](./configuration) on demand; ask it for an image, a workflow,
 or a change and it works against your ComfyUI.
 
 ## Hooks

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -9,7 +9,7 @@ icon: "rocket"
     Install [ComfyUI Desktop](https://www.comfy.org/download) or run it
     [from source](https://github.com/comfyanonymous/ComfyUI), and start it. ComfyUI MCP
     auto-detects a local install and its port (8188 / 8000). To target a remote instance,
-    see [Configuration](/configuration).
+    see [Configuration](./configuration).
   </Step>
 
   <Step title="Add the MCP server to Claude Code">
@@ -41,26 +41,26 @@ icon: "rocket"
 
     > Generate an image of a watercolor fox in a misty forest.
 
-    Under the hood this calls [`generate_image`](/tools/image-generation), which builds a
+    Under the hood this calls [`generate_image`](./tools/image-generation), which builds a
     txt2img workflow, auto-selects a checkpoint, enqueues it, and returns a `prompt_id`. The
     finished image arrives via the completion notification — view it with
-    [`view_image`](/tools/assets-images).
+    [`view_image`](./tools/assets-images).
   </Step>
 </Steps>
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Installation details" icon="download" href="/installation">
+  <Card title="Installation details" icon="download" href="./installation">
     Local vs. remote setups and `npm link` for development.
   </Card>
-  <Card title="Configuration" icon="gear" href="/configuration">
+  <Card title="Configuration" icon="gear" href="./configuration">
     All environment variables and the HTTP transport.
   </Card>
-  <Card title="How it works" icon="diagram-project" href="/concepts">
+  <Card title="How it works" icon="diagram-project" href="./concepts">
     The model behind the tools — and which ones need a local install.
   </Card>
-  <Card title="Browse the tools" icon="wrench" href="/tools/image-generation">
+  <Card title="Browse the tools" icon="wrench" href="./tools/image-generation">
     The full, schema-generated reference.
   </Card>
 </CardGroup>

--- a/docs/remote-connector.mdx
+++ b/docs/remote-connector.mdx
@@ -18,7 +18,7 @@ when you set a token or pass `--tunnel`.
 
 <Note>
 **Looking to drive a remote ComfyUI pod (e.g. RunPod) with the Agent Panel
-instead?** That's a different feature — see [Cloud deployment](/cloud-deployment).
+instead?** That's a different feature — see [Cloud deployment](./cloud-deployment).
 This page is about exposing the **comfyui-mcp MCP server itself** to remote
 clients like Claude Desktop; it doesn't touch ComfyUI or the panel bridge at all.
 Both happen to use a cloudflared quick tunnel under the hood, which is the
@@ -157,6 +157,6 @@ follow-up — it's a heavier change and isn't required to connect manually.
 
 ## See also
 
-- [Cloud deployment](/cloud-deployment) — drive a remote ComfyUI pod with the
+- [Cloud deployment](./cloud-deployment) — drive a remote ComfyUI pod with the
   Agent Panel (a different tunnel, a different purpose)
-- [Configuration](/configuration) — the full environment variable reference
+- [Configuration](./configuration) — the full environment variable reference

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -49,15 +49,15 @@ Everything here works today and is covered by the docs.
 
 | Area | What you get |
 |---|---|
-| **Agent in ComfyUI** | The panel puts an agent beside your canvas — it reads the graph, edits nodes, runs workflows, and explains failures. See [Panel](/panel). |
-| **Bring your own model** | Claude, ChatGPT/Codex, Gemini, Antigravity, Grok, Kimi, GLM, Ollama, LM Studio, llama.cpp, OpenRouter, or a custom endpoint — one picker, one orchestrator. See [Backends](/backends). |
-| **Local models** | Fully local operation through Ollama / LM Studio / llama.cpp, including small models. See [Local LLMs](/local-llms). |
+| **Agent in ComfyUI** | The panel puts an agent beside your canvas — it reads the graph, edits nodes, runs workflows, and explains failures. See [Panel](./panel). |
+| **Bring your own model** | Claude, ChatGPT/Codex, Gemini, Antigravity, Grok, Kimi, GLM, Ollama, LM Studio, llama.cpp, OpenRouter, or a custom endpoint — one picker, one orchestrator. See [Backends](./backends). |
+| **Local models** | Fully local operation through Ollama / LM Studio / llama.cpp, including small models. See [Local LLMs](./local-llms). |
 | **Workflow authoring** | Build, patch, slice, validate and lock workflows from natural language; import from an image's metadata. |
 | **Models & custom nodes** | Search, install and repair node packs; find and download models — including working out which models a workflow is missing and which quantisation fits your VRAM. |
 | **Civitai browser** | Browse images, videos and models in-panel, filter by base model and creator, and pull a workflow straight onto the canvas. |
-| **Mobile app** | Chat to the agent, watch the queue, browse LoRAs, and mirror a desktop tab to drive your rig from your phone. See [Mobile](/mobile). |
-| **Apps (micro-apps)** | Turn a workflow into a one-click app with a real form: convert and publish in the panel, run it locally or on a pod, install others' apps from the public registry — and run the same apps from the phone's Apps tab or an agent via the `apps_*` tools. See [Apps](/apps). |
-| **Remote & cloud** | Point the panel at a remote ComfyUI, a self-hosted relay, or Comfy Cloud. See [Remote connector](/remote-connector). |
+| **Mobile app** | Chat to the agent, watch the queue, browse LoRAs, and mirror a desktop tab to drive your rig from your phone. See [Mobile](./mobile). |
+| **Apps (micro-apps)** | Turn a workflow into a one-click app with a real form: convert and publish in the panel, run it locally or on a pod, install others' apps from the public registry — and run the same apps from the phone's Apps tab or an agent via the `apps_*` tools. See [Apps](./apps). |
+| **Remote & cloud** | Point the panel at a remote ComfyUI, a self-hosted relay, or Comfy Cloud. See [Remote connector](./remote-connector). |
 | **RunPod pods** | Create, connect to and stop RunPod pods from the panel, with billing-safe defaults and an honest host indicator. |
 | **LoRA training (local)** | Character LoRAs on FLUX.1-dev, driven by the agent through `train_*` tools in a GPU Docker container — dataset in, `.safetensors` in `models/loras/` out. |
 
@@ -76,7 +76,7 @@ Queued and specified, not started. Ordered.
 
 | Item | Why it's here |
 |---|---|
-| **Honest previews in the mobile app** | The **Training** tab is still inert placeholder UI — six cards that read as a shipped feature and have already misled people into asking how far along it is. Either label it plainly or hide it — the cheapest fix on this list. (The **Apps** tab was the other half of this item and is now real; see [Apps](/apps).) |
+| **Honest previews in the mobile app** | The **Training** tab is still inert placeholder UI — six cards that read as a shipped feature and have already misled people into asking how far along it is. Either label it plainly or hide it — the cheapest fix on this list. (The **Apps** tab was the other half of this item and is now real; see [Apps](./apps).) |
 | **Mobile training** | Wire the mobile Training tab to the trainer that already works. The hard part is done; this is mostly plumbing, and it retires the item above. |
 | **Tablet layout** | Real, unglamorous responsive work. Worth doing once the screens above have something worth showing. |
 
@@ -139,7 +139,7 @@ product with a different trust model, and it isn't this one.
 
 The arc so far, for context on where the next items sit. This is deliberately
 coarse — for what changed in a specific release, see the
-[Changelog](/changelog).
+[Changelog](./changelog).
 
 <Note>
   Public releases begin at **v0.2.0**. There is no v0.0.1 or v0.1.x — the first

--- a/docs/self-hosted-relay.mdx
+++ b/docs/self-hosted-relay.mdx
@@ -4,7 +4,7 @@ description: "Own the full loop: run your own relay for the secure wss:// bridge
 icon: "building-columns"
 ---
 
-When [`connect`](/cloud-deployment) drives a remote HTTPS pod, comfyui-mcp needs a
+When [`connect`](./cloud-deployment) drives a remote HTTPS pod, comfyui-mcp needs a
 valid-TLS `wss://` path from the pod's browser panel back to the agent bridge on
 your machine (a plain `ws://` from an `https://` page is browser-blocked). By
 default this is a **cloudflared quick tunnel** — zero setup, but ephemeral (a

--- a/docs/third-party-hosts.mdx
+++ b/docs/third-party-hosts.mdx
@@ -4,7 +4,7 @@ description: "Build your own front-end (Blender panel, browser extension, anothe
 icon: "plug"
 ---
 
-The Agent Panel, the [mobile app](/mobile), and any tool that pairs with a running
+The Agent Panel, the [mobile app](./mobile), and any tool that pairs with a running
 session all speak **one small WebSocket protocol** to the orchestrator's pairing
 listener. A **third-party host** is any client you build on that protocol — a
 Blender panel, a browser extension, a CLI, another editor — that **attaches to a

--- a/docs/tools/skills-knowledge.mdx
+++ b/docs/tools/skills-knowledge.mdx
@@ -8,7 +8,7 @@ icon: "book-open"
   These knowledge tools are exposed on the headless `comfyui` MCP server, so
   **any MCP client** has them — including the panel's **ChatGPT/Codex** backend,
   which can't load Claude's native skills. That's what gives both providers the
-  same expertise (knowledge parity). See [Backends / providers](/backends).
+  same expertise (knowledge parity). See [Backends / providers](../backends).
 </Info>
 
 ## Why these exist
@@ -120,6 +120,6 @@ graph. The replaced graph is captured as an undo point (double-Esc / `/revert`).
 
 ## See also
 
-- [Backends / providers](/backends) — Claude vs ChatGPT, the picker, capability parity
-- [API / partner nodes](/tools/api-nodes) — `list_api_nodes` and the paid-credit surface
-- [Sidebar Panel](/panel) — the full panel UX
+- [Backends / providers](../backends) — Claude vs ChatGPT, the picker, capability parity
+- [API / partner nodes](./api-nodes) — `list_api_nodes` and the paid-credit surface
+- [Sidebar Panel](../panel) — the full panel UX

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -28,7 +28,7 @@ pip install -U comfyui_manager
 # then remove/disable the old custom_nodes/ComfyUI-Manager clone and restart
 ```
 
-The [RunPod image](/cloud-deployment) already ships Manager v4.
+The [RunPod image](./cloud-deployment) already ships Manager v4.
 
 **Note on `useCmCli: true`:** the cm-cli fallback runs Manager's CLI as a
 subprocess, so it needs the **local filesystem** — it can't work against a
@@ -168,7 +168,7 @@ stdio mode (the default, what MCP clients use) needs none of this.
 
 ## Local models: tool calls fail or the model "can't see" tools
 
-- **First move: use [our fine-tuned model](/local-llms#our-fine-tuned-local-models-free-recommended)** —
+- **First move: use [our fine-tuned model](./local-llms#our-fine-tuned-local-models-free-recommended)** —
   `ollama pull artokun/gemma4-comfyui-mcp:e4b` (the panel's Ollama default).
   It's Gemma 4 trained on the comfyui-mcp tool suite itself, which eliminates
   most "wrong tool / malformed args" failures out of the box (`:e2b` for
@@ -176,7 +176,7 @@ stdio mode (the default, what MCP clients use) needs none of this.
   arena; `:e4b` remains the sweet spot).
 - **gemma3 has no native tool calling in Ollama** — unsupported; use
   our fine-tune above, stock `gemma4` (e4b+), `qwen3`, or `llama3.1+`.
-- Make sure [compact tool mode](/local-llms) is on for small models —
+- Make sure [compact tool mode](./local-llms) is on for small models —
   it's the default, so this only bites if you opted into `--full`: ~200 full
   schemas overflow small contexts and the model starts hallucinating tool
   names.


### PR DESCRIPTION
## Problem

The docs site is served under a **subpath** (`comfyui-mcp.artokun.io/docs`) via the proxy worker in `infra/cloudflare/`. Mintlify prefixes its **own** generated links (nav, logo, favicon) with `/docs`, but **not** links authored in MDX content — so ~400 root-relative authored links (`[text](/local-llms)`, `<Card href="/backends">`, `<img src="/images/...">`) resolved against the **bare host** and 404'd (worker-side, they now 301 — see below).

## Approach

Convert every root-relative internal link in `docs/**/*.mdx` to the correct **relative** path from the file's location:

- `/x` from `docs/a.mdx` → `./x`; from `docs/blog/a.mdx` → `../x`
- `/blog/b` from `docs/blog/a.mdx` → `./b`
- `/` from a subdirectory page → `../`
- anchors and query strings preserved (`/x#y` → `./x#y`)

Relative links are portable: they work in local `mint dev`, in production under `/docs`, and don't depend on the redirect hop. This complements the worker-side 301 from #737 (already deployed), which remains as the safety net for any stragglers and external bookmarks.

## What changed

**404 links converted across 73 files (398 changed lines):**

| Form | Count |
|---|---|
| inline markdown `](/...)` | 322 |
| JSX `href="/..."` (Card etc.) | 79 |
| JSX `src="/..."` (images) | 3 |

No reference-style link definitions (`[1]: /x`) exist in the docs. External URLs, `mailto:`, and anchor-only links untouched.

**`docs/docs.json` deliberately unchanged:**

- `navigation.*.pages` already use page-ids without leading slashes — nothing to convert.
- `errors.404.description` contains three authored markdown links (`/`, `/blog`, `/quickstart`). With `"redirect": false` the 404 page renders at the *arbitrary* requested URL, so any relative link would resolve against an unknown path depth and break. Root-relative there is caught by the worker 301 (and works in local dev). Left as-is on purpose.
- `favicon`, `logo.light/dark`, `og:image`, `twitter:image` are Mintlify config fields whose URLs Mintlify generates (and prefixes) itself. Not authored content; left as-is.

## Verification

A scratch script (run, then deleted) re-scanned **every** converted link and resolved it against the filesystem, emulating browser resolution from each page's route under `/docs`:

```
converted relative links checked : 404
root-relative links remaining    : 8 (pre-existing broken /packs/* — left unchanged on purpose)
external links skipped           : 265
unresolvable converted links     : 0
anchor warnings (best-effort)    : 1 (pre-existing stale anchor, see below)
```

Docs-related CI checks run locally, all green:

- `npm run check:vocabulary` — OK (1038 tracked files, no live references to dead tool names)
- `npm run vocab:export -- --check` — OK (artefact matches ledger)
- `node scripts/asset-counts.mjs --check` — OK (after `npm run build`)
- The `docs:gen` no-op gate is Ubuntu-only in CI by design (CRLF checkouts on Windows produce spurious whole-file diffs — see `ci.yml` comment). This branch touches **no generated page**: the only `docs/tools/` file changed is `skills-knowledge.mdx`, which `gen-tool-docs.ts` lists under `HAND_WRITTEN_PAGES` and never overwrites.

## Pre-existing broken links (NOT introduced here, left unchanged)

- `/packs/z-image-turbo` (3×), `/packs/z-image-base` (3×), `/packs/z-image-xy-plot` (2×) in `docs/blog/z-image-comfyui.mdx` — there is no `docs/packs/` directory (pack docs live in the repo's `packs/` folder, not on the docs site). These were broken before this change; worth a follow-up decision (create pack pages, or repoint to GitHub URLs).
- Stale anchor in `docs/changelog/2026-06-16.mdx:34`: links to `configuration#channels--drive-the-comfyui-sidebar-panel-from-your-own-agent-session`, but `docs/configuration.mdx` no longer has a "Channels" heading. Page resolves; the anchor was already dead. Anchor preserved as-is per scope.

Worker-side companion (already merged/deployed): #737.