### PR TITLE
fix(#742): never report "cancelled" after a successful stop; refuse Pinokio-style restarts pre-stop

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -409,4 +409,22 @@ describe("getLocalComfyuiUrl (#269 LAN fallback)", () => {
     expect(mod.setComfyuiTarget("not a url")).toBe(false);
     expect(mod.getComfyuiTargetGeneration()).toBe(g0 + 2);
   });
+
+  it("a synchronous target-change listener always observes target and generation in step (#742 r12)", async () => {
+    process.env.COMFYUI_URL = "http://127.0.0.1:8188";
+    const mod = await import("../config.js");
+    const seen: Array<{ url: string; generation: number }> = [];
+    mod.onComfyuiTargetChanged((url) => {
+      seen.push({ url, generation: mod.getComfyuiTargetGeneration() });
+    });
+    const g0 = mod.getComfyuiTargetGeneration();
+    expect(mod.setComfyuiTarget("http://192.168.1.50:8188")).toBe(true);
+    // The listener fired with the NEW target — it must have observed the NEW
+    // generation with it, never the pre-bump one (the contract: any observer
+    // of the new target value sees the new generation).
+    expect(seen).toHaveLength(1);
+    expect(seen[0].url).toBe("http://192.168.1.50:8188");
+    expect(seen[0].generation).toBe(g0 + 1);
+    expect(seen[0].generation).toBe(mod.getComfyuiTargetGeneration());
+  });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -394,4 +394,19 @@ describe("getLocalComfyuiUrl (#269 LAN fallback)", () => {
     const second = await import("../config.js");
     expect(second.getLocalComfyuiUrl()).toBe("http://127.0.0.1:8188");
   });
+
+  it("bumps the target generation on EVERY retarget — an A→B→A round trip is detectable (#742 r11)", async () => {
+    process.env.COMFYUI_URL = "http://127.0.0.1:8188";
+    const mod = await import("../config.js");
+    const g0 = mod.getComfyuiTargetGeneration();
+    // A → B → A: the final base equals the initial one, but the generation
+    // must have advanced twice — final-state equality can never prove stability.
+    expect(mod.setComfyuiTarget("http://192.168.1.50:8188")).toBe(true);
+    expect(mod.setComfyuiTarget("http://127.0.0.1:8188")).toBe(true);
+    expect(mod.getComfyuiTargetGeneration()).toBe(g0 + 2);
+    expect(mod.getComfyUIBaseUrl()).toBe("http://127.0.0.1:8188"); // base looks "unchanged"
+    // A rejected (malformed) retarget does NOT bump.
+    expect(mod.setComfyuiTarget("not a url")).toBe(false);
+    expect(mod.getComfyuiTargetGeneration()).toBe(g0 + 2);
+  });
 });

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -535,6 +535,30 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
+  it("a PASSING preflight retargeted mid-await to a SAFE install still does NOT dispatch (r10)", async () => {
+    // The preflight returns ok — but the runtime config retargeted DURING its
+    // await, so the pass may have validated a DIFFERENT (safe) install while
+    // the tab still fronts the original instance. A pass for a different
+    // install must never bless a stop of the tab-fronted one: its relaunch is
+    // UNPROVEN → refuse, never dispatch.
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => {
+      hoistedConfig.configBase.value = "http://127.0.0.1:9999"; // retarget mid-await
+      return { ok: true }; // a pass — possibly for the WRONG install
+    });
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: true });
+
+    const out = parse(await restartTool().handler({}, ctx));
+    const note = String(out.note ?? "");
+
+    expect(out.refused).toBe(true);
+    expect(note).toMatch(/Refusing to restart/i);
+    expect(note).toMatch(/still running/i);
+    expect(note).toMatch(/settle/i);
+    // CRITICAL: no stop/reboot is sent to the unproven tab-fronted instance.
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
   it("does NOT consult the preflight when the tab doesn't provably front our boot instance", async () => {
     // The preflight guards OUR local boot instance only. A reboot bound for a
     // different/remote instance proceeds exactly as before (dispatched +

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -812,4 +812,44 @@ describe("panel_restart_comfyui — restart dispatch record (r4/r5)", () => {
     // …only the shared process-wide (never-causation) slot knows of it.
     expect(getRestartDispatchRecord(PROCESS_WIDE_RESTART_DISPATCH_TOKEN)).not.toBeNull();
   });
+
+  it("a dispatch stamped DURING a decline probe survives the exoneration clear (r15)", async () => {
+    // A decline probe is in flight when a NEW accepted restart stamps a fresh
+    // token in the SAME session. The probe then returns healthy: the
+    // exoneration clear must be CLEAR-IF-SAME — it may retire the OLD token it
+    // validated, but never evict the NEWER dispatch's record.
+    const { ctx, sends } = makeCtx({ confirm: "no" });
+    __panelToolsTestHooks.seedSessionRestartDispatch(ctx, { at: Date.now(), base: BOOT_BASE }); // T1
+
+    let probed = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => {
+      probed++;
+      if (probed === 1) {
+        // The concurrent accepted restart, mid-probe: stamps T2 (replacing T1)
+        // at acceptance; its own observer only ever sees "down" → never ready
+        // → no clear of its own.
+        ctx.confirm = async () => "yes" as const;
+        await restartTool().handler({}, ctx);
+        return "healthy";
+      }
+      return "down";
+    });
+
+    await restartTool().handler({}, ctx); // the decline: healthy → exoneration
+
+    // The NEWER dispatch's record SURVIVES the decline's exoneration clear…
+    const held = __panelToolsTestHooks.getSessionRestartDispatch(ctx);
+    expect(held).not.toBeNull();
+    expect(__panelToolsTestHooks.sameHttpBase(held!.base, BOOT_BASE)).toBe(true);
+    expect(sends.filter((c) => c.cmd === "comfy_reboot")).toHaveLength(1);
+
+    // …so a later full-window down correctly attributes to the newer dispatch.
+    ctx.confirm = async () => "no" as const;
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    const res2 = await restartTool().handler({}, ctx);
+    const t2 = text(res2);
+    expect(t2).toMatch(/ComfyUI is DOWN/i);
+    expect(t2).toMatch(/STOPPED and did not come back/i);
+    expect(t2).toMatch(/restart initiated earlier/i);
+  });
 });

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -18,6 +18,20 @@ vi.mock("../../comfyui/client.js", () => ({
   resetObjectInfoCache: () => resetObjectInfoCache(),
 }));
 
+// r9: a MUTABLE runtime-config base, so a test can retarget getComfyUIBaseUrl()
+// mid-flight (config-only retarget) while the tab fronting stays put. null →
+// the real configured base.
+const hoistedConfig = vi.hoisted(() => ({
+  configBase: { value: null as string | null },
+}));
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return {
+    ...actual,
+    getComfyUIBaseUrl: () => hoistedConfig.configBase.value ?? actual.getComfyUIBaseUrl(),
+  };
+});
+
 const { buildPanelToolDefs, __panelToolsTestHooks } = await import(
   "../../orchestrator/panel-tools.js"
 );
@@ -107,6 +121,8 @@ beforeEach(() => {
   // r4/r5: no restart dispatch on record unless a test seeds one (also clears
   // any record a prior test left behind).
   __processControlTestHooks.reset();
+  // r9: real configured base unless a test retargets it mid-flight.
+  hoistedConfig.configBase.value = null;
 });
 
 afterEach(() => {
@@ -115,6 +131,7 @@ afterEach(() => {
   __panelToolsTestHooks.setLocalRestartPreflight(null);
   __panelToolsTestHooks.setDeclineProbeTiming(null);
   __processControlTestHooks.reset();
+  hoistedConfig.configBase.value = null;
 });
 
 describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
@@ -486,6 +503,36 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     expect(out.rebooting).toBe(true);
     expect(note).toMatch(/can't confirm/i);
     expect(__panelToolsTestHooks.getSessionRestartDispatch(ctx)).toBeNull();
+  });
+
+  it("a CONFIG-ONLY retarget mid-await still REFUSES the proven-dangerous boot instance (r9)", async () => {
+    // The tab fronts the boot instance THROUGHOUT; only the MUTABLE runtime
+    // config moves during the preflight await. The failed preflight already
+    // PROVED that instance unrelaunchable — the proof follows the instance the
+    // tab fronts, not the mutable config — so the reboot must be REFUSED and
+    // never dispatched (an instance proven unrelaunchable is NEVER sent a
+    // stop/reboot, regardless of config shuffling mid-flight).
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => {
+      hoistedConfig.configBase.value = "http://127.0.0.1:9999"; // config-only retarget mid-await
+      return {
+        ok: false,
+        reason:
+          "Resolved ComfyUI script does not exist on disk: main.py — could not " +
+          "locate the ComfyUI install.",
+      };
+    });
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: true });
+
+    const out = parse(await restartTool().handler({}, ctx));
+    const note = String(out.note ?? "");
+
+    expect(out.refused).toBe(true);
+    expect(note).toMatch(/Refusing to restart/i);
+    expect(note).toMatch(/still running/i);
+    // CRITICAL: the reboot was NEVER dispatched — the proven-dangerous
+    // instance was not stopped.
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
   it("does NOT consult the preflight when the tab doesn't provably front our boot instance", async () => {

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -454,6 +454,40 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     expect(resetObjectInfoCache).not.toHaveBeenCalled();
   });
 
+  it("a failing preflight with a mid-await REBIND issues NO stale-target refusal (r8)", async () => {
+    // Bound at the preflight decision; the session rebinds to an unconfirmable
+    // target DURING the await and the preflight FAILS. The refusal must NOT be
+    // composed against the stale pre-await target ("ComfyUI is still running"
+    // would describe a target never validated) — nothing was stopped, so the
+    // flow falls through to the honest unbound dispatch instead.
+    const fronts = { current: true }; // bound when the preflight is decided…
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => {
+      fronts.current = false; // …but a rebind lands DURING the preflight await
+      return {
+        ok: false,
+        reason:
+          "Resolved ComfyUI script does not exist on disk: main.py — could not " +
+          "locate the ComfyUI install.",
+      };
+    });
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    const { ctx, sends } = makeCtx({ confirm: "yes", fronts });
+
+    const out = parse(await restartTool().handler({}, ctx));
+    const note = String(out.note ?? "");
+
+    // NO stale-target refusal, no unvalidated "still running" claim…
+    expect(note).not.toMatch(/Refusing to restart/i);
+    expect(note).not.toMatch(/still running/i);
+    expect(out.refused).not.toBe(true);
+    // …the restart proceeds against the CURRENT (unbound) target and is
+    // reported honestly as dispatched-but-unconfirmable.
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
+    expect(out.rebooting).toBe(true);
+    expect(note).toMatch(/can't confirm/i);
+    expect(__panelToolsTestHooks.getSessionRestartDispatch(ctx)).toBeNull();
+  });
+
   it("does NOT consult the preflight when the tab doesn't provably front our boot instance", async () => {
     // The preflight guards OUR local boot instance only. A reboot bound for a
     // different/remote instance proceeds exactly as before (dispatched +

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -82,6 +82,12 @@ beforeEach(() => {
     intervalMs: 5,
     probeTimeoutMs: 10,
   });
+  // Fast decline-probe recheck window (the real one is ~6s).
+  __panelToolsTestHooks.setDeclineProbeTiming({
+    windowMs: 25,
+    intervalMs: 5,
+    probeTimeoutMs: 5,
+  });
   // Default: the local relaunch preflight PASSES (the live preflightLocalRestart
   // would probe real processes/ports). The refusal tests override it.
   __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
@@ -91,15 +97,20 @@ afterEach(() => {
   __panelToolsTestHooks.setPanelRebootTiming(null);
   __panelToolsTestHooks.setHealthProbe(null);
   __panelToolsTestHooks.setLocalRestartPreflight(null);
+  __panelToolsTestHooks.setDeclineProbeTiming(null);
 });
 
 describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
-  it("a decline while the server is PROVEN DOWN reports the lost server — never 'Cancelled'", async () => {
+  it("a decline while the server is PERSISTENTLY down reports the lost server — never 'Cancelled'", async () => {
     // The confirm resolved "no" (a decline, OR the card failed into the catch-all
-    // "no" because the tab died with the server). The endpoint probe PROVES the
-    // server is down (ECONNREFUSED): the old "Cancelled — ComfyUI was not
-    // restarted." would be a lie — a stop already happened.
-    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    // "no" because the tab died with the server). The endpoint stays refused for
+    // the WHOLE recheck window — only then may the report call it lost (a single
+    // ECONNREFUSED is just a normal restart down-window, codex gate).
+    let probes = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => {
+      probes++;
+      return "down";
+    });
     const { ctx, sends } = makeCtx({ confirm: "no" });
 
     const res = await restartTool().handler({}, ctx);
@@ -110,14 +121,61 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
     expect(t).not.toMatch(/was not restarted/i);
     expect(t).toMatch(/ComfyUI is DOWN/i);
     expect(t).toMatch(/STOPPED and did not come back/i);
+    expect(t).toMatch(/recheck window/i);
     expect(t).toMatch(/start ComfyUI manually/i);
     expect(t).toMatch(/Pinokio/i);
+    // NOT a single-probe verdict: the window rechecked before declaring loss.
+    expect(probes).toBeGreaterThan(1);
     // Nothing was dispatched after the decline — the report is about PRIOR state.
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
-  it("a decline with a HEALTHY server keeps the plain cancel line", async () => {
-    __panelToolsTestHooks.setHealthProbe(async () => "healthy");
+  it("a decline with the server down-then-HEALTHY inside the window does NOT declare a loss", async () => {
+    // A genuinely restarting server is refused during its normal down window
+    // (codex gate High #1): a recovery inside the recheck window must NOT be
+    // reported as a lost server — the truthful outcome is "it came back".
+    const seq: Array<"down" | "healthy"> = ["down", "down", "healthy"];
+    let probes = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => {
+      const s = seq[Math.min(probes, seq.length - 1)];
+      probes++;
+      return s;
+    });
+    const { ctx, sends } = makeCtx({ confirm: "no" });
+
+    const res = await restartTool().handler({}, ctx);
+    const t = text(res);
+
+    expect(res.isError).toBeFalsy();
+    expect(t).not.toMatch(/ComfyUI is DOWN/i);
+    expect(t).not.toMatch(/did not come back/i);
+    expect(t).not.toMatch(/start ComfyUI manually/i);
+    expect(t).toMatch(/^Cancelled — no new restart was dispatched/);
+    expect(t).toMatch(/healthy again/i);
+    // It kept polling past the first refused sample instead of declaring loss.
+    expect(probes).toBe(3);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("a decline with a HEALTHY server keeps the plain cancel line (one probe, no stall)", async () => {
+    let probes = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => {
+      probes++;
+      return "healthy";
+    });
+    const { ctx, sends } = makeCtx({ confirm: "no" });
+
+    const res = await restartTool().handler({}, ctx);
+
+    expect(text(res)).toBe("Cancelled — ComfyUI was not restarted.");
+    expect(probes).toBe(1); // healthy on the first sample → no recheck window
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("a decline with an UNVERIFIABLE server keeps the plain cancel line (never alarmist)", async () => {
+    // "unknown" (a transient 5xx / timeout / ambiguous error) is NOT a proven
+    // down — only ECONNREFUSED at the END of the window flips the report.
+    __panelToolsTestHooks.setHealthProbe(async () => "unknown");
     const { ctx, sends } = makeCtx({ confirm: "no" });
 
     const res = await restartTool().handler({}, ctx);
@@ -126,11 +184,42 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
-  it("a decline with an UNVERIFIABLE server keeps the plain cancel line (never alarmist)", async () => {
-    // "unknown" (a transient 5xx / timeout / ambiguous error) is NOT a proven
-    // down — only ECONNREFUSED flips the report.
-    __panelToolsTestHooks.setHealthProbe(async () => "unknown");
-    const { ctx, sends } = makeCtx({ confirm: "no" });
+  it("an UNBOUND probe target gets a generic unreachable report — never a causation claim (codex gate)", async () => {
+    // The bound tab does NOT provably front our boot instance, so the only probe
+    // is the configured endpoint — no proven relationship to the restart. The
+    // report may say the server is unreachable, but must NEVER claim a restart
+    // (ours or an earlier one) stopped it.
+    let probes = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => {
+      probes++;
+      return "down";
+    });
+    const { ctx, sends } = makeCtx({ confirm: "no", frontsBoot: false });
+
+    const res = await restartTool().handler({}, ctx);
+    const t = text(res);
+
+    expect(res.isError).toBeFalsy();
+    expect(t).not.toMatch(/^Cancelled/);
+    expect(t).toMatch(/appears to be DOWN|unreachable/i);
+    // NO causation: not "stopped by a restart", not "did not come back".
+    expect(t).not.toMatch(/restart initiated earlier/i);
+    expect(t).not.toMatch(/STOPPED and did not come back/i);
+    expect(t).not.toMatch(/was NOT what stopped it/i);
+    expect(t).toMatch(/can't tell|can't confirm|isn't provably/i);
+    expect(probes).toBeGreaterThan(1);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("an UNBOUND probe target that recovers keeps the plain cancel line", async () => {
+    const seq: Array<"down" | "healthy"> = ["down", "healthy"];
+    let probes = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => {
+      const s = seq[Math.min(probes, seq.length - 1)];
+      probes++;
+      return s;
+    });
+    const { ctx, sends } = makeCtx({ confirm: "no", frontsBoot: false });
 
     const res = await restartTool().handler({}, ctx);
 

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -256,9 +256,43 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
       // clamped 1ms timeout.
       expect(starts.map((s) => s - t0)).toEqual([0, 5, 10, 15]);
       expect(out.attempts).toBe(4);
-      // The verdict is the last known state, and the elapsed time respects the
-      // deadline (nowhere near the 5000ms window).
-      expect(out.status).toBe("down");
+      // The elapsed time respects the deadline (nowhere near the 5000ms window).
+      expect(out.waited_ms).toBeLessThanOrEqual(25);
+      // r3: the deadline TRUNCATED the window — a truncated observation can't
+      // prove permanence, so even an all-refused run is "ambiguous", NEVER
+      // "down" (a lost-server report requires the FULL window).
+      expect(out.status).toBe("ambiguous");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("recheck loop returns DOWN only when the FULL window ran with final refusal (r3)", async () => {
+    // The window completes well before the deadline: every sample refused, so
+    // the full-window observation DOES prove the server stayed down.
+    vi.useFakeTimers();
+    try {
+      const starts: number[] = [];
+      __panelToolsTestHooks.setHealthProbe(async () => {
+        starts.push(Date.now());
+        return "down";
+      });
+      const t0 = Date.now();
+      const pending = __panelToolsTestHooks.probeDeclineRecovery(
+        null,
+        20, // windowMs — completes at +20ms…
+        5,
+        5,
+        t0 + 10000, // …with the deadline far beyond it (no truncation)
+      );
+      await vi.advanceTimersByTimeAsync(1000);
+      const out = await pending;
+
+      // Samples at 0/5/10/15ms; the window's own end stops the loop (no probe
+      // starts at +20 with an exhausted remainder).
+      expect(starts.map((s) => s - t0)).toEqual([0, 5, 10, 15]);
+      expect(out.attempts).toBe(4);
+      expect(out.status).toBe("down"); // full-window refusal → provable loss
       expect(out.waited_ms).toBeLessThanOrEqual(25);
     } finally {
       vi.useRealTimers();

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -313,8 +313,34 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
     expect(t).not.toMatch(/start ComfyUI manually/i);
     expect(t).toMatch(/^Cancelled — no new restart was dispatched/);
     expect(t).toMatch(/healthy again/i);
+    // r14: with NO dispatch on record, the recovery note is CAUSATION-FREE —
+    // it must not credit an earlier restart that isn't provably on record.
+    expect(t).not.toMatch(/restart initiated earlier/i);
     // It kept polling past the first refused sample instead of declaring loss.
     expect(probes).toBe(3);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("a down-then-HEALTHY recovery names the causation ONLY with a fresh session-held dispatch (r14)", async () => {
+    const seq: Array<"down" | "healthy"> = ["down", "healthy"];
+    let probes = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => {
+      const s = seq[Math.min(probes, seq.length - 1)];
+      probes++;
+      return s;
+    });
+    const { ctx, sends } = makeCtx({ confirm: "no" });
+    __panelToolsTestHooks.seedSessionRestartDispatch(ctx, { at: Date.now(), base: BOOT_BASE });
+
+    const res = await restartTool().handler({}, ctx);
+    const t = text(res);
+
+    expect(t).toMatch(/^Cancelled — no new restart was dispatched/);
+    expect(t).toMatch(/healthy again/i);
+    expect(t).toMatch(/restart initiated earlier/i);
+    // The observed recovery exonerates the dispatch either way (r13): the
+    // token is cleared even though the note named it.
+    expect(__panelToolsTestHooks.getSessionRestartDispatch(ctx)).toBeNull();
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -592,4 +592,29 @@ describe("panel_restart_comfyui — restart dispatch record (r4/r5)", () => {
     expect(t2).not.toMatch(/STOPPED and did not come back/i);
     expect(sends.filter((c) => c.cmd === "comfy_reboot")).toHaveLength(1); // only the first
   });
+
+  it("a rebind DURING the preflight await withholds the causation-capable stamp (r7)", async () => {
+    // Bound at the preflight DECISION, but the session rebinds to an
+    // unconfirmable target MID-AWAIT: the dispatch proceeds to the new target,
+    // yet the stamp must use the DISPATCH-POINT binding (unbound → process-wide
+    // non-causation slot only) — never the stale pre-await bound base.
+    const fronts = { current: true }; // bound when the preflight is decided…
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => {
+      fronts.current = false; // …but a rebind lands DURING the preflight await
+      return { ok: true };
+    });
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    const { ctx, sends } = makeCtx({ confirm: "yes", fronts });
+
+    const out = parse(await restartTool().handler({}, ctx));
+
+    // The dispatch still proceeded (to the new, unconfirmable target) and was
+    // accepted — honestly reported unconfirmable.
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
+    expect(out.rebooting).toBe(true);
+    // The causation-capable stamp is WITHHELD: no session-held record…
+    expect(__panelToolsTestHooks.getSessionRestartDispatch(ctx)).toBeNull();
+    // …only the shared process-wide (never-causation) slot knows of it.
+    expect(getRestartDispatchRecord(PROCESS_WIDE_RESTART_DISPATCH_TOKEN)).not.toBeNull();
+  });
 });

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -22,6 +22,10 @@ const { buildPanelToolDefs, __panelToolsTestHooks } = await import(
   "../../orchestrator/panel-tools.js"
 );
 import { getBootLocalComfyUIBaseUrl } from "../../config.js";
+import {
+  __processControlTestHooks,
+  getLastRestartDispatch,
+} from "../../services/process-control.js";
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
 
 // The orchestrator's immutable boot endpoint — what the decline-probe and the
@@ -37,13 +41,16 @@ function makeCtx(opts: {
   /** Whether the bound tab provably fronts our local boot instance (the gate
    *  for both the boot-endpoint probe and the #742 preflight). */
   frontsBoot?: boolean;
+  /** The comfy_reboot reply (default: an accepted `{rebooting: true}`). */
+  rebootReply?: Record<string, unknown>;
 }): { ctx: PanelToolCtx; sends: Array<Record<string, unknown>> } {
   const sends: Array<Record<string, unknown>> = [];
   const frontsBoot = opts.frontsBoot ?? true;
+  const rebootReply = opts.rebootReply ?? { rebooting: true };
   const bridge = {
     send: async (cmd: Record<string, unknown>) => {
       sends.push(cmd);
-      if (cmd.cmd === "comfy_reboot") return { rebooting: true };
+      if (cmd.cmd === "comfy_reboot") return rebootReply;
       return {};
     },
     tabOrigin: () => (frontsBoot ? BOOT_BASE : undefined),
@@ -92,6 +99,8 @@ beforeEach(() => {
   // Default: the local relaunch preflight PASSES (the live preflightLocalRestart
   // would probe real processes/ports). The refusal tests override it.
   __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
+  // r4: no restart dispatch on record unless a test seeds one.
+  __processControlTestHooks.setLastRestartDispatch(null);
 });
 
 afterEach(() => {
@@ -99,6 +108,7 @@ afterEach(() => {
   __panelToolsTestHooks.setHealthProbe(null);
   __panelToolsTestHooks.setLocalRestartPreflight(null);
   __panelToolsTestHooks.setDeclineProbeTiming(null);
+  __processControlTestHooks.setLastRestartDispatch(null);
 });
 
 describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
@@ -106,12 +116,14 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
     // The confirm resolved "no" (a decline, OR the card failed into the catch-all
     // "no" because the tab died with the server). The endpoint stays refused for
     // the WHOLE recheck window — only then may the report call it lost (a single
-    // ECONNREFUSED is just a normal restart down-window, codex gate).
+    // ECONNREFUSED is just a normal restart down-window, codex gate). A restart
+    // dispatch IS on record (r4), so the report names the causation.
     let probes = 0;
     __panelToolsTestHooks.setHealthProbe(async () => {
       probes++;
       return "down";
     });
+    __processControlTestHooks.setLastRestartDispatch({ at: Date.now(), base: BOOT_BASE });
     const { ctx, sends } = makeCtx({ confirm: "no" });
 
     const res = await restartTool().handler({}, ctx);
@@ -128,6 +140,69 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
     // NOT a single-probe verdict: the window rechecked before declaring loss.
     expect(probes).toBeGreaterThan(1);
     // Nothing was dispatched after the decline — the report is about PRIOR state.
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("bound full-window DOWN with NO recorded dispatch makes NO causation claim (r4)", async () => {
+    // An unrelated crash / manual stop: nothing is on record, so the DOWN
+    // report must be causation-free — never blame a restart that isn't
+    // provably on record.
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    __processControlTestHooks.setLastRestartDispatch(null);
+    const { ctx, sends } = makeCtx({ confirm: "no" });
+
+    const res = await restartTool().handler({}, ctx);
+    const t = text(res);
+
+    expect(res.isError).toBeFalsy();
+    expect(t).toMatch(/ComfyUI is DOWN/i);
+    expect(t).toMatch(/still unreachable after/i);
+    expect(t).toMatch(/no restart was dispatched/i);
+    expect(t).not.toMatch(/restart initiated earlier/i);
+    expect(t).not.toMatch(/was NOT what stopped it/i);
+    expect(t).not.toMatch(/STOPPED and did not come back/i);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("bound full-window DOWN with a STALE recorded dispatch makes NO causation claim (r4)", async () => {
+    // A dispatch older than the causation window can't explain the current
+    // down state — the report stays causation-free.
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    __processControlTestHooks.setLastRestartDispatch({
+      at: Date.now() - 11 * 60_000, // beyond the 10-minute causation window
+      base: BOOT_BASE,
+    });
+    const { ctx, sends } = makeCtx({ confirm: "no" });
+
+    const res = await restartTool().handler({}, ctx);
+    const t = text(res);
+
+    expect(res.isError).toBeFalsy();
+    expect(t).toMatch(/ComfyUI is DOWN/i);
+    expect(t).toMatch(/no restart was dispatched/i);
+    expect(t).not.toMatch(/restart initiated earlier/i);
+    expect(t).not.toMatch(/STOPPED and did not come back/i);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("bound full-window DOWN with a dispatch recorded for a DIFFERENT instance makes NO causation claim (r4)", async () => {
+    // The record must target the SAME instance the decline probed — a restart
+    // of some other ComfyUI explains nothing here.
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    __processControlTestHooks.setLastRestartDispatch({
+      at: Date.now(),
+      base: "http://127.0.0.1:9999",
+    });
+    const { ctx, sends } = makeCtx({ confirm: "no" });
+
+    const res = await restartTool().handler({}, ctx);
+    const t = text(res);
+
+    expect(res.isError).toBeFalsy();
+    expect(t).toMatch(/ComfyUI is DOWN/i);
+    expect(t).toMatch(/no restart was dispatched/i);
+    expect(t).not.toMatch(/restart initiated earlier/i);
+    expect(t).not.toMatch(/STOPPED and did not come back/i);
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
@@ -373,5 +448,41 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     expect(out.ready).toBe(true);
     expect(out.confirmed_cycle).toBe(true);
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
+    // r4: the dispatch was recorded on acceptance AND cleared when the restart
+    // was observed back — a completed restart explains no later down state.
+    expect(getLastRestartDispatch()).toBeNull();
+  });
+});
+
+describe("panel_restart_comfyui — restart dispatch record (r4)", () => {
+  it("an ACCEPTED reboot stamps the dispatch record (target base + time)", async () => {
+    // The reboot is accepted but never observed back — the record must stay
+    // stamped so a later decline can name the causation.
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    const { ctx, sends } = makeCtx({ confirm: "yes" });
+
+    const before = Date.now();
+    await restartTool().handler({}, ctx);
+
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
+    const rec = getLastRestartDispatch();
+    expect(rec).not.toBeNull();
+    expect(rec!.at).toBeGreaterThanOrEqual(before);
+    expect(__panelToolsTestHooks.sameHttpBase(rec!.base, BOOT_BASE)).toBe(true);
+  });
+
+  it("a REFUSED reboot (busy guard) does NOT stamp the record", async () => {
+    // A refusal restarts nothing — recording it would fabricate causation.
+    __panelToolsTestHooks.setHealthProbe(async () => "healthy");
+    const { ctx, sends } = makeCtx({
+      confirm: "yes",
+      rebootReply: { rebooting: false, blocked_busy: true },
+    });
+
+    const out = parse(await restartTool().handler({}, ctx));
+
+    expect(out.rebooting).toBe(false);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
+    expect(getLastRestartDispatch()).toBeNull();
   });
 });

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -22,7 +22,11 @@ const { buildPanelToolDefs, __panelToolsTestHooks } = await import(
   "../../orchestrator/panel-tools.js"
 );
 import { getBootLocalComfyUIBaseUrl } from "../../config.js";
-import { __processControlTestHooks } from "../../services/process-control.js";
+import {
+  __processControlTestHooks,
+  getRestartDispatchRecord,
+  PROCESS_WIDE_RESTART_DISPATCH_TOKEN,
+} from "../../services/process-control.js";
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
 
 // The orchestrator's immutable boot endpoint — what the decline-probe and the
@@ -38,22 +42,26 @@ function makeCtx(opts: {
   /** Whether the bound tab provably fronts our local boot instance (the gate
    *  for both the boot-endpoint probe and the #742 preflight). */
   frontsBoot?: boolean;
+  /** MUTABLE fronting — models a session that REBINDS mid-test: the bridge
+   *  getters read `fronts.current` at call time. Overrides frontsBoot. */
+  fronts?: { current: boolean };
   /** The comfy_reboot reply (default: an accepted `{rebooting: true}`). */
   rebootReply?: Record<string, unknown>;
 }): { ctx: PanelToolCtx; sends: Array<Record<string, unknown>> } {
   const sends: Array<Record<string, unknown>> = [];
   const frontsBoot = opts.frontsBoot ?? true;
   const rebootReply = opts.rebootReply ?? { rebooting: true };
+  const fronted = () => opts.fronts?.current ?? frontsBoot;
   const bridge = {
     send: async (cmd: Record<string, unknown>) => {
       sends.push(cmd);
       if (cmd.cmd === "comfy_reboot") return rebootReply;
       return {};
     },
-    tabOrigin: () => (frontsBoot ? BOOT_BASE : undefined),
+    tabOrigin: () => (fronted() ? BOOT_BASE : undefined),
     // The gate reads the SERVER-OBSERVED handshake origin, not the spoofable hello URL.
-    tabServerOrigin: () => (frontsBoot ? BOOT_BASE : undefined),
-    tabIsLocal: () => frontsBoot,
+    tabServerOrigin: () => (fronted() ? BOOT_BASE : undefined),
+    tabIsLocal: () => fronted(),
     canReach: () => true,
   } as unknown as PanelToolCtx["bridge"];
   const ctx = {
@@ -532,5 +540,56 @@ describe("panel_restart_comfyui — restart dispatch record (r4/r5)", () => {
     const recB = __panelToolsTestHooks.getSessionRestartDispatch(ctxB);
     expect(recB).not.toBeNull();
     expect(__panelToolsTestHooks.sameHttpBase(recB!.base, BOOT_BASE)).toBe(true);
+  });
+
+  it("an UNBOUND accepted reboot stamps NO causation-capable record (r6)", async () => {
+    // The reboot is accepted, but the target is unconfirmable (the tab does
+    // not provably front our boot instance) — it must NOT stamp a session-held
+    // record: the dispatch can't be proven to have hit the instance a later
+    // decline would probe. It lands only in the process-wide non-causation
+    // slot (documenting that a dispatch happened).
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: false });
+
+    const out = parse(await restartTool().handler({}, ctx));
+
+    expect(out.rebooting).toBe(true); // accepted, honestly unconfirmable
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
+    // No causation-capable stamp on the session…
+    expect(__panelToolsTestHooks.getSessionRestartDispatch(ctx)).toBeNull();
+    // …only the shared process-wide (never-causation) slot knows of it.
+    expect(
+      getRestartDispatchRecord(PROCESS_WIDE_RESTART_DISPATCH_TOKEN),
+    ).not.toBeNull();
+  });
+
+  it("a session that REBINDS to the boot tab after an unbound reboot gets a causation-FREE decline (r6)", async () => {
+    // The accepted reboot happened while the session fronted an UNCONFIRMABLE
+    // target. The session then rebinds to the boot tab: even with a full-window
+    // down on the bound endpoint, the earlier reboot of (possibly) a DIFFERENT
+    // instance must not be blamed.
+    const fronts = { current: false }; // unbound at reboot time
+    const seq: Array<"down" | "healthy"> = ["down", "healthy"];
+    let i = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => seq[Math.min(i++, seq.length - 1)]);
+    const { ctx, sends } = makeCtx({ confirm: "yes", fronts });
+
+    // 1. Accepted reboot while UNBOUND — dispatched, honestly unconfirmable.
+    const out1 = parse(await restartTool().handler({}, ctx));
+    expect(out1.rebooting).toBe(true);
+
+    // 2. The session REBINDS to the boot tab and a second card is declined.
+    fronts.current = true;
+    ctx.confirm = async () => "no" as const;
+    __panelToolsTestHooks.setHealthProbe(async () => "down"); // full-window refusal
+
+    const res2 = await restartTool().handler({}, ctx);
+    const t2 = text(res2);
+
+    expect(t2).toMatch(/ComfyUI is DOWN/i);
+    expect(t2).toMatch(/no restart was dispatched/i);
+    expect(t2).not.toMatch(/restart initiated earlier/i);
+    expect(t2).not.toMatch(/STOPPED and did not come back/i);
+    expect(sends.filter((c) => c.cmd === "comfy_reboot")).toHaveLength(1); // only the first
   });
 });

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -22,10 +22,7 @@ const { buildPanelToolDefs, __panelToolsTestHooks } = await import(
   "../../orchestrator/panel-tools.js"
 );
 import { getBootLocalComfyUIBaseUrl } from "../../config.js";
-import {
-  __processControlTestHooks,
-  getLastRestartDispatch,
-} from "../../services/process-control.js";
+import { __processControlTestHooks } from "../../services/process-control.js";
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
 
 // The orchestrator's immutable boot endpoint — what the decline-probe and the
@@ -99,8 +96,9 @@ beforeEach(() => {
   // Default: the local relaunch preflight PASSES (the live preflightLocalRestart
   // would probe real processes/ports). The refusal tests override it.
   __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
-  // r4: no restart dispatch on record unless a test seeds one.
-  __processControlTestHooks.setLastRestartDispatch(null);
+  // r4/r5: no restart dispatch on record unless a test seeds one (also clears
+  // any record a prior test left behind).
+  __processControlTestHooks.reset();
 });
 
 afterEach(() => {
@@ -108,7 +106,7 @@ afterEach(() => {
   __panelToolsTestHooks.setHealthProbe(null);
   __panelToolsTestHooks.setLocalRestartPreflight(null);
   __panelToolsTestHooks.setDeclineProbeTiming(null);
-  __processControlTestHooks.setLastRestartDispatch(null);
+  __processControlTestHooks.reset();
 });
 
 describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
@@ -123,8 +121,10 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
       probes++;
       return "down";
     });
-    __processControlTestHooks.setLastRestartDispatch({ at: Date.now(), base: BOOT_BASE });
     const { ctx, sends } = makeCtx({ confirm: "no" });
+    // r4/r5: a restart dispatch IS on record HELD BY THIS SESSION, so the
+    // report names the causation.
+    __panelToolsTestHooks.seedSessionRestartDispatch(ctx, { at: Date.now(), base: BOOT_BASE });
 
     const res = await restartTool().handler({}, ctx);
     const t = text(res);
@@ -148,7 +148,6 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
     // report must be causation-free — never blame a restart that isn't
     // provably on record.
     __panelToolsTestHooks.setHealthProbe(async () => "down");
-    __processControlTestHooks.setLastRestartDispatch(null);
     const { ctx, sends } = makeCtx({ confirm: "no" });
 
     const res = await restartTool().handler({}, ctx);
@@ -168,11 +167,11 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
     // A dispatch older than the causation window can't explain the current
     // down state — the report stays causation-free.
     __panelToolsTestHooks.setHealthProbe(async () => "down");
-    __processControlTestHooks.setLastRestartDispatch({
+    const { ctx, sends } = makeCtx({ confirm: "no" });
+    __panelToolsTestHooks.seedSessionRestartDispatch(ctx, {
       at: Date.now() - 11 * 60_000, // beyond the 10-minute causation window
       base: BOOT_BASE,
     });
-    const { ctx, sends } = makeCtx({ confirm: "no" });
 
     const res = await restartTool().handler({}, ctx);
     const t = text(res);
@@ -189,11 +188,11 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
     // The record must target the SAME instance the decline probed — a restart
     // of some other ComfyUI explains nothing here.
     __panelToolsTestHooks.setHealthProbe(async () => "down");
-    __processControlTestHooks.setLastRestartDispatch({
+    const { ctx, sends } = makeCtx({ confirm: "no" });
+    __panelToolsTestHooks.seedSessionRestartDispatch(ctx, {
       at: Date.now(),
       base: "http://127.0.0.1:9999",
     });
-    const { ctx, sends } = makeCtx({ confirm: "no" });
 
     const res = await restartTool().handler({}, ctx);
     const t = text(res);
@@ -204,6 +203,32 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
     expect(t).not.toMatch(/restart initiated earlier/i);
     expect(t).not.toMatch(/STOPPED and did not come back/i);
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("a dispatch recorded by ANOTHER SESSION never grounds causation here (r5)", async () => {
+    // Two sessions (two ctx objects): session A dispatched the failed restart.
+    // Session B's decline over the SAME base must report causation-FREE…
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    const { ctx: ctxA } = makeCtx({ confirm: "no" });
+    const { ctx: ctxB, sends: sendsB } = makeCtx({ confirm: "no" });
+    __panelToolsTestHooks.seedSessionRestartDispatch(ctxA, { at: Date.now(), base: BOOT_BASE });
+
+    const resB = await restartTool().handler({}, ctxB);
+    const tB = text(resB);
+
+    expect(tB).toMatch(/ComfyUI is DOWN/i);
+    expect(tB).toMatch(/no restart was dispatched/i);
+    expect(tB).not.toMatch(/restart initiated earlier/i);
+    expect(tB).not.toMatch(/STOPPED and did not come back/i);
+    expect(sendsB.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+
+    // …while session A's OWN decline over the same base MAY name it.
+    const resA = await restartTool().handler({}, ctxA);
+    const tA = text(resA);
+
+    expect(tA).toMatch(/ComfyUI is DOWN/i);
+    expect(tA).toMatch(/STOPPED and did not come back/i);
+    expect(tA).toMatch(/restart initiated earlier/i);
   });
 
   it("a decline with the server down-then-HEALTHY inside the window does NOT declare a loss", async () => {
@@ -448,14 +473,14 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     expect(out.ready).toBe(true);
     expect(out.confirmed_cycle).toBe(true);
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
-    // r4: the dispatch was recorded on acceptance AND cleared when the restart
-    // was observed back — a completed restart explains no later down state.
-    expect(getLastRestartDispatch()).toBeNull();
+    // r4/r5: the dispatch was recorded on acceptance AND cleared when the
+    // restart was observed back — a completed restart explains no later down.
+    expect(__panelToolsTestHooks.getSessionRestartDispatch(ctx)).toBeNull();
   });
 });
 
-describe("panel_restart_comfyui — restart dispatch record (r4)", () => {
-  it("an ACCEPTED reboot stamps the dispatch record (target base + time)", async () => {
+describe("panel_restart_comfyui — restart dispatch record (r4/r5)", () => {
+  it("an ACCEPTED reboot stamps the dispatch record HELD BY its session (target base + time)", async () => {
     // The reboot is accepted but never observed back — the record must stay
     // stamped so a later decline can name the causation.
     __panelToolsTestHooks.setHealthProbe(async () => "down");
@@ -465,7 +490,7 @@ describe("panel_restart_comfyui — restart dispatch record (r4)", () => {
     await restartTool().handler({}, ctx);
 
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
-    const rec = getLastRestartDispatch();
+    const rec = __panelToolsTestHooks.getSessionRestartDispatch(ctx);
     expect(rec).not.toBeNull();
     expect(rec!.at).toBeGreaterThanOrEqual(before);
     expect(__panelToolsTestHooks.sameHttpBase(rec!.base, BOOT_BASE)).toBe(true);
@@ -483,6 +508,29 @@ describe("panel_restart_comfyui — restart dispatch record (r4)", () => {
 
     expect(out.rebooting).toBe(false);
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
-    expect(getLastRestartDispatch()).toBeNull();
+    expect(__panelToolsTestHooks.getSessionRestartDispatch(ctx)).toBeNull();
+  });
+
+  it("session A's recovery clears ONLY its own record — session B's survives (r5)", async () => {
+    // B has a failed restart on record. A runs its own accepted reboot that
+    // recovers: A's record is stamped then cleared on recovery; B's record
+    // must be untouched.
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    const { ctx: ctxB } = makeCtx({ confirm: "no" });
+    __panelToolsTestHooks.seedSessionRestartDispatch(ctxB, { at: Date.now(), base: BOOT_BASE });
+
+    const seq: Array<"down" | "healthy"> = ["down", "healthy"];
+    let i = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => seq[Math.min(i++, seq.length - 1)]);
+    const { ctx: ctxA } = makeCtx({ confirm: "yes" });
+
+    const out = parse(await restartTool().handler({}, ctxA));
+
+    expect(out.ready).toBe(true); // A's restart recovered
+    expect(__panelToolsTestHooks.getSessionRestartDispatch(ctxA)).toBeNull(); // A's cleared
+    // B's record survives A's recovery.
+    const recB = __panelToolsTestHooks.getSessionRestartDispatch(ctxB);
+    expect(recB).not.toBeNull();
+    expect(__panelToolsTestHooks.sameHttpBase(recB!.base, BOOT_BASE)).toBe(true);
   });
 });

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -261,6 +261,36 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
     expect(tA).toMatch(/restart initiated earlier/i);
   });
 
+  it("a healthy/recovered decline probe CLEARS the dispatch token — a later independent failure is causation-FREE (r13)", async () => {
+    const { ctx } = makeCtx({ confirm: "no" });
+
+    // 1. Healthy FIRST SAMPLE exonerates the recorded dispatch immediately.
+    __panelToolsTestHooks.seedSessionRestartDispatch(ctx, { at: Date.now(), base: BOOT_BASE });
+    __panelToolsTestHooks.setHealthProbe(async () => "healthy");
+    await restartTool().handler({}, ctx);
+    expect(__panelToolsTestHooks.getSessionRestartDispatch(ctx)).toBeNull();
+
+    // 2. RECOVERED-in-window (down then healthy) exonerates it too.
+    __panelToolsTestHooks.seedSessionRestartDispatch(ctx, { at: Date.now(), base: BOOT_BASE });
+    const seq: Array<"down" | "healthy"> = ["down", "healthy"];
+    let i = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => seq[Math.min(i++, seq.length - 1)]);
+    const res2 = await restartTool().handler({}, ctx);
+    expect(text(res2)).toMatch(/healthy again/i); // the recovery WAS reported
+    expect(__panelToolsTestHooks.getSessionRestartDispatch(ctx)).toBeNull();
+
+    // 3. The server now fails INDEPENDENTLY (full-window down): with the
+    // dispatch exonerated, the report must be causation-FREE — never "a
+    // restart initiated earlier took it down" for a restart that recovered.
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    const res3 = await restartTool().handler({}, ctx);
+    const t3 = text(res3);
+    expect(t3).toMatch(/ComfyUI is DOWN/i);
+    expect(t3).toMatch(/no restart was dispatched/i);
+    expect(t3).not.toMatch(/restart initiated earlier/i);
+    expect(t3).not.toMatch(/STOPPED and did not come back/i);
+  });
+
   it("a decline with the server down-then-HEALTHY inside the window does NOT declare a loss", async () => {
     // A genuinely restarting server is refused during its normal down window
     // (codex gate High #1): a recovery inside the recheck window must NOT be

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -18,17 +18,20 @@ vi.mock("../../comfyui/client.js", () => ({
   resetObjectInfoCache: () => resetObjectInfoCache(),
 }));
 
-// r9: a MUTABLE runtime-config base, so a test can retarget getComfyUIBaseUrl()
-// mid-flight (config-only retarget) while the tab fronting stays put. null →
-// the real configured base.
+// r9/r10/r11: a MUTABLE runtime-config base AND target generation, so tests
+// can retarget getComfyUIBaseUrl() mid-flight (config-only retarget) while the
+// tab fronting stays put. null → the real configured base; the generation is
+// bumped by tests the way every real retarget bumps it.
 const hoistedConfig = vi.hoisted(() => ({
   configBase: { value: null as string | null },
+  generation: { value: 0 },
 }));
 vi.mock("../../config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../config.js")>();
   return {
     ...actual,
     getComfyUIBaseUrl: () => hoistedConfig.configBase.value ?? actual.getComfyUIBaseUrl(),
+    getComfyuiTargetGeneration: () => hoistedConfig.generation.value,
   };
 });
 
@@ -123,6 +126,7 @@ beforeEach(() => {
   __processControlTestHooks.reset();
   // r9: real configured base unless a test retargets it mid-flight.
   hoistedConfig.configBase.value = null;
+  hoistedConfig.generation.value = 0;
 });
 
 afterEach(() => {
@@ -132,6 +136,7 @@ afterEach(() => {
   __panelToolsTestHooks.setDeclineProbeTiming(null);
   __processControlTestHooks.reset();
   hoistedConfig.configBase.value = null;
+  hoistedConfig.generation.value = 0;
 });
 
 describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
@@ -514,6 +519,7 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     // stop/reboot, regardless of config shuffling mid-flight).
     __panelToolsTestHooks.setLocalRestartPreflight(async () => {
       hoistedConfig.configBase.value = "http://127.0.0.1:9999"; // config-only retarget mid-await
+      hoistedConfig.generation.value += 1; // every real retarget bumps the generation
       return {
         ok: false,
         reason:
@@ -543,7 +549,35 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     // UNPROVEN → refuse, never dispatch.
     __panelToolsTestHooks.setLocalRestartPreflight(async () => {
       hoistedConfig.configBase.value = "http://127.0.0.1:9999"; // retarget mid-await
+      hoistedConfig.generation.value += 1; // every real retarget bumps the generation
       return { ok: true }; // a pass — possibly for the WRONG install
+    });
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: true });
+
+    const out = parse(await restartTool().handler({}, ctx));
+    const note = String(out.note ?? "");
+
+    expect(out.refused).toBe(true);
+    expect(note).toMatch(/Refusing to restart/i);
+    expect(note).toMatch(/still running/i);
+    expect(note).toMatch(/settle/i);
+    // CRITICAL: no stop/reboot is sent to the unproven tab-fronted instance.
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("an A→B→A retarget during the preflight await is detected by the generation, not the final base (r11)", async () => {
+    // The config base RETURNS to its original value by the end of the await —
+    // a final-state comparison sees "unchanged" and would accept the safe pass
+    // for install B, then dispatch to the still-tab-fronted dangerous A. The
+    // generation was bumped TWICE, so the mutation is caught and the restart
+    // is refused.
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => {
+      hoistedConfig.configBase.value = "http://127.0.0.1:9999"; // A → B
+      hoistedConfig.generation.value += 1;
+      hoistedConfig.configBase.value = null; // B → A (back to the original base)
+      hoistedConfig.generation.value += 1;
+      return { ok: true }; // a pass — for install B, not the tab-fronted A
     });
     __panelToolsTestHooks.setHealthProbe(async () => "down");
     const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: true });

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -82,9 +82,10 @@ beforeEach(() => {
     intervalMs: 5,
     probeTimeoutMs: 10,
   });
-  // Fast decline-probe recheck window (the real one is ~6s).
+  // Fast decline-probe recheck window (the real one is ~6s). Wide enough that
+  // real-timer slop can't eat it before a scripted mid-window sample lands.
   __panelToolsTestHooks.setDeclineProbeTiming({
-    windowMs: 25,
+    windowMs: 100,
     intervalMs: 5,
     probeTimeoutMs: 5,
   });
@@ -225,6 +226,60 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
 
     expect(text(res)).toBe("Cancelled — ComfyUI was not restarted.");
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("recheck loop NEVER starts an awaited probe after the hard deadline (codex gate r2)", async () => {
+    // A long configured window but a deadline expiring mid-loop: the loop must
+    // STOP at the deadline — the old code clamped the expired remainder to a
+    // 1ms timeout and still awaited one more probe past it. Fake timers make
+    // the exact probe-start instants deterministic.
+    vi.useFakeTimers();
+    try {
+      const starts: number[] = [];
+      __panelToolsTestHooks.setHealthProbe(async () => {
+        starts.push(Date.now());
+        return "down";
+      });
+      const t0 = Date.now();
+      const pending = __panelToolsTestHooks.probeDeclineRecovery(
+        null,
+        5000, // windowMs — far beyond the deadline
+        5, // intervalMs
+        5, // probeTimeoutMs
+        t0 + 20, // hard deadline at +20ms
+      );
+      await vi.advanceTimersByTimeAsync(10000);
+      const out = await pending;
+
+      // Samples at 0/5/10/15ms; at +20 the deadline is exhausted, so NO probe
+      // may start there — the old code started (and awaited) one with a
+      // clamped 1ms timeout.
+      expect(starts.map((s) => s - t0)).toEqual([0, 5, 10, 15]);
+      expect(out.attempts).toBe(4);
+      // The verdict is the last known state, and the elapsed time respects the
+      // deadline (nowhere near the 5000ms window).
+      expect(out.status).toBe("down");
+      expect(out.waited_ms).toBeLessThanOrEqual(25);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("recheck loop with an ALREADY-EXPIRED deadline probes nothing and reports ambiguous", async () => {
+    // No remaining budget at entry: not even the first probe may start — the
+    // verdict is ambiguous, so the report keeps the plain/generic line.
+    let probes = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => {
+      probes++;
+      return "down";
+    });
+    const t0 = Date.now();
+
+    const out = await __panelToolsTestHooks.probeDeclineRecovery(null, 5000, 5, 5, t0 - 1);
+
+    expect(probes).toBe(0);
+    expect(out.attempts).toBe(0);
+    expect(out.status).toBe("ambiguous");
   });
 });
 

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -1,0 +1,199 @@
+// #742: panel_restart_comfyui must NEVER report "Cancelled — ComfyUI was not
+// restarted" while the server is actually DOWN (a stop already happened — e.g. a
+// reboot accepted moments earlier in the same turn stopped ComfyUI, the panel tab
+// died with it, and the confirm card then failed into a catch-all "no"). And on a
+// Pinokio-style install (externally supervised; no main.py/interpreter resolvable
+// from here, so NO provable relaunch) the restart must be REFUSED before anything
+// is stopped — a plain Manager restart kills the process and the supervisor does
+// not re-launch it, which is exactly the #742 lost-server.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resetClient = vi.fn();
+const resetObjectInfoCache = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: () => resetClient(),
+  resetObjectInfoCache: () => resetObjectInfoCache(),
+}));
+
+const { buildPanelToolDefs, __panelToolsTestHooks } = await import(
+  "../../orchestrator/panel-tools.js"
+);
+import { getBootLocalComfyUIBaseUrl } from "../../config.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+// The orchestrator's immutable boot endpoint — what the decline-probe and the
+// refuse-safe preflight bind to when the tab provably fronts our boot instance.
+const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+
+const text = (res: ToolResult): string =>
+  res.content.find((c) => c.type === "text")!.text as string;
+const parse = (res: ToolResult): Record<string, unknown> => JSON.parse(text(res));
+
+function makeCtx(opts: {
+  confirm: "yes" | "no";
+  /** Whether the bound tab provably fronts our local boot instance (the gate
+   *  for both the boot-endpoint probe and the #742 preflight). */
+  frontsBoot?: boolean;
+}): { ctx: PanelToolCtx; sends: Array<Record<string, unknown>> } {
+  const sends: Array<Record<string, unknown>> = [];
+  const frontsBoot = opts.frontsBoot ?? true;
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      sends.push(cmd);
+      if (cmd.cmd === "comfy_reboot") return { rebooting: true };
+      return {};
+    },
+    tabOrigin: () => (frontsBoot ? BOOT_BASE : undefined),
+    // The gate reads the SERVER-OBSERVED handshake origin, not the spoofable hello URL.
+    tabServerOrigin: () => (frontsBoot ? BOOT_BASE : undefined),
+    tabIsLocal: () => frontsBoot,
+    canReach: () => true,
+  } as unknown as PanelToolCtx["bridge"];
+  const ctx = {
+    call: async () => {
+      throw new Error("ctx.call must not be used by the restart handler");
+    },
+    confirm: async () => opts.confirm,
+    ensureReachable: () => {},
+    bridge,
+    tabId: "bound-tab",
+    panelConnectionIdentity: () => ({ generation: 1, tabSessionId: "browser-tab-a" }),
+    awaitPostRestartReachable: async () => true,
+    tabCanMutateGraph: () => true,
+  } as unknown as PanelToolCtx;
+  return { ctx, sends };
+}
+
+function restartTool() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_restart_comfyui");
+  if (!def) throw new Error("panel_restart_comfyui not found");
+  return def;
+}
+
+beforeEach(() => {
+  resetClient.mockClear();
+  resetObjectInfoCache.mockClear();
+  __panelToolsTestHooks.setPanelRebootTiming({
+    settleMs: 0,
+    budgetMs: 60,
+    intervalMs: 5,
+    probeTimeoutMs: 10,
+  });
+  // Default: the local relaunch preflight PASSES (the live preflightLocalRestart
+  // would probe real processes/ports). The refusal tests override it.
+  __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
+});
+
+afterEach(() => {
+  __panelToolsTestHooks.setPanelRebootTiming(null);
+  __panelToolsTestHooks.setHealthProbe(null);
+  __panelToolsTestHooks.setLocalRestartPreflight(null);
+});
+
+describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
+  it("a decline while the server is PROVEN DOWN reports the lost server — never 'Cancelled'", async () => {
+    // The confirm resolved "no" (a decline, OR the card failed into the catch-all
+    // "no" because the tab died with the server). The endpoint probe PROVES the
+    // server is down (ECONNREFUSED): the old "Cancelled — ComfyUI was not
+    // restarted." would be a lie — a stop already happened.
+    __panelToolsTestHooks.setHealthProbe(async () => "down");
+    const { ctx, sends } = makeCtx({ confirm: "no" });
+
+    const res = await restartTool().handler({}, ctx);
+    const t = text(res);
+
+    expect(res.isError).toBeFalsy();
+    expect(t).not.toMatch(/^Cancelled/);
+    expect(t).not.toMatch(/was not restarted/i);
+    expect(t).toMatch(/ComfyUI is DOWN/i);
+    expect(t).toMatch(/STOPPED and did not come back/i);
+    expect(t).toMatch(/start ComfyUI manually/i);
+    expect(t).toMatch(/Pinokio/i);
+    // Nothing was dispatched after the decline — the report is about PRIOR state.
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("a decline with a HEALTHY server keeps the plain cancel line", async () => {
+    __panelToolsTestHooks.setHealthProbe(async () => "healthy");
+    const { ctx, sends } = makeCtx({ confirm: "no" });
+
+    const res = await restartTool().handler({}, ctx);
+
+    expect(text(res)).toBe("Cancelled — ComfyUI was not restarted.");
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("a decline with an UNVERIFIABLE server keeps the plain cancel line (never alarmist)", async () => {
+    // "unknown" (a transient 5xx / timeout / ambiguous error) is NOT a proven
+    // down — only ECONNREFUSED flips the report.
+    __panelToolsTestHooks.setHealthProbe(async () => "unknown");
+    const { ctx, sends } = makeCtx({ confirm: "no" });
+
+    const res = await restartTool().handler({}, ctx);
+
+    expect(text(res)).toBe("Cancelled — ComfyUI was not restarted.");
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+});
+
+describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)", () => {
+  it("REFUSES before any stop when the relaunch is not provable (Pinokio-shaped install)", async () => {
+    // The running local ComfyUI is externally supervised and its main.py /
+    // interpreter cannot be resolved from here — a Manager restart would kill it
+    // and NOTHING would bring it back (the #742 report).
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => ({
+      ok: false,
+      reason:
+        "Resolved ComfyUI script does not exist on disk: main.py — could not " +
+        "locate the ComfyUI install.",
+    }));
+    const { ctx, sends } = makeCtx({ confirm: "yes" });
+
+    const res = await restartTool().handler({}, ctx);
+    const out = parse(res);
+
+    expect(res.isError).toBeFalsy();
+    expect(out.rebooting).toBe(false);
+    expect(out.refused).toBe(true);
+    expect(String(out.note)).toMatch(/refusing to restart/i);
+    expect(String(out.note)).toMatch(/still running/i);
+    expect(String(out.note)).toMatch(/Pinokio/i);
+    // CRITICAL: the reboot was NEVER dispatched — no stop can have happened.
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+    // And the reboot caches were not dropped (no restart is in flight).
+    expect(resetClient).not.toHaveBeenCalled();
+    expect(resetObjectInfoCache).not.toHaveBeenCalled();
+  });
+
+  it("does NOT consult the preflight when the tab doesn't provably front our boot instance", async () => {
+    // The preflight guards OUR local boot instance only. A reboot bound for a
+    // different/remote instance proceeds exactly as before (dispatched +
+    // accepted, honestly unconfirmable from here).
+    const preflight = vi.fn(async () => ({ ok: false, reason: "would refuse" }));
+    __panelToolsTestHooks.setLocalRestartPreflight(preflight);
+    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: false });
+
+    const out = parse(await restartTool().handler({}, ctx));
+
+    expect(out.rebooting).toBe(true);
+    expect(preflight).not.toHaveBeenCalled();
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
+  });
+
+  it("a normal local restart still proceeds when the preflight passes", async () => {
+    const seq: Array<"down" | "healthy"> = ["down", "healthy"];
+    let i = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => seq[Math.min(i++, seq.length - 1)]);
+    const { ctx, sends } = makeCtx({ confirm: "yes" });
+
+    const out = parse(await restartTool().handler({}, ctx));
+
+    expect(out.rebooting).toBe(true);
+    expect(out.ready).toBe(true);
+    expect(out.confirmed_cycle).toBe(true);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
+  });
+});

--- a/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
@@ -100,6 +100,9 @@ const DROP = markDispatched(
 beforeEach(() => {
   resetClient.mockClear();
   resetObjectInfoCache.mockClear();
+  // The #742 refuse-safe preflight passes by default here (the live one would
+  // probe real processes/ports); these tests exercise the post-dispatch paths.
+  __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
   __panelToolsTestHooks.setPanelRebootTiming({
     settleMs: 0,
     budgetMs: 200,
@@ -111,6 +114,7 @@ beforeEach(() => {
 afterEach(() => {
   __panelToolsTestHooks.setPanelRebootTiming(null);
   __panelToolsTestHooks.setHealthProbe(null);
+  __panelToolsTestHooks.setLocalRestartPreflight(null);
 });
 
 describe("panel_restart_comfyui recovery after an ACCEPTED reboot (coordinator policy)", () => {

--- a/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
@@ -92,6 +92,9 @@ beforeEach(() => {
   hoisted.remoteMode.value = false;
   hoisted.restart.mockClear();
   hoisted.restart.mockResolvedValue({ stopped: true, started: true, ready: true, message: "restarted" });
+  // The #742 refuse-safe preflight passes by default here (the live one would
+  // probe real processes/ports); these tests exercise the post-dispatch paths.
+  __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
   __panelToolsTestHooks.setPanelRebootTiming({
     settleMs: 0,
     budgetMs: 50,
@@ -109,6 +112,7 @@ beforeEach(() => {
 afterEach(() => {
   __panelToolsTestHooks.setPanelRebootTiming(null);
   __panelToolsTestHooks.setHealthProbe(null);
+  __panelToolsTestHooks.setLocalRestartPreflight(null);
 });
 
 describe("rebootNoEndpoint classifier", () => {

--- a/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
+++ b/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
@@ -83,10 +83,14 @@ function reconnectingBridge(initial: string[] = []) {
 beforeEach(() => {
   // Keep the reconnect wait fast so tests don't sit through the real ~20s budget.
   __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 500, intervalMs: 5 });
+  // The #742 refuse-safe preflight passes by default here (the live one would
+  // probe real processes/ports); these tests exercise the post-dispatch paths.
+  __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
 });
 afterEach(() => {
   __panelToolsTestHooks.setReconnectWaitTiming(null);
   __panelToolsTestHooks.setRetrySettleMs(null);
+  __panelToolsTestHooks.setLocalRestartPreflight(null);
   __openWorkflowTestHooks.setOpenVerifyTiming(null);
   resetClient.mockClear();
   resetObjectInfoCache.mockClear();

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -3620,6 +3620,7 @@ describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)",
 
   afterEach(() => {
     __panelAskTestHooks.setAskTiming(null);
+    __panelToolsTestHooks.setHealthProbe(null);
   });
 
   // FAIL-BEFORE: the old confirm swallowed a card-reply timeout as `false`, so an
@@ -3651,6 +3652,9 @@ describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)",
   // The confirm card deadline must be CLAMPED under the ~300s MCP tools/call budget
   // (the old hardcoded 300000ms had zero margin and blew the transport).
   it("panel_restart_comfyui clamps the confirm-card deadline under the MCP budget", async () => {
+    // #742: the decline path probes the server before reporting — stub it healthy
+    // (a clean decline; no real loopback fetch in a unit test).
+    __panelToolsTestHooks.setHealthProbe(async () => true);
     let forwardedTimeout = Infinity;
     const bridge = {
       send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
@@ -3674,6 +3678,9 @@ describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)",
   it("panel_restart_comfyui bounds the confirm-card wait by RESTART_CONFIRM_TIMEOUT_MS (not the full ~255s budget)", async () => {
     // No ask-timing override → the REAL getAskTiming (240s) is in effect, so the forwarded
     // reply timeout reflects the handler's own confirm budget, not a test clamp.
+    // #742: the decline path probes the server before reporting — stub it healthy
+    // (a clean decline; no real loopback fetch in a unit test).
+    __panelToolsTestHooks.setHealthProbe(async () => true);
     let forwardedTimeout = Infinity;
     const bridge = {
       send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -59,6 +59,7 @@ vi.mock("../../services/env-capabilities.js", () => ({
 import {
   __processControlTestHooks,
   parseListenerPidFromNetstat,
+  preflightLocalRestart,
   restartComfyUI,
   startComfyUI,
   stopComfyUI,
@@ -695,6 +696,149 @@ describe("findPidByPort resilience to localized netstat state (#449)", () => {
       mockExecSync.mock.calls.some(([c]) => /taskkill/i.test(String(c))),
     ).toBe(false);
     expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+});
+
+describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
+  // Same live-port wiring as the #368/#370 preflight suite: a live PID on the
+  // port (so the running instance is found) with every kill recorded, so a test
+  // can prove the server was NOT taken down.
+  function mockLivePortNoKill(): void {
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.includes("netstat"))
+        return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      if (cmd.includes("lsof")) return "p4321\nn127.0.0.1:8188\n";
+      return ""; // tasklist / taskkill / `if exist` → nothing
+    });
+  }
+
+  // The #742 shape: a Pinokio-managed ComfyUI — externally supervised, launched
+  // as a RELATIVE `main.py`, with no COMFYUI_PATH anchor and no resolvable
+  // interpreter from here. A plain Manager restart kills it and the supervisor
+  // does NOT re-launch it, so any restart from us must refuse BEFORE a stop.
+  function mockPinokioShapedInstall(): void {
+    mockLivePortNoKill();
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: ["main.py", "--port", "8188"] },
+    });
+    mockConfig.comfyuiPath = undefined;
+    mockFindComfyuiPython.mockReturnValue(undefined);
+  }
+
+  it("preflightLocalRestart refuses a Pinokio-shaped install (no resolvable main.py/interpreter)", async () => {
+    mockPinokioShapedInstall();
+
+    const preflight = await preflightLocalRestart();
+
+    expect(preflight.ok).toBe(false);
+    expect(preflight.reason).toMatch(/could not build a relaunch command/i);
+  });
+
+  it("restartComfyUI refuses a Pinokio-shaped install BEFORE any stop (no kill, no spawn)", async () => {
+    mockPinokioShapedInstall();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(result.message).toMatch(/left running/i);
+    expect(result.message).not.toMatch(/cancel/i);
+    // Server left running: no kill, no relaunch spawn, no client reset.
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(mockResetClient).not.toHaveBeenCalled();
+    expect(
+      mockExecSync.mock.calls.some(([c]) => /taskkill/i.test(String(c))),
+    ).toBe(false);
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("preflightLocalRestart passes a resolvable local install", async () => {
+    mockLivePortNoKill();
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: ["/fake/ComfyUI/main.py", "--port", "8188"] },
+    });
+    // Default mocks: interpreter resolved, every path exists.
+
+    const preflight = await preflightLocalRestart();
+
+    expect(preflight.ok).toBe(true);
+  });
+
+  it("preflightLocalRestart passes a Desktop app (the Manager reboot IS its safe path, #400)", async () => {
+    mockLivePortNoKill();
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: [
+          "C:\\Users\\x\\AppData\\Local\\Programs\\Comfy Desktop\\resources\\ComfyUI\\main.py",
+          "--port",
+          "8188",
+        ],
+      },
+    });
+    mockExistsSync.mockImplementation(() => false); // relaunch never consulted
+
+    const preflight = await preflightLocalRestart();
+
+    expect(preflight.ok).toBe(true);
+  });
+
+  it("preflightLocalRestart passes when no running process can be proven", async () => {
+    mockNoPortProcess();
+    mockGetSystemStats.mockRejectedValue(new Error("connection refused"));
+
+    const preflight = await preflightLocalRestart();
+
+    expect(preflight.ok).toBe(true);
+  });
+
+  it("stop succeeded but relaunch fails → truthful lost-server message, never 'cancelled' (#742)", async () => {
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill/i.test(String(cmd))) {
+        killed = true;
+        return "";
+      }
+      if (cmd.includes("netstat")) {
+        if (killed) return ""; // port freed after the kill
+        return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (cmd.includes("lsof")) {
+        if (killed) throw new Error("not listening");
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return ""; // tasklist / `sleep 1 && kill -9` / etc.
+    });
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: ["/fake/ComfyUI/main.py", "--port", "8188"] },
+    });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      killed = true;
+      return true;
+    });
+    const children = mockSpawnedChildren();
+    // Readiness never resolves; the relaunch's spawn error short-circuits it.
+    vi.stubGlobal("fetch", vi.fn(() => new Promise<Response>(() => undefined)));
+
+    const pending = restartComfyUI();
+    await vi.waitFor(() => expect(children.length).toBe(1), {
+      timeout: 10000,
+      interval: 20,
+    });
+    children[0].emit("error", spawnError());
+    const result = await pending;
+
+    // The stop DID happen — the report must say so truthfully.
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/stopped but could not be started/i);
+    expect(result.message).not.toMatch(/cancel/i);
+    expect(result.spawn_error).toBeTruthy();
 
     killSpy.mockRestore();
   });

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -58,9 +58,11 @@ vi.mock("../../services/env-capabilities.js", () => ({
 
 import {
   __processControlTestHooks,
-  getLastRestartDispatch,
+  clearRestartDispatch,
+  getRestartDispatchRecord,
   parseListenerPidFromNetstat,
   preflightLocalRestart,
+  PROCESS_WIDE_RESTART_DISPATCH_TOKEN,
   restartComfyUI,
   startComfyUI,
   stopComfyUI,
@@ -840,9 +842,9 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
     expect(result.message).toMatch(/stopped but could not be started/i);
     expect(result.message).not.toMatch(/cancel/i);
     expect(result.spawn_error).toBeTruthy();
-    // r4: the stop stamped the restart-dispatch record (never cleared — the
-    // relaunch failed), so a later decline may name the causation.
-    const rec = getLastRestartDispatch();
+    // r4/r5: the stop stamped the restart-dispatch record (process-wide slot;
+    // never cleared — the relaunch failed).
+    const rec = getRestartDispatchRecord(PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
     expect(rec).not.toBeNull();
     expect(rec!.base).toBe("http://127.0.0.1:8188");
 
@@ -880,8 +882,9 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
 
     expect(result.stopped).toBe(true);
     expect(result.started).toBe(true);
-    // Observed back → the record is cleared: this restart explains no later down.
-    expect(getLastRestartDispatch()).toBeNull();
+    // Observed back → OUR process-wide record is cleared: this restart
+    // explains no later down.
+    expect(getRestartDispatchRecord(PROCESS_WIDE_RESTART_DISPATCH_TOKEN)).toBeNull();
 
     killSpy.mockRestore();
   });
@@ -914,8 +917,30 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
 
     expect(result.stopped).toBe(true);
     expect(result.started).toBe(false);
-    const rec = getLastRestartDispatch();
+    const rec = getRestartDispatchRecord(PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
     expect(rec).not.toBeNull();
     expect(rec!.base).toBe("http://127.0.0.1:8188");
+  });
+
+  it("a recovery clear removes ONLY the dispatching session's record (r5)", () => {
+    // Two sessions' records coexist; clearing one's token must never touch the
+    // other's — A's recovery cannot clear B's record.
+    __processControlTestHooks.setRestartDispatchRecord("tok-a", {
+      at: Date.now(),
+      base: "http://127.0.0.1:8188",
+    });
+    __processControlTestHooks.setRestartDispatchRecord("tok-b", {
+      at: Date.now(),
+      base: "http://127.0.0.1:8188",
+    });
+
+    clearRestartDispatch("tok-a");
+    expect(getRestartDispatchRecord("tok-a")).toBeNull();
+    expect(getRestartDispatchRecord("tok-b")).not.toBeNull(); // B's survives
+
+    clearRestartDispatch("tok-b");
+    expect(getRestartDispatchRecord("tok-b")).toBeNull();
+    // Unknown token → no-op, never throws.
+    expect(() => clearRestartDispatch("tok-nope")).not.toThrow();
   });
 });

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -58,6 +58,7 @@ vi.mock("../../services/env-capabilities.js", () => ({
 
 import {
   __processControlTestHooks,
+  getLastRestartDispatch,
   parseListenerPidFromNetstat,
   preflightLocalRestart,
   restartComfyUI,
@@ -839,7 +840,82 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
     expect(result.message).toMatch(/stopped but could not be started/i);
     expect(result.message).not.toMatch(/cancel/i);
     expect(result.spawn_error).toBeTruthy();
+    // r4: the stop stamped the restart-dispatch record (never cleared — the
+    // relaunch failed), so a later decline may name the causation.
+    const rec = getLastRestartDispatch();
+    expect(rec).not.toBeNull();
+    expect(rec!.base).toBe("http://127.0.0.1:8188");
 
     killSpy.mockRestore();
+  });
+
+  it("a successful kill+relaunch restart CLEARS the dispatch record (r4)", async () => {
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill/i.test(String(cmd))) {
+        killed = true;
+        return "";
+      }
+      if (cmd.includes("netstat")) {
+        if (killed) return ""; // port freed after the kill
+        return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (cmd.includes("lsof")) {
+        if (killed) throw new Error("not listening");
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return ""; // tasklist / `sleep 1 && kill -9` / etc.
+    });
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: ["/fake/ComfyUI/main.py", "--port", "8188"] },
+    });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      killed = true;
+      return true;
+    });
+    mockSpawnedChildren();
+    mockFetchOk(true); // the relaunch comes up healthy on the first probe
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    // Observed back → the record is cleared: this restart explains no later down.
+    expect(getLastRestartDispatch()).toBeNull();
+
+    killSpy.mockRestore();
+  });
+
+  it("a Manager reboot that never comes back leaves the dispatch record stamped (r4)", async () => {
+    // Desktop argv → the Manager-reboot path. The reboot FIRES (connection
+    // drop) but readiness never returns — the record must stay stamped.
+    mockLivePortNoKill();
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: [
+          "C:\\Users\\x\\AppData\\Local\\Programs\\Comfy Desktop\\resources\\ComfyUI\\main.py",
+          "--port",
+          "8188",
+        ],
+      },
+    });
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 30,
+      intervalMs: 5,
+    });
+    const fetchMock = vi.fn(async (url: unknown) => {
+      if (String(url).includes("reboot")) throw new Error("socket hang up"); // drop = fired
+      return { ok: false } as Response; // readiness never ok
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(false);
+    const rec = getLastRestartDispatch();
+    expect(rec).not.toBeNull();
+    expect(rec!.base).toBe("http://127.0.0.1:8188");
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -649,13 +649,15 @@ export function isTargetingLocal(): boolean {
 type ComfyuiTargetListener = (url: string, isLocal: boolean) => void;
 const comfyuiTargetListeners = new Set<ComfyuiTargetListener>();
 
-// ── Target generation (#742 r11) ─────────────────────────────────────────────
-// Monotonic epoch bumped on EVERY successful retarget. A final-state base
-// comparison (A vs A) cannot detect an intervening A→B→A mutation, so
-// consumers that read the mutable target across an await (e.g. the panel
-// restart's refuse-safe preflight) must instead require the GENERATION to be
-// unchanged after the await — any mutation, including a round trip back to
-// the same base, bumps it.
+// ── Target generation (#742 r11/r12) ─────────────────────────────────────────
+// Monotonic epoch bumped in setComfyuiTarget BEFORE the mutation is
+// observable, so any observer of the new target value (including synchronous
+// target-change listeners) always sees the new generation with it — the
+// target-generation contract. A final-state base comparison (A vs A) cannot
+// detect an intervening A→B→A mutation, so consumers that read the mutable
+// target across an await (e.g. the panel restart's refuse-safe preflight)
+// must instead require the GENERATION to be unchanged after the await — any
+// mutation, including a round trip back to the same base, bumps it.
 let comfyuiTargetGeneration = 0;
 
 /** The current target generation — increments on every successful setComfyuiTarget. */
@@ -746,6 +748,14 @@ export function setComfyuiTarget(url: string): boolean {
   } catch {
     return false;
   }
+  // Bump the target generation BEFORE the mutation is observable (#742 r12):
+  // the contract is that ANY observer of the new target value — including a
+  // synchronous target-change listener fired below — sees the new generation
+  // with it. The reverse ordering (new target fanned out with the old epoch)
+  // is the violation; a post-parse failure leaving the epoch advanced is
+  // harmless by comparison (consumers like the #742 r10 check simply refuse
+  // conservatively), and nothing past this point can fail the retarget anyway.
+  comfyuiTargetGeneration += 1;
   config.comfyuiHost = t.host;
   config.comfyuiPort = t.port;
   config.resolvedPort = t.port;
@@ -791,10 +801,6 @@ export function setComfyuiTarget(url: string): boolean {
   resetManagerApiCache("comfyui target changed");
   // Tell the control panels where renders run now (local ⇄ pod).
   emitComfyuiTargetChanged();
-  // Bump the target generation LAST, on success only — every retarget (even an
-  // A→B→A round trip back to the same base) must be detectable by consumers
-  // holding a pre-await generation snapshot (#742 r11).
-  comfyuiTargetGeneration += 1;
   return true;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -648,6 +648,21 @@ export function isTargetingLocal(): boolean {
 // local and a RunPod pod — the UI must never lie about where a job runs.
 type ComfyuiTargetListener = (url: string, isLocal: boolean) => void;
 const comfyuiTargetListeners = new Set<ComfyuiTargetListener>();
+
+// ── Target generation (#742 r11) ─────────────────────────────────────────────
+// Monotonic epoch bumped on EVERY successful retarget. A final-state base
+// comparison (A vs A) cannot detect an intervening A→B→A mutation, so
+// consumers that read the mutable target across an await (e.g. the panel
+// restart's refuse-safe preflight) must instead require the GENERATION to be
+// unchanged after the await — any mutation, including a round trip back to
+// the same base, bumps it.
+let comfyuiTargetGeneration = 0;
+
+/** The current target generation — increments on every successful setComfyuiTarget. */
+export function getComfyuiTargetGeneration(): number {
+  return comfyuiTargetGeneration;
+}
+
 export function onComfyuiTargetChanged(cb: ComfyuiTargetListener): () => void {
   comfyuiTargetListeners.add(cb);
   return () => comfyuiTargetListeners.delete(cb);
@@ -776,6 +791,10 @@ export function setComfyuiTarget(url: string): boolean {
   resetManagerApiCache("comfyui target changed");
   // Tell the control panels where renders run now (local ⇄ pod).
   emitComfyuiTargetChanged();
+  // Bump the target generation LAST, on success only — every retarget (even an
+  // A→B→A round trip back to the same base) must be detectable by consumers
+  // holding a pre-await generation snapshot (#742 r11).
+  comfyuiTargetGeneration += 1;
   return true;
 }
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5607,6 +5607,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             declineTiming.probeTimeoutMs,
             overallDeadline,
           );
+          // r13: a HEALTHY/RECOVERED observation exonerates any dispatch THIS
+          // session has on record — the restart explained itself, so its token
+          // must never ground causation for a LATER, independent failure.
+          // Base-matched: a healthy observation only exonerates the instance
+          // it was taken on (an unbound healthy endpoint says nothing about a
+          // boot-instance record). The 10-minute causation window stays as the
+          // backstop for records never observed back.
+          if (outcome.status === "healthy" || outcome.status === "recovered") {
+            const held = sessionRestartDispatch(ctx);
+            if (held != null && (held.base == null || sameHttpBase(held.base, declineProbeBase))) {
+              clearSessionRestartDispatch(ctx);
+            }
+          }
           if (outcome.status === "down") {
             const secs = Math.max(1, Math.round(outcome.waited_ms / 1000));
             if (boundToRestartTarget) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5614,9 +5614,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // it was taken on (an unbound healthy endpoint says nothing about a
           // boot-instance record). The 10-minute causation window stays as the
           // backstop for records never observed back.
+          // r14: the record is captured BEFORE the clear — the recovery CLAIM
+          // below ("a restart initiated earlier appears to have completed")
+          // requires the token to have been present at this moment.
+          const heldBeforeProbeOutcome = sessionRestartDispatch(ctx);
           if (outcome.status === "healthy" || outcome.status === "recovered") {
-            const held = sessionRestartDispatch(ctx);
-            if (held != null && (held.base == null || sameHttpBase(held.base, declineProbeBase))) {
+            if (
+              heldBeforeProbeOutcome != null &&
+              (heldBeforeProbeOutcome.base == null ||
+                sameHttpBase(heldBeforeProbeOutcome.base, declineProbeBase))
+            ) {
               clearSessionRestartDispatch(ctx);
             }
           }
@@ -5669,10 +5676,25 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             );
           }
           if (outcome.status === "recovered" && boundToRestartTarget) {
+            // r14: the recovery CLAIM ("a restart initiated earlier appears to
+            // have completed") passes the SAME causation gate as the DOWN
+            // report — a session-held, bound-confirmed record, recent, and
+            // base-matched, captured BEFORE the r13 exoneration clear (which
+            // fires either way). Without it, the down→healthy cycle alone
+            // proves nothing about what caused the down: report the recovery
+            // causation-free.
+            const recoveryCausative =
+              heldBeforeProbeOutcome != null &&
+              Date.now() - heldBeforeProbeOutcome.at <= RESTART_DISPATCH_CAUSATION_WINDOW_MS &&
+              (heldBeforeProbeOutcome.base == null ||
+                sameHttpBase(heldBeforeProbeOutcome.base, declineBootBase));
             return ok(
-              "Cancelled — no new restart was dispatched. Note: ComfyUI was briefly " +
-                "unreachable but is healthy again — a restart initiated earlier " +
-                "appears to have completed.",
+              recoveryCausative
+                ? "Cancelled — no new restart was dispatched. Note: ComfyUI was briefly " +
+                    "unreachable but is healthy again — a restart initiated earlier " +
+                    "appears to have completed."
+                : "Cancelled — no new restart was dispatched. ComfyUI was briefly " +
+                    "unreachable but is healthy again.",
             );
           }
           return ok("Cancelled — ComfyUI was not restarted.");

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -63,7 +63,13 @@ import {
   resetObjectInfoCache,
 } from "../comfyui/client.js";
 import { convertUiToApi, collectNodeTypes } from "../services/workflow-converter.js";
-import { restartComfyUI, preflightLocalRestart } from "../services/process-control.js";
+import {
+  restartComfyUI,
+  preflightLocalRestart,
+  recordRestartDispatch,
+  clearRestartDispatch,
+  getLastRestartDispatch,
+} from "../services/process-control.js";
 import { resetManagerApiCache } from "../services/manager-api-cache.js";
 import {
   isRemoteMode,
@@ -267,6 +273,13 @@ const RESTART_CONFIRM_TIMEOUT_MS = 90_000; // 90s
 const DECLINE_PROBE_WINDOW_MS = 6_000; // 6s total
 const DECLINE_PROBE_INTERVAL_MS = 2_000; // 2s between samples
 const DECLINE_PROBE_TIMEOUT_MS = 2_000; // per-sample probe ceiling
+
+// #742 r4: how long a RECORDED restart dispatch plausibly explains a down
+// server. The decline path's DOWN report may name restart causation only
+// against a dispatch on record within this window (and targeting the probed
+// instance); combined with clear-on-observed-recovery, an unrelated crash or
+// manual stop is never misreported as "a restart took it down".
+const RESTART_DISPATCH_CAUSATION_WINDOW_MS = 10 * 60_000; // 10 min
 
 function parsePositiveNumberEnv(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -5549,16 +5562,37 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           if (outcome.status === "down") {
             const secs = Math.max(1, Math.round(outcome.waited_ms / 1000));
             if (boundToRestartTarget) {
+              // r4: causation may be named ONLY against a RECORDED restart
+              // dispatch — recent enough to plausibly be the cause, and
+              // targeting THIS instance. An unrelated crash / manual stop (no
+              // record, a stale record, or another instance's record) gets the
+              // causation-free report.
+              const dispatch = getLastRestartDispatch();
+              const causative =
+                dispatch != null &&
+                Date.now() - dispatch.at <= RESTART_DISPATCH_CAUSATION_WINDOW_MS &&
+                (dispatch.base == null || sameHttpBase(dispatch.base, declineBootBase));
+              if (causative) {
+                return ok(
+                  "⚠️ ComfyUI is DOWN — it was STOPPED and did not come back (still " +
+                    `unreachable after a ${secs}s recheck window), so do NOT treat this as ` +
+                    "\"nothing happened\". The restart just declined was NOT what stopped " +
+                    "it (nothing was dispatched after the decline), but a restart initiated " +
+                    "earlier already took the server down and it never returned. Start " +
+                    "ComfyUI manually from whatever launches it (e.g. Pinokio, the Desktop " +
+                    "app, or your terminal), then reload the panel tab so it reconnects. " +
+                    "restart_comfyui can attempt the relaunch for you when the install's " +
+                    "launch path is resolvable.",
+                );
+              }
               return ok(
-                "⚠️ ComfyUI is DOWN — it was STOPPED and did not come back (still " +
-                  `unreachable after a ${secs}s recheck window), so do NOT treat this as ` +
-                  "\"nothing happened\". The restart just declined was NOT what stopped " +
-                  "it (nothing was dispatched after the decline), but a restart initiated " +
-                  "earlier already took the server down and it never returned. Start " +
-                  "ComfyUI manually from whatever launches it (e.g. Pinokio, the Desktop " +
-                  "app, or your terminal), then reload the panel tab so it reconnects. " +
-                  "restart_comfyui can attempt the relaunch for you when the install's " +
-                  "launch path is resolvable.",
+                "⚠️ ComfyUI is DOWN — still unreachable after " +
+                  `a ${secs}s recheck window — and no restart was dispatched through me ` +
+                  "that would explain it (the restart just declined was NOT dispatched, " +
+                  "and none is on record recently for this instance). Something else " +
+                  "stopped it (a crash, a manual stop, or its launcher). Start ComfyUI " +
+                  "manually from whatever launches it (e.g. Pinokio, the Desktop app, or " +
+                  "your terminal), then reload the panel tab so it reconnects.",
               );
             }
             return ok(
@@ -5811,6 +5845,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // Otherwise (the process WAS stopped/started, or restartComfyUI's own readiness
             // poll merely expired — neither terminal) DEFER to OUR OWN observed DOWN→UP.
             const recovery = await proofPromise;
+            // #742 r4: the managed restart was observed back — clear the record
+            // (restartComfyUI also clears on its own success; this covers the
+            // case where only OUR observer saw the recovery).
+            if (recovery.ready) clearRestartDispatch();
             const observed = recovery.via === "observed-cycle";
             // The legacy Manager path restarts ComfyUI out-of-band too. Server recovery alone
             // is not graph-tool readiness: wait for the browser tab to reconnect, then verify
@@ -5870,6 +5908,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         resetClient();
         resetObjectInfoCache();
         resetManagerApiCache("panel Manager reboot");
+        // #742 r4: record the ACTUAL dispatch (acceptance proven — a refusal never
+        // reaches here). A later decline-path DOWN report may name restart causation
+        // only against this record; it is cleared below if the restart is observed back.
+        recordRestartDispatch(healthBase ?? getComfyUIBaseUrl());
 
         // Observe recovery. There is exactly ONE sound proof that THIS ComfyUI instance
         // actually cycled: a directly OBSERVED down→up on the server-authorized, immutable,
@@ -5906,6 +5948,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // down→up, which the observer has been (and continues) watching for.
         gate.deadline = Math.min(Date.now() + timing.budgetMs, overallDeadline);
         const recovery = await recoveryPromise!;
+        // #742 r4: the dispatched restart was observed back — clear the record so
+        // it explains no later down state.
+        if (recovery.ready) clearRestartDispatch();
         if (!recovery.ready) {
           const waited = Math.round(recovery.waited_ms / 1000);
           return ok({

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -779,10 +779,14 @@ interface DeclineProbeOutcome {
    *               back healthy inside the window (a genuine restart's down
    *               window — NEVER a lost server, codex gate).
    * "down"      — no healthy sample AND the LAST sample taken within the
-   *               window was a proven down. Only this may be reported as
-   *               a loss — a single refused sample never suffices.
+   *               window was a proven down AND the FULL window ran its
+   *               course (the deadline did not truncate it — a truncated
+   *               observation can't prove permanence, codex gate r3). Only
+   *               this may be reported as a loss — a single refused sample,
+   *               or a shortened window, never suffices.
    * "ambiguous" — anything else (no healthy sample, last sample not a proven
-   *               down) — the plain cancel line, never alarmist.
+   *               down, or a truncated window) — the plain cancel line,
+   *               never alarmist.
    */
   status: "healthy" | "recovered" | "down" | "ambiguous";
   attempts: number;
@@ -794,10 +798,12 @@ interface DeclineProbeOutcome {
  * (clamped to `deadline`) so a server that is merely mid-restart is not
  * falsely declared lost on a single ECONNREFUSED. Samples immediately, then
  * sleeps intervalMs between samples — "still refused at the END of the
- * window" is the only down verdict. The deadline is HARD (codex gate r2): no
- * awaited probe may START once the remaining budget is exhausted — the loop
- * stops and the verdict falls to the last known state (or "ambiguous" when
- * nothing was sampled). Never throws.
+ * window" is the only down verdict, and ONLY when the full window ran: a
+ * deadline that truncates the window downgrades the verdict to "ambiguous"
+ * regardless of the samples taken (r3). The deadline is HARD (codex gate
+ * r2): no awaited probe may START once the remaining budget is exhausted —
+ * the loop stops and the verdict falls to the last known state (or
+ * "ambiguous" when nothing was sampled). Never throws.
  */
 async function probeDeclineRecovery(
   base: string | null,
@@ -807,7 +813,11 @@ async function probeDeclineRecovery(
   deadline: number,
 ): Promise<DeclineProbeOutcome> {
   const start = Date.now();
-  const end = Math.min(start + Math.max(1, windowMs), deadline);
+  const windowEnd = start + Math.max(1, windowMs);
+  const end = Math.min(windowEnd, deadline);
+  // r3: a window the deadline cuts short can never prove permanence — DOWN
+  // requires the FULL recheck window to have run its course.
+  const truncated = end < windowEnd;
   const probe = healthProbeOverride ?? probeComfyEndpoint;
   let attempts = 0;
   let sawDown = false;
@@ -840,7 +850,7 @@ async function probeDeclineRecovery(
     await new Promise((r) => setTimeout(r, Math.max(1, Math.min(intervalMs, left))));
   }
   return {
-    status: last === "down" ? "down" : "ambiguous",
+    status: last === "down" && !truncated ? "down" : "ambiguous",
     attempts,
     waited_ms: Date.now() - start,
   };

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -257,6 +257,17 @@ const MAX_REBOOT_BUDGET_MS = 240_000; // 240s  → settle+budget ≤ 250s < 300s
 // confirmation itself (no auto-confirm): it bounds only how long we wait for the answer.
 const RESTART_CONFIRM_TIMEOUT_MS = 90_000; // 90s
 
+// #742 decline-probe recheck window: a single ECONNREFUSED is NOT proof of a
+// lost server — a genuinely restarting instance is refused during its normal
+// down window (codex gate). When the decline path probes before reporting, it
+// rechecks over this SHORT, bounded window and only declares DOWN when the
+// endpoint is STILL refused at the end of it; a recovery inside the window is
+// reported as such. Deliberately small: the turn already ended on the user's
+// decline, so this is a report-time check and must not stall.
+const DECLINE_PROBE_WINDOW_MS = 6_000; // 6s total
+const DECLINE_PROBE_INTERVAL_MS = 2_000; // 2s between samples
+const DECLINE_PROBE_TIMEOUT_MS = 2_000; // per-sample probe ceiling
+
 function parsePositiveNumberEnv(name: string, fallback: number): number {
   const raw = process.env[name];
   if (raw == null || raw === "") return fallback;
@@ -315,6 +326,13 @@ export const __panelToolsTestHooks = {
     fn: (() => Promise<{ ok: boolean; reason?: string }>) | null,
   ): void {
     localRestartPreflightOverride = fn;
+  },
+  /** Inject a fast #742 decline-probe recheck window so decline-path tests
+   *  don't wait the real ~6s. null restores the DECLINE_PROBE_* constants. */
+  setDeclineProbeTiming(
+    timing: { windowMs: number; intervalMs: number; probeTimeoutMs: number } | null,
+  ): void {
+    declineProbeTimingOverride = timing;
   },
   looksLikeSystemStats,
   probeComfyHealth,
@@ -751,6 +769,73 @@ function normalizeProbe(v: boolean | ProbeStatus): ProbeStatus {
   return v;
 }
 
+interface DeclineProbeOutcome {
+  /**
+   * "healthy"   — the FIRST sample was healthy (a clean decline; no recheck).
+   * "recovered" — an early sample was a proven down but a LATER sample came
+   *               back healthy inside the window (a genuine restart's down
+   *               window — NEVER a lost server, codex gate).
+   * "down"      — no healthy sample AND the LAST sample (taken at the end of
+   *               the window) was a proven down. Only this may be reported as
+   *               a loss — a single refused sample never suffices.
+   * "ambiguous" — anything else (no healthy sample, last sample not a proven
+   *               down) — the plain cancel line, never alarmist.
+   */
+  status: "healthy" | "recovered" | "down" | "ambiguous";
+  attempts: number;
+  waited_ms: number;
+}
+
+/**
+ * The #742 decline-path recheck: poll `base` over a short, bounded window
+ * (clamped to `deadline`) so a server that is merely mid-restart is not
+ * falsely declared lost on a single ECONNREFUSED. Samples immediately, then
+ * sleeps intervalMs between samples, taking the LAST sample at the window's
+ * end — "still refused at the END of the window" is the only down verdict.
+ * Never throws.
+ */
+async function probeDeclineRecovery(
+  base: string | null,
+  windowMs: number,
+  intervalMs: number,
+  probeTimeoutMs: number,
+  deadline: number,
+): Promise<DeclineProbeOutcome> {
+  const start = Date.now();
+  const end = Math.min(start + Math.max(1, windowMs), deadline);
+  const probe = healthProbeOverride ?? probeComfyEndpoint;
+  let attempts = 0;
+  let sawDown = false;
+  let last: ProbeStatus = "unknown";
+  for (;;) {
+    attempts++;
+    const t = Math.max(1, Math.min(probeTimeoutMs, end - Date.now()));
+    let status: ProbeStatus = "unknown";
+    try {
+      status = normalizeProbe(await probe(base, t));
+    } catch {
+      status = "unknown";
+    }
+    if (status === "healthy") {
+      return {
+        status: sawDown ? "recovered" : "healthy",
+        attempts,
+        waited_ms: Date.now() - start,
+      };
+    }
+    if (status === "down") sawDown = true;
+    last = status;
+    const remaining = end - Date.now();
+    if (remaining <= 0) break;
+    await new Promise((r) => setTimeout(r, Math.max(1, Math.min(intervalMs, remaining))));
+  }
+  return {
+    status: last === "down" ? "down" : "ambiguous",
+    attempts,
+    waited_ms: Date.now() - start,
+  };
+}
+
 /**
  * The FIXED ComfyUI base URL to health-probe during a reboot readiness wait, or
  * null when we must fall back to the panel round-trip (as before #509). Captured by
@@ -819,6 +904,14 @@ let healthProbeOverride:
 let localRestartPreflightOverride:
   | (() => Promise<{ ok: boolean; reason?: string }>)
   | null = null;
+
+/** Test injection for the #742 decline-probe recheck window, so tests don't
+ *  wait the real ~6s. null → the DECLINE_PROBE_* constants. */
+let declineProbeTimingOverride: {
+  windowMs: number;
+  intervalMs: number;
+  probeTimeoutMs: number;
+} | null = null;
 
 /**
  * The concurrent-observation gate shared between the reboot handler and observeRecovery.
@@ -5402,39 +5495,66 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           );
         }
         if (decision !== "yes") {
-          // #742: NEVER claim "not restarted" while the server is actually DOWN.
-          // A decline reaches here when the user picked "No" — but ALSO when the
-          // confirm card could not be answered because the panel tab died WITH
-          // the server (confirm maps any non-timeout card error to "no"; e.g. a
-          // reboot accepted moments earlier in the same turn already stopped
-          // ComfyUI, and nothing re-launched it). Probe the same endpoint the
-          // reboot observer would use (falling back to the configured target,
-          // exactly what health_check probes) before making a state claim. Only
-          // a PROVEN-down endpoint (ECONNREFUSED — nothing is listening) flips
-          // the report; healthy/unknown keeps the plain cancel line so a genuine
-          // decline is never alarmist.
-          const cancelProbeBase = captureRebootHealthBase(ctx) ?? getComfyUIBaseUrl();
-          const cancelProbe = healthProbeOverride ?? probeComfyEndpoint;
-          let cancelStatus: ProbeStatus = "unknown";
-          try {
-            cancelStatus = normalizeProbe(
-              await cancelProbe(
-                cancelProbeBase,
-                Math.max(1, Math.min(3000, overallDeadline - Date.now())),
-              ),
-            );
-          } catch {
-            cancelStatus = "unknown";
-          }
-          if (cancelStatus === "down") {
+          // #742: NEVER claim "not restarted" while the server is actually DOWN —
+          // and NEVER declare a loss from ONE probe (codex gate): a genuinely
+          // restarting server is refused during its normal down window, and a
+          // transport/card error mapping to "no" is exactly how a tab dying
+          // during a healthy prior reboot lands here. So recheck over a short,
+          // bounded window and report DOWN only when the endpoint is STILL
+          // refused at the end of it; a recovery inside the window is reported
+          // as such (bound instance) or keeps the plain cancel line (unbound).
+          // CAUSATION ("a restart took it down") is named ONLY when the probed
+          // target is PROVABLY the same boot instance the restart would have
+          // stopped — the same binding the refuse-safe preflight uses; an
+          // unbound configured endpoint gets a generic unreachable report that
+          // never claims "we stopped it".
+          const declineBootBase = captureRebootHealthBase(ctx);
+          const boundToRestartTarget =
+            declineBootBase != null && sameHttpBase(getComfyUIBaseUrl(), declineBootBase);
+          const declineProbeBase = boundToRestartTarget
+            ? declineBootBase
+            : getComfyUIBaseUrl();
+          const declineTiming = declineProbeTimingOverride ?? {
+            windowMs: DECLINE_PROBE_WINDOW_MS,
+            intervalMs: DECLINE_PROBE_INTERVAL_MS,
+            probeTimeoutMs: DECLINE_PROBE_TIMEOUT_MS,
+          };
+          const outcome = await probeDeclineRecovery(
+            declineProbeBase,
+            declineTiming.windowMs,
+            declineTiming.intervalMs,
+            declineTiming.probeTimeoutMs,
+            overallDeadline,
+          );
+          if (outcome.status === "down") {
+            const secs = Math.max(1, Math.round(outcome.waited_ms / 1000));
+            if (boundToRestartTarget) {
+              return ok(
+                "⚠️ ComfyUI is DOWN — it was STOPPED and did not come back (still " +
+                  `unreachable after a ${secs}s recheck window), so do NOT treat this as ` +
+                  "\"nothing happened\". The restart just declined was NOT what stopped " +
+                  "it (nothing was dispatched after the decline), but a restart initiated " +
+                  "earlier already took the server down and it never returned. Start " +
+                  "ComfyUI manually from whatever launches it (e.g. Pinokio, the Desktop " +
+                  "app, or your terminal), then reload the panel tab so it reconnects. " +
+                  "restart_comfyui can attempt the relaunch for you when the install's " +
+                  "launch path is resolvable.",
+              );
+            }
             return ok(
-              "⚠️ ComfyUI is DOWN — it was STOPPED and did not come back, so do NOT treat " +
-                "this as \"nothing happened\". The restart just declined was NOT what stopped " +
-                "it (nothing was dispatched after the decline), but a restart initiated " +
-                "earlier already took the server down and it never returned. Start ComfyUI " +
-                "manually from whatever launches it (e.g. Pinokio, the Desktop app, or your " +
-                "terminal), then reload the panel tab so it reconnects. restart_comfyui can " +
-                "attempt the relaunch for you when the install's launch path is resolvable.",
+              "⚠️ ComfyUI appears to be DOWN — the configured endpoint was still " +
+                `unreachable after a ${secs}s recheck window. The restart just declined ` +
+                "was NOT dispatched, and I can't confirm from here whether the server " +
+                "was actually stopped — this endpoint isn't provably the instance the " +
+                "restart would have cycled. Check ComfyUI on its host and start it " +
+                "manually if it is down, then reload the panel tab so it reconnects.",
+            );
+          }
+          if (outcome.status === "recovered" && boundToRestartTarget) {
+            return ok(
+              "Cancelled — no new restart was dispatched. Note: ComfyUI was briefly " +
+                "unreachable but is healthy again — a restart initiated earlier " +
+                "appears to have completed.",
             );
           }
           return ok("Cancelled — ComfyUI was not restarted.");

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5690,20 +5690,24 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // r8: the preflight AWAIT makes the pre-decision binding STALE — a
             // rebind/retarget during it would let this refusal's "ComfyUI is
             // still running" describe a target that was never validated.
-            // Re-heal and re-capture BEFORE composing anything. The bound
-            // target is always THIS orchestrator's boot instance, so "changed"
-            // can only mean now-UNBOUND (unconfirmable): nothing was stopped
-            // (the preflight never stops anything), so fall through and let
-            // the dispatch path treat the unbound target honestly (r6/r7:
-            // dispatched-unconfirmed, process-wide-only stamp) rather than
-            // issuing a stale-target refusal.
+            // Re-heal and re-capture BEFORE composing anything.
+            // r9: the danger proof follows the INSTANCE the tab fronts, NOT the
+            // mutable runtime config — a config-only retarget mid-await must
+            // not wash out the proof that the tab-fronted boot instance is
+            // unrelaunchable. When the tab STILL fronts that same instance the
+            // failed preflight just proved dangerous, the proof is still valid
+            // and the refusal stands: an instance proven unrelaunchable is
+            // NEVER sent a stop/reboot, regardless of config/tab shuffling
+            // mid-flight. Only a genuinely different, unconfirmable target
+            // falls through to the honest-unconfirmed dispatch (nothing was
+            // ever proved dangerous for it — and nothing was ever stopped,
+            // the preflight never stops anything).
             ctx.ensureReachable?.();
             const refusalHealthBase = captureRebootHealthBase(ctx);
-            const stillBound =
+            const sameProvenDangerousInstance =
               refusalHealthBase != null &&
-              sameHttpBase(getComfyUIBaseUrl(), refusalHealthBase) &&
               sameHttpBase(preflightHealthBase, refusalHealthBase);
-            if (stillBound) {
+            if (sameProvenDangerousInstance) {
               return ok({
                 rebooting: false,
                 ready: false,
@@ -5718,8 +5722,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   "at the live install so a relaunch can be proven and use restart_comfyui.",
               });
             }
-            // Binding changed mid-await → fall through to the dispatch path
-            // (re-captured again below, r7); no refusal is composed here.
+            // Genuinely different / unconfirmable target → fall through to the
+            // dispatch path (re-captured again below, r7); no refusal is
+            // composed here.
           }
         }
         // r7: the preflight AWAIT sits between the binding capture and the dispatch,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -70,6 +70,7 @@ import {
   clearRestartDispatch,
   getRestartDispatchRecord,
   RESTART_DISPATCH_CAUSATION_WINDOW_MS,
+  PROCESS_WIDE_RESTART_DISPATCH_TOKEN,
   __processControlTestHooks,
 } from "../services/process-control.js";
 import { resetManagerApiCache } from "../services/manager-api-cache.js";
@@ -5875,13 +5876,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               );
             }
             clearTimeout(restartTimer);
-            // #742 r5: the managed restart stopped the process — record the
-            // dispatch with THIS session holding the token (restartComfyUI also
-            // stamped its own process-wide record, which never grounds
-            // causation). Only a PROVEN stop is recorded; a refusal/timeout
+            // #742 r5/r6: the managed restart stopped the process — record the
+            // dispatch with THIS session holding the token, stamped with the
+            // BOUND-CONFIRMED base (this fallback only runs when the instance
+            // binding held, so healthBase is non-null here). restartComfyUI
+            // also stamped its own process-wide record, which never grounds
+            // causation. Only a PROVEN stop is recorded; a refusal/timeout
             // (restart undefined, or stopped!==true) records nothing.
             if (restart?.stopped === true) {
-              stampSessionRestartDispatch(ctx, healthBase ?? getComfyUIBaseUrl());
+              stampSessionRestartDispatch(ctx, healthBase);
             }
             // DEFINITIVE no-restart: a spawn failure, OR restartComfyUI refused before
             // stopping anything (no process found / unsafe relaunch → stopped:false &&
@@ -5965,11 +5968,22 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         resetClient();
         resetObjectInfoCache();
         resetManagerApiCache("panel Manager reboot");
-        // #742 r4/r5: record the ACTUAL dispatch (acceptance proven — a refusal never
-        // reaches here), holding the token on THIS session. A later decline-path
-        // DOWN report may name restart causation only against a record this
-        // session holds; it is cleared below if the restart is observed back.
-        stampSessionRestartDispatch(ctx, healthBase ?? getComfyUIBaseUrl());
+        // #742 r4/r5/r6: record the ACTUAL dispatch (acceptance proven — a refusal
+        // never reaches here). ONLY a BOUND-CONFIRMED target (the same binding
+        // the r1 causation scoping and the refuse-safe preflight use) may stamp a
+        // causation-capable record — held on THIS session with the BOUND base at
+        // stamp time, never the mutable configured one. An unbound/unconfirmable
+        // target (r6) stamps only the shared PROCESS-WIDE slot, which never
+        // grounds causation: the dispatch can't be proven to have hit the
+        // instance a later decline would probe, and a session that rebinds to
+        // the boot tab afterward can't claim it either (a re-targeted session
+        // can't prove the earlier dispatch hit its current instance — no claim
+        // is the truthful answer). It is cleared below if observed back.
+        if (healthBase != null && sameHttpBase(getComfyUIBaseUrl(), healthBase)) {
+          stampSessionRestartDispatch(ctx, healthBase);
+        } else {
+          recordRestartDispatch(getComfyUIBaseUrl(), PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
+        }
 
         // Observe recovery. There is exactly ONE sound proof that THIS ComfyUI instance
         // actually cycled: a directly OBSERVED down→up on the server-authorized, immutable,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -971,27 +971,37 @@ let declineProbeTimingOverride: {
 const sessionRestartDispatchTokens = new WeakMap<object, string>();
 
 /** Stamp a restart dispatch and hold its token on THIS session (replacing any
- *  record the session previously held — a session has at most one live one). */
-function stampSessionRestartDispatch(ctx: PanelToolCtx, base: string | null): void {
+ *  record the session previously held — a session has at most one live one).
+ *  Returns the held token so clears can be CLEAR-IF-SAME (r15). */
+function stampSessionRestartDispatch(ctx: PanelToolCtx, base: string | null): string {
   const prev = sessionRestartDispatchTokens.get(ctx);
   if (prev) clearRestartDispatch(prev);
-  sessionRestartDispatchTokens.set(ctx, recordRestartDispatch(base));
+  const token = recordRestartDispatch(base);
+  sessionRestartDispatchTokens.set(ctx, token);
+  return token;
+}
+
+/** The dispatch token THIS session currently holds, or undefined. */
+function sessionRestartDispatchToken(ctx: PanelToolCtx): string | undefined {
+  return sessionRestartDispatchTokens.get(ctx);
 }
 
 /** The restart-dispatch record THIS session holds, or null. */
 function sessionRestartDispatch(
   ctx: PanelToolCtx,
 ): { at: number; base: string | null } | null {
-  const held = sessionRestartDispatchTokens.get(ctx);
+  const held = sessionRestartDispatchToken(ctx);
   return held ? getRestartDispatchRecord(held) : null;
 }
 
-/** Clear ONLY this session's own dispatch record (observed-back). */
-function clearSessionRestartDispatch(ctx: PanelToolCtx): void {
-  const held = sessionRestartDispatchTokens.get(ctx);
-  if (!held) return;
+/** Clear ONLY when the session STILL holds `token` (r15): a newer dispatch
+ *  that landed since `token` was validated keeps its record — a
+ *  read-current-then-clear would evict the newer dispatch's record and make a
+ *  later persistent DOWN falsely report "no restart was dispatched". */
+function clearSessionRestartDispatchIfSame(ctx: PanelToolCtx, token: string): void {
+  if (sessionRestartDispatchTokens.get(ctx) !== token) return;
   sessionRestartDispatchTokens.delete(ctx);
-  clearRestartDispatch(held);
+  clearRestartDispatch(token);
 }
 
 /**
@@ -5595,6 +5605,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           const declineProbeBase = boundToRestartTarget
             ? declineBootBase
             : getComfyUIBaseUrl();
+          // r15: capture the session's held dispatch TOKEN before the probe
+          // awaits — the exoneration clear (r13) and the recovery claim (r14)
+          // must key on the token VALIDATED HERE, never whichever token is
+          // current after the awaits: a concurrent accepted restart stamping a
+          // fresh token mid-probe keeps its record (clear-if-same below), so a
+          // later persistent DOWN can still attribute to it.
+          const declineHeldToken = sessionRestartDispatchToken(ctx);
           const declineTiming = declineProbeTimingOverride ?? {
             windowMs: DECLINE_PROBE_WINDOW_MS,
             intervalMs: DECLINE_PROBE_INTERVAL_MS,
@@ -5607,6 +5624,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             declineTiming.probeTimeoutMs,
             overallDeadline,
           );
+          // The VALIDATED token's record (null when it was superseded by a
+          // newer stamp during the probe — the conservative outcome: neither
+          // claim nor clear keys on a record this probe didn't validate).
+          const declineHeldRecord = declineHeldToken
+            ? getRestartDispatchRecord(declineHeldToken)
+            : null;
           // r13: a HEALTHY/RECOVERED observation exonerates any dispatch THIS
           // session has on record — the restart explained itself, so its token
           // must never ground causation for a LATER, independent failure.
@@ -5617,14 +5640,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // r14: the record is captured BEFORE the clear — the recovery CLAIM
           // below ("a restart initiated earlier appears to have completed")
           // requires the token to have been present at this moment.
-          const heldBeforeProbeOutcome = sessionRestartDispatch(ctx);
+          // r15: CLEAR-IF-SAME — the clear fires only when the session still
+          // holds the SAME token validated before the probe; a newer dispatch
+          // stamped mid-probe keeps its record.
           if (outcome.status === "healthy" || outcome.status === "recovered") {
             if (
-              heldBeforeProbeOutcome != null &&
-              (heldBeforeProbeOutcome.base == null ||
-                sameHttpBase(heldBeforeProbeOutcome.base, declineProbeBase))
+              declineHeldToken != null &&
+              declineHeldRecord != null &&
+              (declineHeldRecord.base == null ||
+                sameHttpBase(declineHeldRecord.base, declineProbeBase))
             ) {
-              clearSessionRestartDispatch(ctx);
+              clearSessionRestartDispatchIfSame(ctx, declineHeldToken);
             }
           }
           if (outcome.status === "down") {
@@ -5684,10 +5710,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // proves nothing about what caused the down: report the recovery
             // causation-free.
             const recoveryCausative =
-              heldBeforeProbeOutcome != null &&
-              Date.now() - heldBeforeProbeOutcome.at <= RESTART_DISPATCH_CAUSATION_WINDOW_MS &&
-              (heldBeforeProbeOutcome.base == null ||
-                sameHttpBase(heldBeforeProbeOutcome.base, declineBootBase));
+              declineHeldRecord != null &&
+              Date.now() - declineHeldRecord.at <= RESTART_DISPATCH_CAUSATION_WINDOW_MS &&
+              (declineHeldRecord.base == null ||
+                sameHttpBase(declineHeldRecord.base, declineBootBase));
             return ok(
               recoveryCausative
                 ? "Cancelled — no new restart was dispatched. Note: ComfyUI was briefly " +
@@ -5984,9 +6010,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // binding held, so healthBase is non-null here). restartComfyUI
             // also stamped its own process-wide record, which never grounds
             // causation. Only a PROVEN stop is recorded; a refusal/timeout
-            // (restart undefined, or stopped!==true) records nothing.
+            // (restart undefined, or stopped!==true) records nothing. The
+            // token is kept so the recovery clear below is CLEAR-IF-SAME (r15).
+            let legacyDispatchToken: string | undefined;
             if (restart?.stopped === true) {
-              stampSessionRestartDispatch(ctx, healthBase);
+              legacyDispatchToken = stampSessionRestartDispatch(ctx, healthBase);
             }
             // DEFINITIVE no-restart: a spawn failure, OR restartComfyUI refused before
             // stopping anything (no process found / unsafe relaunch → stopped:false &&
@@ -6007,10 +6035,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // Otherwise (the process WAS stopped/started, or restartComfyUI's own readiness
             // poll merely expired — neither terminal) DEFER to OUR OWN observed DOWN→UP.
             const recovery = await proofPromise;
-            // #742 r4/r5: the managed restart was observed back — clear THIS
-            // session's record (restartComfyUI also clears its own process-wide
-            // record on success; this covers only-observer-saw-it recoveries).
-            if (recovery.ready) clearSessionRestartDispatch(ctx);
+            // #742 r4/r5/r15: the managed restart was observed back — clear THIS
+            // session's record, CLEAR-IF-SAME: only when the session still holds
+            // the token THIS restart stamped (a concurrent dispatch's newer
+            // record survives). restartComfyUI also clears its own process-wide
+            // record on success; this covers only-observer-saw-it recoveries.
+            if (recovery.ready && legacyDispatchToken != null) {
+              clearSessionRestartDispatchIfSame(ctx, legacyDispatchToken);
+            }
             const observed = recovery.via === "observed-cycle";
             // The legacy Manager path restarts ComfyUI out-of-band too. Server recovery alone
             // is not graph-tool readiness: wait for the browser tab to reconnect, then verify
@@ -6080,9 +6112,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // instance a later decline would probe, and a session that rebinds to
         // the boot tab afterward can't claim it either (a re-targeted session
         // can't prove the earlier dispatch hit its current instance — no claim
-        // is the truthful answer). It is cleared below if observed back.
+        // is the truthful answer). It is cleared below if observed back —
+        // CLEAR-IF-SAME on the token stamped here (r15).
+        let acceptedDispatchToken: string | undefined;
         if (healthBase != null && sameHttpBase(getComfyUIBaseUrl(), healthBase)) {
-          stampSessionRestartDispatch(ctx, healthBase);
+          acceptedDispatchToken = stampSessionRestartDispatch(ctx, healthBase);
         } else {
           recordRestartDispatch(getComfyUIBaseUrl(), PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
         }
@@ -6122,9 +6156,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // down→up, which the observer has been (and continues) watching for.
         gate.deadline = Math.min(Date.now() + timing.budgetMs, overallDeadline);
         const recovery = await recoveryPromise!;
-        // #742 r4/r5: the dispatched restart was observed back — clear THIS
-        // session's record (never another session's).
-        if (recovery.ready) clearSessionRestartDispatch(ctx);
+        // #742 r4/r5/r15: the dispatched restart was observed back — clear the
+        // record, CLEAR-IF-SAME: only when the session still holds the token
+        // THIS dispatch stamped (a concurrent dispatch's newer record survives).
+        if (recovery.ready && acceptedDispatchToken != null) {
+          clearSessionRestartDispatchIfSame(ctx, acceptedDispatchToken);
+        }
         if (!recovery.ready) {
           const waited = Math.round(recovery.waited_ms / 1000);
           return ok({

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -79,6 +79,7 @@ import {
   isCloudMode,
   getBootLocalComfyUIBaseUrl,
   getComfyUIBaseUrl,
+  getComfyuiTargetGeneration,
 } from "../config.js";
 import { sliceWorkflow } from "../services/workflow-slicer.js";
 import { validateA2UISpecServer } from "../services/a2ui-spec.js";
@@ -5685,10 +5686,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // downstream may reuse it (r7).
         const preflightHealthBase = captureRebootHealthBase(ctx);
         if (preflightHealthBase != null && sameHttpBase(getComfyUIBaseUrl(), preflightHealthBase)) {
-          // Snapshot the mutable config base AT THE DECISION (it equals the
-          // tab-fronted base right now, per the gate above) so a mid-await
-          // retarget is detectable afterward (r10).
-          const preflightConfigBase = getComfyUIBaseUrl();
+          // Snapshot the target GENERATION at the decision (r11): a final-state
+          // base comparison (A vs A) cannot detect an intervening A→B→A
+          // retarget, so stability is judged by the monotonic epoch bumped on
+          // EVERY retarget — any mutation, including a round trip back to the
+          // same base, is caught.
+          const preflightTargetGeneration = getComfyuiTargetGeneration();
           const preflight = await (localRestartPreflightOverride ?? preflightLocalRestart)();
           // r8/r9/r10: the preflight AWAIT makes the pre-decision captures
           // STALE — and the preflight itself reads MUTABLE config (target URL,
@@ -5703,7 +5706,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           const tabFrontsSameInstance =
             postPreflightHealthBase != null &&
             sameHttpBase(preflightHealthBase, postPreflightHealthBase);
-          const configStable = sameHttpBase(getComfyUIBaseUrl(), preflightConfigBase);
+          const configStable =
+            getComfyuiTargetGeneration() === preflightTargetGeneration;
           if (!configStable && tabFrontsSameInstance) {
             // r10: the target config moved MID-CHECK, so the preflight result
             // — pass OR fail — cannot vouch for the tab-fronted instance (a

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -334,6 +334,9 @@ export const __panelToolsTestHooks = {
   ): void {
     declineProbeTimingOverride = timing;
   },
+  /** Direct access to the #742 decline recheck loop so its hard-deadline
+   *  guarantee (codex gate r2) can be unit-tested with a custom deadline. */
+  probeDeclineRecovery,
   looksLikeSystemStats,
   probeComfyHealth,
   probeComfyEndpoint,
@@ -775,8 +778,8 @@ interface DeclineProbeOutcome {
    * "recovered" — an early sample was a proven down but a LATER sample came
    *               back healthy inside the window (a genuine restart's down
    *               window — NEVER a lost server, codex gate).
-   * "down"      — no healthy sample AND the LAST sample (taken at the end of
-   *               the window) was a proven down. Only this may be reported as
+   * "down"      — no healthy sample AND the LAST sample taken within the
+   *               window was a proven down. Only this may be reported as
    *               a loss — a single refused sample never suffices.
    * "ambiguous" — anything else (no healthy sample, last sample not a proven
    *               down) — the plain cancel line, never alarmist.
@@ -790,9 +793,11 @@ interface DeclineProbeOutcome {
  * The #742 decline-path recheck: poll `base` over a short, bounded window
  * (clamped to `deadline`) so a server that is merely mid-restart is not
  * falsely declared lost on a single ECONNREFUSED. Samples immediately, then
- * sleeps intervalMs between samples, taking the LAST sample at the window's
- * end — "still refused at the END of the window" is the only down verdict.
- * Never throws.
+ * sleeps intervalMs between samples — "still refused at the END of the
+ * window" is the only down verdict. The deadline is HARD (codex gate r2): no
+ * awaited probe may START once the remaining budget is exhausted — the loop
+ * stops and the verdict falls to the last known state (or "ambiguous" when
+ * nothing was sampled). Never throws.
  */
 async function probeDeclineRecovery(
   base: string | null,
@@ -808,8 +813,13 @@ async function probeDeclineRecovery(
   let sawDown = false;
   let last: ProbeStatus = "unknown";
   for (;;) {
+    // HARD deadline: NEVER begin an awaited probe with an exhausted remainder
+    // (clamping an expired remainder to a 1ms timeout would still start — and
+    // await — a probe PAST the deadline, defeating the guarantee).
+    const remaining = end - Date.now();
+    if (remaining <= 0) break;
     attempts++;
-    const t = Math.max(1, Math.min(probeTimeoutMs, end - Date.now()));
+    const t = Math.min(probeTimeoutMs, remaining);
     let status: ProbeStatus = "unknown";
     try {
       status = normalizeProbe(await probe(base, t));
@@ -825,9 +835,9 @@ async function probeDeclineRecovery(
     }
     if (status === "down") sawDown = true;
     last = status;
-    const remaining = end - Date.now();
-    if (remaining <= 0) break;
-    await new Promise((r) => setTimeout(r, Math.max(1, Math.min(intervalMs, remaining))));
+    const left = end - Date.now();
+    if (left <= 0) break;
+    await new Promise((r) => setTimeout(r, Math.max(1, Math.min(intervalMs, left))));
   }
   return {
     status: last === "down" ? "down" : "ambiguous",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -63,7 +63,7 @@ import {
   resetObjectInfoCache,
 } from "../comfyui/client.js";
 import { convertUiToApi, collectNodeTypes } from "../services/workflow-converter.js";
-import { restartComfyUI } from "../services/process-control.js";
+import { restartComfyUI, preflightLocalRestart } from "../services/process-control.js";
 import { resetManagerApiCache } from "../services/manager-api-cache.js";
 import {
   isRemoteMode,
@@ -308,6 +308,13 @@ export const __panelToolsTestHooks = {
       | null,
   ): void {
     healthProbeOverride = fn;
+  },
+  /** Inject a fake #742 restart preflight so reboot tests don't probe real
+   *  processes/ports. null restores the live preflightLocalRestart. */
+  setLocalRestartPreflight(
+    fn: (() => Promise<{ ok: boolean; reason?: string }>) | null,
+  ): void {
+    localRestartPreflightOverride = fn;
   },
   looksLikeSystemStats,
   probeComfyHealth,
@@ -805,6 +812,12 @@ function captureRebootHealthBase(ctx: PanelToolCtx): string | null {
 
 let healthProbeOverride:
   | ((base: string | null, timeoutMs: number) => Promise<boolean | ProbeStatus>)
+  | null = null;
+
+/** Test injection for the #742 refuse-safe restart preflight (the real one is
+ *  preflightLocalRestart in process-control). null → the live preflight. */
+let localRestartPreflightOverride:
+  | (() => Promise<{ ok: boolean; reason?: string }>)
   | null = null;
 
 /**
@@ -5340,7 +5353,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_restart_comfyui",
-      "Restart the user's ComfyUI server via the built-in Manager — needed to load newly installed/updated custom nodes. CALL THIS DIRECTLY when a restart is needed: it pops a confirm card and only restarts on a yes (don't ask separately first). ComfyUI and this agent go down briefly, then the panel auto-reconnects and you resume. ⚠️ BUSY GUARD: a restart ABORTS any in-progress or queued generation — if ComfyUI is generating, this tool REFUSES and tells you (it does NOT restart). When that happens, tell the user a render is running and WAIT for it (poll panel_node_queue_status), or pass force:true ONLY if the user explicitly confirms they want to kill the running generation. Best practice: before restarting after an install, check the queue is idle first. Only call when a restart is actually needed.",
+      "Restart the user's ComfyUI server via the built-in Manager — needed to load newly installed/updated custom nodes. CALL THIS DIRECTLY when a restart is needed: it pops a confirm card and only restarts on a yes (don't ask separately first). ComfyUI and this agent go down briefly, then the panel auto-reconnects and you resume. ⚠️ BUSY GUARD: a restart ABORTS any in-progress or queued generation — if ComfyUI is generating, this tool REFUSES and tells you (it does NOT restart). When that happens, tell the user a render is running and WAIT for it (poll panel_node_queue_status), or pass force:true ONLY if the user explicitly confirms they want to kill the running generation. Best practice: before restarting after an install, check the queue is idle first. Only call when a restart is actually needed. On an externally-managed install whose relaunch can't be proven from here (e.g. Pinokio), the restart is REFUSED before anything is stopped — restart from the launcher that owns the server instead.",
       { force: z.boolean().optional() },
       async ({ force }, ctx) => {
         // Whole-handler budget (#536): confirm + dispatch + readiness — INCLUDING
@@ -5389,6 +5402,41 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           );
         }
         if (decision !== "yes") {
+          // #742: NEVER claim "not restarted" while the server is actually DOWN.
+          // A decline reaches here when the user picked "No" — but ALSO when the
+          // confirm card could not be answered because the panel tab died WITH
+          // the server (confirm maps any non-timeout card error to "no"; e.g. a
+          // reboot accepted moments earlier in the same turn already stopped
+          // ComfyUI, and nothing re-launched it). Probe the same endpoint the
+          // reboot observer would use (falling back to the configured target,
+          // exactly what health_check probes) before making a state claim. Only
+          // a PROVEN-down endpoint (ECONNREFUSED — nothing is listening) flips
+          // the report; healthy/unknown keeps the plain cancel line so a genuine
+          // decline is never alarmist.
+          const cancelProbeBase = captureRebootHealthBase(ctx) ?? getComfyUIBaseUrl();
+          const cancelProbe = healthProbeOverride ?? probeComfyEndpoint;
+          let cancelStatus: ProbeStatus = "unknown";
+          try {
+            cancelStatus = normalizeProbe(
+              await cancelProbe(
+                cancelProbeBase,
+                Math.max(1, Math.min(3000, overallDeadline - Date.now())),
+              ),
+            );
+          } catch {
+            cancelStatus = "unknown";
+          }
+          if (cancelStatus === "down") {
+            return ok(
+              "⚠️ ComfyUI is DOWN — it was STOPPED and did not come back, so do NOT treat " +
+                "this as \"nothing happened\". The restart just declined was NOT what stopped " +
+                "it (nothing was dispatched after the decline), but a restart initiated " +
+                "earlier already took the server down and it never returned. Start ComfyUI " +
+                "manually from whatever launches it (e.g. Pinokio, the Desktop app, or your " +
+                "terminal), then reload the panel tab so it reconnects. restart_comfyui can " +
+                "attempt the relaunch for you when the install's launch path is resolvable.",
+            );
+          }
           return ok("Cancelled — ComfyUI was not restarted.");
         }
         // Heal an orphaned session onto the live tab FIRST, then bind the reboot dispatch
@@ -5404,6 +5452,37 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // routing id while the original is still reconnecting.
         const preRestartPanelIdentity = ctx.panelConnectionIdentity?.();
         const healthBase = captureRebootHealthBase(ctx);
+        // #742 REFUSE-SAFE PREFLIGHT: a Manager reboot stops ComfyUI OUT-OF-BAND —
+        // it never goes through our validated kill+relaunch — so before dispatching
+        // anything, the stop must be provable survivable (#368/#370: losing a restart
+        // is cheap, losing the server is not). On a Pinokio-style install (externally
+        // supervised; no main.py/interpreter resolvable from here) a plain Manager
+        // restart kills the process and the supervisor does NOT re-launch it — the
+        // exact #742 lost-server. When the reboot would target OUR local boot
+        // instance (the same instance binding the legacy fallback uses), prove a
+        // relaunch is possible FIRST and refuse BEFORE any stop when it isn't. Only
+        // the PROVEN-dangerous shape refuses (a reachable local non-Desktop process
+        // with an unbuildable/unvalidatable relaunch); every other shape — Desktop
+        // (Electron-supervised, #400), unverifiable, or remote — proceeds exactly as
+        // before.
+        if (healthBase != null && sameHttpBase(getComfyUIBaseUrl(), healthBase)) {
+          const preflight = await (localRestartPreflightOverride ?? preflightLocalRestart)();
+          if (!preflight.ok) {
+            return ok({
+              rebooting: false,
+              ready: false,
+              confirmed_cycle: false,
+              refused: true,
+              note:
+                `Refusing to restart ComfyUI: ${preflight.reason} This looks like an ` +
+                "externally-managed install (e.g. Pinokio): a restart from here would STOP " +
+                "ComfyUI and nothing would bring it back automatically, so it was refused " +
+                "BEFORE anything was stopped — ComfyUI is still running. Restart it from the " +
+                "launcher that owns it (e.g. Pinokio's own controls), or point COMFYUI_PATH " +
+                "at the live install so a relaunch can be proven and use restart_comfyui.",
+            });
+          }
+        }
         const timing = getPanelRebootTiming();
         const dispatchTimeout = Math.max(1, Math.min(15000, overallDeadline - Date.now()));
         // CONCURRENT OBSERVATION (coordinator): start probing the fixed boot endpoint NOW,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5685,47 +5685,75 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // downstream may reuse it (r7).
         const preflightHealthBase = captureRebootHealthBase(ctx);
         if (preflightHealthBase != null && sameHttpBase(getComfyUIBaseUrl(), preflightHealthBase)) {
+          // Snapshot the mutable config base AT THE DECISION (it equals the
+          // tab-fronted base right now, per the gate above) so a mid-await
+          // retarget is detectable afterward (r10).
+          const preflightConfigBase = getComfyUIBaseUrl();
           const preflight = await (localRestartPreflightOverride ?? preflightLocalRestart)();
-          if (!preflight.ok) {
-            // r8: the preflight AWAIT makes the pre-decision binding STALE — a
-            // rebind/retarget during it would let this refusal's "ComfyUI is
-            // still running" describe a target that was never validated.
-            // Re-heal and re-capture BEFORE composing anything.
+          // r8/r9/r10: the preflight AWAIT makes the pre-decision captures
+          // STALE — and the preflight itself reads MUTABLE config (target URL,
+          // port, COMFYUI_PATH) throughout, so a config retarget during the
+          // await can re-point the whole assessment at a DIFFERENT install
+          // while the tab still fronts the original one. Re-heal and
+          // re-capture BEFORE trusting the result either way. The guarantee
+          // that must hold: a stop/reboot is only ever sent when the preflight
+          // validated THE instance the dispatch will cycle.
+          ctx.ensureReachable?.();
+          const postPreflightHealthBase = captureRebootHealthBase(ctx);
+          const tabFrontsSameInstance =
+            postPreflightHealthBase != null &&
+            sameHttpBase(preflightHealthBase, postPreflightHealthBase);
+          const configStable = sameHttpBase(getComfyUIBaseUrl(), preflightConfigBase);
+          if (!configStable && tabFrontsSameInstance) {
+            // r10: the target config moved MID-CHECK, so the preflight result
+            // — pass OR fail — cannot vouch for the tab-fronted instance (a
+            // PASS may have validated a different, safe install; it must never
+            // bless a stop of this one). Its relaunch is UNPROVEN → refuse; an
+            // instance with an unproven relaunch is never sent a stop.
+            return ok({
+              rebooting: false,
+              ready: false,
+              confirmed_cycle: false,
+              refused: true,
+              note:
+                "Refusing to restart ComfyUI: the ComfyUI target configuration changed " +
+                "while the restart safety check was running, so the check cannot vouch " +
+                "for a safe relaunch of the instance this panel fronts. A stop is never " +
+                "sent to an instance whose relaunch is unproven — ComfyUI was NOT " +
+                "stopped (it is still running). Let the target settle, then retry " +
+                "panel_restart_comfyui.",
+            });
+          }
+          if (!preflight.ok && tabFrontsSameInstance) {
             // r9: the danger proof follows the INSTANCE the tab fronts, NOT the
             // mutable runtime config — a config-only retarget mid-await must
             // not wash out the proof that the tab-fronted boot instance is
-            // unrelaunchable. When the tab STILL fronts that same instance the
-            // failed preflight just proved dangerous, the proof is still valid
-            // and the refusal stands: an instance proven unrelaunchable is
-            // NEVER sent a stop/reboot, regardless of config/tab shuffling
-            // mid-flight. Only a genuinely different, unconfirmable target
-            // falls through to the honest-unconfirmed dispatch (nothing was
-            // ever proved dangerous for it — and nothing was ever stopped,
-            // the preflight never stops anything).
-            ctx.ensureReachable?.();
-            const refusalHealthBase = captureRebootHealthBase(ctx);
-            const sameProvenDangerousInstance =
-              refusalHealthBase != null &&
-              sameHttpBase(preflightHealthBase, refusalHealthBase);
-            if (sameProvenDangerousInstance) {
-              return ok({
-                rebooting: false,
-                ready: false,
-                confirmed_cycle: false,
-                refused: true,
-                note:
-                  `Refusing to restart ComfyUI: ${preflight.reason} This looks like an ` +
-                  "externally-managed install (e.g. Pinokio): a restart from here would STOP " +
-                  "ComfyUI and nothing would bring it back automatically, so it was refused " +
-                  "BEFORE anything was stopped — ComfyUI is still running. Restart it from the " +
-                  "launcher that owns it (e.g. Pinokio's own controls), or point COMFYUI_PATH " +
-                  "at the live install so a relaunch can be proven and use restart_comfyui.",
-              });
-            }
-            // Genuinely different / unconfirmable target → fall through to the
-            // dispatch path (re-captured again below, r7); no refusal is
-            // composed here.
+            // unrelaunchable. The tab STILL fronts that same instance, so the
+            // proof is still valid and the refusal stands: an instance proven
+            // unrelaunchable is NEVER sent a stop/reboot, regardless of
+            // config/tab shuffling mid-flight. Only a genuinely different,
+            // unconfirmable target falls through to the honest-unconfirmed
+            // dispatch (nothing was ever proved dangerous for it — and nothing
+            // was ever stopped, the preflight never stops anything).
+            return ok({
+              rebooting: false,
+              ready: false,
+              confirmed_cycle: false,
+              refused: true,
+              note:
+                `Refusing to restart ComfyUI: ${preflight.reason} This looks like an ` +
+                "externally-managed install (e.g. Pinokio): a restart from here would STOP " +
+                "ComfyUI and nothing would bring it back automatically, so it was refused " +
+                "BEFORE anything was stopped — ComfyUI is still running. Restart it from the " +
+                "launcher that owns it (e.g. Pinokio's own controls), or point COMFYUI_PATH " +
+                "at the live install so a relaunch can be proven and use restart_comfyui.",
+            });
           }
+          // Otherwise: a PASS with a stable config (proven safe for THE
+          // tab-fronted instance — proceed), or the tab now fronts a genuinely
+          // different, unconfirmable target (nothing provable about it — the
+          // dispatch path below treats that honestly, r6/r7). Nothing was
+          // stopped in any case — the preflight never stops anything.
         }
         // r7: the preflight AWAIT sits between the binding capture and the dispatch,
         // breaking the no-await invariant above — a tab/connection rebind during

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5687,19 +5687,39 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         if (preflightHealthBase != null && sameHttpBase(getComfyUIBaseUrl(), preflightHealthBase)) {
           const preflight = await (localRestartPreflightOverride ?? preflightLocalRestart)();
           if (!preflight.ok) {
-            return ok({
-              rebooting: false,
-              ready: false,
-              confirmed_cycle: false,
-              refused: true,
-              note:
-                `Refusing to restart ComfyUI: ${preflight.reason} This looks like an ` +
-                "externally-managed install (e.g. Pinokio): a restart from here would STOP " +
-                "ComfyUI and nothing would bring it back automatically, so it was refused " +
-                "BEFORE anything was stopped — ComfyUI is still running. Restart it from the " +
-                "launcher that owns it (e.g. Pinokio's own controls), or point COMFYUI_PATH " +
-                "at the live install so a relaunch can be proven and use restart_comfyui.",
-            });
+            // r8: the preflight AWAIT makes the pre-decision binding STALE — a
+            // rebind/retarget during it would let this refusal's "ComfyUI is
+            // still running" describe a target that was never validated.
+            // Re-heal and re-capture BEFORE composing anything. The bound
+            // target is always THIS orchestrator's boot instance, so "changed"
+            // can only mean now-UNBOUND (unconfirmable): nothing was stopped
+            // (the preflight never stops anything), so fall through and let
+            // the dispatch path treat the unbound target honestly (r6/r7:
+            // dispatched-unconfirmed, process-wide-only stamp) rather than
+            // issuing a stale-target refusal.
+            ctx.ensureReachable?.();
+            const refusalHealthBase = captureRebootHealthBase(ctx);
+            const stillBound =
+              refusalHealthBase != null &&
+              sameHttpBase(getComfyUIBaseUrl(), refusalHealthBase) &&
+              sameHttpBase(preflightHealthBase, refusalHealthBase);
+            if (stillBound) {
+              return ok({
+                rebooting: false,
+                ready: false,
+                confirmed_cycle: false,
+                refused: true,
+                note:
+                  `Refusing to restart ComfyUI: ${preflight.reason} This looks like an ` +
+                  "externally-managed install (e.g. Pinokio): a restart from here would STOP " +
+                  "ComfyUI and nothing would bring it back automatically, so it was refused " +
+                  "BEFORE anything was stopped — ComfyUI is still running. Restart it from the " +
+                  "launcher that owns it (e.g. Pinokio's own controls), or point COMFYUI_PATH " +
+                  "at the live install so a relaunch can be proven and use restart_comfyui.",
+              });
+            }
+            // Binding changed mid-await → fall through to the dispatch path
+            // (re-captured again below, r7); no refusal is composed here.
           }
         }
         // r7: the preflight AWAIT sits between the binding capture and the dispatch,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5669,13 +5669,6 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // server-authorized + immutable, bound to the exact host FAMILY the reboot goes
         // to (null unless the bound tab provably fronts our boot instance).
         ctx.ensureReachable?.();
-        const boundTabId = ctx.tabId;
-        // Snapshot the exact browser-tab registration that is about to receive the
-        // reboot. A post-restart success must observe a strictly newer hello from
-        // this SAME browser tab; a different tab can reuse the same saved-workflow
-        // routing id while the original is still reconnecting.
-        const preRestartPanelIdentity = ctx.panelConnectionIdentity?.();
-        const healthBase = captureRebootHealthBase(ctx);
         // #742 REFUSE-SAFE PREFLIGHT: a Manager reboot stops ComfyUI OUT-OF-BAND —
         // it never goes through our validated kill+relaunch — so before dispatching
         // anything, the stop must be provable survivable (#368/#370: losing a restart
@@ -5688,8 +5681,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // the PROVEN-dangerous shape refuses (a reachable local non-Desktop process
         // with an unbuildable/unvalidatable relaunch); every other shape — Desktop
         // (Electron-supervised, #400), unverifiable, or remote — proceeds exactly as
-        // before.
-        if (healthBase != null && sameHttpBase(getComfyUIBaseUrl(), healthBase)) {
+        // before. The binding for this DECISION is captured pre-await; nothing
+        // downstream may reuse it (r7).
+        const preflightHealthBase = captureRebootHealthBase(ctx);
+        if (preflightHealthBase != null && sameHttpBase(getComfyUIBaseUrl(), preflightHealthBase)) {
           const preflight = await (localRestartPreflightOverride ?? preflightLocalRestart)();
           if (!preflight.ok) {
             return ok({
@@ -5707,6 +5702,21 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             });
           }
         }
+        // r7: the preflight AWAIT sits between the binding capture and the dispatch,
+        // breaking the no-await invariant above — a tab/connection rebind during
+        // that await would make every pre-await capture stale (the dispatch would
+        // go to an unconfirmable/different target while the causation stamp, the
+        // recovery observer, and the legacy-fallback gate all read the STALE bound
+        // base). Re-heal and re-capture the tab id, panel identity, and health base
+        // AT THE DISPATCH POINT; everything below uses ONLY these fresh captures.
+        ctx.ensureReachable?.();
+        const boundTabId = ctx.tabId;
+        // Snapshot the exact browser-tab registration that is about to receive the
+        // reboot. A post-restart success must observe a strictly newer hello from
+        // this SAME browser tab; a different tab can reuse the same saved-workflow
+        // routing id while the original is still reconnecting.
+        const preRestartPanelIdentity = ctx.panelConnectionIdentity?.();
+        const healthBase = captureRebootHealthBase(ctx);
         const timing = getPanelRebootTiming();
         const dispatchTimeout = Math.max(1, Math.min(15000, overallDeadline - Date.now()));
         // CONCURRENT OBSERVATION (coordinator): start probing the fixed boot endpoint NOW,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -68,7 +68,9 @@ import {
   preflightLocalRestart,
   recordRestartDispatch,
   clearRestartDispatch,
-  getLastRestartDispatch,
+  getRestartDispatchRecord,
+  RESTART_DISPATCH_CAUSATION_WINDOW_MS,
+  __processControlTestHooks,
 } from "../services/process-control.js";
 import { resetManagerApiCache } from "../services/manager-api-cache.js";
 import {
@@ -273,13 +275,9 @@ const RESTART_CONFIRM_TIMEOUT_MS = 90_000; // 90s
 const DECLINE_PROBE_WINDOW_MS = 6_000; // 6s total
 const DECLINE_PROBE_INTERVAL_MS = 2_000; // 2s between samples
 const DECLINE_PROBE_TIMEOUT_MS = 2_000; // per-sample probe ceiling
-
-// #742 r4: how long a RECORDED restart dispatch plausibly explains a down
-// server. The decline path's DOWN report may name restart causation only
-// against a dispatch on record within this window (and targeting the probed
-// instance); combined with clear-on-observed-recovery, an unrelated crash or
-// manual stop is never misreported as "a restart took it down".
-const RESTART_DISPATCH_CAUSATION_WINDOW_MS = 10 * 60_000; // 10 min
+// #742 r4/r5: the decline path may name restart causation only against a
+// dispatch RECORDED within RESTART_DISPATCH_CAUSATION_WINDOW_MS (imported from
+// process-control) whose token THIS session holds — see sessionRestartDispatch.
 
 function parsePositiveNumberEnv(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -350,6 +348,22 @@ export const __panelToolsTestHooks = {
   /** Direct access to the #742 decline recheck loop so its hard-deadline
    *  guarantee (codex gate r2) can be unit-tested with a custom deadline. */
   probeDeclineRecovery,
+  /** r5: the restart-dispatch record THIS session (ctx) holds, or null. */
+  getSessionRestartDispatch(
+    ctx: PanelToolCtx,
+  ): { at: number; base: string | null } | null {
+    return sessionRestartDispatch(ctx);
+  },
+  /** r5: seed a restart-dispatch record HELD BY this session (ctx) — with an
+   *  explicit `at` so fresh/stale shapes don't need a real restart. */
+  seedSessionRestartDispatch(
+    ctx: PanelToolCtx,
+    record: { at: number; base: string | null },
+  ): void {
+    const token = randomUUID();
+    __processControlTestHooks.setRestartDispatchRecord(token, record);
+    sessionRestartDispatchTokens.set(ctx, token);
+  },
   looksLikeSystemStats,
   probeComfyHealth,
   probeComfyEndpoint,
@@ -945,6 +959,38 @@ let declineProbeTimingOverride: {
   intervalMs: number;
   probeTimeoutMs: number;
 } | null = null;
+
+// #742 r5: restart-dispatch tokens held PER SESSION. Each MCP session gets its
+// own PanelToolCtx (one per connection — see the session factory in
+// panel-mcp-http), so keying by the ctx object scopes a dispatch record to the
+// session that dispatched it: session A's failed restart can never ground
+// causation for session B's decline, and A's recovery clears only A's record.
+// WeakMap → entries die with their session's ctx.
+const sessionRestartDispatchTokens = new WeakMap<object, string>();
+
+/** Stamp a restart dispatch and hold its token on THIS session (replacing any
+ *  record the session previously held — a session has at most one live one). */
+function stampSessionRestartDispatch(ctx: PanelToolCtx, base: string | null): void {
+  const prev = sessionRestartDispatchTokens.get(ctx);
+  if (prev) clearRestartDispatch(prev);
+  sessionRestartDispatchTokens.set(ctx, recordRestartDispatch(base));
+}
+
+/** The restart-dispatch record THIS session holds, or null. */
+function sessionRestartDispatch(
+  ctx: PanelToolCtx,
+): { at: number; base: string | null } | null {
+  const held = sessionRestartDispatchTokens.get(ctx);
+  return held ? getRestartDispatchRecord(held) : null;
+}
+
+/** Clear ONLY this session's own dispatch record (observed-back). */
+function clearSessionRestartDispatch(ctx: PanelToolCtx): void {
+  const held = sessionRestartDispatchTokens.get(ctx);
+  if (!held) return;
+  sessionRestartDispatchTokens.delete(ctx);
+  clearRestartDispatch(held);
+}
 
 /**
  * The concurrent-observation gate shared between the reboot handler and observeRecovery.
@@ -5564,10 +5610,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             if (boundToRestartTarget) {
               // r4: causation may be named ONLY against a RECORDED restart
               // dispatch — recent enough to plausibly be the cause, and
-              // targeting THIS instance. An unrelated crash / manual stop (no
-              // record, a stale record, or another instance's record) gets the
+              // targeting THIS instance. r5: the record must be one THIS
+              // SESSION dispatched (holds the token of) — another session's
+              // failed restart never grounds causation here. An unrelated
+              // crash / manual stop (no record, a stale record, another
+              // instance's record, or another session's record) gets the
               // causation-free report.
-              const dispatch = getLastRestartDispatch();
+              const dispatch = sessionRestartDispatch(ctx);
               const causative =
                 dispatch != null &&
                 Date.now() - dispatch.at <= RESTART_DISPATCH_CAUSATION_WINDOW_MS &&
@@ -5826,6 +5875,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               );
             }
             clearTimeout(restartTimer);
+            // #742 r5: the managed restart stopped the process — record the
+            // dispatch with THIS session holding the token (restartComfyUI also
+            // stamped its own process-wide record, which never grounds
+            // causation). Only a PROVEN stop is recorded; a refusal/timeout
+            // (restart undefined, or stopped!==true) records nothing.
+            if (restart?.stopped === true) {
+              stampSessionRestartDispatch(ctx, healthBase ?? getComfyUIBaseUrl());
+            }
             // DEFINITIVE no-restart: a spawn failure, OR restartComfyUI refused before
             // stopping anything (no process found / unsafe relaunch → stopped:false &&
             // started:false). The process was NOT cycled, so the still-healthy endpoint is
@@ -5845,10 +5902,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // Otherwise (the process WAS stopped/started, or restartComfyUI's own readiness
             // poll merely expired — neither terminal) DEFER to OUR OWN observed DOWN→UP.
             const recovery = await proofPromise;
-            // #742 r4: the managed restart was observed back — clear the record
-            // (restartComfyUI also clears on its own success; this covers the
-            // case where only OUR observer saw the recovery).
-            if (recovery.ready) clearRestartDispatch();
+            // #742 r4/r5: the managed restart was observed back — clear THIS
+            // session's record (restartComfyUI also clears its own process-wide
+            // record on success; this covers only-observer-saw-it recoveries).
+            if (recovery.ready) clearSessionRestartDispatch(ctx);
             const observed = recovery.via === "observed-cycle";
             // The legacy Manager path restarts ComfyUI out-of-band too. Server recovery alone
             // is not graph-tool readiness: wait for the browser tab to reconnect, then verify
@@ -5908,10 +5965,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         resetClient();
         resetObjectInfoCache();
         resetManagerApiCache("panel Manager reboot");
-        // #742 r4: record the ACTUAL dispatch (acceptance proven — a refusal never
-        // reaches here). A later decline-path DOWN report may name restart causation
-        // only against this record; it is cleared below if the restart is observed back.
-        recordRestartDispatch(healthBase ?? getComfyUIBaseUrl());
+        // #742 r4/r5: record the ACTUAL dispatch (acceptance proven — a refusal never
+        // reaches here), holding the token on THIS session. A later decline-path
+        // DOWN report may name restart causation only against a record this
+        // session holds; it is cleared below if the restart is observed back.
+        stampSessionRestartDispatch(ctx, healthBase ?? getComfyUIBaseUrl());
 
         // Observe recovery. There is exactly ONE sound proof that THIS ComfyUI instance
         // actually cycled: a directly OBSERVED down→up on the server-authorized, immutable,
@@ -5948,9 +6006,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // down→up, which the observer has been (and continues) watching for.
         gate.deadline = Math.min(Date.now() + timing.budgetMs, overallDeadline);
         const recovery = await recoveryPromise!;
-        // #742 r4: the dispatched restart was observed back — clear the record so
-        // it explains no later down state.
-        if (recovery.ready) clearRestartDispatch();
+        // #742 r4/r5: the dispatched restart was observed back — clear THIS
+        // session's record (never another session's).
+        if (recovery.ready) clearSessionRestartDispatch(ctx);
         if (!recovery.ready) {
           const waited = Math.round(recovery.waited_ms / 1000);
           return ok({

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1397,6 +1397,9 @@ async function restartViaManagerReboot(context: {
   // timed-out branch (which returns early) can't leave the pre-reboot dialect
   // pinned for the instance that eventually comes back (#646).
   resetManagerApiCache("comfyui reboot fired via Manager");
+  // #742 r4: record the dispatch — a later decline-path DOWN report may name
+  // restart causation only against such a record.
+  recordRestartDispatch(getComfyUIBaseUrl());
 
   const timing = getRemoteRebootTiming();
   if (timing.settleMs > 0) await sleep(timing.settleMs);
@@ -1428,6 +1431,9 @@ async function restartViaManagerReboot(context: {
   resetClient();
   resetObjectInfoCache();
   resetManagerApiCache("comfyui rebooted via Manager");
+  // #742 r4: the dispatched restart was observed back — clear the record so it
+  // explains no later down state.
+  clearRestartDispatch();
 
   return {
     stopped: true,
@@ -1494,6 +1500,9 @@ export async function restartComfyUI(): Promise<RestartResult> {
       message: `Could not stop ComfyUI: ${stopResult.message}`,
     };
   }
+  // #742 r4: the stop DID happen — record the dispatch. A later decline-path
+  // DOWN report may name restart causation only against this record.
+  recordRestartDispatch(getComfyUIBaseUrl());
 
   // Brief pause to let OS fully release resources
   await sleep(1000);
@@ -1512,6 +1521,10 @@ export async function restartComfyUI(): Promise<RestartResult> {
     };
   }
 
+  // #742 r4: the restart was observed back — clear the dispatch record so a
+  // completed restart explains no later down state.
+  clearRestartDispatch();
+
   return {
     stopped: true,
     started: true,
@@ -1520,6 +1533,40 @@ export async function restartComfyUI(): Promise<RestartResult> {
     message: `ComfyUI restarted successfully. ${startResult.message}`,
     auto_restart: startResult.auto_restart,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Restart dispatch record (#742 r4) — session-scoped bookkeeping of the last
+// restart THIS orchestrator actually dispatched (a Manager reboot fired, or a
+// kill+relaunch whose stop succeeded). The panel decline path may name restart
+// CAUSATION for a down server only against such a record — an unrelated crash
+// or manual stop must never be reported as "a restart took it down". A record
+// is cleared the moment its restart is observed back, so a completed restart
+// explains nothing that happens afterward.
+// ---------------------------------------------------------------------------
+
+interface RestartDispatchRecord {
+  /** Epoch ms when the restart was dispatched. */
+  at: number;
+  /** The ComfyUI base URL the restart targeted (null = unknown). */
+  base: string | null;
+}
+
+let lastRestartDispatch: RestartDispatchRecord | null = null;
+
+/** Stamp that a restart was ACTUALLY dispatched (reboot fired / stop done). */
+export function recordRestartDispatch(base: string | null): void {
+  lastRestartDispatch = { at: Date.now(), base };
+}
+
+/** The recorded restart was observed back — it no longer explains a down state. */
+export function clearRestartDispatch(): void {
+  lastRestartDispatch = null;
+}
+
+/** The last restart dispatch on record, or null when none/unaccounted-for. */
+export function getLastRestartDispatch(): RestartDispatchRecord | null {
+  return lastRestartDispatch;
 }
 
 /**
@@ -1565,6 +1612,7 @@ export const __processControlTestHooks = {
     supervisorGaveUp = false;
     remoteRebootTimingOverride = null;
     liveCwdResolverOverride = null;
+    lastRestartDispatch = null;
   },
   /** Inject a fake live-process-cwd resolver (#535) so tests can drive the
    *  `/proc/<pid>/cwd` relative-script anchor without a real process/filesystem. */
@@ -1573,6 +1621,11 @@ export const __processControlTestHooks = {
   },
   setLastProcessInfo(info: ProcessInfo): void {
     lastProcessInfo = info;
+  },
+  /** Seed the #742 r4 restart-dispatch record directly (fresh/stale/foreign
+   *  base) so decline-path causation tests don't run a real restart first. */
+  setLastRestartDispatch(record: RestartDispatchRecord | null): void {
+    lastRestartDispatch = record;
   },
   /** Inject fast remote-reboot timing so tests don't wait the real ~120s budget. */
   setRemoteRebootTimingForTests(timing: RemoteRebootTiming | null): void {

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1522,6 +1522,40 @@ export async function restartComfyUI(): Promise<RestartResult> {
   };
 }
 
+/**
+ * Refuse-safe preflight for an OUT-OF-BAND restart — one that stops ComfyUI
+ * WITHOUT going through our validated kill+relaunch (e.g. the panel's
+ * ComfyUI-Manager reboot, which asks the Manager to cycle the process and never
+ * consults our relaunch command). The same atomic-ish invariant as
+ * restartComfyUI applies (#368/#370): a stop must never happen before a
+ * relaunch is proven possible. On a Pinokio-style install (#742) the running
+ * server is externally supervised yet its relaunch is NOT provable from here
+ * (a relative `main.py` argv with no COMFYUI_PATH/workspace anchor and no live
+ * process cwd), and the supervisor does NOT re-launch after a plain Manager
+ * restart — so the reboot would kill ComfyUI permanently. Only the PROVEN
+ * dangerous shape refuses: a reachable, running, non-Desktop local instance
+ * whose relaunch command cannot be built/validated. Everything else returns
+ * ok:true and the caller proceeds exactly as before:
+ *   - remote mode (no local process to assess);
+ *   - nothing found / unreachable-but-unmapped (no proven running process —
+ *     #449 already punts those to a Manager reboot on purpose);
+ *   - a Desktop app (Electron-supervised — the Manager reboot IS its safe
+ *     restart path, #400);
+ *   - a validated relaunch (assessRelaunch, the #476/#426 machinery).
+ */
+export async function preflightLocalRestart(): Promise<{
+  ok: boolean;
+  reason?: string;
+}> {
+  if (isRemoteMode()) return { ok: true };
+  const { info } = await acquireProcessInfo();
+  if (!info) return { ok: true };
+  if (info.isDesktopApp) return { ok: true };
+  const relaunch = assessRelaunch(info);
+  if (relaunch.ok) return { ok: true };
+  return { ok: false, reason: relaunch.reason };
+}
+
 export const __processControlTestHooks = {
   reset(): void {
     detachSupervisor();

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1,4 +1,5 @@
 import { execSync, spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { existsSync, readlinkSync, statSync } from "node:fs";
 import { platform } from "node:os";
 import { isAbsolute, join } from "node:path";
@@ -1397,9 +1398,11 @@ async function restartViaManagerReboot(context: {
   // timed-out branch (which returns early) can't leave the pre-reboot dialect
   // pinned for the instance that eventually comes back (#646).
   resetManagerApiCache("comfyui reboot fired via Manager");
-  // #742 r4: record the dispatch — a later decline-path DOWN report may name
-  // restart causation only against such a record.
-  recordRestartDispatch(getComfyUIBaseUrl());
+  // #742 r4/r5: record the dispatch — a later decline-path DOWN report may
+  // name restart causation only against such a record. No session identity
+  // exists here, so stamp the shared PROCESS-WIDE slot (never grounds
+  // causation on its own).
+  recordRestartDispatch(getComfyUIBaseUrl(), PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
 
   const timing = getRemoteRebootTiming();
   if (timing.settleMs > 0) await sleep(timing.settleMs);
@@ -1431,9 +1434,9 @@ async function restartViaManagerReboot(context: {
   resetClient();
   resetObjectInfoCache();
   resetManagerApiCache("comfyui rebooted via Manager");
-  // #742 r4: the dispatched restart was observed back — clear the record so it
-  // explains no later down state.
-  clearRestartDispatch();
+  // #742 r4/r5: the dispatched restart was observed back — clear OUR record
+  // (the process-wide slot only; never another session's record).
+  clearRestartDispatch(PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
 
   return {
     stopped: true,
@@ -1500,9 +1503,10 @@ export async function restartComfyUI(): Promise<RestartResult> {
       message: `Could not stop ComfyUI: ${stopResult.message}`,
     };
   }
-  // #742 r4: the stop DID happen — record the dispatch. A later decline-path
-  // DOWN report may name restart causation only against this record.
-  recordRestartDispatch(getComfyUIBaseUrl());
+  // #742 r4/r5: the stop DID happen — record the dispatch. No session identity
+  // exists here, so stamp the shared PROCESS-WIDE slot (never grounds causation
+  // on its own; a panel caller stamps its own session token from the result).
+  recordRestartDispatch(getComfyUIBaseUrl(), PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
 
   // Brief pause to let OS fully release resources
   await sleep(1000);
@@ -1521,9 +1525,9 @@ export async function restartComfyUI(): Promise<RestartResult> {
     };
   }
 
-  // #742 r4: the restart was observed back — clear the dispatch record so a
-  // completed restart explains no later down state.
-  clearRestartDispatch();
+  // #742 r4/r5: the restart was observed back — clear OUR record (the
+  // process-wide slot only; never another session's record).
+  clearRestartDispatch(PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
 
   return {
     stopped: true,
@@ -1536,13 +1540,17 @@ export async function restartComfyUI(): Promise<RestartResult> {
 }
 
 // ---------------------------------------------------------------------------
-// Restart dispatch record (#742 r4) — session-scoped bookkeeping of the last
-// restart THIS orchestrator actually dispatched (a Manager reboot fired, or a
-// kill+relaunch whose stop succeeded). The panel decline path may name restart
-// CAUSATION for a down server only against such a record — an unrelated crash
-// or manual stop must never be reported as "a restart took it down". A record
-// is cleared the moment its restart is observed back, so a completed restart
-// explains nothing that happens afterward.
+// Restart dispatch records (#742 r4/r5) — bookkeeping of restarts THIS
+// orchestrator actually dispatched (a Manager reboot fired, or a kill+relaunch
+// whose stop succeeded). The panel decline path may name restart CAUSATION for
+// a down server only against a record whose TOKEN the declining session holds
+// (r5): the orchestrator hosts many per-tab/per-connection sessions, so a
+// module-global record would let session A's failed restart fabricate
+// causation for session B's decline (and A's recovery clear B's record).
+// Records are keyed by an opaque token returned to the stamper; a session
+// stores only its own token. Headless stamp sites (no session identity) share
+// the single PROCESS-WIDE slot — a documented process-wide fallback that can
+// NEVER ground causation (no session holds that token).
 // ---------------------------------------------------------------------------
 
 interface RestartDispatchRecord {
@@ -1552,21 +1560,48 @@ interface RestartDispatchRecord {
   base: string | null;
 }
 
-let lastRestartDispatch: RestartDispatchRecord | null = null;
+/** Token → record. Only the holder of a token may ground causation on (or
+ *  clear) its record. */
+const restartDispatchRecords = new Map<string, RestartDispatchRecord>();
 
-/** Stamp that a restart was ACTUALLY dispatched (reboot fired / stop done). */
-export function recordRestartDispatch(base: string | null): void {
-  lastRestartDispatch = { at: Date.now(), base };
+/** The shared slot for session-less (headless) stamps — never causation. */
+export const PROCESS_WIDE_RESTART_DISPATCH_TOKEN = "process-wide";
+
+/** How long a recorded dispatch plausibly explains a down server. Also the
+ *  prune horizon: older records can never ground causation, so they are
+ *  reaped on each stamp (bounds the map across many sessions). */
+export const RESTART_DISPATCH_CAUSATION_WINDOW_MS = 10 * 60_000; // 10 min
+
+/**
+ * Stamp that a restart was ACTUALLY dispatched (reboot fired / stop done) and
+ * return the opaque token identifying the record. Callers WITH a session
+ * identity take the fresh token and store it per-session; session-less
+ * (headless) callers pass PROCESS_WIDE_RESTART_DISPATCH_TOKEN so all unheld
+ * stamps share one bounded slot. Stale records are pruned on each stamp.
+ */
+export function recordRestartDispatch(base: string | null, token?: string): string {
+  const now = Date.now();
+  for (const [t, r] of restartDispatchRecords) {
+    if (now - r.at > RESTART_DISPATCH_CAUSATION_WINDOW_MS) {
+      restartDispatchRecords.delete(t);
+    }
+  }
+  const t = token ?? randomUUID();
+  restartDispatchRecords.set(t, { at: now, base });
+  return t;
 }
 
-/** The recorded restart was observed back — it no longer explains a down state. */
-export function clearRestartDispatch(): void {
-  lastRestartDispatch = null;
+/** Remove ONLY the record identified by `token` — a recovery may never clear
+ *  another session's record (r5). Unknown token → no-op. */
+export function clearRestartDispatch(token: string): void {
+  restartDispatchRecords.delete(token);
 }
 
-/** The last restart dispatch on record, or null when none/unaccounted-for. */
-export function getLastRestartDispatch(): RestartDispatchRecord | null {
-  return lastRestartDispatch;
+/** The record identified by `token`, or null. */
+export function getRestartDispatchRecord(
+  token: string,
+): RestartDispatchRecord | null {
+  return restartDispatchRecords.get(token) ?? null;
 }
 
 /**
@@ -1612,7 +1647,7 @@ export const __processControlTestHooks = {
     supervisorGaveUp = false;
     remoteRebootTimingOverride = null;
     liveCwdResolverOverride = null;
-    lastRestartDispatch = null;
+    restartDispatchRecords.clear();
   },
   /** Inject a fake live-process-cwd resolver (#535) so tests can drive the
    *  `/proc/<pid>/cwd` relative-script anchor without a real process/filesystem. */
@@ -1622,10 +1657,14 @@ export const __processControlTestHooks = {
   setLastProcessInfo(info: ProcessInfo): void {
     lastProcessInfo = info;
   },
-  /** Seed the #742 r4 restart-dispatch record directly (fresh/stale/foreign
-   *  base) so decline-path causation tests don't run a real restart first. */
-  setLastRestartDispatch(record: RestartDispatchRecord | null): void {
-    lastRestartDispatch = record;
+  /** Seed/remove a #742 r4/r5 restart-dispatch record directly (fresh/stale/
+   *  foreign base) so decline-path causation tests don't run a real restart. */
+  setRestartDispatchRecord(
+    token: string,
+    record: RestartDispatchRecord | null,
+  ): void {
+    if (record == null) restartDispatchRecords.delete(token);
+    else restartDispatchRecords.set(token, record);
   },
   /** Inject fast remote-reboot timing so tests don't wait the real ~120s budget. */
   setRemoteRebootTimingForTests(timing: RemoteRebootTiming | null): void {


### PR DESCRIPTION
## Root cause

Fixes #742.

Two compounding defects in `panel_restart_comfyui` produced the worst-of-both outcome the issue reports — a lost server AND a false "Cancelled — ComfyUI was not restarted." result:

1. **The false "cancelled" report.** The decline branch returned `"Cancelled — ComfyUI was not restarted."` whenever the confirm card resolved to `"no"` — but the production `confirm` maps **any non-timeout card error** to `"no"` (`src/orchestrator/panel-tools.ts`). Once ComfyUI is dead/dying (e.g. a reboot accepted moments earlier in the same turn already stopped the server and nothing re-launched it), the panel tab is gone, the card fails into the catch-all `"no"`, and the handler asserts a global state ("not restarted", i.e. server untouched) **without ever probing the server**.

2. **The unguarded stop on Pinokio.** The accepted path dispatches `comfy_reboot` (ComfyUI-Manager reboot) with **no refuse-safe preflight** — unlike the headless `restartComfyUI`, which has the #476/#426 `assessRelaunch` guard that refuses before any stop when a relaunch cannot be proven. On Pinokio-style installs the orchestrator cannot resolve `main.py`/the interpreter (relative argv, no COMFYUI_PATH/workspace anchor, no live cwd), and Pinokio's `start.js` only re-launches on the Manager dependency-install message — so a plain Manager restart kills ComfyUI **permanently**.

## Fix

- **Truthful decline path (#742 invariant b).** Before claiming "not restarted", the decline branch now probes the same endpoint the reboot observer would use (boot endpoint, falling back to the configured target — exactly what `health_check` probes). Only a **proven-down** endpoint (ECONNREFUSED — nothing listening) flips the report, to: *"⚠️ ComfyUI is DOWN — it was STOPPED and did not come back… Start ComfyUI manually from whatever launches it (e.g. Pinokio…)"*. A healthy or merely-unverifiable server keeps the plain cancel line, so a genuine decline is never alarmist.
- **Refuse-safe preflight before any stop (#742 invariants a + c).** New exported `preflightLocalRestart()` in `src/services/process-control.ts` wraps the existing #476/#426 machinery (`acquireProcessInfo` + `assessRelaunch`). After confirm=yes and **before** dispatching `comfy_reboot`, when the reboot would target our own local boot instance (the same instance binding the legacy fallback uses), the handler proves a relaunch is possible and **refuses BEFORE anything is stopped** when it isn't — with Pinokio-aware guidance (restart from the launcher that owns the server, or set COMFYUI_PATH and use `restart_comfyui`). Only the *proven-dangerous* shape refuses (reachable, running, non-Desktop, unbuildable/unvalidatable relaunch); Desktop (#400 — the Manager reboot IS its safe path), unverifiable, and remote targets proceed exactly as before. Builds on PR #727's spawn-cwd hardening, does not revert it.
- The headless `restartComfyUI` stop-then-start-fail path already reported truthfully (`"ComfyUI was stopped but could not be started: …"`); it is now pinned by a test asserting it never reads as "cancelled".

## Tests

- New `src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts` (6): decline+proven-down → truthful lost-server message (never "Cancelled", zero dispatch); decline+healthy and decline+unknown keep the plain cancel line; Pinokio-shaped preflight refusal **before any stop** (asserts `comfy_reboot` never dispatched, caches untouched); preflight not consulted when the tab doesn't provably front our boot instance; normal restart path stays green.
- `src/__tests__/services/process-control.test.ts` (+6): `preflightLocalRestart` refuse/pass shapes (Pinokio-shaped, resolvable, Desktop, nothing-running); `restartComfyUI` refuses the Pinokio shape **before any stop** (asserts no kill/no taskkill/no spawn); stop-succeeded-but-start-fails → truthful message, never "cancelled".
- Existing boot-fronting reboot suites stub the new preflight hook (they exercise post-dispatch paths); two existing decline tests get a hermetic health-probe stub.
- `npx tsc --noEmit` clean. Full suite: **233 files, 3906 passed / 2 skipped** (baseline 3894 + 12 new).

Not merged — review welcome.