### PR TITLE
fix(#709): capability refusal guidance — typed refusal, full tab id, hard-refresh recovery

### DIFF
--- a/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
+++ b/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
@@ -429,6 +429,46 @@ describe("#442 defect 4: a MUTATING panel command names the rebind on a no-route
     expect(text).not.toMatch(/Retry in a moment/);
   });
 
+  it("#709: a NO-IDENTITY refusal (not capability-marked) keeps the retry/rebind wrapper", async () => {
+    // Same gate, THIRD branch: the panel enforces the stamp but the workflow has no
+    // trusted identity to fence against — a binding/identity problem where retrying
+    // or rebinding onto the live tab genuinely re-resolves the identity. The error
+    // is dispatched:false but deliberately NOT capability-marked, so the generic
+    // recovery wrapper MUST still fire.
+    const identityCause = markDispatched(
+      new Error(
+        `"graph_set_widget" cannot be safely targeted to the active workflow: this workflow ` +
+          `has no trusted identity for the panel to fence the command against. Read-only graph ` +
+          `commands (graph_outline, graph_query, graph_get_state) still work.`,
+      ),
+      false,
+    );
+    const live = new Set(["wf:workflows/x.json"]);
+    const sent: Array<{ cmd: Record<string, unknown> }> = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+        if (opts?.tabId && !live.has(opts.tabId)) throw new Error("unexpected route");
+        throw identityCause;
+      },
+      push: () => 1,
+      canReach: (id: string) => live.has(id),
+      tabs: () => [...live].map((t) => ({ tab_id: t, title: t, connected_at: 0 })),
+      resolveActiveTabId: () => [...live][0],
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "wf:workflows/x.json", new WorkflowTargetStore());
+
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 7, widget: "steps", value: 20 },
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    expect(sent.length).toBe(0);
+    const text = textOf(res);
+    expect(text).toMatch(/no trusted identity/); // the cause is preserved…
+    expect(text).toContain('rebind with panel_set_workflow_target({mode:"current"})'); // …AND the wrapper fires
+    expect(text).toMatch(/Nothing was applied/i);
+  });
+
   it("does NOT mis-wrap a POST-dispatch executor failure that merely quotes 'no connected tab' as 'nothing applied'", async () => {    // A LIVE tab that ACCEPTS the command (it IS dispatched, pushed to `sent`) but whose
     // executor rejects with a message quoting the routing phrase. Because the typed flag is
     // absent (dispatchOutcomeOf === undefined, not false), the wrapper must NOT fire — the

--- a/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
+++ b/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
@@ -27,7 +27,7 @@ const { buildPanelToolDefs, makePanelToolCtx, __panelToolsTestHooks, __openWorkf
   await import("../../orchestrator/panel-tools.js");
 import { getBootLocalComfyUIBaseUrl } from "../../config.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
-import { markDispatched } from "../../services/ui-bridge.js";
+import { markCapabilityRefusal, markDispatched } from "../../services/ui-bridge.js";
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
 
 const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
@@ -382,8 +382,54 @@ describe("#442 defect 4: a MUTATING panel command names the rebind on a no-route
     expect(sent.length).toBe(0); // the mutating write was NEVER dispatched (no double-apply)
   });
 
-  it("does NOT mis-wrap a POST-dispatch executor failure that merely quotes 'no connected tab' as 'nothing applied'", async () => {
-    // A LIVE tab that ACCEPTS the command (it IS dispatched, pushed to `sent`) but whose
+  it("#709: a CAPABILITY refusal surfaces its own guidance verbatim — no futile retry/rebind suffix", async () => {
+    // The connected tab runs a stale panel bundle (no workflow-stamp enforcement).
+    // The bridge refuses pre-dispatch with the SAME typed dispatched:false flag as a
+    // transient no-route — but the generic "retry / rebind with
+    // panel_set_workflow_target({mode:"current"})" wrapper can never clear a missing
+    // capability, contradicts the refusal's own text, and sent agents into a loop.
+    const capabilityCause = markCapabilityRefusal(
+      markDispatched(
+        new Error(
+          `"graph_set_widget" cannot be safely targeted to the active workflow: panel tab ` +
+            `wf:workflows/x.json does not enforce per-command workflow targeting (detected panel ` +
+            `0.11.20; this MCP requires panel 0.11.35+). Run install_panel(action:'update'), ` +
+            `restart ComfyUI, then hard-refresh the ComfyUI browser tab (Ctrl+Shift+R); rebinding ` +
+            `cannot add the missing capability. Read-only graph commands still work.`,
+        ),
+        false,
+      ),
+    );
+    const live = new Set(["wf:workflows/x.json"]);
+    const sent: Array<{ cmd: Record<string, unknown> }> = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+        if (opts?.tabId && !live.has(opts.tabId)) throw new Error("unexpected route");
+        throw capabilityCause; // the gate's pre-dispatch refusal
+      },
+      push: () => 1,
+      canReach: (id: string) => live.has(id),
+      tabs: () => [...live].map((t) => ({ tab_id: t, title: t, connected_at: 0 })),
+      resolveActiveTabId: () => [...live][0],
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "wf:workflows/x.json", new WorkflowTargetStore());
+
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 7, widget: "steps", value: 20 },
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    expect(sent.length).toBe(0); // pre-dispatch: nothing was sent
+    const text = textOf(res);
+    // The refusal's own, correct recovery is surfaced…
+    expect(text).toMatch(/hard-refresh the ComfyUI browser tab/);
+    expect(text).toMatch(/rebinding cannot add the missing capability/);
+    // …and the contradictory generic advice is NOT appended.
+    expect(text).not.toContain('rebind with panel_set_workflow_target({mode:"current"})');
+    expect(text).not.toMatch(/Retry in a moment/);
+  });
+
+  it("does NOT mis-wrap a POST-dispatch executor failure that merely quotes 'no connected tab' as 'nothing applied'", async () => {    // A LIVE tab that ACCEPTS the command (it IS dispatched, pushed to `sent`) but whose
     // executor rejects with a message quoting the routing phrase. Because the typed flag is
     // absent (dispatchOutcomeOf === undefined, not false), the wrapper must NOT fire — the
     // raw executor error surfaces and we never falsely claim nothing applied.

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -10,6 +10,7 @@ import {
   minPanelVersionForCmd,
   markDispatched,
   dispatchOutcomeOf,
+  isCapabilityRefusal,
   defaultBridgeTimeoutMs,
   BRIDGE_DEFAULT_TIMEOUT_MS,
   BRIDGE_READ_DEFAULT_TIMEOUT_MS,
@@ -1732,6 +1733,46 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     await expect(
       bridge.send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "old-skew" }),
     ).rejects.toThrow(/detected panel 0\.11\.0.*requires panel 0\.11\.35\+.*install_panel\(action:'update'\).*restart ComfyUI.*rebinding cannot/i);
+    old.close();
+  });
+
+  it("#709: the capability refusal carries the typed marker, the FULL tab id, and the hard-refresh recovery", async () => {
+    // The stale-bundle recurrence: on-disk panel current, browser tab still running a
+    // cached pre-#570 bundle. The refusal must (a) be typed so the tool layer never
+    // appends the futile retry/rebind suffix, (b) name the full routing id — the old
+    // slice(0,8) rendering ("wf:workf") was misread as a corrupted identity — and
+    // (c) lead with the hard-refresh recovery a bare restart cannot achieve.
+    const old = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      old.on("open", () => {
+        old.send(
+          JSON.stringify({
+            type: "hello",
+            tab_id: "wf:workflows/portrait.json",
+            title: "portrait",
+            panel_version: "0.11.20",
+          }),
+        );
+        res();
+      });
+      old.on("error", rej);
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:workflows/portrait.json")).toBe(true));
+    const caught = await bridge
+      .send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "wf:workflows/portrait.json" })
+      .then(
+        () => null,
+        (err) => err,
+      );
+    expect(caught).toBeInstanceOf(Error);
+    expect(isCapabilityRefusal(caught)).toBe(true); // typed — the tool layer keys on this
+    expect(dispatchOutcomeOf(caught)).toBe(false); // still categorically pre-dispatch
+    expect((caught as Error).message).toContain("panel tab wf:workflows/portrait.json"); // full id, not "wf:workf"
+    expect((caught as Error).message).toMatch(/hard-refresh the ComfyUI browser tab/);
+    expect((caught as Error).message).toMatch(/cached old panel JS/);
+    // Non-capability errors are NOT mismarked.
+    expect(isCapabilityRefusal(new Error("no connected tab"))).toBe(false);
+    expect(isCapabilityRefusal(undefined)).toBe(false);
     old.close();
   });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1776,6 +1776,30 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     old.close();
   });
 
+  it("#709: the NO-IDENTITY refusal is NOT capability-marked — retry/rebind stays the right guidance", async () => {
+    // An ENFORCING panel (both stamps advertised) whose workflow identity the
+    // orchestrator cannot resolve: a binding/identity problem, NOT a missing panel
+    // capability. The refusal must NOT carry the capability marker — marking it
+    // would suppress the retry/rebind wrapper, which IS the right recovery here
+    // (a rebind re-resolves the identity; nothing needs a panel update).
+    const modern = await connectPanel("tmp:enforcing-unresolved", "M");
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tmp:enforcing-unresolved")).toBe(true),
+    );
+    bridge.setTabWorkflowUuidResolver(() => undefined); // no trusted identity to stamp
+    const caught = await bridge
+      .send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "tmp:enforcing-unresolved" })
+      .then(
+        () => null,
+        (err) => err,
+      );
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/no trusted identity/);
+    expect(isCapabilityRefusal(caught)).toBe(false); // NOT a capability refusal
+    expect(dispatchOutcomeOf(caught)).toBe(false); // still categorically pre-dispatch
+    modern.close();
+  });
+
   it("FAILS CLOSED when a panel has only the pre-await stamp fence (#718)", async () => {
     const old = new WebSocket(`ws://127.0.0.1:${port}`);
     await new Promise<void>((res, rej) => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -37,6 +37,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UiBridge } from "../services/ui-bridge.js";
 import {
   dispatchOutcomeOf,
+  isCapabilityRefusal,
   isPanelCmdUnsupportedError,
   isReplyTimeoutTagged,
   requiresWorkflowStampEnforcement,
@@ -2737,6 +2738,17 @@ export function makePanelToolCtx(
       // preserving the raw cause. Keying on the TYPED flag (not error text) means a
       // POST-dispatch executor ok:false reply that merely quotes "no connected tab" is
       // never mis-wrapped as "nothing applied".
+      // #709: a CAPABILITY refusal (the tab's panel does not enforce the workflow-stamp
+      // contract) shares the dispatched:false flag with transient routing failures, but
+      // the generic recovery below — "retry in a moment / rebind with
+      // panel_set_workflow_target({mode:"current"})" — can NEVER clear it (the refusal's
+      // own text says so: rebinding cannot add the missing capability). Appending it
+      // sent agents into a futile retry/rebind loop that contradicted the embedded
+      // guidance. Key on the TYPED marker and surface the cause verbatim instead; it
+      // already names the real recovery (update + restart + browser hard-refresh).
+      if (isCapabilityRefusal(err)) {
+        return fail(err instanceof Error ? err.message : String(err));
+      }
       if (dispatchOutcomeOf(err) === false) {
         const name = typeof cmd.cmd === "string" ? cmd.cmd : "panel command";
         // Neutral wording: a dispatched:false flag proves only that the command was NOT

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2043,6 +2043,13 @@ export class UiBridge {
       const stamp = this.resolveTabWorkflowUuid?.(opts.tabId ?? conn.tabId);
       const hasTrustedStamp = typeof stamp === "string" && stamp.length > 0;
       if (!conn.enforcesWorkflowStamp || !conn.enforcesWorkflowStampAtWrite || !hasTrustedStamp) {
+        // The two CAPABILITY branches (missing panel fences) are typed so the tool
+        // layer drops its futile retry/rebind suffix (#709). The NO-IDENTITY branch
+        // is deliberately NOT capability-marked: an unresolvable workflow identity
+        // is a binding problem a retry/rebind genuinely fixes, so the generic
+        // wrapper must keep firing for it (codex gate — the marker must never
+        // false-positive a non-capability refusal).
+        const capabilityMissing = !conn.enforcesWorkflowStamp || !conn.enforcesWorkflowStampAtWrite;
         // #709 — user-facing, so name the FULL tab id: the log-style slice(0,8)
         // rendering ("wf:workf") was misread as a corrupted routing identity and
         // sent the diagnosis down a wrong path. And lead with the recovery that
@@ -2064,17 +2071,14 @@ export class UiBridge {
               `boundary after asynchronous work (detected panel ${conn.panelVersion ?? "version unknown"}; this MCP ` +
                 `requires panel ${requiredPanelVersion()}+). ${recovery}`
           : `this workflow has no trusted identity for the panel to fence the command against`;
-        return Promise.reject(
-          markCapabilityRefusal(
-            markDispatched(
-              new Error(
-                `"${cmd.cmd}" cannot be safely targeted to the active workflow: ${why}. Read-only graph ` +
-                  `commands (graph_outline, graph_query, graph_get_state) still work.`,
-              ),
-              false,
-            ),
+        const refusal = markDispatched(
+          new Error(
+            `"${cmd.cmd}" cannot be safely targeted to the active workflow: ${why}. Read-only graph ` +
+              `commands (graph_outline, graph_query, graph_get_state) still work.`,
           ),
+          false,
         );
+        return Promise.reject(capabilityMissing ? markCapabilityRefusal(refusal) : refusal);
       }
     }
     if (conn.sock.readyState !== WebSocket.OPEN) {

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -603,6 +603,31 @@ export function dispatchOutcomeOf(err: unknown): boolean | undefined {
  *  buffer. */
 const REPLY_TIMEOUT = Symbol.for("comfyui-mcp.bridge.reply-timeout");
 
+/** Marks an error as a CAPABILITY refusal: the connected panel does not enforce the
+ *  workflow-stamp contract a mutation needs (#570/#718), so the command was refused
+ *  pre-dispatch. Unlike a transient routing failure, NEITHER a retry nor a rebind can
+ *  add the missing capability — only a panel update + browser hard-refresh can — so
+ *  callers must key their recovery wording on THIS typed marker (#709) instead of
+ *  appending the generic "retry / rebind" suffix, which sends the agent into a futile
+ *  loop that contradicts the refusal's own guidance. */
+const CAPABILITY_REFUSAL = Symbol.for("comfyui-mcp.bridge.capability-refusal");
+
+/** Tag an error as a capability refusal and return it (for throw/reject). */
+export function markCapabilityRefusal<E extends Error>(err: E): E {
+  Object.defineProperty(err, CAPABILITY_REFUSAL, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+  return err;
+}
+
+/** True when `err` carries the typed capability-refusal marker set by the bridge. */
+export function isCapabilityRefusal(err: unknown): boolean {
+  if (err == null || (typeof err !== "object" && typeof err !== "function")) return false;
+  return (err as Record<symbol, unknown>)[CAPABILITY_REFUSAL] === true;
+}
+
 /** Tag an error as a reply-timeout and return it (for throw/reject). */
 export function markReplyTimeout<E extends Error>(err: E): E {
   Object.defineProperty(err, REPLY_TIMEOUT, {
@@ -2018,24 +2043,36 @@ export class UiBridge {
       const stamp = this.resolveTabWorkflowUuid?.(opts.tabId ?? conn.tabId);
       const hasTrustedStamp = typeof stamp === "string" && stamp.length > 0;
       if (!conn.enforcesWorkflowStamp || !conn.enforcesWorkflowStampAtWrite || !hasTrustedStamp) {
+        // #709 — user-facing, so name the FULL tab id: the log-style slice(0,8)
+        // rendering ("wf:workf") was misread as a corrupted routing identity and
+        // sent the diagnosis down a wrong path. And lead with the recovery that
+        // actually clears the dominant cause: the on-disk pack can be current
+        // while the open browser tab keeps running a CACHED older bundle (a
+        // restart reconnects the tab but never re-downloads the extension JS),
+        // so the capability the hello advertises lags the version on disk.
+        const recovery =
+          `Run install_panel(action:'update'), restart ComfyUI, then hard-refresh the ` +
+          `ComfyUI browser tab (Ctrl+Shift+R) so it loads the updated bundle — a restart ` +
+          `alone leaves the tab running its cached old panel JS; rebinding cannot add the ` +
+          `missing capability`;
         const why = !conn.enforcesWorkflowStamp
-          ? `panel tab ${conn.tabId.slice(0, 8)} does not enforce per-command workflow targeting ` +
+          ? `panel tab ${conn.tabId} does not enforce per-command workflow targeting ` +
             `(detected panel ${conn.panelVersion ?? "version unknown"}; this MCP requires panel ` +
-              `${requiredPanelVersion()}+). Run install_panel(action:'update') and restart ComfyUI; ` +
-              `rebinding cannot add the missing capability`
+              `${requiredPanelVersion()}+). ${recovery}`
           : !conn.enforcesWorkflowStampAtWrite
-            ? `panel tab ${conn.tabId.slice(0, 8)} does not recheck workflow targeting at the graph write ` +
+            ? `panel tab ${conn.tabId} does not recheck workflow targeting at the graph write ` +
               `boundary after asynchronous work (detected panel ${conn.panelVersion ?? "version unknown"}; this MCP ` +
-                `requires panel ${requiredPanelVersion()}+). Run install_panel(action:'update'), restart ComfyUI, ` +
-                `then hard-refresh the ComfyUI browser tab; rebinding cannot add the missing capability`
+                `requires panel ${requiredPanelVersion()}+). ${recovery}`
           : `this workflow has no trusted identity for the panel to fence the command against`;
         return Promise.reject(
-          markDispatched(
-            new Error(
-              `"${cmd.cmd}" cannot be safely targeted to the active workflow: ${why}. Read-only graph ` +
-                `commands (graph_outline, graph_query, graph_get_state) still work.`,
+          markCapabilityRefusal(
+            markDispatched(
+              new Error(
+                `"${cmd.cmd}" cannot be safely targeted to the active workflow: ${why}. Read-only graph ` +
+                  `commands (graph_outline, graph_query, graph_get_state) still work.`,
+              ),
+              false,
             ),
-            false,
           ),
         );
       }


### PR DESCRIPTION
## Summary

Fixes artokun/comfyui-mcp#709 (reopened recurrence on 0.49.2 + panel 0.11.37)

- The `#570 P0c` workflow-stamp gate's refusal is now **typed** (`markCapabilityRefusal` / `isCapabilityRefusal`, mirroring the `DISPATCHED` / `REPLY_TIMEOUT` markers), so the panel-tools `dispatched:false` wrapper no longer appends the generic "Retry in a moment, or rebind with `panel_set_workflow_target({mode:"current"})`" suffix to a refusal that retry and rebind can never clear — the wrapper was contradicting the refusal's own text ("rebinding cannot add the missing capability") and sending agents into the exact futile loop the issue reports.
- Both gate branches now lead with the recovery that clears the dominant cause: the on-disk pack can be current while the open browser tab keeps running a **cached older bundle** (a restart reconnects the tab but never re-downloads the extension JS — the #749-era stale-bundle shape). Update + restart + **hard-refresh (Ctrl+Shift+R)** is now stated in the dispatch-time branch too, with the cache-lag explanation.
- The error names the **full tab id** (`wf:workflows/portrait.json`) instead of the log-style `slice(0, 8)` ("wf:workf"), which the reporter misread as a corrupted routing identity.

## Root-cause findings (what was NOT broken)

- **Truncated tab id**: cosmetic only — `conn.tabId.slice(0, 8)` in the user-facing error text, not a routing-key truncation. Capability lookup keys on the full id.
- **Reconnect/re-hello flag loss**: not present — `enforcesWorkflowStamp` / `enforcesWorkflowStampAtWrite` are re-read from every hello with strict `=== true`, never inherited (`ui-bridge.ts` hello handler), and the panel's `buildHelloPayload` sets both unconditionally on every hello path.
- The recurrence is the stale-loaded-bundle condition (on-disk 0.11.37, browser running a cached pre-0.11.30 bundle) — the capability report was **honest**; only the guidance was wrong. The concurrent empty-workflow desync noted in the report is the panel-side #565 shape, already fixed on panel main by #570.

## Invariants preserved

- The `#570 P0c` fail-closed gate is untouched: no stamp enforcement ⇒ mutations refused pre-dispatch, reads and path-targeted ops unaffected. `dispatchOutcomeOf === false` semantics preserved (the refusal is still categorically pre-dispatch).
- `#349` wrong-canvas fence and `#559` scope guarantees unaffected (no panel-protocol change; the panel still self-asserts the capability in its hello).

## Validation

- `src/__tests__/services/ui-bridge.test.ts` +1 (typed marker, full tab id, hard-refresh recovery), `src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts` +1 (no retry/rebind suffix on a capability refusal)
- `npx tsc --noEmit` clean; targeted vitest 167 pass; full `npx vitest run`: **4005 passed, 2 skipped** (238 files)