### PR TITLE
release: 0.49.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.49.3] - 2026-08-03
+
+### MCP
+
+#### Fixed
+- panel_ask and other blocking card tools no longer die at 60s on ollama-family backends — the internal panel MCP client now uses a 315s timeout, above the longest card budget (#325) (#754)
+- list_assets reconciles from ComfyUI history, so panel-dispatched renders and earlier sessions surface — every registered record requires affirmative success evidence (on both the watched and reconcile paths), a non-empty filename, a real output, and a truthfully-sourced completion time (#751) (#753)
+- the too-old panel verdict now quotes both detected panel and MCP versions (#422) (#755)
+
+
 ## [0.49.2] - 2026-08-02
 
 ### MCP

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.49.2",
+  "version": "0.49.3",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + hand-written changelog for 0.49.3: #754 (panel_ask 60s timeout), #753 (list_assets history reconcile, 5 codex rounds), #755 (both-versions verdict). All codex-gated SHIP + CI-green.