### PR TITLE
fix: preserve AUTOGROW dotted workflow inputs

### DIFF
--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -154,6 +154,70 @@ describe("convertUiToApi — bypass / mute resolution", () => {
     expect(workflow["1"].inputs).not.toHaveProperty("aspect_ratio");
   });
 
+  it("preserves linked COMFY_AUTOGROW_V3 entries without a serialized parent value", () => {
+    const objectInfo = {
+      PrimitiveInt: {
+        input: { required: { value: ["INT", { default: 0 }] } },
+        output: ["INT"],
+      },
+      ComfyMathExpression: {
+        input: {
+          required: {
+            expression: ["STRING", { default: "a + b" }],
+            values: [
+              "COMFY_AUTOGROW_V3",
+              {
+                template: {
+                  input: { required: { value: ["FLOAT,INT,BOOLEAN", {}] } },
+                  names: ["a", "b"],
+                  min: 1,
+                },
+              },
+            ],
+          },
+        },
+        output: ["FLOAT", "INT", "BOOLEAN"],
+      },
+    } as never;
+
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveInt",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "INT", type: "INT", links: [1, 2] }],
+          widgets_values: [8],
+        },
+        {
+          id: 2,
+          type: "ComfyMathExpression",
+          mode: 0,
+          inputs: [
+            { name: "values.a", type: "FLOAT,INT,BOOLEAN", link: 1 },
+            { name: "values.b", type: "FLOAT,INT,BOOLEAN", link: 2 },
+            { name: "expression", type: "STRING", link: null, widget: { name: "expression" } },
+          ],
+          outputs: [{ name: "INT", type: "INT", links: null }],
+          widgets_values: ["a + b"],
+        },
+      ],
+      links: [
+        [1, 1, 0, 2, 0, "INT"],
+        [2, 1, 0, 2, 1, "INT"],
+      ],
+    } as never;
+
+    const { workflow } = convertUiToApi(ui, objectInfo);
+    expect(workflow["2"].inputs).toEqual({
+      expression: "a + b",
+      "values.a": ["1", 0],
+      "values.b": ["1", 0],
+    });
+    expect(workflow["2"].inputs).not.toHaveProperty("values");
+  });
+
   it("virtual Set/Get bus nodes are dropped and consumers resolve through the bus", () => {
     // LoadImage(1) -> SetNode(2,'BUS');  GetNode(3,'BUS') -> SaveImage(4)
     const ui = {

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -102,6 +102,10 @@ describe("convertUiToApi — bypass / mute resolution", () => {
           },
         },
       },
+      ImageSource: {
+        input: { required: {} },
+        output: ["IMAGE"],
+      },
       SaveImage: {
         input: { required: { images: ["IMAGE"], filename_prefix: ["STRING"] } },
       },
@@ -113,7 +117,9 @@ describe("convertUiToApi — bypass / mute resolution", () => {
           id: 1,
           type: "GeminiNanoBanana2V2",
           mode: 0,
-          inputs: [],
+          inputs: [
+            { name: "model.images.image_1", type: "IMAGE", link: 2 },
+          ],
           outputs: [{ name: "IMAGE", type: "IMAGE", links: [1] }],
           widgets_values: [
             "a red cube", // prompt
@@ -127,6 +133,14 @@ describe("convertUiToApi — bypass / mute resolution", () => {
           ],
         },
         {
+          id: 3,
+          type: "ImageSource",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [2] }],
+          widgets_values: [],
+        },
+        {
           id: 2,
           type: "SaveImage",
           mode: 0,
@@ -135,7 +149,10 @@ describe("convertUiToApi — bypass / mute resolution", () => {
           widgets_values: ["out"],
         },
       ],
-      links: [[1, 1, 0, 2, 0, "IMAGE"]],
+      links: [
+        [1, 1, 0, 2, 0, "IMAGE"],
+        [2, 3, 0, 1, 0, "IMAGE"],
+      ],
     } as never;
 
     const { workflow } = convertUiToApi(ui, objectInfo);
@@ -145,6 +162,7 @@ describe("convertUiToApi — bypass / mute resolution", () => {
       "model.aspect_ratio": "16:9",
       "model.resolution": "2K",
       "model.thinking_level": "HIGH",
+      "model.images.image_1": ["3", 0],
       seed: 7,
       response_modalities: "IMAGE",
     });

--- a/src/__tests__/services/workflow-validator.test.ts
+++ b/src/__tests__/services/workflow-validator.test.ts
@@ -99,6 +99,57 @@ describe("validateWorkflow — combo value_not_in_list parity with the ComfyUI f
   });
 });
 
+describe("validateWorkflow — COMFY_AUTOGROW_V3 required inputs", () => {
+  const autogrowObjectInfo = {
+    PrimitiveInt: {
+      input: { required: { value: ["INT", { default: 0 }] } },
+      output: ["INT"],
+    },
+    ComfyMathExpression: {
+      input: {
+        required: {
+          expression: ["STRING", { default: "a + b" }],
+          values: ["COMFY_AUTOGROW_V3", { min: 1 }],
+        },
+      },
+      output: ["FLOAT", "INT", "BOOLEAN"],
+    },
+  } as const;
+
+  it("accepts dotted child entries without a separate parent value", async () => {
+    getObjectInfoMock.mockResolvedValue(autogrowObjectInfo);
+    const r = await validateWorkflow(
+      wf({
+        "1": { class_type: "PrimitiveInt", inputs: { value: 8 } },
+        "2": {
+          class_type: "ComfyMathExpression",
+          inputs: { expression: "a / 2", "values.a": ["1", 0] },
+        },
+      }),
+      { health: false },
+    );
+    expect(r.issues.filter((issue) => issue.severity === "error")).toHaveLength(0);
+    expect(r.valid).toBe(true);
+  });
+
+  it("still reports a missing required AUTOGROW input when it has no children", async () => {
+    getObjectInfoMock.mockResolvedValue(autogrowObjectInfo);
+    const r = await validateWorkflow(
+      wf({
+        "2": { class_type: "ComfyMathExpression", inputs: { expression: "a / 2" } },
+      }),
+      { health: false },
+    );
+    expect(r.issues).toContainEqual(
+      expect.objectContaining({
+        node_id: "2",
+        message: 'Missing required input "values"',
+      }),
+    );
+    expect(r.valid).toBe(false);
+  });
+});
+
 describe("validateWorkflow — graph-health merge", () => {
   it("merges health findings (warning/info) without flipping `valid` and returns a health section", async () => {
     // Combo-clean graph, but structurally an isolated CLIPLoader (nothing reads it).

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -378,6 +378,49 @@ function resolveWidgetSpec(
 }
 
 /**
+ * Return the full schema path of an AUTOGROW ancestor for a dotted prompt key.
+ * AUTOGROW can be top-level (`values.a`) or nested below one or more selected
+ * dynamic-combo options (`model.images.image_1`). In the latter case, looking
+ * only at the first segment mistakes `images.image_1` for a combo leaf and the
+ * final re-anchoring pass deletes the wired entry as unknown.
+ */
+function autogrowParentPath(
+  def: ComfyUINodeDef,
+  key: string,
+  inputs: Record<string, unknown>,
+): string | undefined {
+  const parts = key.split(".");
+  if (parts.length < 2) return undefined;
+
+  let path = parts[0];
+  let spec =
+    (def.input?.required as Record<string, unknown>)?.[path] ??
+    (def.input?.optional as Record<string, unknown>)?.[path];
+
+  for (let i = 1; i < parts.length; i++) {
+    if (Array.isArray(spec) && spec[0] === "COMFY_AUTOGROW_V3") return path;
+    if (!Array.isArray(spec)) return undefined;
+
+    const options = (spec[1] as {
+      options?: Array<{
+        key?: unknown;
+        inputs?: {
+          required?: Record<string, unknown>;
+          optional?: Record<string, unknown>;
+        };
+      }>;
+    } | undefined)?.options;
+    if (!Array.isArray(options)) return undefined;
+
+    const selected = options.find((option) => option?.key === inputs[path])?.inputs;
+    path = `${path}.${parts[i]}`;
+    spec = selected?.required?.[parts[i]] ?? selected?.optional?.[parts[i]];
+  }
+
+  return undefined;
+}
+
+/**
  * Whether a widget SPEC carries a control_after_generate phantom slot — either
  * flagged in its config, or a seed-type INT the ComfyUI frontend auto-augments.
  * Works for both top-level inputs and V3 dynamic-combo NESTED leaves (which have
@@ -2089,16 +2132,11 @@ export function convertUiToApi(
     for (const key of Object.keys(inputs)) {
       const dot = key.indexOf(".");
       if (dot < 0) continue;
+      // AUTOGROW entries may be top-level (`values.a`) or nested inside a
+      // dynamic-combo option (`model.images.image_1`). Preserve the whole
+      // repeated-entry subtree; it is not a dynamic-combo leaf to re-anchor.
+      if (autogrowParentPath(def, key, inputs)) continue;
       const parent = key.slice(0, dot);
-      const parentSpec =
-        (def.input?.required as Record<string, unknown>)?.[parent] ??
-        (def.input?.optional as Record<string, unknown>)?.[parent];
-      const parentType = Array.isArray(parentSpec) ? parentSpec[0] : undefined;
-      // AUTOGROW inputs serialize each repeated entry as a dotted key
-      // (`values.a`, `values.b`, …) without a separate `values` parent value.
-      // They are not dynamic-combo leaves and must bypass the combo-specific
-      // orphan/re-anchoring pass below.
-      if (parentType === "COMFY_AUTOGROW_V3") continue;
       // Orphaned dotted leaf: its dynamic parent isn't in the prompt (e.g. an
       // optional parent left unset while the leaf was linked). There's no option
       // context to validate against, and the leaf is meaningless without its

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -2090,6 +2090,15 @@ export function convertUiToApi(
       const dot = key.indexOf(".");
       if (dot < 0) continue;
       const parent = key.slice(0, dot);
+      const parentSpec =
+        (def.input?.required as Record<string, unknown>)?.[parent] ??
+        (def.input?.optional as Record<string, unknown>)?.[parent];
+      const parentType = Array.isArray(parentSpec) ? parentSpec[0] : undefined;
+      // AUTOGROW inputs serialize each repeated entry as a dotted key
+      // (`values.a`, `values.b`, …) without a separate `values` parent value.
+      // They are not dynamic-combo leaves and must bypass the combo-specific
+      // orphan/re-anchoring pass below.
+      if (parentType === "COMFY_AUTOGROW_V3") continue;
       // Orphaned dotted leaf: its dynamic parent isn't in the prompt (e.g. an
       // optional parent left unset while the leaf was linked). There's no option
       // context to validate against, and the leaf is meaningless without its

--- a/src/services/workflow-validator.ts
+++ b/src/services/workflow-validator.ts
@@ -90,7 +90,11 @@ export async function validateWorkflow(
     // 2b. Check required inputs are present
     const requiredInputs = nodeDef.input?.required ?? {};
     for (const [inputName, inputSpec] of Object.entries(requiredInputs)) {
-      if (!(inputName in node.inputs)) {
+      const inputType = Array.isArray(inputSpec) ? inputSpec[0] : undefined;
+      const hasAutogrowChildren =
+        inputType === "COMFY_AUTOGROW_V3" &&
+        Object.keys(node.inputs).some((name) => name.startsWith(`${inputName}.`));
+      if (!(inputName in node.inputs) && !hasAutogrowChildren) {
         issues.push({
           severity: "error",
           node_id: nodeId,


### PR DESCRIPTION
Closes #762.

## Summary

- preserve dotted children such as values.a and values.b when their declared parent is COMFY_AUTOGROW_V3
- keep the existing strict orphan handling unchanged for COMFY_DYNAMICCOMBO_V3 and unknown dotted inputs
- treat required AUTOGROW inputs as present in validateWorkflow when at least one dotted child exists
- retain the missing-required error when no parent and no dotted children are present

## Tests

- npx vitest run src/__tests__/services/workflow-converter.test.ts src/__tests__/services/workflow-validator.test.ts: 80 passed
- npm run build: passed
- end-to-end conversion and validation against a 52-node ComfyUI workflow containing four ComfyMathExpression nodes: valid, no ComfyMathExpression issues
- npm test: 4005 passed, 4 skipped, 5 environment failures in generation-tracker-path.test.ts because this host runs unsupported Node 26 and better-sqlite3 did not install a native binding; the focused suites and TypeScript build pass