### PR TITLE
fix(#756): local ComfyUI no longer misclassified as remote after a restart

### DIFF
--- a/src/__tests__/services/hello-retarget.test.ts
+++ b/src/__tests__/services/hello-retarget.test.ts
@@ -2,12 +2,17 @@ import { describe, expect, it, vi } from "vitest";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { judgeHelloRetarget, canonComfyuiTargetUrl } from "../../services/hello-retarget.js";
+import { judgeHelloRetarget, canonComfyuiTargetUrl, comfyuiOriginKey } from "../../services/hello-retarget.js";
 
 // #756 (local ComfyUI misclassified as remote after a restart) + the #303
-// zombie-tab guard the veto exists for. The /system_stats probe is injected,
-// so "unreachable" is simulated by a probe that resolves false — no real I/O,
-// no timing dependence.
+// zombie-tab guard + the codex-gate trust model: hello.comfyui_url is
+// page-JS-WRITABLE (spoofable by a stale/confused tab), so a retarget is
+// trusted ONLY when the tab's server-observed WebSocket handshake Origin —
+// which the browser sets and page JS cannot forge — corroborates the claim.
+// Untrusted claims are probed and may apply on EVIDENCE (a live instance),
+// but never on trust alone: no no-probe shortcut and no #756 both-dead
+// recovery. The /system_stats probe is injected, so "unreachable" is a probe
+// resolving false — no real I/O, no timing dependence.
 
 /** A probe that answers true only for the listed reachable base URLs. */
 function probeFor(...reachableBases: string[]) {
@@ -15,23 +20,29 @@ function probeFor(...reachableBases: string[]) {
   return vi.fn(async (systemStatsUrl: string) => reachable.has(systemStatsUrl));
 }
 
-describe("judgeHelloRetarget (#756 restart window)", () => {
+const LOCAL = "http://127.0.0.1:8188";
+const POD = "https://abc123-3000.proxy.runpod.net";
+
+describe("judgeHelloRetarget — origin-trusted claims (#756 restart window)", () => {
   it("APPLIES a local hello that races the ComfyUI restart window when the current (stale remote) target is dead too", async () => {
     // The orchestrator is pinned to a stale RunPod target; the local panel
     // reconnects while the local ComfyUI is still booting — BOTH probes read
-    // dead. Pre-#756 the veto dropped this hello and pinned remote forever.
+    // dead, but the tab's handshake origin PROVES it fronts the local
+    // instance it claims. Pre-#756 the veto dropped this hello and pinned
+    // remote forever.
     const probe = probeFor(); // nothing answers — the restart window
     const verdict = await judgeHelloRetarget({
-      helloUrl: "http://127.0.0.1:8188",
-      currentUrl: "https://abc123-3000.proxy.runpod.net",
+      helloUrl: LOCAL,
+      currentUrl: POD,
+      observedOrigin: LOCAL,
       probe,
     });
     expect(verdict.apply).toBe(true);
     expect(verdict.reason).toBe("current-also-unreachable");
-    expect(verdict.base).toBe("http://127.0.0.1:8188");
-    // Both sides were probed before deciding.
-    expect(probe).toHaveBeenCalledWith("http://127.0.0.1:8188/system_stats");
-    expect(probe).toHaveBeenCalledWith("https://abc123-3000.proxy.runpod.net/system_stats");
+    expect(verdict.trusted).toBe(true);
+    expect(verdict.base).toBe(LOCAL);
+    expect(probe).toHaveBeenCalledWith(`${LOCAL}/system_stats`);
+    expect(probe).toHaveBeenCalledWith(`${POD}/system_stats`);
   });
 
   it("restart → reconnect → local ref resolution + Manager probing recover (composed with the real config)", async () => {
@@ -50,14 +61,15 @@ describe("judgeHelloRetarget (#756 restart window)", () => {
       process.env.COMFYUI_HOST = "";
       process.env.COMFYUI_PORT = "8188";
       process.env.COMFYUI_MCP_FORCE_REMOTE = "";
-      process.env.COMFYUI_URL = "https://abc123-3000.proxy.runpod.net";
+      process.env.COMFYUI_URL = POD;
       const mod = await import("../../config.js");
       expect(mod.isRemoteMode()).toBe(true); // genuinely-remote config classifies remote
 
       const probe = probeFor(); // restart window: local ComfyUI still booting
       const verdict = await judgeHelloRetarget({
-        helloUrl: "http://127.0.0.1:8188",
+        helloUrl: LOCAL,
         currentUrl: mod.getComfyUIBaseUrl(),
+        observedOrigin: LOCAL,
         probe,
       });
       expect(verdict.apply).toBe(true);
@@ -70,30 +82,35 @@ describe("judgeHelloRetarget (#756 restart window)", () => {
       expect(mod.isLocalMode()).toBe(true);
       // …and Manager's queue probing (managerBaseUrl() = getComfyUIBaseUrl())
       // targets the reconnected local server, not the dead remote.
-      expect(mod.getComfyUIBaseUrl()).toBe("http://127.0.0.1:8188");
+      expect(mod.getComfyUIBaseUrl()).toBe(LOCAL);
     } finally {
       process.env = OLD_ENV;
     }
   });
 
   it("VETOES a dead hello while the current target is healthy (#303 zombie-tab guard preserved)", async () => {
-    const probe = probeFor("http://127.0.0.1:8188"); // current answers, corpse doesn't
+    // The zombie tab's observed origin IS the corpse it fronts — trust does
+    // not save it: its instance is dead and the current target is healthy.
+    const probe = probeFor(LOCAL); // current answers, corpse doesn't
     const verdict = await judgeHelloRetarget({
       helloUrl: "http://127.0.0.1:8189",
-      currentUrl: "http://127.0.0.1:8188",
+      currentUrl: LOCAL,
+      observedOrigin: "http://127.0.0.1:8189",
       probe,
     });
     expect(verdict.apply).toBe(false);
     expect(verdict.reason).toBe("vetoed-unreachable");
+    expect(verdict.trusted).toBe(true);
     expect(probe).toHaveBeenCalledWith("http://127.0.0.1:8189/system_stats");
-    expect(probe).toHaveBeenCalledWith("http://127.0.0.1:8188/system_stats");
+    expect(probe).toHaveBeenCalledWith(`${LOCAL}/system_stats`);
   });
 
   it("a transiently-unreachable REMOTE hello does not flip a healthy LOCAL target (#303, remote direction)", async () => {
-    const probe = probeFor("http://127.0.0.1:8188");
+    const probe = probeFor(LOCAL);
     const verdict = await judgeHelloRetarget({
       helloUrl: "http://comfy.example-vps.com:8188",
-      currentUrl: "http://127.0.0.1:8188",
+      currentUrl: LOCAL,
+      observedOrigin: "http://comfy.example-vps.com:8188",
       probe,
     });
     expect(verdict.apply).toBe(false);
@@ -103,8 +120,9 @@ describe("judgeHelloRetarget (#756 restart window)", () => {
   it("a transiently-unreachable LOCAL hello does not flip a healthy REMOTE target (genuinely-remote stays remote)", async () => {
     const probe = probeFor("http://192.168.1.50:8188");
     const verdict = await judgeHelloRetarget({
-      helloUrl: "http://127.0.0.1:8188",
+      helloUrl: LOCAL,
       currentUrl: "http://192.168.1.50:8188",
+      observedOrigin: LOCAL,
       probe,
     });
     expect(verdict.apply).toBe(false);
@@ -115,45 +133,180 @@ describe("judgeHelloRetarget (#756 restart window)", () => {
     const probe = probeFor("http://192.168.1.50:8188");
     const verdict = await judgeHelloRetarget({
       helloUrl: "http://192.168.1.50:8188",
-      currentUrl: "http://127.0.0.1:8188",
+      currentUrl: LOCAL,
+      observedOrigin: "http://192.168.1.50:8188",
       probe,
     });
     expect(verdict.apply).toBe(true);
     expect(verdict.reason).toBe("healthy");
+    expect(verdict.trusted).toBe(true);
     expect(probe).toHaveBeenCalledTimes(1);
     expect(probe).toHaveBeenCalledWith("http://192.168.1.50:8188/system_stats");
   });
 
-  it("APPLIES a RunPod proxy hello WITHOUT probing (booting pods answer late — #303)", async () => {
+  it("APPLIES a RunPod proxy hello WITHOUT probing when the tab provably fronts the pod (#303)", async () => {
     const probe = probeFor();
     const verdict = await judgeHelloRetarget({
-      helloUrl: "https://abc123-8188.proxy.runpod.net",
-      currentUrl: "http://127.0.0.1:8188",
+      helloUrl: POD,
+      currentUrl: LOCAL,
+      observedOrigin: POD,
       probe,
     });
     expect(verdict.apply).toBe(true);
     expect(verdict.reason).toBe("runpod-proxy");
+    expect(verdict.trusted).toBe(true);
     expect(probe).not.toHaveBeenCalled();
   });
 
   it("a same-target hello is a no-op APPLY and is NEVER probed (no restart-window stall)", async () => {
     const probe = probeFor();
     const verdict = await judgeHelloRetarget({
-      helloUrl: "http://127.0.0.1:8188/",
-      currentUrl: "http://127.0.0.1:8188",
+      helloUrl: `${LOCAL}/`,
+      currentUrl: LOCAL,
+      observedOrigin: LOCAL,
       probe,
     });
     expect(verdict.apply).toBe(true);
     expect(verdict.reason).toBe("same-target");
+    expect(verdict.trusted).toBe(true);
     expect(probe).not.toHaveBeenCalled();
   });
 
   it("rejects a non-string hello URL without probing", async () => {
     const probe = probeFor();
-    const verdict = await judgeHelloRetarget({ helloUrl: undefined, currentUrl: "http://127.0.0.1:8188", probe });
+    const verdict = await judgeHelloRetarget({
+      helloUrl: undefined,
+      currentUrl: LOCAL,
+      observedOrigin: LOCAL,
+      probe,
+    });
     expect(verdict.apply).toBe(false);
     expect(verdict.reason).toBe("not-a-url");
     expect(probe).not.toHaveBeenCalled();
+  });
+});
+
+describe("judgeHelloRetarget — UNTRUSTED claims (spoofable hello.comfyui_url, codex gate)", () => {
+  it("claimed != observed origin and BOTH probes dead → REFUSES (never retargets on trust alone)", async () => {
+    // A stale/confused tab CLAIMS the local instance while its handshake
+    // origin says it fronts something else entirely. Both instances read
+    // dead — the #756 recovery must NOT fire on an uncorroborated claim.
+    const probe = probeFor();
+    const verdict = await judgeHelloRetarget({
+      helloUrl: LOCAL,
+      currentUrl: POD,
+      observedOrigin: "http://192.168.1.99:8188",
+      probe,
+    });
+    expect(verdict.apply).toBe(false);
+    expect(verdict.reason).toBe("vetoed-untrusted");
+    expect(verdict.trusted).toBe(false);
+    // The claimed URL was probed (evidence sought); the current target was
+    // NOT — the both-dead recovery is reserved for trusted claims.
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(probe).toHaveBeenCalledWith(`${LOCAL}/system_stats`);
+  });
+
+  it("claimed != observed origin but the claimed instance is HEALTHY → applies on evidence", async () => {
+    const probe = probeFor(LOCAL);
+    const verdict = await judgeHelloRetarget({
+      helloUrl: LOCAL,
+      currentUrl: POD,
+      observedOrigin: "http://192.168.1.99:8188",
+      probe,
+    });
+    expect(verdict.apply).toBe(true);
+    expect(verdict.reason).toBe("healthy-untrusted");
+    expect(verdict.trusted).toBe(false);
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it("an ABSENT observed origin (relay/headless client) is untrusted: dead claim refuses, live claim applies on evidence", async () => {
+    const dead = probeFor();
+    const refused = await judgeHelloRetarget({
+      helloUrl: LOCAL,
+      currentUrl: POD,
+      observedOrigin: undefined,
+      probe: dead,
+    });
+    expect(refused.apply).toBe(false);
+    expect(refused.reason).toBe("vetoed-untrusted");
+    expect(refused.trusted).toBe(false);
+
+    const live = probeFor(LOCAL);
+    const applied = await judgeHelloRetarget({
+      helloUrl: LOCAL,
+      currentUrl: POD,
+      observedOrigin: undefined,
+      probe: live,
+    });
+    expect(applied.apply).toBe(true);
+    expect(applied.reason).toBe("healthy-untrusted");
+  });
+
+  it("a RunPod claim whose origin does NOT corroborate it is probed like any other claim", async () => {
+    // The unprobed proxy skip is trust-gated: a tab fronting a LOCAL instance
+    // cannot name a dead pod and have it applied sight-unseen.
+    const probe = probeFor();
+    const verdict = await judgeHelloRetarget({
+      helloUrl: POD,
+      currentUrl: LOCAL,
+      observedOrigin: LOCAL,
+      probe,
+    });
+    expect(verdict.apply).toBe(false);
+    expect(verdict.reason).toBe("vetoed-untrusted");
+    expect(probe).toHaveBeenCalledWith(`${POD}/system_stats`);
+  });
+
+  it("the same-target no-probe shortcut compares the OBSERVED origin, not the claim", async () => {
+    // Claimed URL == current target, but the tab's origin says it fronts a
+    // DIFFERENT instance: the no-probe shortcut must NOT fire — the claim is
+    // probed instead. (Applying would be a no-op either way; the point is the
+    // shortcut's trust key, which later paths rely on.)
+    const probe = probeFor(LOCAL); // claimed == current answers
+    const verdict = await judgeHelloRetarget({
+      helloUrl: LOCAL,
+      currentUrl: LOCAL,
+      observedOrigin: "http://127.0.0.1:8189",
+      probe,
+    });
+    expect(verdict.apply).toBe(true);
+    expect(verdict.reason).toBe("healthy-untrusted"); // NOT "same-target"
+    expect(verdict.trusted).toBe(false);
+    expect(probe).toHaveBeenCalledWith(`${LOCAL}/system_stats`);
+  });
+
+  it("a same-target claim with a mismatched origin and a DEAD instance refuses (fail closed)", async () => {
+    const probe = probeFor(); // restart window — nothing answers
+    const verdict = await judgeHelloRetarget({
+      helloUrl: LOCAL,
+      currentUrl: LOCAL,
+      observedOrigin: "http://127.0.0.1:8189",
+      probe,
+    });
+    expect(verdict.apply).toBe(false);
+    expect(verdict.reason).toBe("vetoed-untrusted");
+  });
+});
+
+describe("comfyuiOriginKey", () => {
+  it("canonicalizes loopback families (v4 → 127.0.0.1, v6 → ::1) with explicit default ports", () => {
+    expect(comfyuiOriginKey("http://0.0.0.0:8188/path")).toBe("http://127.0.0.1:8188");
+    expect(comfyuiOriginKey("http://[::1]:8188")).toBe("http://::1:8188");
+    expect(comfyuiOriginKey("https://example.com/")).toBe("https://example.com:443");
+    expect(comfyuiOriginKey("http://example.com")).toBe("http://example.com:80");
+  });
+
+  it("ignores the path (the WS handshake Origin carries none) and keeps families distinct", () => {
+    expect(comfyuiOriginKey("http://127.0.0.1:8188/comfy")).toBe(comfyuiOriginKey("http://127.0.0.1:8188"));
+    expect(comfyuiOriginKey("http://[::1]:8188")).not.toBe(comfyuiOriginKey("http://127.0.0.1:8188"));
+    // `localhost` is DNS-ambiguous — deliberately NOT family-canonicalized.
+    expect(comfyuiOriginKey("http://localhost:8188")).toBe("http://localhost:8188");
+  });
+
+  it("returns null for unparseable input", () => {
+    expect(comfyuiOriginKey("not a url")).toBeNull();
   });
 });
 

--- a/src/__tests__/services/hello-retarget.test.ts
+++ b/src/__tests__/services/hello-retarget.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { judgeHelloRetarget, canonComfyuiTargetUrl } from "../../services/hello-retarget.js";
+
+// #756 (local ComfyUI misclassified as remote after a restart) + the #303
+// zombie-tab guard the veto exists for. The /system_stats probe is injected,
+// so "unreachable" is simulated by a probe that resolves false — no real I/O,
+// no timing dependence.
+
+/** A probe that answers true only for the listed reachable base URLs. */
+function probeFor(...reachableBases: string[]) {
+  const reachable = new Set(reachableBases.map((b) => `${b.replace(/\/+$/, "")}/system_stats`));
+  return vi.fn(async (systemStatsUrl: string) => reachable.has(systemStatsUrl));
+}
+
+describe("judgeHelloRetarget (#756 restart window)", () => {
+  it("APPLIES a local hello that races the ComfyUI restart window when the current (stale remote) target is dead too", async () => {
+    // The orchestrator is pinned to a stale RunPod target; the local panel
+    // reconnects while the local ComfyUI is still booting — BOTH probes read
+    // dead. Pre-#756 the veto dropped this hello and pinned remote forever.
+    const probe = probeFor(); // nothing answers — the restart window
+    const verdict = await judgeHelloRetarget({
+      helloUrl: "http://127.0.0.1:8188",
+      currentUrl: "https://abc123-3000.proxy.runpod.net",
+      probe,
+    });
+    expect(verdict.apply).toBe(true);
+    expect(verdict.reason).toBe("current-also-unreachable");
+    expect(verdict.base).toBe("http://127.0.0.1:8188");
+    // Both sides were probed before deciding.
+    expect(probe).toHaveBeenCalledWith("http://127.0.0.1:8188/system_stats");
+    expect(probe).toHaveBeenCalledWith("https://abc123-3000.proxy.runpod.net/system_stats");
+  });
+
+  it("restart → reconnect → local ref resolution + Manager probing recover (composed with the real config)", async () => {
+    // Boot the shared config ON a stale pod target (remote), then apply the
+    // hello verdict through the same setComfyuiTarget the orchestrator calls:
+    // the classification must return to LOCAL and the base URL every tool
+    // (train refs, Manager v4 queue probing) derives must be the local one.
+    vi.resetModules();
+    const OLD_ENV = process.env;
+    process.env = { ...OLD_ENV };
+    try {
+      const fakeHome = mkdtempSync(join(tmpdir(), "hello-retarget-home-"));
+      process.env.COMFYUI_MCP_LOCAL_TARGET_FILE = join(fakeHome, "local-target.json");
+      process.env.COMFYUI_API_KEY = "";
+      process.env.COMFYUI_PATH = "";
+      process.env.COMFYUI_HOST = "";
+      process.env.COMFYUI_PORT = "8188";
+      process.env.COMFYUI_MCP_FORCE_REMOTE = "";
+      process.env.COMFYUI_URL = "https://abc123-3000.proxy.runpod.net";
+      const mod = await import("../../config.js");
+      expect(mod.isRemoteMode()).toBe(true); // genuinely-remote config classifies remote
+
+      const probe = probeFor(); // restart window: local ComfyUI still booting
+      const verdict = await judgeHelloRetarget({
+        helloUrl: "http://127.0.0.1:8188",
+        currentUrl: mod.getComfyUIBaseUrl(),
+        probe,
+      });
+      expect(verdict.apply).toBe(true);
+      expect(verdict.reason).toBe("current-also-unreachable");
+
+      expect(mod.setComfyuiTarget(verdict.base!)).toBe(true);
+      // Local classification holds after the retarget: train refs resolve
+      // locally (isRemoteMode() gates "ref items need a LOCAL ComfyUI")…
+      expect(mod.isRemoteMode()).toBe(false);
+      expect(mod.isLocalMode()).toBe(true);
+      // …and Manager's queue probing (managerBaseUrl() = getComfyUIBaseUrl())
+      // targets the reconnected local server, not the dead remote.
+      expect(mod.getComfyUIBaseUrl()).toBe("http://127.0.0.1:8188");
+    } finally {
+      process.env = OLD_ENV;
+    }
+  });
+
+  it("VETOES a dead hello while the current target is healthy (#303 zombie-tab guard preserved)", async () => {
+    const probe = probeFor("http://127.0.0.1:8188"); // current answers, corpse doesn't
+    const verdict = await judgeHelloRetarget({
+      helloUrl: "http://127.0.0.1:8189",
+      currentUrl: "http://127.0.0.1:8188",
+      probe,
+    });
+    expect(verdict.apply).toBe(false);
+    expect(verdict.reason).toBe("vetoed-unreachable");
+    expect(probe).toHaveBeenCalledWith("http://127.0.0.1:8189/system_stats");
+    expect(probe).toHaveBeenCalledWith("http://127.0.0.1:8188/system_stats");
+  });
+
+  it("a transiently-unreachable REMOTE hello does not flip a healthy LOCAL target (#303, remote direction)", async () => {
+    const probe = probeFor("http://127.0.0.1:8188");
+    const verdict = await judgeHelloRetarget({
+      helloUrl: "http://comfy.example-vps.com:8188",
+      currentUrl: "http://127.0.0.1:8188",
+      probe,
+    });
+    expect(verdict.apply).toBe(false);
+    expect(verdict.reason).toBe("vetoed-unreachable");
+  });
+
+  it("a transiently-unreachable LOCAL hello does not flip a healthy REMOTE target (genuinely-remote stays remote)", async () => {
+    const probe = probeFor("http://192.168.1.50:8188");
+    const verdict = await judgeHelloRetarget({
+      helloUrl: "http://127.0.0.1:8188",
+      currentUrl: "http://192.168.1.50:8188",
+      probe,
+    });
+    expect(verdict.apply).toBe(false);
+    expect(verdict.reason).toBe("vetoed-unreachable");
+  });
+
+  it("APPLIES a healthy hello without probing the current target", async () => {
+    const probe = probeFor("http://192.168.1.50:8188");
+    const verdict = await judgeHelloRetarget({
+      helloUrl: "http://192.168.1.50:8188",
+      currentUrl: "http://127.0.0.1:8188",
+      probe,
+    });
+    expect(verdict.apply).toBe(true);
+    expect(verdict.reason).toBe("healthy");
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(probe).toHaveBeenCalledWith("http://192.168.1.50:8188/system_stats");
+  });
+
+  it("APPLIES a RunPod proxy hello WITHOUT probing (booting pods answer late — #303)", async () => {
+    const probe = probeFor();
+    const verdict = await judgeHelloRetarget({
+      helloUrl: "https://abc123-8188.proxy.runpod.net",
+      currentUrl: "http://127.0.0.1:8188",
+      probe,
+    });
+    expect(verdict.apply).toBe(true);
+    expect(verdict.reason).toBe("runpod-proxy");
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("a same-target hello is a no-op APPLY and is NEVER probed (no restart-window stall)", async () => {
+    const probe = probeFor();
+    const verdict = await judgeHelloRetarget({
+      helloUrl: "http://127.0.0.1:8188/",
+      currentUrl: "http://127.0.0.1:8188",
+      probe,
+    });
+    expect(verdict.apply).toBe(true);
+    expect(verdict.reason).toBe("same-target");
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-string hello URL without probing", async () => {
+    const probe = probeFor();
+    const verdict = await judgeHelloRetarget({ helloUrl: undefined, currentUrl: "http://127.0.0.1:8188", probe });
+    expect(verdict.apply).toBe(false);
+    expect(verdict.reason).toBe("not-a-url");
+    expect(probe).not.toHaveBeenCalled();
+  });
+});
+
+describe("canonComfyuiTargetUrl", () => {
+  it("strips the scheme's default port only (http:443 and http:80 are NOT the same endpoint)", () => {
+    // Trailing slashes (including the root "/") are stripped by the canon.
+    expect(canonComfyuiTargetUrl("http://example.com:80/")).toBe("http://example.com");
+    expect(canonComfyuiTargetUrl("https://example.com:443/")).toBe("https://example.com");
+    expect(canonComfyuiTargetUrl("http://example.com:443/")).toBe("http://example.com:443");
+    expect(canonComfyuiTargetUrl("https://example.com:80/")).toBe("https://example.com:80");
+  });
+
+  it("strips trailing slashes and tolerates unparseable input", () => {
+    expect(canonComfyuiTargetUrl("http://127.0.0.1:8188///")).toBe("http://127.0.0.1:8188");
+    expect(canonComfyuiTargetUrl("not a url//")).toBe("not a url");
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2555,23 +2555,36 @@ export async function runPanelOrchestrator(): Promise<void> {
       // current target reads dead too — the ComfyUI restart window — the live
       // tab's hello is trusted instead, so the reconnect correction back to a
       // LOCAL target can never be vetoed into keeping a stale REMOTE one (#756).
-      // RunPod proxies still skip the probe (booting pods answer late — readiness
-      // is the connector's job).
+      // TRUST: hello.comfyui_url is page-JS-writable, so every apply path is
+      // gated on the SERVER-OBSERVED handshake origin (tabServerOrigin — the
+      // browser sets it, page JS can't forge it; #509's trusted source, codex
+      // gate). Only a corroborated claim gets the no-probe shortcuts and the
+      // both-dead recovery; an uncorroborated claim must earn its retarget by
+      // answering its probe, and a dead one fails closed. RunPod proxies still
+      // skip the probe for corroborated claims (booting pods answer late —
+      // readiness is the connector's job).
       const helloUrl = (event as { comfyui_url?: unknown }).comfyui_url;
       void (async () => {
         const verdict = await judgeHelloRetarget({
           helloUrl,
           currentUrl: comfyuiUrl,
+          observedOrigin: bridge.tabServerOrigin(panelTab),
           probe: (u) => probeOk(u, 3_000),
         });
         if (!verdict.apply) {
-          logger.warn(`[panel-orchestrator] ignoring hello retarget to unreachable ${verdict.base} (stale tab on a dead instance?) — keeping ${comfyuiUrl}`);
+          logger.warn(
+            verdict.reason === "vetoed-untrusted"
+              ? `[panel-orchestrator] refusing hello retarget to ${verdict.base}: the tab's handshake origin does not ` +
+                `corroborate the claimed URL and the claimed instance is unreachable — NOT retargeting on an ` +
+                `unverifiable claim (keeping ${comfyuiUrl})`
+              : `[panel-orchestrator] ignoring hello retarget to unreachable ${verdict.base} (stale tab on a dead instance?) — keeping ${comfyuiUrl}`,
+          );
           return;
         }
         if (verdict.reason === "current-also-unreachable") {
           logger.info(
             `[panel-orchestrator] hello target ${verdict.base} and current target ${comfyuiUrl} are BOTH unreachable ` +
-              `(ComfyUI restart window?) — trusting the live tab's hello rather than pinning a stale target (#756)`,
+              `(ComfyUI restart window?) — trusting the live tab's origin-corroborated hello rather than pinning a stale target (#756)`,
           );
         }
         applyComfyuiUrl(helloUrl);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -18,6 +18,7 @@ import { randomBytes } from "node:crypto";
 import readline from "node:readline";
 import { startUiBridge, isLoopbackBindHost, SESSION_EPOCH, type UiBridge } from "../services/ui-bridge.js";
 import { setupSecureBridge, resolveComfyuiPathForTarget, type SecureBridge } from "../services/secure-bridge.js";
+import { judgeHelloRetarget, canonComfyuiTargetUrl } from "../services/hello-retarget.js";
 import { startQuickTunnel } from "../services/tunnel.js";
 import { detectInstallMode } from "../services/self-update.js";
 import { performPanelSync } from "../services/panel-sync.js";
@@ -2144,15 +2145,9 @@ export async function runPanelOrchestrator(): Promise<void> {
   // http://h:443 and http://h are NOT the same endpoint (codex finding).
   // Shared by applyComfyuiUrl's dedupe and the control-channel ack check
   // (runpodProxyUrl omits :443 while getComfyUIBaseUrl includes it — codex).
-  const canonTargetUrl = (u: string): string => {
-    try {
-      const p = new URL(u);
-      if ((p.protocol === "https:" && p.port === "443") || (p.protocol === "http:" && p.port === "80")) p.port = "";
-      return p.toString().replace(/\/+$/, "");
-    } catch {
-      return u.replace(/\/+$/, "");
-    }
-  };
+  // ONE implementation with the hello-retarget judge's same-target check so
+  // the dedupe and the veto can never disagree (canonComfyuiTargetUrl).
+  const canonTargetUrl = (u: string): string => canonComfyuiTargetUrl(u);
   const applyComfyuiUrl = (rawUrl: unknown): boolean => {
     if (typeof rawUrl !== "string") return false;
     const next = rawUrl.trim().replace(/\/+$/, "");
@@ -2555,17 +2550,29 @@ export async function runPanelOrchestrator(): Promise<void> {
       // BEFORE the readiness probe so the "ready" ack reflects the right instance —
       // but a hello can arrive from a STALE browser tab on a DEAD instance (E2E
       // finding: a zombie :8189 tab kept retargeting the orchestrator to a corpse
-      // and silently breaking every tool that probes the target). Probe
-      // loopback/LAN hellos first; RunPod proxies skip the probe (booting pods
-      // answer late — readiness is the connector's job).
+      // and silently breaking every tool that probes the target). The veto
+      // (judgeHelloRetarget, #303) protects only a HEALTHY current target: when the
+      // current target reads dead too — the ComfyUI restart window — the live
+      // tab's hello is trusted instead, so the reconnect correction back to a
+      // LOCAL target can never be vetoed into keeping a stale REMOTE one (#756).
+      // RunPod proxies still skip the probe (booting pods answer late — readiness
+      // is the connector's job).
       const helloUrl = (event as { comfyui_url?: unknown }).comfyui_url;
       void (async () => {
-        if (typeof helloUrl === "string" && !/\.proxy\.runpod\.net/i.test(helloUrl)) {
-          const base = helloUrl.trim().replace(/\/+$/, "");
-          if (base && !(await probeOk(`${base}/system_stats`, 3_000))) {
-            logger.warn(`[panel-orchestrator] ignoring hello retarget to unreachable ${base} (stale tab on a dead instance?) — keeping ${comfyuiUrl}`);
-            return;
-          }
+        const verdict = await judgeHelloRetarget({
+          helloUrl,
+          currentUrl: comfyuiUrl,
+          probe: (u) => probeOk(u, 3_000),
+        });
+        if (!verdict.apply) {
+          logger.warn(`[panel-orchestrator] ignoring hello retarget to unreachable ${verdict.base} (stale tab on a dead instance?) — keeping ${comfyuiUrl}`);
+          return;
+        }
+        if (verdict.reason === "current-also-unreachable") {
+          logger.info(
+            `[panel-orchestrator] hello target ${verdict.base} and current target ${comfyuiUrl} are BOTH unreachable ` +
+              `(ComfyUI restart window?) — trusting the live tab's hello rather than pinning a stale target (#756)`,
+          );
         }
         applyComfyuiUrl(helloUrl);
       })();

--- a/src/services/hello-retarget.ts
+++ b/src/services/hello-retarget.ts
@@ -1,0 +1,114 @@
+// Panel-`hello` ComfyUI-target retarget policy (#303 zombie-tab guard + #756
+// restart-window fix), extracted from the orchestrator so the decision is
+// unit-testable. Pure decision logic — the probe is injected, so no I/O lives
+// here.
+//
+// Background: a panel tab's hello carries the ComfyUI URL the browser was
+// SERVED from (window.location), and the orchestrator retargets to it — that
+// is the auto-point-at-whatever-ComfyUI-the-user-has-open mechanism, and the
+// ONLY refresh of the connected target after a ComfyUI restart (a connected
+// panel never re-hellos). #303 added a liveness veto: probe the hello URL's
+// /system_stats first and drop the retarget when it doesn't answer, because a
+// STALE browser tab on a DEAD instance kept dragging the target to a corpse.
+//
+// #756: the veto was UNCONDITIONAL — it also dropped the correction back to a
+// LOCAL target when that hello raced the local ComfyUI's own restart window
+// (the one moment /system_stats is guaranteed to read dead). With the stale
+// (possibly REMOTE) target kept and no re-hello ever arriving, the
+// orchestrator — and every tool child respawned against it — stayed pinned to
+// the dead remote: asset tools returned `fetch failed`, local-only ref inputs
+// were rejected ("ref items need a LOCAL ComfyUI"), and Manager probes
+// reported the queue API unreachable while the local server answered 200. A
+// durable decision — the connected target, hence the local/remote
+// classification — was keyed on a transient signal (one 3s probe taken
+// mid-restart).
+//
+// The policy below keeps the #303 protection where it matters and removes the
+// #756 pin: the veto protects a HEALTHY current target from a dead hello, and
+// can never KEEP a dead one. Locality is always classified from the target
+// URL's host (durable), never from a probe reading (transient).
+
+export type HelloRetargetReason =
+  /** The hello carried no usable URL string — nothing to apply. */
+  | "not-a-url"
+  /** The hello IS the current target — a no-op retarget; never probed. */
+  | "same-target"
+  /** RunPod proxies skip the probe (#303: booting pods answer late — readiness is the connector's job). */
+  | "runpod-proxy"
+  /** The hello's instance answered /system_stats. */
+  | "healthy"
+  /** #303 zombie-tab guard: hello dead, current target healthy — KEEP current. */
+  | "vetoed-unreachable"
+  /** #756: hello dead but the current target reads dead too — trust the live tab's hello. */
+  | "current-also-unreachable";
+
+export interface HelloRetargetVerdict {
+  /** Whether the caller should apply the hello's retarget. */
+  apply: boolean;
+  reason: HelloRetargetReason;
+  /** The normalized hello base URL (trimmed, trailing slashes stripped), when usable. */
+  base?: string;
+}
+
+/**
+ * Canonical form for same-target comparisons — scheme-aware but
+ * DEFAULT-PORT-INSENSITIVE: strip only the scheme's actual default (:443 for
+ * https, :80 for http); http://h:443 and http://h are NOT the same endpoint.
+ * Trailing slashes stripped. Unparseable input is returned slash-stripped.
+ * This is the single implementation the orchestrator's target dedupe and this
+ * module's same-target check share, so the two can never drift apart.
+ */
+export function canonComfyuiTargetUrl(u: string): string {
+  try {
+    const p = new URL(u);
+    if ((p.protocol === "https:" && p.port === "443") || (p.protocol === "http:" && p.port === "80")) p.port = "";
+    return p.toString().replace(/\/+$/, "");
+  } catch {
+    return u.replace(/\/+$/, "");
+  }
+}
+
+/**
+ * Decide whether a panel hello's `comfyui_url` should be applied as the new
+ * ComfyUI target. `probe` answers whether a given /system_stats URL responds
+ * (the caller supplies the timeout); it must never throw — a probe failure
+ * reads as unreachable.
+ */
+export async function judgeHelloRetarget(opts: {
+  helloUrl: unknown;
+  currentUrl: string;
+  probe: (systemStatsUrl: string) => Promise<boolean>;
+}): Promise<HelloRetargetVerdict> {
+  const { helloUrl, currentUrl, probe } = opts;
+  if (typeof helloUrl !== "string") return { apply: false, reason: "not-a-url" };
+  const base = helloUrl.trim().replace(/\/+$/, "");
+  if (!base) return { apply: false, reason: "not-a-url" };
+  // RunPod proxies skip the probe: a booting pod answers late — readiness is
+  // the connector's job (#303).
+  if (/\.proxy\.runpod\.net/i.test(base)) {
+    return { apply: true, reason: "runpod-proxy", base };
+  }
+  // A hello for the CURRENT target is a no-op retarget (applyComfyuiUrl dedupes
+  // it) — never probe: during the target's OWN restart window the probe reads
+  // dead, stalling every reconnect for seconds to decide nothing.
+  if (canonComfyuiTargetUrl(base) === canonComfyuiTargetUrl(currentUrl)) {
+    return { apply: true, reason: "same-target", base };
+  }
+  if (await probe(`${base}/system_stats`)) {
+    return { apply: true, reason: "healthy", base };
+  }
+  // The hello's instance doesn't answer. Veto ONLY while the current target is
+  // healthy (#303's zombie-tab guard: a stale tab on a dead instance must not
+  // steal a GOOD target). When the current target doesn't answer EITHER, both
+  // reads are dead — trust the live tab's hello: it reflects the browser
+  // session the user actually has open, applying keys locality on the hello
+  // URL's durable host (never on a transient probe), and it is the
+  // self-healing direction. #756: vetoing the LOCAL hello during the ComfyUI
+  // restart window pinned a stale REMOTE target forever — a connected panel
+  // never re-hellos — leaving every tool misclassified as remote.
+  const currentBase = currentUrl.trim().replace(/\/+$/, "");
+  if (currentBase && (await probe(`${currentBase}/system_stats`))) {
+    return { apply: false, reason: "vetoed-unreachable", base };
+  }
+  return { apply: true, reason: "current-also-unreachable", base };
+}

--- a/src/services/hello-retarget.ts
+++ b/src/services/hello-retarget.ts
@@ -1,7 +1,7 @@
 // Panel-`hello` ComfyUI-target retarget policy (#303 zombie-tab guard + #756
-// restart-window fix), extracted from the orchestrator so the decision is
-// unit-testable. Pure decision logic — the probe is injected, so no I/O lives
-// here.
+// restart-window fix + the codex-gate trust model), extracted from the
+// orchestrator so the decision is unit-testable. Pure decision logic — the
+// probe is injected, so no I/O lives here.
 //
 // Background: a panel tab's hello carries the ComfyUI URL the browser was
 // SERVED from (window.location), and the orchestrator retargets to it — that
@@ -10,36 +10,50 @@
 // panel never re-hellos). #303 added a liveness veto: probe the hello URL's
 // /system_stats first and drop the retarget when it doesn't answer, because a
 // STALE browser tab on a DEAD instance kept dragging the target to a corpse.
-//
 // #756: the veto was UNCONDITIONAL — it also dropped the correction back to a
-// LOCAL target when that hello raced the local ComfyUI's own restart window
-// (the one moment /system_stats is guaranteed to read dead). With the stale
-// (possibly REMOTE) target kept and no re-hello ever arriving, the
-// orchestrator — and every tool child respawned against it — stayed pinned to
-// the dead remote: asset tools returned `fetch failed`, local-only ref inputs
-// were rejected ("ref items need a LOCAL ComfyUI"), and Manager probes
-// reported the queue API unreachable while the local server answered 200. A
-// durable decision — the connected target, hence the local/remote
-// classification — was keyed on a transient signal (one 3s probe taken
-// mid-restart).
+// LOCAL target when that hello raced the local ComfyUI's own restart window,
+// pinning a stale (possibly REMOTE) target forever.
 //
-// The policy below keeps the #303 protection where it matters and removes the
-// #756 pin: the veto protects a HEALTHY current target from a dead hello, and
-// can never KEEP a dead one. Locality is always classified from the target
-// URL's host (durable), never from a probe reading (transient).
+// TRUST MODEL (codex gate on #756): hello.comfyui_url is page-JS-writable —
+// a stale, confused, or malicious tab can CLAIM any instance. The ONLY
+// unspoofable proof of which ComfyUI a real browser tab fronts is the
+// server-observed WebSocket handshake Origin (ui-bridge's serverOrigin: the
+// browser sets it and forbids page scripts from overriding it). So the
+// decision is two-tiered:
+//
+//   TRUSTED (handshake origin canonically matches the claimed URL): the tab
+//   provably fronts what it names. All #303/#756 semantics apply — the
+//   same-target no-probe shortcut, the RunPod-proxy skip (booting pods answer
+//   late), the healthy-current veto, and the #756 both-dead recovery.
+//
+//   UNTRUSTED (origin mismatches, or absent — a non-browser/relay client):
+//   NOTHING is taken on the claim's word. No no-probe shortcut (the
+//   same-target comparison keys on the observed origin, never the bare
+//   claim), no proxy skip, and NO both-dead recovery — applying a
+//   wrong-host retarget to an unverifiable claim is the wrong-workflow
+//   hazard the gate closed. The claim may still apply on EVIDENCE: probe
+//   the claimed instance, and a live, answering one earns the retarget; a
+//   dead one fails closed.
+//
+// Locality is always classified from the target URL's host (durable), never
+// from a probe reading (transient).
 
 export type HelloRetargetReason =
   /** The hello carried no usable URL string — nothing to apply. */
   | "not-a-url"
-  /** The hello IS the current target — a no-op retarget; never probed. */
+  /** TRUSTED: the tab provably fronts the CURRENT target — a no-op retarget; never probed. */
   | "same-target"
-  /** RunPod proxies skip the probe (#303: booting pods answer late — readiness is the connector's job). */
+  /** TRUSTED RunPod proxy: skips the probe (#303: booting pods answer late — readiness is the connector's job). */
   | "runpod-proxy"
-  /** The hello's instance answered /system_stats. */
+  /** TRUSTED: the claimed instance answered /system_stats. */
   | "healthy"
-  /** #303 zombie-tab guard: hello dead, current target healthy — KEEP current. */
+  /** UNTRUSTED claim applied on EVIDENCE: the claimed instance answered /system_stats. */
+  | "healthy-untrusted"
+  /** TRUSTED #303 zombie-tab guard: claim dead, current target healthy — KEEP current. */
   | "vetoed-unreachable"
-  /** #756: hello dead but the current target reads dead too — trust the live tab's hello. */
+  /** UNTRUSTED and dead: refused — never retarget on an uncorroborated claim. */
+  | "vetoed-untrusted"
+  /** TRUSTED #756: claim dead but the current target reads dead too — trust the live tab's hello. */
   | "current-also-unreachable";
 
 export interface HelloRetargetVerdict {
@@ -48,6 +62,10 @@ export interface HelloRetargetVerdict {
   reason: HelloRetargetReason;
   /** The normalized hello base URL (trimmed, trailing slashes stripped), when usable. */
   base?: string;
+  /** Whether the claimed URL was corroborated by the tab's server-observed
+   *  handshake origin (the only unspoofable proof of which instance the tab
+   *  fronts). Trust gates every no-probe shortcut and the #756 recovery. */
+  trusted: boolean;
 }
 
 /**
@@ -68,47 +86,114 @@ export function canonComfyuiTargetUrl(u: string): string {
   }
 }
 
+/** Loopback family canonicalization, mirroring loopbackFamily in
+ *  orchestrator/panel-tools.ts (kept local so this leaf module doesn't import
+ *  the heavyweight panel-tools unit): every IPv4-family loopback literal
+ *  (127.0.0.1 / the 0.0.0.0 wildcard) → 127.0.0.1; every IPv6-family literal
+ *  (::1 / the :: wildcard) → ::1. The families stay DISTINCT — a v4 and a v6
+ *  instance at the same port are different instances — and `localhost` is
+ *  deliberately NOT canonicalized: a DNS-ambiguous name can't be pinned to a
+ *  family, so it never aliases a concrete loopback literal. */
+function loopbackFamilyKey(host: string): "127.0.0.1" | "::1" | null {
+  const h = host.toLowerCase().replace(/^\[|\]$/g, "");
+  if (h === "127.0.0.1" || h === "0.0.0.0") return "127.0.0.1";
+  if (h === "::1" || h === "::" || h === "0000:0000:0000:0000:0000:0000:0000:0000") return "::1";
+  return null;
+}
+
+/**
+ * Canonical scheme://host:port key of a ComfyUI URL for instance-identity
+ * comparison — path ignored (the WebSocket handshake Origin carries none; a
+ * basePath on the claim is a mount on the proven instance), default ports made
+ * explicit, loopback hosts family-canonicalized. null when unparseable.
+ * Mirrors httpOriginOf in orchestrator/panel-tools.ts.
+ */
+export function comfyuiOriginKey(rawUrl: string): string | null {
+  try {
+    const u = new URL(rawUrl);
+    const port = u.port || (u.protocol === "https:" ? "443" : "80");
+    const host = u.hostname.toLowerCase();
+    return `${u.protocol}//${loopbackFamilyKey(host) ?? host}:${port}`;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Decide whether a panel hello's `comfyui_url` should be applied as the new
- * ComfyUI target. `probe` answers whether a given /system_stats URL responds
- * (the caller supplies the timeout); it must never throw — a probe failure
- * reads as unreachable.
+ * ComfyUI target.
+ *
+ * `observedOrigin` is the SERVER-OBSERVED WebSocket handshake Origin of the
+ * tab that sent the hello (ui-bridge's tabServerOrigin) — the ONLY unspoofable
+ * corroboration of the claim. Undefined for non-browser/relay clients, whose
+ * claims are therefore always probed, never trusted.
+ *
+ * `probe` answers whether a given /system_stats URL responds (the caller
+ * supplies the timeout); it must never throw — a probe failure reads as
+ * unreachable.
  */
 export async function judgeHelloRetarget(opts: {
   helloUrl: unknown;
   currentUrl: string;
+  observedOrigin?: string;
   probe: (systemStatsUrl: string) => Promise<boolean>;
 }): Promise<HelloRetargetVerdict> {
   const { helloUrl, currentUrl, probe } = opts;
-  if (typeof helloUrl !== "string") return { apply: false, reason: "not-a-url" };
+  const observedOrigin = opts.observedOrigin?.trim() || undefined;
+  if (typeof helloUrl !== "string") return { apply: false, reason: "not-a-url", trusted: false };
   const base = helloUrl.trim().replace(/\/+$/, "");
-  if (!base) return { apply: false, reason: "not-a-url" };
-  // RunPod proxies skip the probe: a booting pod answers late — readiness is
-  // the connector's job (#303).
-  if (/\.proxy\.runpod\.net/i.test(base)) {
-    return { apply: true, reason: "runpod-proxy", base };
+  if (!base) return { apply: false, reason: "not-a-url", trusted: false };
+
+  // TRUST: the claim is page-JS-writable; only the browser-set handshake
+  // Origin (unforgeable by page JS) proves which instance the tab fronts.
+  // Compared canonically at origin granularity — the Origin carries no path.
+  const claimKey = comfyuiOriginKey(base);
+  const originKey = observedOrigin ? comfyuiOriginKey(observedOrigin) : null;
+  const trusted = claimKey !== null && originKey !== null && claimKey === originKey;
+
+  if (!trusted) {
+    // Nothing is taken on the claim's word: no no-probe shortcut (the
+    // same-target comparison keys on the observed origin, never the bare
+    // claim — and a trusted same-target claim implies the observed origin
+    // fronts the current target, so no trusted case is lost here), no RunPod
+    // skip, and NO #756 both-dead recovery. The claim may apply on EVIDENCE
+    // only: a live, answering instance earns the retarget; a dead or
+    // unreachable one fails closed (#303's zombie-tab hazard in its general
+    // form — a wrong-host retarget is a wrong-workflow hazard regardless of
+    // adversary framing).
+    if (await probe(`${base}/system_stats`)) {
+      return { apply: true, reason: "healthy-untrusted", base, trusted };
+    }
+    return { apply: false, reason: "vetoed-untrusted", base, trusted };
   }
-  // A hello for the CURRENT target is a no-op retarget (applyComfyuiUrl dedupes
-  // it) — never probe: during the target's OWN restart window the probe reads
-  // dead, stalling every reconnect for seconds to decide nothing.
+
+  // TRUSTED claim: the tab provably fronts the instance it names.
+  // Same-target hello — the corroborated claim IS the current target, so the
+  // observed origin fronts it too: a no-op retarget that must not stall on
+  // probes during the target's own restart window.
   if (canonComfyuiTargetUrl(base) === canonComfyuiTargetUrl(currentUrl)) {
-    return { apply: true, reason: "same-target", base };
+    return { apply: true, reason: "same-target", base, trusted };
+  }
+  // RunPod proxies skip the probe: a booting pod answers late — readiness is
+  // the connector's job (#303). Trust-gated: the tab fronts the pod it names.
+  if (/\.proxy\.runpod\.net/i.test(base)) {
+    return { apply: true, reason: "runpod-proxy", base, trusted };
   }
   if (await probe(`${base}/system_stats`)) {
-    return { apply: true, reason: "healthy", base };
+    return { apply: true, reason: "healthy", base, trusted };
   }
-  // The hello's instance doesn't answer. Veto ONLY while the current target is
-  // healthy (#303's zombie-tab guard: a stale tab on a dead instance must not
-  // steal a GOOD target). When the current target doesn't answer EITHER, both
-  // reads are dead — trust the live tab's hello: it reflects the browser
-  // session the user actually has open, applying keys locality on the hello
-  // URL's durable host (never on a transient probe), and it is the
-  // self-healing direction. #756: vetoing the LOCAL hello during the ComfyUI
-  // restart window pinned a stale REMOTE target forever — a connected panel
-  // never re-hellos — leaving every tool misclassified as remote.
+  // The claimed instance doesn't answer. Veto ONLY while the current target
+  // is healthy (#303's zombie-tab guard: a stale tab on a dead instance must
+  // not steal a GOOD target). When the current target doesn't answer EITHER,
+  // both reads are dead — trust the live tab's corroborated hello: applying
+  // keys locality on the claim's durable host (never on a transient probe)
+  // and is the self-healing direction. #756: vetoing the LOCAL hello during
+  // the ComfyUI restart window pinned a stale REMOTE target forever — a
+  // connected panel never re-hellos — leaving every tool misclassified as
+  // remote.
   const currentBase = currentUrl.trim().replace(/\/+$/, "");
   if (currentBase && (await probe(`${currentBase}/system_stats`))) {
-    return { apply: false, reason: "vetoed-unreachable", base };
+    return { apply: false, reason: "vetoed-unreachable", base, trusted };
   }
-  return { apply: true, reason: "current-also-unreachable", base };
+  return { apply: true, reason: "current-also-unreachable", base, trusted };
 }


### PR DESCRIPTION
## Root cause

The #303 zombie-tab guard (`src/orchestrator/index.ts` hello handler) probed the panel hello's `/system_stats` and **unconditionally vetoed** the retarget when it didn't answer. A local panel reconnecting during the ComfyUI **restart window** always reads dead on that probe, so the correction back to the LOCAL target was dropped — and a connected panel never re-hellos, so the misclassification never healed. With a stale (possibly REMOTE) target kept, every tool child respawned against it:

- `stage_output_as_input` / `upload_video` → `fetch failed` (HTTP to the dead host)
- `train_prepare_dataset` → `ref items need a LOCAL ComfyUI` (`isRemoteMode()` true)
- `download_model` → `ComfyUI-Manager's queue API is not reachable` while local `/v2/manager/queue/status` answered 200

A durable decision — the connected target, hence the local/remote classification — was keyed on a transient probe reading taken mid-restart.

## Fix

The veto now protects only a **healthy** current target (`judgeHelloRetarget` in new `src/services/hello-retarget.ts`):

- hello answers → apply (unchanged)
- hello dead, current target healthy → veto (#303 zombie-tab guard preserved)
- hello dead, current target **also** dead → **apply**: both reads are transient; the live tab's hello reflects the user's real session, and locality keys on the URL's durable host, never on a probe. This is the self-healing direction — once ComfyUI finishes booting, every tool works again.
- same-canonical-target hello → apply without probing (no-op retarget must not stall on the restart window)
- RunPod proxy hellos keep skipping the probe (#303: booting pods answer late)

The policy is extracted into a unit-testable module sharing ONE URL canon (`canonComfyuiTargetUrl`) with the orchestrator's target dedupe so the two can never disagree.

## Tests

New `src/__tests__/services/hello-retarget.test.ts` (11 tests):
- **restart → reconnect**: local hello racing the restart window (probe dead everywhere) is APPLIED over a stale remote target; composed with the real config — `isRemoteMode()` flips back to false (local ref resolution restored) and `getComfyUIBaseUrl()` returns the local URL Manager v4 queue probing uses
- #303 guards preserved: dead hello vetoed while current is healthy (local and remote directions)
- transient-unreachable local hello does not flip a healthy REMOTE target (genuinely-remote stays remote)
- healthy hello applies; RunPod proxy + same-target hellos never probe; canon unit tests

`npx tsc --noEmit` clean. Targeted: hello-retarget + config 48/48, orchestrator 827/827. Full `npx vitest run`: **4022 passed | 2 skipped (4024)**, 239 files.

Fixes #756