### PR TITLE
fix(#741): panel_add_node accepts frontend-only virtual nodes (Note/MarkdownNote)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- `panel_add_node` documents the frontend-only virtual types (Note/MarkdownNote/Reroute/PrimitiveNode) as the supported way to annotate a workflow, so agents know annotation is possible at all (#741)
+
 ## [0.49.1] - 2026-08-02
 
 ### MCP

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -237,6 +237,27 @@ describe("panel-tools: fresh /object_info ack timeout (#599)", () => {
   });
 });
 
+describe("panel-tools: panel_add_node frontend-only virtual types (#741)", () => {
+  // #741: Note/MarkdownNote/Reroute/PrimitiveNode are frontend-only virtual types —
+  // they exist only in LiteGraph, never in the backend /object_info. The MCP side
+  // must route them straight through to the panel (no class_type pre-validation),
+  // and the description must tell agents annotation is possible at all.
+  it("routes Note/MarkdownNote through to graph_add_node untouched", async () => {
+    for (const class_type of ["Note", "MarkdownNote", "Reroute", "PrimitiveNode"]) {
+      const { ctx, calls } = makeFakeCtx();
+      await defByName("panel_add_node").handler({ class_type, pos: [0, 0] }, ctx);
+      expect(calls[0]).toMatchObject({ cmd: "graph_add_node", class_type });
+    }
+  });
+
+  it("documents Note/MarkdownNote as the supported annotation path", () => {
+    const desc = defByName("panel_add_node").description;
+    expect(desc).toContain("Note");
+    expect(desc).toContain("MarkdownNote");
+    expect(desc).toMatch(/annotat/i);
+  });
+});
+
 describe("panel-tools: panel_refresh_nodes (#608 — force a combo/object_info refresh)", () => {
   it("forwards a bare refresh_nodes command (no graph mutation) with the refresh ack budget", async () => {
     const { ctx, calls, timeouts } = makeFakeCtx();

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3569,7 +3569,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_add_node",
-      "Add a node to the user's OPEN ComfyUI graph by class_type (e.g. 'KSampler', 'CheckpointLoaderSimple'). The user sees it appear live; Ctrl+Z undoes it. Returns the created node's id, slots, and default widget values.",
+      "Add a node to the user's OPEN ComfyUI graph by class_type (e.g. 'KSampler', 'CheckpointLoaderSimple'). The user sees it appear live; Ctrl+Z undoes it. Returns the created node's id, slots, and default widget values. Frontend-only virtual types are addable too: 'Note' and 'MarkdownNote' — the supported way to ANNOTATE a workflow with on-canvas instructions (add the node, then put the text in its 'text' widget via panel_set_widget) — plus 'Reroute' and 'PrimitiveNode'. These are LiteGraph-native and never appear in the backend node registry, so they legitimately bypass the backend class_type check.",
       {
         class_type: z.string().describe("Exact ComfyUI node class_type to create."),
         pos: xy()


### PR DESCRIPTION
## Summary

Fixes #741 (together with the sibling panel PR artokun/comfyui-mcp-panel#564).

**Root cause:** `panel_add_node` rejected `Note`/`MarkdownNote` on the reporter's panel 0.11.32 because those frontend-only virtual types never appear in `/object_info`. The MCP router never pre-validated `class_type` — validation lives in the panel's `graph_add_node` handler, whose add-side exemption for genuine frontend-only types shipped in panel 0.11.33 (#496). So the rejection itself is already fixed upstream.

**What remained (this PR):** agents had no signal that annotation is possible at all — the issue's second follow-up.

- `src/orchestrator/panel-tools.ts` — `panel_add_node`'s description now documents `Note`/`MarkdownNote` as the supported way to **annotate a workflow** with on-canvas instructions (add the node, then put the text in its `text` widget via `panel_set_widget`), plus `Reroute` and `PrimitiveNode` as addable LiteGraph-native virtual types that legitimately bypass the backend class_type check.
- `src/__tests__/orchestrator/panel-tools.test.ts` — new #741 tests: all four virtual types route straight through to `graph_add_node` untouched, and the description documents the Note/MarkdownNote annotation path.

## Test plan
- `npx tsc --noEmit` — clean
- `npx vitest run src/__tests__/orchestrator/panel-tools.test.ts` — **218/218 pass**
- `npx vitest run` (full suite) — **232 files, 3896 passed / 2 skipped** (baseline 3894/2 + 2 new)

Fixes #741