### PR TITLE
fix(#751): reconcile list_assets from ComfyUI history

### DIFF
--- a/docs/tools/assets-images.mdx
+++ b/docs/tools/assets-images.mdx
@@ -397,7 +397,7 @@ List recently generated image AND video files from ComfyUI's output/ directory, 
 
 ## list_assets
 
-List recently generated assets from the in-memory registry, newest-first. Assets are registered automatically when a workflow completes successfully. The registry is ephemeral and clears on server restart; records expire after COMFYUI_ASSET_TTL_HOURS (default 24h).
+List recently generated assets, newest-first. Each call first reconciles ComfyUI's /history, so outputs are listed even when this session did not watch the render complete (e.g. queued via panel_run, by an earlier session, or before a server restart) — those are tagged source:'history-reconcile', versus source:'watched' for renders this server saw finish. Returns count + assets (asset_id, prompt_id, filename, url, source, created_at). The registry is ephemeral and clears on server restart; records expire after COMFYUI_ASSET_TTL_HOURS (default 24h), and only the most recent completed runs are reconciled — use get_history / get_image by filename for anything older.
 
 ### Parameters
 

--- a/src/__tests__/services/asset-reconcile.test.ts
+++ b/src/__tests__/services/asset-reconcile.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+// Mock the ComfyUI client + config so reconcile runs against canned /history
+// payloads. getClient/ensureConnected are imported by job-watcher (same module
+// graph), so the mock must provide them even though reconcile never calls them.
+const getHistoryMock = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getHistory: (...a: unknown[]) => getHistoryMock(...a),
+  getClient: vi.fn(),
+  ensureConnected: vi.fn(),
+}));
+vi.mock("../../config.js", () => ({
+  isCloudMode: () => false,
+  getCloudUrl: () => "",
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+}));
+
+import { reconcileAssetsFromHistory } from "../../services/asset-reconcile.js";
+import { AssetRegistry } from "../../services/asset-registry.js";
+import type { WorkflowJSON } from "../../comfyui/types.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function sampleGraph(): WorkflowJSON {
+  return {
+    "3": {
+      class_type: "KSampler",
+      inputs: { seed: 42, steps: 20, cfg: 7, sampler_name: "euler" },
+    },
+    "9": {
+      class_type: "SaveImage",
+      inputs: { filename_prefix: "ComfyUI", images: ["8", 0] },
+    },
+  };
+}
+
+interface EntryOpts {
+  queue: number;
+  promptId: string;
+  filename?: string;
+  /** ms epoch for execution_start/execution_success (start = end - 5s). */
+  successTs?: number;
+  completed?: boolean;
+  withError?: boolean;
+  graph?: unknown;
+  outputs?: Record<string, unknown>;
+}
+
+function historyEntry(opts: EntryOpts) {
+  const {
+    queue,
+    promptId,
+    filename = `${promptId}_00001_.png`,
+    successTs,
+    completed = true,
+    withError = false,
+    graph = sampleGraph(),
+    outputs,
+  } = opts;
+  const messages: Array<[string, Record<string, unknown>]> = [];
+  if (successTs !== undefined) {
+    messages.push(["execution_start", { prompt_id: promptId, timestamp: successTs - 5000 }]);
+    messages.push([
+      withError ? "execution_error" : "execution_success",
+      withError
+        ? { prompt_id: promptId, timestamp: successTs, exception_message: "boom" }
+        : { prompt_id: promptId, timestamp: successTs },
+    ]);
+  }
+  return {
+    prompt: [queue, promptId, graph, {}, []],
+    outputs: outputs ?? {
+      "9": { images: [{ filename, subfolder: "", type: "output" }] },
+    },
+    status: {
+      status_str: withError ? "error" : "success",
+      completed,
+      messages,
+    },
+  };
+}
+
+beforeEach(() => {
+  getHistoryMock.mockReset();
+  AssetRegistry.configure({ ttlMs: DAY_MS, now: Date.now });
+  AssetRegistry.clear();
+});
+
+describe("reconcileAssetsFromHistory", () => {
+  it("registers outputs from a completed run this session never watched (#751)", async () => {
+    const successTs = Date.now() - 10_000;
+    getHistoryMock.mockResolvedValue({
+      "panel-prompt": historyEntry({ queue: 5, promptId: "panel-prompt", successTs }),
+    });
+
+    const result = await reconcileAssetsFromHistory();
+
+    expect(result).toEqual({ scanned: 1, registered: 1, skippedExisting: 0 });
+    const [record] = AssetRegistry.list();
+    expect(record).toMatchObject({
+      promptId: "panel-prompt",
+      nodeId: "9",
+      filename: "panel-prompt_00001_.png",
+      subfolder: "",
+      type: "output",
+      source: "history-reconcile",
+      createdAt: successTs,
+    });
+    expect(record.assetId).toMatch(/^a_[0-9a-f]{8}$/);
+    expect(record.url).toContain("filename=panel-prompt_00001_.png");
+    // The recorded graph is the regenerate / get_asset_metadata provenance.
+    expect(AssetRegistry.get(record.assetId)?.workflow["3"].class_type).toBe("KSampler");
+  });
+
+  it("does not overwrite or duplicate an existing watched registration", async () => {
+    const watchedTs = Date.now() - 60_000;
+    AssetRegistry.configure({ now: () => watchedTs });
+    const [watched] = AssetRegistry.register({
+      promptId: "p1",
+      workflow: sampleGraph(),
+      outputs: [
+        {
+          node_id: "9",
+          images: [
+            {
+              filename: "p1_00001_.png",
+              subfolder: "",
+              type: "output",
+              url: "http://127.0.0.1:8188/view?filename=p1_00001_.png&subfolder=&type=output",
+            },
+          ],
+        },
+      ],
+    });
+    AssetRegistry.configure({ now: Date.now });
+
+    getHistoryMock.mockResolvedValue({
+      p1: historyEntry({
+        queue: 9,
+        promptId: "p1",
+        filename: "p1_00001_.png",
+        successTs: Date.now() - 1000,
+      }),
+    });
+
+    const result = await reconcileAssetsFromHistory();
+
+    expect(result).toEqual({ scanned: 1, registered: 0, skippedExisting: 1 });
+    const all = AssetRegistry.list();
+    expect(all).toHaveLength(1);
+    expect(all[0].assetId).toBe(watched.assetId);
+    expect(all[0].source).toBe("watched");
+    expect(all[0].createdAt).toBe(watchedTs);
+  });
+
+  it("fabricates nothing: skips errored, incomplete, graph-less, and output-less entries", async () => {
+    const ts = Date.now() - 1000;
+    getHistoryMock.mockResolvedValue({
+      errored: historyEntry({ queue: 4, promptId: "errored", successTs: ts, withError: true }),
+      running: historyEntry({ queue: 3, promptId: "running", successTs: ts, completed: false }),
+      nograph: historyEntry({ queue: 2, promptId: "nograph", successTs: ts, graph: {} }),
+      nooutput: historyEntry({ queue: 1, promptId: "nooutput", successTs: ts, outputs: {} }),
+    });
+
+    const result = await reconcileAssetsFromHistory();
+
+    expect(result.registered).toBe(0);
+    expect(AssetRegistry.list()).toHaveLength(0);
+  });
+
+  it("reconciles only the newest maxPrompts completed prompts, ordered by queue number", async () => {
+    const ts = Date.now() - 1000;
+    getHistoryMock.mockResolvedValue({
+      oldest: historyEntry({ queue: 1, promptId: "oldest", successTs: ts }),
+      newest: historyEntry({ queue: 3, promptId: "newest", successTs: ts }),
+      middle: historyEntry({ queue: 2, promptId: "middle", successTs: ts }),
+    });
+
+    const result = await reconcileAssetsFromHistory({ maxPrompts: 2 });
+
+    expect(result).toEqual({ scanned: 2, registered: 2, skippedExisting: 0 });
+    const filenames = AssetRegistry.list().map((r) => r.promptId).sort();
+    expect(filenames).toEqual(["middle", "newest"]);
+  });
+
+  it("normalizes epoch-seconds history timestamps to ms", async () => {
+    const successMs = Date.now() - 30_000;
+    const successS = Math.floor(successMs / 1000);
+    getHistoryMock.mockResolvedValue({
+      "seconds-prompt": historyEntry({
+        queue: 1,
+        promptId: "seconds-prompt",
+        successTs: successS,
+      }),
+    });
+
+    await reconcileAssetsFromHistory();
+
+    const [record] = AssetRegistry.list();
+    expect(record.createdAt).toBe(successS * 1000);
+  });
+
+  it("falls back to now when history carries no usable timestamp", async () => {
+    getHistoryMock.mockResolvedValue({
+      "timeless-prompt": historyEntry({ queue: 1, promptId: "timeless-prompt" }),
+    });
+
+    const before = Date.now();
+    await reconcileAssetsFromHistory();
+    const after = Date.now();
+
+    const [record] = AssetRegistry.list();
+    expect(record.createdAt).toBeGreaterThanOrEqual(before);
+    expect(record.createdAt).toBeLessThanOrEqual(after);
+  });
+
+  it("registers entries older than the TTL but they read as expired (TTL stays authoritative)", async () => {
+    AssetRegistry.configure({ ttlMs: 60_000 });
+    getHistoryMock.mockResolvedValue({
+      "old-prompt": historyEntry({
+        queue: 1,
+        promptId: "old-prompt",
+        successTs: Date.now() - 120_000,
+      }),
+    });
+
+    const result = await reconcileAssetsFromHistory();
+
+    expect(result.registered).toBe(1);
+    expect(AssetRegistry.list()).toHaveLength(0);
+  });
+});

--- a/src/__tests__/services/asset-reconcile.test.ts
+++ b/src/__tests__/services/asset-reconcile.test.ts
@@ -248,6 +248,41 @@ describe("reconcileAssetsFromHistory", () => {
     expect(all[0].createdAt).toBe(ts);
   });
 
+  it("rejects malformed image refs — never registers filename=undefined (codex r2 P1)", async () => {
+    const ts = Date.now() - 1000;
+    getHistoryMock.mockResolvedValue({
+      mixed: historyEntry({
+        queue: 2,
+        promptId: "mixed",
+        successTs: ts,
+        outputs: {
+          "9": {
+            images: [
+              { subfolder: "", type: "output" }, // filename missing
+              { filename: "", subfolder: "", type: "output" }, // empty filename
+              { filename: 123, subfolder: "", type: "output" }, // non-string filename
+              null, // not an object at all
+              { filename: "mixed_00002_.png", subfolder: "", type: "output" },
+            ],
+          },
+        },
+      }),
+      allbad: historyEntry({
+        queue: 1,
+        promptId: "allbad",
+        successTs: ts,
+        outputs: { "9": { images: [{ type: "output" }] } },
+      }),
+    });
+
+    const result = await reconcileAssetsFromHistory();
+
+    expect(result.registered).toBe(1);
+    const all = AssetRegistry.list();
+    expect(all).toHaveLength(1);
+    expect(all[0]).toMatchObject({ promptId: "mixed", filename: "mixed_00002_.png" });
+  });
+
   it("reconciles only the newest maxPrompts completed prompts, ordered by queue number", async () => {
     const ts = Date.now() - 1000;
     getHistoryMock.mockResolvedValue({

--- a/src/__tests__/services/asset-reconcile.test.ts
+++ b/src/__tests__/services/asset-reconcile.test.ts
@@ -100,6 +100,7 @@ describe("reconcileAssetsFromHistory", () => {
       type: "output",
       source: "history-reconcile",
       createdAt: successTs,
+      createdAtSource: "history",
     });
     expect(record.assetId).toMatch(/^a_[0-9a-f]{8}$/);
     expect(record.url).toContain("filename=panel-prompt_00001_.png");

--- a/src/__tests__/services/asset-reconcile.test.ts
+++ b/src/__tests__/services/asset-reconcile.test.ts
@@ -38,12 +38,14 @@ interface EntryOpts {
   queue: number;
   promptId: string;
   filename?: string;
-  /** ms epoch for execution_start/execution_success (start = end - 5s). */
-  successTs?: number;
-  completed?: boolean;
-  withError?: boolean;
   graph?: unknown;
   outputs?: Record<string, unknown>;
+  /** Full status override; defaults to a completed success with
+   *  execution_start + execution_success messages at successTs. */
+  status?: Record<string, unknown>;
+  /** ms epoch for execution_start/execution_success (start = end - 5s).
+   *  Omit to produce a success entry with NO timestamp messages. */
+  successTs?: number;
 }
 
 function historyEntry(opts: EntryOpts) {
@@ -51,32 +53,25 @@ function historyEntry(opts: EntryOpts) {
     queue,
     promptId,
     filename = `${promptId}_00001_.png`,
-    successTs,
-    completed = true,
-    withError = false,
     graph = sampleGraph(),
-    outputs,
+    outputs = { "9": { images: [{ filename, subfolder: "", type: "output" }] } },
+    successTs,
   } = opts;
-  const messages: Array<[string, Record<string, unknown>]> = [];
-  if (successTs !== undefined) {
-    messages.push(["execution_start", { prompt_id: promptId, timestamp: successTs - 5000 }]);
-    messages.push([
-      withError ? "execution_error" : "execution_success",
-      withError
-        ? { prompt_id: promptId, timestamp: successTs, exception_message: "boom" }
-        : { prompt_id: promptId, timestamp: successTs },
-    ]);
-  }
+  const status = opts.status ?? {
+    status_str: "success",
+    completed: true,
+    messages:
+      successTs === undefined
+        ? []
+        : [
+            ["execution_start", { prompt_id: promptId, timestamp: successTs - 5000 }],
+            ["execution_success", { prompt_id: promptId, timestamp: successTs }],
+          ],
+  };
   return {
     prompt: [queue, promptId, graph, {}, []],
-    outputs: outputs ?? {
-      "9": { images: [{ filename, subfolder: "", type: "output" }] },
-    },
-    status: {
-      status_str: withError ? "error" : "success",
-      completed,
-      messages,
-    },
+    outputs,
+    status,
   };
 }
 
@@ -153,11 +148,18 @@ describe("reconcileAssetsFromHistory", () => {
     expect(all[0].createdAt).toBe(watchedTs);
   });
 
-  it("fabricates nothing: skips errored, incomplete, graph-less, and output-less entries", async () => {
+  it("fabricates nothing: skips incomplete, graph-less, and output-less entries", async () => {
     const ts = Date.now() - 1000;
     getHistoryMock.mockResolvedValue({
-      errored: historyEntry({ queue: 4, promptId: "errored", successTs: ts, withError: true }),
-      running: historyEntry({ queue: 3, promptId: "running", successTs: ts, completed: false }),
+      running: historyEntry({
+        queue: 3,
+        promptId: "running",
+        status: {
+          status_str: "success",
+          completed: false,
+          messages: [["execution_start", { prompt_id: "running", timestamp: ts }]],
+        },
+      }),
       nograph: historyEntry({ queue: 2, promptId: "nograph", successTs: ts, graph: {} }),
       nooutput: historyEntry({ queue: 1, promptId: "nooutput", successTs: ts, outputs: {} }),
     });
@@ -166,6 +168,84 @@ describe("reconcileAssetsFromHistory", () => {
 
     expect(result.registered).toBe(0);
     expect(AssetRegistry.list()).toHaveLength(0);
+  });
+
+  it("registers only entries whose history status AFFIRMATIVELY says success (codex P1)", async () => {
+    const ts = Date.now() - 1000;
+    getHistoryMock.mockResolvedValue({
+      // The codex P1 case: status_str "error" with NO messages — the
+      // notification builder would default this to "success".
+      "error-no-messages": historyEntry({
+        queue: 5,
+        promptId: "error-no-messages",
+        status: { status_str: "error", completed: true, messages: [] },
+      }),
+      // Error with the messages key missing entirely.
+      "error-messages-missing": historyEntry({
+        queue: 4,
+        promptId: "error-messages-missing",
+        status: { status_str: "error", completed: true },
+      }),
+      // Unknown status: completed but no status_str at all.
+      "status-unknown": historyEntry({
+        queue: 3,
+        promptId: "status-unknown",
+        status: { completed: true, messages: [] },
+      }),
+      // Contradictory: status_str says success but an execution_error
+      // message exists — fail toward NOT registering.
+      "status-contradictory": historyEntry({
+        queue: 2,
+        promptId: "status-contradictory",
+        status: {
+          status_str: "success",
+          completed: true,
+          messages: [
+            ["execution_error", { prompt_id: "status-contradictory", timestamp: ts, exception_message: "boom" }],
+          ],
+        },
+      }),
+      // Control: a genuine success DOES register, proving the scan continued.
+      good: historyEntry({ queue: 1, promptId: "good", successTs: ts }),
+    });
+
+    const result = await reconcileAssetsFromHistory();
+
+    expect(result.registered).toBe(1);
+    const all = AssetRegistry.list();
+    expect(all).toHaveLength(1);
+    expect(all[0].promptId).toBe("good");
+  });
+
+  it("skips entries with no real completion timestamp rather than fabricating one (codex P1)", async () => {
+    const ts = Date.now() - 1000;
+    getHistoryMock.mockResolvedValue({
+      // No messages at all — no execution_success timestamp anywhere.
+      timeless: historyEntry({ queue: 4, promptId: "timeless" }),
+      // Only execution_start: that is NOT completion time — using it would
+      // backdate a long render past the TTL/since boundary and hide it.
+      "start-only": historyEntry({
+        queue: 3,
+        promptId: "start-only",
+        status: {
+          status_str: "success",
+          completed: true,
+          messages: [["execution_start", { prompt_id: "start-only", timestamp: ts }]],
+        },
+      }),
+      // Bogus far-future timestamp — untrustworthy.
+      "future-ts": historyEntry({ queue: 2, promptId: "future-ts", successTs: Date.now() + 3_600_000 }),
+      // Control: properly timestamped success registers.
+      good: historyEntry({ queue: 1, promptId: "good", successTs: ts }),
+    });
+
+    const result = await reconcileAssetsFromHistory();
+
+    expect(result.registered).toBe(1);
+    const all = AssetRegistry.list();
+    expect(all).toHaveLength(1);
+    expect(all[0].promptId).toBe("good");
+    expect(all[0].createdAt).toBe(ts);
   });
 
   it("reconciles only the newest maxPrompts completed prompts, ordered by queue number", async () => {
@@ -179,8 +259,8 @@ describe("reconcileAssetsFromHistory", () => {
     const result = await reconcileAssetsFromHistory({ maxPrompts: 2 });
 
     expect(result).toEqual({ scanned: 2, registered: 2, skippedExisting: 0 });
-    const filenames = AssetRegistry.list().map((r) => r.promptId).sort();
-    expect(filenames).toEqual(["middle", "newest"]);
+    const promptIds = AssetRegistry.list().map((r) => r.promptId).sort();
+    expect(promptIds).toEqual(["middle", "newest"]);
   });
 
   it("normalizes epoch-seconds history timestamps to ms", async () => {
@@ -198,20 +278,6 @@ describe("reconcileAssetsFromHistory", () => {
 
     const [record] = AssetRegistry.list();
     expect(record.createdAt).toBe(successS * 1000);
-  });
-
-  it("falls back to now when history carries no usable timestamp", async () => {
-    getHistoryMock.mockResolvedValue({
-      "timeless-prompt": historyEntry({ queue: 1, promptId: "timeless-prompt" }),
-    });
-
-    const before = Date.now();
-    await reconcileAssetsFromHistory();
-    const after = Date.now();
-
-    const [record] = AssetRegistry.list();
-    expect(record.createdAt).toBeGreaterThanOrEqual(before);
-    expect(record.createdAt).toBeLessThanOrEqual(after);
   });
 
   it("registers entries older than the TTL but they read as expired (TTL stays authoritative)", async () => {

--- a/src/__tests__/services/job-history.test.ts
+++ b/src/__tests__/services/job-history.test.ts
@@ -5,6 +5,7 @@ import {
   extractExecutionError,
   extractExecutionStats,
   extractTextOutputs,
+  hasAffirmativeSuccessStatus,
 } from "../../services/job-history.js";
 
 function historyEntry(messages: unknown): HistoryEntry {
@@ -143,5 +144,75 @@ describe("extractTextOutputs — real ComfyUI payload", () => {
     expect(analyzeHistoryEntry(entry).text_outputs).toEqual([
       { node_id: "2", text: ["TEXT-PREVIEW-PROOF-42"] },
     ]);
+  });
+});
+
+describe("hasAffirmativeSuccessStatus (#751 asset-registration gate)", () => {
+  const entryWith = (status: Record<string, unknown>): HistoryEntry =>
+    ({ prompt: {}, outputs: {}, status }) as unknown as HistoryEntry;
+
+  it("accepts a genuine success (status_str success, no error messages)", () => {
+    expect(
+      hasAffirmativeSuccessStatus(
+        entryWith({
+          status_str: "success",
+          completed: true,
+          messages: [
+            ["execution_start", { timestamp: 1 }],
+            ["execution_success", { timestamp: 2 }],
+          ],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects status_str 'error' even when messages are absent", () => {
+    expect(
+      hasAffirmativeSuccessStatus(
+        entryWith({ status_str: "error", completed: true, messages: [] }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects missing status_str / missing status (default-success is not evidence)", () => {
+    expect(
+      hasAffirmativeSuccessStatus(entryWith({ completed: true, messages: [] })),
+    ).toBe(false);
+    expect(hasAffirmativeSuccessStatus(entryWith({}))).toBe(false);
+  });
+
+  it("rejects a contradictory entry: status_str success but an error/interrupt message exists", () => {
+    expect(
+      hasAffirmativeSuccessStatus(
+        entryWith({
+          status_str: "success",
+          completed: true,
+          messages: [["execution_error", { exception_message: "boom" }]],
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      hasAffirmativeSuccessStatus(
+        entryWith({
+          status_str: "success",
+          completed: true,
+          messages: [["execution_interrupted", {}]],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("treats malformed messages as no evidence either way (status_str still decides)", () => {
+    // Malformed tuples are dropped by normalization — they are neither an
+    // error veto nor success evidence; the affirming status_str carries it.
+    expect(
+      hasAffirmativeSuccessStatus(
+        entryWith({
+          status_str: "success",
+          completed: true,
+          messages: ["execution_error", ["execution_error"], ["execution_error", null]],
+        }),
+      ),
+    ).toBe(true);
   });
 });

--- a/src/__tests__/services/job-history.test.ts
+++ b/src/__tests__/services/job-history.test.ts
@@ -6,6 +6,7 @@ import {
   extractExecutionStats,
   extractTextOutputs,
   hasAffirmativeSuccessStatus,
+  historyCompletionTimeMs,
 } from "../../services/job-history.js";
 
 function historyEntry(messages: unknown): HistoryEntry {
@@ -214,5 +215,54 @@ describe("hasAffirmativeSuccessStatus (#751 asset-registration gate)", () => {
         }),
       ),
     ).toBe(true);
+  });
+});
+
+describe("historyCompletionTimeMs (#751 r4 real-completion-time gate)", () => {
+  const NOW = 1_800_000_000_000;
+  const entryWith = (messages: unknown[]): HistoryEntry =>
+    ({
+      prompt: {},
+      outputs: {},
+      status: { status_str: "success", completed: true, messages },
+    }) as unknown as HistoryEntry;
+
+  it("returns the execution_success timestamp (epoch ms)", () => {
+    const entry = entryWith([
+      ["execution_start", { timestamp: NOW - 5000 }],
+      ["execution_success", { timestamp: NOW - 1000 }],
+    ]);
+    expect(historyCompletionTimeMs(entry, NOW)).toBe(NOW - 1000);
+  });
+
+  it("normalizes epoch-seconds timestamps to ms", () => {
+    const successS = Math.floor((NOW - 2000) / 1000);
+    const entry = entryWith([["execution_success", { timestamp: successS }]]);
+    expect(historyCompletionTimeMs(entry, NOW)).toBe(successS * 1000);
+  });
+
+  it("does NOT fall back to execution_start (start time is not completion time)", () => {
+    const entry = entryWith([["execution_start", { timestamp: NOW - 5000 }]]);
+    expect(historyCompletionTimeMs(entry, NOW)).toBeUndefined();
+  });
+
+  it("returns undefined when messages are absent or the timestamp is not a number", () => {
+    expect(historyCompletionTimeMs(entryWith([]), NOW)).toBeUndefined();
+    expect(
+      historyCompletionTimeMs(entryWith([["execution_success", {}]]), NOW),
+    ).toBeUndefined();
+    expect(
+      historyCompletionTimeMs(
+        entryWith([["execution_success", { timestamp: "soon" }]]),
+        NOW,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("rejects implausibly far-future timestamps as untrustworthy", () => {
+    const entry = entryWith([
+      ["execution_success", { timestamp: NOW + 3_600_000 }],
+    ]);
+    expect(historyCompletionTimeMs(entry, NOW)).toBeUndefined();
   });
 });

--- a/src/__tests__/services/job-watcher.test.ts
+++ b/src/__tests__/services/job-watcher.test.ts
@@ -1,10 +1,30 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HistoryEntry } from "../../comfyui/client.js";
+
+// The watched-path registration tests drive JobWatcher.watch end to end; mock
+// the ComfyUI client/config boundary so no real server is needed. The pure
+// buildCompletionNotification tests above are unaffected by these mocks (they
+// assert no URLs).
+const getHistoryMock = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getHistory: (...a: unknown[]) => getHistoryMock(...a),
+  getClient: vi.fn(),
+  ensureConnected: vi.fn(),
+}));
+vi.mock("../../config.js", () => ({
+  isCloudMode: () => false,
+  getCloudUrl: () => "",
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+}));
+
 import {
   buildCompletionNotification,
+  JobWatcher,
   pollIntervalMs,
   watcherTimeoutMs,
 } from "../../services/job-watcher.js";
+import { AssetRegistry } from "../../services/asset-registry.js";
+import type { WorkflowJSON } from "../../comfyui/types.js";
 
 const PROMPT_ID = "prompt-complete";
 const START = 1_705_505_423_000;
@@ -197,6 +217,115 @@ describe("buildCompletionNotification", () => {
         ],
       },
     ]);
+  });
+});
+
+function sampleWorkflow(): WorkflowJSON {
+  return {
+    "3": { class_type: "KSampler", inputs: { seed: 42, steps: 20, cfg: 7 } },
+    "9": {
+      class_type: "SaveImage",
+      inputs: { filename_prefix: "ComfyUI", images: ["8", 0] },
+    },
+  };
+}
+
+function completionEntry(opts: {
+  statusStr?: string;
+  messages?: unknown[];
+  outputs?: Record<string, unknown>;
+}): HistoryEntry {
+  return {
+    prompt: [1, "p", sampleWorkflow(), {}, []],
+    outputs: opts.outputs ?? {
+      "9": {
+        images: [{ filename: "watched_00001_.png", subfolder: "", type: "output" }],
+      },
+    },
+    status: {
+      ...(opts.statusStr !== undefined ? { status_str: opts.statusStr } : {}),
+      completed: true,
+      messages: opts.messages ?? [],
+    },
+  } as unknown as HistoryEntry;
+}
+
+/** Drive one watched completion through the real poll track and wait until
+ *  handleCompletion has fully finished (it always ends by deleting the
+ *  watcher — on success, on history failure, and on write failure alike). */
+async function runWatchedCompletion(
+  promptId: string,
+  entry: HistoryEntry,
+): Promise<void> {
+  process.env.COMFYUI_JOB_POLL_INTERVAL_S = "0.01";
+  getHistoryMock.mockResolvedValue({ [promptId]: entry });
+  JobWatcher.watch(promptId, sampleWorkflow());
+  try {
+    await vi.waitFor(
+      () => {
+        expect(JobWatcher.listActive()).not.toContain(promptId);
+      },
+      { timeout: 3000, interval: 10 },
+    );
+  } finally {
+    JobWatcher.unwatch(promptId);
+    delete process.env.COMFYUI_JOB_POLL_INTERVAL_S;
+  }
+}
+
+describe("watched-path asset registration (#751 r3 gate)", () => {
+  beforeEach(() => {
+    getHistoryMock.mockReset();
+    AssetRegistry.configure({ ttlMs: 24 * 60 * 60 * 1000, now: Date.now });
+    AssetRegistry.clear();
+  });
+
+  afterEach(() => {
+    for (const id of JobWatcher.listActive()) JobWatcher.unwatch(id);
+    delete process.env.COMFYUI_JOB_POLL_INTERVAL_S;
+  });
+
+  it("does NOT register when the history entry's status_str is 'error' (messages absent)", async () => {
+    await runWatchedCompletion(
+      "watched-error",
+      completionEntry({ statusStr: "error", messages: [] }),
+    );
+    expect(AssetRegistry.list()).toHaveLength(0);
+  });
+
+  it("does NOT register when success is only the builder's default (no status_str, malformed messages)", async () => {
+    await runWatchedCompletion(
+      "watched-default-success",
+      completionEntry({
+        messages: [
+          "execution_error",
+          ["execution_error"],
+          ["execution_error", null],
+        ],
+      }),
+    );
+    expect(AssetRegistry.list()).toHaveLength(0);
+  });
+
+  it("registers a genuinely successful watched completion", async () => {
+    const ts = Date.now() - 1000;
+    await runWatchedCompletion(
+      "watched-success",
+      completionEntry({
+        statusStr: "success",
+        messages: [
+          ["execution_start", { prompt_id: "watched-success", timestamp: ts - 4000 }],
+          ["execution_success", { prompt_id: "watched-success", timestamp: ts }],
+        ],
+      }),
+    );
+    const all = AssetRegistry.list();
+    expect(all).toHaveLength(1);
+    expect(all[0]).toMatchObject({
+      promptId: "watched-success",
+      filename: "watched_00001_.png",
+      source: "watched",
+    });
   });
 });
 

--- a/src/__tests__/services/job-watcher.test.ts
+++ b/src/__tests__/services/job-watcher.test.ts
@@ -97,6 +97,49 @@ describe("buildCompletionNotification", () => {
     expect(notification.execution_stats).toBeUndefined();
   });
 
+  it("drops malformed image/video refs — never emits filename=undefined (codex r2 P1)", () => {
+    const entry = {
+      prompt: {},
+      outputs: {
+        "9": {
+          images: [
+            { subfolder: "", type: "output" }, // filename missing
+            { filename: "", subfolder: "", type: "output" }, // empty filename
+            { filename: 123, subfolder: "", type: "output" }, // non-string filename
+            null, // not an object at all
+            { filename: "good.png", subfolder: "", type: "output" },
+          ],
+          videos: [{ type: "output" }, { filename: "clip.mp4", type: "output" }],
+        },
+        // Every ref malformed — the node must drop out entirely, not emit
+        // an output entry with zero real files.
+        "10": { images: [{ type: "output" }] },
+      },
+      status: {
+        status_str: "success",
+        completed: true,
+        messages: [
+          ["execution_success", { prompt_id: PROMPT_ID, timestamp: START }],
+        ],
+      },
+    } as unknown as HistoryEntry;
+
+    const notification = buildCompletionNotification(PROMPT_ID, entry, START);
+
+    expect(notification.outputs).toEqual([
+      {
+        node_id: "9",
+        images: [expect.objectContaining({ filename: "good.png" })],
+      },
+    ]);
+    expect(notification.video_outputs).toEqual([
+      {
+        node_id: "9",
+        videos: [expect.objectContaining({ filename: "clip.mp4" })],
+      },
+    ]);
+  });
+
   it("extracts image and video outputs (videos/video/gifs keys)", () => {
     const entry: HistoryEntry = {
       prompt: {},

--- a/src/__tests__/services/job-watcher.test.ts
+++ b/src/__tests__/services/job-watcher.test.ts
@@ -329,6 +329,64 @@ describe("watched-path asset registration (#751 r3 gate)", () => {
   });
 });
 
+describe("watched-path createdAt provenance (#751 r4 gate)", () => {
+  beforeEach(() => {
+    getHistoryMock.mockReset();
+    AssetRegistry.configure({ ttlMs: 24 * 60 * 60 * 1000, now: Date.now });
+    AssetRegistry.clear();
+  });
+
+  afterEach(() => {
+    for (const id of JobWatcher.listActive()) JobWatcher.unwatch(id);
+    delete process.env.COMFYUI_JOB_POLL_INTERVAL_S;
+  });
+
+  it("uses the entry's real execution_success timestamp when present", async () => {
+    const ts = Date.now() - 8000;
+    await runWatchedCompletion(
+      "watched-ts",
+      completionEntry({
+        statusStr: "success",
+        messages: [
+          ["execution_start", { prompt_id: "watched-ts", timestamp: ts - 5000 }],
+          ["execution_success", { prompt_id: "watched-ts", timestamp: ts }],
+        ],
+      }),
+    );
+    const [rec] = AssetRegistry.list();
+    expect(rec.createdAt).toBe(ts);
+    expect(rec.createdAtSource).toBe("history");
+  });
+
+  it("uses the watch's observed finish time (provenance 'observed') when the entry has no timestamp", async () => {
+    const before = Date.now();
+    await runWatchedCompletion(
+      "watched-nots",
+      completionEntry({ statusStr: "success", messages: [] }),
+    );
+    const after = Date.now();
+    const [rec] = AssetRegistry.list();
+    expect(rec.createdAtSource).toBe("observed");
+    expect(rec.createdAt).toBeGreaterThanOrEqual(before);
+    expect(rec.createdAt).toBeLessThanOrEqual(after);
+  });
+
+  it("treats a far-future execution_success timestamp as bogus and falls back to observed", async () => {
+    await runWatchedCompletion(
+      "watched-futurets",
+      completionEntry({
+        statusStr: "success",
+        messages: [
+          ["execution_success", { prompt_id: "watched-futurets", timestamp: Date.now() + 3_600_000 }],
+        ],
+      }),
+    );
+    const [rec] = AssetRegistry.list();
+    expect(rec.createdAtSource).toBe("observed");
+    expect(rec.createdAt).toBeLessThan(Date.now() + 60_000);
+  });
+});
+
 describe("watcher timeout / poll env overrides", () => {
   afterEach(() => {
     delete process.env.COMFYUI_JOB_TIMEOUT_S;

--- a/src/__tests__/tools/list-assets.test.ts
+++ b/src/__tests__/tools/list-assets.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+// Tool-level test for list_assets (#751). The REAL reconcile path runs; only
+// the ComfyUI client/config boundary is mocked, so a panel-dispatched render
+// (never watched by this process) must surface via the history reconcile.
+// workflow-executor / view-image are mocked only to keep their heavier import
+// graphs (and side effects) out of this test — list_assets never calls them.
+const getHistoryMock = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getHistory: (...a: unknown[]) => getHistoryMock(...a),
+  getClient: vi.fn(),
+  ensureConnected: vi.fn(),
+}));
+vi.mock("../../config.js", () => ({
+  isCloudMode: () => false,
+  getCloudUrl: () => "",
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+}));
+vi.mock("../../services/workflow-executor.js", () => ({
+  enqueueWorkflow: vi.fn(),
+}));
+vi.mock("../../services/view-image.js", () => ({
+  viewAssetImage: vi.fn(),
+}));
+
+import { registerAssetTools } from "../../tools/assets.js";
+import { AssetRegistry } from "../../services/asset-registry.js";
+import type { WorkflowJSON } from "../../comfyui/types.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerAssetTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+interface ListResult {
+  count: number;
+  assets: Array<{
+    asset_id: string;
+    prompt_id: string;
+    node_id: string;
+    filename: string;
+    subfolder: string;
+    type: string;
+    url: string;
+    source: string;
+    created_at: string;
+  }>;
+  note?: string;
+}
+
+async function callListAssets(args: Record<string, unknown> = {}): Promise<ListResult> {
+  const res = await getHandler("list_assets")(args);
+  expect(res.isError).toBeUndefined();
+  return JSON.parse(res.content[0].text) as ListResult;
+}
+
+function sampleGraph(): WorkflowJSON {
+  return {
+    "3": { class_type: "KSampler", inputs: { seed: 42, steps: 20, cfg: 7 } },
+    "9": { class_type: "SaveImage", inputs: { filename_prefix: "ComfyUI", images: ["8", 0] } },
+  };
+}
+
+function panelHistoryEntry(queue: number, promptId: string, filename: string, successTs: number) {
+  return {
+    prompt: [queue, promptId, sampleGraph(), {}, []],
+    outputs: { "9": { images: [{ filename, subfolder: "", type: "output" }] } },
+    status: {
+      status_str: "success",
+      completed: true,
+      messages: [
+        ["execution_start", { prompt_id: promptId, timestamp: successTs - 8000 }],
+        ["execution_success", { prompt_id: promptId, timestamp: successTs }],
+      ],
+    },
+  };
+}
+
+function registerWatched(promptId: string, filename: string) {
+  const [record] = AssetRegistry.register({
+    promptId,
+    workflow: sampleGraph(),
+    outputs: [
+      {
+        node_id: "9",
+        images: [
+          {
+            filename,
+            subfolder: "",
+            type: "output",
+            url: `http://127.0.0.1:8188/view?filename=${filename}&subfolder=&type=output`,
+          },
+        ],
+      },
+    ],
+  });
+  return record;
+}
+
+beforeEach(() => {
+  getHistoryMock.mockReset();
+  AssetRegistry.configure({ ttlMs: 24 * 60 * 60 * 1000, now: Date.now });
+  AssetRegistry.clear();
+});
+
+describe("list_assets (#751)", () => {
+  it("lists a panel-dispatched render that this session never watched", async () => {
+    // The bug: panel_run queues via the browser's app.queuePrompt, so no
+    // JobWatcher/AssetRegistry.register ever ran for this prompt — yet
+    // get_history has the output. list_assets must surface it via reconcile.
+    const successTs = Date.now() - 4000;
+    getHistoryMock.mockResolvedValue({
+      "6afad7e0-59f1-422c-9298-e2dcb34058e0": panelHistoryEntry(
+        12,
+        "6afad7e0-59f1-422c-9298-e2dcb34058e0",
+        "修月人_08B_Krea2_ID01A_HEAD_C05主_C04补_B01T_take3-final2_00001_.png",
+        successTs,
+      ),
+    });
+
+    const out = await callListAssets({ limit: 20 });
+
+    expect(out.count).toBe(1);
+    expect(out.note).toBeUndefined();
+    const asset = out.assets[0];
+    expect(asset).toMatchObject({
+      prompt_id: "6afad7e0-59f1-422c-9298-e2dcb34058e0",
+      node_id: "9",
+      filename: "修月人_08B_Krea2_ID01A_HEAD_C05主_C04补_B01T_take3-final2_00001_.png",
+      subfolder: "",
+      type: "output",
+      source: "history-reconcile",
+      created_at: new Date(successTs).toISOString(),
+    });
+    expect(asset.asset_id).toMatch(/^a_[0-9a-f]{8}$/);
+    expect(asset.url).toContain("type=output");
+    // The reconciled asset is genuinely registered — view_image / regenerate
+    // can resolve it by id afterwards.
+    expect(AssetRegistry.get(asset.asset_id)).toBeDefined();
+  });
+
+  it("keeps watched registrations truthful and does not duplicate them", async () => {
+    const watched = registerWatched("watched-prompt", "watched_00001_.png");
+    const successTs = Date.now() - 4000;
+    getHistoryMock.mockResolvedValue({
+      // Same run this session already watched — must stay source "watched".
+      "watched-prompt": panelHistoryEntry(9, "watched-prompt", "watched_00001_.png", successTs),
+      // Plus one the session never saw — must appear as history-reconcile.
+      "panel-prompt": panelHistoryEntry(10, "panel-prompt", "panel_00002_.png", successTs),
+    });
+
+    const out = await callListAssets();
+
+    expect(out.count).toBe(2);
+    const byFilename = new Map(out.assets.map((a) => [a.filename, a]));
+    expect(byFilename.get("watched_00001_.png")).toMatchObject({
+      asset_id: watched.assetId,
+      source: "watched",
+    });
+    expect(byFilename.get("panel_00002_.png")).toMatchObject({
+      prompt_id: "panel-prompt",
+      source: "history-reconcile",
+    });
+  });
+
+  it("says so honestly when nothing is watched and history has no completed outputs", async () => {
+    getHistoryMock.mockResolvedValue({});
+
+    const out = await callListAssets();
+
+    expect(out.count).toBe(0);
+    expect(out.assets).toEqual([]);
+    expect(out.note).toContain("no recent completed outputs in ComfyUI history");
+    expect(out.note).toContain("get_history");
+    expect(out.note).toContain("get_image");
+  });
+
+  it("still returns watched assets (with a note) when the history fetch fails", async () => {
+    registerWatched("watched-prompt", "watched_00001_.png");
+    getHistoryMock.mockRejectedValue(new Error("connection refused"));
+
+    const out = await callListAssets();
+
+    expect(out.count).toBe(1);
+    expect(out.assets[0]).toMatchObject({ filename: "watched_00001_.png", source: "watched" });
+    expect(out.note).toContain("Could not reconcile from ComfyUI history");
+    expect(out.note).toContain("watched-session assets only");
+  });
+
+  it("respects the limit argument across reconciled assets", async () => {
+    const ts = Date.now() - 4000;
+    getHistoryMock.mockResolvedValue({
+      p1: panelHistoryEntry(1, "p1", "p1_00001_.png", ts),
+      p2: panelHistoryEntry(2, "p2", "p2_00001_.png", ts + 1000),
+    });
+
+    const out = await callListAssets({ limit: 1 });
+
+    expect(out.count).toBe(1);
+    expect(out.assets[0].filename).toBe("p2_00001_.png");
+  });
+});

--- a/src/__tests__/tools/list-assets.test.ts
+++ b/src/__tests__/tools/list-assets.test.ts
@@ -182,21 +182,64 @@ describe("list_assets (#751)", () => {
 
     expect(out.count).toBe(0);
     expect(out.assets).toEqual([]);
-    expect(out.note).toContain("no recent completed outputs in ComfyUI history");
+    expect(out.note).toContain("no recent successfully completed outputs in ComfyUI history");
     expect(out.note).toContain("get_history");
     expect(out.note).toContain("get_image");
   });
 
-  it("still returns watched assets (with a note) when the history fetch fails", async () => {
+  it("degrades truthfully when the history fetch fails: keeps all records, flags staleness", async () => {
     registerWatched("watched-prompt", "watched_00001_.png");
+    // A record reconciled from history on an earlier, successful call.
+    AssetRegistry.register({
+      promptId: "reconciled-prompt",
+      workflow: sampleGraph(),
+      source: "history-reconcile",
+      outputs: [
+        {
+          node_id: "9",
+          images: [
+            {
+              filename: "reconciled_00001_.png",
+              subfolder: "",
+              type: "output",
+              url: "http://127.0.0.1:8188/view?filename=reconciled_00001_.png&subfolder=&type=output",
+            },
+          ],
+        },
+      ],
+    });
     getHistoryMock.mockRejectedValue(new Error("connection refused"));
 
     const out = await callListAssets();
 
-    expect(out.count).toBe(1);
-    expect(out.assets[0]).toMatchObject({ filename: "watched_00001_.png", source: "watched" });
-    expect(out.note).toContain("Could not reconcile from ComfyUI history");
-    expect(out.note).toContain("watched-session assets only");
+    // Both records stay listed — but the note must SAY the result includes
+    // previously reconciled assets and may be stale, never "watched-only".
+    expect(out.count).toBe(2);
+    const sources = new Map(out.assets.map((a) => [a.filename, a.source]));
+    expect(sources.get("watched_00001_.png")).toBe("watched");
+    expect(sources.get("reconciled_00001_.png")).toBe("history-reconcile");
+    expect(out.note).toContain("Could not refresh from ComfyUI history");
+    expect(out.note).toContain("may be stale");
+    expect(out.note).not.toContain("watched-session assets only");
+  });
+
+  it("excludes error-status history entries even when their messages are missing (codex P1)", async () => {
+    // completed:true + status_str:"error" + image outputs + NO messages: the
+    // completion-notification builder would default this to "success", so
+    // eligibility must come from the history entry's own status fields.
+    getHistoryMock.mockResolvedValue({
+      "errored-prompt": {
+        prompt: [7, "errored-prompt", sampleGraph(), {}, []],
+        outputs: { "9": { images: [{ filename: "err_00001_.png", subfolder: "", type: "output" }] } },
+        status: { status_str: "error", completed: true, messages: [] },
+      },
+    });
+
+    const out = await callListAssets();
+
+    expect(out.count).toBe(0);
+    expect(out.assets).toEqual([]);
+    expect(out.note).toContain("no recent successfully completed outputs in ComfyUI history");
   });
 
   it("respects the limit argument across reconciled assets", async () => {

--- a/src/__tests__/tools/list-assets.test.ts
+++ b/src/__tests__/tools/list-assets.test.ts
@@ -56,6 +56,7 @@ interface ListResult {
     url: string;
     source: string;
     created_at: string;
+    created_at_source?: string;
   }>;
   note?: string;
 }
@@ -143,6 +144,7 @@ describe("list_assets (#751)", () => {
       type: "output",
       source: "history-reconcile",
       created_at: new Date(successTs).toISOString(),
+      created_at_source: "history",
     });
     expect(asset.asset_id).toMatch(/^a_[0-9a-f]{8}$/);
     expect(asset.url).toContain("type=output");

--- a/src/services/asset-reconcile.ts
+++ b/src/services/asset-reconcile.ts
@@ -1,0 +1,126 @@
+import { getHistory, type HistoryEntry } from "../comfyui/client.js";
+import { buildCompletionNotification } from "./job-watcher.js";
+import { extractWorkflowGraph } from "./history-select.js";
+import { normalizeHistoryMessages } from "./job-history.js";
+import { AssetRegistry } from "./asset-registry.js";
+import { logger } from "../utils/logger.js";
+
+/**
+ * Reconcile the in-memory AssetRegistry with ComfyUI's /history (#751).
+ *
+ * The registry is populated by JobWatcher, which only sees prompts THIS process
+ * submitted via enqueueWorkflow. A render dispatched any other way — panel_run
+ * (the panel queues via the browser's own app.queuePrompt), an earlier MCP
+ * session, or anything before a server restart — completes without a watcher,
+ * so its outputs never registered and list_assets read as empty even though
+ * get_history showed them. Reconciling on demand closes that gap: outputs that
+ * really exist in history are registered with source "history-reconcile",
+ * with the prompt's recorded graph as the workflow snapshot (so regenerate /
+ * get_asset_metadata keep working) and the run's real completion time as
+ * createdAt (so ordering, `since` filters, and TTL expiry stay truthful).
+ *
+ * Nothing is fabricated: only entries that are completed, successful, carry a
+ * usable prompt graph, and list real image outputs are registered. Entries
+ * older than the registry TTL register but read as expired immediately — the
+ * TTL stays the single source of truth for record lifetime.
+ */
+
+export interface ReconcileResult {
+  /** Completed prompts inspected (after the recency cap). */
+  scanned: number;
+  /** Newly registered records. */
+  registered: number;
+  /** History outputs already present in the registry (left untouched). */
+  skippedExisting: number;
+}
+
+/** Only the newest N completed prompts are reconciled per call. */
+const DEFAULT_MAX_PROMPTS = 25;
+
+function queueNumberOf(entry: HistoryEntry): number {
+  const p = entry?.prompt as unknown;
+  return Array.isArray(p) ? Number(p[0]) || 0 : 0;
+}
+
+/** ComfyUI history timestamps are epoch seconds or milliseconds depending on
+ *  version — infer from magnitude, mirroring durationMs in job-history.ts. */
+function normalizeEpochMs(ts: unknown): number | undefined {
+  if (typeof ts !== "number" || !Number.isFinite(ts)) return undefined;
+  if (ts > 1_000_000_000_000) return ts; // epoch ms
+  if (ts > 1_000_000_000) return ts * 1000; // epoch s
+  return undefined;
+}
+
+/** The run's real completion time (ms epoch), or undefined when history has no
+ *  usable timestamp — the caller then falls back to "now". */
+function completionTimeMs(entry: HistoryEntry, now: number): number | undefined {
+  const messages = normalizeHistoryMessages(entry);
+  const success = messages.find((m) => m[0] === "execution_success");
+  const start = messages.find((m) => m[0] === "execution_start");
+  const ms = normalizeEpochMs((success ?? start)?.[1]?.timestamp);
+  // Implausibly far in the future (clock skew, non-epoch value) — untrustworthy.
+  if (ms === undefined || ms > now + 60_000) return undefined;
+  return ms;
+}
+
+export async function reconcileAssetsFromHistory(opts: {
+  maxPrompts?: number;
+  now?: () => number;
+} = {}): Promise<ReconcileResult> {
+  const maxPrompts = opts.maxPrompts ?? DEFAULT_MAX_PROMPTS;
+  const now = opts.now ?? Date.now;
+
+  const history = await getHistory();
+  const completed = Object.entries(history)
+    .filter(([, entry]) => entry?.status?.completed === true)
+    .sort((a, b) => queueNumberOf(b[1]) - queueNumberOf(a[1]))
+    .slice(0, maxPrompts);
+
+  let registered = 0;
+  let skippedExisting = 0;
+
+  for (const [promptId, entry] of completed) {
+    // Parse exactly like the watched path does — same status derivation, same
+    // output extraction, same URL building.
+    const notification = buildCompletionNotification(promptId, entry, now());
+    if (notification.status !== "success" || notification.outputs.length === 0) {
+      continue;
+    }
+    // The recorded graph is the provenance regenerate / get_asset_metadata
+    // rely on; without it there is nothing truthful to register.
+    const workflow = extractWorkflowGraph(entry);
+    if (!workflow) continue;
+
+    const fresh = notification.outputs
+      .map((output) => ({
+        node_id: output.node_id,
+        images: output.images.filter((img) => {
+          // Keep the original (watched or earlier-reconciled) record: its
+          // createdAt and any already-handed-out asset_id stay stable.
+          if (AssetRegistry.has(promptId, img)) {
+            skippedExisting++;
+            return false;
+          }
+          return true;
+        }),
+      }))
+      .filter((output) => output.images.length > 0);
+    if (fresh.length === 0) continue;
+
+    const createdAt = completionTimeMs(entry, now()) ?? now();
+    const records = AssetRegistry.register({
+      promptId,
+      workflow,
+      outputs: fresh,
+      source: "history-reconcile",
+      createdAt,
+    });
+    registered += records.length;
+  }
+
+  const result = { scanned: completed.length, registered, skippedExisting };
+  if (result.registered > 0) {
+    logger.info("Reconciled assets from ComfyUI history", result);
+  }
+  return result;
+}

--- a/src/services/asset-reconcile.ts
+++ b/src/services/asset-reconcile.ts
@@ -1,7 +1,7 @@
 import { getHistory, type HistoryEntry } from "../comfyui/client.js";
 import { buildCompletionNotification } from "./job-watcher.js";
 import { extractWorkflowGraph } from "./history-select.js";
-import { normalizeHistoryMessages } from "./job-history.js";
+import { hasAffirmativeSuccessStatus, normalizeHistoryMessages } from "./job-history.js";
 import { AssetRegistry } from "./asset-registry.js";
 import { logger } from "../utils/logger.js";
 
@@ -20,14 +20,15 @@ import { logger } from "../utils/logger.js";
  * createdAt (so ordering, `since` filters, and TTL expiry stay truthful).
  *
  * Nothing is fabricated: an entry registers only when its history status
- * affirmatively says success (status_str === "success" AND no error/interrupt
- * message — missing, unknown, or contradictory status fails toward NOT
- * registering), it carries a usable prompt graph, it lists real image outputs,
- * and it has a real execution_success timestamp for createdAt (execution_start
- * is not completion time, and "now" would silently misorder — untimed entries
- * are skipped, not guessed). Entries older than the registry TTL register but
- * read as expired immediately — the TTL stays the single source of truth for
- * record lifetime.
+ * affirmatively says success (hasAffirmativeSuccessStatus — the predicate
+ * shared with the watched path: status_str === "success" AND no
+ * error/interrupt message, with missing, unknown, or contradictory status
+ * failing toward NOT registering), it carries a usable prompt graph, it lists
+ * real image outputs, and it has a real execution_success timestamp for
+ * createdAt (execution_start is not completion time, and "now" would silently
+ * misorder — untimed entries are skipped, not guessed). Entries older than
+ * the registry TTL register but read as expired immediately — the TTL stays
+ * the single source of truth for record lifetime.
  */
 
 export interface ReconcileResult {
@@ -88,22 +89,15 @@ export async function reconcileAssetsFromHistory(opts: {
   let skippedExisting = 0;
 
   for (const [promptId, entry] of completed) {
-    // Eligibility keys on the HISTORY entry's own status fields, not the
-    // notification builder's default: buildCompletionNotification assumes
-    // success unless it finds a well-formed execution_error/interrupted
-    // message, which would admit a status_str:"error" entry whose messages
-    // are missing or malformed. Anything short of an affirmative success
-    // fails toward NOT registering.
-    if (entry.status?.status_str !== "success") continue;
+    // Eligibility keys on the HISTORY entry's own status via the shared
+    // affirmative-success predicate (job-history) — the SAME gate the watched
+    // path registers through, never the notification builder's default-success.
+    if (!hasAffirmativeSuccessStatus(entry)) continue;
 
     // Parse outputs exactly like the watched path does — same extraction and
-    // URL building. The notification's message-derived status acts as a veto:
-    // a contradictory execution_error/interrupted message rejects the entry
-    // even when status_str says success.
+    // URL building.
     const notification = buildCompletionNotification(promptId, entry, now());
-    if (notification.status !== "success" || notification.outputs.length === 0) {
-      continue;
-    }
+    if (notification.outputs.length === 0) continue;
     // The recorded graph is the provenance regenerate / get_asset_metadata
     // rely on; without it there is nothing truthful to register.
     const workflow = extractWorkflowGraph(entry);

--- a/src/services/asset-reconcile.ts
+++ b/src/services/asset-reconcile.ts
@@ -1,7 +1,7 @@
 import { getHistory, type HistoryEntry } from "../comfyui/client.js";
 import { buildCompletionNotification } from "./job-watcher.js";
 import { extractWorkflowGraph } from "./history-select.js";
-import { hasAffirmativeSuccessStatus, normalizeHistoryMessages } from "./job-history.js";
+import { hasAffirmativeSuccessStatus, historyCompletionTimeMs } from "./job-history.js";
 import { AssetRegistry } from "./asset-registry.js";
 import { logger } from "../utils/logger.js";
 
@@ -48,30 +48,6 @@ function queueNumberOf(entry: HistoryEntry): number {
   return Array.isArray(p) ? Number(p[0]) || 0 : 0;
 }
 
-/** ComfyUI history timestamps are epoch seconds or milliseconds depending on
- *  version — infer from magnitude, mirroring durationMs in job-history.ts. */
-function normalizeEpochMs(ts: unknown): number | undefined {
-  if (typeof ts !== "number" || !Number.isFinite(ts)) return undefined;
-  if (ts > 1_000_000_000_000) return ts; // epoch ms
-  if (ts > 1_000_000_000) return ts * 1000; // epoch s
-  return undefined;
-}
-
-/** The run's real completion time (ms epoch), taken ONLY from the
- *  execution_success message — the one truthful completion timestamp.
- *  execution_start is deliberately not a fallback: it is start time, and using
- *  it would backdate a long render past the TTL / a `since` boundary and hide
- *  it. Returns undefined when history carries no trustworthy value. */
-function completionTimeMs(entry: HistoryEntry, now: number): number | undefined {
-  const success = normalizeHistoryMessages(entry).find(
-    (m) => m[0] === "execution_success",
-  );
-  const ms = normalizeEpochMs(success?.[1]?.timestamp);
-  // Implausibly far in the future (clock skew, non-epoch value) — untrustworthy.
-  if (ms === undefined || ms > now + 60_000) return undefined;
-  return ms;
-}
-
 export async function reconcileAssetsFromHistory(opts: {
   maxPrompts?: number;
   now?: () => number;
@@ -105,8 +81,10 @@ export async function reconcileAssetsFromHistory(opts: {
 
     // createdAt must be the run's REAL completion time — an entry without a
     // trustworthy execution_success timestamp is skipped rather than guessed
-    // (see completionTimeMs).
-    const createdAt = completionTimeMs(entry, now());
+    // (see historyCompletionTimeMs; the watched path can fall back to its own
+    // observed finish time, but a reconciler running long after the fact has
+    // no such observation).
+    const createdAt = historyCompletionTimeMs(entry, now());
     if (createdAt === undefined) {
       logger.debug("Skipping history entry with no usable completion timestamp", {
         prompt_id: promptId,
@@ -136,6 +114,7 @@ export async function reconcileAssetsFromHistory(opts: {
       outputs: fresh,
       source: "history-reconcile",
       createdAt,
+      createdAtSource: "history",
     });
     registered += records.length;
   }

--- a/src/services/asset-reconcile.ts
+++ b/src/services/asset-reconcile.ts
@@ -19,10 +19,15 @@ import { logger } from "../utils/logger.js";
  * get_asset_metadata keep working) and the run's real completion time as
  * createdAt (so ordering, `since` filters, and TTL expiry stay truthful).
  *
- * Nothing is fabricated: only entries that are completed, successful, carry a
- * usable prompt graph, and list real image outputs are registered. Entries
- * older than the registry TTL register but read as expired immediately — the
- * TTL stays the single source of truth for record lifetime.
+ * Nothing is fabricated: an entry registers only when its history status
+ * affirmatively says success (status_str === "success" AND no error/interrupt
+ * message — missing, unknown, or contradictory status fails toward NOT
+ * registering), it carries a usable prompt graph, it lists real image outputs,
+ * and it has a real execution_success timestamp for createdAt (execution_start
+ * is not completion time, and "now" would silently misorder — untimed entries
+ * are skipped, not guessed). Entries older than the registry TTL register but
+ * read as expired immediately — the TTL stays the single source of truth for
+ * record lifetime.
  */
 
 export interface ReconcileResult {
@@ -51,13 +56,16 @@ function normalizeEpochMs(ts: unknown): number | undefined {
   return undefined;
 }
 
-/** The run's real completion time (ms epoch), or undefined when history has no
- *  usable timestamp — the caller then falls back to "now". */
+/** The run's real completion time (ms epoch), taken ONLY from the
+ *  execution_success message — the one truthful completion timestamp.
+ *  execution_start is deliberately not a fallback: it is start time, and using
+ *  it would backdate a long render past the TTL / a `since` boundary and hide
+ *  it. Returns undefined when history carries no trustworthy value. */
 function completionTimeMs(entry: HistoryEntry, now: number): number | undefined {
-  const messages = normalizeHistoryMessages(entry);
-  const success = messages.find((m) => m[0] === "execution_success");
-  const start = messages.find((m) => m[0] === "execution_start");
-  const ms = normalizeEpochMs((success ?? start)?.[1]?.timestamp);
+  const success = normalizeHistoryMessages(entry).find(
+    (m) => m[0] === "execution_success",
+  );
+  const ms = normalizeEpochMs(success?.[1]?.timestamp);
   // Implausibly far in the future (clock skew, non-epoch value) — untrustworthy.
   if (ms === undefined || ms > now + 60_000) return undefined;
   return ms;
@@ -80,8 +88,18 @@ export async function reconcileAssetsFromHistory(opts: {
   let skippedExisting = 0;
 
   for (const [promptId, entry] of completed) {
-    // Parse exactly like the watched path does — same status derivation, same
-    // output extraction, same URL building.
+    // Eligibility keys on the HISTORY entry's own status fields, not the
+    // notification builder's default: buildCompletionNotification assumes
+    // success unless it finds a well-formed execution_error/interrupted
+    // message, which would admit a status_str:"error" entry whose messages
+    // are missing or malformed. Anything short of an affirmative success
+    // fails toward NOT registering.
+    if (entry.status?.status_str !== "success") continue;
+
+    // Parse outputs exactly like the watched path does — same extraction and
+    // URL building. The notification's message-derived status acts as a veto:
+    // a contradictory execution_error/interrupted message rejects the entry
+    // even when status_str says success.
     const notification = buildCompletionNotification(promptId, entry, now());
     if (notification.status !== "success" || notification.outputs.length === 0) {
       continue;
@@ -90,6 +108,17 @@ export async function reconcileAssetsFromHistory(opts: {
     // rely on; without it there is nothing truthful to register.
     const workflow = extractWorkflowGraph(entry);
     if (!workflow) continue;
+
+    // createdAt must be the run's REAL completion time — an entry without a
+    // trustworthy execution_success timestamp is skipped rather than guessed
+    // (see completionTimeMs).
+    const createdAt = completionTimeMs(entry, now());
+    if (createdAt === undefined) {
+      logger.debug("Skipping history entry with no usable completion timestamp", {
+        prompt_id: promptId,
+      });
+      continue;
+    }
 
     const fresh = notification.outputs
       .map((output) => ({
@@ -107,7 +136,6 @@ export async function reconcileAssetsFromHistory(opts: {
       .filter((output) => output.images.length > 0);
     if (fresh.length === 0) continue;
 
-    const createdAt = completionTimeMs(entry, now()) ?? now();
     const records = AssetRegistry.register({
       promptId,
       workflow,

--- a/src/services/asset-registry.ts
+++ b/src/services/asset-registry.ts
@@ -13,6 +13,14 @@ export interface AssetOutput {
   images: AssetImage[];
 }
 
+/**
+ * Provenance of a record: "watched" means this process saw the prompt complete
+ * (JobWatcher); "history-reconcile" means the record was recovered from
+ * ComfyUI's /history after the fact (render dispatched by the panel, an earlier
+ * session, or before a server restart — see issue #751).
+ */
+export type AssetSource = "watched" | "history-reconcile";
+
 export interface AssetRecord {
   assetId: string;
   promptId: string;
@@ -23,12 +31,18 @@ export interface AssetRecord {
   url: string;
   workflow: WorkflowJSON;
   createdAt: number;
+  source: AssetSource;
 }
 
 export interface RegisterArgs {
   promptId: string;
   workflow: WorkflowJSON;
   outputs: AssetOutput[];
+  /** Defaults to "watched". */
+  source?: AssetSource;
+  /** ms epoch. Reconciled records pass the run's real completion time so
+   *  ordering, `since` filters, and TTL expiry stay truthful. Defaults to now. */
+  createdAt?: number;
 }
 
 export interface ListArgs {
@@ -53,7 +67,10 @@ const state = {
   config: { ttlMs: DEFAULT_TTL_MS, now: Date.now } as RegistryConfig,
 };
 
-function makeAssetId(promptId: string, img: AssetImage): string {
+function makeAssetId(
+  promptId: string,
+  img: Pick<AssetImage, "filename" | "subfolder" | "type">,
+): string {
   const hash = createHash("sha256")
     .update(`${promptId}\0${img.filename}\0${img.subfolder}\0${img.type}`)
     .digest("hex");
@@ -73,7 +90,7 @@ export const AssetRegistry = {
    * Register all images produced by a completed prompt.
    * Returns the AssetRecords created (one per image).
    */
-  register({ promptId, workflow, outputs }: RegisterArgs): AssetRecord[] {
+  register({ promptId, workflow, outputs, source, createdAt }: RegisterArgs): AssetRecord[] {
     const snapshot = deepCloneWorkflow(workflow);
     const created: AssetRecord[] = [];
     for (const output of outputs) {
@@ -88,13 +105,23 @@ export const AssetRegistry = {
           type: img.type,
           url: img.url,
           workflow: snapshot,
-          createdAt: state.config.now(),
+          createdAt: createdAt ?? state.config.now(),
+          source: source ?? "watched",
         };
         state.records.set(assetId, record);
         created.push(record);
       }
     }
     return created;
+  },
+
+  /** True when a live (unexpired) record exists for this prompt + image. */
+  has(
+    promptId: string,
+    img: Pick<AssetImage, "filename" | "subfolder" | "type">,
+  ): boolean {
+    const record = state.records.get(makeAssetId(promptId, img));
+    return record !== undefined && !isExpired(record);
   },
 
   /** Look up a record by id. Returns undefined for missing or expired. */

--- a/src/services/asset-registry.ts
+++ b/src/services/asset-registry.ts
@@ -21,6 +21,14 @@ export interface AssetOutput {
  */
 export type AssetSource = "watched" | "history-reconcile";
 
+/**
+ * Provenance of a record's createdAt: "history" means the run's recorded
+ * execution_success timestamp; "observed" means the moment this process
+ * observed the finish (the live watch's detection, or the registry clock
+ * fallback) — a real observation, but not ComfyUI's recorded time.
+ */
+export type CreatedAtSource = "history" | "observed";
+
 export interface AssetRecord {
   assetId: string;
   promptId: string;
@@ -31,6 +39,7 @@ export interface AssetRecord {
   url: string;
   workflow: WorkflowJSON;
   createdAt: number;
+  createdAtSource: CreatedAtSource;
   source: AssetSource;
 }
 
@@ -40,9 +49,13 @@ export interface RegisterArgs {
   outputs: AssetOutput[];
   /** Defaults to "watched". */
   source?: AssetSource;
-  /** ms epoch. Reconciled records pass the run's real completion time so
-   *  ordering, `since` filters, and TTL expiry stay truthful. Defaults to now. */
+  /** ms epoch. Callers pass a REAL time — the run's recorded completion
+   *  timestamp or their own observed finish time. Defaults to the registry
+   *  clock (itself an observation). */
   createdAt?: number;
+  /** Provenance of createdAt. Defaults to "observed" — pass "history" only
+   *  when createdAt is the entry's recorded execution_success timestamp. */
+  createdAtSource?: CreatedAtSource;
 }
 
 export interface ListArgs {
@@ -90,7 +103,7 @@ export const AssetRegistry = {
    * Register all images produced by a completed prompt.
    * Returns the AssetRecords created (one per image).
    */
-  register({ promptId, workflow, outputs, source, createdAt }: RegisterArgs): AssetRecord[] {
+  register({ promptId, workflow, outputs, source, createdAt, createdAtSource }: RegisterArgs): AssetRecord[] {
     const snapshot = deepCloneWorkflow(workflow);
     const created: AssetRecord[] = [];
     for (const output of outputs) {
@@ -106,6 +119,7 @@ export const AssetRegistry = {
           url: img.url,
           workflow: snapshot,
           createdAt: createdAt ?? state.config.now(),
+          createdAtSource: createdAtSource ?? "observed",
           source: source ?? "watched",
         };
         state.records.set(assetId, record);

--- a/src/services/job-history.ts
+++ b/src/services/job-history.ts
@@ -35,6 +35,28 @@ export interface HistoryAnalysis {
 
 export type HistoryStatusMessage = readonly [string, Record<string, unknown>];
 
+/**
+ * Affirmative-success test for a history entry — the ONE eligibility gate both
+ * asset-registration paths (JobWatcher.handleCompletion and the list_assets
+ * history reconcile) share, so a run can never become an asset without real
+ * success evidence (#751 codex gate r3).
+ *
+ * It deliberately does NOT trust buildCompletionNotification's derived status:
+ * that derivation defaults to "success" whenever messages carry no well-formed
+ * execution_error/interrupted event, which silently promotes a run ComfyUI
+ * marked status_str:"error" (or any entry with missing/malformed status or
+ * messages) to "success". Here the entry's OWN status_str must affirm success
+ * AND no error/interrupt message may exist; anything short fails toward NOT
+ * registering.
+ */
+export function hasAffirmativeSuccessStatus(entry: HistoryEntry): boolean {
+  if (entry?.status?.status_str !== "success") return false;
+  const messages = normalizeHistoryMessages(entry);
+  return !messages.some(
+    (m) => m[0] === "execution_error" || m[0] === "execution_interrupted",
+  );
+}
+
 const executionErrorSchema = z.object({
   node_id: z.union([z.string(), z.number()]).optional(),
   node_type: z.string().optional(),

--- a/src/services/job-history.ts
+++ b/src/services/job-history.ts
@@ -57,6 +57,39 @@ export function hasAffirmativeSuccessStatus(entry: HistoryEntry): boolean {
   );
 }
 
+/** ComfyUI history timestamps are epoch seconds or milliseconds depending on
+ *  version — infer from magnitude, mirroring durationMs below. */
+function normalizeEpochMs(ts: unknown): number | undefined {
+  if (typeof ts !== "number" || !Number.isFinite(ts)) return undefined;
+  if (ts > 1_000_000_000_000) return ts; // epoch ms
+  if (ts > 1_000_000_000) return ts * 1000; // epoch s
+  return undefined;
+}
+
+/**
+ * The run's real completion time (ms epoch), taken ONLY from the
+ * execution_success message — the one truthful completion timestamp recorded
+ * by ComfyUI. execution_start is deliberately not a fallback: it is start
+ * time, and using it would backdate a long render past the TTL / a `since`
+ * boundary and hide it. Values implausibly far in the future (clock skew,
+ * non-epoch garbage) are rejected. Returns undefined when history carries no
+ * trustworthy value — the caller must then use its own truthful observation
+ * time (watched path) or skip the record (reconcile path). Shared by both
+ * asset-registration paths so "real completion time" means the same thing on
+ * each (#751 codex gate r4).
+ */
+export function historyCompletionTimeMs(
+  entry: HistoryEntry,
+  now: number,
+): number | undefined {
+  const success = normalizeHistoryMessages(entry).find(
+    (m) => m[0] === "execution_success",
+  );
+  const ms = normalizeEpochMs(success?.[1]?.timestamp);
+  if (ms === undefined || ms > now + 60_000) return undefined;
+  return ms;
+}
+
 const executionErrorSchema = z.object({
   node_id: z.union([z.string(), z.number()]).optional(),
   node_type: z.string().optional(),

--- a/src/services/job-watcher.ts
+++ b/src/services/job-watcher.ts
@@ -129,6 +129,22 @@ function buildImageUrl(
   return `${getComfyUIBaseUrl()}/view?${params.toString()}`;
 }
 
+/** A media ref from history is only real when it carries a non-empty string
+ *  filename. Anything else — null, missing, empty, or non-string filename — is
+ *  malformed /history data and must be dropped here, never emitted as an
+ *  output or registered as an asset with filename=undefined (#753 gate). */
+interface HistoryMediaRef {
+  filename: string;
+  subfolder?: string;
+  type?: string;
+}
+
+function isHistoryMediaRef(value: unknown): value is HistoryMediaRef {
+  if (value === null || typeof value !== "object") return false;
+  const filename = (value as { filename?: unknown }).filename;
+  return typeof filename === "string" && filename.length > 0;
+}
+
 export function buildCompletionNotification(
   promptId: string,
   entry: HistoryEntry,
@@ -177,24 +193,22 @@ export function buildCompletionNotification(
     if (!nodeOutput || typeof nodeOutput !== "object") continue;
     const out = nodeOutput as Record<string, unknown>;
 
-    // Extract image outputs (SaveImage, PreviewImage)
+    // Extract image outputs (SaveImage, PreviewImage) — malformed refs are
+    // filtered BEFORE any use, so a bad /history entry can neither crash the
+    // parse nor surface as an output with filename=undefined.
     if (Array.isArray(out.images)) {
-      const images = (
-        out.images as Array<{
-          filename: string;
-          subfolder?: string;
-          type?: string;
-        }>
-      ).map((img) => ({
-        filename: img.filename,
-        subfolder: img.subfolder ?? "",
-        type: img.type ?? "output",
-        url: buildImageUrl(
-          img.filename,
-          img.subfolder ?? "",
-          img.type ?? "output",
-        ),
-      }));
+      const images = (out.images as unknown[])
+        .filter(isHistoryMediaRef)
+        .map((img) => ({
+          filename: img.filename,
+          subfolder: img.subfolder ?? "",
+          type: img.type ?? "output",
+          url: buildImageUrl(
+            img.filename,
+            img.subfolder ?? "",
+            img.type ?? "output",
+          ),
+        }));
       if (images.length > 0) {
         outputs.push({ node_id: nodeId, images });
       }
@@ -208,11 +222,7 @@ export function buildCompletionNotification(
     for (const videoKey of ["videos", "video", "gifs"] as const) {
       const videoData = out[videoKey];
       if (!Array.isArray(videoData)) continue;
-      for (const vid of videoData as Array<{
-        filename: string;
-        subfolder?: string;
-        type?: string;
-      }>) {
+      for (const vid of (videoData as unknown[]).filter(isHistoryMediaRef)) {
         videos.push({
           filename: vid.filename,
           subfolder: vid.subfolder ?? "",

--- a/src/services/job-watcher.ts
+++ b/src/services/job-watcher.ts
@@ -18,6 +18,7 @@ import { AssetRegistry } from "./asset-registry.js";
 import type { WorkflowJSON } from "../comfyui/types.js";
 import {
   analyzeHistoryEntry,
+  hasAffirmativeSuccessStatus,
   normalizeHistoryMessages,
   type ExecutionStats,
   type ExecutionErrorDetails,
@@ -302,9 +303,16 @@ async function handleCompletion(
     const notification = buildCompletionNotification(promptId, entry, state.startTime);
 
     // Register outputs with the AssetRegistry so they can be referenced by
-    // asset_id for view_image / regenerate. Only register on successful
-    // completion with a stored workflow snapshot.
-    if (notification.status === "success" && state.workflow) {
+    // asset_id for view_image / regenerate. Registration requires AFFIRMATIVE
+    // success evidence — the shared predicate (job-history) both registration
+    // paths use. The live watch only detects "finished" (WS and poll both
+    // route success AND error to this handler), and notification.status is a
+    // derivation that defaults to success when messages are absent/malformed;
+    // the history entry's own status_str + messages are therefore the
+    // AUTHORITATIVE status source for registration on this path too. (The
+    // derived status still drives the completion FILE, where presenting a
+    // best-effort outcome is a display matter, not an asset guarantee.)
+    if (hasAffirmativeSuccessStatus(entry) && state.workflow) {
       try {
         const records = AssetRegistry.register({
           promptId,

--- a/src/services/job-watcher.ts
+++ b/src/services/job-watcher.ts
@@ -19,6 +19,7 @@ import type { WorkflowJSON } from "../comfyui/types.js";
 import {
   analyzeHistoryEntry,
   hasAffirmativeSuccessStatus,
+  historyCompletionTimeMs,
   normalizeHistoryMessages,
   type ExecutionStats,
   type ExecutionErrorDetails,
@@ -264,6 +265,14 @@ async function handleCompletion(
   if (state.completed) return;
   state.completed = true;
 
+  // The watch's OWN observed finish time: the moment this watcher detected
+  // the completion (WS event or poll tick). For a live-watched job this is a
+  // real, truthful observation — within one poll interval / WS latency of the
+  // actual finish — and serves as the createdAt fallback when the history
+  // entry carries no usable execution_success timestamp (never the registry's
+  // silent default-now; provenance is recorded on the record, #751 r4 gate).
+  const observedFinishAt = Date.now();
+
   logger.info(`Completion detected via ${detectedBy}`, { prompt_id: promptId });
 
   // Stop both monitoring tracks
@@ -314,6 +323,11 @@ async function handleCompletion(
     // best-effort outcome is a display matter, not an asset guarantee.)
     if (hasAffirmativeSuccessStatus(entry) && state.workflow) {
       try {
+        // createdAt is a REAL time, never the registry's silent default-now:
+        // prefer the entry's recorded execution_success timestamp; fall back
+        // to this watcher's own observed finish time — distinguishable via
+        // createdAtSource ("history" vs "observed").
+        const recordedAt = historyCompletionTimeMs(entry, observedFinishAt);
         const records = AssetRegistry.register({
           promptId,
           workflow: state.workflow,
@@ -326,6 +340,8 @@ async function handleCompletion(
               url: img.url,
             })),
           })),
+          createdAt: recordedAt ?? observedFinishAt,
+          createdAtSource: recordedAt !== undefined ? "history" : "observed",
         });
         const idByKey = new Map(
           records.map((r) => [`${r.nodeId}|${r.filename}|${r.subfolder}|${r.type}`, r.assetId]),

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -19,6 +19,7 @@ function summarizeRecord(record: ReturnType<typeof AssetRegistry.get>) {
     url: record.url,
     source: record.source,
     created_at: new Date(record.createdAt).toISOString(),
+    created_at_source: record.createdAtSource,
   };
 }
 

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { AssetRegistry, applyOverrides } from "../services/asset-registry.js";
+import { reconcileAssetsFromHistory } from "../services/asset-reconcile.js";
 import { enqueueWorkflow } from "../services/workflow-executor.js";
 import { viewAssetImage } from "../services/view-image.js";
 import { errorToToolResult } from "../utils/errors.js";
+import { logger } from "../utils/logger.js";
 
 function summarizeRecord(record: ReturnType<typeof AssetRegistry.get>) {
   if (!record) return null;
@@ -15,6 +17,7 @@ function summarizeRecord(record: ReturnType<typeof AssetRegistry.get>) {
     subfolder: record.subfolder,
     type: record.type,
     url: record.url,
+    source: record.source,
     created_at: new Date(record.createdAt).toISOString(),
   };
 }
@@ -44,7 +47,7 @@ export function registerAssetTools(server: McpServer): void {
 
   server.tool(
     "list_assets",
-    "List recently generated assets from the in-memory registry, newest-first. Assets are registered automatically when a workflow completes successfully. The registry is ephemeral and clears on server restart; records expire after COMFYUI_ASSET_TTL_HOURS (default 24h).",
+    "List recently generated assets, newest-first. Each call first reconciles ComfyUI's /history, so outputs are listed even when this session did not watch the render complete (e.g. queued via panel_run, by an earlier session, or before a server restart) — those are tagged source:'history-reconcile', versus source:'watched' for renders this server saw finish. Returns count + assets (asset_id, prompt_id, filename, url, source, created_at). The registry is ephemeral and clears on server restart; records expire after COMFYUI_ASSET_TTL_HOURS (default 24h), and only the most recent completed runs are reconciled — use get_history / get_image by filename for anything older.",
     {
       limit: z
         .number()
@@ -61,13 +64,37 @@ export function registerAssetTools(server: McpServer): void {
     async (args) => {
       try {
         const since = args.since ? Date.parse(args.since) : undefined;
+        // Close the #751 gap: outputs whose completion this process didn't
+        // watch (panel_run dispatches, earlier sessions, pre-restart runs)
+        // register from history on demand. Best-effort — the registry still
+        // answers when ComfyUI is unreachable.
+        let note: string | undefined;
+        try {
+          await reconcileAssetsFromHistory();
+        } catch (reconcileErr) {
+          const message =
+            reconcileErr instanceof Error
+              ? reconcileErr.message
+              : String(reconcileErr);
+          logger.warn("list_assets history reconcile failed", { error: message });
+          note = `Could not reconcile from ComfyUI history (${message}); showing watched-session assets only.`;
+        }
         const records = AssetRegistry.list({ limit: args.limit, since });
+        if (records.length === 0 && note === undefined) {
+          note =
+            "No assets found — nothing completed under this server's watch and no recent completed outputs in ComfyUI history. " +
+            "Use get_history to inspect past runs and get_image to fetch an output by filename.";
+        }
         return {
           content: [
             {
               type: "text" as const,
               text: JSON.stringify(
-                { count: records.length, assets: records.map(summarizeRecord) },
+                {
+                  count: records.length,
+                  assets: records.map(summarizeRecord),
+                  ...(note !== undefined ? { note } : {}),
+                },
                 null,
                 2,
               ),

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -77,12 +77,16 @@ export function registerAssetTools(server: McpServer): void {
               ? reconcileErr.message
               : String(reconcileErr);
           logger.warn("list_assets history reconcile failed", { error: message });
-          note = `Could not reconcile from ComfyUI history (${message}); showing watched-session assets only.`;
+          // Truthful degradation: previously reconciled records stay listed
+          // (they name real outputs) — the note must not claim watched-only.
+          note =
+            `Could not refresh from ComfyUI history (${message}); results may be stale — ` +
+            "they still include assets reconciled from history earlier, and very recent completions may be missing.";
         }
         const records = AssetRegistry.list({ limit: args.limit, since });
         if (records.length === 0 && note === undefined) {
           note =
-            "No assets found — nothing completed under this server's watch and no recent completed outputs in ComfyUI history. " +
+            "No assets found — nothing completed under this server's watch and no recent successfully completed outputs in ComfyUI history. " +
             "Use get_history to inspect past runs and get_image to fetch an output by filename.";
         }
         return {


### PR DESCRIPTION
Fixes #751

## Root cause

`list_assets` read only the in-memory `AssetRegistry`, which is populated in exactly one place: `JobWatcher.handleCompletion` (`src/services/job-watcher.ts`) — and only for prompts **this process** submitted via `enqueueWorkflow` (`src/services/workflow-executor.ts:65`).

`panel_run` does not go through that path: it forwards `graph_run` to the panel, which queues via the browser's own `app.queuePrompt` (`src/orchestrator/panel-tools.ts:1324`). So a panel-dispatched render — or anything from an earlier session / before a server restart — completes without a watcher in this process, its outputs never register, and `list_assets` returns `count: 0` while `get_history` correctly shows the output.

## Fix (direction (a): reconcile from history)

`list_assets` now reconciles from ComfyUI's `/history` on each call (new `src/services/asset-reconcile.ts`). An entry registers **only** when ALL of these hold — anything short fails toward NOT registering:

- its history status **affirmatively** says success, via `hasAffirmativeSuccessStatus` (`src/services/job-history.ts`) — the ONE predicate both registration paths share: `status_str === "success"` AND no `execution_error`/`execution_interrupted` message. The notification builder's derived status (which defaults to success on absent/malformed messages) is never trusted for registration — on either path. The watched path's live watch only detects "finished", so the history entry is the documented authoritative status source for registration;
- it is `completed: true`, carries a usable recorded prompt graph (`extractWorkflowGraph` — the provenance `regenerate` / `get_asset_metadata` rely on), and lists real image outputs;
- every media ref carries a **non-empty string filename**: `buildCompletionNotification` (the single parser shared by the watched path and reconcile) filters malformed refs (missing / empty / non-string filename, null) before any use — no `filename=undefined` output or asset, and no mid-parse crash on null refs;
- `createdAt` is a **real time**, via `historyCompletionTimeMs` (shared, `job-history.ts`): the entry's `execution_success` timestamp, epoch s/ms normalized, far-future rejected. Reconcile skips untimed entries (a reconciler has no observation of its own); the watched path falls back to **its own observed finish time** — the moment `handleCompletion` detected the finish, truthful for a live-watched job — never the registry's silent default-now. Every record carries `createdAtSource: "history" | "observed"` (surfaced by `list_assets` as `created_at_source`) so the provenance is distinguishable.

Reconciled records are tagged `source: "history-reconcile"` vs `"watched"` (new field on every asset summary); truthful `createdAt` keeps newest-first ordering, `since` filters, and TTL expiry honest. Watched registrations are never overwritten or duplicated (`AssetRegistry.has`). Bounded to the newest 25 completed prompts per call.

Failure/empty paths are truthful:

- history fetch fails → all current records (watched + previously reconciled) stay listed, with a `note` that results include reconciled assets and **may be stale** — it never claims "watched-only" while listing reconciled ones;
- empty result → a `note` says nothing was watched and no recent successfully completed outputs exist in history, pointing at `get_history` / `get_image`.

## Tests (red-first; every codex-gate P1 was reproduced failing before its fix)

- `src/__tests__/services/asset-reconcile.test.ts` (9) — registers unwatched completed runs (asserting `createdAt` = real success ts, `createdAtSource: "history"`); preserves watched registrations; fabricates nothing; affirmative-success gating; missing-timestamp handling; malformed image refs rejected; recency cap; epoch-seconds normalization; TTL authoritative.
- `src/__tests__/tools/list-assets.test.ts` (6) — the #751 repro end-to-end (panel-dispatched render appears with `created_at_source: "history"`, using the issue's real prompt_id/filename); watched assets stay `watched`; honest empty-state note; truthful degradation on history-fetch failure; error-status entry excluded end-to-end; `limit` respected.
- `src/__tests__/services/job-watcher.test.ts` (14) — malformed media refs dropped at the shared builder; watched-path registration gate driven end-to-end through `JobWatcher.watch` (error-status / default-success-with-malformed-messages → no registration; genuine success → registers); **createdAt provenance: real execution_success ts used when present, observed finish time with `createdAtSource: "observed"` when absent or far-future-bogus — never silent default-now**.
- `src/__tests__/services/job-history.test.ts` (21) — `hasAffirmativeSuccessStatus` and `historyCompletionTimeMs` unit tests (ms/seconds normalization, no execution_start fallback, absent/malformed/far-future rejected).

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` (full) — **238 files, 3999 passed | 2 skipped, 0 failures** (baseline ~3934 passed / 2 skipped)
- `npm run check:vocabulary` — OK
- `npm run docs:gen` — regenerated; only `docs/tools/assets-images.mdx` changed (the `list_assets` description)