### PR TITLE
fix(#325): panel_ask timeout — cover blocking card tools in the internal panel MCP client

### DIFF
--- a/src/__tests__/orchestrator/ollama-backend.test.ts
+++ b/src/__tests__/orchestrator/ollama-backend.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OllamaBackend, comfyuiSpawnEnv, isOllamaModel, type McpToolClient } from "../../orchestrator/ollama-backend.js";
+import { PANEL_TOOL_MCP_TIMEOUT_MS, __panelAskTestHooks } from "../../orchestrator/panel-tools.js";
 import type { AgentEvent, NeutralTurn } from "../../orchestrator/agent-backend.js";
 
 // ---------------------------------------------------------------------------
@@ -394,8 +395,13 @@ describe("OllamaBackend", () => {
     expect(String(listResult?.content)).toContain("panel_focus_node: Focus a node in the canvas.");
     expect(String(listResult?.content)).toContain("panel_clear");
     expect(String(listResult?.content)).not.toContain("Long detail here");
-    // panel_call_tool unwrapped the JSON-string args and dispatched the real tool
-    expect(panelCall).toHaveBeenCalledWith({ name: "panel_focus_node", arguments: { node_id: 3 } });
+    // panel_call_tool unwrapped the JSON-string args and dispatched the real tool —
+    // carrying the #325 request timeout that covers long-blocking card tools.
+    expect(panelCall).toHaveBeenCalledWith(
+      { name: "panel_focus_node", arguments: { node_id: 3 } },
+      undefined,
+      { timeout: PANEL_TOOL_MCP_TIMEOUT_MS },
+    );
     expect(events.filter((e) => e.type === "result")).toHaveLength(1);
   });
 
@@ -624,5 +630,139 @@ describe("comfyuiSpawnEnv (#667)", () => {
   it("unset env AND no spec mode gets the documented compact default", () => {
     const env = comfyuiSpawnEnv(undefined, {});
     expect(env.COMFYUI_MCP_TOOL_MODE).toBe("compact");
+  });
+});
+
+describe("panel_ask survives a slow human answer (#325)", () => {
+  // ROOT CAUSE of #325: the ollama-family backends reach panel_* tools over the
+  // loopback HTTP MCP with an MCP SDK Client whose DEFAULT request timeout is
+  // 60s. panel_ask is DESIGNED to block on a human up to ~285s (240s card
+  // deadline + 45s late-answer grace, #486), so a user who didn't pick within
+  // 60s got `MCP error -32001: Request timed out` — and their eventual choice,
+  // delivered server-side, never reached the model. The fake panel client below
+  // models the SDK's timeout behavior faithfully: it rejects with the exact
+  // -32001 error when the request's timeout budget is shorter than the (slow)
+  // user's answer time, and delivers the pick otherwise.
+  const ASK_TOOL = [{ name: "panel_ask", description: "Ask the user to choose." }];
+  const ANSWERED_AT_MS = 90_000; // a slow-but-normal human answer (T+90s)
+  const USER_PICK = "Local GPU + Blender";
+
+  function sdkTimeoutPanelClient(calls: Array<{ name: string; timeout?: number }>) {
+    const callTool = vi.fn(
+      async (
+        params: { name: string; arguments: Record<string, unknown> },
+        _resultSchema?: unknown,
+        options?: { timeout?: number },
+      ) => {
+        calls.push({ name: params.name, timeout: options?.timeout });
+        // The MCP SDK's Protocol.request rejects with -32001 after `timeout` ms
+        // (60s when unspecified) — before a slow answer could ever arrive.
+        const budget = options?.timeout ?? 60_000;
+        if (budget < ANSWERED_AT_MS) throw new Error("MCP error -32001: Request timed out");
+        return { content: [{ type: "text", text: USER_PICK }] };
+      },
+    );
+    const client: McpToolClient = {
+      listTools: async () => ({ tools: ASK_TOOL }),
+      callTool: callTool as unknown as McpToolClient["callTool"],
+      close: async () => {},
+    };
+    return { client, callTool };
+  }
+
+  const ASK_ARGS = {
+    question: "Which?",
+    options: [{ label: "Local GPU + Blender" }, { label: "Cloud" }],
+  };
+
+  function scriptPanelAskTurn(direct: boolean) {
+    chatScript.push(
+      [
+        {
+          message: {
+            content: "",
+            tool_calls: [
+              {
+                function: direct
+                  ? { name: "panel_ask", arguments: ASK_ARGS } // bare name — forgiving dispatch
+                  : { name: "panel_call_tool", arguments: { name: "panel_ask", args: ASK_ARGS } },
+              },
+            ],
+          },
+          done: true,
+        },
+      ],
+      [{ message: { content: "done." }, done: true }],
+    );
+  }
+
+  function lastToolResult(): string {
+    const toolMsg = chatRequests[1].messages.filter((m) => m.role === "tool").at(-1);
+    return String(toolMsg?.content ?? "");
+  }
+
+  it("an answered card resolves the call with the user's choice (panel_call_tool router)", async () => {
+    const calls: Array<{ name: string; timeout?: number }> = [];
+    const { client: panel, callTool } = sdkTimeoutPanelClient(calls);
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ panel }),
+    });
+    scriptPanelAskTurn(false);
+
+    await collect(backend, turnsOf({ text: "ask me which" }));
+    // The request carried a timeout that covers a slow human answer — NOT the
+    // SDK's 60s default that produced #325's -32001.
+    expect(calls).toEqual([{ name: "panel_ask", timeout: PANEL_TOOL_MCP_TIMEOUT_MS }]);
+    expect(callTool).toHaveBeenCalledTimes(1);
+    // …so the user's pick (validated at T+90s, past the old 60s kill) was fed
+    // back to the model as the tool result, not a -32001 transport error.
+    expect(lastToolResult()).toContain(USER_PICK);
+    expect(lastToolResult()).not.toContain("-32001");
+  });
+
+  it("an answered card resolves with the user's choice (forgiving direct dispatch)", async () => {
+    const calls: Array<{ name: string; timeout?: number }> = [];
+    const { client: panel } = sdkTimeoutPanelClient(calls);
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ panel }),
+    });
+    scriptPanelAskTurn(true);
+
+    await collect(backend, turnsOf({ text: "ask me which" }));
+    expect(calls).toEqual([{ name: "panel_ask", timeout: PANEL_TOOL_MCP_TIMEOUT_MS }]);
+    expect(lastToolResult()).toContain(USER_PICK);
+    expect(lastToolResult()).not.toContain("-32001");
+  });
+
+  it("a genuine request timeout still surfaces truthfully (never swallowed)", async () => {
+    // The transport REALLY timed out (e.g. the user walked away past the whole
+    // card budget): the -32001 must reach the model as an honest tool error —
+    // the fix widens the budget, it does not hide a real timeout.
+    const callTool = vi.fn(async () => {
+      throw new Error("MCP error -32001: Request timed out");
+    });
+    const panel: McpToolClient = {
+      listTools: async () => ({ tools: ASK_TOOL }),
+      callTool: callTool as unknown as McpToolClient["callTool"],
+      close: async () => {},
+    };
+    const backend = new OllamaBackend({
+      model: "gemma4:e4b",
+      connectToolClients: async () => ({ panel }),
+    });
+    scriptPanelAskTurn(false);
+
+    await collect(backend, turnsOf({ text: "ask me which" }));
+    expect(lastToolResult()).toContain("-32001");
+  });
+
+  it("the client timeout covers the LONGEST blocking panel card with margin", () => {
+    // panel_ask / confirm / consent are hard-capped at ASK_TOTAL_BUDGET_CAP_MS;
+    // panel_request_secret waits up to 300s on its masked input. The client
+    // timeout must exceed BOTH or one can still be killed client-side mid-answer.
+    expect(PANEL_TOOL_MCP_TIMEOUT_MS).toBeGreaterThan(__panelAskTestHooks.ASK_TOTAL_BUDGET_CAP_MS);
+    expect(PANEL_TOOL_MCP_TIMEOUT_MS).toBeGreaterThan(300_000);
   });
 });

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -30,14 +30,23 @@ import { OLLAMA_CAPABILITIES, stampTurn } from "./agent-backend.js";
 import type { GeminiMcpServerSpec } from "./gemini-backend.js";
 import { resolvePrompt } from "../services/prompt-overrides.js";
 import { retiredToolMessage } from "../tools/vocabulary.js";
+import { PANEL_TOOL_MCP_TIMEOUT_MS } from "./panel-tools.js";
 
 type McpToolInfo = { name: string; description?: string; inputSchema?: unknown };
 type McpCallResult = { isError?: boolean; content?: Array<{ type: string; text?: string }> };
 
-/** The slice of the MCP SDK Client the backend uses — injectable for tests. */
+/** The slice of the MCP SDK Client the backend uses — injectable for tests.
+ *  callTool mirrors the SDK's real 3-arg signature (params, resultSchema?,
+ *  options?) so a per-request timeout can ride along: the SDK's 60s default
+ *  kills long-blocking panel card tools client-side before the user answers
+ *  (#325). */
 export interface McpToolClient {
   listTools(): Promise<{ tools: McpToolInfo[] }>;
-  callTool(params: { name: string; arguments: Record<string, unknown> }): Promise<McpCallResult>;
+  callTool(
+    params: { name: string; arguments: Record<string, unknown> },
+    resultSchema?: unknown,
+    options?: { timeout?: number },
+  ): Promise<McpCallResult>;
   close(): Promise<void>;
 }
 
@@ -518,7 +527,16 @@ export class OllamaBackend implements AgentBackend {
         if (inner === null || typeof inner !== "object" || Array.isArray(inner)) {
           return { text: `args must be a JSON object. See panel_describe_tool {"name": "${wanted}"}.`, isError: true };
         }
-        const res = await this.panel.callTool({ name: wanted, arguments: inner as Record<string, unknown> });
+        // #325 — a blocking card tool (panel_ask / secret / consent) waits on the
+        // HUMAN up to ~285-300s server-side; the MCP SDK's 60s default request
+        // timeout would kill the call first ("MCP error -32001: Request timed
+        // out") and silently drop the user's eventual pick. Carry a timeout that
+        // covers the longest card (harmless for fast tools — an upper bound only).
+        const res = await this.panel.callTool(
+          { name: wanted, arguments: inner as Record<string, unknown> },
+          undefined,
+          { timeout: PANEL_TOOL_MCP_TIMEOUT_MS },
+        );
         if (res.isError) {
           logger.warn(`[ollama-backend] panel tool '${wanted}' returned isError: ${textOf(res).slice(0, 300)}`);
         }
@@ -530,7 +548,10 @@ export class OllamaBackend implements AgentBackend {
       // the compact server's call_tool, whose unknown-name error carries
       // close-match suggestions the model can recover from.
       if (this.panel && this.panelTools.some((t) => t.name === name)) {
-        const res = await this.panel.callTool({ name, arguments: args });
+        // Same #325 timeout as the panel_call_tool router path above.
+        const res = await this.panel.callTool({ name, arguments: args }, undefined, {
+          timeout: PANEL_TOOL_MCP_TIMEOUT_MS,
+        });
         return { text: textOf(res), isError: !!res.isError };
       }
       if (this.comfy && this.comfyTools.some((t) => t.name === "call_tool")) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3172,6 +3172,20 @@ let askTimingOverride: AskTiming | null = null;
 // misconfigured COMFYUI_PANEL_ASK_DEADLINE_S/GRACE_S can never recreate #486.
 const ASK_TOTAL_BUDGET_CAP_MS = 285_000;
 
+/**
+ * The per-request timeout an INTERNAL MCP client must use when calling panel_*
+ * tools (#325). Several panel tools are DESIGNED to block on a human well past
+ * the MCP SDK's 60s default request timeout: panel_ask / the confirm / consent
+ * cards wait up to ASK_TOTAL_BUDGET_CAP_MS (285s), and panel_request_secret
+ * waits up to 300s on its masked input. A client that calls them with the SDK
+ * default (the ollama-family backends' loopback panel client did) kills the
+ * request at 60s with `MCP error -32001: Request timed out` — the user picks an
+ * option minutes later, the server delivers it, and the model never sees it.
+ * Sized above the LONGEST blocking card (the 300s secret card) with margin for
+ * loopback transport + processing. Fast tools are unaffected: this is only an
+ * upper bound, never a wait. */
+export const PANEL_TOOL_MCP_TIMEOUT_MS = 315_000;
+
 function getAskTiming(): AskTiming {
   if (askTimingOverride) return askTimingOverride;
   const pollMs = Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_ASK_POLL_S", 0.5) * 1000);


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#325 (recurrence on comfyui-mcp 0.49.1 / panel 0.11.36).

## Root cause

The ollama-family backends (ollama / GLM / Moonshot / Copilot / ChatGPT-OAuth / Grok-direct — all share `OllamaBackend`) reach `panel_*` tools over the loopback HTTP MCP (`panel-mcp-http`) with an MCP SDK `Client` whose request timeout **defaults to 60s** (`DEFAULT_REQUEST_TIMEOUT_MSEC`). `panel_ask` is *designed* to block on a human far longer: up to ~285s (240s card deadline + 45s late-answer grace, #486), and `panel_request_secret` up to 300s.

So a user who didn't pick within 60s got `MCP error -32001: Request timed out` client-side; their eventual choice was delivered server-side (bridge `pending` by rid, late-reply buffer by `ask_id`) but the model never saw it. Exactly the recurrence report: *"returns MCP error -32001: Request timed out when the user does not select immediately."*

The original 300s report in the issue body was the pre-#525 600s card wait (0.48.15) — already fixed in 0.48.22. The server-side ask path (deadline clamp, late-reply buffer, truthful timeout result) needed no change; I verified the full answer path (bridge rid correlation, mid-command disconnect → honest OUTCOME-UNKNOWN, late-answer buffer) is sound on main.

## Fix

- `src/orchestrator/panel-tools.ts` — export `PANEL_TOOL_MCP_TIMEOUT_MS` (315s), sized above the longest blocking card (the 300s secret card) with margin, documented next to `ASK_TOTAL_BUDGET_CAP_MS` so the budgets stay in sync.
- `src/orchestrator/ollama-backend.ts` — pass that timeout as the per-request option on **both** panel `callTool` paths (the `panel_call_tool` router and the forgiving direct dispatch); widen `McpToolClient.callTool` to the SDK's real 3-arg signature. Fast tools are unaffected — an upper bound, never a wait. All ollama-family subclasses inherit the fix (none override `dispatch`).

Codex/Gemini/Grok (ACP) backends use their external MCP clients (≥300s timeouts) against the same server, which clamps at 285s — unaffected.

## Tests (`src/__tests__/orchestrator/ollama-backend.test.ts`, +4)

- **an answered card resolves the call with the user's choice** — on both dispatch paths; the fake panel client reproduces the SDK behavior (rejects with the exact `-32001` error when the request budget is shorter than a slow T+90s answer), so the tests fail pre-fix and pass now.
- **the timeout path is truthful** — a genuine request timeout still surfaces as an honest tool error, never swallowed.
- **budget sizing** — `PANEL_TOOL_MCP_TIMEOUT_MS` exceeds both `ASK_TOTAL_BUDGET_CAP_MS` and the 300s secret-card wait.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run src/__tests__/orchestrator/ollama-backend.test.ts` — 29/29
- `npx vitest run src/__tests__/orchestrator/panel-tools.test.ts src/__tests__/services/ui-bridge.test.ts` — 349/349
- Full `npx vitest run` — **3971 passed / 2 skipped / 0 failed** (236 files)