### PR TITLE
fix(#728): stall watchdog reports once and holds the turn gate

### DIFF
--- a/src/__tests__/orchestrator/antigravity-backend.test.ts
+++ b/src/__tests__/orchestrator/antigravity-backend.test.ts
@@ -422,8 +422,8 @@ describe("AntigravityBackend turns", () => {
       "Second answer",
     ]);
     expect(events.filter((e) => e.type === "result")).toEqual([
-      { type: "result", ok: true, subtype: "end_turn" },
-      { type: "result", ok: true, subtype: "end_turn" },
+      { type: "result", ok: true, subtype: "end_turn", turn: 1 },
+      { type: "result", ok: true, subtype: "end_turn", turn: 2 },
     ]);
 
     // Turn 1: fresh (-p, no -c), persona prepended, model + skip-permissions set.
@@ -491,7 +491,7 @@ describe("AntigravityBackend turns", () => {
     expect(err.message).toContain("code 7");
     expect(err.message).toContain("quota exceeded");
     expect(events.filter((e) => e.type === "result")).toEqual([
-      { type: "result", ok: false, subtype: "error" },
+      { type: "result", ok: false, subtype: "error", turn: 1 },
     ]);
   });
 
@@ -517,7 +517,7 @@ describe("AntigravityBackend turns", () => {
     await drain;
     expect(hoisted.killed).toContain(hoisted.procs[0]!.pid);
     expect(events.filter((e) => e.type === "result")).toEqual([
-      { type: "result", ok: false, subtype: "cancelled" },
+      { type: "result", ok: false, subtype: "cancelled", turn: 1 },
     ]);
   });
 
@@ -543,7 +543,7 @@ describe("AntigravityBackend turns", () => {
     await drain;
 
     expect(events.filter((e) => e.type === "result")).toEqual([
-      { type: "result", ok: false, subtype: "cancelled" },
+      { type: "result", ok: false, subtype: "cancelled", turn: 1 },
     ]);
     // and the child must not be left running
     if (hoisted.procs[0]) expect(hoisted.killed).toContain(hoisted.procs[0]!.pid);
@@ -556,7 +556,7 @@ describe("AntigravityBackend turns", () => {
     await new Promise((r) => setTimeout(r, 650)); // let it expire (no turn started)
     const events = await collect(backend.run({ channel: channelOf([{ text: "hi" }]) }));
     expect(events.filter((e) => e.type === "result")).toEqual([
-      { type: "result", ok: true, subtype: "end_turn" },
+      { type: "result", ok: true, subtype: "end_turn", turn: 1 },
     ]);
     expect(hoisted.killed).toEqual([]);
   });
@@ -571,7 +571,7 @@ describe("AntigravityBackend turns", () => {
     const err = events.find((e) => e.type === "error") as { message: string };
     expect(err.message).toMatch(/too large/i);
     expect(events.filter((e) => e.type === "result")).toEqual([
-      { type: "result", ok: false, subtype: "error" },
+      { type: "result", ok: false, subtype: "error", turn: 1 },
     ]);
   });
 

--- a/src/__tests__/orchestrator/claude-empty-turn.test.ts
+++ b/src/__tests__/orchestrator/claude-empty-turn.test.ts
@@ -78,9 +78,10 @@ const INIT = {
 
 const RESULT_SUCCESS = { type: "result", subtype: "success" };
 
-/** The interrupt landing (#728 r5 contract: an interrupted turn ends with an
- *  INTERRUPTED-subtype result). */
-const RESULT_INTERRUPTED = { type: "result", subtype: "interrupted" };
+/** The interrupt landing in the SDK's REAL result vocabulary (#728 r9: an
+ *  interrupted turn ends with an error_during_execution result — there is no
+ *  "interrupted" result subtype). */
+const RESULT_INTERRUPTED = { type: "result", subtype: "error_during_execution" };
 
 function assistantMsg(text: string) {
   return {
@@ -357,11 +358,10 @@ describe("Claude backend — interruptPending is strictly turn-scoped (#745 revi
     releaseTurnB();
     await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
     // NOW turn A's late empty result arrives: it is the interrupt landing for
-    // A — subtype "interrupted" per the SDK contract (#728 r5: an interrupted
-    // turn ends with an INTERRUPTED-subtype result; a success-subtype result
-    // with a newer trace pending would instead correlate to the NEWER turn) →
-    // ok:true, NO synthetic failure attributed to the turn in flight, and turn
-    // B's state untouched.
+    // A — error_during_execution per the SDK's real result vocabulary (#728 r9;
+    // a success-subtype result with a newer trace pending would instead
+    // correlate to the NEWER turn) → ok:true, NO synthetic failure attributed
+    // to the turn in flight, and turn B's state untouched.
     hoisted.queue.push(RESULT_INTERRUPTED);
     await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(1));
     expect(resultsOf(events)[0]).toMatchObject({ ok: true });

--- a/src/__tests__/orchestrator/claude-empty-turn.test.ts
+++ b/src/__tests__/orchestrator/claude-empty-turn.test.ts
@@ -338,7 +338,7 @@ describe("Claude backend — interruptPending is strictly turn-scoped (#745 revi
     expect(errors[0].message).toContain("without producing a reply");
   });
 
-  it("a LATE result from an interrupted turn classifies by its OWN flags and leaves the next turn untouched", async () => {
+  it("a superseded interrupted turn never delivers — the first result classifies to the NEWER turn (#728 r10)", async () => {
     let releaseTurnB!: () => void;
     const gate = new Promise<void>((resolve) => {
       releaseTurnB = resolve;
@@ -352,31 +352,28 @@ describe("Claude backend — interruptPending is strictly turn-scoped (#745 revi
     hoisted.queue.push(INIT);
     await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
     // Turn A is interrupted mid-flight and produces NO result; the panel's
-    // no-result fallback releases the gate (panel-agent.ts:671 acknowledges the
-    // late result) and turn B is submitted.
+    // no-result fallback releases the gate and turn B is submitted. Per the
+    // r10 contract, a killed turn SUPERSEDED by a newer submission never
+    // delivers — so the FIRST result after the supersession is the newer
+    // turn's own, even as error_during_execution (A is written off/parked;
+    // pre-r10 this stream was attributed to A — that premise is rejected).
     await backend.interrupt();
     releaseTurnB();
     await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
-    // NOW turn A's late empty result arrives: it is the interrupt landing for
-    // A — error_during_execution per the SDK's real result vocabulary (#728 r9;
-    // a success-subtype result with a newer trace pending would instead
-    // correlate to the NEWER turn) → ok:true, NO synthetic failure attributed
-    // to the turn in flight, and turn B's state untouched.
-    hoisted.queue.push(RESULT_INTERRUPTED);
+    hoisted.queue.push(RESULT_INTERRUPTED); // classifies as B's genuine error
     await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(1));
-    expect(resultsOf(events)[0]).toMatchObject({ ok: true });
-    expect(errorsOf(events)).toHaveLength(0);
-    // Turn B's own empty result then classifies on B's flags → ok:false + the
-    // synthetic error, exactly as required for a genuinely empty turn.
-    hoisted.queue.push(RESULT_SUCCESS);
+    expect(resultsOf(events)[0]).toMatchObject({ ok: false, turn: 2 });
+    expect(errorsOf(events)).toHaveLength(0); // genuine error result — no synthetic error
+    // A's genuinely late landing, if it ever arrives, is then tolerated via
+    // its parked trace: blessed ok:true (the interrupt landing, not a failure),
+    // stamped with A's own marker — and turn B's classification untouched.
+    hoisted.queue.push(RESULT_INTERRUPTED);
     hoisted.queue.end();
     await done;
     const results = resultsOf(events);
     expect(results).toHaveLength(2);
-    expect(results[1]).toMatchObject({ ok: false });
-    const errors = errorsOf(events);
-    expect(errors).toHaveLength(1);
-    expect(errors[0].message).toContain("without producing a reply");
+    expect(results[1]).toMatchObject({ ok: true, turn: 1 });
+    expect(errorsOf(events)).toHaveLength(0);
   });
 
   it("an interrupt's blessing does not survive a session restart, and a stray result from the dead session fails closed", async () => {

--- a/src/__tests__/orchestrator/claude-empty-turn.test.ts
+++ b/src/__tests__/orchestrator/claude-empty-turn.test.ts
@@ -78,6 +78,10 @@ const INIT = {
 
 const RESULT_SUCCESS = { type: "result", subtype: "success" };
 
+/** The interrupt landing (#728 r5 contract: an interrupted turn ends with an
+ *  INTERRUPTED-subtype result). */
+const RESULT_INTERRUPTED = { type: "result", subtype: "interrupted" };
+
 function assistantMsg(text: string) {
   return {
     type: "assistant",
@@ -352,10 +356,13 @@ describe("Claude backend — interruptPending is strictly turn-scoped (#745 revi
     await backend.interrupt();
     releaseTurnB();
     await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
-    // NOW turn A's late empty result/success arrives: it is the interrupt
-    // landing for A → ok:true, NO synthetic failure attributed to the turn in
-    // flight, and turn B's state untouched.
-    hoisted.queue.push(RESULT_SUCCESS);
+    // NOW turn A's late empty result arrives: it is the interrupt landing for
+    // A — subtype "interrupted" per the SDK contract (#728 r5: an interrupted
+    // turn ends with an INTERRUPTED-subtype result; a success-subtype result
+    // with a newer trace pending would instead correlate to the NEWER turn) →
+    // ok:true, NO synthetic failure attributed to the turn in flight, and turn
+    // B's state untouched.
+    hoisted.queue.push(RESULT_INTERRUPTED);
     await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(1));
     expect(resultsOf(events)[0]).toMatchObject({ ok: true });
     expect(errorsOf(events)).toHaveLength(0);

--- a/src/__tests__/orchestrator/claude-turn-markers.test.ts
+++ b/src/__tests__/orchestrator/claude-turn-markers.test.ts
@@ -84,6 +84,10 @@ const INIT = {
 
 const RESULT_SUCCESS = { type: "result", subtype: "success" };
 
+/** The interrupt landing (#728 r5 contract: an interrupted turn ends with an
+ *  INTERRUPTED-subtype result). */
+const RESULT_INTERRUPTED = { type: "result", subtype: "interrupted" };
+
 function assistantMsg(text: string) {
   return {
     type: "assistant",
@@ -106,6 +110,8 @@ async function startBackend(channelGen: AsyncGenerator<{ text: string }>) {
 }
 
 const resultsOf = (events: AgentEvent[]) => events.filter((e) => e.type === "result");
+const errorsOf = (events: AgentEvent[]) =>
+  events.filter((e): e is Extract<AgentEvent, { type: "error" }> => e.type === "error");
 
 describe("Claude backend turn markers (#728 r4)", () => {
   it("stamps a result with its OWN turn and stream events with the newest in-flight turn", async () => {
@@ -137,8 +143,10 @@ describe("Claude backend turn markers (#728 r4)", () => {
 
     // B's valid stream event WHILE A's result is still missing.
     hoisted.queue.push(assistantMsg("B working"));
-    // A's LATE result (the interrupt landing)…
-    hoisted.queue.push(RESULT_SUCCESS);
+    // A's LATE result — the interrupt landing, subtype "interrupted" per the
+    // SDK contract (#728 r5; a success subtype here would correlate to the
+    // NEWER turn, not A)…
+    hoisted.queue.push(RESULT_INTERRUPTED);
     // …then B's result-only terminal.
     hoisted.queue.push(RESULT_SUCCESS);
     hoisted.queue.end();
@@ -184,5 +192,53 @@ describe("Claude backend turn markers (#728 r4)", () => {
       .filter((e) => e.type === "assistant" || e.type === "result")
       .map((e) => `${e.type}:${e.turn}`);
     expect(stamped).toEqual(["assistant:1", "result:1", "assistant:2", "result:2"]);
+  });
+
+  it("permanent loss: B's terminal classifies/stamps as B when A's result never arrives (#728 r5)", async () => {
+    // The r5 codex-gate finding: A is interrupted and its result NEVER arrives
+    // (permanent loss). The SDK contract is that an interrupted turn ends with
+    // an INTERRUPTED-subtype result, so B's success terminal can never be A's
+    // terminal — the oldest (interrupted) trace is skipped/parked and B's
+    // terminal pops/stamps B's OWN trace. (Blind FIFO would pop A's trace:
+    // B's terminal would be blessed by A's interrupt and stamped 1 — blessed
+    // AND dead-lettered by the panel: a permanent wedge.)
+    let releaseTurnB!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseTurnB = resolve;
+    });
+    async function* twoTurns() {
+      yield { text: "turn A" };
+      await gate;
+      yield { text: "turn B" };
+    }
+    const { backend, events, done } = await startBackend(twoTurns());
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    await backend.interrupt(); // A interrupted mid-flight; its result NEVER comes
+    releaseTurnB();
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
+
+    // B's result-only terminal (EMPTY turn) arrives FIRST — classified by B's
+    // OWN flags (ok:false + the synthetic empty-turn error, NOT A's interrupt
+    // blessing) and stamped with B's marker, so the panel completes B's gate.
+    hoisted.queue.push(RESULT_SUCCESS);
+    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(1));
+    expect(resultsOf(events)[0]).toMatchObject({ ok: false, turn: 2 });
+    const errors = errorsOf(events);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("without producing a reply");
+    expect(errors[0]).toMatchObject({ turn: 2 });
+
+    // A's genuinely late INTERRUPTED landing then pops its own parked trace:
+    // blessed (ok:true — the interrupt landing, not a failure) and stamped with
+    // A's marker, so the panel dead-letters it as the abandoned turn's
+    // straggler. B's classification stays untouched.
+    hoisted.queue.push(RESULT_INTERRUPTED);
+    hoisted.queue.end();
+    await done;
+    const results = resultsOf(events);
+    expect(results).toHaveLength(2);
+    expect(results[1]).toMatchObject({ ok: true, turn: 1 });
+    expect(errorsOf(events)).toHaveLength(1); // still only B's synthetic error
   });
 });

--- a/src/__tests__/orchestrator/claude-turn-markers.test.ts
+++ b/src/__tests__/orchestrator/claude-turn-markers.test.ts
@@ -122,10 +122,10 @@ describe("Claude backend turn markers (#728 r4)", () => {
     //   • B's valid stream event must stamp with B's marker (2) — a per-result
     //     counter would stamp it 1 (A's), and PanelAgent would dead-letter B's
     //     legitimate work;
-    //   • A's LATE result must stamp with A's own marker (1) → PanelAgent
-    //     dead-letters the abandoned turn's straggler;
-    //   • B's result-only terminal must stamp with B's own marker (2) →
-    //     PanelAgent completes B's gate (no wedge).
+    //   • B's terminal pops/stamps B (a killed, superseded turn never delivers
+    //     — the r10 contract), completing B's gate (no wedge);
+    //   • A's LATE landing then pops its own parked trace, stamped with A's
+    //     own marker (1) → PanelAgent dead-letters the straggler.
     let releaseTurnB!: () => void;
     const gate = new Promise<void>((resolve) => {
       releaseTurnB = resolve;
@@ -144,12 +144,13 @@ describe("Claude backend turn markers (#728 r4)", () => {
 
     // B's valid stream event WHILE A's result is still missing.
     hoisted.queue.push(assistantMsg("B working"));
-    // A's LATE result — the interrupt landing (error_during_execution in the
-    // SDK's real vocabulary; a success subtype here would correlate to the
-    // NEWER turn, not A)…
-    hoisted.queue.push(RESULT_INTERRUPTED);
-    // …then B's result-only terminal.
+    // B's terminal FIRST (per the r10 contract: a killed, superseded turn never
+    // delivers, so B's success writes A off and pops/stamps B)…
     hoisted.queue.push(RESULT_SUCCESS);
+    // …then A's LATE landing (error_during_execution in the SDK's real
+    // vocabulary) — tolerated via its parked trace, stamped with A's own
+    // marker, so PanelAgent dead-letters the abandoned turn's straggler.
+    hoisted.queue.push(RESULT_INTERRUPTED);
     hoisted.queue.end();
     await done;
 
@@ -157,11 +158,11 @@ describe("Claude backend turn markers (#728 r4)", () => {
     expect(events.find((e) => e.type === "session")?.turn).toBeUndefined();
     // B's stream event is attributed to B, NOT to the still-open abandoned turn.
     expect(events.find((e) => e.type === "assistant")).toMatchObject({ turn: 2 });
-    // Each terminal is stamped with its OWN turn, in submission order.
+    // Each terminal is stamped with its OWN turn, in arrival order.
     const results = resultsOf(events);
     expect(results).toHaveLength(2);
-    expect(results[0]).toMatchObject({ turn: 1 }); // A's late terminal
-    expect(results[1]).toMatchObject({ turn: 2 }); // B's result-only terminal
+    expect(results[0]).toMatchObject({ ok: true, turn: 2 }); // B's terminal
+    expect(results[1]).toMatchObject({ ok: true, turn: 1 }); // A's late landing
   });
 
   it("stamps a normal two-turn flow 1, 1, 2, 2 (run-relative, matching the panel mirror)", async () => {
@@ -345,6 +346,48 @@ describe("Claude backend turn markers (#728 r4)", () => {
     const results = resultsOf(events);
     expect(results).toHaveLength(2);
     expect(results[1]).toMatchObject({ ok: true, turn: 2 });
+    expect(errorsOf(events)).toHaveLength(0);
+  });
+
+  it("healthy newer turn's genuine error pops/stamps itself — not the killed older turn (#728 r10)", async () => {
+    // The r10 codex-gate finding: A was interrupted (marked) and superseded by
+    // healthy B; A's interrupt terminal is missing (a killed, superseded turn
+    // never delivers). B's GENUINE error_during_execution must pop/stamp B —
+    // popping A instead would bless a fabricated ok:true stamped 1 that the
+    // panel dead-letters while B's gate stays held.
+    let releaseB!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseB = resolve;
+    });
+    async function* twoTurns() {
+      yield { text: "turn A" };
+      await gate;
+      yield { text: "turn B" };
+    }
+    const { backend, events, done } = await startBackend(twoTurns());
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    await backend.interrupt(); // marks A; A's terminal will never arrive
+    releaseB();
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
+
+    // B's GENUINE error lands first: A is written off (parked), B is popped —
+    // classified by B's OWN flags (a genuine failure, NO blessing) and stamped
+    // with B's marker, so the panel completes B's gate.
+    hoisted.queue.push(RESULT_INTERRUPTED); // error_during_execution — B's genuine error
+    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(1));
+    expect(resultsOf(events)[0]).toMatchObject({ ok: false, turn: 2 });
+    expect(errorsOf(events)).toHaveLength(0); // a genuine error result carries no synthetic error
+
+    // A's late interrupt landing (if it ever arrives) pops its own parked
+    // trace: blessed via ITS mark (ok:true — the landing, not a failure) and
+    // stamped with A's marker, so the panel dead-letters the straggler.
+    hoisted.queue.push(RESULT_INTERRUPTED);
+    hoisted.queue.end();
+    await done;
+    const results = resultsOf(events);
+    expect(results).toHaveLength(2);
+    expect(results[1]).toMatchObject({ ok: true, turn: 1 });
     expect(errorsOf(events)).toHaveLength(0);
   });
 });

--- a/src/__tests__/orchestrator/claude-turn-markers.test.ts
+++ b/src/__tests__/orchestrator/claude-turn-markers.test.ts
@@ -303,63 +303,47 @@ describe("Claude backend turn markers (#728 r4)", () => {
     expect(errorsOf(events).some((e) => /could not be matched|unverifiable/i.test(e.message))).toBe(true);
   });
 
-  it("two interrupted unparked turns: the later turn's first landing is its OWN (#728 r7)", async () => {
-    // The r7 codex-gate finding: A and newer C are BOTH interrupted and BOTH
-    // unparked (no non-interrupted result ever triggered the skip). The SDK
-    // processes turns sequentially and the panel only submits a newer turn
-    // after the older turn's result was written off, so C's terminal arriving
-    // first belongs to C — the older interrupted A is provably lost and is
-    // written off (parked) on the spot. (Blindly popping the oldest fabricated
-    // an ok:true turn-A result that the panel dead-letters, wedging C.)
-    let releaseA!: () => void;
+  it("queued-input ordering: C's trace exists while A is unsettled — A's landing pops A, then C's pops C (#728 r8)", async () => {
+    // The r8 codex-gate reframing: the SDK emits results in PROCESSING ORDER,
+    // so a newer turn's trace can exist while the older turn is still settling
+    // (queued input) — and the older turn's legitimate landing MUST still pop
+    // the OLDEST live interrupted trace. (The r7 newest-preference assigned
+    // A's legitimate landing to C — writing A off and fabricating C's
+    // terminal — and its C-terminal-first ordering is impossible under this
+    // contract, so that test is replaced by this valid one.)
     let releaseC!: () => void;
-    const gateA = new Promise<void>((resolve) => {
-      releaseA = resolve;
-    });
     const gateC = new Promise<void>((resolve) => {
       releaseC = resolve;
     });
-    async function* threeTurns() {
-      yield { text: "turn 1" };
-      await gateA;
+    async function* twoTurns() {
       yield { text: "turn A" };
       await gateC;
       yield { text: "turn C" };
     }
-    const { backend, events, done } = await startBackend(threeTurns());
+    const { backend, events, done } = await startBackend(twoTurns());
     hoisted.queue.push(INIT);
     await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
-    // Turn 1 completes normally (establishes the A=2 / C=3 numbering).
-    hoisted.queue.push(assistantMsg("one"));
-    hoisted.queue.push(RESULT_SUCCESS);
+
+    // A is interrupted; C's trace is then created while A is STILL unsettled,
+    // and C is marked interrupted too (the SDK is still settling A).
+    await backend.interrupt(); // marks A (newest at the time)
+    releaseC();
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
+    await backend.interrupt(); // marks C
+
+    // A's legitimate interrupted result arrives FIRST (processing order) →
+    // pops/stamps A, NOT C.
+    hoisted.queue.push(RESULT_INTERRUPTED);
     await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(1));
     expect(resultsOf(events)[0]).toMatchObject({ ok: true, turn: 1 });
 
-    // A and C are BOTH interrupted, BOTH unparked; C's landing arrives FIRST.
-    releaseA();
-    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
-    await backend.interrupt(); // marks A (newest at the time)
-    releaseC();
-    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(3));
-    await backend.interrupt(); // marks C
-    hoisted.queue.push(RESULT_INTERRUPTED); // C's terminal, arriving first
-    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(2));
-    // …stamped and classified as C's OWN (blessed landing) — A written off.
-    expect(resultsOf(events)[1]).toMatchObject({ ok: true, turn: 3 });
-
-    // A's OWN late landing (no newer trace anymore) still pops A's trace.
-    hoisted.queue.push(RESULT_INTERRUPTED);
-    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(3));
-    expect(resultsOf(events)[2]).toMatchObject({ ok: true, turn: 2 });
-
-    // A landing AFTER A was already consumed → anomalous → fail closed.
+    // C's own landing then pops C.
     hoisted.queue.push(RESULT_INTERRUPTED);
     hoisted.queue.end();
     await done;
     const results = resultsOf(events);
-    expect(results).toHaveLength(4);
-    expect(results[3]).toMatchObject({ ok: false });
-    expect(results[3].turn).toBeUndefined();
-    expect(errorsOf(events).some((e) => /could not be matched|unverifiable/i.test(e.message))).toBe(true);
+    expect(results).toHaveLength(2);
+    expect(results[1]).toMatchObject({ ok: true, turn: 2 });
+    expect(errorsOf(events)).toHaveLength(0);
   });
 });

--- a/src/__tests__/orchestrator/claude-turn-markers.test.ts
+++ b/src/__tests__/orchestrator/claude-turn-markers.test.ts
@@ -302,4 +302,64 @@ describe("Claude backend turn markers (#728 r4)", () => {
     expect(results[3].turn).toBeUndefined();
     expect(errorsOf(events).some((e) => /could not be matched|unverifiable/i.test(e.message))).toBe(true);
   });
+
+  it("two interrupted unparked turns: the later turn's first landing is its OWN (#728 r7)", async () => {
+    // The r7 codex-gate finding: A and newer C are BOTH interrupted and BOTH
+    // unparked (no non-interrupted result ever triggered the skip). The SDK
+    // processes turns sequentially and the panel only submits a newer turn
+    // after the older turn's result was written off, so C's terminal arriving
+    // first belongs to C — the older interrupted A is provably lost and is
+    // written off (parked) on the spot. (Blindly popping the oldest fabricated
+    // an ok:true turn-A result that the panel dead-letters, wedging C.)
+    let releaseA!: () => void;
+    let releaseC!: () => void;
+    const gateA = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    const gateC = new Promise<void>((resolve) => {
+      releaseC = resolve;
+    });
+    async function* threeTurns() {
+      yield { text: "turn 1" };
+      await gateA;
+      yield { text: "turn A" };
+      await gateC;
+      yield { text: "turn C" };
+    }
+    const { backend, events, done } = await startBackend(threeTurns());
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    // Turn 1 completes normally (establishes the A=2 / C=3 numbering).
+    hoisted.queue.push(assistantMsg("one"));
+    hoisted.queue.push(RESULT_SUCCESS);
+    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(1));
+    expect(resultsOf(events)[0]).toMatchObject({ ok: true, turn: 1 });
+
+    // A and C are BOTH interrupted, BOTH unparked; C's landing arrives FIRST.
+    releaseA();
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
+    await backend.interrupt(); // marks A (newest at the time)
+    releaseC();
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(3));
+    await backend.interrupt(); // marks C
+    hoisted.queue.push(RESULT_INTERRUPTED); // C's terminal, arriving first
+    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(2));
+    // …stamped and classified as C's OWN (blessed landing) — A written off.
+    expect(resultsOf(events)[1]).toMatchObject({ ok: true, turn: 3 });
+
+    // A's OWN late landing (no newer trace anymore) still pops A's trace.
+    hoisted.queue.push(RESULT_INTERRUPTED);
+    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(3));
+    expect(resultsOf(events)[2]).toMatchObject({ ok: true, turn: 2 });
+
+    // A landing AFTER A was already consumed → anomalous → fail closed.
+    hoisted.queue.push(RESULT_INTERRUPTED);
+    hoisted.queue.end();
+    await done;
+    const results = resultsOf(events);
+    expect(results).toHaveLength(4);
+    expect(results[3]).toMatchObject({ ok: false });
+    expect(results[3].turn).toBeUndefined();
+    expect(errorsOf(events).some((e) => /could not be matched|unverifiable/i.test(e.message))).toBe(true);
+  });
 });

--- a/src/__tests__/orchestrator/claude-turn-markers.test.ts
+++ b/src/__tests__/orchestrator/claude-turn-markers.test.ts
@@ -1,0 +1,188 @@
+// #728 r4 — the Claude backend's turn markers must be TRUE turn attribution,
+// not a per-result output counter. The SDK's input pump and output reader are
+// independent streams, and a turn's result can go MISSING (the panel's
+// no-result fallback then releases the next turn) or arrive LATE — a counter
+// that increments per result lags behind the panel's per-dispatch mirror in
+// exactly those cases, stamping the NEXT turn's valid events with the abandoned
+// turn's marker so PanelAgent dead-letters them (the r3 result-only wedge,
+// Claude edition).
+//
+// The fix stamps from the #745 per-turn trace FIFO: a RESULT carries the trace
+// it pops (the oldest in-flight — its OWN turn, even when late); every other
+// message carries the NEWEST in-flight trace (the turn currently producing
+// output). Pattern follows claude-empty-turn.test.ts: the optional Agent SDK is
+// mocked, the backend is driven through run(), and the canonical AgentEvents
+// are collected and asserted on.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import type { AgentEvent } from "../../orchestrator/agent-backend.js";
+
+const hoisted = vi.hoisted(() => ({
+  /** A push-based async message source — stands in for the live SDK query stream. */
+  queue: new (class {
+    private buf: unknown[] = [];
+    private waiters: Array<() => void> = [];
+    private closed = false;
+    reset(): void {
+      this.buf = [];
+      this.closed = false;
+    }
+    push(m: unknown): void {
+      this.buf.push(m);
+      for (const w of this.waiters.splice(0)) w();
+    }
+    end(): void {
+      this.closed = true;
+      for (const w of this.waiters.splice(0)) w();
+    }
+    async *iterate(): AsyncGenerator<unknown> {
+      for (;;) {
+        while (this.buf.length) yield this.buf.shift();
+        if (this.closed) return;
+        await new Promise<void>((resolve) => this.waiters.push(resolve));
+      }
+    }
+  })(),
+  onInterrupt: null as null | (() => void),
+  /** User turns the mock SDK pulled from the prompt channel (proves submission). */
+  promptsSeen: 0,
+}));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (arg: { prompt?: AsyncIterable<unknown> }) => {
+    // The real SDK pulls user turns out of the prompt generator — drain it the
+    // same way so the backend's turn tracking sees every submitted turn.
+    void (async () => {
+      for await (const _ of arg.prompt ?? []) hoisted.promptsSeen += 1;
+    })();
+    const iter = hoisted.queue.iterate();
+    return Object.assign(iter, {
+      supportedModels: async () => [],
+      supportedCommands: async () => [],
+      interrupt: async () => {
+        hoisted.onInterrupt?.();
+      },
+      setModel: async () => {},
+    });
+  },
+}));
+
+beforeEach(() => {
+  hoisted.queue.reset();
+  hoisted.onInterrupt = null;
+  hoisted.promptsSeen = 0;
+});
+
+const INIT = {
+  type: "system",
+  subtype: "init",
+  session_id: "00000000-1111-2222-3333-444444444444",
+  model: "claude-test-1",
+  apiKeySource: "none",
+  skills: [],
+};
+
+const RESULT_SUCCESS = { type: "result", subtype: "success" };
+
+function assistantMsg(text: string) {
+  return {
+    type: "assistant",
+    message: { role: "assistant", id: "msg-1", content: [{ type: "text", text }] },
+    uuid: "a-1",
+    session_id: INIT.session_id,
+    parent_tool_use_id: null,
+  };
+}
+
+/** Start a live backend over a caller-controlled channel (for multi-turn flows). */
+async function startBackend(channelGen: AsyncGenerator<{ text: string }>) {
+  const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
+  const backend = new ClaudeBackend({ mcpServers: {}, systemAppend: "" });
+  const events: AgentEvent[] = [];
+  const done = (async () => {
+    for await (const ev of backend.run({ channel: channelGen as never })) events.push(ev);
+  })();
+  return { backend, events, done };
+}
+
+const resultsOf = (events: AgentEvent[]) => events.filter((e) => e.type === "result");
+
+describe("Claude backend turn markers (#728 r4)", () => {
+  it("stamps a result with its OWN turn and stream events with the newest in-flight turn", async () => {
+    // A is interrupted mid-flight and produces NO result yet (the panel's
+    // no-result fallback has already released the gate); B is submitted. While
+    // A's result is still missing:
+    //   • B's valid stream event must stamp with B's marker (2) — a per-result
+    //     counter would stamp it 1 (A's), and PanelAgent would dead-letter B's
+    //     legitimate work;
+    //   • A's LATE result must stamp with A's own marker (1) → PanelAgent
+    //     dead-letters the abandoned turn's straggler;
+    //   • B's result-only terminal must stamp with B's own marker (2) →
+    //     PanelAgent completes B's gate (no wedge).
+    let releaseTurnB!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseTurnB = resolve;
+    });
+    async function* twoTurns() {
+      yield { text: "turn A" };
+      await gate;
+      yield { text: "turn B" };
+    }
+    const { backend, events, done } = await startBackend(twoTurns());
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    await backend.interrupt(); // A interrupted mid-flight; no result arrives
+    releaseTurnB();
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
+
+    // B's valid stream event WHILE A's result is still missing.
+    hoisted.queue.push(assistantMsg("B working"));
+    // A's LATE result (the interrupt landing)…
+    hoisted.queue.push(RESULT_SUCCESS);
+    // …then B's result-only terminal.
+    hoisted.queue.push(RESULT_SUCCESS);
+    hoisted.queue.end();
+    await done;
+
+    // Session init is never stamped (unmarked = never dead-lettered).
+    expect(events.find((e) => e.type === "session")?.turn).toBeUndefined();
+    // B's stream event is attributed to B, NOT to the still-open abandoned turn.
+    expect(events.find((e) => e.type === "assistant")).toMatchObject({ turn: 2 });
+    // Each terminal is stamped with its OWN turn, in submission order.
+    const results = resultsOf(events);
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ turn: 1 }); // A's late terminal
+    expect(results[1]).toMatchObject({ turn: 2 }); // B's result-only terminal
+  });
+
+  it("stamps a normal two-turn flow 1, 1, 2, 2 (run-relative, matching the panel mirror)", async () => {
+    // Model the panel's turn gate: turn B is submitted only AFTER turn A's
+    // result (production ordering — the gate releases the next batch on the
+    // result), so each turn is the newest in-flight while it produces output.
+    let releaseTurnB!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseTurnB = resolve;
+    });
+    async function* twoTurns() {
+      yield { text: "turn A" };
+      await gate;
+      yield { text: "turn B" };
+    }
+    const { events, done } = await startBackend(twoTurns());
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+    hoisted.queue.push(assistantMsg("reply A"));
+    hoisted.queue.push(RESULT_SUCCESS);
+    releaseTurnB(); // the result opens the panel's gate → B is submitted
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
+    hoisted.queue.push(assistantMsg("reply B"));
+    hoisted.queue.push(RESULT_SUCCESS);
+    hoisted.queue.end();
+    await done;
+
+    const stamped = events
+      .filter((e) => e.type === "assistant" || e.type === "result")
+      .map((e) => `${e.type}:${e.turn}`);
+    expect(stamped).toEqual(["assistant:1", "result:1", "assistant:2", "result:2"]);
+  });
+});

--- a/src/__tests__/orchestrator/claude-turn-markers.test.ts
+++ b/src/__tests__/orchestrator/claude-turn-markers.test.ts
@@ -241,4 +241,65 @@ describe("Claude backend turn markers (#728 r4)", () => {
     expect(results[1]).toMatchObject({ ok: true, turn: 1 });
     expect(errorsOf(events)).toHaveLength(1); // still only B's synthetic error
   });
+
+  it("a newer interrupted turn's terminal does not re-consume a parked trace (#728 r6)", async () => {
+    // The r6 codex-gate finding: with A parked (its result already declared
+    // lost), a NEW interrupted turn C's interrupted terminal must pop/stamp
+    // C's OWN trace — blindly popping the oldest (parked A) stamps A, so the
+    // panel dead-letters C's real terminal and C wedges. Each trace lands at
+    // most once; a landing with no unconsumed candidate fails closed.
+    let releaseB!: () => void;
+    let releaseC!: () => void;
+    const gateB = new Promise<void>((resolve) => {
+      releaseB = resolve;
+    });
+    const gateC = new Promise<void>((resolve) => {
+      releaseC = resolve;
+    });
+    async function* threeTurns() {
+      yield { text: "turn A" };
+      await gateB;
+      yield { text: "turn B" };
+      await gateC;
+      yield { text: "turn C" };
+    }
+    const { backend, events, done } = await startBackend(threeTurns());
+    hoisted.queue.push(INIT);
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(1));
+
+    // A is interrupted (its result will never come); B's success terminal
+    // parks A and classifies/stamps B (the permanent-loss path).
+    await backend.interrupt();
+    releaseB();
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(2));
+    hoisted.queue.push(RESULT_SUCCESS); // B's terminal → skip/park A
+    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(1));
+    expect(resultsOf(events)[0]).toMatchObject({ turn: 2 });
+
+    // C is interrupted; C's interrupted terminal must pop/stamp C's OWN trace —
+    // NOT the parked A.
+    releaseC();
+    await vi.waitFor(() => expect(hoisted.promptsSeen).toBe(3));
+    await backend.interrupt(); // marks the newest unresolved trace — C
+    hoisted.queue.push(RESULT_INTERRUPTED); // C's landing
+    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(2));
+    expect(resultsOf(events)[1]).toMatchObject({ ok: true, turn: 3 });
+
+    // A's OWN late landing still pops its parked trace — exactly once.
+    hoisted.queue.push(RESULT_INTERRUPTED); // A's landing
+    await vi.waitFor(() => expect(resultsOf(events)).toHaveLength(3));
+    expect(resultsOf(events)[2]).toMatchObject({ ok: true, turn: 1 });
+
+    // A SECOND landing with no unconsumed candidate is anomalous → fail closed
+    // (the #745 traceless rule): unverifiable, ok:false, never fabricated, and
+    // UNMARKED so the panel still sees it.
+    hoisted.queue.push(RESULT_INTERRUPTED);
+    hoisted.queue.end();
+    await done;
+    const results = resultsOf(events);
+    expect(results).toHaveLength(4);
+    expect(results[3]).toMatchObject({ ok: false });
+    expect(results[3].turn).toBeUndefined();
+    expect(errorsOf(events).some((e) => /could not be matched|unverifiable/i.test(e.message))).toBe(true);
+  });
 });

--- a/src/__tests__/orchestrator/claude-turn-markers.test.ts
+++ b/src/__tests__/orchestrator/claude-turn-markers.test.ts
@@ -84,9 +84,10 @@ const INIT = {
 
 const RESULT_SUCCESS = { type: "result", subtype: "success" };
 
-/** The interrupt landing (#728 r5 contract: an interrupted turn ends with an
- *  INTERRUPTED-subtype result). */
-const RESULT_INTERRUPTED = { type: "result", subtype: "interrupted" };
+/** The interrupt landing in the SDK's REAL result vocabulary (#728 r9: an
+ *  interrupted turn ends with an error_during_execution result — there is no
+ *  "interrupted" result subtype). */
+const RESULT_INTERRUPTED = { type: "result", subtype: "error_during_execution" };
 
 function assistantMsg(text: string) {
   return {
@@ -143,8 +144,8 @@ describe("Claude backend turn markers (#728 r4)", () => {
 
     // B's valid stream event WHILE A's result is still missing.
     hoisted.queue.push(assistantMsg("B working"));
-    // A's LATE result — the interrupt landing, subtype "interrupted" per the
-    // SDK contract (#728 r5; a success subtype here would correlate to the
+    // A's LATE result — the interrupt landing (error_during_execution in the
+    // SDK's real vocabulary; a success subtype here would correlate to the
     // NEWER turn, not A)…
     hoisted.queue.push(RESULT_INTERRUPTED);
     // …then B's result-only terminal.
@@ -196,12 +197,12 @@ describe("Claude backend turn markers (#728 r4)", () => {
 
   it("permanent loss: B's terminal classifies/stamps as B when A's result never arrives (#728 r5)", async () => {
     // The r5 codex-gate finding: A is interrupted and its result NEVER arrives
-    // (permanent loss). The SDK contract is that an interrupted turn ends with
-    // an INTERRUPTED-subtype result, so B's success terminal can never be A's
-    // terminal — the oldest (interrupted) trace is skipped/parked and B's
-    // terminal pops/stamps B's OWN trace. (Blind FIFO would pop A's trace:
-    // B's terminal would be blessed by A's interrupt and stamped 1 — blessed
-    // AND dead-lettered by the panel: a permanent wedge.)
+    // (permanent loss). In the SDK's real result vocabulary an interrupted turn
+    // ends with an error_during_execution result, so B's success terminal can
+    // never be A's terminal — the oldest (interrupted) trace is skipped/parked
+    // and B's terminal pops/stamps B's OWN trace. (Blind FIFO would pop A's
+    // trace: B's terminal would be blessed by A's interrupt and stamped 1 —
+    // blessed AND dead-lettered by the panel: a permanent wedge.)
     let releaseTurnB!: () => void;
     const gate = new Promise<void>((resolve) => {
       releaseTurnB = resolve;

--- a/src/__tests__/orchestrator/ollama-backend.test.ts
+++ b/src/__tests__/orchestrator/ollama-backend.test.ts
@@ -177,7 +177,7 @@ describe("OllamaBackend", () => {
     expect(assistant.text).toBe("Hello!");
     expect(assistant.usage).toEqual({ input_tokens: 10, output_tokens: 5 });
     const results = events.filter((e) => e.type === "result");
-    expect(results).toEqual([{ type: "result", ok: true, usage: { input_tokens: 10, output_tokens: 5 } }]);
+    expect(results).toEqual([{ type: "result", ok: true, turn: 1, usage: { input_tokens: 10, output_tokens: 5 } }]);
   });
 
   it("num_ctx is model-aware: 16384 for stock, OMITTED for the fine-tune (baked 65536 governs), env override wins", async () => {
@@ -248,7 +248,7 @@ describe("OllamaBackend", () => {
     expect(nudges.length).toBeGreaterThanOrEqual(1);
     // Turn ends with the loop-breaker, not max_tool_rounds (32 rounds later).
     expect(events.filter((e) => e.type === "result")).toEqual([
-      { type: "result", ok: false, subtype: "tool_loop" },
+      { type: "result", ok: false, subtype: "tool_loop", turn: 1 },
     ]);
     expect(chatRequests.length).toBeLessThanOrEqual(5);
   });
@@ -315,7 +315,7 @@ describe("OllamaBackend", () => {
     expect(String(limitNudges[0].content)).toContain("panel_add_node");
     // And the turn ends on the loop-breaker, not by running to max_tool_rounds.
     expect(events.filter((e) => e.type === "result")).toEqual([
-      { type: "result", ok: false, subtype: "tool_loop" },
+      { type: "result", ok: false, subtype: "tool_loop", turn: 1 },
     ]);
   });
 
@@ -340,7 +340,7 @@ describe("OllamaBackend", () => {
     const second = chatRequests[1];
     const toolMsg = second.messages.find((m) => m.role === "tool");
     expect(toolMsg).toMatchObject({ tool_name: "list_tools", content: "result-of-list_tools" });
-    expect(events.filter((e) => e.type === "result")).toEqual([{ type: "result", ok: true, usage: expect.anything() }]);
+    expect(events.filter((e) => e.type === "result")).toEqual([{ type: "result", ok: true, turn: 1, usage: expect.anything() }]);
   });
 
   it("a retired comfy tool name gets the ledger's specific error, not the bare Available list (#659)", async () => {
@@ -427,7 +427,7 @@ describe("OllamaBackend", () => {
     const events = await collect(backend, turnsOf({ text: "hi" }));
     expect(events.some((e) => e.type === "error")).toBe(true);
     const results = events.filter((e) => e.type === "result");
-    expect(results).toEqual([{ type: "result", ok: false, subtype: "error" }]);
+    expect(results).toEqual([{ type: "result", ok: false, subtype: "error", turn: 1 }]);
   });
 
   it("interrupt() aborts the in-flight stream and yields one interrupted result", async () => {
@@ -445,7 +445,7 @@ describe("OllamaBackend", () => {
     })();
     await done;
     const results = events.filter((e) => e.type === "result");
-    expect(results).toEqual([{ type: "result", ok: false, subtype: "interrupted" }]);
+    expect(results).toEqual([{ type: "result", ok: false, subtype: "interrupted", turn: 1 }]);
     expect(events.some((e) => e.type === "error")).toBe(false); // interrupt is not an error
   });
 

--- a/src/__tests__/orchestrator/pi-backend.test.ts
+++ b/src/__tests__/orchestrator/pi-backend.test.ts
@@ -332,8 +332,8 @@ describe("PiBackend turns", () => {
       "Second",
     ]);
     expect(events.filter((e) => e.type === "result")).toEqual([
-      { type: "result", ok: true, subtype: "end_turn" },
-      { type: "result", ok: true, subtype: "end_turn" },
+      { type: "result", ok: true, subtype: "end_turn", turn: 1 },
+      { type: "result", ok: true, subtype: "end_turn", turn: 2 },
     ]);
 
     // Turn 1: fresh (no --session), --mode json, persona prepended, model set.
@@ -468,7 +468,7 @@ describe("PiBackend turns", () => {
     expect(err.message).toContain("code 7");
     expect(err.message).toContain("quota exceeded");
     expect(events.filter((e) => e.type === "result")).toEqual([
-      { type: "result", ok: false, subtype: "error" },
+      { type: "result", ok: false, subtype: "error", turn: 1 },
     ]);
   });
 
@@ -480,7 +480,7 @@ describe("PiBackend turns", () => {
     const events = await collect(backend.run({ channel: channelOf([{ text: "hi" }]) }));
     expect(events.some((e) => e.type === "session")).toBe(false);
     expect(events.filter((e) => e.type === "result")).toEqual([
-      { type: "result", ok: false, subtype: "error" },
+      { type: "result", ok: false, subtype: "error", turn: 1 },
     ]);
   });
 
@@ -512,7 +512,7 @@ describe("PiBackend turns", () => {
     await drain;
     expect(hoisted.killed).toContain(hoisted.procs[0]!.pid);
     expect(events.filter((e) => e.type === "result")).toEqual([
-      { type: "result", ok: false, subtype: "cancelled" },
+      { type: "result", ok: false, subtype: "cancelled", turn: 1 },
     ]);
   });
 
@@ -527,7 +527,7 @@ describe("PiBackend turns", () => {
     await backend.interrupt();
     await drain;
     expect(events.filter((e) => e.type === "result")).toEqual([
-      { type: "result", ok: false, subtype: "cancelled" },
+      { type: "result", ok: false, subtype: "cancelled", turn: 1 },
     ]);
     if (hoisted.procs[0]) expect(hoisted.killed).toContain(hoisted.procs[0]!.pid);
   });
@@ -539,7 +539,7 @@ describe("PiBackend turns", () => {
     await new Promise((r) => setTimeout(r, 650));
     const events = await collect(backend.run({ channel: channelOf([{ text: "hi" }]) }));
     expect(events.filter((e) => e.type === "result")).toEqual([
-      { type: "result", ok: true, subtype: "end_turn" },
+      { type: "result", ok: true, subtype: "end_turn", turn: 1 },
     ]);
     expect(hoisted.killed).toEqual([]);
   });

--- a/src/__tests__/orchestrator/stall-watchdog-interrupt.test.ts
+++ b/src/__tests__/orchestrator/stall-watchdog-interrupt.test.ts
@@ -14,7 +14,9 @@
 // FIX: the watchdog marks the failure surfaced (errorSurfaced) and routes
 // through the guarded interrupt() flow — the aborted turn's terminal result (or
 // the bounded interrupt-release fallback if none arrives) opens the gate at the
-// genuine turn end.
+// genuine turn end. ONE report per turn, both directions: a stall after an
+// `error` event already painted the failure line suppresses the stall warning,
+// and a late `error` event after the stall warning suppresses the error line.
 //
 // TURN_IDLE_MS / INTERRUPT_RELEASE_FALLBACK_MS are read from the env at
 // panel-agent module load, so set SHORT windows BEFORE importing the module.
@@ -103,6 +105,15 @@ class HeldResultBackend implements AgentBackend {
     this.releaseResolvers.shift()?.();
   }
 
+  /** Emit an `error` event for the in-flight turn (test-controlled) — the way
+   *  codex/gemini/grok report a turn failure BEFORE their terminal result. The
+   *  error leaves the turn ACTIVE (no result), so the watchdog can still trip. */
+  emitError(message: string): void {
+    this.emitFn?.({ type: "error", message });
+  }
+
+  private emitFn: ((ev: AgentEvent) => void) | null = null;
+
   async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
     const out: AgentEvent[] = [];
     let wakeOut: (() => void) | null = null;
@@ -146,6 +157,7 @@ class HeldResultBackend implements AgentBackend {
     })();
 
     emit({ type: "session", sessionId: "sess-held" });
+    this.emitFn = emit;
     try {
       while (!inputDone || out.length) {
         if (!out.length) {
@@ -270,5 +282,79 @@ describe("stall watchdog interrupt reports once and holds the turn gate (#728)",
     const warnings = says.filter((s) => s.includes("⚠️"));
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatch(/stopped responding/i);
+  });
+
+  it("error event first, result withheld → the watchdog does NOT paint a second report", async () => {
+    // The codex-gate finding on PR #746: handleEvent('error') paints the turn's
+    // failure line but leaves the turn ACTIVE; if the terminal result never
+    // arrives, the watchdog must NOT add its stall warning on top (one report
+    // per turn) — while still interrupting and releasing the gate via the
+    // guarded fallback.
+    const says: string[] = [];
+    const backend = new HeldResultBackend();
+    const agent = new PanelAgent("tab-728c", makeDeps(says) as never, backend);
+    void agent.start();
+
+    agent.send("first message");
+    await backend.waitStarted(1);
+    agent.send("second message queued behind the stall");
+
+    // The backend reports the turn's failure, then goes silent (no result).
+    backend.emitError("provider exploded");
+    await waitFor(() => says.some((s) => /turn failed/i.test(s)));
+
+    // The watchdog still trips on the silence (the error left the turn active)
+    // and interrupts the backend…
+    await waitFor(() => backend.interrupted >= 1);
+
+    // …the gate stays held until the bounded fallback opens it (no result ever
+    // arrives)…
+    await new Promise((r) => setTimeout(r, GATE_HELD_MS));
+    expect(backend.turns).toEqual(["first message"]);
+    await backend.waitStarted(2);
+    expect(backend.turns[1]).toContain("second message");
+
+    backend.releaseOnInterrupt = true; // let stop()'s interrupt unwind the pump
+    await agent.stop();
+
+    // …but the stall warning is SUPPRESSED: the error event was this turn's ONE
+    // failure report.
+    const warnings = says.filter((s) => s.includes("⚠️"));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/turn failed/i);
+    expect(says.join("\n")).not.toMatch(/stopped responding/i);
+  });
+
+  it("stall warning first, late error event for the same turn → the error line is suppressed", async () => {
+    // The symmetric order: the watchdog's stall warning already reported this
+    // turn's failure (errorSurfaced), so a late backend `error` event for the
+    // SAME turn must not paint a second line.
+    const says: string[] = [];
+    const backend = new HeldResultBackend();
+    const agent = new PanelAgent("tab-728d", makeDeps(says) as never, backend);
+    void agent.start();
+
+    agent.send("first message");
+    await backend.waitStarted(1);
+    agent.send("second message queued behind the stall");
+
+    // Watchdog trips first: stall warning painted, backend interrupted.
+    await waitFor(() => tripped(backend, says));
+
+    // A late `error` event arrives for the same (already-reported) turn, then
+    // the interrupted result settles the turn and opens the gate.
+    backend.emitError("late backend error");
+    backend.releaseTurn();
+    await backend.waitStarted(2);
+    expect(backend.turns[1]).toContain("second message");
+
+    backend.releaseOnInterrupt = true; // let stop()'s interrupt unwind the pump
+    await agent.stop();
+
+    // Exactly ONE report — the stall warning; the late error line is suppressed.
+    const warnings = says.filter((s) => s.includes("⚠️"));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/stopped responding/i);
+    expect(says.join("\n")).not.toMatch(/turn failed/i);
   });
 });

--- a/src/__tests__/orchestrator/stall-watchdog-interrupt.test.ts
+++ b/src/__tests__/orchestrator/stall-watchdog-interrupt.test.ts
@@ -17,6 +17,9 @@
 // genuine turn end. ONE report per turn, both directions: a stall after an
 // `error` event already painted the failure line suppresses the stall warning,
 // and a late `error` event after the stall warning suppresses the error line.
+// And when the fallback abandons a turn (force-release with no result), the dead
+// turn's straggler `error`/`result` are dead-lettered — never painted against,
+// and never completing the gate of, the turn that replaces it (r2).
 //
 // TURN_IDLE_MS / INTERRUPT_RELEASE_FALLBACK_MS are read from the env at
 // panel-agent module load, so set SHORT windows BEFORE importing the module.
@@ -64,9 +67,6 @@ class HeldResultBackend implements AgentBackend {
    *  the test alone decides when (if ever) the interrupted result lands. Set to
    *  true right before agent.stop() so teardown's interrupt unwinds the pump. */
   releaseOnInterrupt = false;
-  /** One resolver per in-flight turn, FIFO — resolved by `releaseTurn()` to emit
-   *  that turn's interrupted `result`. */
-  private releaseResolvers: Array<() => void> = [];
   private startedCount = 0;
   private startedWaiters: Array<{ n: number; resolve: () => void }> = [];
 
@@ -100,9 +100,11 @@ class HeldResultBackend implements AgentBackend {
     });
   }
 
-  /** Release the OLDEST held turn so its interrupted `result` is emitted. */
-  releaseTurn(): void {
-    this.releaseResolvers.shift()?.();
+  /** Release the OLDEST held turn, emitting `ev` as its terminal event (default:
+   *  the interrupt landing). Turn 2+ can thus end with a SUCCESS result while the
+   *  stalled turn's straggler is the interrupted one. */
+  releaseTurn(ev: AgentEvent = { type: "result", ok: false, subtype: "interrupted" }): void {
+    this.releaseResolvers.shift()?.(ev);
   }
 
   /** Emit an `error` event for the in-flight turn (test-controlled) — the way
@@ -113,6 +115,9 @@ class HeldResultBackend implements AgentBackend {
   }
 
   private emitFn: ((ev: AgentEvent) => void) | null = null;
+  /** One resolver per in-flight turn, FIFO — resolved by `releaseTurn()` with the
+   *  terminal event to emit for that turn. */
+  private releaseResolvers: Array<(ev: AgentEvent) => void> = [];
 
   async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
     const out: AgentEvent[] = [];
@@ -144,11 +149,12 @@ class HeldResultBackend implements AgentBackend {
         // DECOUPLED read-ahead: begin reading the NEXT turn now (parks at the
         // turn gate while this turn is held) — mirrors the SDK input pump.
         const readAhead = read();
-        // SILENCE: no events for this turn until the test releases its result.
-        await new Promise<void>((resolve) => {
+        // SILENCE: no events for this turn until the test releases its terminal
+        // event (an interrupted result, or whatever releaseTurn was given).
+        const terminal = await new Promise<AgentEvent>((resolve) => {
           this.releaseResolvers.push(resolve);
         });
-        emit({ type: "result", ok: false, subtype: "interrupted" });
+        emit(terminal);
         r = await readAhead;
       }
       inputDone = true;
@@ -181,7 +187,7 @@ class HeldResultBackend implements AgentBackend {
     if (!this.releaseOnInterrupt) return;
     const held = this.releaseResolvers;
     this.releaseResolvers = [];
-    for (const r of held) r();
+    for (const r of held) r({ type: "result", ok: false, subtype: "interrupted" });
   }
 
   async listModels(): Promise<ModelChoice[]> {
@@ -352,6 +358,56 @@ describe("stall watchdog interrupt reports once and holds the turn gate (#728)",
     await agent.stop();
 
     // Exactly ONE report — the stall warning; the late error line is suppressed.
+    const warnings = says.filter((s) => s.includes("⚠️"));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/stopped responding/i);
+    expect(says.join("\n")).not.toMatch(/turn failed/i);
+  });
+
+  it("fallback release + new dispatch → the dead turn's straggler error/result are dead-lettered", async () => {
+    // The r2 codex-gate finding on PR #746: after the bounded fallback force-opens
+    // the gate, the ABANDONED turn may still emit. Its straggler `error` must not
+    // paint against the NEW turn (whose dispatch reset errorSurfaced), and its
+    // straggler `result` must not complete the NEW turn's gate early — the new
+    // turn completes on its OWN result.
+    const says: string[] = [];
+    const backend = new HeldResultBackend();
+    const agent = new PanelAgent("tab-728e", makeDeps(says) as never, backend);
+    void agent.start();
+
+    agent.send("first message");
+    await backend.waitStarted(1);
+    agent.send("second message");
+
+    // Watchdog trips; the interrupted result NEVER arrives, so the bounded
+    // fallback abandons turn 1 and opens the gate → turn 2 dispatches.
+    await waitFor(() => tripped(backend, says));
+    await backend.waitStarted(2);
+    expect(backend.turns).toEqual(["first message", "second message"]);
+
+    // A third message queues behind turn 2's gate.
+    agent.send("third message");
+
+    // Straggler #1: the DEAD turn's late error — dead-lettered, never painted.
+    backend.emitError("late old-turn error");
+    await new Promise((r) => setTimeout(r, 100));
+    expect(says.filter((s) => s.includes("⚠️"))).toHaveLength(1); // still only the stall warning
+
+    // Straggler #2: the DEAD turn's late result — dead-lettered; it must NOT
+    // complete turn 2's gate, so turn 3 stays parked.
+    backend.releaseTurn(); // FIFO: turn 1's withheld terminal (interrupted)
+    await new Promise((r) => setTimeout(r, GATE_HELD_MS));
+    expect(backend.turns).toEqual(["first message", "second message"]);
+
+    // Turn 2's OWN result (success) completes turn 2 → turn 3 drains.
+    backend.releaseTurn({ type: "result", ok: true, subtype: "success" });
+    await backend.waitStarted(3);
+    expect(backend.turns[2]).toContain("third message");
+
+    backend.releaseOnInterrupt = true; // let stop()'s interrupt unwind the pump
+    await agent.stop();
+
+    // Exactly ONE report overall: the original stall warning.
     const warnings = says.filter((s) => s.includes("⚠️"));
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatch(/stopped responding/i);

--- a/src/__tests__/orchestrator/stall-watchdog-interrupt.test.ts
+++ b/src/__tests__/orchestrator/stall-watchdog-interrupt.test.ts
@@ -18,8 +18,12 @@
 // `error` event already painted the failure line suppresses the stall warning,
 // and a late `error` event after the stall warning suppresses the error line.
 // And when the fallback abandons a turn (force-release with no result), the dead
-// turn's straggler `error`/`result` are dead-lettered — never painted against,
-// and never completing the gate of, the turn that replaces it (r2).
+// turn's stragglers are dead-lettered by BACKEND-MINTED TURN MARKER (r3): every
+// event is stamped with the monotonic marker of the turn it belongs to, so an
+// event stamped OLDER than the in-flight turn (or ≤ the abandoned turn's marker)
+// is logged but never painted and never gate-affecting — regardless of
+// interleaving with the new turn's own events. Backends that never stamp
+// (legacy) get NO dead-lettering — previous behavior.
 //
 // TURN_IDLE_MS / INTERRUPT_RELEASE_FALLBACK_MS are read from the env at
 // panel-agent module load, so set SHORT windows BEFORE importing the module.
@@ -57,7 +61,18 @@ const GATE_HELD_MS = 150;
  *  current one is held, mirroring the Claude SDK's independent input pump), so
  *  a turn-gate release is observable as a new turn being READ — independent of
  *  the withheld result. No events are ever emitted spontaneously, so the
- *  watchdog trips on schedule. */
+ *  watchdog trips on schedule.
+ *
+ *  TURN MARKERS (#728 r3): like the real backends, it mints a monotonic marker
+ *  per turn READ (1, 2, …) and stamps it on that turn's terminal event — even
+ *  when the event is emitted LATE, after a newer turn was read (true attribution
+ *  is the contract). Terminal emission is decoupled from the pump loop (the gate
+ *  promise is registered at READ time and emits itself), so a later turn's
+ *  terminal can land while an earlier turn's is still withheld. Test-driven
+ *  emissions (emitError/emitEvent) carry an explicit marker so a straggler can
+ *  be attributed to a DEAD turn on purpose. `legacy = true` suppresses all
+ *  markers, modeling a third-party backend that never stamps (PanelAgent must
+ *  then do NO dead-lettering — previous behavior). */
 class HeldResultBackend implements AgentBackend {
   readonly id = "claude" as const;
   readonly capabilities = CLAUDE_CAPABILITIES;
@@ -67,6 +82,12 @@ class HeldResultBackend implements AgentBackend {
    *  the test alone decides when (if ever) the interrupted result lands. Set to
    *  true right before agent.stop() so teardown's interrupt unwinds the pump. */
   releaseOnInterrupt = false;
+  /** Legacy mode: emit every event WITHOUT a turn marker (third-party backend). */
+  legacy = false;
+  /** Turns with marker ≥ this emit LIVENESS (onActivity pings) while held — a
+   *  healthy working backend, so the (correctly re-armed) watchdog stays quiet
+   *  for them during long observation windows. Default ∞: nothing pings. */
+  livenessFromTurn = Number.POSITIVE_INFINITY;
   private startedCount = 0;
   private startedWaiters: Array<{ n: number; resolve: () => void }> = [];
 
@@ -100,24 +121,35 @@ class HeldResultBackend implements AgentBackend {
     });
   }
 
-  /** Release the OLDEST held turn, emitting `ev` as its terminal event (default:
-   *  the interrupt landing). Turn 2+ can thus end with a SUCCESS result while the
-   *  stalled turn's straggler is the interrupted one. */
-  releaseTurn(ev: AgentEvent = { type: "result", ok: false, subtype: "interrupted" }): void {
-    this.releaseResolvers.shift()?.(ev);
+  /** Release the held turn whose marker is `n` (1 = the first turn read),
+   *  emitting `ev` as its terminal event (default: the interrupt landing),
+   *  stamped with turn n so even a LATE straggler is attributed to its own turn. */
+  releaseTurn(n: number, ev: AgentEvent = { type: "result", ok: false, subtype: "interrupted" }): void {
+    this.held.get(n)?.(ev);
   }
 
-  /** Emit an `error` event for the in-flight turn (test-controlled) — the way
-   *  codex/gemini/grok report a turn failure BEFORE their terminal result. The
-   *  error leaves the turn ACTIVE (no result), so the watchdog can still trip. */
-  emitError(message: string): void {
-    this.emitFn?.({ type: "error", message });
+  /** Emit an `error` event (test-controlled) — the way codex/gemini/grok report
+   *  a turn failure BEFORE their terminal result. The error leaves the turn
+   *  ACTIVE (no result), so the watchdog can still trip. `turn` is the marker it
+   *  belongs to (the DEAD turn's marker manufactures a straggler). */
+  emitError(message: string, turn?: number): void {
+    this.emitFn?.({
+      type: "error",
+      message,
+      ...(turn !== undefined && !this.legacy ? { turn } : {}),
+    });
+  }
+
+  /** Emit any event verbatim (test-controlled, marker included as given). */
+  emitEvent(ev: AgentEvent): void {
+    this.emitFn?.(ev);
   }
 
   private emitFn: ((ev: AgentEvent) => void) | null = null;
-  /** One resolver per in-flight turn, FIFO — resolved by `releaseTurn()` with the
-   *  terminal event to emit for that turn. */
-  private releaseResolvers: Array<(ev: AgentEvent) => void> = [];
+  /** Held terminal gates by marker — resolved by `releaseTurn()` with the
+   *  terminal event to emit. Registered AT READ TIME so a later turn can be
+   *  released while an earlier one is still withheld. */
+  private held = new Map<number, (ev: AgentEvent) => void>();
 
   async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
     const out: AgentEvent[] = [];
@@ -129,33 +161,44 @@ class HeldResultBackend implements AgentBackend {
       wakeOut = null;
     };
 
-    // INPUT PUMP — concurrent, read-ahead, manual per-turn result release.
+    // INPUT PUMP — read each turn as the gate releases it; hold its terminal
+    // event until the test releases it. Record + register at READ time (via the
+    // read promise itself), NOT at a pump loop top that only advances after the
+    // previous turn's release — an early (buggy) gate release or an out-of-order
+    // terminal would otherwise be invisible to the test.
     const pump = (async () => {
       const it = opts.channel[Symbol.asyncIterator]();
-      // Record each turn at READ time — the moment the gate releases it into the
-      // backend — via the read promise itself, NOT at the pump loop top: the loop
-      // only consumes the read-ahead AFTER this turn's withheld result, which
-      // would make an early (buggy) gate release invisible to the test.
+      let marker = 0;
       const read = () =>
         it.next().then((res) => {
-          if (!res.done) {
-            this.turns.push(res.value.text);
-            this.markStarted();
+          if (res.done) return res;
+          marker += 1; // mint: the marker of the turn just read
+          const k = marker;
+          this.turns.push(res.value.text);
+          this.markStarted();
+          // SILENCE: no events for this turn until the test releases its
+          // terminal event. The gate emits ITSELF when released — decoupled
+          // from this pump's read loop, so any turn's terminal can land while
+          // an earlier turn's is still withheld.
+          const gate = new Promise<AgentEvent>((resolve) => {
+            this.held.set(k, resolve);
+          });
+          void gate.then((terminal) => {
+            this.held.delete(k);
+            emit(this.legacy ? terminal : { ...terminal, turn: k });
+          });
+          // Liveness for healthy held turns (opt-in per test): re-arms the
+          // panel's idle watchdog so it correctly does NOT trip them.
+          if (k >= this.livenessFromTurn) {
+            const ping = setInterval(() => opts.onActivity?.(), 40);
+            ping.unref?.();
+            void gate.then(() => clearInterval(ping));
           }
           return res;
         });
       let r = await read(); // read turn 1
       while (!r.done) {
-        // DECOUPLED read-ahead: begin reading the NEXT turn now (parks at the
-        // turn gate while this turn is held) — mirrors the SDK input pump.
-        const readAhead = read();
-        // SILENCE: no events for this turn until the test releases its terminal
-        // event (an interrupted result, or whatever releaseTurn was given).
-        const terminal = await new Promise<AgentEvent>((resolve) => {
-          this.releaseResolvers.push(resolve);
-        });
-        emit(terminal);
-        r = await readAhead;
+        r = await read(); // gated by the panel's turn gate — one per release
       }
       inputDone = true;
       wakeOut?.();
@@ -185,8 +228,8 @@ class HeldResultBackend implements AgentBackend {
     // test armed releaseOnInterrupt (teardown), which lets agent.stop()'s
     // interrupt unwind the pump so the run loop can end.
     if (!this.releaseOnInterrupt) return;
-    const held = this.releaseResolvers;
-    this.releaseResolvers = [];
+    const held = [...this.held.values()];
+    this.held.clear();
     for (const r of held) r({ type: "result", ok: false, subtype: "interrupted" });
   }
 
@@ -243,7 +286,7 @@ describe("stall watchdog interrupt reports once and holds the turn gate (#728)",
 
     // The backend delivers the interrupted turn's terminal result — the genuine
     // turn end. NOW the gate opens and the queued turn drains.
-    backend.releaseTurn();
+    backend.releaseTurn(1);
     await backend.waitStarted(2);
     expect(backend.turns[1]).toContain("second message");
 
@@ -306,7 +349,7 @@ describe("stall watchdog interrupt reports once and holds the turn gate (#728)",
     agent.send("second message queued behind the stall");
 
     // The backend reports the turn's failure, then goes silent (no result).
-    backend.emitError("provider exploded");
+    backend.emitError("provider exploded", 1);
     await waitFor(() => says.some((s) => /turn failed/i.test(s)));
 
     // The watchdog still trips on the silence (the error left the turn active)
@@ -349,8 +392,8 @@ describe("stall watchdog interrupt reports once and holds the turn gate (#728)",
 
     // A late `error` event arrives for the same (already-reported) turn, then
     // the interrupted result settles the turn and opens the gate.
-    backend.emitError("late backend error");
-    backend.releaseTurn();
+    backend.emitError("late backend error", 1);
+    backend.releaseTurn(1);
     await backend.waitStarted(2);
     expect(backend.turns[1]).toContain("second message");
 
@@ -372,6 +415,10 @@ describe("stall watchdog interrupt reports once and holds the turn gate (#728)",
     // turn completes on its OWN result.
     const says: string[] = [];
     const backend = new HeldResultBackend();
+    // Turn 2+ is a HEALTHY working backend (liveness pings) — only turn 1 is
+    // frozen — so turn 2's (correctly re-armed) watchdog stays quiet while the
+    // test holds it through the straggler-observation windows.
+    backend.livenessFromTurn = 2;
     const agent = new PanelAgent("tab-728e", makeDeps(says) as never, backend);
     void agent.start();
 
@@ -389,18 +436,18 @@ describe("stall watchdog interrupt reports once and holds the turn gate (#728)",
     agent.send("third message");
 
     // Straggler #1: the DEAD turn's late error — dead-lettered, never painted.
-    backend.emitError("late old-turn error");
+    backend.emitError("late old-turn error", 1);
     await new Promise((r) => setTimeout(r, 100));
     expect(says.filter((s) => s.includes("⚠️"))).toHaveLength(1); // still only the stall warning
 
     // Straggler #2: the DEAD turn's late result — dead-lettered; it must NOT
     // complete turn 2's gate, so turn 3 stays parked.
-    backend.releaseTurn(); // FIFO: turn 1's withheld terminal (interrupted)
+    backend.releaseTurn(1); // turn 1's withheld terminal (interrupted)
     await new Promise((r) => setTimeout(r, GATE_HELD_MS));
     expect(backend.turns).toEqual(["first message", "second message"]);
 
     // Turn 2's OWN result (success) completes turn 2 → turn 3 drains.
-    backend.releaseTurn({ type: "result", ok: true, subtype: "success" });
+    backend.releaseTurn(2, { type: "result", ok: true, subtype: "success" });
     await backend.waitStarted(3);
     expect(backend.turns[2]).toContain("third message");
 
@@ -412,5 +459,123 @@ describe("stall watchdog interrupt reports once and holds the turn gate (#728)",
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatch(/stopped responding/i);
     expect(says.join("\n")).not.toMatch(/turn failed/i);
+  });
+
+  it("result-only new turn after a fallback abandonment is NOT dead-lettered (no wedge)", async () => {
+    // The r3 codex-gate finding #1: after the fallback abandons A, B's VALID
+    // first event may be its terminal result (the event contract permits
+    // result-only turns). With markers it is stamped B — not A — so it reaches
+    // completeTurn() and B's gate opens. (The credit heuristic dead-lettered it
+    // as A's and wedged B.)
+    const says: string[] = [];
+    const backend = new HeldResultBackend();
+    const agent = new PanelAgent("tab-728f", makeDeps(says) as never, backend);
+    void agent.start();
+
+    agent.send("first message");
+    await backend.waitStarted(1);
+    agent.send("second message");
+
+    // A stalls → watchdog → fallback abandons A (its result NEVER comes) → B.
+    await waitFor(() => tripped(backend, says));
+    await backend.waitStarted(2);
+    expect(backend.turns).toEqual(["first message", "second message"]);
+    agent.send("third message"); // queued behind B's gate
+
+    // B's FIRST and ONLY event is its terminal result — stamped 2, so it
+    // completes B's gate even though A's terminal never arrived.
+    backend.releaseTurn(2, { type: "result", ok: true, subtype: "success" });
+    await backend.waitStarted(3); // would time out if B were wedged
+    expect(backend.turns[2]).toContain("third message");
+
+    backend.releaseOnInterrupt = true; // let stop()'s interrupt unwind the pump
+    await agent.stop();
+
+    const warnings = says.filter((s) => s.includes("⚠️"));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/stopped responding/i);
+  });
+
+  it("new turn's work before the dead turn's late terminal keeps the straggler dead-lettered", async () => {
+    // The r3 codex-gate finding #2: B emits ordinary work BEFORE A's late
+    // terminal. Markers make attribution order-independent — A's terminal is
+    // stamped 1, so it is dead-lettered no matter what B emitted first: no wrong
+    // report, no premature gate completion. (The credit heuristic cleared the
+    // credit on B's work and then attributed A's terminal to B.)
+    const says: string[] = [];
+    const backend = new HeldResultBackend();
+    backend.livenessFromTurn = 2; // B works healthily while held (see test E)
+    const agent = new PanelAgent("tab-728g", makeDeps(says) as never, backend);
+    void agent.start();
+
+    agent.send("first message");
+    await backend.waitStarted(1);
+    agent.send("second message");
+
+    await waitFor(() => tripped(backend, says));
+    await backend.waitStarted(2);
+    expect(backend.turns).toEqual(["first message", "second message"]);
+    agent.send("third message"); // queued behind B's gate
+
+    // B's valid work arrives FIRST (stamped 2 → processed normally)…
+    backend.emitEvent({ type: "assistant", text: "B is working", turn: 2 });
+    await waitFor(() => says.some((s) => s.includes("B is working")));
+
+    // …THEN A's late terminal (stamped 1): still dead-lettered — turn 3 parked.
+    backend.releaseTurn(1);
+    await new Promise((r) => setTimeout(r, GATE_HELD_MS));
+    expect(backend.turns).toEqual(["first message", "second message"]);
+
+    // B's OWN terminal completes B → turn 3 drains.
+    backend.releaseTurn(2, { type: "result", ok: true, subtype: "success" });
+    await backend.waitStarted(3);
+    expect(backend.turns[2]).toContain("third message");
+
+    backend.releaseOnInterrupt = true; // let stop()'s interrupt unwind the pump
+    await agent.stop();
+
+    // No wrong report: only the original stall warning.
+    const warnings = says.filter((s) => s.includes("⚠️"));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/stopped responding/i);
+    expect(says.join("\n")).not.toMatch(/turn failed/i);
+  });
+
+  it("legacy no-marker backend gets NO dead-lettering (previous behavior)", async () => {
+    // A backend that never stamps turn markers must behave exactly as before
+    // this PR series: PanelAgent can't attribute stragglers, so it does NOT
+    // dead-letter — better a rare duplicate than a wedge.
+    const says: string[] = [];
+    const backend = new HeldResultBackend();
+    backend.legacy = true; // emit everything WITHOUT a turn marker
+    const agent = new PanelAgent("tab-728h", makeDeps(says) as never, backend);
+    void agent.start();
+
+    agent.send("first message");
+    await backend.waitStarted(1);
+    agent.send("second message");
+
+    await waitFor(() => tripped(backend, says));
+    await backend.waitStarted(2);
+    expect(backend.turns).toEqual(["first message", "second message"]);
+    agent.send("third message"); // queued behind turn 2's gate
+
+    // Unmarked straggler error → processed (painted), exactly as pre-markers.
+    backend.emitError("legacy straggler error");
+    await waitFor(() => says.some((s) => /turn failed/i.test(s)));
+
+    // Unmarked straggler result → completes the gate, exactly as pre-markers:
+    // turn 3 drains WITHOUT turn 2's own result ever arriving.
+    backend.releaseTurn(1);
+    await backend.waitStarted(3);
+    expect(backend.turns[2]).toContain("third message");
+
+    backend.releaseOnInterrupt = true; // let stop()'s interrupt unwind the pump
+    await agent.stop();
+
+    const warnings = says.filter((s) => s.includes("⚠️"));
+    expect(warnings).toHaveLength(2); // stall warning + the painted straggler error
+    expect(warnings[0]).toMatch(/stopped responding/i);
+    expect(warnings[1]).toMatch(/turn failed/i);
   });
 });

--- a/src/__tests__/orchestrator/stall-watchdog-interrupt.test.ts
+++ b/src/__tests__/orchestrator/stall-watchdog-interrupt.test.ts
@@ -1,0 +1,274 @@
+// #728 — the stall watchdog's interrupt path must report the failure ONCE and
+// hold the turn gate until the turn GENUINELY ends.
+//
+// OLD BUG: onTurnStalled() surfaced "⚠️ The agent stopped responding…", then
+// released the turn gate SYNCHRONOUSLY (completeTurn()) and called
+// backend.interrupt() directly. Two failures followed:
+//   1. When the backend emitted the expected terminal
+//      `{ ok: false, subtype: "interrupted" }` result, the result handler didn't
+//      know it was watchdog-initiated, so the never-end-in-silence guard painted
+//      a SECOND, contradictory failure: "⚠️ That turn failed (interrupted)…".
+//   2. The synchronous completeTurn() made the next queued batch eligible BEFORE
+//      the interrupted turn had settled.
+//
+// FIX: the watchdog marks the failure surfaced (errorSurfaced) and routes
+// through the guarded interrupt() flow — the aborted turn's terminal result (or
+// the bounded interrupt-release fallback if none arrives) opens the gate at the
+// genuine turn end.
+//
+// TURN_IDLE_MS / INTERRUPT_RELEASE_FALLBACK_MS are read from the env at
+// panel-agent module load, so set SHORT windows BEFORE importing the module.
+
+process.env.COMFYUI_MCP_TURN_IDLE_MS = "100";
+process.env.COMFYUI_MCP_INTERRUPT_RELEASE_MS = "500";
+
+import { describe, expect, it, beforeAll } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+
+let PanelAgent: typeof import("../../orchestrator/panel-agent.js").PanelAgent;
+
+beforeAll(async () => {
+  ({ PanelAgent } = await import("../../orchestrator/panel-agent.js"));
+});
+
+/** How long after the observed trip we wait before asserting the gate is still
+ *  held. The OLD code released the gate synchronously INSIDE onTurnStalled, so
+ *  the queued turn drained within a few ms of the trip — 150ms is ~30x margin.
+ *  Still comfortably before the 500ms interrupt-release fallback (armed at the
+ *  trip), so a held gate here proves the RESULT — not the fallback — opens it. */
+const GATE_HELD_MS = 150;
+
+/** A backend whose turn emits NOTHING (the true zero-event freeze the watchdog
+ *  exists to catch) until the test releases that turn's terminal result, which
+ *  is always the interrupt landing: `{ ok: false, subtype: "interrupted" }`.
+ *
+ *  The input pump is DECOUPLED (it starts reading the NEXT turn while the
+ *  current one is held, mirroring the Claude SDK's independent input pump), so
+ *  a turn-gate release is observable as a new turn being READ — independent of
+ *  the withheld result. No events are ever emitted spontaneously, so the
+ *  watchdog trips on schedule. */
+class HeldResultBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turns: string[] = [];
+  interrupted = 0;
+  /** The wedge: an interrupt does NOT end the held turn or emit its result —
+   *  the test alone decides when (if ever) the interrupted result lands. Set to
+   *  true right before agent.stop() so teardown's interrupt unwinds the pump. */
+  releaseOnInterrupt = false;
+  /** One resolver per in-flight turn, FIFO — resolved by `releaseTurn()` to emit
+   *  that turn's interrupted `result`. */
+  private releaseResolvers: Array<() => void> = [];
+  private startedCount = 0;
+  private startedWaiters: Array<{ n: number; resolve: () => void }> = [];
+
+  private markStarted(): void {
+    this.startedCount += 1;
+    this.startedWaiters = this.startedWaiters.filter((w) => {
+      if (this.startedCount >= w.n) {
+        w.resolve();
+        return false;
+      }
+      return true;
+    });
+  }
+
+  /** Resolve once the pump has READ at least `n` turns. Rejects after
+   *  `timeoutMs` so a gate that never drains fails fast instead of hanging. */
+  waitStarted(n: number, timeoutMs = 3000): Promise<void> {
+    if (this.startedCount >= n) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`turn ${n} never started (gate did not drain)`)),
+        timeoutMs,
+      );
+      this.startedWaiters.push({
+        n,
+        resolve: () => {
+          clearTimeout(timer);
+          resolve();
+        },
+      });
+    });
+  }
+
+  /** Release the OLDEST held turn so its interrupted `result` is emitted. */
+  releaseTurn(): void {
+    this.releaseResolvers.shift()?.();
+  }
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    const out: AgentEvent[] = [];
+    let wakeOut: (() => void) | null = null;
+    let inputDone = false;
+    const emit = (ev: AgentEvent) => {
+      out.push(ev);
+      wakeOut?.();
+      wakeOut = null;
+    };
+
+    // INPUT PUMP — concurrent, read-ahead, manual per-turn result release.
+    const pump = (async () => {
+      const it = opts.channel[Symbol.asyncIterator]();
+      // Record each turn at READ time — the moment the gate releases it into the
+      // backend — via the read promise itself, NOT at the pump loop top: the loop
+      // only consumes the read-ahead AFTER this turn's withheld result, which
+      // would make an early (buggy) gate release invisible to the test.
+      const read = () =>
+        it.next().then((res) => {
+          if (!res.done) {
+            this.turns.push(res.value.text);
+            this.markStarted();
+          }
+          return res;
+        });
+      let r = await read(); // read turn 1
+      while (!r.done) {
+        // DECOUPLED read-ahead: begin reading the NEXT turn now (parks at the
+        // turn gate while this turn is held) — mirrors the SDK input pump.
+        const readAhead = read();
+        // SILENCE: no events for this turn until the test releases its result.
+        await new Promise<void>((resolve) => {
+          this.releaseResolvers.push(resolve);
+        });
+        emit({ type: "result", ok: false, subtype: "interrupted" });
+        r = await readAhead;
+      }
+      inputDone = true;
+      wakeOut?.();
+      wakeOut = null;
+    })();
+
+    emit({ type: "session", sessionId: "sess-held" });
+    try {
+      while (!inputDone || out.length) {
+        if (!out.length) {
+          await new Promise<void>((resolve) => {
+            wakeOut = resolve;
+          });
+          continue;
+        }
+        yield out.shift()!;
+      }
+    } finally {
+      await pump.catch(() => {});
+    }
+  }
+
+  async interrupt(): Promise<void> {
+    this.interrupted += 1;
+    // The wedged turn survives an interrupt — no result is emitted — unless the
+    // test armed releaseOnInterrupt (teardown), which lets agent.stop()'s
+    // interrupt unwind the pump so the run loop can end.
+    if (!this.releaseOnInterrupt) return;
+    const held = this.releaseResolvers;
+    this.releaseResolvers = [];
+    for (const r of held) r();
+  }
+
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+function makeDeps(says: string[]) {
+  return {
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-test",
+    onSay: (_tab: string, text: string) => {
+      says.push(text);
+    },
+    onTurn: () => {},
+  };
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+/** The watchdog fired: stall warning surfaced and the backend interrupted. */
+function tripped(backend: HeldResultBackend, says: string[]): boolean {
+  return backend.interrupted >= 1 && says.some((s) => /stopped responding/i.test(s));
+}
+
+describe("stall watchdog interrupt reports once and holds the turn gate (#728)", () => {
+  it("emits exactly ONE failure report and holds the gate until the interrupted result lands", async () => {
+    const says: string[] = [];
+    const backend = new HeldResultBackend();
+    const agent = new PanelAgent("tab-728a", makeDeps(says) as never, backend);
+    void agent.start();
+
+    // Turn 1 starts and freezes (zero events); turn 2 queues behind the gate.
+    agent.send("first message");
+    await backend.waitStarted(1);
+    agent.send("second message queued behind the stall");
+
+    // The watchdog trips: one stall warning + one backend interrupt.
+    await waitFor(() => tripped(backend, says));
+
+    // The gate must still be HELD — the interrupted turn hasn't settled (its
+    // result is withheld). The old synchronous completeTurn() drained turn 2
+    // within ms of the trip, so this assertion failed before the fix.
+    await new Promise((r) => setTimeout(r, GATE_HELD_MS));
+    expect(backend.turns).toEqual(["first message"]);
+
+    // The backend delivers the interrupted turn's terminal result — the genuine
+    // turn end. NOW the gate opens and the queued turn drains.
+    backend.releaseTurn();
+    await backend.waitStarted(2);
+    expect(backend.turns[1]).toContain("second message");
+
+    backend.releaseOnInterrupt = true; // let stop()'s interrupt unwind the pump
+    await agent.stop();
+
+    // Exactly ONE user-visible failure report: the stall warning. The follow-up
+    // interrupted result must NOT paint a second "That turn failed" line.
+    const warnings = says.filter((s) => s.includes("⚠️"));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/stopped responding/i);
+    expect(says.join("\n")).not.toMatch(/That turn failed/i);
+  });
+
+  it("still releases the gate via the bounded fallback when no result ever arrives", async () => {
+    const says: string[] = [];
+    const backend = new HeldResultBackend();
+    const agent = new PanelAgent("tab-728b", makeDeps(says) as never, backend);
+    void agent.start();
+
+    agent.send("first message");
+    await backend.waitStarted(1);
+    agent.send("second message queued behind the stall");
+
+    await waitFor(() => tripped(backend, says));
+
+    // Held before the fallback window (500ms from the trip) elapses…
+    await new Promise((r) => setTimeout(r, GATE_HELD_MS));
+    expect(backend.turns).toEqual(["first message"]);
+
+    // …then the bounded interrupt-release fallback force-opens the gate (the
+    // interrupted result NEVER comes), so the queued turn still drains — an
+    // interrupt can't stop cold. waitStarted rejects if it never does.
+    await backend.waitStarted(2);
+    expect(backend.turns[1]).toContain("second message");
+
+    backend.releaseOnInterrupt = true; // let stop()'s interrupt unwind the pump
+    await agent.stop();
+
+    // No result ever arrived, so there is nothing to duplicate — still exactly
+    // one visible warning.
+    const warnings = says.filter((s) => s.includes("⚠️"));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/stopped responding/i);
+  });
+});

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -75,7 +75,7 @@ export interface AgentCapabilities {
  * meter, the result subtype/contextWindow/cost, live thinking-token counts). A
  * non-Claude backend simply omits the optional fields it can't supply.
  */
-export type AgentEvent =
+export type AgentEvent = (
   /** Session opened/continued; `model` is the SDK-reported active model, if any. */
   | { type: "session"; sessionId: string; model?: string }
   /** Incremental assistant/thinking text (token-by-token streaming). */
@@ -100,7 +100,31 @@ export type AgentEvent =
       costUsd?: number;
     }
   | { type: "rate_limit"; resetsAt?: number; kind?: string }
-  | { type: "error"; message: string };
+  | { type: "error"; message: string }
+) & {
+  /** Backend-minted TURN MARKER (#728): a monotonically increasing id (1 = the
+   *  first turn read from the channel in this run) the backend stamps on every
+   *  event it emits FOR a submitted turn, so PanelAgent can attribute stragglers:
+   *  an event stamped with a turn OLDER than the in-flight turn is dead-lettered
+   *  (logged, never painted, never gate-affecting) instead of corrupting the turn
+   *  that replaced an abandoned one. OMITTED = legacy/third-party backend (or an
+   *  event outside any turn, like session init) — NO dead-lettering, previous
+   *  behavior (better a rare duplicate than a wedge). */
+  turn?: number;
+};
+
+/** Stamp every event of a per-turn stream with the backend-minted `turn` marker
+ *  (see AgentEvent.turn). Backends mint one incrementing marker per turn read
+ *  from the channel and wrap their per-turn generator: events inside a turn are
+ *  stamped; a `session` event (outside any turn) passes through unstamped. */
+export async function* stampTurn(
+  stream: AsyncIterable<AgentEvent>,
+  turn: number,
+): AsyncGenerator<AgentEvent> {
+  for await (const ev of stream) {
+    yield ev.type === "session" ? ev : { ...ev, turn };
+  }
+}
 
 export interface ModelChoice {
   id: string;

--- a/src/orchestrator/antigravity-backend.ts
+++ b/src/orchestrator/antigravity-backend.ts
@@ -81,6 +81,7 @@ import {
   type ModelChoice,
   type NeutralTurn,
   ANTIGRAVITY_CAPABILITIES,
+  stampTurn,
 } from "./agent-backend.js";
 import type { GeminiMcpServerSpec } from "./gemini-backend.js";
 
@@ -551,8 +552,9 @@ export class AntigravityBackend implements AgentBackend {
       ...(this.model ? { model: this.model } : {}),
     };
 
+    let turnSeq = 0;
     for await (const turn of opts.channel) {
-      yield* this.runTurn(turn, cwd, opts.onActivity);
+      yield* stampTurn(this.runTurn(turn, cwd, opts.onActivity), ++turnSeq);
     }
   }
 

--- a/src/orchestrator/chatgpt-oauth-backend.ts
+++ b/src/orchestrator/chatgpt-oauth-backend.ts
@@ -8,7 +8,7 @@ import { randomUUID } from "node:crypto";
 import { logger } from "../utils/logger.js";
 import { errorText } from "./error-text.js";
 import type { AgentEvent, BackendStartOptions, ModelChoice, NeutralTurn } from "./agent-backend.js";
-import { CHATGPT_CAPABILITIES } from "./agent-backend.js";
+import { CHATGPT_CAPABILITIES, stampTurn } from "./agent-backend.js";
 import { resolveOpenAICodexOAuth } from "../services/code-provider-auth.js";
 import { OllamaBackend, type OllamaBackendDeps } from "./ollama-backend.js";
 
@@ -321,8 +321,9 @@ export class ChatGptOAuthBackend extends OllamaBackend {
 
     const instructions = [CHATGPT_SYSTEM_PROMPT, this.deps.systemAppend].filter(Boolean).join("\n\n");
 
+    let turnSeq = 0;
     for await (const turn of opts.channel) {
-      yield* this.runCodexTurn(turn, instructions, opts);
+      yield* stampTurn(this.runCodexTurn(turn, instructions, opts), ++turnSeq);
     }
   }
 

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -283,6 +283,11 @@ export class ClaudeBackend implements AgentBackend {
    *  jump in lastResultTurnId, and lets a genuinely interrupted late landing
    *  still pop its OWN trace (a backward pop) and classify/stamp by its flags. */
   private parkedInterrupted = new Set<number>();
+  /** Interrupted traces whose late landing already HAPPENED (moved out of
+   *  parkedInterrupted on the pop) — consumption tracking so a SECOND
+   *  interrupted landing can never re-consume a landed trace; with no
+   *  unconsumed candidate it fails closed as traceless (#728 r6). */
+  private consumedInterrupted = new Set<number>();
   private turns: Array<{
     id: number;
     hasContent: boolean;
@@ -425,6 +430,7 @@ export class ClaudeBackend implements AgentBackend {
     this.lastResultTurnId = this.turnSeq;
     this.classificationPoisoned = false;
     this.parkedInterrupted.clear(); // dead session's parks die with it
+    this.consumedInterrupted.clear(); // …and its landing history
     this.markerBase = this.lastResultTurnId; // turn markers are run-relative (#728)
     // Wrap the neutral channel: shape each turn into the SDK's native form right
     // before it's read, so PanelAgent never deals in SDKUserMessage.
@@ -685,8 +691,8 @@ export class ClaudeBackend implements AgentBackend {
         // is unrecoverable once crossed, so the poison is terminal for the
         // session — content evidence must not rescue it (it accrued to a
         // mismatched trace, which is not proof of ITS turn's success).
-        // SUBTYPE-AWARE correlation (#728 r5): an interrupted turn ends with an
-        // INTERRUPTED-subtype result, so a result with any OTHER subtype can
+        // SUBTYPE-AWARE correlation (#728 r5/r6): an interrupted turn ends with
+        // an INTERRUPTED-subtype result, so a result with any OTHER subtype can
         // never be an interrupted trace's terminal. If the oldest trace is
         // marked interrupted and this result is NOT, that turn's result is
         // permanently LOST (the panel's fallback released the next turn long
@@ -694,20 +700,39 @@ export class ClaudeBackend implements AgentBackend {
         // interrupted trace(s) and pop the first non-interrupted one, for
         // classification AND for the turn-marker stamp (otherwise the new turn's
         // terminal stamps with the abandoned turn's marker and PanelAgent
-        // dead-letters it — a permanent wedge). A genuinely INTERRUPTED-subtype
-        // landing does not skip: it pops the oldest (parked) interrupted trace
-        // and classifies/stamps by ITS flags.
+        // dead-letters it — a permanent wedge).
+        //
+        // An INTERRUPTED-subtype landing does not skip — but it does NOT blindly
+        // pop the oldest trace either (r6): a parked trace's result was already
+        // declared lost, so a fresh landing belongs to the oldest UNPARKED
+        // interrupted trace (a NEWER turn interrupted after the park — blindly
+        // popping parked A would stamp C's real terminal with A's marker and
+        // wedge C). Only when no unparked candidate remains is it the parked
+        // trace's own late landing. Each trace lands at most once: a landed
+        // park moves to consumedInterrupted, so a SECOND landing for the same
+        // turn finds no candidate and fails closed (traceless) below.
         const resultSubtype: string = message.subtype;
         const interruptedLanding = resultSubtype === "interrupted";
-        let traceIndex = 0;
+        let trace: (typeof this.turns)[number] | null = null;
         if (!interruptedLanding) {
+          let traceIndex = 0;
           while (traceIndex < this.turns.length - 1 && this.turns[traceIndex].interrupted) {
             this.parkedInterrupted.add(this.turns[traceIndex].id);
             traceIndex += 1;
           }
+          trace = traceIndex === 0 ? (this.turns.shift() ?? null) : (this.turns.splice(traceIndex, 1)[0] ?? null);
+        } else {
+          let idx = this.turns.findIndex((t) => t.interrupted && !this.parkedInterrupted.has(t.id));
+          if (idx < 0) {
+            idx = this.turns.findIndex(
+              (t) =>
+                t.interrupted &&
+                this.parkedInterrupted.has(t.id) &&
+                !this.consumedInterrupted.has(t.id),
+            );
+          }
+          trace = idx >= 0 ? (this.turns.splice(idx, 1)[0] ?? null) : null;
         }
-        const trace =
-          traceIndex === 0 ? (this.turns.shift() ?? null) : (this.turns.splice(traceIndex, 1)[0] ?? null);
         let unverifiable: string | null = null;
         if (this.classificationPoisoned) {
           unverifiable = "Turn bookkeeping was poisoned by an earlier overflow — no result in this session can be verified";
@@ -723,8 +748,9 @@ export class ClaudeBackend implements AgentBackend {
               if (!this.parkedInterrupted.has(id)) crossesGap = true;
             }
           } else if (trace.id <= this.lastResultTurnId) {
-            // Backward pop: legit only for a parked interrupted trace's landing.
-            crossesGap = !this.parkedInterrupted.has(trace.id);
+            // Backward pop: legit only for a parked (or landed-once) interrupted
+            // trace's deferred landing.
+            crossesGap = !(this.parkedInterrupted.has(trace.id) || this.consumedInterrupted.has(trace.id));
           }
           if (crossesGap) {
             // The pop crossed an evicted-turn gap → poison the session (do NOT
@@ -736,7 +762,9 @@ export class ClaudeBackend implements AgentBackend {
               `[claude-backend] result crosses an evicted-turn gap (popped turn ${trace.id}, expected ${this.lastResultTurnId + 1}) — unverifiable; classification poisoned for the rest of the session (#740)`,
             );
           } else {
-            this.parkedInterrupted.delete(trace.id);
+            // A legitimately popped park is now LANDED — consumed once, so a
+            // second landing for it finds no candidate (#728 r6).
+            if (this.parkedInterrupted.delete(trace.id)) this.consumedInterrupted.add(trace.id);
             if (trace.id > this.lastResultTurnId) this.lastResultTurnId = trace.id;
           }
         }
@@ -751,7 +779,10 @@ export class ClaudeBackend implements AgentBackend {
         let ok =
           resultSubtype === "success" ||
           (resultSubtype === "interrupted" && trace !== null && trace.interrupted);
-        if (ok && unverifiable !== null) {
+        if (unverifiable !== null) {
+          // Fail closed with the reason VISIBLE — including an anomalous
+          // interrupted landing with no unconsumed candidate (#728 r6), whose
+          // ok is already false.
           ok = false;
           yield {
             type: "error",

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -691,18 +691,20 @@ export class ClaudeBackend implements AgentBackend {
         // is unrecoverable once crossed, so the poison is terminal for the
         // session — content evidence must not rescue it (it accrued to a
         // mismatched trace, which is not proof of ITS turn's success).
-        // An INTERRUPTED-subtype landing does not skip — and it is not blindly
-        // the oldest trace either (r6/r7). The SDK processes turns
-        // SEQUENTIALLY and the panel's turn gate only ever submits a newer turn
-        // after the older turn's result was written off, so with SEVERAL
-        // unconsumed interrupted traces pending the landing belongs to the
-        // NEWEST of them — the older interrupted turns' results are provably
-        // LOST and are written off (parked) here too, uniformly with the r5
-        // skip. With exactly ONE candidate the landing is simply its own (the
-        // normal in-order case, or a parked trace's late landing). Each trace
-        // lands at most once: candidates are unconsumed (landed parks move to
-        // consumedInterrupted on the pop), so a SECOND landing for the same
-        // turn finds no candidate and fails closed (traceless) below.
+        // An INTERRUPTED-subtype landing does not skip. SEQUENTIAL-EMISSION
+        // INVARIANT (#728 r8): the SDK emits results in processing order — a
+        // turn's result ALWAYS precedes the next turn's result in the stream,
+        // so the oldest LIVE (unparked) interrupted trace owns the next
+        // landing. A turn is only ever written off by a NON-interrupted result
+        // passing it (the r5 skip parks it — its result is then provably lost),
+        // NEVER by preference: a newer interrupted turn's trace can exist while
+        // an older turn is still settling (queued input), and the older turn's
+        // legitimate landing MUST still pop the older trace. The parked
+        // fallback below is the tolerance for a write-off that proved wrong
+        // (a genuinely late landing for an already-parked turn). Each trace
+        // lands at most once: landed parks move to consumedInterrupted, so a
+        // SECOND landing for the same turn finds no candidate and fails closed
+        // (traceless) below.
         const resultSubtype: string = message.subtype;
         const interruptedLanding = resultSubtype === "interrupted";
         let trace: (typeof this.turns)[number] | null = null;
@@ -714,23 +716,19 @@ export class ClaudeBackend implements AgentBackend {
           }
           trace = traceIndex === 0 ? (this.turns.shift() ?? null) : (this.turns.splice(traceIndex, 1)[0] ?? null);
         } else {
-          let idx = -1;
-          for (let i = this.turns.length - 1; i >= 0; i--) {
-            if (this.turns[i].interrupted && !this.consumedInterrupted.has(this.turns[i].id)) {
-              idx = i; // newest unconsumed interrupted trace
-              break;
-            }
+          // Oldest LIVE (unparked) interrupted trace first; a parked trace's
+          // result was already written off, so only when no live candidate
+          // remains is the landing a parked trace's own late one.
+          let idx = this.turns.findIndex((t) => t.interrupted && !this.parkedInterrupted.has(t.id));
+          if (idx < 0) {
+            idx = this.turns.findIndex(
+              (t) =>
+                t.interrupted &&
+                this.parkedInterrupted.has(t.id) &&
+                !this.consumedInterrupted.has(t.id),
+            );
           }
-          if (idx >= 0) {
-            // Write off every OTHER unconsumed interrupted trace older than the
-            // landing's turn — their results are provably lost (above).
-            for (let i = 0; i < idx; i++) {
-              if (this.turns[i].interrupted && !this.consumedInterrupted.has(this.turns[i].id)) {
-                this.parkedInterrupted.add(this.turns[i].id);
-              }
-            }
-            trace = this.turns.splice(idx, 1)[0] ?? null;
-          }
+          trace = idx >= 0 ? (this.turns.splice(idx, 1)[0] ?? null) : null;
         }
         let unverifiable: string | null = null;
         if (this.classificationPoisoned) {

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -691,24 +691,32 @@ export class ClaudeBackend implements AgentBackend {
         // is unrecoverable once crossed, so the poison is terminal for the
         // session — content evidence must not rescue it (it accrued to a
         // mismatched trace, which is not proof of ITS turn's success).
-        // An INTERRUPTED-subtype landing does not skip. SEQUENTIAL-EMISSION
-        // INVARIANT (#728 r8): the SDK emits results in processing order — a
-        // turn's result ALWAYS precedes the next turn's result in the stream,
-        // so the oldest LIVE (unparked) interrupted trace owns the next
-        // landing. A turn is only ever written off by a NON-interrupted result
-        // passing it (the r5 skip parks it — its result is then provably lost),
-        // NEVER by preference: a newer interrupted turn's trace can exist while
-        // an older turn is still settling (queued input), and the older turn's
-        // legitimate landing MUST still pop the older trace. The parked
-        // fallback below is the tolerance for a write-off that proved wrong
-        // (a genuinely late landing for an already-parked turn). Each trace
-        // lands at most once: landed parks move to consumedInterrupted, so a
-        // SECOND landing for the same turn finds no candidate and fails closed
-        // (traceless) below.
+        // SUBTYPE-AWARE correlation on the SDK's REAL result vocabulary
+        // (#728 r5–r9): results arrive as `success` or `error_*` — an
+        // interrupted turn ends with an error_during_execution result (the
+        // interrupt landing); there is no "interrupted" result subtype.
+        // Combined with SEQUENTIAL EMISSION (results always emit in processing
+        // order — a turn's result ALWAYS precedes the next turn's result in
+        // the stream):
+        //  • A SUCCESS landing can never belong to an interrupted-marked turn,
+        //    so if the oldest trace is interrupted and a newer trace exists,
+        //    that turn's result is permanently LOST — skip (park) the
+        //    interrupted trace(s) and pop the first non-interrupted one (the
+        //    r5 skip). This is the ONLY write-off; never by preference.
+        //  • An error_* landing belongs to the OLDEST LIVE (unparked) trace —
+        //    interrupted turn or not (a healthy turn's genuine failure is
+        //    likewise its own). A newer interrupted turn's trace may exist
+        //    while the older turn is still settling (queued input); the older
+        //    turn's legitimate landing MUST still pop the older trace. Only
+        //    when no live candidate remains is the landing a parked trace's
+        //    own late one (a write-off that proved wrong). Each trace lands at
+        //    most once: landed parks move to consumedInterrupted, so a SECOND
+        //    landing for the same turn finds no candidate and fails closed
+        //    (traceless) below.
         const resultSubtype: string = message.subtype;
-        const interruptedLanding = resultSubtype === "interrupted";
+        const successLanding = resultSubtype === "success";
         let trace: (typeof this.turns)[number] | null = null;
-        if (!interruptedLanding) {
+        if (successLanding) {
           let traceIndex = 0;
           while (traceIndex < this.turns.length - 1 && this.turns[traceIndex].interrupted) {
             this.parkedInterrupted.add(this.turns[traceIndex].id);
@@ -716,16 +724,13 @@ export class ClaudeBackend implements AgentBackend {
           }
           trace = traceIndex === 0 ? (this.turns.shift() ?? null) : (this.turns.splice(traceIndex, 1)[0] ?? null);
         } else {
-          // Oldest LIVE (unparked) interrupted trace first; a parked trace's
-          // result was already written off, so only when no live candidate
-          // remains is the landing a parked trace's own late one.
-          let idx = this.turns.findIndex((t) => t.interrupted && !this.parkedInterrupted.has(t.id));
+          // Oldest LIVE (unparked) trace first — interrupted or not; a parked
+          // trace's result was already written off, so only when no live
+          // candidate remains is the landing a parked trace's own late one.
+          let idx = this.turns.findIndex((t) => !this.parkedInterrupted.has(t.id));
           if (idx < 0) {
             idx = this.turns.findIndex(
-              (t) =>
-                t.interrupted &&
-                this.parkedInterrupted.has(t.id) &&
-                !this.consumedInterrupted.has(t.id),
+              (t) => this.parkedInterrupted.has(t.id) && !this.consumedInterrupted.has(t.id),
             );
           }
           trace = idx >= 0 ? (this.turns.splice(idx, 1)[0] ?? null) : null;
@@ -770,12 +775,14 @@ export class ClaudeBackend implements AgentBackend {
         // subtype-aware skip). A traceless result stays UNMARKED so its
         // fail-closed error and gate completion still reach the panel.
         const stamp = trace ? { turn: trace.id - this.markerBase } : {};
-        // An interrupted turn's terminal (subtype "interrupted") is the
-        // interrupt LANDING for its own interrupted trace, not a failure —
-        // blessed like a success; the empty-turn guard below still spares it.
+        // An interrupted turn's terminal (an error_during_execution landing for
+        // its own interrupted-marked trace) is the interrupt LANDING, not a
+        // failure — blessed like a success; the empty-turn guard below still
+        // spares it. Any other error_* subtype classifies by the trace's own
+        // flags (a genuine failure for a non-interrupted turn).
         let ok =
           resultSubtype === "success" ||
-          (resultSubtype === "interrupted" && trace !== null && trace.interrupted);
+          (resultSubtype === "error_during_execution" && trace !== null && trace.interrupted);
         if (unverifiable !== null) {
           // Fail closed with the reason VISIBLE — including an anomalous
           // interrupted landing with no unconsumed candidate (#728 r6), whose

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -435,12 +435,16 @@ export class ClaudeBackend implements AgentBackend {
     }
     const q = query({ prompt: prompt(), options: this.buildOptions(opts) });
     this.q = q;
-    // TURN MARKERS (#728): the SDK's input pump and output reader are independent
-    // streams, so the marker can't ride the input side — instead stamp output-side
-    // by turn boundary: the SDK ends every turn with a `result` message, so events
-    // between results belong to that turn. The count restarts with each run(),
-    // matching PanelAgent's per-dispatch mirror (Nth submitted turn = marker N).
-    let outTurn = 1;
+    // TURN MARKERS (#728 r4): stamp every event with the marker of the turn it
+    // BELONGS to, derived from the #745 per-turn trace FIFO (the SDK's input pump
+    // and output reader are independent streams, so the marker can't ride the
+    // input side, and a per-result counter lags behind once a turn's result goes
+    // missing). A result stamps with the trace it POPS (the oldest in-flight —
+    // its OWN turn, even when LATE); every other message stamps with the NEWEST
+    // in-flight trace (the turn currently producing output). markerBase re-zeroes
+    // the backend-wide trace ids per run (1 = this run's first turn), matching
+    // PanelAgent's per-dispatch mirror (Nth submitted turn = marker N).
+    const markerBase = this.lastResultTurnId;
     for await (const message of q) {
       // LIVENESS: every SDKMessage — including the ones route() doesn't translate
       // (tool-progress, rate-limit, etc.) — is a sign the session is alive, so
@@ -448,12 +452,22 @@ export class ClaudeBackend implements AgentBackend {
       // this is effectively a no-op for behavior here; it keeps the watchdog's
       // re-arm source uniform across both backends via the port.
       opts.onActivity?.();
+      // route()'s result case pops the OLDEST trace for classification — capture
+      // it BEFORE the generator is consumed so the stamp is the result's own turn.
+      const resultTurn = message.type === "result" ? this.turns[0]?.id : undefined;
+      const streamTurn = this.turns[this.turns.length - 1]?.id;
       for (const ev of this.route(message)) {
         // Session init arrives OUTSIDE any turn — leave it unstamped (an unmarked
-        // event is never dead-lettered). Everything else belongs to outTurn.
-        yield ev.type === "session" ? ev : { ...ev, turn: outTurn };
+        // event is never dead-lettered). A TRACELESS result (a stray from a dead
+        // session, which classification fails closed) is also left unstamped so
+        // its error and gate completion still reach the panel.
+        if (ev.type === "session") {
+          yield ev;
+          continue;
+        }
+        const id = message.type === "result" ? resultTurn : streamTurn;
+        yield id === undefined ? ev : { ...ev, turn: id - markerBase };
       }
-      if (message.type === "result") outTurn += 1;
     }
   }
 

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -365,6 +365,12 @@ export class ClaudeBackend implements AgentBackend {
     }
     const q = query({ prompt: prompt(), options: this.buildOptions(opts) });
     this.q = q;
+    // TURN MARKERS (#728): the SDK's input pump and output reader are independent
+    // streams, so the marker can't ride the input side — instead stamp output-side
+    // by turn boundary: the SDK ends every turn with a `result` message, so events
+    // between results belong to that turn. The count restarts with each run(),
+    // matching PanelAgent's per-dispatch mirror (Nth submitted turn = marker N).
+    let outTurn = 1;
     for await (const message of q) {
       // LIVENESS: every SDKMessage — including the ones route() doesn't translate
       // (tool-progress, rate-limit, etc.) — is a sign the session is alive, so
@@ -372,7 +378,12 @@ export class ClaudeBackend implements AgentBackend {
       // this is effectively a no-op for behavior here; it keeps the watchdog's
       // re-arm source uniform across both backends via the port.
       opts.onActivity?.();
-      yield* this.route(message);
+      for (const ev of this.route(message)) {
+        // Session init arrives OUTSIDE any turn — leave it unstamped (an unmarked
+        // event is never dead-lettered). Everything else belongs to outTurn.
+        yield ev.type === "session" ? ev : { ...ev, turn: outTurn };
+      }
+      if (message.type === "result") outTurn += 1;
     }
   }
 

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -691,25 +691,17 @@ export class ClaudeBackend implements AgentBackend {
         // is unrecoverable once crossed, so the poison is terminal for the
         // session — content evidence must not rescue it (it accrued to a
         // mismatched trace, which is not proof of ITS turn's success).
-        // SUBTYPE-AWARE correlation (#728 r5/r6): an interrupted turn ends with
-        // an INTERRUPTED-subtype result, so a result with any OTHER subtype can
-        // never be an interrupted trace's terminal. If the oldest trace is
-        // marked interrupted and this result is NOT, that turn's result is
-        // permanently LOST (the panel's fallback released the next turn long
-        // ago) and this result belongs to a NEWER turn — skip (park) the
-        // interrupted trace(s) and pop the first non-interrupted one, for
-        // classification AND for the turn-marker stamp (otherwise the new turn's
-        // terminal stamps with the abandoned turn's marker and PanelAgent
-        // dead-letters it — a permanent wedge).
-        //
-        // An INTERRUPTED-subtype landing does not skip — but it does NOT blindly
-        // pop the oldest trace either (r6): a parked trace's result was already
-        // declared lost, so a fresh landing belongs to the oldest UNPARKED
-        // interrupted trace (a NEWER turn interrupted after the park — blindly
-        // popping parked A would stamp C's real terminal with A's marker and
-        // wedge C). Only when no unparked candidate remains is it the parked
-        // trace's own late landing. Each trace lands at most once: a landed
-        // park moves to consumedInterrupted, so a SECOND landing for the same
+        // An INTERRUPTED-subtype landing does not skip — and it is not blindly
+        // the oldest trace either (r6/r7). The SDK processes turns
+        // SEQUENTIALLY and the panel's turn gate only ever submits a newer turn
+        // after the older turn's result was written off, so with SEVERAL
+        // unconsumed interrupted traces pending the landing belongs to the
+        // NEWEST of them — the older interrupted turns' results are provably
+        // LOST and are written off (parked) here too, uniformly with the r5
+        // skip. With exactly ONE candidate the landing is simply its own (the
+        // normal in-order case, or a parked trace's late landing). Each trace
+        // lands at most once: candidates are unconsumed (landed parks move to
+        // consumedInterrupted on the pop), so a SECOND landing for the same
         // turn finds no candidate and fails closed (traceless) below.
         const resultSubtype: string = message.subtype;
         const interruptedLanding = resultSubtype === "interrupted";
@@ -722,16 +714,23 @@ export class ClaudeBackend implements AgentBackend {
           }
           trace = traceIndex === 0 ? (this.turns.shift() ?? null) : (this.turns.splice(traceIndex, 1)[0] ?? null);
         } else {
-          let idx = this.turns.findIndex((t) => t.interrupted && !this.parkedInterrupted.has(t.id));
-          if (idx < 0) {
-            idx = this.turns.findIndex(
-              (t) =>
-                t.interrupted &&
-                this.parkedInterrupted.has(t.id) &&
-                !this.consumedInterrupted.has(t.id),
-            );
+          let idx = -1;
+          for (let i = this.turns.length - 1; i >= 0; i--) {
+            if (this.turns[i].interrupted && !this.consumedInterrupted.has(this.turns[i].id)) {
+              idx = i; // newest unconsumed interrupted trace
+              break;
+            }
           }
-          trace = idx >= 0 ? (this.turns.splice(idx, 1)[0] ?? null) : null;
+          if (idx >= 0) {
+            // Write off every OTHER unconsumed interrupted trace older than the
+            // landing's turn — their results are provably lost (above).
+            for (let i = 0; i < idx; i++) {
+              if (this.turns[i].interrupted && !this.consumedInterrupted.has(this.turns[i].id)) {
+                this.parkedInterrupted.add(this.turns[i].id);
+              }
+            }
+            trace = this.turns.splice(idx, 1)[0] ?? null;
+          }
         }
         let unverifiable: string | null = null;
         if (this.classificationPoisoned) {

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -270,6 +270,19 @@ export class ClaudeBackend implements AgentBackend {
   private turnSeq = 0;
   private lastResultTurnId = 0;
   private classificationPoisoned = false;
+  /** Run-relative zero for turn MARKERS (#728): set at every run() entry to the
+   *  backend-wide lastResultTurnId, so event stamps are 1-based per run and
+   *  match PanelAgent's per-dispatch mirror. */
+  private markerBase = 0;
+  /** Interrupted traces PARKED by subtype-aware correlation (#728 r5): an
+   *  interrupted turn ends with an INTERRUPTED-subtype result, so when a result
+   *  with any other subtype arrives while the oldest trace is interrupted and a
+   *  newer trace exists, that turn's result is permanently LOST and the arriving
+   *  result belongs to the newer turn — the interrupted trace is skipped
+   *  (parked) rather than popped. The park legitimizes the resulting forward
+   *  jump in lastResultTurnId, and lets a genuinely interrupted late landing
+   *  still pop its OWN trace (a backward pop) and classify/stamp by its flags. */
+  private parkedInterrupted = new Set<number>();
   private turns: Array<{
     id: number;
     hasContent: boolean;
@@ -411,6 +424,8 @@ export class ClaudeBackend implements AgentBackend {
     this.turns.length = 0;
     this.lastResultTurnId = this.turnSeq;
     this.classificationPoisoned = false;
+    this.parkedInterrupted.clear(); // dead session's parks die with it
+    this.markerBase = this.lastResultTurnId; // turn markers are run-relative (#728)
     // Wrap the neutral channel: shape each turn into the SDK's native form right
     // before it's read, so PanelAgent never deals in SDKUserMessage.
     async function* prompt(): AsyncGenerator<SDKUserMessage> {
@@ -435,16 +450,15 @@ export class ClaudeBackend implements AgentBackend {
     }
     const q = query({ prompt: prompt(), options: this.buildOptions(opts) });
     this.q = q;
-    // TURN MARKERS (#728 r4): stamp every event with the marker of the turn it
-    // BELONGS to, derived from the #745 per-turn trace FIFO (the SDK's input pump
-    // and output reader are independent streams, so the marker can't ride the
-    // input side, and a per-result counter lags behind once a turn's result goes
-    // missing). A result stamps with the trace it POPS (the oldest in-flight —
-    // its OWN turn, even when LATE); every other message stamps with the NEWEST
-    // in-flight trace (the turn currently producing output). markerBase re-zeroes
-    // the backend-wide trace ids per run (1 = this run's first turn), matching
-    // PanelAgent's per-dispatch mirror (Nth submitted turn = marker N).
-    const markerBase = this.lastResultTurnId;
+    // TURN MARKERS (#728): stamp every event with the marker of the turn it
+    // BELONGS to, derived from the #745 per-turn trace FIFO (the SDK's input
+    // pump and output reader are independent streams, so the marker can't ride
+    // the input side). RESULT-message events are stamped by route() itself with
+    // the trace it popped (the result's OWN turn, subtype-aware — #728 r5);
+    // every other message is stamped here with the NEWEST in-flight trace (the
+    // turn currently producing output). markerBase re-zeroes the backend-wide
+    // trace ids per run (1 = this run's first turn), matching PanelAgent's
+    // per-dispatch mirror (Nth submitted turn = marker N).
     for await (const message of q) {
       // LIVENESS: every SDKMessage — including the ones route() doesn't translate
       // (tool-progress, rate-limit, etc.) — is a sign the session is alive, so
@@ -452,21 +466,16 @@ export class ClaudeBackend implements AgentBackend {
       // this is effectively a no-op for behavior here; it keeps the watchdog's
       // re-arm source uniform across both backends via the port.
       opts.onActivity?.();
-      // route()'s result case pops the OLDEST trace for classification — capture
-      // it BEFORE the generator is consumed so the stamp is the result's own turn.
-      const resultTurn = message.type === "result" ? this.turns[0]?.id : undefined;
       const streamTurn = this.turns[this.turns.length - 1]?.id;
       for (const ev of this.route(message)) {
-        // Session init arrives OUTSIDE any turn — leave it unstamped (an unmarked
-        // event is never dead-lettered). A TRACELESS result (a stray from a dead
-        // session, which classification fails closed) is also left unstamped so
-        // its error and gate completion still reach the panel.
-        if (ev.type === "session") {
+        // Session init arrives OUTSIDE any turn — leave it unstamped (an
+        // unmarked event is never dead-lettered). Result-message events arrive
+        // pre-stamped by route().
+        if (ev.type === "session" || message.type === "result") {
           yield ev;
           continue;
         }
-        const id = message.type === "result" ? resultTurn : streamTurn;
-        yield id === undefined ? ev : { ...ev, turn: id - markerBase };
+        yield streamTurn === undefined ? ev : { ...ev, turn: streamTurn - this.markerBase };
       }
     }
   }
@@ -676,31 +685,78 @@ export class ClaudeBackend implements AgentBackend {
         // is unrecoverable once crossed, so the poison is terminal for the
         // session — content evidence must not rescue it (it accrued to a
         // mismatched trace, which is not proof of ITS turn's success).
-        const trace = this.turns.shift() ?? null;
+        // SUBTYPE-AWARE correlation (#728 r5): an interrupted turn ends with an
+        // INTERRUPTED-subtype result, so a result with any OTHER subtype can
+        // never be an interrupted trace's terminal. If the oldest trace is
+        // marked interrupted and this result is NOT, that turn's result is
+        // permanently LOST (the panel's fallback released the next turn long
+        // ago) and this result belongs to a NEWER turn — skip (park) the
+        // interrupted trace(s) and pop the first non-interrupted one, for
+        // classification AND for the turn-marker stamp (otherwise the new turn's
+        // terminal stamps with the abandoned turn's marker and PanelAgent
+        // dead-letters it — a permanent wedge). A genuinely INTERRUPTED-subtype
+        // landing does not skip: it pops the oldest (parked) interrupted trace
+        // and classifies/stamps by ITS flags.
+        const resultSubtype: string = message.subtype;
+        const interruptedLanding = resultSubtype === "interrupted";
+        let traceIndex = 0;
+        if (!interruptedLanding) {
+          while (traceIndex < this.turns.length - 1 && this.turns[traceIndex].interrupted) {
+            this.parkedInterrupted.add(this.turns[traceIndex].id);
+            traceIndex += 1;
+          }
+        }
+        const trace =
+          traceIndex === 0 ? (this.turns.shift() ?? null) : (this.turns.splice(traceIndex, 1)[0] ?? null);
         let unverifiable: string | null = null;
         if (this.classificationPoisoned) {
           unverifiable = "Turn bookkeeping was poisoned by an earlier overflow — no result in this session can be verified";
         } else if (!trace) {
           unverifiable = "The result could not be matched to any submitted turn";
           logger.warn(`[claude-backend] ${unverifiable} — unverifiable, failing closed (#740)`);
-        } else if (trace.id !== this.lastResultTurnId + 1) {
-          // The pop crossed an evicted-turn gap → poison the session (do NOT
-          // advance lastResultTurnId to the wrong trace's id — alignment is
-          // unrecoverable, so resyncing would just hide the next mismatch).
-          this.classificationPoisoned = true;
-          unverifiable = "Turn bookkeeping overflowed, so the result cannot be matched to its turn";
-          logger.warn(
-            `[claude-backend] result crosses an evicted-turn gap (popped turn ${trace.id}, expected ${this.lastResultTurnId + 1}) — unverifiable; classification poisoned for the rest of the session (#740)`,
-          );
         } else {
-          this.lastResultTurnId = trace.id;
+          let crossesGap = false;
+          if (trace.id > this.lastResultTurnId + 1) {
+            // Forward jump: legit only when EVERY skipped id is a parked
+            // interrupted trace; anything else is an evicted-turn gap.
+            for (let id = this.lastResultTurnId + 1; id < trace.id && !crossesGap; id++) {
+              if (!this.parkedInterrupted.has(id)) crossesGap = true;
+            }
+          } else if (trace.id <= this.lastResultTurnId) {
+            // Backward pop: legit only for a parked interrupted trace's landing.
+            crossesGap = !this.parkedInterrupted.has(trace.id);
+          }
+          if (crossesGap) {
+            // The pop crossed an evicted-turn gap → poison the session (do NOT
+            // advance lastResultTurnId to the wrong trace's id — alignment is
+            // unrecoverable, so resyncing would just hide the next mismatch).
+            this.classificationPoisoned = true;
+            unverifiable = "Turn bookkeeping overflowed, so the result cannot be matched to its turn";
+            logger.warn(
+              `[claude-backend] result crosses an evicted-turn gap (popped turn ${trace.id}, expected ${this.lastResultTurnId + 1}) — unverifiable; classification poisoned for the rest of the session (#740)`,
+            );
+          } else {
+            this.parkedInterrupted.delete(trace.id);
+            if (trace.id > this.lastResultTurnId) this.lastResultTurnId = trace.id;
+          }
         }
-        let ok = message.subtype === "success";
+        // The result's OWN turn marker (#728): stamped here, where the trace it
+        // popped is known (a per-message stamp in run() could not see the
+        // subtype-aware skip). A traceless result stays UNMARKED so its
+        // fail-closed error and gate completion still reach the panel.
+        const stamp = trace ? { turn: trace.id - this.markerBase } : {};
+        // An interrupted turn's terminal (subtype "interrupted") is the
+        // interrupt LANDING for its own interrupted trace, not a failure —
+        // blessed like a success; the empty-turn guard below still spares it.
+        let ok =
+          resultSubtype === "success" ||
+          (resultSubtype === "interrupted" && trace !== null && trace.interrupted);
         if (ok && unverifiable !== null) {
           ok = false;
           yield {
             type: "error",
             message: `${unverifiable} — reporting the turn as unverifiable rather than a success.`,
+            ...stamp,
           };
         } else if (ok && trace !== null && trace.blockReason !== null) {
           // The blocking informational already yielded the visible error above.
@@ -711,6 +767,7 @@ export class ClaudeBackend implements AgentBackend {
           yield {
             type: "error",
             message: "The model ended the turn without producing a reply.",
+            ...stamp,
           };
         }
         yield {
@@ -719,6 +776,7 @@ export class ClaudeBackend implements AgentBackend {
           subtype: message.subtype,
           ...(contextWindow !== undefined ? { contextWindow } : {}),
           ...(typeof m.total_cost_usd === "number" ? { costUsd: m.total_cost_usd } : {}),
+          ...stamp,
         };
         break;
       }

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -692,49 +692,45 @@ export class ClaudeBackend implements AgentBackend {
         // session — content evidence must not rescue it (it accrued to a
         // mismatched trace, which is not proof of ITS turn's success).
         // SUBTYPE-AWARE correlation on the SDK's REAL result vocabulary
-        // (#728 r5–r9): results arrive as `success` or `error_*` — an
+        // (#728 r5–r10): results arrive as `success` or `error_*` — an
         // interrupted turn ends with an error_during_execution result (the
         // interrupt landing); there is no "interrupted" result subtype.
-        // Combined with SEQUENTIAL EMISSION (results always emit in processing
-        // order — a turn's result ALWAYS precedes the next turn's result in
-        // the stream):
-        //  • A SUCCESS landing can never belong to an interrupted-marked turn,
-        //    so if the oldest trace is interrupted and a newer trace exists,
-        //    that turn's result is permanently LOST — skip (park) the
-        //    interrupted trace(s) and pop the first non-interrupted one (the
-        //    r5 skip). This is the ONLY write-off; never by preference.
-        //  • An error_* landing belongs to the OLDEST LIVE (unparked) trace —
-        //    interrupted turn or not (a healthy turn's genuine failure is
-        //    likewise its own). A newer interrupted turn's trace may exist
-        //    while the older turn is still settling (queued input); the older
-        //    turn's legitimate landing MUST still pop the older trace. Only
-        //    when no live candidate remains is the landing a parked trace's
-        //    own late one (a write-off that proved wrong). Each trace lands at
-        //    most once: landed parks move to consumedInterrupted, so a SECOND
-        //    landing for the same turn finds no candidate and fails closed
-        //    (traceless) below.
+        //
+        // UNIFORM write-off (r10): an interrupted turn the PANEL killed (its
+        // trace is marked) that was then SUPERSEDED by a newer submission never
+        // delivers — the turn gate only submits newer work after the older
+        // turn's result was written off. So for EVERY landing (success or
+        // error_*): any interrupted-marked trace OLDER than the oldest LIVE
+        // non-interrupted trace is written off (parked as lost), and the
+        // landing pops that oldest live non-interrupted trace — a healthy
+        // turn's genuine success or error classifies by ITS flags (a genuine
+        // error_during_execution from a healthy newer turn is NOT blessed and
+        // is NOT attributed to the killed older turn). With NO live
+        // non-interrupted trace, the landing is an interrupt landing and pops
+        // the oldest LIVE interrupted trace (kills settle in submission order —
+        // the older turn's legitimate landing still pops the older trace, even
+        // when a newer interrupted turn's trace exists from queued input), else
+        // the oldest PARKED-but-unconsumed interrupted trace (a late landing
+        // for a written-off turn — the r6 tolerance), else nothing (anomalous
+        // → traceless fail-closed below). Each trace still lands at most once
+        // (landed parks move to consumedInterrupted).
         const resultSubtype: string = message.subtype;
-        const successLanding = resultSubtype === "success";
-        let trace: (typeof this.turns)[number] | null = null;
-        if (successLanding) {
-          let traceIndex = 0;
-          while (traceIndex < this.turns.length - 1 && this.turns[traceIndex].interrupted) {
-            this.parkedInterrupted.add(this.turns[traceIndex].id);
-            traceIndex += 1;
+        const oldestLive = this.turns.findIndex((t) => !t.interrupted);
+        if (oldestLive > 0) {
+          for (let i = 0; i < oldestLive; i++) {
+            if (this.turns[i].interrupted) this.parkedInterrupted.add(this.turns[i].id);
           }
-          trace = traceIndex === 0 ? (this.turns.shift() ?? null) : (this.turns.splice(traceIndex, 1)[0] ?? null);
-        } else {
-          // Oldest LIVE (unparked) trace first — interrupted or not; a parked
-          // trace's result was already written off, so only when no live
-          // candidate remains is the landing a parked trace's own late one.
-          let idx = this.turns.findIndex((t) => !this.parkedInterrupted.has(t.id));
-          if (idx < 0) {
-            idx = this.turns.findIndex(
-              (t) => this.parkedInterrupted.has(t.id) && !this.consumedInterrupted.has(t.id),
-            );
-          }
-          trace = idx >= 0 ? (this.turns.splice(idx, 1)[0] ?? null) : null;
         }
+        let idx = oldestLive;
+        if (idx < 0) {
+          idx = this.turns.findIndex((t) => t.interrupted && !this.parkedInterrupted.has(t.id));
+        }
+        if (idx < 0) {
+          idx = this.turns.findIndex(
+            (t) => t.interrupted && this.parkedInterrupted.has(t.id) && !this.consumedInterrupted.has(t.id),
+          );
+        }
+        const trace = idx >= 0 ? (this.turns.splice(idx, 1)[0] ?? null) : null;
         let unverifiable: string | null = null;
         if (this.classificationPoisoned) {
           unverifiable = "Turn bookkeeping was poisoned by an earlier overflow — no result in this session can be verified";

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -51,6 +51,7 @@ import {
   type ModelChoice,
   type NeutralTurn,
   CODEX_CAPABILITIES,
+  stampTurn,
 } from "./agent-backend.js";
 import type { ImageRef } from "./panel-agent.js";
 
@@ -944,8 +945,9 @@ export class CodexBackend implements AgentBackend {
     // Process the neutral channel one turn at a time. onActivity is the LIVENESS
     // signal — every raw app-server notification for the active turn re-arms
     // PanelAgent's idle watchdog so a long, quiet generation doesn't falsely trip.
+    let turnSeq = 0;
     for await (const turn of opts.channel) {
-      yield* this.runTurn(client, turn, opts.onActivity);
+      yield* stampTurn(this.runTurn(client, turn, opts.onActivity), ++turnSeq);
       // A timed-out interrupt detaches this client. End the old run before it can
       // consume another queued turn; PanelAgent will start a fresh app-server.
       if (this.client !== client) return;

--- a/src/orchestrator/gemini-backend.ts
+++ b/src/orchestrator/gemini-backend.ts
@@ -74,6 +74,7 @@ import {
   type ModelChoice,
   type NeutralTurn,
   GEMINI_CAPABILITIES,
+  stampTurn,
 } from "./agent-backend.js";
 import type { ImageRef } from "./panel-agent.js";
 
@@ -825,6 +826,7 @@ export class GeminiBackend implements AgentBackend {
     };
 
     // Process the neutral channel one turn at a time.
+    let turnSeq = 0;
     for await (const turn of opts.channel) {
       // LIVE MODEL SWITCH (P1): PanelAgent treats setModel as live and does NOT
       // restart run() for a model-only change, so the persistent loop adopts it
@@ -842,7 +844,7 @@ export class GeminiBackend implements AgentBackend {
           ...(this.model ? { model: this.model } : {}),
         };
       }
-      yield* this.runTurn(this.client, turn, opts.onActivity);
+      yield* stampTurn(this.runTurn(this.client, turn, opts.onActivity), ++turnSeq);
     }
   }
 

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -73,6 +73,7 @@ import {
   type ModelChoice,
   type NeutralTurn,
   GROK_CAPABILITIES,
+  stampTurn,
 } from "./agent-backend.js";
 import type { ImageRef } from "./panel-agent.js";
 import {
@@ -820,6 +821,7 @@ export class GrokBackend implements AgentBackend {
     };
 
     // Process the neutral channel one turn at a time.
+    let turnSeq = 0;
     for await (const turn of opts.channel) {
       // LIVE MODEL SWITCH (P1): PanelAgent treats setModel as live and does NOT
       // restart run() for a model-only change, so the persistent loop adopts it
@@ -837,7 +839,7 @@ export class GrokBackend implements AgentBackend {
           ...(this.model ? { model: this.model } : {}),
         };
       }
-      yield* this.runTurn(this.client, turn, opts.onActivity);
+      yield* stampTurn(this.runTurn(this.client, turn, opts.onActivity), ++turnSeq);
     }
   }
 
@@ -1520,8 +1522,9 @@ export class GrokDirectBackend extends OllamaBackend {
       .filter(Boolean)
       .join("\n\n");
 
+    let turnSeq = 0;
     for await (const turn of opts.channel) {
-      yield* this.runGrokTurn(turn, instructions, opts);
+      yield* stampTurn(this.runGrokTurn(turn, instructions, opts), ++turnSeq);
     }
   }
 

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -26,7 +26,7 @@ import type {
   NeutralTurn,
 } from "./agent-backend.js";
 import type { ImageRef } from "./panel-agent.js";
-import { OLLAMA_CAPABILITIES } from "./agent-backend.js";
+import { OLLAMA_CAPABILITIES, stampTurn } from "./agent-backend.js";
 import type { GeminiMcpServerSpec } from "./gemini-backend.js";
 import { resolvePrompt } from "../services/prompt-overrides.js";
 import { retiredToolMessage } from "../tools/vocabulary.js";
@@ -803,8 +803,9 @@ export class OllamaBackend implements AgentBackend {
     }
     yield { type: "session", sessionId: this.sessionId, model: this.model };
 
+    let turnSeq = 0;
     for await (const turn of opts.channel) {
-      yield* this.runTurn(turn, opts);
+      yield* stampTurn(this.runTurn(turn, opts), ++turnSeq);
     }
   }
 

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -221,10 +221,11 @@ export class PanelAgent {
   // IDLE timer (reset on every received event), NOT a hard turn cap: legit tool
   // work is slow but still streams progress/tool events, so only a TRUE stall
   // (no events at all for the whole window) trips it. On trip we surface a clear
-  // terminal error, advance the turn-gate (so the next queued batch runs), and
-  // best-effort interrupt the backend. Composes with the backend's own terminal
-  // result: completeTurn() is capped at yieldedTurns, so a late real result after
-  // a trip can't double-advance the gate.
+  // terminal error (the turn's ONE failure report) and route through the guarded
+  // interrupt() flow: the aborted turn's terminal result — or the bounded
+  // interrupt-release fallback if no result ever arrives — advances the turn-gate
+  // at the genuine turn end, so the next queued batch never runs ahead of the
+  // wedged turn settling (#728).
   private idleTimer: ReturnType<typeof setTimeout> | null = null;
   /** Guards against a trip firing twice / racing a real result for one turn. */
   private idleTripped = false;
@@ -934,10 +935,14 @@ export class PanelAgent {
   }
 
   /** The current turn produced NO events for the whole idle window → it's frozen.
-   *  Surface a clear error, clear the "working" indicator, advance the turn-gate
-   *  so the next queued batch can run, and best-effort interrupt the backend so a
-   *  wedged child stops. Idempotent per turn via idleTripped; completeTurn() is
-   *  capped at yieldedTurns so a late real result can't double-advance the gate. */
+   *  Surface a clear error, clear the "working" indicator, and interrupt via the
+   *  guarded interrupt() flow so the turn-gate opens only when the turn GENUINELY
+   *  ends (the aborted turn's terminal result, or the bounded interrupt-release
+   *  fallback if none arrives) — not synchronously here, which let the next queued
+   *  batch run before the wedged turn had settled. The stall warning is this turn's
+   *  ONE failure report: errorSurfaced + interruptRequested suppress the follow-up
+   *  interrupted result's "turn failed" line (#728). Idempotent per turn via
+   *  idleTripped. */
   private onTurnStalled(): void {
     if (this.closed || this.idleTripped || !this.busy) return;
     // A tool call in flight is legitimate work even with a silent app-server (an
@@ -952,21 +957,30 @@ export class PanelAgent {
     this.idleTripped = true;
     this.idleTimer = null;
     logger.error(
-      `[panel-agent ${this.short()}] turn stalled — no events for ${Math.round(TURN_IDLE_MS / 1000)}s; surfacing error and releasing the gate`,
+      `[panel-agent ${this.short()}] turn stalled — no events for ${Math.round(TURN_IDLE_MS / 1000)}s; surfacing error and interrupting`,
     );
+    // The stall warning below IS this turn's failure report — mark it surfaced so
+    // the backend's terminal `{ ok: false, subtype: "interrupted" }` result isn't
+    // painted as a SECOND, contradictory failure. (interrupt() also sets
+    // interruptRequested, so the result case treats that result as the interrupt
+    // landing, not a new failure.)
+    this.errorSurfaced = true;
+    this.busy = false;
+    // The stalled turn is abandoned + surfaced as an error — don't re-queue its
+    // text (a wedged message could otherwise loop on every interrupt, and it may
+    // already have performed tool side effects).
+    this.inFlight = null;
     this.deps.onSay(
       this.tabId,
       "⚠️ The agent stopped responding (the turn stalled with no activity). I've cleared it — please try again.",
     );
-    this.busy = false;
-    // The stalled turn is abandoned + surfaced as an error — don't re-queue its
-    // text (a wedged message could otherwise loop on every interrupt).
-    this.inFlight = null;
-    this.completeTurn(); // release the next queued batch instead of hanging
     this.deps.onTurn?.(this.tabId, "done");
-    // Best-effort: stop the wedged turn so the backend doesn't keep a dead child
-    // half-alive. The self-restart loop in start() recovers the session.
-    void this.backend.interrupt().catch(() => {});
+    // Do NOT completeTurn() here: the gate must stay held until the turn genuinely
+    // ends. interrupt() arms the bounded release fallback and stops the wedged
+    // backend; the aborted turn's `result` (or that fallback) releases the next
+    // queued batch at the right moment. The self-restart loop in start() recovers
+    // the session.
+    void this.interrupt();
   }
 
   // Handle a canonical AgentEvent from the backend. This is the provider-agnostic

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -262,15 +262,19 @@ export class PanelAgent {
    *  the one parked on the gate, so a stale timer can't cut a later, legit turn
    *  short. Refreshed on every interrupt(). See armInterruptReleaseFallback(). */
   private interruptGuardTurn = 0;
-  /** Turns the interrupt-release fallback ABANDONED (force-released with no
-   *  terminal result) whose straggler emissions may still arrive — the turn-epoch
-   *  attribution for events, which carry no turn id: the backend streams turns
-   *  strictly sequentially, so while this is > 0 an `error`/`result` belongs to a
-   *  DEAD turn and is dead-lettered (logged, never painted, never completes the
-   *  NEW turn's gate — #728 r2). A `result` consumes one credit (the dead turn's
-   *  terminal); any ordinary work event (assistant/tool_call/…) proves the backend
-   *  moved past the dead turn(s) with no result coming and clears the rest. */
-  private deadLetterTurns = 0;
+  /** Monotonic marker of the CURRENT in-flight turn, mirrored from the backend's
+   *  mint: the backend increments its marker once per turn it reads from the
+   *  channel and stamps it on every event of that turn; PanelAgent increments
+   *  this once per turn it YIELDS — same sequence, same reset point (run start)
+   *  — so the Nth dispatched turn's events all carry marker N (#728 r3). Events
+   *  stamped with an OLDER marker are stragglers from an abandoned turn and are
+   *  dead-lettered (see handleEvent). Backends that never stamp (turn undefined)
+   *  get NO dead-lettering — previous behavior. */
+  private currentTurnMarker = 0;
+  /** Marker of the turn the interrupt-release fallback most recently ABANDONED
+   *  (force-released with no terminal result). Its stragglers are provably dead
+   *  even before the next dispatch increments currentTurnMarker. 0 = none. */
+  private abandonedTurnMarker = 0;
   /** Mutable so the model/effort picker can change them at runtime. */
   private model: string;
   private effort?: Effort;
@@ -640,10 +644,11 @@ export class PanelAgent {
         logger.debug(
           `[panel-agent ${this.short()}] interrupt: no result within ${INTERRUPT_RELEASE_FALLBACK_MS}ms — releasing the gate`,
         );
-        // Mark the abandoned turn CLOSED: its terminal result never arrived, so a
-        // straggler `error`/`result` from it must dead-letter (logged only) rather
-        // than paint against — or complete the gate of — the turn that replaces it.
-        this.deadLetterTurns += 1;
+        // Mark the abandoned turn CLOSED: its terminal result never arrived, so
+        // its straggler emissions are provably dead (their stamped marker is ≤
+        // this watermark) and dead-letter rather than paint against — or complete
+        // the gate of — the turn that replaces it.
+        this.abandonedTurnMarker = this.currentTurnMarker;
         this.releaseTurns();
       }
     }, INTERRUPT_RELEASE_FALLBACK_MS);
@@ -756,6 +761,9 @@ export class PanelAgent {
       // re-queue it (send-now must address BOTH the interrupted and new message).
       this.inFlight = { text, ...(images.length ? { images } : {}) };
       this.yieldedTurns += 1; // this batch is turn N
+      // Mirror the backend's turn-marker mint: the Nth turn yielded here is the
+      // Nth turn the backend reads — its events carry marker N (#728 r3).
+      this.currentTurnMarker += 1;
       // Mark the turn in flight AT DISPATCH (not on the first event). Without this
       // the watchdog's `busy` guard would be false for the exact zero-event freeze
       // it's meant to catch, so onTurnStalled() would no-op. (handleEvent's later
@@ -767,6 +775,13 @@ export class PanelAgent {
       // the outgoing turn's result restore the wrong context window (#543).
       this.turnModel = this.model;
       this.deps.onTurn?.(this.tabId, "working");
+      // Drop the PREVIOUS turn's watchdog state at dispatch: a stale idle timer
+      // left by an abandoned turn (its result never disarmed it — e.g. after the
+      // interrupt fallback, whose stragglers are now dead-lettered instead) would
+      // otherwise fire into THIS turn and trip it spuriously, and a latched
+      // idleTripped would leave this turn with no watchdog at all. Fresh turn →
+      // fresh watchdog.
+      this.clearIdleWatchdog();
       // Arm the freeze watchdog AT DISPATCH: a turn that produces NO events at all
       // (the exact ROOT CAUSE B freeze — turn/start sent, no notifications ever
       // returned) never reaches handleEvent, so arming here is what catches it.
@@ -816,13 +831,15 @@ export class PanelAgent {
       // recoverable resume-miss from counting toward the give-up threshold.
       let resumeMiss = false;
       // Fresh channel → reset the turn-gate counters so a restart/resume never
-      // inherits a stale offset that would mis-gate the first batch. A restarted
-      // session can also never receive the OLD session's straggler emissions, so
-      // any dead-letter credits die with it.
+      // inherits a stale offset that would mis-gate the first batch. The backend's
+      // turn-marker mint also restarts with the new run, so the mirrored markers
+      // reset too (and a restarted session can never receive the OLD session's
+      // straggler emissions anyway).
       this.yieldedTurns = 0;
       this.completedTurns = 0;
       this.turnWaiter = null;
-      this.deadLetterTurns = 0;
+      this.currentTurnMarker = 0;
+      this.abandonedTurnMarker = 0;
       // Drop the prior session's last assistant UUID so a fork can't report a
       // stale (pre-fork) anchor for the first turn of the new session.
       this.lastAssistantUuid = null;
@@ -1017,30 +1034,22 @@ export class PanelAgent {
     // this agent was retired in favor of (a leak of the old workflow's reply/session into
     // the switched-to one). Dropping the event is safe: a stopped agent's turn is over.
     if (this.closed) return;
-    // DEAD-LETTER (#728 r2): events attributed to a turn the interrupt-release
-    // fallback already abandoned (force-released with no terminal result). The
-    // backend streams turns strictly sequentially, so while deadLetterTurns > 0
-    // an `error` is the DEAD turn's trailing failure report (never painted against
-    // the new turn) and a `result` is the dead turn's terminal (consumes one
-    // credit; must NOT completeTurn — that would open the NEW turn's gate early,
-    // and must not clear the new turn's watchdog/busy either). Any ordinary work
-    // event proves the backend moved past the dead turn(s) with no result coming,
-    // so the remaining credits are dropped and the event is handled normally.
-    if (this.deadLetterTurns > 0) {
-      if (ev.type === "result") {
-        this.deadLetterTurns -= 1;
-        logger.debug(
-          `[panel-agent ${this.short()}] dead-lettered a straggler result (subtype=${ev.subtype}) from an abandoned turn`,
-        );
-        return;
-      }
-      if (ev.type === "error") {
-        logger.debug(
-          `[panel-agent ${this.short()}] dead-lettered a straggler error from an abandoned turn`,
-        );
-        return;
-      }
-      this.deadLetterTurns = 0;
+    // DEAD-LETTER by turn marker (#728 r3): an event stamped with a turn OLDER
+    // than the in-flight turn — or belonging to the fallback-abandoned turn — is
+    // a straggler from a turn that is no longer current. It is logged but NEVER
+    // painted (a dead turn's error must not report against the new turn) and
+    // NEVER gate-affecting (a dead turn's result must not completeTurn the new
+    // turn's gate early, nor clear its watchdog/busy). Events with NO marker
+    // (legacy backend, or session-level traffic) skip this entirely — previous
+    // behavior; better a rare duplicate than a wedge.
+    if (
+      typeof ev.turn === "number" &&
+      (ev.turn <= this.abandonedTurnMarker || ev.turn < this.currentTurnMarker)
+    ) {
+      logger.debug(
+        `[panel-agent ${this.short()}] dead-lettered a straggler ${ev.type} from turn ${ev.turn} (current=${this.currentTurnMarker}, abandoned≤${this.abandonedTurnMarker})`,
+      );
+      return;
     }
     // Any event means the turn is alive — reset the idle watchdog. The `result`
     // case below disarms it entirely (turn ended). Placed before the switch so it

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -262,6 +262,15 @@ export class PanelAgent {
    *  the one parked on the gate, so a stale timer can't cut a later, legit turn
    *  short. Refreshed on every interrupt(). See armInterruptReleaseFallback(). */
   private interruptGuardTurn = 0;
+  /** Turns the interrupt-release fallback ABANDONED (force-released with no
+   *  terminal result) whose straggler emissions may still arrive — the turn-epoch
+   *  attribution for events, which carry no turn id: the backend streams turns
+   *  strictly sequentially, so while this is > 0 an `error`/`result` belongs to a
+   *  DEAD turn and is dead-lettered (logged, never painted, never completes the
+   *  NEW turn's gate — #728 r2). A `result` consumes one credit (the dead turn's
+   *  terminal); any ordinary work event (assistant/tool_call/…) proves the backend
+   *  moved past the dead turn(s) with no result coming and clears the rest. */
+  private deadLetterTurns = 0;
   /** Mutable so the model/effort picker can change them at runtime. */
   private model: string;
   private effort?: Effort;
@@ -631,6 +640,10 @@ export class PanelAgent {
         logger.debug(
           `[panel-agent ${this.short()}] interrupt: no result within ${INTERRUPT_RELEASE_FALLBACK_MS}ms — releasing the gate`,
         );
+        // Mark the abandoned turn CLOSED: its terminal result never arrived, so a
+        // straggler `error`/`result` from it must dead-letter (logged only) rather
+        // than paint against — or complete the gate of — the turn that replaces it.
+        this.deadLetterTurns += 1;
         this.releaseTurns();
       }
     }, INTERRUPT_RELEASE_FALLBACK_MS);
@@ -803,10 +816,13 @@ export class PanelAgent {
       // recoverable resume-miss from counting toward the give-up threshold.
       let resumeMiss = false;
       // Fresh channel → reset the turn-gate counters so a restart/resume never
-      // inherits a stale offset that would mis-gate the first batch.
+      // inherits a stale offset that would mis-gate the first batch. A restarted
+      // session can also never receive the OLD session's straggler emissions, so
+      // any dead-letter credits die with it.
       this.yieldedTurns = 0;
       this.completedTurns = 0;
       this.turnWaiter = null;
+      this.deadLetterTurns = 0;
       // Drop the prior session's last assistant UUID so a fork can't report a
       // stale (pre-fork) anchor for the first turn of the new session.
       this.lastAssistantUuid = null;
@@ -1001,6 +1017,31 @@ export class PanelAgent {
     // this agent was retired in favor of (a leak of the old workflow's reply/session into
     // the switched-to one). Dropping the event is safe: a stopped agent's turn is over.
     if (this.closed) return;
+    // DEAD-LETTER (#728 r2): events attributed to a turn the interrupt-release
+    // fallback already abandoned (force-released with no terminal result). The
+    // backend streams turns strictly sequentially, so while deadLetterTurns > 0
+    // an `error` is the DEAD turn's trailing failure report (never painted against
+    // the new turn) and a `result` is the dead turn's terminal (consumes one
+    // credit; must NOT completeTurn — that would open the NEW turn's gate early,
+    // and must not clear the new turn's watchdog/busy either). Any ordinary work
+    // event proves the backend moved past the dead turn(s) with no result coming,
+    // so the remaining credits are dropped and the event is handled normally.
+    if (this.deadLetterTurns > 0) {
+      if (ev.type === "result") {
+        this.deadLetterTurns -= 1;
+        logger.debug(
+          `[panel-agent ${this.short()}] dead-lettered a straggler result (subtype=${ev.subtype}) from an abandoned turn`,
+        );
+        return;
+      }
+      if (ev.type === "error") {
+        logger.debug(
+          `[panel-agent ${this.short()}] dead-lettered a straggler error from an abandoned turn`,
+        );
+        return;
+      }
+      this.deadLetterTurns = 0;
+    }
     // Any event means the turn is alive — reset the idle watchdog. The `result`
     // case below disarms it entirely (turn ended). Placed before the switch so it
     // covers every event type without per-case bumps.

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -935,14 +935,14 @@ export class PanelAgent {
   }
 
   /** The current turn produced NO events for the whole idle window → it's frozen.
-   *  Surface a clear error, clear the "working" indicator, and interrupt via the
+   *  Surface a clear error (unless this turn's failure was ALREADY reported — one
+   *  report per turn), clear the "working" indicator, and interrupt via the
    *  guarded interrupt() flow so the turn-gate opens only when the turn GENUINELY
    *  ends (the aborted turn's terminal result, or the bounded interrupt-release
    *  fallback if none arrives) — not synchronously here, which let the next queued
-   *  batch run before the wedged turn had settled. The stall warning is this turn's
-   *  ONE failure report: errorSurfaced + interruptRequested suppress the follow-up
-   *  interrupted result's "turn failed" line (#728). Idempotent per turn via
-   *  idleTripped. */
+   *  batch run before the wedged turn had settled. errorSurfaced +
+   *  interruptRequested suppress the follow-up interrupted result's "turn failed"
+   *  line (#728). Idempotent per turn via idleTripped. */
   private onTurnStalled(): void {
     if (this.closed || this.idleTripped || !this.busy) return;
     // A tool call in flight is legitimate work even with a silent app-server (an
@@ -956,24 +956,30 @@ export class PanelAgent {
     }
     this.idleTripped = true;
     this.idleTimer = null;
+    // ONE failure report per turn: if an `error` event already painted this turn's
+    // failure line (errorSurfaced), the stall warning would be a SECOND report for
+    // the same turn — suppress it (the log line below still records the stall).
+    // Otherwise the stall warning below IS this turn's failure report — mark it
+    // surfaced so the backend's terminal `{ ok: false, subtype: "interrupted" }`
+    // result (or a late `error` event) isn't painted as a second, contradictory
+    // failure. (interrupt() also sets interruptRequested, so the result case
+    // treats that result as the interrupt landing, not a new failure.)
+    const alreadyReported = this.errorSurfaced;
     logger.error(
-      `[panel-agent ${this.short()}] turn stalled — no events for ${Math.round(TURN_IDLE_MS / 1000)}s; surfacing error and interrupting`,
+      `[panel-agent ${this.short()}] turn stalled — no events for ${Math.round(TURN_IDLE_MS / 1000)}s; interrupting${alreadyReported ? " (failure already reported)" : " and surfacing error"}`,
     );
-    // The stall warning below IS this turn's failure report — mark it surfaced so
-    // the backend's terminal `{ ok: false, subtype: "interrupted" }` result isn't
-    // painted as a SECOND, contradictory failure. (interrupt() also sets
-    // interruptRequested, so the result case treats that result as the interrupt
-    // landing, not a new failure.)
     this.errorSurfaced = true;
     this.busy = false;
     // The stalled turn is abandoned + surfaced as an error — don't re-queue its
     // text (a wedged message could otherwise loop on every interrupt, and it may
     // already have performed tool side effects).
     this.inFlight = null;
-    this.deps.onSay(
-      this.tabId,
-      "⚠️ The agent stopped responding (the turn stalled with no activity). I've cleared it — please try again.",
-    );
+    if (!alreadyReported) {
+      this.deps.onSay(
+        this.tabId,
+        "⚠️ The agent stopped responding (the turn stalled with no activity). I've cleared it — please try again.",
+      );
+    }
     this.deps.onTurn?.(this.tabId, "done");
     // Do NOT completeTurn() here: the gate must stay held until the turn genuinely
     // ends. interrupt() arms the bounded release fallback and stops the wedged
@@ -1086,13 +1092,17 @@ export class PanelAgent {
         // `default` and the user watched a turn end in TOTAL silence — the
         // exact "three Hellos into the void" failure from the support thread.
         // Surface it as a visible chat line; the follow-up `result` event still
-        // advances the turn gate normally.
+        // advances the turn gate normally. ONE report per turn: if the failure
+        // was already surfaced (the stall watchdog's warning, or an earlier
+        // error event this turn), skip the chat line but still log it (#728).
         const detail = typeof ev.message === "string" && ev.message.trim() ? ev.message.trim() : "unknown error";
-        this.errorSurfaced = true;
-        this.deps.onSay(
-          this.tabId,
-          `⚠️ The ${this.model} turn failed: ${detail}\n\nNothing was lost — try again, switch models from the composer picker, or check the terminal running the orchestrator for more detail.`,
-        );
+        if (!this.errorSurfaced) {
+          this.errorSurfaced = true;
+          this.deps.onSay(
+            this.tabId,
+            `⚠️ The ${this.model} turn failed: ${detail}\n\nNothing was lost — try again, switch models from the composer picker, or check the terminal running the orchestrator for more detail.`,
+          );
+        }
         logger.warn(`[panel-agent ${this.short()}] backend error: ${detail}`);
         break;
       }

--- a/src/orchestrator/pi-backend.ts
+++ b/src/orchestrator/pi-backend.ts
@@ -69,6 +69,7 @@ import {
   type ModelChoice,
   type NeutralTurn,
   PI_CAPABILITIES,
+  stampTurn,
 } from "./agent-backend.js";
 
 /** The per-turn child: stdin ignored (pi takes the prompt via argv), stdout +
@@ -333,8 +334,9 @@ export class PiBackend implements AgentBackend {
       };
     }
 
+    let turnSeq = 0;
     for await (const turn of opts.channel) {
-      yield* this.runTurn(turn, cwd, opts.onActivity);
+      yield* stampTurn(this.runTurn(turn, cwd, opts.onActivity), ++turnSeq);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #728.

`PanelAgent.onTurnStalled()` surfaced the stall warning, then released the turn gate **synchronously** via `completeTurn()` and called `backend.interrupt()` directly, bypassing the guarded interrupt flow:

1. **Duplicate failure report** — when the backend then emitted the expected terminal `{ ok: false, subtype: "interrupted" }` result, the result handler didn't know it was watchdog-initiated (`errorSurfaced` / `interruptRequested` were never set), so the never-end-in-silence guard painted a second, contradictory failure: `⚠️ That turn failed (interrupted) without a reply…` on top of `⚠️ The agent stopped responding…`.
2. **Early gate release** — the synchronous `completeTurn()` made the next queued batch eligible before the interrupted turn's result (or the bounded interrupt fallback) had settled the turn.

## Fix

`onTurnStalled()` now marks the turn's failure as surfaced (`errorSurfaced = true`), keeps the gate held (no synchronous `completeTurn()`), and routes through the existing guarded `interrupt()` flow — which sets `interruptRequested`, arms the bounded interrupt-release fallback, and stops the wedged backend. The aborted turn's terminal `result` (or the fallback if none ever arrives) opens the gate at the genuine turn end. The stalled turn's text is still not re-queued (it may already have performed tool side effects).

## Tests

New `src/__tests__/orchestrator/stall-watchdog-interrupt.test.ts` (fake backend with a decoupled read-ahead pump and a test-controlled interrupted result; both tests fail on the old code):

- watchdog interrupt + withheld `interrupted` result → gate stays held until the result lands, then the queued turn drains, and exactly ONE ⚠️ failure report is shown;
- watchdog interrupt + no result ever → the bounded `COMFYUI_MCP_INTERRUPT_RELEASE_MS` fallback opens the gate so the queued turn still drains (no stop-cold), still exactly one warning.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` (full suite) — **3896 passed | 2 skipped** (233 files; baseline 3894 + 2 new)
- New tests confirmed red on pre-fix `panel-agent.ts`, green after