### PR TITLE
fix(restart): preserve the launcher environment and refuse before stopping when it cannot be restored (#776)

### DIFF
--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -5,7 +5,7 @@
 // like the remote path. Everything runs through mocked comfyuiFetch + execSync +
 // spawn; no real process/port/network is touched.
 
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   remoteMode: { value: false },
@@ -54,6 +54,27 @@ import {
   restartComfyUI,
   __processControlTestHooks,
 } from "../../services/process-control.js";
+import { __portOwnerTestHooks } from "../../services/port-owner.js";
+
+/**
+ * One `/proc/net/tcp` row for a socket LISTENING on `port`, in the kernel's own
+ * format (hex big-endian address:port, state `0A` = TCP_LISTEN).
+ *
+ * On Linux the port probe consults this table BEFORE `lsof`, because it sees every
+ * socket regardless of owner. That makes it the host's answer, not the fixture's —
+ * so a test that does not state what the table says is graded against the runner's
+ * real network state, where port 8188 is idle, and the execSync port fixtures below
+ * are never reached at all (#776 CI). This file models the host it means to model:
+ * a live Desktop instance IS listening on the port, and lsof then names its owner.
+ */
+function procNetTableWithListenerOn(port: number): string {
+  const hexPort = port.toString(16).toUpperCase().padStart(4, "0");
+  return [
+    "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode",
+    `   0: 0100007F:${hexPort} 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 54321 1 0000000000000000 100 0 0 10 0`,
+    "",
+  ].join("\n");
+}
 
 type FetchCall = [string, RequestInit | undefined];
 const pathOf = (u: string): string => new URL(u).pathname;
@@ -79,6 +100,13 @@ beforeEach(() => {
     if (/lsof/i.test(cmd)) return "p4321\nn127.0.0.1:8188\n";
     return "";
   });
+  // …and state the kernel table to match, so the Linux-first branch answers from
+  // the fixture rather than from the runner's own sockets. `/proc/net/tcp6` is
+  // absent here — one readable table is a complete answer.
+  __portOwnerTestHooks.setProcNetReader((table) => {
+    if (table === "/proc/net/tcp") return procNetTableWithListenerOn(8188);
+    throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  });
   __processControlTestHooks.reset();
   // The identity bracket around /system_stats (#776) runs for Desktop too — the
   // Desktop classification is itself derived from that same possibly-stale argv, so
@@ -87,6 +115,11 @@ beforeEach(() => {
   __processControlTestHooks.setProcessIdentityResolver(() => ({
     startedAt: "stable-stamp",
   }));
+});
+
+afterEach(() => {
+  __portOwnerTestHooks.reset();
+  __processControlTestHooks.reset();
 });
 
 describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]", () => {

--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -80,6 +80,13 @@ beforeEach(() => {
     return "";
   });
   __processControlTestHooks.reset();
+  // The identity bracket around /system_stats (#776) runs for Desktop too — the
+  // Desktop classification is itself derived from that same possibly-stale argv, so
+  // it cannot be what decides whether to verify. It needs the port owner's creation
+  // time at both ends; model the ordinary host where that is readable.
+  __processControlTestHooks.setProcessIdentityResolver(() => ({
+    startedAt: "stable-stamp",
+  }));
 });
 
 describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]", () => {

--- a/src/__tests__/services/port-owner-probe.test.ts
+++ b/src/__tests__/services/port-owner-probe.test.ts
@@ -88,6 +88,52 @@ describe("probePortOwner — POSIX (lsof)", () => {
     expect(probe.state).toBe("unknown");
   });
 
+  it("reports UNKNOWN when lsof exits 1 but COMPLAINS on stderr", async () => {
+    // A permission-restricted lsof exits 1 having enumerated nothing and says so on
+    // stderr. Exit status alone would read that as "the port is free" — certifying
+    // a release that never happened, and tearing down supervision under a server
+    // that may still be serving.
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stderr: string };
+      err.stderr = "lsof: WARNING: can't stat() /proc/1234: Permission denied";
+      throw err;
+    });
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("reports UNKNOWN when lsof exits 1 with partial output on stdout", async () => {
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "p999\n";
+      throw err;
+    });
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("still reports FREE for a QUIET exit 1 (empty stdout and stderr)", async () => {
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string; stderr: string };
+      err.stdout = "";
+      err.stderr = "";
+      throw err;
+    });
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188)).toEqual({ state: "free" });
+  });
+
+  it("passes -w so lsof's routine warnings do not masquerade as a failed enumeration", async () => {
+    mockExecSync.mockReturnValue("");
+    const { probePortOwner } = await loadProbe();
+    probePortOwner(8188);
+
+    expect(String(mockExecSync.mock.calls[0][0])).toMatch(/lsof -w /);
+  });
+
   it("reports UNKNOWN for a spawn-level failure (errno), not free", async () => {
     mockExecSync.mockImplementation(() => {
       throw spawnFailure("ENOENT");

--- a/src/__tests__/services/port-owner-probe.test.ts
+++ b/src/__tests__/services/port-owner-probe.test.ts
@@ -1,0 +1,162 @@
+// The port-owner probe's TRI-STATE contract (#776).
+//
+// `findPidByPort` answers `null` both for "nothing is listening" and for "the
+// lookup itself failed". That is fine for "find me a pid", and dangerous for "has
+// the port been released?" — a failed lookup would certify that a still-running
+// server had gone. `probePortOwner` separates them, and this file pins the exact
+// signals it classifies from.
+//
+// It exists because that contract broke in CI in a way no test could see: the
+// suite's port fixtures modelled "nothing is listening" as a bare `throw new
+// Error(...)`, which carries neither an exit status nor an errno. On Windows the
+// netstat branch runs and never reaches it; on POSIX the lsof branch does, read it
+// as "I could not look", and the caller waited out its whole budget. Green on one
+// platform, hung on the other. Both branches are therefore driven explicitly here.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExecSync = vi.hoisted(() => vi.fn());
+const mockPlatform = vi.hoisted(() => vi.fn(() => "linux"));
+
+vi.mock("node:child_process", () => ({ execSync: mockExecSync }));
+vi.mock("node:os", () => ({ platform: mockPlatform }));
+
+/** `execSync` throws with `status` (the exit code) for a command that RAN and
+ *  failed, and with `code` (an errno) only for a spawn-level failure. */
+function exitWith(status: number): Error {
+  const err = new Error(`exited ${status}`) as Error & { status: number };
+  err.status = status;
+  return err;
+}
+function spawnFailure(code: string): NodeJS.ErrnoException {
+  const err = new Error(code) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  mockPlatform.mockReturnValue("linux");
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+/** Import fresh so the module-level `IS_WIN` picks up the mocked platform. */
+async function loadProbe() {
+  const mod = await import("../../services/port-owner.js");
+  return mod;
+}
+
+describe("probePortOwner — POSIX (lsof)", () => {
+  it("reports OWNED when lsof names a listener", async () => {
+    mockExecSync.mockReturnValue("p4321\nn127.0.0.1:8188\n");
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188)).toEqual({ state: "owned", pid: 4321 });
+  });
+
+  it("reports FREE for lsof's 'ran fine, matched nothing' (exit 1)", async () => {
+    // lsof's documented convention for an empty result set. This is real evidence
+    // that the port is free — the probe ran and saw nothing.
+    mockExecSync.mockImplementation(() => {
+      throw exitWith(1);
+    });
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188)).toEqual({ state: "free" });
+  });
+
+  it("reports FREE when lsof succeeds with no matching records", async () => {
+    mockExecSync.mockReturnValue("");
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188)).toEqual({ state: "free" });
+  });
+
+  it("reports UNKNOWN when the command is MISSING (shell exit 127), not free", async () => {
+    // A container without lsof. "I could not look" must never be spent as "nobody
+    // is listening" — that is what would certify a live server as gone.
+    mockExecSync.mockImplementation(() => {
+      throw exitWith(127);
+    });
+    const { probePortOwner } = await loadProbe();
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+  });
+
+  it("reports UNKNOWN for a spawn-level failure (errno), not free", async () => {
+    mockExecSync.mockImplementation(() => {
+      throw spawnFailure("ENOENT");
+    });
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("reports UNKNOWN for an error carrying NEITHER a status nor an errno", async () => {
+    // Exactly the shape the suite's own fixtures used to throw. Classifying it as
+    // "free" is the bug this module guards; classifying it as "unknown" is correct,
+    // and is why those fixtures had to start modelling lsof's real contract.
+    mockExecSync.mockImplementation(() => {
+      throw new Error("not listening");
+    });
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("findPidByPort keeps its null-for-anything-but-owned contract", async () => {
+    mockExecSync.mockImplementation(() => {
+      throw exitWith(1);
+    });
+    const { findPidByPort } = await loadProbe();
+
+    expect(findPidByPort(8188)).toBeNull();
+  });
+});
+
+describe("probePortOwner — Windows (netstat, then Get-NetTCPConnection)", () => {
+  beforeEach(() => {
+    mockPlatform.mockReturnValue("win32");
+  });
+
+  it("reports OWNED from netstat", async () => {
+    mockExecSync.mockReturnValue(
+      "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321",
+    );
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188)).toEqual({ state: "owned", pid: 4321 });
+  });
+
+  it("reports FREE when a probe RAN and matched nothing", async () => {
+    mockExecSync.mockReturnValue("");
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188)).toEqual({ state: "free" });
+  });
+
+  it("reports UNKNOWN only when EVERY probe failed", async () => {
+    mockExecSync.mockImplementation(() => {
+      throw spawnFailure("ENOENT");
+    });
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("reports FREE when netstat fails but the PowerShell fallback runs", async () => {
+    // One probe failing is not "I could not look" — the other one looked.
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/netstat/i.test(cmd)) throw spawnFailure("ENOENT");
+      return "";
+    });
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188)).toEqual({ state: "free" });
+  });
+});

--- a/src/__tests__/services/port-owner-probe.test.ts
+++ b/src/__tests__/services/port-owner-probe.test.ts
@@ -25,8 +25,12 @@ vi.mock("node:os", () => ({ platform: mockPlatform }));
 // deterministically (a real Linux runner would otherwise answer from
 // /proc/net/tcp first and never reach the code under test).
 vi.mock("node:fs", () => ({
+  // ENOENT, not a bare Error: the probe classifies a failed table read from its
+  // ERRNO. "The table does not exist" (this host has no /proc) hides nothing and
+  // leaves lsof as the only source; "I could not open it" (EACCES) is a blind spot
+  // lsof may share. A bare Error carries no errno and so reads as the latter.
   readFileSync: vi.fn(() => {
-    throw new Error("no /proc in test");
+    throw Object.assign(new Error("no /proc in test"), { code: "ENOENT" });
   }),
 }));
 
@@ -80,6 +84,100 @@ describe("probePortOwner — POSIX (lsof)", () => {
     const { probePortOwner } = await loadProbe();
 
     expect(probePortOwner(8188)).toEqual({ state: "free" });
+  });
+
+  it("the absence marker is VOID when lsof also admits it could not look everywhere", async () => {
+    // The two can appear together: lsof reports what it skipped AND still names what
+    // it failed to locate. "I searched and did not find it" is a claim about the whole
+    // machine; a run that could not stat part of /proc searched only what it could
+    // see. Reading that combination as free certifies a release from an enumeration
+    // that admits it was partial.
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & {
+        status: number;
+        stdout: string;
+        stderr: string;
+      };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      err.stderr =
+        "lsof: WARNING: can't stat() /proc/1234: Permission denied\nOutput information may be incomplete.";
+      throw err;
+    });
+    const { probePortOwner } = await loadProbe();
+
+    // The REASON is asserted, not just the state. lsof plainly DID report an empty
+    // search here — we declined to spend it — so a message saying it "did not report
+    // an empty search" would name the one cause that did not apply, and a caller that
+    // waits out its budget could not tell the refusal came from the warning.
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/could not enumerate everything/i),
+    });
+    expect(probe).not.toMatchObject({
+      reason: expect.stringMatching(/did not report an empty search/i),
+    });
+  });
+
+  it("the absence marker is VOID alongside a warning on the exit-0 path too", async () => {
+    mockExecSync.mockReturnValue(
+      "lsof: WARNING: can't stat() /proc/1234: Permission denied\nlsof: Internet address not located: TCP:8188",
+    );
+    const { probePortOwner } = await loadProbe();
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/could not enumerate everything/i),
+    });
+    expect(probe).not.toMatchObject({
+      reason: expect.stringMatching(/did not report an empty search/i),
+    });
+  });
+
+  it("a diagnostic that says neither WARNING nor 'permission denied' still voids it", async () => {
+    // The set of complaints lsof can make is open — `lsof: can't read proc table
+    // info` is documented and matches none of the words I would have listed. So the
+    // rule is inverted: any `lsof:` line that is not part of the `-V` "not located"
+    // report is a complaint, whatever it says.
+    mockExecSync.mockReturnValue(
+      "lsof: can't read proc table info\nlsof: Internet address not located: TCP:8188",
+    );
+    const { probePortOwner } = await loadProbe();
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/could not enumerate everything/i),
+    });
+  });
+
+  it("the -V report's OWN lines are not complaints — a clean absence is still FREE", async () => {
+    // The control for the inversion. A real `-V` run on a free port emits TWO
+    // `lsof:` lines, captured verbatim from a live lsof 4.99.4. If the rule counted
+    // those as complaints, no port could ever be certified free through lsof.
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout =
+        "lsof: Internet address not located: TCP:8188\nlsof: TCP state not located: LISTEN";
+      throw err;
+    });
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188)).toEqual({ state: "free" });
+  });
+
+  it("a SILENT exit-0 still reports the silent cause, not the warning one", async () => {
+    // The counterpart, so the two causes cannot both drift onto one string: lsof
+    // exited 0, named nobody, and said nothing about an empty search.
+    mockExecSync.mockReturnValue("");
+    const { probePortOwner } = await loadProbe();
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/did not report an empty search/i),
+    });
   });
 
   it("reports UNKNOWN for a BARE exit 1 with no such statement", async () => {
@@ -168,6 +266,18 @@ describe("probePortOwner — POSIX (lsof)", () => {
     expect(String(mockExecSync.mock.calls[0][0])).not.toMatch(/ -w /);
   });
 
+  it("CAPTURES stderr, or a success-path warning would never be seen", async () => {
+    // lsof reports an incomplete enumeration on stderr, and on the success path
+    // `execSync` returns stdout only. Without the redirect, a marker on stdout beside
+    // a warning on stderr reads as a clean absence — the classification below cannot
+    // reject what it was never handed, so the ACQUISITION has to be pinned here.
+    mockExecSync.mockReturnValue("");
+    const { probePortOwner } = await loadProbe();
+    probePortOwner(8188);
+
+    expect(String(mockExecSync.mock.calls[0][0])).toMatch(/2>&1/);
+  });
+
   it("reports UNKNOWN for a spawn-level failure (errno), not free", async () => {
     mockExecSync.mockImplementation(() => {
       throw spawnFailure("ENOENT");
@@ -196,6 +306,882 @@ describe("probePortOwner — POSIX (lsof)", () => {
     const { findPidByPort } = await loadProbe();
 
     expect(findPidByPort(8188)).toBeNull();
+  });
+});
+
+describe("probePortOwner — POSIX (kernel socket table, consulted before lsof)", () => {
+  // The real column headers, captured from a live kernel. IPv4 says `rem_address`,
+  // IPv6 says `remote_address`; both end at `inode`. Kept verbatim and shared so a
+  // fixture cannot accidentally supply a TRUNCATED header, which is itself one of
+  // the states under test.
+  const HEADER_V4 =
+    "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode";
+  const HEADER_V6 =
+    "  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode";
+
+  /** A `/proc/net/tcp` body; `state` is the kernel's hex code (`0A` = LISTEN). */
+  function table(port: number, state = "0A"): string {
+    const hexPort = port.toString(16).toUpperCase().padStart(4, "0");
+    return [
+      HEADER_V4,
+      `   0: 0100007F:${hexPort} 00000000:0000 ${state} 00000000:00000000 00:00000000 00000000  1000        0 54321 1`,
+      "",
+    ].join("\n");
+  }
+  /**
+   * A `/proc/net/tcp6` body. The local address is THIRTY-TWO hex digits, not eight
+   * — this is `::1` exactly as a real kernel prints it, captured from a live IPv6
+   * listener. Using an IPv4-width row here would let a regression that narrowed the
+   * endpoint pattern to IPv4-only still pass.
+   */
+  function table6(port: number, state = "0A"): string {
+    const hexPort = port.toString(16).toUpperCase().padStart(4, "0");
+    return [
+      HEADER_V6,
+      `   0: 00000000000000000000000001000000:${hexPort} 00000000000000000000000000000000:0000 ${state} 00000000:00000000 00:00000000 00000000  1000        0 22454 1`,
+      "",
+    ].join("\n");
+  }
+  /**
+   * A table with NO sockets at all — a header and nothing else. This is what an idle
+   * host really serves, and it must stay a CLEAN NEGATIVE. Using `""` as a stand-in
+   * would instead model a table that came back as nothing, which is damage.
+   */
+  function emptyTable(path: string): string {
+    return `${path === "/proc/net/tcp6" ? HEADER_V6 : HEADER_V4}\n`;
+  }
+  const enoent = (): NodeJS.ErrnoException =>
+    Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+
+  it("reports FREE from the kernel table WITHOUT running lsof at all", async () => {
+    // The whole point of consulting /proc first: it sees every socket regardless of
+    // owner, so "nothing is listening" is a real answer here where lsof can only
+    // give an ambiguous one. lsof must not even be spawned.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const reader = vi.fn((t: string) => (t === "/proc/net/tcp" ? table(9999) : emptyTable(t)));
+    __portOwnerTestHooks.setProcNetReader(reader);
+
+    expect(probePortOwner(8188)).toEqual({ state: "free" });
+    expect(reader).toHaveBeenCalledWith("/proc/net/tcp");
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("a non-LISTEN socket on the port is not a listener", async () => {
+    // `01` is ESTABLISHED: an outbound connection whose local side happens to use
+    // the port does not mean anything is accepting on it.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? table(8188, "01") : emptyTable(t),
+    );
+
+    expect(probePortOwner(8188)).toEqual({ state: "free" });
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("falls through to lsof to NAME the owner when the kernel says something listens", async () => {
+    // The kernel table settles free-vs-occupied but cannot name a pid, so a LISTEN
+    // row must not short-circuit: lsof still has to run. Asserting the table was
+    // read AND lsof was spawned is what distinguishes this from lsof answering on
+    // its own with /proc never consulted.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const reader = vi.fn((t: string) => (t === "/proc/net/tcp" ? table(8188) : emptyTable(t)));
+    __portOwnerTestHooks.setProcNetReader(reader);
+    mockExecSync.mockReturnValue("p4321\nn127.0.0.1:8188\n");
+
+    expect(probePortOwner(8188)).toEqual({ state: "owned", pid: 4321 });
+    expect(reader).toHaveBeenCalledWith("/proc/net/tcp");
+    expect(mockExecSync).toHaveBeenCalled();
+  });
+
+  it("a listening socket whose owner lsof cannot name is UNKNOWN, never free", async () => {
+    // Both sources ran and disagree in the one direction that matters: something IS
+    // accepting on the port. Calling that "free" is what would certify a release
+    // that never happened.
+    //
+    // The REASON is asserted, not just the state: this wording is reachable only
+    // when the kernel table positively reported a listener. The same lsof output
+    // with /proc unread yields "listed no owner and did not report an empty
+    // search" — so this pins that the kernel evidence actually reached the verdict.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? table(8188) : emptyTable(t),
+    );
+    mockExecSync.mockReturnValue("");
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({ reason: expect.stringMatching(/socket is listening/i) });
+  });
+
+  it("reads tcp6 when only that table is available — a REAL 32-hex-digit row", async () => {
+    // End-to-end IPv6: the kernel row carries a 32-hex-digit address and lsof
+    // reports the listener in its bracketed form, both exactly as captured from a
+    // live `::1` listener.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const reader = vi.fn((t: string) => {
+      if (t === "/proc/net/tcp6") return table6(8188);
+      throw enoent();
+    });
+    __portOwnerTestHooks.setProcNetReader(reader);
+    mockExecSync.mockReturnValue("p4321\nn[::1]:8188\n");
+
+    expect(probePortOwner(8188)).toEqual({ state: "owned", pid: 4321 });
+    expect(reader).toHaveBeenCalledWith("/proc/net/tcp6");
+  });
+
+  it("an IPv6-only listener is seen even when the IPv4 table is clean", async () => {
+    // The reason a negative needs BOTH tables: nothing is on IPv4, the listener is
+    // on IPv6, and only reading tcp6 reveals it. Reported as a kernel positive, so
+    // lsof's inability to name it can never downgrade this to free.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? table(9999) : table6(8188),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/socket is listening/i),
+    });
+  });
+
+  it("a PARTIAL read is not a negative — an unreadable tcp6 may hold the listener", async () => {
+    // IPv4 has no row for the port and the IPv6 table cannot be opened. That is
+    // "I did not finish looking", not "nothing is listening": an IPv6 listener may
+    // still hold the port. Short-circuiting to `free` here would certify a release
+    // that never happened, so the verdict must fall through to lsof.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) => {
+      if (t === "/proc/net/tcp") return table(9999);
+      throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+    });
+    mockExecSync.mockReturnValue("p4321\nn127.0.0.1:8188\n");
+
+    expect(probePortOwner(8188)).toEqual({ state: "owned", pid: 4321 });
+    expect(mockExecSync).toHaveBeenCalled();
+  });
+
+  it("a PARTIAL read plus an lsof that cannot look is UNKNOWN, never free", async () => {
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) => {
+      if (t === "/proc/net/tcp") return table(9999);
+      throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+    });
+    mockExecSync.mockImplementation(() => {
+      throw exitWith(1);
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("lsof STATING absence does NOT override a listener the kernel can see (error path)", async () => {
+    // The unprivileged case: /proc sees the socket, lsof cannot enumerate it and
+    // exits 1 with its `-V` "Internet address not located" marker. Believing lsof
+    // would make waitForPortFree report a release while the socket is still bound.
+    // The weaker source's negative must not beat the stronger source's positive.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? table(8188) : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/socket is listening/i),
+    });
+  });
+
+  it("lsof STATING absence does NOT override a listener the kernel can see (exit-0 path)", async () => {
+    // Same rule on the branch where lsof exits 0 and prints the marker.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? table(8188) : emptyTable(t),
+    );
+    mockExecSync.mockReturnValue("lsof: Internet address not located: TCP:8188");
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("a PARTIAL read plus lsof's -V absence marker is UNKNOWN, never free", async () => {
+    // The blind spots COMPOSE: tcp6 is unreadable, and an unprivileged lsof cannot
+    // enumerate another user's socket either — it reports exactly this marker while
+    // being unable to see. Neither source can rule out an IPv6 listener, so the
+    // marker must not be spent as proof of release against the table we could not
+    // finish reading.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) => {
+      if (t === "/proc/net/tcp") return table(9999);
+      throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+    });
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/could not be read in full/i),
+    });
+  });
+
+  it("an UNPARSEABLE row makes the table incomplete, not a clean negative", async () => {
+    // A truncated/garbled row is a row we cannot rule out. Skipping it and then
+    // reporting "no listener found" would certify free on a table we did not fully
+    // understand — so the read is incomplete and lsof's absence cannot settle it.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) => {
+      if (t === "/proc/net/tcp") {
+        return [HEADER_V4, "   0: 0100007F", ""].join("\n");
+      }
+      return emptyTable(t);
+    });
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("the single terminating newline is structure, not damage", async () => {
+    // The guard on the rule above: /proc tables end with a newline, so the blank
+    // final split element must stay an ordinary clean negative. Otherwise EVERY read
+    // would degrade to "incomplete" and no port could ever be certified free.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? table(9999) : emptyTable(t),
+    );
+
+    expect(probePortOwner(8188)).toEqual({ state: "free" });
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("an INTERIOR blank line is an empty record the kernel never wrote", async () => {
+    // The kernel emits exactly one non-empty line per entry, so a gap between rows is
+    // not "nothing was there" — it is a record that went missing. Only the final
+    // split element may be blank.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const row = (slot: number, port: number): string => {
+      const hexPort = port.toString(16).toUpperCase().padStart(4, "0");
+      return `   ${slot}: 0100007F:${hexPort} 00000000:0000 01 00000000:00000000 00:00000000 00000000  1000        0 5432${slot} 1`;
+    };
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `${HEADER_V4}\n${row(0, 9998)}\n\n${row(1, 9999)}\n`
+        : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("the HIGHEST state these tables print (0B, TCP_CLOSING) is accepted", async () => {
+    // The boundary from the legitimate side — a bound has two ways to be wrong, and
+    // rejecting real data is the one that fails silently rather than safely.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `${HEADER_V4}\n   0: 0100007F:270F 00000000:0000 0B 00000000:00000000 00:00000000 00000000  1000        0 54321 1\n`
+        : emptyTable(t),
+    );
+
+    expect(probePortOwner(8188)).toEqual({ state: "free" });
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  // The two enum values ABOVE the printable range. Both are real states; neither
+  // reaches this column, so both are damage here rather than sockets.
+  for (const [state, why] of [
+    ["0C", "TCP_NEW_SYN_RECV — a request socket prints as SYN_RECV (03) instead"],
+    ["0D", "TCP_BOUND_INACTIVE — an inet_diag pseudo-state; these files never bind-walk"],
+  ] as const) {
+    it(`${state} is never printed here (${why})`, async () => {
+      const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+      __portOwnerTestHooks.setProcNetReader((t) =>
+        t === "/proc/net/tcp"
+          ? `${HEADER_V4}\n   0: 0100007F:270F 00000000:0000 ${state} 00000000:00000000 00:00000000 00000000  1000        0 54321 1\n`
+          : emptyTable(t),
+      );
+      mockExecSync.mockImplementation(() => {
+        const err = exitWith(1) as Error & { status: number; stdout: string };
+        err.stdout = "lsof: Internet address not located: TCP:8188";
+        throw err;
+      });
+
+      expect(probePortOwner(8188).state).toBe("unknown");
+    });
+  }
+
+  it("an IMPOSSIBLE TCP state is not a socket we may reason about", async () => {
+    // The state enum is bounded and starts at 1. `FF` is two valid hex digits and no
+    // kernel state at all, so a row carrying it cannot help certify free.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `${HEADER_V4}\n   0: 0100007F:270F 00000000:0000 FF 00000000:00000000 00:00000000 00000000  1000        0 54321 1\n`
+        : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  // A row's endpoint width is fixed by the table it appears in — one 32-bit word for
+  // IPv4, four for IPv6 — so an IPv4-width row inside tcp6 is impossible. It must
+  // fabricate neither a listener (`0A`) nor a clean negative (`01`).
+  for (const [state, label] of [
+    ["0A", "a listener"],
+    ["01", "a clean negative"],
+  ] as const) {
+    it(`an IPv4-width row inside tcp6 cannot produce ${label}`, async () => {
+      const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+      const hexPort = (8188).toString(16).toUpperCase().padStart(4, "0");
+      __portOwnerTestHooks.setProcNetReader((t) =>
+        t === "/proc/net/tcp6"
+          ? `${HEADER_V6}\n   0: 0100007F:${hexPort} 00000000:0000 ${state} 00000000:00000000 00:00000000 00000000  1000        0 54321 1\n`
+          : emptyTable(t),
+      );
+      mockExecSync.mockImplementation(() => {
+        const err = exitWith(1) as Error & { status: number; stdout: string };
+        err.stdout = "lsof: Internet address not located: TCP:8188";
+        throw err;
+      });
+
+      const probe = probePortOwner(8188);
+      expect(probe.state).toBe("unknown");
+      expect(probe).toMatchObject({
+        reason: expect.stringMatching(/could not be read in full/i),
+      });
+    });
+  }
+
+  it("BOTH tables EACCES plus lsof's marker is UNKNOWN — unreadable is not absent", async () => {
+    // A restricted Linux container: /proc/net exists but neither table can be
+    // opened, and the same lack of privilege is why lsof reports nothing. "Every
+    // read failed" is NOT evidence the source is absent — the two blind spots are
+    // the same blind spot, and certifying free here is the exact fold this rule
+    // exists to reject. Distinguished from macOS purely by the errno.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader(() => {
+      throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+    });
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  // Only a pathname that resolves to nothing proves absence. These two describe a
+  // failed OPERATION, so they cannot rule out a listener in the table they failed
+  // to read — they must behave like EACCES, not like ENOENT.
+  for (const code of ["ENOSYS", "ENXIO"]) {
+    it(`${code} on tcp6 is a blind spot, not an absent table`, async () => {
+      const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+      __portOwnerTestHooks.setProcNetReader((t) => {
+        if (t === "/proc/net/tcp") return table(9999);
+        throw Object.assign(new Error(code), { code });
+      });
+      mockExecSync.mockImplementation(() => {
+        const err = exitWith(1) as Error & { status: number; stdout: string };
+        err.stdout = "lsof: Internet address not located: TCP:8188";
+        throw err;
+      });
+
+      expect(probePortOwner(8188).state).toBe("unknown");
+    });
+  }
+
+  it("a table TRUNCATED after its header is not a clean negative", async () => {
+    // "The header parsed" is not "the body was read". A header cut short — here to
+    // just `sl local_address` — with no rows after it looks, by row count alone,
+    // exactly like an idle table. Requiring the COMPLETE header (through its final
+    // `inode` column) is what tells them apart: a truncated one is not a header, so
+    // it counts as damage and the read is incomplete.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? "  sl  local_address\n" : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("a header missing its MIDDLE columns is truncation one level in", async () => {
+    // Pinning only the two ends and allowing anything between would accept this:
+    // the first two column names and the last, with every intervening column gone.
+    // That is the same truncation, just not at the tail, so the whole column
+    // sequence has to be spelled out.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? "  sl  local_address rem_address inode\n" : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("a ROW truncated after `st` is damage, however well-formed its prefix", async () => {
+    // The same truncation as the header case, in the body. Four valid leading tokens
+    // is a valid PREFIX, not a complete row: EOF may have cut this row short and
+    // taken later listener rows with it. Validating through `inode` is what makes a
+    // partial read fail to look like a clean "nothing is listening".
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `${HEADER_V4}\n   0: 0100007F:270F 00000000:0000 01\n`
+        : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("a row truncated AFTER its state still proves the LISTENER it showed", async () => {
+    // The asymmetry pointed at the case that nearly inverted it. This row is cut off
+    // short of `inode`, so it cannot support a negative — but its local endpoint and
+    // its LISTEN state are both intact and visible. Truncation after the state
+    // cannot unmake what precedes it, so this is a positive observation.
+    //
+    // lsof is given its absence marker, so the two candidate verdicts differ only in
+    // REASON: "a socket is listening" (the positive was extracted) versus "could not
+    // be read in full" (the completeness gate swallowed it). Asserting the state
+    // alone would pass either way.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const hexPort = (8188).toString(16).toUpperCase().padStart(4, "0");
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `${HEADER_V4}\n   0: 0100007F:${hexPort} 00000000:0000 0A\n`
+        : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/socket is listening/i),
+    });
+  });
+
+  it("a GARBLED row cannot fabricate a listener from two intact fields", async () => {
+    // The positive-first rule pointed at its own risk. `cols[1]` and `cols[3]` here
+    // are individually well-shaped and say "LISTEN on 8188", but the slot and the
+    // remote endpoint around them are junk — these are bytes we have every reason to
+    // distrust, and untrustworthy input must not become a definite finding in EITHER
+    // direction. This must read as damage, not as a listener.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const hexPort = (8188).toString(16).toUpperCase().padStart(4, "0");
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `${HEADER_V4}\n   corrupt 0100007F:${hexPort} garbage 0A\n`
+        : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/could not be read in full/i),
+    });
+  });
+
+  it("mismatched address FAMILIES are a row no kernel wrote", async () => {
+    // Every token here is individually well-shaped, but an IPv4 local endpoint beside
+    // an IPv6 remote one cannot occur in a single table. Four valid tokens is not the
+    // same as a valid row, in either direction: this must not read as a listener, and
+    // with state `01` it must not help certify free either.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const hexPort = (8188).toString(16).toUpperCase().padStart(4, "0");
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `${HEADER_V4}\n   0: 0100007F:${hexPort} 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 54321 1\n`
+        : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/could not be read in full/i),
+    });
+  });
+
+  it("a LISTEN row with a PEER is not a listener", async () => {
+    // A listening socket has no peer — its remote endpoint is all zeros on port 0.
+    // A row claiming state `0A` while naming a peer is self-contradictory, so it is
+    // damage rather than a listener we may report.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const hexPort = (8188).toString(16).toUpperCase().padStart(4, "0");
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `${HEADER_V4}\n   0: 0100007F:${hexPort} 0200007F:1F90 0A 00000000:00000000 00:00000000 00000000  1000        0 54321 1\n`
+        : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/could not be read in full/i),
+    });
+  });
+
+  it("a table that does not OPEN with its header cannot support a negative", async () => {
+    // A leading blank line, then a perfectly good header. The contract is that a real
+    // table OPENS with its header; "somewhere after some blank lines" is not that,
+    // and whatever stood before it is exactly what we cannot see.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? `\n${HEADER_V4}\n` : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("a row standing BEFORE the header cannot support a negative either", async () => {
+    // The same contract from the other side: the header is not merely present, it is
+    // where the table begins. A row above it means rows above THAT may be missing.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `   0: 0100007F:270F 00000000:0000 01 00000000:00000000 00:00000000 00000000  1000        0 54321 1\n${HEADER_V4}\n`
+        : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("a table that comes back as NOTHING is damage, not an idle table", async () => {
+    // The extreme of the same truncation: zero bytes. A real table always carries at
+    // least its header, so recognising neither a header nor a single row means we
+    // did not read the table, whatever the read returned.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? "" : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("a legitimately EMPTY table — header, no sockets — is still FREE", async () => {
+    // The other direction, and the constraint that makes this subtle: an idle Linux
+    // host serves a header and zero rows. That must remain a decisive negative and
+    // answer WITHOUT lsof, or every idle host burns its whole release budget on
+    // every stop — the same always-unknown failure the macOS split exists to avoid.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) => emptyTable(t));
+
+    expect(probePortOwner(8188)).toEqual({ state: "free" });
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("an IPv4-form header over tcp6 is a table we did not really read", async () => {
+    // `rem_address` and `remote_address` are not interchangeable: the IPv4 spelling
+    // standing over /proc/net/tcp6 means what came back is not that table, so it
+    // cannot be certified idle.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp6" ? `${HEADER_V4}\n` : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("a damaged row that merely MENTIONS local_address is not the header", async () => {
+    // The header is recognised by its anchored shape. A garbled row that happens to
+    // contain the word must still count as damage, or the skip becomes a hole in
+    // the "every unparseable row is incomplete" rule.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) => {
+      if (t === "/proc/net/tcp") {
+        return [
+          HEADER_V4,
+          "   0: corrupted local_address garbage",
+          "",
+        ].join("\n");
+      }
+      return emptyTable(t);
+    });
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  // The counterweight to the blind-spot rule: a pathname that resolves to nothing
+  // proves the table does not exist (a Linux kernel without IPv6 has no tcp6), so
+  // the IPv4 read alone is a COMPLETE answer and the port is free without consulting
+  // lsof. Treating this as a blind spot would cost every such host its fast path.
+  // Both codes in the absent set are driven, so dropping either is a test failure.
+  for (const code of ["ENOENT", "ENOTDIR"]) {
+    it(`an ABSENT tcp6 table (${code}) still allows a clean negative`, async () => {
+      const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+      __portOwnerTestHooks.setProcNetReader((t) => {
+        if (t === "/proc/net/tcp") return table(9999);
+        throw Object.assign(new Error(code), { code });
+      });
+
+      expect(probePortOwner(8188)).toEqual({ state: "free" });
+      expect(mockExecSync).not.toHaveBeenCalled();
+    });
+  }
+
+  it("a row with four columns but a GARBLED endpoint is damage, not a clean skip", async () => {
+    // `cols.length >= 4` is not "parsed". A row whose address/port is not hex, or
+    // whose state is not a two-digit code, was silently skipped and the table then
+    // reported "no listener" — certifying free on data we did not understand.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) => {
+      if (t === "/proc/net/tcp") {
+        return [
+          HEADER_V4,
+          "   0: junk:ZZZZ garbage QQ 00000000:00000000",
+          "",
+        ].join("\n");
+      }
+      return emptyTable(t);
+    });
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("a headerless table cannot support a clean NEGATIVE", async () => {
+    // A real table always opens with its header, so its absence means we did not see
+    // where the table starts — rows before the point we picked it up may be gone.
+    // A well-formed row proves only that the bytes we got were well-formed.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const hexPort = (9999).toString(16).toUpperCase().padStart(4, "0");
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `   0: 0100007F:${hexPort} 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 54321 1\n`
+        : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("a GAP in the kernel's row counter means a record went missing", async () => {
+    // Slots 0 and 2, with 1 absent. Every row here is individually well-formed and
+    // the table has both boundaries — only the SEQUENCE shows that a record between
+    // them is gone, and that record could have been the listener.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const row = (slot: number, port: number): string => {
+      const hexPort = port.toString(16).toUpperCase().padStart(4, "0");
+      return `   ${slot}: 0100007F:${hexPort} 00000000:0000 01 00000000:00000000 00:00000000 00000000  1000        0 5432${slot} 1`;
+    };
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `${HEADER_V4}\n${row(0, 9998)}\n${row(2, 9999)}\n`
+        : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("a first row numbered above 0 means the table was picked up mid-way", async () => {
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `${HEADER_V4}\n   1: 0100007F:270F 00000000:0000 01 00000000:00000000 00:00000000 00000000  1000        0 54321 1\n`
+        : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("consecutive slots are NOT damage — a normal multi-row table stays free", async () => {
+    // The control for the two above: an ordinary busy host has many rows, and they
+    // must read as a clean negative or no such host ever gets its fast path.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const row = (slot: number, port: number): string => {
+      const hexPort = port.toString(16).toUpperCase().padStart(4, "0");
+      return `   ${slot}: 0100007F:${hexPort} 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 5432${slot} 1`;
+    };
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `${HEADER_V4}\n${row(0, 9997)}\n${row(1, 9998)}\n${row(2, 9999)}\n`
+        : emptyTable(t),
+    );
+
+    expect(probePortOwner(8188)).toEqual({ state: "free" });
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("a table whose FINAL NEWLINE is missing is truncated at its end", async () => {
+    // The other boundary. A complete header and a well-formed non-matching row still
+    // do not prove the table ended where the bytes did.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const hexPort = (9999).toString(16).toUpperCase().padStart(4, "0");
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `${HEADER_V4}\n   0: 0100007F:${hexPort} 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 54321 1`
+        : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("a LISTEN row in a headerless table is a POSITIVE, not merely an incomplete read", async () => {
+    // The asymmetry, pinned where it can actually be seen. lsof is given its absence
+    // marker so it cannot name anyone, which makes the two candidate verdicts differ
+    // only in their REASON: "a socket is listening" (the kernel positive survived the
+    // incomplete read) versus "could not be read in full" (it did not). Asserting the
+    // state alone would pass either way.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const hexPort = (8188).toString(16).toUpperCase().padStart(4, "0");
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? `   0: 0100007F:${hexPort} 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 54321 1\n`
+        : emptyTable(t),
+    );
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/socket is listening/i),
+    });
+  });
+
+  it("lsof STATING absence IS believed when there is no kernel table AT ALL (macOS)", async () => {
+    // The positive control, and the reason "no source" and "blind spot" are kept
+    // apart: on every non-Linux POSIX host /proc/net does not exist, so lsof is the
+    // only evidence there has ever been. Gating `free` on a kernel negative alone
+    // would leave macOS permanently unable to observe a release — the rule must not
+    // have degraded every free verdict into "unknown".
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader(() => {
+      throw enoent();
+    });
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
+    });
+
+    expect(probePortOwner(8188)).toEqual({ state: "free" });
+  });
+
+  it("an ABSENT source leaves lsof as the only judge — and it IS consulted", async () => {
+    // ENOENT is the ABSENT case, not the inaccessible one (EACCES has its own test
+    // above): with no kernel table anywhere, lsof is the only evidence there is, so
+    // it must actually be run. Asserting the call is what distinguishes this from
+    // skipping the probe altogether. lsof here cannot look either — a bare exit 1 —
+    // so "could not look" must not be spent as "nothing is listening".
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader(() => {
+      throw enoent();
+    });
+    mockExecSync.mockImplementation(() => {
+      throw exitWith(1);
+    });
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+    expect(mockExecSync).toHaveBeenCalled();
+    expect(String(mockExecSync.mock.calls[0][0])).toMatch(/lsof/);
   });
 });
 

--- a/src/__tests__/services/port-owner-probe.test.ts
+++ b/src/__tests__/services/port-owner-probe.test.ts
@@ -20,6 +20,15 @@ const mockPlatform = vi.hoisted(() => vi.fn(() => "linux"));
 
 vi.mock("node:child_process", () => ({ execSync: mockExecSync }));
 vi.mock("node:os", () => ({ platform: mockPlatform }));
+// The kernel socket table is consulted before lsof on Linux. These tests drive the
+// LSOF contract specifically, so make /proc unreadable and let it fall through
+// deterministically (a real Linux runner would otherwise answer from
+// /proc/net/tcp first and never reach the code under test).
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(() => {
+    throw new Error("no /proc in test");
+  }),
+}));
 
 /** `execSync` throws with `status` (the exit code) for a command that RAN and
  *  failed, and with `code` (an errno) only for a spawn-level failure. */
@@ -58,22 +67,42 @@ describe("probePortOwner — POSIX (lsof)", () => {
     expect(probePortOwner(8188)).toEqual({ state: "owned", pid: 4321 });
   });
 
-  it("reports FREE for lsof's 'ran fine, matched nothing' (exit 1)", async () => {
-    // lsof's documented convention for an empty result set. This is real evidence
-    // that the port is free — the probe ran and saw nothing.
+  it("reports FREE only when lsof STATES the address was not located", async () => {
+    // Verified against lsof(8) and by experiment: exit 1 means "an error was
+    // detected, INCLUDING failure to locate", so it cannot distinguish "searched
+    // and found nothing" from "could not search". `-V` makes lsof say which it was,
+    // and that statement is the only thing treated as evidence of a free port.
     mockExecSync.mockImplementation(() => {
-      throw exitWith(1);
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188";
+      throw err;
     });
     const { probePortOwner } = await loadProbe();
 
     expect(probePortOwner(8188)).toEqual({ state: "free" });
   });
 
-  it("reports FREE when lsof succeeds with no matching records", async () => {
-    mockExecSync.mockReturnValue("");
+  it("reports UNKNOWN for a BARE exit 1 with no such statement", async () => {
+    mockExecSync.mockImplementation(() => {
+      throw exitWith(1);
+    });
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("reports FREE when lsof exits 0 and states the address was not located", async () => {
+    mockExecSync.mockReturnValue("lsof: Internet address not located: TCP:8188");
     const { probePortOwner } = await loadProbe();
 
     expect(probePortOwner(8188)).toEqual({ state: "free" });
+  });
+
+  it("reports UNKNOWN when lsof exits 0 but names nobody and states nothing", async () => {
+    mockExecSync.mockReturnValue("");
+    const { probePortOwner } = await loadProbe();
+
+    expect(probePortOwner(8188).state).toBe("unknown");
   });
 
   it("reports UNKNOWN when the command is MISSING (shell exit 127), not free", async () => {
@@ -114,7 +143,10 @@ describe("probePortOwner — POSIX (lsof)", () => {
     expect(probePortOwner(8188).state).toBe("unknown");
   });
 
-  it("still reports FREE for a QUIET exit 1 (empty stdout and stderr)", async () => {
+  it("reports UNKNOWN for a QUIET exit 1 — silence is not a finding", async () => {
+    // MEASURED on Linux: an enumeration that cannot see another user's sockets
+    // exits 1 with EMPTY stdout and EMPTY stderr, with or without `-w`. Reading
+    // that as "free" is what would certify a release that never happened.
     mockExecSync.mockImplementation(() => {
       const err = exitWith(1) as Error & { status: number; stdout: string; stderr: string };
       err.stdout = "";
@@ -123,15 +155,17 @@ describe("probePortOwner — POSIX (lsof)", () => {
     });
     const { probePortOwner } = await loadProbe();
 
-    expect(probePortOwner(8188)).toEqual({ state: "free" });
+    expect(probePortOwner(8188).state).toBe("unknown");
   });
 
-  it("passes -w so lsof's routine warnings do not masquerade as a failed enumeration", async () => {
+  it("passes -V so lsof STATES what it failed to locate", async () => {
     mockExecSync.mockReturnValue("");
     const { probePortOwner } = await loadProbe();
     probePortOwner(8188);
 
-    expect(String(mockExecSync.mock.calls[0][0])).toMatch(/lsof -w /);
+    expect(String(mockExecSync.mock.calls[0][0])).toMatch(/lsof -V /);
+    // `-w` would SUPPRESS warnings, making silence less informative, not more.
+    expect(String(mockExecSync.mock.calls[0][0])).not.toMatch(/ -w /);
   });
 
   it("reports UNKNOWN for a spawn-level failure (errno), not free", async () => {

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -370,7 +370,11 @@ describe("process-control crash supervision", () => {
     mockExecSync.mockImplementation((cmd: string) => {
       if (cmd.includes("netstat") || cmd.includes("lsof")) {
         portCheckCalls += 1;
-        if (portCheckCalls === 3) {
+        // Call 3 is stop_comfyui's port→PID lookup; call 4 is the pre-kill
+        // identity re-check (#776) confirming that PID still owns the port — a
+        // process that vanished in between must NOT be killed. Calls 5+ model the
+        // port freeing after the kill so waitForPortFree returns immediately.
+        if (portCheckCalls === 3 || portCheckCalls === 4) {
           if (cmd.includes("netstat"))
             return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
           // `lsof -nP -iTCP:PORT -sTCP:LISTEN -Fpn` field output: p<pid> / n<addr:port>.

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -141,6 +141,13 @@ beforeEach(() => {
   // real. Individual tests re-spy this where they assert on killing.
   vi.spyOn(process, "kill").mockImplementation(() => true);
   __processControlTestHooks.reset();
+  // The identity bracket around /system_stats (#776) needs the port owner's process
+  // creation time at both ends — pid equality alone is what pid REUSE defeats. This
+  // module's child_process mock has no execFileSync, so the real reader cannot run;
+  // model the ordinary host where the stamp IS readable.
+  __processControlTestHooks.setProcessIdentityResolver(() => ({
+    startedAt: "stable-stamp",
+  }));
 });
 
 afterEach(() => {

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -39,6 +39,14 @@ const mockStatSync = vi.hoisted(() =>
 vi.mock("node:fs", () => ({
   existsSync: mockExistsSync,
   statSync: mockStatSync,
+  // The port probe reads the kernel socket tables and classifies a failure from its
+  // ERRNO: ENOENT ("no /proc on this host") hides nothing and leaves lsof as the
+  // only source, which is what these tests model. Omitting this entirely used to
+  // throw "readFileSync is not a function" — errno-less, i.e. "I could not look" —
+  // which would make every post-kill probe `unknown` and hang the suite.
+  readFileSync: vi.fn(() => {
+    throw Object.assign(new Error("no /proc in test"), { code: "ENOENT" });
+  }),
 }));
 
 vi.mock("../../comfyui/client.js", () => ({
@@ -69,16 +77,31 @@ import {
 } from "../../services/process-control.js";
 
 /**
- * `lsof` exiting 1 with no output — its convention for "ran fine, matched
- * nothing", which the port probe reads as definite evidence the port is free.
- * A bare `Error` carries neither an exit status nor an errno, so it means
- * "I could not look" instead, and a caller waiting for the port to be released
- * would wait out its whole budget. That difference is invisible on Windows (the
- * netstat branch never reaches lsof) and hangs the suite on POSIX (#776).
+ * `lsof -V` STATING that nothing is listening — the port is free.
+ *
+ * The exit status alone cannot say this: lsof exits 1 both when it searched and
+ * matched nothing AND when it could not search at all, and a run that enumerates
+ * nothing for lack of permission exits 1 with BOTH streams empty. So the probe
+ * keys on the `-V` marker, which is lsof positively naming what it failed to
+ * locate. Verified against lsof 4.99.4: with `-V` and nothing listening, status is
+ * 1 and `lsof: Internet address not located: TCP:<port>` goes to STDOUT; without
+ * `-V`, status is 1 and both streams are empty — the ambiguity that makes
+ * "quiet ⇒ free" unsound, so a fixture must not model absence as mere silence.
+ *
+ * Getting this wrong is invisible on Windows (the netstat branch never reaches
+ * lsof) and HANGS the suite on POSIX: a caller waiting for the port to be released
+ * never sees a release and waits out its whole budget (#776).
  */
 function noListener(): Error {
-  const err = new Error("no listener") as Error & { status?: number };
+  const err = new Error("no listener") as Error & {
+    status?: number;
+    stdout?: string;
+    stderr?: string;
+  };
   err.status = 1;
+  err.stdout =
+    "lsof: Internet address not located: TCP:8188\nlsof: TCP state not located: LISTEN\n";
+  err.stderr = "";
   return err;
 }
 

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -367,14 +367,21 @@ describe("process-control crash supervision", () => {
     mockFetchOk(true);
 
     let portCheckCalls = 0;
+    let killIssued = false;
     mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killIssued = true;
+        return "";
+      }
       if (cmd.includes("netstat") || cmd.includes("lsof")) {
         portCheckCalls += 1;
-        // Call 3 is stop_comfyui's port→PID lookup; call 4 is the pre-kill
-        // identity re-check (#776) confirming that PID still owns the port — a
-        // process that vanished in between must NOT be killed. Calls 5+ model the
-        // port freeing after the kill so waitForPortFree returns immediately.
-        if (portCheckCalls === 3 || portCheckCalls === 4) {
+        // The first two lookups belong to start_comfyui (the already-running guard
+        // and the post-readiness PID). From then until the kill, the port is OWNED:
+        // stop_comfyui looks it up, re-confirms the server that answered still owns
+        // it, and re-checks the identity again immediately before killing (#776) —
+        // a count-based fixture would break every time that evidence chain grows.
+        // After the kill the port is free, so waitForPortFree returns at once.
+        if (portCheckCalls >= 3 && !killIssued) {
           if (cmd.includes("netstat"))
             return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
           // `lsof -nP -iTCP:PORT -sTCP:LISTEN -Fpn` field output: p<pid> / n<addr:port>.

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -68,6 +68,20 @@ import {
   stopComfyUI,
 } from "../../services/process-control.js";
 
+/**
+ * `lsof` exiting 1 with no output — its convention for "ran fine, matched
+ * nothing", which the port probe reads as definite evidence the port is free.
+ * A bare `Error` carries neither an exit status nor an errno, so it means
+ * "I could not look" instead, and a caller waiting for the port to be released
+ * would wait out its whole budget. That difference is invisible on Windows (the
+ * netstat branch never reaches lsof) and hangs the suite on POSIX (#776).
+ */
+function noListener(): Error {
+  const err = new Error("no listener") as Error & { status?: number };
+  err.status = 1;
+  return err;
+}
+
 class FakeChild extends EventEmitter {
   unref = vi.fn();
   /**
@@ -101,7 +115,7 @@ function mockSpawnedChildren(): FakeChild[] {
 
 function mockNoPortProcess(): void {
   mockExecSync.mockImplementation((cmd: string) => {
-    if (cmd.includes("lsof")) throw new Error("not listening");
+    if (cmd.includes("lsof")) throw noListener();
     return "";
   });
 }
@@ -405,7 +419,7 @@ describe("process-control crash supervision", () => {
           // `lsof -nP -iTCP:PORT -sTCP:LISTEN -Fpn` field output: p<pid> / n<addr:port>.
           return "p4321\nn127.0.0.1:8188\n";
         }
-        throw new Error("not listening");
+        throw noListener();
       }
       return "";
     });
@@ -656,7 +670,7 @@ describe("findPidByPort resilience to localized netstat state (#449)", () => {
         }
         return GERMAN_BLOB;
       }
-      if (cmd.includes("lsof")) throw new Error("not listening");
+      if (cmd.includes("lsof")) throw noListener();
       return ""; // tasklist / powershell fallback / `if exist` → nothing
     });
     mockGetSystemStats.mockResolvedValue({
@@ -678,7 +692,7 @@ describe("findPidByPort resilience to localized netstat state (#449)", () => {
     // back empty. Liveness is the reachable server, so we must NOT claim the
     // process is absent — and we must NOT take the server down (issue #449).
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.includes("lsof")) throw new Error("not listening");
+      if (cmd.includes("lsof")) throw noListener();
       return ""; // netstat, powershell, tasklist → nothing resolves a PID
     });
     mockGetSystemStats.mockResolvedValue({
@@ -706,7 +720,7 @@ describe("findPidByPort resilience to localized netstat state (#449)", () => {
     // (Comfy Desktop.exe) is present. We must NOT kill that shell — we can't
     // confirm it owns :8188 — so leave everything untouched and diagnose.
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.includes("lsof")) throw new Error("not listening");
+      if (cmd.includes("lsof")) throw noListener();
       if (/tasklist/i.test(cmd)) {
         // A Comfy Desktop shell IS running.
         return '"Comfy Desktop.exe","4242","Console","1","206,248 K"';
@@ -841,7 +855,7 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
         return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
       }
       if (cmd.includes("lsof")) {
-        if (killed) throw new Error("not listening");
+        if (killed) throw noListener();
         return "p4321\nn127.0.0.1:8188\n";
       }
       return ""; // tasklist / `sleep 1 && kill -9` / etc.
@@ -892,7 +906,7 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
         return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
       }
       if (cmd.includes("lsof")) {
-        if (killed) throw new Error("not listening");
+        if (killed) throw noListener();
         return "p4321\nn127.0.0.1:8188\n";
       }
       return ""; // tasklist / `sleep 1 && kill -9` / etc.

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -70,6 +70,12 @@ import {
 
 class FakeChild extends EventEmitter {
   unref = vi.fn();
+  /**
+   * Node only leaves `pid` undefined when the spawn FAILED, so a fake that models
+   * a successful launch must carry one — 4321, matching the pid the port fixtures
+   * below report (#776 listener-ownership).
+   */
+  pid: number | undefined = 4321;
 }
 
 const ORIGINAL_ENV = { ...process.env };
@@ -129,6 +135,11 @@ beforeEach(() => {
   mockFindComfyuiPython.mockReturnValue("/fake/ComfyUI/python_embeded/python.exe");
   mockExistsSync.mockImplementation(() => true);
   mockStatSync.mockImplementation(() => ({ isDirectory: () => true }));
+  // The listener-ownership check (#776) probes the spawned child's liveness with a
+  // signal-0 `process.kill`. These fakes model a LIVE child, so the probe must say
+  // so rather than reaching the real OS and getting ESRCH for a pid that was never
+  // real. Individual tests re-spy this where they assert on killing.
+  vi.spyOn(process, "kill").mockImplementation(() => true);
   __processControlTestHooks.reset();
 });
 

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -24,6 +24,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 class FakeChild extends EventEmitter {
   unref = vi.fn();
+  /** Set per-test when the listener-ownership check matters. */
+  pid: number | undefined = undefined;
 }
 
 const mockConfig = vi.hoisted(() => ({
@@ -161,10 +163,11 @@ function mockLivePortThenFree(): { killed: () => boolean } {
   return { killed: () => killed };
 }
 
-function spawnCapturingChildren(): FakeChild[] {
+function spawnCapturingChildren(pid?: number): FakeChild[] {
   const children: FakeChild[] = [];
   mockSpawn.mockImplementation(() => {
     const child = new FakeChild();
+    child.pid = pid;
     children.push(child);
     return child;
   });
@@ -506,6 +509,76 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     // No env override: `spawn` inherits process.env, exactly as before #776.
     expect(spawnOptions().env).toBeUndefined();
     expect(result.launch_env?.source).toBe("inherited");
+
+    killSpy.mockRestore();
+  });
+
+  it("does NOT claim a successful restart when the healthy listener is somebody ELSE's process", async () => {
+    // Readiness only proves that SOMETHING answers on the port. If an external
+    // launcher/supervisor bound it while our child failed, the server is up but
+    // OUR relaunch did not do it — saying "restarted successfully" would be false.
+    usePlainInstall();
+    // The port owner reported after the relaunch (4321) is not our child (999).
+    spawnCapturingChildren(999);
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        // Free during the post-kill wait, then a DIFFERENT process owns it again.
+        return killed && !restarted
+          ? ""
+          : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && !restarted) throw new Error("not listening");
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    let restarted = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        restarted = true; // something answers on the port again
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_is_launched_process).toBe(false);
+    expect(result.message).not.toMatch(/restarted successfully/i);
+    expect(result.message).toMatch(/NOT as a result of this restart/i);
+    expect(result.message).toMatch(/another launcher or supervisor owns it/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("names the launched process's EXIT when it dies before the API comes up", async () => {
+    usePlainInstall();
+    mockLivePortThenFree();
+    const children = spawnCapturingChildren();
+    // The API never answers; meanwhile the process we launched dies (the #776
+    // shape: ComfyUI aborting during import in a degraded environment).
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        children[0]?.emit("exit", 1, null);
+        throw new Error("ECONNREFUSED");
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/EXITED \(exit code 1\)/);
+    expect(result.message).toMatch(/failed relaunch, not a slow start/i);
 
     killSpy.mockRestore();
   });

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -176,13 +176,26 @@ const BENIGN_PINOKIO_PY = join(PINOKIO_BIN, "comfy", "venv", "bin", "python");
 const ORIGINAL_ENV = { ...process.env };
 
 /**
- * `lsof` exiting 1 with no output — its convention for "ran fine, matched
- * nothing". Distinct from a spawn failure (which carries a `code`), because the
- * port probe must not read "I could not look" as "the port is free".
+ * `lsof -V` STATING that nothing is listening — the port is free.
+ *
+ * Distinct from a spawn failure (which carries a `code`), because the port probe
+ * must not read "I could not look" as "the port is free". The exit status alone
+ * cannot carry that distinction either: lsof exits 1 both when it searched and
+ * matched nothing AND when it could not search, and a permission-restricted run
+ * exits 1 with BOTH streams empty. The `-V` marker — lsof naming what it failed to
+ * locate — is the only positive statement of absence, verified against lsof 4.99.4
+ * (it lands on STDOUT, with status 1).
  */
 function noListener(): Error {
-  const err = new Error("no listener") as Error & { status?: number };
+  const err = new Error("no listener") as Error & {
+    status?: number;
+    stdout?: string;
+    stderr?: string;
+  };
   err.status = 1;
+  err.stdout =
+    "lsof: Internet address not located: TCP:8188\nlsof: TCP state not located: LISTEN\n";
+  err.stderr = "";
   return err;
 }
 
@@ -1880,7 +1893,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     let killed = false;
     let relaunched = false;
     mockExecSync.mockImplementation((cmd: string) => {
-      if (/taskkill|pkill|kill/i.test(cmd)) {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
         killed = true;
         return "";
       }

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -1164,7 +1164,11 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
 
     expect(result.stopped).toBe(false);
     expect(result.started).toBe(false);
-    expect(result.message).toMatch(/could not be observed on both sides/i);
+    // The refusal names the MISSING CAPABILITY and a remedy, rather than leaving
+    // the user to guess why a restart declined on their host.
+    expect(result.message).toMatch(/could not be tied to PID/i);
+    expect(result.message).toMatch(/no usable port-owner lookup|creation time/i);
+    expect(result.message).toMatch(/restart ComfyUI from the launcher|install the missing tool/i);
     expect(killSpy).not.toHaveBeenCalled();
     expect(mockSpawn).not.toHaveBeenCalled();
 
@@ -1204,7 +1208,7 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
 
     const result = await restartComfyUI();
 
-    expect(result.message).not.toMatch(/could not be observed on both sides/i);
+    expect(result.message).not.toMatch(/could not be tied to PID/i);
     expect(result.stopped).toBe(true);
     expect(result.started).toBe(true);
 

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -1220,6 +1220,22 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
 });
 
 describe("restart_comfyui — plain installs are unchanged (#776)", () => {
+  /**
+   * After the restart, make `/system_stats` describe a DIFFERENT server than the
+   * one we launched (or fail outright). The identification phase before the stop
+   * consumes two calls — the bracketed fetch and the re-confirmation — so only the
+   * third and later answers belong to whatever came back on the port.
+   */
+  function servingArgvAfterRestart(argv: string[] | "unreachable"): void {
+    let calls = 0;
+    mockGetSystemStats.mockImplementation(async () => {
+      calls++;
+      if (calls <= 2) return { system: { argv: [PLAIN_MAIN, "--port", "8188"] } };
+      if (argv === "unreachable") throw new Error("ECONNRESET");
+      return { system: { argv } };
+    });
+  }
+
   function usePlainInstall(): void {
     mockFindComfyuiPython.mockReturnValue(PLAIN_PY);
     mockLiveRootFromArgv.mockReturnValue(PLAIN_BASE);
@@ -1314,6 +1330,8 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     // child is decisive on its own — it cannot be the process now answering — so
     // "undecidable PID" must not launder a failed relaunch into a success.
     usePlainInstall();
+    // The replacement is another launcher's ComfyUI, running a different install.
+    servingArgvAfterRestart([join(resolve("OtherComfy"), "main.py"), "--port", "8188"]);
     const children = spawnCapturingChildren(999);
     let killed = false;
     mockExecSync.mockImplementation((cmd: string) => {
@@ -1401,6 +1419,9 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     // delivers the `exit` event. A bare `portOwnerPid === ourPid` would call it
     // "ours". A synchronous signal-0 probe says otherwise.
     usePlainInstall();
+    // ...and the process that inherited the number runs a different install, so the
+    // argv cross-check agrees rather than rescuing it.
+    servingArgvAfterRestart([join(resolve("OtherComfy"), "main.py"), "--port", "8188"]);
     spawnCapturingChildren(4321);
     let killed = false;
     let relaunched = false;
@@ -1713,12 +1734,97 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     killSpy.mockRestore();
   });
 
+  it("resolves an unmappable port owner by asking the SERVER what it is running", async () => {
+    // The #449 host: no usable port-owner lookup. Rather than a permanent shrug,
+    // the server's own argv answers it — a match is as strong as a pid comparison.
+    usePlainInstall();
+    servingArgvAfterRestart([PLAIN_MAIN, "--port", "8188"]);
+    spawnCapturingChildren(4321);
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        // Owned while identifying; never mappable again afterwards.
+        return killed ? "" : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw new Error("not listening");
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("ours");
+    expect(result.started).toBe(true);
+    expect(result.message).toMatch(/restarted successfully/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("claims a GRANDCHILD listener as ours even when the WRAPPER has already exited", async () => {
+    // A wrapper script launches ComfyUI and exits; the grandchild is reparented, so
+    // lineage can no longer place it in our tree. The server's own command line
+    // still can — otherwise a legitimately indirect launcher reads as "not ours".
+    usePlainInstall();
+    servingArgvAfterRestart([PLAIN_MAIN, "--port", "8188"]);
+    const children = spawnCapturingChildren(4321);
+    let killed = false;
+    let relaunched = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed && !relaunched
+          ? ""
+          : `  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       ${relaunched ? 9999 : 4321}`;
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && !relaunched) throw new Error("not listening");
+        return `p${relaunched ? 9999 : 4321}\nn127.0.0.1:8188\n`;
+      }
+      return "";
+    });
+    // The grandchild has been reparented to init — lineage is a dead end here.
+    __processControlTestHooks.setParentPidResolver(() => 1);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        relaunched = true;
+        // The wrapper we spawned exits once its child is up.
+        children[0]?.emit("exit", 0, null);
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("ours");
+    expect(result.started).toBe(true);
+
+    killSpy.mockRestore();
+  });
+
   it("says so plainly when listener ownership is UNDECIDABLE — without denying a restart that worked", async () => {
-    // Unmappable port owner + a still-alive launched child. Reporting this as a
-    // FAILED restart would mislabel every ordinary restart on hosts where the
+    // Unmappable port owner, a still-alive launched child, AND a server that will
+    // not say what it is running — every identity signal exhausted. Reporting this
+    // as a FAILED restart would mislabel every ordinary restart on hosts where the
     // port-owner lookup is unavailable, so the result stays started:true and the
     // uncertainty is stated instead of guessed either way.
     usePlainInstall();
+    servingArgvAfterRestart("unreachable");
     spawnCapturingChildren(999);
     let killed = false;
     mockExecSync.mockImplementation((cmd: string) => {

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -109,9 +109,11 @@ const SM_DATA = resolve("StabilityMatrixTest", "Data");
 const SM_PKG = join(SM_DATA, "Packages", "ComfyUI");
 const SM_MAIN = join(SM_PKG, "main.py");
 const SM_PY = join(SM_PKG, "venv", "Scripts", "python.exe");
-const SM_GIT_DIR = join(SM_DATA, "PortableGit", "cmd");
+const SM_GIT_ROOT = join(SM_DATA, "PortableGit");
+const SM_GIT_DIR = join(SM_GIT_ROOT, "cmd");
 const SM_GIT_EXE = join(SM_GIT_DIR, "git.exe");
-const SM_FFMPEG_DIR = join(SM_DATA, "Assets", "ffmpeg", "bin");
+const SM_FFMPEG_ROOT = join(SM_DATA, "Assets", "ffmpeg");
+const SM_FFMPEG_DIR = join(SM_FFMPEG_ROOT, "bin");
 const SM_FFMPEG_EXE = join(SM_FFMPEG_DIR, "ffmpeg.exe");
 
 // A plain install (no launcher marker anywhere in its paths).
@@ -120,7 +122,9 @@ const PLAIN_MAIN = join(PLAIN_BASE, "main.py");
 const PLAIN_PY = join(PLAIN_BASE, "venv", "bin", "python");
 
 // Pinokio: an app tree under a `pinokio` root.
-const PINOKIO_APP = resolve("pinokio", "api", "comfy.git", "app");
+const PINOKIO_HOME = resolve("pinokio");
+const PINOKIO_API = join(PINOKIO_HOME, "api");
+const PINOKIO_APP = join(PINOKIO_API, "comfy.git", "app");
 const PINOKIO_MAIN = join(PINOKIO_APP, "main.py");
 const PINOKIO_PY = join(PINOKIO_APP, "env", "bin", "python");
 
@@ -199,8 +203,19 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("restart_comfyui — Stability Matrix launcher environment (#776)", () => {
-  function useStabilityMatrix(opts?: { assets?: boolean }): void {
-    const assets = opts?.assets ?? true;
+  /**
+   * @param git    the bundled git binary is resolvable
+   * @param ffmpeg the bundled ffmpeg binary is resolvable
+   * @param roots  which tooling ROOT directories exist (the detection evidence)
+   */
+  function useStabilityMatrix(opts?: {
+    git?: boolean;
+    ffmpeg?: boolean;
+    roots?: string[];
+  }): void {
+    const git = opts?.git ?? true;
+    const ffmpeg = opts?.ffmpeg ?? true;
+    const roots = opts?.roots ?? [SM_GIT_ROOT, SM_FFMPEG_ROOT];
     mockFindComfyuiPython.mockReturnValue(SM_PY);
     mockLiveRootFromArgv.mockReturnValue(SM_PKG);
     mockGetSystemStats.mockResolvedValue({
@@ -211,8 +226,10 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
     mockExistsSync.mockImplementation((p: string) => {
       const s = String(p);
       if (s === SM_MAIN || s === SM_PY) return true;
-      if (!assets) return false;
-      return s === SM_GIT_EXE || s === SM_FFMPEG_EXE;
+      if (roots.includes(s)) return true;
+      if (git && s === SM_GIT_EXE) return true;
+      if (ffmpeg && s === SM_FFMPEG_EXE) return true;
+      return false;
     });
   }
 
@@ -256,11 +273,7 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
     killSpy.mockRestore();
   });
 
-  it("REFUSES before stopping when the launcher's tooling cannot be found on disk", async () => {
-    // The install is provably launcher-owned, but its Git/FFmpeg assets are gone,
-    // so its environment cannot be reproduced. Guessing (= inheriting ours) is
-    // exactly what took the server down in #776.
-    useStabilityMatrix({ assets: false });
+  async function expectRefusedBeforeStopping(): Promise<string> {
     mockLivePortThenFree();
     spawnCapturingChildren();
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
@@ -270,9 +283,6 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
     expect(result.stopped).toBe(false);
     expect(result.started).toBe(false);
     expect(result.message).toMatch(/refusing to restart/i);
-    expect(result.message).toMatch(/Stability Matrix/i);
-    // Told to use the owning launcher — not the generic COMFYUI_PATH advice.
-    expect(result.message).toMatch(/Restart ComfyUI from Stability Matrix/i);
     // NOTHING was stopped and nothing was spawned.
     expect(mockSpawn).not.toHaveBeenCalled();
     expect(killSpy).not.toHaveBeenCalled();
@@ -281,11 +291,70 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
     ).toBe(false);
 
     killSpy.mockRestore();
+    return result.message;
+  }
+
+  it("REFUSES before stopping when NONE of the launcher's tooling resolves", async () => {
+    // Provably launcher-owned (both tooling roots are there) but neither binary
+    // resolves — the environment cannot be reproduced. Guessing (= inheriting
+    // ours) is exactly what took the server down in #776.
+    useStabilityMatrix({ git: false, ffmpeg: false });
+
+    const message = await expectRefusedBeforeStopping();
+
+    expect(message).toMatch(/Stability Matrix/i);
+    // Told to use the owning launcher — not the generic COMFYUI_PATH advice.
+    expect(message).toMatch(/Restart ComfyUI from Stability Matrix/i);
+  });
+
+  it("REFUSES before stopping on a PARTIAL layout — FFmpeg present but the bundled Git missing", async () => {
+    // A half-rebuilt environment is not a rebuilt environment: relaunching with
+    // ffmpeg but no git reproduces the exact #776 failure (Manager aborts at
+    // import with "Bad git executable" and the server never comes back).
+    useStabilityMatrix({ git: false, ffmpeg: true });
+
+    const message = await expectRefusedBeforeStopping();
+
+    expect(message).toMatch(/bundled Git/i);
+    expect(message).toMatch(/Bad git executable/i);
+  });
+
+  it("REFUSES before stopping when the FFmpeg asset dir exists but holds no ffmpeg binary", async () => {
+    useStabilityMatrix({ git: true, ffmpeg: false });
+
+    const message = await expectRefusedBeforeStopping();
+
+    expect(message).toMatch(/bundled FFmpeg/i);
+  });
+
+  it("does NOT mistake an ordinary install that merely lives under a `Data/Packages` path for Stability Matrix", async () => {
+    // Name-only evidence must never trigger a refusal: no PortableGit/Assets
+    // beside `Packages` means there is no launcher tooling to reconstruct, and
+    // this install restarted fine before #776.
+    useStabilityMatrix({ git: false, ffmpeg: false, roots: [] });
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(result.started).toBe(true);
+    expect(result.launch_env?.source).toBe("inherited");
+    expect(result.launch_env?.reproducible).toBe(true);
+    expect(spawnOptions().env).toBeUndefined();
+
+    killSpy.mockRestore();
   });
 });
 
 describe("restart_comfyui — irreproducible launcher environments (#776)", () => {
-  function usePinokio(): void {
+  function usePinokio(opts?: { corroborated?: boolean }): void {
+    const corroborated = opts?.corroborated ?? true;
     mockFindComfyuiPython.mockReturnValue(PINOKIO_PY);
     mockLiveRootFromArgv.mockReturnValue(PINOKIO_APP);
     mockGetSystemStats.mockResolvedValue({
@@ -293,7 +362,9 @@ describe("restart_comfyui — irreproducible launcher environments (#776)", () =
     });
     mockExistsSync.mockImplementation((p: string) => {
       const s = String(p);
-      return s === PINOKIO_MAIN || s === PINOKIO_PY;
+      if (s === PINOKIO_MAIN || s === PINOKIO_PY) return true;
+      // The `api/` tree is the on-disk evidence that this really is a Pinokio home.
+      return corroborated && s === PINOKIO_API;
     });
   }
 
@@ -311,6 +382,27 @@ describe("restart_comfyui — irreproducible launcher environments (#776)", () =
     expect(result.message).toMatch(/Pinokio/);
     expect(mockSpawn).not.toHaveBeenCalled();
     expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("does NOT treat a directory merely NAMED `pinokio` as a Pinokio install", async () => {
+    // Name-only evidence must never refuse a restart that works today.
+    usePinokio({ corroborated: false });
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(result.started).toBe(true);
+    expect(result.launch_env?.source).toBe("inherited");
+    expect(result.launch_env?.reproducible).toBe(true);
 
     killSpy.mockRestore();
   });

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -558,6 +558,48 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     killSpy.mockRestore();
   });
 
+  it("does NOT claim success when our child died and the replacement listener's PID cannot even be mapped", async () => {
+    // The #449 shape: a healthy API but an unmappable port owner. A DEAD launched
+    // child is decisive on its own — it cannot be the process now answering — so
+    // "undecidable PID" must not launder a failed relaunch into a success.
+    usePlainInstall();
+    const children = spawnCapturingChildren(999);
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      // After the kill the port owner is never mappable again.
+      if (/netstat/i.test(cmd)) {
+        return killed ? "" : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw new Error("not listening");
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        // Our child is gone, yet something healthy answers on the port.
+        children[0]?.emit("exit", 1, null);
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_is_launched_process).toBe(false);
+    expect(result.message).not.toMatch(/restarted successfully/i);
+    expect(result.message).toMatch(/NOT as a result of this restart/i);
+    expect(result.message).toMatch(/which exited: exit code 1/);
+
+    killSpy.mockRestore();
+  });
+
   it("names the launched process's EXIT when it dies before the API comes up", async () => {
     usePlainInstall();
     mockLivePortThenFree();

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -43,6 +43,16 @@ const mockLiveRootFromArgv = vi.hoisted(() =>
   vi.fn<[string[], string?], string | undefined>(),
 );
 /** Contents served for `<Data>/settings.json`, or undefined for "no such file". */
+/** An error carrying an errno `code`, as the real fs/child_process produce. */
+const errno = vi.hoisted(
+  () =>
+    (code: string, message?: string): NodeJS.ErrnoException => {
+      const err = new Error(message ?? code) as NodeJS.ErrnoException;
+      err.code = code;
+      return err;
+    },
+);
+
 const mockSettingsJsonRef = vi.hoisted(() => ({
   value: undefined as string | undefined,
   /** The file exists on disk but reading it throws. */
@@ -71,13 +81,15 @@ vi.mock("node:fs", () => ({
   }),
   // Serves the launcher's own config file (launcherConfigMentions); everything
   // else — /proc reads — is absent, as on the reporter's platform.
+  // Errors carry a `code`, because the launcher-config classifier reads the FAILURE
+  // MODE: only ENOENT means "not there", everything else means "could not look".
   readFileSync: vi.fn((p: string) => {
     const s = String(p);
     if (/settings\.jsonc?$/i.test(s)) {
-      if (mockSettingsJsonRef.unreadable) throw new Error("EACCES");
+      if (mockSettingsJsonRef.unreadable) throw errno("EACCES", "permission denied");
       if (mockSettingsJsonRef.value !== undefined) return mockSettingsJsonRef.value;
     }
-    throw new Error("ENOENT");
+    throw errno("ENOENT", "no such file or directory");
   }),
   statSync: vi.fn((p: string) => {
     if (!mockExistsSync(String(p))) throw new Error("ENOENT");
@@ -154,6 +166,24 @@ const BENIGN_PINOKIO_PY = join(PINOKIO_BIN, "comfy", "venv", "bin", "python");
 
 const ORIGINAL_ENV = { ...process.env };
 
+/**
+ * `lsof` exiting 1 with no output — its convention for "ran fine, matched
+ * nothing". Distinct from a spawn failure (which carries a `code`), because the
+ * port probe must not read "I could not look" as "the port is free".
+ */
+function noListener(): Error {
+  const err = new Error("no listener") as Error & { status?: number };
+  err.status = 1;
+  return err;
+}
+
+/** A port probe that FAILS rather than reporting the port free. */
+function portProbeUnavailable(): NodeJS.ErrnoException {
+  const err = new Error("spawn lsof ENOENT") as NodeJS.ErrnoException;
+  err.code = "ENOENT";
+  return err;
+}
+
 /** Case-insensitive env lookup (Windows env blocks are case-insensitive). */
 function envGet(env: NodeJS.ProcessEnv, name: string): string | undefined {
   const wanted = name.toLowerCase();
@@ -177,7 +207,7 @@ function mockLivePortThenFree(): { killed: () => boolean } {
         : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
     }
     if (/lsof/i.test(cmd)) {
-      if (killed) throw new Error("not listening");
+      if (killed) throw noListener();
       return "p4321\nn127.0.0.1:8188\n";
     }
     return "";
@@ -222,10 +252,13 @@ beforeEach(() => {
   // No live-process environment is readable by default (the Windows/macOS case,
   // and the #776 reporter's platform). Individual tests opt in.
   __processControlTestHooks.setLiveEnvResolver(() => undefined);
-  // Likewise no creation-time stamp by default — the shape on the platforms where
-  // the native read is deliberately skipped. Tests that exercise PID identity
-  // install their own resolver.
-  __processControlTestHooks.setProcessIdentityResolver(() => undefined);
+  // A readable creation stamp but no command line — the neutral shape. The stamp is
+  // required to close the identity bracket around /system_stats; leaving the command
+  // line out keeps the argv-corroboration check out of the way of tests that are not
+  // about it. Tests exercising PID identity install their own resolver.
+  __processControlTestHooks.setProcessIdentityResolver(() => ({
+    startedAt: "stable-stamp",
+  }));
   // Default lineage: the process on the port IS our child. Ownership tests
   // override this; every other test just needs the common case not to lie.
   __processControlTestHooks.setParentPidResolver(() => process.pid);
@@ -779,8 +812,9 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
       PATH: "/some/unrelated/process/path",
       NOT_COMFYUI: "1",
     }));
-    // lookup, then the re-verify after the env read sees a different process.
-    identitySequence(["t1", "t2"], PINOKIO_ARGV);
+    // The identity bracket around /system_stats closes cleanly (reads 1-3 agree);
+    // it is the re-verify AFTER the environment read that sees a different process.
+    identitySequence(["t1", "t1", "t1", "t2"], PINOKIO_ARGV);
     mockLivePortThenFree();
     spawnCapturingChildren();
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
@@ -924,7 +958,7 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
       }
       if (/lsof/i.test(cmd)) {
         netstatCalls++;
-        if (netstatCalls > IDENTIFY_LOOKUPS) throw new Error("not listening");
+        if (netstatCalls > IDENTIFY_LOOKUPS) throw noListener();
         return "p4321\nn127.0.0.1:8188\n";
       }
       return "";
@@ -951,7 +985,9 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
     // The stronger identity: the number is still listening, but it is not the
     // process we identified (#650's pid + creation-time identity).
     usePlainInstallForIdentity();
-    identitySequence(["t1", "t2"], PLAIN_ARGV); // lookup, then the pre-kill re-verify
+    // Identification (reads 1-3) is consistent; the PRE-KILL re-verify sees the
+    // number now belonging to a different process.
+    identitySequence(["t1", "t1", "t1", "t2"], PLAIN_ARGV);
     mockLivePortThenFree();
     spawnCapturingChildren();
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
@@ -1008,6 +1044,64 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
     killSpy.mockRestore();
   });
 
+  it("REFUSES when the SAME pid number is a different process at each end of the bracket", async () => {
+    // Pid equality across a window is exactly what pid REUSE defeats: A owns 4321,
+    // answers /system_stats, exits, and B inherits 4321 before the closing lookup.
+    // Comparing numbers alone closes the bracket; comparing IDENTITY does not.
+    usePlainInstallForIdentity();
+    identitySequence(["A-started", "B-started"], PLAIN_ARGV);
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/changed while ComfyUI was being identified/i);
+    expect(result.message).toMatch(/different process reusing that number/i);
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("does NOT treat an unreadable port probe as proof the killed process died", async () => {
+    // `findPidByPort` answers null both for "port is free" and for "the lookup
+    // failed". Spending the second as the first tears supervision down under a
+    // server that may still be running.
+    usePlainInstallForIdentity();
+    let killIssued = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killIssued = true;
+        return "";
+      }
+      // EVERY port probe — netstat, the Get-NetTCPConnection fallback, and lsof —
+      // stops working once the kill has been issued. Anything less would leave one
+      // probe running and legitimately reporting the port free.
+      if (/netstat|Get-NetTCPConnection|lsof/i.test(cmd)) {
+        if (killIssued) throw portProbeUnavailable();
+        return /lsof/i.test(cmd)
+          ? "p4321\nn127.0.0.1:8188\n"
+          : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      return "";
+    });
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.message).toMatch(/could not be checked after the kill/i);
+    expect(result.message).toMatch(/no evidence PID 4321 actually died/i);
+    expect(result.message).toMatch(/nothing was torn down/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  }, 30_000);
+
   it("REFUSES rather than binding an answer it could not bracket (port lookup unreadable on one side)", async () => {
     // The bracket must be REQUIRED, not best-effort: if the pre-call lookup comes
     // back empty there is no anchor, and A-answers-then-B-takes-the-port with
@@ -1025,7 +1119,7 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
       }
       if (/lsof/i.test(cmd)) {
         lookups++;
-        if (lookups % 2 === 1) throw new Error("not listening");
+        if (lookups % 2 === 1) throw noListener();
         return "p4321\nn127.0.0.1:8188\n";
       }
       return "";
@@ -1037,7 +1131,7 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
 
     expect(result.stopped).toBe(false);
     expect(result.started).toBe(false);
-    expect(result.message).toMatch(/could not be read on both sides/i);
+    expect(result.message).toMatch(/could not be observed on both sides/i);
     expect(killSpy).not.toHaveBeenCalled();
     expect(mockSpawn).not.toHaveBeenCalled();
 
@@ -1063,7 +1157,7 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
       }
       if (/lsof/i.test(cmd)) {
         lookups++;
-        if (lookups === 1 || lookups >= 100) throw new Error("not listening");
+        if (lookups === 1 || lookups >= 100) throw noListener();
         return "p4321\nn127.0.0.1:8188\n";
       }
       return "";
@@ -1077,7 +1171,7 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
 
     const result = await restartComfyUI();
 
-    expect(result.message).not.toMatch(/could not be read on both sides/i);
+    expect(result.message).not.toMatch(/could not be observed on both sides/i);
     expect(result.stopped).toBe(true);
     expect(result.started).toBe(true);
 
@@ -1293,7 +1387,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
           : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
       }
       if (/lsof/i.test(cmd)) {
-        if (killed && !restarted) throw new Error("not listening");
+        if (killed && !restarted) throw noListener();
         return "p4321\nn127.0.0.1:8188\n";
       }
       return "";
@@ -1344,7 +1438,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
         return killed ? "" : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
       }
       if (/lsof/i.test(cmd)) {
-        if (killed) throw new Error("not listening");
+        if (killed) throw noListener();
         return "p4321\nn127.0.0.1:8188\n";
       }
       return "";
@@ -1389,7 +1483,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
           : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
       }
       if (/lsof/i.test(cmd)) {
-        if (killed && !relaunched) throw new Error("not listening");
+        if (killed && !relaunched) throw noListener();
         return "p4321\nn127.0.0.1:8188\n";
       }
       return "";
@@ -1436,7 +1530,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
           : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
       }
       if (/lsof/i.test(cmd)) {
-        if (killed && !relaunched) throw new Error("not listening");
+        if (killed && !relaunched) throw noListener();
         return "p4321\nn127.0.0.1:8188\n";
       }
       return "";
@@ -1492,7 +1586,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
           : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
       }
       if (/lsof/i.test(cmd)) {
-        if (killed && !relaunched) throw new Error("not listening");
+        if (killed && !relaunched) throw noListener();
         return "p4321\nn127.0.0.1:8188\n";
       }
       return "";
@@ -1564,7 +1658,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
           : `  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       ${relaunched ? 9999 : 4321}`;
       }
       if (/lsof/i.test(cmd)) {
-        if (killed && !relaunched) throw new Error("not listening");
+        if (killed && !relaunched) throw noListener();
         return `p${relaunched ? 9999 : 4321}\nn127.0.0.1:8188\n`;
       }
       return "";
@@ -1607,7 +1701,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
           : `  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       ${relaunched ? 9999 : 4321}`;
       }
       if (/lsof/i.test(cmd)) {
-        if (killed && !relaunched) throw new Error("not listening");
+        if (killed && !relaunched) throw noListener();
         return `p${relaunched ? 9999 : 4321}\nn127.0.0.1:8188\n`;
       }
       return "";
@@ -1664,7 +1758,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
           : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       7777";
       }
       if (/lsof/i.test(cmd)) {
-        if (killed && !relaunched) throw new Error("not listening");
+        if (killed && !relaunched) throw noListener();
         return "p7777\nn127.0.0.1:8188\n";
       }
       return "";
@@ -1710,7 +1804,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
         return probed ? "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       7777" : "";
       }
       if (/lsof/i.test(cmd)) {
-        if (!probed) throw new Error("not listening");
+        if (!probed) throw noListener();
         return "p7777\nn127.0.0.1:8188\n";
       }
       return "";
@@ -1754,7 +1848,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
         return killed ? "" : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
       }
       if (/lsof/i.test(cmd)) {
-        if (killed) throw new Error("not listening");
+        if (killed) throw noListener();
         return "p4321\nn127.0.0.1:8188\n";
       }
       return "";
@@ -1770,6 +1864,93 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     expect(result.listener_ownership).toBe("unconfirmed");
     expect(result.started).toBe(true);
     expect(result.message).not.toMatch(/restarted successfully/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("does NOT call a foreign listener ours when its argv is a strict SUBSET of what we launched", async () => {
+    // `commandLineMatchesArgv(haystack, tokens)` is a containment test, so a single
+    // call in one direction is a SUBSET check: a foreign server started with fewer
+    // flags would "match" ours and be promoted. Comparing both ways closes that.
+    usePlainInstall();
+    // Ours carries an extra flag; theirs is otherwise identical.
+    mockGetSystemStats.mockImplementation(async () => ({
+      system: { argv: [PLAIN_MAIN, "--port", "8188"] },
+    }));
+    servingArgvAfterRestart([PLAIN_MAIN]); // a strict subset of our launch argv
+    spawnCapturingChildren(4321);
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed ? "" : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw noListener();
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    // The port owner is unmappable after the kill, so argv is the only signal —
+    // and a subset must read as DIFFERENT, not as a match.
+    expect(result.listener_ownership).toBe("not-ours");
+    expect(result.message).not.toMatch(/restarted successfully/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("treats an EXHAUSTED lineage walk as 'do not know', never as a foreign process", async () => {
+    // A deep-but-legitimate wrapper chain runs out of hop budget. Running out of
+    // budget is not a negative answer, and reporting one would tell that user their
+    // own server is not theirs.
+    usePlainInstall();
+    servingArgvAfterRestart("unreachable"); // argv cannot rescue it either
+    spawnCapturingChildren(4321);
+    let killed = false;
+    let relaunched = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed && !relaunched
+          ? ""
+          : `  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       ${relaunched ? 9999 : 4321}`;
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && !relaunched) throw noListener();
+        return `p${relaunched ? 9999 : 4321}\nn127.0.0.1:8188\n`;
+      }
+      return "";
+    });
+    // An unbroken chain that never reaches us and never reaches init.
+    __processControlTestHooks.setParentPidResolver((pid) => pid + 1);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        relaunched = true;
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("unconfirmed");
+    expect(result.started).toBe(true);
+    expect(result.message).not.toMatch(/NOT as a result of this restart/i);
 
     killSpy.mockRestore();
   });
@@ -1796,7 +1977,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
           : `  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       ${relaunched ? 9999 : 4321}`;
       }
       if (/lsof/i.test(cmd)) {
-        if (killed && !relaunched) throw new Error("not listening");
+        if (killed && !relaunched) throw noListener();
         return `p${relaunched ? 9999 : 4321}\nn127.0.0.1:8188\n`;
       }
       return "";
@@ -1842,7 +2023,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
         return killed ? "" : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
       }
       if (/lsof/i.test(cmd)) {
-        if (killed) throw new Error("not listening");
+        if (killed) throw noListener();
         return "p4321\nn127.0.0.1:8188\n";
       }
       return "";
@@ -1916,7 +2097,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
           : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       7777";
       }
       if (/lsof/i.test(cmd)) {
-        if (killed && netstatCalls++ === 0) throw new Error("not listening");
+        if (killed && netstatCalls++ === 0) throw noListener();
         return "p7777\nn127.0.0.1:8188\n";
       }
       return "";

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -43,7 +43,11 @@ const mockLiveRootFromArgv = vi.hoisted(() =>
   vi.fn<[string[], string?], string | undefined>(),
 );
 /** Contents served for `<Data>/settings.json`, or undefined for "no such file". */
-const mockSettingsJsonRef = vi.hoisted(() => ({ value: undefined as string | undefined }));
+const mockSettingsJsonRef = vi.hoisted(() => ({
+  value: undefined as string | undefined,
+  /** The file exists on disk but reading it throws. */
+  unreadable: false,
+}));
 
 vi.mock("../../config.js", () => ({
   config: mockConfig,
@@ -69,8 +73,9 @@ vi.mock("node:fs", () => ({
   // else — /proc reads — is absent, as on the reporter's platform.
   readFileSync: vi.fn((p: string) => {
     const s = String(p);
-    if (mockSettingsJsonRef.value !== undefined && /settings\.jsonc?$/i.test(s)) {
-      return mockSettingsJsonRef.value;
+    if (/settings\.jsonc?$/i.test(s)) {
+      if (mockSettingsJsonRef.unreadable) throw new Error("EACCES");
+      if (mockSettingsJsonRef.value !== undefined) return mockSettingsJsonRef.value;
     }
     throw new Error("ENOENT");
   }),
@@ -124,6 +129,7 @@ const SM_GIT_ROOT = join(SM_DATA, "PortableGit");
 const SM_GIT_DIR = join(SM_GIT_ROOT, "cmd");
 const SM_GIT_EXE = join(SM_GIT_DIR, "git.exe");
 const SM_FFMPEG_ROOT = join(SM_DATA, "Assets", "ffmpeg");
+const SM_SETTINGS = join(SM_DATA, "settings.json");
 const SM_FFMPEG_DIR = join(SM_FFMPEG_ROOT, "bin");
 const SM_FFMPEG_EXE = join(SM_FFMPEG_DIR, "ffmpeg.exe");
 
@@ -217,6 +223,7 @@ beforeEach(() => {
   // override this; every other test just needs the common case not to lie.
   __processControlTestHooks.setParentPidResolver(() => process.pid);
   mockSettingsJsonRef.value = undefined;
+  mockSettingsJsonRef.unreadable = false;
 });
 
 afterEach(() => {
@@ -240,11 +247,14 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
     roots?: string[];
     /** Contents of `<Data>/settings.json`, when the test wants one to exist. */
     settingsJson?: string;
+    /** The config file EXISTS but every read of it throws. */
+    settingsUnreadable?: boolean;
   }): void {
     const git = opts?.git ?? true;
     const ffmpeg = opts?.ffmpeg ?? true;
     const roots = opts?.roots ?? [SM_GIT_ROOT, SM_FFMPEG_ROOT];
     mockSettingsJsonRef.value = opts?.settingsJson;
+    mockSettingsJsonRef.unreadable = opts?.settingsUnreadable ?? false;
     mockFindComfyuiPython.mockReturnValue(SM_PY);
     mockLiveRootFromArgv.mockReturnValue(SM_PKG);
     mockGetSystemStats.mockResolvedValue({
@@ -252,12 +262,15 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
         argv: [SM_MAIN, "--preview-method", "auto", "--enable-manager"],
       },
     });
+    const configExists =
+      opts?.settingsJson !== undefined || (opts?.settingsUnreadable ?? false);
     mockExistsSync.mockImplementation((p: string) => {
       const s = String(p);
       if (s === SM_MAIN || s === SM_PY) return true;
       if (roots.includes(s)) return true;
       if (git && s === SM_GIT_EXE) return true;
       if (ffmpeg && s === SM_FFMPEG_EXE) return true;
+      if (configExists && s === SM_SETTINGS) return true;
       return false;
     });
   }
@@ -386,6 +399,25 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
     expect(result.message).toMatch(/no bundled FFmpeg anywhere under its Data folder/i);
 
     killSpy.mockRestore();
+  });
+
+  it("REFUSES when the launcher's config EXISTS but cannot be read", async () => {
+    // "not-installed" needs BOTH halves: directory absent AND config silent. An
+    // unreadable config is neither — folding it into "no mention" would classify a
+    // missing PortableGit as not-installed, relaunch without it, and let
+    // ComfyUI-Manager abort at import. That is the original down-server bug,
+    // reached through the very rule that stops over-refusing.
+    useStabilityMatrix({
+      git: false,
+      ffmpeg: true,
+      roots: [SM_FFMPEG_ROOT],
+      settingsUnreadable: true,
+    });
+
+    const message = await expectRefusedBeforeStopping();
+
+    expect(message).toMatch(/bundled Git/i);
+    expect(message).toMatch(/Restart ComfyUI from Stability Matrix/i);
   });
 
   it("REFUSES when the launcher's own config names a component whose directory is missing", async () => {
@@ -840,18 +872,21 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
     // The server exited between the port lookup and the stop. Its number may
     // already belong to something else, so nothing may be killed.
     usePlainInstallForIdentity();
+    // Three lookups belong to identifying the server: the one bracketing
+    // /system_stats on each side, and the re-confirmation's. The FOURTH is the
+    // pre-kill re-check — by which point the process has exited on its own.
+    const IDENTIFY_LOOKUPS = 3;
     let netstatCalls = 0;
     mockExecSync.mockImplementation((cmd: string) => {
       if (/netstat/i.test(cmd)) {
         netstatCalls++;
-        // Owned during the lookup; gone by the pre-kill re-check.
-        return netstatCalls <= 1
+        return netstatCalls <= IDENTIFY_LOOKUPS
           ? "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321"
           : "";
       }
       if (/lsof/i.test(cmd)) {
         netstatCalls++;
-        if (netstatCalls > 1) throw new Error("not listening");
+        if (netstatCalls > IDENTIFY_LOOKUPS) throw new Error("not listening");
         return "p4321\nn127.0.0.1:8188\n";
       }
       return "";
@@ -889,6 +924,46 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
     expect(result.started).toBe(false);
     expect(result.message).toMatch(/creation time/i);
     expect(result.message).toMatch(/must not be killed/i);
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("REFUSES when the port changes hands around the /system_stats call, even with IDENTICAL argv", async () => {
+    // The re-ask cannot settle this on its own: A answers, A exits, B binds the
+    // port, and if B reports the same argv then both the second answer and the
+    // second port lookup are self-consistent — B is accepted and killed. What B
+    // cannot reproduce is the identity of the port owner BEFORE the HTTP call, so
+    // that observation is what the answer is bracketed by.
+    usePlainInstallForIdentity();
+    let portLookups = 0;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/netstat/i.test(cmd)) {
+        portLookups++;
+        // A owns it during the pre-fetch lookup; B owns it by the post-fetch one.
+        return portLookups <= 1
+          ? "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321"
+          : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       5555";
+      }
+      if (/lsof/i.test(cmd)) {
+        portLookups++;
+        return portLookups <= 1
+          ? "p4321\nn127.0.0.1:8188\n"
+          : "p5555\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/changed while ComfyUI was being identified/i);
+    expect(result.message).toMatch(/4321/);
+    expect(result.message).toMatch(/5555/);
     expect(killSpy).not.toHaveBeenCalled();
     expect(mockSpawn).not.toHaveBeenCalled();
 
@@ -953,6 +1028,37 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
 
     killSpy.mockRestore();
   });
+
+  it("does NOT report a successful stop when the killed process still holds the port", async () => {
+    // A kill that RETURNS is not proof of death: on POSIX the forced `kill -9` runs
+    // through a shell whose failure is swallowed, so an ignored signal looks exactly
+    // like success. Teardown would then disarm supervision on a live server and
+    // report stopped:true. The port release is the observable that decides.
+    usePlainInstallForIdentity();
+    mockExecSync.mockImplementation((cmd: string) => {
+      // The kill "succeeds" (returns cleanly) but the process never dies, so the
+      // port stays held by the very PID we targeted.
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) return "";
+      if (/netstat/i.test(cmd)) {
+        return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) return "p4321\nn127.0.0.1:8188\n";
+      return "";
+    });
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/still holds port 8188/i);
+    expect(result.message).toMatch(/nothing was torn down/i);
+    // Critically: no relaunch was attempted against a server that is still running.
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  }, 30_000);
 
   it("leaves crash supervision INTACT when the kill itself fails", async () => {
     // `taskkill`/`kill` fail for ordinary reasons — access denied above all — and
@@ -1038,8 +1144,12 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     // launcher/supervisor bound it while our child failed, the server is up but
     // OUR relaunch did not do it — saying "restarted successfully" would be false.
     usePlainInstall();
-    // The port owner reported after the relaunch (4321) is not our child (999).
+    // The port owner reported after the relaunch (4321) is not our child (999),
+    // and it sits outside our process tree entirely (parented to init).
     spawnCapturingChildren(999);
+    __processControlTestHooks.setParentPidResolver((pid) =>
+      pid === 999 ? process.pid : 1,
+    );
     let killed = false;
     mockExecSync.mockImplementation((cmd: string) => {
       if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
@@ -1295,6 +1405,93 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     expect(result.listener_ownership).toBe("unconfirmed");
     expect(result.started).toBe(true);
     expect(result.message).not.toMatch(/restarted successfully/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("claims a GRANDCHILD listener as ours — a wrapper/double-fork launch is not a foreign server", async () => {
+    // An indirect launcher (wrapper script, double fork, trampoline) means the
+    // process holding the port is our grandchild, not our child. A direct-child
+    // test would tell that user their own server "was not started by us".
+    usePlainInstall();
+    spawnCapturingChildren(4321);
+    let killed = false;
+    let relaunched = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        // After the relaunch a DIFFERENT pid (our grandchild) holds the port.
+        return killed && !relaunched
+          ? ""
+          : `  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       ${relaunched ? 9999 : 4321}`;
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && !relaunched) throw new Error("not listening");
+        return `p${relaunched ? 9999 : 4321}\nn127.0.0.1:8188\n`;
+      }
+      return "";
+    });
+    // 9999's parent is 4321 (the child we spawned), whose parent is us.
+    __processControlTestHooks.setParentPidResolver((pid) =>
+      pid === 9999 ? 4321 : pid === 4321 ? process.pid : 1,
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        relaunched = true;
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("ours");
+    expect(result.started).toBe(true);
+    expect(result.message).toMatch(/restarted successfully/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("reports a listener OUTSIDE our process tree as not-ours", async () => {
+    usePlainInstall();
+    spawnCapturingChildren(4321);
+    let killed = false;
+    let relaunched = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed && !relaunched
+          ? ""
+          : `  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       ${relaunched ? 9999 : 4321}`;
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && !relaunched) throw new Error("not listening");
+        return `p${relaunched ? 9999 : 4321}\nn127.0.0.1:8188\n`;
+      }
+      return "";
+    });
+    // 9999 belongs to some other launcher's tree, rooted at init.
+    __processControlTestHooks.setParentPidResolver((pid) => (pid === 9999 ? 1 : process.pid));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        relaunched = true;
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("not-ours");
+    expect(result.started).toBe(false);
 
     killSpy.mockRestore();
   });

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -1734,9 +1734,12 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     killSpy.mockRestore();
   });
 
-  it("resolves an unmappable port owner by asking the SERVER what it is running", async () => {
-    // The #449 host: no usable port-owner lookup. Rather than a permanent shrug,
-    // the server's own argv answers it — a match is as strong as a pid comparison.
+  it("does NOT promote a matching server argv to ownership — another supervisor can run the same command", async () => {
+    // The #449 host: no usable port-owner lookup, and the server reports exactly the
+    // command line we launched. That is corroboration, NOT proof: another supervisor
+    // could have started the same ComfyUI and won the bind race. So it stays
+    // unconfirmed — never "restarted successfully" — while still not denying a
+    // restart that almost certainly worked.
     usePlainInstall();
     servingArgvAfterRestart([PLAIN_MAIN, "--port", "8188"]);
     spawnCapturingChildren(4321);
@@ -1764,17 +1767,19 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
 
     const result = await restartComfyUI();
 
-    expect(result.listener_ownership).toBe("ours");
+    expect(result.listener_ownership).toBe("unconfirmed");
     expect(result.started).toBe(true);
-    expect(result.message).toMatch(/restarted successfully/i);
+    expect(result.message).not.toMatch(/restarted successfully/i);
 
     killSpy.mockRestore();
   });
 
-  it("claims a GRANDCHILD listener as ours even when the WRAPPER has already exited", async () => {
+  it("does NOT report a wrapper-launched grandchild as NOT ours once the wrapper has exited", async () => {
     // A wrapper script launches ComfyUI and exits; the grandchild is reparented, so
-    // lineage can no longer place it in our tree. The server's own command line
-    // still can — otherwise a legitimately indirect launcher reads as "not ours".
+    // lineage is a dead end by construction. The server's own command line cannot
+    // prove the listener is ours (another supervisor could run the same command),
+    // but it does stop us asserting the negative — otherwise a legitimately
+    // indirect launcher is told its own server is not its own.
     usePlainInstall();
     servingArgvAfterRestart([PLAIN_MAIN, "--port", "8188"]);
     const children = spawnCapturingChildren(4321);
@@ -1811,8 +1816,9 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
 
     const result = await restartComfyUI();
 
-    expect(result.listener_ownership).toBe("ours");
+    expect(result.listener_ownership).toBe("unconfirmed");
     expect(result.started).toBe(true);
+    expect(result.message).not.toMatch(/NOT as a result of this restart/i);
 
     killSpy.mockRestore();
   });

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -727,13 +727,13 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
     killSpy.mockRestore();
   });
 
-  it("does NOT bind to a PID whose command line does not match the argv ComfyUI reported", async () => {
+  it("REFUSES outright when the OS says the port owner is running something other than the server that answered", async () => {
     // The gap a creation-time stamp alone cannot close: if the pid was recycled
     // BEFORE we ever read its stamp, every later re-read agrees with itself about
     // the WRONG process. The independent signal is the server's own /system_stats
-    // argv — an unrelated program on that number cannot match it. Same proof as
-    // above: this Pinokio install is only restartable via a live environment, so
-    // rejecting the binding must drop it back to the refusal.
+    // argv — an unrelated program on that number cannot match it. That is POSITIVE
+    // counter-evidence, so it must refuse on its own rather than merely decline to
+    // bind (which would leave a later transport hiccup free to wave it through).
     usePinokioInstall();
     __processControlTestHooks.setLiveEnvResolver(() => ({ NOT_COMFYUI: "1" }));
     __processControlTestHooks.setProcessIdentityResolver(() => ({
@@ -747,9 +747,90 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
     const result = await restartComfyUI();
 
     expect(result.stopped).toBe(false);
-    expect(result.message).toMatch(/refusing to restart/i);
-    expect(result.message).toMatch(/Pinokio/);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/not running the ComfyUI that answered/i);
+    expect(result.message).toMatch(/some-unrelated-daemon/);
     expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("REFUSES on that mismatch EVEN IF the HTTP re-check then fails transiently", async () => {
+    // The combination that used to slip through: the command-line mismatch was
+    // downgraded to "no identity", the re-fetch errored so it proved nothing, and
+    // the pre-kill check then only re-verified the numeric PID's port ownership —
+    // killing the replacement using the previous server's argv and env plan.
+    usePinokioInstall();
+    let answers = 0;
+    mockGetSystemStats.mockImplementation(async () => {
+      answers++;
+      if (answers > 1) throw new Error("ECONNRESET");
+      return { system: { argv: [PINOKIO_MAIN, "--port", "8188"] } };
+    });
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "t9",
+      commandLine: "/usr/bin/some-unrelated-daemon --serve",
+    }));
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.message).toMatch(/not running the ComfyUI that answered/i);
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(
+      mockExecSync.mock.calls.some(([cmd]) => /taskkill/i.test(String(cmd))),
+    ).toBe(false);
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("re-checks identity for a DESKTOP answer too, so a substituted instance is never rebooted in its place", async () => {
+    // `isDesktopApp` is derived from the FIRST, possibly stale argv. Skipping the
+    // recheck there is how a Desktop answer from A gets a ComfyUI-Manager reboot
+    // fired at a non-Desktop B that took the port in the meantime.
+    const DESKTOP_MAIN = join(
+      resolve("AppData", "Local", "Programs", "@comfyorgcomfyui-electron"),
+      "resources",
+      "ComfyUI",
+      "main.py",
+    );
+    let answers = 0;
+    mockFindComfyuiPython.mockReturnValue(PLAIN_PY);
+    mockLiveRootFromArgv.mockReturnValue(PLAIN_BASE);
+    mockGetSystemStats.mockImplementation(async () => {
+      answers++;
+      // A = the Desktop app; B = an ordinary install that grabbed the port.
+      return {
+        system: {
+          argv:
+            answers <= 1
+              ? [DESKTOP_MAIN, "--port", "8188"]
+              : [PLAIN_MAIN, "--port", "8188"],
+        },
+      };
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === PLAIN_MAIN || s === PLAIN_PY;
+    });
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    const rebootFetch = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", rebootFetch);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/changed while it was being identified/i);
+    // No Manager reboot was fired at the substituted instance, and nothing killed.
+    expect(rebootFetch).not.toHaveBeenCalled();
     expect(killSpy).not.toHaveBeenCalled();
 
     killSpy.mockRestore();

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -53,6 +53,11 @@ const errno = vi.hoisted(
     },
 );
 
+/** Per-test override letting a path's `statSync` fail with a chosen errno. */
+const mockStatThrows = vi.hoisted(() => ({
+  value: undefined as ((p: string) => NodeJS.ErrnoException | undefined) | undefined,
+}));
+
 const mockSettingsJsonRef = vi.hoisted(() => ({
   value: undefined as string | undefined,
   /** The file exists on disk but reading it throws. */
@@ -91,8 +96,12 @@ vi.mock("node:fs", () => ({
     }
     throw errno("ENOENT", "no such file or directory");
   }),
+  // statSync backs the launcher-evidence probe, which classifies from the ERRNO:
+  // ENOENT means "not there", anything else means "could not look".
   statSync: vi.fn((p: string) => {
-    if (!mockExistsSync(String(p))) throw new Error("ENOENT");
+    const forced = mockStatThrows.value?.(String(p));
+    if (forced) throw forced;
+    if (!mockExistsSync(String(p))) throw errno("ENOENT", "no such file");
     return { isFile: () => true, isDirectory: () => false };
   }),
 }));
@@ -267,6 +276,7 @@ beforeEach(() => {
   __processControlTestHooks.setParentPidResolver(() => process.pid);
   mockSettingsJsonRef.value = undefined;
   mockSettingsJsonRef.unreadable = false;
+  mockStatThrows.value = undefined;
 });
 
 afterEach(() => {
@@ -454,6 +464,36 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
     expect(result.message).toMatch(/no bundled FFmpeg anywhere under its Data folder/i);
 
     killSpy.mockRestore();
+  });
+
+  it("REFUSES when the launcher's tooling directories cannot be READ", async () => {
+    // An ACL-unreadable `Data/PortableGit` looks exactly like "this install has no
+    // PortableGit" to `existsSync`. Falling through to the plain-install plan there
+    // relaunches a launcher-managed server WITHOUT its environment — #776 itself,
+    // reached through the fix for it.
+    mockFindComfyuiPython.mockReturnValue(SM_PY);
+    mockLiveRootFromArgv.mockReturnValue(SM_PKG);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [SM_MAIN, "--port", "8188"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === SM_MAIN || s === SM_PY;
+    });
+    // statSync is what the launcher probe uses: EACCES on the tooling roots means
+    // "we could not look", which must not be spent as "there is nothing here".
+    mockStatThrows.value = (p: string) => {
+      const s = String(p);
+      if (s === SM_GIT_ROOT || s === SM_ASSETS_ROOT || s === SM_FFMPEG_ROOT) {
+        return errno("EACCES", "permission denied");
+      }
+      return undefined;
+    };
+
+    const message = await expectRefusedBeforeStopping();
+
+    expect(message).toMatch(/could not be read/i);
+    expect(message).toMatch(/Restart ComfyUI from its launcher/i);
   });
 
   it("REFUSES when the launcher's config EXISTS but cannot be read", async () => {
@@ -2198,10 +2238,16 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
 
     const result = await restartComfyUI();
 
-    expect(result.listener_ownership).toBe("not-ours");
+    // `unconfirmed`, NOT `not-ours`: this branch never ran ownership
+    // classification — it returned the moment it saw the port occupied. Only the
+    // classifier may name a definite verdict, so a site that did not classify
+    // cannot claim one (it is a compile error to try). What this test guards is
+    // unchanged: the field is PRESENT on this path, it survives JSON, and no
+    // success is claimed.
+    expect(result.listener_ownership).toBe("unconfirmed");
     const serialized = JSON.parse(JSON.stringify(result));
     expect(Object.hasOwn(serialized, "listener_ownership")).toBe(true);
-    expect(serialized.listener_ownership).toBe("not-ours");
+    expect(serialized.listener_ownership).toBe("unconfirmed");
     expect(result.message).not.toMatch(/restarted successfully/i);
 
     killSpy.mockRestore();

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -42,6 +42,8 @@ const mockResolveBase = vi.hoisted(() => vi.fn<[], string | undefined>());
 const mockLiveRootFromArgv = vi.hoisted(() =>
   vi.fn<[string[], string?], string | undefined>(),
 );
+/** Contents served for `<Data>/settings.json`, or undefined for "no such file". */
+const mockSettingsJsonRef = vi.hoisted(() => ({ value: undefined as string | undefined }));
 
 vi.mock("../../config.js", () => ({
   config: mockConfig,
@@ -63,8 +65,14 @@ vi.mock("node:fs", () => ({
   readlinkSync: vi.fn(() => {
     throw new Error("no /proc in test");
   }),
-  readFileSync: vi.fn(() => {
-    throw new Error("no /proc in test");
+  // Serves the launcher's own config file (launcherConfigMentions); everything
+  // else — /proc reads — is absent, as on the reporter's platform.
+  readFileSync: vi.fn((p: string) => {
+    const s = String(p);
+    if (mockSettingsJsonRef.value !== undefined && /settings\.jsonc?$/i.test(s)) {
+      return mockSettingsJsonRef.value;
+    }
+    throw new Error("ENOENT");
   }),
   statSync: vi.fn((p: string) => {
     if (!mockExistsSync(String(p))) throw new Error("ENOENT");
@@ -205,6 +213,10 @@ beforeEach(() => {
   // the native read is deliberately skipped. Tests that exercise PID identity
   // install their own resolver.
   __processControlTestHooks.setProcessIdentityResolver(() => undefined);
+  // Default lineage: the process on the port IS our child. Ownership tests
+  // override this; every other test just needs the common case not to lie.
+  __processControlTestHooks.setParentPidResolver(() => process.pid);
+  mockSettingsJsonRef.value = undefined;
 });
 
 afterEach(() => {
@@ -226,10 +238,13 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
     git?: boolean;
     ffmpeg?: boolean;
     roots?: string[];
+    /** Contents of `<Data>/settings.json`, when the test wants one to exist. */
+    settingsJson?: string;
   }): void {
     const git = opts?.git ?? true;
     const ffmpeg = opts?.ffmpeg ?? true;
     const roots = opts?.roots ?? [SM_GIT_ROOT, SM_FFMPEG_ROOT];
+    mockSettingsJsonRef.value = opts?.settingsJson;
     mockFindComfyuiPython.mockReturnValue(SM_PY);
     mockLiveRootFromArgv.mockReturnValue(SM_PKG);
     mockGetSystemStats.mockResolvedValue({
@@ -339,21 +354,55 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
     const message = await expectRefusedBeforeStopping();
 
     expect(message).toMatch(/bundled FFmpeg/i);
-    expect(message).toMatch(/no ffmpeg binary inside it/i);
+    expect(message).toMatch(/Assets/);
   });
 
-  it("REFUSES before stopping with an intact PortableGit when the FFmpeg asset dir is ABSENT ENTIRELY", async () => {
-    // The exact partial-approval hole: Git resolves, so a "Git is the fatal one"
-    // rule would approve, stop a healthy server, and relaunch knowingly incomplete.
-    // From here we cannot tell "this install has no FFmpeg" from "its FFmpeg lives
-    // somewhere we don't know to look", and the #776 lesson is that guessing wrong
-    // costs the user their server — so an unresolvable component always refuses.
+  it("RESTARTS with Git alone when FFmpeg is provably NOT INSTALLED, and names what was not injected", async () => {
+    // A legitimate SM install with PortableGit and no FFmpeg asset at all. There is
+    // nothing for the launcher to inject either, so relaunching without it is
+    // exactly what the launcher itself would do — refusing here would make such an
+    // install PERMANENTLY unrestartable, which is not a safer resting place than a
+    // launch that works.
     useStabilityMatrix({ git: true, ffmpeg: false, roots: [SM_GIT_ROOT] });
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(result.started).toBe(true);
+    expect(result.launch_env?.source).toBe("stability-matrix");
+    // Git IS injected; FFmpeg is reported as absent rather than silently ignored.
+    const opts = spawnOptions();
+    expect(envGet(opts.env!, "PATH")!.split(delimiter)[0]).toBe(SM_GIT_DIR);
+    expect(envGet(opts.env!, "GIT_PYTHON_GIT_EXECUTABLE")).toBe(SM_GIT_EXE);
+    expect(result.launch_env?.path_additions).toEqual([SM_GIT_DIR]);
+    expect(result.launch_env?.not_installed).toEqual(["FFmpeg"]);
+    expect(result.message).toMatch(/no bundled FFmpeg anywhere under its Data folder/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("REFUSES when the launcher's own config names a component whose directory is missing", async () => {
+    // "Absent" only means not-installed when NOTHING references it. Stability
+    // Matrix records what it manages in Data/settings.json, so a mention there
+    // turns absence into "expected but unlocatable" — the genuinely ambiguous case
+    // that must refuse rather than silently drop what the launcher injects.
+    useStabilityMatrix({
+      git: true,
+      ffmpeg: false,
+      roots: [SM_GIT_ROOT],
+      settingsJson: '{"assets":["ffmpeg","python310"]}',
+    });
 
     const message = await expectRefusedBeforeStopping();
 
     expect(message).toMatch(/bundled FFmpeg/i);
-    expect(message).toMatch(/does not exist, so we cannot tell/i);
     expect(message).toMatch(/Restart ComfyUI from Stability Matrix/i);
   });
 
@@ -765,6 +814,97 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
     killSpy.mockRestore();
   });
 
+  it("REFUSES when the server that answered is NOT the one that ends up owning the port", async () => {
+    // ComfyUI A answers /system_stats, exits, and ComfyUI B — a DIFFERENT install,
+    // different argv — takes the port before the lookup. Binding A's answer to B's
+    // pid would make us kill B on the strength of A's launch arguments. Re-asking
+    // the server after the pid is in hand catches exactly that.
+    usePlainInstallForIdentity();
+    const OTHER_MAIN = join(resolve("OtherComfy"), "main.py");
+    let answers = 0;
+    mockGetSystemStats.mockImplementation(async () => {
+      answers++;
+      // First answer: install A. Second (after the pid was bound): install B.
+      return {
+        system: { argv: answers <= 1 ? PLAIN_ARGV : [OTHER_MAIN, "--port", "8188"] },
+      };
+    });
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/changed while it was being identified/i);
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(
+      mockExecSync.mock.calls.some(([cmd]) => /taskkill/i.test(String(cmd))),
+    ).toBe(false);
+
+    killSpy.mockRestore();
+  });
+
+  it("does NOT refuse when the identity re-check merely fails to reach the server", async () => {
+    // Absence of evidence is not evidence: a transport hiccup on the re-fetch must
+    // not turn a perfectly good restart into a refusal.
+    usePlainInstallForIdentity();
+    let answers = 0;
+    mockGetSystemStats.mockImplementation(async () => {
+      answers++;
+      if (answers > 1) throw new Error("ECONNRESET");
+      return { system: { argv: PLAIN_ARGV } };
+    });
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+
+    killSpy.mockRestore();
+  });
+
+  it("leaves crash supervision INTACT when the kill itself fails", async () => {
+    // `taskkill`/`kill` fail for ordinary reasons — access denied above all — and
+    // the server is then still running. Tearing supervision down before the kill
+    // would disarm auto-restart for a server we did not manage to stop.
+    usePlainInstallForIdentity();
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        throw new Error("ERROR: The process ... could not be terminated. Access is denied.");
+      }
+      if (/netstat/i.test(cmd)) {
+        return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) return "p4321\nn127.0.0.1:8188\n";
+      return "";
+    });
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("EPERM");
+    });
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/could not stop comfyui/i);
+    expect(result.message).toMatch(/crash supervision and launch record are untouched/i);
+    // Nothing was relaunched — the old server is still the one running.
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
   function usePlainInstallForIdentity(): void {
     mockFindComfyuiPython.mockReturnValue(PLAIN_PY);
     mockLiveRootFromArgv.mockReturnValue(PLAIN_BASE);
@@ -1007,113 +1147,9 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     killSpy.mockRestore();
   });
 
-  it("does NOT claim an ALIVE recycled PID as ours — the process creation time tells instances apart", async () => {
-    // The hardest variant: our child died, the OS reused its number, the
-    // replacement is ALIVE (signal-0 succeeds), owns the port, and is even another
-    // ComfyUI with an identical command line. Nothing but the per-instance
-    // creation time can tell them apart.
-    usePlainInstall();
-    let killed = false;
-    let relaunched = false;
-    // Identity by PHASE: the old server before the spawn, our child at the spawn,
-    // then a DIFFERENT instance on the same number when the listener is checked.
-    let readsAfterSpawn = 0;
-    let spawnedYet = false;
-    __processControlTestHooks.setProcessIdentityResolver(() => {
-      const commandLine = `${PLAIN_PY} ${PLAIN_MAIN} --port 8188`;
-      if (!spawnedYet) return { startedAt: "old-server", commandLine };
-      readsAfterSpawn++;
-      return {
-        startedAt: readsAfterSpawn <= 1 ? "our-child" : "recycled-instance",
-        commandLine,
-      };
-    });
-    mockSpawn.mockImplementation(() => {
-      spawnedYet = true;
-      const child = new FakeChild();
-      child.pid = 4321;
-      return child;
-    });
-    mockExecSync.mockImplementation((cmd: string) => {
-      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
-        killed = true;
-        return "";
-      }
-      if (/netstat/i.test(cmd)) {
-        return killed && !relaunched
-          ? ""
-          : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
-      }
-      if (/lsof/i.test(cmd)) {
-        if (killed && !relaunched) throw new Error("not listening");
-        return "p4321\nn127.0.0.1:8188\n";
-      }
-      return "";
-    });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => {
-        relaunched = true;
-        return { ok: true } as Response;
-      }),
-    );
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
-    const result = await restartComfyUI();
-
-    expect(result.listener_ownership).toBe("not-ours");
-    expect(result.started).toBe(false);
-    expect(result.ready).toBe(true);
-    expect(result.message).not.toMatch(/restarted successfully/i);
-
-    killSpy.mockRestore();
-  });
-
-  it("DOES claim it when the creation time still matches (the stamp is not a blanket veto)", async () => {
-    usePlainInstall();
-    spawnCapturingChildren(4321);
-    let killed = false;
-    let relaunched = false;
-    mockExecSync.mockImplementation((cmd: string) => {
-      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
-        killed = true;
-        return "";
-      }
-      if (/netstat/i.test(cmd)) {
-        return killed && !relaunched
-          ? ""
-          : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
-      }
-      if (/lsof/i.test(cmd)) {
-        if (killed && !relaunched) throw new Error("not listening");
-        return "p4321\nn127.0.0.1:8188\n";
-      }
-      return "";
-    });
-    __processControlTestHooks.setProcessIdentityResolver(() => ({
-      startedAt: "spawned-at-1000",
-      commandLine: `${PLAIN_PY} ${PLAIN_MAIN} --port 8188`,
-    }));
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => {
-        relaunched = true;
-        return { ok: true } as Response;
-      }),
-    );
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-
-    const result = await restartComfyUI();
-
-    expect(result.listener_ownership).toBe("ours");
-    expect(result.started).toBe(true);
-    expect(result.message).toMatch(/restarted successfully/i);
-
-    killSpy.mockRestore();
-  });
-
-  /** The relaunch scenario shared by the coarse-stamp tests: same pid, alive, and
-   *  the port owned again once the API answers. */
+  /** The relaunch scenario shared by the lineage tests: same pid, alive, and the
+   *  port owned again once the API answers. */
   function stableRelaunchOnPid4321(): void {
     usePlainInstall();
     spawnCapturingChildren(4321);
@@ -1148,39 +1184,41 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     );
   }
 
-  it("does NOT claim ownership on a COARSE (second-resolution) stamp when lineage says the process is not our child", async () => {
-    // macOS `ps -o lstart` is second-resolution, so a pid recycled inside the same
-    // second by ANOTHER ComfyUI with identical argv matches on pid, liveness,
-    // creation time and command line alike. Lineage is the discriminator: that
-    // process was not spawned by us.
-    __processControlTestHooks.setCoarseCreationStamp(true);
+  it("does NOT claim ownership when LINEAGE says the process on the port is not our child", async () => {
+    // Everything else matches — pid, liveness, creation stamp, command line — as it
+    // would for a number recycled by ANOTHER ComfyUI with identical argv (and on
+    // macOS, within the same `lstart` second). Parentage is the one signal that
+    // does not depend on when we looked.
     stableRelaunchOnPid4321();
     __processControlTestHooks.setParentPidResolver(() => process.pid + 1);
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
     const result = await restartComfyUI();
 
-    expect(result.listener_ownership).toBe("unconfirmed");
+    expect(result.listener_ownership).toBe("not-ours");
+    expect(result.started).toBe(false);
     expect(result.message).not.toMatch(/restarted successfully/i);
 
     killSpy.mockRestore();
   });
 
-  it("withholds the claim on a COARSE stamp when the parent cannot be read at all", async () => {
-    __processControlTestHooks.setCoarseCreationStamp(true);
+  it("withholds the claim when the parent cannot be read at all", async () => {
     stableRelaunchOnPid4321();
     __processControlTestHooks.setParentPidResolver(() => undefined);
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
     const result = await restartComfyUI();
 
+    // Not knowing is never promoted to a claim — but it does not deny the restart
+    // either, so the server stays reported as up.
     expect(result.listener_ownership).toBe("unconfirmed");
+    expect(result.started).toBe(true);
+    expect(result.message).not.toMatch(/restarted successfully/i);
 
     killSpy.mockRestore();
   });
 
-  it("DOES claim it on a COARSE stamp when the process is provably our own child", async () => {
-    __processControlTestHooks.setCoarseCreationStamp(true);
+  it("DOES claim it when the process is provably our own child", async () => {
     stableRelaunchOnPid4321();
     __processControlTestHooks.setParentPidResolver(() => process.pid);
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
@@ -1189,23 +1227,6 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
 
     expect(result.listener_ownership).toBe("ours");
     expect(result.message).toMatch(/restarted successfully/i);
-
-    killSpy.mockRestore();
-  });
-
-  it("does NOT pay for the lineage read where the stamp is already sub-second", async () => {
-    // Linux ticks / Windows FileTime identify an instance on their own, so the
-    // extra `ps` call must not happen there.
-    __processControlTestHooks.setCoarseCreationStamp(false);
-    stableRelaunchOnPid4321();
-    const parentPid = vi.fn(() => process.pid);
-    __processControlTestHooks.setParentPidResolver(parentPid);
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-
-    const result = await restartComfyUI();
-
-    expect(result.listener_ownership).toBe("ours");
-    expect(parentPid).not.toHaveBeenCalled();
 
     killSpy.mockRestore();
   });
@@ -1278,6 +1299,45 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     expect(result.started).toBe(false);
     expect(result.message).toMatch(/EXITED \(exit code 1\)/);
     expect(result.message).toMatch(/failed relaunch, not a slow start/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("states listener ownership on EVERY return path, including 'another launcher took the port'", async () => {
+    // After our stop, a different launcher binds the port during the settle delay,
+    // so start_comfyui exits via its "already running" branch. That branch used to
+    // carry no ownership at all — and since JSON.stringify DROPS undefined, the
+    // payload was indistinguishable from an old build that never had the field.
+    usePlainInstall();
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        // Freed by the kill, then taken again by somebody else before the relaunch.
+        return killed && netstatCalls++ === 0
+          ? ""
+          : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       7777";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && netstatCalls++ === 0) throw new Error("not listening");
+        return "p7777\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    let netstatCalls = 0;
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("not-ours");
+    const serialized = JSON.parse(JSON.stringify(result));
+    expect(Object.hasOwn(serialized, "listener_ownership")).toBe(true);
+    expect(serialized.listener_ownership).toBe("not-ours");
+    expect(result.message).not.toMatch(/restarted successfully/i);
 
     killSpy.mockRestore();
   });

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -1112,6 +1112,104 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     killSpy.mockRestore();
   });
 
+  /** The relaunch scenario shared by the coarse-stamp tests: same pid, alive, and
+   *  the port owned again once the API answers. */
+  function stableRelaunchOnPid4321(): void {
+    usePlainInstall();
+    spawnCapturingChildren(4321);
+    let killed = false;
+    let relaunched = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed && !relaunched
+          ? ""
+          : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && !relaunched) throw new Error("not listening");
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "same-second",
+      commandLine: `${PLAIN_PY} ${PLAIN_MAIN} --port 8188`,
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        relaunched = true;
+        return { ok: true } as Response;
+      }),
+    );
+  }
+
+  it("does NOT claim ownership on a COARSE (second-resolution) stamp when lineage says the process is not our child", async () => {
+    // macOS `ps -o lstart` is second-resolution, so a pid recycled inside the same
+    // second by ANOTHER ComfyUI with identical argv matches on pid, liveness,
+    // creation time and command line alike. Lineage is the discriminator: that
+    // process was not spawned by us.
+    __processControlTestHooks.setCoarseCreationStamp(true);
+    stableRelaunchOnPid4321();
+    __processControlTestHooks.setParentPidResolver(() => process.pid + 1);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("unconfirmed");
+    expect(result.message).not.toMatch(/restarted successfully/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("withholds the claim on a COARSE stamp when the parent cannot be read at all", async () => {
+    __processControlTestHooks.setCoarseCreationStamp(true);
+    stableRelaunchOnPid4321();
+    __processControlTestHooks.setParentPidResolver(() => undefined);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("unconfirmed");
+
+    killSpy.mockRestore();
+  });
+
+  it("DOES claim it on a COARSE stamp when the process is provably our own child", async () => {
+    __processControlTestHooks.setCoarseCreationStamp(true);
+    stableRelaunchOnPid4321();
+    __processControlTestHooks.setParentPidResolver(() => process.pid);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("ours");
+    expect(result.message).toMatch(/restarted successfully/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("does NOT pay for the lineage read where the stamp is already sub-second", async () => {
+    // Linux ticks / Windows FileTime identify an instance on their own, so the
+    // extra `ps` call must not happen there.
+    __processControlTestHooks.setCoarseCreationStamp(false);
+    stableRelaunchOnPid4321();
+    const parentPid = vi.fn(() => process.pid);
+    __processControlTestHooks.setParentPidResolver(parentPid);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("ours");
+    expect(parentPid).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
   it("says so plainly when listener ownership is UNDECIDABLE — without denying a restart that worked", async () => {
     // Unmappable port owner + a still-alive launched child. Reporting this as a
     // FAILED restart would mislabel every ordinary restart on hosts where the

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -185,11 +185,17 @@ function mockLivePortThenFree(): { killed: () => boolean } {
   return { killed: () => killed };
 }
 
-function spawnCapturingChildren(pid?: number): FakeChild[] {
+/**
+ * Model a spawn. The default pid matches the pid the port fixtures report, since
+ * Node only leaves `pid` undefined when the spawn FAILED — a successful launch
+ * always has one, and modelling it as absent would model a failure.
+ * Pass `null` to model that failure explicitly.
+ */
+function spawnCapturingChildren(pid: number | null = 4321): FakeChild[] {
   const children: FakeChild[] = [];
   mockSpawn.mockImplementation(() => {
     const child = new FakeChild();
-    child.pid = pid;
+    child.pid = pid ?? undefined;
     children.push(child);
     return child;
   });
@@ -1613,6 +1619,53 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
 
     expect(result.listener_ownership).toBe("ours");
     expect(result.message).toMatch(/restarted successfully/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("does NOT launder a FAILED spawn into an unconfirmed success when someone else answers first", async () => {
+    // The spawn fails asynchronously and the child never gets a pid, but another
+    // launcher's server answers readiness before the `error` event wins the race.
+    // "We could not tell whose listener that is" would be a lie: we know our launch
+    // never happened.
+    usePlainInstall();
+    const children = spawnCapturingChildren(null);
+    let killed = false;
+    let relaunched = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed && !relaunched
+          ? ""
+          : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       7777";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && !relaunched) throw new Error("not listening");
+        return "p7777\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        relaunched = true;
+        // Readiness WINS the race — the spawn error lands later, so ownership must
+        // be decided from the missing pid alone.
+        setTimeout(() => children[0]?.emit("error", new Error("spawn EACCES")), 50);
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("not-ours");
+    expect(result.started).toBe(false);
+    expect(result.message).not.toMatch(/restarted successfully/i);
+    expect(result.message).not.toMatch(/up and ready after the restart/i);
 
     killSpy.mockRestore();
   });

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -667,6 +667,44 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     killSpy.mockRestore();
   });
 
+  it("says so plainly when listener ownership is UNDECIDABLE — without denying a restart that worked", async () => {
+    // Unmappable port owner + a still-alive launched child. Reporting this as a
+    // FAILED restart would mislabel every ordinary restart on hosts where the
+    // port-owner lookup is unavailable, so the result stays started:true and the
+    // uncertainty is stated instead of guessed either way.
+    usePlainInstall();
+    spawnCapturingChildren(999);
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed ? "" : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw new Error("not listening");
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.started).toBe(true);
+    expect(result.ready).toBe(true);
+    expect(result.listener_is_launched_process).toBeUndefined();
+    expect(result.message).toMatch(/could not be confirmed as the process this call launched/i);
+
+    killSpy.mockRestore();
+  });
+
   it("names the launched process's EXIT when it dies before the API comes up", async () => {
     usePlainInstall();
     mockLivePortThenFree();

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -19,7 +19,7 @@
 // process/port/network/filesystem is touched.
 
 import { EventEmitter } from "node:events";
-import { delimiter, join, resolve } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 class FakeChild extends EventEmitter {
@@ -128,7 +128,8 @@ const SM_PY = join(SM_PKG, "venv", "Scripts", "python.exe");
 const SM_GIT_ROOT = join(SM_DATA, "PortableGit");
 const SM_GIT_DIR = join(SM_GIT_ROOT, "cmd");
 const SM_GIT_EXE = join(SM_GIT_DIR, "git.exe");
-const SM_FFMPEG_ROOT = join(SM_DATA, "Assets", "ffmpeg");
+const SM_ASSETS_ROOT = join(SM_DATA, "Assets");
+const SM_FFMPEG_ROOT = join(SM_ASSETS_ROOT, "ffmpeg");
 const SM_SETTINGS = join(SM_DATA, "settings.json");
 const SM_FFMPEG_DIR = join(SM_FFMPEG_ROOT, "bin");
 const SM_FFMPEG_EXE = join(SM_FFMPEG_DIR, "ffmpeg.exe");
@@ -264,10 +265,22 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
     });
     const configExists =
       opts?.settingsJson !== undefined || (opts?.settingsUnreadable ?? false);
+    // A real filesystem implies every ancestor of an existing directory, so
+    // listing `Assets/ffmpeg` must also make `Assets` exist — otherwise the mock
+    // models a shape that cannot occur on disk.
+    const existingDirs = new Set<string>();
+    for (const root of roots) {
+      let cur = root;
+      while (cur.length > SM_DATA.length && cur.startsWith(SM_DATA)) {
+        existingDirs.add(cur);
+        cur = dirname(cur);
+      }
+      existingDirs.add(SM_DATA);
+    }
     mockExistsSync.mockImplementation((p: string) => {
       const s = String(p);
       if (s === SM_MAIN || s === SM_PY) return true;
-      if (roots.includes(s)) return true;
+      if (existingDirs.has(s)) return true;
       if (git && s === SM_GIT_EXE) return true;
       if (ffmpeg && s === SM_FFMPEG_EXE) return true;
       if (configExists && s === SM_SETTINGS) return true;
@@ -436,6 +449,25 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
 
     expect(message).toMatch(/bundled FFmpeg/i);
     expect(message).toMatch(/Restart ComfyUI from Stability Matrix/i);
+  });
+
+  it("recognizes the `<Data>/Assets` store as Stability Matrix even without an ffmpeg subfolder", async () => {
+    // The corroboration boundary: requiring `Assets/ffmpeg` specifically missed a
+    // real layout — `Data/Packages/…` beside `Data/Assets`, with PortableGit
+    // expected but unlocatable. That fell through as a plain install, inherited our
+    // environment, and reproduced "Bad git executable". With the store recognized,
+    // the per-component evidence rules apply: PortableGit is present but its binary
+    // is not, which is ambiguous and must refuse.
+    useStabilityMatrix({
+      git: false,
+      ffmpeg: false,
+      roots: [SM_ASSETS_ROOT, SM_GIT_ROOT],
+    });
+
+    const message = await expectRefusedBeforeStopping();
+
+    expect(message).toMatch(/Stability Matrix/i);
+    expect(message).toMatch(/bundled Git/i);
   });
 
   it("does NOT mistake an ordinary install that merely lives under a `Data/Packages` path for Stability Matrix", async () => {
@@ -966,6 +998,82 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
     expect(result.message).toMatch(/5555/);
     expect(killSpy).not.toHaveBeenCalled();
     expect(mockSpawn).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("REFUSES rather than binding an answer it could not bracket (port lookup unreadable on one side)", async () => {
+    // The bracket must be REQUIRED, not best-effort: if the pre-call lookup comes
+    // back empty there is no anchor, and A-answers-then-B-takes-the-port with
+    // identical argv would satisfy every later self-consistent check. One flaky
+    // lookup is retried; a bracket that still cannot be closed refuses.
+    usePlainInstallForIdentity();
+    let lookups = 0;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/netstat/i.test(cmd)) {
+        lookups++;
+        // Every PRE-call lookup (odd) is unreadable; every post-call one succeeds.
+        return lookups % 2 === 1
+          ? ""
+          : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) {
+        lookups++;
+        if (lookups % 2 === 1) throw new Error("not listening");
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/could not be read on both sides/i);
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("RETRIES a single flaky lookup rather than refusing outright", async () => {
+    // Refusing on the first hiccup would be its own regression — one bad read is
+    // retried, and a stable bracket on the retry proceeds normally.
+    usePlainInstallForIdentity();
+    let lookups = 0;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        lookups = 100; // past the kill the port is free
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        lookups++;
+        if (lookups === 1) return ""; // one flaky pre-call read
+        return lookups < 100
+          ? "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321"
+          : "";
+      }
+      if (/lsof/i.test(cmd)) {
+        lookups++;
+        if (lookups === 1 || lookups >= 100) throw new Error("not listening");
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/could not be read on both sides/i);
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
 
     killSpy.mockRestore();
   });

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -1670,6 +1670,49 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     killSpy.mockRestore();
   });
 
+  it("does NOT launder a failed DESKTOP launch either — the never-launched checks precede the Desktop shortcut", async () => {
+    // Desktop ownership is undecidable by design ONCE IT HAS STARTED (we spawn the
+    // shell; its child binds the port). But a launch that never happened is
+    // decisive on every path, so the Desktop shortcut must not sit in front of it.
+    __processControlTestHooks.setLastProcessInfo({
+      pid: 4321,
+      port: 8188,
+      argv: [],
+      isDesktopApp: true,
+      desktopExePath: join(resolve("Programs"), "Comfy Desktop", "Comfy Desktop.exe"),
+    });
+    const children = spawnCapturingChildren(null); // the spawn produced no process
+    let probed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/netstat/i.test(cmd)) {
+        // Nothing listening at the pre-launch check; another launcher answers after.
+        return probed ? "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       7777" : "";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (!probed) throw new Error("not listening");
+        return "p7777\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        probed = true;
+        setTimeout(() => children[0]?.emit("error", new Error("spawn ENOENT")), 50);
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await startComfyUI();
+
+    expect(result.listener_ownership).toBe("not-ours");
+    expect(result.started).toBe(false);
+    expect(result.message).not.toMatch(/^ComfyUI started/);
+
+    killSpy.mockRestore();
+  });
+
   it("says so plainly when listener ownership is UNDECIDABLE — without denying a restart that worked", async () => {
     // Unmappable port owner + a still-alive launched child. Reporting this as a
     // FAILED restart would mislabel every ordinary restart on hosts where the

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -127,9 +127,15 @@ const PLAIN_PY = join(PLAIN_BASE, "venv", "bin", "python");
 // Pinokio: an app tree under a `pinokio` root.
 const PINOKIO_HOME = resolve("pinokio");
 const PINOKIO_API = join(PINOKIO_HOME, "api");
+const PINOKIO_BIN = join(PINOKIO_HOME, "bin");
 const PINOKIO_APP = join(PINOKIO_API, "comfy.git", "app");
 const PINOKIO_MAIN = join(PINOKIO_APP, "main.py");
 const PINOKIO_PY = join(PINOKIO_APP, "env", "bin", "python");
+
+// An ordinary install that merely SITS under a `pinokio` tree (not inside its
+// `api/` app subtree) — this must never be mistaken for a Pinokio-managed server.
+const BENIGN_PINOKIO_PATH = join(PINOKIO_BIN, "comfy", "main.py");
+const BENIGN_PINOKIO_PY = join(PINOKIO_BIN, "comfy", "venv", "bin", "python");
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -195,6 +201,10 @@ beforeEach(() => {
   // No live-process environment is readable by default (the Windows/macOS case,
   // and the #776 reporter's platform). Individual tests opt in.
   __processControlTestHooks.setLiveEnvResolver(() => undefined);
+  // Likewise no creation-time stamp by default — the shape on the platforms where
+  // the native read is deliberately skipped. Tests that exercise PID identity
+  // install their own resolver.
+  __processControlTestHooks.setProcessIdentityResolver(() => undefined);
 });
 
 afterEach(() => {
@@ -329,6 +339,22 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
     const message = await expectRefusedBeforeStopping();
 
     expect(message).toMatch(/bundled FFmpeg/i);
+    expect(message).toMatch(/no ffmpeg binary inside it/i);
+  });
+
+  it("REFUSES before stopping with an intact PortableGit when the FFmpeg asset dir is ABSENT ENTIRELY", async () => {
+    // The exact partial-approval hole: Git resolves, so a "Git is the fatal one"
+    // rule would approve, stop a healthy server, and relaunch knowingly incomplete.
+    // From here we cannot tell "this install has no FFmpeg" from "its FFmpeg lives
+    // somewhere we don't know to look", and the #776 lesson is that guessing wrong
+    // costs the user their server — so an unresolvable component always refuses.
+    useStabilityMatrix({ git: true, ffmpeg: false, roots: [SM_GIT_ROOT] });
+
+    const message = await expectRefusedBeforeStopping();
+
+    expect(message).toMatch(/bundled FFmpeg/i);
+    expect(message).toMatch(/does not exist, so we cannot tell/i);
+    expect(message).toMatch(/Restart ComfyUI from Stability Matrix/i);
   });
 
   it("does NOT mistake an ordinary install that merely lives under a `Data/Packages` path for Stability Matrix", async () => {
@@ -426,8 +452,8 @@ describe("restart_comfyui — irreproducible launcher environments (#776)", () =
     mockExistsSync.mockImplementation((p: string) => {
       const s = String(p);
       if (s === PINOKIO_MAIN || s === PINOKIO_PY) return true;
-      // The `api/` tree is the on-disk evidence that this really is a Pinokio home.
-      return corroborated && s === PINOKIO_API;
+      // BOTH `api/` and `bin/` are the on-disk evidence of a real Pinokio home.
+      return corroborated && (s === PINOKIO_API || s === PINOKIO_BIN);
     });
   }
 
@@ -445,6 +471,44 @@ describe("restart_comfyui — irreproducible launcher environments (#776)", () =
     expect(result.message).toMatch(/Pinokio/);
     expect(mockSpawn).not.toHaveBeenCalled();
     expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("does NOT refuse an ordinary install that merely SITS under a `pinokio` tree", async () => {
+    // The inverse regression: a real Pinokio home (both `api/` and `bin/` present)
+    // but an install living under `pinokio/bin/...`, NOT inside the `api/` app
+    // subtree Pinokio manages. A path-component name is not evidence, and a false
+    // refusal blocks a restart that would have worked.
+    mockFindComfyuiPython.mockReturnValue(BENIGN_PINOKIO_PY);
+    mockLiveRootFromArgv.mockReturnValue(join(PINOKIO_BIN, "comfy"));
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [BENIGN_PINOKIO_PATH, "--port", "8188"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return (
+        s === BENIGN_PINOKIO_PATH ||
+        s === BENIGN_PINOKIO_PY ||
+        s === PINOKIO_API ||
+        s === PINOKIO_BIN
+      );
+    });
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(result.message).not.toMatch(/Pinokio/);
+    expect(result.started).toBe(true);
+    expect(result.launch_env?.source).toBe("inherited");
+    expect(result.launch_env?.reproducible).toBe(true);
 
     killSpy.mockRestore();
   });
@@ -519,6 +583,9 @@ describe("restart_comfyui — irreproducible launcher environments (#776)", () =
       PINOKIO_APP_NAME: "comfy",
     };
     __processControlTestHooks.setLiveEnvResolver(() => ({ ...LIVE_ENV }));
+    // A STABLE process identity across the read — the capture is only adopted
+    // when the pid provably still denotes the same process.
+    __processControlTestHooks.setProcessIdentityResolver(() => ({ startedAt: "t1" }));
     mockLivePortThenFree();
     spawnCapturingChildren();
     vi.stubGlobal(
@@ -537,6 +604,134 @@ describe("restart_comfyui — irreproducible launcher environments (#776)", () =
 
     killSpy.mockRestore();
   });
+});
+
+describe("restart_comfyui — a PID is not a process identity (#776)", () => {
+  function usePinokioInstall(): void {
+    mockFindComfyuiPython.mockReturnValue(PINOKIO_PY);
+    mockLiveRootFromArgv.mockReturnValue(PINOKIO_APP);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [PINOKIO_MAIN, "--port", "8188"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return (
+        s === PINOKIO_MAIN ||
+        s === PINOKIO_PY ||
+        s === PINOKIO_API ||
+        s === PINOKIO_BIN
+      );
+    });
+  }
+
+  /** An identity reader that returns the given stamps in call order. */
+  function identitySequence(stamps: string[]): void {
+    let i = 0;
+    __processControlTestHooks.setProcessIdentityResolver(() => {
+      const stamp = stamps[Math.min(i, stamps.length - 1)];
+      i++;
+      return { startedAt: stamp };
+    });
+  }
+
+  it("does NOT adopt the environment of a PID that was recycled during the read", async () => {
+    // ComfyUI exits after the port lookup and the OS hands its number to an
+    // unrelated process, whose /proc/<pid>/environ we would otherwise adopt as
+    // ComfyUI's launch environment. Proof that it is rejected: this Pinokio
+    // install is only restartable BECAUSE of a live environment, so discarding
+    // the bogus capture must drop it back to the irreproducible-launcher refusal.
+    usePinokioInstall();
+    __processControlTestHooks.setLiveEnvResolver(() => ({
+      PATH: "/some/unrelated/process/path",
+      NOT_COMFYUI: "1",
+    }));
+    identitySequence(["t1", "t2"]); // lookup, then re-verify after the env read
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(result.message).toMatch(/Pinokio/);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("does NOT KILL a PID that no longer owns the port it was found on", async () => {
+    // The server exited between the port lookup and the stop. Its number may
+    // already belong to something else, so nothing may be killed.
+    usePlainInstallForIdentity();
+    let netstatCalls = 0;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/netstat/i.test(cmd)) {
+        netstatCalls++;
+        // Owned during the lookup; gone by the pre-kill re-check.
+        return netstatCalls <= 1
+          ? "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321"
+          : "";
+      }
+      if (/lsof/i.test(cmd)) {
+        netstatCalls++;
+        if (netstatCalls > 1) throw new Error("not listening");
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/no longer owns that port/i);
+    expect(result.message).toMatch(/must not be killed/i);
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(
+      mockExecSync.mock.calls.some(([cmd]) => /taskkill/i.test(String(cmd))),
+    ).toBe(false);
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("does NOT KILL a PID whose process CREATION TIME changed under it", async () => {
+    // The stronger identity: the number is still listening, but it is not the
+    // process we identified (#650's pid + creation-time identity).
+    usePlainInstallForIdentity();
+    identitySequence(["t1", "t2"]); // lookup, then the pre-kill re-verify
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/creation time/i);
+    expect(result.message).toMatch(/must not be killed/i);
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  function usePlainInstallForIdentity(): void {
+    mockFindComfyuiPython.mockReturnValue(PLAIN_PY);
+    mockLiveRootFromArgv.mockReturnValue(PLAIN_BASE);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [PLAIN_MAIN, "--port", "8188"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === PLAIN_MAIN || s === PLAIN_PY;
+    });
+  }
 });
 
 describe("restart_comfyui — plain installs are unchanged (#776)", () => {
@@ -610,7 +805,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
 
     const result = await restartComfyUI();
 
-    expect(result.listener_is_launched_process).toBe(false);
+    expect(result.listener_ownership).toBe("not-ours");
     // The STRUCTURED result must not read as a successful restart either: this
     // call did not start the server. `ready` stays true — the server really is up.
     expect(result.started).toBe(false);
@@ -619,6 +814,8 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     expect(result.message).toMatch(/NOT as a result of this restart/i);
     expect(result.message).toMatch(/another launcher or supervisor owns it/i);
     expect(result.message).not.toMatch(/could not be started/i);
+    // ...and it must SURVIVE the tool's JSON serialization.
+    expect(JSON.parse(JSON.stringify(result)).listener_ownership).toBe("not-ours");
 
     killSpy.mockRestore();
   });
@@ -657,7 +854,7 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
 
     const result = await restartComfyUI();
 
-    expect(result.listener_is_launched_process).toBe(false);
+    expect(result.listener_ownership).toBe("not-ours");
     expect(result.started).toBe(false);
     expect(result.ready).toBe(true);
     expect(result.message).not.toMatch(/restarted successfully/i);
@@ -699,8 +896,14 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
 
     expect(result.started).toBe(true);
     expect(result.ready).toBe(true);
-    expect(result.listener_is_launched_process).toBeUndefined();
+    expect(result.listener_ownership).toBe("unconfirmed");
     expect(result.message).toMatch(/could not be confirmed as the process this call launched/i);
+    // THE POINT of a string state: `undefined` would be dropped by JSON.stringify,
+    // leaving a payload indistinguishable from one that never carried the field —
+    // i.e. from a plain success. The uncertainty has to reach the consumer.
+    const serialized = JSON.parse(JSON.stringify(result));
+    expect(Object.hasOwn(serialized, "listener_ownership")).toBe(true);
+    expect(serialized.listener_ownership).toBe("unconfirmed");
 
     killSpy.mockRestore();
   });

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -611,9 +611,14 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     const result = await restartComfyUI();
 
     expect(result.listener_is_launched_process).toBe(false);
+    // The STRUCTURED result must not read as a successful restart either: this
+    // call did not start the server. `ready` stays true — the server really is up.
+    expect(result.started).toBe(false);
+    expect(result.ready).toBe(true);
     expect(result.message).not.toMatch(/restarted successfully/i);
     expect(result.message).toMatch(/NOT as a result of this restart/i);
     expect(result.message).toMatch(/another launcher or supervisor owns it/i);
+    expect(result.message).not.toMatch(/could not be started/i);
 
     killSpy.mockRestore();
   });
@@ -653,6 +658,8 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     const result = await restartComfyUI();
 
     expect(result.listener_is_launched_process).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.ready).toBe(true);
     expect(result.message).not.toMatch(/restarted successfully/i);
     expect(result.message).toMatch(/NOT as a result of this restart/i);
     expect(result.message).toMatch(/which exited: exit code 1/);

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -950,6 +950,63 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     killSpy.mockRestore();
   });
 
+  it("does NOT claim a matching PID as ours when the child is already gone but its `exit` event has not been delivered", async () => {
+    // The lifecycle race: our child dies, the OS reuses its number for a program
+    // that binds the port, and readiness sees that healthy replacement BEFORE Node
+    // delivers the `exit` event. A bare `portOwnerPid === ourPid` would call it
+    // "ours". A synchronous signal-0 probe says otherwise.
+    usePlainInstall();
+    spawnCapturingChildren(4321);
+    let killed = false;
+    let relaunched = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed && !relaunched
+          ? ""
+          : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && !relaunched) throw new Error("not listening");
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        relaunched = true;
+        return { ok: true } as Response;
+      }),
+    );
+    // Signal-0 liveness probes for our child report ESRCH; the process-group kill
+    // during the stop still succeeds. NOTE the `exit` event is deliberately never
+    // emitted — that is the whole point of the race.
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation((pid: number, signal?: string | number) => {
+        if (signal === 0) {
+          const err = new Error("ESRCH") as NodeJS.ErrnoException;
+          err.code = "ESRCH";
+          throw err;
+        }
+        return true;
+      });
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("not-ours");
+    expect(result.started).toBe(false);
+    expect(result.ready).toBe(true);
+    expect(result.message).not.toMatch(/restarted successfully/i);
+    expect(result.message).toMatch(/NOT as a result of this restart/i);
+
+    killSpy.mockRestore();
+  });
+
   it("says so plainly when listener ownership is UNDECIDABLE — without denying a restart that worked", async () => {
     // Unmappable port owner + a still-alive launched child. Reporting this as a
     // FAILED restart would mislabel every ordinary restart on hosts where the

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -1,0 +1,446 @@
+// Launcher environment preservation across restart_comfyui (#776).
+//
+// restart_comfyui rebuilt the launch COMMAND but not the launch ENVIRONMENT: the
+// relaunch spawned with no `env`, so the child inherited the ORCHESTRATOR's
+// process.env instead of the environment the launcher gave the server. On a
+// Stability Matrix install that dropped its bundled PortableGit and FFmpeg from
+// PATH — ComfyUI-Manager aborted at import with "Bad git executable", ComfyUI
+// never answered /system_stats, and the restart left the server DOWN.
+//
+// The invariants under test:
+//   1. the environment is PRESERVED across a restart (live-read, or reconstructed
+//      from a detected Stability Matrix layout);
+//   2. an environment we cannot reproduce REFUSES **before** anything is stopped;
+//   3. a relaunch that does not come back reports the truth (stopped, not started)
+//      instead of claiming a successful restart.
+//
+// Boundaries only are mocked: config, workspace-env, the python resolver,
+// child_process, node:fs, the ComfyUI client and global fetch. No real
+// process/port/network/filesystem is touched.
+
+import { EventEmitter } from "node:events";
+import { delimiter, join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class FakeChild extends EventEmitter {
+  unref = vi.fn();
+}
+
+const mockConfig = vi.hoisted(() => ({
+  resolvedPort: 8188,
+  comfyuiPath: undefined as string | undefined,
+}));
+
+const mockExecSync = vi.hoisted(() => vi.fn());
+const mockSpawn = vi.hoisted(() => vi.fn());
+const mockGetSystemStats = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn((_p: string) => true));
+const mockFindComfyuiPython = vi.hoisted(() => vi.fn());
+const mockResolveBase = vi.hoisted(() => vi.fn<[], string | undefined>());
+const mockLiveRootFromArgv = vi.hoisted(() =>
+  vi.fn<[string[], string?], string | undefined>(),
+);
+
+vi.mock("../../config.js", () => ({
+  config: mockConfig,
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyUIAuthHeaders: () => ({}),
+  isRemoteMode: () => false,
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: mockExecSync,
+  spawn: mockSpawn,
+}));
+
+// node:fs is shared by process-control (script/interpreter validation) AND by
+// launcher-env (the on-disk corroboration of a launcher layout), so one existsSync
+// map drives both.
+vi.mock("node:fs", () => ({
+  existsSync: mockExistsSync,
+  readlinkSync: vi.fn(() => {
+    throw new Error("no /proc in test");
+  }),
+  readFileSync: vi.fn(() => {
+    throw new Error("no /proc in test");
+  }),
+  statSync: vi.fn((p: string) => {
+    if (!mockExistsSync(String(p))) throw new Error("ENOENT");
+    return { isFile: () => true, isDirectory: () => false };
+  }),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getSystemStats: mockGetSystemStats,
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../services/env-capabilities.js", () => ({
+  findComfyuiPython: mockFindComfyuiPython,
+}));
+
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveEffectiveComfyUIBase: mockResolveBase,
+  liveRootFromArgv: mockLiveRootFromArgv,
+  markLocalComfyUILaunched: vi.fn(),
+  resetLocalComfyUILaunchState: vi.fn(),
+}));
+
+import {
+  __processControlTestHooks,
+  preflightLocalRestart,
+  restartComfyUI,
+  startComfyUI,
+  stopComfyUI,
+} from "../../services/process-control.js";
+
+// ---------------------------------------------------------------------------
+// Install layouts. HOST-NATIVE absolute paths so the separator-agnostic
+// detection is exercised on whatever OS runs the suite.
+// ---------------------------------------------------------------------------
+
+// Stability Matrix: packages under <Data>/Packages/<pkg>, shared tooling beside it.
+const SM_DATA = resolve("StabilityMatrixTest", "Data");
+const SM_PKG = join(SM_DATA, "Packages", "ComfyUI");
+const SM_MAIN = join(SM_PKG, "main.py");
+const SM_PY = join(SM_PKG, "venv", "Scripts", "python.exe");
+const SM_GIT_DIR = join(SM_DATA, "PortableGit", "cmd");
+const SM_GIT_EXE = join(SM_GIT_DIR, "git.exe");
+const SM_FFMPEG_DIR = join(SM_DATA, "Assets", "ffmpeg", "bin");
+const SM_FFMPEG_EXE = join(SM_FFMPEG_DIR, "ffmpeg.exe");
+
+// A plain install (no launcher marker anywhere in its paths).
+const PLAIN_BASE = resolve("PlainComfyTest", "ComfyUI");
+const PLAIN_MAIN = join(PLAIN_BASE, "main.py");
+const PLAIN_PY = join(PLAIN_BASE, "venv", "bin", "python");
+
+// Pinokio: an app tree under a `pinokio` root.
+const PINOKIO_APP = resolve("pinokio", "api", "comfy.git", "app");
+const PINOKIO_MAIN = join(PINOKIO_APP, "main.py");
+const PINOKIO_PY = join(PINOKIO_APP, "env", "bin", "python");
+
+const ORIGINAL_ENV = { ...process.env };
+
+/** Case-insensitive env lookup (Windows env blocks are case-insensitive). */
+function envGet(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const wanted = name.toLowerCase();
+  for (const [k, v] of Object.entries(env)) {
+    if (k.toLowerCase() === wanted) return v;
+  }
+  return undefined;
+}
+
+/** execSync that reports a live PID on the port until a kill, then port free. */
+function mockLivePortThenFree(): { killed: () => boolean } {
+  let killed = false;
+  mockExecSync.mockImplementation((cmd: string) => {
+    if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+      killed = true;
+      return "";
+    }
+    if (/netstat/i.test(cmd)) {
+      return killed
+        ? ""
+        : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+    }
+    if (/lsof/i.test(cmd)) {
+      if (killed) throw new Error("not listening");
+      return "p4321\nn127.0.0.1:8188\n";
+    }
+    return "";
+  });
+  return { killed: () => killed };
+}
+
+function spawnCapturingChildren(): FakeChild[] {
+  const children: FakeChild[] = [];
+  mockSpawn.mockImplementation(() => {
+    const child = new FakeChild();
+    children.push(child);
+    return child;
+  });
+  return children;
+}
+
+function spawnOptions(): { cwd?: string; env?: NodeJS.ProcessEnv } {
+  return mockSpawn.mock.calls[0][2] as { cwd?: string; env?: NodeJS.ProcessEnv };
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  process.env = { ...ORIGINAL_ENV };
+  process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+  process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "1";
+  process.env.PATH = ORIGINAL_ENV.PATH ?? "/usr/bin";
+  mockConfig.resolvedPort = 8188;
+  mockConfig.comfyuiPath = undefined;
+  mockResolveBase.mockReturnValue(undefined);
+  mockLiveRootFromArgv.mockReturnValue(undefined);
+  __processControlTestHooks.reset();
+  // No live-process environment is readable by default (the Windows/macOS case,
+  // and the #776 reporter's platform). Individual tests opt in.
+  __processControlTestHooks.setLiveEnvResolver(() => undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  process.env = { ...ORIGINAL_ENV };
+  __processControlTestHooks.reset();
+});
+
+// ---------------------------------------------------------------------------
+
+describe("restart_comfyui — Stability Matrix launcher environment (#776)", () => {
+  function useStabilityMatrix(opts?: { assets?: boolean }): void {
+    const assets = opts?.assets ?? true;
+    mockFindComfyuiPython.mockReturnValue(SM_PY);
+    mockLiveRootFromArgv.mockReturnValue(SM_PKG);
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: [SM_MAIN, "--preview-method", "auto", "--enable-manager"],
+      },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      if (s === SM_MAIN || s === SM_PY) return true;
+      if (!assets) return false;
+      return s === SM_GIT_EXE || s === SM_FFMPEG_EXE;
+    });
+  }
+
+  it("restores PortableGit + FFmpeg on PATH (and GIT_PYTHON_GIT_EXECUTABLE) for the relaunch", async () => {
+    useStabilityMatrix();
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    expect(result.ready).toBe(true);
+
+    // The relaunch DID carry an explicit environment (the bug was `env` omitted,
+    // silently inheriting the orchestrator's).
+    const opts = spawnOptions();
+    expect(opts.env).toBeDefined();
+    const path = envGet(opts.env!, "PATH") ?? "";
+    const entries = path.split(delimiter);
+    // Both launcher directories are PREPENDED, ahead of whatever we inherited —
+    // the launcher's own copies must win.
+    expect(entries[0]).toBe(SM_GIT_DIR);
+    expect(entries[1]).toBe(SM_FFMPEG_DIR);
+    expect(envGet(opts.env!, "GIT_PYTHON_GIT_EXECUTABLE")).toBe(SM_GIT_EXE);
+
+    // ...and the result SAYS the launcher shape was detected and restored.
+    expect(result.launch_env?.source).toBe("stability-matrix");
+    expect(result.launch_env?.launcher).toBe("Stability Matrix");
+    expect(result.launch_env?.path_additions).toEqual([
+      SM_GIT_DIR,
+      SM_FFMPEG_DIR,
+    ]);
+    expect(result.message).toMatch(/Stability Matrix/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("REFUSES before stopping when the launcher's tooling cannot be found on disk", async () => {
+    // The install is provably launcher-owned, but its Git/FFmpeg assets are gone,
+    // so its environment cannot be reproduced. Guessing (= inheriting ours) is
+    // exactly what took the server down in #776.
+    useStabilityMatrix({ assets: false });
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(result.message).toMatch(/Stability Matrix/i);
+    // Told to use the owning launcher — not the generic COMFYUI_PATH advice.
+    expect(result.message).toMatch(/Restart ComfyUI from Stability Matrix/i);
+    // NOTHING was stopped and nothing was spawned.
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(
+      mockExecSync.mock.calls.some(([cmd]) => /taskkill/i.test(String(cmd))),
+    ).toBe(false);
+
+    killSpy.mockRestore();
+  });
+});
+
+describe("restart_comfyui — irreproducible launcher environments (#776)", () => {
+  function usePinokio(): void {
+    mockFindComfyuiPython.mockReturnValue(PINOKIO_PY);
+    mockLiveRootFromArgv.mockReturnValue(PINOKIO_APP);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [PINOKIO_MAIN, "--port", "8188"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === PINOKIO_MAIN || s === PINOKIO_PY;
+    });
+  }
+
+  it("REFUSES a Pinokio-launched server BEFORE stopping it", async () => {
+    usePinokio();
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(result.message).toMatch(/Pinokio/);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("still allows the OUT-OF-BAND Manager reboot preflight (that restart preserves the environment itself)", async () => {
+    // A Manager reboot re-execs the SAME process, which keeps its own launcher
+    // environment — so the environment rule must NOT leak into this preflight.
+    usePinokio();
+    mockLivePortThenFree();
+
+    await expect(preflightLocalRestart()).resolves.toEqual({ ok: true });
+  });
+
+  it("does NOT refuse from start_comfyui when the server is ALREADY down — it launches and warns", async () => {
+    // The refusal exists to protect a RUNNING server. Once ComfyUI is already
+    // stopped, refusing would leave it down forever — the one outcome worse than a
+    // possibly-degraded launch. So start_comfyui launches and says so plainly.
+    usePinokio();
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const stopped = await stopComfyUI();
+    expect(stopped.stopped).toBe(true);
+
+    const started = await startComfyUI();
+
+    expect(started.started).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    // Best available environment = ours (never a fabricated launcher one).
+    expect(spawnOptions().env).toBeUndefined();
+    expect(started.launch_env?.reproducible).toBe(false);
+    expect(started.launch_env?.launcher).toBe("Pinokio");
+    expect(started.message).toMatch(/WARNING/);
+    expect(started.message).toMatch(/Pinokio/);
+
+    killSpy.mockRestore();
+  });
+
+  it("relaunches a Pinokio server when its LIVE environment could be read", async () => {
+    // Same install, but this time we captured the real environment off the live
+    // process — there is nothing left to guess, so the restart proceeds.
+    usePinokio();
+    const LIVE_ENV = {
+      PATH: `/pinokio/bin/git:/usr/bin`,
+      GIT_PYTHON_GIT_EXECUTABLE: "/pinokio/bin/git/git",
+      PINOKIO_APP_NAME: "comfy",
+    };
+    __processControlTestHooks.setLiveEnvResolver(() => ({ ...LIVE_ENV }));
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    // Spawned with the LIVE environment verbatim — not the orchestrator's.
+    expect(spawnOptions().env).toEqual(LIVE_ENV);
+    expect(result.launch_env?.source).toBe("live-process");
+
+    killSpy.mockRestore();
+  });
+});
+
+describe("restart_comfyui — plain installs are unchanged (#776)", () => {
+  function usePlainInstall(): void {
+    mockFindComfyuiPython.mockReturnValue(PLAIN_PY);
+    mockLiveRootFromArgv.mockReturnValue(PLAIN_BASE);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [PLAIN_MAIN, "--port", "8188"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === PLAIN_MAIN || s === PLAIN_PY;
+    });
+  }
+
+  it("inherits this process's environment (no `env` override) and still restarts", async () => {
+    usePlainInstall();
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    // No env override: `spawn` inherits process.env, exactly as before #776.
+    expect(spawnOptions().env).toBeUndefined();
+    expect(result.launch_env?.source).toBe("inherited");
+
+    killSpy.mockRestore();
+  });
+
+  it("reports the TRUTH when the relaunch never comes back (stopped, not started)", async () => {
+    usePlainInstall();
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    // The process is spawned but the API never answers — the server is DOWN.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(false);
+    expect(result.ready).toBe(false);
+    expect(result.message).toMatch(/stopped but could not be started/i);
+    expect(result.message).not.toMatch(/restarted successfully/i);
+    // The environment it was launched into is named, so the failure is debuggable.
+    expect(result.launch_env?.source).toBe("inherited");
+
+    killSpy.mockRestore();
+  });
+});

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -243,6 +243,9 @@ beforeEach(() => {
   process.env = { ...ORIGINAL_ENV };
   process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
   process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "1";
+  // Keep the port-free wait short: these fixtures deliberately exercise the
+  // TIMEOUT path, and 15s of real waiting per test destabilises the whole suite.
+  process.env.COMFYUI_PORT_FREE_TIMEOUT_S = "1";
   process.env.PATH = ORIGINAL_ENV.PATH ?? "/usr/bin";
   mockConfig.resolvedPort = 8188;
   mockConfig.comfyuiPath = undefined;
@@ -1987,9 +1990,11 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
 
     const result = await restartComfyUI();
 
-    // The port owner is unmappable after the kill, so argv is the only signal —
-    // and a subset must read as DIFFERENT, not as a match.
-    expect(result.listener_ownership).toBe("not-ours");
+    // The port owner is unmappable, so NO listener was identified — and an absence
+    // can never yield the positive verdict `not-ours`. What matters here is that a
+    // subset argv does not read as a MATCH and so cannot promote to "ours": the
+    // claim is withheld, and no success is reported.
+    expect(result.listener_ownership).toBe("unconfirmed");
     expect(result.message).not.toMatch(/restarted successfully/i);
 
     killSpy.mockRestore();

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -1007,6 +1007,111 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     killSpy.mockRestore();
   });
 
+  it("does NOT claim an ALIVE recycled PID as ours — the process creation time tells instances apart", async () => {
+    // The hardest variant: our child died, the OS reused its number, the
+    // replacement is ALIVE (signal-0 succeeds), owns the port, and is even another
+    // ComfyUI with an identical command line. Nothing but the per-instance
+    // creation time can tell them apart.
+    usePlainInstall();
+    let killed = false;
+    let relaunched = false;
+    // Identity by PHASE: the old server before the spawn, our child at the spawn,
+    // then a DIFFERENT instance on the same number when the listener is checked.
+    let readsAfterSpawn = 0;
+    let spawnedYet = false;
+    __processControlTestHooks.setProcessIdentityResolver(() => {
+      const commandLine = `${PLAIN_PY} ${PLAIN_MAIN} --port 8188`;
+      if (!spawnedYet) return { startedAt: "old-server", commandLine };
+      readsAfterSpawn++;
+      return {
+        startedAt: readsAfterSpawn <= 1 ? "our-child" : "recycled-instance",
+        commandLine,
+      };
+    });
+    mockSpawn.mockImplementation(() => {
+      spawnedYet = true;
+      const child = new FakeChild();
+      child.pid = 4321;
+      return child;
+    });
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed && !relaunched
+          ? ""
+          : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && !relaunched) throw new Error("not listening");
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        relaunched = true;
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("not-ours");
+    expect(result.started).toBe(false);
+    expect(result.ready).toBe(true);
+    expect(result.message).not.toMatch(/restarted successfully/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("DOES claim it when the creation time still matches (the stamp is not a blanket veto)", async () => {
+    usePlainInstall();
+    spawnCapturingChildren(4321);
+    let killed = false;
+    let relaunched = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed && !relaunched
+          ? ""
+          : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && !relaunched) throw new Error("not listening");
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "spawned-at-1000",
+      commandLine: `${PLAIN_PY} ${PLAIN_MAIN} --port 8188`,
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        relaunched = true;
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("ours");
+    expect(result.started).toBe(true);
+    expect(result.message).toMatch(/restarted successfully/i);
+
+    killSpy.mockRestore();
+  });
+
   it("says so plainly when listener ownership is UNDECIDABLE — without denying a restart that worked", async () => {
     // Unmappable port owner + a still-alive launched child. Reporting this as a
     // FAILED restart would mislabel every ordinary restart on hosts where the

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -93,6 +93,7 @@ vi.mock("../../services/workspace-env.js", () => ({
   resetLocalComfyUILaunchState: vi.fn(),
 }));
 
+import { detectStabilityMatrix } from "../../services/launcher-env.js";
 import {
   __processControlTestHooks,
   preflightLocalRestart,
@@ -352,6 +353,65 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
     expect(spawnOptions().env).toBeUndefined();
 
     killSpy.mockRestore();
+  });
+});
+
+describe("launcher layout detection — path-root handling (#776)", () => {
+  // The paths come from the running ComfyUI's sys.argv, which is WINDOWS-flavored
+  // whenever ComfyUI runs on Windows regardless of this host. These are pure
+  // string+existsSync tests, so they pin the parsing on every OS.
+  function pinTooling(dataRoot: string, sep: string): string {
+    const gitRoot = `${dataRoot}${sep}PortableGit`;
+    const gitExe = `${gitRoot}${sep}cmd${sep}git.exe`;
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === gitRoot || s === gitExe;
+    });
+    return gitExe;
+  }
+
+  it("keeps a UNC root intact (both leading backslashes)", () => {
+    const DATA = "\\\\server\\share\\SM\\Data";
+    const gitExe = pinTooling(DATA, "\\");
+
+    const sm = detectStabilityMatrix([`${DATA}\\Packages\\ComfyUI\\main.py`]);
+
+    expect(sm?.dataRoot).toBe(DATA);
+    expect(sm?.gitExe).toBe(gitExe);
+  });
+
+  it("keeps an extended-length (\\\\?\\) root intact", () => {
+    const DATA = "\\\\?\\C:\\SM\\Data";
+    const gitExe = pinTooling(DATA, "\\");
+
+    const sm = detectStabilityMatrix([`${DATA}\\Packages\\ComfyUI\\main.py`]);
+
+    expect(sm?.dataRoot).toBe(DATA);
+    expect(sm?.gitExe).toBe(gitExe);
+  });
+
+  it("keeps a drive-letter root intact", () => {
+    const DATA = "C:\\Stability Matrix\\Data";
+    const gitExe = pinTooling(DATA, "\\");
+
+    const sm = detectStabilityMatrix([`${DATA}\\Packages\\ComfyUI\\main.py`]);
+
+    expect(sm?.dataRoot).toBe(DATA);
+    expect(sm?.gitExe).toBe(gitExe);
+  });
+
+  it("keeps a POSIX absolute root intact", () => {
+    const DATA = "/home/u/StabilityMatrix/Data";
+    const gitExe = `${DATA}/PortableGit/cmd/git`;
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === `${DATA}/PortableGit` || s === gitExe;
+    });
+
+    const sm = detectStabilityMatrix([`${DATA}/Packages/ComfyUI/main.py`]);
+
+    expect(sm?.dataRoot).toBe(DATA);
+    expect(sm?.gitExe).toBe(gitExe);
   });
 });
 

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -1066,10 +1066,12 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
     killSpy.mockRestore();
   });
 
-  it("does NOT treat an unreadable port probe as proof the killed process died", async () => {
-    // `findPidByPort` answers null both for "port is free" and for "the lookup
-    // failed". Spending the second as the first tears supervision down under a
-    // server that may still be running.
+  it("does NOT treat an unreadable port probe as proof the killed process died — but still brings the server back", async () => {
+    // Two mirror-image mistakes to avoid. Reading "the probe failed" as "the port is
+    // free" would tear supervision down under a live server. But REFUSING on it is
+    // worse: the kill has already been issued, so a refusal cannot restore anything
+    // and would leave a dead server unrelaunched — the cardinal failure. So the stop
+    // commits, says plainly that it is unverified, and the relaunch runs.
     usePlainInstallForIdentity();
     let killIssued = false;
     mockExecSync.mockImplementation((cmd: string) => {
@@ -1089,13 +1091,44 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
       return "";
     });
     spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    // The stop went through — refusing here could not have un-killed anything.
+    expect(result.stopped).toBe(true);
+    expect(result.message).toMatch(/could not be checked after the kill/i);
+    expect(result.message).toMatch(/not confirmed that PID 4321 exited/i);
+    // ...and, crucially, the relaunch was attempted rather than abandoned.
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+
+    killSpy.mockRestore();
+  }, 30_000);
+
+  it("still REFUSES when the probe can see that our target is the one holding the port", async () => {
+    // The determinable half of the same situation: the kill did not work and the
+    // server is provably still running. Here a refusal costs a restart, not a
+    // server — so nothing is torn down and no second instance is launched.
+    usePlainInstallForIdentity();
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) return "";
+      if (/netstat/i.test(cmd)) {
+        return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) return "p4321\nn127.0.0.1:8188\n";
+      return "";
+    });
+    spawnCapturingChildren();
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
     const result = await restartComfyUI();
 
     expect(result.stopped).toBe(false);
-    expect(result.message).toMatch(/could not be checked after the kill/i);
-    expect(result.message).toMatch(/no evidence PID 4321 actually died/i);
+    expect(result.message).toMatch(/still holds port 8188/i);
     expect(result.message).toMatch(/nothing was torn down/i);
     expect(mockSpawn).not.toHaveBeenCalled();
 

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -478,22 +478,31 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
     });
     mockExistsSync.mockImplementation((p: string) => {
       const s = String(p);
-      return s === SM_MAIN || s === SM_PY;
+      return s === SM_MAIN || s === SM_PY || s === SM_ASSETS_ROOT;
     });
-    // statSync is what the launcher probe uses: EACCES on the tooling roots means
-    // "we could not look", which must not be spent as "there is nothing here".
+    // The layout is CORROBORATED — `Data/Assets` is present — and it is the
+    // PortableGit directory that cannot be read. EACCES means "we could not look",
+    // which must not be spent as "there is nothing here": that would relaunch a
+    // launcher-managed server without the environment it needs.
+    //
+    // Note the corroboration is deliberately positive. An install whose ONLY
+    // Stability Matrix evidence is an unreadable sibling is NOT treated as one —
+    // unreadable evidence cannot prove the other shape either, and refusing there
+    // would strand a plain install that merely lives under a `Data/Packages` path.
     mockStatThrows.value = (p: string) => {
       const s = String(p);
-      if (s === SM_GIT_ROOT || s === SM_ASSETS_ROOT || s === SM_FFMPEG_ROOT) {
-        return errno("EACCES", "permission denied");
-      }
+      if (s === SM_GIT_ROOT) return errno("EACCES", "permission denied");
       return undefined;
     };
 
     const message = await expectRefusedBeforeStopping();
 
-    expect(message).toMatch(/could not be read/i);
-    expect(message).toMatch(/Restart ComfyUI from its launcher/i);
+    // Refused through the ordinary component-evidence path: an unreadable
+    // PortableGit is `ambiguous`, exactly like one that exists but whose binary
+    // cannot be located. There is no separate "inaccessible" verdict to maintain.
+    expect(message).toMatch(/Stability Matrix/i);
+    expect(message).toMatch(/bundled Git/i);
+    expect(message).toMatch(/Restart ComfyUI from Stability Matrix/i);
   });
 
   it("REFUSES when the launcher's config EXISTS but cannot be read", async () => {
@@ -1587,6 +1596,53 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     killSpy.mockRestore();
   });
 
+  it("does NOT convict a departed child when the server's argv is UNREADABLE", async () => {
+    // The third leg of a tri-state, which is how the polarity bug survived: the
+    // existing tests covered `match` and `differ`, so testing `=== "match"` and
+    // defaulting the rest to `not-ours` looked correct. `unknown` — the serving
+    // argv could not be obtained — is an ABSENCE, and must degrade exactly as a
+    // match does. Otherwise the wrapper-launched user this branch exists to protect
+    // is told their own server is not theirs whenever the argv cannot be read.
+    usePlainInstall();
+    servingArgvAfterRestart("unreachable");
+    const children = spawnCapturingChildren(4321);
+    let killed = false;
+    let relaunched = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed && !relaunched
+          ? ""
+          : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && !relaunched) throw noListener();
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        relaunched = true;
+        // The wrapper we spawned has exited; its grandchild serves the port.
+        children[0]?.emit("exit", 0, null);
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("unconfirmed");
+    expect(result.message).not.toMatch(/NOT as a result of this restart/i);
+
+    killSpy.mockRestore();
+  });
+
   it("does NOT claim a matching PID as ours when the child is already gone but its `exit` event has not been delivered", async () => {
     // The lifecycle race: our child dies, the OS reuses its number for a program
     // that binds the port, and readiness sees that healthy replacement BEFORE Node
@@ -1794,6 +1850,56 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     // 9999 IS our grandchild — lineage alone would say "ours".
     __processControlTestHooks.setParentPidResolver((pid) =>
       pid === 9999 ? 4321 : pid === 4321 ? process.pid : 1,
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        relaunched = true;
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("not-ours");
+    expect(result.started).toBe(false);
+    expect(result.message).not.toMatch(/restarted successfully/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("does NOT claim a SIBLING of this call's child — ancestry under the orchestrator is not ancestry under the launch", async () => {
+    // The stale-instance case. A ComfyUI started by an EARLIER request is also a
+    // descendant of this long-lived MCP process, has identical argv, and may still
+    // hold the port. Tracing ancestry to the ORCHESTRATOR reports it as ours and
+    // announces a restart that never happened — while the child we just spawned may
+    // have died on a bind failure. Lineage has to be traced to THIS launch's child.
+    usePlainInstall();
+    spawnCapturingChildren(4321);
+    let killed = false;
+    let relaunched = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|kill/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed && !relaunched
+          ? ""
+          : `  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       ${relaunched ? 7777 : 4321}`;
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && !relaunched) throw noListener();
+        return `p${relaunched ? 7777 : 4321}
+n127.0.0.1:8188
+`;
+      }
+      return "";
+    });
+    // 7777 is a SIBLING: its parent is the orchestrator, not our child 4321.
+    __processControlTestHooks.setParentPidResolver((pid) =>
+      pid === 7777 ? process.pid : pid === 4321 ? process.pid : 1,
     );
     vi.stubGlobal(
       "fetch",

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -1718,6 +1718,54 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     killSpy.mockRestore();
   });
 
+  it("does NOT claim a DESCENDANT listener that is running something other than what we launched", async () => {
+    // Lineage says the port owner is in our tree, but the server reports different
+    // launch arguments — our wrapper stayed alive and brought up a different (or
+    // stale) ComfyUI. Being in our tree does not make it the process we launched,
+    // so this must not read as a successful restart.
+    usePlainInstall();
+    servingArgvAfterRestart([join(resolve("OtherComfy"), "main.py"), "--port", "8188"]);
+    spawnCapturingChildren(4321);
+    let killed = false;
+    let relaunched = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed && !relaunched
+          ? ""
+          : `  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       ${relaunched ? 9999 : 4321}`;
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && !relaunched) throw noListener();
+        return `p${relaunched ? 9999 : 4321}\nn127.0.0.1:8188\n`;
+      }
+      return "";
+    });
+    // 9999 IS our grandchild — lineage alone would say "ours".
+    __processControlTestHooks.setParentPidResolver((pid) =>
+      pid === 9999 ? 4321 : pid === 4321 ? process.pid : 1,
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        relaunched = true;
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("not-ours");
+    expect(result.started).toBe(false);
+    expect(result.message).not.toMatch(/restarted successfully/i);
+
+    killSpy.mockRestore();
+  });
+
   it("reports a listener OUTSIDE our process tree as not-ours", async () => {
     usePlainInstall();
     spawnCapturingChildren(4321);

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -583,9 +583,12 @@ describe("restart_comfyui — irreproducible launcher environments (#776)", () =
       PINOKIO_APP_NAME: "comfy",
     };
     __processControlTestHooks.setLiveEnvResolver(() => ({ ...LIVE_ENV }));
-    // A STABLE process identity across the read — the capture is only adopted
-    // when the pid provably still denotes the same process.
-    __processControlTestHooks.setProcessIdentityResolver(() => ({ startedAt: "t1" }));
+    // A STABLE identity that also CORROBORATES the server's own argv — the capture
+    // is only adopted when the pid provably still denotes that same ComfyUI.
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "t1",
+      commandLine: `${PINOKIO_PY} ${PINOKIO_MAIN} --port 8188`,
+    }));
     mockLivePortThenFree();
     spawnCapturingChildren();
     vi.stubGlobal(
@@ -607,11 +610,14 @@ describe("restart_comfyui — irreproducible launcher environments (#776)", () =
 });
 
 describe("restart_comfyui — a PID is not a process identity (#776)", () => {
+  const PINOKIO_ARGV = [PINOKIO_MAIN, "--port", "8188"];
+  const PLAIN_ARGV = [PLAIN_MAIN, "--port", "8188"];
+
   function usePinokioInstall(): void {
     mockFindComfyuiPython.mockReturnValue(PINOKIO_PY);
     mockLiveRootFromArgv.mockReturnValue(PINOKIO_APP);
     mockGetSystemStats.mockResolvedValue({
-      system: { argv: [PINOKIO_MAIN, "--port", "8188"] },
+      system: { argv: PINOKIO_ARGV },
     });
     mockExistsSync.mockImplementation((p: string) => {
       const s = String(p);
@@ -624,13 +630,22 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
     });
   }
 
-  /** An identity reader that returns the given stamps in call order. */
-  function identitySequence(stamps: string[]): void {
+  /**
+   * An identity reader returning the given (creation-time, command-line) pairs in
+   * call order. A plain string is shorthand for "this stamp, still running the
+   * ComfyUI we identified".
+   */
+  function identitySequence(
+    steps: Array<string | { startedAt: string; commandLine: string }>,
+    matchingArgv: string[],
+  ): void {
     let i = 0;
     __processControlTestHooks.setProcessIdentityResolver(() => {
-      const stamp = stamps[Math.min(i, stamps.length - 1)];
+      const step = steps[Math.min(i, steps.length - 1)];
       i++;
-      return { startedAt: stamp };
+      return typeof step === "string"
+        ? { startedAt: step, commandLine: matchingArgv.join(" ") }
+        : step;
     });
   }
 
@@ -645,7 +660,8 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
       PATH: "/some/unrelated/process/path",
       NOT_COMFYUI: "1",
     }));
-    identitySequence(["t1", "t2"]); // lookup, then re-verify after the env read
+    // lookup, then the re-verify after the env read sees a different process.
+    identitySequence(["t1", "t2"], PINOKIO_ARGV);
     mockLivePortThenFree();
     spawnCapturingChildren();
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
@@ -654,6 +670,34 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
 
     expect(result.stopped).toBe(false);
     expect(result.started).toBe(false);
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(result.message).toMatch(/Pinokio/);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("does NOT bind to a PID whose command line does not match the argv ComfyUI reported", async () => {
+    // The gap a creation-time stamp alone cannot close: if the pid was recycled
+    // BEFORE we ever read its stamp, every later re-read agrees with itself about
+    // the WRONG process. The independent signal is the server's own /system_stats
+    // argv — an unrelated program on that number cannot match it. Same proof as
+    // above: this Pinokio install is only restartable via a live environment, so
+    // rejecting the binding must drop it back to the refusal.
+    usePinokioInstall();
+    __processControlTestHooks.setLiveEnvResolver(() => ({ NOT_COMFYUI: "1" }));
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "t9",
+      commandLine: "/usr/bin/some-unrelated-daemon --serve",
+    }));
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
     expect(result.message).toMatch(/refusing to restart/i);
     expect(result.message).toMatch(/Pinokio/);
     expect(mockSpawn).not.toHaveBeenCalled();
@@ -704,7 +748,7 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
     // The stronger identity: the number is still listening, but it is not the
     // process we identified (#650's pid + creation-time identity).
     usePlainInstallForIdentity();
-    identitySequence(["t1", "t2"]); // lookup, then the pre-kill re-verify
+    identitySequence(["t1", "t2"], PLAIN_ARGV); // lookup, then the pre-kill re-verify
     mockLivePortThenFree();
     spawnCapturingChildren();
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
@@ -725,7 +769,7 @@ describe("restart_comfyui — a PID is not a process identity (#776)", () => {
     mockFindComfyuiPython.mockReturnValue(PLAIN_PY);
     mockLiveRootFromArgv.mockReturnValue(PLAIN_BASE);
     mockGetSystemStats.mockResolvedValue({
-      system: { argv: [PLAIN_MAIN, "--port", "8188"] },
+      system: { argv: PLAIN_ARGV },
     });
     mockExistsSync.mockImplementation((p: string) => {
       const s = String(p);
@@ -864,6 +908,48 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     killSpy.mockRestore();
   });
 
+  it("claims a successful restart ONLY when the port owner is matched to the process we launched", async () => {
+    // The one case where "restarted successfully" is a claim we can back: the
+    // mapped port owner IS our child's pid.
+    usePlainInstall();
+    spawnCapturingChildren(4321);
+    let killed = false;
+    let relaunched = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed && !relaunched
+          ? ""
+          : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed && !relaunched) throw new Error("not listening");
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        relaunched = true;
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.started).toBe(true);
+    expect(result.listener_ownership).toBe("ours");
+    expect(result.message).toMatch(/restarted successfully/i);
+    expect(result.message).not.toMatch(/could not be confirmed/i);
+
+    killSpy.mockRestore();
+  });
+
   it("says so plainly when listener ownership is UNDECIDABLE — without denying a restart that worked", async () => {
     // Unmappable port owner + a still-alive launched child. Reporting this as a
     // FAILED restart would mislabel every ordinary restart on hosts where the
@@ -898,6 +984,9 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     expect(result.ready).toBe(true);
     expect(result.listener_ownership).toBe("unconfirmed");
     expect(result.message).toMatch(/could not be confirmed as the process this call launched/i);
+    // ...and the headline must not ATTRIBUTE the healthy listener to this restart.
+    expect(result.message).not.toMatch(/restarted successfully/i);
+    expect(result.message).toMatch(/could not be confirmed as the one serving the port/i);
     // THE POINT of a string state: `undefined` would be dropped by JSON.stringify,
     // leaving a payload indistinguishable from one that never carried the field —
     // i.e. from a plain success. The uncertainty has to reach the consumer.

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -17,6 +17,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 class FakeChild extends EventEmitter {
   unref = vi.fn();
+  /**
+   * Node only leaves `pid` undefined when the spawn FAILED, so a fake that models
+   * a successful launch must carry one — 4321, matching the pid the port fixtures
+   * below report (#776 listener-ownership).
+   */
+  pid: number | undefined = 4321;
 }
 
 const mockConfig = vi.hoisted(() => ({

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -218,6 +218,11 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
     // It did NOT take the refuse-safe branch — it actually restarted.
     expect(result.message).not.toMatch(/refusing to restart/i);
     expect(result.stopped).toBe(true);
+    // Ownership is asserted explicitly: `started` is derived from it (#776), so
+    // pinning only `started` would report "false" without saying which evidence
+    // produced it. The port is free after the kill in this fixture, so the port
+    // owner is unmappable and ownership is honestly unconfirmed — never "not-ours".
+    expect(result.listener_ownership).toBe("unconfirmed");
     expect(result.started).toBe(true);
     expect(result.ready).toBe(true);
 
@@ -481,6 +486,8 @@ describe("restart_comfyui — explicit absolute spawn cwd, truthful refusal (#71
 
     expect(result.message).not.toMatch(/refusing to restart/i);
     expect(result.stopped).toBe(true);
+    // See the note above: pin the evidence, not just the flag derived from it.
+    expect(result.listener_ownership).toBe("unconfirmed");
     expect(result.started).toBe(true);
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     const [exe, args, opts] = mockSpawn.mock.calls[0];

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -15,6 +15,20 @@ import { EventEmitter } from "node:events";
 import { isAbsolute, join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+/**
+ * `lsof` exiting 1 with no output — its convention for "ran fine, matched
+ * nothing", which the port probe reads as definite evidence the port is free.
+ * A bare `Error` carries neither an exit status nor an errno, so it means
+ * "I could not look" instead, and a caller waiting for the port to be released
+ * would wait out its whole budget. That difference is invisible on Windows (the
+ * netstat branch never reaches lsof) and hangs the suite on POSIX (#776).
+ */
+function noListener(): Error {
+  const err = new Error("no listener") as Error & { status?: number };
+  err.status = 1;
+  return err;
+}
+
 class FakeChild extends EventEmitter {
   unref = vi.fn();
   /**
@@ -131,7 +145,7 @@ function mockLivePortThenFree(): { killed: () => boolean } {
         : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
     }
     if (/lsof/i.test(cmd)) {
-      if (killed) throw new Error("not listening");
+      if (killed) throw noListener();
       // `lsof -nP -iTCP:PORT -sTCP:LISTEN -Fpn` field output: p<pid> / n<addr:port>.
       return "p4321\nn127.0.0.1:8188\n";
     }

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -166,6 +166,13 @@ beforeEach(() => {
     system: { argv: ["ComfyUI\\main.py", "--port", "8188"] },
   });
   __processControlTestHooks.reset();
+  // The identity bracket around /system_stats (#776) needs the port owner's process
+  // creation time at both ends — pid equality alone is what pid REUSE defeats. This
+  // module's child_process mock has no execFileSync, so the real reader cannot run;
+  // model the ordinary host where the stamp IS readable.
+  __processControlTestHooks.setProcessIdentityResolver(() => ({
+    startedAt: "stable-stamp",
+  }));
 });
 
 afterEach(() => {

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -16,16 +16,31 @@ import { isAbsolute, join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
- * `lsof` exiting 1 with no output — its convention for "ran fine, matched
- * nothing", which the port probe reads as definite evidence the port is free.
- * A bare `Error` carries neither an exit status nor an errno, so it means
- * "I could not look" instead, and a caller waiting for the port to be released
- * would wait out its whole budget. That difference is invisible on Windows (the
- * netstat branch never reaches lsof) and hangs the suite on POSIX (#776).
+ * `lsof -V` STATING that nothing is listening — the port is free.
+ *
+ * The exit status alone cannot say this: lsof exits 1 both when it searched and
+ * matched nothing AND when it could not search at all, and a run that enumerates
+ * nothing for lack of permission exits 1 with BOTH streams empty. So the probe
+ * keys on the `-V` marker, which is lsof positively naming what it failed to
+ * locate. Verified against lsof 4.99.4: with `-V` and nothing listening, status is
+ * 1 and `lsof: Internet address not located: TCP:<port>` goes to STDOUT; without
+ * `-V`, status is 1 and both streams are empty — the ambiguity that makes
+ * "quiet ⇒ free" unsound, so a fixture must not model absence as mere silence.
+ *
+ * Getting this wrong is invisible on Windows (the netstat branch never reaches
+ * lsof) and HANGS the suite on POSIX: a caller waiting for the port to be released
+ * never sees a release and waits out its whole budget (#776).
  */
 function noListener(): Error {
-  const err = new Error("no listener") as Error & { status?: number };
+  const err = new Error("no listener") as Error & {
+    status?: number;
+    stdout?: string;
+    stderr?: string;
+  };
   err.status = 1;
+  err.stdout =
+    "lsof: Internet address not located: TCP:8188\nlsof: TCP state not located: LISTEN\n";
+  err.stderr = "";
   return err;
 }
 
@@ -79,6 +94,14 @@ vi.mock("node:fs", () => ({
   // keep a throwing stub so any un-mocked call path stays refuse-safe (#535).
   readlinkSync: vi.fn(() => {
     throw new Error("no /proc in test");
+  }),
+  // The port probe reads the kernel socket tables and classifies a failure from its
+  // ERRNO: ENOENT ("no /proc on this host") hides nothing and leaves lsof as the
+  // only source, which is what these tests model. Omitting this entirely used to
+  // throw "readFileSync is not a function" — errno-less, i.e. "I could not look" —
+  // which would make every post-kill probe `unknown` and hang the suite.
+  readFileSync: vi.fn(() => {
+    throw Object.assign(new Error("no /proc in test"), { code: "ENOENT" });
   }),
   // isRegularFile(#535) calls statSync().isFile(); throw for non-existent paths so
   // it returns false, mirroring existsSync, and honor per-test isFile overrides.

--- a/src/__tests__/services/restart-posix-port-release.test.ts
+++ b/src/__tests__/services/restart-posix-port-release.test.ts
@@ -278,6 +278,188 @@ describe("restart_comfyui on POSIX — port release via lsof (#776)", () => {
     killSpy.mockRestore();
   }, 20_000);
 
+  it("does NOT claim a start when the port was never OBSERVED free before launching", async () => {
+    // The stop committed unverified, and the port lookup is unavailable from then
+    // on. We still launch (refusing after a kill could leave the server down), but
+    // readiness may be reaching the server that was ALREADY there — so a healthy
+    // API is not evidence that THIS call started anything.
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/kill/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw lsofMissing(); // probe unusable from here on
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.ready).toBe(true);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/never observed free before launching/i);
+    expect(result.message).not.toMatch(/restarted successfully/i);
+
+    killSpy.mockRestore();
+  }, 30_000);
+
+  it("does NOT treat CASE-DISTINCT POSIX paths as the same install", async () => {
+    // The dangerous direction. Folding case unconditionally made
+    // `/opt/PosixComfy/ComfyUI/main.py` and `/opt/posixcomfy/comfyui/main.py` —
+    // different directories on a case-sensitive filesystem — compare EQUAL, which
+    // fabricates a MATCH. A match can promote a descendant listener to "ours" and
+    // so license stopping a process that is not ours.
+    //
+    // Driven through the child-exited branch, where the argv comparison decides:
+    // a fabricated match would read "unconfirmed", the real answer is "not-ours".
+    let answers = 0;
+    mockGetSystemStats.mockImplementation(async () => {
+      answers++;
+      return {
+        system: {
+          argv:
+            answers <= 2
+              ? ARGV
+              : ["/opt/posixcomfy/comfyui/main.py", "--port", "8188"],
+        },
+      };
+    });
+    let killed = false;
+    const children: FakeChild[] = [];
+    mockSpawn.mockImplementation(() => {
+      const child = new FakeChild();
+      children.push(child);
+      return child;
+    });
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/kill/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw lsofNoMatches();
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        children[0]?.emit("exit", 0, null);
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("not-ours");
+
+    killSpy.mockRestore();
+  }, 20_000);
+
+  it("DOES treat case-distinct WINDOWS paths as the same install", async () => {
+    // The other half of the same rule: Windows filesystems ARE case-insensitive, so
+    // folding is correct there — and withholding it would manufacture a spurious
+    // "different program" for a perfectly ordinary Windows install.
+    let answers = 0;
+    mockGetSystemStats.mockImplementation(async () => {
+      answers++;
+      return {
+        system: {
+          argv: answers <= 2 ? ARGV : ["COMFYUI\\MAIN.PY", "--port", "8188"],
+        },
+      };
+    });
+    let killed = false;
+    const children: FakeChild[] = [];
+    mockSpawn.mockImplementation(() => {
+      const child = new FakeChild();
+      children.push(child);
+      return child;
+    });
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/kill/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw lsofNoMatches();
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        children[0]?.emit("exit", 0, null);
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("unconfirmed");
+
+    killSpy.mockRestore();
+  }, 20_000);
+
+  it("treats `.`/`..` spellings of the SAME path as equal, not as a difference", async () => {
+    let answers = 0;
+    mockGetSystemStats.mockImplementation(async () => {
+      answers++;
+      return {
+        system: {
+          argv:
+            answers <= 2
+              ? ARGV
+              : ["/opt/PosixComfy/x/../ComfyUI/./main.py", "--port", "8188"],
+        },
+      };
+    });
+    let killed = false;
+    const children: FakeChild[] = [];
+    mockSpawn.mockImplementation(() => {
+      const child = new FakeChild();
+      children.push(child);
+      return child;
+    });
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/kill/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw lsofNoMatches();
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        children[0]?.emit("exit", 0, null);
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("unconfirmed");
+
+    killSpy.mockRestore();
+  }, 20_000);
+
   it("does NOT read a MISSING lsof as proof the port is free", async () => {
     // A container without lsof. The probe did not run, so the stop cannot claim the
     // process died — but it still commits and relaunches, because a refusal after

--- a/src/__tests__/services/restart-posix-port-release.test.ts
+++ b/src/__tests__/services/restart-posix-port-release.test.ts
@@ -1,0 +1,216 @@
+// The restart flow on POSIX, where the port is probed with `lsof` (#776).
+//
+// This file exists because of a failure that NO amount of local testing on Windows
+// could have caught. `probePortOwner` distinguishes "the port is free" from "I
+// could not look", and on POSIX it draws that distinction from how `lsof` FAILED:
+// exit 1 means "ran fine, matched nothing"; anything else means the probe itself
+// did not work. The rest of the suite modelled "nothing is listening" as a bare
+// `throw new Error(...)`, which carries neither an exit status nor an errno — so on
+// POSIX every post-kill wait read it as "could not look", polled for its full
+// budget, and the tests timed out. On Windows the netstat branch answers first and
+// never reaches lsof, so the same suite was green.
+//
+// The platform is therefore MOCKED here rather than inherited, so this path is
+// exercised on every developer machine and not only on a Linux runner.
+
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class FakeChild extends EventEmitter {
+  unref = vi.fn();
+  pid: number | undefined = 4321;
+}
+
+const mockConfig = vi.hoisted(() => ({
+  resolvedPort: 8188,
+  comfyuiPath: undefined as string | undefined,
+}));
+const mockExecSync = vi.hoisted(() => vi.fn());
+const mockSpawn = vi.hoisted(() => vi.fn());
+const mockGetSystemStats = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn((_p: string) => true));
+const mockFindComfyuiPython = vi.hoisted(() => vi.fn());
+
+// FORCE THE POSIX BRANCH. port-owner captures `IS_WIN` at module load, so the
+// platform has to be mocked before it is imported.
+vi.mock("node:os", () => ({ platform: () => "linux" }));
+
+vi.mock("../../config.js", () => ({
+  config: mockConfig,
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyUIAuthHeaders: () => ({}),
+  isRemoteMode: () => false,
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: mockExecSync,
+  spawn: mockSpawn,
+  execFile: vi.fn(),
+  execFileSync: vi.fn(() => {
+    throw new Error("no process reader in test");
+  }),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: mockExistsSync,
+  readlinkSync: vi.fn(() => {
+    throw new Error("no /proc in test");
+  }),
+  readFileSync: vi.fn(() => {
+    throw new Error("no /proc in test");
+  }),
+  statSync: vi.fn((p: string) => {
+    if (!mockExistsSync(String(p))) throw new Error("ENOENT");
+    return { isFile: () => true, isDirectory: () => false };
+  }),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getSystemStats: mockGetSystemStats,
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../services/env-capabilities.js", () => ({
+  findComfyuiPython: mockFindComfyuiPython,
+}));
+
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveEffectiveComfyUIBase: () => BASE,
+  liveRootFromArgv: () => BASE,
+  markLocalComfyUILaunched: vi.fn(),
+  resetLocalComfyUILaunchState: vi.fn(),
+}));
+
+import {
+  __processControlTestHooks,
+  restartComfyUI,
+} from "../../services/process-control.js";
+
+// POSIX-DIALECT LITERALS, deliberately not `path.join`/`resolve`. The platform is
+// mocked to linux, so every separator-sensitive comparison downstream (notably
+// commandLineMatchesArgv, which normalises differently per platform) evaluates as
+// POSIX. Building these with the host's `path` would produce Windows separators
+// under a POSIX-thinking comparison — a test written in one dialect and evaluated
+// in the other, which is its own class of false result.
+const BASE = "/opt/PosixComfy/ComfyUI";
+const MAIN = `${BASE}/main.py`;
+const PYTHON = `${BASE}/venv/bin/python`;
+const ARGV = [MAIN, "--port", "8188"];
+
+/** `lsof` exiting 1 with no output: "ran fine, matched nothing". */
+function lsofNoMatches(): Error {
+  const err = new Error("no listener") as Error & { status?: number };
+  err.status = 1;
+  return err;
+}
+
+/** `lsof` not installed — the shell reports 127. The probe did NOT run. */
+function lsofMissing(): Error {
+  const err = new Error("sh: lsof: not found") as Error & { status?: number };
+  err.status = 127;
+  return err;
+}
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  process.env = { ...ORIGINAL_ENV };
+  process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+  process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "1";
+  mockConfig.resolvedPort = 8188;
+  mockConfig.comfyuiPath = BASE;
+  mockFindComfyuiPython.mockReturnValue(PYTHON);
+  mockExistsSync.mockImplementation((p: string) => {
+    const s = String(p);
+    return s === MAIN || s === PYTHON || s === BASE;
+  });
+  mockGetSystemStats.mockResolvedValue({ system: { argv: ARGV } });
+  mockSpawn.mockImplementation(() => new FakeChild());
+  __processControlTestHooks.reset();
+  __processControlTestHooks.setProcessIdentityResolver(() => ({
+    startedAt: "stable-stamp",
+  }));
+  __processControlTestHooks.setParentPidResolver(() => process.pid);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  process.env = { ...ORIGINAL_ENV };
+  __processControlTestHooks.reset();
+});
+
+describe("restart_comfyui on POSIX — port release via lsof (#776)", () => {
+  it("completes PROMPTLY when lsof reports the port free after the kill", async () => {
+    // The regression: reading lsof's exit-1 as "could not look" made the port-free
+    // wait burn its entire budget on every successful restart. A generous ceiling
+    // here still fails loudly against that behaviour (the wait is 15s).
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/kill/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw lsofNoMatches();
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const startedAt = Date.now();
+    const result = await restartComfyUI();
+    const elapsed = Date.now() - startedAt;
+
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    expect(elapsed).toBeLessThan(8000);
+
+    killSpy.mockRestore();
+  }, 20_000);
+
+  it("does NOT read a MISSING lsof as proof the port is free", async () => {
+    // A container without lsof. The probe did not run, so the stop cannot claim the
+    // process died — but it still commits and relaunches, because a refusal after
+    // the kill could not restore anything.
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/kill/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw lsofMissing();
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(true);
+    expect(result.message).toMatch(/could not be checked after the kill/i);
+    // ...and the server was brought back rather than abandoned.
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+
+    killSpy.mockRestore();
+  }, 30_000);
+});

--- a/src/__tests__/services/restart-posix-port-release.test.ts
+++ b/src/__tests__/services/restart-posix-port-release.test.ts
@@ -56,8 +56,13 @@ vi.mock("node:fs", () => ({
   readlinkSync: vi.fn(() => {
     throw new Error("no /proc in test");
   }),
+  // ENOENT, not a bare Error: the port probe classifies a failed kernel-table read
+  // from its ERRNO. "The table does not exist" (this host has no /proc) hides
+  // nothing and leaves lsof as the only source, which is the host these tests
+  // model; an errno-less failure reads as "I could not look" — a blind spot that
+  // would make every lsof answer here `unknown`.
   readFileSync: vi.fn(() => {
-    throw new Error("no /proc in test");
+    throw Object.assign(new Error("no /proc in test"), { code: "ENOENT" });
   }),
   statSync: vi.fn((p: string) => {
     if (!mockExistsSync(String(p))) throw new Error("ENOENT");

--- a/src/__tests__/services/restart-posix-port-release.test.ts
+++ b/src/__tests__/services/restart-posix-port-release.test.ts
@@ -125,6 +125,9 @@ beforeEach(() => {
   process.env = { ...ORIGINAL_ENV };
   process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
   process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "1";
+  // Keep the port-free wait short: these fixtures deliberately exercise the
+  // TIMEOUT path, and 15s of real waiting per test destabilises the whole suite.
+  process.env.COMFYUI_PORT_FREE_TIMEOUT_S = "1";
   mockConfig.resolvedPort = 8188;
   mockConfig.comfyuiPath = BASE;
   mockFindComfyuiPython.mockReturnValue(PYTHON);
@@ -151,8 +154,10 @@ afterEach(() => {
 describe("restart_comfyui on POSIX — port release via lsof (#776)", () => {
   it("completes PROMPTLY when lsof reports the port free after the kill", async () => {
     // The regression: reading lsof's exit-1 as "could not look" made the port-free
-    // wait burn its entire budget on every successful restart. A generous ceiling
-    // here still fails loudly against that behaviour (the wait is 15s).
+    // wait burn its entire budget on every successful restart. The budget is raised
+    // back to 10s for THIS test so the ceiling below actually proves the wait
+    // resolved early, rather than passing because the budget itself was short.
+    process.env.COMFYUI_PORT_FREE_TIMEOUT_S = "10";
     let killed = false;
     mockExecSync.mockImplementation((cmd: string) => {
       if (/kill/i.test(cmd)) {
@@ -178,6 +183,97 @@ describe("restart_comfyui on POSIX — port release via lsof (#776)", () => {
     expect(result.stopped).toBe(true);
     expect(result.started).toBe(true);
     expect(elapsed).toBeLessThan(8000);
+
+    killSpy.mockRestore();
+  }, 20_000);
+
+  /** Port owned while identifying, then unmappable for good once the kill lands. */
+  function killThenUnmappablePort(): void {
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/kill/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw lsofNoMatches();
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+  }
+
+  it("does NOT fabricate 'not-ours' when the port owner is UNMAPPABLE", async () => {
+    // No listener can be identified at all after the kill. "I could not determine
+    // who owns this listener" must not be reported as "I determined this listener is
+    // not ours" — `not-ours` is a POSITIVE finding about an identified process,
+    // never the shape of an absence.
+    killThenUnmappablePort();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("unconfirmed");
+    expect(result.started).toBe(true);
+
+    killSpy.mockRestore();
+  }, 20_000);
+
+  it("does NOT read a WINDOWS-flavoured sys.argv as a different program", async () => {
+    // `sys.argv` follows the SERVER, not us: a Windows-launched ComfyUI answers
+    // `ComfyUI\main.py` however this orchestrator is running. Compared with
+    // host-dialect normalisation that never matches our POSIX-resolved absolute
+    // path, and the "difference" reported is really "I could not compare these".
+    //
+    // Driven through the child-exited branch, where the argv comparison is what
+    // decides: our direct child is gone (positive evidence), so a genuine mismatch
+    // would say `not-ours` — only a correct match keeps it at `unconfirmed`.
+    let answers = 0;
+    mockGetSystemStats.mockImplementation(async () => {
+      answers++;
+      // Identification uses the absolute argv; the server that answers AFTER the
+      // relaunch reports the Windows-flavoured relative form of the same script.
+      return {
+        system: {
+          argv: answers <= 2 ? ARGV : ["ComfyUI\\main.py", "--port", "8188"],
+        },
+      };
+    });
+    let killed = false;
+    const children: FakeChild[] = [];
+    mockSpawn.mockImplementation(() => {
+      const child = new FakeChild();
+      children.push(child);
+      return child;
+    });
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/kill/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw lsofNoMatches();
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        // The process we launched is gone — the branch where argv decides.
+        children[0]?.emit("exit", 0, null);
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("unconfirmed");
 
     killSpy.mockRestore();
   }, 20_000);

--- a/src/__tests__/services/restart-posix-port-release.test.ts
+++ b/src/__tests__/services/restart-posix-port-release.test.ts
@@ -102,10 +102,32 @@ const MAIN = `${BASE}/main.py`;
 const PYTHON = `${BASE}/venv/bin/python`;
 const ARGV = [MAIN, "--port", "8188"];
 
-/** `lsof` exiting 1 with no output: "ran fine, matched nothing". */
+/**
+ * `lsof -V` positively STATING that nothing is listening — verbatim the shape a
+ * real lsof produces (status 1, the "not located" line on stdout). This marker,
+ * not the exit status, is what makes "the port is free" an actual finding: a
+ * permission-restricted run also exits 1, and does so with empty stdout AND empty
+ * stderr, so silence proves nothing.
+ */
 function lsofNoMatches(): Error {
-  const err = new Error("no listener") as Error & { status?: number };
+  const err = new Error("no listener") as Error & {
+    status?: number;
+    stdout?: string;
+    stderr?: string;
+  };
   err.status = 1;
+  err.stdout = "lsof: Internet address not located: TCP:8188\n";
+  err.stderr = "";
+  return err;
+}
+
+/** `lsof` exiting 1 SILENTLY — the shape a restricted enumeration produces. Not
+ *  a statement about the port, and must never be read as one. */
+function lsofQuietFailure(): Error {
+  const err = new Error("") as Error & { status?: number; stdout?: string; stderr?: string };
+  err.status = 1;
+  err.stdout = "";
+  err.stderr = "";
   return err;
 }
 
@@ -159,21 +181,29 @@ describe("restart_comfyui on POSIX — port release via lsof (#776)", () => {
     // resolved early, rather than passing because the budget itself was short.
     process.env.COMFYUI_PORT_FREE_TIMEOUT_S = "10";
     let killed = false;
+    let relaunched = false;
     mockExecSync.mockImplementation((cmd: string) => {
       if (/kill/i.test(cmd)) {
         killed = true;
         return "";
       }
       if (/lsof/i.test(cmd)) {
-        if (killed) throw lsofNoMatches();
+        // Free once the kill lands, then owned again by the relaunched child. That
+        // is the ordinary successful shape — and the only one that can PROVE a
+        // start, now that a claim requires identifying our own listener.
+        if (killed && !relaunched) throw lsofNoMatches();
         return "p4321\nn127.0.0.1:8188\n";
       }
       return "";
     });
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({ ok: true }) as Response),
+      vi.fn(async () => {
+        relaunched = true;
+        return { ok: true } as Response;
+      }),
     );
+    __processControlTestHooks.setParentPidResolver(() => process.pid);
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
     const startedAt = Date.now();
@@ -181,6 +211,7 @@ describe("restart_comfyui on POSIX — port release via lsof (#776)", () => {
     const elapsed = Date.now() - startedAt;
 
     expect(result.stopped).toBe(true);
+    expect(result.listener_ownership).toBe("ours");
     expect(result.started).toBe(true);
     expect(elapsed).toBeLessThan(8000);
 
@@ -218,7 +249,13 @@ describe("restart_comfyui on POSIX — port release via lsof (#776)", () => {
     const result = await restartComfyUI();
 
     expect(result.listener_ownership).toBe("unconfirmed");
+    // `started` stays TRUE for `unconfirmed` by standing ruling: denying it would
+    // report every ordinary restart as failed on a host whose port-owner lookup is
+    // unavailable. What must NOT happen is a definite verdict — and the message
+    // qualifies the claim rather than asserting proof.
+    expect(result.ready).toBe(true);
     expect(result.started).toBe(true);
+    expect(result.message).not.toMatch(/restarted successfully/i);
 
     killSpy.mockRestore();
   }, 20_000);
@@ -304,7 +341,11 @@ describe("restart_comfyui on POSIX — port release via lsof (#776)", () => {
     const result = await restartComfyUI();
 
     expect(result.ready).toBe(true);
-    expect(result.started).toBe(false);
+    // The stale pre-launch observation carries no CLAIM either way — it is a fact
+    // about a moment that has passed. What it still earns is disclosure: the
+    // message states that the port was never seen free, so a reader knows the
+    // healthy API may be the server that was already there.
+    expect(result.listener_ownership).toBe("unconfirmed");
     expect(result.message).toMatch(/never observed free before launching/i);
     expect(result.message).not.toMatch(/restarted successfully/i);
 
@@ -370,12 +411,29 @@ describe("restart_comfyui on POSIX — port release via lsof (#776)", () => {
     // The other half of the same rule: Windows filesystems ARE case-insensitive, so
     // folding is correct there — and withholding it would manufacture a spurious
     // "different program" for a perfectly ordinary Windows install.
+    //
+    // The launch path must be DRIVE-ROOTED, which is what identifies the dialect.
+    // A bare `COMFYUI\MAIN.PY` alone cannot: backslashes with no drive are equally
+    // a legal POSIX filename, and folding on that evidence is the false-match bug
+    // the sibling test guards. On a real Windows host our side is always rooted,
+    // so the pair folds; pairing a POSIX launch path with a Windows-cased serving
+    // argv is a combination that cannot occur.
+    const WIN_MAIN = "C:\\Comfy\\ComfyUI\\main.py";
+    const WIN_PY = "C:\\Comfy\\ComfyUI\\venv\\Scripts\\python.exe";
+    mockFindComfyuiPython.mockReturnValue(WIN_PY);
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === WIN_MAIN || s === WIN_PY;
+    });
     let answers = 0;
     mockGetSystemStats.mockImplementation(async () => {
       answers++;
       return {
         system: {
-          argv: answers <= 2 ? ARGV : ["COMFYUI\\MAIN.PY", "--port", "8188"],
+          argv:
+            answers <= 2
+              ? [WIN_MAIN, "--port", "8188"]
+              : ["COMFYUI\\MAIN.PY", "--port", "8188"],
         },
       };
     });
@@ -459,6 +517,146 @@ describe("restart_comfyui on POSIX — port release via lsof (#776)", () => {
 
     killSpy.mockRestore();
   }, 20_000);
+
+  it("does NOT fold case for a POSIX path that merely CONTAINS a backslash", async () => {
+    // Backslash is a legal filename character on POSIX. Treating it as a Windows
+    // marker enabled case folding, so `/srv/Comfy\A` and `/srv/comfy\a` — two
+    // different installs — compared equal. That is the false-MATCH direction, and
+    // with a descendant listener a false match promotes to `ours`, which licenses
+    // stopping a process that is not ours.
+    let answers = 0;
+    mockGetSystemStats.mockImplementation(async () => {
+      answers++;
+      return {
+        system: {
+          argv:
+            answers <= 2
+              ? ["/opt/Comfy\\A/main.py", "--port", "8188"]
+              : ["/opt/comfy\\a/main.py", "--port", "8188"],
+        },
+      };
+    });
+    mockFindComfyuiPython.mockReturnValue("/opt/Comfy\\A/venv/bin/python");
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === "/opt/Comfy\\A/main.py" || s === "/opt/Comfy\\A/venv/bin/python";
+    });
+    let killed = false;
+    const children: FakeChild[] = [];
+    mockSpawn.mockImplementation(() => {
+      const child = new FakeChild();
+      children.push(child);
+      return child;
+    });
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/kill/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw lsofNoMatches();
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        children[0]?.emit("exit", 0, null);
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.listener_ownership).toBe("not-ours");
+
+    killSpy.mockRestore();
+  }, 20_000);
+
+  it("cannot compare DRIVE-RELATIVE paths, and says so rather than matching them", async () => {
+    // `C:ComfyUI\main.py` resolves against that drive's own working directory, so
+    // identical text can denote different installs in two processes. Comparing it
+    // as if it were a location is a fabricated match.
+    let answers = 0;
+    mockGetSystemStats.mockImplementation(async () => {
+      answers++;
+      return {
+        system: {
+          argv: answers <= 2 ? ARGV : ["C:ComfyUI\\main.py", "--port", "8188"],
+        },
+      };
+    });
+    let killed = false;
+    const children: FakeChild[] = [];
+    mockSpawn.mockImplementation(() => {
+      const child = new FakeChild();
+      children.push(child);
+      return child;
+    });
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/kill/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw lsofNoMatches();
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        children[0]?.emit("exit", 0, null);
+        return { ok: true } as Response;
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    // Not comparable => "unknown" => the departed-child branch degrades rather
+    // than convicting, and certainly does not promote.
+    expect(result.listener_ownership).toBe("unconfirmed");
+
+    killSpy.mockRestore();
+  }, 20_000);
+
+  it("does NOT read a SILENT lsof failure as proof the port is free", async () => {
+    // The inverse of the fix: a restricted enumeration exits 1 having listed
+    // nothing and says nothing on either stream. Reading "quiet" as "free" would
+    // certify a release that never happened — and no `-w`/warning heuristic can
+    // rescue it, since the silence is indistinguishable. Only lsof's explicit
+    // "Internet address not located" is a finding.
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/kill/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw lsofQuietFailure();
+        return "p4321\nn127.0.0.1:8188\n";
+      }
+      return "";
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    // The stop still COMMITS (a refusal after the kill could not restore anything)
+    // but it is reported as unverified rather than as a confirmed release.
+    expect(result.stopped).toBe(true);
+    expect(result.message).toMatch(/could not be checked after the kill/i);
+
+    killSpy.mockRestore();
+  }, 30_000);
 
   it("does NOT read a MISSING lsof as proof the port is free", async () => {
     // A container without lsof. The probe did not run, so the stop cannot claim the

--- a/src/services/launcher-env.ts
+++ b/src/services/launcher-env.ts
@@ -100,6 +100,12 @@ export interface StabilityMatrixLayout {
   gitExe?: string;
   /** `<Data>/Assets/ffmpeg[/bin]` — absent when not on disk. */
   ffmpegDir?: string;
+  /**
+   * TRUE when `<Data>/Assets/ffmpeg` exists but no ffmpeg binary could be found
+   * inside it — a layout we do not understand, which must refuse rather than
+   * relaunch with an incomplete reconstruction.
+   */
+  ffmpegPresentButUnresolved: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -178,9 +184,12 @@ function dirOf(p: string): string | undefined {
  * Stability Matrix keeps every package under `<Data>/Packages/<PackageName>` and
  * its shared tooling as siblings of `Packages` (`<Data>/PortableGit`,
  * `<Data>/Assets`). So: find an ancestor literally named `Packages` whose parent
- * either is named `Data` or actually HOLDS one of those tooling directories.
- * Both halves are evidence, not assumption — a directory that merely happens to
- * be called `Packages` never matches on its own.
+ * ACTUALLY HOLDS one of those tooling directories on disk.
+ *
+ * The tooling directory is REQUIRED corroboration, never inferred from a name: a
+ * perfectly ordinary install that happens to live under some `…/Data/Packages/…`
+ * path must NOT be mistaken for a Stability Matrix one, because that
+ * misclassification would refuse a restart that works today.
  */
 export function detectStabilityMatrix(
   paths: ReadonlyArray<string | undefined>,
@@ -191,29 +200,33 @@ export function detectStabilityMatrix(
       if (basenameOf(ancestor).toLowerCase() !== "packages") continue;
       const dataRoot = dirOf(ancestor);
       if (!dataRoot) continue;
-      const isDataRoot =
-        basenameOf(dataRoot).toLowerCase() === "data" ||
-        pathExists(joinPath(dataRoot, "PortableGit")) ||
-        pathExists(joinPath(dataRoot, "Assets"));
-      if (!isDataRoot) continue;
+      const gitRoot = joinPath(dataRoot, "PortableGit");
+      const ffmpegRoot = joinPath(dataRoot, "Assets", "ffmpeg");
+      const hasGitRoot = pathExists(gitRoot);
+      const hasFfmpegRoot = pathExists(ffmpegRoot);
+      // No Stability Matrix tooling beside `Packages` → not a Stability Matrix
+      // install (or one with nothing to inject). Either way there is nothing to
+      // reconstruct, so fall through to the ordinary inherit path.
+      if (!hasGitRoot && !hasFfmpegRoot) continue;
 
       const gitExe = firstExisting([
-        joinPath(dataRoot, "PortableGit", "cmd", "git.exe"),
-        joinPath(dataRoot, "PortableGit", "cmd", "git"),
-        joinPath(dataRoot, "PortableGit", "bin", "git.exe"),
-        joinPath(dataRoot, "PortableGit", "bin", "git"),
+        joinPath(gitRoot, "cmd", "git.exe"),
+        joinPath(gitRoot, "cmd", "git"),
+        joinPath(gitRoot, "bin", "git.exe"),
+        joinPath(gitRoot, "bin", "git"),
       ]);
       const ffmpegExe = firstExisting([
-        joinPath(dataRoot, "Assets", "ffmpeg", "bin", "ffmpeg.exe"),
-        joinPath(dataRoot, "Assets", "ffmpeg", "bin", "ffmpeg"),
-        joinPath(dataRoot, "Assets", "ffmpeg", "ffmpeg.exe"),
-        joinPath(dataRoot, "Assets", "ffmpeg", "ffmpeg"),
+        joinPath(ffmpegRoot, "bin", "ffmpeg.exe"),
+        joinPath(ffmpegRoot, "bin", "ffmpeg"),
+        joinPath(ffmpegRoot, "ffmpeg.exe"),
+        joinPath(ffmpegRoot, "ffmpeg"),
       ]);
       return {
         dataRoot,
         gitExe,
         gitDir: gitExe ? dirOf(gitExe) : undefined,
         ffmpegDir: ffmpegExe ? dirOf(ffmpegExe) : undefined,
+        ffmpegPresentButUnresolved: hasFfmpegRoot && !ffmpegExe,
       };
     }
   }
@@ -231,10 +244,21 @@ export function detectStabilityMatrix(
  * disk tells us what the running process actually got. Relaunching such a server
  * with OUR environment is precisely the #776 failure mode, so these refuse.
  */
-const OPAQUE_LAUNCHER_DIRS: ReadonlyArray<{ dir: string; name: string }> = [
-  { dir: "pinokio", name: "Pinokio" },
+const OPAQUE_LAUNCHER_DIRS: ReadonlyArray<{
+  dir: string;
+  name: string;
+  /** At least one of these must exist under the root — name alone is not proof. */
+  corroborate: string[];
+}> = [
+  // A Pinokio home holds `api/` (the installed apps) and `bin/` (its shims).
+  { dir: "pinokio", name: "Pinokio", corroborate: ["api", "bin"] },
 ];
 
+/**
+ * A recognized launcher whose environment we cannot rebuild. As with Stability
+ * Matrix, the directory NAME is only a candidate — the launcher's own layout must
+ * be corroborated on disk before we let it refuse a restart that otherwise works.
+ */
 export function detectOpaqueLauncher(
   paths: ReadonlyArray<string | undefined>,
 ): { name: string; root: string } | null {
@@ -243,7 +267,9 @@ export function detectOpaqueLauncher(
     for (const ancestor of ancestorsOf(p)) {
       const base = basenameOf(ancestor).toLowerCase();
       const hit = OPAQUE_LAUNCHER_DIRS.find((l) => l.dir === base);
-      if (hit) return { name: hit.name, root: ancestor };
+      if (!hit) continue;
+      if (!hit.corroborate.some((d) => pathExists(joinPath(ancestor, d)))) continue;
+      return { name: hit.name, root: ancestor };
     }
   }
   return null;
@@ -385,13 +411,28 @@ export function resolveLaunchEnvironment(
   // 2. Stability Matrix — reconstruct exactly what it injects, from disk.
   const sm = detectStabilityMatrix(input.paths);
   if (sm) {
-    const additions = [sm.gitDir, sm.ffmpegDir].filter(
-      (d): d is string => typeof d === "string" && d.length > 0,
-    );
-    if (additions.length === 0) {
-      // We KNOW this install is launcher-owned but found none of the tooling it
-      // injects. Reproducing the environment is impossible and inheriting ours
-      // is the exact #776 failure — refuse instead of guessing.
+    // PARTIAL reconstruction is NOT reconstruction (codex gate). Detection above
+    // only fires when at least one tooling root exists beside `Packages`, so this
+    // IS a launcher-owned install — and a component we can see but cannot resolve
+    // means we would relaunch it missing exactly the thing the launcher supplies.
+    // The git binary is the fatal one: without it ComfyUI-Manager aborts during
+    // import and the server never comes up at all (#776), so it is REQUIRED. An
+    // ffmpeg asset directory that exists but holds no recognizable binary is a
+    // shape we do not understand — refuse rather than half-rebuild.
+    const missing: string[] = [];
+    if (!sm.gitExe) {
+      missing.push(
+        `its bundled Git (looked under "${joinPath(sm.dataRoot, "PortableGit")}") — ` +
+          "without it ComfyUI-Manager aborts at import with \"Bad git executable\"",
+      );
+    }
+    if (sm.ffmpegPresentButUnresolved) {
+      missing.push(
+        `its bundled FFmpeg (found "${joinPath(sm.dataRoot, "Assets", "ffmpeg")}" but no ` +
+          "ffmpeg binary inside it)",
+      );
+    }
+    if (missing.length > 0) {
       return {
         reproducible: false,
         info: {
@@ -399,30 +440,30 @@ export function resolveLaunchEnvironment(
           reproducible: false,
           launcher: "Stability Matrix",
           note:
-            "Stability Matrix install detected, but its bundled Git/FFmpeg could not " +
-            "be located on disk — the launcher environment could NOT be reproduced",
+            "Stability Matrix install detected, but part of the tooling it injects could " +
+            "not be located on disk — the launcher environment could NOT be reproduced",
         },
         reason:
           `This ComfyUI is managed by Stability Matrix (${sm.dataRoot}), which launches it ` +
-          "with its own bundled Git and FFmpeg on PATH, but neither " +
-          `"${joinPath(sm.dataRoot, "PortableGit")}" nor ` +
-          `"${joinPath(sm.dataRoot, "Assets", "ffmpeg")}" could be found on disk, so that ` +
-          "environment cannot be reproduced here.",
+          `with its own bundled tooling on PATH, but this could not be located: ${missing.join("; ")}. ` +
+          "That environment cannot be reproduced here.",
         advice:
           "Restart ComfyUI from Stability Matrix itself so it comes back with the " +
           "environment its packages expect.",
       };
     }
+    const additions = [sm.gitDir, sm.ffmpegDir].filter(
+      (d): d is string => typeof d === "string" && d.length > 0,
+    );
     const { env, added } = withPathAdditions(baseEnv, additions);
-    if (sm.gitExe) {
-      // GitPython (ComfyUI-Manager) resolves `git` through this variable first;
-      // Stability Matrix sets it, and without it Manager aborts at import with
-      // "Bad git executable" even when PATH is right (#776).
-      const gitKey = findEnvKey(env, "GIT_PYTHON_GIT_EXECUTABLE") ?? "GIT_PYTHON_GIT_EXECUTABLE";
-      env[gitKey] = sm.gitExe;
-    }
-    const parts: string[] = [];
-    if (sm.gitDir) parts.push("PortableGit");
+    // GitPython (ComfyUI-Manager) resolves `git` through this variable first;
+    // Stability Matrix sets it, and without it Manager aborts at import with
+    // "Bad git executable" even when PATH is right (#776). Guaranteed present —
+    // a missing git refused above.
+    const gitKey =
+      findEnvKey(env, "GIT_PYTHON_GIT_EXECUTABLE") ?? "GIT_PYTHON_GIT_EXECUTABLE";
+    env[gitKey] = sm.gitExe!;
+    const parts = ["PortableGit"];
     if (sm.ffmpegDir) parts.push("FFmpeg");
     return {
       reproducible: true,
@@ -434,9 +475,8 @@ export function resolveLaunchEnvironment(
         path_additions: added,
         note:
           `Stability Matrix install detected (${sm.dataRoot}) — relaunched with its ` +
-          `${parts.join(" + ")} on PATH` +
-          (sm.gitExe ? " and GIT_PYTHON_GIT_EXECUTABLE set" : "") +
-          ", so ComfyUI-Manager and ffmpeg-dependent nodes keep working",
+          `${parts.join(" + ")} on PATH and GIT_PYTHON_GIT_EXECUTABLE set, ` +
+          "so ComfyUI-Manager and ffmpeg-dependent nodes keep working",
       },
     };
   }

--- a/src/services/launcher-env.ts
+++ b/src/services/launcher-env.ts
@@ -225,15 +225,22 @@ function launcherConfigMentions(
     // a momentarily unreadable config would let a component be declared
     // "not installed", the restart proceed without it, and ComfyUI-Manager abort at
     // import — the original down-server bug, reached through the very rule meant to
-    // stop over-refusing. A config we cannot read tells us nothing, which is the
-    // ambiguous case (codex gate).
-    if (!pathExists(path)) continue;
+    // stop over-refusing.
+    //
+    // Which is why there is NO `existsSync` pre-screen here: `existsSync` answers
+    // FALSE for a path it cannot access, collapsing the two states before they can
+    // be told apart. Attempt the read and classify from the FAILURE MODE instead —
+    // only ENOENT/ENOTDIR mean "not there"; everything else means "could not look"
+    // (codex gate).
     try {
       const raw = readFileSync(path, "utf-8");
       // Config files here are a few KB; cap the scan so a pathological file
       // cannot cost anything meaningful.
       if (raw.slice(0, 512 * 1024).toLowerCase().includes(needle)) return "mentions";
-    } catch {
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT" || code === "ENOTDIR") continue;
+      // EACCES, EPERM, EISDIR, EBUSY, an unset code — all "we cannot look".
       sawUnreadable = true;
     }
   }

--- a/src/services/launcher-env.ts
+++ b/src/services/launcher-env.ts
@@ -1,0 +1,477 @@
+/**
+ * The ENVIRONMENT a restart must relaunch ComfyUI into (#776).
+ *
+ * `restart_comfyui` reconstructs the launch COMMAND (interpreter + argv) from the
+ * running server's `/system_stats`, but until this module existed it never
+ * reconstructed the launch ENVIRONMENT: `spawn()` with no `env` option inherits
+ * the ORCHESTRATOR's `process.env`, which is a DIFFERENT environment from the one
+ * a third-party launcher gave the server.
+ *
+ * That is exactly what broke #776. Stability Matrix does not put its bundled
+ * tools on the system PATH — it injects them into the child it launches:
+ *   • `<Data>/PortableGit/cmd`      → GitPython finds `git` (ComfyUI-Manager
+ *                                     aborts with "Bad git executable" without it)
+ *   • `<Data>/Assets/ffmpeg[/bin]`  → nodes that shell out to ffmpeg/ffprobe
+ * Relaunching the same venv + argv WITHOUT those PATH entries produced an import
+ * failure at startup, ComfyUI never answered `/system_stats`, and the restart left
+ * the user's server DOWN.
+ *
+ * The rules here, hardest evidence first:
+ *   1. LIVE PROCESS — on Linux we can read the running server's real environment
+ *      (`/proc/<pid>/environ`) while it is still alive. That is the launch
+ *      environment, verbatim, whatever launcher produced it. Use it.
+ *   2. STABILITY MATRIX — a Stability Matrix-managed install is recognizable from
+ *      its on-disk shape (`<Data>/Packages/<pkg>/…` beside `<Data>/PortableGit`
+ *      and `<Data>/Assets`). Its injected environment is small, documented and
+ *      VERIFIABLE on disk, so we reconstruct exactly those two PATH entries plus
+ *      GIT_PYTHON_GIT_EXECUTABLE — the same recovery launch the #776 reporter
+ *      verified by hand — and say so in the tool result.
+ *   3. AN OPAQUE LAUNCHER — a launcher we can recognize but whose environment we
+ *      canNOT reproduce (Pinokio builds it from a per-app script). We do NOT
+ *      guess: the caller REFUSES *before stopping anything*, because a refusal is
+ *      always better than a stop we cannot undo.
+ *   4. PLAIN INSTALL — no launcher marker at all (a terminal / .bat / venv
+ *      launch). Inheriting our environment is the long-standing behavior and the
+ *      one these installs were already restarted with successfully; nothing is
+ *      known to be missing, so nothing is reconstructed.
+ *
+ * Everything here is filesystem-evidence based: no shape is ever ASSUMED, and a
+ * marker that cannot be corroborated on disk downgrades to a refusal, never to a
+ * guess.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { delimiter } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Where the relaunch environment came from — reported to the caller. */
+export type LaunchEnvSource =
+  /** Read from the LIVE process while it was still running (Linux /proc). */
+  | "live-process"
+  /** Reconstructed from a Stability Matrix install detected on disk. */
+  | "stability-matrix"
+  /** No launcher marker — the child inherits this process's environment. */
+  | "inherited";
+
+/** The launch-environment facts surfaced in the start/restart tool result. */
+export interface LaunchEnvInfo {
+  source: LaunchEnvSource;
+  /** One-line human summary, safe to append to a tool message. */
+  note: string;
+  /**
+   * FALSE when the server's real launch environment is known to be
+   * launcher-owned and could NOT be rebuilt — the relaunch would be degraded.
+   * The pre-stop preflight turns this into a refusal; a server that is ALREADY
+   * down only gets a warning (see `reason`/`advice`).
+   */
+  reproducible: boolean;
+  /** Directories prepended to PATH (empty/absent when nothing was injected). */
+  path_additions?: string[];
+  /** The recognized launcher, when one was recognized. */
+  launcher?: string;
+}
+
+export interface LaunchEnvResolution {
+  /** Mirrors `info.reproducible` — the single gate the callers branch on. */
+  reproducible: boolean;
+  /**
+   * The environment to hand to `spawn()`. `undefined` means "pass no `env`
+   * option" — i.e. inherit this process's environment verbatim, unchanged from
+   * the behavior that predates #776. Always `undefined` when
+   * `reproducible` is false: we never fabricate a launcher environment.
+   */
+  env?: NodeJS.ProcessEnv;
+  info: LaunchEnvInfo;
+  /** Set only when NOT reproducible: why the environment cannot be rebuilt. */
+  reason?: string;
+  /** Set only when NOT reproducible: what the user should do instead. */
+  advice?: string;
+}
+
+export interface StabilityMatrixLayout {
+  /** The Stability Matrix `Data` root (parent of `Packages`). */
+  dataRoot: string;
+  /** `<Data>/PortableGit/cmd` (or `/bin`) — absent when not on disk. */
+  gitDir?: string;
+  /** The git binary inside `gitDir` — absent when not on disk. */
+  gitExe?: string;
+  /** `<Data>/Assets/ffmpeg[/bin]` — absent when not on disk. */
+  ffmpegDir?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Separator-agnostic path helpers
+//
+// The paths we inspect come from the running ComfyUI's sys.argv, which is
+// WINDOWS-flavored whenever ComfyUI runs on Windows — regardless of the host this
+// orchestrator process runs on. node:path would mangle `C:\…` on POSIX, so parse
+// with an explicit both-separators split and re-join with the separator the input
+// itself used (the same approach resolveLaunchCommand already takes).
+// ---------------------------------------------------------------------------
+
+function separatorOf(p: string): string {
+  return p.includes("\\") ? "\\" : "/";
+}
+
+function segmentsOf(p: string): string[] {
+  return p.split(/[\\/]/);
+}
+
+function basenameOf(p: string): string {
+  const segs = segmentsOf(p).filter((s) => s !== "");
+  return segs.length > 0 ? segs[segs.length - 1] : p;
+}
+
+/**
+ * Ancestor directories of `p`, NEAREST first. The filesystem root itself is
+ * skipped (nothing useful is ever detected there).
+ */
+function ancestorsOf(p: string): string[] {
+  const sep = separatorOf(p);
+  const segs = segmentsOf(p);
+  const out: string[] = [];
+  for (let i = segs.length - 1; i >= 1; i--) {
+    const joined = segs.slice(0, i).join(sep);
+    if (joined === "") continue; // POSIX root — nothing to detect there
+    out.push(joined);
+  }
+  return out;
+}
+
+function joinPath(base: string, ...parts: string[]): string {
+  const sep = separatorOf(base);
+  return [base.replace(/[\\/]+$/, ""), ...parts].join(sep);
+}
+
+/** existsSync that can never throw (a bad path must read as "absent"). */
+function pathExists(p: string): boolean {
+  try {
+    return existsSync(p);
+  } catch {
+    return false;
+  }
+}
+
+function firstExisting(candidates: string[]): string | undefined {
+  for (const c of candidates) {
+    if (pathExists(c)) return c;
+  }
+  return undefined;
+}
+
+/** The directory holding `p` (its nearest ancestor). */
+function dirOf(p: string): string | undefined {
+  return ancestorsOf(p)[0];
+}
+
+// ---------------------------------------------------------------------------
+// Stability Matrix detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Recognize a Stability Matrix-managed install from the paths involved in the
+ * relaunch (script, interpreter, cwd, raw argv[0]).
+ *
+ * Stability Matrix keeps every package under `<Data>/Packages/<PackageName>` and
+ * its shared tooling as siblings of `Packages` (`<Data>/PortableGit`,
+ * `<Data>/Assets`). So: find an ancestor literally named `Packages` whose parent
+ * either is named `Data` or actually HOLDS one of those tooling directories.
+ * Both halves are evidence, not assumption — a directory that merely happens to
+ * be called `Packages` never matches on its own.
+ */
+export function detectStabilityMatrix(
+  paths: ReadonlyArray<string | undefined>,
+): StabilityMatrixLayout | null {
+  for (const p of paths) {
+    if (!p) continue;
+    for (const ancestor of ancestorsOf(p)) {
+      if (basenameOf(ancestor).toLowerCase() !== "packages") continue;
+      const dataRoot = dirOf(ancestor);
+      if (!dataRoot) continue;
+      const isDataRoot =
+        basenameOf(dataRoot).toLowerCase() === "data" ||
+        pathExists(joinPath(dataRoot, "PortableGit")) ||
+        pathExists(joinPath(dataRoot, "Assets"));
+      if (!isDataRoot) continue;
+
+      const gitExe = firstExisting([
+        joinPath(dataRoot, "PortableGit", "cmd", "git.exe"),
+        joinPath(dataRoot, "PortableGit", "cmd", "git"),
+        joinPath(dataRoot, "PortableGit", "bin", "git.exe"),
+        joinPath(dataRoot, "PortableGit", "bin", "git"),
+      ]);
+      const ffmpegExe = firstExisting([
+        joinPath(dataRoot, "Assets", "ffmpeg", "bin", "ffmpeg.exe"),
+        joinPath(dataRoot, "Assets", "ffmpeg", "bin", "ffmpeg"),
+        joinPath(dataRoot, "Assets", "ffmpeg", "ffmpeg.exe"),
+        joinPath(dataRoot, "Assets", "ffmpeg", "ffmpeg"),
+      ]);
+      return {
+        dataRoot,
+        gitExe,
+        gitDir: gitExe ? dirOf(gitExe) : undefined,
+        ffmpegDir: ffmpegExe ? dirOf(ffmpegExe) : undefined,
+      };
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Opaque launchers — recognized, but NOT reproducible
+// ---------------------------------------------------------------------------
+
+/**
+ * Launchers that own the server's environment in a way we cannot rebuild from
+ * disk. Pinokio composes each app's environment in a per-app JS install script
+ * (its own conda/git/ffmpeg shims, per-app venvs, arbitrary exports); nothing on
+ * disk tells us what the running process actually got. Relaunching such a server
+ * with OUR environment is precisely the #776 failure mode, so these refuse.
+ */
+const OPAQUE_LAUNCHER_DIRS: ReadonlyArray<{ dir: string; name: string }> = [
+  { dir: "pinokio", name: "Pinokio" },
+];
+
+export function detectOpaqueLauncher(
+  paths: ReadonlyArray<string | undefined>,
+): { name: string; root: string } | null {
+  for (const p of paths) {
+    if (!p) continue;
+    for (const ancestor of ancestorsOf(p)) {
+      const base = basenameOf(ancestor).toLowerCase();
+      const hit = OPAQUE_LAUNCHER_DIRS.find((l) => l.dir === base);
+      if (hit) return { name: hit.name, root: ancestor };
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Live process environment (Linux)
+// ---------------------------------------------------------------------------
+
+/**
+ * The RUNNING server's own environment, read from `/proc/<pid>/environ`.
+ *
+ * This is the launch environment verbatim — whatever launcher produced it — so it
+ * is the best possible answer when it is available. It MUST be read while the
+ * process is still alive (the whole `/proc/<pid>` tree vanishes the instant the
+ * stop kills the pid), which is why the caller captures it at gather-time next to
+ * the live cwd (#535). Linux only; every other platform has no supported way to
+ * read another process's environment block, and we do not guess.
+ */
+export function readLiveProcessEnv(pid: number): NodeJS.ProcessEnv | undefined {
+  if (!pid || pid <= 0 || process.platform !== "linux") return undefined;
+  try {
+    // /proc/<pid>/environ is a NUL-separated KEY=VALUE list. Build the separator
+    // from a char code rather than writing a raw control byte into this file.
+    const NUL = String.fromCharCode(0);
+    const raw = readFileSync(`/proc/${pid}/environ`, "utf-8");
+    const env: NodeJS.ProcessEnv = {};
+    let count = 0;
+    for (const entry of raw.split(NUL)) {
+      if (entry === "") continue;
+      const eq = entry.indexOf("=");
+      if (eq <= 0) continue;
+      env[entry.slice(0, eq)] = entry.slice(eq + 1);
+      count++;
+    }
+    // An empty read tells us nothing (permission-trimmed / raced) — treat it as
+    // "unknown" rather than relaunching into a blank environment.
+    return count > 0 ? env : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Environment construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Find an env key case-insensitively. Windows environment blocks are
+ * case-insensitive and Node's `process.env` emulates that, but a plain object
+ * copy does NOT — writing a fresh "PATH" next to an inherited "Path" would hand
+ * the child two competing PATHs.
+ */
+function findEnvKey(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const wanted = name.toLowerCase();
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === wanted) return key;
+  }
+  return undefined;
+}
+
+function pathAlreadyContains(current: string, dir: string): boolean {
+  const target = dir.replace(/[\\/]+$/, "").toLowerCase();
+  return current
+    .split(delimiter)
+    .some((part) => part.trim().replace(/[\\/]+$/, "").toLowerCase() === target);
+}
+
+/**
+ * Copy `base` and PREPEND `additions` to its PATH (creating PATH if absent),
+ * skipping entries already present. Prepending — not appending — is what the
+ * launcher itself does, and it is what makes the bundled git/ffmpeg win over any
+ * different copy the orchestrator happens to have.
+ */
+function withPathAdditions(
+  base: NodeJS.ProcessEnv,
+  additions: string[],
+): { env: NodeJS.ProcessEnv; added: string[] } {
+  const env: NodeJS.ProcessEnv = { ...base };
+  const pathKey = findEnvKey(env, "PATH") ?? "PATH";
+  const current = env[pathKey] ?? "";
+  const added: string[] = [];
+  for (const dir of additions) {
+    if (!dir || pathAlreadyContains(current, dir) || added.includes(dir)) continue;
+    added.push(dir);
+  }
+  if (added.length > 0) {
+    env[pathKey] = current
+      ? [...added, current].join(delimiter)
+      : added.join(delimiter);
+  }
+  return { env, added };
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+export interface LaunchEnvInput {
+  /** Paths involved in the relaunch: script, interpreter, cwd, raw argv[0]. */
+  paths: ReadonlyArray<string | undefined>;
+  /** The live process's own environment, if it could be captured. */
+  liveEnv?: NodeJS.ProcessEnv;
+  /** Injectable base environment (defaults to this process's). */
+  baseEnv?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Decide what environment a relaunch should use, and whether that environment is
+ * actually REPRODUCIBLE.
+ *
+ * `reproducible:false` is a hard STOP for a caller that is about to KILL a healthy
+ * server: it must refuse BEFORE the server is touched, never after (#776 cardinal
+ * rule — a refusal costs a restart, a bad relaunch costs the server). A caller
+ * whose server is ALREADY down must NOT refuse: keeping it down is the one
+ * outcome worse than a possibly-degraded launch, so it launches with the best
+ * environment available and warns.
+ */
+export function resolveLaunchEnvironment(
+  input: LaunchEnvInput,
+): LaunchEnvResolution {
+  const baseEnv = input.baseEnv ?? process.env;
+
+  // 1. The live process's REAL environment beats every inference.
+  if (input.liveEnv && Object.keys(input.liveEnv).length > 0) {
+    return {
+      reproducible: true,
+      env: { ...input.liveEnv },
+      info: {
+        source: "live-process",
+        reproducible: true,
+        note:
+          "relaunched with the environment captured from the running ComfyUI " +
+          "process itself (read live before the stop)",
+      },
+    };
+  }
+
+  // 2. Stability Matrix — reconstruct exactly what it injects, from disk.
+  const sm = detectStabilityMatrix(input.paths);
+  if (sm) {
+    const additions = [sm.gitDir, sm.ffmpegDir].filter(
+      (d): d is string => typeof d === "string" && d.length > 0,
+    );
+    if (additions.length === 0) {
+      // We KNOW this install is launcher-owned but found none of the tooling it
+      // injects. Reproducing the environment is impossible and inheriting ours
+      // is the exact #776 failure — refuse instead of guessing.
+      return {
+        reproducible: false,
+        info: {
+          source: "inherited",
+          reproducible: false,
+          launcher: "Stability Matrix",
+          note:
+            "Stability Matrix install detected, but its bundled Git/FFmpeg could not " +
+            "be located on disk — the launcher environment could NOT be reproduced",
+        },
+        reason:
+          `This ComfyUI is managed by Stability Matrix (${sm.dataRoot}), which launches it ` +
+          "with its own bundled Git and FFmpeg on PATH, but neither " +
+          `"${joinPath(sm.dataRoot, "PortableGit")}" nor ` +
+          `"${joinPath(sm.dataRoot, "Assets", "ffmpeg")}" could be found on disk, so that ` +
+          "environment cannot be reproduced here.",
+        advice:
+          "Restart ComfyUI from Stability Matrix itself so it comes back with the " +
+          "environment its packages expect.",
+      };
+    }
+    const { env, added } = withPathAdditions(baseEnv, additions);
+    if (sm.gitExe) {
+      // GitPython (ComfyUI-Manager) resolves `git` through this variable first;
+      // Stability Matrix sets it, and without it Manager aborts at import with
+      // "Bad git executable" even when PATH is right (#776).
+      const gitKey = findEnvKey(env, "GIT_PYTHON_GIT_EXECUTABLE") ?? "GIT_PYTHON_GIT_EXECUTABLE";
+      env[gitKey] = sm.gitExe;
+    }
+    const parts: string[] = [];
+    if (sm.gitDir) parts.push("PortableGit");
+    if (sm.ffmpegDir) parts.push("FFmpeg");
+    return {
+      reproducible: true,
+      env,
+      info: {
+        source: "stability-matrix",
+        reproducible: true,
+        launcher: "Stability Matrix",
+        path_additions: added,
+        note:
+          `Stability Matrix install detected (${sm.dataRoot}) — relaunched with its ` +
+          `${parts.join(" + ")} on PATH` +
+          (sm.gitExe ? " and GIT_PYTHON_GIT_EXECUTABLE set" : "") +
+          ", so ComfyUI-Manager and ffmpeg-dependent nodes keep working",
+      },
+    };
+  }
+
+  // 3. A launcher we recognize but cannot reproduce — refuse before stopping.
+  const opaque = detectOpaqueLauncher(input.paths);
+  if (opaque) {
+    return {
+      reproducible: false,
+      info: {
+        source: "inherited",
+        reproducible: false,
+        launcher: opaque.name,
+        note:
+          `${opaque.name} builds this server's environment at launch time — it could ` +
+          "NOT be reproduced here",
+      },
+      reason:
+        `This ComfyUI is launched by ${opaque.name} (${opaque.root}), which builds the ` +
+        "server's environment (its own git/ffmpeg/python shims and exports) at launch " +
+        "time. That environment cannot be read from a process we did not start, so a " +
+        "relaunch from here would come back missing it.",
+      advice:
+        `Restart ComfyUI from ${opaque.name} itself so it comes back with the ` +
+        "environment it was launched with.",
+    };
+  }
+
+  // 4. Plain install — inherit, exactly as before #776.
+  return {
+    reproducible: true,
+    info: {
+      source: "inherited",
+      reproducible: true,
+      note: "relaunched with this process's environment (no launcher-owned environment detected)",
+    },
+  };
+}

--- a/src/services/launcher-env.ts
+++ b/src/services/launcher-env.ts
@@ -268,12 +268,15 @@ function launcherConfigMentions(
 
 function componentEvidence(
   resolved: boolean,
-  rootExists: boolean,
+  rootProbe: DirProbe,
   dataRoot: string,
   configNeedle: string,
 ): ComponentEvidence {
   if (resolved) return "resolved";
-  if (rootExists) return "ambiguous";
+  // PRESENT: it is there but we could not point at the binary. INACCESSIBLE: we
+  // could not look at all. Both mean "this component may well be injected and we
+  // would silently drop it" — the ambiguous case.
+  if (rootProbe !== "absent") return "ambiguous";
   // "not-installed" requires BOTH halves of the evidence: the directory absent AND
   // the launcher's own config silent about it. An unreadable config is neither, so
   // it stays ambiguous.
@@ -284,7 +287,7 @@ function componentEvidence(
 
 export function detectStabilityMatrix(
   paths: ReadonlyArray<string | undefined>,
-): StabilityMatrixLayout | "inaccessible" | null {
+): StabilityMatrixLayout | null {
   for (const p of paths) {
     if (!p) continue;
     for (const ancestor of ancestorsOf(p)) {
@@ -297,25 +300,20 @@ export function detectStabilityMatrix(
       const gitRootProbe = probePath(gitRoot);
       const assetsRootProbe = probePath(assetsRoot);
       const ffmpegRootProbe = probePath(ffmpegRoot);
-      // We could not READ the evidence that would tell us whether this is a
-      // launcher-managed install. That is not "it isn't one" — falling through to
-      // the plain-install plan here is exactly how a launcher-owned server gets
-      // relaunched without its environment. Surface it so the caller refuses.
-      if (
-        gitRootProbe === "inaccessible" ||
-        assetsRootProbe === "inaccessible" ||
-        ffmpegRootProbe === "inaccessible"
-      ) {
-        return "inaccessible";
-      }
       const hasGitRoot = gitRootProbe === "present";
       const hasFfmpegRoot = ffmpegRootProbe === "present";
-      // Corroboration is `PortableGit` OR the `Assets` STORE — not `Assets/ffmpeg`
-      // specifically. Requiring the ffmpeg subdirectory missed a real layout
-      // (`Data/Packages/…` beside `Data/Assets`, with PortableGit expected but
-      // currently unlocatable): it fell through as a plain install, inherited our
-      // environment, and reproduced "Bad git executable" (codex gate). Recognising
-      // it lets the per-component evidence rules below decide properly.
+      // Corroboration must be POSITIVE: at least one piece of Stability Matrix
+      // tooling actually PRESENT beside `Packages`. `PortableGit` OR the `Assets`
+      // STORE — not `Assets/ffmpeg` specifically, since a real layout can have the
+      // store without that subdirectory.
+      //
+      // An INACCESSIBLE sibling is deliberately not corroboration. Treating it as
+      // such made a plain install at `C:\Work\Data\Packages\ComfyUI` refuse to
+      // restart at all merely because an unrelated `C:\Work\Data\Assets` was
+      // ACL-denied — unreadable evidence proving the OTHER shape, which is the same
+      // fold in the opposite direction. Where the layout IS corroborated, an
+      // unreadable component is still ambiguous and still refuses (below); where it
+      // is not, we proceed unverified like any other plain install.
       if (!hasGitRoot && assetsRootProbe !== "present") continue;
 
       const gitExe = firstExisting([
@@ -335,8 +333,8 @@ export function detectStabilityMatrix(
         gitExe,
         gitDir: gitExe ? dirOf(gitExe) : undefined,
         ffmpegDir: ffmpegExe ? dirOf(ffmpegExe) : undefined,
-        git: componentEvidence(!!gitExe, hasGitRoot, dataRoot, "portablegit"),
-        ffmpeg: componentEvidence(!!ffmpegExe, hasFfmpegRoot, dataRoot, "ffmpeg"),
+        git: componentEvidence(!!gitExe, gitRootProbe, dataRoot, "portablegit"),
+        ffmpeg: componentEvidence(!!ffmpegExe, ffmpegRootProbe, dataRoot, "ffmpeg"),
       };
     }
   }
@@ -547,31 +545,6 @@ export function resolveLaunchEnvironment(
 
   // 2. Stability Matrix — reconstruct exactly what it injects, from disk.
   const sm = detectStabilityMatrix(input.paths);
-  if (sm === "inaccessible") {
-    // We could not READ the evidence that decides whether this install is
-    // launcher-managed. Treating that as "not a launcher install" is what would
-    // relaunch a Stability Matrix server without its PATH — #776 exactly. So it
-    // refuses, like every other case where the launcher environment is known to be
-    // beyond our reach.
-    return {
-      reproducible: false,
-      info: {
-        source: "inherited",
-        reproducible: false,
-        note:
-          "the launcher evidence beside this install could not be read, so whether " +
-          "its environment needs reconstructing could NOT be determined",
-      },
-      reason:
-        "This ComfyUI sits in a Stability Matrix-shaped layout, but the directories that " +
-        "would say whether the launcher injects its own Git/FFmpeg could not be read " +
-        "(permission denied or otherwise inaccessible). Relaunching without an " +
-        "environment it may require is the failure this check exists to prevent.",
-      advice:
-        "Restart ComfyUI from its launcher, or make the launcher's Data folder readable " +
-        "by this process and try again.",
-    };
-  }
   if (sm) {
     // PARTIAL reconstruction is NOT reconstruction — but "partial" has to mean
     // something we would actually DROP, not merely something that isn't there.

--- a/src/services/launcher-env.ts
+++ b/src/services/launcher-env.ts
@@ -41,6 +41,8 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
+// NOTE: readFileSync is used both for `/proc/<pid>/environ` and for the launcher's
+// own config file (launcherConfigMentions).
 import { delimiter } from "node:path";
 
 // ---------------------------------------------------------------------------
@@ -70,6 +72,12 @@ export interface LaunchEnvInfo {
   reproducible: boolean;
   /** Directories prepended to PATH (empty/absent when nothing was injected). */
   path_additions?: string[];
+  /**
+   * Launcher components this install provably does NOT have, so nothing was
+   * injected for them. Named so a later "ffmpeg not found" from a node is
+   * traceable to a missing asset rather than to the restart.
+   */
+  not_installed?: string[];
   /** The recognized launcher, when one was recognized. */
   launcher?: string;
 }
@@ -100,10 +108,17 @@ export interface StabilityMatrixLayout {
   gitExe?: string;
   /** `<Data>/Assets/ffmpeg[/bin]` — absent when not on disk. */
   ffmpegDir?: string;
-  /** Whether `<Data>/Assets/ffmpeg` itself exists (drives the refusal wording:
-   *  "present but unreadable" vs "not there at all" — both irreproducible). */
-  ffmpegRootExists: boolean;
+  /**
+   * Per-component evidence, which decides REFUSE vs PROCEED-WITHOUT (see
+   * `componentVerdict`). "resolved" = we can inject it; "ambiguous" = something
+   * says this install has it but we cannot point at it; "not-installed" = no
+   * trace of it anywhere, so the launcher cannot be injecting it either.
+   */
+  git: ComponentEvidence;
+  ffmpeg: ComponentEvidence;
 }
+
+export type ComponentEvidence = "resolved" | "ambiguous" | "not-installed";
 
 // ---------------------------------------------------------------------------
 // Separator-agnostic path helpers
@@ -188,6 +203,44 @@ function dirOf(p: string): string | undefined {
  * path must NOT be mistaken for a Stability Matrix one, because that
  * misclassification would refuse a restart that works today.
  */
+/**
+ * Does the launcher's OWN configuration mention this component?
+ *
+ * The tie-breaker for "the component's directory is not on disk". That can mean
+ * the user never installed it — in which case the launcher injects nothing and we
+ * lose nothing by proceeding — or that it lives somewhere we do not know to look,
+ * in which case proceeding drops it. Stability Matrix records what it manages in
+ * `<Data>/settings.json`, so a mention there turns "absent" into "absent but
+ * expected", which is the ambiguous case that must refuse. Unreadable/missing
+ * config reads as "not mentioned": we never manufacture ambiguity.
+ */
+function launcherConfigMentions(dataRoot: string, needle: string): boolean {
+  for (const name of ["settings.json", "settings.jsonc"]) {
+    try {
+      const raw = readFileSync(joinPath(dataRoot, name), "utf-8");
+      // Config files here are a few KB; cap the scan so a pathological file
+      // cannot cost anything meaningful.
+      if (raw.slice(0, 512 * 1024).toLowerCase().includes(needle)) return true;
+    } catch {
+      // Missing or unreadable — not a mention.
+    }
+  }
+  return false;
+}
+
+function componentEvidence(
+  resolved: boolean,
+  rootExists: boolean,
+  dataRoot: string,
+  configNeedle: string,
+): ComponentEvidence {
+  if (resolved) return "resolved";
+  if (rootExists) return "ambiguous";
+  return launcherConfigMentions(dataRoot, configNeedle)
+    ? "ambiguous"
+    : "not-installed";
+}
+
 export function detectStabilityMatrix(
   paths: ReadonlyArray<string | undefined>,
 ): StabilityMatrixLayout | null {
@@ -223,7 +276,8 @@ export function detectStabilityMatrix(
         gitExe,
         gitDir: gitExe ? dirOf(gitExe) : undefined,
         ffmpegDir: ffmpegExe ? dirOf(ffmpegExe) : undefined,
-        ffmpegRootExists: hasFfmpegRoot,
+        git: componentEvidence(!!gitExe, hasGitRoot, dataRoot, "portablegit"),
+        ffmpeg: componentEvidence(!!ffmpegExe, hasFfmpegRoot, dataRoot, "ffmpeg"),
       };
     }
   }
@@ -435,35 +489,34 @@ export function resolveLaunchEnvironment(
   // 2. Stability Matrix — reconstruct exactly what it injects, from disk.
   const sm = detectStabilityMatrix(input.paths);
   if (sm) {
-    // PARTIAL reconstruction is NOT reconstruction. Detection above only fires when
-    // Stability Matrix tooling actually exists beside `Packages`, so this IS a
-    // launcher-owned install — and EVERY component it is known to inject must be
-    // resolvable before we may call the environment reproducible.
+    // PARTIAL reconstruction is NOT reconstruction — but "partial" has to mean
+    // something we would actually DROP, not merely something that isn't there.
+    // Each component is therefore classified by EVIDENCE:
     //
-    // Crucially, "the directory isn't there" does NOT license us to skip a
-    // component: from here we cannot tell "the user never installed FFmpeg" (so
-    // the launcher injects nothing) apart from "the assets live somewhere we do
-    // not know how to look" (so the launcher injects something we would drop). The
-    // #776 lesson is that dropping the second case costs the user their server, so
-    // an unresolvable component ALWAYS refuses (coordinator gate P1(1)) — the
-    // wording just distinguishes the two shapes for the human reading it.
-    const missing: string[] = [];
-    if (!sm.gitExe) {
-      missing.push(
+    //   ambiguous     — the component's own directory exists (or the launcher's
+    //                   config names it) but we cannot point at its binary. Then it
+    //                   plausibly IS injected and we would silently drop it, which
+    //                   is the #776 failure. REFUSE.
+    //   not-installed — no directory, no mention anywhere. The launcher has nothing
+    //                   to inject either, so relaunching without it is exactly what
+    //                   the launcher itself would do. PROCEED — and say which
+    //                   component was not injected, because a permanent inability to
+    //                   restart is not a safer resting place than a launch that
+    //                   works (coordinator gate P2(4)).
+    const ambiguous: string[] = [];
+    if (sm.git === "ambiguous") {
+      ambiguous.push(
         `its bundled Git (looked under "${joinPath(sm.dataRoot, "PortableGit")}") — ` +
           "without it ComfyUI-Manager aborts at import with \"Bad git executable\"",
       );
     }
-    if (!sm.ffmpegDir) {
-      const ffmpegRoot = joinPath(sm.dataRoot, "Assets", "ffmpeg");
-      missing.push(
-        sm.ffmpegRootExists
-          ? `its bundled FFmpeg (found "${ffmpegRoot}" but no ffmpeg binary inside it)`
-          : `its bundled FFmpeg ("${ffmpegRoot}" does not exist, so we cannot tell whether ` +
-            "this install has no FFmpeg or keeps it somewhere we do not know to look)",
+    if (sm.ffmpeg === "ambiguous") {
+      ambiguous.push(
+        `its bundled FFmpeg (looked under "${joinPath(sm.dataRoot, "Assets", "ffmpeg")}")`,
       );
     }
-    if (missing.length > 0) {
+    if (ambiguous.length > 0) {
+      const missing = ambiguous;
       return {
         reproducible: false,
         info: {
@@ -483,15 +536,28 @@ export function resolveLaunchEnvironment(
           "environment its packages expect.",
       };
     }
-    // Both components are guaranteed resolved here — anything less refused above.
-    const { env, added } = withPathAdditions(baseEnv, [sm.gitDir!, sm.ffmpegDir!]);
-    // GitPython (ComfyUI-Manager) resolves `git` through this variable first;
-    // Stability Matrix sets it, and without it Manager aborts at import with
-    // "Bad git executable" even when PATH is right (#776). Guaranteed present —
-    // a missing git refused above.
-    const gitKey =
-      findEnvKey(env, "GIT_PYTHON_GIT_EXECUTABLE") ?? "GIT_PYTHON_GIT_EXECUTABLE";
-    env[gitKey] = sm.gitExe!;
+    // Everything still unresolved here is provably NOT INSTALLED, so there is
+    // nothing to drop. Inject what exists.
+    const additions = [sm.gitDir, sm.ffmpegDir].filter(
+      (d): d is string => typeof d === "string" && d.length > 0,
+    );
+    const { env, added } = withPathAdditions(baseEnv, additions);
+    if (sm.gitExe) {
+      // GitPython (ComfyUI-Manager) resolves `git` through this variable first;
+      // Stability Matrix sets it, and without it Manager aborts at import with
+      // "Bad git executable" even when PATH is right (#776).
+      const gitKey =
+        findEnvKey(env, "GIT_PYTHON_GIT_EXECUTABLE") ?? "GIT_PYTHON_GIT_EXECUTABLE";
+      env[gitKey] = sm.gitExe;
+    }
+    const injected: string[] = [];
+    if (sm.gitDir) injected.push("PortableGit");
+    if (sm.ffmpegDir) injected.push("FFmpeg");
+    // Name what this install simply does not have, so a later "ffmpeg not found"
+    // from a node is immediately traceable rather than mysterious.
+    const notInstalled: string[] = [];
+    if (sm.git === "not-installed") notInstalled.push("PortableGit");
+    if (sm.ffmpeg === "not-installed") notInstalled.push("FFmpeg");
     return {
       reproducible: true,
       env,
@@ -500,10 +566,15 @@ export function resolveLaunchEnvironment(
         reproducible: true,
         launcher: "Stability Matrix",
         path_additions: added,
+        not_installed: notInstalled.length > 0 ? notInstalled : undefined,
         note:
           `Stability Matrix install detected (${sm.dataRoot}) — relaunched with its ` +
-          "PortableGit + FFmpeg on PATH and GIT_PYTHON_GIT_EXECUTABLE set, " +
-          "so ComfyUI-Manager and ffmpeg-dependent nodes keep working",
+          (injected.length > 0
+            ? `${injected.join(" + ")} on PATH${sm.gitExe ? " and GIT_PYTHON_GIT_EXECUTABLE set" : ""}`
+            : "environment") +
+          (notInstalled.length > 0
+            ? `; this install has no bundled ${notInstalled.join(" or ")} anywhere under its Data folder, so none was injected (nodes that need ${notInstalled.join("/")} may not work — install it from Stability Matrix if you need it)`
+            : ", so ComfyUI-Manager and ffmpeg-dependent nodes keep working"),
       },
     };
   }

--- a/src/services/launcher-env.ts
+++ b/src/services/launcher-env.ts
@@ -214,18 +214,30 @@ function dirOf(p: string): string | undefined {
  * expected", which is the ambiguous case that must refuse. Unreadable/missing
  * config reads as "not mentioned": we never manufacture ambiguity.
  */
-function launcherConfigMentions(dataRoot: string, needle: string): boolean {
+function launcherConfigMentions(
+  dataRoot: string,
+  needle: string,
+): "mentions" | "absent" | "unreadable" {
+  let sawUnreadable = false;
   for (const name of ["settings.json", "settings.jsonc"]) {
+    const path = joinPath(dataRoot, name);
+    // MISSING and UNREADABLE are NOT the same answer. Folding them together is how
+    // a momentarily unreadable config would let a component be declared
+    // "not installed", the restart proceed without it, and ComfyUI-Manager abort at
+    // import — the original down-server bug, reached through the very rule meant to
+    // stop over-refusing. A config we cannot read tells us nothing, which is the
+    // ambiguous case (codex gate).
+    if (!pathExists(path)) continue;
     try {
-      const raw = readFileSync(joinPath(dataRoot, name), "utf-8");
+      const raw = readFileSync(path, "utf-8");
       // Config files here are a few KB; cap the scan so a pathological file
       // cannot cost anything meaningful.
-      if (raw.slice(0, 512 * 1024).toLowerCase().includes(needle)) return true;
+      if (raw.slice(0, 512 * 1024).toLowerCase().includes(needle)) return "mentions";
     } catch {
-      // Missing or unreadable — not a mention.
+      sawUnreadable = true;
     }
   }
-  return false;
+  return sawUnreadable ? "unreadable" : "absent";
 }
 
 function componentEvidence(
@@ -236,9 +248,12 @@ function componentEvidence(
 ): ComponentEvidence {
   if (resolved) return "resolved";
   if (rootExists) return "ambiguous";
-  return launcherConfigMentions(dataRoot, configNeedle)
-    ? "ambiguous"
-    : "not-installed";
+  // "not-installed" requires BOTH halves of the evidence: the directory absent AND
+  // the launcher's own config silent about it. An unreadable config is neither, so
+  // it stays ambiguous.
+  return launcherConfigMentions(dataRoot, configNeedle) === "absent"
+    ? "not-installed"
+    : "ambiguous";
 }
 
 export function detectStabilityMatrix(

--- a/src/services/launcher-env.ts
+++ b/src/services/launcher-env.ts
@@ -100,12 +100,9 @@ export interface StabilityMatrixLayout {
   gitExe?: string;
   /** `<Data>/Assets/ffmpeg[/bin]` — absent when not on disk. */
   ffmpegDir?: string;
-  /**
-   * TRUE when `<Data>/Assets/ffmpeg` exists but no ffmpeg binary could be found
-   * inside it — a layout we do not understand, which must refuse rather than
-   * relaunch with an incomplete reconstruction.
-   */
-  ffmpegPresentButUnresolved: boolean;
+  /** Whether `<Data>/Assets/ffmpeg` itself exists (drives the refusal wording:
+   *  "present but unreadable" vs "not there at all" — both irreproducible). */
+  ffmpegRootExists: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -226,7 +223,7 @@ export function detectStabilityMatrix(
         gitExe,
         gitDir: gitExe ? dirOf(gitExe) : undefined,
         ffmpegDir: ffmpegExe ? dirOf(ffmpegExe) : undefined,
-        ffmpegPresentButUnresolved: hasFfmpegRoot && !ffmpegExe,
+        ffmpegRootExists: hasFfmpegRoot,
       };
     }
   }
@@ -247,17 +244,43 @@ export function detectStabilityMatrix(
 const OPAQUE_LAUNCHER_DIRS: ReadonlyArray<{
   dir: string;
   name: string;
-  /** At least one of these must exist under the root — name alone is not proof. */
-  corroborate: string[];
+  /** ALL of these must exist under the root — name alone is never proof. */
+  requireDirs: string[];
+  /** The install must live under this subdirectory of the root. */
+  requireInstallUnder: string;
 }> = [
-  // A Pinokio home holds `api/` (the installed apps) and `bin/` (its shims).
-  { dir: "pinokio", name: "Pinokio", corroborate: ["api", "bin"] },
+  // A Pinokio home holds BOTH `api/` (the installed apps) and `bin/` (its shims),
+  // and every app it manages lives under `<root>/api/…`.
+  {
+    dir: "pinokio",
+    name: "Pinokio",
+    requireDirs: ["api", "bin"],
+    requireInstallUnder: "api",
+  },
 ];
 
+/** Is `child` inside `parent`? Separator- and (Windows-)case-insensitive. */
+function isUnder(child: string, parent: string): boolean {
+  const norm = (s: string): string[] =>
+    segmentsOf(s)
+      .filter((seg) => seg !== "")
+      .map((seg) => seg.toLowerCase());
+  const c = norm(child);
+  const p = norm(parent);
+  if (p.length === 0 || c.length <= p.length) return false;
+  return p.every((seg, i) => c[i] === seg);
+}
+
 /**
- * A recognized launcher whose environment we cannot rebuild. As with Stability
- * Matrix, the directory NAME is only a candidate — the launcher's own layout must
- * be corroborated on disk before we let it refuse a restart that otherwise works.
+ * A recognized launcher whose environment we cannot rebuild.
+ *
+ * A refusal here BLOCKS a restart, so the evidence bar is deliberately higher than
+ * for Stability Matrix (whose detection only unlocks a reconstruction): a
+ * false positive costs the user a restart that would have worked. A directory
+ * merely NAMED `pinokio`, or one that merely happens to contain a `bin`, is not
+ * enough (coordinator gate). We require three independent signals: the named root,
+ * ALL of the launcher's own top-level directories, and the install actually
+ * sitting inside the subtree the launcher keeps its apps in.
  */
 export function detectOpaqueLauncher(
   paths: ReadonlyArray<string | undefined>,
@@ -268,7 +291,8 @@ export function detectOpaqueLauncher(
       const base = basenameOf(ancestor).toLowerCase();
       const hit = OPAQUE_LAUNCHER_DIRS.find((l) => l.dir === base);
       if (!hit) continue;
-      if (!hit.corroborate.some((d) => pathExists(joinPath(ancestor, d)))) continue;
+      if (!hit.requireDirs.every((d) => pathExists(joinPath(ancestor, d)))) continue;
+      if (!isUnder(p, joinPath(ancestor, hit.requireInstallUnder))) continue;
       return { name: hit.name, root: ancestor };
     }
   }
@@ -411,14 +435,18 @@ export function resolveLaunchEnvironment(
   // 2. Stability Matrix — reconstruct exactly what it injects, from disk.
   const sm = detectStabilityMatrix(input.paths);
   if (sm) {
-    // PARTIAL reconstruction is NOT reconstruction (codex gate). Detection above
-    // only fires when at least one tooling root exists beside `Packages`, so this
-    // IS a launcher-owned install — and a component we can see but cannot resolve
-    // means we would relaunch it missing exactly the thing the launcher supplies.
-    // The git binary is the fatal one: without it ComfyUI-Manager aborts during
-    // import and the server never comes up at all (#776), so it is REQUIRED. An
-    // ffmpeg asset directory that exists but holds no recognizable binary is a
-    // shape we do not understand — refuse rather than half-rebuild.
+    // PARTIAL reconstruction is NOT reconstruction. Detection above only fires when
+    // Stability Matrix tooling actually exists beside `Packages`, so this IS a
+    // launcher-owned install — and EVERY component it is known to inject must be
+    // resolvable before we may call the environment reproducible.
+    //
+    // Crucially, "the directory isn't there" does NOT license us to skip a
+    // component: from here we cannot tell "the user never installed FFmpeg" (so
+    // the launcher injects nothing) apart from "the assets live somewhere we do
+    // not know how to look" (so the launcher injects something we would drop). The
+    // #776 lesson is that dropping the second case costs the user their server, so
+    // an unresolvable component ALWAYS refuses (coordinator gate P1(1)) — the
+    // wording just distinguishes the two shapes for the human reading it.
     const missing: string[] = [];
     if (!sm.gitExe) {
       missing.push(
@@ -426,10 +454,13 @@ export function resolveLaunchEnvironment(
           "without it ComfyUI-Manager aborts at import with \"Bad git executable\"",
       );
     }
-    if (sm.ffmpegPresentButUnresolved) {
+    if (!sm.ffmpegDir) {
+      const ffmpegRoot = joinPath(sm.dataRoot, "Assets", "ffmpeg");
       missing.push(
-        `its bundled FFmpeg (found "${joinPath(sm.dataRoot, "Assets", "ffmpeg")}" but no ` +
-          "ffmpeg binary inside it)",
+        sm.ffmpegRootExists
+          ? `its bundled FFmpeg (found "${ffmpegRoot}" but no ffmpeg binary inside it)`
+          : `its bundled FFmpeg ("${ffmpegRoot}" does not exist, so we cannot tell whether ` +
+            "this install has no FFmpeg or keeps it somewhere we do not know to look)",
       );
     }
     if (missing.length > 0) {
@@ -452,10 +483,8 @@ export function resolveLaunchEnvironment(
           "environment its packages expect.",
       };
     }
-    const additions = [sm.gitDir, sm.ffmpegDir].filter(
-      (d): d is string => typeof d === "string" && d.length > 0,
-    );
-    const { env, added } = withPathAdditions(baseEnv, additions);
+    // Both components are guaranteed resolved here — anything less refused above.
+    const { env, added } = withPathAdditions(baseEnv, [sm.gitDir!, sm.ffmpegDir!]);
     // GitPython (ComfyUI-Manager) resolves `git` through this variable first;
     // Stability Matrix sets it, and without it Manager aborts at import with
     // "Bad git executable" even when PATH is right (#776). Guaranteed present —
@@ -463,8 +492,6 @@ export function resolveLaunchEnvironment(
     const gitKey =
       findEnvKey(env, "GIT_PYTHON_GIT_EXECUTABLE") ?? "GIT_PYTHON_GIT_EXECUTABLE";
     env[gitKey] = sm.gitExe!;
-    const parts = ["PortableGit"];
-    if (sm.ffmpegDir) parts.push("FFmpeg");
     return {
       reproducible: true,
       env,
@@ -475,7 +502,7 @@ export function resolveLaunchEnvironment(
         path_additions: added,
         note:
           `Stability Matrix install detected (${sm.dataRoot}) — relaunched with its ` +
-          `${parts.join(" + ")} on PATH and GIT_PYTHON_GIT_EXECUTABLE set, ` +
+          "PortableGit + FFmpeg on PATH and GIT_PYTHON_GIT_EXECUTABLE set, " +
           "so ComfyUI-Manager and ffmpeg-dependent nodes keep working",
       },
     };

--- a/src/services/launcher-env.ts
+++ b/src/services/launcher-env.ts
@@ -40,7 +40,7 @@
  * guess.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 // NOTE: readFileSync is used both for `/proc/<pid>/environ` and for the launcher's
 // own config file (launcherConfigMentions).
 import { delimiter } from "node:path";
@@ -164,13 +164,32 @@ function joinPath(base: string, ...parts: string[]): string {
   return [base.replace(/[\\/]+$/, ""), ...parts].join(sep);
 }
 
-/** existsSync that can never throw (a bad path must read as "absent"). */
-function pathExists(p: string): boolean {
+/**
+ * Does this path exist? THREE answers, because `existsSync` only has two and
+ * spends the wrong one: it returns FALSE for a path it cannot access, so an
+ * ACL-unreadable `Data/PortableGit` looked exactly like "this install has no
+ * PortableGit". Detection then fell through to the plain-install plan and the
+ * relaunch dropped the launcher environment — the #776 failure itself, reached
+ * through the fix for it (codex gate P1-e).
+ */
+type DirProbe = "present" | "absent" | "inaccessible";
+
+function probePath(p: string): DirProbe {
   try {
-    return existsSync(p);
-  } catch {
-    return false;
+    statSync(p);
+    return "present";
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // Only these mean "there is nothing here". EACCES/EPERM/ELOOP/EIO and an
+    // unset code all mean "we could not look".
+    if (code === "ENOENT" || code === "ENOTDIR") return "absent";
+    return "inaccessible";
   }
+}
+
+/** Convenience for the places where only "definitely there" matters. */
+function pathExists(p: string): boolean {
+  return probePath(p) === "present";
 }
 
 function firstExisting(candidates: string[]): string | undefined {
@@ -265,7 +284,7 @@ function componentEvidence(
 
 export function detectStabilityMatrix(
   paths: ReadonlyArray<string | undefined>,
-): StabilityMatrixLayout | null {
+): StabilityMatrixLayout | "inaccessible" | null {
   for (const p of paths) {
     if (!p) continue;
     for (const ancestor of ancestorsOf(p)) {
@@ -275,15 +294,29 @@ export function detectStabilityMatrix(
       const gitRoot = joinPath(dataRoot, "PortableGit");
       const assetsRoot = joinPath(dataRoot, "Assets");
       const ffmpegRoot = joinPath(assetsRoot, "ffmpeg");
-      const hasGitRoot = pathExists(gitRoot);
-      const hasFfmpegRoot = pathExists(ffmpegRoot);
+      const gitRootProbe = probePath(gitRoot);
+      const assetsRootProbe = probePath(assetsRoot);
+      const ffmpegRootProbe = probePath(ffmpegRoot);
+      // We could not READ the evidence that would tell us whether this is a
+      // launcher-managed install. That is not "it isn't one" — falling through to
+      // the plain-install plan here is exactly how a launcher-owned server gets
+      // relaunched without its environment. Surface it so the caller refuses.
+      if (
+        gitRootProbe === "inaccessible" ||
+        assetsRootProbe === "inaccessible" ||
+        ffmpegRootProbe === "inaccessible"
+      ) {
+        return "inaccessible";
+      }
+      const hasGitRoot = gitRootProbe === "present";
+      const hasFfmpegRoot = ffmpegRootProbe === "present";
       // Corroboration is `PortableGit` OR the `Assets` STORE — not `Assets/ffmpeg`
       // specifically. Requiring the ffmpeg subdirectory missed a real layout
       // (`Data/Packages/…` beside `Data/Assets`, with PortableGit expected but
       // currently unlocatable): it fell through as a plain install, inherited our
       // environment, and reproduced "Bad git executable" (codex gate). Recognising
       // it lets the per-component evidence rules below decide properly.
-      if (!hasGitRoot && !pathExists(assetsRoot)) continue;
+      if (!hasGitRoot && assetsRootProbe !== "present") continue;
 
       const gitExe = firstExisting([
         joinPath(gitRoot, "cmd", "git.exe"),
@@ -514,6 +547,31 @@ export function resolveLaunchEnvironment(
 
   // 2. Stability Matrix — reconstruct exactly what it injects, from disk.
   const sm = detectStabilityMatrix(input.paths);
+  if (sm === "inaccessible") {
+    // We could not READ the evidence that decides whether this install is
+    // launcher-managed. Treating that as "not a launcher install" is what would
+    // relaunch a Stability Matrix server without its PATH — #776 exactly. So it
+    // refuses, like every other case where the launcher environment is known to be
+    // beyond our reach.
+    return {
+      reproducible: false,
+      info: {
+        source: "inherited",
+        reproducible: false,
+        note:
+          "the launcher evidence beside this install could not be read, so whether " +
+          "its environment needs reconstructing could NOT be determined",
+      },
+      reason:
+        "This ComfyUI sits in a Stability Matrix-shaped layout, but the directories that " +
+        "would say whether the launcher injects its own Git/FFmpeg could not be read " +
+        "(permission denied or otherwise inaccessible). Relaunching without an " +
+        "environment it may require is the failure this check exists to prevent.",
+      advice:
+        "Restart ComfyUI from its launcher, or make the launcher's Data folder readable " +
+        "by this process and try again.",
+    };
+  }
   if (sm) {
     // PARTIAL reconstruction is NOT reconstruction — but "partial" has to mean
     // something we would actually DROP, not merely something that isn't there.

--- a/src/services/launcher-env.ts
+++ b/src/services/launcher-env.ts
@@ -266,13 +266,17 @@ export function detectStabilityMatrix(
       const dataRoot = dirOf(ancestor);
       if (!dataRoot) continue;
       const gitRoot = joinPath(dataRoot, "PortableGit");
-      const ffmpegRoot = joinPath(dataRoot, "Assets", "ffmpeg");
+      const assetsRoot = joinPath(dataRoot, "Assets");
+      const ffmpegRoot = joinPath(assetsRoot, "ffmpeg");
       const hasGitRoot = pathExists(gitRoot);
       const hasFfmpegRoot = pathExists(ffmpegRoot);
-      // No Stability Matrix tooling beside `Packages` → not a Stability Matrix
-      // install (or one with nothing to inject). Either way there is nothing to
-      // reconstruct, so fall through to the ordinary inherit path.
-      if (!hasGitRoot && !hasFfmpegRoot) continue;
+      // Corroboration is `PortableGit` OR the `Assets` STORE — not `Assets/ffmpeg`
+      // specifically. Requiring the ffmpeg subdirectory missed a real layout
+      // (`Data/Packages/…` beside `Data/Assets`, with PortableGit expected but
+      // currently unlocatable): it fell through as a plain install, inherited our
+      // environment, and reproduced "Bad git executable" (codex gate). Recognising
+      // it lets the per-component evidence rules below decide properly.
+      if (!hasGitRoot && !pathExists(assetsRoot)) continue;
 
       const gitExe = firstExisting([
         joinPath(gitRoot, "cmd", "git.exe"),

--- a/src/services/listener-ownership.ts
+++ b/src/services/listener-ownership.ts
@@ -1,0 +1,330 @@
+// Who owns the healthy listener after a launch? (#776)
+//
+// This module exists to make one invariant UNFORGEABLE rather than merely
+// documented: a definite verdict — `ours` or `not-ours` — may only be produced by
+// the code that actually gathered the evidence for it. The same defect kept
+// reappearing on new paths (#796): an early return naming a definite answer it had
+// no basis for. A comment could not stop that; a type can.
+//
+// `ListenerOwnership` is a branded string. The values serialise and compare as
+// ordinary `"ours"` / `"not-ours"` / `"unconfirmed"`, but the type carries a
+// phantom property no literal satisfies, and the only cast that mints one lives in
+// `classified()` — which is private to this file and used solely inside
+// `classifyListenerOwnership`. Callers get exactly two ways to obtain a value:
+// classify (and earn a verdict), or `unclassifiedOwnership()` (and admit you did
+// not). Living in its own module is the point: in a 2600-line file the cast was
+// reachable by any future early return, which made the guarantee "that file's
+// discipline" rather than the compiler's.
+
+import type { ChildProcess } from "node:child_process";
+import { commandLineMatchesArgv, type ProcessIdentity } from "./live-interpreter.js";
+
+declare const CLASSIFIED: unique symbol;
+
+export type ListenerOwnership = ("ours" | "not-ours" | "unconfirmed") & {
+  readonly [CLASSIFIED]: true;
+};
+
+/** Mint a verdict. PRIVATE — the whole point of the module boundary. */
+function classified(
+  verdict: "ours" | "not-ours" | "unconfirmed",
+): ListenerOwnership {
+  return verdict as ListenerOwnership;
+}
+
+/** The only verdict a caller that did NOT classify is entitled to return. */
+export function unclassifiedOwnership(): ListenerOwnership {
+  return "unconfirmed" as ListenerOwnership;
+}
+
+// ---------------------------------------------------------------------------
+// Path tokens
+// ---------------------------------------------------------------------------
+
+/**
+ * A token's path dialect, decided from ROOTING rather than from the presence of a
+ * separator character.
+ *
+ * Backslash is a legal filename character on POSIX, so "contains a backslash"
+ * cannot mean "Windows": under that rule `/srv/Comfy\A` and `/srv/comfy\a` — two
+ * different installs — normalised identically and case-folded into a false MATCH,
+ * which is the direction that licenses stopping somebody else's process.
+ *
+ *   "win-rooted"  — a drive (`C:\`, `C:/`) or UNC (`\\host\share`) root. Windows
+ *                   for certain: separators are interchangeable, case is not
+ *                   significant.
+ *   "win-relative"— backslashes and NO forward slash, e.g. `ComfyUI\main.py`. This
+ *                   is how a Windows-launched ComfyUI reports `sys.argv[0]`, but it
+ *                   is also a legal POSIX filename, so separators are normalised
+ *                   and case is NOT folded on this evidence alone.
+ *   "drive-relative" — `C:ComfyUI\main.py`, which resolves against that drive's
+ *                   own working directory. Two processes can resolve the same text
+ *                   to DIFFERENT installs, so it is not comparable at all.
+ *   "posix"       — everything else. Case-sensitive, backslashes literal.
+ */
+type Dialect = "win-rooted" | "win-relative" | "drive-relative" | "posix";
+
+function dialectOf(token: string): Dialect {
+  if (/^[a-zA-Z]:[\\/]/.test(token) || /^\\\\/.test(token)) return "win-rooted";
+  if (/^[a-zA-Z]:[^\\/]/.test(token)) return "drive-relative";
+  if (token.includes("\\") && !token.includes("/")) return "win-relative";
+  return "posix";
+}
+
+interface PathToken {
+  text: string;
+  /** Case may be folded when comparing against another token. */
+  foldable: boolean;
+  /** The text cannot be resolved to a location at all (drive-relative). */
+  unresolvable: boolean;
+}
+
+function prepareToken(raw: string): PathToken {
+  const trimmed = raw.trim().replace(/^["']+|["']+$/g, "");
+  const dialect = dialectOf(trimmed);
+  if (dialect === "drive-relative") {
+    return { text: trimmed, foldable: false, unresolvable: true };
+  }
+  // Separators are only interchangeable in a Windows dialect. On POSIX a backslash
+  // is part of the name and must stay.
+  const windows = dialect === "win-rooted" || dialect === "win-relative";
+  let t = windows ? trimmed.replace(/\\/g, "/") : trimmed;
+  // Extended-length and UNC prefixes denote the same locations as their plain
+  // spellings.
+  t = t.replace(/^\/\/\?\/unc\//i, "//").replace(/^\/\/\?\//, "");
+  if (t.includes("/")) {
+    const drive = /^([a-zA-Z]:)(?=\/)/.exec(t)?.[1] ?? "";
+    const rooted = t.startsWith("/") || drive !== "";
+    const body = t.slice(drive.length);
+    const out: string[] = [];
+    for (const seg of body.split("/")) {
+      if (seg === "" || seg === ".") continue;
+      if (seg === "..") {
+        if (out.length > 0 && out[out.length - 1] !== "..") out.pop();
+        // At a ROOT, `..` has nowhere to go — the OS clamps it, so we must too,
+        // or `/../ComfyUI` and `/ComfyUI` (the same directory) read as different.
+        else if (!rooted) out.push("..");
+        continue;
+      }
+      out.push(seg);
+    }
+    t = `${drive}${rooted ? "/" : ""}${out.join("/")}`;
+  }
+  return { text: t, foldable: dialect === "win-rooted", unresolvable: false };
+}
+
+/**
+ * Do two argv tokens denote the same thing?
+ *
+ * Case is folded ONLY when a side is rooted in a Windows path (that filesystem is
+ * case-insensitive); everywhere else the comparison is exact, because a spurious
+ * equality here can promote a listener to `ours`. Paths compare SEGMENT-ALIGNED —
+ * one may be a suffix of the other — since we launch the script by absolute path
+ * while the server reports the relative one it was handed.
+ */
+function tokensAgree(a: PathToken, b: PathToken): boolean {
+  if (a.unresolvable || b.unresolvable) return false;
+  const fold = a.foldable || b.foldable;
+  const x = fold ? a.text.toLowerCase() : a.text;
+  const y = fold ? b.text.toLowerCase() : b.text;
+  if (x === y) return true;
+  const pathish = (s: string): boolean => /\//.test(s) || /^[a-zA-Z]:/.test(s);
+  if (!pathish(x) || !pathish(y)) return false;
+  return x.endsWith(`/${y}`) || y.endsWith(`/${x}`);
+}
+
+// ---------------------------------------------------------------------------
+// Liveness and lineage
+// ---------------------------------------------------------------------------
+
+/**
+ * Is the process we spawned still alive? Tri-state, because only a DEFINITE answer
+ * may change a verdict.
+ *
+ *   false     — an exit was recorded, or a signal-0 probe says ESRCH: it is gone.
+ *   undefined — no pid to probe, or EPERM (something holds that number but it is
+ *               not ours to signal). "Cannot tell", never "alive" and never "dead".
+ *   true      — the pid exists and is signalable. Necessary, NOT sufficient: a
+ *               recycled number passes too, which is why lineage is also required.
+ */
+export function launchedChildStillRunning(
+  child: ChildProcess,
+  kill: (pid: number, signal: 0) => void = (pid, signal) => {
+    process.kill(pid, signal);
+  },
+): boolean | undefined {
+  const pid = child.pid;
+  if (pid == null) return undefined;
+  // Loose null check: a not-yet-exited child reports `null`, and an absent
+  // property must read the same way rather than as "already exited".
+  if (child.exitCode != null || child.signalCode != null) return false;
+  try {
+    kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "ESRCH" ? false : undefined;
+  }
+}
+
+/**
+ * Is `pid` THIS CALL'S CHILD, or a descendant of it?
+ *
+ * Traced to `childPid`, deliberately NOT to the orchestrator. Ancestry under the
+ * long-lived MCP process proves almost nothing: a stale ComfyUI from an EARLIER
+ * request is also descended from it, has identical argv, and may still hold the
+ * port — so tracing to the orchestrator would report that sibling as `ours` and
+ * announce a restart that never happened, while the child we just spawned may have
+ * died on a bind failure. Only lineage through this launch's own child answers the
+ * question actually being asked.
+ *
+ * `undefined` the moment the chain becomes unreadable, and on budget exhaustion:
+ * running out of hops is "did not finish looking", not a negative answer.
+ */
+export function isDescendantOfChild(
+  pid: number,
+  childPid: number,
+  readParentPid: (pid: number) => number | undefined,
+  maxHops = 8,
+): boolean | undefined {
+  let current = pid;
+  for (let hop = 0; hop < maxHops; hop++) {
+    if (current === childPid) return true;
+    const parent = readParentPid(current);
+    if (parent == null) return undefined;
+    // Reached the top of the tree without passing through our child.
+    if (parent === current || parent <= 1) return false;
+    current = parent;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// The classifier
+// ---------------------------------------------------------------------------
+
+export interface OwnershipEvidence {
+  isDesktopApp: boolean;
+  /** The child's `exit` event has already been delivered. */
+  childExited: boolean;
+  /** The child's `error` event has been delivered — the spawn FAILED. */
+  spawnFailed: boolean;
+  child: ChildProcess;
+  /** The exact (interpreter + args) we launched. */
+  launchArgv?: string[];
+  /** The pid holding the port after readiness, or null when unmappable. */
+  portOwnerPid: number | null;
+  /** `sys.argv` as reported by whatever server is now answering. */
+  servingArgv?: string[];
+  readParentPid: (pid: number) => number | undefined;
+  readIdentity: (pid: number) => ProcessIdentity | undefined;
+  childIsAlive?: boolean | undefined;
+}
+
+export function classifyListenerOwnership(
+  input: OwnershipEvidence,
+): ListenerOwnership {
+  /**
+   * Does the server that is answering run what we launched?
+   *
+   * ASYMMETRIC by design. A MISMATCH is proof of the negative — nobody else's
+   * command line is ours. A match is only CORROBORATION: another supervisor can
+   * start the very same command, win the bind race, and answer identically, so it
+   * may never promote anything to `ours`. And `unknown` is neither: it is the
+   * absence of a comparison, and must not be spent as either.
+   */
+  const byArgv = (): "match" | "differ" | "unknown" => {
+    if (!input.servingArgv?.length || !input.launchArgv?.length) return "unknown";
+    // The interpreter is dropped from our side: the server reports `sys.argv`,
+    // which never contains it. Order is preserved on both sides (a relaunch passes
+    // the same arguments in the same order), so compare positionally, and require
+    // the same COUNT so a foreign subset cannot pass as a match.
+    const ours = input.launchArgv.slice(1).map(prepareToken).filter((t) => t.text);
+    const serving = input.servingArgv.map(prepareToken).filter((t) => t.text);
+    if (ours.length === 0 || serving.length === 0) return "unknown";
+    // A drive-relative token resolves against a per-drive working directory we do
+    // not know, so identical text can denote different installs. Not comparable.
+    if (ours.some((t) => t.unresolvable) || serving.some((t) => t.unresolvable)) {
+      return "unknown";
+    }
+    const same =
+      ours.length === serving.length &&
+      ours.every((token, i) => tokensAgree(token, serving[i]));
+    return same ? "match" : "differ";
+  };
+
+  // A LAUNCH THAT NEVER HAPPENED is decisive on every path, Desktop included, so
+  // these come first and no later shortcut can soften them. The spawn error is
+  // latched independently of the readiness race, and Node leaves `pid` undefined
+  // only when the spawn did not happen — the same fact by two routes.
+  if (input.spawnFailed) return classified("not-ours");
+  if (input.child.pid == null) return classified("not-ours");
+  // A Desktop launch is undecidable BY DESIGN once it HAS started: we spawn the
+  // Electron shell (or macOS `open`, which exits immediately by design) and its
+  // child binds the port. Sits after the never-launched checks, before
+  // `childExited`, because for Desktop a launcher exiting is normal.
+  if (input.isDesktopApp) return classified("unconfirmed");
+
+  const alive = input.childIsAlive;
+  // OUR DIRECT CHILD IS GONE — by its `exit` event or by a signal-0 probe. Usually
+  // that means the listener is somebody else's, but it is ALSO the shape of a
+  // wrapper that launched ComfyUI as a grandchild and exited, after which the
+  // grandchild is reparented and lineage cannot place it. So only a real, comparable
+  // MISMATCH is decisive here; a match and an unreadable comparison alike degrade,
+  // rather than telling that user their own server is not theirs.
+  if (input.childExited || alive === false) {
+    return byArgv() === "differ"
+      ? classified("not-ours")
+      : classified("unconfirmed");
+  }
+
+  const ourPid = input.child.pid;
+  if (input.portOwnerPid == null) {
+    // NO LISTENER WAS IDENTIFIED. `not-ours` is a positive finding about an
+    // identified process, so it cannot be reached from here — there is nothing to
+    // have found.
+    return classified("unconfirmed");
+  }
+  if (input.portOwnerPid !== ourPid) {
+    // A different pid holds the port. That is usually somebody else's server, but
+    // it is also the shape of an indirect launch (wrapper, double fork,
+    // trampoline) where the listener is our GRANDchild — so trace lineage through
+    // THIS launch's child before concluding.
+    const descendant = isDescendantOfChild(
+      input.portOwnerPid,
+      ourPid,
+      input.readParentPid,
+    );
+    // Lineage does not outrank direct contrary evidence: a wrapper of ours can
+    // bring up a DIFFERENT or stale ComfyUI, which would be in our tree while
+    // plainly not being what we launched.
+    if (descendant === true) {
+      return byArgv() === "differ" ? classified("not-ours") : classified("ours");
+    }
+    if (descendant === false) return classified("not-ours");
+    return byArgv() === "differ"
+      ? classified("not-ours")
+      : classified("unconfirmed");
+  }
+  // The pid MATCHES — but it could be a recycled number we cannot signal.
+  if (alive !== true) return classified("unconfirmed");
+
+  // LINEAGE is the discriminator that does not depend on WHEN we looked: we
+  // spawned this child, so the process on the port must still be it. A recycled
+  // number has a different parent. Not knowing is never promoted to `ours`.
+  const parent = input.readParentPid(ourPid);
+  if (parent == null) return classified("unconfirmed");
+  if (parent !== process.pid) return classified("not-ours");
+
+  // Belt and braces: the OS's view of the command line, and the server's own
+  // account of itself, must both agree. Each is a decisive negative only.
+  const identity = input.readIdentity(ourPid);
+  if (
+    identity?.commandLine &&
+    input.launchArgv &&
+    !commandLineMatchesArgv(identity.commandLine, input.launchArgv)
+  ) {
+    return classified("not-ours");
+  }
+  if (byArgv() === "differ") return classified("not-ours");
+  return classified("ours");
+}

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -111,6 +111,13 @@ export interface ProcessIdentity {
   /** Process creation time, in whatever stable form the platform provides. Only ever
    *  compared against another reading taken on the SAME platform. */
   startedAt?: string;
+  /**
+   * The process's PARENT pid. Read in the same OS call as the rest, because
+   * process-control uses it to prove that the process serving ComfyUI's port
+   * really is the child it spawned (#776) — lineage is the one identity signal
+   * that does not depend on WHEN it is read.
+   */
+  parentPid?: number;
 }
 
 /**
@@ -128,6 +135,12 @@ export interface ProcessIdentity {
  * through the venv symlink to the base interpreter.
  * macOS: `ps -o lstart=,command=`.
  */
+function parsePid(raw: string | undefined): number | undefined {
+  if (raw == null) return undefined;
+  const parsed = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 export function readProcessIdentity(pid: number): ProcessIdentity | undefined {
   try {
     if (IS_WIN) {
@@ -137,41 +150,58 @@ export function readProcessIdentity(pid: number): ProcessIdentity | undefined {
           "-NoProfile",
           "-Command",
           `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; ` +
-            `if ($p) { "START=" + $p.CreationDate.ToFileTimeUtc(); "CMD=" + $p.CommandLine }`,
+            `if ($p) { "START=" + $p.CreationDate.ToFileTimeUtc(); "PPID=" + $p.ParentProcessId; "CMD=" + $p.CommandLine }`,
         ],
         { encoding: "utf-8", timeout: 8000, windowsHide: true },
       );
       const startedAt = out.match(/^START=(.+)$/m)?.[1]?.trim();
+      // PPID before CMD in the output so a multi-line command line (captured with
+      // [\s\S]) cannot swallow it.
+      const parentPid = parsePid(out.match(/^PPID=(.+)$/m)?.[1]);
       const commandLine = out.match(/^CMD=([\s\S]*)$/m)?.[1]?.trim();
       if (!startedAt && !commandLine) return undefined;
-      return { commandLine: commandLine || undefined, startedAt: startedAt || undefined };
+      return {
+        commandLine: commandLine || undefined,
+        startedAt: startedAt || undefined,
+        parentPid,
+      };
     }
     if (platform() === "linux") {
       // argv entries are "\u0000"-separated; rejoin them as a command line.
       const raw = readFileSync(`/proc/${pid}/cmdline`, "utf-8");
       const commandLine = raw.split("\u0000").filter(Boolean).join(" ").trim();
       let startedAt: string | undefined;
+      let parentPid: number | undefined;
       try {
         const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
         // Field 2 (comm) can contain spaces and parens — parse after the LAST ')'.
         const after = stat.slice(stat.lastIndexOf(")") + 1).trim().split(/\s+/);
         // After comm, fields run state(3)… so starttime (field 22) is index 19 here.
         startedAt = after[19];
+        // ppid is field 4, i.e. index 1 in this same post-comm numbering.
+        parentPid = parsePid(after[1]);
       } catch {
         /* start time unavailable → the launched-by-us tier fails closed */
       }
       if (!commandLine && !startedAt) return undefined;
-      return { commandLine: commandLine || undefined, startedAt };
+      return { commandLine: commandLine || undefined, startedAt, parentPid };
     }
-    const out = execFileSync("ps", ["-p", String(pid), "-o", "lstart=,command="], {
-      encoding: "utf-8",
-      timeout: 8000,
-    }).trim();
+    const out = execFileSync(
+      "ps",
+      ["-p", String(pid), "-o", "ppid=,lstart=,command="],
+      { encoding: "utf-8", timeout: 8000 },
+    ).trim();
     if (!out) return undefined;
-    // `lstart` is a ctime-style stamp: "Fri Aug  1 12:00:00 2026".
-    const m = out.match(/^(\w{3}\s+\w{3}\s+\d+\s+\d{2}:\d{2}:\d{2}\s+\d{4})\s+([\s\S]*)$/);
+    // `ppid` first, then `lstart` (a ctime-style stamp: "Fri Aug  1 12:00:00 2026").
+    const m = out.match(
+      /^\s*(\d+)\s+(\w{3}\s+\w{3}\s+\d+\s+\d{2}:\d{2}:\d{2}\s+\d{4})\s+([\s\S]*)$/,
+    );
     if (!m) return { commandLine: out };
-    return { startedAt: m[1].replace(/\s+/g, " "), commandLine: m[2].trim() };
+    return {
+      parentPid: parsePid(m[1]),
+      startedAt: m[2].replace(/\s+/g, " "),
+      commandLine: m[3].trim(),
+    };
   } catch {
     return undefined;
   }

--- a/src/services/port-owner.ts
+++ b/src/services/port-owner.ts
@@ -118,58 +118,84 @@ export function parseListenerPidFromLsof(
   return null;
 }
 
-export function findPidByPort(port: number, host?: string): number | null {
+/**
+ * The result of asking "who owns this port?" — with "I could not find out" kept
+ * DISTINCT from "nobody".
+ *
+ * `findPidByPort` collapses both into `null`, which is fine for "find me the pid"
+ * but dangerous for "has the port been released?": a lookup that merely FAILED
+ * would read as proof the port is free, and callers acting on that proof (tearing
+ * down supervision after a kill) would act on a server that is still running.
+ */
+export type PortOwnerProbe =
+  | { state: "owned"; pid: number }
+  | { state: "free" }
+  | { state: "unknown"; reason: string };
+
+/** Did this execSync failure mean "ran fine, matched nothing"? */
+function isEmptyResultExit(err: unknown): boolean {
+  const e = err as NodeJS.ErrnoException & { status?: number };
+  // A spawn-level failure (command missing, timeout) tells us nothing about the
+  // port; only a clean "no matches" exit does. lsof uses exit 1 for that.
+  if (e?.code) return false;
+  return e?.status === 1;
+}
+
+export function probePortOwner(port: number, host?: string): PortOwnerProbe {
   if (IS_WIN) {
-    // Parse `netstat -ano` ourselves instead of piping through
-    // `findstr LISTENING` — that state word is localized and made detection fail
-    // on non-English Windows even when ComfyUI was reachable (issue #449).
+    let ranSomething = false;
+    const failures: string[] = [];
     try {
       const out = execSync(`netstat -ano -p TCP`, {
         encoding: "utf-8",
         timeout: 5000,
       });
+      ranSomething = true;
       const pid = parseListenerPidFromNetstat(out, port, host);
-      if (pid) return pid;
-    } catch {
-      // netstat unavailable / failed — fall through to the PowerShell probe.
+      if (pid) return { state: "owned", pid };
+    } catch (err) {
+      failures.push(`netstat: ${err instanceof Error ? err.message : String(err)}`);
     }
-    // Fallback: Get-NetTCPConnection maps port→owning PID structurally, with no
-    // dependence on console locale or column layout. Belt-and-suspenders for the
-    // portable/embedded-Python launch shape reported in #449. LocalAddress is
-    // selected too so the host filter still applies.
     try {
       const out = execSync(
         `powershell -NoProfile -Command "Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | ForEach-Object { \\"$($_.LocalAddress) $($_.OwningProcess)\\" }"`,
         { encoding: "utf-8", timeout: 8000 },
       );
+      ranSomething = true;
       for (const raw of out.split(/\r?\n/)) {
         const [addr, pidText] = raw.trim().split(/\s+/);
         if (!addr || !pidText) continue;
         if (!addressServesHost(addr.replace(/^\[|\]$/g, ""), host)) continue;
         const pid = parseInt(pidText, 10);
-        if (!Number.isNaN(pid) && pid > 0) return pid;
+        if (!Number.isNaN(pid) && pid > 0) return { state: "owned", pid };
       }
-    } catch {
-      // PowerShell unavailable / nothing listening.
+    } catch (err) {
+      failures.push(`powershell: ${err instanceof Error ? err.message : String(err)}`);
     }
-    return null;
+    // A probe that RAN and matched nothing is real evidence the port is free.
+    // Every probe failing is not.
+    return ranSomething
+      ? { state: "free" }
+      : { state: "unknown", reason: failures.join("; ") || "no port probe available" };
   }
 
   try {
-    // LISTENER-ONLY, TCP only, and bound to the ADDRESS we actually talk to. A bare
-    // `lsof -ti :PORT` also matches processes merely CONNECTED to that port (and
-    // UDP), so it can return a client — a browser, or our own fetch — instead of the
-    // ComfyUI server. That PID is used to kill the server AND (since #401) to read
-    // the interpreter it runs, so a client must never be mistaken for it. `-Fpn`
-    // field output carries the bind address, which terse `-t` cannot express.
     const out = execSync(`lsof -nP -iTCP:${port} -sTCP:LISTEN -Fpn`, {
       encoding: "utf-8",
       timeout: 5000,
     });
     const pid = parseListenerPidFromLsof(out, port, host);
-    if (pid) return pid;
-  } catch {
-    // Command failed — no process listening on that port
+    return pid ? { state: "owned", pid } : { state: "free" };
+  } catch (err) {
+    if (isEmptyResultExit(err)) return { state: "free" };
+    return {
+      state: "unknown",
+      reason: `lsof: ${err instanceof Error ? err.message : String(err)}`,
+    };
   }
-  return null;
+}
+
+export function findPidByPort(port: number, host?: string): number | null {
+  const probe = probePortOwner(port, host);
+  return probe.state === "owned" ? probe.pid : null;
 }

--- a/src/services/port-owner.ts
+++ b/src/services/port-owner.ts
@@ -85,7 +85,7 @@ export function parseListenerPidFromNetstat(
 }
 
 /**
- * Parse `lsof -nP -iTCP:PORT -sTCP:LISTEN -Fpn` field output. Records look like
+ * Parse `lsof -w -nP -iTCP:PORT -sTCP:LISTEN -Fpn` field output. Records look like
  *   p1234
  *   n127.0.0.1:8188
  * so we can bind the match to the ADDRESS as well as the port, which the plain
@@ -132,13 +132,32 @@ export type PortOwnerProbe =
   | { state: "free" }
   | { state: "unknown"; reason: string };
 
-/** Did this execSync failure mean "ran fine, matched nothing"? */
+/**
+ * Did this execSync failure mean "ran fine, enumerated everything, matched
+ * nothing"? Only that reading is evidence the port is free.
+ *
+ * Exit status 1 alone is NOT enough. `lsof` also exits 1 when it could not
+ * enumerate — a permission-restricted run reports what it could not open on
+ * stderr and exits 1 having listed nothing, which is "I could not look", not
+ * "nobody is listening". Certifying that as free would let `waitForPortFree`
+ * report a release that never happened and tear down supervision under a live
+ * server. So a clean empty result must ALSO be quiet on both streams; the `-w`
+ * flag on the invocation suppresses lsof's routine warnings so that anything
+ * remaining on stderr genuinely means the enumeration was incomplete.
+ */
 function isEmptyResultExit(err: unknown): boolean {
-  const e = err as NodeJS.ErrnoException & { status?: number };
+  const e = err as NodeJS.ErrnoException & {
+    status?: number;
+    stdout?: Buffer | string;
+    stderr?: Buffer | string;
+  };
   // A spawn-level failure (command missing, timeout) tells us nothing about the
-  // port; only a clean "no matches" exit does. lsof uses exit 1 for that.
+  // port; only a clean "no matches" exit does.
   if (e?.code) return false;
-  return e?.status === 1;
+  if (e?.status !== 1) return false;
+  const text = (v: Buffer | string | undefined): string =>
+    v == null ? "" : (typeof v === "string" ? v : v.toString("utf-8")).trim();
+  return text(e.stdout) === "" && text(e.stderr) === "";
 }
 
 export function probePortOwner(port: number, host?: string): PortOwnerProbe {
@@ -180,7 +199,7 @@ export function probePortOwner(port: number, host?: string): PortOwnerProbe {
   }
 
   try {
-    const out = execSync(`lsof -nP -iTCP:${port} -sTCP:LISTEN -Fpn`, {
+    const out = execSync(`lsof -w -nP -iTCP:${port} -sTCP:LISTEN -Fpn`, {
       encoding: "utf-8",
       timeout: 5000,
     });

--- a/src/services/port-owner.ts
+++ b/src/services/port-owner.ts
@@ -149,19 +149,107 @@ export type PortOwnerProbe =
  * and nothing else, is treated as "free". Anything else exits to "unknown", which
  * a caller may not spend as proof of release.
  */
-function statesAddressNotLocated(err: unknown): boolean {
+/**
+ * lsof reporting that its own enumeration was INCOMPLETE.
+ *
+ * Any such note voids the absence marker: "I searched and did not find it" is a
+ * statement about the whole machine, but a run that could not stat or open part of
+ * `/proc` only searched the part it could see. The marker and a warning can appear
+ * TOGETHER — lsof reports what it skipped and still names what it failed to locate —
+ * and reading that combination as "free" certifies a release from an enumeration
+ * that admits it was partial.
+ */
+/**
+ * Did lsof complain about anything, i.e. admit its enumeration was incomplete?
+ *
+ * Recognised by INVERSION rather than by enumerating diagnostics. Listing the ones I
+ * could think of (`WARNING`, `permission denied`, …) missed real ones lsof documents
+ * — `lsof: can't read proc table info` among them — and every miss certifies a
+ * release from a partial search. The set of things lsof can complain about is open;
+ * the set of things it says as ITS `-V` REPORT is closed and known: `not located`
+ * lines, verified from a live run to be exactly
+ *
+ *     lsof: Internet address not located: TCP:65432
+ *     lsof: TCP state not located: LISTEN
+ *
+ * So any `lsof:`-prefixed line that is NOT part of that report is a complaint,
+ * whatever it says. `Output information may be incomplete.` is checked separately
+ * because lsof prints it without the prefix.
+ */
+function admitsIncompleteEnumeration(output: string): boolean {
+  if (/may be incomplete/i.test(output)) return true;
+  return output.split("\n").some((raw) => {
+    const line = raw.trim();
+    if (!/^lsof:/i.test(line)) return false;
+    return !/\bnot located\b/i.test(line);
+  });
+}
+
+/**
+ * What lsof said about absence — kept as THREE outcomes, not a boolean.
+ *
+ *   "stated"     — it named what it failed to locate, and reported no gaps.
+ *   "inconclusive" — it named what it failed to locate AND admitted it could not
+ *                  enumerate everything. The verdict is the same as `silent`
+ *                  (`unknown`), but the CAUSE is not, and a caller that waits out a
+ *                  budget deserves to be told which one it was.
+ *   "silent"     — it said nothing about an empty search.
+ *
+ * Collapsing the middle case into `silent` is how the verdict stayed right while the
+ * message asserted something that did not happen — lsof plainly DID report an empty
+ * search; we declined to spend it.
+ */
+type LsofAbsence = "stated" | "inconclusive" | "silent";
+
+const LSOF_INCONCLUSIVE_REASON =
+  "lsof reported nothing listening on the port but also reported that it could not enumerate everything, so its search describes only what it could see";
+
+function readLsofAbsence(output: string): LsofAbsence {
+  if (!/internet address not located/i.test(output)) return "silent";
+  return admitsIncompleteEnumeration(output) ? "inconclusive" : "stated";
+}
+
+function lsofErrorAbsence(err: unknown): LsofAbsence {
   const e = err as NodeJS.ErrnoException & {
     status?: number;
     stdout?: Buffer | string;
     stderr?: Buffer | string;
   };
   // A spawn-level failure (command missing, timeout) tells us nothing at all.
-  if (e?.code) return false;
-  if (e?.status !== 1) return false;
+  if (e?.code) return "silent";
+  if (e?.status !== 1) return "silent";
   const text = (v: Buffer | string | undefined): string =>
     v == null ? "" : typeof v === "string" ? v : v.toString("utf-8");
-  return /internet address not located/i.test(`${text(e.stdout)}\n${text(e.stderr)}`);
+  return readLsofAbsence(`${text(e.stdout)}\n${text(e.stderr)}`);
 }
+
+/**
+ * How the kernel socket tables are read.
+ *
+ * Injected rather than called directly so a test can drive this branch the way it
+ * already drives the `lsof` branch (through the `node:child_process` mock):
+ * present-and-listening, present-and-free, or inaccessible, on demand. Reading
+ * `readFileSync` directly made the answer depend on the HOST — on a Linux runner
+ * `/proc` genuinely exists, so the real socket table silently outranked a test's
+ * port fixtures and the assertions were graded against the runner's own network
+ * state instead (#776 CI). A suite that can only be green on a machine with
+ * nothing on port 8188 is not testing anything.
+ */
+export type ProcNetTableReader = (table: string) => string;
+
+const defaultProcNetReader: ProcNetTableReader = (table) => readFileSync(table, "utf-8");
+
+let procNetReader: ProcNetTableReader = defaultProcNetReader;
+
+export const __portOwnerTestHooks = {
+  /** Drive the kernel-table read. `null` restores the real `/proc` reader. */
+  setProcNetReader(fn: ProcNetTableReader | null): void {
+    procNetReader = fn ?? defaultProcNetReader;
+  },
+  reset(): void {
+    procNetReader = defaultProcNetReader;
+  },
+};
 
 /**
  * Is a socket LISTENING on `port`, according to the kernel's own table?
@@ -173,29 +261,305 @@ function statesAddressNotLocated(err: unknown): boolean {
  * `/proc/<pid>/fd` scan) — but the safety-critical question after a kill is
  * whether the port was RELEASED, and this settles exactly that.
  *
- * Returns undefined when the tables cannot be read, which is not an answer.
+ * A POSITIVE is decisive from a single table: one LISTEN row is a socket, whatever
+ * the other table says. A NEGATIVE requires having read them BOTH — "no IPv4
+ * listener, and I could not open the IPv6 table" is not "nothing is listening", it
+ * is "I did not finish looking". Certifying that as free is the same fold this
+ * whole change exists to remove: a source that could not answer producing a
+ * definite one.
+ *
+ *   "listening"   — a LISTEN row was seen. Decisive.
+ *   "none"        — every table was read AND fully parsed, and none held a LISTEN
+ *                   row for the port. The only decisive negative.
+ *   "incomplete"  — something was read, but a table could not be opened or held a
+ *                   row that could not be parsed. A NAMED BLIND SPOT: an unreadable
+ *                   tcp6 may hold an IPv6 listener.
+ *   "unavailable" — no table could be read at all.
+ *
+ * The last two are both "not an answer", but they are NOT interchangeable once lsof
+ * then states absence. With a blind spot, lsof may simply SHARE it — an
+ * unprivileged lsof cannot see another user's sockets either, so the same listener
+ * is invisible to both and "free" would be a guess. With no table at all (every
+ * non-Linux POSIX host, where /proc/net does not exist) lsof is the only evidence
+ * there has ever been, and refusing to believe it would leave macOS permanently
+ * unable to observe a port release.
  */
-function procNetHasListener(port: number): boolean | undefined {
-  const LISTEN_STATE = "0A";
+type KernelSocketTables = "listening" | "none" | "incomplete" | "unavailable";
+
+/**
+ * Does a failed table read mean the table is ABSENT, or that we could not look?
+ *
+ * Classified from the errno, exactly as this change classifies a launcher config,
+ * because "both reads failed" is not by itself evidence of an absent source.
+ *
+ * Only ENOENT and ENOTDIR prove absence: they say this PATHNAME does not resolve to
+ * a file, so there is no table and nothing can be hiding in it. Every non-Linux
+ * POSIX host has no `/proc/net` at all, and a kernel booted with `ipv6.disable=1`
+ * has no `tcp6`.
+ *
+ * Everything else is "I could not look": a blind spot an unprivileged lsof may
+ * SHARE, which must never be spent as proof the port is free. That deliberately
+ * includes ENOSYS ("function not implemented") and ENXIO ("no such device or
+ * address") — both describe a failed OPERATION, not a pathname that resolves to
+ * nothing, so neither rules out a listener in a table we did not read. An
+ * errno-less failure is likewise a blind spot.
+ */
+function tableIsAbsent(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException)?.code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+/**
+ * A kernel socket row: `<hex-address>:<hex-port>` (8 hex digits for IPv4, 32 for
+ * IPv6) and a two-hex-digit state. Verified against real kernel output —
+ * `0100007F:1FFC` / `00000000000000000000000001000000:49D3`, state `0A`. Requiring
+ * the SHAPE, not merely four fields, is what stops a garbled row from being
+ * silently skipped and then reported as "no listener here".
+ */
+const KERNEL_LOCAL_ENDPOINT = /^([0-9A-Fa-f]{8}|[0-9A-Fa-f]{32}):([0-9A-Fa-f]{4})$/;
+const KERNEL_STATE = /^[0-9A-Fa-f]{2}$/;
+const KERNEL_SLOT = /^(\d+):$/;
+/** The kernel's hex code for TCP_LISTEN. */
+const LISTEN_STATE = "0A";
+/**
+ * The highest TCP state these tables can print: `TCP_CLOSING` (11 = 0x0B).
+ *
+ * The enum defines two values above it, and NEITHER reaches this column:
+ *
+ *   `TCP_NEW_SYN_RECV` (12 = 0x0C) is the sk_state of a request socket, but the
+ *     seq_show path renders those through `get_openreq4`, which prints the state as
+ *     `TCP_SYN_RECV` (3). So a half-open connection appears here as `03`, never `0C`.
+ *   `TCP_BOUND_INACTIVE` (13 = 0x0D) is a pseudo-state for inet_diag, which walks the
+ *     BIND table — and these files do not. `/proc/net/tcp` iterates the listening and
+ *     established hashes only. MEASURED on 6.18: a socket bound to a port without
+ *     `listen()` produces NO row here at all, in any state.
+ *
+ * So the domain is 01..0B, and anything above it is damage rather than a socket. A
+ * future kernel printing a new state costs that host only its fast path
+ * (`incomplete`, i.e. `unknown`), never a false answer.
+ */
+const MAX_TCP_STATE = 0x0b;
+/**
+ * The socket tables, each with the address width it is DEFINED to print: one 32-bit
+ * word for IPv4, four for IPv6. Binding rows to their table is what stops a 32-hex
+ * row in `/proc/net/tcp` — impossible, and therefore evidence of nothing — from
+ * being read as either a listener or a clean negative.
+ */
+const KERNEL_TABLES: ReadonlyArray<{
+  path: string;
+  addressHexWidth: number;
+  header: RegExp;
+}> = [
+  { path: "/proc/net/tcp", addressHexWidth: 8, header: kernelHeader("rem_address") },
+  {
+    path: "/proc/net/tcp6",
+    addressHexWidth: 32,
+    header: kernelHeader("remote_address"),
+  },
+];
+const KERNEL_QUEUES = /^[0-9A-Fa-f]{8}:[0-9A-Fa-f]{8}$/;
+const KERNEL_TIMER = /^[0-9A-Fa-f]{2}:[0-9A-Fa-f]{8}$/;
+const KERNEL_HEX8 = /^[0-9A-Fa-f]{8}$/;
+const KERNEL_DECIMAL = /^\d+$/;
+
+/**
+ * The local hex port of a COMPLETE socket row, or undefined if this is not one.
+ *
+ * The row is validated through its `inode` column for the same reason the header is
+ * validated through its last column: a row cut short after `st` still has four
+ * well-formed tokens, and accepting it would mean accepting a table that EOF
+ * truncated mid-row — taking any later listener rows with it — as a clean, complete
+ * "nothing is listening". Trailing columns beyond `inode` (refcount, pointer, and
+ * the rest, which vary by kernel) are accepted without inspection.
+ *
+ * Column shapes captured from a live kernel:
+ *   0:  slot            `0:`
+ *   1:  local_address   `0100007F:1FFC` / 32-hex for IPv6
+ *   2:  rem_address     same widths
+ *   3:  st              `0A`
+ *   4:  tx_queue:rx_queue `00000000:00000000`
+ *   5:  tr:tm->when     `00:00000000`
+ *   6:  retrnsmt        `00000000`
+ *   7:  uid             decimal
+ *   8:  timeout         decimal
+ *   9:  inode           decimal
+ */
+interface KernelRow {
+  slot: number;
+  localPort: string;
+  state: string;
+}
+
+/**
+ * The first four columns — slot, local endpoint, remote endpoint, state — which are
+ * the MINIMUM that can carry a positive finding.
+ *
+ * A positive is read from this prefix rather than from a whole row, because
+ * truncation after the state cannot unmake the fields before it. But it must be the
+ * whole prefix: `cols[1]` and `cols[3]` alone would let a line like
+ * `corrupt 0100007F:1FFC garbage 0A` fabricate a listener out of bytes we have
+ * every reason to distrust. Untrustworthy input must not become a definite finding
+ * in EITHER direction.
+ */
+function parseKernelRowPrefix(
+  cols: string[],
+  addressHexWidth: number,
+): KernelRow | undefined {
+  const slot = KERNEL_SLOT.exec(cols[0] ?? "");
+  const local = KERNEL_LOCAL_ENDPOINT.exec(cols[1] ?? "");
+  const remote = KERNEL_LOCAL_ENDPOINT.exec(cols[2] ?? "");
+  const state = cols[3] ?? "";
+  if (!slot || !local || !remote || !KERNEL_STATE.test(state)) return undefined;
+  // CROSS-FIELD consistency, because four individually well-shaped tokens can still
+  // be a row no kernel ever wrote. Both endpoints must be the width THIS TABLE is
+  // defined to print — which also settles the two against each other.
+  if (local[1].length !== addressHexWidth || remote[1].length !== addressHexWidth) {
+    return undefined;
+  }
+  // The state must be one the kernel can actually be in.
+  const stateCode = parseInt(state, 16);
+  if (stateCode < 1 || stateCode > MAX_TCP_STATE) return undefined;
+  // A LISTENING socket has no peer: its remote endpoint is all zeros on port 0. The
+  // netstat parser above leans on the same invariant (#401) to tell a listener from
+  // an established connection that merely bound its local side to the port.
+  if (
+    state.toUpperCase() === LISTEN_STATE &&
+    (remote[2] !== "0000" || /[^0]/.test(remote[1]))
+  ) {
+    return undefined;
+  }
+  return { slot: Number(slot[1]), localPort: local[2], state };
+}
+
+function parseKernelRow(
+  cols: string[],
+  addressHexWidth: number,
+): KernelRow | undefined {
+  if (cols.length < 10) return undefined;
+  const prefix = parseKernelRowPrefix(cols, addressHexWidth);
+  if (
+    !prefix ||
+    !KERNEL_QUEUES.test(cols[4]) ||
+    !KERNEL_TIMER.test(cols[5]) ||
+    !KERNEL_HEX8.test(cols[6]) ||
+    !KERNEL_DECIMAL.test(cols[7]) ||
+    !KERNEL_DECIMAL.test(cols[8]) ||
+    !KERNEL_DECIMAL.test(cols[9])
+  ) {
+    return undefined;
+  }
+  return prefix;
+}
+
+/**
+ * The COMPLETE column header, matched end to end — EVERY column named in order.
+ *
+ * Anchoring only the start would accept a header truncated to `sl local_address`,
+ * and a body truncated to nothing then reads as a table with no listeners — "the
+ * header parsed" silently standing in for "the body was read". Nor is it enough to
+ * pin only the two ends and allow anything between: `sl local_address rem_address
+ * inode` would satisfy that while missing every intervening column, which is the
+ * same truncation one level in. So the whole sequence is spelled out.
+ *
+ * Captured from a live kernel: IPv4 says `rem_address`, IPv6 says `remote_address`,
+ * and the IPv4 line carries trailing padding (removed by the caller's trim). Each
+ * table gets its OWN pattern rather than accepting either spelling, because the two
+ * are not interchangeable — an IPv4-form header standing over `/proc/net/tcp6` is a
+ * table we did not really read, not a table with nothing in it.
+ *
+ * A layout this does not recognise costs that host only its fast path — the read
+ * becomes `incomplete`, which is the safe direction — never a false negative.
+ */
+function kernelHeader(remoteColumn: string): RegExp {
+  return new RegExp(
+    `^sl\\s+local_address\\s+${remoteColumn}\\s+st\\s+tx_queue\\s+rx_queue\\s+tr\\s+tm->when\\s+retrnsmt\\s+uid\\s+timeout\\s+inode$`,
+    "i",
+  );
+}
+
+function readKernelSocketTables(port: number): KernelSocketTables {
   const wanted = port.toString(16).toUpperCase().padStart(4, "0");
-  let sawAnyTable = false;
-  for (const table of ["/proc/net/tcp", "/proc/net/tcp6"]) {
+  let tablesRead = 0;
+  let blind = false;
+  for (const { path: table, addressHexWidth, header } of KERNEL_TABLES) {
     let raw: string;
     try {
-      raw = readFileSync(table, "utf-8");
-    } catch {
+      raw = procNetReader(table);
+    } catch (err) {
+      // An absent table hides nothing; an unreadable one hides anything.
+      if (!tableIsAbsent(err)) blind = true;
       continue;
     }
-    sawAnyTable = true;
-    for (const line of raw.split("\n").slice(1)) {
-      const cols = line.trim().split(/\s+/);
-      if (cols.length < 4) continue;
-      const localPort = cols[1]?.split(":")[1];
-      if (localPort !== wanted) continue;
-      if (cols[3]?.toUpperCase() === LISTEN_STATE) return true;
+    tablesRead++;
+    // Row COUNT cannot distinguish a genuinely idle table from one truncated after
+    // its header — both have zero rows. So the table's OWN BOUNDARIES do: a real
+    // /proc/net/tcp always opens with the column header and always ends with a
+    // newline. Seeing neither end is what separates "I read the whole table and it
+    // held no listener" from "I read part of a table".
+    //
+    // A POSITIVE is unaffected and returns immediately below: a socket we can see is
+    // a socket, however much else was lost. Only the NEGATIVE needs completeness.
+    let sawHeader = false;
+    let nextSlot = 0;
+    const lines = raw.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const text = lines[i].trim();
+      // The header must OPEN the table — its first physical line. Accepting it
+      // wherever it turns up would let a table whose beginning was lost, or one with
+      // rows standing before it, pass as a table we watched from the start.
+      if (i === 0 && header.test(text)) {
+        sawHeader = true;
+        continue;
+      }
+      if (text === "") {
+        // Only the FINAL element may be blank — it is the artifact of the table's
+        // terminating newline. A blank ANYWHERE else is an empty record, which the
+        // kernel never writes: one non-empty line per entry. Treating an interior
+        // gap as ordinary structure would let a record deleted from the middle pass
+        // as a table that simply had nothing there.
+        if (i !== lines.length - 1) blind = true;
+        continue;
+      }
+      const cols = text.split(/\s+/);
+      // THE POSITIVE COMES FIRST, and needs only the fields that carry it: a local
+      // endpoint on the port we asked about, in the LISTEN state. Truncation AFTER
+      // the state cannot unmake the fields before it, so a row cut short of `inode`
+      // still proves the socket it already showed us. Putting the completeness gate
+      // ahead of this would be the same fold as everywhere else in this function,
+      // merely pointed at a positive: withholding a finding we actually made.
+      const prefix = parseKernelRowPrefix(cols, addressHexWidth);
+      if (
+        prefix &&
+        prefix.localPort.toUpperCase() === wanted &&
+        prefix.state.toUpperCase() === LISTEN_STATE
+      ) {
+        return "listening";
+      }
+      // Everything below serves the NEGATIVE, which is the half that needs the row
+      // to be whole.
+      const row = parseKernelRow(cols, addressHexWidth);
+      if (row === undefined) {
+        blind = true;
+        continue;
+      }
+      // The kernel numbers rows with a running counter from 0, so the sequence is
+      // its own continuity check: a GAP means a record between these two is missing
+      // from what we read, and a first row numbered above 0 means we picked the
+      // table up after its beginning. Neither is visible in any single row.
+      if (row.slot !== nextSlot) blind = true;
+      nextSlot = row.slot + 1;
     }
+    // No header on the first line means we did not see where the table STARTS — rows
+    // before the point we picked it up may be missing, and a well-formed row proves
+    // only that the bytes we got were well-formed. No trailing newline means we did
+    // not see where it ENDS. Either way this read cannot support a definite negative.
+    if (!sawHeader || !raw.endsWith("\n")) blind = true;
   }
-  return sawAnyTable ? false : undefined;
+  // A blind spot outranks everything except a positive: it means something could
+  // still be hiding. Only when nothing could be — every table either read cleanly
+  // or provably does not exist — may this answer be spent.
+  if (blind) return "incomplete";
+  return tablesRead === 0 ? "unavailable" : "none";
 }
 
 export function probePortOwner(port: number, host?: string): PortOwnerProbe {
@@ -236,29 +600,80 @@ export function probePortOwner(port: number, host?: string): PortOwnerProbe {
       : { state: "unknown", reason: failures.join("; ") || "no port probe available" };
   }
 
-  // The kernel's own socket table is consulted FIRST for free-vs-occupied: it sees
-  // every socket regardless of owner and cannot be silenced, which is exactly the
-  // ambiguity lsof leaves. `false` here is a real answer; lsof is then only needed
-  // to name the pid when something IS listening.
-  const kernelSaysListening = procNetHasListener(port);
-  if (kernelSaysListening === false) return { state: "free" };
+  // THE PRECEDENCE BETWEEN THE TWO SOURCES — stated here because it is the thing a
+  // future edit will get wrong, and because getting it wrong certifies a stop that
+  // never happened:
+  //
+  //   EXISTENCE is decided by the kernel table wherever it is available.
+  //   lsof only ATTRIBUTES an existing socket to a pid.
+  //
+  // The kernel table sees every socket regardless of owner and cannot be silenced —
+  // that is the entire reason it is consulted. lsof needs privileges the table does
+  // not, so lsof failing to find or name a listener the kernel CAN see means "I
+  // could not identify it", never "it is not there". A positive existence finding is
+  // therefore never overridable by a negative from a source that sees strictly less.
+  const kernel = readKernelSocketTables(port);
+  if (kernel === "none") return { state: "free" };
+
+  const listeningButUnnamed = {
+    state: "unknown",
+    reason: "a socket is listening on the port but lsof could not name its owner",
+  } as const;
+
+  /**
+   * lsof positively STATED that nothing is listening. Believable only when the
+   * kernel has neither contradicted it nor left a blind spot lsof could share: an
+   * unprivileged lsof reports exactly this while being unable to enumerate another
+   * user's listener, so it may not be spent as proof against a table we could not
+   * finish reading.
+   */
+  const lsofReportsNothingListening = (): PortOwnerProbe => {
+    if (kernel === "listening") return listeningButUnnamed;
+    if (kernel === "incomplete") {
+      return {
+        state: "unknown",
+        reason:
+          "lsof found nothing, but a kernel socket table could not be read in full — an unreadable table may hold the listener",
+      };
+    }
+    return { state: "free" };
+  };
 
   try {
     // `-V` makes lsof STATE what it failed to locate, which is the only positive
-    // "nothing is listening" signal it offers (see statesAddressNotLocated).
-    const out = execSync(`lsof -V -nP -iTCP:${port} -sTCP:LISTEN -Fpn`, {
+    // "nothing is listening" signal it offers (see readLsofAbsence).
+    //
+    // `2>&1` because lsof reports an INCOMPLETE enumeration on stderr, and on the
+    // success path `execSync` returns stdout ONLY — so without the redirect a marker
+    // on stdout beside a warning on stderr reads as a clean absence, and certifies a
+    // release from a search that admitted it was partial. The error path already sees
+    // both streams; this makes the success path see what the error path sees.
+    // Warnings do not disturb the field parser, which keys on `p`/`n` line prefixes.
+    // A host whose lsof warns routinely therefore loses the fast path — it costs a
+    // wait, never a wrong answer, which is the trade this whole probe makes.
+    const out = execSync(`lsof -V -nP -iTCP:${port} -sTCP:LISTEN -Fpn 2>&1`, {
       encoding: "utf-8",
       timeout: 5000,
     });
     const pid = parseListenerPidFromLsof(out, port, host);
     if (pid) return { state: "owned", pid };
-    if (/internet address not located/i.test(out)) return { state: "free" };
+    const absence = readLsofAbsence(out);
+    if (absence === "stated") return lsofReportsNothingListening();
+    // It DID report an empty search; we declined to spend it. Say that, rather than
+    // reporting the one cause we know did not apply.
+    if (absence === "inconclusive") {
+      return { state: "unknown", reason: LSOF_INCONCLUSIVE_REASON };
+    }
     // Exited 0 but named nobody, and did not say it looked and found nothing.
-    return kernelSaysListening === true
-      ? { state: "unknown", reason: "a socket is listening but its owner could not be named" }
+    return kernel === "listening"
+      ? listeningButUnnamed
       : { state: "unknown", reason: "lsof listed no owner and did not report an empty search" };
   } catch (err) {
-    if (statesAddressNotLocated(err)) return { state: "free" };
+    const absence = lsofErrorAbsence(err);
+    if (absence === "stated") return lsofReportsNothingListening();
+    if (absence === "inconclusive") {
+      return { state: "unknown", reason: LSOF_INCONCLUSIVE_REASON };
+    }
     return {
       state: "unknown",
       reason: `lsof: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/services/port-owner.ts
+++ b/src/services/port-owner.ts
@@ -7,6 +7,7 @@
 // existing tests keep importing it from there.
 
 import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { platform } from "node:os";
 
 const IS_WIN = platform() === "win32";
@@ -85,7 +86,7 @@ export function parseListenerPidFromNetstat(
 }
 
 /**
- * Parse `lsof -w -nP -iTCP:PORT -sTCP:LISTEN -Fpn` field output. Records look like
+ * Parse `lsof -V -nP -iTCP:PORT -sTCP:LISTEN -Fpn` field output. Records look like
  *   p1234
  *   n127.0.0.1:8188
  * so we can bind the match to the ADDRESS as well as the port, which the plain
@@ -133,31 +134,68 @@ export type PortOwnerProbe =
   | { state: "unknown"; reason: string };
 
 /**
- * Did this execSync failure mean "ran fine, enumerated everything, matched
- * nothing"? Only that reading is evidence the port is free.
+ * Did `lsof` positively STATE that nothing is listening?
  *
- * Exit status 1 alone is NOT enough. `lsof` also exits 1 when it could not
- * enumerate — a permission-restricted run reports what it could not open on
- * stderr and exits 1 having listed nothing, which is "I could not look", not
- * "nobody is listening". Certifying that as free would let `waitForPortFree`
- * report a release that never happened and tear down supervision under a live
- * server. So a clean empty result must ALSO be quiet on both streams; the `-w`
- * flag on the invocation suppresses lsof's routine warnings so that anything
- * remaining on stderr genuinely means the enumeration was incomplete.
+ * Its exit status cannot answer this. Verified against the manual and by
+ * experiment: lsof "returns a one (1) if any error was detected, INCLUDING the
+ * failure to locate ... Internet addresses", so status 1 conflates "searched and
+ * found nothing" with "could not search". Worse, a run that enumerates nothing
+ * because it lacks permission also produces status 1 with EMPTY stdout and EMPTY
+ * stderr — so "quiet" is not evidence either, with or without `-w` (which only
+ * suppresses warnings and therefore makes silence less meaningful, not more).
+ *
+ * What IS a positive statement of absence is `-V`, which makes lsof say what it
+ * failed to locate: `lsof: Internet address not located: TCP:8188`. That marker,
+ * and nothing else, is treated as "free". Anything else exits to "unknown", which
+ * a caller may not spend as proof of release.
  */
-function isEmptyResultExit(err: unknown): boolean {
+function statesAddressNotLocated(err: unknown): boolean {
   const e = err as NodeJS.ErrnoException & {
     status?: number;
     stdout?: Buffer | string;
     stderr?: Buffer | string;
   };
-  // A spawn-level failure (command missing, timeout) tells us nothing about the
-  // port; only a clean "no matches" exit does.
+  // A spawn-level failure (command missing, timeout) tells us nothing at all.
   if (e?.code) return false;
   if (e?.status !== 1) return false;
   const text = (v: Buffer | string | undefined): string =>
-    v == null ? "" : (typeof v === "string" ? v : v.toString("utf-8")).trim();
-  return text(e.stdout) === "" && text(e.stderr) === "";
+    v == null ? "" : typeof v === "string" ? v : v.toString("utf-8");
+  return /internet address not located/i.test(`${text(e.stdout)}\n${text(e.stderr)}`);
+}
+
+/**
+ * Is a socket LISTENING on `port`, according to the kernel's own table?
+ *
+ * `/proc/net/tcp{,6}` lists every TCP socket on the machine regardless of owner
+ * and needs no external tool, so it answers free-vs-occupied definitively where
+ * `lsof` can only answer ambiguously (and cannot see another user's sockets at
+ * all). It does not name the owning pid — that still needs lsof (or #795's
+ * `/proc/<pid>/fd` scan) — but the safety-critical question after a kill is
+ * whether the port was RELEASED, and this settles exactly that.
+ *
+ * Returns undefined when the tables cannot be read, which is not an answer.
+ */
+function procNetHasListener(port: number): boolean | undefined {
+  const LISTEN_STATE = "0A";
+  const wanted = port.toString(16).toUpperCase().padStart(4, "0");
+  let sawAnyTable = false;
+  for (const table of ["/proc/net/tcp", "/proc/net/tcp6"]) {
+    let raw: string;
+    try {
+      raw = readFileSync(table, "utf-8");
+    } catch {
+      continue;
+    }
+    sawAnyTable = true;
+    for (const line of raw.split("\n").slice(1)) {
+      const cols = line.trim().split(/\s+/);
+      if (cols.length < 4) continue;
+      const localPort = cols[1]?.split(":")[1];
+      if (localPort !== wanted) continue;
+      if (cols[3]?.toUpperCase() === LISTEN_STATE) return true;
+    }
+  }
+  return sawAnyTable ? false : undefined;
 }
 
 export function probePortOwner(port: number, host?: string): PortOwnerProbe {
@@ -198,15 +236,29 @@ export function probePortOwner(port: number, host?: string): PortOwnerProbe {
       : { state: "unknown", reason: failures.join("; ") || "no port probe available" };
   }
 
+  // The kernel's own socket table is consulted FIRST for free-vs-occupied: it sees
+  // every socket regardless of owner and cannot be silenced, which is exactly the
+  // ambiguity lsof leaves. `false` here is a real answer; lsof is then only needed
+  // to name the pid when something IS listening.
+  const kernelSaysListening = procNetHasListener(port);
+  if (kernelSaysListening === false) return { state: "free" };
+
   try {
-    const out = execSync(`lsof -w -nP -iTCP:${port} -sTCP:LISTEN -Fpn`, {
+    // `-V` makes lsof STATE what it failed to locate, which is the only positive
+    // "nothing is listening" signal it offers (see statesAddressNotLocated).
+    const out = execSync(`lsof -V -nP -iTCP:${port} -sTCP:LISTEN -Fpn`, {
       encoding: "utf-8",
       timeout: 5000,
     });
     const pid = parseListenerPidFromLsof(out, port, host);
-    return pid ? { state: "owned", pid } : { state: "free" };
+    if (pid) return { state: "owned", pid };
+    if (/internet address not located/i.test(out)) return { state: "free" };
+    // Exited 0 but named nobody, and did not say it looked and found nothing.
+    return kernelSaysListening === true
+      ? { state: "unknown", reason: "a socket is listening but its owner could not be named" }
+      : { state: "unknown", reason: "lsof listed no owner and did not report an empty search" };
   } catch (err) {
-    if (isEmptyResultExit(err)) return { state: "free" };
+    if (statesAddressNotLocated(err)) return { state: "free" };
     return {
       state: "unknown",
       reason: `lsof: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -552,6 +552,7 @@ function classifyListenerOwnership(input: {
   childExited: boolean;
   child: ChildProcess;
   launchArgv?: string[];
+  launchedAt?: string;
   portOwnerPid: number | null;
 }): ListenerOwnership {
   // A Desktop launch is undecidable BY DESIGN: we spawn the Electron shell (or
@@ -569,9 +570,32 @@ function classifyListenerOwnership(input: {
   if (input.portOwnerPid !== ourPid) return "not-ours";
   // The pid MATCHES — but it could be a recycled number we cannot signal.
   if (alive !== true) return "unconfirmed";
-  // Where the OS exposes it, require the port owner to still be running what we
-  // launched. Unreadable (the platforms where the identity read is skipped) leaves
-  // the pid+liveness match standing; a POSITIVE mismatch is counter-evidence.
+
+  // PER-INSTANCE identity. Everything above can be satisfied by a recycled number:
+  // same pid, signalable, and (if the replacement is another ComfyUI started with
+  // the same argv) even the same command line. Only the process CREATION TIME
+  // distinguishes instances, so when we captured ours at spawn it has to still be
+  // there. A positive mismatch is proof this is a different process; losing the
+  // ability to read it is not proof of anything, but it does mean we can no longer
+  // CLAIM the launch, so it degrades to "unconfirmed" rather than "ours".
+  if (input.launchedAt) {
+    const now = resolveProcessIdentityUnbounded(ourPid);
+    if (!now?.startedAt) return "unconfirmed";
+    if (now.startedAt !== input.launchedAt) return "not-ours";
+    if (
+      now.commandLine &&
+      input.launchArgv &&
+      !commandLineMatchesArgv(now.commandLine, input.launchArgv)
+    ) {
+      return "not-ours";
+    }
+    return "ours";
+  }
+
+  // No creation-time stamp was available at spawn. Fall back to the weaker signal:
+  // where the OS exposes it, the port owner must still be running what we launched.
+  // A POSITIVE mismatch is counter-evidence; unreadable leaves the pid+liveness
+  // match standing.
   const identity = resolveProcessIdentity(ourPid);
   if (
     identity?.commandLine &&
@@ -667,6 +691,14 @@ interface SpawnedComfyUI {
    * started, rather than a different program that inherited its pid.
    */
   launchArgv?: string[];
+  /**
+   * OUR child's process creation time, captured at spawn. A pid NUMBER is not an
+   * instance: a recycled number can match, be signalable, and even carry an
+   * identical command line (a second ComfyUI started with the same argv). The
+   * creation time is what tells instances apart, so it is what lets a later check
+   * say "the process on the port really is the one we launched".
+   */
+  launchedAt?: string;
 }
 
 let recordedLaunchChild: ChildProcess | undefined;
@@ -736,7 +768,13 @@ function spawnFromProcessInfo(info: ProcessInfo): SpawnedComfyUI | null {
   // the moment a different process owns the port. (Desktop-app launches return
   // above: that exe is a launcher, not an interpreter.)
   if (child.pid) recordLaunchedInterpreter(child.pid, cmd.exe);
-  return { child, launchArgv: [cmd.exe, ...cmd.args] };
+  return {
+    child,
+    launchArgv: [cmd.exe, ...cmd.args],
+    launchedAt: child.pid
+      ? resolveProcessIdentityUnbounded(child.pid)?.startedAt
+      : undefined,
+  };
 }
 
 /**
@@ -827,6 +865,25 @@ function resolveProcessIdentity(pid: number): ProcessIdentity | undefined {
   // `/proc/<pid>/environ` at all — so the expensive readers buy nothing the
   // port-ownership re-check does not already give.
   if (!pid || pid <= 0 || process.platform !== "linux") return undefined;
+  try {
+    return readProcessIdentity(pid);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Identity read WITHOUT the platform gate above.
+ *
+ * Reserved for the two moments that decide whether we may CLAIM to have started
+ * the server: recording our own child's creation time at spawn, and re-checking it
+ * against the process later found on the port. Those are the only places where the
+ * expensive Windows read buys something the cheap checks cannot give — a
+ * per-INSTANCE identity. Everything else stays on the gated reader.
+ */
+function resolveProcessIdentityUnbounded(pid: number): ProcessIdentity | undefined {
+  if (processIdentityOverride) return processIdentityOverride(pid);
+  if (!pid || pid <= 0) return undefined;
   try {
     return readProcessIdentity(pid);
   } catch {
@@ -1690,6 +1747,7 @@ export async function startComfyUI(): Promise<StartResult> {
     childExited: launchedChildExit != null,
     child: launched.child,
     launchArgv: launched.launchArgv,
+    launchedAt: launched.launchedAt,
     portOwnerPid: newPid,
   });
   // Only the NON-Desktop undecidable case is worth calling out: for a Desktop

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -21,6 +21,8 @@ import {
   recordLaunchedInterpreter,
   clearLaunchedInterpreter,
   readProcessIdentity,
+  commandLineMatchesArgv,
+  type ProcessIdentity,
 } from "./live-interpreter.js";
 import {
   liveRootFromArgv,
@@ -724,17 +726,55 @@ function resolveLiveProcessEnv(pid: number): NodeJS.ProcessEnv | undefined {
  * scenarios on any host.
  */
 let processIdentityOverride:
-  | ((pid: number) => { startedAt?: string } | undefined)
+  | ((pid: number) => ProcessIdentity | undefined)
   | null = null;
 
-function resolveProcessIdentity(pid: number): { startedAt?: string } | undefined {
+function resolveProcessIdentity(pid: number): ProcessIdentity | undefined {
   if (processIdentityOverride) return processIdentityOverride(pid);
+  // MEASURED: the Windows reader (a PowerShell `Get-CimInstance` spawn) costs
+  // ~2.4s per call even for a pid that does not exist, which would be paid twice
+  // on every restart and ~40x across the test suite. Linux's `/proc/<pid>/stat`
+  // read is free, and Linux is also the only platform where we read
+  // `/proc/<pid>/environ` at all — so the expensive readers buy nothing the
+  // port-ownership re-check does not already give.
   if (!pid || pid <= 0 || process.platform !== "linux") return undefined;
   try {
     return readProcessIdentity(pid);
   } catch {
     return undefined;
   }
+}
+
+/**
+ * A process identity we are willing to BIND to the ComfyUI that answered us.
+ *
+ * A creation-time stamp read moments after the port lookup is not by itself proof
+ * that the number still denotes the server: in the window between them ComfyUI can
+ * exit, the OS can recycle the pid, and a replacement can take the port — after
+ * which every later re-read agrees with itself about the WRONG process (coordinator
+ * gate). A timestamp cannot close that; an INDEPENDENT observation can. So the
+ * OS's view of the pid must corroborate the server's own view of itself: the
+ * process's command line has to match the `sys.argv` that `/system_stats` reported
+ * over HTTP (the same correlation #401 uses to keep a proxy on the port from
+ * passing itself off as ComfyUI). Anything unreadable or non-matching yields no
+ * identity at all, and the caller falls back to evidence that refuses rather than
+ * guesses.
+ */
+function resolveCorroboratedIdentity(
+  pid: number,
+  argv: string[],
+): ProcessIdentity | undefined {
+  if (argv.length === 0) return undefined;
+  const identity = resolveProcessIdentity(pid);
+  if (!identity?.startedAt) return undefined;
+  if (!commandLineMatchesArgv(identity.commandLine, argv)) {
+    logger.warn(
+      "Not binding to PID: the OS's command line for it does not match the argv ComfyUI reported",
+      { pid, commandLine: identity.commandLine ?? "(unavailable)" },
+    );
+    return undefined;
+  }
+  return identity;
 }
 
 /**
@@ -751,11 +791,14 @@ function resolveProcessIdentity(pid: number): { startedAt?: string } | undefined
 function captureVerifiedLiveEnv(
   pid: number,
   startedAt: string | undefined,
+  argv: string[],
 ): NodeJS.ProcessEnv | undefined {
   if (!startedAt) return undefined;
   const env = resolveLiveProcessEnv(pid);
   if (!env) return undefined;
-  const after = resolveProcessIdentity(pid)?.startedAt;
+  // Re-verify with the SAME corroboration used to bind in the first place, so a
+  // recycled pid cannot satisfy the re-check just by agreeing with itself.
+  const after = resolveCorroboratedIdentity(pid, argv)?.startedAt;
   if (!after || after !== startedAt) {
     logger.warn(
       "Discarding the captured ComfyUI environment: the pid's identity changed while reading it",
@@ -801,13 +844,24 @@ function processIdentityStillValid(
     }
   }
   if (info.startedAt) {
-    const now = resolveProcessIdentity(info.pid)?.startedAt;
-    if (now && now !== info.startedAt) {
+    // Same corroboration as the binding: a changed creation time OR a command line
+    // that no longer matches the server's argv both mean this number is not the
+    // process we identified.
+    const now = resolveProcessIdentity(info.pid);
+    if (now?.startedAt && now.startedAt !== info.startedAt) {
       return {
         ok: false,
         reason:
           `PID ${info.pid} is no longer the ComfyUI process we identified (its creation time ` +
           "changed), so the number has been reused by a different program and must not be killed",
+      };
+    }
+    if (now?.commandLine && !commandLineMatchesArgv(now.commandLine, info.argv)) {
+      return {
+        ok: false,
+        reason:
+          `PID ${info.pid} is running something other than the ComfyUI we identified ` +
+          `(its command line no longer matches that server's arguments), so it must not be killed`,
       };
     }
   }
@@ -1266,11 +1320,16 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   // Same live-only window for the ENVIRONMENT (#776): read it now, while the pid
   // is guaranteed alive, so a relaunch can reproduce the launcher environment the
   // server was actually started with instead of substituting the orchestrator's.
-  // The pid's IDENTITY (creation time), taken at the same moment as the pid itself
-  // so everything downstream can prove the number still denotes THIS process.
-  const startedAt = desktop ? undefined : resolveProcessIdentity(pid)?.startedAt;
+  // The pid's IDENTITY (creation time), CORROBORATED against the argv the server
+  // itself reported — so a pid recycled between the port lookup and this read is
+  // never bound to, however self-consistent its own later re-reads would be.
+  const startedAt = desktop
+    ? undefined
+    : resolveCorroboratedIdentity(pid, argv)?.startedAt;
   // Bound to that identity - never adopted from a pid we cannot still prove.
-  const liveEnv = desktop ? undefined : captureVerifiedLiveEnv(pid, startedAt);
+  const liveEnv = desktop
+    ? undefined
+    : captureVerifiedLiveEnv(pid, startedAt, argv);
 
   return {
     pid,
@@ -1296,14 +1355,6 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
     );
   }
   logger.info("Stopping ComfyUI...");
-  detachSupervisor();
-  // The server we may have launched is going away — clear the shares-our-env flag so
-  // a differently-launched successor doesn't inherit env-trust it shouldn't (#633 P1b).
-  // Forget the recorded interpreter too: a stop was requested, so the launch record
-  // must not outlive the process it describes (#401).
-  recordedLaunchChild = undefined;
-  resetLocalComfyUILaunchState();
-  clearLaunchedInterpreter();
 
   // Gather info before we kill it (or reuse the caller's pre-validated info so a
   // relaunch preflight in restartComfyUI is not discarded).
@@ -1329,6 +1380,11 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
   // and the OS recycled the number, killing it would destroy an unrelated program.
   // Refuse instead - nothing has been touched yet, so this costs a restart, never
   // the server.
+  //
+  // ORDERING IS LOAD-BEARING (coordinator gate): this runs BEFORE the supervisor
+  // teardown below. A refusal leaves a still-RUNNING server, and tearing down its
+  // crash supervision first would silently disarm auto-restart for a server we
+  // then declined to touch — turning a safe refusal into a later lost server.
   const identity = processIdentityStillValid(info);
   if (!identity.ok) {
     return {
@@ -1339,6 +1395,16 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
       has_restart_info: false,
     };
   }
+
+  // Past this point the stop is COMMITTED — only now may we drop supervision.
+  detachSupervisor();
+  // The server we may have launched is going away — clear the shares-our-env flag so
+  // a differently-launched successor doesn't inherit env-trust it shouldn't (#633 P1b).
+  // Forget the recorded interpreter too: a stop was requested, so the launch record
+  // must not outlive the process it describes (#401).
+  recordedLaunchChild = undefined;
+  resetLocalComfyUILaunchState();
+  clearLaunchedInterpreter();
 
   // Save for later start
   lastProcessInfo = info;
@@ -1945,7 +2011,17 @@ export async function restartComfyUI(): Promise<RestartResult> {
     // Reached only when startComfyUI reported started:true — i.e. the healthy
     // listener is ours, or ownership was undecidable. A listener that is provably
     // NOT ours returns started:false and is handled in the branch above.
-    message: `ComfyUI restarted successfully. ${startResult.message}`,
+    //
+    // "restarted successfully" is a claim of PROOF, so it is reserved for the case
+    // where the port owner was actually matched to the process we launched. When
+    // ownership could not be determined the server is genuinely up and the flags
+    // stay positive (denying that would mislabel every ordinary restart on hosts
+    // where the port-owner lookup is unavailable), but the sentence must not
+    // ATTRIBUTE that healthy listener to this restart (coordinator gate).
+    message:
+      (startResult.listener_ownership === "unconfirmed"
+        ? "ComfyUI is up and ready after the restart, though this call's own process could not be confirmed as the one serving the port. "
+        : "ComfyUI restarted successfully. ") + startResult.message,
     auto_restart: startResult.auto_restart,
     launch_env: startResult.launch_env,
     listener_ownership: startResult.listener_ownership,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -625,7 +625,16 @@ function classifyListenerOwnership(input: {
    */
   servingArgv?: string[];
 }): ListenerOwnership {
-  /** Does the server that is answering run what we launched? */
+  /**
+   * Does the server that is answering run what we launched?
+   *
+   * Deliberately ASYMMETRIC in what it can conclude. A MISMATCH is proof the
+   * listener is not ours — nobody else's command line is ours. A match is only
+   * CORROBORATION: another supervisor can start the very same ComfyUI command, win
+   * the bind race, and answer with identical argv, so "runs what we launched" can
+   * never by itself promote anything to "ours" (codex gate). It can only stop us
+   * asserting the negative.
+   */
   const byArgv = (): "match" | "differ" | "unknown" => {
     if (!input.servingArgv?.length || !input.launchArgv?.length) return "unknown";
     return commandLineMatchesArgv(input.launchArgv.join(" "), input.servingArgv)
@@ -656,19 +665,19 @@ function classifyListenerOwnership(input: {
   // is reparented and lineage can no longer place it in our tree. What still can:
   // the server is running the exact command line we launched (codex gate P2).
   if (input.childExited || alive === false) {
-    return byArgv() === "match" ? "ours" : "not-ours";
+    // A match cannot make this "ours" — our direct child is gone, and the server
+    // could equally be another supervisor's identical instance. But it does mean we
+    // cannot honestly assert the negative either, so the wrapper case degrades to
+    // "unconfirmed" instead of telling that user their own server is not theirs.
+    return byArgv() === "match" ? "unconfirmed" : "not-ours";
   }
 
   const ourPid = input.child.pid;
   if (input.portOwnerPid == null) {
-    // The port owner could not be mapped (#449). Rather than shrug, ask the server
-    // what it is running: a match is as strong as a pid comparison, and a MISMATCH
-    // is decisive counter-evidence that this call did not start the healthy
-    // listener — which is exactly the case that must not read as success.
-    const verdict = byArgv();
-    if (verdict === "match") return "ours";
-    if (verdict === "differ") return "not-ours";
-    return "unconfirmed";
+    // The port owner could not be mapped (#449). The server's own argv still
+    // decides the NEGATIVE: a different command line proves this call did not start
+    // the healthy listener, which is the case that must never read as success.
+    return byArgv() === "differ" ? "not-ours" : "unconfirmed";
   }
   if (ourPid == null) return "unconfirmed";
   if (input.portOwnerPid !== ourPid) {
@@ -681,11 +690,8 @@ function classifyListenerOwnership(input: {
     const descendant = isOurDescendant(input.portOwnerPid);
     if (descendant === true) return "ours";
     if (descendant === false) return "not-ours";
-    // Lineage unreadable — fall back to what the server says it is running.
-    const verdict = byArgv();
-    if (verdict === "match") return "ours";
-    if (verdict === "differ") return "not-ours";
-    return "unconfirmed";
+    // Lineage unreadable — the server's argv can still rule the listener OUT.
+    return byArgv() === "differ" ? "not-ours" : "unconfirmed";
   }
   // The pid MATCHES — but it could be a recycled number we cannot signal.
   if (alive !== true) return "unconfirmed";

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -9,6 +9,12 @@ import { comfyuiFetch } from "../comfyui/fetch.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { findComfyuiPython } from "./env-capabilities.js";
+import {
+  readLiveProcessEnv,
+  resolveLaunchEnvironment,
+  type LaunchEnvInfo,
+  type LaunchEnvResolution,
+} from "./launcher-env.js";
 import { resetManagerApiCache } from "./manager-api-cache.js";
 import { parseListenerPidFromNetstat, findPidByPort } from "./port-owner.js";
 import {
@@ -40,6 +46,22 @@ interface ProcessInfo {
    * after the stop kills the pid (when `/proc/<pid>/cwd` is gone) (#535).
    */
   liveCwd?: string;
+  /**
+   * The live ComfyUI process's own ENVIRONMENT, captured at gather-time while the
+   * process is still ALIVE — the same known-good moment (and the same
+   * disappears-on-kill constraint) as `liveCwd`. This is the launch environment
+   * verbatim, so a relaunch reproduces it exactly instead of silently
+   * substituting the orchestrator's own environment (#776). Linux only; other
+   * platforms cannot read another process's environment block.
+   */
+  liveEnv?: NodeJS.ProcessEnv;
+  /**
+   * The resolved relaunch ENVIRONMENT decision (#776) — computed once by
+   * assessRelaunch (pre-stop, so a refusal happens before anything is killed) and
+   * reused verbatim by the spawn, so the process that comes back is launched into
+   * the same environment the preflight approved.
+   */
+  envPlan?: LaunchEnvResolution;
 }
 
 interface StopResult {
@@ -57,6 +79,8 @@ interface StartResult {
   readiness?: StartupReadinessResult;
   auto_restart?: SupervisorResult;
   spawn_error?: ChildProcessErrorDetails;
+  /** How the relaunch environment was resolved (#776). */
+  launch_env?: LaunchEnvInfo;
 }
 
 interface RestartResult {
@@ -67,6 +91,8 @@ interface RestartResult {
   readiness?: StartupReadinessResult;
   auto_restart?: SupervisorResult;
   spawn_error?: ChildProcessErrorDetails;
+  /** How the relaunch environment was resolved (#776). */
+  launch_env?: LaunchEnvInfo;
 }
 
 interface StartupReadinessResult {
@@ -431,6 +457,26 @@ function childProcessErrorDetails(err: unknown): ChildProcessErrorDetails {
   };
 }
 
+/** The launch-environment facts to report, once a plan has been resolved (#776). */
+function launchEnvInfo(info?: ProcessInfo): LaunchEnvInfo | undefined {
+  return info?.envPlan?.info;
+}
+
+/**
+ * The sentence appended to a start/restart message when the server had to be
+ * launched WITHOUT a launcher environment we could not rebuild (#776). Only
+ * reachable from the already-down path — the still-running path refuses instead.
+ */
+function launchEnvWarning(info?: ProcessInfo): string {
+  const plan = info?.envPlan;
+  if (!plan || plan.reproducible) return "";
+  return (
+    ` WARNING: ${plan.reason ?? plan.info.note}` +
+    ` It was launched with this process's environment instead, which may not be enough for it to come up. ` +
+    (plan.advice ?? "")
+  ).replace(/\s+$/, "");
+}
+
 function supervisorResult(info?: ProcessInfo): SupervisorResult {
   const policy = getRestartPolicy();
   return {
@@ -503,9 +549,25 @@ function spawnFromProcessInfo(info: ProcessInfo): SpawnedComfyUI | null {
 
   const cmd = resolveLaunchCommand(info);
   if (!cmd) return null;
+  // #776: the relaunch ENVIRONMENT is as load-bearing as the relaunch command.
+  // Resolve it here too (not only in assessRelaunch) so EVERY spawn site — the
+  // restart relaunch, a bare start_comfyui, and the crash supervisor — launches
+  // into the SAME environment the preflight approved.
+  //
+  // This site never REFUSES: reaching it means nothing is listening on the port,
+  // i.e. the server is already down, and leaving it down is the one outcome worse
+  // than a possibly-degraded launch (#776 cardinal rule). An irreproducible
+  // launcher environment is refused earlier, by assessRelaunch, while the server
+  // is still UP; here it only downgrades to "inherit + warn".
+  const envPlan = ensureLaunchEnvPlan(info, cmd);
   const child = spawn(cmd.exe, cmd.args, {
     detached: true,
     stdio: "ignore",
+    // Omitted (undefined) for a plain install → the child inherits this process's
+    // environment, exactly as before #776. Set only when we have a BETTER answer:
+    // the live process's own environment, or a launcher environment reconstructed
+    // from disk.
+    env: envPlan.env,
     // Prefer the cwd the command resolved against (the live process cwd or the
     // absolute install anchor for a relaunch, #535/#711); only then the
     // configured install dir — and only as an ABSOLUTE path that exists on disk.
@@ -572,6 +634,19 @@ function resolveScriptAnchor(argv: string[]): string | undefined {
  * equivalent and return undefined (the existing refuse-safe fallback still applies).
  */
 let liveCwdResolverOverride: ((pid: number) => string | undefined) | null = null;
+/**
+ * Injectable live-ENVIRONMENT reader (#776) — same rationale and lifetime as the
+ * live-cwd resolver above: it must run while the process is alive, and tests need
+ * to drive it without a real `/proc`.
+ */
+let liveEnvResolverOverride:
+  | ((pid: number) => NodeJS.ProcessEnv | undefined)
+  | null = null;
+
+function resolveLiveProcessEnv(pid: number): NodeJS.ProcessEnv | undefined {
+  if (liveEnvResolverOverride) return liveEnvResolverOverride(pid);
+  return readLiveProcessEnv(pid);
+}
 
 function resolveLiveProcessCwd(pid: number): string | undefined {
   if (liveCwdResolverOverride) return liveCwdResolverOverride(pid);
@@ -677,6 +752,27 @@ function resolveLaunchCommand(
   return { exe: first, args: rest };
 }
 
+/**
+ * Resolve (once) the ENVIRONMENT this instance must be relaunched into (#776),
+ * memoized on the ProcessInfo so the pre-stop preflight and the post-stop spawn
+ * can never disagree: whatever assessRelaunch approved is exactly what gets
+ * spawned. The paths handed to the resolver are the ones the relaunch actually
+ * uses (resolved script, interpreter, cwd) plus the raw argv[0], so a launcher
+ * layout is recognized whichever of them carries it.
+ */
+function ensureLaunchEnvPlan(
+  info: ProcessInfo,
+  cmd: { exe: string; args: string[]; cwd?: string },
+): LaunchEnvResolution {
+  if (info.envPlan) return info.envPlan;
+  const plan = resolveLaunchEnvironment({
+    paths: [cmd.args[0], cmd.exe, cmd.cwd, info.argv[0], info.liveCwd],
+    liveEnv: info.liveEnv,
+  });
+  info.envPlan = plan;
+  return plan;
+}
+
 function fileExists(p: string | undefined): boolean {
   if (!p) return false;
   try {
@@ -738,7 +834,20 @@ function looksLikePath(s: string): boolean {
  * `main.py` exist on disk — catching a stale COMFYUI_PATH that points at an
  * install with no runnable server.
  */
-function assessRelaunch(info: ProcessInfo): { ok: boolean; reason?: string } {
+function assessRelaunch(
+  info: ProcessInfo,
+  opts?: {
+    /**
+     * Also require that the launch ENVIRONMENT can be reproduced (#776). TRUE for
+     * our own kill+relaunch, which spawns a brand-new process and must therefore
+     * rebuild its environment. FALSE for an OUT-OF-BAND restart preflight (the
+     * panel's ComfyUI-Manager reboot): Manager re-execs the SAME process, which
+     * inherits its own environment, so the launcher environment is preserved for
+     * free and refusing on it would only cost the user a working restart.
+     */
+    requireReproducibleEnv?: boolean;
+  },
+): { ok: boolean; reason?: string; advice?: string } {
   if (info.isDesktopApp) {
     if (IS_WIN) {
       const exe = fileExists(info.desktopExePath)
@@ -805,6 +914,21 @@ function assessRelaunch(info: ProcessInfo): { ok: boolean; reason?: string } {
           "could not locate the ComfyUI install; set COMFYUI_PATH or a default " +
           "workspace (COMFYUI_PATH may point at a stale/old install that has no " +
           "runnable server).",
+      };
+    }
+  }
+  // #776: the command is only half the relaunch. A launcher (Stability Matrix,
+  // Pinokio) hands ComfyUI an environment we do NOT inherit — relaunching without
+  // it starts a process that dies during import and leaves the server DOWN. Decide
+  // it HERE, pre-stop, so an irreproducible environment refuses while the server is
+  // still running rather than after it has been killed.
+  if (opts?.requireReproducibleEnv) {
+    const envPlan = ensureLaunchEnvPlan(info, cmd);
+    if (!envPlan.reproducible) {
+      return {
+        ok: false,
+        reason: envPlan.reason ?? envPlan.info.note,
+        advice: envPlan.advice,
       };
     }
   }
@@ -973,6 +1097,10 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   // Capture the live process cwd NOW, while the pid is guaranteed alive — the
   // `/proc/<pid>/cwd` symlink is gone the instant a later stop kills it (#535).
   const liveCwd = desktop ? undefined : resolveLiveProcessCwd(pid);
+  // Same live-only window for the ENVIRONMENT (#776): read it now, while the pid
+  // is guaranteed alive, so a relaunch can reproduce the launcher environment the
+  // server was actually started with instead of substituting the orchestrator's.
+  const liveEnv = desktop ? undefined : resolveLiveProcessEnv(pid);
 
   return {
     pid,
@@ -981,6 +1109,7 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
     isDesktopApp: desktop,
     desktopExePath: desktopExe,
     liveCwd,
+    liveEnv,
   };
 }
 
@@ -1157,29 +1286,45 @@ export async function startComfyUI(): Promise<StartResult> {
         `ComfyUI process failed to launch: ${startupResult.spawn_error.message}`,
       spawn_error: startupResult.spawn_error,
       auto_restart: supervisorResult(info),
+      launch_env: launchEnvInfo(info),
     };
   }
 
   const readiness = startupResult.readiness;
   if (!readiness.ready) {
+    const env = launchEnvInfo(info);
     return {
       started: false,
       ready: false,
       readiness,
+      // TRUTHFUL FAILURE (#776): the process was spawned but never answered, so
+      // ComfyUI is DOWN. Report that plainly — and name the environment it was
+      // launched into, which is the first thing to check when a relaunch of an
+      // otherwise-healthy install fails during import.
       message:
-        `ComfyUI process was launched but the API did not become ready after ${readiness.waited_ms}ms (${readiness.attempts}/${readiness.max_tries} probes). Check the ComfyUI logs.`,
+        `ComfyUI process was launched but the API did not become ready after ${readiness.waited_ms}ms (${readiness.attempts}/${readiness.max_tries} probes). Check the ComfyUI logs.` +
+        (env ? ` Launch environment: ${env.note}.` : "") +
+        launchEnvWarning(info),
       auto_restart: supervisorResult(info),
+      launch_env: env,
     };
   }
 
   const newPid = findPidByPort(port);
+  const env = launchEnvInfo(info);
   return {
     started: true,
     ready: true,
     readiness,
-    message: `ComfyUI started on port ${port}${newPid ? ` (PID ${newPid})` : ""}`,
+    message:
+      `ComfyUI started on port ${port}${newPid ? ` (PID ${newPid})` : ""}` +
+      // Say WHICH environment it came back in whenever that was not simply ours
+      // (#776) — the user needs to know a launcher environment was restored.
+      (env && env.source !== "inherited" ? ` — ${env.note}.` : "") +
+      launchEnvWarning(info),
     pid: newPid ?? undefined,
     auto_restart: supervisorResult(info),
+    launch_env: env,
   };
 }
 
@@ -1482,14 +1627,18 @@ export async function restartComfyUI(): Promise<RestartResult> {
     return restartViaManagerReboot({ label: "Desktop" });
   }
 
-  const relaunch = assessRelaunch(info);
+  // requireReproducibleEnv: this path KILLS the process and spawns a fresh one, so
+  // the launch ENVIRONMENT has to be rebuilt as well as the command (#776).
+  const relaunch = assessRelaunch(info, { requireReproducibleEnv: true });
   if (!relaunch.ok) {
     return {
       stopped: false,
       started: false,
       message:
         `Refusing to restart: ${relaunch.reason} ComfyUI was left running (not stopped) ` +
-        "so you don't lose the server. Fix the launch path (e.g. COMFYUI_PATH) and try again.",
+        "so you don't lose the server. " +
+        (relaunch.advice ??
+          "Fix the launch path (e.g. COMFYUI_PATH) and try again."),
     };
   }
 
@@ -1522,6 +1671,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
       message: `ComfyUI was stopped but could not be started: ${startResult.message}`,
       auto_restart: startResult.auto_restart,
       spawn_error: startResult.spawn_error,
+      launch_env: startResult.launch_env,
     };
   }
 
@@ -1536,6 +1686,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
     readiness: startResult.readiness,
     message: `ComfyUI restarted successfully. ${startResult.message}`,
     auto_restart: startResult.auto_restart,
+    launch_env: startResult.launch_env,
   };
 }
 
@@ -1633,6 +1784,11 @@ export async function preflightLocalRestart(): Promise<{
   const { info } = await acquireProcessInfo();
   if (!info) return { ok: true };
   if (info.isDesktopApp) return { ok: true };
+  // NOTE (#776): the launch-ENVIRONMENT check is deliberately NOT applied here.
+  // This preflight guards an OUT-OF-BAND ComfyUI-Manager reboot, which re-execs
+  // the SAME process — it inherits its own (launcher-supplied) environment, so a
+  // Stability Matrix / Pinokio environment survives that restart for free.
+  // Refusing on it would cost those users a restart path that actually works.
   const relaunch = assessRelaunch(info);
   if (relaunch.ok) return { ok: true };
   return { ok: false, reason: relaunch.reason };
@@ -1647,7 +1803,15 @@ export const __processControlTestHooks = {
     supervisorGaveUp = false;
     remoteRebootTimingOverride = null;
     liveCwdResolverOverride = null;
+    liveEnvResolverOverride = null;
     restartDispatchRecords.clear();
+  },
+  /** Inject a fake live-process-ENVIRONMENT reader (#776) so tests can drive the
+   *  `/proc/<pid>/environ` capture without a real process. */
+  setLiveEnvResolver(
+    fn: ((pid: number) => NodeJS.ProcessEnv | undefined) | null,
+  ): void {
+    liveEnvResolverOverride = fn;
   },
   /** Inject a fake live-process-cwd resolver (#535) so tests can drive the
    *  `/proc/<pid>/cwd` relative-script anchor without a real process/filesystem. */

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1546,29 +1546,56 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   // reproduce: the identity of the port owner BEFORE the HTTP call. If the same
   // pid still owns the port afterwards, the answer we hold was produced while that
   // one process held the socket throughout.
-  let ownerBefore: number | null = null;
-  try {
-    ownerBefore = findPidByPort(port);
-  } catch {
-    ownerBefore = null;
-  }
-
+  // The bracket is REQUIRED, not best-effort (codex gate): if the first lookup
+  // came back empty we have no anchor, and A-answers-then-B-takes-the-port with
+  // identical argv would sail through every later self-consistent check. A single
+  // flaky lookup is retried; a bracket we still cannot close refuses.
+  const safeFindPid = (): number | null => {
+    try {
+      return findPidByPort(port);
+    } catch {
+      return null;
+    }
+  };
   let argv: string[] = [];
-  try {
-    const stats = await getSystemStats();
-    argv = stats.system.argv ?? [];
-  } catch {
-    logger.warn("Could not fetch system_stats — will rely on PID detection");
+  let pid: number | null = null;
+  let bracketed = false;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const ownerBefore = safeFindPid();
+    try {
+      const stats = await getSystemStats();
+      argv = stats.system.argv ?? [];
+    } catch {
+      argv = [];
+      logger.warn("Could not fetch system_stats — will rely on PID detection");
+    }
+    const ownerAfter = safeFindPid();
+    pid = ownerAfter ?? ownerBefore;
+    // No answer to bind means there is nothing to mis-bind: the pid-only paths
+    // below (including #449's reachable-but-unmapped) own that case.
+    if (argv.length === 0) break;
+    if (ownerBefore != null && ownerAfter != null) {
+      if (ownerBefore !== ownerAfter) {
+        const err = new ProcessControlError(
+          `The process listening on port ${port} changed while ComfyUI was being identified ` +
+            `(PID ${ownerBefore} answered, PID ${ownerAfter} holds the port now). Nothing was ` +
+            `stopped: the launch arguments we hold describe the instance that has gone, not the ` +
+            `one running now. Re-run once the server has settled.`,
+        );
+        err.identityAmbiguous = true;
+        throw err;
+      }
+      bracketed = true;
+      break;
+    }
+    // One side of the bracket was unreadable — retry once before giving up.
   }
-
-  // 2. Find PID by port
-  const pid = findPidByPort(port);
-  if (ownerBefore != null && pid != null && ownerBefore !== pid) {
+  if (argv.length > 0 && pid != null && !bracketed) {
     const err = new ProcessControlError(
-      `The process listening on port ${port} changed while ComfyUI was being identified ` +
-        `(PID ${ownerBefore} answered, PID ${pid} holds the port now). Nothing was stopped: ` +
-        `the launch arguments we hold describe the instance that has gone, not the one ` +
-        `running now. Re-run once the server has settled.`,
+      `ComfyUI answered on port ${port}, but the process owning that port could not be read ` +
+        `on both sides of the request, so its answer cannot be tied to PID ${pid}. Nothing was ` +
+        `stopped: acting on an unverified pairing risks controlling the wrong process. Re-run, ` +
+        `or restart ComfyUI from the launcher that owns it.`,
     );
     err.identityAmbiguous = true;
     throw err;

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -500,6 +500,89 @@ function childProcessErrorDetails(err: unknown): ChildProcessErrorDetails {
   };
 }
 
+/**
+ * Is the process we spawned still alive? Tri-state, because only a DEFINITE answer
+ * may change a verdict.
+ *
+ * Node delivers a child's `exit` event through the event loop, so "the handler has
+ * not run yet" is NOT evidence the child is alive — and a pid whose child died can
+ * be recycled by another program in that window (codex gate). A signal-0 probe
+ * answers synchronously:
+ *   false     - ESRCH, or an exit already recorded: our child is definitively gone.
+ *   undefined - no pid to probe, or EPERM (a process has that pid but we may not
+ *               signal it, i.e. it belongs to another user). "Cannot tell", never
+ *               "alive" — and never "dead" either, since a missing pid must not by
+ *               itself convict a launch that may well have worked.
+ *   true      - the pid exists and is signalable. Necessary, NOT sufficient: a
+ *               recycled pid also passes, which is why the caller additionally
+ *               corroborates the command line.
+ */
+function launchedChildStillRunning(child: ChildProcess): boolean | undefined {
+  const pid = child.pid;
+  if (pid == null) return undefined;
+  // Loose null check on purpose: a not-yet-exited child reports `null` here, and
+  // an absent property must read the same way rather than as "already exited".
+  if (child.exitCode != null || child.signalCode != null) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") return false;
+    return undefined;
+  }
+}
+
+/**
+ * Who owns the healthy listener after a launch — the single place that decides
+ * whether this call may claim it started the server.
+ *
+ * The trap it exists to avoid: a matching pid NUMBER is not proof. Our child can
+ * die, the OS can hand its number to another program, and that program can bind the
+ * port — all before Node delivers the `exit` event, at which point a naive
+ * `portOwnerPid === ourPid` says "ours" about somebody else's process. So a
+ * positive verdict requires the number to match AND the child to be provably alive
+ * AND (where the OS will tell us) the port owner's command line to match what we
+ * actually launched. Any hole in that chain degrades to "unconfirmed"; definite
+ * counter-evidence gives "not-ours".
+ */
+function classifyListenerOwnership(input: {
+  isDesktopApp: boolean;
+  /** The child's `exit` event has already been delivered. */
+  childExited: boolean;
+  child: ChildProcess;
+  launchArgv?: string[];
+  portOwnerPid: number | null;
+}): ListenerOwnership {
+  // A Desktop launch is undecidable BY DESIGN: we spawn the Electron shell (or
+  // macOS `open`) and its child binds the port, so a pid mismatch proves nothing.
+  if (input.isDesktopApp) return "unconfirmed";
+  if (input.childExited) return "not-ours";
+
+  const alive = launchedChildStillRunning(input.child);
+  // Definitively gone (ESRCH) — whatever is serving the port is not it, even
+  // though the `exit` event has not been delivered yet.
+  if (alive === false) return "not-ours";
+
+  const ourPid = input.child.pid;
+  if (ourPid == null || input.portOwnerPid == null) return "unconfirmed";
+  if (input.portOwnerPid !== ourPid) return "not-ours";
+  // The pid MATCHES — but it could be a recycled number we cannot signal.
+  if (alive !== true) return "unconfirmed";
+  // Where the OS exposes it, require the port owner to still be running what we
+  // launched. Unreadable (the platforms where the identity read is skipped) leaves
+  // the pid+liveness match standing; a POSITIVE mismatch is counter-evidence.
+  const identity = resolveProcessIdentity(ourPid);
+  if (
+    identity?.commandLine &&
+    input.launchArgv &&
+    !commandLineMatchesArgv(identity.commandLine, input.launchArgv)
+  ) {
+    return "not-ours";
+  }
+  return "ours";
+}
+
 /** The launch-environment facts to report, once a plan has been resolved (#776). */
 function launchEnvInfo(info?: ProcessInfo): LaunchEnvInfo | undefined {
   return info?.envPlan?.info;
@@ -578,6 +661,12 @@ function rememberRestartAttempt(policy: RestartPolicy): boolean {
 
 interface SpawnedComfyUI {
   child: ChildProcess;
+  /**
+   * The exact (interpreter + args) we launched, for a NON-Desktop spawn. Used to
+   * corroborate that the process later found on the port really is the one we
+   * started, rather than a different program that inherited its pid.
+   */
+  launchArgv?: string[];
 }
 
 let recordedLaunchChild: ChildProcess | undefined;
@@ -647,7 +736,7 @@ function spawnFromProcessInfo(info: ProcessInfo): SpawnedComfyUI | null {
   // the moment a different process owns the port. (Desktop-app launches return
   // above: that exe is a launcher, not an interpreter.)
   if (child.pid) recordLaunchedInterpreter(child.pid, cmd.exe);
-  return { child };
+  return { child, launchArgv: [cmd.exe, ...cmd.args] };
 }
 
 /**
@@ -1596,15 +1685,13 @@ export async function startComfyUI(): Promise<StartResult> {
   //     success. That uncertainty is carried by an EXPLICIT string state, so it
   //     survives JSON serialization instead of vanishing with an `undefined`.
   const ourPid = launched.child.pid;
-  const ownership: ListenerOwnership = info.isDesktopApp
-    ? "unconfirmed"
-    : launchedChildExit
-      ? "not-ours"
-      : ourPid == null || newPid == null
-        ? "unconfirmed"
-        : newPid === ourPid
-          ? "ours"
-          : "not-ours";
+  const ownership: ListenerOwnership = classifyListenerOwnership({
+    isDesktopApp: info.isDesktopApp,
+    childExited: launchedChildExit != null,
+    child: launched.child,
+    launchArgv: launched.launchArgv,
+    portOwnerPid: newPid,
+  });
   // Only the NON-Desktop undecidable case is worth calling out: for a Desktop
   // launcher the pid relationship is indirect by design, not a gap in evidence.
   const ownershipUnconfirmed = !info.isDesktopApp && ownership === "unconfirmed";

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -91,6 +91,12 @@ interface StopResult {
   message: string;
   has_restart_info: boolean;
   auto_restart?: SupervisorResult;
+  /**
+   * Set when the stop was COMMITTED without being able to confirm the process
+   * actually exited (every port probe failed after the kill). Carried separately
+   * so a caller composing its own message cannot silently drop the caveat.
+   */
+  unverified_exit?: string;
 }
 
 interface StartResult {
@@ -1881,6 +1887,13 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
     argv: info.argv.join(" "),
   });
 
+  // Remember HOW to relaunch before doing anything irreversible. Saving this only
+  // after a committed stop meant that any later refusal — including one taken while
+  // the server may already be dead — left `start_comfyui` with no launch info to
+  // recover from (codex gate). It is only a record of what we observed; a start
+  // still re-validates and refuses to double-launch onto an occupied port.
+  lastProcessInfo = info;
+
   // Kill process tree (for Desktop app, kill the Electron shell too).
   //
   // A KILL THAT THREW IS NOT A COMMITTED STOP (coordinator gate P1(3)). `taskkill`
@@ -1923,24 +1936,36 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
   // success from here. The port is the observable that settles it: wait for it to
   // be released, and let the timeout DECIDE rather than merely warn.
   let blockedReason: string | undefined;
+  let unverified: string | undefined;
   try {
     await waitForPortFree(info.port);
   } catch {
     // Timed out. Three outcomes, and they must NOT be conflated:
-    //   • still held by OUR target → the kill did not work; the server is UP, so
-    //     refusing is both safe and correct;
-    //   • held by somebody else → our target did die and a successor took the port;
-    //   • could not be determined → we have no proof the process died, and
-    //     "unknown" must never be spent as if it were proof.
+    //   • still held by OUR target → the kill did not work, so the server is UP.
+    //     Refusing is safe AND correct: it costs a restart, never the server.
+    //   • held by somebody else → our target did die and a successor took the port.
+    //   • could not be determined → see below.
     const probe = probePortOwner(info.port);
     if (probe.state === "owned" && probe.pid === info.pid) {
       blockedReason =
         `PID ${info.pid} still holds port ${info.port} after the kill was issued, so it is ` +
         `still running`;
     } else if (probe.state === "unknown") {
-      blockedReason =
-        `the port could not be checked after the kill (${probe.reason}), so there is no ` +
-        `evidence PID ${info.pid} actually died`;
+      // We CANNOT tell whether the process died — and unlike every other
+      // uncertainty in this file, refusing here does not restore anything: the kill
+      // has already been issued. If it worked, refusing leaves the user's server
+      // dead AND unrelaunched, which is the one outcome this whole issue exists to
+      // prevent. So we commit and let the relaunch run; if the kill in fact failed,
+      // the old server is still serving and the relaunch simply finds the port
+      // taken (reported honestly as `not-ours`). Proceed — and say it is unverified.
+      unverified =
+        `the port could not be checked after the kill (${probe.reason}), so it is not ` +
+        `confirmed that PID ${info.pid} exited`;
+      logger.warn("Stop committed without port verification", {
+        pid: info.pid,
+        port: info.port,
+        reason: probe.reason,
+      });
     } else {
       logger.warn(
         "Port did not free in time, but it is no longer held by the process we killed",
@@ -1961,7 +1986,9 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
     };
   }
 
-  // COMMITTED — the process is provably gone. Only now may we drop supervision.
+  // COMMITTED — the process is gone, or (when `unverified`) the kill has been
+  // issued and we have chosen going forward over a refusal that could not restore
+  // anything. Only now may we drop supervision.
   detachSupervisor();
   // The server we may have launched is going away — clear the shares-our-env flag so
   // a differently-launched successor doesn't inherit env-trust it shouldn't (#633 P1b).
@@ -1971,9 +1998,6 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
   resetLocalComfyUILaunchState();
   clearLaunchedInterpreter();
   deliberateStop = false;
-
-  // Save for later start
-  lastProcessInfo = info;
 
   // Reset the WebSocket client singleton + the memoized /object_info —
   // a restart is exactly when the node set may have changed. The detected
@@ -1987,9 +2011,12 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
 
   return {
     stopped: true,
-    message: `ComfyUI (PID ${info.pid}) stopped on port ${info.port}`,
+    message:
+      `ComfyUI (PID ${info.pid}) stopped on port ${info.port}` +
+      (unverified ? ` — NOTE: ${unverified}; continuing so the server can be brought back.` : ""),
     has_restart_info: true,
     auto_restart: supervisorResult(info),
+    unverified_exit: unverified,
   };
 }
 
@@ -2563,6 +2590,14 @@ export async function restartComfyUI(): Promise<RestartResult> {
   // Brief pause to let OS fully release resources
   await sleep(1000);
 
+  // A caveat from the stop must survive into whatever we report: the stop can
+  // commit WITHOUT confirming the process exited (every port probe failed after
+  // the kill), and that is exactly the situation where a bare "restarted
+  // successfully" would overstate what we know.
+  const stopCaveat = stopResult.unverified_exit
+    ? ` NOTE from the stop: ${stopResult.unverified_exit}.`
+    : "";
+
   // Start
   const startResult = await startComfyUI();
   if (!startResult.started) {
@@ -2576,9 +2611,11 @@ export async function restartComfyUI(): Promise<RestartResult> {
       // somebody else (an external supervisor beat us to the port — our relaunch
       // still failed). Saying "could not be started" about a healthy server would
       // be as wrong as claiming success for it (codex gate).
-      message: startResult.ready
-        ? `ComfyUI is back up, but NOT as a result of this restart: ${startResult.message}`
-        : `ComfyUI was stopped but could not be started: ${startResult.message}`,
+      message:
+        (startResult.ready
+          ? `ComfyUI is back up, but NOT as a result of this restart: ${startResult.message}`
+          : `ComfyUI was stopped but could not be started: ${startResult.message}`) +
+        stopCaveat,
       auto_restart: startResult.auto_restart,
       spawn_error: startResult.spawn_error,
       launch_env: startResult.launch_env,
@@ -2608,7 +2645,9 @@ export async function restartComfyUI(): Promise<RestartResult> {
     message:
       (startResult.listener_ownership === "unconfirmed"
         ? "ComfyUI is up and ready after the restart, though this call's own process could not be confirmed as the one serving the port. "
-        : "ComfyUI restarted successfully. ") + startResult.message,
+        : "ComfyUI restarted successfully. ") +
+      startResult.message +
+      stopCaveat,
     auto_restart: startResult.auto_restart,
     launch_env: startResult.launch_env,
     listener_ownership: startResult.listener_ownership,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -619,16 +619,20 @@ function classifyListenerOwnership(input: {
 }): ListenerOwnership {
   // A Desktop launch is undecidable BY DESIGN: we spawn the Electron shell (or
   // macOS `open`) and its child binds the port, so a pid mismatch proves nothing.
+  // A LAUNCH THAT NEVER HAPPENED is decisive on every path, Desktop included —
+  // these come FIRST so no later shortcut can soften them (codex gate). The spawn
+  // error is latched independently of the readiness race, and Node leaves `pid`
+  // undefined only when the spawn did not happen, so the two are the same fact
+  // arriving by different routes.
+  if (input.spawnFailed) return "not-ours";
+  if (input.child.pid == null) return "not-ours";
+  // A Desktop launch is undecidable BY DESIGN once it HAS started: we spawn the
+  // Electron shell (or macOS `open`, which exits immediately by design), and the
+  // process that binds the port is its child. Note this sits AFTER the
+  // never-launched checks but BEFORE `childExited`, because for Desktop a launcher
+  // exiting is normal rather than evidence of failure.
   if (input.isDesktopApp) return "unconfirmed";
   if (input.childExited) return "not-ours";
-  // The spawn FAILED — whatever is answering, we did not start it. Checked before
-  // anything else so a healthy listener that won the readiness race cannot launder
-  // a failed launch into an unconfirmed success (codex gate).
-  if (input.spawnFailed) return "not-ours";
-  // Node leaves `pid` undefined when the spawn did not happen at all. That is the
-  // same fact arriving by a different route (the `error` event may not have been
-  // delivered yet), so it gets the same verdict rather than "we cannot tell".
-  if (input.child.pid == null) return "not-ours";
 
   const alive = launchedChildStillRunning(input.child);
   // Definitively gone (ESRCH) — whatever is serving the port is not it, even

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -607,6 +607,12 @@ function classifyListenerOwnership(input: {
   isDesktopApp: boolean;
   /** The child's `exit` event has already been delivered. */
   childExited: boolean;
+  /**
+   * The child's `error` event has been delivered — the spawn FAILED. Latched
+   * independently of the readiness race, because a healthy listener answering
+   * first must not hide the fact that our launch never happened.
+   */
+  spawnFailed: boolean;
   child: ChildProcess;
   launchArgv?: string[];
   portOwnerPid: number | null;
@@ -615,6 +621,14 @@ function classifyListenerOwnership(input: {
   // macOS `open`) and its child binds the port, so a pid mismatch proves nothing.
   if (input.isDesktopApp) return "unconfirmed";
   if (input.childExited) return "not-ours";
+  // The spawn FAILED — whatever is answering, we did not start it. Checked before
+  // anything else so a healthy listener that won the readiness race cannot launder
+  // a failed launch into an unconfirmed success (codex gate).
+  if (input.spawnFailed) return "not-ours";
+  // Node leaves `pid` undefined when the spawn did not happen at all. That is the
+  // same fact arriving by a different route (the `error` event may not have been
+  // delivered yet), so it gets the same verdict rather than "we cannot tell".
+  if (input.child.pid == null) return "not-ours";
 
   const alive = launchedChildStillRunning(input.child);
   // Definitively gone (ESRCH) — whatever is serving the port is not it, even
@@ -1942,6 +1956,14 @@ export async function startComfyUI(): Promise<StartResult> {
   launched.child.once("exit", (code, signal) => {
     launchedChildExit = { code, signal };
   });
+  // Latched SEPARATELY from the readiness race below: if another launcher's server
+  // answers first, the race resolves on readiness and the spawn failure would never
+  // be consulted — leaving a launch that never happened reported as an unconfirmed
+  // success (codex gate).
+  let launchedSpawnFailed = false;
+  launched.child.once("error", () => {
+    launchedSpawnFailed = true;
+  });
   launched.child.unref();
   lastProcessInfo = info;
   superviseChild(launched.child, info);
@@ -1978,7 +2000,9 @@ export async function startComfyUI(): Promise<StartResult> {
       spawn_error: startupResult.spawn_error,
       auto_restart: supervisorResult(info),
       launch_env: launchEnvInfo(info),
-      listener_ownership: "unconfirmed",
+      // The spawn failed outright: whatever may be serving that port, it is
+      // certainly not something this call started.
+      listener_ownership: "not-ours",
     };
   }
 
@@ -2028,6 +2052,7 @@ export async function startComfyUI(): Promise<StartResult> {
   const ownership: ListenerOwnership = classifyListenerOwnership({
     isDesktopApp: info.isDesktopApp,
     childExited: launchedChildExit != null,
+    spawnFailed: launchedSpawnFailed,
     child: launched.child,
     launchArgv: launched.launchArgv,
     portOwnerPid: newPid,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -81,6 +81,13 @@ interface StartResult {
   spawn_error?: ChildProcessErrorDetails;
   /** How the relaunch environment was resolved (#776). */
   launch_env?: LaunchEnvInfo;
+  /**
+   * Whether the process now listening on the port is the one WE launched.
+   * `undefined` when it cannot be decided (no spawn pid, or the port owner could
+   * not be mapped). `false` means a healthy server is up but somebody else owns
+   * it — readiness alone must never be read as "our relaunch worked".
+   */
+  listener_is_launched_process?: boolean;
 }
 
 interface RestartResult {
@@ -93,6 +100,13 @@ interface RestartResult {
   spawn_error?: ChildProcessErrorDetails;
   /** How the relaunch environment was resolved (#776). */
   launch_env?: LaunchEnvInfo;
+  /**
+   * Whether the process now listening on the port is the one WE launched.
+   * `undefined` when it cannot be decided (no spawn pid, or the port owner could
+   * not be mapped). `false` means a healthy server is up but somebody else owns
+   * it — readiness alone must never be read as "our relaunch worked".
+   */
+  listener_is_launched_process?: boolean;
 }
 
 interface StartupReadinessResult {
@@ -460,6 +474,25 @@ function childProcessErrorDetails(err: unknown): ChildProcessErrorDetails {
 /** The launch-environment facts to report, once a plan has been resolved (#776). */
 function launchEnvInfo(info?: ProcessInfo): LaunchEnvInfo | undefined {
   return info?.envPlan?.info;
+}
+
+/**
+ * The sentence naming the DEATH of the process we launched, when it died before
+ * the API answered. Far more actionable than "60/60 probes": it says the relaunch
+ * itself failed (the #776 shape — ComfyUI aborting during import), not that it is
+ * merely slow.
+ */
+function describeLaunchedChildExit(
+  exit: { code: number | null; signal: NodeJS.Signals | null } | undefined,
+): string {
+  if (!exit) return "";
+  const how =
+    exit.signal != null
+      ? `killed by ${exit.signal}`
+      : exit.code != null
+        ? `exit code ${exit.code}`
+        : "for an unknown reason";
+  return ` The process this call launched EXITED (${how}) before the API came up, so ComfyUI is DOWN — this was a failed relaunch, not a slow start.`;
 }
 
 /**
@@ -1251,6 +1284,16 @@ export async function startComfyUI(): Promise<StartResult> {
     };
   }
   const spawnError = captureChildProcessError(launched.child);
+  // TRUTHFULNESS WATCH (codex gate): remember whether the process WE launched died
+  // before the readiness poll finished. Readiness only proves that SOMETHING answers
+  // on the port — it cannot tell our relaunch apart from an external
+  // launcher/supervisor that grabbed the port meanwhile. Recording the exit (rather
+  // than racing it) changes no timing and no outcome; it only lets the report name
+  // what actually happened instead of implying our child is the healthy server.
+  let launchedChildExit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+  launched.child.once("exit", (code, signal) => {
+    launchedChildExit = { code, signal };
+  });
   launched.child.unref();
   lastProcessInfo = info;
   superviseChild(launched.child, info);
@@ -1303,15 +1346,23 @@ export async function startComfyUI(): Promise<StartResult> {
       // otherwise-healthy install fails during import.
       message:
         `ComfyUI process was launched but the API did not become ready after ${readiness.waited_ms}ms (${readiness.attempts}/${readiness.max_tries} probes). Check the ComfyUI logs.` +
+        describeLaunchedChildExit(launchedChildExit) +
         (env ? ` Launch environment: ${env.note}.` : "") +
         launchEnvWarning(info),
       auto_restart: supervisorResult(info),
       launch_env: env,
+      listener_is_launched_process: false,
     };
   }
 
   const newPid = findPidByPort(port);
   const env = launchEnvInfo(info);
+  // Is the healthy listener actually OURS? Only decidable when we know both PIDs;
+  // an unmappable port owner (the #449 shape) stays `undefined` rather than
+  // asserting either way.
+  const ourPid = launched.child.pid;
+  const listenerIsOurs =
+    ourPid == null || newPid == null ? undefined : newPid === ourPid;
   return {
     started: true,
     ready: true,
@@ -1321,10 +1372,19 @@ export async function startComfyUI(): Promise<StartResult> {
       // Say WHICH environment it came back in whenever that was not simply ours
       // (#776) — the user needs to know a launcher environment was restored.
       (env && env.source !== "inherited" ? ` — ${env.note}.` : "") +
+      // NEVER imply our relaunch is the healthy server when the port is owned by
+      // a DIFFERENT process (codex gate): an external launcher/supervisor can bind
+      // the port while our child fails, and readiness alone cannot tell them apart.
+      (listenerIsOurs === false
+        ? ` NOTE: the process serving port ${port} (PID ${newPid}) is NOT the one this call launched (PID ${ourPid}${
+            launchedChildExit ? ", which has since exited" : ""
+          }) — another launcher or supervisor owns it, so this server was not started by us.`
+        : "") +
       launchEnvWarning(info),
     pid: newPid ?? undefined,
     auto_restart: supervisorResult(info),
     launch_env: env,
+    listener_is_launched_process: listenerIsOurs,
   };
 }
 
@@ -1672,6 +1732,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
       auto_restart: startResult.auto_restart,
       spawn_error: startResult.spawn_error,
       launch_env: startResult.launch_env,
+      listener_is_launched_process: startResult.listener_is_launched_process,
     };
   }
 
@@ -1684,9 +1745,17 @@ export async function restartComfyUI(): Promise<RestartResult> {
     started: true,
     ready: startResult.ready,
     readiness: startResult.readiness,
-    message: `ComfyUI restarted successfully. ${startResult.message}`,
+    // Only claim a clean "restarted successfully" when the healthy listener is the
+    // process we launched (or we could not tell). When it provably is NOT ours, say
+    // the server is up but somebody ELSE brought it back (codex gate) — startResult's
+    // own message carries the PID detail.
+    message:
+      (startResult.listener_is_launched_process === false
+        ? "ComfyUI is back up, but NOT as a result of this restart. "
+        : "ComfyUI restarted successfully. ") + startResult.message,
     auto_restart: startResult.auto_restart,
     launch_env: startResult.launch_env,
+    listener_is_launched_process: startResult.listener_is_launched_process,
   };
 }
 

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1674,16 +1674,33 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   // close on the number alone). So each end reads pid + creation time together, and
   // an end whose stamp cannot be read is "did not observe", never "observed the
   // same" (codex gate).
+  //
+  // `missing` records WHICH capability was unavailable, so a refusal can name it
+  // rather than leaving the user to guess. This is a real, if narrow, platform
+  // limitation: a host that cannot report process creation times cannot have its
+  // restart verified, and we would rather say so than kill on an unverified pairing.
+  let missingCapability: string | undefined;
   const observeOwner = (): { pid: number; startedAt: string } | null => {
     let owner: number | null = null;
     try {
       owner = findPidByPort(port);
     } catch {
+      owner = null;
+    }
+    if (owner == null) {
+      missingCapability =
+        `the process listening on port ${port} could not be identified (no usable ` +
+        `port-owner lookup — on Linux this needs \`lsof\`, on Windows \`netstat\`/PowerShell)`;
       return null;
     }
-    if (owner == null) return null;
     const startedAt = resolveProcessIdentity(owner)?.startedAt;
-    return startedAt ? { pid: owner, startedAt } : null;
+    if (!startedAt) {
+      missingCapability =
+        `the creation time of PID ${owner} could not be read, so that number cannot be ` +
+        `tied to a specific process (this host does not expose process start times to us)`;
+      return null;
+    }
+    return { pid: owner, startedAt };
   };
 
   let argv: string[] = [];
@@ -1729,10 +1746,11 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   }
   if (argv.length > 0 && pid != null && !bracketed) {
     const err = new ProcessControlError(
-      `ComfyUI answered on port ${port}, but the identity of the process owning that port ` +
-        `could not be observed on both sides of the request, so its answer cannot be tied to ` +
-        `PID ${pid}. Nothing was stopped: acting on an unverified pairing risks controlling the ` +
-        `wrong process. Re-run, or restart ComfyUI from the launcher that owns it.`,
+      `ComfyUI answered on port ${port}, but its answer could not be tied to PID ${pid}: ` +
+        `${missingCapability ?? "the port owner's identity could not be observed on both sides of the request"}. ` +
+        `Nothing was stopped — killing a process we cannot identify risks taking down the wrong ` +
+        `one. Restart ComfyUI from the launcher that owns it, or install the missing tool ` +
+        `(\`lsof\` on Linux) and try again.`,
     );
     err.identityAmbiguous = true;
     throw err;

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -20,6 +20,13 @@ import {
   type LaunchEnvInfo,
   type LaunchEnvResolution,
 } from "./launcher-env.js";
+import {
+  classifyListenerOwnership,
+  isDescendantOfChild,
+  launchedChildStillRunning,
+  unclassifiedOwnership,
+  type ListenerOwnership,
+} from "./listener-ownership.js";
 import { resetManagerApiCache } from "./manager-api-cache.js";
 import {
   parseListenerPidFromNetstat,
@@ -145,48 +152,6 @@ interface RestartResult {
    * it explicitly.
    */
   listener_ownership: ListenerOwnership;
-}
-
-/**
- * Who owns the process serving the port after a launch (#776).
- *   "ours"        - the port owner IS the process this call launched (proven).
- *   "not-ours"    - a healthy listener that provably is NOT ours (a different
- *                   mapped owner, or our launched child already dead).
- *   "unconfirmed" - genuinely undecidable: the launched child is alive and the API
- *                   is ready, but the port owner could not be mapped (a supported
- *                   condition, #449), or the launcher's pid is indirect (Desktop).
- *                   Never silently upgraded to "ours".
- */
-declare const CLASSIFIED: unique symbol;
-
-/**
- * A verdict about who owns the healthy listener.
- *
- * BRANDED ON PURPOSE. The values are ordinary strings at runtime (they serialise
- * and compare as `"ours"` / `"not-ours"` / `"unconfirmed"`), but the type carries a
- * phantom property no literal can satisfy — so `listener_ownership: "not-ours"`
- * simply does not compile. Only `classifyListenerOwnership`, which actually gathers
- * the evidence, can mint a definite verdict; every other return path must call
- * `unclassifiedOwnership()` and therefore cannot claim more than it knows.
- *
- * This exists because the same defect kept reappearing on new paths: a definite
- * answer returned by code that never ran the check (#796). Making it a convention
- * meant remembering it at each site; making it a TYPE means the compiler remembers.
- */
-type ListenerOwnership = ("ours" | "not-ours" | "unconfirmed") & {
-  readonly [CLASSIFIED]: true;
-};
-
-/** The only verdict a site that did NOT classify is entitled to return. */
-function unclassifiedOwnership(): ListenerOwnership {
-  return "unconfirmed" as ListenerOwnership;
-}
-
-/** Mint a classified verdict. Callable only from the classifier below. */
-function classified(
-  verdict: "ours" | "not-ours" | "unconfirmed",
-): ListenerOwnership {
-  return verdict as ListenerOwnership;
 }
 
 interface StartupReadinessResult {
@@ -575,38 +540,6 @@ function childProcessErrorDetails(err: unknown): ChildProcessErrorDetails {
   };
 }
 
-/**
- * Is the process we spawned still alive? Tri-state, because only a DEFINITE answer
- * may change a verdict.
- *
- * Node delivers a child's `exit` event through the event loop, so "the handler has
- * not run yet" is NOT evidence the child is alive — and a pid whose child died can
- * be recycled by another program in that window (codex gate). A signal-0 probe
- * answers synchronously:
- *   false     - ESRCH, or an exit already recorded: our child is definitively gone.
- *   undefined - no pid to probe, or EPERM (a process has that pid but we may not
- *               signal it, i.e. it belongs to another user). "Cannot tell", never
- *               "alive" — and never "dead" either, since a missing pid must not by
- *               itself convict a launch that may well have worked.
- *   true      - the pid exists and is signalable. Necessary, NOT sufficient: a
- *               recycled pid also passes, which is why the caller additionally
- *               corroborates the command line.
- */
-function launchedChildStillRunning(child: ChildProcess): boolean | undefined {
-  const pid = child.pid;
-  if (pid == null) return undefined;
-  // Loose null check on purpose: a not-yet-exited child reports `null` here, and
-  // an absent property must read the same way rather than as "already exited".
-  if (child.exitCode != null || child.signalCode != null) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ESRCH") return false;
-    return undefined;
-  }
-}
 
 /** Injectable parent-pid reader (see readParentPid). */
 let parentPidResolverOverride: ((pid: number) => number | undefined) | null = null;
@@ -629,262 +562,7 @@ function readParentPid(pid: number): number | undefined {
   return resolveProcessIdentity(pid)?.parentPid;
 }
 
-/**
- * Is `pid` this orchestrator, or a DESCENDANT of it?
- *
- * A direct-child test is too strict for a legitimately indirect launcher: a
- * wrapper script, a double fork, or a venv trampoline all mean the process that
- * ends up holding the port is our grandchild, not our child. Telling those users
- * "this server was not started by us" is a false negative, so the parent chain is
- * walked (a few hops, hard-bounded) before concluding anything.
- *
- * Returns `undefined` the moment the chain becomes unreadable — not knowing is
- * never promoted to a claim in either direction.
- */
-function isOurDescendant(pid: number, maxHops = 8): boolean | undefined {
-  let current = pid;
-  for (let hop = 0; hop < maxHops; hop++) {
-    if (current === process.pid) return true;
-    const parent = readParentPid(current);
-    if (parent == null) return undefined;
-    // pid 1 / 0 / self-parenting = we reached the TOP of the tree without finding
-    // ourselves, which is a real negative answer.
-    if (parent === current || parent <= 1) return false;
-    current = parent;
-  }
-  // Ran out of budget. That is "I did not finish looking", NOT "it is not ours" —
-  // a deep-but-legitimate wrapper chain must not be reported as a foreign server
-  // just because the walk was bounded (codex gate).
-  return undefined;
-}
 
-/**
- * Who owns the healthy listener after a launch — the single place that decides
- * whether this call may claim it started the server.
- *
- * The trap it exists to avoid: a matching pid NUMBER is not proof. Our child can
- * die, the OS can hand its number to another program, and that program can bind the
- * port — all before Node delivers the `exit` event, at which point a naive
- * `portOwnerPid === ourPid` says "ours" about somebody else's process. So a
- * positive verdict requires the number to match AND the child to be provably alive
- * AND (where the OS will tell us) the port owner's command line to match what we
- * actually launched. Any hole in that chain degrades to "unconfirmed"; definite
- * counter-evidence gives "not-ours".
- */
-function classifyListenerOwnership(input: {
-  isDesktopApp: boolean;
-  /** The child's `exit` event has already been delivered. */
-  childExited: boolean;
-  /**
-   * The child's `error` event has been delivered — the spawn FAILED. Latched
-   * independently of the readiness race, because a healthy listener answering
-   * first must not hide the fact that our launch never happened.
-   */
-  spawnFailed: boolean;
-  child: ChildProcess;
-  launchArgv?: string[];
-  portOwnerPid: number | null;
-  /**
-   * The `sys.argv` reported by whatever server is now answering. An independent
-   * line of evidence that does not need a pid at all: a healthy server running the
-   * command line we just launched is ours; one running something else is not. This
-   * is what lets a host with no usable port-owner lookup (#449) still get a real
-   * answer instead of a permanent shrug.
-   */
-  servingArgv?: string[];
-}): ListenerOwnership {
-  /**
-   * Does the server that is answering run what we launched?
-   *
-   * Deliberately ASYMMETRIC in what it can conclude. A MISMATCH is proof the
-   * listener is not ours — nobody else's command line is ours. A match is only
-   * CORROBORATION: another supervisor can start the very same ComfyUI command, win
-   * the bind race, and answer with identical argv, so "runs what we launched" can
-   * never by itself promote anything to "ours" (codex gate). It can only stop us
-   * asserting the negative.
-   */
-  const byArgv = (): "match" | "differ" | "unknown" => {
-    if (!input.servingArgv?.length || !input.launchArgv?.length) return "unknown";
-    // Compared as normalised token MULTISETS, both directions at once. A one-way
-    // containment test is a SUBSET check, and a foreign server whose argv is a
-    // strict subset of ours would "match" (codex gate); requiring the same tokens
-    // on both sides rules that out.
-    //
-    // The normalisation is deliberately NOT `commandLineMatchesArgv`, which was the
-    // second half of this bug. That helper normalises separators only when the HOST
-    // is Windows — correct for its own job (#401 compares two observations of the
-    // same machine), wrong here: `sys.argv` follows the SERVER, so a Windows-launched
-    // ComfyUI answers `ComfyUI\main.py` even when this orchestrator runs on Linux.
-    // Under host-normalisation that never matches our POSIX-resolved absolute path,
-    // and the "difference" it reports is really "I could not compare these" — an
-    // absence dressed as a finding.
-    /** A token written in a Windows path dialect (drive prefix or backslashes). */
-    const isWindowsDialect = (t: string): boolean =>
-      /^[a-zA-Z]:[\\/]/.test(t) || /^\\\\/.test(t) || t.includes("\\");
-    /**
-     * Canonicalise a token WITHOUT deciding case: separators to `/`, extended
-     * prefixes (`\\?\`, `\\?\UNC\`) stripped, and `.`/`..` segments resolved, so
-     * two spellings of the same path compare equal instead of reading as `differ`.
-     */
-    const normalise = (token: string): string => {
-      let t = token.trim().replace(/^["']+|["']+$/g, "").replace(/\\/g, "/");
-      t = t.replace(/^\/\/\?\/unc\//i, "//").replace(/^\/\/\?\//, "");
-      if (!/\//.test(t)) return t;
-      const rooted = t.startsWith("/");
-      const drive = /^([a-zA-Z]:)(?=\/)/.exec(t)?.[1] ?? "";
-      const out: string[] = [];
-      for (const seg of t.slice(drive.length).split("/")) {
-        if (seg === "" || seg === ".") continue;
-        if (seg === ".." && out.length > 0 && out[out.length - 1] !== "..") {
-          out.pop();
-          continue;
-        }
-        out.push(seg);
-      }
-      return `${drive}${rooted && !drive ? "/" : drive ? "/" : ""}${out.join("/")}`;
-    };
-    /**
-     * Do two argv tokens denote the same thing? Paths are compared SEGMENT-ALIGNED
-     * (one may be a suffix of the other) rather than by basename: we launch the
-     * script by absolute path while the server reports the relative one it was
-     * handed, so `/opt/x/ComfyUI/main.py` and `ComfyUI\main.py` agree — while two
-     * DIFFERENT installs do not, which a basename comparison could never tell apart
-     * given every ComfyUI script is called `main.py`.
-     */
-    /** Canonical text plus the dialect it was WRITTEN in (read before normalising,
-     *  which strips the backslashes that identify it). */
-    const prepare = (raw: string): { text: string; windows: boolean } => ({
-      text: normalise(raw),
-      windows: isWindowsDialect(raw.trim().replace(/^["']+|["']+$/g, "")),
-    });
-    const tokensAgree = (
-      a: { text: string; windows: boolean },
-      b: { text: string; windows: boolean },
-    ): boolean => {
-      // CASE-FOLDING IS CONDITIONAL ON THE DIALECT, never unconditional. Folding
-      // everything made `/srv/ComfyUI/main.py` and `/srv/comfyui/main.py` — two
-      // genuinely different directories on a case-sensitive filesystem — compare
-      // equal, which fabricates a MATCH. That is the dangerous direction: a match
-      // can promote a descendant listener to "ours" and so license stopping a
-      // process that isn't ours. Windows paths ARE case-insensitive, so fold only
-      // when a side was written in that dialect; POSIX paths compare exactly.
-      const fold = a.windows || b.windows;
-      const x = fold ? a.text.toLowerCase() : a.text;
-      const y = fold ? b.text.toLowerCase() : b.text;
-      if (x === y) return true;
-      const pathish = (s: string): boolean => /\//.test(s) || /^[a-zA-Z]:/.test(s);
-      if (!pathish(x) || !pathish(y)) return false;
-      return x.endsWith(`/${y}`) || y.endsWith(`/${x}`);
-    };
-    // The interpreter is dropped from our side: the server reports `sys.argv`,
-    // which never contains it. Order is preserved on both sides (a relaunch passes
-    // the same arguments in the same order), so compare positionally.
-    const ours = input.launchArgv.slice(1).map(prepare).filter((t) => t.text);
-    const serving = input.servingArgv.map(prepare).filter((t) => t.text);
-    if (ours.length === 0 || serving.length === 0) return "unknown";
-    const same =
-      ours.length === serving.length &&
-      ours.every((token, i) => tokensAgree(token, serving[i]));
-    return same ? "match" : "differ";
-  };
-  // A Desktop launch is undecidable BY DESIGN: we spawn the Electron shell (or
-  // macOS `open`) and its child binds the port, so a pid mismatch proves nothing.
-  // A LAUNCH THAT NEVER HAPPENED is decisive on every path, Desktop included —
-  // these come FIRST so no later shortcut can soften them (codex gate). The spawn
-  // error is latched independently of the readiness race, and Node leaves `pid`
-  // undefined only when the spawn did not happen, so the two are the same fact
-  // arriving by different routes.
-  if (input.spawnFailed) return classified("not-ours");
-  if (input.child.pid == null) return classified("not-ours");
-  // A Desktop launch is undecidable BY DESIGN once it HAS started: we spawn the
-  // Electron shell (or macOS `open`, which exits immediately by design), and the
-  // process that binds the port is its child. Note this sits AFTER the
-  // never-launched checks but BEFORE `childExited`, because for Desktop a launcher
-  // exiting is normal rather than evidence of failure.
-  if (input.isDesktopApp) return classified("unconfirmed");
-
-  const alive = launchedChildStillRunning(input.child);
-  // OUR DIRECT CHILD IS GONE — by its `exit` event, or by a signal-0 probe (ESRCH)
-  // that does not wait for the event loop. Usually that means the healthy listener
-  // is somebody else's. But it is ALSO the shape of a wrapper script that launched
-  // ComfyUI as its grandchild and then exited normally, after which the grandchild
-  // is reparented and lineage can no longer place it in our tree. What still can:
-  // the server is running the exact command line we launched (codex gate P2).
-  if (input.childExited || alive === false) {
-    // A match cannot make this "ours" — our direct child is gone, and the server
-    // could equally be another supervisor's identical instance. But it does mean we
-    // cannot honestly assert the negative either, so the wrapper case degrades to
-    // "unconfirmed" instead of telling that user their own server is not theirs.
-    return byArgv() === "match" ? classified("unconfirmed") : classified("not-ours");
-  }
-
-  const ourPid = input.child.pid;
-  if (input.portOwnerPid == null) {
-    // NO LISTENER WAS IDENTIFIED — the port owner could not be mapped at all (#449:
-    // no `lsof`, a permission-denied probe, the process already gone, the port
-    // already free). `not-ours` is a POSITIVE finding about an identified process,
-    // so it cannot be reached from here: there is nothing to have found. Reporting
-    // one would be manufacturing a definite answer out of an absence, which is the
-    // error this whole class of bug keeps taking (#796).
-    //
-    // The server's own argv is deliberately NOT consulted as a negative here. It
-    // describes whatever is ANSWERING, not which process holds the socket, and it
-    // cannot distinguish "a different program" from "we could not compare" — see
-    // byArgv, whose "differ" is not a proof of difference.
-    return classified("unconfirmed");
-  }
-  if (ourPid == null) return classified("unconfirmed");
-  if (input.portOwnerPid !== ourPid) {
-    // A DIFFERENT pid holds the port. That is usually somebody else's server — but
-    // it is also the shape of a legitimately indirect launch (a wrapper script, a
-    // double fork, a trampoline), where the listener is our GRANDchild. Walk the
-    // parent chain before concluding: descendant => still ours; provably outside
-    // our tree => not ours; unreadable => unconfirmed, never a false negative that
-    // tells a wrapper-launched user their own server isn't theirs.
-    const descendant = isOurDescendant(input.portOwnerPid);
-    // Lineage does not outrank direct contrary evidence: a wrapper of ours can
-    // stay alive and bring up a DIFFERENT (or stale) ComfyUI, which would be in our
-    // process tree while plainly not being what we launched. `listener_ownership`
-    // answers "is this the process THIS CALL launched", so a differing command line
-    // is decisive there too (codex gate).
-    if (descendant === true) return byArgv() === "differ" ? classified("not-ours") : classified("ours");
-    if (descendant === false) return classified("not-ours");
-    // Lineage unreadable — the server's argv can still rule the listener OUT.
-    return byArgv() === "differ" ? classified("not-ours") : classified("unconfirmed");
-  }
-  // The pid MATCHES — but it could be a recycled number we cannot signal.
-  if (alive !== true) return classified("unconfirmed");
-
-  // LINEAGE is the discriminator, and the only one that does not depend on WHEN we
-  // looked (coordinator gate P1(2)). A creation stamp read after `spawn()` returns
-  // can already describe a replacement — the child may have died and its number
-  // been reused before the read, and on Windows that read alone takes seconds. But
-  // parentage cannot be forged by timing: we spawned this child, so the process on
-  // the port must still be OUR child. Another ComfyUI — even one with a
-  // byte-identical command line and an identical creation second — has a different
-  // parent.
-  //
-  // Not knowing is never promoted to "ours": an unreadable parent withholds the
-  // claim. Knowing it is somebody else's is decisive.
-  const parent = readParentPid(ourPid);
-  if (parent == null) return classified("unconfirmed");
-  if (parent !== process.pid) return classified("not-ours");
-
-  // Belt and braces: where the OS exposes it, the port owner must also still be
-  // running what we launched — and the SERVER's own account of itself must agree.
-  // Both are decisive negatives, for the same reason as above: pid identity says
-  // which process, not which program it is running.
-  const identity = resolveProcessIdentity(ourPid);
-  if (
-    identity?.commandLine &&
-    input.launchArgv &&
-    !commandLineMatchesArgv(identity.commandLine, input.launchArgv)
-  ) {
-    return classified("not-ours");
-  }
-  if (byArgv() === "differ") return classified("not-ours");
-  return classified("ours");
-}
 
 /** The launch-environment facts to report, once a plan has been resolved (#776). */
 function launchEnvInfo(info?: ProcessInfo): LaunchEnvInfo | undefined {
@@ -2343,18 +2021,29 @@ export async function startComfyUI(): Promise<StartResult> {
     launchArgv: launched.launchArgv,
     portOwnerPid: newPid,
     servingArgv,
+    // The OS readers are injected so the classifier stays free of platform code
+    // (and so tests can drive lineage without a real process tree).
+    readParentPid,
+    readIdentity: resolveProcessIdentity,
+    childIsAlive: launchedChildStillRunning(launched.child),
   });
   // Only the NON-Desktop undecidable case is worth calling out: for a Desktop
   // launcher the pid relationship is indirect by design, not a gap in evidence.
   const ownershipUnconfirmed = !info.isDesktopApp && ownership === "unconfirmed";
-  // A start may be CLAIMED only on evidence. Ownership "ours" is proof. Ownership
-  // "unconfirmed" is accepted as a start ONLY when we also observed the port to be
-  // FREE before spawning — otherwise the healthy API may be the very server that
-  // was already there, and readiness would be certifying somebody else's process
-  // as our restart (codex gate P1-c).
-  const mayClaimStart =
-    ownership === "ours" ||
-    (ownership === "unconfirmed" && portObservedFreeBeforeLaunch);
+  // The pre-launch "the port was free" observation deliberately does NOT carry the
+  // claim: another process can bind between that probe and `spawn()`, so it is a
+  // fact about a moment that has PASSED, not about the server now answering. It was
+  // briefly used to gate `started` and that was wrong twice over — stale evidence,
+  // and it made an `unconfirmed` classification report success for somebody else's
+  // process. It now only ever appears as a stated ABSENCE in the message below,
+  // which is a safe thing to spend.
+  //
+  // `started` therefore rests on the classification alone: `not-ours` is the one
+  // verdict that denies it. `unconfirmed` keeps it TRUE by the standing ruling —
+  // denying it would report every ordinary restart as failed on any host whose
+  // port-owner lookup is unavailable, a far more common and more damaging lie than
+  // an unconfirmed success that the message explicitly qualifies.
+  const mayClaimStart = ownership !== "not-ours";
   return {
     // `started` means "THIS call started the server". When the healthy listener is
     // provably NOT the process we launched, we did not start it — programmatic

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -105,9 +105,12 @@ interface StartResult {
    * A STRING tri-state, not a boolean-or-undefined, precisely so the uncertain
    * case survives `JSON.stringify` (which DROPS `undefined` keys, making "we could
    * not determine this" indistinguishable from a response that never carried the
-   * field at all).
+   * field at all). REQUIRED for the same reason: a field that is only SOMETIMES
+   * present cannot be told apart from an older build that never emitted it, so
+   * every return path — including the ones that never launched anything — states
+   * it explicitly.
    */
-  listener_ownership?: ListenerOwnership;
+  listener_ownership: ListenerOwnership;
 }
 
 interface RestartResult {
@@ -126,9 +129,12 @@ interface RestartResult {
    * A STRING tri-state, not a boolean-or-undefined, precisely so the uncertain
    * case survives `JSON.stringify` (which DROPS `undefined` keys, making "we could
    * not determine this" indistinguishable from a response that never carried the
-   * field at all).
+   * field at all). REQUIRED for the same reason: a field that is only SOMETIMES
+   * present cannot be told apart from an older build that never emitted it, so
+   * every return path — including the ones that never launched anything — states
+   * it explicitly.
    */
-  listener_ownership?: ListenerOwnership;
+  listener_ownership: ListenerOwnership;
 }
 
 /**
@@ -538,38 +544,40 @@ function launchedChildStillRunning(child: ChildProcess): boolean | undefined {
   }
 }
 
-/**
- * TRUE where the platform's process creation stamp is too COARSE to identify an
- * instance on its own. macOS `ps -o lstart` is SECOND-resolution, so a pid
- * recycled inside the same second compares EQUAL — the same limitation
- * live-interpreter documents for its launched-by-us tier. Linux ticks and Windows
- * FileTime are sub-second, where equality really is proof.
- */
-const PLATFORM_HAS_COARSE_CREATION_STAMP = platform() === "darwin";
-/** Mutable only so tests can exercise the macOS branch from any host. */
-let coarseCreationStamp = PLATFORM_HAS_COARSE_CREATION_STAMP;
-
 /** Injectable parent-pid reader (see readParentPid). */
 let parentPidResolverOverride: ((pid: number) => number | undefined) | null = null;
 
 /**
- * The parent pid of `pid`, used ONLY to break the macOS coarse-stamp tie.
+ * The parent pid of `pid` — the evidence that a process IS the child we spawned.
  *
- * A process that inherited our child's number within the same second is still a
- * DIFFERENT process, and the discriminator that survives is lineage: we spawned
- * our child, so its parent is this very orchestrator. Another ComfyUI — even one
- * with a byte-identical command line, started by some other launcher — has a
- * different parent. Unreadable means "cannot tell", never "ours".
+ * Unlike a creation stamp (which can only ever be read some time AFTER the spawn,
+ * by which point a same-instant exit may already have handed the number to
+ * somebody else), parentage does not depend on when we look: we spawned our child,
+ * so its parent is this very orchestrator. Another ComfyUI — even one with a
+ * byte-identical command line and an identical creation second, started by some
+ * other launcher — has a different parent. Unreadable means "cannot tell", never
+ * "ours". Consulted only on the ownership decision, so its cost (a PowerShell
+ * spawn on Windows) is paid once per start, never per poll.
  */
 function readParentPid(pid: number): number | undefined {
   if (parentPidResolverOverride) return parentPidResolverOverride(pid);
-  if (!pid || pid <= 0 || IS_WIN) return undefined;
+  if (!pid || pid <= 0) return undefined;
   try {
-    const out = execFileSync("ps", ["-p", String(pid), "-o", "ppid="], {
-      encoding: "utf-8",
-      timeout: 5000,
-    }).trim();
-    const parsed = Number.parseInt(out, 10);
+    const out = IS_WIN
+      ? execFileSync(
+          "powershell",
+          [
+            "-NoProfile",
+            "-Command",
+            `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}").ParentProcessId`,
+          ],
+          { encoding: "utf-8", timeout: 8000, windowsHide: true },
+        )
+      : execFileSync("ps", ["-p", String(pid), "-o", "ppid="], {
+          encoding: "utf-8",
+          timeout: 5000,
+        });
+    const parsed = Number.parseInt(out.trim(), 10);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
   } catch {
     return undefined;
@@ -595,7 +603,6 @@ function classifyListenerOwnership(input: {
   childExited: boolean;
   child: ChildProcess;
   launchArgv?: string[];
-  launchedAt?: string;
   portOwnerPid: number | null;
 }): ListenerOwnership {
   // A Desktop launch is undecidable BY DESIGN: we spawn the Electron shell (or
@@ -614,39 +621,23 @@ function classifyListenerOwnership(input: {
   // The pid MATCHES — but it could be a recycled number we cannot signal.
   if (alive !== true) return "unconfirmed";
 
-  // PER-INSTANCE identity. Everything above can be satisfied by a recycled number:
-  // same pid, signalable, and (if the replacement is another ComfyUI started with
-  // the same argv) even the same command line. Only the process CREATION TIME
-  // distinguishes instances, so when we captured ours at spawn it has to still be
-  // there. A positive mismatch is proof this is a different process; losing the
-  // ability to read it is not proof of anything, but it does mean we can no longer
-  // CLAIM the launch, so it degrades to "unconfirmed" rather than "ours".
-  if (input.launchedAt) {
-    const now = resolveProcessIdentityUnbounded(ourPid);
-    if (!now?.startedAt) return "unconfirmed";
-    if (now.startedAt !== input.launchedAt) return "not-ours";
-    if (
-      now.commandLine &&
-      input.launchArgv &&
-      !commandLineMatchesArgv(now.commandLine, input.launchArgv)
-    ) {
-      return "not-ours";
-    }
-    // Where the stamp is only second-resolution (macOS), equality is NOT proof:
-    // a number recycled inside the same second by another ComfyUI with identical
-    // argv would satisfy everything above. Lineage settles it — we spawned our
-    // child, so it is still OUR child. Anything else (including an unreadable
-    // parent) withholds the claim instead of making it.
-    if (coarseCreationStamp && readParentPid(ourPid) !== process.pid) {
-      return "unconfirmed";
-    }
-    return "ours";
-  }
+  // LINEAGE is the discriminator, and the only one that does not depend on WHEN we
+  // looked (coordinator gate P1(2)). A creation stamp read after `spawn()` returns
+  // can already describe a replacement — the child may have died and its number
+  // been reused before the read, and on Windows that read alone takes seconds. But
+  // parentage cannot be forged by timing: we spawned this child, so the process on
+  // the port must still be OUR child. Another ComfyUI — even one with a
+  // byte-identical command line and an identical creation second — has a different
+  // parent.
+  //
+  // Not knowing is never promoted to "ours": an unreadable parent withholds the
+  // claim. Knowing it is somebody else's is decisive.
+  const parent = readParentPid(ourPid);
+  if (parent == null) return "unconfirmed";
+  if (parent !== process.pid) return "not-ours";
 
-  // No creation-time stamp was available at spawn. Fall back to the weaker signal:
-  // where the OS exposes it, the port owner must still be running what we launched.
-  // A POSITIVE mismatch is counter-evidence; unreadable leaves the pid+liveness
-  // match standing.
+  // Belt and braces: where the OS exposes it, the port owner must also still be
+  // running what we launched.
   const identity = resolveProcessIdentity(ourPid);
   if (
     identity?.commandLine &&
@@ -742,14 +733,6 @@ interface SpawnedComfyUI {
    * started, rather than a different program that inherited its pid.
    */
   launchArgv?: string[];
-  /**
-   * OUR child's process creation time, captured at spawn. A pid NUMBER is not an
-   * instance: a recycled number can match, be signalable, and even carry an
-   * identical command line (a second ComfyUI started with the same argv). The
-   * creation time is what tells instances apart, so it is what lets a later check
-   * say "the process on the port really is the one we launched".
-   */
-  launchedAt?: string;
 }
 
 let recordedLaunchChild: ChildProcess | undefined;
@@ -819,13 +802,7 @@ function spawnFromProcessInfo(info: ProcessInfo): SpawnedComfyUI | null {
   // the moment a different process owns the port. (Desktop-app launches return
   // above: that exe is a launcher, not an interpreter.)
   if (child.pid) recordLaunchedInterpreter(child.pid, cmd.exe);
-  return {
-    child,
-    launchArgv: [cmd.exe, ...cmd.args],
-    launchedAt: child.pid
-      ? resolveProcessIdentityUnbounded(child.pid)?.startedAt
-      : undefined,
-  };
+  return { child, launchArgv: [cmd.exe, ...cmd.args] };
 }
 
 /**
@@ -916,25 +893,6 @@ function resolveProcessIdentity(pid: number): ProcessIdentity | undefined {
   // `/proc/<pid>/environ` at all — so the expensive readers buy nothing the
   // port-ownership re-check does not already give.
   if (!pid || pid <= 0 || process.platform !== "linux") return undefined;
-  try {
-    return readProcessIdentity(pid);
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Identity read WITHOUT the platform gate above.
- *
- * Reserved for the two moments that decide whether we may CLAIM to have started
- * the server: recording our own child's creation time at spawn, and re-checking it
- * against the process later found on the port. Those are the only places where the
- * expensive Windows read buys something the cheap checks cannot give — a
- * per-INSTANCE identity. Everything else stays on the gated reader.
- */
-function resolveProcessIdentityUnbounded(pid: number): ProcessIdentity | undefined {
-  if (processIdentityOverride) return processIdentityOverride(pid);
-  if (!pid || pid <= 0) return undefined;
   try {
     return readProcessIdentity(pid);
   } catch {
@@ -1367,7 +1325,10 @@ async function acquireProcessInfo(): Promise<{
     // #449: the server answered /system_stats but we could not map its port to
     // a PID. Do NOT fall through to killing a Desktop shell we can't confirm
     // owns :PORT — surface the diagnostic and leave everything untouched.
-    if (err instanceof ProcessControlError && err.reachableButNoPid) {
+    if (
+      err instanceof ProcessControlError &&
+      (err.reachableButNoPid || err.identityAmbiguous)
+    ) {
       return { info: null, diagnostic: err.message };
     }
     const desktopPids = findDesktopAppPids();
@@ -1391,6 +1352,14 @@ async function acquireProcessInfo(): Promise<{
   }
 }
 
+/**
+ * TRUE while a deliberate stop is mid-kill. The supervisor must not read the exit
+ * WE are causing as a crash and respawn into it — that window exists because the
+ * supervisor teardown deliberately happens AFTER the kill returns, so that a kill
+ * which THREW leaves supervision intact (coordinator gate P1(3)).
+ */
+let deliberateStop = false;
+
 function handleSupervisedChildStop(
   child: ChildProcess,
   reason: {
@@ -1400,6 +1369,8 @@ function handleSupervisedChildStop(
   },
 ): void {
   if (supervisedChild !== child) return;
+  // A stop WE are performing is not a crash — never respawn into it.
+  if (deliberateStop) return;
   detachSupervisor();
 
   // The supervised ComfyUI is GONE (crash/exit), whether or not we go on to
@@ -1475,6 +1446,47 @@ function superviseChild(child: ChildProcess, info: ProcessInfo): void {
 // Gather process info from running ComfyUI
 // ---------------------------------------------------------------------------
 
+/**
+ * Re-ask the server who it is, now that a pid is in hand, and require the answer
+ * to be unchanged AND that pid to still own the port.
+ *
+ * Returns:
+ *   "confirmed" — same argv, same port owner. The pid and the HTTP response are
+ *                 bound to each other as tightly as observation allows.
+ *   "changed"   — the server answered with DIFFERENT launch arguments, or the port
+ *                 changed hands. Positive evidence of substitution.
+ *   "unknown"   — the re-fetch failed (transport hiccup). Absence of evidence, and
+ *                 deliberately NOT treated as evidence of absence: a transient
+ *                 network error must not refuse a restart that would work.
+ */
+async function reconfirmAnsweringServer(
+  argv: string[],
+  pid: number,
+  port: number,
+): Promise<"confirmed" | "changed" | "unknown"> {
+  let secondArgv: string[];
+  try {
+    const stats = await getSystemStats();
+    secondArgv = stats.system.argv ?? [];
+  } catch {
+    return "unknown";
+  }
+  // An empty second answer says nothing about identity.
+  if (secondArgv.length === 0 && argv.length === 0) return "unknown";
+  const same =
+    secondArgv.length === argv.length &&
+    secondArgv.every((token, i) => token === argv[i]);
+  if (!same) return "changed";
+  let ownerNow: number | null = null;
+  try {
+    ownerNow = findPidByPort(port);
+  } catch {
+    return "unknown";
+  }
+  if (ownerNow == null) return "unknown";
+  return ownerNow === pid ? "confirmed" : "changed";
+}
+
 async function gatherProcessInfo(): Promise<ProcessInfo> {
   const port = config.resolvedPort;
 
@@ -1523,6 +1535,33 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   const startedAt = desktop
     ? undefined
     : resolveCorroboratedIdentity(pid, argv)?.startedAt;
+
+  // BIND THE PID TO THE PROCESS THAT ANSWERED (coordinator gate P1(1)).
+  //
+  // `argv` came from an HTTP response; the pid came from a port lookup made
+  // AFTERWARDS. Nothing so far rules out: ComfyUI A answers /system_stats, exits,
+  // and ComfyUI B takes the port before the lookup — B is then "identified" from
+  // A's answer and is what we would kill. A creation stamp cannot see that: it
+  // only proves B was stable AFTER the lookup.
+  //
+  // So close the loop against the observation itself: ask the server again, now
+  // that we hold a pid, and require the SAME argv to come back AND the same pid to
+  // still own the port. A substitution by a differently-launched instance changes
+  // the argv and is caught; a transport failure proves nothing and is not treated
+  // as evidence either way.
+  if (!desktop) {
+    const recheck = await reconfirmAnsweringServer(argv, pid, port);
+    if (recheck === "changed") {
+      const err = new ProcessControlError(
+        `The ComfyUI answering on port ${port} changed while it was being identified ` +
+          `(a different instance now owns the port, or reports different launch ` +
+          `arguments). Nothing was stopped. Re-run once the server has settled.`,
+      );
+      err.identityAmbiguous = true;
+      throw err;
+    }
+  }
+
   // Bound to that identity - never adopted from a pid we cannot still prove.
   const liveEnv = desktop
     ? undefined
@@ -1593,7 +1632,50 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
     };
   }
 
-  // Past this point the stop is COMMITTED — only now may we drop supervision.
+  logger.info("Captured process info", {
+    pid: info.pid,
+    port: info.port,
+    isDesktopApp: info.isDesktopApp,
+    argv: info.argv.join(" "),
+  });
+
+  // Kill process tree (for Desktop app, kill the Electron shell too).
+  //
+  // A KILL THAT THREW IS NOT A COMMITTED STOP (coordinator gate P1(3)). `taskkill`
+  // / `kill` fail for ordinary reasons — access denied above all — and the server
+  // is then still running. Tearing supervision down first would disarm auto-restart
+  // for a server we did not manage to stop, which is the same "safe refusal turned
+  // into a later lost server" bug one step further along. So the teardown happens
+  // ONLY after the kill returns, and a throw leaves every guarantee intact.
+  //
+  // `deliberateStop` covers the tiny window in between: the kill can deliver our
+  // supervised child's `exit` before the teardown runs, and the supervisor must not
+  // read a stop we asked for as a crash to recover from.
+  deliberateStop = true;
+  try {
+    if (info.isDesktopApp) {
+      killDesktopApp(info.pid);
+    } else {
+      killProcessTree(info.pid);
+    }
+  } catch (err) {
+    deliberateStop = false;
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn("Stop aborted: the kill failed, so nothing was torn down", {
+      pid: info.pid,
+      error: msg,
+    });
+    return {
+      stopped: false,
+      message:
+        `Could not stop ComfyUI (PID ${info.pid}): ${msg}. The server was left as it was — ` +
+        "its crash supervision and launch record are untouched. This is usually a " +
+        "permissions problem: stop it from the launcher/console that owns it.",
+      has_restart_info: false,
+    };
+  }
+
+  // COMMITTED — only now may we drop supervision.
   detachSupervisor();
   // The server we may have launched is going away — clear the shares-our-env flag so
   // a differently-launched successor doesn't inherit env-trust it shouldn't (#633 P1b).
@@ -1602,22 +1684,10 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
   recordedLaunchChild = undefined;
   resetLocalComfyUILaunchState();
   clearLaunchedInterpreter();
+  deliberateStop = false;
 
   // Save for later start
   lastProcessInfo = info;
-  logger.info("Captured process info", {
-    pid: info.pid,
-    port: info.port,
-    isDesktopApp: info.isDesktopApp,
-    argv: info.argv.join(" "),
-  });
-
-  // Kill process tree (for Desktop app, kill the Electron shell too)
-  if (info.isDesktopApp) {
-    killDesktopApp(info.pid);
-  } else {
-    killProcessTree(info.pid);
-  }
 
   // Reset the WebSocket client singleton + the memoized /object_info —
   // a restart is exactly when the node set may have changed. The detected
@@ -1660,6 +1730,11 @@ export async function startComfyUI(): Promise<StartResult> {
       started: false,
       message: `ComfyUI is already running on port ${port} (PID ${existingPid})`,
       pid: existingPid,
+      // Something is serving the port and it is emphatically NOT a process this
+      // call launched — we never got as far as spawning. Reached during a restart
+      // when another launcher grabbed the port in the gap after our stop
+      // (coordinator gate P2(5)).
+      listener_ownership: "not-ours",
     };
   }
 
@@ -1681,6 +1756,7 @@ export async function startComfyUI(): Promise<StartResult> {
         started: false,
         message:
           "No previous process info and could not find ComfyUI Desktop app. Start ComfyUI manually.",
+        listener_ownership: "unconfirmed",
       };
     }
   }
@@ -1698,6 +1774,7 @@ export async function startComfyUI(): Promise<StartResult> {
         ? "Could not determine ComfyUI Desktop executable path. Please start it manually."
         : "No command-line info captured from previous run. Start ComfyUI manually.",
       auto_restart: supervisorResult(info),
+      listener_ownership: "unconfirmed",
     };
   }
   const spawnError = captureChildProcessError(launched.child);
@@ -1747,6 +1824,7 @@ export async function startComfyUI(): Promise<StartResult> {
       spawn_error: startupResult.spawn_error,
       auto_restart: supervisorResult(info),
       launch_env: launchEnvInfo(info),
+      listener_ownership: "unconfirmed",
     };
   }
 
@@ -1798,7 +1876,6 @@ export async function startComfyUI(): Promise<StartResult> {
     childExited: launchedChildExit != null,
     child: launched.child,
     launchArgv: launched.launchArgv,
-    launchedAt: launched.launchedAt,
     portOwnerPid: newPid,
   });
   // Only the NON-Desktop undecidable case is worth calling out: for a Desktop
@@ -2041,6 +2118,9 @@ async function restartViaManagerReboot(context: {
       stopped: false,
       started: false,
       message: reboot.note ?? "ComfyUI-Manager reboot could not be triggered.",
+      // The Manager reboot path never spawns a process of ours, so ownership of
+      // whatever serves the port is never something this call can claim.
+      listener_ownership: "unconfirmed",
     };
   }
 
@@ -2080,6 +2160,7 @@ async function restartViaManagerReboot(context: {
       message:
         `Reboot was triggered but ComfyUI did not come back within ${timing.budgetMs}ms — ` +
         "check the host (is it the Desktop app / supervised?).",
+      listener_ownership: "unconfirmed",
     };
   }
 
@@ -2103,6 +2184,9 @@ async function restartViaManagerReboot(context: {
     message:
       `ComfyUI rebooted via ComfyUI-Manager and came back ready (${readiness.waited_ms}ms) — ` +
       `${context.label}/supervised restart.`,
+    // The supervisor that owns the process cycled it; we launched nothing, so we
+    // cannot (and must not) claim the listener as ours.
+    listener_ownership: "unconfirmed",
   };
 }
 
@@ -2127,6 +2211,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
       message:
         diagnostic ??
         `No ComfyUI process found on port ${config.resolvedPort} to restart. Is ComfyUI running?`,
+      listener_ownership: "unconfirmed",
     };
   }
   // A locally-installed ComfyUI **Desktop** instance is Electron-supervised.
@@ -2151,6 +2236,9 @@ export async function restartComfyUI(): Promise<RestartResult> {
         "so you don't lose the server. " +
         (relaunch.advice ??
           "Fix the launch path (e.g. COMFYUI_PATH) and try again."),
+      // Refused before touching anything: the still-running server is the one that
+      // was already there, which this call did not start.
+      listener_ownership: "not-ours",
     };
   }
 
@@ -2162,6 +2250,9 @@ export async function restartComfyUI(): Promise<RestartResult> {
       stopped: false,
       started: false,
       message: `Could not stop ComfyUI: ${stopResult.message}`,
+      // Nothing was stopped and nothing launched — whatever is on the port is not
+      // this call's doing.
+      listener_ownership: "not-ours",
     };
   }
   // #742 r4/r5: the stop DID happen — record the dispatch. No session identity
@@ -2340,18 +2431,13 @@ export const __processControlTestHooks = {
     liveEnvResolverOverride = null;
     processIdentityOverride = null;
     parentPidResolverOverride = null;
-    coarseCreationStamp = PLATFORM_HAS_COARSE_CREATION_STAMP;
+    deliberateStop = false;
     restartDispatchRecords.clear();
   },
-  /** Inject a fake parent-pid reader so the macOS coarse-stamp tiebreak can be
-   *  driven on any host. */
+  /** Inject a fake parent-pid reader so the lineage check can be driven without a
+   *  real process tree. */
   setParentPidResolver(fn: ((pid: number) => number | undefined) | null): void {
     parentPidResolverOverride = fn;
-  },
-  /** Pretend this platform's creation stamp is second-resolution (macOS) so the
-   *  tiebreak branch can be tested from any host. */
-  setCoarseCreationStamp(coarse: boolean): void {
-    coarseCreationStamp = coarse;
   },
   /** Inject a fake process-identity (creation time) reader so tests can drive
    *  recycled-PID scenarios on any host, including where the native read is

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -915,21 +915,34 @@ function resolveProcessIdentity(pid: number): ProcessIdentity | undefined {
  * identity at all, and the caller falls back to evidence that refuses rather than
  * guesses.
  */
+type IdentityCorroboration =
+  /** The OS's view of the pid matches the server's own — safe to bind. */
+  | { kind: "confirmed"; identity: ProcessIdentity }
+  /**
+   * POSITIVE counter-evidence: the OS says that pid is running something OTHER
+   * than the ComfyUI that answered us. Never collapsed into "unknown" — that would
+   * let a later transport hiccup wave the substitution through (codex gate).
+   */
+  | { kind: "mismatch"; commandLine: string }
+  /** No readable evidence either way. Absence of proof, not proof of absence. */
+  | { kind: "unknown" };
+
 function resolveCorroboratedIdentity(
   pid: number,
   argv: string[],
-): ProcessIdentity | undefined {
-  if (argv.length === 0) return undefined;
+): IdentityCorroboration {
+  if (argv.length === 0) return { kind: "unknown" };
   const identity = resolveProcessIdentity(pid);
-  if (!identity?.startedAt) return undefined;
-  if (!commandLineMatchesArgv(identity.commandLine, argv)) {
+  if (!identity) return { kind: "unknown" };
+  if (identity.commandLine && !commandLineMatchesArgv(identity.commandLine, argv)) {
     logger.warn(
-      "Not binding to PID: the OS's command line for it does not match the argv ComfyUI reported",
-      { pid, commandLine: identity.commandLine ?? "(unavailable)" },
+      "PID mismatch: the OS's command line for the port owner does not match the argv ComfyUI reported",
+      { pid, commandLine: identity.commandLine },
     );
-    return undefined;
+    return { kind: "mismatch", commandLine: identity.commandLine };
   }
-  return identity;
+  if (!identity.startedAt) return { kind: "unknown" };
+  return { kind: "confirmed", identity };
 }
 
 /**
@@ -953,7 +966,8 @@ function captureVerifiedLiveEnv(
   if (!env) return undefined;
   // Re-verify with the SAME corroboration used to bind in the first place, so a
   // recycled pid cannot satisfy the re-check just by agreeing with itself.
-  const after = resolveCorroboratedIdentity(pid, argv)?.startedAt;
+  const recheck = resolveCorroboratedIdentity(pid, argv);
+  const after = recheck.kind === "confirmed" ? recheck.identity.startedAt : undefined;
   if (!after || after !== startedAt) {
     logger.warn(
       "Discarding the captured ComfyUI environment: the pid's identity changed while reading it",
@@ -998,27 +1012,27 @@ function processIdentityStillValid(
       };
     }
   }
-  if (info.startedAt) {
-    // Same corroboration as the binding: a changed creation time OR a command line
-    // that no longer matches the server's argv both mean this number is not the
-    // process we identified.
-    const now = resolveProcessIdentity(info.pid);
-    if (now?.startedAt && now.startedAt !== info.startedAt) {
-      return {
-        ok: false,
-        reason:
-          `PID ${info.pid} is no longer the ComfyUI process we identified (its creation time ` +
-          "changed), so the number has been reused by a different program and must not be killed",
-      };
-    }
-    if (now?.commandLine && !commandLineMatchesArgv(now.commandLine, info.argv)) {
-      return {
-        ok: false,
-        reason:
-          `PID ${info.pid} is running something other than the ComfyUI we identified ` +
-          `(its command line no longer matches that server's arguments), so it must not be killed`,
-      };
-    }
+  // Same corroboration as the binding. NOTE both checks are independent of whether
+  // a creation stamp was ever obtained: a command line that does not match the
+  // server's argv is POSITIVE evidence this pid is somebody else, and gating it
+  // behind `startedAt` would discard that evidence exactly when we have least of
+  // it (codex gate).
+  const now = resolveProcessIdentity(info.pid);
+  if (now?.commandLine && !commandLineMatchesArgv(now.commandLine, info.argv)) {
+    return {
+      ok: false,
+      reason:
+        `PID ${info.pid} is running something other than the ComfyUI we identified ` +
+        `(its command line does not match that server's arguments), so it must not be killed`,
+    };
+  }
+  if (info.startedAt && now?.startedAt && now.startedAt !== info.startedAt) {
+    return {
+      ok: false,
+      reason:
+        `PID ${info.pid} is no longer the ComfyUI process we identified (its creation time ` +
+        "changed), so the number has been reused by a different program and must not be killed",
+    };
   }
   return { ok: true };
 }
@@ -1532,9 +1546,27 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   // The pid's IDENTITY (creation time), CORROBORATED against the argv the server
   // itself reported — so a pid recycled between the port lookup and this read is
   // never bound to, however self-consistent its own later re-reads would be.
-  const startedAt = desktop
-    ? undefined
-    : resolveCorroboratedIdentity(pid, argv)?.startedAt;
+  // POSITIVE counter-evidence refuses outright: if the OS says the process holding
+  // our port is running something other than the ComfyUI that just answered us,
+  // then the answer and the pid describe different processes, and everything built
+  // on that pairing — the environment we would reproduce, the argv we would
+  // relaunch, the process we would KILL — is about the wrong one. Applies whatever
+  // the argv looked like, Desktop included (codex gate).
+  const corroboration = resolveCorroboratedIdentity(pid, argv);
+  if (corroboration.kind === "mismatch") {
+    const err = new ProcessControlError(
+      `The process listening on port ${port} (PID ${pid}) is not running the ComfyUI that ` +
+        `answered /system_stats — the OS reports its command line as "${corroboration.commandLine}", ` +
+        `which does not match that server's launch arguments. Nothing was stopped: acting on this ` +
+        `pairing would control the wrong process. Re-run once the server has settled.`,
+    );
+    err.identityAmbiguous = true;
+    throw err;
+  }
+  const startedAt =
+    desktop || corroboration.kind !== "confirmed"
+      ? undefined
+      : corroboration.identity.startedAt;
 
   // BIND THE PID TO THE PROCESS THAT ANSWERED (coordinator gate P1(1)).
   //
@@ -1549,17 +1581,19 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   // still own the port. A substitution by a differently-launched instance changes
   // the argv and is caught; a transport failure proves nothing and is not treated
   // as evidence either way.
-  if (!desktop) {
-    const recheck = await reconfirmAnsweringServer(argv, pid, port);
-    if (recheck === "changed") {
-      const err = new ProcessControlError(
-        `The ComfyUI answering on port ${port} changed while it was being identified ` +
-          `(a different instance now owns the port, or reports different launch ` +
-          `arguments). Nothing was stopped. Re-run once the server has settled.`,
-      );
-      err.identityAmbiguous = true;
-      throw err;
-    }
+  //
+  // Runs for DESKTOP too (codex gate): `desktop` is itself derived from the FIRST,
+  // possibly stale argv, so skipping the recheck there is how a Desktop answer from
+  // A gets a Manager reboot fired at a non-Desktop B that took the port.
+  const recheck = await reconfirmAnsweringServer(argv, pid, port);
+  if (recheck === "changed") {
+    const err = new ProcessControlError(
+      `The ComfyUI answering on port ${port} changed while it was being identified ` +
+        `(a different instance now owns the port, or reports different launch ` +
+        `arguments). Nothing was stopped. Re-run once the server has settled.`,
+    );
+    err.identityAmbiguous = true;
+    throw err;
   }
 
   // Bound to that identity - never adopted from a pid we cannot still prove.

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1379,11 +1379,17 @@ export async function startComfyUI(): Promise<StartResult> {
         ? undefined
         : newPid === ourPid;
   return {
-    started: true,
+    // `started` means "THIS call started the server". When the healthy listener is
+    // provably NOT the process we launched, we did not start it — programmatic
+    // callers must not read a failed relaunch as a success just because something
+    // answers (codex gate). `ready` stays TRUE because the server genuinely IS
+    // ready: claiming otherwise would be its own lie and would push callers into
+    // needless recovery.
+    started: listenerIsOurs !== false,
     ready: true,
     readiness,
     message:
-      `ComfyUI started on port ${port}${newPid ? ` (PID ${newPid})` : ""}` +
+      `ComfyUI ${listenerIsOurs === false ? "is ready" : "started"} on port ${port}${newPid ? ` (PID ${newPid})` : ""}` +
       // Say WHICH environment it came back in whenever that was not simply ours
       // (#776) — the user needs to know a launcher environment was restored.
       (env && env.source !== "inherited" ? ` — ${env.note}.` : "") +
@@ -1743,7 +1749,14 @@ export async function restartComfyUI(): Promise<RestartResult> {
       started: false,
       ready: startResult.ready,
       readiness: startResult.readiness,
-      message: `ComfyUI was stopped but could not be started: ${startResult.message}`,
+      // Two distinct failures share this branch, and they must NOT read alike: the
+      // server may be DOWN (our relaunch never answered), or UP but owned by
+      // somebody else (an external supervisor beat us to the port — our relaunch
+      // still failed). Saying "could not be started" about a healthy server would
+      // be as wrong as claiming success for it (codex gate).
+      message: startResult.ready
+        ? `ComfyUI is back up, but NOT as a result of this restart: ${startResult.message}`
+        : `ComfyUI was stopped but could not be started: ${startResult.message}`,
       auto_restart: startResult.auto_restart,
       spawn_error: startResult.spawn_error,
       launch_env: startResult.launch_env,
@@ -1760,14 +1773,10 @@ export async function restartComfyUI(): Promise<RestartResult> {
     started: true,
     ready: startResult.ready,
     readiness: startResult.readiness,
-    // Only claim a clean "restarted successfully" when the healthy listener is the
-    // process we launched (or we could not tell). When it provably is NOT ours, say
-    // the server is up but somebody ELSE brought it back (codex gate) — startResult's
-    // own message carries the PID detail.
-    message:
-      (startResult.listener_is_launched_process === false
-        ? "ComfyUI is back up, but NOT as a result of this restart. "
-        : "ComfyUI restarted successfully. ") + startResult.message,
+    // Reached only when startComfyUI reported started:true — i.e. the healthy
+    // listener is ours, or ownership was undecidable. A listener that is provably
+    // NOT ours returns started:false and is handled in the branch above.
+    message: `ComfyUI restarted successfully. ${startResult.message}`,
     auto_restart: startResult.auto_restart,
     launch_env: startResult.launch_env,
     listener_is_launched_process: startResult.listener_is_launched_process,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -396,7 +396,17 @@ function findDesktopExePath(argv: string[]): string | undefined {
  * definite `free`; an `unknown` keeps waiting and, if that is all we ever get,
  * surfaces as the timeout — a caller must not read it as success.
  */
-async function waitForPortFree(port: number, timeoutMs = 15000): Promise<void> {
+/** How long to wait for the port to be observed free after a kill. Tunable for the
+ *  same reason the startup probes are (COMFYUI_STARTUP_CHECK_*): a host with a slow
+ *  or unavailable port probe should not be stuck with one hardcoded budget. */
+function getPortFreeTimeoutMs(): number {
+  return Math.round(parsePositiveNumberEnv("COMFYUI_PORT_FREE_TIMEOUT_S", 15) * 1000);
+}
+
+async function waitForPortFree(
+  port: number,
+  timeoutMs = getPortFreeTimeoutMs(),
+): Promise<void> {
   const start = Date.now();
   let lastUnknown: string | undefined;
   while (Date.now() - start < timeoutMs) {
@@ -665,32 +675,49 @@ function classifyListenerOwnership(input: {
    */
   const byArgv = (): "match" | "differ" | "unknown" => {
     if (!input.servingArgv?.length || !input.launchArgv?.length) return "unknown";
-    // BOTH directions. `commandLineMatchesArgv(haystack, tokens)` only asks whether
-    // every token appears in the haystack, so a single call is a SUBSET test — and
-    // a foreign server whose argv is a strict subset of ours would "match", turning
-    // the deliberately non-promoting match into a false one (codex gate). Compare
-    // each way instead. The interpreter is dropped from our side because the server
-    // reports `sys.argv`, which never contains it.
-    // Path-like tokens are reduced to their final segment for the reverse check.
-    // We resolve the script to an ABSOLUTE path to launch it, while the server
-    // reports the (often RELATIVE) `sys.argv` it was handed — and
-    // commandLineMatchesArgv treats an absolute token as an exact claim by design
-    // (#401). Comparing them verbatim would make every portable-launcher install
-    // read as a different server. Flags are left alone, so a foreign SUBSET still
-    // fails on the missing ones.
-    const ourTokens = input.launchArgv
-      .slice(1)
-      .map((t) => (looksLikePath(t) ? t.split(/[\\/]/).pop() || t : t));
-    if (ourTokens.length === 0) return "unknown";
-    const servingContainsOurs = commandLineMatchesArgv(
-      input.servingArgv.join(" "),
-      ourTokens,
-    );
-    const oursContainsServing = commandLineMatchesArgv(
-      input.launchArgv.join(" "),
-      input.servingArgv,
-    );
-    return servingContainsOurs && oursContainsServing ? "match" : "differ";
+    // Compared as normalised token MULTISETS, both directions at once. A one-way
+    // containment test is a SUBSET check, and a foreign server whose argv is a
+    // strict subset of ours would "match" (codex gate); requiring the same tokens
+    // on both sides rules that out.
+    //
+    // The normalisation is deliberately NOT `commandLineMatchesArgv`, which was the
+    // second half of this bug. That helper normalises separators only when the HOST
+    // is Windows — correct for its own job (#401 compares two observations of the
+    // same machine), wrong here: `sys.argv` follows the SERVER, so a Windows-launched
+    // ComfyUI answers `ComfyUI\main.py` even when this orchestrator runs on Linux.
+    // Under host-normalisation that never matches our POSIX-resolved absolute path,
+    // and the "difference" it reports is really "I could not compare these" — an
+    // absence dressed as a finding.
+    const normalise = (token: string): string =>
+      token
+        .trim()
+        .replace(/^["']+|["']+$/g, "")
+        .toLowerCase()
+        .replace(/\\/g, "/");
+    /**
+     * Do two argv tokens denote the same thing? Paths are compared SEGMENT-ALIGNED
+     * (one may be a suffix of the other) rather than by basename: we launch the
+     * script by absolute path while the server reports the relative one it was
+     * handed, so `/opt/x/ComfyUI/main.py` and `ComfyUI\main.py` agree — while two
+     * DIFFERENT installs do not, which a basename comparison could never tell apart
+     * given every ComfyUI script is called `main.py`.
+     */
+    const tokensAgree = (a: string, b: string): boolean => {
+      if (a === b) return true;
+      const pathish = (s: string): boolean => /\//.test(s) || /^[a-z]:/.test(s);
+      if (!pathish(a) || !pathish(b)) return false;
+      return a.endsWith(`/${b}`) || b.endsWith(`/${a}`);
+    };
+    // The interpreter is dropped from our side: the server reports `sys.argv`,
+    // which never contains it. Order is preserved on both sides (a relaunch passes
+    // the same arguments in the same order), so compare positionally.
+    const ours = input.launchArgv.slice(1).map(normalise).filter(Boolean);
+    const serving = input.servingArgv.map(normalise).filter(Boolean);
+    if (ours.length === 0 || serving.length === 0) return "unknown";
+    const same =
+      ours.length === serving.length &&
+      ours.every((token, i) => tokensAgree(token, serving[i]));
+    return same ? "match" : "differ";
   };
   // A Desktop launch is undecidable BY DESIGN: we spawn the Electron shell (or
   // macOS `open`) and its child binds the port, so a pid mismatch proves nothing.
@@ -725,10 +752,18 @@ function classifyListenerOwnership(input: {
 
   const ourPid = input.child.pid;
   if (input.portOwnerPid == null) {
-    // The port owner could not be mapped (#449). The server's own argv still
-    // decides the NEGATIVE: a different command line proves this call did not start
-    // the healthy listener, which is the case that must never read as success.
-    return byArgv() === "differ" ? "not-ours" : "unconfirmed";
+    // NO LISTENER WAS IDENTIFIED — the port owner could not be mapped at all (#449:
+    // no `lsof`, a permission-denied probe, the process already gone, the port
+    // already free). `not-ours` is a POSITIVE finding about an identified process,
+    // so it cannot be reached from here: there is nothing to have found. Reporting
+    // one would be manufacturing a definite answer out of an absence, which is the
+    // error this whole class of bug keeps taking (#796).
+    //
+    // The server's own argv is deliberately NOT consulted as a negative here. It
+    // describes whatever is ANSWERING, not which process holds the socket, and it
+    // cannot distinguish "a different program" from "we could not compare" — see
+    // byArgv, whose "differ" is not a proof of difference.
+    return "unconfirmed";
   }
   if (ourPid == null) return "unconfirmed";
   if (input.portOwnerPid !== ourPid) {

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -616,7 +616,22 @@ function classifyListenerOwnership(input: {
   child: ChildProcess;
   launchArgv?: string[];
   portOwnerPid: number | null;
+  /**
+   * The `sys.argv` reported by whatever server is now answering. An independent
+   * line of evidence that does not need a pid at all: a healthy server running the
+   * command line we just launched is ours; one running something else is not. This
+   * is what lets a host with no usable port-owner lookup (#449) still get a real
+   * answer instead of a permanent shrug.
+   */
+  servingArgv?: string[];
 }): ListenerOwnership {
+  /** Does the server that is answering run what we launched? */
+  const byArgv = (): "match" | "differ" | "unknown" => {
+    if (!input.servingArgv?.length || !input.launchArgv?.length) return "unknown";
+    return commandLineMatchesArgv(input.launchArgv.join(" "), input.servingArgv)
+      ? "match"
+      : "differ";
+  };
   // A Desktop launch is undecidable BY DESIGN: we spawn the Electron shell (or
   // macOS `open`) and its child binds the port, so a pid mismatch proves nothing.
   // A LAUNCH THAT NEVER HAPPENED is decisive on every path, Desktop included —
@@ -632,15 +647,30 @@ function classifyListenerOwnership(input: {
   // never-launched checks but BEFORE `childExited`, because for Desktop a launcher
   // exiting is normal rather than evidence of failure.
   if (input.isDesktopApp) return "unconfirmed";
-  if (input.childExited) return "not-ours";
 
   const alive = launchedChildStillRunning(input.child);
-  // Definitively gone (ESRCH) — whatever is serving the port is not it, even
-  // though the `exit` event has not been delivered yet.
-  if (alive === false) return "not-ours";
+  // OUR DIRECT CHILD IS GONE — by its `exit` event, or by a signal-0 probe (ESRCH)
+  // that does not wait for the event loop. Usually that means the healthy listener
+  // is somebody else's. But it is ALSO the shape of a wrapper script that launched
+  // ComfyUI as its grandchild and then exited normally, after which the grandchild
+  // is reparented and lineage can no longer place it in our tree. What still can:
+  // the server is running the exact command line we launched (codex gate P2).
+  if (input.childExited || alive === false) {
+    return byArgv() === "match" ? "ours" : "not-ours";
+  }
 
   const ourPid = input.child.pid;
-  if (ourPid == null || input.portOwnerPid == null) return "unconfirmed";
+  if (input.portOwnerPid == null) {
+    // The port owner could not be mapped (#449). Rather than shrug, ask the server
+    // what it is running: a match is as strong as a pid comparison, and a MISMATCH
+    // is decisive counter-evidence that this call did not start the healthy
+    // listener — which is exactly the case that must not read as success.
+    const verdict = byArgv();
+    if (verdict === "match") return "ours";
+    if (verdict === "differ") return "not-ours";
+    return "unconfirmed";
+  }
+  if (ourPid == null) return "unconfirmed";
   if (input.portOwnerPid !== ourPid) {
     // A DIFFERENT pid holds the port. That is usually somebody else's server — but
     // it is also the shape of a legitimately indirect launch (a wrapper script, a
@@ -651,6 +681,10 @@ function classifyListenerOwnership(input: {
     const descendant = isOurDescendant(input.portOwnerPid);
     if (descendant === true) return "ours";
     if (descendant === false) return "not-ours";
+    // Lineage unreadable — fall back to what the server says it is running.
+    const verdict = byArgv();
+    if (verdict === "match") return "ours";
+    if (verdict === "differ") return "not-ours";
     return "unconfirmed";
   }
   // The pid MATCHES — but it could be a recycled number we cannot signal.
@@ -2036,6 +2070,15 @@ export async function startComfyUI(): Promise<StartResult> {
 
   const newPid = findPidByPort(port);
   const env = launchEnvInfo(info);
+  // The API just answered, so ask it what it is running. This is the one identity
+  // signal that needs no pid at all, and it is what keeps hosts with an unusable
+  // port-owner lookup from getting a permanent "cannot tell".
+  let servingArgv: string[] | undefined;
+  try {
+    servingArgv = (await getSystemStats()).system.argv ?? undefined;
+  } catch {
+    servingArgv = undefined;
+  }
   // Is the healthy listener actually OURS?
   //   • A Desktop launch is UNDECIDABLE by design: we spawn the Electron shell (or
   //     macOS `open`), and the process that binds the port is its child, so a pid
@@ -2060,6 +2103,7 @@ export async function startComfyUI(): Promise<StartResult> {
     child: launched.child,
     launchArgv: launched.launchArgv,
     portOwnerPid: newPid,
+    servingArgv,
   });
   // Only the NON-Desktop undecidable case is worth calling out: for a Desktop
   // launcher the pid relationship is indirect by design, not a gap in evidence.

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -157,7 +157,37 @@ interface RestartResult {
  *                   condition, #449), or the launcher's pid is indirect (Desktop).
  *                   Never silently upgraded to "ours".
  */
-type ListenerOwnership = "ours" | "not-ours" | "unconfirmed";
+declare const CLASSIFIED: unique symbol;
+
+/**
+ * A verdict about who owns the healthy listener.
+ *
+ * BRANDED ON PURPOSE. The values are ordinary strings at runtime (they serialise
+ * and compare as `"ours"` / `"not-ours"` / `"unconfirmed"`), but the type carries a
+ * phantom property no literal can satisfy — so `listener_ownership: "not-ours"`
+ * simply does not compile. Only `classifyListenerOwnership`, which actually gathers
+ * the evidence, can mint a definite verdict; every other return path must call
+ * `unclassifiedOwnership()` and therefore cannot claim more than it knows.
+ *
+ * This exists because the same defect kept reappearing on new paths: a definite
+ * answer returned by code that never ran the check (#796). Making it a convention
+ * meant remembering it at each site; making it a TYPE means the compiler remembers.
+ */
+type ListenerOwnership = ("ours" | "not-ours" | "unconfirmed") & {
+  readonly [CLASSIFIED]: true;
+};
+
+/** The only verdict a site that did NOT classify is entitled to return. */
+function unclassifiedOwnership(): ListenerOwnership {
+  return "unconfirmed" as ListenerOwnership;
+}
+
+/** Mint a classified verdict. Callable only from the classifier below. */
+function classified(
+  verdict: "ours" | "not-ours" | "unconfirmed",
+): ListenerOwnership {
+  return verdict as ListenerOwnership;
+}
 
 interface StartupReadinessResult {
   ready: boolean;
@@ -688,12 +718,31 @@ function classifyListenerOwnership(input: {
     // Under host-normalisation that never matches our POSIX-resolved absolute path,
     // and the "difference" it reports is really "I could not compare these" — an
     // absence dressed as a finding.
-    const normalise = (token: string): string =>
-      token
-        .trim()
-        .replace(/^["']+|["']+$/g, "")
-        .toLowerCase()
-        .replace(/\\/g, "/");
+    /** A token written in a Windows path dialect (drive prefix or backslashes). */
+    const isWindowsDialect = (t: string): boolean =>
+      /^[a-zA-Z]:[\\/]/.test(t) || /^\\\\/.test(t) || t.includes("\\");
+    /**
+     * Canonicalise a token WITHOUT deciding case: separators to `/`, extended
+     * prefixes (`\\?\`, `\\?\UNC\`) stripped, and `.`/`..` segments resolved, so
+     * two spellings of the same path compare equal instead of reading as `differ`.
+     */
+    const normalise = (token: string): string => {
+      let t = token.trim().replace(/^["']+|["']+$/g, "").replace(/\\/g, "/");
+      t = t.replace(/^\/\/\?\/unc\//i, "//").replace(/^\/\/\?\//, "");
+      if (!/\//.test(t)) return t;
+      const rooted = t.startsWith("/");
+      const drive = /^([a-zA-Z]:)(?=\/)/.exec(t)?.[1] ?? "";
+      const out: string[] = [];
+      for (const seg of t.slice(drive.length).split("/")) {
+        if (seg === "" || seg === ".") continue;
+        if (seg === ".." && out.length > 0 && out[out.length - 1] !== "..") {
+          out.pop();
+          continue;
+        }
+        out.push(seg);
+      }
+      return `${drive}${rooted && !drive ? "/" : drive ? "/" : ""}${out.join("/")}`;
+    };
     /**
      * Do two argv tokens denote the same thing? Paths are compared SEGMENT-ALIGNED
      * (one may be a suffix of the other) rather than by basename: we launch the
@@ -702,17 +751,36 @@ function classifyListenerOwnership(input: {
      * DIFFERENT installs do not, which a basename comparison could never tell apart
      * given every ComfyUI script is called `main.py`.
      */
-    const tokensAgree = (a: string, b: string): boolean => {
-      if (a === b) return true;
-      const pathish = (s: string): boolean => /\//.test(s) || /^[a-z]:/.test(s);
-      if (!pathish(a) || !pathish(b)) return false;
-      return a.endsWith(`/${b}`) || b.endsWith(`/${a}`);
+    /** Canonical text plus the dialect it was WRITTEN in (read before normalising,
+     *  which strips the backslashes that identify it). */
+    const prepare = (raw: string): { text: string; windows: boolean } => ({
+      text: normalise(raw),
+      windows: isWindowsDialect(raw.trim().replace(/^["']+|["']+$/g, "")),
+    });
+    const tokensAgree = (
+      a: { text: string; windows: boolean },
+      b: { text: string; windows: boolean },
+    ): boolean => {
+      // CASE-FOLDING IS CONDITIONAL ON THE DIALECT, never unconditional. Folding
+      // everything made `/srv/ComfyUI/main.py` and `/srv/comfyui/main.py` — two
+      // genuinely different directories on a case-sensitive filesystem — compare
+      // equal, which fabricates a MATCH. That is the dangerous direction: a match
+      // can promote a descendant listener to "ours" and so license stopping a
+      // process that isn't ours. Windows paths ARE case-insensitive, so fold only
+      // when a side was written in that dialect; POSIX paths compare exactly.
+      const fold = a.windows || b.windows;
+      const x = fold ? a.text.toLowerCase() : a.text;
+      const y = fold ? b.text.toLowerCase() : b.text;
+      if (x === y) return true;
+      const pathish = (s: string): boolean => /\//.test(s) || /^[a-zA-Z]:/.test(s);
+      if (!pathish(x) || !pathish(y)) return false;
+      return x.endsWith(`/${y}`) || y.endsWith(`/${x}`);
     };
     // The interpreter is dropped from our side: the server reports `sys.argv`,
     // which never contains it. Order is preserved on both sides (a relaunch passes
     // the same arguments in the same order), so compare positionally.
-    const ours = input.launchArgv.slice(1).map(normalise).filter(Boolean);
-    const serving = input.servingArgv.map(normalise).filter(Boolean);
+    const ours = input.launchArgv.slice(1).map(prepare).filter((t) => t.text);
+    const serving = input.servingArgv.map(prepare).filter((t) => t.text);
     if (ours.length === 0 || serving.length === 0) return "unknown";
     const same =
       ours.length === serving.length &&
@@ -726,14 +794,14 @@ function classifyListenerOwnership(input: {
   // error is latched independently of the readiness race, and Node leaves `pid`
   // undefined only when the spawn did not happen, so the two are the same fact
   // arriving by different routes.
-  if (input.spawnFailed) return "not-ours";
-  if (input.child.pid == null) return "not-ours";
+  if (input.spawnFailed) return classified("not-ours");
+  if (input.child.pid == null) return classified("not-ours");
   // A Desktop launch is undecidable BY DESIGN once it HAS started: we spawn the
   // Electron shell (or macOS `open`, which exits immediately by design), and the
   // process that binds the port is its child. Note this sits AFTER the
   // never-launched checks but BEFORE `childExited`, because for Desktop a launcher
   // exiting is normal rather than evidence of failure.
-  if (input.isDesktopApp) return "unconfirmed";
+  if (input.isDesktopApp) return classified("unconfirmed");
 
   const alive = launchedChildStillRunning(input.child);
   // OUR DIRECT CHILD IS GONE — by its `exit` event, or by a signal-0 probe (ESRCH)
@@ -747,7 +815,7 @@ function classifyListenerOwnership(input: {
     // could equally be another supervisor's identical instance. But it does mean we
     // cannot honestly assert the negative either, so the wrapper case degrades to
     // "unconfirmed" instead of telling that user their own server is not theirs.
-    return byArgv() === "match" ? "unconfirmed" : "not-ours";
+    return byArgv() === "match" ? classified("unconfirmed") : classified("not-ours");
   }
 
   const ourPid = input.child.pid;
@@ -763,9 +831,9 @@ function classifyListenerOwnership(input: {
     // describes whatever is ANSWERING, not which process holds the socket, and it
     // cannot distinguish "a different program" from "we could not compare" — see
     // byArgv, whose "differ" is not a proof of difference.
-    return "unconfirmed";
+    return classified("unconfirmed");
   }
-  if (ourPid == null) return "unconfirmed";
+  if (ourPid == null) return classified("unconfirmed");
   if (input.portOwnerPid !== ourPid) {
     // A DIFFERENT pid holds the port. That is usually somebody else's server — but
     // it is also the shape of a legitimately indirect launch (a wrapper script, a
@@ -779,13 +847,13 @@ function classifyListenerOwnership(input: {
     // process tree while plainly not being what we launched. `listener_ownership`
     // answers "is this the process THIS CALL launched", so a differing command line
     // is decisive there too (codex gate).
-    if (descendant === true) return byArgv() === "differ" ? "not-ours" : "ours";
-    if (descendant === false) return "not-ours";
+    if (descendant === true) return byArgv() === "differ" ? classified("not-ours") : classified("ours");
+    if (descendant === false) return classified("not-ours");
     // Lineage unreadable — the server's argv can still rule the listener OUT.
-    return byArgv() === "differ" ? "not-ours" : "unconfirmed";
+    return byArgv() === "differ" ? classified("not-ours") : classified("unconfirmed");
   }
   // The pid MATCHES — but it could be a recycled number we cannot signal.
-  if (alive !== true) return "unconfirmed";
+  if (alive !== true) return classified("unconfirmed");
 
   // LINEAGE is the discriminator, and the only one that does not depend on WHEN we
   // looked (coordinator gate P1(2)). A creation stamp read after `spawn()` returns
@@ -799,8 +867,8 @@ function classifyListenerOwnership(input: {
   // Not knowing is never promoted to "ours": an unreadable parent withholds the
   // claim. Knowing it is somebody else's is decisive.
   const parent = readParentPid(ourPid);
-  if (parent == null) return "unconfirmed";
-  if (parent !== process.pid) return "not-ours";
+  if (parent == null) return classified("unconfirmed");
+  if (parent !== process.pid) return classified("not-ours");
 
   // Belt and braces: where the OS exposes it, the port owner must also still be
   // running what we launched — and the SERVER's own account of itself must agree.
@@ -812,10 +880,10 @@ function classifyListenerOwnership(input: {
     input.launchArgv &&
     !commandLineMatchesArgv(identity.commandLine, input.launchArgv)
   ) {
-    return "not-ours";
+    return classified("not-ours");
   }
-  if (byArgv() === "differ") return "not-ours";
-  return "ours";
+  if (byArgv() === "differ") return classified("not-ours");
+  return classified("ours");
 }
 
 /** The launch-environment facts to report, once a plan has been resolved (#776). */
@@ -2090,19 +2158,29 @@ export async function startComfyUI(): Promise<StartResult> {
   }
   const port = config.resolvedPort;
 
-  // Check if already running
-  const existingPid = findPidByPort(port);
-  if (existingPid) {
+  // Check if already running. TRI-STATE: "the lookup could not run" is NOT "the
+  // port is free". Collapsing them let us spawn into a port the old server may
+  // still hold, and then report `started:true` because readiness reached THAT
+  // server before the new child's bind failure surfaced — a restart claimed on
+  // evidence nobody had (codex gate P1-c).
+  const preLaunchProbe = probePortOwner(port);
+  if (preLaunchProbe.state === "owned") {
     return {
       started: false,
-      message: `ComfyUI is already running on port ${port} (PID ${existingPid})`,
-      pid: existingPid,
-      // Something is serving the port and it is emphatically NOT a process this
-      // call launched — we never got as far as spawning. Reached during a restart
-      // when another launcher grabbed the port in the gap after our stop
-      // (coordinator gate P2(5)).
-      listener_ownership: "not-ours",
+      message: `ComfyUI is already running on port ${port} (PID ${preLaunchProbe.pid})`,
+      pid: preLaunchProbe.pid,
+      // Something is serving the port and we never got as far as spawning. We did
+      // not classify a launch of ours, so we may not name a definite verdict.
+      listener_ownership: unclassifiedOwnership(),
     };
+  }
+  /** Was the port OBSERVED free before we spawned? `false` = we could not tell. */
+  const portObservedFreeBeforeLaunch = preLaunchProbe.state === "free";
+  if (!portObservedFreeBeforeLaunch) {
+    logger.warn(
+      "Could not determine whether the port was free before launching — a start will not be claimed on readiness alone",
+      { port, reason: preLaunchProbe.state === "unknown" ? preLaunchProbe.reason : "" },
+    );
   }
 
   let info = lastProcessInfo;
@@ -2123,7 +2201,7 @@ export async function startComfyUI(): Promise<StartResult> {
         started: false,
         message:
           "No previous process info and could not find ComfyUI Desktop app. Start ComfyUI manually.",
-        listener_ownership: "unconfirmed",
+        listener_ownership: unclassifiedOwnership(),
       };
     }
   }
@@ -2141,7 +2219,7 @@ export async function startComfyUI(): Promise<StartResult> {
         ? "Could not determine ComfyUI Desktop executable path. Please start it manually."
         : "No command-line info captured from previous run. Start ComfyUI manually.",
       auto_restart: supervisorResult(info),
-      listener_ownership: "unconfirmed",
+      listener_ownership: unclassifiedOwnership(),
     };
   }
   const spawnError = captureChildProcessError(launched.child);
@@ -2201,7 +2279,7 @@ export async function startComfyUI(): Promise<StartResult> {
       launch_env: launchEnvInfo(info),
       // The spawn failed outright: whatever may be serving that port, it is
       // certainly not something this call started.
-      listener_ownership: "not-ours",
+      listener_ownership: unclassifiedOwnership(),
     };
   }
 
@@ -2225,7 +2303,7 @@ export async function startComfyUI(): Promise<StartResult> {
       launch_env: env,
       // Nothing is serving the port, so there is no listener to attribute — the
       // down state is already carried by started:false / ready:false.
-      listener_ownership: "unconfirmed",
+      listener_ownership: unclassifiedOwnership(),
     };
   }
 
@@ -2269,6 +2347,14 @@ export async function startComfyUI(): Promise<StartResult> {
   // Only the NON-Desktop undecidable case is worth calling out: for a Desktop
   // launcher the pid relationship is indirect by design, not a gap in evidence.
   const ownershipUnconfirmed = !info.isDesktopApp && ownership === "unconfirmed";
+  // A start may be CLAIMED only on evidence. Ownership "ours" is proof. Ownership
+  // "unconfirmed" is accepted as a start ONLY when we also observed the port to be
+  // FREE before spawning — otherwise the healthy API may be the very server that
+  // was already there, and readiness would be certifying somebody else's process
+  // as our restart (codex gate P1-c).
+  const mayClaimStart =
+    ownership === "ours" ||
+    (ownership === "unconfirmed" && portObservedFreeBeforeLaunch);
   return {
     // `started` means "THIS call started the server". When the healthy listener is
     // provably NOT the process we launched, we did not start it — programmatic
@@ -2276,7 +2362,7 @@ export async function startComfyUI(): Promise<StartResult> {
     // answers (codex gate). `ready` stays TRUE because the server genuinely IS
     // ready: claiming otherwise would be its own lie and would push callers into
     // needless recovery.
-    started: ownership !== "not-ours",
+    started: mayClaimStart,
     ready: true,
     readiness,
     message:
@@ -2296,6 +2382,11 @@ export async function startComfyUI(): Promise<StartResult> {
       // "our relaunch is the healthy server" is unconfirmed rather than proven.
       (ownershipUnconfirmed
         ? ` (Could not map the process owning port ${port}, so this could not be confirmed as the process this call launched — the launched process is alive and the API is ready.)`
+        : "") +
+      // The port was never observed free, so a healthy API is not evidence WE
+      // produced it — it may be the server that was already there.
+      (!portObservedFreeBeforeLaunch && ownership !== "ours"
+        ? ` NOTE: the port was never observed free before launching, so this call cannot claim to have started the server that is answering.`
         : "") +
       launchEnvWarning(info),
     pid: newPid ?? undefined,
@@ -2508,7 +2599,7 @@ async function restartViaManagerReboot(context: {
       message: reboot.note ?? "ComfyUI-Manager reboot could not be triggered.",
       // The Manager reboot path never spawns a process of ours, so ownership of
       // whatever serves the port is never something this call can claim.
-      listener_ownership: "unconfirmed",
+      listener_ownership: unclassifiedOwnership(),
     };
   }
 
@@ -2548,7 +2639,7 @@ async function restartViaManagerReboot(context: {
       message:
         `Reboot was triggered but ComfyUI did not come back within ${timing.budgetMs}ms — ` +
         "check the host (is it the Desktop app / supervised?).",
-      listener_ownership: "unconfirmed",
+      listener_ownership: unclassifiedOwnership(),
     };
   }
 
@@ -2574,7 +2665,7 @@ async function restartViaManagerReboot(context: {
       `${context.label}/supervised restart.`,
     // The supervisor that owns the process cycled it; we launched nothing, so we
     // cannot (and must not) claim the listener as ours.
-    listener_ownership: "unconfirmed",
+    listener_ownership: unclassifiedOwnership(),
   };
 }
 
@@ -2599,7 +2690,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
       message:
         diagnostic ??
         `No ComfyUI process found on port ${config.resolvedPort} to restart. Is ComfyUI running?`,
-      listener_ownership: "unconfirmed",
+      listener_ownership: unclassifiedOwnership(),
     };
   }
   // A locally-installed ComfyUI **Desktop** instance is Electron-supervised.
@@ -2626,7 +2717,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
           "Fix the launch path (e.g. COMFYUI_PATH) and try again."),
       // Refused before touching anything: the still-running server is the one that
       // was already there, which this call did not start.
-      listener_ownership: "not-ours",
+      listener_ownership: unclassifiedOwnership(),
     };
   }
 
@@ -2640,7 +2731,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
       message: `Could not stop ComfyUI: ${stopResult.message}`,
       // Nothing was stopped and nothing launched — whatever is on the port is not
       // this call's doing.
-      listener_ownership: "not-ours",
+      listener_ownership: unclassifiedOwnership(),
     };
   }
   // #742 r4/r5: the stop DID happen — record the dispatch. No session identity

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -739,7 +739,12 @@ function classifyListenerOwnership(input: {
     // our tree => not ours; unreadable => unconfirmed, never a false negative that
     // tells a wrapper-launched user their own server isn't theirs.
     const descendant = isOurDescendant(input.portOwnerPid);
-    if (descendant === true) return "ours";
+    // Lineage does not outrank direct contrary evidence: a wrapper of ours can
+    // stay alive and bring up a DIFFERENT (or stale) ComfyUI, which would be in our
+    // process tree while plainly not being what we launched. `listener_ownership`
+    // answers "is this the process THIS CALL launched", so a differing command line
+    // is decisive there too (codex gate).
+    if (descendant === true) return byArgv() === "differ" ? "not-ours" : "ours";
     if (descendant === false) return "not-ours";
     // Lineage unreadable — the server's argv can still rule the listener OUT.
     return byArgv() === "differ" ? "not-ours" : "unconfirmed";
@@ -763,7 +768,9 @@ function classifyListenerOwnership(input: {
   if (parent !== process.pid) return "not-ours";
 
   // Belt and braces: where the OS exposes it, the port owner must also still be
-  // running what we launched.
+  // running what we launched — and the SERVER's own account of itself must agree.
+  // Both are decisive negatives, for the same reason as above: pid identity says
+  // which process, not which program it is running.
   const identity = resolveProcessIdentity(ourPid);
   if (
     identity?.commandLine &&
@@ -772,6 +779,7 @@ function classifyListenerOwnership(input: {
   ) {
     return "not-ours";
   }
+  if (byArgv() === "differ") return "not-ours";
   return "ours";
 }
 

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1368,8 +1368,14 @@ export async function startComfyUI(): Promise<StartResult> {
   //     that is decisive even when the port owner cannot be mapped at all (the #449
   //     shape), which is precisely the "an external supervisor restored the API"
   //     case that must never be reported as our successful restart (codex gate).
-  //   • Otherwise it needs both pids; an unmappable port owner stays `undefined`
-  //     rather than asserting either way.
+  //   • Otherwise it needs both pids. An unmappable port owner (a real, supported
+  //     condition on some hosts — #449) stays `undefined`: we assert NEITHER way.
+  //     It deliberately does NOT become a failure — the child we launched is still
+  //     alive and the API is ready, so denying it would report every ordinary
+  //     restart as failed on any host where the port-owner lookup is unavailable,
+  //     which is a far worse (and far more common) lie than an unconfirmed
+  //     success. The undecidability is stated in the message AND in
+  //     `listener_is_launched_process`, so no caller has to infer it.
   const ourPid = launched.child.pid;
   const listenerIsOurs = info.isDesktopApp
     ? undefined
@@ -1378,6 +1384,9 @@ export async function startComfyUI(): Promise<StartResult> {
       : ourPid == null || newPid == null
         ? undefined
         : newPid === ourPid;
+  // Only the NON-Desktop undecidable case is worth calling out: for a Desktop
+  // launcher the pid relationship is indirect by design, not a gap in evidence.
+  const ownershipUnconfirmed = !info.isDesktopApp && listenerIsOurs === undefined;
   return {
     // `started` means "THIS call started the server". When the healthy listener is
     // provably NOT the process we launched, we did not start it — programmatic
@@ -1400,6 +1409,11 @@ export async function startComfyUI(): Promise<StartResult> {
         ? ` NOTE: the healthy server on port ${port}${newPid ? ` (PID ${newPid})` : ""} is NOT the process this call launched (PID ${
             ourPid ?? "unknown"
           }${launchedChildExit ? `, which exited: ${exitCause(launchedChildExit)}` : ""}) — another launcher or supervisor owns it, so this server was not started by us.`
+        : "") +
+      // Undecidable ownership is stated, never implied away: the caller learns that
+      // "our relaunch is the healthy server" is unconfirmed rather than proven.
+      (ownershipUnconfirmed
+        ? ` (Could not map the process owning port ${port}, so this could not be confirmed as the process this call launched — the launched process is alive and the API is ready.)`
         : "") +
       launchEnvWarning(info),
     pid: newPid ?? undefined,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -20,6 +20,7 @@ import { parseListenerPidFromNetstat, findPidByPort } from "./port-owner.js";
 import {
   recordLaunchedInterpreter,
   clearLaunchedInterpreter,
+  readProcessIdentity,
 } from "./live-interpreter.js";
 import {
   liveRootFromArgv,
@@ -56,6 +57,16 @@ interface ProcessInfo {
    */
   liveEnv?: NodeJS.ProcessEnv;
   /**
+   * The port owner's process CREATION TIME, read at the same moment as the pid.
+   * A pid is not an identity (pids are recycled), so anything that acts ON this
+   * process (reading its environment, killing it) re-verifies this stamp first;
+   * a changed stamp means the number now belongs to somebody else. Reuses #650's
+   * pid+creation-time identity rather than inventing a second scheme.
+   * `undefined` when the platform/permissions make it unreadable, in which case
+   * the cheaper port-ownership re-check is the only guard.
+   */
+  startedAt?: string;
+  /**
    * The resolved relaunch ENVIRONMENT decision (#776) — computed once by
    * assessRelaunch (pre-stop, so a refusal happens before anything is killed) and
    * reused verbatim by the spawn, so the process that comes back is launched into
@@ -83,11 +94,13 @@ interface StartResult {
   launch_env?: LaunchEnvInfo;
   /**
    * Whether the process now listening on the port is the one WE launched.
-   * `undefined` when it cannot be decided (no spawn pid, or the port owner could
-   * not be mapped). `false` means a healthy server is up but somebody else owns
-   * it — readiness alone must never be read as "our relaunch worked".
+   *
+   * A STRING tri-state, not a boolean-or-undefined, precisely so the uncertain
+   * case survives `JSON.stringify` (which DROPS `undefined` keys, making "we could
+   * not determine this" indistinguishable from a response that never carried the
+   * field at all).
    */
-  listener_is_launched_process?: boolean;
+  listener_ownership?: ListenerOwnership;
 }
 
 interface RestartResult {
@@ -102,12 +115,26 @@ interface RestartResult {
   launch_env?: LaunchEnvInfo;
   /**
    * Whether the process now listening on the port is the one WE launched.
-   * `undefined` when it cannot be decided (no spawn pid, or the port owner could
-   * not be mapped). `false` means a healthy server is up but somebody else owns
-   * it — readiness alone must never be read as "our relaunch worked".
+   *
+   * A STRING tri-state, not a boolean-or-undefined, precisely so the uncertain
+   * case survives `JSON.stringify` (which DROPS `undefined` keys, making "we could
+   * not determine this" indistinguishable from a response that never carried the
+   * field at all).
    */
-  listener_is_launched_process?: boolean;
+  listener_ownership?: ListenerOwnership;
 }
+
+/**
+ * Who owns the process serving the port after a launch (#776).
+ *   "ours"        - the port owner IS the process this call launched (proven).
+ *   "not-ours"    - a healthy listener that provably is NOT ours (a different
+ *                   mapped owner, or our launched child already dead).
+ *   "unconfirmed" - genuinely undecidable: the launched child is alive and the API
+ *                   is ready, but the port owner could not be mapped (a supported
+ *                   condition, #449), or the launcher's pid is indirect (Desktop).
+ *                   Never silently upgraded to "ours".
+ */
+type ListenerOwnership = "ours" | "not-ours" | "unconfirmed";
 
 interface StartupReadinessResult {
   ready: boolean;
@@ -684,6 +711,109 @@ function resolveLiveProcessEnv(pid: number): NodeJS.ProcessEnv | undefined {
   return readLiveProcessEnv(pid);
 }
 
+/**
+ * Injectable process-IDENTITY reader (creation time), reusing #650's identity
+ * scheme from live-interpreter rather than inventing a second one.
+ *
+ * Native reads happen only on Linux, where `/proc/<pid>/stat` is a free file read
+ * AND which is the only platform where we read `/proc/<pid>/environ` at all. The
+ * Windows/macOS readers cost a PowerShell/`ps` spawn per call and would buy
+ * nothing the port-ownership re-check below does not already give: a recycled pid
+ * belongs to an unrelated program, which by definition is not listening on our
+ * port. An injected override always wins so tests can drive recycled-pid
+ * scenarios on any host.
+ */
+let processIdentityOverride:
+  | ((pid: number) => { startedAt?: string } | undefined)
+  | null = null;
+
+function resolveProcessIdentity(pid: number): { startedAt?: string } | undefined {
+  if (processIdentityOverride) return processIdentityOverride(pid);
+  if (!pid || pid <= 0 || process.platform !== "linux") return undefined;
+  try {
+    return readProcessIdentity(pid);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The live environment of a pid we can still PROVE is the process we identified.
+ *
+ * Reading `/proc/<pid>/environ` from a bare number is not enough: between the port
+ * lookup and the read, ComfyUI can exit and the OS can hand the number to an
+ * unrelated process, whose environment we would then adopt as ComfyUI's launch
+ * environment. So the creation time is re-verified immediately AFTER the read, and
+ * any gap in the evidence (no stamp before, no stamp after, or a changed stamp)
+ * discards the capture and falls through to the on-disk tiers, which refuse rather
+ * than guess.
+ */
+function captureVerifiedLiveEnv(
+  pid: number,
+  startedAt: string | undefined,
+): NodeJS.ProcessEnv | undefined {
+  if (!startedAt) return undefined;
+  const env = resolveLiveProcessEnv(pid);
+  if (!env) return undefined;
+  const after = resolveProcessIdentity(pid)?.startedAt;
+  if (!after || after !== startedAt) {
+    logger.warn(
+      "Discarding the captured ComfyUI environment: the pid's identity changed while reading it",
+      { pid, before: startedAt, after: after ?? "(unavailable)" },
+    );
+    return undefined;
+  }
+  return env;
+}
+
+/**
+ * May we still act on (kill) the process we identified? Returns a refusal reason
+ * when the pid provably no longer denotes that process.
+ *
+ * Two independent checks, cheapest first:
+ *   1. it must STILL own the port we found it on - a recycled pid belongs to some
+ *      unrelated program, which by definition is not listening there;
+ *   2. when a creation-time stamp was captured, it must still match.
+ * Missing evidence is NOT treated as failure (that would refuse restarts on hosts
+ * where the reads are unavailable); only a POSITIVE mismatch refuses.
+ */
+function processIdentityStillValid(
+  info: ProcessInfo,
+): { ok: true } | { ok: false; reason: string } {
+  // A Desktop pid may legitimately not be the port owner (it can come from the
+  // Electron-shell scan when the API is unreachable), so the port check is
+  // meaningless there.
+  if (!info.isDesktopApp) {
+    let owner: number | null = null;
+    try {
+      owner = findPidByPort(info.port);
+    } catch {
+      owner = null;
+    }
+    if (owner !== info.pid) {
+      return {
+        ok: false,
+        reason:
+          `the process identified on port ${info.port} (PID ${info.pid}) no longer owns that port ` +
+          `(now ${owner ?? "nothing"}), so it exited on its own - this PID may since have been ` +
+          "reused by an unrelated program and must not be killed",
+      };
+    }
+  }
+  if (info.startedAt) {
+    const now = resolveProcessIdentity(info.pid)?.startedAt;
+    if (now && now !== info.startedAt) {
+      return {
+        ok: false,
+        reason:
+          `PID ${info.pid} is no longer the ComfyUI process we identified (its creation time ` +
+          "changed), so the number has been reused by a different program and must not be killed",
+      };
+    }
+  }
+  return { ok: true };
+}
+
 function resolveLiveProcessCwd(pid: number): string | undefined {
   if (liveCwdResolverOverride) return liveCwdResolverOverride(pid);
   if (!pid || IS_WIN) return undefined;
@@ -1136,7 +1266,11 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   // Same live-only window for the ENVIRONMENT (#776): read it now, while the pid
   // is guaranteed alive, so a relaunch can reproduce the launcher environment the
   // server was actually started with instead of substituting the orchestrator's.
-  const liveEnv = desktop ? undefined : resolveLiveProcessEnv(pid);
+  // The pid's IDENTITY (creation time), taken at the same moment as the pid itself
+  // so everything downstream can prove the number still denotes THIS process.
+  const startedAt = desktop ? undefined : resolveProcessIdentity(pid)?.startedAt;
+  // Bound to that identity - never adopted from a pid we cannot still prove.
+  const liveEnv = desktop ? undefined : captureVerifiedLiveEnv(pid, startedAt);
 
   return {
     pid,
@@ -1146,6 +1280,7 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
     desktopExePath: desktopExe,
     liveCwd,
     liveEnv,
+    startedAt,
   };
 }
 
@@ -1185,6 +1320,22 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
       message:
         acquireDiagnostic ??
         `No ComfyUI process found on port ${config.resolvedPort}. Is ComfyUI running?`,
+      has_restart_info: false,
+    };
+  }
+
+  // LAST-MOMENT IDENTITY CHECK: the pid was resolved before the relaunch preflight
+  // ran, and a pid is not a process identity. If the server exited in that window
+  // and the OS recycled the number, killing it would destroy an unrelated program.
+  // Refuse instead - nothing has been touched yet, so this costs a restart, never
+  // the server.
+  const identity = processIdentityStillValid(info);
+  if (!identity.ok) {
+    return {
+      stopped: false,
+      message:
+        `Refusing to stop: ${identity.reason}. Nothing was killed. ` +
+        "Re-run once ComfyUI is running again (or start it with start_comfyui).",
       has_restart_info: false,
     };
   }
@@ -1354,7 +1505,9 @@ export async function startComfyUI(): Promise<StartResult> {
         launchEnvWarning(info),
       auto_restart: supervisorResult(info),
       launch_env: env,
-      listener_is_launched_process: false,
+      // Nothing is serving the port, so there is no listener to attribute — the
+      // down state is already carried by started:false / ready:false.
+      listener_ownership: "unconfirmed",
     };
   }
 
@@ -1369,24 +1522,26 @@ export async function startComfyUI(): Promise<StartResult> {
   //     shape), which is precisely the "an external supervisor restored the API"
   //     case that must never be reported as our successful restart (codex gate).
   //   • Otherwise it needs both pids. An unmappable port owner (a real, supported
-  //     condition on some hosts — #449) stays `undefined`: we assert NEITHER way.
+  //     condition on some hosts — #449) is "unconfirmed": we assert NEITHER way.
   //     It deliberately does NOT become a failure — the child we launched is still
   //     alive and the API is ready, so denying it would report every ordinary
   //     restart as failed on any host where the port-owner lookup is unavailable,
   //     which is a far worse (and far more common) lie than an unconfirmed
-  //     success. The undecidability is stated in the message AND in
-  //     `listener_is_launched_process`, so no caller has to infer it.
+  //     success. That uncertainty is carried by an EXPLICIT string state, so it
+  //     survives JSON serialization instead of vanishing with an `undefined`.
   const ourPid = launched.child.pid;
-  const listenerIsOurs = info.isDesktopApp
-    ? undefined
+  const ownership: ListenerOwnership = info.isDesktopApp
+    ? "unconfirmed"
     : launchedChildExit
-      ? false
+      ? "not-ours"
       : ourPid == null || newPid == null
-        ? undefined
-        : newPid === ourPid;
+        ? "unconfirmed"
+        : newPid === ourPid
+          ? "ours"
+          : "not-ours";
   // Only the NON-Desktop undecidable case is worth calling out: for a Desktop
   // launcher the pid relationship is indirect by design, not a gap in evidence.
-  const ownershipUnconfirmed = !info.isDesktopApp && listenerIsOurs === undefined;
+  const ownershipUnconfirmed = !info.isDesktopApp && ownership === "unconfirmed";
   return {
     // `started` means "THIS call started the server". When the healthy listener is
     // provably NOT the process we launched, we did not start it — programmatic
@@ -1394,18 +1549,18 @@ export async function startComfyUI(): Promise<StartResult> {
     // answers (codex gate). `ready` stays TRUE because the server genuinely IS
     // ready: claiming otherwise would be its own lie and would push callers into
     // needless recovery.
-    started: listenerIsOurs !== false,
+    started: ownership !== "not-ours",
     ready: true,
     readiness,
     message:
-      `ComfyUI ${listenerIsOurs === false ? "is ready" : "started"} on port ${port}${newPid ? ` (PID ${newPid})` : ""}` +
+      `ComfyUI ${ownership === "not-ours" ? "is ready" : "started"} on port ${port}${newPid ? ` (PID ${newPid})` : ""}` +
       // Say WHICH environment it came back in whenever that was not simply ours
       // (#776) — the user needs to know a launcher environment was restored.
       (env && env.source !== "inherited" ? ` — ${env.note}.` : "") +
       // NEVER imply our relaunch is the healthy server when the port is owned by
       // a DIFFERENT process (codex gate): an external launcher/supervisor can bind
       // the port while our child fails, and readiness alone cannot tell them apart.
-      (listenerIsOurs === false
+      (ownership === "not-ours"
         ? ` NOTE: the healthy server on port ${port}${newPid ? ` (PID ${newPid})` : ""} is NOT the process this call launched (PID ${
             ourPid ?? "unknown"
           }${launchedChildExit ? `, which exited: ${exitCause(launchedChildExit)}` : ""}) — another launcher or supervisor owns it, so this server was not started by us.`
@@ -1419,7 +1574,7 @@ export async function startComfyUI(): Promise<StartResult> {
     pid: newPid ?? undefined,
     auto_restart: supervisorResult(info),
     launch_env: env,
-    listener_is_launched_process: listenerIsOurs,
+    listener_ownership: ownership,
   };
 }
 
@@ -1774,7 +1929,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
       auto_restart: startResult.auto_restart,
       spawn_error: startResult.spawn_error,
       launch_env: startResult.launch_env,
-      listener_is_launched_process: startResult.listener_is_launched_process,
+      listener_ownership: startResult.listener_ownership,
     };
   }
 
@@ -1793,7 +1948,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
     message: `ComfyUI restarted successfully. ${startResult.message}`,
     auto_restart: startResult.auto_restart,
     launch_env: startResult.launch_env,
-    listener_is_launched_process: startResult.listener_is_launched_process,
+    listener_ownership: startResult.listener_ownership,
   };
 }
 
@@ -1911,7 +2066,16 @@ export const __processControlTestHooks = {
     remoteRebootTimingOverride = null;
     liveCwdResolverOverride = null;
     liveEnvResolverOverride = null;
+    processIdentityOverride = null;
     restartDispatchRecords.clear();
+  },
+  /** Inject a fake process-identity (creation time) reader so tests can drive
+   *  recycled-PID scenarios on any host, including where the native read is
+   *  deliberately skipped. */
+  setProcessIdentityResolver(
+    fn: ((pid: number) => { startedAt?: string } | undefined) | null,
+  ): void {
+    processIdentityOverride = fn;
   },
   /** Inject a fake live-process-ENVIRONMENT reader (#776) so tests can drive the
    *  `/proc/<pid>/environ` capture without a real process. */

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -21,7 +21,11 @@ import {
   type LaunchEnvResolution,
 } from "./launcher-env.js";
 import { resetManagerApiCache } from "./manager-api-cache.js";
-import { parseListenerPidFromNetstat, findPidByPort } from "./port-owner.js";
+import {
+  parseListenerPidFromNetstat,
+  findPidByPort,
+  probePortOwner,
+} from "./port-owner.js";
 import {
   recordLaunchedInterpreter,
   clearLaunchedInterpreter,
@@ -376,14 +380,28 @@ function findDesktopExePath(argv: string[]): string | undefined {
   return undefined;
 }
 
+/**
+ * Wait until the port is OBSERVED free.
+ *
+ * "Observed" is the load-bearing word: `findPidByPort` returns null both when
+ * nothing is listening and when the lookup itself failed, and treating the second
+ * as the first would let a transient failure certify that a still-running server
+ * had gone (codex gate). So this polls the tri-state probe and returns only on a
+ * definite `free`; an `unknown` keeps waiting and, if that is all we ever get,
+ * surfaces as the timeout — a caller must not read it as success.
+ */
 async function waitForPortFree(port: number, timeoutMs = 15000): Promise<void> {
   const start = Date.now();
+  let lastUnknown: string | undefined;
   while (Date.now() - start < timeoutMs) {
-    if (findPidByPort(port) === null) return;
+    const probe = probePortOwner(port);
+    if (probe.state === "free") return;
+    if (probe.state === "unknown") lastUnknown = probe.reason;
     await sleep(500);
   }
   throw new ProcessControlError(
-    `Port ${port} still in use after ${timeoutMs / 1000}s`,
+    `Port ${port} still in use after ${timeoutMs / 1000}s` +
+      (lastUnknown ? ` (last port probe could not complete: ${lastUnknown})` : ""),
   );
 }
 
@@ -577,17 +595,21 @@ function readParentPid(pid: number): number | undefined {
  * Returns `undefined` the moment the chain becomes unreadable — not knowing is
  * never promoted to a claim in either direction.
  */
-function isOurDescendant(pid: number, maxHops = 4): boolean | undefined {
+function isOurDescendant(pid: number, maxHops = 8): boolean | undefined {
   let current = pid;
   for (let hop = 0; hop < maxHops; hop++) {
     if (current === process.pid) return true;
     const parent = readParentPid(current);
     if (parent == null) return undefined;
-    // pid 1 / 0 / self-parenting = we reached the top without finding ourselves.
+    // pid 1 / 0 / self-parenting = we reached the TOP of the tree without finding
+    // ourselves, which is a real negative answer.
     if (parent === current || parent <= 1) return false;
     current = parent;
   }
-  return false;
+  // Ran out of budget. That is "I did not finish looking", NOT "it is not ours" —
+  // a deep-but-legitimate wrapper chain must not be reported as a foreign server
+  // just because the walk was bounded (codex gate).
+  return undefined;
 }
 
 /**
@@ -637,9 +659,32 @@ function classifyListenerOwnership(input: {
    */
   const byArgv = (): "match" | "differ" | "unknown" => {
     if (!input.servingArgv?.length || !input.launchArgv?.length) return "unknown";
-    return commandLineMatchesArgv(input.launchArgv.join(" "), input.servingArgv)
-      ? "match"
-      : "differ";
+    // BOTH directions. `commandLineMatchesArgv(haystack, tokens)` only asks whether
+    // every token appears in the haystack, so a single call is a SUBSET test — and
+    // a foreign server whose argv is a strict subset of ours would "match", turning
+    // the deliberately non-promoting match into a false one (codex gate). Compare
+    // each way instead. The interpreter is dropped from our side because the server
+    // reports `sys.argv`, which never contains it.
+    // Path-like tokens are reduced to their final segment for the reverse check.
+    // We resolve the script to an ABSOLUTE path to launch it, while the server
+    // reports the (often RELATIVE) `sys.argv` it was handed — and
+    // commandLineMatchesArgv treats an absolute token as an exact claim by design
+    // (#401). Comparing them verbatim would make every portable-launcher install
+    // read as a different server. Flags are left alone, so a foreign SUBSET still
+    // fails on the missing ones.
+    const ourTokens = input.launchArgv
+      .slice(1)
+      .map((t) => (looksLikePath(t) ? t.split(/[\\/]/).pop() || t : t));
+    if (ourTokens.length === 0) return "unknown";
+    const servingContainsOurs = commandLineMatchesArgv(
+      input.servingArgv.join(" "),
+      ourTokens,
+    );
+    const oursContainsServing = commandLineMatchesArgv(
+      input.launchArgv.join(" "),
+      input.servingArgv,
+    );
+    return servingContainsOurs && oursContainsServing ? "match" : "differ";
   };
   // A Desktop launch is undecidable BY DESIGN: we spawn the Electron shell (or
   // macOS `open`) and its child binds the port, so a pid mismatch proves nothing.
@@ -1608,18 +1653,30 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   // came back empty we have no anchor, and A-answers-then-B-takes-the-port with
   // identical argv would sail through every later self-consistent check. A single
   // flaky lookup is retried; a bracket we still cannot close refuses.
-  const safeFindPid = (): number | null => {
+  //
+  // Both ends of the bracket compare a full process IDENTITY, not a pid number:
+  // pid equality across a window is exactly what pid REUSE defeats (A owns 4321,
+  // answers, exits; B inherits 4321 before the closing lookup and the bracket would
+  // close on the number alone). So each end reads pid + creation time together, and
+  // an end whose stamp cannot be read is "did not observe", never "observed the
+  // same" (codex gate).
+  const observeOwner = (): { pid: number; startedAt: string } | null => {
+    let owner: number | null = null;
     try {
-      return findPidByPort(port);
+      owner = findPidByPort(port);
     } catch {
       return null;
     }
+    if (owner == null) return null;
+    const startedAt = resolveProcessIdentity(owner)?.startedAt;
+    return startedAt ? { pid: owner, startedAt } : null;
   };
+
   let argv: string[] = [];
   let pid: number | null = null;
   let bracketed = false;
   for (let attempt = 0; attempt < 2; attempt++) {
-    const ownerBefore = safeFindPid();
+    const before = observeOwner();
     try {
       const stats = await getSystemStats();
       argv = stats.system.argv ?? [];
@@ -1627,18 +1684,26 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
       argv = [];
       logger.warn("Could not fetch system_stats — will rely on PID detection");
     }
-    const ownerAfter = safeFindPid();
-    pid = ownerAfter ?? ownerBefore;
+    const after = observeOwner();
+    pid = after?.pid ?? before?.pid ?? null;
+    if (pid == null) {
+      try {
+        pid = findPidByPort(port);
+      } catch {
+        pid = null;
+      }
+    }
     // No answer to bind means there is nothing to mis-bind: the pid-only paths
     // below (including #449's reachable-but-unmapped) own that case.
     if (argv.length === 0) break;
-    if (ownerBefore != null && ownerAfter != null) {
-      if (ownerBefore !== ownerAfter) {
+    if (before && after) {
+      if (before.pid !== after.pid || before.startedAt !== after.startedAt) {
         const err = new ProcessControlError(
           `The process listening on port ${port} changed while ComfyUI was being identified ` +
-            `(PID ${ownerBefore} answered, PID ${ownerAfter} holds the port now). Nothing was ` +
-            `stopped: the launch arguments we hold describe the instance that has gone, not the ` +
-            `one running now. Re-run once the server has settled.`,
+            `(PID ${before.pid} answered; PID ${after.pid} holds the port now${
+              before.pid === after.pid ? ", and it is a different process reusing that number" : ""
+            }). Nothing was stopped: the launch arguments we hold describe the instance that has ` +
+            `gone, not the one running now. Re-run once the server has settled.`,
         );
         err.identityAmbiguous = true;
         throw err;
@@ -1646,14 +1711,14 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
       bracketed = true;
       break;
     }
-    // One side of the bracket was unreadable — retry once before giving up.
+    // One side of the bracket was unobservable — retry once before giving up.
   }
   if (argv.length > 0 && pid != null && !bracketed) {
     const err = new ProcessControlError(
-      `ComfyUI answered on port ${port}, but the process owning that port could not be read ` +
-        `on both sides of the request, so its answer cannot be tied to PID ${pid}. Nothing was ` +
-        `stopped: acting on an unverified pairing risks controlling the wrong process. Re-run, ` +
-        `or restart ComfyUI from the launcher that owns it.`,
+      `ComfyUI answered on port ${port}, but the identity of the process owning that port ` +
+        `could not be observed on both sides of the request, so its answer cannot be tied to ` +
+        `PID ${pid}. Nothing was stopped: acting on an unverified pairing risks controlling the ` +
+        `wrong process. Re-run, or restart ComfyUI from the launcher that owns it.`,
     );
     err.identityAmbiguous = true;
     throw err;
@@ -1857,39 +1922,41 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
   // wholesale — an ignored SIGTERM followed by a failed SIGKILL looks exactly like
   // success from here. The port is the observable that settles it: wait for it to
   // be released, and let the timeout DECIDE rather than merely warn.
-  let stillOurs = false;
+  let blockedReason: string | undefined;
   try {
     await waitForPortFree(info.port);
   } catch {
-    // Timed out. Distinguish "our target is still sitting there" (the kill did not
-    // work — the server is UP, so refusing is safe and correct) from "somebody else
-    // now holds the port" (our target did die; a successor took it).
-    let ownerNow: number | null = null;
-    try {
-      ownerNow = findPidByPort(info.port);
-    } catch {
-      ownerNow = null;
-    }
-    stillOurs = ownerNow === info.pid;
-    if (!stillOurs) {
+    // Timed out. Three outcomes, and they must NOT be conflated:
+    //   • still held by OUR target → the kill did not work; the server is UP, so
+    //     refusing is both safe and correct;
+    //   • held by somebody else → our target did die and a successor took the port;
+    //   • could not be determined → we have no proof the process died, and
+    //     "unknown" must never be spent as if it were proof.
+    const probe = probePortOwner(info.port);
+    if (probe.state === "owned" && probe.pid === info.pid) {
+      blockedReason =
+        `PID ${info.pid} still holds port ${info.port} after the kill was issued, so it is ` +
+        `still running`;
+    } else if (probe.state === "unknown") {
+      blockedReason =
+        `the port could not be checked after the kill (${probe.reason}), so there is no ` +
+        `evidence PID ${info.pid} actually died`;
+    } else {
       logger.warn(
         "Port did not free in time, but it is no longer held by the process we killed",
-        { pid: info.pid, owner: ownerNow ?? "(unmappable)" },
+        { pid: info.pid, owner: probe.state === "owned" ? probe.pid : "(free)" },
       );
     }
   }
-  if (stillOurs) {
+  if (blockedReason) {
     deliberateStop = false;
-    logger.warn("Stop aborted: the killed process still holds the port", {
-      pid: info.pid,
-      port: info.port,
-    });
+    logger.warn("Stop aborted before commit", { pid: info.pid, port: info.port, blockedReason });
     return {
       stopped: false,
       message:
-        `Could not stop ComfyUI: PID ${info.pid} still holds port ${info.port} after the kill ` +
-        `was issued, so it is still running. Nothing was torn down — its crash supervision ` +
-        `and launch record are untouched. Stop it from the launcher/console that owns it.`,
+        `Could not stop ComfyUI: ${blockedReason}. Nothing was torn down — its crash ` +
+        `supervision and launch record are untouched. Stop it from the launcher/console ` +
+        `that owns it.`,
       has_restart_info: false,
     };
   }

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -561,27 +561,33 @@ let parentPidResolverOverride: ((pid: number) => number | undefined) | null = nu
  */
 function readParentPid(pid: number): number | undefined {
   if (parentPidResolverOverride) return parentPidResolverOverride(pid);
-  if (!pid || pid <= 0) return undefined;
-  try {
-    const out = IS_WIN
-      ? execFileSync(
-          "powershell",
-          [
-            "-NoProfile",
-            "-Command",
-            `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}").ParentProcessId`,
-          ],
-          { encoding: "utf-8", timeout: 8000, windowsHide: true },
-        )
-      : execFileSync("ps", ["-p", String(pid), "-o", "ppid="], {
-          encoding: "utf-8",
-          timeout: 5000,
-        });
-    const parsed = Number.parseInt(out.trim(), 10);
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
-  } catch {
-    return undefined;
+  // Same OS call as the rest of the identity — never a second spawn.
+  return resolveProcessIdentity(pid)?.parentPid;
+}
+
+/**
+ * Is `pid` this orchestrator, or a DESCENDANT of it?
+ *
+ * A direct-child test is too strict for a legitimately indirect launcher: a
+ * wrapper script, a double fork, or a venv trampoline all mean the process that
+ * ends up holding the port is our grandchild, not our child. Telling those users
+ * "this server was not started by us" is a false negative, so the parent chain is
+ * walked (a few hops, hard-bounded) before concluding anything.
+ *
+ * Returns `undefined` the moment the chain becomes unreadable — not knowing is
+ * never promoted to a claim in either direction.
+ */
+function isOurDescendant(pid: number, maxHops = 4): boolean | undefined {
+  let current = pid;
+  for (let hop = 0; hop < maxHops; hop++) {
+    if (current === process.pid) return true;
+    const parent = readParentPid(current);
+    if (parent == null) return undefined;
+    // pid 1 / 0 / self-parenting = we reached the top without finding ourselves.
+    if (parent === current || parent <= 1) return false;
+    current = parent;
   }
+  return false;
 }
 
 /**
@@ -617,7 +623,18 @@ function classifyListenerOwnership(input: {
 
   const ourPid = input.child.pid;
   if (ourPid == null || input.portOwnerPid == null) return "unconfirmed";
-  if (input.portOwnerPid !== ourPid) return "not-ours";
+  if (input.portOwnerPid !== ourPid) {
+    // A DIFFERENT pid holds the port. That is usually somebody else's server — but
+    // it is also the shape of a legitimately indirect launch (a wrapper script, a
+    // double fork, a trampoline), where the listener is our GRANDchild. Walk the
+    // parent chain before concluding: descendant => still ours; provably outside
+    // our tree => not ours; unreadable => unconfirmed, never a false negative that
+    // tells a wrapper-launched user their own server isn't theirs.
+    const descendant = isOurDescendant(input.portOwnerPid);
+    if (descendant === true) return "ours";
+    if (descendant === false) return "not-ours";
+    return "unconfirmed";
+  }
   // The pid MATCHES — but it could be a recycled number we cannot signal.
   if (alive !== true) return "unconfirmed";
 
@@ -884,15 +901,27 @@ let processIdentityOverride:
   | ((pid: number) => ProcessIdentity | undefined)
   | null = null;
 
+/**
+ * Read a process's identity — command line, creation time and PARENT pid — in one
+ * OS call.
+ *
+ * This is deliberately NOT platform-gated any more. It was, on cost grounds: the
+ * Windows reader is a PowerShell `Get-CimInstance` spawn, measured at ~2.4s even
+ * for a pid that does not exist. But skipping it there meant Windows had NO
+ * identity evidence at all, so "the re-check couldn't reach the server" collapsed
+ * to a bare numeric port/pid comparison — and a replacement instance with
+ * different argv was killed on the strength of the previous one's answer (codex
+ * gate). That is the reported platform and the common case on it.
+ *
+ * The cost is bounded by WHERE it is called: once when binding the pid, once
+ * immediately before the kill, and once when deciding ownership after a launch —
+ * never inside a poll. A restart already spends tens of seconds; a few of them
+ * buying "we are certain this is the right process" is the trade the whole issue
+ * is about.
+ */
 function resolveProcessIdentity(pid: number): ProcessIdentity | undefined {
   if (processIdentityOverride) return processIdentityOverride(pid);
-  // MEASURED: the Windows reader (a PowerShell `Get-CimInstance` spawn) costs
-  // ~2.4s per call even for a pid that does not exist, which would be paid twice
-  // on every restart and ~40x across the test suite. Linux's `/proc/<pid>/stat`
-  // read is free, and Linux is also the only platform where we read
-  // `/proc/<pid>/environ` at all — so the expensive readers buy nothing the
-  // port-ownership re-check does not already give.
-  if (!pid || pid <= 0 || process.platform !== "linux") return undefined;
+  if (!pid || pid <= 0) return undefined;
   try {
     return readProcessIdentity(pid);
   } catch {
@@ -1504,7 +1533,26 @@ async function reconfirmAnsweringServer(
 async function gatherProcessInfo(): Promise<ProcessInfo> {
   const port = config.resolvedPort;
 
-  // 1. Get argv from /system_stats
+  // 1. Get argv from /system_stats, BRACKETED by port-owner lookups.
+  //
+  // The argv and the pid are two separate observations, and the whole hazard is
+  // that they may describe two different processes: A answers, A exits, B binds
+  // the port, and the pid we then look up is B's — after which B is "identified"
+  // from A's answer and is what a restart would kill. Re-asking afterwards does
+  // NOT settle this: it only proves the CURRENT owner is self-consistent, which a
+  // replacement with identical argv satisfies perfectly (codex gate).
+  //
+  // So carry something across the two observations that a substitution cannot
+  // reproduce: the identity of the port owner BEFORE the HTTP call. If the same
+  // pid still owns the port afterwards, the answer we hold was produced while that
+  // one process held the socket throughout.
+  let ownerBefore: number | null = null;
+  try {
+    ownerBefore = findPidByPort(port);
+  } catch {
+    ownerBefore = null;
+  }
+
   let argv: string[] = [];
   try {
     const stats = await getSystemStats();
@@ -1515,6 +1563,16 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
 
   // 2. Find PID by port
   const pid = findPidByPort(port);
+  if (ownerBefore != null && pid != null && ownerBefore !== pid) {
+    const err = new ProcessControlError(
+      `The process listening on port ${port} changed while ComfyUI was being identified ` +
+        `(PID ${ownerBefore} answered, PID ${pid} holds the port now). Nothing was stopped: ` +
+        `the launch arguments we hold describe the instance that has gone, not the one ` +
+        `running now. Re-run once the server has settled.`,
+    );
+    err.identityAmbiguous = true;
+    throw err;
+  }
   if (!pid) {
     // Liveness is the reachable SERVER, not only a local PID scan. If
     // /system_stats just answered (argv populated) yet we still can't map the
@@ -1709,7 +1767,49 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
     };
   }
 
-  // COMMITTED — only now may we drop supervision.
+  // A KILL THAT RETURNED IS STILL NOT PROOF THE PROCESS DIED (codex gate). On
+  // POSIX the forced `kill -9` is issued through a shell whose failure is swallowed
+  // wholesale — an ignored SIGTERM followed by a failed SIGKILL looks exactly like
+  // success from here. The port is the observable that settles it: wait for it to
+  // be released, and let the timeout DECIDE rather than merely warn.
+  let stillOurs = false;
+  try {
+    await waitForPortFree(info.port);
+  } catch {
+    // Timed out. Distinguish "our target is still sitting there" (the kill did not
+    // work — the server is UP, so refusing is safe and correct) from "somebody else
+    // now holds the port" (our target did die; a successor took it).
+    let ownerNow: number | null = null;
+    try {
+      ownerNow = findPidByPort(info.port);
+    } catch {
+      ownerNow = null;
+    }
+    stillOurs = ownerNow === info.pid;
+    if (!stillOurs) {
+      logger.warn(
+        "Port did not free in time, but it is no longer held by the process we killed",
+        { pid: info.pid, owner: ownerNow ?? "(unmappable)" },
+      );
+    }
+  }
+  if (stillOurs) {
+    deliberateStop = false;
+    logger.warn("Stop aborted: the killed process still holds the port", {
+      pid: info.pid,
+      port: info.port,
+    });
+    return {
+      stopped: false,
+      message:
+        `Could not stop ComfyUI: PID ${info.pid} still holds port ${info.port} after the kill ` +
+        `was issued, so it is still running. Nothing was torn down — its crash supervision ` +
+        `and launch record are untouched. Stop it from the launcher/console that owns it.`,
+      has_restart_info: false,
+    };
+  }
+
+  // COMMITTED — the process is provably gone. Only now may we drop supervision.
   detachSupervisor();
   // The server we may have launched is going away — clear the shares-our-env flag so
   // a differently-launched successor doesn't inherit env-trust it shouldn't (#633 P1b).
@@ -1732,13 +1832,6 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
   resetClient();
   resetObjectInfoCache();
   resetManagerApiCache("comfyui stopped");
-
-  // Wait for port to actually free
-  try {
-    await waitForPortFree(info.port);
-  } catch {
-    logger.warn("Port did not free in time, but process kill was sent");
-  }
 
   return {
     stopped: true,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1,4 +1,9 @@
-import { execSync, spawn, type ChildProcess } from "node:child_process";
+import {
+  execSync,
+  execFileSync,
+  spawn,
+  type ChildProcess,
+} from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, readlinkSync, statSync } from "node:fs";
 import { platform } from "node:os";
@@ -534,6 +539,44 @@ function launchedChildStillRunning(child: ChildProcess): boolean | undefined {
 }
 
 /**
+ * TRUE where the platform's process creation stamp is too COARSE to identify an
+ * instance on its own. macOS `ps -o lstart` is SECOND-resolution, so a pid
+ * recycled inside the same second compares EQUAL — the same limitation
+ * live-interpreter documents for its launched-by-us tier. Linux ticks and Windows
+ * FileTime are sub-second, where equality really is proof.
+ */
+const PLATFORM_HAS_COARSE_CREATION_STAMP = platform() === "darwin";
+/** Mutable only so tests can exercise the macOS branch from any host. */
+let coarseCreationStamp = PLATFORM_HAS_COARSE_CREATION_STAMP;
+
+/** Injectable parent-pid reader (see readParentPid). */
+let parentPidResolverOverride: ((pid: number) => number | undefined) | null = null;
+
+/**
+ * The parent pid of `pid`, used ONLY to break the macOS coarse-stamp tie.
+ *
+ * A process that inherited our child's number within the same second is still a
+ * DIFFERENT process, and the discriminator that survives is lineage: we spawned
+ * our child, so its parent is this very orchestrator. Another ComfyUI — even one
+ * with a byte-identical command line, started by some other launcher — has a
+ * different parent. Unreadable means "cannot tell", never "ours".
+ */
+function readParentPid(pid: number): number | undefined {
+  if (parentPidResolverOverride) return parentPidResolverOverride(pid);
+  if (!pid || pid <= 0 || IS_WIN) return undefined;
+  try {
+    const out = execFileSync("ps", ["-p", String(pid), "-o", "ppid="], {
+      encoding: "utf-8",
+      timeout: 5000,
+    }).trim();
+    const parsed = Number.parseInt(out, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Who owns the healthy listener after a launch — the single place that decides
  * whether this call may claim it started the server.
  *
@@ -588,6 +631,14 @@ function classifyListenerOwnership(input: {
       !commandLineMatchesArgv(now.commandLine, input.launchArgv)
     ) {
       return "not-ours";
+    }
+    // Where the stamp is only second-resolution (macOS), equality is NOT proof:
+    // a number recycled inside the same second by another ComfyUI with identical
+    // argv would satisfy everything above. Lineage settles it — we spawned our
+    // child, so it is still OUR child. Anything else (including an unreadable
+    // parent) withholds the claim instead of making it.
+    if (coarseCreationStamp && readParentPid(ourPid) !== process.pid) {
+      return "unconfirmed";
     }
     return "ours";
   }
@@ -2288,7 +2339,19 @@ export const __processControlTestHooks = {
     liveCwdResolverOverride = null;
     liveEnvResolverOverride = null;
     processIdentityOverride = null;
+    parentPidResolverOverride = null;
+    coarseCreationStamp = PLATFORM_HAS_COARSE_CREATION_STAMP;
     restartDispatchRecords.clear();
+  },
+  /** Inject a fake parent-pid reader so the macOS coarse-stamp tiebreak can be
+   *  driven on any host. */
+  setParentPidResolver(fn: ((pid: number) => number | undefined) | null): void {
+    parentPidResolverOverride = fn;
+  },
+  /** Pretend this platform's creation stamp is second-resolution (macOS) so the
+   *  tiebreak branch can be tested from any host. */
+  setCoarseCreationStamp(coarse: boolean): void {
+    coarseCreationStamp = coarse;
   },
   /** Inject a fake process-identity (creation time) reader so tests can drive
    *  recycled-PID scenarios on any host, including where the native read is

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -482,17 +482,20 @@ function launchEnvInfo(info?: ProcessInfo): LaunchEnvInfo | undefined {
  * itself failed (the #776 shape — ComfyUI aborting during import), not that it is
  * merely slow.
  */
+function exitCause(exit: {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}): string {
+  if (exit.signal != null) return `killed by ${exit.signal}`;
+  if (exit.code != null) return `exit code ${exit.code}`;
+  return "for an unknown reason";
+}
+
 function describeLaunchedChildExit(
   exit: { code: number | null; signal: NodeJS.Signals | null } | undefined,
 ): string {
   if (!exit) return "";
-  const how =
-    exit.signal != null
-      ? `killed by ${exit.signal}`
-      : exit.code != null
-        ? `exit code ${exit.code}`
-        : "for an unknown reason";
-  return ` The process this call launched EXITED (${how}) before the API came up, so ComfyUI is DOWN — this was a failed relaunch, not a slow start.`;
+  return ` The process this call launched EXITED (${exitCause(exit)}) before the API came up, so ComfyUI is DOWN — this was a failed relaunch, not a slow start.`;
 }
 
 /**
@@ -1357,12 +1360,24 @@ export async function startComfyUI(): Promise<StartResult> {
 
   const newPid = findPidByPort(port);
   const env = launchEnvInfo(info);
-  // Is the healthy listener actually OURS? Only decidable when we know both PIDs;
-  // an unmappable port owner (the #449 shape) stays `undefined` rather than
-  // asserting either way.
+  // Is the healthy listener actually OURS?
+  //   • A Desktop launch is UNDECIDABLE by design: we spawn the Electron shell (or
+  //     macOS `open`), and the process that binds the port is its child, so a pid
+  //     mismatch there proves nothing.
+  //   • A launched child that has ALREADY EXITED cannot be the healthy listener —
+  //     that is decisive even when the port owner cannot be mapped at all (the #449
+  //     shape), which is precisely the "an external supervisor restored the API"
+  //     case that must never be reported as our successful restart (codex gate).
+  //   • Otherwise it needs both pids; an unmappable port owner stays `undefined`
+  //     rather than asserting either way.
   const ourPid = launched.child.pid;
-  const listenerIsOurs =
-    ourPid == null || newPid == null ? undefined : newPid === ourPid;
+  const listenerIsOurs = info.isDesktopApp
+    ? undefined
+    : launchedChildExit
+      ? false
+      : ourPid == null || newPid == null
+        ? undefined
+        : newPid === ourPid;
   return {
     started: true,
     ready: true,
@@ -1376,9 +1391,9 @@ export async function startComfyUI(): Promise<StartResult> {
       // a DIFFERENT process (codex gate): an external launcher/supervisor can bind
       // the port while our child fails, and readiness alone cannot tell them apart.
       (listenerIsOurs === false
-        ? ` NOTE: the process serving port ${port} (PID ${newPid}) is NOT the one this call launched (PID ${ourPid}${
-            launchedChildExit ? ", which has since exited" : ""
-          }) — another launcher or supervisor owns it, so this server was not started by us.`
+        ? ` NOTE: the healthy server on port ${port}${newPid ? ` (PID ${newPid})` : ""} is NOT the process this call launched (PID ${
+            ourPid ?? "unknown"
+          }${launchedChildExit ? `, which exited: ${exitCause(launchedChildExit)}` : ""}) — another launcher or supervisor owns it, so this server was not started by us.`
         : "") +
       launchEnvWarning(info),
     pid: newPid ?? undefined,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -70,6 +70,14 @@ export class ProcessControlError extends ComfyUIError {
    */
   reachableButNoPid?: boolean;
 
+  /**
+   * Set when the server that answered could NOT be bound to the process we would
+   * act on — the instance behind the port changed while it was being identified
+   * (#776). Callers must surface the diagnostic and touch nothing: killing on an
+   * identity we could not confirm is exactly the wrong-instance hazard.
+   */
+  identityAmbiguous?: boolean;
+
   constructor(message: string, details?: unknown) {
     super(message, "PROCESS_CONTROL_ERROR", details);
     this.name = "ProcessControlError";


### PR DESCRIPTION
## Root cause — exactly what was dropped

`restart_comfyui` rebuilt the launch **command** from `/system_stats` but never the launch **environment**. `spawnFromProcessInfo` called `spawn(exe, args, { detached, stdio, cwd, shell, windowsHide })` with **no `env` option**, so Node handed the relaunched ComfyUI the *orchestrator's* `process.env` — not the environment the server was actually started with.

Stability Matrix does not put its bundled tooling on the system PATH; it injects it into the child it launches:

| dropped | consequence |
| --- | --- |
| `<Data>/PortableGit/cmd` on PATH + `GIT_PYTHON_GIT_EXECUTABLE` | GitPython fails → ComfyUI-Manager aborts at import: `ImportError: Failed to initialize: Bad git executable.` → **ComfyUI never finishes booting** |
| `<Data>/Assets/ffmpeg[/bin]` on PATH | FFMPEGA and other nodes report FFmpeg/FFprobe missing |

So the relaunch died during import, `/system_stats` never answered, the readiness poll timed out after 60 probes, and the user was left with `stopped:true, started:false` — a stopped server the tool could not bring back. This is the same class as the Desktop rule (never kill an Electron-supervised instance): a third-party launcher owns part of the runtime contract, and reconstructing only half of it is worse than not touching it.

## The fix

New leaf module `src/services/launcher-env.ts` resolves the relaunch environment, hardest evidence first:

1. **The live process's own environment** — `/proc/<pid>/environ`, read at gather-time while the pid is still alive (next to the existing `liveCwd` capture, and gone the instant the stop kills it). This is the launch environment *verbatim*, whatever launcher produced it, so on Linux every launcher is handled with zero inference.
2. **Stability Matrix, corroborated on disk** — an ancestor literally named `Packages` whose parent actually holds `PortableGit` or `Assets/ffmpeg`. The reconstruction is exactly the recovery launch the reporter verified by hand: both directories **prepended** to PATH (case-insensitive PATH key, so a Windows `Path` is never shadowed by a second `PATH`) plus `GIT_PYTHON_GIT_EXECUTABLE`. Reported as `launch_env.source = "stability-matrix"`.
3. **A recognized launcher we cannot reproduce** — Pinokio composes each app's environment in a per-app install script; nothing on disk says what the running process got. `reproducible:false`.
4. **No launcher marker** — inherit, byte-for-byte the pre-#776 behavior.

**Partial reconstruction is not reconstruction — but "partial" has to mean something we would actually drop.** Each component is classified by evidence:

- `resolved` → inject it;
- `ambiguous` (its directory exists, or the launcher's own `<Data>/settings.json` names it, but no binary is locatable) → it plausibly *is* injected and we would silently drop it → **refuse**;
- `not-installed` (no directory, no mention anywhere) → the launcher has nothing to inject either, so relaunching without it is exactly what the launcher itself would do → **proceed**, and name the omission in the result (`launch_env.not_installed`) so a later "ffmpeg not found" from a node is traceable.

A permanent inability to restart is not a safer resting place than a launch that works, so the refusal is reserved for the genuinely ambiguous case. Detection itself requires on-disk corroboration, never a directory name, so an ordinary install under some `…/Data/Packages/…` path is not swept up.

### What happens when the environment is unknown

**It refuses before stopping, and only while the server is still up.**

- `restartComfyUI` calls `assessRelaunch(info, { requireReproducibleEnv: true })` **before** `stopComfyUI`. On `reproducible:false` it returns `stopped:false, started:false` with launcher-specific advice ("Restart ComfyUI from Stability Matrix itself…") instead of the generic COMFYUI_PATH hint. The server is never touched.
- The **already-down** paths (`start_comfyui`, the crash supervisor) never refuse — leaving a stopped server down is the one outcome worse than a possibly-degraded launch. They launch with the best environment available and the message carries an explicit `WARNING` naming the launcher.
- `preflightLocalRestart` (which guards the panel's out-of-band ComfyUI-Manager reboot) deliberately **skips** the environment check: Manager re-execs the *same* process, which keeps its own launcher environment, so refusing there would only cost those users a restart path that actually works.

The plan is memoized on `ProcessInfo`, so the pre-stop preflight and the post-stop spawn can never disagree about what was approved.

### A PID is not a process identity

Reading `/proc/<pid>/environ` from a bare number, or killing one, assumes the number still means what it did at the port lookup. It may not: ComfyUI can exit and the OS can hand the number — and the port — to something else. **Identity has to be bound to the observation it certifies, at the moment that observation is made.**

- The argv comes from an HTTP response; the pid from a lookup made *afterwards*. So the `/system_stats` call is **bracketed** by port-owner observations: the same process must own the port on both sides, or the answer describes an instance that has since gone. Re-asking afterwards is not enough on its own — a replacement reporting identical argv satisfies any self-consistency check, so the anchor has to predate the answer. Each end compares **pid *and* creation time**, because pid equality across a window is precisely what pid reuse defeats. The bracket is required, not best-effort: one flaky read is retried, and a bracket that cannot be closed refuses.
- A second round trip then re-confirms the same argv and the same owner once the pid is in hand. This runs for Desktop too, because `isDesktopApp` is itself derived from that same possibly-stale argv.
- The OS's command line for the port owner must match what the server reported (`commandLineMatchesArgv`, #401's correlation). A **positive mismatch refuses outright** rather than degrading to "no identity" — otherwise a later transport hiccup waves the substitution through.
- `stopComfyUI` re-checks immediately **before the kill** (still owns the port; command line still matching; creation time unchanged) and refuses, killing nothing.

Missing evidence is never treated as failure — only positive counter-evidence refuses. `readProcessIdentity` now returns command line, creation time and **parent pid** in one OS call, and is no longer platform-gated: gating it to Linux on cost grounds (the Windows `Get-CimInstance` spawn measures ~2.4 s) left Windows — the reported platform — with no identity evidence at all, so every check collapsed to a numeric port/pid comparison. The cost is bounded by call sites instead: once when binding the pid, once before the kill, once when deciding ownership. Never inside a poll.

**Nothing is torn down until the stop is committed — and "committed" means the process is gone.** The identity refusal runs before `detachSupervisor`; the teardown runs only after `killProcessTree` *returns*; and returning is not dying. On POSIX the forced `kill -9` goes through a shell whose failure is swallowed, so an ignored signal looks exactly like success. The **port release decides**, via a new `probePortOwner()` that answers `owned | free | unknown` rather than collapsing the last two into `null`. A `deliberateStop` flag covers the window so the supervisor cannot read the exit we caused as a crash to respawn into.

**The rule is asymmetric around the point of no return**, which is what makes the cardinal rule hold in both directions:

- **Before the kill**, an undeterminable observation *refuses*. Nothing has been touched, so it costs a restart and never the server.
- **After the kill**, an undeterminable observation must *not* refuse — a refusal there cannot un-kill anything, and would leave a dead server unrelaunched. The stop commits, the relaunch runs, and the caveat rides along in its own field (`StopResult.unverified_exit`) so a caller composing its own message cannot silently drop it.
- The **determinable** half is unchanged: when the probe can see our own target still holding the port, the kill did not work, the server is up, and nothing is torn down.

`lastProcessInfo` is recorded *before* anything irreversible, so no refusal can leave `start_comfyui` without the launch info to recover from.

### Truthful reporting (the second half of the cardinal rule)

- The launched child's **exit** is recorded, so a readiness timeout says *"The process this call launched EXITED (exit code 1) before the API came up… a failed relaunch, not a slow start"* rather than only "60/60 probes".
- Readiness only proves that *something* answers on the port. `classifyListenerOwnership()` is the single place that decides whether we may claim we started it, and it is ordered so nothing can soften a launch that never happened: a latched spawn `error`, or a `pid` Node never assigned, is `"not-ours"` **before** even the Desktop shortcut. `"ours"` is reserved for actual proof — the mapped port owner is our live child (lineage and command line agreeing), or it is provably our **descendant** by walking the parent chain.
- **Lineage, not a timestamp**, is the discriminator. A creation stamp can only ever be read *after* `spawn()` returns, by which point a same-instant exit may already have handed the number to somebody else — and that read costs seconds on Windows, widening the very window it is meant to close. Parentage does not depend on when we look. The chain is *walked*, not just checked one level, so a wrapper script or double fork whose grandchild binds the port is still ours rather than a false negative; running out of hop budget is "did not finish looking", never "not ours".
- The server's own `sys.argv` is a third line of evidence, needing no pid at all — and deliberately **asymmetric**. A mismatch is proof of the negative (nobody else's command line is ours) and yields `"not-ours"` — including against lineage, since lineage says which *process*, not which *program* it is running. A *match* is only corroboration: another supervisor can start the same ComfyUI command and win the bind race, so it never promotes anything to `"ours"` — it only stops us asserting the negative. The comparison runs **both ways** (a one-way containment test would let a foreign server whose argv is a strict subset of ours pass), with path-like tokens reduced to their final segment so the common relative-`sys.argv` install is not mistaken for a different server.
- `"not-ours"` ⇒ `started:false`, `ready:true`, and *"ComfyUI is back up, but NOT as a result of this restart"*. `"unconfirmed"` keeps the positive flags (denying them would mislabel every ordinary restart on hosts where the port-owner lookup is unavailable) but the headline no longer **attributes** the listener to this call — "restarted successfully" is reserved for `"ours"`.
- The state is a **required string** tri-state, not `boolean | undefined`, because the tool returns `JSON.stringify(result)` and JSON drops `undefined` keys — a sometimes-absent field cannot be told apart from an older build that never emitted it. Making it required let the compiler find all ten return paths, including the "another launcher already took the port" branch that had none.

## Codex self-gate (`gpt-5.6-terra`, 23 rounds to PASS)

| Round | Finding | Resolution |
| --- | --- | --- |
| 1 | **P1** a partial Stability Matrix layout (FFmpeg found, PortableGit missing) passed the preflight, got killed, then relaunched without git | any incomplete reconstruction refuses pre-stop |
| 1 | **P2** name-only classification created new unjustified refusals for plain installs | detection requires on-disk corroboration |
| 2 | **P1** readiness proves only that *some* process answers; no comparison against the spawned child | ownership state + recorded launched-child exit |
| 3 | **P1** dead child + unmappable replacement PID still reported success | a dead child forces `not-ours` on its own |
| 4 | **P1** claimed the ancestor walk corrupts UNC roots | **not reproducible** — disproven by execution; four root-form tests added, not restated later |
| 5 | **P1** the *structured* result still said `started:true` for a foreign listener, and cleared the dispatch record | `started:false`; restart distinguishes "server DOWN" from "server UP but not ours" |
| 6 | **P1** asked that *undecidable* ownership also be a failure | rejected with reasoning, surfaced explicitly instead; accepted in round 7 |
| 7 | — | **PASS** (superseded by the independent review below) |
| 8 | **P1** the pid identity was not captured atomically with the port lookup | corroborated against the server's own argv — an independent observation, not a narrower race |
| 8 | **P1** `unconfirmed` still produced "restarted successfully" | that sentence is now reserved for a matched port owner |
| 8 | **P1** the new pre-kill refusal detached the auto-restart supervisor | identity check moved ahead of the teardown |
| 9 | **P1** a matching pid classified as ours while the child's `exit` was merely undelivered | synchronous signal-0 liveness probe |
| 10 | **P1** an *alive* recycled pid (identical argv) still classified as ours | per-instance creation-time stamp captured at spawn |
| 11 | **P1** macOS `lstart` is second-resolution, so a same-second recycle matched everything | lineage tiebreak: the port owner's parent must be this orchestrator |
| 13 | **P1** a positive command-line mismatch was downgraded to "no identity", so a failing HTTP re-check left only a numeric-PID port check | mismatch is now a distinct verdict that refuses on its own, and the pre-kill command-line check is no longer gated behind having a creation stamp |
| 13 | **P1** the identity re-check was skipped when the (possibly stale) argv looked like Desktop, so a Manager reboot could be fired at a substituted instance | the re-check runs for every case, Desktop included |
| 15 | **P1** the new "owner before `/system_stats`" anchor was optional — a transient first lookup skipped it entirely | the bracket is required, with a bounded retry; one that cannot be closed refuses |
| 15 | **P1** detection never checked the `<Data>/Assets` marker, so a real SM layout with an unlocatable PortableGit fell through as a plain install | corroboration is `PortableGit` **or** the `Assets` store |
| 16 | **P1** a failed spawn with no child pid was laundered into an unconfirmed success when another launcher won the readiness race | the spawn `error` is latched independently of the race; no pid ⇒ `not-ours` |
| 17 | **P1** the Desktop shortcut returned "unconfirmed" *before* the never-launched checks | those checks now precede it (Desktop still precedes `childExited`, where a launcher exiting is normal) |
| 19 | **P1** a matching server argv was treated as proof of ownership | made asymmetric — a mismatch decides, a match only corroborates |
| 21 | **P1** refusing on an unverifiable port probe *after* the kill could leave the server dead and unrelaunched | the rule is now asymmetric around the point of no return (see above) |
| 22 | **P1** a descendant listener was claimed as ours without consulting the server's argv | lineage does not outrank direct contrary evidence |

Final verdict: **PASS**, no traced findings.

**Four independent reviews** ran alongside this gate and caught defects the self-gate had passed. The first found the partial-SM approval, the unbound `/proc` capture, the `undefined`-drops-through-JSON gap, and the Pinokio over-detection. The second found identity established at the wrong *moment* relative to the observation it binds (twice), the supervisor teardown preceding the *kill* rather than a committed stop, a legitimate FFmpeg-less Stability Matrix install rendered permanently unrestartable, and `listener_ownership` missing from the "already running" path. The third found that the second round trip could not exclude a same-argv replacement, that `unknown` collapsed to a numeric check on Windows, that an *unreadable* launcher config was being read as "not installed", and that a `killProcessTree()` that returned was being treated as proof the listener died.

The fourth found that the bracket compared pid *numbers* rather than identities; that the unreadable-config fix was unreachable behind an `existsSync` pre-screen (which itself returns false for an inaccessible path); that port-release success was inferred from a *failed* lookup; that the argv comparison was a one-way subset test; and that lineage-walk exhaustion was asserted as "foreign". **Four of those five were one error** — a state meaning *"I could not determine this"* folded into one meaning *"I determined it is not so"* — and that framing is now applied throughout: `probePortOwner` returns `owned | free | unknown`, the launcher config returns `mentions | absent | unreadable` classified from the errno, hop exhaustion returns `undefined`, and an unobservable bracket end is "did not observe".

I re-ran the new tests against the pre-fix source to confirm each finding was a real defect rather than a static-analysis artifact, and reported the one I could not reproduce in-harness rather than claiming a green test I did not get.

## Tests

`src/__tests__/services/restart-launcher-env.test.ts` (56 tests, boundaries-only mocks — no real process/port/network/filesystem):

- **environment preserved**: PortableGit + FFmpeg prepended to PATH and `GIT_PYTHON_GIT_EXECUTABLE` set, with the launcher named in the message; a live-read `/proc` environment passed to `spawn` verbatim;
- **unknown environment refuses BEFORE stopping**: nothing resolves; FFmpeg present but git missing; an ffmpeg dir with no binary; a component the launcher's own `settings.json` names but whose directory is gone; a config that **exists but cannot be read**; `<Data>/Assets` corroborating SM with an unlocatable PortableGit; a Pinokio install — each asserts `stopped:false`, no `spawn`, no kill of any kind;
- **not-installed proceeds**: Git alone with FFmpeg provably absent restarts, injects Git, and names FFmpeg in `launch_env.not_installed`;
- **no new refusals**: an ordinary install under `…/Data/Packages/…`; a directory merely *named* `pinokio`; an ordinary install sitting under a real `pinokio` tree but outside its `api/` subtree; and the Manager-reboot preflight still passing on a Pinokio install;
- **already-down never refuses**: `stop_comfyui` → `start_comfyui` on a Pinokio install launches and warns;
- **a PID is not an identity**: **A answers then B takes the port** (both with *identical* argv, caught by the bracket) → refuses before stopping; the **same pid number being a different process** at each end of the bracket also refuses; an un-closable bracket refuses, while a *single* flaky lookup is retried and proceeds; a failing re-check does *not* refuse; a command-line mismatch refuses on its own, **and still refuses when the HTTP re-check also fails**; a **Desktop-A → non-Desktop-B** substitution refuses before any Manager reboot is fired; a recycled pid's environment is not adopted; a pid that no longer owns its port, or whose creation time changed, is not killed;
- **nothing torn down on a failed stop**: a kill that throws leaves the launch record and crash supervision intact; a kill that *returns* while the target provably still holds the port reports `stopped:false` and relaunches nothing; and an **unverifiable** port probe after the kill does the opposite — it commits, says so, and still brings the server back;
- **truthful reporting**: a relaunch that never answers; a launched child that exits (named with its exit code); a foreign listener; a dead child with an unmappable owner; a matching pid whose `exit` is merely undelivered (ESRCH); a **failed spawn** (no pid) while another launcher wins the readiness race — on both the plain and **Desktop** paths; lineage saying the port owner is not our child; an unreadable parent; a **grandchild** listener claimed via the parent chain, and a grandchild running a *different* install correctly refused; an exhausted lineage walk reading as "don't know"; a wrapper that has already exited not being called "not ours"; a matching server argv *not* being promoted to ownership, and a foreign **subset** argv not passing as a match; ownership surviving `JSON.stringify` on both the foreign-listener and the **"another launcher already took the port"** paths; and the positive control that `"ours"` really does say "restarted successfully";
- **path roots**: UNC, extended-length `\\?\`, drive-letter and POSIX roots all survive the launcher-layout walk.

Pre-existing fixtures were corrected rather than the rules weakened: `process-control.test.ts` made the port lookup succeed exactly once (now "owned until the kill is issued", so it does not break again as the evidence chain grows); it and `restart-live-first.test.ts` had a `FakeChild` that modelled a *successful* spawn while leaving `pid` undefined, a shape Node never produces; and three files now model a host whose process creation times are readable, since their `child_process` mocks have no `execFileSync` for the real reader to use.

`npm run build` clean; full suite green (240 files / 4095 tests).

## Stated limitation: hosts that cannot identify a process

Binding the server's answer to a pid needs two OS observations — *who owns the port* and *when that process started*. Where either is unavailable, the restart **refuses rather than killing a process it cannot identify**, and the refusal now names the missing capability and a remedy:

> ComfyUI answered on port 8188, but its answer could not be tied to PID 4321: the process listening on port 8188 could not be identified (no usable port-owner lookup — on Linux this needs `lsof`, on Windows `netstat`/PowerShell). Nothing was stopped — killing a process we cannot identify risks taking down the wrong one. Restart ComfyUI from the launcher that owns it, or install the missing tool (`lsof` on Linux) and try again.

The affected set is small: `/proc/<pid>/stat` is world-readable on ordinary Linux containers, so the creation time is available there, and `lsof` is the only piece that has to be installed. A slim container without it degrades in two specific ways — the pre-kill path refuses (via the existing #449 route), and the post-kill path waits its full 15s budget before committing as *unverified* — both documented on **#795**, which would remove them by resolving the listener from `/proc/net/tcp` + `/proc/<pid>/fd/*` with no external binary.

This is a deliberate trade in the direction the whole issue argues for: a refusal costs a restart, a misidentified kill costs the server.

## Notes / left out

- **Windows and macOS cannot read another process's environment block** — there is no supported API short of reading the PEB. That is why tier 2 (recognize the launcher and rebuild from disk) and tier 3 (refuse) exist at all; on Linux tier 1 makes both moot.
- **Only Stability Matrix is reconstructed.** Other launchers can be added to the same table when their injected environment is documented and verifiable on disk; until then they land in tier 3 or tier 4 by evidence, never by guess.
- Local single-trust-domain project: accidental-bug correctness only. No adversarial hardening was added.

Closes #776


---

## The kernel socket table, and what twenty-three review rounds actually taught

The last stretch of this PR was one function: `readKernelSocketTables`, the
`/proc/net/tcp{,6}` reader that answers free-vs-occupied on Linux without needing
`lsof`. Twelve separate defects were found in it, and **every one was the same
mistake**. They are worth recording as a single lesson rather than a changelog,
because the shape recurs and the obvious summary of it is wrong.

### The invariant

The rule I started with was *"don't fold `unknown` into `false`"* — don't let "I
could not determine this" become "I determined it is not so". That is true, and it
is not enough. Stated that way it points in one direction, and every fix that
followed it created a matching defect pointing the other way.

What actually holds is:

> **The same evidence standard must gate both answers, and each answer must require
> exactly what it proves — no more and no less.**
>
> Existence needs only the fields that carry it. Absence needs the whole table.

That asymmetry is not a special case; it is the content of the rule. A LISTEN row
proves a socket exists even if the row is truncated a column later, because
truncation after the state cannot unmake the fields before it. The same truncated
row proves *nothing* about absence, because what was cut off might have been the
listener. Requiring the whole table for the positive is as wrong as accepting a
fragment for the negative — the second fabricates `free`, the first suppresses a
listener that was plainly visible.

This is why the defects alternated direction. Each time the negative was tightened,
the tightening was applied to the shared path and silently swallowed positives too.
Concretely, in order: a partial `/proc` read certified `free`; then lsof's negative
overrode the kernel's positive; then the two blind spots composed; then an
unparseable row was a clean negative; then "every read failed" was read as "no
source"; then a truncated header, a truncated row, a table picked up mid-way, an
interior blank record, an impossible TCP state, an impossible endpoint pair — and
then, having fixed the row-completeness rule, **the completeness gate was placed
ahead of the positive extraction**, so a row that visibly proved a listener was
reported as an unreadable table. Then the positive, once extracted first, was too
permissive and could fabricate a listener from two intact fields.

If you read this file and conclude "be strict about the table", you will re-invert
it. The strictness belongs to the *negative*.

### The shape in the type system

The mechanical cause is always the same: **a two-valued answer cannot carry a
three-valued observation, and the third value leaks out as a false assertion.**

That is the same defect `PortOwnerProbe` exists to fix — `findPidByPort` returning
`number | null` could not distinguish "nobody is listening" from "I could not look",
so callers spent the second as the first. Every recurrence was a fresh instance of
that collapse at a smaller scale:

| collapsed | leaked as |
| --- | --- |
| `procNetHasListener(): boolean \| undefined` | "no table at all" (macOS) vs "a table I could not read" (restricted container) |
| `statesNothingListening(): boolean` | "lsof said nothing" vs "lsof stated absence and I declined to spend it" |

The second of those produced a message that said lsof *"did not report an empty
search"* when it demonstrably had — a sentence asserting something that did not
happen, inside a change about not asserting what you did not observe. The verdict
was correct and the explanation was false, which is the failure mode that survives
review longest because the tests pass.

`readKernelSocketTables` now returns
`"listening" | "none" | "incomplete" | "unavailable"`, and lsof absence is
`"stated" | "inconclusive" | "silent"`. Both distinctions exist solely so that no
caller has to guess which of two very different situations produced a `false`.

### Tests that assert a state, not a reason, do not discriminate

Four times, a test named for a behaviour passed without exercising it, because it
asserted only the final `state`. The verdict is frequently reachable by a second
path — lsof names the pid anyway, or a different branch also yields `unknown` — so
the assertion holds while the behaviour is gone. Each was caught by mutation, not by
reading.

Where two candidate outcomes share a `state`, the tests now assert the **reason**,
positively and negatively, so the two causes cannot drift onto one string. And a
test that pins a classification must also pin the **acquisition**: one fix
classified stderr correctly while the success path never captured stderr at all, and
the test hid it by putting both strings in stdout.

### `TCP_BOUND_INACTIVE`: the enum was the wrong artifact

The state column is validated against a domain of `01..0B`. Two values above it are
real states that these files never print, for two different structural reasons:

- **`0C` (`TCP_NEW_SYN_RECV`)** — a request socket's `sk_state`, but the seq_show
  path renders those through `get_openreq4`, which prints `TCP_SYN_RECV` (`03`). A
  half-open connection appears here as `03`, never `0C`.
- **`0D` (`TCP_BOUND_INACTIVE`)** — a pseudo-state for `inet_diag`, which walks the
  **bind table**. These files do not: `/proc/net/tcp` iterates the listening and
  established hashes only.

The second was nearly gotten wrong in the safest-looking way. Reading
`include/net/tcp_states.h` shows `TCP_BOUND_INACTIVE = 13`, which is a real state a
socket can be in — so the citation says "accept `0D`", and rejecting it looks like
rejecting real kernel data. The reasoning was sound and the artifact was wrong: **the
enum describes states a socket can be *in*; procfs describes what these files
*render*.**

One command settled it — bind a socket without `listen()`, then read the table:

```
bound-not-listening rows in /proc/net/tcp: (none)
state column: []
```

No row at all, in any state. A measurement resolved in seconds what the citation
would have gotten wrong indefinitely.

This particular boundary deserves the care because **a wrong ceiling here fails
silently in both directions**: too high and an impossible row helps certify `free`;
too low and a legitimate row is rejected as damage, quietly costing every affected
host its fast path with nothing in the output to say so.

### Direction of failure

Every tightening in this function degrades to `incomplete` → `unknown`, which costs
a wait and never an answer. That is deliberate and is the only reason the ratchet was
safe to keep turning: an unrecognised kernel layout, an unknown lsof diagnostic, or a
future TCP state loses the fast path rather than producing a wrong verdict.

The one exception is worth naming, because it is the trap: **rejecting data the
kernel really emits also fails safe, but it fails *silently* and permanently.** That
is why the `0C`/`0D` ceiling, the address-family widths, and the header spelling were
each verified against live kernel output rather than reasoned about — and why every
tightening has a paired control test proving the legitimate case still reaches
`free`.
