### PR TITLE
fix(#422): too-old panel verdict quotes both detected panel and MCP versions

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2054,6 +2054,24 @@ describe("makeUnknownCommandError (old-panel version gate)", () => {
     expect(e?.message).toContain("0.6.8");
   });
 
+  // #422 — the error must name BOTH sides of the skew: the detected PANEL build
+  // AND the detecting MCP server build ("return the detected MCP + panel versions
+  // in the error"), so a "stale panel version" report shows which orchestrator
+  // build (and thus which minimum table) produced the verdict.
+  it("includes the detected MCP server version alongside the panel version (#422)", () => {
+    const e = makeUnknownCommandError('Unknown command "graph_query"', "0.6.8", "0.48.27");
+    expect(e?.message).toContain("detected panel 0.6.8");
+    expect(e?.message).toContain("mcp 0.48.27");
+  });
+
+  // …and when the caller does not supply it, the running server's own version is
+  // resolved (from this package's package.json) — never silently dropped.
+  it("self-resolves the running MCP server version when not supplied (#422)", () => {
+    const e = makeUnknownCommandError('Unknown command "graph_query"', "0.6.8");
+    expect(e?.message).toContain("detected panel 0.6.8");
+    expect(e?.message).toMatch(/, mcp \d+\.\d+\.\d+/);
+  });
+
   // #352 FALSE-NEGATIVE boundary: a panel that ADVERTISES a version at/above the
   // command's real minimum must NEVER be told it is "too old". An Unknown-command
   // reply from a provably-new-enough panel is not an age problem, so it is NOT
@@ -2396,6 +2414,73 @@ describe("UiBridge.send (graceful gate end-to-end)", () => {
     );
     // The FIRST call is gated before dispatch — the panel is never asked.
     expect(dispatchCount).toBe(0);
+  });
+
+  // #422 — the gate's verdict names BOTH detected versions: the panel build that
+  // undercuts the minimum AND the running MCP server build making the verdict, so
+  // a "stale panel version" report is actionable without guessing which side is old.
+  it("proactive-gate verdict quotes the detected panel AND mcp versions (#422)", async () => {
+    const sock = await connectPanel(undefined);
+    sock.send(JSON.stringify({ type: "hello", tab_id: "skew-tab", title: "wf", panel_version: "0.6.8" }));
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd) {
+        sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { cmd: msg.cmd } }));
+      }
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    await expect(bridge.send({ cmd: "graph_query" }, { tabId: "skew-tab" })).rejects.toThrow(
+      /too old for "graph_query" \(detected panel 0\.6\.8, mcp \d+\.\d+\.\d+\)/i,
+    );
+  });
+
+  // #422 — a reconnect/hello at a NEWER version must update the REPORTED version:
+  // the detected-version the gate quotes is re-read from every hello, so after the
+  // refresh nothing ever quotes the stale pre-reconnect build. FAIL-before (the
+  // original report): a later verdict quoted a version state the tab had long since
+  // re-helloed past.
+  it("quotes the REFRESHED panel version after a reconnect at a newer build — never the stale one (#422)", async () => {
+    const sock1 = await connectPanel(undefined);
+    sock1.send(JSON.stringify({ type: "hello", tab_id: "refresh-tab", title: "wf", panel_version: "0.6.8" }));
+    await new Promise((r) => setTimeout(r, 50));
+    // 0.6.8 undercuts graph_query's 0.7.0 minimum → gated, quoting 0.6.8.
+    await expect(bridge.send({ cmd: "graph_query" }, { tabId: "refresh-tab" })).rejects.toThrow(
+      /detected panel 0\.6\.8/i,
+    );
+
+    // The tab reloads at a NEWER build (0.7.0) under the same tab id. graph_query
+    // now meets its minimum and must dispatch; a command with a HIGHER minimum
+    // (refresh_nodes → 0.11.28) is still gated — but quotes the NEW 0.7.0, not the
+    // stale 0.6.8 the first connection advertised.
+    const sock2 = await connectPanel(undefined);
+    const dispatched: string[] = [];
+    sock2.send(JSON.stringify({ type: "hello", tab_id: "refresh-tab", title: "wf", panel_version: "0.7.0" }));
+    sock2.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd) {
+        dispatched.push(msg.cmd);
+        sock2.send(JSON.stringify({ rid: msg.rid, ok: true, result: { cmd: msg.cmd } }));
+      }
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(await bridge.send({ cmd: "graph_query" }, { tabId: "refresh-tab" })).toEqual({
+      cmd: "graph_query",
+    });
+    expect(dispatched).toContain("graph_query");
+    const gated = await bridge
+      .send({ cmd: "refresh_nodes" }, { tabId: "refresh-tab" })
+      .then(
+        () => {
+          throw new Error("refresh_nodes should have been gated, not dispatched");
+        },
+        (e: Error) => e,
+      );
+    expect(gated.message).toMatch(
+      /too old for "refresh_nodes" \(detected panel 0\.7\.0, mcp \d+\.\d+\.\d+\).*≥0\.11\.28/is,
+    );
+    expect(gated.message).not.toContain("0.6.8");
   });
 
   // A command that has NEVER been tried on this connection must never be

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -18,7 +18,7 @@
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import { WebSocketServer, WebSocket } from "ws";
 import { logger } from "../utils/logger.js";
-import { compareSemver } from "./self-update.js";
+import { compareSemver, detectInstallMode } from "./self-update.js";
 
 export const DEFAULT_BRIDGE_PORT = 9101;
 
@@ -358,9 +358,33 @@ export function panelVersionProvesUnsupported(cmd: string, panelVersion?: string
  *  gate only ever fires for tabled commands), so "this panel build does not
  *  implement it" is an observed fact, and "update to the latest release" is the
  *  only remedy guaranteed sufficient — never a fabricated, possibly-already-met
- *  version number. */
-function buildPanelTooOldError(cmd: string, panelVersion?: string): Error {
-  const detected = panelVersion ? ` (detected ${panelVersion})` : "";
+ *  version number.
+ *
+ *  The "(detected …)" parenthetical names BOTH sides of the skew (#422): the
+ *  detected PANEL build (when known) AND the detecting MCP server build. A
+ *  "stale panel version" report is only actionable when the reader can see which
+ *  MCP build made the verdict — an outdated orchestrator can hold an outdated
+ *  minimum table, so both versions belong in the error. The MCP version is
+ *  resolved once per process (it cannot change without a restart); callers may
+ *  pass `mcpVersion` explicitly (tests). */
+let cachedMcpVersion: string | undefined;
+function mcpServerVersion(): string | undefined {
+  if (cachedMcpVersion === undefined) {
+    cachedMcpVersion = detectInstallMode().currentVersion;
+  }
+  return cachedMcpVersion;
+}
+
+function buildPanelTooOldError(
+  cmd: string,
+  panelVersion?: string,
+  mcpVersion: string | undefined = mcpServerVersion(),
+): Error {
+  const detected = panelVersion
+    ? ` (detected panel ${panelVersion}${mcpVersion ? `, mcp ${mcpVersion}` : ""})`
+    : mcpVersion
+      ? ` (detected mcp ${mcpVersion})`
+      : "";
   const min = BRIDGE_CMD_MIN_PANEL_VERSION[cmd];
   const e = new Error(
     min
@@ -435,6 +459,7 @@ export function isUnknownCommandReply(error: string): boolean {
 export function makeUnknownCommandError(
   error: string,
   panelVersion?: string,
+  mcpVersion?: string,
 ): Error | null {
   // Match the panel's exact shape: `Unknown command "graph_query"` (quotes
   // optional/variable). ANCHORED at the start of the (trimmed) message so an
@@ -451,7 +476,7 @@ export function makeUnknownCommandError(
   // (which would also POISON the #236 unsupported-cmd gate against a capable panel).
   // Return null so the raw error surfaces and the gate is never poisoned.
   if (panelSupportsCmd(cmd, panelVersion)) return null;
-  return buildPanelTooOldError(cmd, panelVersion);
+  return buildPanelTooOldError(cmd, panelVersion, mcpVersion);
 }
 
 /**

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -367,12 +367,20 @@ export function panelVersionProvesUnsupported(cmd: string, panelVersion?: string
  *  minimum table, so both versions belong in the error. The MCP version is
  *  resolved once per process (it cannot change without a restart); callers may
  *  pass `mcpVersion` explicitly (tests). */
-let cachedMcpVersion: string | undefined;
+// The resolution result is cached BOTH ways — an unavailable version (or a
+// throwing detectInstallMode) resolves to null ONCE, never re-probed per error
+// (codex gate: undefined would conflate 'not yet resolved' with 'unavailable'
+// and re-run detectInstallMode on every error on those installs).
+let cachedMcpVersion: string | null | undefined;
 function mcpServerVersion(): string | undefined {
   if (cachedMcpVersion === undefined) {
-    cachedMcpVersion = detectInstallMode().currentVersion;
+    try {
+      cachedMcpVersion = detectInstallMode().currentVersion ?? null;
+    } catch {
+      cachedMcpVersion = null;
+    }
   }
-  return cachedMcpVersion;
+  return cachedMcpVersion ?? undefined;
 }
 
 function buildPanelTooOldError(


### PR DESCRIPTION
## Problem

**comfyui-mcp-panel#422** — `panel_query_graph` intermittently reported a stale panel version (`too old for "graph_query"`) after earlier successful calls in the same session.

### Root-cause findings (what main already fixes)

The core symptom is **already fixed on main** by 44a6e69 (PR #604, released in **0.48.27**): the #392 proactive version gate had no memory of commands the connection already ran, so a graph-edit-triggered re-hello (`tmp:`→`wf:` migration) advertising an undercutting version flipped the gate closed for a command the panel had demonstrably served. The `provenSupportedCmds` veto (inherited across reconnects, carried across same-socket tab-id migration, cleared by a genuine `Unknown command` reply) closed that, with regression tests. The reporter was on **0.48.21**, which predates both the #392 gate and the veto — there the same message came from the *reactive* path: the panel's loaded bundle genuinely replied `Unknown command "graph_query"` (stale/duplicate loaded bundle under Manager 3.x legacy — the panel-side #562 case), rewritten with the old blanket ≥0.11.4 phrasing.

Ruled out while investigating:
- **Caching/refresh gap**: `Conn.panelVersion` is re-read from *every* hello that carries `panel_version` (only inherited when omitted, and `panelVersionAdvertised` keeps an inherited value out of the proactive gate).
- **Wrong source (panel side)**: the panel's hello always advertises the compile-time `PANEL_VERSION` of the actually-loaded bundle (`web/js/comfyui-mcp-panel.js`), so the advertised version always matches the running code.

### The remaining gap this PR closes

The issue's unfulfilled ask: *"return the detected MCP + panel versions in the error."* The verdict quoted only the panel's advertised version (`(detected 0.6.8)`), so a stale-version report couldn't show which orchestrator build (and thus which minimum table) produced the verdict.

## Fix

`buildPanelTooOldError` — the single funnel for the reactive rewrite, the #236 learned gate, and the #392 proactive gate — now emits `(detected panel X, mcp Y)`, consistent with the stamp-fence errors' existing `detected panel X` phrasing. The MCP version is resolved once per process via `detectInstallMode().currentVersion` (it cannot change without a restart); tests can inject it explicitly. When the panel version is unknown the MCP version still appears (`(detected mcp Y)`).

## Tests

- Unit: injected MCP version appears alongside the panel version; self-resolved running-server version when not supplied.
- E2E: the proactive-gate verdict quotes both detected versions.
- E2E: reconnect/hello at a **newer** build updates the reported version — `graph_query` dispatches again, a still-unsupported command quotes the new build, and nothing ever quotes the stale pre-reconnect one.

`npx tsc --noEmit` clean; full suite **4003 passed / 2 skipped (238 files)** — baseline was ~3999/2, +4 new tests.

Closes artokun/comfyui-mcp-panel#422