### PR TITLE
fix(#740): Claude backend handles blocking SDK info messages; empty turn is not success

### DIFF
--- a/src/__tests__/orchestrator/claude-empty-turn.test.ts
+++ b/src/__tests__/orchestrator/claude-empty-turn.test.ts
@@ -104,14 +104,16 @@ async function* channel() {
   yield { text: "hi" };
 }
 
-/** Drive one backend session over the given script; resolve with the events. */
+/** Drive one backend session over the given script; resolve with the events.
+ *  The turn is SUBMITTED before the script's messages are pushed — production
+ *  ordering (the SDK pulls the user prompt before any turn message exists),
+ *  which per-turn state tracking relies on. */
 async function runScript(script: unknown[]): Promise<AgentEvent[]> {
-  const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
-  const backend = new ClaudeBackend({ mcpServers: {}, systemAppend: "" });
+  const { events, done } = await startBackend(channel());
+  await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
   for (const m of script) hoisted.queue.push(m);
   hoisted.queue.end();
-  const events: AgentEvent[] = [];
-  for await (const ev of backend.run({ channel: channel() as never })) events.push(ev);
+  await done;
   return events;
 }
 
@@ -314,7 +316,7 @@ describe("Claude backend — interruptPending is strictly turn-scoped (#745 revi
     expect(errors[0].message).toContain("without producing a reply");
   });
 
-  it("an interrupt's blessing does not survive a session re-init", async () => {
+  it("a LATE result from an interrupted turn classifies by its OWN flags and leaves the next turn untouched", async () => {
     let releaseTurnB!: () => void;
     const gate = new Promise<void>((resolve) => {
       releaseTurnB = resolve;
@@ -327,18 +329,71 @@ describe("Claude backend — interruptPending is strictly turn-scoped (#745 revi
     const { backend, events, done } = await startBackend(twoTurns());
     hoisted.queue.push(INIT);
     await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
-    await backend.interrupt(); // turn A in flight → marked
-    // The session RESTARTS before turn A's result ever arrives: per-turn state
-    // (including the mark) resets.
-    hoisted.queue.push(INIT);
+    // Turn A is interrupted mid-flight and produces NO result; the panel's
+    // no-result fallback releases the gate (panel-agent.ts:671 acknowledges the
+    // late result) and turn B is submitted.
+    await backend.interrupt();
     releaseTurnB();
     await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
+    // NOW turn A's late empty result/success arrives: it is the interrupt
+    // landing for A → ok:true, NO synthetic failure attributed to the turn in
+    // flight, and turn B's state untouched.
+    hoisted.queue.push(RESULT_SUCCESS);
+    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(1));
+    expect(resultsOf(events)[0]).toMatchObject({ ok: true });
+    expect(errorsOf(events)).toHaveLength(0);
+    // Turn B's own empty result then classifies on B's flags → ok:false + the
+    // synthetic error, exactly as required for a genuinely empty turn.
     hoisted.queue.push(RESULT_SUCCESS);
     hoisted.queue.end();
     await done;
     const results = resultsOf(events);
-    expect(results).toHaveLength(1);
-    expect(results[0]).toMatchObject({ ok: false });
+    expect(results).toHaveLength(2);
+    expect(results[1]).toMatchObject({ ok: false });
+    const errors = errorsOf(events);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("without producing a reply");
+  });
+
+  it("an interrupt's blessing does not survive a session restart, and a stray result from the dead session is inert", async () => {
+    const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
+    const backend = new ClaudeBackend({ mcpServers: {}, systemAppend: "" });
+    // Session 1: turn A goes in flight and is interrupted; the session then
+    // dies with NO result for A — the self-restart loop re-calls run() on the
+    // SAME backend instance (as PanelAgent does).
+    const events1: AgentEvent[] = [];
+    const done1 = (async () => {
+      for await (const ev of backend.run({ channel: channel() as never })) events1.push(ev);
+    })();
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    await backend.interrupt();
+    hoisted.queue.end();
+    await done1;
+    // Session 2.
+    hoisted.queue.reset();
+    hoisted.promptsSeen = 0;
+    const events: AgentEvent[] = [];
+    const done2 = (async () => {
+      for await (const ev of backend.run({ channel: channel() as never })) events.push(ev);
+    })();
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    // Turn B ends genuinely empty → failure + the synthetic error (no leak of
+    // session 1's blessing across the restart boundary).
+    hoisted.queue.push(RESULT_SUCCESS);
+    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(1));
+    expect(resultsOf(events)[0]).toMatchObject({ ok: false });
     expect(errorsOf(events)).toHaveLength(1);
+    // A STRAY late result from the dead session (no matching submitted turn)
+    // classifies by its subtype only — it must not fail, fail again, or consume
+    // anything belonging to session 2.
+    hoisted.queue.push(RESULT_SUCCESS);
+    hoisted.queue.end();
+    await done2;
+    const results = resultsOf(events);
+    expect(results).toHaveLength(2);
+    expect(results[1]).toMatchObject({ ok: true });
+    expect(errorsOf(events)).toHaveLength(1); // still exactly the one from turn B
   });
 });

--- a/src/__tests__/orchestrator/claude-empty-turn.test.ts
+++ b/src/__tests__/orchestrator/claude-empty-turn.test.ts
@@ -522,4 +522,44 @@ describe("Claude backend — interruptPending is strictly turn-scoped (#745 revi
     expect(results[0]).toMatchObject({ ok: true });
     expect(errorsOf(events)).toHaveLength(0);
   });
+
+  it("a run() restart after a FULLY DRAINED poisoned session does not falsely re-poison the first new turn", async () => {
+    const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
+    const backend = new ClaudeBackend({ mcpServers: {}, systemAppend: "" });
+    // Session 1: overflow, trip the gap (poisoned), then drain EVERY result so
+    // the trace FIFO ends EMPTY — no dead traces remain at the boundary.
+    async function* seventeenTurns() {
+      for (let i = 1; i <= 17; i++) yield { text: `turn ${i}` };
+    }
+    const events1: AgentEvent[] = [];
+    const done1 = (async () => {
+      for await (const ev of backend.run({ channel: seventeenTurns() as never })) events1.push(ev);
+    })();
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(17));
+    for (let i = 0; i < 17; i++) hoisted.queue.push(RESULT_SUCCESS); // gap → poison → all fail closed; FIFO drains to empty
+    hoisted.queue.end();
+    await done1;
+    expect(resultsOf(events1)).toHaveLength(17);
+    expect(resultsOf(events1).some((r) => r.type === "result" && r.ok === true)).toBe(false);
+    // Session 2 (restart boundary): the result sequence must advance past the
+    // drained session's turn ids even with an EMPTY FIFO — otherwise the first
+    // new turn re-crosses the old gap and falsely re-poisons (#745 r5).
+    hoisted.queue.reset();
+    hoisted.promptsSeen = 0;
+    const events: AgentEvent[] = [];
+    const done2 = (async () => {
+      for await (const ev of backend.run({ channel: channel() as never })) events.push(ev);
+    })();
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    hoisted.queue.push(assistantMsg("back to normal"));
+    hoisted.queue.push(RESULT_SUCCESS);
+    hoisted.queue.end();
+    await done2;
+    const results = resultsOf(events);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ ok: true });
+    expect(errorsOf(events)).toHaveLength(0);
+  });
 });

--- a/src/__tests__/orchestrator/claude-empty-turn.test.ts
+++ b/src/__tests__/orchestrator/claude-empty-turn.test.ts
@@ -38,10 +38,17 @@ const hoisted = vi.hoisted(() => ({
     }
   })(),
   onInterrupt: null as null | (() => void),
+  /** User turns the mock SDK pulled from the prompt channel (proves submission). */
+  promptsSeen: 0,
 }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
-  query: () => {
+  query: (arg: { prompt?: AsyncIterable<unknown> }) => {
+    // The real SDK pulls user turns out of the prompt generator — drain it the
+    // same way so the backend's turn tracking sees every submitted turn.
+    void (async () => {
+      for await (const _ of arg.prompt ?? []) hoisted.promptsSeen += 1;
+    })();
     const iter = hoisted.queue.iterate();
     return Object.assign(iter, {
       supportedModels: async () => [],
@@ -57,6 +64,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
 beforeEach(() => {
   hoisted.queue.reset();
   hoisted.onInterrupt = null;
+  hoisted.promptsSeen = 0;
 });
 
 const INIT = {
@@ -105,6 +113,17 @@ async function runScript(script: unknown[]): Promise<AgentEvent[]> {
   const events: AgentEvent[] = [];
   for await (const ev of backend.run({ channel: channel() as never })) events.push(ev);
   return events;
+}
+
+/** Start a live backend over a caller-controlled channel (for multi-turn flows). */
+async function startBackend(channelGen: AsyncGenerator<{ text: string }>) {
+  const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
+  const backend = new ClaudeBackend({ mcpServers: {}, systemAppend: "" });
+  const events: AgentEvent[] = [];
+  const done = (async () => {
+    for await (const ev of backend.run({ channel: channelGen as never })) events.push(ev);
+  })();
+  return { backend, events, done };
 }
 
 const resultsOf = (events: AgentEvent[]) => events.filter((e) => e.type === "result");
@@ -207,25 +226,119 @@ describe("Claude backend #740 — an empty turn is never a success", () => {
     expect(resultsOf(events)[0]).toMatchObject({ ok: true });
   });
 
-  it("an empty result right after interrupt() is the interrupt landing, not a failure", async () => {
-    const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
-    const backend = new ClaudeBackend({ mcpServers: {}, systemAppend: "" });
+  it("an empty result right after a MID-TURN interrupt() is the interrupt landing, not a failure", async () => {
+    const { backend, events, done } = await startBackend(channel());
     hoisted.onInterrupt = () => {
       hoisted.queue.push(RESULT_SUCCESS);
       hoisted.queue.end();
     };
     hoisted.queue.push(INIT);
-    const events: AgentEvent[] = [];
-    const done = (async () => {
-      for await (const ev of backend.run({ channel: channel() as never })) events.push(ev);
-    })();
-    // Wait until the session event proves run() is live (q exists), then stop.
-    await vi.waitFor(() => expect(events.some((e) => e.type === "session")).toBe(true));
+    // Wait until the turn is actually IN FLIGHT (submitted to the SDK)…
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    // …then stop it: the aborted empty result stays a clean ok:true.
     await backend.interrupt();
     await done;
     expect(errorsOf(events)).toHaveLength(0);
     const results = resultsOf(events);
     expect(results).toHaveLength(1);
     expect(results[0]).toMatchObject({ ok: true });
+  });
+});
+
+describe("Claude backend — interruptPending is strictly turn-scoped (#745 review)", () => {
+  it("an interrupt() while NO turn is in flight does not bless a later empty turn", async () => {
+    let releaseTurnB!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseTurnB = resolve;
+    });
+    async function* twoTurns() {
+      yield { text: "turn A" };
+      await gate; // hold turn B until the test says the session is idle
+      yield { text: "turn B" };
+    }
+    const { backend, events, done } = await startBackend(twoTurns());
+    hoisted.queue.push(INIT);
+    // Turn A goes in flight, produces content, and completes successfully.
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    hoisted.queue.push(assistantMsg("A reply"));
+    hoisted.queue.push(RESULT_SUCCESS);
+    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(1));
+    expect(resultsOf(events)[0]).toMatchObject({ ok: true });
+    // Idle now: turn A's result is consumed and turn B is not yet submitted.
+    // This interrupt must leave NO state behind.
+    await backend.interrupt();
+    releaseTurnB();
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
+    // Turn B ends genuinely empty → still a failure with the synthetic error.
+    hoisted.queue.push(RESULT_SUCCESS);
+    hoisted.queue.end();
+    await done;
+    const results = resultsOf(events);
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ ok: true });
+    expect(results[1]).toMatchObject({ ok: false });
+    const errors = errorsOf(events);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("without producing a reply");
+  });
+
+  it("a mid-turn interrupt's blessing is consumed by its OWN result, not the next turn's", async () => {
+    let releaseTurnB!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseTurnB = resolve;
+    });
+    async function* twoTurns() {
+      yield { text: "turn A" };
+      await gate;
+      yield { text: "turn B" };
+    }
+    const { backend, events, done } = await startBackend(twoTurns());
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    // Interrupt turn A in flight → its aborted empty result stays ok:true…
+    await backend.interrupt();
+    hoisted.queue.push(RESULT_SUCCESS);
+    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(1));
+    expect(resultsOf(events)[0]).toMatchObject({ ok: true });
+    // …but the blessing dies with that result: turn B's empty result still fails.
+    releaseTurnB();
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
+    hoisted.queue.push(RESULT_SUCCESS);
+    hoisted.queue.end();
+    await done;
+    const results = resultsOf(events);
+    expect(results).toHaveLength(2);
+    expect(results[1]).toMatchObject({ ok: false });
+    const errors = errorsOf(events);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("without producing a reply");
+  });
+
+  it("an interrupt's blessing does not survive a session re-init", async () => {
+    let releaseTurnB!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseTurnB = resolve;
+    });
+    async function* twoTurns() {
+      yield { text: "turn A" };
+      await gate;
+      yield { text: "turn B" };
+    }
+    const { backend, events, done } = await startBackend(twoTurns());
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    await backend.interrupt(); // turn A in flight → marked
+    // The session RESTARTS before turn A's result ever arrives: per-turn state
+    // (including the mark) resets.
+    hoisted.queue.push(INIT);
+    releaseTurnB();
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
+    hoisted.queue.push(RESULT_SUCCESS);
+    hoisted.queue.end();
+    await done;
+    const results = resultsOf(events);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ ok: false });
+    expect(errorsOf(events)).toHaveLength(1);
   });
 });

--- a/src/__tests__/orchestrator/claude-empty-turn.test.ts
+++ b/src/__tests__/orchestrator/claude-empty-turn.test.ts
@@ -1,0 +1,231 @@
+// #740 — the Claude backend must not drop blocking SDK informational messages
+// (e.g. a UserPromptSubmit hook denying the prompt) and must never report a turn
+// that produced NO assistant content as a successful turn. The SDK ends such a
+// turn with a `result` whose subtype is STILL "success"; the adapter has to
+// classify it truthfully and surface the reason.
+//
+// Pattern follows claude-spawn-env.test.ts: the optional Agent SDK is mocked,
+// the backend is driven through run(), and the canonical AgentEvents are
+// collected and asserted on.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import type { AgentEvent } from "../../orchestrator/agent-backend.js";
+
+const hoisted = vi.hoisted(() => ({
+  /** A push-based async message source — stands in for the live SDK query stream. */
+  queue: new (class {
+    private buf: unknown[] = [];
+    private waiters: Array<() => void> = [];
+    private closed = false;
+    reset(): void {
+      this.buf = [];
+      this.closed = false;
+    }
+    push(m: unknown): void {
+      this.buf.push(m);
+      for (const w of this.waiters.splice(0)) w();
+    }
+    end(): void {
+      this.closed = true;
+      for (const w of this.waiters.splice(0)) w();
+    }
+    async *iterate(): AsyncGenerator<unknown> {
+      for (;;) {
+        while (this.buf.length) yield this.buf.shift();
+        if (this.closed) return;
+        await new Promise<void>((resolve) => this.waiters.push(resolve));
+      }
+    }
+  })(),
+  onInterrupt: null as null | (() => void),
+}));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: () => {
+    const iter = hoisted.queue.iterate();
+    return Object.assign(iter, {
+      supportedModels: async () => [],
+      supportedCommands: async () => [],
+      interrupt: async () => {
+        hoisted.onInterrupt?.();
+      },
+      setModel: async () => {},
+    });
+  },
+}));
+
+beforeEach(() => {
+  hoisted.queue.reset();
+  hoisted.onInterrupt = null;
+});
+
+const INIT = {
+  type: "system",
+  subtype: "init",
+  session_id: "00000000-1111-2222-3333-444444444444",
+  model: "claude-test-1",
+  apiKeySource: "none",
+  skills: [],
+};
+
+const RESULT_SUCCESS = { type: "result", subtype: "success" };
+
+function assistantMsg(text: string) {
+  return {
+    type: "assistant",
+    message: { role: "assistant", id: "msg-1", content: [{ type: "text", text }] },
+    uuid: "a-1",
+    session_id: INIT.session_id,
+    parent_tool_use_id: null,
+  };
+}
+
+function informational(extra: Record<string, unknown>) {
+  return {
+    type: "system",
+    subtype: "informational",
+    content: "UserPromptSubmit operation blocked by hook: memory-worker unavailable",
+    level: "warning",
+    uuid: "i-1",
+    session_id: INIT.session_id,
+    ...extra,
+  };
+}
+
+async function* channel() {
+  yield { text: "hi" };
+}
+
+/** Drive one backend session over the given script; resolve with the events. */
+async function runScript(script: unknown[]): Promise<AgentEvent[]> {
+  const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
+  const backend = new ClaudeBackend({ mcpServers: {}, systemAppend: "" });
+  for (const m of script) hoisted.queue.push(m);
+  hoisted.queue.end();
+  const events: AgentEvent[] = [];
+  for await (const ev of backend.run({ channel: channel() as never })) events.push(ev);
+  return events;
+}
+
+const resultsOf = (events: AgentEvent[]) => events.filter((e) => e.type === "result");
+const errorsOf = (events: AgentEvent[]) =>
+  events.filter((e): e is Extract<AgentEvent, { type: "error" }> => e.type === "error");
+
+describe("Claude backend #740 — blocking SDK informational messages", () => {
+  it("surfaces the hook-block reason and fails the turn (prevent_continuation)", async () => {
+    const events = await runScript([
+      INIT,
+      informational({ prevent_continuation: true }),
+      RESULT_SUCCESS,
+    ]);
+    // The user receives the block reason…
+    const errors = errorsOf(events);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("UserPromptSubmit operation blocked by hook");
+    // …exactly one terminal result is emitted, and it is a FAILED one…
+    const results = resultsOf(events);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ type: "result", ok: false, subtype: "success" });
+    // …and no successful/empty assistant turn was produced.
+    expect(events.some((e) => e.type === "assistant")).toBe(false);
+  });
+
+  it("honors the camelCase preventContinuation wire spelling too", async () => {
+    const events = await runScript([
+      INIT,
+      informational({ preventContinuation: true }),
+      RESULT_SUCCESS,
+    ]);
+    expect(errorsOf(events)).toHaveLength(1);
+    expect(resultsOf(events)).toHaveLength(1);
+    expect(resultsOf(events)[0]).toMatchObject({ ok: false });
+  });
+
+  it("a blocking turn does not leak its failure into the NEXT turn", async () => {
+    const events = await runScript([
+      INIT,
+      informational({ prevent_continuation: true }),
+      RESULT_SUCCESS,
+      assistantMsg("recovered"),
+      RESULT_SUCCESS,
+    ]);
+    const results = resultsOf(events);
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ ok: false });
+    expect(results[1]).toMatchObject({ ok: true });
+  });
+});
+
+describe("Claude backend #740 — an empty turn is never a success", () => {
+  it("a result/success with no assistant content is reported as a failure", async () => {
+    const events = await runScript([INIT, RESULT_SUCCESS]);
+    const errors = errorsOf(events);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("without producing a reply");
+    const results = resultsOf(events);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ ok: false, subtype: "success" });
+  });
+
+  it("a normal turn (assistant text + result/success) still reports success", async () => {
+    const events = await runScript([INIT, assistantMsg("Hello!"), RESULT_SUCCESS]);
+    expect(errorsOf(events)).toHaveLength(0);
+    const results = resultsOf(events);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ ok: true });
+    const said = events.filter((e) => e.type === "assistant");
+    expect(said).toHaveLength(1);
+    expect(said[0]).toMatchObject({ text: "Hello!" });
+  });
+
+  it("a non-blocking informational does not fail or replace the turn", async () => {
+    const events = await runScript([
+      INIT,
+      informational({}), // no prevent_continuation → execution continues
+      assistantMsg("still answered"),
+      RESULT_SUCCESS,
+    ]);
+    expect(errorsOf(events)).toHaveLength(0);
+    expect(resultsOf(events)).toHaveLength(1);
+    expect(resultsOf(events)[0]).toMatchObject({ ok: true });
+  });
+
+  it("slash-command output (local_command_output) counts as turn content", async () => {
+    const events = await runScript([
+      INIT,
+      {
+        type: "system",
+        subtype: "local_command_output",
+        content: "Context: 12k / 200k",
+        uuid: "l-1",
+        session_id: INIT.session_id,
+      },
+      RESULT_SUCCESS,
+    ]);
+    expect(errorsOf(events)).toHaveLength(0);
+    expect(resultsOf(events)).toHaveLength(1);
+    expect(resultsOf(events)[0]).toMatchObject({ ok: true });
+  });
+
+  it("an empty result right after interrupt() is the interrupt landing, not a failure", async () => {
+    const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
+    const backend = new ClaudeBackend({ mcpServers: {}, systemAppend: "" });
+    hoisted.onInterrupt = () => {
+      hoisted.queue.push(RESULT_SUCCESS);
+      hoisted.queue.end();
+    };
+    hoisted.queue.push(INIT);
+    const events: AgentEvent[] = [];
+    const done = (async () => {
+      for await (const ev of backend.run({ channel: channel() as never })) events.push(ev);
+    })();
+    // Wait until the session event proves run() is live (q exists), then stop.
+    await vi.waitFor(() => expect(events.some((e) => e.type === "session")).toBe(true));
+    await backend.interrupt();
+    await done;
+    expect(errorsOf(events)).toHaveLength(0);
+    const results = resultsOf(events);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ ok: true });
+  });
+});

--- a/src/__tests__/orchestrator/claude-empty-turn.test.ts
+++ b/src/__tests__/orchestrator/claude-empty-turn.test.ts
@@ -163,16 +163,33 @@ describe("Claude backend #740 — blocking SDK informational messages", () => {
   });
 
   it("a blocking turn does not leak its failure into the NEXT turn", async () => {
-    const events = await runScript([
-      INIT,
-      informational({ prevent_continuation: true }),
-      RESULT_SUCCESS,
-      assistantMsg("recovered"),
-      RESULT_SUCCESS,
-    ]);
+    // Two REAL turns (turn identity: each needs its own submission + trace).
+    let releaseTurnB!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseTurnB = resolve;
+    });
+    async function* twoTurns() {
+      yield { text: "turn A" };
+      await gate;
+      yield { text: "turn B" };
+    }
+    const { events, done } = await startBackend(twoTurns());
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    // Turn A is hook-blocked and fails…
+    hoisted.queue.push(informational({ prevent_continuation: true }));
+    hoisted.queue.push(RESULT_SUCCESS);
+    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(1));
+    expect(resultsOf(events)[0]).toMatchObject({ ok: false });
+    // …and turn B then recovers and classifies cleanly on its own flags.
+    releaseTurnB();
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
+    hoisted.queue.push(assistantMsg("recovered"));
+    hoisted.queue.push(RESULT_SUCCESS);
+    hoisted.queue.end();
+    await done;
     const results = resultsOf(events);
     expect(results).toHaveLength(2);
-    expect(results[0]).toMatchObject({ ok: false });
     expect(results[1]).toMatchObject({ ok: true });
   });
 });
@@ -355,7 +372,7 @@ describe("Claude backend — interruptPending is strictly turn-scoped (#745 revi
     expect(errors[0].message).toContain("without producing a reply");
   });
 
-  it("an interrupt's blessing does not survive a session restart, and a stray result from the dead session is inert", async () => {
+  it("an interrupt's blessing does not survive a session restart, and a stray result from the dead session fails closed", async () => {
     const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
     const backend = new ClaudeBackend({ mcpServers: {}, systemAppend: "" });
     // Session 1: turn A goes in flight and is interrupted; the session then
@@ -386,14 +403,57 @@ describe("Claude backend — interruptPending is strictly turn-scoped (#745 revi
     expect(resultsOf(events)[0]).toMatchObject({ ok: false });
     expect(errorsOf(events)).toHaveLength(1);
     // A STRAY late result from the dead session (no matching submitted turn)
-    // classifies by its subtype only — it must not fail, fail again, or consume
-    // anything belonging to session 2.
+    // must FAIL CLOSED — unverifiable, ok:false — never forwarded as a success
+    // that completes the current turn (#745 r3 review).
     hoisted.queue.push(RESULT_SUCCESS);
     hoisted.queue.end();
     await done2;
     const results = resultsOf(events);
     expect(results).toHaveLength(2);
-    expect(results[1]).toMatchObject({ ok: true });
-    expect(errorsOf(events)).toHaveLength(1); // still exactly the one from turn B
+    expect(results[1]).toMatchObject({ ok: false });
+    const errors = errorsOf(events);
+    expect(errors).toHaveLength(2); // turn B's synthetic error + the stray's unverifiable one
+    expect(errors[1].message).toMatch(/unverifiable/i);
+  });
+
+  it("a result/success with NO matching turn fails closed (unverifiable) instead of forwarding ok:true", async () => {
+    const { events, done } = await startBackend(channel());
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    // One submission, TWO results: the second has no trace. A normal successful
+    // turn ALWAYS has a trace (stamped at submission), so traceless is
+    // anomalous by construction — it must not fabricate a success (#745 r3).
+    hoisted.queue.push(RESULT_SUCCESS);
+    hoisted.queue.push(RESULT_SUCCESS);
+    hoisted.queue.end();
+    await done;
+    const results = resultsOf(events);
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ ok: false }); // genuinely empty turn
+    expect(results[1]).toMatchObject({ ok: false }); // traceless → unverifiable
+    const errors = errorsOf(events);
+    expect(errors).toHaveLength(2);
+    expect(errors[0].message).toContain("without producing a reply");
+    expect(errors[1].message).toMatch(/unverifiable/i);
+  });
+
+  it("overflow eviction poisons classification — NO result across an evicted-turn gap is fabricated as ok:true", async () => {
+    async function* seventeenTurns() {
+      for (let i = 1; i <= 17; i++) yield { text: `turn ${i}` };
+    }
+    const { events, done } = await startBackend(seventeenTurns());
+    hoisted.queue.push(INIT);
+    // The 17th submission overflows the 16-trace bound and evicts trace #1.
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(17));
+    // Every turn's result arrives late. Turn 1's result crosses the evicted
+    // gap (poisoned → unverifiable); turn 17's own result ends up traceless
+    // (fail closed). NOTHING may be forwarded as ok:true.
+    for (let i = 0; i < 17; i++) hoisted.queue.push(RESULT_SUCCESS);
+    hoisted.queue.end();
+    await done;
+    const results = resultsOf(events);
+    expect(results).toHaveLength(17);
+    expect(results.some((r) => r.type === "result" && r.ok === true)).toBe(false);
+    expect(errorsOf(events).some((e) => /unverifiable/i.test(e.message))).toBe(true);
   });
 });

--- a/src/__tests__/orchestrator/claude-empty-turn.test.ts
+++ b/src/__tests__/orchestrator/claude-empty-turn.test.ts
@@ -456,4 +456,70 @@ describe("Claude backend — interruptPending is strictly turn-scoped (#745 revi
     expect(results.some((r) => r.type === "result" && r.ok === true)).toBe(false);
     expect(errorsOf(events).some((e) => /unverifiable/i.test(e.message))).toBe(true);
   });
+
+  it("an evicted-turn gap poisons the SESSION — later results never recover ok:true, content included", async () => {
+    async function* seventeenTurns() {
+      for (let i = 1; i <= 17; i++) yield { text: `turn ${i}` };
+    }
+    const { events, done } = await startBackend(seventeenTurns());
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(17)); // 17th submission evicts trace #1
+    // Turn 1's late result crosses the evicted gap → FIFO alignment is
+    // UNRECOVERABLE → the session is poisoned terminally.
+    hoisted.queue.push(RESULT_SUCCESS);
+    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(1));
+    expect(resultsOf(events)[0]).toMatchObject({ ok: false });
+    // Content streaming in afterward accrues to a MISMATCHED trace — it is not
+    // proof of its own turn's success and must NOT rescue classification:
+    // every later result in this session fails closed too (#745 r4).
+    hoisted.queue.push(assistantMsg("late content from a mismatched turn"));
+    for (let i = 0; i < 16; i++) hoisted.queue.push(RESULT_SUCCESS);
+    hoisted.queue.end();
+    await done;
+    const results = resultsOf(events);
+    expect(results).toHaveLength(17);
+    expect(results.some((r) => r.type === "result" && r.ok === true)).toBe(false);
+    const errors = errorsOf(events);
+    expect(errors).toHaveLength(17);
+    expect(errors.every((e) => /unverifiable/i.test(e.message))).toBe(true);
+  });
+
+  it("a genuine run() restart clears the poison — the first new turn classifies normally", async () => {
+    const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
+    const backend = new ClaudeBackend({ mcpServers: {}, systemAppend: "" });
+    // Session 1: overflow the trace bound and trip the gap → poisoned.
+    async function* seventeenTurns() {
+      for (let i = 1; i <= 17; i++) yield { text: `turn ${i}` };
+    }
+    const events1: AgentEvent[] = [];
+    const done1 = (async () => {
+      for await (const ev of backend.run({ channel: seventeenTurns() as never })) events1.push(ev);
+    })();
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(17));
+    hoisted.queue.push(RESULT_SUCCESS); // crosses the evicted gap → poison
+    hoisted.queue.end();
+    await done1;
+    expect(resultsOf(events1)).toHaveLength(1);
+    expect(resultsOf(events1)[0]).toMatchObject({ ok: false });
+    // Session 2 (the self-restart loop re-calls run() on the same backend): the
+    // restart boundary is the ONLY poison reset — a normal successful turn must
+    // classify ok:true again.
+    hoisted.queue.reset();
+    hoisted.promptsSeen = 0;
+    const events: AgentEvent[] = [];
+    const done2 = (async () => {
+      for await (const ev of backend.run({ channel: channel() as never })) events.push(ev);
+    })();
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    hoisted.queue.push(assistantMsg("hello again"));
+    hoisted.queue.push(RESULT_SUCCESS);
+    hoisted.queue.end();
+    await done2;
+    const results = resultsOf(events);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ ok: true });
+    expect(errorsOf(events)).toHaveLength(0);
+  });
 });

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -243,9 +243,15 @@ export class ClaudeBackend implements AgentBackend {
   // the SDK's own result still arrives with subtype "success".
   private turnHasContent = false;
   private turnBlockReason: string | null = null;
-  // Set by interrupt(); consumed by the next result (mirrors PanelAgent's
-  // interruptRequested): an interrupted turn's empty result is the interrupt
-  // landing, not an empty-turn failure.
+  // A turn is ACTIVE from the moment its user batch is handed to the SDK (the
+  // prompt generator in run()) until its terminal result is consumed.
+  private turnActive = false;
+  // Set by interrupt() — but only while a turn is ACTIVE — and consumed by that
+  // turn's result (mirrors PanelAgent's interruptRequested): an interrupted
+  // turn's empty result is the interrupt landing, not an empty-turn failure.
+  // Strictly turn-scoped (#745 review): an idle/late interrupt() leaves NO state
+  // behind, and a newly submitted turn clears any stale mark, so neither can
+  // bless a LATER turn's genuinely-empty result/success.
   private interruptPending = false;
 
   constructor(deps: ClaudeBackendDeps) {
@@ -371,7 +377,14 @@ export class ClaudeBackend implements AgentBackend {
     // before it's read, so PanelAgent never deals in SDKUserMessage.
     async function* prompt(): AsyncGenerator<SDKUserMessage> {
       for await (const turn of opts.channel) {
-        yield await self.shapeTurn(turn);
+        const msg = await self.shapeTurn(turn);
+        // The batch is handed to the SDK: this turn is now in flight until its
+        // terminal result. A newly submitted turn also clears any stale
+        // interruptPending mark — an interrupt only ever blesses the result of
+        // the turn that was in flight when it landed (#745 review).
+        self.turnActive = true;
+        self.interruptPending = false;
+        yield msg;
       }
     }
     const q = query({ prompt: prompt(), options: this.buildOptions(opts) });
@@ -398,7 +411,9 @@ export class ClaudeBackend implements AgentBackend {
   }
 
   async interrupt(): Promise<void> {
-    this.interruptPending = true;
+    // Scope the empty-turn blessing to the turn actually in flight: an
+    // interrupt() with NO active turn leaves no state behind (#745 review).
+    if (this.turnActive) this.interruptPending = true;
     await this.q?.interrupt();
   }
 
@@ -429,10 +444,16 @@ export class ClaudeBackend implements AgentBackend {
     switch (message.type) {
       case "system":
         if (message.subtype === "init") {
-          // New session (or a restarted one): turn classification starts clean.
+          // New session (or a restarted one): STREAM-side turn classification
+          // starts clean (init is always the first in-stream message, so this
+          // can only precede the session's assistant/result messages).
+          // turnActive/interruptPending are NOT reset here: they are
+          // SUBMISSION-side state — the prompt drain can hand a turn to the SDK
+          // before this init is processed, and clearing here would unmark that
+          // genuinely in-flight turn (#745 review). A stale mark is cleared by
+          // the next prompt submission instead.
           this.turnHasContent = false;
           this.turnBlockReason = null;
-          this.interruptPending = false;
           yield {
             type: "session",
             sessionId: message.session_id,
@@ -568,6 +589,7 @@ export class ClaudeBackend implements AgentBackend {
         const wasInterrupted = this.interruptPending;
         this.turnHasContent = false;
         this.turnBlockReason = null;
+        this.turnActive = false;
         this.interruptPending = false;
         let ok = message.subtype === "success";
         if (ok && blockReason !== null) {

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -236,23 +236,28 @@ export class ClaudeBackend implements AgentBackend {
   readonly capabilities = CLAUDE_CAPABILITIES;
   private deps: ClaudeBackendDeps;
   private q: Query | null = null;
-  // #740 turn-truthfulness state (reset on init and after every result): a turn
-  // that produced NO user-visible content must never be reported as a successful
-  // turn, and a blocking SDK informational message (prevent_continuation — e.g. a
-  // UserPromptSubmit hook denied the prompt) makes the turn a failure even when
-  // the SDK's own result still arrives with subtype "success".
-  private turnHasContent = false;
-  private turnBlockReason: string | null = null;
-  // A turn is ACTIVE from the moment its user batch is handed to the SDK (the
-  // prompt generator in run()) until its terminal result is consumed.
-  private turnActive = false;
-  // Set by interrupt() — but only while a turn is ACTIVE — and consumed by that
-  // turn's result (mirrors PanelAgent's interruptRequested): an interrupted
-  // turn's empty result is the interrupt landing, not an empty-turn failure.
-  // Strictly turn-scoped (#745 review): an idle/late interrupt() leaves NO state
-  // behind, and a newly submitted turn clears any stale mark, so neither can
-  // bless a LATER turn's genuinely-empty result/success.
-  private interruptPending = false;
+  // #740 turn-truthfulness, with TURN IDENTITY (#745 r2 review): every submitted
+  // turn gets a trace; stream messages accrue to the LATEST trace, and each
+  // terminal result is classified against the trace it belongs to (results
+  // arrive in submission order, possibly with a turn's result missing or LATE —
+  // the panel's no-result fallback releases the next turn and tolerates the
+  // late result, panel-agent.ts:671 — so the backend must too). A late result
+  // from a superseded turn therefore classifies by ITS OWN flags and never
+  // resets or consumes the in-flight turn's state. A turn that produced NO
+  // user-visible content is never a successful turn, and a blocking SDK
+  // informational message (prevent_continuation — e.g. a UserPromptSubmit hook
+  // denied the prompt) fails its turn even when the SDK's own result still
+  // arrives with subtype "success". `interrupted` mirrors PanelAgent's
+  // interruptRequested: an interrupted turn's empty result is the interrupt
+  // landing, not an empty-turn failure — and only the turn that was in flight
+  // when interrupt() landed may be marked.
+  private turnSeq = 0;
+  private turns: Array<{
+    id: number;
+    hasContent: boolean;
+    blockReason: string | null;
+    interrupted: boolean;
+  }> = [];
 
   constructor(deps: ClaudeBackendDeps) {
     this.deps = deps;
@@ -373,17 +378,27 @@ export class ClaudeBackend implements AgentBackend {
   async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
     const query = await loadQuery();
     const self = this;
+    // A (re)started session can never produce results for turns submitted to a
+    // PREVIOUS session — drop those dead traces. Done here, at run() entry
+    // (BEFORE the new query exists), rather than on system/init: the SDK's
+    // prompt drain legitimately pulls the first batch before init is processed,
+    // and an init-time clear would unmark that genuinely in-flight turn (#745).
+    this.turns.length = 0;
     // Wrap the neutral channel: shape each turn into the SDK's native form right
     // before it's read, so PanelAgent never deals in SDKUserMessage.
     async function* prompt(): AsyncGenerator<SDKUserMessage> {
       for await (const turn of opts.channel) {
         const msg = await self.shapeTurn(turn);
-        // The batch is handed to the SDK: this turn is now in flight until its
-        // terminal result. A newly submitted turn also clears any stale
-        // interruptPending mark — an interrupt only ever blesses the result of
-        // the turn that was in flight when it landed (#745 review).
-        self.turnActive = true;
-        self.interruptPending = false;
+        // The batch is handed to the SDK: stamp the turn's identity. Its trace
+        // accrues this turn's content/block/interrupt flags until its terminal
+        // result pops it (FIFO) for classification. Bounded: wedged turns whose
+        // result never arrives would otherwise grow the queue without limit —
+        // past the cap the oldest (long-superseded) trace is dropped.
+        self.turns.push({ id: ++self.turnSeq, hasContent: false, blockReason: null, interrupted: false });
+        if (self.turns.length > 16) {
+          self.turns.shift();
+          logger.warn("[claude-backend] over 16 unresolved turns — dropped the oldest turn trace (#740)");
+        }
         yield msg;
       }
     }
@@ -411,9 +426,12 @@ export class ClaudeBackend implements AgentBackend {
   }
 
   async interrupt(): Promise<void> {
-    // Scope the empty-turn blessing to the turn actually in flight: an
-    // interrupt() with NO active turn leaves no state behind (#745 review).
-    if (this.turnActive) this.interruptPending = true;
+    // Scope the empty-turn blessing to the turn actually in flight (the latest
+    // unresolved submission): an interrupt() with NO turn in flight leaves no
+    // state behind, and a superseded turn's trace keeps whatever mark IT earned
+    // (#745 review).
+    const active = this.turns[this.turns.length - 1];
+    if (active) active.interrupted = true;
     await this.q?.interrupt();
   }
 
@@ -444,16 +462,11 @@ export class ClaudeBackend implements AgentBackend {
     switch (message.type) {
       case "system":
         if (message.subtype === "init") {
-          // New session (or a restarted one): STREAM-side turn classification
-          // starts clean (init is always the first in-stream message, so this
-          // can only precede the session's assistant/result messages).
-          // turnActive/interruptPending are NOT reset here: they are
-          // SUBMISSION-side state — the prompt drain can hand a turn to the SDK
-          // before this init is processed, and clearing here would unmark that
-          // genuinely in-flight turn (#745 review). A stale mark is cleared by
-          // the next prompt submission instead.
-          this.turnHasContent = false;
-          this.turnBlockReason = null;
+          // New session (or a restarted one). No turn state is reset here: all
+          // of it is per-turn (the `turns` FIFO), and dead traces from a
+          // previous session are dropped at run() entry — an init-time clear
+          // could unmark a turn the prompt drain already handed to the SDK
+          // before this init was processed (#745 review).
           yield {
             type: "session",
             sessionId: message.session_id,
@@ -475,16 +488,19 @@ export class ClaudeBackend implements AgentBackend {
           // turn logic depends on. A BLOCKING one (prevent_continuation, e.g. a
           // UserPromptSubmit hook denied the prompt) means execution stops here,
           // yet the SDK still ends the turn with a result whose subtype is
-          // "success". Remember the reason so that result is classified as the
-          // failure it actually is, and surface the reason now so the user never
-          // watches a turn silently produce nothing.
+          // "success". Record the reason on the CURRENT turn's trace so that
+          // turn's result is classified as the failure it actually is, and
+          // surface the reason now so the user never watches a turn silently
+          // produce nothing.
           const prevent =
             message.prevent_continuation === true ||
             (message as unknown as { preventContinuation?: unknown }).preventContinuation === true;
           const content = typeof message.content === "string" ? message.content.trim() : "";
           if (prevent) {
-            this.turnBlockReason = content || "blocked by a hook";
-            logger.warn(`[claude-backend] turn blocked: ${this.turnBlockReason}`);
+            const reason = content || "blocked by a hook";
+            const turn = this.turns[this.turns.length - 1];
+            if (turn) turn.blockReason = reason;
+            logger.warn(`[claude-backend] turn blocked: ${reason}`);
             yield {
               type: "error",
               message: content || "The turn was blocked before it could produce a reply.",
@@ -499,7 +515,8 @@ export class ClaudeBackend implements AgentBackend {
           // payload, so the turn counts as having content and is not
           // misclassified as an empty one. (The panel doesn't render these
           // banners today — unchanged.)
-          this.turnHasContent = true;
+          const turn = this.turns[this.turns.length - 1];
+          if (turn) turn.hasContent = true;
         }
         break;
       case "stream_event": {
@@ -526,9 +543,12 @@ export class ClaudeBackend implements AgentBackend {
         break;
       }
       case "assistant": {
-        // An assistant message means the model actually responded this turn —
-        // the turn counts as having content (#740).
-        this.turnHasContent = true;
+        // An assistant message means the model actually responded — the CURRENT
+        // (latest submitted, still unresolved) turn counts as having content
+        // (#740). In-stream messages always belong to the newest in-flight turn:
+        // a superseded turn's output ends with its own result, which pops it.
+        const turn = this.turns[this.turns.length - 1];
+        if (turn) turn.hasContent = true;
         // Remember this message's UUID — it's the rewind anchor for the turn.
         const auid = (message as unknown as { uuid?: string }).uuid;
         // Each assistant API response carries the CURRENT context size — report
@@ -579,23 +599,28 @@ export class ClaudeBackend implements AgentBackend {
             contextWindow = mu.contextWindow;
           }
         }
-        // #740: classify the result truthfully. The SDK reports subtype "success"
-        // even for a turn a blocking hook prevented from producing ANY output (the
-        // informational above), and for a turn that simply ended with no assistant
-        // message — the panel must never present either as a silent empty success.
-        // One result consumes the per-turn state; the next turn starts clean.
-        const blockReason = this.turnBlockReason;
-        const empty = !this.turnHasContent;
-        const wasInterrupted = this.interruptPending;
-        this.turnHasContent = false;
-        this.turnBlockReason = null;
-        this.turnActive = false;
-        this.interruptPending = false;
+        // #740: classify the result truthfully, against the trace of the turn it
+        // BELONGS to (#745 r2). Results arrive in submission order, so the oldest
+        // unresolved trace is this result's turn — even when the result is LATE
+        // (an earlier turn was interrupted, produced nothing, and the panel's
+        // fallback already released the next turn; panel-agent.ts:671 tolerates
+        // that late result, and so does this FIFO: popping the old trace leaves
+        // the in-flight turn's state untouched). The SDK reports subtype
+        // "success" even for a turn a blocking hook prevented from producing ANY
+        // output, and for a turn that simply ended with no assistant message —
+        // the panel must never present either as a silent empty success.
+        const trace = this.turns.shift() ?? null;
+        if (!trace) {
+          // A result with no matching submission (e.g. a stray from a session
+          // that was restarted at run() entry): provenance unknown — pass it
+          // through by subtype rather than fabricating either outcome.
+          logger.warn("[claude-backend] result with no matching submitted turn — classifying by subtype only (#740)");
+        }
         let ok = message.subtype === "success";
-        if (ok && blockReason !== null) {
+        if (ok && trace?.blockReason != null) {
           // The blocking informational already yielded the visible error above.
           ok = false;
-        } else if (ok && empty && !wasInterrupted) {
+        } else if (ok && trace && !trace.hasContent && !trace.interrupted) {
           ok = false;
           logger.warn("[claude-backend] result/success with no assistant content — reporting a failed turn (#740)");
           yield {

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -227,6 +227,12 @@ export interface ClaudeBackendDeps {
   pluginPath?: string;
 }
 
+/** Bound on unresolved turn traces (wedged turns whose result never arrives).
+ *  Overflow evicts the oldest trace — and POISONS classification rather than
+ *  silently realigning it: the pop that crosses the evicted gap (and any
+ *  traceless result) fails closed as unverifiable, never ok:true (#745 r3). */
+const MAX_UNRESOLVED_TURNS = 16;
+
 /**
  * The Claude Agent SDK adapter. One instance per PanelAgent; it holds the live
  * `Query` for the current session and re-creates it on each `run()`.
@@ -251,7 +257,14 @@ export class ClaudeBackend implements AgentBackend {
   // interruptRequested: an interrupted turn's empty result is the interrupt
   // landing, not an empty-turn failure — and only the turn that was in flight
   // when interrupt() landed may be marked.
+  //
+  // FAIL CLOSED (#745 r3 review): classification must never produce ok:true
+  // without positive evidence. A normal successful turn ALWAYS has a trace, so
+  // a result whose trace is missing (stray from a dead session, or pushed off
+  // by the MAX_UNRESOLVED_TURNS bound) or whose id crosses an evicted-turn gap
+  // is UNVERIFIABLE → ok:false, never a forwarded success.
   private turnSeq = 0;
+  private lastResultTurnId = 0;
   private turns: Array<{
     id: number;
     hasContent: boolean;
@@ -379,11 +392,16 @@ export class ClaudeBackend implements AgentBackend {
     const query = await loadQuery();
     const self = this;
     // A (re)started session can never produce results for turns submitted to a
-    // PREVIOUS session — drop those dead traces. Done here, at run() entry
-    // (BEFORE the new query exists), rather than on system/init: the SDK's
-    // prompt drain legitimately pulls the first batch before init is processed,
-    // and an init-time clear would unmark that genuinely in-flight turn (#745).
+    // PREVIOUS session — drop those dead traces, advancing the result sequence
+    // past them so the new session's first result isn't falsely gap-poisoned
+    // (their stray late results then arrive TRACELESS and fail closed instead).
+    // Done here, at run() entry (BEFORE the new query exists), rather than on
+    // system/init: the SDK's prompt drain legitimately pulls the first batch
+    // before init is processed, and an init-time clear would unmark that
+    // genuinely in-flight turn (#745).
+    const deadThrough = this.turns[this.turns.length - 1]?.id;
     this.turns.length = 0;
+    if (deadThrough !== undefined) this.lastResultTurnId = deadThrough;
     // Wrap the neutral channel: shape each turn into the SDK's native form right
     // before it's read, so PanelAgent never deals in SDKUserMessage.
     async function* prompt(): AsyncGenerator<SDKUserMessage> {
@@ -392,12 +410,16 @@ export class ClaudeBackend implements AgentBackend {
         // The batch is handed to the SDK: stamp the turn's identity. Its trace
         // accrues this turn's content/block/interrupt flags until its terminal
         // result pops it (FIFO) for classification. Bounded: wedged turns whose
-        // result never arrives would otherwise grow the queue without limit —
-        // past the cap the oldest (long-superseded) trace is dropped.
+        // result never arrives would otherwise grow the queue without limit.
+        // Eviction is recorded via the id sequence — the pop that crosses the
+        // evicted gap fails closed as unverifiable (#745 r3), it does NOT
+        // silently realign classification onto the wrong turn.
         self.turns.push({ id: ++self.turnSeq, hasContent: false, blockReason: null, interrupted: false });
-        if (self.turns.length > 16) {
-          self.turns.shift();
-          logger.warn("[claude-backend] over 16 unresolved turns — dropped the oldest turn trace (#740)");
+        if (self.turns.length > MAX_UNRESOLVED_TURNS) {
+          const evicted = self.turns.shift();
+          logger.warn(
+            `[claude-backend] over ${MAX_UNRESOLVED_TURNS} unresolved turns — evicted turn ${evicted?.id}'s trace; its result will fail closed as unverifiable (#740)`,
+          );
         }
         yield msg;
       }
@@ -609,18 +631,37 @@ export class ClaudeBackend implements AgentBackend {
         // "success" even for a turn a blocking hook prevented from producing ANY
         // output, and for a turn that simply ended with no assistant message —
         // the panel must never present either as a silent empty success.
+        //
+        // FAIL CLOSED (#745 r3): ok:true requires positive evidence. A normal
+        // successful turn ALWAYS has a trace (stamped at submission), so a
+        // result that is TRACELESS (stray from a dead session, or pushed off by
+        // the MAX_UNRESOLVED_TURNS bound) or whose id crosses an EVICTED-turn
+        // gap is anomalous by construction — unverifiable, never a forwarded
+        // success. (The panel consumes every result as completion/done, so a
+        // pass-through would NOT be inert.)
         const trace = this.turns.shift() ?? null;
+        let unverifiable: string | null = null;
         if (!trace) {
-          // A result with no matching submission (e.g. a stray from a session
-          // that was restarted at run() entry): provenance unknown — pass it
-          // through by subtype rather than fabricating either outcome.
-          logger.warn("[claude-backend] result with no matching submitted turn — classifying by subtype only (#740)");
+          unverifiable = "The result could not be matched to any submitted turn";
+          logger.warn(`[claude-backend] ${unverifiable} — unverifiable, failing closed (#740)`);
+        } else if (trace.id !== this.lastResultTurnId + 1) {
+          unverifiable = "Turn bookkeeping overflowed, so the result cannot be matched to its turn";
+          logger.warn(
+            `[claude-backend] result crosses an evicted-turn gap (popped turn ${trace.id}, expected ${this.lastResultTurnId + 1}) — unverifiable, failing closed (#740)`,
+          );
         }
+        if (trace) this.lastResultTurnId = trace.id;
         let ok = message.subtype === "success";
-        if (ok && trace?.blockReason != null) {
+        if (ok && unverifiable !== null) {
+          ok = false;
+          yield {
+            type: "error",
+            message: `${unverifiable} — reporting the turn as unverifiable rather than a success.`,
+          };
+        } else if (ok && trace !== null && trace.blockReason !== null) {
           // The blocking informational already yielded the visible error above.
           ok = false;
-        } else if (ok && trace && !trace.hasContent && !trace.interrupted) {
+        } else if (ok && trace !== null && !trace.hasContent && !trace.interrupted) {
           ok = false;
           logger.warn("[claude-backend] result/success with no assistant content — reporting a failed turn (#740)");
           yield {

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -397,17 +397,19 @@ export class ClaudeBackend implements AgentBackend {
     const query = await loadQuery();
     const self = this;
     // A (re)started session can never produce results for turns submitted to a
-    // PREVIOUS session — drop those dead traces, advancing the result sequence
-    // past them so the new session's first result isn't falsely gap-poisoned
-    // (their stray late results then arrive TRACELESS and fail closed instead).
-    // This genuine restart boundary is also the ONLY reset of the sticky
-    // classification poison (#745 r4). Done here, at run() entry (BEFORE the
-    // new query exists), rather than on system/init: the SDK's prompt drain
+    // PREVIOUS session — drop any dead traces and advance the result sequence
+    // past EVERY turn stamped so far (turnSeq), whether or not traces remain:
+    // in a FULLY DRAINED (e.g. poisoned) session the FIFO is already empty, but
+    // the sequence must still move past the old ids or the new session's first
+    // result re-crosses the old gap and falsely re-poisons (#745 r5). Stray
+    // late results from the dead session then arrive TRACELESS and fail closed
+    // instead. This genuine restart boundary is also the ONLY reset of the
+    // sticky classification poison (#745 r4). Done here, at run() entry (BEFORE
+    // the new query exists), rather than on system/init: the SDK's prompt drain
     // legitimately pulls the first batch before init is processed, and an
     // init-time clear would unmark that genuinely in-flight turn (#745).
-    const deadThrough = this.turns[this.turns.length - 1]?.id;
     this.turns.length = 0;
-    if (deadThrough !== undefined) this.lastResultTurnId = deadThrough;
+    this.lastResultTurnId = this.turnSeq;
     this.classificationPoisoned = false;
     // Wrap the neutral channel: shape each turn into the SDK's native form right
     // before it's read, so PanelAgent never deals in SDKUserMessage.

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -258,13 +258,18 @@ export class ClaudeBackend implements AgentBackend {
   // landing, not an empty-turn failure — and only the turn that was in flight
   // when interrupt() landed may be marked.
   //
-  // FAIL CLOSED (#745 r3 review): classification must never produce ok:true
+  // FAIL CLOSED (#745 r3/r4 review): classification must never produce ok:true
   // without positive evidence. A normal successful turn ALWAYS has a trace, so
   // a result whose trace is missing (stray from a dead session, or pushed off
   // by the MAX_UNRESOLVED_TURNS bound) or whose id crosses an evicted-turn gap
-  // is UNVERIFIABLE → ok:false, never a forwarded success.
+  // is UNVERIFIABLE → ok:false, never a forwarded success. The gap case is
+  // additionally STICKY: once a pop crosses an evicted-turn gap the FIFO
+  // alignment is unrecoverable (content accrued to a mismatched trace is not
+  // proof of ITS turn's success), so `classificationPoisoned` fails every later
+  // result in the session closed — cleared only by a genuine run() restart.
   private turnSeq = 0;
   private lastResultTurnId = 0;
+  private classificationPoisoned = false;
   private turns: Array<{
     id: number;
     hasContent: boolean;
@@ -395,13 +400,15 @@ export class ClaudeBackend implements AgentBackend {
     // PREVIOUS session — drop those dead traces, advancing the result sequence
     // past them so the new session's first result isn't falsely gap-poisoned
     // (their stray late results then arrive TRACELESS and fail closed instead).
-    // Done here, at run() entry (BEFORE the new query exists), rather than on
-    // system/init: the SDK's prompt drain legitimately pulls the first batch
-    // before init is processed, and an init-time clear would unmark that
-    // genuinely in-flight turn (#745).
+    // This genuine restart boundary is also the ONLY reset of the sticky
+    // classification poison (#745 r4). Done here, at run() entry (BEFORE the
+    // new query exists), rather than on system/init: the SDK's prompt drain
+    // legitimately pulls the first batch before init is processed, and an
+    // init-time clear would unmark that genuinely in-flight turn (#745).
     const deadThrough = this.turns[this.turns.length - 1]?.id;
     this.turns.length = 0;
     if (deadThrough !== undefined) this.lastResultTurnId = deadThrough;
+    this.classificationPoisoned = false;
     // Wrap the neutral channel: shape each turn into the SDK's native form right
     // before it's read, so PanelAgent never deals in SDKUserMessage.
     async function* prompt(): AsyncGenerator<SDKUserMessage> {
@@ -632,25 +639,35 @@ export class ClaudeBackend implements AgentBackend {
         // output, and for a turn that simply ended with no assistant message —
         // the panel must never present either as a silent empty success.
         //
-        // FAIL CLOSED (#745 r3): ok:true requires positive evidence. A normal
+        // FAIL CLOSED (#745 r3/r4): ok:true requires positive evidence. A normal
         // successful turn ALWAYS has a trace (stamped at submission), so a
         // result that is TRACELESS (stray from a dead session, or pushed off by
         // the MAX_UNRESOLVED_TURNS bound) or whose id crosses an EVICTED-turn
         // gap is anomalous by construction — unverifiable, never a forwarded
         // success. (The panel consumes every result as completion/done, so a
-        // pass-through would NOT be inert.)
+        // pass-through would NOT be inert.) The gap case is STICKY: alignment
+        // is unrecoverable once crossed, so the poison is terminal for the
+        // session — content evidence must not rescue it (it accrued to a
+        // mismatched trace, which is not proof of ITS turn's success).
         const trace = this.turns.shift() ?? null;
         let unverifiable: string | null = null;
-        if (!trace) {
+        if (this.classificationPoisoned) {
+          unverifiable = "Turn bookkeeping was poisoned by an earlier overflow — no result in this session can be verified";
+        } else if (!trace) {
           unverifiable = "The result could not be matched to any submitted turn";
           logger.warn(`[claude-backend] ${unverifiable} — unverifiable, failing closed (#740)`);
         } else if (trace.id !== this.lastResultTurnId + 1) {
+          // The pop crossed an evicted-turn gap → poison the session (do NOT
+          // advance lastResultTurnId to the wrong trace's id — alignment is
+          // unrecoverable, so resyncing would just hide the next mismatch).
+          this.classificationPoisoned = true;
           unverifiable = "Turn bookkeeping overflowed, so the result cannot be matched to its turn";
           logger.warn(
-            `[claude-backend] result crosses an evicted-turn gap (popped turn ${trace.id}, expected ${this.lastResultTurnId + 1}) — unverifiable, failing closed (#740)`,
+            `[claude-backend] result crosses an evicted-turn gap (popped turn ${trace.id}, expected ${this.lastResultTurnId + 1}) — unverifiable; classification poisoned for the rest of the session (#740)`,
           );
+        } else {
+          this.lastResultTurnId = trace.id;
         }
-        if (trace) this.lastResultTurnId = trace.id;
         let ok = message.subtype === "success";
         if (ok && unverifiable !== null) {
           ok = false;

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -236,6 +236,17 @@ export class ClaudeBackend implements AgentBackend {
   readonly capabilities = CLAUDE_CAPABILITIES;
   private deps: ClaudeBackendDeps;
   private q: Query | null = null;
+  // #740 turn-truthfulness state (reset on init and after every result): a turn
+  // that produced NO user-visible content must never be reported as a successful
+  // turn, and a blocking SDK informational message (prevent_continuation — e.g. a
+  // UserPromptSubmit hook denied the prompt) makes the turn a failure even when
+  // the SDK's own result still arrives with subtype "success".
+  private turnHasContent = false;
+  private turnBlockReason: string | null = null;
+  // Set by interrupt(); consumed by the next result (mirrors PanelAgent's
+  // interruptRequested): an interrupted turn's empty result is the interrupt
+  // landing, not an empty-turn failure.
+  private interruptPending = false;
 
   constructor(deps: ClaudeBackendDeps) {
     this.deps = deps;
@@ -387,6 +398,7 @@ export class ClaudeBackend implements AgentBackend {
   }
 
   async interrupt(): Promise<void> {
+    this.interruptPending = true;
     await this.q?.interrupt();
   }
 
@@ -417,6 +429,10 @@ export class ClaudeBackend implements AgentBackend {
     switch (message.type) {
       case "system":
         if (message.subtype === "init") {
+          // New session (or a restarted one): turn classification starts clean.
+          this.turnHasContent = false;
+          this.turnBlockReason = null;
+          this.interruptPending = false;
           yield {
             type: "session",
             sessionId: message.session_id,
@@ -432,6 +448,37 @@ export class ClaudeBackend implements AgentBackend {
           if (typeof t === "number") {
             yield { type: "thinking", tokens: t };
           }
+        } else if (message.subtype === "informational") {
+          // #740: SDK informational banners are host-rendered plaintext (hook
+          // feedback, status lines, slash-command notices) — never drop one the
+          // turn logic depends on. A BLOCKING one (prevent_continuation, e.g. a
+          // UserPromptSubmit hook denied the prompt) means execution stops here,
+          // yet the SDK still ends the turn with a result whose subtype is
+          // "success". Remember the reason so that result is classified as the
+          // failure it actually is, and surface the reason now so the user never
+          // watches a turn silently produce nothing.
+          const prevent =
+            message.prevent_continuation === true ||
+            (message as unknown as { preventContinuation?: unknown }).preventContinuation === true;
+          const content = typeof message.content === "string" ? message.content.trim() : "";
+          if (prevent) {
+            this.turnBlockReason = content || "blocked by a hook";
+            logger.warn(`[claude-backend] turn blocked: ${this.turnBlockReason}`);
+            yield {
+              type: "error",
+              message: content || "The turn was blocked before it could produce a reply.",
+            };
+          } else if (content) {
+            // Non-blocking notices don't affect turn classification — the panel
+            // doesn't render them, but keep them visible in the log.
+            logger.info(`[claude-backend] informational (${message.level ?? "info"}): ${content}`);
+          }
+        } else if (message.subtype === "local_command_output") {
+          // Slash-command output (/usage, /voice, …) IS the turn's visible
+          // payload, so the turn counts as having content and is not
+          // misclassified as an empty one. (The panel doesn't render these
+          // banners today — unchanged.)
+          this.turnHasContent = true;
         }
         break;
       case "stream_event": {
@@ -458,6 +505,9 @@ export class ClaudeBackend implements AgentBackend {
         break;
       }
       case "assistant": {
+        // An assistant message means the model actually responded this turn —
+        // the turn counts as having content (#740).
+        this.turnHasContent = true;
         // Remember this message's UUID — it's the rewind anchor for the turn.
         const auid = (message as unknown as { uuid?: string }).uuid;
         // Each assistant API response carries the CURRENT context size — report
@@ -508,9 +558,32 @@ export class ClaudeBackend implements AgentBackend {
             contextWindow = mu.contextWindow;
           }
         }
+        // #740: classify the result truthfully. The SDK reports subtype "success"
+        // even for a turn a blocking hook prevented from producing ANY output (the
+        // informational above), and for a turn that simply ended with no assistant
+        // message — the panel must never present either as a silent empty success.
+        // One result consumes the per-turn state; the next turn starts clean.
+        const blockReason = this.turnBlockReason;
+        const empty = !this.turnHasContent;
+        const wasInterrupted = this.interruptPending;
+        this.turnHasContent = false;
+        this.turnBlockReason = null;
+        this.interruptPending = false;
+        let ok = message.subtype === "success";
+        if (ok && blockReason !== null) {
+          // The blocking informational already yielded the visible error above.
+          ok = false;
+        } else if (ok && empty && !wasInterrupted) {
+          ok = false;
+          logger.warn("[claude-backend] result/success with no assistant content — reporting a failed turn (#740)");
+          yield {
+            type: "error",
+            message: "The model ended the turn without producing a reply.",
+          };
+        }
         yield {
           type: "result",
-          ok: message.subtype === "success",
+          ok,
           subtype: message.subtype,
           ...(contextWindow !== undefined ? { contextWindow } : {}),
           ...(typeof m.total_cost_usd === "number" ? { costUsd: m.total_cost_usd } : {}),


### PR DESCRIPTION
## Summary

Fixes #740.

When a `UserPromptSubmit` hook blocks a prompt, the Claude Agent SDK emits a `system/informational` message with the block reason and `prevent_continuation: true`, produces no assistant message, and still ends the turn with a `result` whose subtype is `success`. The panel showed a silent empty "success" — Claude appeared to start generating and then just stopped.

## Root cause

`ClaudeBackend.route()` only handled `system/init` and `system/thinking_tokens`; every other system message — including `system/informational` — was discarded. The terminal `result` was then classified solely as `ok: message.subtype === "success"`, so a blocked/empty turn was reported to the panel as a successful one.

## Fix (`src/orchestrator/claude-backend.ts` only)

- **`system/informational` is no longer dropped.** A blocking one (`prevent_continuation`, plus the camelCase `preventContinuation` wire spelling seen in the wild) records the block reason for the turn and immediately yields an `error` AgentEvent with the hook's content, so the user sees the block reason in the panel. Non-blocking informational notices don't affect turn classification (logged instead of silently discarded).
- **Turn-content tracking.** Any `assistant` message, and slash-command `system/local_command_output` (which IS that turn's visible payload, e.g. `/usage`), mark the turn as having content.
- **Truthful result classification.** A `result/success` is forced to `ok: false` when (a) the turn was blocked by an informational message, or (b) the turn produced no assistant content at all — case (b) also yields a synthetic `error` event ("The model ended the turn without producing a reply.") so the turn never ends in silence. Per-turn state resets on `init` and after every result, and an `interruptPending` flag (set by `interrupt()`, mirroring PanelAgent's `interruptRequested`) keeps a user-initiated Stop from being misreported as an empty-turn failure.

No other provider backend shares the classification line (`ok: message.subtype === "success"` exists only here), so no other backend was touched.

## Tests

New `src/__tests__/orchestrator/claude-empty-turn.test.ts` (8 tests, SDK mocked per the existing `claude-spawn-env.test.ts` pattern):

- Blocking informational (`prevent_continuation` and camelCase `preventContinuation`): the block reason is surfaced via exactly one `error` event, exactly one terminal `result` is emitted with `ok: false`, and no assistant/success event exists.
- Blocked-turn state does not leak into the next turn (subsequent good turn reports `ok: true`).
- `result/success` with no assistant content → `ok: false` + visible error.
- Regression guards: a normal turn still reports success; a non-blocking informational does not fail the turn; `local_command_output` counts as content; an empty result right after `interrupt()` stays a clean `ok: true`.

## Verification

- `npx tsc --noEmit` — clean.
- `npx vitest run src/__tests__/orchestrator/claude-empty-turn.test.ts src/__tests__/orchestrator/claude-spawn-env.test.ts` — 11 passed.
- Full `npx vitest run` — **233 files, 3902 passed / 2 skipped** (baseline 3894 passed / 2 skipped + 8 new).
