### PR TITLE
fix: retain stale persisted downloads (#761)

### DIFF
--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -108,7 +108,7 @@ import {
 import { setProgressDir, PERSIST_OWNER } from "../../services/download-progress.js";
 import * as progressModule from "../../services/download-progress.js";
 import { downloadModel, resolveDownloadTarget } from "../../services/model-resolver.js";
-import { mkdtemp, mkdir, symlink, writeFile, rm as fsRm } from "node:fs/promises";
+import { mkdtemp, mkdir, symlink, writeFile, readFile, rm as fsRm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
 
@@ -1080,23 +1080,54 @@ describe("download job registry", () => {
       }
     });
 
-    it("reaps a DEAD (crashed-writer) in-flight record so it is not reported as still streaming", async () => {
+    it("keeps a heartbeat-stale in-flight record visible without deleting its persisted state (#761)", async () => {
       const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
       setProgressDir(dir);
       try {
-        // A crashed session left a stale in-flight record (heartbeat stopped long ago).
+        // A reconnect can interrupt the owner's heartbeat while its HTTP transfer and
+        // .partial continue. A status read must not erase the only record for it.
+        const id = "stalejobxxxxxxxx1";
+        const owner = "reconnecting-session";
         await writeForeignJobRecord(dir, {
-          id: "deadjobxxxxxxxx1",
-          trayId: "deadtrayxxxxxxx1",
-          progressId: "dead-prog",
+          id,
+          trayId: downloadIdFor(URL_A),
+          progressId: "stale-prog",
           url: URL_A,
-          owner: "crashedsession",
-          ageMs: 10 * 60 * 1000,
+          owner,
+          ageMs: 5 * 60 * 1000,
         });
-        // It must NOT be resolvable/listed as a live download (it's dead, not streaming).
-        expect(getDownloadJob("deadjobxxxxxxxx1")).toBeUndefined();
-        expect(listDownloadJobs().some((j) => j.id === "deadjobxxxxxxxx1")).toBe(false);
-        expect(findDownloadJob({ url: URL_A })).toBeUndefined();
+        const listed = listDownloadJobs().find((j) => j.id === id);
+        expect(listed).toMatchObject({ status: "downloading", staleInflight: true });
+        expect(listed?.staleForMs).toBeGreaterThan(60_000);
+        // The control file survives the read; a later owner heartbeat can refresh it.
+        await expect(readFile(pathJoin(dir, `control-job-${id}-${owner}.json`), "utf8")).resolves.toContain(id);
+        // URL status can still surface the stale record, but the independent
+        // start/adoption and ambiguity paths retain their short freshness checks.
+        expect(findDownloadJob({ url: URL_A })).toMatchObject({ id, staleInflight: true });
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("reaps terminal persisted records after the bounded TTL", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        const id = "expiredterminal0001";
+        const owner = "old-session";
+        await writeForeignJobRecord(dir, {
+          id,
+          trayId: "expiredtray00001",
+          progressId: "expired-prog",
+          url: URL_A,
+          owner,
+          status: "done",
+          path: "/M/checkpoints/old.safetensors",
+          ageMs: 7 * 60 * 60 * 1000,
+        });
+        expect(listDownloadJobs().some((j) => j.id === id)).toBe(false);
+        await expect(readFile(pathJoin(dir, `control-job-${id}-${owner}.json`), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
       } finally {
         setProgressDir("");
         await fsRm(dir, { recursive: true, force: true });

--- a/src/__tests__/tools/model-management.test.ts
+++ b/src/__tests__/tools/model-management.test.ts
@@ -23,6 +23,10 @@ vi.mock("../../services/model-resolver.js", async () => {
 });
 
 import { registerModelManagementTools } from "../../tools/model-management.js";
+import { setProgressDir } from "../../services/download-progress.js";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 type ToolHandler = (args: Record<string, unknown>) => Promise<{
   isError?: boolean;
@@ -39,6 +43,7 @@ function makeServer() {
   registerModelManagementTools(server as never);
   return {
     downloadModel: handlers.get("download_model")!,
+    downloadStatus: handlers.get("download_status")!,
     listLocalModels: handlers.get("list_local_models")!,
   };
 }
@@ -77,6 +82,42 @@ describe("download_model tool", () => {
       expect.any(Function), // onLanded callback — commits done synchronously at the destination rename (#515)
     );
     expect(res.isError).toBeFalsy();
+  });
+});
+
+describe("download_status tool", () => {
+  it("keeps a heartbeat-stale persisted transfer visible without prompting a concurrent reissue (#761)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "model-management-status-"));
+    setProgressDir(dir);
+    try {
+      const id = "status-stale-job";
+      await writeFile(
+        join(dir, `control-job-${id}-other-session.json`),
+        JSON.stringify({
+          id,
+          trayId: "status-stale-tray",
+          progressId: "status-stale-progress",
+          url: "https://example.com/large.safetensors",
+          target_subfolder: "checkpoints",
+          status: "downloading",
+          started_at: Date.now() - 10 * 60 * 1000,
+          owner: "other-session",
+          updated: Date.now() - 5 * 60 * 1000,
+        }),
+      );
+
+      const { downloadStatus } = makeServer();
+      const res = await downloadStatus({});
+      const text = res.content[0].text;
+      expect(text).toContain(id);
+      expect(text).toContain("heartbeat stale for");
+      expect(text).toContain("Do NOT re-issue download_model while this warning remains");
+      expect(text).toContain("only after confirming the .partial has stopped growing");
+      expect(text).toContain("Do not report this download as failed or missing.");
+    } finally {
+      setProgressDir("");
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -94,6 +94,11 @@ export interface DownloadJob {
    *  download outlives its tool call they have to survive somewhere the agent
    *  can still read them, or handing back a handle would silently drop them. */
   notes?: string[];
+  /** A persisted in-flight record missed its owner heartbeat. It stays visible
+   *  because this is not proof the physical transfer stopped (#761). */
+  staleInflight?: boolean;
+  /** Age of the missing persisted heartbeat, used only for status diagnostics. */
+  staleForMs?: number;
 }
 
 interface Entry {
@@ -116,11 +121,10 @@ interface Entry {
 /** How often an in-flight job re-persists its record (liveness heartbeat). Must stay
  *  comfortably below PERSISTED_INFLIGHT_STALE_MS so a live download is always fresh. */
 const HEARTBEAT_MS = 15_000;
-/** Cap on heartbeat retries of a transiently-failing TERMINAL persist. Chosen so the
- *  total window (attempts × HEARTBEAT_MS) exceeds PERSISTED_INFLIGHT_STALE_MS — by then
- *  the last-successful (in-flight) record has already aged out via the stale reap, so
- *  giving up can't leave a fresh, adoptable record. Prevents a permanently-unwritable
- *  progress store from keeping a COMPLETED job's interval doing filesystem work forever. */
+/** Cap on heartbeat retries of a transiently-failing TERMINAL persist. Once this
+ *  bounded retry window ends the completed job stops touching the filesystem; its
+ *  last in-flight snapshot remains non-adoptable after the freshness window and is
+ *  reaped only by the long persisted-record retention bound (#761). */
 const TERMINAL_PERSIST_MAX_ATTEMPTS = 6; // 6 × 15s = 90s > 60s stale window
 
 // The in-flight registry is indexed under MULTIPLE keys per job so dedup is
@@ -591,8 +595,9 @@ export async function startDownloadJob(
       // outcome (#529) instead of a forever-"downloading" record. If this atomic
       // replace transiently fails (rare), the heartbeat below KEEPS retrying until the
       // terminal state is durable — so a done/cancelled job can't linger as a
-      // fresh-and-adoptable "downloading" record (beyond the stale reap that already
-      // bounds it). Only once the terminal record is durable does the heartbeat stop.
+      // fresh-and-adoptable "downloading" record. The freshness window excludes it from
+      // adoption immediately; long retention later bounds the persisted record. Only once
+      // the terminal record is durable does the heartbeat stop.
       if (persistJobRecord(job) && heartbeat) clearInterval(heartbeat);
     }
   })();
@@ -631,8 +636,8 @@ export async function startDownloadJob(
       const durable = persistJobRecord(job);
       if (job.status !== "downloading") {
         // Stop the interval once the terminal state is durable, OR the retry budget is
-        // spent (by which point the stale record is already reaped), OR persistence went
-        // inactive — never let a completed job's interval do filesystem work forever.
+        // spent (after which the snapshot is non-adoptable), OR persistence went inactive
+        // — never let a completed job's interval do filesystem work forever.
         if (
           (durable ||
             ++terminalPersistAttempts >= TERMINAL_PERSIST_MAX_ATTEMPTS ||
@@ -741,6 +746,8 @@ function jobFromPersisted(rec: PersistedDownloadJob): DownloadJob {
     reqKey: rec.req_key,
     viaManager: rec.via_manager,
     resume: rec.resume as ResumeDiagnostic | undefined,
+    staleInflight: rec.staleInflight,
+    staleForMs: rec.staleForMs,
   };
 }
 
@@ -748,7 +755,7 @@ function jobFromPersisted(rec: PersistedDownloadJob): DownloadJob {
  *  DIFFERENT trayId — a distinct concurrent physical download in ANOTHER session (two
  *  distinct URLs resolving to the same dest+auth). The id alone can't disambiguate, so
  *  a by-id lookup/cancel must decline rather than silently act on the local one.
- *  Excludes this process's own records (same owner) and stale/dead ones (heartbeat). */
+ *  Excludes this process's own records (same owner) and heartbeat-stale ones. */
 function hasAmbiguousForeignSibling(id: string, localTrayId: string): boolean {
   const now = Date.now();
   return listPersistedDownloadJobs().some(
@@ -831,9 +838,9 @@ export function findDownloadJob(query: { url?: string; destKey?: string }): Down
     }
   }
   for (const rec of listPersistedDownloadJobs()) {
-    // Only FRESH in-flight records count as live candidates — a stale/dead record
-    // (crashed session, never reaped) must not inflate the ambiguity count and force a
-    // false "no download" (matching the persisted helpers' fresh-in-flight rule).
+    // Only FRESH in-flight records count as live candidates — a heartbeat-stale record
+    // may still stream, but must not inflate the ambiguity count and force a false
+    // "no download" (matching the persisted helpers' fresh-in-flight rule).
     if (rec.status !== "downloading" || now - (rec.updated ?? 0) >= PERSISTED_INFLIGHT_STALE_MS) {
       continue;
     }

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -518,6 +518,13 @@ export interface PersistedDownloadJob {
   resume?: unknown;
   /** Epoch ms of this snapshot (set on write). */
   updated: number;
+  /**
+   * Read-only diagnostics added when an in-flight record missed the liveness
+   * heartbeat. These are never persisted: a stale heartbeat is not proof that
+   * the physical transfer stopped, so callers must keep the record visible.
+   */
+  staleInflight?: boolean;
+  staleForMs?: number;
 }
 
 function sanitizeIdPart(id: string): string {
@@ -547,7 +554,7 @@ let persistSeq = 0;
  *  Returns TRUE iff the record was DURABLY replaced (the atomic rename succeeded), so the
  *  caller (the heartbeat) can keep retrying a transiently-failing TERMINAL persist until
  *  the terminal state is durable — otherwise a done/cancelled job could linger as a fresh
- *  "downloading" record (bounded by the stale reap, but this recovers it sooner). Returns
+ *  "downloading" record (bounded by long record retention, but this recovers it sooner). Returns
  *  false when there is no channel dir (nothing to persist) or the replace didn't happen. */
 export function persistDownloadJob(job: Omit<PersistedDownloadJob, "updated">): boolean {
   const dir = channelDir();
@@ -570,7 +577,7 @@ export function persistDownloadJob(job: Omit<PersistedDownloadJob, "updated">): 
     // the torn-read that lets another process see the record as absent and start a SECOND
     // writer. On persistent failure we KEEP the prior COMPLETE record untouched and drop
     // the temp; the next ~15s heartbeat retries the atomic replace (self-healing). A
-    // terminal persist that can't replace ages out via the stale-in-flight reap instead
+    // terminal persist that can't replace ages out via long record retention instead
     // of ever corrupting the scanned .json.
     let renamed = false;
     for (let attempt = 0; attempt < 5 && !renamed; attempt++) {
@@ -606,11 +613,10 @@ export function removePersistedDownloadJob(id: string): void {
   }
 }
 
-/** How long a TERMINAL (done/error/cancelled) persisted record is kept for late
- *  adoption before it's reaped on the next scan. A slow multi-GB in-flight download
- *  stays adoptable because its owner heartbeats the record within
- *  PERSISTED_INFLIGHT_STALE_MS — so only a DEAD (crashed) writer's in-flight record
- *  goes stale and gets reaped (below). */
+// A missed heartbeat is only a liveness hint, not proof the transfer stopped:
+// an orchestrator/session reconnect can interrupt persistence while the HTTP
+// stream continues. Keep in-flight records for the same bounded retention as
+// terminal records so read paths cannot delete a live owner's state (#761).
 const PERSISTED_JOB_TTL_MS = 6 * 60 * 60 * 1000; // 6h
 
 function parseJobFile(dir: string, f: string): PersistedDownloadJob | null {
@@ -618,21 +624,20 @@ function parseJobFile(dir: string, f: string): PersistedDownloadJob | null {
     const raw = JSON.parse(readFileSync(join(dir, f), "utf8")) as PersistedDownloadJob;
     if (!raw || typeof raw !== "object" || typeof raw.id !== "string") return null;
     const age = typeof raw.updated === "number" ? Date.now() - raw.updated : 0;
-    // Reap a record that is either a long-settled terminal one OR a DEAD in-flight one.
-    // In-flight records are heartbeated every ~15s by their live owner, so an in-flight
-    // record older than PERSISTED_INFLIGHT_STALE_MS (60s) means the writer crashed —
-    // reap it so download_status / cancel_download never report a dead download as
-    // "still streaming". A genuinely-live (even stalled) download keeps heartbeating and
-    // is never stale; a falsely-reaped one reappears on the owner's next heartbeat.
-    const terminalExpired = raw.status !== "downloading" && age > PERSISTED_JOB_TTL_MS;
-    const inflightDead = raw.status === "downloading" && age > PERSISTED_INFLIGHT_STALE_MS;
-    if (terminalExpired || inflightDead) {
+    // This parser backs read paths (including download_status). A heartbeat gap
+    // beyond the short freshness window is not sufficient evidence to destructively
+    // delete a potentially live transfer; adoption/cancel freshness checks below
+    // still treat it as non-live. Reap only after the bounded long retention.
+    if (age > PERSISTED_JOB_TTL_MS) {
       try {
         rmSync(join(dir, f), { force: true });
       } catch {
         /* ignore */
       }
       return null;
+    }
+    if (raw.status === "downloading" && age > PERSISTED_INFLIGHT_STALE_MS) {
+      return { ...raw, staleInflight: true, staleForMs: age };
     }
     return raw;
   } catch {
@@ -711,8 +716,8 @@ export function findPersistedDownloadJob(query: { trayId?: string; destKey?: str
   // jobs (they share a dest_key). Adopting by URL/destination alone then can't tell them
   // apart — so REFUSE to guess when more than one DISTINCT LIVE job matches; the caller
   // must use the exact id. Distinctness is (id, trayId). Ambiguity is judged over LIVE
-  // (fresh in-flight) records ONLY: a stale/dead record (crashed session, explicitly
-  // never reaped) must not block adoption or force a false decline.
+  // (fresh in-flight) records ONLY: a heartbeat-stale record may still be streaming,
+  // but must not block adoption or force a false decline.
   const distinctKey = (j: PersistedDownloadJob): string => `${j.id}\n${j.trayId}`;
   const now = Date.now();
   const live = matches.filter(

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -274,6 +274,10 @@ export function registerModelManagementTools(server: McpServer): void {
                     // restored) — surface it so the user can recover, not mask it.
                     (j.error ? `\n    IMPORTANT: ${j.error}` : "")
                   : `\n    still streaming — started ${Math.round((Date.now() - j.started_at) / 1000)}s ago`;
+          const staleNote =
+            j.status === "downloading" && j.staleInflight
+              ? `\n    NOTE: heartbeat stale for ${Math.round((j.staleForMs ?? 0) / 1000)}s. The owning session may have reconnected, and the transfer may still be running. Do NOT re-issue download_model while this warning remains: the original owner may still be writing the same .partial. Wait and check download_status again; only after confirming the .partial has stopped growing should you decide on recovery. Do not report this download as failed or missing.`
+              : "";
           // Surface a declined resume so the agent/user knows a pre-existing
           // .partial was discarded and why — instead of it being silent (#467).
           // The decision is stored on THIS job by its own physical download, so it
@@ -304,7 +308,7 @@ export function registerModelManagementTools(server: McpServer): void {
                 : "re-downloading in full";
             resumeNote = `\n    resume: ${diag.outcome} — ${fate} because ${why}; ${next}`;
           }
-          return `${head}${detail}${resumeNote}\n    from: ${j.url}`;
+          return `${head}${detail}${staleNote}${resumeNote}\n    from: ${j.url}`;
         });
 
         return { content: [{ type: "text", text: `## Downloads\n\n${lines.join("\n")}` }] };


### PR DESCRIPTION
Fixes #761.

A heartbeat gap no longer lets the download_status read path delete a persisted in-flight record. The record remains visible with an explicit stale-heartbeat warning, while the existing short freshness window continues to prevent stale records from participating in automatic adoption, ambiguity checks, or cancellation ownership. Persisted terminal records and long-abandoned in-flight records remain bounded by the six-hour retention TTL.

Validation: npm.cmd test -- --run src/__tests__/services/download-jobs.test.ts src/__tests__/tools/model-management.test.ts; npm.cmd test (4013 passed, 2 skipped); npm.cmd run lint; npm.cmd run build; npm.cmd run check:vocabulary.