### PR TITLE
fix: list reachable local extra paths without argv main.py

### DIFF
--- a/docs/tools/models.mdx
+++ b/docs/tools/models.mdx
@@ -305,12 +305,12 @@ Delete a model file from the local ComfyUI models directories. Resolves the path
 
 ## list_extra_paths
 
-View ComfyUI extra search-path config for standalone/manual installs and ComfyUI Desktop. Resolves LIVE-FIRST: the file the running ComfyUI actually reads (its --extra-model-paths-config, else the extra_model_paths.yaml beside its main.py), falling back to the local heuristic only when no server is reachable — &lt;ComfyUI root&gt;/extra_model_paths.yaml (COMFYUI_PATH, else the saved default workspace from workspace action:"set_default") or the Desktop app-data extra_models_config.yaml. Reports generic categories, so model categories and custom_nodes entries are both visible when present. Read-only.
+View ComfyUI extra search-path config for standalone/manual installs and ComfyUI Desktop. Resolves LIVE-FIRST: the file the running ComfyUI actually reads (its --extra-model-paths-config, else the extra_model_paths.yaml beside its main.py), falling back to the local heuristic only when no server is reachable — &lt;ComfyUI root&gt;/extra_model_paths.yaml (COMFYUI_PATH, else the saved default workspace from workspace action:"set_default") or the Desktop app-data extra_models_config.yaml. Reports generic categories, so model categories and custom_nodes entries are both visible when present. Read-only. Exception: if a reachable LOCAL server does not expose main.py, auto returns a clearly marked unconfirmed local fallback instead of rejecting the list request.
 
 ### Parameters
 
 <ParamField path="target" type="enum">
-  Config target. auto (default) is LIVE-FIRST: the running ComfyUI's own --extra-model-paths-config, else the extra_model_paths.yaml next to its main.py; only when no server is reachable does it fall back to the Desktop config if one exists, otherwise standalone. standalone forces &lt;ComfyUI root&gt;/extra_model_paths.yaml, where the root is COMFYUI_PATH (or an auto-detected install) and falls back to the saved default workspace; desktop forces the OS app-data extra_models_config.yaml. Use standalone/desktop (or config_path) to deliberately target a file the running server does not read. Options: `auto`, `standalone`, `desktop`.
+  Config target. auto (default) is LIVE-FIRST: the running ComfyUI's own --extra-model-paths-config, else the extra_model_paths.yaml next to its main.py. When no server is reachable, or a reachable LOCAL server does not expose main.py, auto shows the Desktop config if one exists, otherwise standalone; the latter case is explicitly marked as an unconfirmed display fallback. standalone forces &lt;ComfyUI root&gt;/extra_model_paths.yaml, where the root is COMFYUI_PATH (or an auto-detected install) and falls back to the saved default workspace; desktop forces the OS app-data extra_models_config.yaml. Use standalone/desktop (or config_path) to deliberately target a file the running server does not read. Options: `auto`, `standalone`, `desktop`.
 </ParamField>
 <ParamField path="config_path" type="string">
   Explicit YAML config path override, mainly for advanced/manual installs.
@@ -336,7 +336,7 @@ Add a directory to a ComfyUI extra search-path YAML config. Use this for model c
 ### Parameters
 
 <ParamField path="target" type="enum">
-  Config target. auto (default) is LIVE-FIRST: the running ComfyUI's own --extra-model-paths-config, else the extra_model_paths.yaml next to its main.py; only when no server is reachable does it fall back to the Desktop config if one exists, otherwise standalone. standalone forces &lt;ComfyUI root&gt;/extra_model_paths.yaml, where the root is COMFYUI_PATH (or an auto-detected install) and falls back to the saved default workspace; desktop forces the OS app-data extra_models_config.yaml. Use standalone/desktop (or config_path) to deliberately target a file the running server does not read. Options: `auto`, `standalone`, `desktop`.
+  Config target. auto (default) is LIVE-FIRST: the running ComfyUI's own --extra-model-paths-config, else the extra_model_paths.yaml next to its main.py. When no server is reachable, or a reachable LOCAL server does not expose main.py, auto shows the Desktop config if one exists, otherwise standalone; the latter case is explicitly marked as an unconfirmed display fallback. standalone forces &lt;ComfyUI root&gt;/extra_model_paths.yaml, where the root is COMFYUI_PATH (or an auto-detected install) and falls back to the saved default workspace; desktop forces the OS app-data extra_models_config.yaml. Use standalone/desktop (or config_path) to deliberately target a file the running server does not read. Options: `auto`, `standalone`, `desktop`.
 </ParamField>
 <ParamField path="config_path" type="string">
   Explicit YAML config path override, mainly for advanced/manual installs.
@@ -377,7 +377,7 @@ Remove a directory from a ComfyUI extra search-path YAML config. Matches the sto
 ### Parameters
 
 <ParamField path="target" type="enum">
-  Config target. auto (default) is LIVE-FIRST: the running ComfyUI's own --extra-model-paths-config, else the extra_model_paths.yaml next to its main.py; only when no server is reachable does it fall back to the Desktop config if one exists, otherwise standalone. standalone forces &lt;ComfyUI root&gt;/extra_model_paths.yaml, where the root is COMFYUI_PATH (or an auto-detected install) and falls back to the saved default workspace; desktop forces the OS app-data extra_models_config.yaml. Use standalone/desktop (or config_path) to deliberately target a file the running server does not read. Options: `auto`, `standalone`, `desktop`.
+  Config target. auto (default) is LIVE-FIRST: the running ComfyUI's own --extra-model-paths-config, else the extra_model_paths.yaml next to its main.py. When no server is reachable, or a reachable LOCAL server does not expose main.py, auto shows the Desktop config if one exists, otherwise standalone; the latter case is explicitly marked as an unconfirmed display fallback. standalone forces &lt;ComfyUI root&gt;/extra_model_paths.yaml, where the root is COMFYUI_PATH (or an auto-detected install) and falls back to the saved default workspace; desktop forces the OS app-data extra_models_config.yaml. Use standalone/desktop (or config_path) to deliberately target a file the running server does not read. Options: `auto`, `standalone`, `desktop`.
 </ParamField>
 <ParamField path="config_path" type="string">
   Explicit YAML config path override, mainly for advanced/manual installs.

--- a/src/__tests__/services/extra-paths.test.ts
+++ b/src/__tests__/services/extra-paths.test.ts
@@ -38,6 +38,7 @@ import { config } from "../../config.js";
 import {
   addExtraPath,
   expandVars,
+  getExtraModelRoots,
   listExtraPaths,
   removeExtraPath,
 } from "../../services/extra-paths.js";
@@ -855,17 +856,36 @@ describe("a reachable server with NO --extra-model-paths-config is still authori
     expect(existsSync(join(stale, "cfg.yaml"))).toBe(false);
   });
 
-  it("REFUSES when a reachable server's argv reveals no main.py and no flag", async () => {
-    // We cannot tell where it reads from; the local heuristic would just be a guess.
-    const workspaceA = await trackTmp();
-    await saveDefaultWorkspace(workspaceA);
-    config.comfyuiPath = undefined;
+  it("lists the local auto target when a reachable local server omits main.py, but keeps mutations fail-closed (#764)", async () => {
+    // Current ComfyUI launchers may report `python -m comfyui` rather than main.py in
+    // /system_stats. The active API target is already classified local (otherwise the
+    // snapshot would be unreachable), so list_auto must not pretend that means remote.
+    // A Desktop config is the exact static fallback a user can successfully select with
+    // target:"desktop"; it is useful to display, but not proven to be the live server's
+    // config and must never be auto-mutated.
+    const appData = await trackTmp();
+    process.env.APPDATA = appData;
+    const desktop = join(appData, "ComfyUI", "extra_models_config.yaml");
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(join(appData, "ComfyUI"), { recursive: true });
+    await writeFile(desktop, "desktop:\n  checkpoints: E:/models\n", "utf-8");
     mockGetSystemStats.mockResolvedValue({ system: { argv: ["python", "-m", "comfyui"] } });
 
-    await expect(listExtraPaths()).rejects.toThrow(/UNRESOLVED.*does not reveal a main\.py/s);
-    // …and the documented escape hatch still works.
-    const forced = await listExtraPaths({ target: "standalone" });
-    expect(forced.path).toBe(join(workspaceA, "extra_model_paths.yaml"));
+    const listed = await listExtraPaths();
+    expect(listed.target).toBe("desktop");
+    expect(listed.path).toBe(desktop);
+    expect(listed.groups[0].categories).toEqual([{ category: "checkpoints", paths: ["E:/models"] }]);
+    expect(listed.notes.some((note) => /local and reachable.*fallback.*not confirmation/is.test(note))).toBe(
+      true,
+    );
+    // The fallback is presentation-only: model lookup/removal must not treat its
+    // unproven paths as live roots.
+    await expect(getExtraModelRoots()).resolves.toEqual([]);
+
+    await expect(addExtraPath({ category: "loras", path: "E:/loras" })).rejects.toThrow(
+      /UNRESOLVED.*does not reveal a main\.py/s,
+    );
+    expect(await readFile(desktop, "utf-8")).toBe("desktop:\n  checkpoints: E:/models\n");
   });
 
   it("falls back to the static heuristic only when the server is UNREACHABLE", async () => {

--- a/src/services/extra-paths.ts
+++ b/src/services/extra-paths.ts
@@ -679,13 +679,17 @@ function implicitLiveTarget(
  * launch flags and the install root can never be read from two different server states.
  * And when the server IS reachable but tells us nothing usable — a relative
  * `--extra-model-paths-config` with no reported cwd, or an argv with no `main.py` — the
- * answer is an explicit UNRESOLVED, never a quiet fall-through to the local heuristic:
- * we would be guessing at a file the running server does not read, and "success" on that
- * guess is exactly the silent no-op this branch exists to stop. `target`/`config_path`
- * remain the deliberate escape hatch, and both short-circuit above this.
+ * answer is normally an explicit UNRESOLVED, never a quiet fall-through to the local
+ * heuristic: a mutation would otherwise report success for a file the running server may
+ * not read. `list_extra_paths` is deliberately narrower: when the connected target is
+ * already classified LOCAL but its argv simply omits main.py, it may show the known local
+ * auto target with an explicit non-authoritative note (#764). Mutations keep refusing that
+ * state, so the fallback cannot fabricate a successful edit. `target`/`config_path` remain
+ * the deliberate escape hatch, and both short-circuit above this.
  */
 async function resolveTargetPathPreferServer(
   opts: ExtraPathOptions = {},
+  allowUnprovenLocalListFallback = false,
 ): Promise<ResolvedTarget & { serverResolved: boolean }> {
   // Explicit config_path or an explicit non-auto target: honor the caller.
   if (opts.configPath || (opts.target && opts.target !== "auto")) {
@@ -724,6 +728,23 @@ async function resolveTargetPathPreferServer(
   if (rawFlags.length === 0) {
     // No flag — ComfyUI loads the yaml next to its own main.py when that file exists.
     if (script && liveRoot) return implicitLiveTarget(liveRoot, opts);
+    // getLiveServerSnapshot only returns reachable:true in local mode. Some supported
+    // launchers use `python -m comfyui` (or otherwise omit main.py from sys.argv), so
+    // there is no live-root proof even though the active API target is local and usable.
+    // Listing the caller's already-known local target is useful and truthful as long as
+    // the response plainly says it is NOT a claim about the running server. Do not share
+    // this fallback with add/remove: an edit here could be a silent no-op (#764).
+    if (allowUnprovenLocalListFallback) {
+      const fallback = resolveTargetPath(opts);
+      return {
+        ...fallback,
+        notes: [
+          ...fallback.notes,
+          "NOTE: the connected ComfyUI is local and reachable, but its /system_stats launch argv does not reveal main.py, so the config the running server reads cannot be proven. Showing the local auto-selected config instead; this is a fallback, not confirmation that the live server reads it. Pass config_path or target: \"standalone\"/\"desktop\" to choose a file explicitly.",
+        ],
+        serverResolved: false,
+      };
+    }
     throw new ValidationError(
       "UNRESOLVED: the running ComfyUI was not launched with --extra-model-paths-config and " +
         "its launch argv does not reveal a main.py, so the extra_model_paths.yaml it reads " +
@@ -844,10 +865,15 @@ async function resolveTargetPathPreferServer(
   };
 }
 
-export async function listExtraPaths(
+/** Read one config for presentation or model discovery. `allowUnprovenLocalListFallback`
+ * must stay false for every caller that uses roots to resolve, delete, or otherwise act
+ * on a model: the #764 fallback is useful display only, not evidence that ComfyUI loads
+ * those directories. */
+async function readExtraPathsConfig(
   opts: ExtraPathOptions = {},
+  allowUnprovenLocalListFallback = false,
 ): Promise<ExtraPathsConfigInfo> {
-  const resolved = await resolveTargetPathPreferServer(opts);
+  const resolved = await resolveTargetPathPreferServer(opts, allowUnprovenLocalListFallback);
   // Point of use: an inferred root that vanished between resolution and this read must
   // surface as UNRESOLVED, NOT as a normal empty config (readConfigFile maps a missing
   // file to {}, which would look authoritative — the exact failure #648 is about).
@@ -855,6 +881,14 @@ export async function listExtraPaths(
   const raw = await readConfigFile(resolved.path);
   assertRootIntact(resolved.guard);
   return summarize(resolved.target, resolved.path, raw, resolved.notes, resolved.serverResolved);
+}
+
+export async function listExtraPaths(
+  opts: ExtraPathOptions = {},
+): Promise<ExtraPathsConfigInfo> {
+  // #764: a display-only read may fall back when a reachable LOCAL server omits main.py
+  // from argv. Model discovery and mutations use the normal fail-closed resolver.
+  return readExtraPathsConfig(opts, true);
 }
 
 /** One model search directory contributed by extra_model_paths configuration. */
@@ -881,7 +915,10 @@ export async function getExtraModelRoots(
 ): Promise<ExtraModelRoot[]> {
   let info: ExtraPathsConfigInfo;
   try {
-    info = await listExtraPaths(opts);
+    // Do NOT use listExtraPaths here: its #764 local fallback is deliberately
+    // non-authoritative and these roots feed model lookup/removal. An unproven config
+    // must contribute no roots rather than allowing a stale path to resolve a model.
+    info = await readExtraPathsConfig(opts);
   } catch {
     return [];
   }

--- a/src/tools/extra-paths.ts
+++ b/src/tools/extra-paths.ts
@@ -15,9 +15,10 @@ const targetArgs = {
     .optional()
     .describe(
       "Config target. auto (default) is LIVE-FIRST: the running ComfyUI's own " +
-        "--extra-model-paths-config, else the extra_model_paths.yaml next to its main.py; " +
-        "only when no server is reachable does it fall back to the Desktop config if one " +
-        "exists, otherwise standalone. standalone forces <ComfyUI root>/extra_model_paths.yaml, " +
+        "--extra-model-paths-config, else the extra_model_paths.yaml next to its main.py. " +
+        "When no server is reachable, or a reachable LOCAL server does not expose main.py, " +
+        "auto shows the Desktop config if one exists, otherwise standalone; the latter case is " +
+        "explicitly marked as an unconfirmed display fallback. standalone forces <ComfyUI root>/extra_model_paths.yaml, " +
         "where the root is COMFYUI_PATH (or an auto-detected install) and falls back to the " +
         "saved default workspace; desktop forces the OS app-data extra_models_config.yaml. " +
         "Use standalone/desktop (or config_path) to deliberately target a file the running " +
@@ -59,7 +60,8 @@ export function registerExtraPathsTools(server: McpServer): void {
       "extra_model_paths.yaml (COMFYUI_PATH, else the saved default workspace from " +
       "workspace action:\"set_default\") or the Desktop app-data extra_models_config.yaml. Reports generic " +
       "categories, so model categories and custom_nodes entries are both visible when present. " +
-      "Read-only.",
+      "Read-only. Exception: if a reachable LOCAL server does not expose main.py, auto returns " +
+      "a clearly marked unconfirmed local fallback instead of rejecting the list request.",
     targetArgs,
     async (args) => {
       try {


### PR DESCRIPTION
Fixes #764.

When the active target is already classified local but /system_stats omits main.py, list_extra_paths now shows the known local auto target with an explicit unconfirmed-fallback note instead of rejecting.

The fallback is display-only: add/remove and extra-model root discovery remain fail-closed, preventing stale fallback paths from influencing model lookup or deletion.

Validated with the full suite (4031 passed, 2 skipped), TypeScript lint/build, vocabulary check, and an independent integrity review.