### PR TITLE
fix(panel): make stale panel-lock recovery fail closed

### DIFF
--- a/src/__tests__/services/panel-pin-guard.test.ts
+++ b/src/__tests__/services/panel-pin-guard.test.ts
@@ -241,24 +241,27 @@ describe("withPanelMutationLock — a FILE lock, so it holds across processes", 
     expect(order).toEqual(["holder:start", "nested", "holder:end", "outsider"]);
   });
 
-  it("times out rather than proceeding when another process holds the lock", async () => {
-    // Simulate a live lock owned by someone else: a fresh lock file we never release.
+  it("does NOT reclaim a fresh lock even when its recorded pid is dead", async () => {
+    // Age is a mandatory part of the proof. A just-created lock can still be
+    // in the small window before its writer has committed its pid record.
     writeFileSync(panelLockPath(), JSON.stringify({ pid: 999999 }));
     await expect(
       withPanelMutationLock(async () => "should not run", { timeoutMs: 300 }),
     ).rejects.toThrow(/Timed out .* waiting for the panel operation lock/);
+    expect(existsSync(panelLockPath())).toBe(true);
   });
 
-  it("fails closed on a stale lock rather than racing a fresh replacement", async () => {
+  it("reclaims a stale lock whose owner is demonstrably dead", async () => {
     const path = panelLockPath();
-    // A pid that is old AND dead.
+    // The age and dead-pid gates are both required before reclaim.
     writeFileSync(path, JSON.stringify({ pid: 0x7fffffff }));
     const old = new Date(Date.now() - 60 * 60_000);
     const { utimesSync } = await import("node:fs");
     utimesSync(path, old, old);
-    await expect(
-      withPanelMutationLock(async () => "recovered", { timeoutMs: 300 }),
-    ).rejects.toThrow(/never auto-reclaimed/i);
+    await expect(withPanelMutationLock(async () => "recovered", { timeoutMs: 300 })).resolves.toBe(
+      "recovered",
+    );
+    expect(existsSync(path)).toBe(false);
   });
 
   it("does NOT reclaim an old lock whose owner is still ALIVE", async () => {
@@ -274,6 +277,7 @@ describe("withPanelMutationLock — a FILE lock, so it holds across processes", 
     await expect(
       withPanelMutationLock(async () => "should not run", { timeoutMs: 300 }),
     ).rejects.toThrow(/Timed out/);
+    expect(existsSync(path)).toBe(true);
   });
 
   it("fails closed on an old unreadable lock", async () => {
@@ -284,7 +288,53 @@ describe("withPanelMutationLock — a FILE lock, so it holds across processes", 
     utimesSync(path, old, old);
     await expect(
       withPanelMutationLock(async () => "recovered", { timeoutMs: 300 }),
-    ).rejects.toThrow(/never auto-reclaimed/i);
+    ).rejects.toThrow(/Timed out/);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("fails closed on an old lock without a valid pid", async () => {
+    const path = panelLockPath();
+    writeFileSync(path, JSON.stringify({ pid: "not-a-pid" }));
+    const old = new Date(Date.now() - 60 * 60_000);
+    const { utimesSync } = await import("node:fs");
+    utimesSync(path, old, old);
+    await expect(
+      withPanelMutationLock(async () => "should not run", { timeoutMs: 300 }),
+    ).rejects.toThrow(/Timed out/);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("keeps a concurrent contender behind the action that reclaimed the stale lock", async () => {
+    // The successor must acquire through the same exclusive-create loop, not
+    // run alongside the action that just reclaimed the abandoned holder.
+    const path = panelLockPath();
+    writeFileSync(path, JSON.stringify({ pid: 0x7fffffff }));
+    const old = new Date(Date.now() - 60 * 60_000);
+    const { utimesSync } = await import("node:fs");
+    utimesSync(path, old, old);
+
+    const order: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstMayFinish = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const first = withPanelMutationLock(async () => {
+      order.push("reclaimed holder started");
+      await firstMayFinish;
+      order.push("reclaimed holder finished");
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const second = withPanelMutationLock(async () => order.push("contender ran"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(order).toEqual(["reclaimed holder started"]);
+
+    releaseFirst?.();
+    await Promise.all([first, second]);
+    expect(order).toEqual([
+      "reclaimed holder started",
+      "reclaimed holder finished",
+      "contender ran",
+    ]);
   });
 
   it("resolves with the action's OWN result, and only after its side effects finished", async () => {

--- a/src/__tests__/services/panel-pin-guard.test.ts
+++ b/src/__tests__/services/panel-pin-guard.test.ts
@@ -6,10 +6,29 @@
 // and `id="all"` reached the SAME ComfyUI-Manager mutation without ever passing
 // the guard. A pinned user was one generic call away from being moved.
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, existsSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+
+const panelLockTestHooks = vi.hoisted(() => ({
+  beforeClaimWrite: undefined as undefined | (() => void),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    writeSync: (...args: Parameters<typeof actual.writeSync>) => {
+      const hook = panelLockTestHooks.beforeClaimWrite;
+      panelLockTestHooks.beforeClaimWrite = undefined;
+      hook?.();
+      return actual.writeSync(...args);
+    },
+  };
+});
 
 import {
   activePanelPendingOps,
@@ -35,6 +54,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
+  panelLockTestHooks.beforeClaimWrite = undefined;
   delete process.env.COMFYUI_MCP_PANEL_SETTINGS;
   delete process.env.COMFYUI_MCP_PANEL_LOCK;
   delete process.env.COMFYUI_MCP_PANEL_PENDING;
@@ -262,6 +283,55 @@ describe("withPanelMutationLock — a FILE lock, so it holds across processes", 
       "recovered",
     );
     expect(existsSync(path)).toBe(false);
+  });
+
+  it("does not delete a fresh cross-process replacement after observing a stale lock", async () => {
+    const path = panelLockPath();
+    const freshRecord = JSON.stringify({ pid: 12345, fresh: true });
+    writeFileSync(path, JSON.stringify({ pid: 0x7fffffff }));
+    const old = new Date(Date.now() - 60 * 60_000);
+    const { utimesSync } = await import("node:fs");
+    utimesSync(path, old, old);
+
+    // Run the replacement in a separate Node process after this process has
+    // observed the abandoned lock but before it records its reclaim claim. It
+    // models an already-running older orchestrator winning the old reclaim.
+    let replaced = false;
+    panelLockTestHooks.beforeClaimWrite = () => {
+      replaced = true;
+      const child = spawnSync(
+        process.execPath,
+        [
+          "-e",
+          `const fs=require('node:fs');fs.rmSync(${JSON.stringify(path)});fs.writeFileSync(${JSON.stringify(path)},${JSON.stringify(freshRecord)});`,
+        ],
+        { encoding: "utf-8" },
+      );
+      expect(child.status).toBe(0);
+    };
+
+    await expect(
+      withPanelMutationLock(async () => "must not run", { timeoutMs: 300 }),
+    ).rejects.toThrow(/Timed out/);
+    expect(replaced).toBe(true);
+    expect(fs.readFileSync(path, "utf-8")).toBe(freshRecord);
+  });
+
+  it("recovers after a dead claimant leaves an old partial reclaim record", async () => {
+    const path = panelLockPath();
+    const claim = `${path}.reclaim`;
+    writeFileSync(path, JSON.stringify({ pid: 0x7fffffff }));
+    writeFileSync(claim, "partial");
+    const old = new Date(Date.now() - 60 * 60_000);
+    const { utimesSync } = await import("node:fs");
+    utimesSync(path, old, old);
+    utimesSync(claim, old, old);
+
+    await expect(withPanelMutationLock(async () => "recovered", { timeoutMs: 500 })).resolves.toBe(
+      "recovered",
+    );
+    expect(existsSync(path)).toBe(false);
+    expect(existsSync(claim)).toBe(false);
   });
 
   it("does NOT reclaim an old lock whose owner is still ALIVE", async () => {

--- a/src/__tests__/services/panel-pin-guard.test.ts
+++ b/src/__tests__/services/panel-pin-guard.test.ts
@@ -15,6 +15,7 @@ import { dirname, join } from "node:path";
 
 const panelLockTestHooks = vi.hoisted(() => ({
   beforeClaimWrite: undefined as undefined | (() => void),
+  afterCleanupWrite: undefined as undefined | (() => void),
 }));
 
 vi.mock("node:fs", async (importOriginal) => {
@@ -25,7 +26,11 @@ vi.mock("node:fs", async (importOriginal) => {
       const hook = panelLockTestHooks.beforeClaimWrite;
       panelLockTestHooks.beforeClaimWrite = undefined;
       hook?.();
-      return actual.writeSync(...args);
+      const result = actual.writeSync(...args);
+      const afterCleanupWrite = panelLockTestHooks.afterCleanupWrite;
+      panelLockTestHooks.afterCleanupWrite = undefined;
+      afterCleanupWrite?.();
+      return result;
     },
   };
 });
@@ -56,6 +61,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
   panelLockTestHooks.beforeClaimWrite = undefined;
+  panelLockTestHooks.afterCleanupWrite = undefined;
   delete process.env.COMFYUI_MCP_PANEL_SETTINGS;
   delete process.env.COMFYUI_MCP_PANEL_LOCK;
   delete process.env.COMFYUI_MCP_PANEL_PENDING;
@@ -332,6 +338,41 @@ describe("withPanelMutationLock — a FILE lock, so it holds across processes", 
     );
     expect(existsSync(path)).toBe(false);
     expect(existsSync(claim)).toBe(false);
+  });
+
+  it("does not delete a fresh claim that replaces an abandoned claim during cleanup", async () => {
+    const path = panelLockPath();
+    const claim = `${path}.reclaim`;
+    const freshClaim = JSON.stringify({ pid: process.pid, token: "fresh-claim" });
+    writeFileSync(path, JSON.stringify({ pid: 0x7fffffff }));
+    writeFileSync(claim, JSON.stringify({ pid: 0x7fffffff, token: "dead-claim" }));
+    const old = new Date(Date.now() - 60 * 60_000);
+    const { utimesSync } = await import("node:fs");
+    utimesSync(path, old, old);
+    utimesSync(claim, old, old);
+
+    // A separate process replaces the fixed claim after cleanup has taken its
+    // exclusive token. Snapshot equality must make cleanup leave this fresh
+    // token intact, so no later claimant can steal its base lock.
+    let replaced = false;
+    panelLockTestHooks.afterCleanupWrite = () => {
+      replaced = true;
+      const child = spawnSync(
+        process.execPath,
+        [
+          "-e",
+          `const fs=require('node:fs');fs.rmSync(${JSON.stringify(claim)});fs.writeFileSync(${JSON.stringify(claim)},${JSON.stringify(freshClaim)});`,
+        ],
+        { encoding: "utf-8" },
+      );
+      expect(child.status).toBe(0);
+    };
+
+    await expect(
+      withPanelMutationLock(async () => "must not run", { timeoutMs: 300 }),
+    ).rejects.toThrow(/Timed out/);
+    expect(replaced).toBe(true);
+    expect(fs.readFileSync(claim, "utf-8")).toBe(freshClaim);
   });
 
   it("does NOT reclaim an old lock whose owner is still ALIVE", async () => {

--- a/src/__tests__/services/panel-pin-guard.test.ts
+++ b/src/__tests__/services/panel-pin-guard.test.ts
@@ -6,34 +6,10 @@
 // and `id="all"` reached the SAME ComfyUI-Manager mutation without ever passing
 // the guard. A pinned user was one generic call away from being moved.
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import * as fs from "node:fs";
-import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtempSync, existsSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-
-const panelLockTestHooks = vi.hoisted(() => ({
-  beforeClaimWrite: undefined as undefined | (() => void),
-  afterCleanupWrite: undefined as undefined | (() => void),
-}));
-
-vi.mock("node:fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs")>();
-  return {
-    ...actual,
-    writeSync: (...args: Parameters<typeof actual.writeSync>) => {
-      const hook = panelLockTestHooks.beforeClaimWrite;
-      panelLockTestHooks.beforeClaimWrite = undefined;
-      hook?.();
-      const result = actual.writeSync(...args);
-      const afterCleanupWrite = panelLockTestHooks.afterCleanupWrite;
-      panelLockTestHooks.afterCleanupWrite = undefined;
-      afterCleanupWrite?.();
-      return result;
-    },
-  };
-});
 
 import {
   activePanelPendingOps,
@@ -59,9 +35,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  vi.restoreAllMocks();
-  panelLockTestHooks.beforeClaimWrite = undefined;
-  panelLockTestHooks.afterCleanupWrite = undefined;
   delete process.env.COMFYUI_MCP_PANEL_SETTINGS;
   delete process.env.COMFYUI_MCP_PANEL_LOCK;
   delete process.env.COMFYUI_MCP_PANEL_PENDING;
@@ -278,101 +251,17 @@ describe("withPanelMutationLock — a FILE lock, so it holds across processes", 
     expect(existsSync(panelLockPath())).toBe(true);
   });
 
-  it("reclaims a stale lock whose owner is demonstrably dead", async () => {
+  it("fails closed on a stale dead-owner lock and names the safe recovery boundary", async () => {
     const path = panelLockPath();
-    // The age and dead-pid gates are both required before reclaim.
     writeFileSync(path, JSON.stringify({ pid: 0x7fffffff }));
     const old = new Date(Date.now() - 60 * 60_000);
     const { utimesSync } = await import("node:fs");
     utimesSync(path, old, old);
-    await expect(withPanelMutationLock(async () => "recovered", { timeoutMs: 300 })).resolves.toBe(
-      "recovered",
-    );
-    expect(existsSync(path)).toBe(false);
-  });
-
-  it("does not delete a fresh cross-process replacement after observing a stale lock", async () => {
-    const path = panelLockPath();
-    const freshRecord = JSON.stringify({ pid: 12345, fresh: true });
-    writeFileSync(path, JSON.stringify({ pid: 0x7fffffff }));
-    const old = new Date(Date.now() - 60 * 60_000);
-    const { utimesSync } = await import("node:fs");
-    utimesSync(path, old, old);
-
-    // Run the replacement in a separate Node process after this process has
-    // observed the abandoned lock but before it records its reclaim claim. It
-    // models an already-running older orchestrator winning the old reclaim.
-    let replaced = false;
-    panelLockTestHooks.beforeClaimWrite = () => {
-      replaced = true;
-      const child = spawnSync(
-        process.execPath,
-        [
-          "-e",
-          `const fs=require('node:fs');fs.rmSync(${JSON.stringify(path)});fs.writeFileSync(${JSON.stringify(path)},${JSON.stringify(freshRecord)});`,
-        ],
-        { encoding: "utf-8" },
-      );
-      expect(child.status).toBe(0);
-    };
 
     await expect(
       withPanelMutationLock(async () => "must not run", { timeoutMs: 300 }),
-    ).rejects.toThrow(/Timed out/);
-    expect(replaced).toBe(true);
-    expect(fs.readFileSync(path, "utf-8")).toBe(freshRecord);
-  });
-
-  it("recovers after a dead claimant leaves an old partial reclaim record", async () => {
-    const path = panelLockPath();
-    const claim = `${path}.reclaim`;
-    writeFileSync(path, JSON.stringify({ pid: 0x7fffffff }));
-    writeFileSync(claim, "partial");
-    const old = new Date(Date.now() - 60 * 60_000);
-    const { utimesSync } = await import("node:fs");
-    utimesSync(path, old, old);
-    utimesSync(claim, old, old);
-
-    await expect(withPanelMutationLock(async () => "recovered", { timeoutMs: 500 })).resolves.toBe(
-      "recovered",
-    );
-    expect(existsSync(path)).toBe(false);
-    expect(existsSync(claim)).toBe(false);
-  });
-
-  it("does not delete a fresh claim that replaces an abandoned claim during cleanup", async () => {
-    const path = panelLockPath();
-    const claim = `${path}.reclaim`;
-    const freshClaim = JSON.stringify({ pid: process.pid, token: "fresh-claim" });
-    writeFileSync(path, JSON.stringify({ pid: 0x7fffffff }));
-    writeFileSync(claim, JSON.stringify({ pid: 0x7fffffff, token: "dead-claim" }));
-    const old = new Date(Date.now() - 60 * 60_000);
-    const { utimesSync } = await import("node:fs");
-    utimesSync(path, old, old);
-    utimesSync(claim, old, old);
-
-    // A separate process replaces the fixed claim after cleanup has taken its
-    // exclusive token. Snapshot equality must make cleanup leave this fresh
-    // token intact, so no later claimant can steal its base lock.
-    let replaced = false;
-    panelLockTestHooks.afterCleanupWrite = () => {
-      replaced = true;
-      const child = spawnSync(
-        process.execPath,
-        [
-          "-e",
-          `const fs=require('node:fs');fs.rmSync(${JSON.stringify(claim)});fs.writeFileSync(${JSON.stringify(claim)},${JSON.stringify(freshClaim)});`,
-        ],
-        { encoding: "utf-8" },
-      );
-      expect(child.status).toBe(0);
-    };
-
-    await expect(
-      withPanelMutationLock(async () => "must not run", { timeoutMs: 300 }),
-    ).rejects.toThrow(/Timed out/);
-    expect(replaced).toBe(true);
-    expect(fs.readFileSync(claim, "utf-8")).toBe(freshClaim);
+    ).rejects.toThrow(/stop or restart every comfyui-mcp orchestrator.*delete this exact lock file/i);
+    expect(existsSync(path)).toBe(true);
   });
 
   it("does NOT reclaim an old lock whose owner is still ALIVE", async () => {
@@ -413,39 +302,6 @@ describe("withPanelMutationLock — a FILE lock, so it holds across processes", 
       withPanelMutationLock(async () => "should not run", { timeoutMs: 300 }),
     ).rejects.toThrow(/Timed out/);
     expect(existsSync(path)).toBe(true);
-  });
-
-  it("keeps a concurrent contender behind the action that reclaimed the stale lock", async () => {
-    // The successor must acquire through the same exclusive-create loop, not
-    // run alongside the action that just reclaimed the abandoned holder.
-    const path = panelLockPath();
-    writeFileSync(path, JSON.stringify({ pid: 0x7fffffff }));
-    const old = new Date(Date.now() - 60 * 60_000);
-    const { utimesSync } = await import("node:fs");
-    utimesSync(path, old, old);
-
-    const order: string[] = [];
-    let releaseFirst: (() => void) | undefined;
-    const firstMayFinish = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
-    const first = withPanelMutationLock(async () => {
-      order.push("reclaimed holder started");
-      await firstMayFinish;
-      order.push("reclaimed holder finished");
-    });
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    const second = withPanelMutationLock(async () => order.push("contender ran"));
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(order).toEqual(["reclaimed holder started"]);
-
-    releaseFirst?.();
-    await Promise.all([first, second]);
-    expect(order).toEqual([
-      "reclaimed holder started",
-      "reclaimed holder finished",
-      "contender ran",
-    ]);
   });
 
   it("resolves with the action's OWN result, and only after its side effects finished", async () => {

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -29,7 +29,6 @@ import {
   openSync,
   readFileSync,
   rmSync,
-  statSync,
   writeFileSync,
   writeSync,
 } from "node:fs";
@@ -227,14 +226,6 @@ export function panelLockPath(): string {
   );
 }
 
-/**
- * A lock older than this is assumed abandoned by a crashed process. Panel
- * operations are ComfyUI-Manager queue cycles measured in seconds; ten minutes
- * is far beyond a legitimate one, so reclaiming at that point cannot cut a live
- * op short, while still guaranteeing a crash can never wedge pinning forever.
- */
-const STALE_LOCK_MS = 10 * 60_000;
-
 /** Default acquisition budget. Callers that must not block (the fire-and-forget
  *  on-load ensure) pass something much shorter. */
 const DEFAULT_ACQUIRE_MS = 60_000;
@@ -272,199 +263,6 @@ function pidAlive(pid: unknown): boolean {
   }
 }
 
-interface StaleLockSnapshot {
-  readonly raw: string;
-  readonly dev: number;
-  readonly ino: number;
-}
-
-function staleLockSnapshot(path: string): StaleLockSnapshot | undefined {
-  try {
-    const before = statSync(path);
-    if (Date.now() - before.mtimeMs <= STALE_LOCK_MS) return undefined;
-    const raw = readFileSync(path, "utf-8");
-    const after = statSync(path);
-    if (
-      before.dev !== after.dev ||
-      before.ino !== after.ino ||
-      before.mtimeMs !== after.mtimeMs ||
-      before.size !== after.size
-    ) {
-      return undefined;
-    }
-    let pid: unknown;
-    try {
-      pid = (JSON.parse(raw) as { pid?: unknown })?.pid;
-    } catch {
-      return undefined;
-    }
-    if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return undefined;
-    return pidAlive(pid) ? undefined : { raw, dev: after.dev, ino: after.ino };
-  } catch {
-    return undefined;
-  }
-}
-
-function stableLockFileSnapshot(path: string): StaleLockSnapshot | undefined {
-  try {
-    const before = statSync(path);
-    const raw = readFileSync(path, "utf-8");
-    const after = statSync(path);
-    if (
-      before.dev !== after.dev ||
-      before.ino !== after.ino ||
-      before.mtimeMs !== after.mtimeMs ||
-      before.size !== after.size
-    ) {
-      return undefined;
-    }
-    return { raw, dev: after.dev, ino: after.ino };
-  } catch {
-    return undefined;
-  }
-}
-
-/** A reclaim claim is only arbitration metadata, not the operation lock. A
- * crashed claimant must therefore never leave future recovery wedged behind an
- * incomplete record. */
-function reclaimClaimIsAbandoned(path: string): boolean {
-  try {
-    if (Date.now() - statSync(path).mtimeMs <= STALE_LOCK_MS) return false;
-    const record = JSON.parse(readFileSync(path, "utf-8")) as { pid?: unknown };
-    return !pidAlive(record.pid);
-  } catch {
-    // This is safe for a claim (unlike the base lock): a writer whose old,
-    // partial claim is removed cannot pass the token ownership check below.
-    try {
-      return Date.now() - statSync(path).mtimeMs > STALE_LOCK_MS;
-    } catch {
-      return false;
-    }
-  }
-}
-
-function snapshotStillMatches(path: string, observed: StaleLockSnapshot): boolean {
-  try {
-    const before = statSync(path);
-    const raw = readFileSync(path, "utf-8");
-    const after = statSync(path);
-    return (
-      before.dev === after.dev &&
-      before.ino === after.ino &&
-      before.mtimeMs === after.mtimeMs &&
-      before.size === after.size &&
-      after.dev === observed.dev &&
-      after.ino === observed.ino &&
-      raw === observed.raw
-    );
-  } catch {
-    return false;
-  }
-}
-
-/**
- * A stale fixed claim is itself reclaimed through an independent, tokenized
- * cleanup claim. The cleanup record is fresh and owned by this process, so a
- * competing cleaner cannot replace the fixed claim between its snapshot check
- * and removal. Reaping an abandoned cleanup record touches only metadata.
- */
-function clearAbandonedReclaimClaim(claim: string): void {
-  const observed = stableLockFileSnapshot(claim);
-  if (!observed) return;
-  const cleanup = `${claim}.cleanup`;
-  const token = randomUUID();
-  let fd: number | undefined;
-  try {
-    fd = openSync(cleanup, "wx");
-    writeSync(fd, JSON.stringify({ pid: process.pid, token }));
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException)?.code === "EEXIST" && reclaimClaimIsAbandoned(cleanup)) {
-      // Cleanup is arbitration metadata only, never the fixed claim pathname.
-      rmSync(cleanup, { force: true });
-    }
-    return;
-  } finally {
-    if (fd !== undefined) closeSync(fd);
-  }
-
-  const ownsCleanup = (): boolean => {
-    try {
-      const record = JSON.parse(readFileSync(cleanup, "utf-8")) as {
-        pid?: unknown;
-        token?: unknown;
-      };
-      return record.pid === process.pid && record.token === token;
-    } catch {
-      return false;
-    }
-  };
-  const releaseCleanup = (): void => {
-    if (ownsCleanup()) rmSync(cleanup, { force: true });
-  };
-
-  try {
-    if (ownsCleanup() && snapshotStillMatches(claim, observed) && ownsCleanup()) {
-      rmSync(claim);
-    }
-  } finally {
-    releaseCleanup();
-  }
-}
-
-function reclaimBoundStaleLock(path: string, observed: StaleLockSnapshot): boolean {
-  const claim = `${path}.reclaim`;
-  const token = randomUUID();
-  let fd: number | undefined;
-  try {
-    // The claim has independent exclusive-create semantics. It binds this
-    // reclaimer to the observed stale snapshot before the base path moves.
-    fd = openSync(claim, "wx");
-    writeSync(fd, JSON.stringify({ pid: process.pid, token }));
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException)?.code === "EEXIST" && reclaimClaimIsAbandoned(claim)) {
-      clearAbandonedReclaimClaim(claim);
-    }
-    return false;
-  } finally {
-    if (fd !== undefined) closeSync(fd);
-  }
-
-  const ownsClaim = (): boolean => {
-    try {
-      const record = JSON.parse(readFileSync(claim, "utf-8")) as {
-        pid?: unknown;
-        token?: unknown;
-      };
-      return record.pid === process.pid && record.token === token;
-    } catch {
-      return false;
-    }
-  };
-  const releaseClaim = (): void => {
-    if (ownsClaim()) rmSync(claim, { force: true });
-  };
-
-  try {
-    if (!ownsClaim()) return false;
-    const current = staleLockSnapshot(path);
-    // A later fresh lock cannot satisfy the source file's exact identity and
-    // bytes, so this reclaimer cannot delete it.
-    if (
-      !current ||
-      current.dev !== observed.dev ||
-      current.ino !== observed.ino ||
-      current.raw !== observed.raw ||
-      !ownsClaim()
-    ) {
-      return false;
-    }
-    rmSync(path);
-    return true;
-  } finally {
-    releaseClaim();
-  }
-}
-
 async function acquireFileLock(timeoutMs: number): Promise<() => void> {
   const path = panelLockPath();
   mkdirSync(dirname(path), { recursive: true });
@@ -489,7 +287,7 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
           logger.warn(
             `[panel] could not remove the panel op lock at ${path}: ${
               err instanceof Error ? err.message : String(err)
-            } (it will be reclaimed as stale).`,
+            } (use the restart-and-recovery instructions from the next panel operation).`,
           );
         }
       };
@@ -503,20 +301,14 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
           }. Refusing to mutate the panel without it.`,
         );
       }
-      const stale = staleLockSnapshot(path);
-      if (stale) {
-        // Only a demonstrably abandoned lock gets here: old locks with a live
-        // owner (and all fresh locks) still wait. The exclusive claim binds
-        // this reclaimer to its observed file before the base is removed.
-        if (reclaimBoundStaleLock(path, stale)) continue;
-      }
       if (Date.now() >= deadline) {
         throw new Error(
           `Timed out after ${timeoutMs}ms waiting for the panel operation lock ` +
             `(${path}). Another panel install/update/pin is in progress — possibly in ` +
-            `another orchestrator process. Fresh locks, malformed locks, and locks owned by a ` +
-            `live process are never auto-reclaimed; a proven abandoned lock is reclaimed ` +
-            `automatically. Retry shortly.`,
+            `another orchestrator process. It is never auto-reclaimed: a concurrent pre-upgrade ` +
+            `orchestrator could replace an observed stale path with a fresh lock. To recover a ` +
+            `proven abandoned lock, stop or restart every comfyui-mcp orchestrator, verify none ` +
+            `remain, delete this exact lock file, then retry.`,
         );
       }
       await sleep(POLL_MS);

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -305,6 +305,25 @@ function staleLockSnapshot(path: string): StaleLockSnapshot | undefined {
   }
 }
 
+function stableLockFileSnapshot(path: string): StaleLockSnapshot | undefined {
+  try {
+    const before = statSync(path);
+    const raw = readFileSync(path, "utf-8");
+    const after = statSync(path);
+    if (
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.mtimeMs !== after.mtimeMs ||
+      before.size !== after.size
+    ) {
+      return undefined;
+    }
+    return { raw, dev: after.dev, ino: after.ino };
+  } catch {
+    return undefined;
+  }
+}
+
 /** A reclaim claim is only arbitration metadata, not the operation lock. A
  * crashed claimant must therefore never leave future recovery wedged behind an
  * incomplete record. */
@@ -324,6 +343,74 @@ function reclaimClaimIsAbandoned(path: string): boolean {
   }
 }
 
+function snapshotStillMatches(path: string, observed: StaleLockSnapshot): boolean {
+  try {
+    const before = statSync(path);
+    const raw = readFileSync(path, "utf-8");
+    const after = statSync(path);
+    return (
+      before.dev === after.dev &&
+      before.ino === after.ino &&
+      before.mtimeMs === after.mtimeMs &&
+      before.size === after.size &&
+      after.dev === observed.dev &&
+      after.ino === observed.ino &&
+      raw === observed.raw
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A stale fixed claim is itself reclaimed through an independent, tokenized
+ * cleanup claim. The cleanup record is fresh and owned by this process, so a
+ * competing cleaner cannot replace the fixed claim between its snapshot check
+ * and removal. Reaping an abandoned cleanup record touches only metadata.
+ */
+function clearAbandonedReclaimClaim(claim: string): void {
+  const observed = stableLockFileSnapshot(claim);
+  if (!observed) return;
+  const cleanup = `${claim}.cleanup`;
+  const token = randomUUID();
+  let fd: number | undefined;
+  try {
+    fd = openSync(cleanup, "wx");
+    writeSync(fd, JSON.stringify({ pid: process.pid, token }));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "EEXIST" && reclaimClaimIsAbandoned(cleanup)) {
+      // Cleanup is arbitration metadata only, never the fixed claim pathname.
+      rmSync(cleanup, { force: true });
+    }
+    return;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+
+  const ownsCleanup = (): boolean => {
+    try {
+      const record = JSON.parse(readFileSync(cleanup, "utf-8")) as {
+        pid?: unknown;
+        token?: unknown;
+      };
+      return record.pid === process.pid && record.token === token;
+    } catch {
+      return false;
+    }
+  };
+  const releaseCleanup = (): void => {
+    if (ownsCleanup()) rmSync(cleanup, { force: true });
+  };
+
+  try {
+    if (ownsCleanup() && snapshotStillMatches(claim, observed) && ownsCleanup()) {
+      rmSync(claim);
+    }
+  } finally {
+    releaseCleanup();
+  }
+}
+
 function reclaimBoundStaleLock(path: string, observed: StaleLockSnapshot): boolean {
   const claim = `${path}.reclaim`;
   const token = randomUUID();
@@ -335,9 +422,7 @@ function reclaimBoundStaleLock(path: string, observed: StaleLockSnapshot): boole
     writeSync(fd, JSON.stringify({ pid: process.pid, token }));
   } catch (err) {
     if ((err as NodeJS.ErrnoException)?.code === "EEXIST" && reclaimClaimIsAbandoned(claim)) {
-      // The claim is coordination metadata, never the operation lock. Removing
-      // a dead claimant's record never removes or edits the base lock.
-      rmSync(claim, { force: true });
+      clearAbandonedReclaimClaim(claim);
     }
     return false;
   } finally {

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -290,8 +290,14 @@ function lockIsStale(path: string): boolean {
     try {
       pid = (JSON.parse(readFileSync(path, "utf-8")) as { pid?: unknown })?.pid;
     } catch {
-      // Unreadable/corrupt content on an already-old lock: nobody can claim it.
-      return true;
+      // We reclaim only a lock whose owner is demonstrably dead. Corrupt
+      // content cannot establish that proof, so preserve it for recovery.
+      return false;
+    }
+    if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) {
+      // Missing, fractional, or otherwise malformed ownership is not a dead
+      // process identity. Failing closed keeps an ambiguous live lock safe.
+      return false;
     }
     return !pidAlive(pid);
   } catch {
@@ -354,18 +360,20 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
         );
       }
       if (lockIsStale(path)) {
-        // Never rename/delete after a stale observation: another process can
-        // replace this path with a fresh lock between the check and reclaim.
-        // Node lacks an atomic compare-and-rename, so failing closed is the
-        // only way to avoid stealing that new holder.
+        // Only a demonstrably abandoned lock gets here: old locks with a live
+        // owner (and all fresh locks) still wait. Claim it by renaming first,
+        // rather than deleting the contested name: exactly one reclaimer can
+        // win, and followers merely retry the exclusive create.
+        reclaimStaleLock(path);
+        continue;
       }
       if (Date.now() >= deadline) {
         throw new Error(
           `Timed out after ${timeoutMs}ms waiting for the panel operation lock ` +
             `(${path}). Another panel install/update/pin is in progress — possibly in ` +
-            `another orchestrator process. The lock is never auto-reclaimed because that could ` +
-            `steal a fresh holder after a stale observation. Retry shortly or recover a proven ` +
-            `abandoned lock explicitly.`,
+            `another orchestrator process. Fresh locks, malformed locks, and locks owned by a ` +
+            `live process are never auto-reclaimed; a proven abandoned lock is reclaimed ` +
+            `automatically. Retry shortly.`,
         );
       }
       await sleep(POLL_MS);

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -28,7 +28,6 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
-  renameSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -273,52 +272,112 @@ function pidAlive(pid: unknown): boolean {
   }
 }
 
-/**
- * A lock is stale only when it is BOTH old AND owned by a dead process.
- *
- * The pid check is what makes reclaiming safe. Age alone let two waiters both
- * judge the same lock stale, and the slower one could then delete the FRESH
- * lock the faster one had just taken — putting two mutations in flight at once,
- * the exact thing the lock exists to prevent. A live holder's lock now never
- * reads as stale, so that interleaving cannot arise. (pid liveness is the right
- * test here precisely because this is a single-machine, local-first project.)
- */
-function lockIsStale(path: string): boolean {
+interface StaleLockSnapshot {
+  readonly raw: string;
+  readonly dev: number;
+  readonly ino: number;
+}
+
+function staleLockSnapshot(path: string): StaleLockSnapshot | undefined {
   try {
-    if (Date.now() - statSync(path).mtimeMs <= STALE_LOCK_MS) return false;
+    const before = statSync(path);
+    if (Date.now() - before.mtimeMs <= STALE_LOCK_MS) return undefined;
+    const raw = readFileSync(path, "utf-8");
+    const after = statSync(path);
+    if (
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.mtimeMs !== after.mtimeMs ||
+      before.size !== after.size
+    ) {
+      return undefined;
+    }
     let pid: unknown;
     try {
-      pid = (JSON.parse(readFileSync(path, "utf-8")) as { pid?: unknown })?.pid;
+      pid = (JSON.parse(raw) as { pid?: unknown })?.pid;
     } catch {
-      // We reclaim only a lock whose owner is demonstrably dead. Corrupt
-      // content cannot establish that proof, so preserve it for recovery.
-      return false;
+      return undefined;
     }
-    if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) {
-      // Missing, fractional, or otherwise malformed ownership is not a dead
-      // process identity. Failing closed keeps an ambiguous live lock safe.
-      return false;
-    }
-    return !pidAlive(pid);
+    if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return undefined;
+    return pidAlive(pid) ? undefined : { raw, dev: after.dev, ino: after.ino };
   } catch {
-    // Vanished between EEXIST and stat — the next create attempt will settle it.
-    return false;
+    return undefined;
   }
 }
 
-/**
- * Remove a lock judged stale, ATOMICALLY. Renaming first means only one waiter
- * can win the reclaim (the rest get ENOENT and simply retry); deleting the path
- * directly would let a straggler delete whatever now sits there.
- */
-function reclaimStaleLock(path: string): void {
-  const claim = `${path}.reclaim-${randomUUID()}`;
+/** A reclaim claim is only arbitration metadata, not the operation lock. A
+ * crashed claimant must therefore never leave future recovery wedged behind an
+ * incomplete record. */
+function reclaimClaimIsAbandoned(path: string): boolean {
   try {
-    renameSync(path, claim);
+    if (Date.now() - statSync(path).mtimeMs <= STALE_LOCK_MS) return false;
+    const record = JSON.parse(readFileSync(path, "utf-8")) as { pid?: unknown };
+    return !pidAlive(record.pid);
   } catch {
-    return; // someone else reclaimed it first — just retry the create
+    // This is safe for a claim (unlike the base lock): a writer whose old,
+    // partial claim is removed cannot pass the token ownership check below.
+    try {
+      return Date.now() - statSync(path).mtimeMs > STALE_LOCK_MS;
+    } catch {
+      return false;
+    }
   }
-  rmSync(claim, { force: true });
+}
+
+function reclaimBoundStaleLock(path: string, observed: StaleLockSnapshot): boolean {
+  const claim = `${path}.reclaim`;
+  const token = randomUUID();
+  let fd: number | undefined;
+  try {
+    // The claim has independent exclusive-create semantics. It binds this
+    // reclaimer to the observed stale snapshot before the base path moves.
+    fd = openSync(claim, "wx");
+    writeSync(fd, JSON.stringify({ pid: process.pid, token }));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "EEXIST" && reclaimClaimIsAbandoned(claim)) {
+      // The claim is coordination metadata, never the operation lock. Removing
+      // a dead claimant's record never removes or edits the base lock.
+      rmSync(claim, { force: true });
+    }
+    return false;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+
+  const ownsClaim = (): boolean => {
+    try {
+      const record = JSON.parse(readFileSync(claim, "utf-8")) as {
+        pid?: unknown;
+        token?: unknown;
+      };
+      return record.pid === process.pid && record.token === token;
+    } catch {
+      return false;
+    }
+  };
+  const releaseClaim = (): void => {
+    if (ownsClaim()) rmSync(claim, { force: true });
+  };
+
+  try {
+    if (!ownsClaim()) return false;
+    const current = staleLockSnapshot(path);
+    // A later fresh lock cannot satisfy the source file's exact identity and
+    // bytes, so this reclaimer cannot delete it.
+    if (
+      !current ||
+      current.dev !== observed.dev ||
+      current.ino !== observed.ino ||
+      current.raw !== observed.raw ||
+      !ownsClaim()
+    ) {
+      return false;
+    }
+    rmSync(path);
+    return true;
+  } finally {
+    releaseClaim();
+  }
 }
 
 async function acquireFileLock(timeoutMs: number): Promise<() => void> {
@@ -359,13 +418,12 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
           }. Refusing to mutate the panel without it.`,
         );
       }
-      if (lockIsStale(path)) {
+      const stale = staleLockSnapshot(path);
+      if (stale) {
         // Only a demonstrably abandoned lock gets here: old locks with a live
-        // owner (and all fresh locks) still wait. Claim it by renaming first,
-        // rather than deleting the contested name: exactly one reclaimer can
-        // win, and followers merely retry the exclusive create.
-        reclaimStaleLock(path);
-        continue;
+        // owner (and all fresh locks) still wait. The exclusive claim binds
+        // this reclaimer to its observed file before the base is removed.
+        if (reclaimBoundStaleLock(path, stale)) continue;
       }
       if (Date.now() >= deadline) {
         throw new Error(


### PR DESCRIPTION
## Summary

- Remove the unsafe automatic stale-lock reclaim path.
- Fail closed for stale, malformed, fresh, and live-owner files.
- Give an explicit safe recovery boundary: stop or restart every `comfyui-mcp` orchestrator, verify none remain, delete the exact reported lock file, then retry.

## Why

Node's cross-platform filesystem API has no atomic compare-and-delete operation. A process can replace a stale pathname after another process observes it but before deletion; this occurs during upgrade when an older orchestrator does not understand any new claim metadata. Automatic deletion therefore cannot meet the no-fresh-lock-steal invariant.

## Validation

- `npm.cmd test -- src/__tests__/services/panel-pin-guard.test.ts`
- `npm.cmd test`
- `npm.cmd run lint`
- `npm.cmd run build`
- `npm.cmd run check:vocabulary`

Fixes #760 by replacing unsafe recovery with an explicit, operator-controlled restart boundary.
