### PR TITLE
fix(docs-proxy): stop root icon requests becoming logged 404s

### DIFF
--- a/infra/cloudflare/docs-proxy.js
+++ b/infra/cloudflare/docs-proxy.js
@@ -14,6 +14,12 @@
 const DOCS_HOST = "artokun.mintlify.dev";
 const PUBLIC_HOST = "comfyui-mcp.artokun.io";
 
+/** Root icon paths user agents fetch on their own, none of which exist as-named.
+ *  Covers /favicon.ico, /favicon.png, /apple-touch-icon.png and the numbered
+ *  /apple-touch-icon-152x152-precomposed.png family iOS probes through. */
+const ICON_ALIASES =
+  /^\/(favicon\.(ico|png)|apple-touch-icon(-\d+x\d+)?(-precomposed)?\.png)$/i;
+
 export default {
   async fetch(request) {
     const url = new URL(request.url);
@@ -34,6 +40,22 @@ export default {
       return fetch(proxied);
     }
 
+    // Root-relative ICON requests are a different animal from content links.
+    // Browsers and crawlers request them on their OWN initiative, on every page
+    // load, whether or not anything references them — so sending them through
+    // the /docs redirect below turns each one into a redirect PLUS a Mintlify
+    // 404, and that pair is logged as a worker error every single time. That is
+    // the bulk of the 404 noise on this host: no `.ico` exists anywhere (not at
+    // /docs/favicon.ico, not on the Mintlify origin either), and iOS Safari asks
+    // for apple-touch-icon*.png unprompted.
+    //
+    // The real asset is /docs/favicon.svg. Point every icon alias at it: SVG
+    // favicons are supported by every browser that requests these paths, and one
+    // 301 to a 200 is both cheaper and quieter than a 301 to a 404.
+    if (ICON_ALIASES.test(url.pathname)) {
+      return Response.redirect(`https://${PUBLIC_HOST}/docs/favicon.svg`, 301);
+    }
+
     // Internal links authored in the MDX pages are root-relative (e.g.
     // /local-llms) — Mintlify prefixes its OWN generated links with /docs but
     // NOT links written in page content, so those land here bare and used to
@@ -41,6 +63,9 @@ export default {
     // instead: every real page then resolves, and genuinely-nonexistent paths
     // still 404 — just from Mintlify, where the 404 page is styled. 301: these
     // are canonical content locations, not experiments.
+    //
+    // NOTE: robots.txt and sitemap.xml deliberately fall through to here and
+    // resolve 200 via /docs — do not "fix" them into the icon branch above.
     const target = `https://${PUBLIC_HOST}/docs${url.pathname}${url.search}`;
     return Response.redirect(target, 301);
   },


### PR DESCRIPTION
## What

The docs-proxy worker is generating constant 404s. The cause is narrower than "broken internal links".

The catch-all redirects *everything* non-`/docs` to `/docs<path>`. That is right for **content** links — root-relative MDX links like `/local-llms` resolve 200 that way. It is wrong for **icons**, which user agents request on their own initiative on every page load:

| request | today | result |
|---|---|---|
| `/favicon.ico` | 301 → `/docs/favicon.ico` | **404**, logged as a worker error |
| `/apple-touch-icon*.png` | 301 → `/docs/apple-touch-icon*.png` | **404**, logged as a worker error |

No `.ico` exists anywhere — `/docs/favicon.ico` **and** `artokun.mintlify.dev/favicon.ico` both 404, so this is not an edge or caching artifact. The real asset is `/docs/favicon.svg` (200).

Because every page load triggers at least one of these, they account for the bulk of the volume rather than any single broken link.

## Fix

Match the icon aliases before the catch-all and point them at the asset that exists — one 301 to a 200 instead of a 301 to a 404.

`robots.txt` and `sitemap.xml` deliberately keep falling through to the `/docs` redirect where they already resolve 200. There's a comment saying so, because they look like they belong in the icon branch and don't.

## Verification

Probed production directly:

```
/docs/favicon.svg                 200   <- the real asset
/docs/favicon.ico                 404   <- nothing serves it
artokun.mintlify.dev/favicon.ico  404   <- not an edge artifact
/robots.txt                       200   <- must keep falling through
/sitemap.xml                      200   <- must keep falling through
/blog/wan-animate-comfyui         200   (via the /docs redirect)
```

Alias matching pinned by 14 cases: `.ico`/`.png` favicons, the numbered and `-precomposed` `apple-touch-icon` family, case-insensitivity, and the non-matches (`robots.txt`, `sitemap.xml`, `/local-llms`, `/favicon.svg`, `/a/favicon.ico`) that must keep current behaviour.

## Deploy

Worker-only change — needs `cd infra/cloudflare && npx wrangler deploy` to take effect.

## On the reported page

`/blog/wan-animate-comfyui` currently resolves **200** through the existing redirect, so that content path is healthy. If it 404'd earlier, that was a Mintlify-side publish gap rather than routing.