### PR TITLE
fix(#587): distinguish watchdog stalls from user cancellations

### DIFF
--- a/src/__tests__/orchestrator/codex-interrupt-recovery.test.ts
+++ b/src/__tests__/orchestrator/codex-interrupt-recovery.test.ts
@@ -56,6 +56,43 @@ function installActiveClient(backend: Backend, client: object): void {
 }
 
 describe("CodexBackend interrupt recovery", () => {
+  it("steers a watchdog stall as an explicit non-user-cancel notice", async () => {
+    const client = {
+      request: vi.fn().mockResolvedValue({}),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const backend = new CodexBackend();
+    installActiveClient(backend, client);
+
+    const notice = "The harness stalled; the user did NOT cancel this tool call.";
+    await expect(backend.recoverStalledTurn(notice)).resolves.toBe(true);
+    expect(client.request).toHaveBeenCalledWith("turn/steer", {
+      threadId: "thread-1",
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: notice }],
+    });
+    expect(client.request).not.toHaveBeenCalledWith(
+      "turn/interrupt",
+      expect.anything(),
+    );
+  });
+
+  it("falls back cleanly when an older app-server rejects stalled-turn steering", async () => {
+    const client = {
+      request: vi.fn().mockRejectedValue(new Error("unknown method turn/steer")),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const backend = new CodexBackend();
+    installActiveClient(backend, client);
+
+    await expect(backend.recoverStalledTurn("harness stall")).resolves.toBe(false);
+    expect(client.request).toHaveBeenCalledWith("turn/steer", {
+      threadId: "thread-1",
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "harness stall" }],
+    });
+  });
+
   it("keeps the turn alive while app-server reports a retryable error", async () => {
     const onActivity = vi.fn();
     const client = {

--- a/src/__tests__/orchestrator/codex-interrupt-recovery.test.ts
+++ b/src/__tests__/orchestrator/codex-interrupt-recovery.test.ts
@@ -16,6 +16,7 @@ let CodexBackend: BackendModule["CodexBackend"];
 
 beforeAll(async () => {
   vi.stubEnv("COMFYUI_MCP_CODEX_INTERRUPT_TIMEOUT_MS", "25");
+  vi.stubEnv("COMFYUI_MCP_CODEX_STALL_STEER_TIMEOUT_MS", "25");
   vi.stubEnv("COMFYUI_MCP_CODEX_CLOSE_TIMEOUT_MS", "25");
   vi.stubEnv("COMFYUI_MCP_CODEX_FORCE_KILL_GRACE_MS", "10");
   vi.resetModules();
@@ -91,6 +92,32 @@ describe("CodexBackend interrupt recovery", () => {
       expectedTurnId: "turn-1",
       input: [{ type: "text", text: "harness stall" }],
     });
+  });
+
+  it("bounds a hung stalled-turn steer so PanelAgent can take legacy recovery", async () => {
+    let resolveSteer!: (value: unknown) => void;
+    const client = {
+      request: vi.fn(
+        () =>
+          new Promise<unknown>((resolve) => {
+            resolveSteer = resolve;
+          }),
+      ),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const backend = new CodexBackend();
+    installActiveClient(backend, client);
+
+    const recovery = backend.recoverStalledTurn("harness stall");
+    expect(await settlesWithin(recovery)).toBe(true);
+    await expect(recovery).resolves.toBe(false);
+    // A late app-server completion belongs to the already-abandoned steer only;
+    // it must not mutate the still-live client or turn identities.
+    resolveSteer({});
+    await new Promise((resolve) => setImmediate(resolve));
+    expect((backend as any).client).toBe(client);
+    expect((backend as any).threadId).toBe("thread-1");
+    expect((backend as any).turnId).toBe("turn-1");
   });
 
   it("keeps the turn alive while app-server reports a retryable error", async () => {

--- a/src/__tests__/orchestrator/turn-watchdog.test.ts
+++ b/src/__tests__/orchestrator/turn-watchdog.test.ts
@@ -135,6 +135,64 @@ class SilentBackend implements AgentBackend {
   }
 }
 
+/** A Codex-shaped backend that accepts an explicit harness-stall notice and
+ * settles the existing turn. This models app-server `turn/steer`: the agent
+ * receives the true origin instead of a synthetic user-rejection result. */
+class SteerRecoveringBackend implements AgentBackend {
+  readonly id = "codex" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  interrupted = 0;
+  notices: string[] = [];
+  private release: (() => void) | null = null;
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    yield { type: "session", sessionId: "sess-steer" };
+    for await (const _turn of opts.channel) {
+      void _turn;
+      await new Promise<void>((resolve) => {
+        this.release = resolve;
+      });
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+  async recoverStalledTurn(notice: string): Promise<boolean> {
+    this.notices.push(notice);
+    this.release?.();
+    return true;
+  }
+  async interrupt(): Promise<void> {
+    this.interrupted += 1;
+  }
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+/** The provider accepts the precise notice but never emits another event. The
+ * second watchdog window must retain the established interrupt escape hatch. */
+class SteerButStillFrozenBackend implements AgentBackend {
+  readonly id = "codex" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  interrupted = 0;
+  notices: string[] = [];
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    yield { type: "session", sessionId: "sess-steer-frozen" };
+    for await (const _turn of opts.channel) {
+      void _turn;
+      await new Promise<void>(() => {});
+    }
+  }
+  async recoverStalledTurn(notice: string): Promise<boolean> {
+    this.notices.push(notice);
+    return true;
+  }
+  async interrupt(): Promise<void> {
+    this.interrupted += 1;
+  }
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
 function makeDeps(says: string[], turns: Array<"working" | "done">) {
   return {
     mcpServers: {},
@@ -189,6 +247,41 @@ describe("per-turn freeze watchdog liveness re-arm", () => {
     expect(says.join("\n")).toMatch(/stopped responding|stalled/i);
     expect(backend.interrupted).toBeGreaterThanOrEqual(1);
     expect(turns).toContain("done"); // gate released so the next batch can run
+    await agent.stop();
+  });
+
+  it("steers a stalled Codex turn with a non-user-cancel notice before legacy interrupt", async () => {
+    const says: string[] = [];
+    const turns: Array<"working" | "done"> = [];
+    const backend = new SteerRecoveringBackend();
+    const agent = new PanelAgent("tab-steer", makeDeps(says, turns) as never, backend);
+    void agent.start();
+    agent.send("the tool call will stall");
+
+    await new Promise((r) => setTimeout(r, IDLE_MS * 4));
+
+    expect(backend.notices).toHaveLength(1);
+    expect(backend.notices[0]).toMatch(/user did NOT reject or cancel/i);
+    expect(backend.notices[0]).toMatch(/safe to retry/i);
+    expect(backend.interrupted).toBe(0);
+    expect(says.join("\n")).toMatch(/you did NOT cancel/i);
+    expect(says.join("\n")).not.toMatch(/I've cleared it/i);
+    expect(turns).toContain("done");
+    await agent.stop();
+  });
+
+  it("falls back to the bounded legacy interrupt if a steered stalled turn stays silent", async () => {
+    const says: string[] = [];
+    const turns: Array<"working" | "done"> = [];
+    const backend = new SteerButStillFrozenBackend();
+    const agent = new PanelAgent("tab-steer-frozen", makeDeps(says, turns) as never, backend);
+    void agent.start();
+    agent.send("the tool call will remain frozen");
+
+    await new Promise((r) => setTimeout(r, IDLE_MS * 4));
+
+    expect(backend.notices).toHaveLength(1);
+    expect(backend.interrupted).toBeGreaterThanOrEqual(1);
     await agent.stop();
   });
 

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -204,6 +204,13 @@ export interface AgentBackend {
   run(opts: BackendStartOptions): AsyncIterable<AgentEvent>;
   /** Stop the current turn without ending the session (if supported). */
   interrupt(): Promise<void>;
+  /**
+   * Try to recover a watchdog-stalled turn without representing the interruption
+   * as a user cancellation. Returns true only when the provider accepted the
+   * supplied agent-facing notice; callers must retain their normal interrupt
+   * fallback for older providers/protocols.
+   */
+  recoverStalledTurn?(notice: string): Promise<boolean>;
   /** Switch the model on the LIVE session (next turn uses it), if supported. */
   setModel?(model: string): Promise<void>;
   /** Models the current account can use (empty if `modelEnumeration` is false). */

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -66,6 +66,11 @@ const CODEX_INTERRUPT_TIMEOUT_MS =
   Number.isFinite(configuredInterruptTimeoutMs) && configuredInterruptTimeoutMs > 0
     ? configuredInterruptTimeoutMs
     : 1500;
+const configuredStallSteerTimeoutMs = Number(process.env.COMFYUI_MCP_CODEX_STALL_STEER_TIMEOUT_MS);
+const CODEX_STALL_STEER_TIMEOUT_MS =
+  Number.isFinite(configuredStallSteerTimeoutMs) && configuredStallSteerTimeoutMs > 0
+    ? configuredStallSteerTimeoutMs
+    : CODEX_INTERRUPT_TIMEOUT_MS;
 const configuredCloseTimeoutMs = Number(process.env.COMFYUI_MCP_CODEX_CLOSE_TIMEOUT_MS);
 const CODEX_CLOSE_TIMEOUT_MS =
   Number.isFinite(configuredCloseTimeoutMs) && configuredCloseTimeoutMs > 0
@@ -1408,16 +1413,30 @@ export class CodexBackend implements AgentBackend {
     const threadId = this.threadId;
     const turnId = this.turnId;
     if (!client || !threadId || !turnId || !notice.trim()) return false;
+    let timer: NodeJS.Timeout | undefined;
+    let timedOut = false;
     try {
-      await client.request("turn/steer", {
-        threadId,
-        expectedTurnId: turnId,
-        input: [{ type: "text", text: notice }],
-      });
+      await Promise.race([
+        client.request("turn/steer", {
+          threadId,
+          expectedTurnId: turnId,
+          input: [{ type: "text", text: notice }],
+        }),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            timedOut = true;
+            reject(new Error(`turn/steer timed out after ${CODEX_STALL_STEER_TIMEOUT_MS}ms`));
+          }, CODEX_STALL_STEER_TIMEOUT_MS);
+        }),
+      ]);
       return true;
     } catch (err) {
-      logger.debug(`[codex-backend] stalled-turn steer unavailable: ${msgOf(err)}`);
+      logger.debug(
+        `[codex-backend] stalled-turn steer ${timedOut ? "timed out" : "unavailable"}: ${msgOf(err)}`,
+      );
       return false;
+    } finally {
+      if (timer) clearTimeout(timer);
     }
   }
 

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -19,6 +19,8 @@
 //   - result              ← `turn/completed` ({threadId, turn:{status}})
 //   - error               ← `error` notification ({error:{message}})
 //   - interrupt()         → `turn/interrupt` ({threadId, turnId})
+//   - recoverStalledTurn()→ `turn/steer` (an explicit harness-stall notice;
+//                            never misrepresented as a user cancellation)
 //   - listModels()        ← `config/read` (or a sensible static fallback)
 //
 // FULL PARITY with Claude: the Codex backend now drives the live ComfyUI canvas
@@ -1388,6 +1390,34 @@ export class CodexBackend implements AgentBackend {
       logger.debug(`[codex-backend] interrupt: ${msgOf(err)}`);
     } finally {
       if (timer) clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Tell Codex that the harness, not the user, observed a stalled turn. The
+   * app-server's `turn/interrupt` schema deliberately has no reason field and
+   * reports a pending tool interruption with its generic user-rejection text.
+   * `turn/steer` is the protocol operation for injecting an explicit message
+   * into the active turn, so it preserves the distinction for the agent.
+   *
+   * Older app-servers can reject `turn/steer`; return false so PanelAgent falls
+   * back to its existing bounded interrupt/restart recovery rather than wedging.
+   */
+  async recoverStalledTurn(notice: string): Promise<boolean> {
+    const client = this.client;
+    const threadId = this.threadId;
+    const turnId = this.turnId;
+    if (!client || !threadId || !turnId || !notice.trim()) return false;
+    try {
+      await client.request("turn/steer", {
+        threadId,
+        expectedTurnId: turnId,
+        input: [{ type: "text", text: notice }],
+      });
+      return true;
+    } catch (err) {
+      logger.debug(`[codex-backend] stalled-turn steer unavailable: ${msgOf(err)}`);
+      return false;
     }
   }
 

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -220,15 +220,16 @@ export class PanelAgent {
   // app-server) would otherwise leave the panel "working" forever. This is an
   // IDLE timer (reset on every received event), NOT a hard turn cap: legit tool
   // work is slow but still streams progress/tool events, so only a TRUE stall
-  // (no events at all for the whole window) trips it. On trip we surface a clear
-  // terminal error (the turn's ONE failure report) and route through the guarded
-  // interrupt() flow: the aborted turn's terminal result — or the bounded
-  // interrupt-release fallback if no result ever arrives — advances the turn-gate
-  // at the genuine turn end, so the next queued batch never runs ahead of the
-  // wedged turn settling (#728).
+  // (no events at all for the whole window) trips it. A capable provider first
+  // receives an explicit harness-stall notice, never a synthetic user rejection.
+  // If that recovery is unavailable or remains silent for another window, the
+  // guarded interrupt() flow provides the existing bounded gate-release fallback
+  // so the next queued batch never runs ahead of a wedged turn settling (#728).
   private idleTimer: ReturnType<typeof setTimeout> | null = null;
   /** Guards against a trip firing twice / racing a real result for one turn. */
   private idleTripped = false;
+  /** A provider-native, non-user-cancel recovery is attempted at most once per turn. */
+  private stallRecoverySteered = false;
   /** Tool calls started (item/started) but not yet ended (item/completed). A tool
    *  in flight is legitimate work even when the app-server sends nothing, so the
    *  watchdog defers while this is > 0 — the fix for the #307-review finding that
@@ -961,21 +962,93 @@ export class PanelAgent {
       this.idleTimer = null;
     }
     this.idleTripped = false;
+    this.stallRecoverySteered = false;
     // The turn ended — drop any tool-busy state so a start whose matching end was
     // never seen (errored/interrupted turn) can't defer the NEXT turn's watchdog.
     this.openToolCalls = 0;
     this.toolBusySince = 0;
   }
 
+  /** The exact notice injected into capable providers when a harness watchdog
+   *  sees a frozen turn. It must never be conflated with a user cancellation. */
+  private static readonly STALL_RECOVERY_NOTICE =
+    "[harness stall notice] This turn stalled with no activity and was detected by the harness. " +
+    "The user did NOT reject or cancel this tool call. Do not tell the user that they stopped it. " +
+    "Inspect side effects if the call may have started; otherwise it is safe to retry the same call.";
+
+  /** Finish the legacy interruption path after no native stall recovery is
+   *  available. This retains the existing gate/restart safety for old providers. */
+  private finishStalledTurn(alreadyReported: boolean): void {
+    this.busy = false;
+    // The stalled turn is abandoned — don't re-queue its text (a wedged message
+    // could otherwise loop on every interrupt, and it may already have performed
+    // tool side effects).
+    this.inFlight = null;
+    if (!alreadyReported) {
+      this.deps.onSay(
+        this.tabId,
+        "⚠️ The agent stopped responding (the turn stalled with no activity). I've cleared it — please try again.",
+      );
+    }
+    this.deps.onTurn?.(this.tabId, "done");
+    // Do NOT completeTurn() here: the gate must stay held until the turn genuinely
+    // ends. interrupt() arms the bounded release fallback and stops the wedged
+    // backend; the aborted turn's `result` (or that fallback) releases the next
+    // queued batch at the right moment. The self-restart loop in start() recovers
+    // the session.
+    void this.interrupt();
+  }
+
+  /** Attempt one provider-native recovery before the legacy interrupt path.
+   *  A steer is an explicit agent-facing harness notice, not a synthetic user
+   *  rejection. Its short re-arm preserves the ordinary bounded fallback if the
+   *  provider remains frozen after accepting it. */
+  private async recoverStalledTurn(stalledMarker: number, alreadyReported: boolean): Promise<void> {
+    const recover = this.backend.recoverStalledTurn;
+    if (!recover || this.stallRecoverySteered) {
+      this.finishStalledTurn(alreadyReported);
+      return;
+    }
+    this.stallRecoverySteered = true;
+    let steered = false;
+    try {
+      steered = await recover.call(this.backend, PanelAgent.STALL_RECOVERY_NOTICE);
+    } catch (err) {
+      logger.debug(`[panel-agent ${this.short()}] stalled-turn recovery: ${msgOf(err)}`);
+    }
+    // The active turn may have completed while the asynchronous steer request was
+    // in flight. Never resurrect a settled or replacement turn.
+    const stillCurrent =
+      !this.closed &&
+      this.busy &&
+      this.currentTurnMarker === stalledMarker &&
+      this.completedTurns < this.yieldedTurns;
+    if (!steered || !stillCurrent) {
+      if (stillCurrent) this.finishStalledTurn(alreadyReported);
+      return;
+    }
+    // The provider accepted the precise notice. Keep the turn authoritative and
+    // allow a second full idle window; if it remains frozen, the next watchdog
+    // trip falls through to the established bounded interrupt/restart recovery.
+    this.idleTripped = false;
+    this.bumpIdleWatchdog();
+    if (!alreadyReported) {
+      this.deps.onSay(
+        this.tabId,
+        "⚠️ The agent stalled with no activity. I sent it a harness-stall notice — you did NOT cancel it; it can inspect state and retry safely.",
+      );
+    }
+  }
+
   /** The current turn produced NO events for the whole idle window → it's frozen.
-   *  Surface a clear error (unless this turn's failure was ALREADY reported — one
-   *  report per turn), clear the "working" indicator, and interrupt via the
-   *  guarded interrupt() flow so the turn-gate opens only when the turn GENUINELY
-   *  ends (the aborted turn's terminal result, or the bounded interrupt-release
-   *  fallback if none arrives) — not synchronously here, which let the next queued
-   *  batch run before the wedged turn had settled. errorSurfaced +
-   *  interruptRequested suppress the follow-up interrupted result's "turn failed"
-   *  line (#728). Idempotent per turn via idleTripped. */
+   *  First send a capable provider an explicit non-user-cancel notice. If that
+   *  is unavailable (or it remains silent through another full window), surface
+   *  the legacy clear + use the guarded interrupt() flow so the turn-gate opens
+   *  only when the turn GENUINELY ends (the aborted turn's terminal result, or the
+   *  bounded interrupt-release fallback if none arrives) — not synchronously here,
+   *  which let the next queued batch run before the wedged turn had settled.
+   *  errorSurfaced + interruptRequested suppress the follow-up interrupted
+   *  result's "turn failed" line (#728). Idempotent per trip via idleTripped. */
   private onTurnStalled(): void {
     if (this.closed || this.idleTripped || !this.busy) return;
     // A tool call in flight is legitimate work even with a silent app-server (an
@@ -998,28 +1071,15 @@ export class PanelAgent {
     // failure. (interrupt() also sets interruptRequested, so the result case
     // treats that result as the interrupt landing, not a new failure.)
     const alreadyReported = this.errorSurfaced;
+    const recovery = this.stallRecoverySteered || !this.backend.recoverStalledTurn
+      ? " via legacy interrupt"
+      : " with provider notice";
     logger.error(
-      `[panel-agent ${this.short()}] turn stalled — no events for ${Math.round(TURN_IDLE_MS / 1000)}s; interrupting${alreadyReported ? " (failure already reported)" : " and surfacing error"}`,
+      `[panel-agent ${this.short()}] turn stalled — no events for ${Math.round(TURN_IDLE_MS / 1000)}s; recovering${recovery}${alreadyReported ? " (failure already reported)" : " and surfacing error"}`,
     );
     this.errorSurfaced = true;
-    this.busy = false;
-    // The stalled turn is abandoned + surfaced as an error — don't re-queue its
-    // text (a wedged message could otherwise loop on every interrupt, and it may
-    // already have performed tool side effects).
-    this.inFlight = null;
-    if (!alreadyReported) {
-      this.deps.onSay(
-        this.tabId,
-        "⚠️ The agent stopped responding (the turn stalled with no activity). I've cleared it — please try again.",
-      );
-    }
-    this.deps.onTurn?.(this.tabId, "done");
-    // Do NOT completeTurn() here: the gate must stay held until the turn genuinely
-    // ends. interrupt() arms the bounded release fallback and stops the wedged
-    // backend; the aborted turn's `result` (or that fallback) releases the next
-    // queued batch at the right moment. The self-restart loop in start() recovers
-    // the session.
-    void this.interrupt();
+    const stalledMarker = this.currentTurnMarker;
+    void this.recoverStalledTurn(stalledMarker, alreadyReported);
   }
 
   // Handle a canonical AgentEvent from the backend. This is the provider-agnostic


### PR DESCRIPTION
Fixes #587.

When the panel-agent watchdog detects a stalled Codex turn, it first uses the app-server's active-turn `turn/steer` protocol to send the agent an explicit harness-stall notice: the user did not reject or cancel the call, and the agent can inspect state/retry safely. The steer request is itself bounded; a hung or unsupported app-server falls through to the established interrupt/restart recovery. `turn/interrupt` has no reason field.

The panel already renders the orchestrator's say frames, so no panel-source change is needed.

Validation:
- `npm.cmd run lint`
- `npm.cmd test -- --run src/__tests__/orchestrator/codex-interrupt-recovery.test.ts src/__tests__/orchestrator/turn-watchdog.test.ts src/__tests__/orchestrator/stall-watchdog-interrupt.test.ts` (25 passed)
- `npm.cmd run build`