### PR TITLE
fix(panel_run): make the completion event durable across automatic goal continuation (#468)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../../orchestrator/panel-tools.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 import { markReplyTimeout } from "../../services/ui-bridge.js";
+import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
 
 type Forwarded = Record<string, unknown>;
 
@@ -707,7 +708,10 @@ describe("panel-tools: panel_run verdict is derived from the ComfyUI reply", () 
   it("#194: a root SaveImage run-to-node the panel ACCEPTS is queued success (not subgraph-rejected)", async () => {
     const reply: ToolResult = {
       content: [
-        { type: "text", text: JSON.stringify({ queued: true, batch_count: 1, to_node_id: 9 }) },
+        {
+          type: "text",
+          text: JSON.stringify({ queued: true, batch_count: 1, to_node_id: 9, prompt_id: "p-194" }),
+        },
       ],
     };
     const { ctx, calls } = makeRunCtx(reply);
@@ -777,12 +781,33 @@ describe("panel-tools: panel_run verdict is derived from the ComfyUI reply", () 
 
   it("a genuine queue (queued:true, no errors) still gets the anti-poll note", async () => {
     const reply: ToolResult = {
-      content: [{ type: "text", text: JSON.stringify({ queued: true, batch_count: 1 }) }],
+      content: [
+        { type: "text", text: JSON.stringify({ queued: true, batch_count: 1, prompt_id: "p-ok" }) },
+      ],
     };
     const { ctx } = makeRunCtx(reply);
     const res = await defByName("panel_run").handler({}, ctx);
     expect(res.isError).toBeFalsy();
     expect(textOf(res)).toContain(QUEUED_NOTE);
+    // #468 — the anti-poll instruction is only safe because the completion can be
+    // correlated back to this exact run; the ticket is what makes that possible.
+    expect(RunCompletions.ticketFor("p-ok")).toBeDefined();
+  });
+
+  it("#468: a queue with NO prompt id does NOT promise automatic delivery — it says UNDETERMINED", async () => {
+    // The panel forwards ComfyUI's /prompt reply; without a prompt_id there is
+    // nothing to correlate a later completion to, so telling the agent to idle
+    // and wait would park it on a promise the orchestrator cannot keep.
+    const reply: ToolResult = {
+      content: [{ type: "text", text: JSON.stringify({ queued: true, batch_count: 1 }) }],
+    };
+    const { ctx } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    const text = textOf(res);
+    expect(text).not.toContain(QUEUED_NOTE);
+    expect(text).toContain("UNDETERMINED");
+    expect(text).toContain("get_history");
   });
 });
 

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -737,13 +737,25 @@ describe("run completion journal correlation (#468)", () => {
     expect(journal.pending("t")[0].correlation.status).toBe("foreign");
   });
 
-  it("a completion re-sent AFTER its delivery was acked is suppressed, not delivered twice", () => {
+  it("a completion re-sent AFTER its delivery was acked is FLAGGED, never suppressed", () => {
+    // "Already delivered" is a LABEL, not a veto. Every proof it could rest on
+    // (the memo, the ticket's settled flag, the ticket itself) is bounded, so
+    // suppressing on one turns into a silent loss the moment it expires at the
+    // wrong time — which is exactly how this defect kept coming back.
     journal.openRun(PROMPT_A, { tabId: "t" });
     const entry = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
     journal.deliverPending("t", () => true);
     journal.ack(entry!.token); // the carrying turn ended — entry is gone
-    expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A })).toBeNull();
-    expect(journal.pending("t")).toHaveLength(0);
+    const resend = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    expect(resend.possibleRepeat).toBe(true);
+    expect(journal.pending("t")).toHaveLength(1);
+    // …and the flag reaches the agent, so it can decline to double-count it.
+    const seen: CompletionPayload[] = [];
+    journal.deliverPending("t", (p) => {
+      seen.push(p);
+      return true;
+    });
+    expect(seen[0].possible_repeat).toBe(true);
   });
 
   it("evicting a HANDED-OFF completion is counted too — a hand-off is not proof of consumption", () => {
@@ -829,7 +841,7 @@ describe("run completion journal correlation (#468)", () => {
     expect(first!.correlation.status).toBe("matched"); // not reused yet
     journal.deliverPending("t", () => true);
     journal.ack(first!.token);
-    expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A })).toBeNull(); // memo holds
+    expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A }).possibleRepeat).toBe(true);
 
     journal.openRun(PROMPT_A, { tabId: "t" }); // ComfyUI reused the id
     expect(journal.ticketFor(PROMPT_A)?.reused).toBe(true);
@@ -1009,6 +1021,39 @@ describe("run completion journal correlation (#468)", () => {
     expect(real!.payload.note).toBe("run B");
   });
 
+  it("even with ALL history expired, a resend can't suppress the run that reused its id", () => {
+    // The last ordering: A is acked, then enough later runs expire BOTH its
+    // ticket (64) and its delivered memo (512), so nothing remembers the id at
+    // all. B then queues it and looks, correctly, like a fresh identity.
+    // A's late resend is now indistinguishable from B's completion — and that is
+    // fine, because "already delivered" no longer VETOES anything. Whatever
+    // arrives is delivered; the worst case is a flagged duplicate, never a loss.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const a = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run A" });
+    journal.deliverPending("t", () => true);
+    journal.ack(a.token);
+
+    for (let i = 0; i < 600; i++) {
+      journal.openRun(`later-${i}`, { tabId: "t" });
+      const e = journal.record("t", { kind: "executed", prompt_id: `later-${i}` });
+      journal.deliverPending("t", () => true);
+      journal.ack(e.token);
+    }
+    expect(journal.ticketFor(PROMPT_A)).toBeUndefined(); // all history expired
+
+    journal.openRun(PROMPT_A, { tabId: "t" }); // B — looks fresh, and is treated so
+    const resend = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "A resend" });
+    journal.deliverPending("t", () => true);
+    journal.ack(resend.token); // the resend settles the ticket it matched
+
+    // B's REAL completion still lands. Under the old suppress-on-proof rule this
+    // was the loss: B's own settled flag swallowed it.
+    const real = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run B" });
+    expect(real.payload.note).toBe("run B");
+    expect(real.possibleRepeat).toBe(true); // …flagged, so it isn't double-counted
+    expect(journal.pending("t")).toHaveLength(1);
+  });
+
   it("the no-coalesce rule survives the reused TICKET being evicted", () => {
     // Tickets are the smallest bound (64) and evictable. If ambiguity were read
     // only from the live ticket, 64 later runs would make the incoming side
@@ -1116,15 +1161,16 @@ describe("run completion journal correlation (#468)", () => {
     expect(seen[0].dropped_completions).toBe(lost);
   });
 
-  it("a resend is suppressed for as long as the run's IDENTITY survives, then reported as undetermined", () => {
-    // Suppression is keyed by ticket GENERATION, so it lasts exactly as long as
-    // the identity that makes "we already reported THIS run" a true statement.
+  it("a resend is FLAGGED while the run's IDENTITY survives, and merely undetermined after", () => {
+    // The repeat FLAG is keyed by ticket generation, so it lasts exactly as long
+    // as the identity that makes "we already reported THIS run" a true statement.
+    // Either way the completion is delivered — only the labelling changes.
     journal.openRun(PROMPT_A, { tabId: "t" });
     const entry = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
     journal.deliverPending("t", () => true);
     journal.ack(entry!.token);
     expect(journal.ticketFor(PROMPT_A)?.settled).toBe(true);
-    expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A })).toBeNull(); // resend: suppressed
+    expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A }).possibleRepeat).toBe(true);
 
     // Flood with REAL runs so the ticket map overflows and this run's identity
     // is evicted. Past that point the journal genuinely cannot tell a resend
@@ -1435,8 +1481,10 @@ describe("run completion journal correlation (#468)", () => {
     journal.moveKey("tmp:draft", "wf:saved.json");
     expect(journal.droppedFor("wf:saved.json")).toBe(lost);
     expect(journal.droppedFor("tmp:draft")).toBe(0);
-    // The re-send is still suppressed under the NEW id.
-    expect(journal.record("wf:saved.json", { kind: "executed", prompt_id: PROMPT_A })).toBeNull();
+    // The re-send is still RECOGNISED under the NEW id (flagged, not suppressed).
+    expect(
+      journal.record("wf:saved.json", { kind: "executed", prompt_id: PROMPT_A }).possibleRepeat,
+    ).toBe(true);
   });
 
   it("moveKey re-addresses a tab's entries without touching anyone else's", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -247,6 +247,42 @@ describe("run completion across automatic goal continuation (#468)", () => {
     expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false); // our run is still open
   });
 
+  it("a completion parked in HELD mail survives a reset that discards that mail", async () => {
+    // A failed start parks the agent's whole queue — including an injected
+    // completion — in heldMessages. `reset()` (New chat / resume_session) throws
+    // that mail away; the completion must come BACK to the journal, not be left
+    // stranded in a hand-off state nothing ever flushes again.
+    const doomed: AgentBackend = {
+      id: "claude" as const,
+      capabilities: CLAUDE_CAPABILITIES,
+      async prepare() {
+        throw new Error("endpoint rejected the key (http 401)");
+      },
+      // eslint-disable-next-line require-yield
+      async *run(): AsyncGenerator<AgentEvent> {
+        throw new Error("never runs");
+      },
+      async interrupt() {},
+      async listModels() {
+        return [];
+      },
+    };
+    const { journal, manager, arrive } = makeHarness(doomed);
+    const tab = "tab-heldmail";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "go"); // spawns an agent whose prepare() rejects
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "held.png" }] });
+    // Taken onto the doomed agent's queue…
+    await waitFor(() => journal.pending(tab).length === 0);
+    // …then parked in held mail when the start failed.
+    await waitFor(() => manager.hasHeldMail(tab));
+
+    manager.reset(tab); // New chat — held mail is discarded
+    expect(journal.pending(tab)).toHaveLength(1); // handed back, replayable
+    expect(journal.outstanding(tab)).toHaveLength(1);
+  });
+
   it("a replayed completion never satisfies a DIFFERENT run", async () => {
     const backend = new ContinuationBackend();
     const { journal, manager, arrive } = makeHarness(backend);
@@ -283,17 +319,68 @@ describe("run completion journal correlation (#468)", () => {
 
   it("correlates ONLY by exact prompt id — there is no most-recent-run fallback", () => {
     journal.openRun(PROMPT_A, { tabId: "t" });
-    expect(journal.correlate({ prompt_id: PROMPT_A })).toEqual({
+    expect(journal.correlate("t", { prompt_id: PROMPT_A })).toEqual({
       status: "matched",
       promptId: PROMPT_A,
     });
-    expect(journal.correlate({ prompt_id: PROMPT_B })).toEqual({
+    expect(journal.correlate("t", { prompt_id: PROMPT_B })).toEqual({
       status: "foreign",
       promptId: PROMPT_B,
     });
-    expect(journal.correlate({})).toEqual({ status: "unidentified" });
+    expect(journal.correlate("t", {})).toEqual({ status: "unidentified" });
     // A near-miss id is foreign, never "close enough".
-    expect(journal.correlate({ prompt_id: `${PROMPT_A}x` }).status).toBe("foreign");
+    expect(journal.correlate("t", { prompt_id: `${PROMPT_A}x` }).status).toBe("foreign");
+  });
+
+  it("a run queued on ANOTHER tab never matches — cross-tab is foreign, not matched", () => {
+    journal.openRun(PROMPT_A, { tabId: "wf:one" });
+    expect(journal.correlate("wf:one", { prompt_id: PROMPT_A }).status).toBe("matched");
+    // The same run finishing after the browser tab switched to a different
+    // workflow must NOT be presented to the new workflow's agent as its own.
+    expect(journal.correlate("wf:two", { prompt_id: PROMPT_A }).status).toBe("foreign");
+  });
+
+  it("forget drops the tab's RUN TICKETS too, so a late completion reads as undetermined", () => {
+    journal.openRun(PROMPT_A, { tabId: "wf:one" });
+    journal.forget("wf:one");
+    expect(journal.ticketFor(PROMPT_A)).toBeUndefined();
+    expect(journal.correlate("wf:one", { prompt_id: PROMPT_A }).status).toBe("foreign");
+  });
+
+  it("moveKey carries the run tickets, so a migrated tab's own run still matches", () => {
+    journal.openRun(PROMPT_A, { tabId: "tmp:draft" });
+    journal.moveKey("tmp:draft", "wf:saved.json");
+    expect(journal.correlate("wf:saved.json", { prompt_id: PROMPT_A }).status).toBe("matched");
+    expect(journal.correlate("tmp:draft", { prompt_id: PROMPT_A }).status).toBe("foreign");
+  });
+
+  it("a re-sent completion does NOT re-arm a hand-off (no duplicate delivery)", () => {
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    journal.deliverPending("t", () => true); // handed off, not yet acked
+    expect(journal.pending("t")).toHaveLength(0);
+    // The panel re-sends the same completion — it must not queue a second copy.
+    journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "resend" });
+    expect(journal.pending("t")).toHaveLength(0);
+    expect(journal.outstanding("t")).toHaveLength(1);
+  });
+
+  it("evicting a still-pending completion is COUNTED and reported on the next delivery", () => {
+    // Fill past the per-tab ceiling with completions nothing can deliver.
+    for (let i = 0; i < 40; i++) {
+      journal.record("t", { kind: "executed", prompt_id: `p-${i}` });
+    }
+    const lost = journal.droppedFor("t");
+    expect(lost).toBeGreaterThan(0);
+    const seen: CompletionPayload[] = [];
+    journal.deliverPending("t", (p) => {
+      seen.push(p);
+      return true;
+    });
+    expect(seen[0].dropped_completions).toBe(lost);
+    // Reported once, then cleared — later deliveries don't re-report it.
+    expect(journal.droppedFor("t")).toBe(0);
+    expect(seen[1]?.dropped_completions).toBeUndefined();
   });
 
   it("freezes the correlation at arrival — a run opened later can never claim it", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -29,6 +29,7 @@ import {
   RunCompletionJournalImpl,
   type CompletionPayload,
 } from "../../orchestrator/run-completion-journal.js";
+import { destinationHasCollisionState } from "../../orchestrator/session-store.js";
 
 let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
 
@@ -54,7 +55,7 @@ async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
  */
 class ContinuationBackend implements AgentBackend {
   readonly id = "claude" as const;
-  readonly capabilities = CLAUDE_CAPABILITIES;
+  readonly capabilities = CLAUDE_CAPABILITIES; // declares turnMarkers: true
   turns: string[] = [];
   /** Resolves the turn currently in flight. */
   private release: (() => void) | null = null;
@@ -63,13 +64,17 @@ class ContinuationBackend implements AgentBackend {
 
   async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
     yield { type: "session", sessionId: "sess-468" };
+    let turnSeq = 0;
     for await (const turn of opts.channel) {
       this.turns.push((turn as { text?: string }).text ?? "");
+      turnSeq += 1;
       await new Promise<void>((resolve) => {
         this.release = resolve;
       });
       if (this.strandTurns) continue;
-      yield { type: "result", ok: true, subtype: "success" };
+      // Stamped with its own turn marker, exactly as a real marker-declaring
+      // backend does — that is what lets it ack the completion it carried.
+      yield { type: "result", ok: true, subtype: "success", turn: turnSeq };
     }
   }
 
@@ -95,10 +100,17 @@ class ContinuationBackend implements AgentBackend {
  */
 class MarkerBackend implements AgentBackend {
   readonly id = "claude" as const;
-  readonly capabilities = CLAUDE_CAPABILITIES;
+  readonly capabilities = CLAUDE_CAPABILITIES; // declares turnMarkers: true
   turns: string[] = [];
   private sink: ((ev: AgentEvent) => void) | null = null;
   private queued: AgentEvent[] = [];
+  /** When true a turn emits NO stamped event at all (the zero-output turn whose
+   *  traceless terminal is what breaks a learn-by-observation ack gate). */
+  private readonly silentTurns: boolean;
+
+  constructor(opts: { silentTurns?: boolean } = {}) {
+    this.silentTurns = opts.silentTurns === true;
+  }
 
   async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
     let wake: (() => void) | null = null;
@@ -111,8 +123,7 @@ class MarkerBackend implements AgentBackend {
     void (async () => {
       for await (const turn of opts.channel) {
         this.turns.push((turn as { text?: string }).text ?? "");
-        // Mark the turn as producing SOME stamped output, so the agent learns
-        // this backend stamps markers (exactly what Claude does).
+        if (this.silentTurns) continue;
         this.sink?.({ type: "assistant", text: "", turn: this.turns.length } as AgentEvent);
       }
     })();
@@ -246,7 +257,7 @@ describe("run completion across automatic goal continuation (#468)", () => {
 
   it("a traceless straggler result does NOT ack the current turn's completion", async () => {
     // #728 lets an UNMARKED result through the dead-letter guard for gate
-    // liveness. On a marker-stamping backend that result may belong to an
+    // liveness. On a marker-declaring backend that result may belong to an
     // abandoned earlier turn, so it must not retire a completion the CURRENT
     // turn is carrying — otherwise a turn that then stalls has nothing to
     // hand back and the completion is gone.
@@ -264,12 +275,77 @@ describe("run completion across automatic goal continuation (#468)", () => {
 
     // An unmarked straggler from the abandoned turn 1 arrives.
     backend.emit({ type: "result", ok: false, subtype: "error_during_execution" });
-    await new Promise((r) => setTimeout(r, 20));
-    expect(journal.outstanding(tab)).toHaveLength(1); // NOT acked
+    // It is handed BACK, not acked — and immediately re-delivered into a new
+    // turn, so the completion is neither lost nor fabricated as delivered.
+    await waitFor(() => backend.turns.length >= 3);
+    expect(backend.turns[2]).toContain("carried.png");
+    expect(backend.turns[2]).toContain("RE-DELIVERED");
+    expect(journal.outstanding(tab)).toHaveLength(1);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false);
 
-    // Turn 2's own (marked) result is what acks it.
-    backend.emit({ type: "result", ok: true, subtype: "success", turn: 2 });
+    // Only the carrying turn's OWN marked result settles it.
+    backend.emit({ type: "result", ok: true, subtype: "success", turn: 3 });
     await waitFor(() => journal.outstanding(tab).length === 0);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(true);
+  });
+
+  it("a straggler arriving BEFORE the carrying turn stamps anything still cannot ack", async () => {
+    // The unsound-inference case: a gate that LEARNS "this backend stamps" by
+    // observation is still unlearned in exactly this window — a zero-output
+    // turn's traceless terminal lands before the replacement turn emits any
+    // stamped event. Capability is DECLARED, so the gate holds from the start.
+    const backend = new MarkerBackend({ silentTurns: true });
+    const { journal, manager, arrive } = makeHarness(backend);
+    const tab = "tab-straggler-early";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "go"); // turn 1 emits NOTHING
+    await waitFor(() => backend.turns.length >= 1);
+    backend.emit({ type: "result", ok: true, subtype: "success", turn: 1 });
+
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "early.png" }] });
+    await waitFor(() => backend.turns.length >= 2); // turn 2 carries it, still silent
+
+    // No marker has EVER been observed on this run at this point — a
+    // learn-by-observation gate would ack here and destroy the replay.
+    backend.emit({ type: "result", ok: false, subtype: "error_during_execution" });
+    await waitFor(() => backend.turns.length >= 3); // handed back and re-delivered
+    expect(backend.turns[2]).toContain("early.png");
+    expect(journal.outstanding(tab)).toHaveLength(1);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false);
+  });
+
+  it("a completion parked in held mail survives retire() (provider switch)", async () => {
+    // retire() PRESERVES held mail, which is why it used to strand the
+    // completion riding in it: the journal entry stayed `handed_off` — a state
+    // deliverPending() skips — with no agent left to consume it.
+    const doomed: AgentBackend = {
+      id: "claude" as const,
+      capabilities: CLAUDE_CAPABILITIES,
+      async prepare() {
+        throw new Error("endpoint rejected the key (http 401)");
+      },
+      // eslint-disable-next-line require-yield
+      async *run(): AsyncGenerator<AgentEvent> {
+        throw new Error("never runs");
+      },
+      async interrupt() {},
+      async listModels() {
+        return [];
+      },
+    };
+    const { journal, manager, arrive } = makeHarness(doomed);
+    const tab = "tab-retire-heldmail";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "go");
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "retired.png" }] });
+    await waitFor(() => journal.pending(tab).length === 0); // taken by the doomed agent
+    await waitFor(() => manager.hasHeldMail(tab));
+
+    manager.retire(tab); // provider switch retires the failed key
+    expect(journal.pending(tab)).toHaveLength(1); // handed back, replayable
+    expect(journal.outstanding(tab)).toHaveLength(1);
   });
 
   it("reports an uncorrelatable completion as UNDETERMINED instead of swallowing it", async () => {
@@ -555,6 +631,73 @@ describe("run completion journal correlation (#468)", () => {
       return false;
     });
     expect(seen).toEqual([PROMPT_A]);
+  });
+
+  it("a tab holding ONLY a journal entry counts as OCCUPIED for a tab-id migration", () => {
+    // CRITICAL: the destination of a same-workflow tab-id migration can have had
+    // its agent AND durable session cleared (New chat) and still hold an
+    // undelivered completion. If the occupancy check ignores the journal, the
+    // destination reads as empty, the source is rebound onto its id, and the
+    // next flush hands the DESTINATION tab's render to the SOURCE tab's
+    // conversation — a cross-conversation delivery, worse than a lost one.
+    expect(
+      destinationHasCollisionState({
+        hasManagerState: false,
+        hasDurableSession: false,
+        renderHeldCount: 0,
+        journaledCompletionCount: 1,
+      }),
+    ).toBe(true);
+    expect(
+      destinationHasCollisionState({
+        hasManagerState: false,
+        hasDurableSession: false,
+        renderHeldCount: 0,
+        journaledCompletionCount: 0,
+      }),
+    ).toBe(false);
+    // …and the purge that follows leaves nothing for the incoming agent to
+    // inherit, for BOTH pending and already-handed-off entries.
+    journal.record("wf:dest", { kind: "executed", prompt_id: PROMPT_B });
+    journal.deliverPending("wf:dest", () => true);
+    journal.record("wf:dest", { kind: "executed", prompt_id: PROMPT_A });
+    expect(journal.outstanding("wf:dest")).toHaveLength(2);
+    journal.forget("wf:dest");
+    expect(journal.outstanding("wf:dest")).toHaveLength(0);
+    journal.moveKey("wf:src", "wf:dest"); // then the source migrates in
+    expect(journal.outstanding("wf:dest")).toHaveLength(0);
+  });
+
+  it("an identical ID-LESS completion re-sent is not delivered twice", () => {
+    // With no prompt id there is no run identity, so content is the only
+    // evidence of sameness. A re-sent frame must not produce a second turn —
+    // UNDETERMINED labelling doesn't stop the agent double-reporting.
+    const payload = { kind: "executed", images: [{ filename: "mystery_0001.png" }] };
+    const first = journal.record("t", { ...payload });
+    expect(first).not.toBeNull();
+    expect(journal.record("t", { ...payload })).toBe(first); // collapses while journaled
+    expect(journal.pending("t")).toHaveLength(1);
+
+    journal.deliverPending("t", () => true);
+    journal.ack(first!.token);
+    // …and still suppressed after the ack, when no entry survives to collapse on.
+    expect(journal.record("t", { ...payload })).toBeNull();
+    expect(journal.pending("t")).toHaveLength(0);
+
+    // A DIFFERENT id-less render is still delivered.
+    expect(
+      journal.record("t", { kind: "executed", images: [{ filename: "other_0002.png" }] }),
+    ).not.toBeNull();
+    expect(journal.pending("t")).toHaveLength(1);
+  });
+
+  it("the id-less content memo moves with a tab-id migration", () => {
+    const payload = { kind: "executed", images: [{ filename: "idless.png" }] };
+    const entry = journal.record("tmp:draft", { ...payload });
+    journal.deliverPending("tmp:draft", () => true);
+    journal.ack(entry!.token);
+    journal.moveKey("tmp:draft", "wf:saved.json");
+    expect(journal.record("wf:saved.json", { ...payload })).toBeNull();
   });
 
   it("moveKey carries the delivered memo and the eviction counter, not just the entries", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -1,0 +1,381 @@
+// #468 — `panel_run`'s completion event must survive AUTOMATIC GOAL CONTINUATION.
+//
+// The old delivery path (agent_event → manager.injectEvent → PanelAgent.queue)
+// was fire-and-forget: uncorrelated, silently dropped when no agent was live,
+// and discarded outright when a queued-but-unread item died with its agent. An
+// ordinary single run leaves the agent IDLE, so the completion is drained
+// instantly and none of that shows. A goal continuation keeps the agent BUSY for
+// the whole render — which is exactly the window where the completion sits
+// unread and the continuation's own turn churn (deferred effort/MCP restarts,
+// the self-restart loop) tears the listener down underneath it.
+//
+// These tests lock the four properties the fix promises:
+//   1. delivered across a continuation (the agent is busy the whole render);
+//   2. a completion with no live agent is JOURNALED and replayed, correlated to
+//      the run it arrived for;
+//   3. a completion that cannot be correlated is REPORTED as undetermined, never
+//      swallowed and never presented as the awaited render;
+//   4. a replay can never satisfy a DIFFERENT run.
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+import {
+  RunCompletionJournalImpl,
+  type CompletionPayload,
+} from "../../orchestrator/run-completion-journal.js";
+
+let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
+
+beforeAll(async () => {
+  ({ PanelAgentManager } = await import("../../orchestrator/panel-agent.js"));
+});
+
+const PROMPT_A = "246da5fc-a6b4-4e85-bbd5-5f2463a757a0";
+const PROMPT_B = "5bc36c41-fe83-481f-8a71-b9dd1c3b05a4";
+
+async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+/**
+ * A backend that models AUTOMATIC GOAL CONTINUATION: it holds each turn open
+ * until the test releases it, so the agent is continuously busy while the render
+ * completes — the exact state the completion has to survive.
+ */
+class ContinuationBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turns: string[] = [];
+  /** Resolves the turn currently in flight. */
+  private release: (() => void) | null = null;
+  /** When true, a turn never produces a `result` (a stalled/abandoned turn). */
+  strandTurns = false;
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    yield { type: "session", sessionId: "sess-468" };
+    for await (const turn of opts.channel) {
+      this.turns.push((turn as { text?: string }).text ?? "");
+      await new Promise<void>((resolve) => {
+        this.release = resolve;
+      });
+      if (this.strandTurns) continue;
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+
+  /** Let the in-flight turn finish (its `result` acks any carried completion). */
+  finishTurn(): void {
+    const r = this.release;
+    this.release = null;
+    r?.();
+  }
+
+  async interrupt(): Promise<void> {
+    this.finishTurn();
+  }
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+/** Wires a manager to a journal exactly as the orchestrator does (index.ts's
+ *  flushRunCompletions / onEventDelivered / onEventUndelivered / onAgentReady),
+ *  through the journal's own deliverPending so no delivery logic is duplicated. */
+function makeHarness(backend: AgentBackend) {
+  const journal = new RunCompletionJournalImpl();
+  const flush = (tab: string) =>
+    journal.deliverPending(tab, (payload, token) =>
+      manager.injectEvent(tab, payload, { eventToken: token }),
+    );
+  const manager = new PanelAgentManager({
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-test",
+    onSay: () => {},
+    onTurn: () => {},
+    makeBackend: () => backend,
+    onEventDelivered: (_key: string, tokens: string[]) => {
+      for (const t of tokens) journal.ack(t);
+    },
+    onEventUndelivered: (key: string, tokens: string[]) => {
+      for (const t of tokens) journal.release(t);
+      flush(key);
+    },
+    onAgentReady: (key: string) => flush(key),
+  } as never);
+  /** The orchestrator's agent_event handler for kind:"executed". */
+  const arrive = (tab: string, payload: CompletionPayload) => {
+    journal.record(tab, payload);
+    flush(tab);
+  };
+  return { journal, manager, flush, arrive };
+}
+
+describe("run completion across automatic goal continuation (#468)", () => {
+  it("delivers the completion into the next turn while the agent is busy continuing a goal", async () => {
+    const backend = new ContinuationBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+    const tab = "tab-continuation";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "render it and keep going");
+    await waitFor(() => backend.turns.length >= 1);
+
+    // The render finishes MID-CONTINUATION: the agent is still inside turn 1.
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "out_0001.png" }] });
+    expect(backend.turns.length).toBe(1); // nothing delivered yet — still busy
+
+    backend.finishTurn(); // the continuation turn ends
+    await waitFor(() => backend.turns.length >= 2);
+
+    expect(backend.turns[1]).toContain("out_0001.png");
+    expect(backend.turns[1]).toContain(PROMPT_A);
+    expect(backend.turns[1]).toContain("This is the run YOU queued");
+    // Still journaled until the turn CARRYING it ends — hand-off is not proof.
+    expect(journal.outstanding(tab)).toHaveLength(1);
+
+    backend.finishTurn();
+    await waitFor(() => journal.outstanding(tab).length === 0);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(true);
+  });
+
+  it("journals a completion that lands with no live agent and replays it to the right run", async () => {
+    const backend = new ContinuationBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+    const tab = "tab-no-agent";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    // No agent exists yet for this tab (the previous one was torn down by a
+    // restart the continuation triggered) — the old code dropped this silently.
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "late_0001.png" }] });
+    expect(journal.outstanding(tab)).toHaveLength(1);
+    expect(journal.pending(tab)).toHaveLength(1); // still awaiting a delivery attempt
+
+    // A fresh agent comes back → onAgentReady replays it.
+    manager.send(tab, "still here?");
+    await waitFor(() => backend.turns.length >= 1);
+
+    // The replay is queued AHEAD of the message that spawned the agent, so both
+    // land; assert the completion text is present in some turn.
+    const all = backend.turns.join("\n");
+    expect(all).toContain("late_0001.png");
+    expect(all).toContain(PROMPT_A);
+    expect(all).toContain("This is the run YOU queued");
+
+    backend.finishTurn();
+    await waitFor(() => journal.outstanding(tab).length === 0);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(true);
+  });
+
+  it("replays a completion whose carrying turn was abandoned — it is never swallowed", async () => {
+    const backend = new ContinuationBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+    const tab = "tab-abandoned";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "go");
+    await waitFor(() => backend.turns.length >= 1);
+    backend.finishTurn();
+
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "kept_0001.png" }] });
+    await waitFor(() => backend.turns.length >= 2);
+    expect(backend.turns[1]).toContain("kept_0001.png");
+
+    // The turn carrying it is thrown away (a plain Stop / abandoned turn). The
+    // completion must come BACK, not die with the turn.
+    await manager.interrupt(tab, { requeueInFlight: false });
+    await waitFor(() => backend.turns.length >= 3);
+    expect(backend.turns[2]).toContain("kept_0001.png");
+    expect(backend.turns[2]).toContain("RE-DELIVERED");
+  });
+
+  it("reports an uncorrelatable completion as UNDETERMINED instead of swallowing it", async () => {
+    const backend = new ContinuationBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+    const tab = "tab-unknown";
+
+    journal.openRun(PROMPT_A, { tabId: tab }); // the agent IS waiting on a run
+    manager.send(tab, "go");
+    await waitFor(() => backend.turns.length >= 1);
+    backend.finishTurn();
+
+    // …but the completion that arrives carries no prompt id at all.
+    arrive(tab, { kind: "executed", images: [{ filename: "mystery_0001.png" }] });
+    await waitFor(() => backend.turns.length >= 2);
+
+    const text = backend.turns[1];
+    expect(text).toContain("mystery_0001.png"); // still delivered
+    expect(text).toContain("UNDETERMINED");
+    expect(text).toContain("get_history");
+    expect(text).not.toContain("This is the run YOU queued");
+    // …and it must not settle the run the agent is actually waiting on.
+    backend.finishTurn();
+    await waitFor(() => journal.outstanding(tab).length === 0);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false);
+  });
+
+  it("reports a completion for a run this session never queued as UNDETERMINED", async () => {
+    const backend = new ContinuationBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+    const tab = "tab-foreign";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "go");
+    await waitFor(() => backend.turns.length >= 1);
+    backend.finishTurn();
+
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_B, images: [{ filename: "theirs.png" }] });
+    await waitFor(() => backend.turns.length >= 2);
+
+    const text = backend.turns[1];
+    expect(text).toContain("does NOT match any run you queued");
+    expect(text).toContain("UNDETERMINED");
+    expect(text).toContain(PROMPT_B);
+
+    backend.finishTurn();
+    await waitFor(() => journal.outstanding(tab).length === 0);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false); // our run is still open
+  });
+
+  it("a replayed completion never satisfies a DIFFERENT run", async () => {
+    const backend = new ContinuationBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+    const tab = "tab-two-runs";
+
+    // Run A completes but its delivery is stranded (no agent yet).
+    journal.openRun(PROMPT_A, { tabId: tab });
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "a.png" }] });
+    expect(journal.pending(tab)).toHaveLength(1);
+
+    // Only AFTER that does the agent queue run B. The stranded completion must
+    // not drift onto it when it is finally replayed.
+    journal.openRun(PROMPT_B, { tabId: tab });
+
+    manager.send(tab, "go");
+    await waitFor(() => backend.turns.length >= 1);
+    backend.finishTurn();
+    await waitFor(() => journal.outstanding(tab).length === 0);
+
+    const all = backend.turns.join("\n");
+    expect(all).toContain("a.png");
+    expect(all).toContain(PROMPT_A);
+    expect(all).not.toContain(PROMPT_B);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(true);
+    expect(journal.ticketFor(PROMPT_B)?.settled).toBe(false); // B is still outstanding
+  });
+});
+
+describe("run completion journal correlation (#468)", () => {
+  let journal: RunCompletionJournalImpl;
+  beforeEach(() => {
+    journal = new RunCompletionJournalImpl();
+  });
+
+  it("correlates ONLY by exact prompt id — there is no most-recent-run fallback", () => {
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    expect(journal.correlate({ prompt_id: PROMPT_A })).toEqual({
+      status: "matched",
+      promptId: PROMPT_A,
+    });
+    expect(journal.correlate({ prompt_id: PROMPT_B })).toEqual({
+      status: "foreign",
+      promptId: PROMPT_B,
+    });
+    expect(journal.correlate({})).toEqual({ status: "unidentified" });
+    // A near-miss id is foreign, never "close enough".
+    expect(journal.correlate({ prompt_id: `${PROMPT_A}x` }).status).toBe("foreign");
+  });
+
+  it("freezes the correlation at arrival — a run opened later can never claim it", () => {
+    const entry = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    expect(entry.correlation.status).toBe("foreign"); // A wasn't queued yet
+    journal.openRun(PROMPT_A, { tabId: "t" }); // …now it is
+    // The stored entry keeps its arrival verdict; only NEW arrivals see the run.
+    expect(journal.pending("t")[0].correlation.status).toBe("foreign");
+  });
+
+  it("openRun without a prompt id is refused — nothing can be correlated to it", () => {
+    expect(journal.openRun(null, { tabId: "t" })).toBe(false);
+    expect(journal.openRun("", { tabId: "t" })).toBe(false);
+    expect(journal.openRun(PROMPT_A, { tabId: "t" })).toBe(true);
+  });
+
+  it("collapses a re-sent completion for the same run onto one entry", () => {
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const first = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    const again = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    expect(again.token).toBe(first.token);
+    expect(journal.outstanding("t")).toHaveLength(1);
+  });
+
+  it("only the entry's OWN run is settled on ack", () => {
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    journal.openRun(PROMPT_B, { tabId: "t" });
+    const entry = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    journal.ack(entry.token);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(true);
+    expect(journal.ticketFor(PROMPT_B)?.settled).toBe(false);
+  });
+
+  it("an entry is only cleared by ack — a hand-off alone keeps it replayable", () => {
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    const dead = journal.deliverPending("t", () => false);
+    expect(dead.delivered).toBe(0);
+    expect(dead.blockedOn).not.toBeNull();
+    expect(journal.pending("t")).toHaveLength(1); // refused → still pending
+
+    const seen: CompletionPayload[] = [];
+    journal.deliverPending("t", (p) => {
+      seen.push(p);
+      return true;
+    });
+    expect(seen[0].replayed).toBe(true); // second attempt is flagged a re-delivery
+    expect(journal.pending("t")).toHaveLength(0); // handed off
+    expect(journal.outstanding("t")).toHaveLength(1); // …but not acked, so kept
+
+    journal.release(journal.outstanding("t")[0].token);
+    expect(journal.pending("t")).toHaveLength(1); // handed back → replayable again
+  });
+
+  it("delivery stops at the first refusal so completions keep arrival order", () => {
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    journal.openRun(PROMPT_B, { tabId: "t" });
+    journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    journal.record("t", { kind: "executed", prompt_id: PROMPT_B });
+    const seen: string[] = [];
+    journal.deliverPending("t", (p) => {
+      seen.push(String(p.prompt_id));
+      return false;
+    });
+    expect(seen).toEqual([PROMPT_A]);
+  });
+
+  it("moveKey re-addresses a tab's entries without touching anyone else's", () => {
+    journal.openRun(PROMPT_A, { tabId: "old" });
+    journal.record("old", { kind: "executed", prompt_id: PROMPT_A });
+    journal.record("other", { kind: "executed", prompt_id: PROMPT_B });
+    journal.moveKey("old", "new");
+    expect(journal.pending("old")).toHaveLength(0);
+    expect(journal.pending("new")).toHaveLength(1);
+    expect(journal.pending("other")).toHaveLength(1);
+  });
+
+  it("forget drops a gone tab's entries and leaves other tabs alone", () => {
+    journal.record("gone", { kind: "executed", prompt_id: PROMPT_A });
+    journal.record("kept", { kind: "executed", prompt_id: PROMPT_B });
+    journal.forget("gone");
+    expect(journal.outstanding("gone")).toHaveLength(0);
+    expect(journal.outstanding("kept")).toHaveLength(1);
+  });
+});

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -697,6 +697,33 @@ describe("run completion journal correlation (#468)", () => {
     expect(journal.outstanding("t")).toHaveLength(1);
   });
 
+  it("re-queuing the SAME prompt id clears the delivered memo, so its new completion lands", () => {
+    // openRun() documents that it REOPENS an existing ticket. Leaving the
+    // already-delivered memo behind made that a lie: panel_run promised
+    // automatic delivery and the journal then suppressed the completion as a
+    // duplicate of the PREVIOUS run's.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const first = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    journal.deliverPending("t", () => true);
+    journal.ack(first!.token);
+    expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A })).toBeNull(); // memo holds
+
+    journal.openRun(PROMPT_A, { tabId: "t" }); // re-queued
+    const second = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    expect(second).not.toBeNull();
+    expect(second!.correlation.status).toBe("matched");
+  });
+
+  it("hasOutstanding reports any undelivered completion (the self-restart gate)", () => {
+    expect(journal.hasOutstanding()).toBe(false);
+    const entry = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    expect(journal.hasOutstanding()).toBe(true);
+    journal.deliverPending("t", () => true);
+    expect(journal.hasOutstanding()).toBe(true); // handed off is NOT delivered
+    journal.ack(entry!.token);
+    expect(journal.hasOutstanding()).toBe(false);
+  });
+
   it("only the entry's OWN run is settled on ack", () => {
     journal.openRun(PROMPT_A, { tabId: "t" });
     journal.openRun(PROMPT_B, { tabId: "t" });

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -513,21 +513,46 @@ describe("run completion across automatic goal continuation (#468)", () => {
     // watchdog) must return the completion it was carrying — but as a CARRIED
     // release, or an agent that keeps abandoning turns would be handed the same
     // completion on every turn forever.
-    const backend = new ContinuationBackend();
+    const backend = new MarkerBackend();
     const { journal, manager, arrive } = makeHarness(backend);
     const tab = "tab-rewind-carried";
 
     journal.openRun(PROMPT_A, { tabId: tab });
     manager.send(tab, "go");
     await waitFor(() => backend.turns.length >= 1);
-    backend.finishTurn();
+    backend.emit({ type: "result", ok: true, subtype: "success", turn: 1 });
 
     arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "rewound.png" }] });
-    await waitFor(() => backend.turns.length >= 2); // turn 2 carries it
+    // MarkerBackend emits a stamped event per turn, so turn 2 is PROVEN received
+    // before the rewind — which is what makes the release carried.
+    await waitFor(() => backend.turns.length >= 2);
+    await waitFor(() => journal.outstanding(tab).length === 1);
 
     manager.rewind(tab, null); // abandons the in-flight turn
     await waitFor(() => (journal.outstanding(tab)[0]?.carriedReleases ?? 0) >= 1);
     expect(journal.outstanding(tab)).toHaveLength(1); // returned, not lost
+  });
+
+  it("a turn the backend never RECEIVED is released UNCARRIED — it can't count toward the bound", async () => {
+    // The token is attached at dispatch, but Claude resolves output images before
+    // submitting the turn. Aborting in that window means the model never saw the
+    // completion, so it must not count toward the settle bound.
+    const silent = new MarkerBackend({ silentTurns: true });
+    const { journal, manager, arrive } = makeHarness(silent);
+    const tab = "tab-unreceived";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "go");
+    await waitFor(() => silent.turns.length >= 1);
+    silent.emit({ type: "result", ok: true, subtype: "success", turn: 1 });
+
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "unseen.png" }] });
+    await waitFor(() => silent.turns.length >= 2); // dispatched, but NO events for it
+
+    manager.rewind(tab, null);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(journal.outstanding(tab)).toHaveLength(1); // returned…
+    expect(journal.outstanding(tab)[0].carriedReleases ?? 0).toBe(0); // …unbounded
   });
 
   it("a completion survives an agent whose self-restart loop GAVE UP", async () => {
@@ -726,21 +751,32 @@ describe("run completion journal correlation (#468)", () => {
     expect(journal.outstanding("t")).toHaveLength(1);
   });
 
-  it("re-queuing the SAME prompt id clears the delivered memo, so its new completion lands", () => {
-    // openRun() documents that it REOPENS an existing ticket. Leaving the
-    // already-delivered memo behind made that a lie: panel_run promised
-    // automatic delivery and the journal then suppressed the completion as a
-    // duplicate of the PREVIOUS run's.
+  it("a REUSED prompt id delivers every completion, as UNDETERMINED, suppressing none", () => {
+    // Nothing on the wire distinguishes generation A's completion from B's — the
+    // panel sends only the id. So once an id is queued twice it identifies no
+    // single run: suppressing on the delivered proofs could swallow B's real
+    // result, and claiming a match could present A's result as B's.
     journal.openRun(PROMPT_A, { tabId: "t" });
     const first = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    expect(first!.correlation.status).toBe("matched"); // not reused yet
     journal.deliverPending("t", () => true);
     journal.ack(first!.token);
     expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A })).toBeNull(); // memo holds
 
-    journal.openRun(PROMPT_A, { tabId: "t" }); // re-queued
+    journal.openRun(PROMPT_A, { tabId: "t" }); // ComfyUI reused the id
+    expect(journal.ticketFor(PROMPT_A)?.reused).toBe(true);
+
+    // Both a late resend of A and B's real completion are now delivered, each
+    // labelled UNDETERMINED. Neither is suppressed; neither claims to be "the
+    // run YOU queued".
     const second = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
     expect(second).not.toBeNull();
-    expect(second!.correlation.status).toBe("matched");
+    expect(second!.correlation.status).toBe("foreign");
+    journal.deliverPending("t", () => true);
+    journal.ack(second!.token);
+    const third = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    expect(third).not.toBeNull(); // NOT swallowed as a duplicate of the previous
+    expect(third!.correlation.status).toBe("foreign");
   });
 
   it("re-queuing a prompt id SUPERSEDES the old entry — the old result can't answer for the new run", () => {
@@ -769,10 +805,11 @@ describe("run completion journal correlation (#468)", () => {
     expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false);
     expect(journal.pending("t")).toHaveLength(1); // run B still awaits delivery
 
-    // Run B's own delivery settles it.
+    // Run B's own completion is delivered too — as UNDETERMINED, because a
+    // reused id can no longer be attributed to one run.
     journal.deliverPending("t", () => true);
     journal.ack(fresh!.token);
-    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(true);
+    expect(journal.outstanding("t")).toHaveLength(0);
   });
 
   it("an eviction disclosure rides a surviving entry, so it can't be discarded before it's told", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -453,16 +453,18 @@ describe("run completion across automatic goal continuation (#468)", () => {
         return [];
       },
     };
-    // Fails the FIRST start (parking the queue in held mail), then works — so the
-    // held mail is genuinely re-delivered and we can count what the agent saw.
+    // Fails the first TWO starts (parking, re-delivering, then re-parking the
+    // queue in held mail), then works. Two consecutive failures matter: the
+    // re-delivery goes through send(), which must preserve the completionOnly
+    // marker or the second parking makes the completion's text un-removable.
     const healthy = new ContinuationBackend();
-    let firstStart = true;
+    let failuresLeft = 2;
     const flaky: AgentBackend = {
       id: "claude" as const,
       capabilities: CLAUDE_CAPABILITIES,
       async prepare() {
-        if (firstStart) {
-          firstStart = false;
+        if (failuresLeft > 0) {
+          failuresLeft -= 1;
           throw new Error("endpoint rejected the key (http 401)");
         }
       },
@@ -481,10 +483,16 @@ describe("run completion across automatic goal continuation (#468)", () => {
     await waitFor(() => journal.pending(tab).length === 0); // taken by the doomed agent
     await waitFor(() => manager.hasHeldMail(tab));
 
+    // A second start also fails: the held mail is re-delivered through send()
+    // and re-parked. The completionOnly marker must survive that round trip.
+    manager.send(tab, "try again");
+    await waitFor(() => manager.hasHeldMail(tab) && failuresLeft === 0);
+
     manager.retire(tab); // provider switch retires the failed key
     expect(journal.pending(tab)).toHaveLength(1); // its token came back
 
-    // Next start: held mail replays, and the journal replays the completion.
+    // Next start succeeds: held mail replays, and the journal replays the
+    // completion. The completion's text must appear exactly once.
     manager.send(tab, "hello again");
     await waitFor(() => healthy.turns.length >= 1);
     healthy.finishTurn();

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -432,6 +432,40 @@ describe("run completion across automatic goal continuation (#468)", () => {
     expect(journal.outstanding(tab)).toHaveLength(1);
   });
 
+  it("a completion survives an agent whose self-restart loop GAVE UP", async () => {
+    // The give-up branch of settle() only unmapped the agent — its still-unread
+    // queue died with it, leaving the journal entry `handed_off`, a state
+    // deliverPending() skips. Silent, permanent loss.
+    let starts = 0;
+    const flappy: AgentBackend = {
+      id: "claude" as const,
+      capabilities: CLAUDE_CAPABILITIES,
+      // A session that ends immediately, every time, without reading the channel.
+      // eslint-disable-next-line require-yield
+      async *run(): AsyncGenerator<AgentEvent> {
+        starts += 1;
+        return;
+      },
+      async interrupt() {},
+      async listModels() {
+        return [];
+      },
+    };
+    const { journal, manager, arrive } = makeHarness(flappy);
+    const tab = "tab-gaveup";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "go");
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "gaveup.png" }] });
+    await waitFor(() => journal.pending(tab).length === 0); // taken onto the doomed queue
+    await waitFor(() => starts >= 4, 5000); // the bounded restart loop gives up
+
+    // Held for the next start, with its token intact — not stranded handed_off.
+    await waitFor(() => manager.hasHeldMail(tab), 5000);
+    expect(journal.outstanding(tab)).toHaveLength(1);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false);
+  });
+
   it("a replayed completion never satisfies a DIFFERENT run", async () => {
     const backend = new ContinuationBackend();
     const { journal, manager, arrive } = makeHarness(backend);
@@ -668,27 +702,43 @@ describe("run completion journal correlation (#468)", () => {
     expect(journal.outstanding("wf:dest")).toHaveLength(0);
   });
 
-  it("an identical ID-LESS completion re-sent is not delivered twice", () => {
+  it("an identical ID-LESS completion re-sent while still journaled collapses onto one entry", () => {
     // With no prompt id there is no run identity, so content is the only
-    // evidence of sameness. A re-sent frame must not produce a second turn —
-    // UNDETERMINED labelling doesn't stop the agent double-reporting.
+    // evidence of sameness. While BOTH copies are undelivered, collapsing them
+    // cannot lose news the agent already has — so a re-sent frame must not
+    // produce two turns.
     const payload = { kind: "executed", images: [{ filename: "mystery_0001.png" }] };
     const first = journal.record("t", { ...payload });
     expect(first).not.toBeNull();
-    expect(journal.record("t", { ...payload })).toBe(first); // collapses while journaled
+    expect(journal.record("t", { ...payload })).toBe(first);
     expect(journal.pending("t")).toHaveLength(1);
 
-    journal.deliverPending("t", () => true);
-    journal.ack(first!.token);
-    // …and still suppressed after the ack, when no entry survives to collapse on.
-    expect(journal.record("t", { ...payload })).toBeNull();
-    expect(journal.pending("t")).toHaveLength(0);
-
-    // A DIFFERENT id-less render is still delivered.
+    // A DIFFERENT id-less render is still its own entry.
     expect(
       journal.record("t", { kind: "executed", images: [{ filename: "other_0002.png" }] }),
     ).not.toBeNull();
-    expect(journal.pending("t")).toHaveLength(1);
+    expect(journal.pending("t")).toHaveLength(2);
+  });
+
+  it("an ID-LESS completion matching an ALREADY-DELIVERED one is FLAGGED, never swallowed", () => {
+    // Identical content is not proof of identity — ComfyUI reuses temp output
+    // names across a restart — so suppressing here could silently lose a second
+    // real render. Deliver it, flagged, and let the agent decide.
+    const payload = { kind: "executed", images: [{ filename: "ComfyUI_temp_00001_.png" }] };
+    const first = journal.record("t", { ...payload });
+    journal.deliverPending("t", () => true);
+    journal.ack(first!.token);
+
+    const again = journal.record("t", { ...payload });
+    expect(again).not.toBeNull(); // NOT swallowed
+    expect(again!.possibleRepeat).toBe(true);
+    const seen: CompletionPayload[] = [];
+    journal.deliverPending("t", (p) => {
+      seen.push(p);
+      return true;
+    });
+    expect(seen[0].possible_repeat).toBe(true);
+    expect(seen[0].run_correlation).toBe("unidentified");
   });
 
   it("the id-less content memo moves with a tab-id migration", () => {
@@ -697,7 +747,30 @@ describe("run completion journal correlation (#468)", () => {
     journal.deliverPending("tmp:draft", () => true);
     journal.ack(entry!.token);
     journal.moveKey("tmp:draft", "wf:saved.json");
-    expect(journal.record("wf:saved.json", { ...payload })).toBeNull();
+    const again = journal.record("wf:saved.json", { ...payload });
+    expect(again!.possibleRepeat).toBe(true); // the memo followed the tab
+  });
+
+  it("teardown hand-backs are UNBOUNDED — only turns that ran count toward the settle bound", () => {
+    // A completion queued behind a busy turn can survive several ordinary
+    // provider/session replacements before anything drains that queue. Those
+    // hand-backs must never settle it: nobody read it.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const entry = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    for (let i = 0; i < 10; i++) {
+      journal.deliverPending("t", () => true);
+      journal.release(entry!.token); // teardown: uncarried
+    }
+    expect(journal.outstanding("t")).toHaveLength(1);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false);
+
+    // A turn that RAN and ended without a provable ack is the cycle that IS
+    // bounded — three of those settle it rather than replay forever.
+    for (let i = 0; i < 3; i++) {
+      journal.deliverPending("t", () => true);
+      journal.release(entry!.token, { carried: true });
+    }
+    expect(journal.outstanding("t")).toHaveLength(0);
   });
 
   it("moveKey carries the delivered memo and the eviction counter, not just the entries", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -839,6 +839,29 @@ describe("run completion journal correlation (#468)", () => {
     expect(third!.correlation.status).toBe("foreign");
   });
 
+  it("a REUSED id never COALESCES — B's completion gets its own entry, so A's ack can't take it", () => {
+    // Coalescing assumes the prompt id identifies one run; `reused` is exactly
+    // the state where that is void. Merging B into A's entry would return A's
+    // entry for B, leave A's text in the already-queued turn, and let A's ack
+    // remove the sole entry — B never delivered. Duplicate over loss.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    journal.openRun(PROMPT_A, { tabId: "t" }); // ComfyUI reused the id
+    expect(journal.ticketFor(PROMPT_A)?.reused).toBe(true);
+
+    const late = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run A (late)" });
+    journal.deliverPending("t", () => true); // A handed off, unread
+
+    const real = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run B (real)" });
+    expect(real).not.toBeNull();
+    expect(real!.token).not.toBe(late!.token); // its OWN entry, never merged
+    expect(real!.payload.note).toBe("run B (real)");
+
+    // A's turn ends: it takes only its own entry with it.
+    journal.ack(late!.token);
+    expect(journal.pending("t")).toHaveLength(1);
+    expect(journal.pending("t")[0].payload.note).toBe("run B (real)");
+  });
+
   it("re-queuing a prompt id SUPERSEDES the old entry — the old result can't answer for the new run", () => {
     // Prompt-id reuse while the previous completion is still in an agent's queue.
     // Merging into that entry would hand the OLD result over as the NEW run's

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -585,6 +585,42 @@ describe("run completion across automatic goal continuation (#468)", () => {
     expect(journal.outstanding(tab)[0].carriedReleases ?? 0).toBe(0); // …unbounded
   });
 
+  it("a failed start never HOLDS a completion — it goes back to the journal", async () => {
+    // Held mail is unbounded and the journal's revocation only reaches a LIVE
+    // agent's queue, so a completion parked in held mail is a copy the journal
+    // can no longer cap: each failed-start/retry cycle would strand another
+    // batch, and the pile eventually drains into one turn. The journal is their
+    // record, so they are handed back instead — and the user's own message is
+    // still held.
+    const doomed: AgentBackend = {
+      id: "claude" as const,
+      capabilities: CLAUDE_CAPABILITIES,
+      async prepare() {
+        throw new Error("endpoint rejected the key (http 401)");
+      },
+      // eslint-disable-next-line require-yield
+      async *run(): AsyncGenerator<AgentEvent> {
+        throw new Error("never runs");
+      },
+      async interrupt() {},
+      async listModels() {
+        return [];
+      },
+    };
+    const { journal, manager, arrive } = makeHarness(doomed);
+    const tab = "tab-no-held-completions";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "keep me"); // a real user message
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "held.png" }] });
+    await waitFor(() => journal.pending(tab).length === 0); // taken by the doomed agent
+    await waitFor(() => manager.hasHeldMail(tab)); // …the USER message is held
+
+    // The completion came straight back to the journal, replayable and capped.
+    expect(journal.pending(tab)).toHaveLength(1);
+    expect(journal.outstanding(tab)).toHaveLength(1);
+  });
+
   it("a completion survives an agent whose self-restart loop GAVE UP", async () => {
     // The give-up branch of settle() only unmapped the agent — its still-unread
     // queue died with it, leaving the journal entry `handed_off`, a state
@@ -1393,22 +1429,34 @@ describe("run completion journal correlation (#468)", () => {
     expect(journal.outstanding("wf:dest")).toHaveLength(0);
   });
 
-  it("an identical ID-LESS completion re-sent while still journaled collapses onto one entry", () => {
-    // With no prompt id there is no run identity, so content is the only
-    // evidence of sameness. While BOTH copies are undelivered, collapsing them
-    // cannot lose news the agent already has — so a re-sent frame must not
-    // produce two turns.
+  it("an identical ID-LESS completion is NEVER merged — it gets its own entry, flagged", () => {
+    // For an id-less completion "a twin nobody has seen yet" is not
+    // establishable: there is no id, and ComfyUI reuses temp output names, so
+    // same-tab/same-content/both-pending is exactly the state two genuinely
+    // different renders present. Merging there would delete one of them. So the
+    // collapse is gone entirely — the last surviving suppression.
     const payload = { kind: "executed", images: [{ filename: "mystery_0001.png" }] };
     const first = journal.record("t", { ...payload });
-    expect(first).not.toBeNull();
-    expect(journal.record("t", { ...payload })).toBe(first);
-    expect(journal.pending("t")).toHaveLength(1);
+    expect(first.possibleRepeat).toBeUndefined(); // nothing preceded it
 
-    // A DIFFERENT id-less render is still its own entry.
-    expect(
-      journal.record("t", { kind: "executed", images: [{ filename: "other_0002.png" }] }),
-    ).not.toBeNull();
+    const second = journal.record("t", { ...payload });
+    expect(second.token).not.toBe(first.token); // its OWN entry
+    expect(second.possibleRepeat).toBe(true); // …flagged, so it isn't double-counted
     expect(journal.pending("t")).toHaveLength(2);
+
+    // Both reach the agent, and the second says so.
+    const seen: CompletionPayload[] = [];
+    journal.deliverPending("t", (p) => {
+      seen.push(p);
+      return true;
+    });
+    expect(seen).toHaveLength(2);
+    expect(seen[0].possible_repeat).toBeUndefined();
+    expect(seen[1].possible_repeat).toBe(true);
+
+    // A DIFFERENT id-less render is its own entry, and NOT flagged.
+    const other = journal.record("t", { kind: "executed", images: [{ filename: "other_0002.png" }] });
+    expect(other.possibleRepeat).toBeUndefined();
   });
 
   it("an ID-LESS twin is NEVER merged into an entry that is already handed off", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -756,15 +756,23 @@ describe("run completion journal correlation (#468)", () => {
     expect(journal.droppedFor("t")).toBe(1);
   });
 
-  it("a re-sent completion does NOT re-arm a hand-off (no duplicate delivery)", () => {
+  it("a re-sent completion never RE-ARMS the handed-off copy (it gets its own entry instead)", () => {
+    // The original hand-off must not be re-armed: its text is already in a turn,
+    // so re-arming would deliver that same text twice off one entry and leave the
+    // second delivery untracked. It gets a separate entry instead — the
+    // deliberate duplicate-over-loss trade, since merging into committed text is
+    // how a newer completion gets deleted by an older one's ack.
     journal.openRun(PROMPT_A, { tabId: "t" });
-    journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    const first = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
     journal.deliverPending("t", () => true); // handed off, not yet acked
     expect(journal.pending("t")).toHaveLength(0);
-    // The panel re-sends the same completion — it must not queue a second copy.
-    journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "resend" });
-    expect(journal.pending("t")).toHaveLength(0);
-    expect(journal.outstanding("t")).toHaveLength(1);
+
+    const resend = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "resend" });
+    expect(resend!.token).not.toBe(first!.token);
+    expect(journal.outstanding("t")).toHaveLength(2);
+    // …and the first entry is untouched: still handed off, still its own payload.
+    expect(journal.outstanding("t")[0].state).toBe("handed_off");
+    expect(journal.outstanding("t")[0].payload.note).toBeUndefined();
   });
 
   it("evicting a still-pending completion is COUNTED and reported on the next delivery", () => {
@@ -860,6 +868,46 @@ describe("run completion journal correlation (#468)", () => {
     journal.ack(late!.token);
     expect(journal.pending("t")).toHaveLength(1);
     expect(journal.pending("t")[0].payload.note).toBe("run B (real)");
+  });
+
+  it("NEVER coalesces onto a handed-off entry — the rule that closes every ordering", () => {
+    // The correctness rule is a property of the TARGET'S CURRENT STATE, so it
+    // holds with no knowledge of history: no reuse, no eviction, nothing marked.
+    // A handed-off entry's text is committed to a turn that will ack and delete
+    // it, so merging newer news into it loses that news.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const first = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "first" });
+    journal.deliverPending("t", () => true); // handed off, unread, unacked
+    expect(first!.ambiguousId).toBeUndefined(); // no marking involved at all
+
+    const second = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "second" });
+    expect(second!.token).not.toBe(first!.token);
+
+    journal.ack(first!.token); // the queued turn ends
+    expect(journal.pending("t")).toHaveLength(1);
+    expect(journal.pending("t")[0].payload.note).toBe("second");
+  });
+
+  it("the eviction-BEFORE-reuse ordering cannot lose the new run either", () => {
+    // The ordering no marking scheme could cover: A's ticket is evicted BEFORE
+    // the id is reused, so B takes the fresh-ticket path and nothing anywhere
+    // knows the id is ambiguous. The `pending` predicate closes it regardless.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const late = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run A (late)" });
+    journal.deliverPending("t", () => true); // handed off, unread
+
+    for (let i = 0; i < 80; i++) journal.openRun(`later-${i}`, { tabId: "t" }); // evict A's ticket
+    expect(journal.ticketFor(PROMPT_A)).toBeUndefined();
+
+    journal.openRun(PROMPT_A, { tabId: "t" }); // B reuses the id — a FRESH ticket
+    expect(journal.ticketFor(PROMPT_A)?.reused).toBeUndefined(); // nothing marked
+    const real = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run B (real)" });
+    expect(real!.token).not.toBe(late!.token);
+
+    journal.ack(late!.token);
+    expect(journal.pending("t")).toHaveLength(1);
+    expect(journal.pending("t")[0].payload.note).toBe("run B (real)");
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false); // B still outstanding
   });
 
   it("the no-coalesce rule survives the reused TICKET being evicted", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -537,6 +537,32 @@ describe("run completion across automatic goal continuation (#468)", () => {
     expect(journal.outstanding(tab)).toHaveLength(1); // returned, not lost
   });
 
+  it("an unmarked straggler RESULT never counts as carried, so it can't settle an unseen completion", async () => {
+    // #728 lets unmarked events past the dead-letter gate. On a marker-declaring
+    // backend such a result may belong to an abandoned turn and arrive while the
+    // replacement turn is still pre-submission — three of those must not walk the
+    // settle bound and retire a completion nobody ever received.
+    const silent = new MarkerBackend({ silentTurns: true });
+    const { journal, manager, arrive } = makeHarness(silent);
+    const tab = "tab-straggler-bound";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "go");
+    await waitFor(() => silent.turns.length >= 1);
+    silent.emit({ type: "result", ok: true, subtype: "success", turn: 1 });
+
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "unseen.png" }] });
+    await waitFor(() => silent.turns.length >= 2); // dispatched, no events for it
+
+    for (let i = 0; i < 4; i++) {
+      silent.emit({ type: "result", ok: false, subtype: "error_during_execution" }); // UNMARKED
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    expect(journal.outstanding(tab)).toHaveLength(1); // never settled
+    expect(journal.outstanding(tab)[0].carriedReleases ?? 0).toBe(0);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false);
+  });
+
   it("a turn the backend never RECEIVED is released UNCARRIED — it can't count toward the bound", async () => {
     // The token is attached at dispatch, but Claude resolves output images before
     // submitting the turn. Aborting in that window means the model never saw the

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -1137,6 +1137,26 @@ describe("run completion journal correlation (#468)", () => {
     expect(seen[0].dropped_completions).toBe(lost);
   });
 
+  it("an eviction REVOKES the queued copy, so the agent's queue stays bounded with the journal", () => {
+    // The journal's cap bounds the journal; the agent's QUEUE owns the payload.
+    // Evicting only the record left the text queued forever, so a panel resending
+    // in a loop grew that queue without limit — and it all drains into one turn,
+    // starving the genuine completion.
+    const queued = new Set<string>();
+    journal.setRevoker((_key, token) => queued.delete(token));
+    for (let i = 0; i < 60; i++) {
+      const e = journal.record("t", { kind: "executed", prompt_id: `p-${i}` });
+      journal.deliverPending("t", (_p, token) => {
+        queued.add(token);
+        return true;
+      });
+      void e;
+    }
+    // The journal is capped… and so is what the agent is actually holding.
+    expect(journal.outstanding("t").length).toBeLessThanOrEqual(32);
+    expect(queued.size).toBe(journal.outstanding("t").length);
+  });
+
   it("an eviction disclosure never lands on a HANDED-OFF entry that can't report it", () => {
     // deliverPending only reads PENDING entries. Stamping the count on a
     // handed-off one attaches the warning to text already queued (nobody will

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -902,12 +902,48 @@ describe("run completion journal correlation (#468)", () => {
     journal.openRun(PROMPT_A, { tabId: "t" }); // B reuses the id — a FRESH ticket
     expect(journal.ticketFor(PROMPT_A)?.reused).toBeUndefined(); // nothing marked
     const real = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run B (real)" });
+    expect(real).not.toBeNull();
     expect(real!.token).not.toBe(late!.token);
 
     journal.ack(late!.token);
     expect(journal.pending("t")).toHaveLength(1);
     expect(journal.pending("t")[0].payload.note).toBe("run B (real)");
     expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false); // B still outstanding
+  });
+
+  it("an older generation's PENDING entry is never merged into by a newer run", () => {
+    // Both entries are `pending`, so the state predicate alone permits the merge
+    // — identity is what forbids it. A's completion arrived with no agent to
+    // take it; its ticket is then evicted and the id re-queued for B. Merging
+    // would overwrite A's result with B's and leave the survivor stamped with
+    // A's generation, so its ack could settle neither run.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const a = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run A" });
+    expect(journal.pending("t")).toHaveLength(1); // never handed off
+
+    for (let i = 0; i < 80; i++) journal.openRun(`later-${i}`, { tabId: "t" }); // evict A's ticket
+    journal.openRun(PROMPT_A, { tabId: "t" }); // B reuses the id — fresh generation
+
+    const b = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run B" });
+    expect(b!.token).not.toBe(a!.token); // separate entries, both deliverable
+    expect(journal.pending("t")).toHaveLength(2);
+    expect(journal.pending("t").map((e) => e.payload.note)).toEqual(["run A", "run B"]);
+  });
+
+  it("an older generation's ack cannot write a memo that suppresses the newer run", () => {
+    // A is handed off; A's ticket is evicted; B reuses the id; THEN A's carrying
+    // turn ends. A's ack must not leave a proof that swallows B's real result.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const a = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run A" });
+    journal.deliverPending("t", () => true); // A handed off, unread
+
+    for (let i = 0; i < 80; i++) journal.openRun(`later-${i}`, { tabId: "t" }); // evict A's ticket
+    journal.openRun(PROMPT_A, { tabId: "t" }); // B reuses the id — fresh generation
+    journal.ack(a!.token); // A's turn ends AFTER B was queued
+
+    const b = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run B" });
+    expect(b).not.toBeNull(); // NOT suppressed by A's memo
+    expect(b!.payload.note).toBe("run B");
   });
 
   it("the no-coalesce rule survives the reused TICKET being evicted", () => {
@@ -1017,29 +1053,33 @@ describe("run completion journal correlation (#468)", () => {
     expect(seen[0].dropped_completions).toBe(lost);
   });
 
-  it("a very late resend is still suppressed after the bounded memo has aged out", () => {
-    // The delivered memo is FIFO-capped, so a busy tab ages it out. The run
-    // TICKET's `settled` flag is the second, longer-lived record of "we already
-    // reported this run" — either one must suppress a resend.
+  it("a resend is suppressed for as long as the run's IDENTITY survives, then reported as undetermined", () => {
+    // Suppression is keyed by ticket GENERATION, so it lasts exactly as long as
+    // the identity that makes "we already reported THIS run" a true statement.
     journal.openRun(PROMPT_A, { tabId: "t" });
     const entry = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
     journal.deliverPending("t", () => true);
     journal.ack(entry!.token);
     expect(journal.ticketFor(PROMPT_A)?.settled).toBe(true);
+    expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A })).toBeNull(); // resend: suppressed
 
-    // Flood with REAL runs (openRun + completion + ack), so the ticket map
-    // overflows too — the settled ticket is evicted preferentially, which is
-    // exactly the window where the proof used to disappear.
+    // Flood with REAL runs so the ticket map overflows and this run's identity
+    // is evicted. Past that point the journal genuinely cannot tell a resend
+    // from a first delivery for an id it no longer knows.
     for (let i = 0; i < 200; i++) {
       journal.openRun(`flood-${i}`, { tabId: "t" });
       const e = journal.record("t", { kind: "executed", prompt_id: `flood-${i}` });
       journal.deliverPending("t", () => true);
       journal.ack(e!.token);
     }
-    // Its ticket is long gone (tickets are the smaller bound, and settled ones
-    // are evicted first) — the memo is what must outlive it.
     expect(journal.ticketFor(PROMPT_A)).toBeUndefined();
-    expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A })).toBeNull();
+
+    // Delivered again rather than swallowed — and honestly, as UNDETERMINED.
+    // Duplicate over loss: the alternative is a generation-blind memo, which is
+    // what used to suppress a genuinely NEW run that reused the id.
+    const late = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    expect(late).not.toBeNull();
+    expect(late!.correlation.status).toBe("foreign");
   });
 
   it("an eviction disclosure survives a hand-off that is never consumed", () => {
@@ -1088,12 +1128,16 @@ describe("run completion journal correlation (#468)", () => {
       journal.ack(e!.token);
     }
     expect(journal.ticketFor(PROMPT_A)).toBeUndefined(); // evicted, so this is a FRESH ticket
-    expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A })).toBeNull(); // resend: suppressed
 
     journal.openRun(PROMPT_A, { tabId: "t" }); // ComfyUI reused the id for a NEW run
     const second = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
     expect(second).not.toBeNull();
+    // A FRESH ticket is a new generation, so the older run's memo cannot reach
+    // it: the new run is matched and delivered as its own.
     expect(second!.correlation.status).toBe("matched");
+    journal.deliverPending("t", () => true);
+    journal.ack(second!.token);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(true); // ITS ticket, settled by ITS ack
   });
 
   it("a stall/rewind abandon is CARRIED, so a freezing backend can't replay forever", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -946,6 +946,41 @@ describe("run completion journal correlation (#468)", () => {
     expect(b!.payload.note).toBe("run B");
   });
 
+  it("a FRESH ticket after eviction also retires the older run's queued completion", () => {
+    // The retire/downgrade pass used to run only on the reopen path. After an
+    // eviction the same id takes the fresh-ticket path, so an older `matched`
+    // entry survived untouched and went on telling the agent "this is the run
+    // YOU queued" — letting run A's output be acted on as run B's.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const a = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run A" });
+    expect(a!.correlation.status).toBe("matched");
+
+    for (let i = 0; i < 80; i++) journal.openRun(`later-${i}`, { tabId: "t" }); // evict A's ticket
+    expect(journal.ticketFor(PROMPT_A)).toBeUndefined();
+
+    journal.openRun(PROMPT_A, { tabId: "t" }); // B takes the FRESH-ticket path
+    expect(a!.correlation.status).toBe("foreign"); // A downgraded…
+    expect(a!.superseded).toBe(true); // …and retired
+  });
+
+  it("two foreign completions sharing a prompt id are BOTH delivered", () => {
+    // Generation 0 means "this tab never queued that id", so it is a bucket
+    // shared by every foreign completion — not an identity. Two genuinely
+    // different external renders that reuse a prompt id (a ComfyUI restart does
+    // exactly that) must not merge, and the second must not be suppressed after
+    // the first is acked.
+    const first = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "external 1" });
+    expect(first!.correlation.status).toBe("foreign");
+    const second = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "external 2" });
+    expect(second!.token).not.toBe(first!.token); // never merged
+    expect(journal.pending("t")).toHaveLength(2);
+
+    journal.deliverPending("t", () => true);
+    journal.ack(first!.token);
+    const third = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "external 3" });
+    expect(third).not.toBeNull(); // never suppressed by the first's ack
+  });
+
   it("the no-coalesce rule survives the reused TICKET being evicted", () => {
     // Tickets are the smallest bound (64) and evictable. If ambiguity were read
     // only from the live ticket, 64 later runs would make the incoming side

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -164,8 +164,10 @@ function makeHarness(backend: AgentBackend) {
     onEventDelivered: (_key: string, tokens: string[]) => {
       for (const t of tokens) journal.ack(t);
     },
-    onEventUndelivered: (key: string, tokens: string[]) => {
-      for (const t of tokens) journal.release(t);
+    // Mirrors index.ts exactly, INCLUDING the `carried` flag — a harness that
+    // drops it would silently exercise the unbounded path.
+    onEventUndelivered: (key: string, tokens: string[], opts?: { carried?: boolean }) => {
+      for (const t of tokens) journal.release(t, { carried: opts?.carried === true });
       flush(key);
     },
     onAgentReady: (key: string) => flush(key),
@@ -504,6 +506,28 @@ describe("run completion across automatic goal continuation (#468)", () => {
     // …and the completion appears EXACTLY ONCE. Stripping only the token left a
     // second, token-less copy of this text behind in the preserved mail.
     expect(all.split("leak.png").length - 1).toBe(1);
+  });
+
+  it("a rewind hands its completion back as CARRIED (bounded, not an infinite replay)", async () => {
+    // A turn abandoned by a rewind (and, by the same wiring, by the stall
+    // watchdog) must return the completion it was carrying — but as a CARRIED
+    // release, or an agent that keeps abandoning turns would be handed the same
+    // completion on every turn forever.
+    const backend = new ContinuationBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+    const tab = "tab-rewind-carried";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "go");
+    await waitFor(() => backend.turns.length >= 1);
+    backend.finishTurn();
+
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "rewound.png" }] });
+    await waitFor(() => backend.turns.length >= 2); // turn 2 carries it
+
+    manager.rewind(tab, null); // abandons the in-flight turn
+    await waitFor(() => (journal.outstanding(tab)[0]?.carriedReleases ?? 0) >= 1);
+    expect(journal.outstanding(tab)).toHaveLength(1); // returned, not lost
   });
 
   it("a completion survives an agent whose self-restart loop GAVE UP", async () => {
@@ -856,6 +880,41 @@ describe("run completion journal correlation (#468)", () => {
     const carrier = journal.outstanding("t")[0];
     journal.ack(carrier.token);
     expect(journal.droppedFor("t")).toBe(0);
+  });
+
+  it("a prompt id reused AFTER its ticket was evicted still delivers the new run's completion", () => {
+    // The memo outlives the ticket by design, so a reuse can take the
+    // FRESH-ticket path with a stale memo still standing. `panel_run` promises
+    // automatic delivery for that new run — the memo must not swallow it.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const first = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    journal.deliverPending("t", () => true);
+    journal.ack(first!.token);
+    for (let i = 0; i < 200; i++) {
+      journal.openRun(`flood-${i}`, { tabId: "t" });
+      const e = journal.record("t", { kind: "executed", prompt_id: `flood-${i}` });
+      journal.deliverPending("t", () => true);
+      journal.ack(e!.token);
+    }
+    expect(journal.ticketFor(PROMPT_A)).toBeUndefined(); // evicted, so this is a FRESH ticket
+    expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A })).toBeNull(); // resend: suppressed
+
+    journal.openRun(PROMPT_A, { tabId: "t" }); // ComfyUI reused the id for a NEW run
+    const second = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    expect(second).not.toBeNull();
+    expect(second!.correlation.status).toBe("matched");
+  });
+
+  it("a stall/rewind abandon is CARRIED, so a freezing backend can't replay forever", () => {
+    // Both auto-repeat, so an unbounded release there is an infinite replay
+    // source. Three dispatched-and-abandoned turns settle it instead.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const entry = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    for (let i = 0; i < 3; i++) {
+      journal.deliverPending("t", () => true);
+      journal.release(entry!.token, { carried: true });
+    }
+    expect(journal.outstanding("t")).toHaveLength(0);
   });
 
   it("hasOutstanding reports any undelivered completion (the self-restart gate)", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -671,9 +671,13 @@ describe("run completion journal correlation (#468)", () => {
       return true;
     });
     expect(seen[0].dropped_completions).toBe(lost);
-    // Reported once, then cleared — later deliveries don't re-report it.
-    expect(journal.droppedFor("t")).toBe(0);
+    // Carried by the entry it rode out on, so only THAT one reports it…
     expect(seen[1]?.dropped_completions).toBeUndefined();
+    // …and it is spent only when that entry's carrying turn ends (a hand-off is
+    // not consumption — see the replay test below).
+    expect(journal.droppedFor("t")).toBe(lost);
+    journal.ack(journal.outstanding("t")[0].token);
+    expect(journal.droppedFor("t")).toBe(0);
   });
 
   it("freezes the correlation at arrival — a run opened later can never claim it", () => {
@@ -730,6 +734,11 @@ describe("run completion journal correlation (#468)", () => {
     expect(fresh!.token).not.toBe(old!.token); // its OWN entry, not a merge
     expect(journal.pending("t")).toHaveLength(1);
 
+    // …and it is DOWNGRADED: it may still be delivered (it is a real result) but
+    // never as "the run YOU queued", which would present run A's output as the
+    // awaited outcome of run B.
+    expect(old!.correlation.status).toBe("foreign");
+
     // The old entry's turn ends: it must NOT settle the reopened ticket, and must
     // NOT memoize the id as delivered (which would suppress run B's completion).
     journal.ack(old!.token);
@@ -767,6 +776,37 @@ describe("run completion journal correlation (#468)", () => {
       return true;
     });
     expect(seen[0].dropped_completions).toBe(lost);
+  });
+
+  it("an eviction disclosure survives a hand-off that is never consumed", () => {
+    // A hand-off is not consumption. If the agent holding the warning is stopped
+    // before its turn runs, the replay must carry the warning again — clearing it
+    // at hand-off left the eviction permanently undisclosed.
+    journal.record("t", { kind: "executed", prompt_id: "keeper" });
+    for (let i = 0; i < 40; i++) journal.record("t", { kind: "executed", prompt_id: `e-${i}` });
+    const lost = journal.droppedFor("t");
+    expect(lost).toBeGreaterThan(0);
+
+    const first: CompletionPayload[] = [];
+    journal.deliverPending("t", (p) => {
+      first.push(p);
+      return true;
+    });
+    expect(first[0].dropped_completions).toBe(lost);
+
+    // The agent died before reading it → released → replayed.
+    for (const e of journal.outstanding("t")) journal.release(e.token);
+    const again: CompletionPayload[] = [];
+    journal.deliverPending("t", (p) => {
+      again.push(p);
+      return true;
+    });
+    expect(again[0].dropped_completions).toBe(lost); // still disclosed
+
+    // Only the carrying turn ENDING spends it.
+    const carrier = journal.outstanding("t")[0];
+    journal.ack(carrier.token);
+    expect(journal.droppedFor("t")).toBe(0);
   });
 
   it("hasOutstanding reports any undelivered completion (the self-restart gate)", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -862,6 +862,29 @@ describe("run completion journal correlation (#468)", () => {
     expect(journal.pending("t")[0].payload.note).toBe("run B (real)");
   });
 
+  it("the no-coalesce rule survives the reused TICKET being evicted", () => {
+    // Tickets are the smallest bound (64) and evictable. If ambiguity were read
+    // only from the live ticket, 64 later runs would make the incoming side
+    // forget — and the next ambiguous completion would merge into the earlier
+    // one, whose ack then removes the sole entry. The mark lives on the ENTRY,
+    // which outlives the ticket.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    journal.openRun(PROMPT_A, { tabId: "t" }); // reused
+    const late = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run A (late)" });
+    expect(late!.ambiguousId).toBe(true);
+    journal.deliverPending("t", () => true); // handed off, unread
+
+    // Evict the reused ticket with 64+ later runs.
+    for (let i = 0; i < 80; i++) journal.openRun(`later-${i}`, { tabId: "t" });
+    expect(journal.ticketFor(PROMPT_A)).toBeUndefined();
+
+    const real = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run B (real)" });
+    expect(real!.token).not.toBe(late!.token); // still its OWN entry
+    journal.ack(late!.token);
+    expect(journal.pending("t")).toHaveLength(1);
+    expect(journal.pending("t")[0].payload.note).toBe("run B (real)");
+  });
+
   it("re-queuing a prompt id SUPERSEDES the old entry — the old result can't answer for the new run", () => {
     // Prompt-id reuse while the previous completion is still in an agent's queue.
     // Merging into that entry would hand the OLD result over as the NEW run's

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -354,6 +354,40 @@ describe("run completion journal correlation (#468)", () => {
     expect(journal.correlate("tmp:draft", { prompt_id: PROMPT_A }).status).toBe("foreign");
   });
 
+  it("closeRuns drops the tab's tickets but KEEPS its arrived completions", () => {
+    // New chat / switch to a historical session: the conversation that queued the
+    // run is gone, so a render it queued must not be introduced to the
+    // replacement agent as "the run YOU queued".
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const arrived = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    journal.closeRuns("t");
+    expect(journal.ticketFor(PROMPT_A)).toBeUndefined();
+    expect(journal.correlate("t", { prompt_id: PROMPT_A }).status).toBe("foreign");
+    // …but a completion that already arrived is still deliverable, with the
+    // verdict frozen at ITS arrival.
+    expect(journal.pending("t")).toHaveLength(1);
+    expect(arrived?.correlation.status).toBe("matched");
+  });
+
+  it("a completion re-sent AFTER its delivery was acked is suppressed, not delivered twice", () => {
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const entry = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    journal.deliverPending("t", () => true);
+    journal.ack(entry!.token); // the carrying turn ended — entry is gone
+    expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A })).toBeNull();
+    expect(journal.pending("t")).toHaveLength(0);
+  });
+
+  it("evicting a HANDED-OFF completion is counted too — a hand-off is not proof of consumption", () => {
+    for (let i = 0; i < 32; i++) journal.record("t", { kind: "executed", prompt_id: `h-${i}` });
+    journal.deliverPending("t", () => true); // all handed off, none acked
+    expect(journal.droppedFor("t")).toBe(0);
+    // One more arrival pushes the oldest handed-off entry out. If its agent dies
+    // before reading it, `release` would have nothing to re-arm — so it counts.
+    journal.record("t", { kind: "executed", prompt_id: "h-overflow" });
+    expect(journal.droppedFor("t")).toBe(1);
+  });
+
   it("a re-sent completion does NOT re-arm a hand-off (no duplicate delivery)", () => {
     journal.openRun(PROMPT_A, { tabId: "t" });
     journal.record("t", { kind: "executed", prompt_id: PROMPT_A });

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -432,6 +432,71 @@ describe("run completion across automatic goal continuation (#468)", () => {
     expect(journal.outstanding(tab)).toHaveLength(1);
   });
 
+  it("retire() removes the completion from held mail, not just its token", async () => {
+    // retire() PRESERVES held mail on purpose. Stripping only the token left the
+    // event's TEXT in that mail: switching Claude→Codex handed the journal token
+    // to Codex (delivered, correctly), and switching BACK to Claude re-delivered
+    // the retained text as an ordinary user message — no token, no flag,
+    // indistinguishable from a real second completion.
+    const doomed: AgentBackend = {
+      id: "claude" as const,
+      capabilities: CLAUDE_CAPABILITIES,
+      async prepare() {
+        throw new Error("endpoint rejected the key (http 401)");
+      },
+      // eslint-disable-next-line require-yield
+      async *run(): AsyncGenerator<AgentEvent> {
+        throw new Error("never runs");
+      },
+      async interrupt() {},
+      async listModels() {
+        return [];
+      },
+    };
+    // Fails the FIRST start (parking the queue in held mail), then works — so the
+    // held mail is genuinely re-delivered and we can count what the agent saw.
+    const healthy = new ContinuationBackend();
+    let firstStart = true;
+    const flaky: AgentBackend = {
+      id: "claude" as const,
+      capabilities: CLAUDE_CAPABILITIES,
+      async prepare() {
+        if (firstStart) {
+          firstStart = false;
+          throw new Error("endpoint rejected the key (http 401)");
+        }
+      },
+      run: (o) => healthy.run(o),
+      async interrupt() {},
+      async listModels() {
+        return [];
+      },
+    };
+    const { journal, manager, arrive } = makeHarness(flaky);
+    const tab = "tab-retire-textleak";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "keep me"); // an ordinary user message must SURVIVE
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "leak.png" }] });
+    await waitFor(() => journal.pending(tab).length === 0); // taken by the doomed agent
+    await waitFor(() => manager.hasHeldMail(tab));
+
+    manager.retire(tab); // provider switch retires the failed key
+    expect(journal.pending(tab)).toHaveLength(1); // its token came back
+
+    // Next start: held mail replays, and the journal replays the completion.
+    manager.send(tab, "hello again");
+    await waitFor(() => healthy.turns.length >= 1);
+    healthy.finishTurn();
+    await new Promise((r) => setTimeout(r, 30));
+
+    const all = healthy.turns.join("\n");
+    expect(all).toContain("keep me"); // the user's message survived
+    // …and the completion appears EXACTLY ONCE. Stripping only the token left a
+    // second, token-less copy of this text behind in the preserved mail.
+    expect(all.split("leak.png").length - 1).toBe(1);
+  });
+
   it("a completion survives an agent whose self-restart loop GAVE UP", async () => {
     // The give-up branch of settle() only unmapped the agent — its still-unread
     // queue died with it, leaving the journal entry `handed_off`, a state
@@ -718,6 +783,28 @@ describe("run completion journal correlation (#468)", () => {
       journal.record("t", { kind: "executed", images: [{ filename: "other_0002.png" }] }),
     ).not.toBeNull();
     expect(journal.pending("t")).toHaveLength(2);
+  });
+
+  it("an ID-LESS twin is NEVER merged into an entry that is already handed off", () => {
+    // The collapse is only safe while BOTH copies are undelivered. A
+    // `handed_off` entry is sitting unread in a busy agent's queue and will be
+    // acked when its turn ends — merging a second real render into it would
+    // delete the second render outright, with no flag. That is a silent swallow,
+    // the exact hazard the design splits to avoid.
+    const payload = { kind: "executed", images: [{ filename: "ComfyUI_temp_00001_.png" }] };
+    const first = journal.record("t", { ...payload });
+    journal.deliverPending("t", () => true); // handed off, still unread + unacked
+    expect(journal.pending("t")).toHaveLength(0);
+
+    const second = journal.record("t", { ...payload });
+    expect(second).not.toBeNull();
+    expect(second!.token).not.toBe(first!.token); // its OWN entry
+    expect(second!.possibleRepeat).toBe(true); // …and flagged
+    expect(journal.pending("t")).toHaveLength(1);
+
+    // Acking the first must not take the second with it.
+    journal.ack(first!.token);
+    expect(journal.outstanding("t")).toHaveLength(1);
   });
 
   it("an ID-LESS completion matching an ALREADY-DELIVERED one is FLAGGED, never swallowed", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -88,6 +88,51 @@ class ContinuationBackend implements AgentBackend {
   }
 }
 
+/**
+ * A MARKER-STAMPING backend (like Claude): every turn's events carry the turn's
+ * marker, and the test drives the event stream by hand so a straggler from an
+ * abandoned turn can be injected at will.
+ */
+class MarkerBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turns: string[] = [];
+  private sink: ((ev: AgentEvent) => void) | null = null;
+  private queued: AgentEvent[] = [];
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    let wake: (() => void) | null = null;
+    this.sink = (ev) => {
+      this.queued.push(ev);
+      const w = wake;
+      wake = null;
+      w?.();
+    };
+    void (async () => {
+      for await (const turn of opts.channel) {
+        this.turns.push((turn as { text?: string }).text ?? "");
+        // Mark the turn as producing SOME stamped output, so the agent learns
+        // this backend stamps markers (exactly what Claude does).
+        this.sink?.({ type: "assistant", text: "", turn: this.turns.length } as AgentEvent);
+      }
+    })();
+    for (;;) {
+      while (this.queued.length) yield this.queued.shift()!;
+      await new Promise<void>((resolve) => {
+        wake = resolve;
+      });
+    }
+  }
+
+  emit(ev: AgentEvent): void {
+    this.sink?.(ev);
+  }
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
 /** Wires a manager to a journal exactly as the orchestrator does (index.ts's
  *  flushRunCompletions / onEventDelivered / onEventUndelivered / onAgentReady),
  *  through the journal's own deliverPending so no delivery logic is duplicated. */
@@ -197,6 +242,34 @@ describe("run completion across automatic goal continuation (#468)", () => {
     await waitFor(() => backend.turns.length >= 3);
     expect(backend.turns[2]).toContain("kept_0001.png");
     expect(backend.turns[2]).toContain("RE-DELIVERED");
+  });
+
+  it("a traceless straggler result does NOT ack the current turn's completion", async () => {
+    // #728 lets an UNMARKED result through the dead-letter guard for gate
+    // liveness. On a marker-stamping backend that result may belong to an
+    // abandoned earlier turn, so it must not retire a completion the CURRENT
+    // turn is carrying — otherwise a turn that then stalls has nothing to
+    // hand back and the completion is gone.
+    const backend = new MarkerBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+    const tab = "tab-straggler";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "go");
+    await waitFor(() => backend.turns.length >= 1);
+    backend.emit({ type: "result", ok: true, subtype: "success", turn: 1 });
+
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "carried.png" }] });
+    await waitFor(() => backend.turns.length >= 2); // turn 2 carries the completion
+
+    // An unmarked straggler from the abandoned turn 1 arrives.
+    backend.emit({ type: "result", ok: false, subtype: "error_during_execution" });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(journal.outstanding(tab)).toHaveLength(1); // NOT acked
+
+    // Turn 2's own (marked) result is what acks it.
+    backend.emit({ type: "result", ok: true, subtype: "success", turn: 2 });
+    await waitFor(() => journal.outstanding(tab).length === 0);
   });
 
   it("reports an uncorrelatable completion as UNDETERMINED instead of swallowing it", async () => {
@@ -354,19 +427,21 @@ describe("run completion journal correlation (#468)", () => {
     expect(journal.correlate("tmp:draft", { prompt_id: PROMPT_A }).status).toBe("foreign");
   });
 
-  it("closeRuns drops the tab's tickets but KEEPS its arrived completions", () => {
+  it("closeRuns keeps the arrived completions but DOWNGRADES them to undetermined", () => {
     // New chat / switch to a historical session: the conversation that queued the
     // run is gone, so a render it queued must not be introduced to the
-    // replacement agent as "the run YOU queued".
+    // replacement agent as "the run YOU queued" — neither a future completion
+    // nor one already sitting undelivered in the journal.
     journal.openRun(PROMPT_A, { tabId: "t" });
     const arrived = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    expect(arrived?.correlation.status).toBe("matched");
     journal.closeRuns("t");
     expect(journal.ticketFor(PROMPT_A)).toBeUndefined();
     expect(journal.correlate("t", { prompt_id: PROMPT_A }).status).toBe("foreign");
-    // …but a completion that already arrived is still deliverable, with the
-    // verdict frozen at ITS arrival.
+    // Still deliverable — never swallowed — but no longer claimed as ours. A
+    // correlation may only ever weaken, never strengthen.
     expect(journal.pending("t")).toHaveLength(1);
-    expect(arrived?.correlation.status).toBe("matched");
+    expect(journal.pending("t")[0].correlation.status).toBe("foreign");
   });
 
   it("a completion re-sent AFTER its delivery was acked is suppressed, not delivered twice", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -778,6 +778,50 @@ describe("run completion journal correlation (#468)", () => {
     expect(seen[0].dropped_completions).toBe(lost);
   });
 
+  it("an eviction disclosure never lands on a HANDED-OFF entry that can't report it", () => {
+    // deliverPending only reads PENDING entries. Stamping the count on a
+    // handed-off one attaches the warning to text already queued (nobody will
+    // build that payload again) and ack() then spends it: neither replayed nor
+    // disclosed. With no pending entry it must go to the side map, where the
+    // next pending delivery picks it up.
+    for (let i = 0; i < 32; i++) journal.record("t", { kind: "executed", prompt_id: `h-${i}` });
+    journal.deliverPending("t", () => true); // all handed off, none acked
+    expect(journal.pending("t")).toHaveLength(0);
+
+    journal.record("t", { kind: "executed", prompt_id: "overflow" }); // evicts one
+    const lost = journal.droppedFor("t");
+    expect(lost).toBeGreaterThan(0);
+    // No pending entry carries it…
+    expect(journal.outstanding("t").filter((e) => e.state === "handed_off" && e.disclose)).toHaveLength(0);
+    // …and the next PENDING delivery reports it.
+    const seen: CompletionPayload[] = [];
+    journal.deliverPending("t", (p) => {
+      seen.push(p);
+      return true;
+    });
+    expect(seen[0].dropped_completions).toBe(lost);
+  });
+
+  it("a very late resend is still suppressed after the bounded memo has aged out", () => {
+    // The delivered memo is FIFO-capped, so a busy tab ages it out. The run
+    // TICKET's `settled` flag is the second, longer-lived record of "we already
+    // reported this run" — either one must suppress a resend.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const entry = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    journal.deliverPending("t", () => true);
+    journal.ack(entry!.token);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(true);
+
+    // Age the memo out with a flood of other acked completions.
+    for (let i = 0; i < 300; i++) {
+      const e = journal.record("t", { kind: "executed", prompt_id: `flood-${i}` });
+      journal.deliverPending("t", () => true);
+      journal.ack(e!.token);
+    }
+    // The late resend is still recognised as already delivered.
+    expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A })).toBeNull();
+  });
+
   it("an eviction disclosure survives a hand-off that is never consumed", () => {
     // A hand-off is not consumption. If the agent holding the warning is stopped
     // before its turn runs, the replay must carry the warning again — clearing it

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -27,6 +27,7 @@ import type {
 import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
 import {
   RunCompletionJournalImpl,
+  describe as describeCorrelation,
   type CompletionPayload,
 } from "../../orchestrator/run-completion-journal.js";
 import { destinationHasCollisionState } from "../../orchestrator/session-store.js";
@@ -714,6 +715,60 @@ describe("run completion journal correlation (#468)", () => {
     expect(second!.correlation.status).toBe("matched");
   });
 
+  it("re-queuing a prompt id SUPERSEDES the old entry — the old result can't answer for the new run", () => {
+    // Prompt-id reuse while the previous completion is still in an agent's queue.
+    // Merging into that entry would hand the OLD result over as the NEW run's
+    // (its queued turn still holds the old text) and the new completion would
+    // never be delivered at all.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const old = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run A" });
+    journal.deliverPending("t", () => true); // handed off, unread, unacked
+
+    journal.openRun(PROMPT_A, { tabId: "t" }); // ComfyUI reused the id
+    const fresh = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run B" });
+    expect(fresh).not.toBeNull();
+    expect(fresh!.token).not.toBe(old!.token); // its OWN entry, not a merge
+    expect(journal.pending("t")).toHaveLength(1);
+
+    // The old entry's turn ends: it must NOT settle the reopened ticket, and must
+    // NOT memoize the id as delivered (which would suppress run B's completion).
+    journal.ack(old!.token);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false);
+    expect(journal.pending("t")).toHaveLength(1); // run B still awaits delivery
+
+    // Run B's own delivery settles it.
+    journal.deliverPending("t", () => true);
+    journal.ack(fresh!.token);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(true);
+  });
+
+  it("an eviction disclosure rides a surviving entry, so it can't be discarded before it's told", () => {
+    // The side map is bounded; a count parked there for a tab that still HAS a
+    // deliverable entry could be discarded before it was ever reported. The
+    // count now rides that entry instead.
+    journal.record("t", { kind: "executed", prompt_id: "keeper" });
+    for (let i = 0; i < 40; i++) journal.record("t", { kind: "executed", prompt_id: `e-${i}` });
+    const lost = journal.droppedFor("t");
+    expect(lost).toBeGreaterThan(0);
+    // The count must live ON a surviving entry, not in the boundable side map —
+    // that is what makes it undiscardable while the tab can still be told.
+    const carrier = journal.outstanding("t").find((e) => (e.disclose ?? 0) > 0);
+    expect(carrier).toBeDefined();
+    expect(carrier!.disclose).toBe(lost);
+    // Churn far past the side map's bound with agentless tabs; ours is untouched.
+    for (let i = 0; i < 200; i++) {
+      journal.record(`ghost-${i}`, { kind: "executed", prompt_id: `g-${i}` });
+      journal.forget(`ghost-${i}`);
+    }
+    expect(journal.droppedFor("t")).toBe(lost); // still intact
+    const seen: CompletionPayload[] = [];
+    journal.deliverPending("t", (p) => {
+      seen.push(p);
+      return true;
+    });
+    expect(seen[0].dropped_completions).toBe(lost);
+  });
+
   it("hasOutstanding reports any undelivered completion (the self-restart gate)", () => {
     expect(journal.hasOutstanding()).toBe(false);
     const entry = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
@@ -722,6 +777,26 @@ describe("run completion journal correlation (#468)", () => {
     expect(journal.hasOutstanding()).toBe(true); // handed off is NOT delivered
     journal.ack(entry!.token);
     expect(journal.hasOutstanding()).toBe(false);
+  });
+
+  it("allOutstanding names every undelivered completion, per tab, for the exit disclosure", () => {
+    // A FATAL self-exit bypasses the idle gate by design and the journal is
+    // in-memory, so these die with the process. They must be reported on the way
+    // out (per tab, naming the run) rather than silently evaporating.
+    journal.openRun(PROMPT_A, { tabId: "wf:one" });
+    journal.record("wf:one", { kind: "executed", prompt_id: PROMPT_A });
+    journal.record("wf:two", { kind: "executed", prompt_id: PROMPT_B });
+    const handed = journal.record("wf:two", { kind: "executed" });
+    journal.deliverPending("wf:two", () => true); // handed off still counts
+
+    const all = journal.allOutstanding();
+    expect(all).toHaveLength(3);
+    expect(all.filter((e) => e.key === "wf:one")).toHaveLength(1);
+    expect(all.filter((e) => e.key === "wf:two")).toHaveLength(2);
+    expect(describeCorrelation(all[0].correlation)).toContain(PROMPT_A);
+
+    journal.ack(handed!.token);
+    expect(journal.allOutstanding()).toHaveLength(2); // acked ones are gone
   });
 
   it("only the entry's OWN run is settled on ack", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -482,6 +482,25 @@ describe("run completion journal correlation (#468)", () => {
     expect(seen).toEqual([PROMPT_A]);
   });
 
+  it("moveKey carries the delivered memo and the eviction counter, not just the entries", () => {
+    // A tmp: → wf: save/rename migration must move ALL per-tab state, or a
+    // post-migration re-send is delivered twice and an eviction disclosure is
+    // silently dropped.
+    journal.openRun(PROMPT_A, { tabId: "tmp:draft" });
+    const entry = journal.record("tmp:draft", { kind: "executed", prompt_id: PROMPT_A });
+    journal.deliverPending("tmp:draft", () => true);
+    journal.ack(entry!.token);
+    for (let i = 0; i < 40; i++) journal.record("tmp:draft", { kind: "executed", prompt_id: `d-${i}` });
+    const lost = journal.droppedFor("tmp:draft");
+    expect(lost).toBeGreaterThan(0);
+
+    journal.moveKey("tmp:draft", "wf:saved.json");
+    expect(journal.droppedFor("wf:saved.json")).toBe(lost);
+    expect(journal.droppedFor("tmp:draft")).toBe(0);
+    // The re-send is still suppressed under the NEW id.
+    expect(journal.record("wf:saved.json", { kind: "executed", prompt_id: PROMPT_A })).toBeNull();
+  });
+
   it("moveKey re-addresses a tab's entries without touching anyone else's", () => {
     journal.openRun(PROMPT_A, { tabId: "old" });
     journal.record("old", { kind: "executed", prompt_id: PROMPT_A });

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -154,6 +154,10 @@ function makeHarness(backend: AgentBackend) {
     journal.deliverPending(tab, (payload, token) =>
       manager.injectEvent(tab, payload, { eventToken: token }),
     );
+  journal.setRevoker(
+    (key, token) => manager.revokeEvent(key, token),
+    (key) => void flush(key),
+  );
   const manager = new PanelAgentManager({
     mcpServers: {},
     systemAppend: "",
@@ -587,6 +591,36 @@ describe("run completion across automatic goal continuation (#468)", () => {
     await waitFor(() => manager.hasHeldMail(tab), 5000);
     expect(journal.outstanding(tab)).toHaveLength(1);
     expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false);
+  });
+
+  it("a queued completion whose id is then REUSED is pulled back and re-worded", async () => {
+    // The wording is baked in when the event is queued. If the completion is
+    // still sitting unread and its correlation then weakens (ComfyUI reused the
+    // prompt id), the stale copy would otherwise reach the agent still claiming
+    // "the run YOU queued" — letting it read run A's output as run B's result.
+    const backend = new ContinuationBackend();
+    const { journal, manager, arrive } = makeHarness(backend);
+    const tab = "tab-reissue";
+
+    journal.openRun(PROMPT_A, { tabId: tab });
+    manager.send(tab, "go");
+    await waitFor(() => backend.turns.length >= 1); // turn 1 is HELD open
+
+    // A's completion lands while the agent is busy → queued, unread.
+    arrive(tab, { kind: "executed", prompt_id: PROMPT_A, images: [{ filename: "runA.png" }] });
+    expect(journal.outstanding(tab)[0].state).toBe("handed_off");
+
+    // ComfyUI reuses the id for run B while A's copy is still unread: the stale
+    // copy is pulled back off the queue and immediately re-queued, re-worded.
+    journal.openRun(PROMPT_A, { tabId: tab });
+    expect(journal.outstanding(tab)).toHaveLength(1); // one copy, not two
+
+    backend.finishTurn();
+    await waitFor(() => backend.turns.length >= 2);
+    const text = backend.turns[1];
+    expect(text).toContain("runA.png"); // still delivered — never swallowed
+    expect(text).not.toContain("This is the run YOU queued");
+    expect(text).toContain("UNDETERMINED");
   });
 
   it("a replayed completion never satisfies a DIFFERENT run", async () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -900,7 +900,9 @@ describe("run completion journal correlation (#468)", () => {
     expect(journal.ticketFor(PROMPT_A)).toBeUndefined();
 
     journal.openRun(PROMPT_A, { tabId: "t" }); // B reuses the id — a FRESH ticket
-    expect(journal.ticketFor(PROMPT_A)?.reused).toBeUndefined(); // nothing marked
+    // …but NOT a fresh identity: this tab already has history for the id, so the
+    // new ticket is born ambiguous and every completion for it reads UNDETERMINED.
+    expect(journal.ticketFor(PROMPT_A)?.reused).toBe(true);
     const real = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run B (real)" });
     expect(real).not.toBeNull();
     expect(real!.token).not.toBe(late!.token);
@@ -908,7 +910,7 @@ describe("run completion journal correlation (#468)", () => {
     journal.ack(late!.token);
     expect(journal.pending("t")).toHaveLength(1);
     expect(journal.pending("t")[0].payload.note).toBe("run B (real)");
-    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false); // B still outstanding
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false); // A's ack settles nothing
   });
 
   it("an older generation's PENDING entry is never merged into by a newer run", () => {
@@ -979,6 +981,32 @@ describe("run completion journal correlation (#468)", () => {
     journal.ack(first!.token);
     const third = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "external 3" });
     expect(third).not.toBeNull(); // never suppressed by the first's ack
+  });
+
+  it("a late resend of an ACKED run cannot settle — nor suppress — the run that reused its id", () => {
+    // The nastiest ordering: A completes and is fully acked; A's ticket is
+    // evicted; B reuses the id. A's late resend is byte-identical to B's
+    // completion, so treating the new ticket as a clean identity meant the
+    // resend correlated as B, its ack SETTLED B, and B's real completion was
+    // then suppressed by B's own settled flag — misattribution and loss.
+    journal.openRun(PROMPT_A, { tabId: "t" });
+    const a = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run A" });
+    journal.deliverPending("t", () => true);
+    journal.ack(a!.token); // A fully delivered and settled
+
+    for (let i = 0; i < 80; i++) journal.openRun(`later-${i}`, { tabId: "t" }); // evict A's ticket
+    journal.openRun(PROMPT_A, { tabId: "t" }); // B reuses the id
+
+    const resend = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "A resend" });
+    expect(resend).not.toBeNull();
+    expect(resend!.correlation.status).toBe("foreign"); // cannot claim to be B
+    journal.deliverPending("t", () => true);
+    journal.ack(resend!.token);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(false); // B is NOT answered
+
+    const real = journal.record("t", { kind: "executed", prompt_id: PROMPT_A, note: "run B" });
+    expect(real).not.toBeNull(); // B's own completion still lands
+    expect(real!.payload.note).toBe("run B");
   });
 
   it("the no-coalesce rule survives the reused TICKET being evicted", () => {
@@ -1151,7 +1179,9 @@ describe("run completion journal correlation (#468)", () => {
   it("a prompt id reused AFTER its ticket was evicted still delivers the new run's completion", () => {
     // The memo outlives the ticket by design, so a reuse can take the
     // FRESH-ticket path with a stale memo still standing. `panel_run` promises
-    // automatic delivery for that new run — the memo must not swallow it.
+    // automatic delivery for that new run — the memo must not swallow it. And
+    // because this tab already has history for the id, the new ticket is born
+    // ambiguous: delivered, but honestly, as UNDETERMINED.
     journal.openRun(PROMPT_A, { tabId: "t" });
     const first = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
     journal.deliverPending("t", () => true);
@@ -1165,14 +1195,16 @@ describe("run completion journal correlation (#468)", () => {
     expect(journal.ticketFor(PROMPT_A)).toBeUndefined(); // evicted, so this is a FRESH ticket
 
     journal.openRun(PROMPT_A, { tabId: "t" }); // ComfyUI reused the id for a NEW run
+    expect(journal.ticketFor(PROMPT_A)?.reused).toBe(true); // history ⇒ ambiguous
     const second = journal.record("t", { kind: "executed", prompt_id: PROMPT_A });
+    // DELIVERED — the older run's memo never reaches it — but as UNDETERMINED,
+    // because a late resend of the older run is indistinguishable from this one.
     expect(second).not.toBeNull();
-    // A FRESH ticket is a new generation, so the older run's memo cannot reach
-    // it: the new run is matched and delivered as its own.
-    expect(second!.correlation.status).toBe("matched");
+    expect(second!.correlation.status).toBe("foreign");
+    // …and a further completion for the id is not suppressed by this one's ack.
     journal.deliverPending("t", () => true);
     journal.ack(second!.token);
-    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(true); // ITS ticket, settled by ITS ack
+    expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A })).not.toBeNull();
   });
 
   it("a stall/rewind abandon is CARRIED, so a freezing backend can't replay forever", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -812,13 +812,18 @@ describe("run completion journal correlation (#468)", () => {
     journal.ack(entry!.token);
     expect(journal.ticketFor(PROMPT_A)?.settled).toBe(true);
 
-    // Age the memo out with a flood of other acked completions.
-    for (let i = 0; i < 300; i++) {
+    // Flood with REAL runs (openRun + completion + ack), so the ticket map
+    // overflows too — the settled ticket is evicted preferentially, which is
+    // exactly the window where the proof used to disappear.
+    for (let i = 0; i < 200; i++) {
+      journal.openRun(`flood-${i}`, { tabId: "t" });
       const e = journal.record("t", { kind: "executed", prompt_id: `flood-${i}` });
       journal.deliverPending("t", () => true);
       journal.ack(e!.token);
     }
-    // The late resend is still recognised as already delivered.
+    // Its ticket is long gone (tickets are the smaller bound, and settled ones
+    // are evicted first) — the memo is what must outlive it.
+    expect(journal.ticketFor(PROMPT_A)).toBeUndefined();
     expect(journal.record("t", { kind: "executed", prompt_id: PROMPT_A })).toBeNull();
   });
 

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -62,6 +62,24 @@ export interface AgentCapabilities {
   /** Accepts inline image input in a user turn (vision). When false, image refs
    *  the panel sends are ignored by the backend (text-only). */
   vision: boolean;
+  /**
+   * Stamps the #728 TURN MARKER (`AgentEvent.turn`) on the events it emits for a
+   * submitted turn. DECLARED, never inferred: #468's run-completion ack requires
+   * knowing up front whether an UNMARKED `result` could be a straggler from an
+   * abandoned turn. Inferring it from "have I seen a marker yet" is unsound while
+   * still unlearned — a zero-output turn's traceless terminal arrives before the
+   * replacement turn stamps anything, and would falsely ack (and destroy the
+   * replay of) a completion the replacement turn is carrying.
+   *
+   * true  → an unmarked result never acks a completion; the carrying turn's own
+   *         marked result does (an unmarked one hands the tokens back instead).
+   * false → a legacy/third-party backend that never stamps; unmarked results ack,
+   *         the pre-#468 behavior.
+   *
+   * Optional so an out-of-tree backend that omits it is treated as non-stamping,
+   * which is the conservative reading for something that also never dead-letters.
+   */
+  turnMarkers?: boolean;
 }
 
 /**
@@ -228,6 +246,7 @@ export const CLAUDE_CAPABILITIES: AgentCapabilities = {
   slashCommands: true,
   hooks: true,
   vision: true, // resolves image refs to inline base64 blocks (shapeTurn)
+  turnMarkers: true, // claude-backend stamps every event from the #745 per-turn trace FIFO
 };
 
 /** Capability descriptor for the Codex app-server backend (Phase 2). */
@@ -241,6 +260,7 @@ export const CODEX_CAPABILITIES: AgentCapabilities = {
   slashCommands: false,
   hooks: false,
   vision: true, // gpt-5.5 sees images; delivered as `localImage` turn input items
+  turnMarkers: true, // stampTurn() wraps each per-turn stream
 };
 
 /** Capability descriptor for the Gemini CLI ACP backend (Agent Client Protocol).
@@ -258,6 +278,7 @@ export const GEMINI_CAPABILITIES: AgentCapabilities = {
   slashCommands: false,
   hooks: false,
   vision: true, // gemini-2.5 sees images; delivered as inline base64 image ContentBlocks
+  turnMarkers: true, // stampTurn() wraps each per-turn stream
 };
 
 /** Capability descriptor for the Antigravity CLI backend (`agy`, issue #262) —
@@ -278,6 +299,7 @@ export const ANTIGRAVITY_CAPABILITIES: AgentCapabilities = {
   slashCommands: false,
   hooks: false,
   vision: false, // no documented image input in -p mode
+  turnMarkers: true, // stampTurn() wraps each per-turn stream
 };
 
 /** Capability descriptor for the pi.dev CLI backend (`pi`, issue #491) — the
@@ -299,6 +321,7 @@ export const PI_CAPABILITIES: AgentCapabilities = {
   slashCommands: false,
   hooks: false,
   vision: false, // no documented headless image input
+  turnMarkers: true, // stampTurn() wraps each per-turn stream
 };
 
 /** Capability descriptor for the Grok CLI ACP backend (xAI / Grok Build).
@@ -314,6 +337,7 @@ export const GROK_CAPABILITIES: AgentCapabilities = {
   slashCommands: false,
   hooks: false,
   vision: true,
+  turnMarkers: true, // stampTurn() wraps each per-turn stream
 };
 
 /** Capability descriptor for the Ollama local-LLM backend (issue #97's panel
@@ -336,6 +360,7 @@ export const OLLAMA_CAPABILITIES: AgentCapabilities = {
   slashCommands: false,
   hooks: false,
   vision: true, // attempted for every model; graceful strip-and-retry on rejection
+  turnMarkers: true, // stampTurn() wraps each per-turn stream
 };
 
 /** ChatGPT subscription via direct Codex OAuth (~/.codex/auth.json) — Codex Responses
@@ -350,6 +375,7 @@ export const CHATGPT_CAPABILITIES: AgentCapabilities = {
   slashCommands: false,
   hooks: false,
   vision: true, // Responses input_image data URLs; strip-and-retry on rejection (#218)
+  turnMarkers: true, // stampTurn() wraps each per-turn stream
 };
 
 /** Kimi Code subscription OAuth or KIMI_API_KEY — OpenAI-compatible coding API. */

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -1319,6 +1319,11 @@ const GROK_DIRECT_CAPABILITIES = {
   slashCommands: false,
   hooks: false,
   vision: false, // the 6-tool router is text-only (mirrors Ollama/ChatGPT); NeutralTurn.images unused here
+  // This adapter DOES stamp turn markers (see stampTurn in run() below), so it
+  // must say so: #468's run-completion ack trusts the declaration, and a backend
+  // that stamps but declares otherwise would let an unmarked straggler ack a
+  // completion it never carried. Declaration and behavior must not disagree.
+  turnMarkers: true,
 };
 
 /** Direct-token Grok (xAI) backend — see the module-level comment above for the

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2105,17 +2105,28 @@ export async function runPanelOrchestrator(): Promise<void> {
    * silently evaporates. Best-effort and never throws — this runs on the way out.
    */
   function reportLostCompletionsOnExit(): void {
+    const byTab = new Map<string, string[]>();
     try {
-      const byTab = new Map<string, string[]>();
       for (const entry of RunCompletions.allOutstanding()) {
         const list = byTab.get(entry.key) ?? [];
         list.push(describeCorrelation(entry.correlation));
         byTab.set(entry.key, list);
       }
+    } catch {
+      return; // nothing readable — nothing to report
+    }
+    // LOG FIRST, unconditionally. The chat push below can only reach a CONNECTED
+    // tab (an offline one's frame lands in the bridge's missedFrames buffer, which
+    // dies with the process moments later), and `bridge` may not even exist yet on
+    // a very early fatal. The log is the record that always survives — it is what
+    // a user or maintainer has after the respawn.
+    for (const [panelTab, runs] of byTab) {
+      logger.error(
+        `[panel-orchestrator] tab ${panelTab.slice(0, 8)} — self-exit with ${runs.length} undelivered run completion(s), outcome UNDETERMINED: ${runs.join("; ")}`,
+      );
+    }
+    try {
       for (const [panelTab, runs] of byTab) {
-        logger.error(
-          `[panel-orchestrator] tab ${panelTab.slice(0, 8)} — self-exit with ${runs.length} undelivered run completion(s): ${runs.join("; ")}`,
-        );
         bridge.push(
           {
             type: "say",
@@ -2129,7 +2140,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       }
     } catch (err) {
       logger.warn(
-        `[panel-orchestrator] could not report lost completions on exit: ${err instanceof Error ? err.message : String(err)}`,
+        `[panel-orchestrator] could not push the lost-completion notice (the log above is the record): ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2795,13 +2795,24 @@ export async function runPanelOrchestrator(): Promise<void> {
           // different provider. Purging first means there is nothing to hand
           // back. Read-only pre-pass over the same predicate the loop uses, so
           // the two can't disagree about what counts as a collision.
+          // #468 CRITICAL — a tab holding ONLY a journal entry is NOT empty. Its
+          // agent and durable session may both be gone (New chat) while an
+          // undelivered completion for its render is still addressed to it;
+          // without counting that the destination reads as unoccupied, the source
+          // is rebound onto its id, and the next flush hands the DESTINATION
+          // tab's render to the SOURCE tab's conversation.
+          const destinationJournaled = RunCompletions.outstanding(panelTab).length;
           const destinationHadState = [...KNOWN_BACKENDS].some((b) =>
             destinationHasCollisionState({
               hasManagerState: manager.hasAnyState(panelTab + AGENT_KEY_SEP + b),
               hasDurableSession: sessionStore.get(panelTab + AGENT_KEY_SEP + b) !== undefined,
               renderHeldCount: heldDuringGen.get(panelTab + AGENT_KEY_SEP + b)?.length ?? 0,
+              journaledCompletionCount: destinationJournaled,
             }),
           );
+          // PURGE, never inherit: the destination's completions belong to the tab
+          // being superseded, and there is no agent left to deliver them to.
+          // forget() logs each one, so the loss is disclosed, not silent.
           if (destinationHadState) RunCompletions.forget(panelTab);
           for (const b of KNOWN_BACKENDS) {
             const srcKey = migratedFrom + AGENT_KEY_SEP + b;
@@ -2825,6 +2836,11 @@ export async function runPanelOrchestrator(): Promise<void> {
                 hasManagerState: manager.hasAnyState(newKey),
                 hasDurableSession: sessionStore.get(newKey) !== undefined,
                 renderHeldCount: heldDuringGen.get(newKey)?.length ?? 0,
+                // #468 — journal state is per PANEL TAB, not per backend, so the
+                // same count applies to every provider's key. Counted BEFORE the
+                // pre-pass purge above so a journal-only destination still drives
+                // the per-backend reset + the bridge-queue drop below.
+                journaledCompletionCount: destinationJournaled,
               })
             ) {
               destinationCollision = true;

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -9,7 +9,16 @@
 // panel-agent.ts). Each agent runs on the user's Claude SUBSCRIPTION with no API
 // key. See docs/design/panel-orchestrator.md.
 
-import { existsSync, mkdirSync, writeFileSync, unlinkSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+  unlinkSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeSync,
+} from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir, homedir, networkInterfaces } from "node:os";
 import { dirname, join } from "node:path";
@@ -2132,15 +2141,24 @@ export async function runPanelOrchestrator(): Promise<void> {
     } catch {
       return; // nothing readable — nothing to report
     }
-    // LOG FIRST, unconditionally. The chat push below can only reach a CONNECTED
-    // tab (an offline one's frame lands in the bridge's missedFrames buffer, which
-    // dies with the process moments later), and `bridge` may not even exist yet on
-    // a very early fatal. The log is the record that always survives — it is what
-    // a user or maintainer has after the respawn.
+    // LOG FIRST, unconditionally, and SYNCHRONOUSLY. This is the durable half of
+    // the disclosure: the chat push below can only reach a CONNECTED tab (an
+    // offline one's frame lands in the bridge's missedFrames buffer, which dies
+    // with the process moments later), and `bridge` may not even exist yet on a
+    // very early fatal.
+    //
+    // `writeSync` on fd 2, not the logger: `process.stderr.write` is async when
+    // stderr is a pipe (the normal case under the ComfyUI launcher), so a
+    // `process.exit()` immediately after can terminate with the record still
+    // queued and never written. Since the whole in-memory-journal tradeoff rests
+    // on "the disclosure always happens", the write it rests on must block.
     for (const [panelTab, runs] of byTab) {
-      logger.error(
-        `[panel-orchestrator] tab ${panelTab.slice(0, 8)} — self-exit with ${runs.length} undelivered run completion(s), outcome UNDETERMINED: ${runs.join("; ")}`,
-      );
+      const line = `[panel-orchestrator] tab ${panelTab.slice(0, 8)} — exiting with ${runs.length} undelivered run completion(s), outcome UNDETERMINED: ${runs.join("; ")}`;
+      try {
+        writeSync(2, `${line}\n`);
+      } catch {
+        logger.error(line); // fd 2 unavailable — best-effort through the logger
+      }
     }
     try {
       for (const [panelTab, runs] of byTab) {
@@ -5214,8 +5232,16 @@ export async function runPanelOrchestrator(): Promise<void> {
       // No lockfile / unreadable — nothing to clean up.
     }
   };
+  /** The single in-flight teardown, so repeated signals queue behind it. */
+  let teardownOnce: Promise<void> | null = null;
   const shutdown = async () => {
-    await teardownCore();
+    // RE-ENTRANT SAFE (#468). teardownCore's `shuttingDown` flag makes a second
+    // call return IMMEDIATELY, so a repeated SIGTERM used to race straight past
+    // the in-flight teardown to process.exit() — skipping the undelivered-
+    // completion disclosure the first one had not reached yet. Memoize the
+    // teardown promise so every later signal AWAITS the first one instead.
+    teardownOnce ??= teardownCore();
+    await teardownOnce;
     process.exit(0);
   };
   process.on("SIGINT", shutdown);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2165,14 +2165,18 @@ export async function runPanelOrchestrator(): Promise<void> {
           `[panel-orchestrator] tab ${panelTab.slice(0, 8)} — exiting with ${runs.length} undelivered run completion(s), outcome UNDETERMINED: ${runs.join("; ")}`,
       )
       .join("\n");
-    // Try each SYNCHRONOUS sink in turn — stderr, stdout, then a file beside the
-    // lockfile. The async logger is the last resort only: on the
-    // uncaughtException path `process.exit(1)` follows immediately, so anything
-    // merely queued would be dropped.
+    // FILE FIRST. A synchronous write to a PIPE can block indefinitely if its
+    // reader has stalled — and blocking here blocks the event loop, so Node can't
+    // even dispatch the repeated SIGTERM that is supposed to force the exit: the
+    // process becomes unkillable through its handled signals. A regular file
+    // always makes progress, so it is the durable sink; the console sinks are
+    // tried only if it is unavailable (e.g. a very early fatal where `lockPath`
+    // doesn't exist yet). The async logger below adds console visibility without
+    // ever blocking.
     const sinks: Array<() => void> = [
+      () => appendFileSync(`${lockPath}.lost-completions.log`, `${new Date().toISOString()} ${record}\n`),
       () => writeSync(2, `${record}\n`),
       () => writeSync(1, `${record}\n`),
-      () => appendFileSync(`${lockPath}.lost-completions.log`, `${new Date().toISOString()} ${record}\n`),
     ];
     let recorded = false;
     for (const write of sinks) {
@@ -2184,7 +2188,13 @@ export async function runPanelOrchestrator(): Promise<void> {
         /* try the next sink */
       }
     }
-    if (!recorded) logger.error(record); // every synchronous sink failed
+    // Console visibility, always — non-blocking, so it can never wedge the exit.
+    // When the file sink took the record this is a convenience; when nothing did,
+    // it is the last chance.
+    logger.error(record);
+    if (!recorded) {
+      logger.error("[panel-orchestrator] …and no synchronous sink accepted that record (it may not survive)");
+    }
     try {
       for (const [panelTab, runs] of byTab) {
         bridge.push(
@@ -4157,11 +4167,9 @@ export async function runPanelOrchestrator(): Promise<void> {
         // the blind gate removed on arrival. `null` = the panel re-sent a
         // completion this tab was already given; suppressed, never duplicated.
         const entry = RunCompletions.record(event.tab_id, evForTab as CompletionPayload);
-        if (entry) {
-          logger.info(
-            `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} run completion for ${describeCorrelation(entry.correlation)}`,
-          );
-        }
+        logger.info(
+          `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} run completion for ${describeCorrelation(entry.correlation)}${entry.possibleRepeat ? " (flagged as a possible repeat)" : ""}`,
+        );
         flushRunCompletions(event.tab_id);
         return;
       }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -794,6 +794,13 @@ export async function runPanelOrchestrator(): Promise<void> {
     logger.error(
       `[panel-orchestrator] self-exit (${why}) — closing the bridge so a fresh orchestrator can take over.`,
     );
+    // #468 — a fatal self-exit deliberately BYPASSES the idle gate (the whole
+    // point is to collapse a wedged orchestrator), and the journal is in-memory,
+    // so any undelivered run completion dies here. It must not die SILENTLY:
+    // tell each affected tab, in the panel chat, exactly which runs it will never
+    // be told about, so the user (and the agent that resumes after the respawn)
+    // treats them as UNDETERMINED instead of still-pending.
+    reportLostCompletionsOnExit();
     if (runShutdown) {
       runShutdown();
     } else {
@@ -2088,6 +2095,45 @@ export async function runPanelOrchestrator(): Promise<void> {
    * onto its queue — the entry stays in the journal until the turn that carried
    * it ends (onEventDelivered), which is what makes it survive a restart.
    */
+  /**
+   * Last-ditch disclosure before the process dies (#468).
+   *
+   * The self-exit paths (agent-fatal, a never-handshaking probe) skip the idle
+   * gate on purpose, and the journal does not survive the process — so a
+   * completion still journaled here is genuinely lost. Say so, per tab, naming
+   * the run: an UNDETERMINED outcome the user can act on beats a promise that
+   * silently evaporates. Best-effort and never throws — this runs on the way out.
+   */
+  function reportLostCompletionsOnExit(): void {
+    try {
+      const byTab = new Map<string, string[]>();
+      for (const entry of RunCompletions.allOutstanding()) {
+        const list = byTab.get(entry.key) ?? [];
+        list.push(describeCorrelation(entry.correlation));
+        byTab.set(entry.key, list);
+      }
+      for (const [panelTab, runs] of byTab) {
+        logger.error(
+          `[panel-orchestrator] tab ${panelTab.slice(0, 8)} — self-exit with ${runs.length} undelivered run completion(s): ${runs.join("; ")}`,
+        );
+        bridge.push(
+          {
+            type: "say",
+            text:
+              `⚠️ The agent backend is being restarted, and ${runs.length} finished render result(s) could not be delivered ` +
+              `(${runs.join("; ")}). Their outcome is UNDETERMINED from the agent's point of view — ask it to check ` +
+              `\`get_history\` for those runs once it reconnects rather than assuming it saw them.`,
+          },
+          panelTab,
+        );
+      }
+    } catch (err) {
+      logger.warn(
+        `[panel-orchestrator] could not report lost completions on exit: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
   function flushRunCompletions(panelTabId: string): void {
     const key = agentKeyFor(panelTabId);
     const { blockedOn } = RunCompletions.deliverPending(panelTabId, (payload, token) =>

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2086,6 +2086,16 @@ export async function runPanelOrchestrator(): Promise<void> {
   // spawned after a ComfyUI restart/reconnect.
   liveManager = manager;
 
+  // #468 — let the journal pull a still-unread completion back off an agent's
+  // queue when it has to WEAKEN that completion's correlation (a reused prompt
+  // id, a replaced conversation). The wording is baked in at queue time, so
+  // without this the stale copy would still reach the agent claiming to be the
+  // run it queued. Only ever removes an injected `completionOnly` item.
+  RunCompletions.setRevoker(
+    (panelTabId, token) => manager.revokeEvent(agentKeyFor(panelTabId), token),
+    (panelTabId) => flushRunCompletions(panelTabId),
+  );
+
   /**
    * Deliver every journaled run completion for a panel tab (#468).
    *

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2787,11 +2787,6 @@ export async function runPanelOrchestrator(): Promise<void> {
           // have a LIVE agent (a provider switch retires the others), so at most one rebind is a
           // live-agent move; the rest are durable-only.
           let destinationCollision = false;
-          // #468 — PROVEN same workflow, new tab id: the journal is keyed by
-          // panel tab, so one move re-addresses every undelivered completion for
-          // every provider. Re-addressing only — never broadening: entries for
-          // other tabs are untouched, and their frozen correlation is unchanged.
-          RunCompletions.moveKey(migratedFrom, panelTab);
           for (const b of KNOWN_BACKENDS) {
             const srcKey = migratedFrom + AGENT_KEY_SEP + b;
             const newKey = panelTab + AGENT_KEY_SEP + b;
@@ -2836,6 +2831,20 @@ export async function runPanelOrchestrator(): Promise<void> {
           // panelTab; the incoming source's in-flight work is under migratedFrom (its canonical id
           // at send time) and is untouched, so the proven migration's own continuity is preserved.
           if (destinationCollision) bridge.dropQueuedDeliveries(panelTab);
+          // #468 — same ordering for the run-completion journal, and for the same
+          // reason. FIRST forget the superseded destination's completions + run
+          // tickets (its conversation is a lost resume; delivering its renders to
+          // the incoming tab would be exactly the cross-run misattribution the
+          // journal exists to prevent), THEN re-address the incoming tab's own
+          // ones onto the new id. The order matters: moveKey first would make the
+          // migrated entries indistinguishable from the destination's and forget
+          // would take both.
+          if (destinationCollision) RunCompletions.forget(panelTab);
+          RunCompletions.moveKey(migratedFrom, panelTab);
+          // rebindAgent MOVES the agent rather than spawning one, so onAgentReady
+          // never fires for the new id — flush explicitly or the re-addressed
+          // entries would sit pending until some unrelated later trigger.
+          flushRunCompletions(panelTab);
           // #570 — carry the PROVEN source identity forward as the tab's prior identity. The
           // rebound agent belongs to it (prevIdentity === newIdentity by sameWorkflow), but the
           // new tab id has no prior identity and the agent may have no durable record yet

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -779,6 +779,10 @@ export async function runPanelOrchestrator(): Promise<void> {
     logger.error(
       `[panel-orchestrator] FATAL uncaught exception — exiting so a fresh orchestrator can take over: ${err.stack ?? err.message}`,
     );
+    // #468 — this path exits without any teardown, so record whatever run
+    // completions die with it. Log-only by construction (see the function): a
+    // crash is no time to await a bridge write.
+    reportLostCompletionsOnExit();
     process.exit(1);
   });
 
@@ -2104,7 +2108,10 @@ export async function runPanelOrchestrator(): Promise<void> {
    * the run: an UNDETERMINED outcome the user can act on beats a promise that
    * silently evaporates. Best-effort and never throws — this runs on the way out.
    */
+  let lostCompletionsReported = false;
   function reportLostCompletionsOnExit(): void {
+    if (lostCompletionsReported) return; // every exit path calls this; report once
+    lostCompletionsReported = true;
     const byTab = new Map<string, string[]>();
     try {
       for (const entry of RunCompletions.allOutstanding()) {
@@ -5158,6 +5165,12 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (shuttingDown) return;
     shuttingDown = true;
     logger.info("[panel-orchestrator] shutting down — stopping agents…");
+    // #468 — EVERY exit path discloses, not just the fatal self-exit: an ordinary
+    // SIGTERM/SIGINT teardown destroys the in-memory journal just as thoroughly.
+    // Runs BEFORE stopAll() so the still-live agents' tabs are still routable for
+    // the chat notice. Idempotent (reportLostCompletionsOnExit no-ops the second
+    // time), so the self-exit path calling it first is harmless.
+    reportLostCompletionsOnExit();
     selfRestarter?.stop();
     clearInterval(downloadTimer);
     clearInterval(queueStatusTimer);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -5259,14 +5259,40 @@ export async function runPanelOrchestrator(): Promise<void> {
   };
   /** The single in-flight teardown, so repeated signals queue behind it. */
   let teardownOnce: Promise<void> | null = null;
+  /** How long a REPEATED shutdown signal waits for the in-flight teardown before
+   *  forcing the exit. Long enough for a healthy teardown to finish, short enough
+   *  that a hung one can't make the process unkillable via SIGINT/SIGTERM. */
+  const FORCED_SHUTDOWN_GRACE_MS = 3000;
   const shutdown = async () => {
     // RE-ENTRANT SAFE (#468). teardownCore's `shuttingDown` flag makes a second
     // call return IMMEDIATELY, so a repeated SIGTERM used to race straight past
     // the in-flight teardown to process.exit() — skipping the undelivered-
     // completion disclosure the first one had not reached yet. Memoize the
     // teardown promise so every later signal AWAITS the first one instead.
+    const first = teardownOnce === null;
     teardownOnce ??= teardownCore();
-    await teardownOnce;
+    // …but BOUNDED. A repeated signal is a user asking harder, and awaiting an
+    // unbounded teardown would make the process unkillable through its handled
+    // signals if anything in it hangs. The first signal waits; a later one gives
+    // the in-flight teardown a short grace and then forces the exit. The
+    // completion disclosure is unaffected either way — it runs at the TOP of
+    // teardownCore, before anything that could block.
+    if (first) {
+      await teardownOnce;
+    } else {
+      await Promise.race([
+        teardownOnce,
+        new Promise<void>((resolve) => {
+          const t = setTimeout(() => {
+            logger.warn(
+              `[panel-orchestrator] shutdown did not finish within ${FORCED_SHUTDOWN_GRACE_MS}ms of a repeated signal — forcing exit`,
+            );
+            resolve();
+          }, FORCED_SHUTDOWN_GRACE_MS);
+          t.unref?.();
+        }),
+      ]);
+    }
     process.exit(0);
   };
   process.on("SIGINT", shutdown);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -101,6 +101,11 @@ import { startPanelConsoleHttpServer, type PanelConsoleHttpServer } from "./pane
 import type { AgentBackend } from "./agent-backend.js";
 import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
 import { QueueMonitor, type StallReport } from "../services/queue-monitor.js";
+import {
+  RunCompletions,
+  describe as describeCorrelation,
+  type CompletionPayload,
+} from "./run-completion-journal.js";
 import { initRunpodWatcher, getRunpodWatcher, type RunpodStatusFrame, type RunpodAlertFrame } from "../services/runpod-watch.js";
 import { getPod } from "../services/runpod-client.js";
 import { listTargetChangeRequests, consumeTargetChange, ackTargetChange, setProgressDir, CONTROL_PREFIX, newestAttemptEpochs, isSupersededAttempt, downloadAttemptKey } from "../services/download-progress.js";
@@ -2031,6 +2036,30 @@ export async function runPanelOrchestrator(): Promise<void> {
     onAgentFatal: (tabId, reason) => {
       requestSelfExit(`tab ${tabId.slice(0, 8)} ${reason}`);
     },
+    // #468 — run-completion journal acks. `key` is the composite agent key; the
+    // journal is keyed by the PANEL TAB, so a provider switch (which retires
+    // `tab::old` and spawns `tab::new`) can never strand a completion.
+    onEventDelivered: (_key, tokens) => {
+      for (const token of tokens) RunCompletions.ack(token);
+    },
+    onEventUndelivered: (key, tokens) => {
+      for (const token of tokens) RunCompletions.release(token);
+      const panelTab = panelTabOf(key);
+      logger.warn(
+        `[panel-orchestrator] tab ${panelTab.slice(0, 8)} handed back ${tokens.length} undelivered run completion(s) — journaled for replay (#468)`,
+      );
+      // Try again immediately. When the agent is still alive (a stall-abandoned
+      // turn, a plain Stop) this re-queues the completion into its next turn;
+      // when it is going away, injectEvent refuses and the entry simply stays
+      // pending for the next spawn. The refusal path returns false WITHOUT
+      // calling back here, so this cannot recurse.
+      flushRunCompletions(panelTab);
+    },
+    // A fresh agent for this key can take mail now — replay whatever the
+    // previous one never delivered.
+    onAgentReady: (key) => {
+      flushRunCompletions(panelTabOf(key));
+    },
     sessionStore,
     // #570 P0 — bind each persisted exact session to its tab's FULL trusted workflow
     // identity (server-observed origin + per-instance uuid), so a saved workflow
@@ -2045,6 +2074,31 @@ export async function runPanelOrchestrator(): Promise<void> {
   // Let refreshEnvCapabilities() feed a freshly-gathered env block into agents
   // spawned after a ComfyUI restart/reconnect.
   liveManager = manager;
+
+  /**
+   * Deliver every journaled run completion for a panel tab (#468).
+   *
+   * Called on arrival, and again at every later delivery opportunity (a fresh
+   * agent spawn). Order is preserved and the loop STOPS at the first refusal, so
+   * a completion can never overtake an older one that is still stuck.
+   *
+   * Nothing here re-correlates: each entry carries the verdict computed when it
+   * ARRIVED, so a replay can never be re-attributed to a run that started after
+   * it landed. `injectEvent` returning true means only that the agent took it
+   * onto its queue — the entry stays in the journal until the turn that carried
+   * it ends (onEventDelivered), which is what makes it survive a restart.
+   */
+  function flushRunCompletions(panelTabId: string): void {
+    const key = agentKeyFor(panelTabId);
+    const { blockedOn } = RunCompletions.deliverPending(panelTabId, (payload, token) =>
+      manager.injectEvent(key, payload, { eventToken: token }),
+    );
+    if (blockedOn) {
+      logger.warn(
+        `[panel-orchestrator] tab ${panelTabId.slice(0, 8)} has no live agent for ${describeCorrelation(blockedOn.correlation)} — journaled, replayed when one comes back (#468)`,
+      );
+    }
+  }
 
   // Flag the mobile mirror picker's "session attached" (green) dot from live agents.
   bridge.setHasSessionPredicate((tabId) => manager.hasLiveAgent(agentKeyFor(tabId)));
@@ -2680,6 +2734,12 @@ export async function runPanelOrchestrator(): Promise<void> {
           // under migratedFrom would still resolve the retired workflow's tool call after the
           // switch (#570 P0). The socket is unchanged, so only queued WORK is dropped.
           bridge.dropQueuedDeliveries(migratedFrom);
+          // #468 — the old id's journaled run completions belong to the workflow
+          // being switched AWAY from. Carrying them onto an unproven-different
+          // workflow would deliver one workflow's render as another's, which is
+          // exactly the misattribution the journal exists to prevent. Drop them
+          // (logged per entry) rather than migrate them.
+          RunCompletions.forget(migratedFrom);
           manager.retire(migratedFrom + AGENT_KEY_SEP + prevBackend);
           logger.info(
             `[panel-orchestrator] same-socket re-hello ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} without proven workflow continuity — old agent retired (NOT rebound); each workflow keeps its own conversation`,
@@ -2727,6 +2787,11 @@ export async function runPanelOrchestrator(): Promise<void> {
           // have a LIVE agent (a provider switch retires the others), so at most one rebind is a
           // live-agent move; the rest are durable-only.
           let destinationCollision = false;
+          // #468 — PROVEN same workflow, new tab id: the journal is keyed by
+          // panel tab, so one move re-addresses every undelivered completion for
+          // every provider. Re-addressing only — never broadening: entries for
+          // other tabs are untouched, and their frozen correlation is unchanged.
+          RunCompletions.moveKey(migratedFrom, panelTab);
           for (const b of KNOWN_BACKENDS) {
             const srcKey = migratedFrom + AGENT_KEY_SEP + b;
             const newKey = panelTab + AGENT_KEY_SEP + b;
@@ -3909,6 +3974,21 @@ export async function runPanelOrchestrator(): Promise<void> {
       // but a mirror viewer (mobile has no Blind concept) can inject
       // agent_event frames with images onto a blinded desktop tab.
       const evForTab = blindTabs.has(event.tab_id) ? { ...ev, images: [] } : ev;
+      // #468 — a RUN COMPLETION is a promise `panel_run` made ("end your turn,
+      // you WILL be notified"), so it goes through the journal: correlated by
+      // exact prompt id ONCE, here, and replayed until the turn that carries it
+      // ends. Other agent_event kinds (download_done) keep the old best-effort
+      // path — nothing is waiting on them the way a render is.
+      if (ev.kind === "executed") {
+        // Journal the BLIND-STRIPPED copy: a replay must not resurrect pixels
+        // the blind gate removed on arrival.
+        const entry = RunCompletions.record(event.tab_id, evForTab as CompletionPayload);
+        logger.info(
+          `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} run completion for ${describeCorrelation(entry.correlation)}`,
+        );
+        flushRunCompletions(event.tab_id);
+        return;
+      }
       const delivered = manager.injectEvent(agentKeyFor(event.tab_id), evForTab);
       if (delivered) {
         logger.info(`[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} event → agent: ${event.kind}`);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -18,6 +18,7 @@ import {
   readdirSync,
   rmSync,
   writeSync,
+  appendFileSync,
 } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir, homedir, networkInterfaces } from "node:os";
@@ -2152,14 +2153,38 @@ export async function runPanelOrchestrator(): Promise<void> {
     // `process.exit()` immediately after can terminate with the record still
     // queued and never written. Since the whole in-memory-journal tradeoff rests
     // on "the disclosure always happens", the write it rests on must block.
-    for (const [panelTab, runs] of byTab) {
-      const line = `[panel-orchestrator] tab ${panelTab.slice(0, 8)} — exiting with ${runs.length} undelivered run completion(s), outcome UNDETERMINED: ${runs.join("; ")}`;
+    // ONE write for every tab, not one per tab: a synchronous write to a full
+    // pipe blocks until its reader drains, so the smallest possible number of
+    // bytes is the right shape. (Blocking here is the deliberate cost of a
+    // guaranteed record — a stderr reader that has stopped consuming is a broken
+    // environment, and losing the disclosure would undercut the whole
+    // in-memory-journal tradeoff.)
+    const record = [...byTab]
+      .map(
+        ([panelTab, runs]) =>
+          `[panel-orchestrator] tab ${panelTab.slice(0, 8)} — exiting with ${runs.length} undelivered run completion(s), outcome UNDETERMINED: ${runs.join("; ")}`,
+      )
+      .join("\n");
+    // Try each SYNCHRONOUS sink in turn — stderr, stdout, then a file beside the
+    // lockfile. The async logger is the last resort only: on the
+    // uncaughtException path `process.exit(1)` follows immediately, so anything
+    // merely queued would be dropped.
+    const sinks: Array<() => void> = [
+      () => writeSync(2, `${record}\n`),
+      () => writeSync(1, `${record}\n`),
+      () => appendFileSync(`${lockPath}.lost-completions.log`, `${new Date().toISOString()} ${record}\n`),
+    ];
+    let recorded = false;
+    for (const write of sinks) {
       try {
-        writeSync(2, `${line}\n`);
+        write();
+        recorded = true;
+        break;
       } catch {
-        logger.error(line); // fd 2 unavailable — best-effort through the logger
+        /* try the next sink */
       }
     }
+    if (!recorded) logger.error(record); // every synchronous sink failed
     try {
       for (const [panelTab, runs] of byTab) {
         bridge.push(

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -17,7 +17,6 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
-  writeSync,
   appendFileSync,
 } from "node:fs";
 import { execFileSync } from "node:child_process";
@@ -2165,35 +2164,28 @@ export async function runPanelOrchestrator(): Promise<void> {
           `[panel-orchestrator] tab ${panelTab.slice(0, 8)} — exiting with ${runs.length} undelivered run completion(s), outcome UNDETERMINED: ${runs.join("; ")}`,
       )
       .join("\n");
-    // FILE FIRST. A synchronous write to a PIPE can block indefinitely if its
-    // reader has stalled — and blocking here blocks the event loop, so Node can't
-    // even dispatch the repeated SIGTERM that is supposed to force the exit: the
-    // process becomes unkillable through its handled signals. A regular file
-    // always makes progress, so it is the durable sink; the console sinks are
-    // tried only if it is unavailable (e.g. a very early fatal where `lockPath`
-    // doesn't exist yet). The async logger below adds console visibility without
-    // ever blocking.
-    const sinks: Array<() => void> = [
-      () => appendFileSync(`${lockPath}.lost-completions.log`, `${new Date().toISOString()} ${record}\n`),
-      () => writeSync(2, `${record}\n`),
-      () => writeSync(1, `${record}\n`),
-    ];
+    // A FILE is the ONLY synchronous sink. A sync write to a PIPE can block
+    // indefinitely when its reader has stalled, and blocking here blocks the
+    // event loop — so Node can never dispatch the repeated SIGTERM that is
+    // supposed to force the exit, and the process becomes unkillable through its
+    // handled signals. A regular file always makes progress.
+    //
+    // There is deliberately NO synchronous fallback. Ranking the two outcomes:
+    // an unkillable process is worse than a missing log line, and a stderr
+    // `writeSync` in the fallback would reintroduce exactly the hang the file
+    // sink exists to avoid. If the file write fails we accept losing the durable
+    // record and fall back to the async logger, which can never wedge the exit.
     let recorded = false;
-    for (const write of sinks) {
-      try {
-        write();
-        recorded = true;
-        break;
-      } catch {
-        /* try the next sink */
-      }
+    try {
+      appendFileSync(`${lockPath}.lost-completions.log`, `${new Date().toISOString()} ${record}\n`);
+      recorded = true;
+    } catch {
+      // No usable file (a very early fatal, a read-only dir) — console only.
     }
-    // Console visibility, always — non-blocking, so it can never wedge the exit.
-    // When the file sink took the record this is a convenience; when nothing did,
-    // it is the last chance.
+    // Console visibility, always, and always non-blocking.
     logger.error(record);
     if (!recorded) {
-      logger.error("[panel-orchestrator] …and no synchronous sink accepted that record (it may not survive)");
+      logger.error("[panel-orchestrator] …and no durable sink accepted that record (it may not survive)");
     }
     try {
       for (const [panelTab, runs] of byTab) {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2787,6 +2787,22 @@ export async function runPanelOrchestrator(): Promise<void> {
           // have a LIVE agent (a provider switch retires the others), so at most one rebind is a
           // live-agent move; the rest are durable-only.
           let destinationCollision = false;
+          // #468 — the journal purge must happen BEFORE the loop, not after it.
+          // manager.reset() inside the loop hands back any run-completion tokens
+          // parked in that provider's held mail, and the hand-back callback
+          // flushes immediately — into whatever agent currently owns panelTab,
+          // which on a collision is the SUPERSEDED destination tab's agent on a
+          // different provider. Purging first means there is nothing to hand
+          // back. Read-only pre-pass over the same predicate the loop uses, so
+          // the two can't disagree about what counts as a collision.
+          const destinationHadState = [...KNOWN_BACKENDS].some((b) =>
+            destinationHasCollisionState({
+              hasManagerState: manager.hasAnyState(panelTab + AGENT_KEY_SEP + b),
+              hasDurableSession: sessionStore.get(panelTab + AGENT_KEY_SEP + b) !== undefined,
+              renderHeldCount: heldDuringGen.get(panelTab + AGENT_KEY_SEP + b)?.length ?? 0,
+            }),
+          );
+          if (destinationHadState) RunCompletions.forget(panelTab);
           for (const b of KNOWN_BACKENDS) {
             const srcKey = migratedFrom + AGENT_KEY_SEP + b;
             const newKey = panelTab + AGENT_KEY_SEP + b;
@@ -2831,15 +2847,9 @@ export async function runPanelOrchestrator(): Promise<void> {
           // panelTab; the incoming source's in-flight work is under migratedFrom (its canonical id
           // at send time) and is untouched, so the proven migration's own continuity is preserved.
           if (destinationCollision) bridge.dropQueuedDeliveries(panelTab);
-          // #468 — same ordering for the run-completion journal, and for the same
-          // reason. FIRST forget the superseded destination's completions + run
-          // tickets (its conversation is a lost resume; delivering its renders to
-          // the incoming tab would be exactly the cross-run misattribution the
-          // journal exists to prevent), THEN re-address the incoming tab's own
-          // ones onto the new id. The order matters: moveKey first would make the
-          // migrated entries indistinguishable from the destination's and forget
-          // would take both.
-          if (destinationCollision) RunCompletions.forget(panelTab);
+          // #468 — the superseded destination's journal state was already purged
+          // above (before anything could hand tokens back); now re-address the
+          // INCOMING tab's own completions + run tickets onto the new id.
           RunCompletions.moveKey(migratedFrom, panelTab);
           // rebindAgent MOVES the agent rather than spawning one, so onAgentReady
           // never fires for the new id — flush explicitly or the re-addressed
@@ -3030,6 +3040,13 @@ export async function runPanelOrchestrator(): Promise<void> {
             heldDuringGen.delete(bKey); // render-held work belonging to the torn-down provider
           }
           bridge.dropQueuedDeliveries(panelTab);
+          // #468 — this tab id is no longer provably serving the workflow that
+          // queued its outstanding runs (replaced in place). Close those tickets
+          // so a late completion is reported to whoever holds the tab now as
+          // UNDETERMINED instead of "the run YOU queued". Journal ENTRIES are
+          // kept: a completion that already arrived is still real news and is
+          // still delivered — just no longer as this conversation's own.
+          RunCompletions.closeRuns(panelTab);
         }
       }
 
@@ -3990,11 +4007,14 @@ export async function runPanelOrchestrator(): Promise<void> {
       // path — nothing is waiting on them the way a render is.
       if (ev.kind === "executed") {
         // Journal the BLIND-STRIPPED copy: a replay must not resurrect pixels
-        // the blind gate removed on arrival.
+        // the blind gate removed on arrival. `null` = the panel re-sent a
+        // completion this tab was already given; suppressed, never duplicated.
         const entry = RunCompletions.record(event.tab_id, evForTab as CompletionPayload);
-        logger.info(
-          `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} run completion for ${describeCorrelation(entry.correlation)}`,
-        );
+        if (entry) {
+          logger.info(
+            `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} run completion for ${describeCorrelation(entry.correlation)}`,
+          );
+        }
         flushRunCompletions(event.tab_id);
         return;
       }
@@ -4038,6 +4058,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       // reset() is synchronous (map cleared now), so no concurrent send() can
       // spawn an agent before we report the cleared session.
       manager.reset(agentKeyFor(tabId));
+      // #468 — the conversation that queued this tab's outstanding renders is
+      // gone. Close its run tickets so a render it queued, finishing after the
+      // New chat, is reported to the replacement agent as UNDETERMINED rather
+      // than as "the run YOU queued". Already-arrived completions keep the
+      // verdict frozen at their arrival and are still delivered.
+      RunCompletions.closeRuns(tabId);
       // reset() clears the exact-tab store; the stable resume index (#570) is the
       // manager's blind spot, so drop it here too — a deliberate NEW chat must not
       // be resurrected by the unsaved-workflow fallback on the next reload.
@@ -4082,6 +4108,10 @@ export async function runPanelOrchestrator(): Promise<void> {
       const sid = typeof event.session_id === "string" ? event.session_id : undefined;
       const key = agentKeyFor(tabId);
       manager.reset(key);
+      // #468 — same as New chat: the conversation being replaced owns the open
+      // runs, so a completion landing after the switch is UNDETERMINED, not the
+      // historical session's own render.
+      RunCompletions.closeRuns(tabId);
       if (sid) manager.setResume(key, sid);
       bridge.push({ type: "ack", ok: true, kind: "resume_session" }, tabId);
       bridge.broadcastTabList(); // live agent dropped → refresh mirror pickers

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2042,8 +2042,8 @@ export async function runPanelOrchestrator(): Promise<void> {
     onEventDelivered: (_key, tokens) => {
       for (const token of tokens) RunCompletions.ack(token);
     },
-    onEventUndelivered: (key, tokens) => {
-      for (const token of tokens) RunCompletions.release(token);
+    onEventUndelivered: (key, tokens, opts) => {
+      for (const token of tokens) RunCompletions.release(token, { carried: opts?.carried === true });
       const panelTab = panelTabOf(key);
       logger.warn(
         `[panel-orchestrator] tab ${panelTab.slice(0, 8)} handed back ${tokens.length} undelivered run completion(s) — journaled for replay (#468)`,

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2962,6 +2962,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         }
       }
       const prev = tabBackends.get(panelTab);
+      let providerSwitched = false;
       if (prev && prev !== backend) {
         // #570 — Provider switch via re-hello: RETIRE (not reset) the previous provider's
         // agent so it stops lingering but its identity-bound durable session is PRESERVED. A
@@ -2971,8 +2972,15 @@ export async function runPanelOrchestrator(): Promise<void> {
         // still starts fresh (the panel replays the transcript as context on its first message).
         manager.retire(panelTab + AGENT_KEY_SEP + prev);
         bridge.broadcastTabList(); // live agent dropped on backend switch → refresh dot
+        providerSwitched = true;
       }
       tabBackends.set(panelTab, backend);
+      // #468 — retire() handed back any run completion the OLD provider held, but
+      // the flush it triggered ran while agentKeyFor() still resolved the OLD
+      // backend, so it could only re-journal it. Re-address it now that the tab
+      // points at the NEW provider, so the completion reaches the conversation
+      // the user actually switched to instead of waiting for their next message.
+      if (providerSwitched) flushRunCompletions(panelTab);
       // A headless client (mobile/remote pseudo-panel, no browser canvas) advertises
       // itself in the hello frame so its agent gets the in-turn-delivery directive.
       if ((event as { headless?: unknown }).headless === true) headlessTabs.add(panelTab);
@@ -3480,6 +3488,12 @@ export async function runPanelOrchestrator(): Promise<void> {
         else tabStableKey.delete(panelTab);
       }
       tabBackends.set(panelTab, reqBackend);
+      // #468 — the retire() above handed back any run completion the outgoing
+      // provider's agent held, but that flush ran while agentKeyFor() still
+      // resolved the OLD backend. Re-address it now that the tab points at the
+      // new one, so the completion reaches the conversation the user switched to
+      // instead of sitting journaled until their next message.
+      if (prev !== reqBackend) flushRunCompletions(panelTab);
       // Leaving a LOCAL provider frees its VRAM (no other tab still on it) —
       // the point of switching to Claude/hosted is usually reclaiming the GPU.
       if (prev !== reqBackend) {
@@ -5144,6 +5158,11 @@ export async function runPanelOrchestrator(): Promise<void> {
       // the gate reads as the full "nothing queued or held" contract.)
       !manager.hasHeldMail() &&
       ![...heldDuringGen.values()].some((msgs) => msgs.length > 0) &&
+      // Undelivered run completions (#468) are in-memory like the held mail
+      // above, so teardown erases them too. A restart while one is journaled
+      // would silently drop the render result the agent was promised — exactly
+      // the failure this whole path exists to prevent. Wait for it to land.
+      !RunCompletions.hasOutstanding() &&
       !QueueMonitor.isBusy(),
     announce: (text) => void bridge.push({ type: "say", text }),
     teardown: teardownCore,

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -262,13 +262,6 @@ export class PanelAgent {
   /** The turn marker `turnEventTokens` belongs to (#468). A completion is acked
    *  only by the result of the turn that CARRIED it — see the `result` case. */
   private turnEventTokensMarker = 0;
-  /** True once this run has seen ANY marker-stamped event, i.e. the backend
-   *  stamps turn markers (Claude does; Codex/Gemini don't). On a stamping
-   *  backend an UNMARKED result is a traceless straggler — possibly from an
-   *  abandoned earlier turn — so it must not ack the current turn's completion
-   *  tokens. On a non-stamping backend there is nothing to compare against, so
-   *  the pre-#468 tolerance applies unchanged. Reset per run. */
-  private sawTurnMarkers = false;
   /** True while a turn is in flight (working→done). Lets the manager defer a
    *  session-restarting option change (effort) until the turn finishes, instead
    *  of interrupting and silently dropping the in-flight reply. */
@@ -1006,10 +999,9 @@ export class PanelAgent {
       this.turnWaiter = null;
       this.currentTurnMarker = 0;
       this.abandonedTurnMarker = 0;
-      // The #468 ack gate mirrors the marker reset: a fresh run re-learns whether
-      // this backend stamps, and no marker from the dead run can satisfy it.
+      // The #468 ack gate mirrors the marker reset: no marker minted by the dead
+      // run can satisfy the new one's first turn.
       this.turnEventTokensMarker = 0;
-      this.sawTurnMarkers = false;
       // Drop the prior session's last assistant UUID so a fork can't report a
       // stale (pre-fork) anchor for the first turn of the new session.
       this.lastAssistantUuid = null;
@@ -1239,10 +1231,6 @@ export class PanelAgent {
       );
       return;
     }
-    // Learn whether this backend stamps turn markers at all (#468 ack gate). Set
-    // from any surviving stamped event; a backend that never stamps leaves it
-    // false and keeps the pre-#468 ack behavior.
-    if (typeof ev.turn === "number") this.sawTurnMarkers = true;
     // Any event means the turn is alive — reset the idle watchdog. The `result`
     // case below disarms it entirely (turn ended). Placed before the switch so it
     // covers every event type without per-case bumps.
@@ -1370,24 +1358,39 @@ export class PanelAgent {
         // them and settles their run tickets. This is the ONLY ack point; every
         // other exit from a turn hands the tokens back for replay.
         //
-        // ACK GATE: only THIS turn's result may ack. On a marker-stamping
-        // backend an UNMARKED result is a traceless straggler (Claude emits one
-        // for a result it cannot match to a submitted turn) that the #728
-        // dead-letter deliberately lets through for gate liveness — it must not
-        // also retire a completion the CURRENT turn is carrying, or a turn that
-        // then stalls would have nothing left to hand back. A non-stamping
-        // backend has nothing to compare, so it keeps the previous behavior. The
-        // un-acked tokens are handed back at the next dispatch (see channel()).
-        const ackable =
-          !this.sawTurnMarkers ||
-          (typeof ev.turn === "number" && ev.turn === this.turnEventTokensMarker);
-        if (this.turnEventTokens.length && ackable) {
-          const delivered = this.turnEventTokens;
+        // ACK GATE: only THIS turn's own result may ack. On a backend that
+        // DECLARES turn markers, an UNMARKED result is a traceless straggler
+        // (Claude emits one for a result it cannot match to a submitted turn)
+        // that the #728 dead-letter deliberately lets through for gate liveness
+        // — it must not also retire a completion the CURRENT turn is carrying,
+        // or a turn that then stalls would have nothing left to hand back.
+        //
+        // The capability is DECLARED, never inferred from "have I seen a marker
+        // yet": a zero-output turn's straggler arrives BEFORE the replacement
+        // turn stamps anything, so an observation-based gate is unsound in
+        // exactly the window it exists to protect. A backend that declares no
+        // markers keeps the pre-#468 behavior (nothing to compare against).
+        //
+        // Not ackable → hand the tokens BACK right here, so a completion can
+        // never dangle on a turn that has already ended. The journal re-queues
+        // it into a later turn: a duplicate at worst, never a loss.
+        if (this.turnEventTokens.length) {
+          const carried = this.turnEventTokens;
           this.turnEventTokens = [];
-          try {
-            this.deps.onEventDelivered?.(this.tabId, delivered);
-          } catch (err) {
-            logger.warn(`[panel-agent ${this.short()}] acking completion tokens: ${msgOf(err)}`);
+          const ackable =
+            this.backend.capabilities.turnMarkers !== true ||
+            (typeof ev.turn === "number" && ev.turn === this.turnEventTokensMarker);
+          if (ackable) {
+            try {
+              this.deps.onEventDelivered?.(this.tabId, carried);
+            } catch (err) {
+              logger.warn(`[panel-agent ${this.short()}] acking completion tokens: ${msgOf(err)}`);
+            }
+          } else {
+            logger.warn(
+              `[panel-agent ${this.short()}] an unmarked result cannot ack turn ${this.turnEventTokensMarker}'s run completion(s) — handing ${carried.length} back for replay (#468)`,
+            );
+            this.releaseEventTokens(carried);
           }
         }
         // Turn ended cleanly → disarm the freeze watchdog. (If it already tripped,
@@ -2178,13 +2181,49 @@ export class PanelAgentManager {
     return { model: this.modelFor(tabId), effort: this.effortFor(tabId), restarted, deferred };
   }
 
-  /** Hand back every run-completion token sitting in a key's HELD mail (#468), so
-   *  discarding that mail can never strand a completion in the journal's
-   *  handed-off state (which `deliverPending` skips). Safe to call before any
-   *  heldMessages drop; a no-op when there is none. */
-  private releaseHeldTokens(key: string): void {
-    const tokens = (this.heldMessages.get(key) ?? []).flatMap((it) => it.eventTokens ?? []);
+  /**
+   * THE SINGLE TEARDOWN SEAM for unbinding a key's agent (#468). Every path that
+   * stops an agent must go through here, so a future third teardown can't
+   * silently re-open the hole that `retire()` had: it preserved `heldMessages`
+   * without releasing the run-completion tokens parked in them, leaving those
+   * entries `handed_off` — a state `deliverPending()` skips — with no agent left
+   * to consume them and no disclosure.
+   *
+   * Held mail is DETACHED from its completion tokens either way: the message
+   * text keeps whatever preservation semantics the caller wants, while ownership
+   * of the completion returns to the journal, which replays it to whatever agent
+   * serves this panel tab next (a different provider's key included — the
+   * journal is keyed by panel tab).
+   *
+   * `dropHeldMail` distinguishes the two callers: reset() is an explicit fresh
+   * start and discards the mail; retire() preserves it for when the workflow is
+   * reopened. Returns the unbound agent (if any) for the caller to stop.
+   */
+  private unbindAgent(key: string, opts: { dropHeldMail: boolean; reason: string }): PanelAgent | undefined {
+    const agent = this.agents.get(key);
+    this.agents.delete(key);
+    this.detachHeldCompletions(key, opts.reason);
+    if (opts.dropHeldMail) this.heldMessages.delete(key);
+    return agent;
+  }
+
+  /** Strip the run-completion tokens out of a key's HELD mail and hand them back
+   *  to the journal (#468). The mail itself is untouched — only ownership of the
+   *  completion moves — so a preserved (retire) or discarded (reset) queue can
+   *  never take a completion down with it. No-op when there is none. */
+  private detachHeldCompletions(key: string, reason: string): void {
+    const held = this.heldMessages.get(key);
+    if (!held?.length) return;
+    const tokens: string[] = [];
+    for (const item of held) {
+      if (!item.eventTokens?.length) continue;
+      tokens.push(...item.eventTokens);
+      delete item.eventTokens; // the journal owns it now — never ack it twice
+    }
     if (!tokens.length) return;
+    logger.warn(
+      `[panel-orchestrator] tab ${key.slice(0, 8)} ${reason}: ${tokens.length} run completion(s) were parked in held mail — returned to the journal for replay (#468)`,
+    );
     try {
       this.opts.onEventUndelivered?.(key, tokens);
     } catch (err) {
@@ -2197,8 +2236,9 @@ export class PanelAgentManager {
    *  so the caller (e.g. resume_session) can set a new pendingResume right after
    *  without a concurrent send() spawning a non-resumed agent in an await gap. */
   reset(tabId: string): void {
-    const agent = this.agents.get(tabId);
-    this.agents.delete(tabId);
+    // Unbind through the SHARED teardown seam (#468) — it is what guarantees a
+    // run completion parked in held mail is handed back rather than discarded.
+    const agent = this.unbindAgent(tabId, { dropHeldMail: true, reason: "reset" });
     this.pendingResume.delete(tabId);
     // Forget the durable session too — a NEW chat must start fresh, so the disk
     // fallback in send() can't resurrect the conversation the user just cleared.
@@ -2207,12 +2247,6 @@ export class PanelAgentManager {
     this.opts.sessionStore?.clear(tabId);
     this.pendingEffortRestart.delete(tabId); // a reset supersedes any deferred restart
     this.pendingMcpRestart.delete(tabId);
-    // A reset is an explicit fresh start — drop held mail. But a run completion
-    // riding in that mail is NEWS, not conversation, and its journal entry is
-    // still marked handed-off; hand its tokens back or the completion would be
-    // stranded in a state nothing ever flushes again (#468).
-    this.releaseHeldTokens(tabId);
-    this.heldMessages.delete(tabId);
     // Drop this key's picker override so a provider switch (which reset()s the old
     // key) can't carry the old provider's model/effort into the new backend's spawn.
     this.modelByKey.delete(tabId);
@@ -2229,11 +2263,17 @@ export class PanelAgentManager {
    *  chat — this preserves sessionStore/pendingResume/held mail, so the retired
    *  workflow resumes exactly where it left off when reopened, while its now-stopped
    *  agent can no longer push frames that the bridge migration alias would leak into
-   *  the newly-targeted view. No-op when no live agent owns the key. */
+   *  the newly-targeted view.
+   *
+   *  Held mail is PRESERVED (that is the point) but its run completions are NOT
+   *  (#468): with the agent gone they would sit `handed_off` forever — a state
+   *  `deliverPending()` skips — so a provider switch that retires the key would
+   *  silently swallow them. The shared teardown detaches and returns them, and it
+   *  runs even when no live agent owns the key (a retire with only held mail is
+   *  exactly the case that lost them). */
   retire(tabId: string): void {
-    const agent = this.agents.get(tabId);
+    const agent = this.unbindAgent(tabId, { dropHeldMail: false, reason: "retire" });
     if (!agent) return;
-    this.agents.delete(tabId);
     void agent.stop();
     logger.info(
       `[panel-orchestrator] tab ${tabId.slice(0, 8)} retired (workflow switch on the same socket) — durable session preserved`,

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -499,6 +499,7 @@ export class PanelAgent {
       prompt_id?: string;
       run_correlation?: "matched" | "foreign" | "unidentified";
       replayed?: boolean;
+      dropped_completions?: number;
     },
     opts?: { eventToken?: string },
   ): boolean {
@@ -523,6 +524,11 @@ export class PanelAgent {
         // agent reads it as "this landed late", not as a second render.
         (ev.replayed
           ? `(RE-DELIVERED — this completion could not be handed to you when it arrived.) `
+          : ``) +
+        // An eviction dropped older completions for this tab — say so rather than
+        // let them disappear (#468). The agent must treat those runs as unknown.
+        (typeof ev.dropped_completions === "number" && ev.dropped_completions > 0
+          ? `⚠️ ${ev.dropped_completions} EARLIER completion(s) for this tab could not be delivered and were dropped — treat the outcome of those runs as UNDETERMINED and check get_history if you were waiting on one. `
           : ``) +
         runIdentityPreamble(ev) +
         (note
@@ -1796,6 +1802,7 @@ export class PanelAgentManager {
       prompt_id?: string;
       run_correlation?: "matched" | "foreign" | "unidentified";
       replayed?: boolean;
+      dropped_completions?: number;
     },
     opts?: { eventToken?: string },
   ): boolean {
@@ -2131,6 +2138,20 @@ export class PanelAgentManager {
     return { model: this.modelFor(tabId), effort: this.effortFor(tabId), restarted, deferred };
   }
 
+  /** Hand back every run-completion token sitting in a key's HELD mail (#468), so
+   *  discarding that mail can never strand a completion in the journal's
+   *  handed-off state (which `deliverPending` skips). Safe to call before any
+   *  heldMessages drop; a no-op when there is none. */
+  private releaseHeldTokens(key: string): void {
+    const tokens = (this.heldMessages.get(key) ?? []).flatMap((it) => it.eventTokens ?? []);
+    if (!tokens.length) return;
+    try {
+      this.opts.onEventUndelivered?.(key, tokens);
+    } catch (err) {
+      logger.warn(`[panel-orchestrator] tab ${key.slice(0, 8)} releasing held completion tokens: ${msgOf(err)}`);
+    }
+  }
+
   /** Forget a tab's agent so the next message starts a brand-new session. The
    *  map mutation is synchronous and the old agent is stopped fire-and-forget,
    *  so the caller (e.g. resume_session) can set a new pendingResume right after
@@ -2146,7 +2167,12 @@ export class PanelAgentManager {
     this.opts.sessionStore?.clear(tabId);
     this.pendingEffortRestart.delete(tabId); // a reset supersedes any deferred restart
     this.pendingMcpRestart.delete(tabId);
-    this.heldMessages.delete(tabId); // a reset is an explicit fresh start — drop held mail
+    // A reset is an explicit fresh start — drop held mail. But a run completion
+    // riding in that mail is NEWS, not conversation, and its journal entry is
+    // still marked handed-off; hand its tokens back or the completion would be
+    // stranded in a state nothing ever flushes again (#468).
+    this.releaseHeldTokens(tabId);
+    this.heldMessages.delete(tabId);
     // Drop this key's picker override so a provider switch (which reset()s the old
     // key) can't carry the old provider's model/effort into the new backend's spawn.
     this.modelByKey.delete(tabId);

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -214,11 +214,12 @@ export interface PanelAgentDeps {
   /** #468 — the turn CARRYING these run-completion journal tokens ended, so the
    *  completions genuinely reached the agent. The journal drops them. */
   onEventDelivered?: (tabId: string, tokens: string[]) => void;
-  /** #468 — these run-completion journal tokens are being handed BACK: the
-   *  agent was stopped, or the turn carrying them was abandoned, before they
-   *  could be read. The journal re-arms them for replay. Also fired for tokens
-   *  refused outright (injecting into a closed agent). */
-  onEventUndelivered?: (tabId: string, tokens: string[]) => void;
+  /** #468 — these run-completion journal tokens are being handed BACK for replay.
+   *  `carried` true means a turn actually DISPATCHED with them and then ended
+   *  (the agent read the text; only its ack couldn't be proven) — the journal
+   *  bounds that cycle. `carried` false/absent means a teardown handed them back
+   *  and NOBODY read them, which must never count toward that bound. */
+  onEventUndelivered?: (tabId: string, tokens: string[], opts?: { carried?: boolean }) => void;
   /** In-process MCP server giving the agent LIVE control of this tab's graph. */
   panelServer?: McpSdkServerConfigWithInstance;
   /**
@@ -429,10 +430,10 @@ export class PanelAgent {
   /** Hand a set of run-completion journal tokens back as UNDELIVERED (#468), so
    *  the journal re-arms them for replay instead of letting them die with this
    *  agent / this abandoned turn. Never throws into the caller's path. */
-  private releaseEventTokens(tokens: string[] | undefined): void {
+  private releaseEventTokens(tokens: string[] | undefined, opts: { carried?: boolean } = {}): void {
     if (!tokens?.length) return;
     try {
-      this.deps.onEventUndelivered?.(this.tabId, [...tokens]);
+      this.deps.onEventUndelivered?.(this.tabId, [...tokens], opts);
     } catch (err) {
       logger.warn(`[panel-agent ${this.short()}] releasing completion tokens: ${msgOf(err)}`);
     }
@@ -503,6 +504,7 @@ export class PanelAgent {
       run_correlation?: "matched" | "foreign" | "unidentified";
       replayed?: boolean;
       dropped_completions?: number;
+      possible_repeat?: boolean;
     },
     opts?: { eventToken?: string },
   ): boolean {
@@ -532,6 +534,12 @@ export class PanelAgent {
         // let them disappear (#468). The agent must treat those runs as unknown.
         (typeof ev.dropped_completions === "number" && ev.dropped_completions > 0
           ? `⚠️ ${ev.dropped_completions} EARLIER completion(s) for this tab could not be delivered and were dropped — treat the outcome of those runs as UNDETERMINED and check get_history if you were waiting on one. `
+          : ``) +
+        // An id-less completion whose content matches one already reported. We
+        // will NOT swallow it (identical content is not proof of identity, and a
+        // swallowed render is a silent loss), so hand the judgement to the agent.
+        (ev.possible_repeat
+          ? `⚠️ POSSIBLE REPEAT: a completion with identical outputs was already reported to you recently, and this one carries no prompt id to tell them apart. It may be the same event re-sent, or a second render that produced identical filenames — do NOT count it twice without checking (get_history). `
           : ``) +
         runIdentityPreamble(ev) +
         (note
@@ -910,7 +918,10 @@ export class PanelAgent {
       if (this.turnEventTokens.length) {
         const stale = this.turnEventTokens;
         this.turnEventTokens = [];
-        this.releaseEventTokens(stale);
+        // CARRIED: a turn genuinely dispatched with these and has now been
+        // superseded, so the agent read the text — this is the same unprovable-
+        // ack cycle as the result path and is bounded with it.
+        this.releaseEventTokens(stale, { carried: true });
       }
       this.turnEventTokens = carriedTokens;
       this.inFlight = {
@@ -1390,7 +1401,10 @@ export class PanelAgent {
             logger.warn(
               `[panel-agent ${this.short()}] an unmarked result cannot ack turn ${this.turnEventTokensMarker}'s run completion(s) — handing ${carried.length} back for replay (#468)`,
             );
-            this.releaseEventTokens(carried);
+            // CARRIED: this turn ran and ended with the completion in it, so the
+            // agent read it — only the ack is unprovable. Bounded, so a backend
+            // that never stamps its results can't replay this forever.
+            this.releaseEventTokens(carried, { carried: true });
           }
         }
         // Turn ended cleanly → disarm the freeze watchdog. (If it already tripped,
@@ -1526,8 +1540,10 @@ export interface PanelAgentManagerOptions {
    *  completions genuinely reached the agent. Forwarded verbatim from the agent. */
   onEventDelivered?: (tabId: string, tokens: string[]) => void;
   /** #468 — these run-completion journal tokens came back UNDELIVERED (agent
-   *  stopped, turn abandoned, injection refused). Re-arm them for replay. */
-  onEventUndelivered?: (tabId: string, tokens: string[]) => void;
+   *  stopped, turn abandoned, injection refused). Re-arm them for replay.
+   *  `carried` true = a turn ran with them and ended (the agent read the text,
+   *  only the ack is unprovable) — the only cycle the journal bounds. */
+  onEventUndelivered?: (tabId: string, tokens: string[], opts?: { carried?: boolean }) => void;
   /** #468 — a fresh agent is mapped and ready for this key. The orchestrator
    *  uses it to replay any journaled run completions the previous agent never
    *  delivered, so a completion survives the restart that lost it. */
@@ -1846,6 +1862,7 @@ export class PanelAgentManager {
       run_correlation?: "matched" | "foreign" | "unidentified";
       replayed?: boolean;
       dropped_completions?: number;
+      possible_repeat?: boolean;
     },
     opts?: { eventToken?: string },
   ): boolean {
@@ -1955,8 +1972,23 @@ export class PanelAgentManager {
         // path (it used to exit, which mooted cleanup).
         void agent.stop().catch(() => {});
       } else if (gaveUp) {
-        // The bounded self-restart loop gave up — the session keeps dropping. Same
-        // fatal signal: let the orchestrator self-exit + respawn.
+        // The bounded self-restart loop gave up — the session keeps dropping.
+        // Same treatment as the hard-start failure above for the agent's QUEUE
+        // (#468): its still-unread messages — a run completion among them — were
+        // dying here. `settle` only unmapped the agent, so a completion sitting
+        // in its queue stayed `handed_off` in the journal, a state deliverPending
+        // skips: no replay, ever. Capture the queue into held mail (its tokens
+        // ride along, so a respawn re-delivers exactly once) and stop() the agent
+        // so anything left over is handed back.
+        const orphaned = agent.takePending();
+        if (orphaned.length) {
+          this.heldMessages.set(key, [...(this.heldMessages.get(key) ?? []), ...orphaned]);
+          logger.warn(
+            `[panel-orchestrator] tab ${key.slice(0, 8)} holding ${orphaned.length} undelivered message(s) from an agent that gave up — re-delivered on the next successful start`,
+          );
+        }
+        void agent.stop().catch(() => {});
+        // Fatal signal: let the orchestrator self-exit + respawn.
         this.opts.onAgentFatal?.(key, "agent session kept dropping (self-restart gave up)");
       }
     };
@@ -2211,6 +2243,9 @@ export class PanelAgentManager {
    *  to the journal (#468). The mail itself is untouched — only ownership of the
    *  completion moves — so a preserved (retire) or discarded (reset) queue can
    *  never take a completion down with it. No-op when there is none. */
+  // NOTE: every teardown release below is UNCARRIED (the default) — nobody read
+  // those completions, so they must not count toward the journal's bounded
+  // replay cycle. Only a turn that ran and ended is `carried`.
   private detachHeldCompletions(key: string, reason: string): void {
     const held = this.heldMessages.get(key);
     if (!held?.length) return;

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -41,6 +41,39 @@ function msgOf(err: unknown): string {
   return errorText(err);
 }
 
+/**
+ * Opening clause naming WHICH run a completion belongs to (#468).
+ *
+ * The whole point is that the agent must never read a completion as the answer
+ * to its own `panel_run` unless the orchestrator PROVED it by exact prompt id.
+ * So:
+ *  • matched      → say so, and name the id.
+ *  • foreign      → real run, real id, but not one this session queued. Say
+ *                   UNDETERMINED and forbid treating it as the awaited render.
+ *  • unidentified → no id at all. Same, plus how to find out for certain.
+ * An event with no correlation field (a legacy/simulated frame) gets the old
+ * neutral wording — unchanged behavior.
+ */
+function runIdentityPreamble(ev: { prompt_id?: string; run_correlation?: string }): string {
+  const pid = typeof ev.prompt_id === "string" && ev.prompt_id.trim() ? ev.prompt_id.trim() : null;
+  switch (ev.run_correlation) {
+    case "matched":
+      return `This is the run YOU queued with panel_run (prompt ${pid}). `;
+    case "foreign":
+      return (
+        `This run (prompt ${pid}) does NOT match any run you queued with panel_run — its origin is UNDETERMINED. ` +
+        `Do NOT treat it as the render you are waiting on; if you are still waiting on your own run, verify it with get_history before acting. `
+      );
+    case "unidentified":
+      return (
+        `The panel reported NO prompt id for this run, so it CANNOT be correlated to the render you queued — its origin is UNDETERMINED. ` +
+        `Do NOT assume it is your run; verify yours with get_history before acting on it. `
+      );
+    default:
+      return pid ? `(prompt ${pid}) ` : ``;
+  }
+}
+
 /** Idle window for the per-turn freeze watchdog: if a turn that's in flight
  *  receives NO events at all for this long, treat it as stalled. Generous (legit
  *  tool work is slow but still streams progress) and overridable for tests via
@@ -127,6 +160,21 @@ export interface ImageRef {
   type?: string; // "input" | "output" | "temp" (ComfyUI /view folder)
 }
 
+/** One queued user turn (a panel message, or an injected panel event).
+ *
+ *  `eventTokens` carry #468's run-completion journal tokens through the queue.
+ *  A completion is only ACKED once the turn that carried it ended, so an item
+ *  that is queued-but-unread when the agent dies (or whose turn is abandoned by
+ *  the stall watchdog) is handed BACK to the journal and replayed instead of
+ *  vanishing with the agent. */
+export interface QueueItem {
+  text: string;
+  images?: ImageRef[];
+  mid?: string;
+  /** Run-completion journal tokens this item is carrying (#468). */
+  eventTokens?: string[];
+}
+
 export interface PanelAgentDeps {
   /** mcpServers config for the spawned agent (the comfyui MCP). */
   mcpServers: Options["mcpServers"];
@@ -163,6 +211,14 @@ export interface PanelAgentDeps {
    *  "read" moment) — carries the client mid so the panel can flip that bubble
    *  from queued/muted to read. */
   onSeen?: (tabId: string, mid: string) => void;
+  /** #468 — the turn CARRYING these run-completion journal tokens ended, so the
+   *  completions genuinely reached the agent. The journal drops them. */
+  onEventDelivered?: (tabId: string, tokens: string[]) => void;
+  /** #468 — these run-completion journal tokens are being handed BACK: the
+   *  agent was stopped, or the turn carrying them was abandoned, before they
+   *  could be read. The journal re-arms them for replay. Also fired for tokens
+   *  refused outright (injecting into a closed agent). */
+  onEventUndelivered?: (tabId: string, tokens: string[]) => void;
   /** In-process MCP server giving the agent LIVE control of this tab's graph. */
   panelServer?: McpSdkServerConfigWithInstance;
   /**
@@ -190,7 +246,7 @@ export class PanelAgent {
    *  turn-gate, rewind tracking and self-restart; the backend owns the SDK call,
    *  option building, and SDKMessage→AgentEvent normalization. */
   private backend: AgentBackend;
-  private queue: Array<{ text: string; images?: ImageRef[]; mid?: string }> = [];
+  private queue: Array<QueueItem> = [];
   private waiting: (() => void) | null = null;
   private closed = false;
   /** The user message(s) of the turn currently in flight — captured at dispatch so
@@ -198,7 +254,11 @@ export class PanelAgent {
    *  new message, instead of dropping the work the agent was mid-reply on. Cleared
    *  on a clean turn result (nothing to re-queue) and on stall/rewind (abandoned on
    *  purpose). Null whenever no turn is in flight. */
-  private inFlight: { text: string; images?: ImageRef[] } | null = null;
+  private inFlight: { text: string; images?: ImageRef[]; eventTokens?: string[] } | null = null;
+  /** Run-completion journal tokens carried by the turn currently in flight
+   *  (#468). Acked when that turn's `result` lands; handed back to the journal
+   *  when the turn is abandoned (stall watchdog) or the agent is stopped. */
+  private turnEventTokens: string[] = [];
   /** True while a turn is in flight (working→done). Lets the manager defer a
    *  session-restarting option change (effort) until the turn finishes, instead
    *  of interrupting and silently dropping the in-flight reply. */
@@ -350,12 +410,29 @@ export class PanelAgent {
 
   /** Queue a panel message and wake the streaming generator (the "channel in").
    *  `images` are ComfyUI refs delivered inline as image blocks (vision). */
-  send(text: string, opts?: { title?: string; images?: ImageRef[]; mid?: string }): void {
+  send(text: string, opts?: { title?: string; images?: ImageRef[]; mid?: string; eventTokens?: string[] }): void {
     if (opts?.title) this.title = opts.title;
-    this.queue.push({ text, images: opts?.images, mid: opts?.mid });
+    this.queue.push({
+      text,
+      images: opts?.images,
+      mid: opts?.mid,
+      ...(opts?.eventTokens?.length ? { eventTokens: [...opts.eventTokens] } : {}),
+    });
     const wake = this.waiting;
     this.waiting = null;
     wake?.();
+  }
+
+  /** Hand a set of run-completion journal tokens back as UNDELIVERED (#468), so
+   *  the journal re-arms them for replay instead of letting them die with this
+   *  agent / this abandoned turn. Never throws into the caller's path. */
+  private releaseEventTokens(tokens: string[] | undefined): void {
+    if (!tokens?.length) return;
+    try {
+      this.deps.onEventUndelivered?.(this.tabId, [...tokens]);
+    } catch (err) {
+      logger.warn(`[panel-agent ${this.short()}] releasing completion tokens: ${msgOf(err)}`);
+    }
   }
 
   /** Rewind the CONVERSATION: fork the session at `anchor` (an assistant UUID
@@ -369,6 +446,12 @@ export class PanelAgent {
     // A rewind deliberately DROPS everything after the anchor (the edited message
     // arrives separately), so the interrupted turn's text must NOT be re-queued.
     this.inFlight = null;
+    // The dropped turn may have been carrying a run completion — that is news,
+    // not conversation, so hand it back for replay rather than rewinding it away
+    // (#468).
+    const rewoundTokens = this.turnEventTokens;
+    this.turnEventTokens = [];
+    this.releaseEventTokens(rewoundTokens);
     // Break the current stream so start()'s loop re-enters and forks.
     void this.backend.interrupt().catch(() => {});
     const wake = this.waiting;
@@ -405,13 +488,26 @@ export class PanelAgent {
    * reached the agent." Only meaningful when a session is live (the manager only
    * calls this for an existing agent, so we never spawn one just for an event).
    */
-  injectEvent(ev: {
-    kind?: string;
-    images?: ImageRef[];
-    error?: string;
-    note?: string;
-    downloads?: Array<{ name: string; status: string }>;
-  }): void {
+  injectEvent(
+    ev: {
+      kind?: string;
+      images?: ImageRef[];
+      error?: string;
+      note?: string;
+      downloads?: Array<{ name: string; status: string }>;
+      /** #468 — run identity + how it correlates to a run this session queued. */
+      prompt_id?: string;
+      run_correlation?: "matched" | "foreign" | "unidentified";
+      replayed?: boolean;
+    },
+    opts?: { eventToken?: string },
+  ): boolean {
+    // A closed agent's queue is never drained again, so accepting an event here
+    // would silently swallow it (#468). REFUSE — and deliberately do NOT hand the
+    // token back through onEventUndelivered: the caller is the journal's own
+    // flush, which keeps a refused entry pending from the `false` return. Calling
+    // back would recurse (release → flush → inject → release → …).
+    if (this.closed) return false;
     let text: string | null = null;
     let images: ImageRef[] | undefined;
     if (ev.kind === "executed") {
@@ -423,6 +519,12 @@ export class PanelAgent {
       const note = typeof ev.note === "string" && ev.note.trim() ? ev.note.trim() : null;
       text =
         `[panel event] ` +
+        // #468 — a completion that was journaled and re-delivered says so, so the
+        // agent reads it as "this landed late", not as a second render.
+        (ev.replayed
+          ? `(RE-DELIVERED — this completion could not be handed to you when it arrived.) `
+          : ``) +
+        runIdentityPreamble(ev) +
         (note
           ? `${note} `
           : `A run on the user's canvas just finished and produced ${imgs.length} output image(s): ${names}. `) +
@@ -453,7 +555,7 @@ export class PanelAgent {
       // batch of settled downloads for this tab), so a multi-file pack install
       // wakes the agent ONCE, not per file.
       const dl = (ev.downloads ?? []).filter((d) => d && d.name);
-      if (dl.length === 0) return;
+      if (dl.length === 0) return false;
       const done = dl.filter((d) => d.status === "done").map((d) => d.name);
       const failed = dl.filter((d) => d.status !== "done").map((d) => d.name);
       const parts: string[] = [];
@@ -466,13 +568,18 @@ export class PanelAgent {
         `call download_status for the exact landed path(s)${failed.length ? " or the error detail" : ""}. ` +
         `Otherwise reply with ONE short sentence acknowledging it and no tool calls.`;
     }
-    if (!text) return;
+    if (!text) return false;
     this.busy = true;
     this.deps.onTurn?.(this.tabId, "working"); // event triggers a turn — show working
-    this.queue.push({ text, images });
+    this.queue.push({
+      text,
+      images,
+      ...(opts?.eventToken ? { eventTokens: [opts.eventToken] } : {}),
+    });
     const wake = this.waiting;
     this.waiting = null;
     wake?.();
+    return true;
   }
 
   /** Push a ComfyUI EXECUTION error into the session with urgency — the "hey,
@@ -548,8 +655,10 @@ export class PanelAgent {
   }
   /** Remove and return any unsent queued messages — so a session restart can hand
    *  them to the replacement agent instead of dropping them. Items keep their
-   *  panel `mid`, so re-delivery still flips the right bubble on dequeue (seen). */
-  takePending(): Array<{ text: string; images?: ImageRef[]; mid?: string }> {
+   *  panel `mid`, so re-delivery still flips the right bubble on dequeue (seen),
+   *  AND their run-completion tokens (#468), so a carried-over completion is
+   *  acked by the replacement agent rather than replayed as a duplicate. */
+  takePending(): Array<QueueItem> {
     const items = this.queue;
     this.queue = [];
     return items;
@@ -585,10 +694,22 @@ export class PanelAgent {
     // the user wants BOTH the interrupted message and the new one answered. A plain
     // Stop / Ctrl+C / Esc (requeueInFlight=false) must NOT re-queue, or it would
     // silently re-run the turn the user just stopped (double tool actions).
+    // #468 — the interrupted turn's run-completion tokens travel with its text.
+    // Re-queued: they ride the re-queued item and are acked when THAT turn ends.
+    // Dropped (plain Stop): hand them back so the completion is replayed rather
+    // than dying with the turn the user cancelled.
+    const interruptedTokens = this.turnEventTokens;
+    this.turnEventTokens = [];
     if (interrupted && opts.requeueInFlight) {
       // Front of the queue: the interrupted work is addressed before whatever the
       // user sends next (which is appended after this interrupt is handled).
-      this.queue.unshift({ text: interrupted.text, images: interrupted.images });
+      this.queue.unshift({
+        text: interrupted.text,
+        images: interrupted.images,
+        ...(interruptedTokens.length ? { eventTokens: interruptedTokens } : {}),
+      });
+    } else {
+      this.releaseEventTokens(interruptedTokens);
     }
     // Track the turn this interrupt is aborting (the one holding the gate). The
     // fallback only force-releases while THIS turn is still the one parked on the
@@ -666,6 +787,15 @@ export class PanelAgent {
   async stop(): Promise<void> {
     this.closed = true;
     this.inFlight = null; // teardown must not leave a turn that could be re-queued
+    // #468 — every run completion this agent still holds (queued-but-unread, or
+    // carried by the turn we're tearing down) goes BACK to the journal. A tab
+    // that is genuinely gone has its entries dropped explicitly by the
+    // orchestrator (forget); everything else is replayed into the replacement
+    // agent. Done before the awaits below so a concurrent spawn can pick them up.
+    const orphanedTokens = [...this.queue.flatMap((it) => it.eventTokens ?? []), ...this.turnEventTokens];
+    this.turnEventTokens = [];
+    for (const item of this.queue) delete item.eventTokens;
+    this.releaseEventTokens(orphanedTokens);
     this.clearIdleWatchdog(); // don't let a turn watchdog fire after teardown
     const wake = this.waiting;
     this.waiting = null;
@@ -759,7 +889,17 @@ export class PanelAgent {
       if (this.closed) return;
       // Remember the in-flight turn's user text so an interrupt mid-reply can
       // re-queue it (send-now must address BOTH the interrupted and new message).
-      this.inFlight = { text, ...(images.length ? { images } : {}) };
+      // #468 — the run-completion tokens this batch carries. They ride with the
+      // in-flight capture so a crash-requeue keeps them attached, and are ACKED
+      // only when this turn's `result` lands (proof the agent actually read the
+      // completion), not merely because it was spliced off the queue.
+      const carriedTokens = batch.flatMap((it) => it.eventTokens ?? []);
+      this.turnEventTokens = carriedTokens;
+      this.inFlight = {
+        text,
+        ...(images.length ? { images } : {}),
+        ...(carriedTokens.length ? { eventTokens: carriedTokens } : {}),
+      };
       this.yieldedTurns += 1; // this batch is turn N
       // Mirror the backend's turn-marker mint: the Nth turn yielded here is the
       // Nth turn the backend reads — its events carry marker N (#728 r3).
@@ -904,6 +1044,10 @@ export class PanelAgent {
         if (this.inFlight) {
           const interrupted = this.inFlight;
           this.inFlight = null;
+          // Its run-completion tokens (#468) ride the re-queued item, so they are
+          // acked when the RE-RUN turn ends — not left dangling on a turn whose
+          // session died.
+          this.turnEventTokens = [];
           this.queue.unshift(interrupted);
           logger.warn(
             `[panel-agent ${this.short()}] crash mid-turn — re-queued the interrupted message so it isn't lost`,
@@ -917,6 +1061,13 @@ export class PanelAgent {
       // first turn — gate run-ahead). The gate counters are reset next iteration.
       this.clearIdleWatchdog();
       this.clearInterruptReleaseFallback();
+      // A turn that never produced a `result` (the session just ended) never
+      // acked its run completions. Hand them back so the restarted session
+      // replays them instead of the completion dying with the dead session
+      // (#468). No-op after a clean result or the crash re-queue above.
+      const strandedTokens = this.turnEventTokens;
+      this.turnEventTokens = [];
+      this.releaseEventTokens(strandedTokens);
       if (this.closed) break;
       // Session ended on its own — bound rapid failure loops so a persistently
       // broken SDK doesn't spin forever or black-hole each message.
@@ -1007,6 +1158,13 @@ export class PanelAgent {
     // text (a wedged message could otherwise loop on every interrupt, and it may
     // already have performed tool side effects).
     this.inFlight = null;
+    // …but a run COMPLETION the abandoned turn was carrying is not the agent's
+    // work, it's news the agent still needs (#468). Hand its tokens back so the
+    // journal replays them into the next turn instead of losing them with the
+    // turn we just wrote off.
+    const stalledTokens = this.turnEventTokens;
+    this.turnEventTokens = [];
+    this.releaseEventTokens(stalledTokens);
     if (!alreadyReported) {
       this.deps.onSay(
         this.tabId,
@@ -1173,6 +1331,19 @@ export class PanelAgent {
         // Turn completed → nothing to re-queue on a later interrupt. (A clean
         // completion must NOT have its message re-queued.)
         this.inFlight = null;
+        // #468 — the turn that CARRIED the run completion(s) has ended, so they
+        // demonstrably reached the model's context. Ack them: the journal drops
+        // them and settles their run tickets. This is the ONLY ack point; every
+        // other exit from a turn hands the tokens back for replay.
+        if (this.turnEventTokens.length) {
+          const delivered = this.turnEventTokens;
+          this.turnEventTokens = [];
+          try {
+            this.deps.onEventDelivered?.(this.tabId, delivered);
+          } catch (err) {
+            logger.warn(`[panel-agent ${this.short()}] acking completion tokens: ${msgOf(err)}`);
+          }
+        }
         // Turn ended cleanly → disarm the freeze watchdog. (If it already tripped,
         // completeTurn() is a capped no-op, so the gate can't double-advance.)
         this.clearIdleWatchdog();
@@ -1302,6 +1473,16 @@ export interface PanelAgentManagerOptions {
    * per-tab configuration errors handled by onStartFailure above.
    */
   onAgentFatal?: (tabId: string, reason: string) => void;
+  /** #468 — a turn carrying these run-completion journal tokens ENDED, so the
+   *  completions genuinely reached the agent. Forwarded verbatim from the agent. */
+  onEventDelivered?: (tabId: string, tokens: string[]) => void;
+  /** #468 — these run-completion journal tokens came back UNDELIVERED (agent
+   *  stopped, turn abandoned, injection refused). Re-arm them for replay. */
+  onEventUndelivered?: (tabId: string, tokens: string[]) => void;
+  /** #468 — a fresh agent is mapped and ready for this key. The orchestrator
+   *  uses it to replay any journaled run completions the previous agent never
+   *  delivered, so a completion survives the restart that lost it. */
+  onAgentReady?: (tabId: string) => void;
   /**
    * Durable per-tab session store. When set, the manager persists each tab's SDK
    * session id here and uses it as the resume fallback when a tab first spawns —
@@ -1326,7 +1507,7 @@ export class PanelAgentManager {
    *  captured here at settle(err) instead of dying with the agent — the next
    *  spawn on the same composite key re-delivers them, so nothing sent into the
    *  spawn → prepare()-reject window is silently dropped. */
-  private heldMessages = new Map<string, Array<{ text: string; images?: ImageRef[]; mid?: string }>>();
+  private heldMessages = new Map<string, Array<QueueItem>>();
   /** Tabs whose effort changed mid-turn — the session restart is deferred to the
    *  next idle moment so we never interrupt (and silently drop) a live reply. */
   private pendingEffortRestart = new Set<string>();
@@ -1407,6 +1588,8 @@ export class PanelAgentManager {
       onThinking: this.opts.onThinking,
       onToolCall: this.opts.onToolCall,
       onSeen: this.opts.onSeen,
+      onEventDelivered: this.opts.onEventDelivered,
+      onEventUndelivered: this.opts.onEventUndelivered,
       panelServer: this.opts.makePanelServer?.(tabId),
       pluginPath: this.opts.pluginPath,
     }, backend);
@@ -1578,7 +1761,16 @@ export class PanelAgentManager {
     const resume = oldAgent.sessionId ?? undefined;
     const pending = oldAgent.takePending();
     const fresh = this.spawn(tabId, resume); // new agent owns the tab now
-    for (const item of pending) fresh.send(item.text, { images: item.images, mid: item.mid });
+    for (const item of pending) {
+      fresh.send(item.text, {
+        images: item.images,
+        mid: item.mid,
+        // #468 — carry the run-completion tokens over so the replacement agent
+        // acks the completion it inherited (rather than the journal replaying it
+        // as a second copy).
+        ...(item.eventTokens?.length ? { eventTokens: item.eventTokens } : {}),
+      });
+    }
     if (nudge) fresh.send(nudge);
     void oldAgent.stop(); // retire the old one; it's no longer mapped
     return pending.length;
@@ -1590,7 +1782,9 @@ export class PanelAgentManager {
   }
 
   /** Feed a ComfyUI execution event to an EXISTING agent (no-op if none — we
-   *  never spawn an agent just to react to an event). Returns whether delivered. */
+   *  never spawn an agent just to react to an event). Returns whether the agent
+   *  TOOK it onto its queue — not that it was read; a run completion carrying an
+   *  `eventToken` is only acked when the turn that delivered it ends (#468). */
   injectEvent(
     tabId: string,
     ev: {
@@ -1599,12 +1793,15 @@ export class PanelAgentManager {
       error?: string;
       note?: string;
       downloads?: Array<{ name: string; status: string }>;
+      prompt_id?: string;
+      run_correlation?: "matched" | "foreign" | "unidentified";
+      replayed?: boolean;
     },
+    opts?: { eventToken?: string },
   ): boolean {
     const agent = this.agents.get(tabId);
     if (!agent || agent.isStopped) return false; // best-effort; don't enqueue into a closed agent
-    agent.injectEvent(ev);
-    return true;
+    return agent.injectEvent(ev, opts);
   }
 
   /** Push a ComfyUI execution error to a tab's agent — interrupt the live turn
@@ -1630,10 +1827,25 @@ export class PanelAgentManager {
     const held = this.heldMessages.get(tabId);
     if (held?.length) {
       this.heldMessages.delete(tabId);
-      for (const item of held) agent.send(item.text, { images: item.images, mid: item.mid });
+      for (const item of held) {
+        agent.send(item.text, {
+          images: item.images,
+          mid: item.mid,
+          ...(item.eventTokens?.length ? { eventTokens: item.eventTokens } : {}),
+        });
+      }
       logger.info(
         `[panel-orchestrator] tab ${tabId.slice(0, 8)} re-delivering ${held.length} message(s) held from the previous failed start`,
       );
+    }
+    // #468 — a fresh agent is mapped and can take mail: replay any run
+    // completions journaled while this key had no live agent. Fired BEFORE
+    // start() so the replay is queued ahead of the session coming up, and after
+    // held mail so ordering stays chronological.
+    try {
+      this.opts.onAgentReady?.(tabId);
+    } catch (err) {
+      logger.warn(`[panel-orchestrator] tab ${tabId.slice(0, 8)} completion replay: ${msgOf(err)}`);
     }
     // start() now SELF-RESTARTS internally on session-end, so it only settles on
     // an intentional stop() or after it gives up (repeated immediate failures),

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -523,6 +523,26 @@ export class PanelAgent {
     wake?.();
   }
 
+  /**
+   * Pull a still-queued INJECTED COMPLETION back off the queue by its journal
+   * token (#468). Returns true only if it was found and removed — false once the
+   * turn carrying it has started, where the text is already in the model's
+   * context and cannot be recalled.
+   *
+   * Needed because the event's wording is materialized when it is queued: if the
+   * journal later has to WEAKEN that completion's correlation (a prompt id
+   * reused, a conversation replaced), the already-queued copy would still claim
+   * "this is the run YOU queued". Revoking lets the journal re-deliver the
+   * downgraded, honest version instead. Only `completionOnly` items are eligible,
+   * so no user message is ever removed.
+   */
+  revokeEvent(token: string): boolean {
+    const i = this.queue.findIndex((item) => item.completionOnly && item.eventTokens?.includes(token));
+    if (i < 0) return false;
+    this.queue.splice(i, 1);
+    return true;
+  }
+
   /** Drop a still-queued message (the user cancelled/edited it before the agent
    *  got to it). Returns true if it was found and removed; false if it was
    *  already dequeued (the turn started — too late to cancel). */
@@ -1317,9 +1337,20 @@ export class PanelAgent {
       );
       return;
     }
-    // Proof the backend RECEIVED the in-flight turn (#468) — stragglers were
-    // already dead-lettered above, so anything reaching here belongs to it.
-    this.turnProducedEvents = true;
+    // Proof the backend RECEIVED the in-flight turn (#468). On a backend that
+    // DECLARES turn markers, only an event stamped with THIS turn counts: #728
+    // deliberately lets UNMARKED events past the dead-letter guard for gate
+    // liveness, and Claude emits an unmarked terminal for a result it cannot
+    // match to any submitted turn — a stale one of those, arriving while the new
+    // turn is still pre-submission, would otherwise "prove" a receipt that never
+    // happened and let the settle bound retire a completion nobody saw.
+    if (this.backend.capabilities.turnMarkers === true) {
+      if (typeof ev.turn === "number" && ev.turn === this.currentTurnMarker) {
+        this.turnProducedEvents = true;
+      }
+    } else {
+      this.turnProducedEvents = true; // nothing to compare against
+    }
     // Any event means the turn is alive — reset the idle watchdog. The `result`
     // case below disarms it entirely (turn ended). Placed before the switch so it
     // covers every event type without per-case bumps.
@@ -1950,6 +1981,15 @@ export class PanelAgentManager {
     const agent = this.agents.get(tabId);
     if (!agent || agent.isStopped) return false; // best-effort; don't enqueue into a closed agent
     return agent.injectEvent(ev, opts);
+  }
+
+  /** Pull a still-queued injected completion back off a tab's agent by journal
+   *  token (#468), so a weakened correlation can be re-delivered honestly.
+   *  False when there is no such agent or the turn carrying it already started. */
+  revokeEvent(tabId: string, token: string): boolean {
+    const agent = this.agents.get(tabId);
+    if (!agent || agent.isStopped) return false;
+    return agent.revokeEvent(token);
   }
 
   /** Push a ComfyUI execution error to a tab's agent — interrupt the live turn

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -173,6 +173,28 @@ export interface QueueItem {
   mid?: string;
   /** Run-completion journal tokens this item is carrying (#468). */
   eventTokens?: string[];
+  /** True when this item is NOTHING BUT an injected panel event — its whole text
+   *  is the event, so removing it removes the event and loses no user message.
+   *  A re-queued turn restores the original items rather than one merged item
+   *  (see PanelAgent.inFlight), so this stays accurate across an interrupt or a
+   *  crash re-queue. */
+  completionOnly?: boolean;
+}
+
+/** The turn currently in flight, captured at dispatch so an interrupt or a
+ *  mid-turn crash can re-queue it. */
+export interface InFlightTurn {
+  text: string;
+  images?: ImageRef[];
+  /** Run-completion journal tokens this turn is carrying (#468). */
+  eventTokens?: string[];
+  /** The ORIGINAL queue items this turn was built from. A re-queue restores
+   *  THESE, not one merged item, so an injected run completion stays its own
+   *  `completionOnly` item instead of being welded into a user turn's text
+   *  (#468). Without that, held mail could retain a completion's TEXT after its
+   *  token had been handed back and replayed elsewhere — one completion, two
+   *  agent turns, the second indistinguishable from a real one. */
+  items: QueueItem[];
 }
 
 export interface PanelAgentDeps {
@@ -255,7 +277,7 @@ export class PanelAgent {
    *  new message, instead of dropping the work the agent was mid-reply on. Cleared
    *  on a clean turn result (nothing to re-queue) and on stall/rewind (abandoned on
    *  purpose). Null whenever no turn is in flight. */
-  private inFlight: { text: string; images?: ImageRef[]; eventTokens?: string[] } | null = null;
+  private inFlight: InFlightTurn | null = null;
   /** Run-completion journal tokens carried by the turn currently in flight
    *  (#468). Acked when that turn's `result` lands; handed back to the journal
    *  when the turn is abandoned (stall watchdog) or the agent is stopped. */
@@ -430,6 +452,15 @@ export class PanelAgent {
   /** Hand a set of run-completion journal tokens back as UNDELIVERED (#468), so
    *  the journal re-arms them for replay instead of letting them die with this
    *  agent / this abandoned turn. Never throws into the caller's path. */
+  /** Capture-and-clear the in-flight turn in one step. Also the read that
+   *  survives control-flow narrowing (channel() assigns `inFlight` from another
+   *  function, so a direct read after a `= null` looks like `never` to TS). */
+  private takeInFlight(): InFlightTurn | null {
+    const turn = this.inFlight;
+    this.inFlight = null;
+    return turn;
+  }
+
   private releaseEventTokens(tokens: string[] | undefined, opts: { carried?: boolean } = {}): void {
     if (!tokens?.length) return;
     try {
@@ -591,6 +622,7 @@ export class PanelAgent {
     this.queue.push({
       text,
       images,
+      completionOnly: true, // the whole item IS the event — safe to drop wholesale
       ...(opts?.eventToken ? { eventTokens: [opts.eventToken] } : {}),
     });
     const wake = this.waiting;
@@ -719,12 +751,11 @@ export class PanelAgent {
     this.turnEventTokens = [];
     if (interrupted && opts.requeueInFlight) {
       // Front of the queue: the interrupted work is addressed before whatever the
-      // user sends next (which is appended after this interrupt is handled).
-      this.queue.unshift({
-        text: interrupted.text,
-        images: interrupted.images,
-        ...(interruptedTokens.length ? { eventTokens: interruptedTokens } : {}),
-      });
+      // user sends next (which is appended after this interrupt is handled). The
+      // ORIGINAL items go back (not one merged item) — the next splice re-joins
+      // them into the same text, while an injected completion stays a separate
+      // `completionOnly` item that a later detach can remove cleanly (#468).
+      this.queue.unshift(...interrupted.items);
     } else {
       this.releaseEventTokens(interruptedTokens);
     }
@@ -928,6 +959,7 @@ export class PanelAgent {
         text,
         ...(images.length ? { images } : {}),
         ...(carriedTokens.length ? { eventTokens: carriedTokens } : {}),
+        items: batch,
       };
       this.yieldedTurns += 1; // this batch is turn N
       // Mirror the backend's turn-marker mint: the Nth turn yielded here is the
@@ -1074,14 +1106,17 @@ export class PanelAgent {
         // in-flight message so the restarted/fresh session actually re-runs it.
         // Idempotent enough: a duplicate render beats a lost request, and the
         // quickRestarts give-up guard still bounds a message that crash-loops.
-        if (this.inFlight) {
-          const interrupted = this.inFlight;
-          this.inFlight = null;
-          // Its run-completion tokens (#468) ride the re-queued item, so they are
-          // acked when the RE-RUN turn ends — not left dangling on a turn whose
-          // session died.
+        // Read through takeInFlight(): channel() assigns this.inFlight from
+        // another function, which control-flow analysis can't see, so a direct
+        // read here is narrowed to `null` by the `= null` at the top of the loop.
+        const interrupted = this.takeInFlight();
+        if (interrupted) {
+          // Its run-completion tokens (#468) ride the re-queued items, so they
+          // are acked when the RE-RUN turn ends — not left dangling on a turn
+          // whose session died. The ORIGINAL items go back, so a completion
+          // stays its own `completionOnly` item (never welded into user text).
           this.turnEventTokens = [];
-          this.queue.unshift(interrupted);
+          this.queue.unshift(...interrupted.items);
           logger.warn(
             `[panel-agent ${this.short()}] crash mid-turn — re-queued the interrupted message so it isn't lost`,
           );
@@ -2239,22 +2274,49 @@ export class PanelAgentManager {
     return agent;
   }
 
-  /** Strip the run-completion tokens out of a key's HELD mail and hand them back
-   *  to the journal (#468). The mail itself is untouched — only ownership of the
-   *  completion moves — so a preserved (retire) or discarded (reset) queue can
-   *  never take a completion down with it. No-op when there is none. */
-  // NOTE: every teardown release below is UNCARRIED (the default) — nobody read
-  // those completions, so they must not count toward the journal's bounded
-  // replay cycle. Only a turn that ran and ended is `carried`.
+  /**
+   * Hand a key's HELD-MAIL run completions back to the journal (#468).
+   *
+   * The completion must leave held mail ENTIRELY, not just lose its token.
+   * Stripping the token alone left the event's TEXT sitting in preserved mail:
+   * `retire()` keeps that mail, so switching Claude→Codex handed the journal's
+   * token to Codex (delivered, correctly) and then switching BACK to Claude
+   * re-delivered the retained text as an ordinary user message — no token, no
+   * `possible_repeat` flag, indistinguishable from a real second completion.
+   * Preservation semantics are for the user's own mail; a completion whose token
+   * has moved on is not that.
+   *
+   * Dropping the item is safe precisely because an injected event is always its
+   * own `completionOnly` item — a re-queued turn restores the original items
+   * rather than one merged blob — so no user message is ever removed with it.
+   *
+   * Every release here is UNCARRIED (the default): nobody read these, so they
+   * must not count toward the journal's bounded replay cycle. Only a turn that
+   * ran and ended is `carried`.
+   */
   private detachHeldCompletions(key: string, reason: string): void {
     const held = this.heldMessages.get(key);
     if (!held?.length) return;
     const tokens: string[] = [];
+    const keep: QueueItem[] = [];
     for (const item of held) {
-      if (!item.eventTokens?.length) continue;
+      if (!item.eventTokens?.length) {
+        keep.push(item);
+        continue;
+      }
       tokens.push(...item.eventTokens);
       delete item.eventTokens; // the journal owns it now — never ack it twice
+      if (item.completionOnly) continue; // …and the event's text goes with it
+      // Defensive: a token on a non-completionOnly item would mean the item
+      // carries user text too, so it must survive — but then its embedded event
+      // text could be re-delivered untracked. Construction prevents this; log
+      // loudly if it ever happens rather than silently allowing a phantom.
+      logger.error(
+        `[panel-orchestrator] tab ${key.slice(0, 8)} ${reason}: held item carried a completion token but is not completionOnly — keeping its text (#468)`,
+      );
+      keep.push(item);
     }
+    if (keep.length !== held.length) this.heldMessages.set(key, keep);
     if (!tokens.length) return;
     logger.warn(
       `[panel-orchestrator] tab ${key.slice(0, 8)} ${reason}: ${tokens.length} run completion(s) were parked in held mail — returned to the journal for replay (#468)`,

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -500,7 +500,10 @@ export class PanelAgent {
     // (#468).
     const rewoundTokens = this.turnEventTokens;
     this.turnEventTokens = [];
-    this.releaseEventTokens(rewoundTokens);
+    // CARRIED, for the same reason as the stall path: the turn was dispatched
+    // with the completion in it, and a rewind can repeat, so this release is
+    // bounded rather than an unbounded replay source.
+    this.releaseEventTokens(rewoundTokens, { carried: true });
     // Break the current stream so start()'s loop re-enters and forks.
     void this.backend.interrupt().catch(() => {});
     const wake = this.waiting;
@@ -771,6 +774,11 @@ export class PanelAgent {
       // `completionOnly` item that a later detach can remove cleanly (#468).
       this.queue.unshift(...interrupted.items);
     } else {
+      // UNCARRIED on purpose. This is a plain Stop — a deliberate human act that
+      // does not repeat on its own, so it cannot form the automatic loop the
+      // bound exists to break; settling a completion on the user's third Stop
+      // would be a surprise, not a safeguard. (The stall watchdog and rewind DO
+      // auto-repeat, so those are carried.)
       this.releaseEventTokens(interruptedTokens);
     }
     // Track the turn this interrupt is aborting (the one holding the gate). The
@@ -1246,7 +1254,11 @@ export class PanelAgent {
     // turn we just wrote off.
     const stalledTokens = this.turnEventTokens;
     this.turnEventTokens = [];
-    this.releaseEventTokens(stalledTokens);
+    // CARRIED: the turn was DISPATCHED with the completion in it. The watchdog
+    // re-arms on every turn, so a backend that keeps freezing would otherwise
+    // replay the same completion forever — this release must count toward the
+    // MAX_CARRIED_RELEASES bound like the result path does.
+    this.releaseEventTokens(stalledTokens, { carried: true });
     if (!alreadyReported) {
       this.deps.onSay(
         this.tabId,

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1188,8 +1188,13 @@ export class PanelAgent {
       // replays them instead of the completion dying with the dead session
       // (#468). No-op after a clean result or the crash re-queue above.
       const strandedTokens = this.turnEventTokens;
+      const strandedWereReceived = this.turnProducedEvents;
       this.turnEventTokens = [];
-      this.releaseEventTokens(strandedTokens);
+      // Same rule again: a session that DID receive this turn (it emitted marked
+      // events) and then died without a terminal result is a bounded replay
+      // cycle — a session that kept dropping before receiving it is not, and
+      // must never count toward the settle bound.
+      this.releaseEventTokens(strandedTokens, { carried: strandedWereReceived });
       if (this.closed) break;
       // Session ended on its own — bound rapid failure loops so a persistently
       // broken SDK doesn't spin forever or black-hole each message.
@@ -1510,10 +1515,12 @@ export class PanelAgent {
             logger.warn(
               `[panel-agent ${this.short()}] an unmarked result cannot ack turn ${this.turnEventTokensMarker}'s run completion(s) — handing ${carried.length} back for replay (#468)`,
             );
-            // CARRIED: this turn ran and ended with the completion in it, so the
-            // agent read it — only the ack is unprovable. Bounded, so a backend
-            // that never stamps its results can't replay this forever.
-            this.releaseEventTokens(carried, { carried: true });
+            // CARRIED only with PROOF the backend received this turn — the same
+            // rule as every other release. An UNMARKED result bypasses the #728
+            // dead-letter gate, so it may be a straggler from an abandoned turn
+            // arriving while this one is still pre-submission; counting it would
+            // let three such stragglers settle a completion nobody ever saw.
+            this.releaseEventTokens(carried, { carried: this.turnProducedEvents });
           }
         }
         // Turn ended cleanly → disarm the freeze watchdog. (If it already tripped,

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -259,6 +259,16 @@ export class PanelAgent {
    *  (#468). Acked when that turn's `result` lands; handed back to the journal
    *  when the turn is abandoned (stall watchdog) or the agent is stopped. */
   private turnEventTokens: string[] = [];
+  /** The turn marker `turnEventTokens` belongs to (#468). A completion is acked
+   *  only by the result of the turn that CARRIED it — see the `result` case. */
+  private turnEventTokensMarker = 0;
+  /** True once this run has seen ANY marker-stamped event, i.e. the backend
+   *  stamps turn markers (Claude does; Codex/Gemini don't). On a stamping
+   *  backend an UNMARKED result is a traceless straggler — possibly from an
+   *  abandoned earlier turn — so it must not ack the current turn's completion
+   *  tokens. On a non-stamping backend there is nothing to compare against, so
+   *  the pre-#468 tolerance applies unchanged. Reset per run. */
+  private sawTurnMarkers = false;
   /** True while a turn is in flight (working→done). Lets the manager defer a
    *  session-restarting option change (effort) until the turn finishes, instead
    *  of interrupting and silently dropping the in-flight reply. */
@@ -900,6 +910,15 @@ export class PanelAgent {
       // only when this turn's `result` lands (proof the agent actually read the
       // completion), not merely because it was spliced off the queue.
       const carriedTokens = batch.flatMap((it) => it.eventTokens ?? []);
+      // SAFETY NET: the previous turn ended without acking (no result at all, or
+      // only a traceless one the ack gate rejected). Its completions are about to
+      // be overwritten here, so hand them back first — the flush re-queues them
+      // into a LATER turn rather than letting them vanish at the handover.
+      if (this.turnEventTokens.length) {
+        const stale = this.turnEventTokens;
+        this.turnEventTokens = [];
+        this.releaseEventTokens(stale);
+      }
       this.turnEventTokens = carriedTokens;
       this.inFlight = {
         text,
@@ -910,6 +929,7 @@ export class PanelAgent {
       // Mirror the backend's turn-marker mint: the Nth turn yielded here is the
       // Nth turn the backend reads — its events carry marker N (#728 r3).
       this.currentTurnMarker += 1;
+      this.turnEventTokensMarker = this.currentTurnMarker;
       // Mark the turn in flight AT DISPATCH (not on the first event). Without this
       // the watchdog's `busy` guard would be false for the exact zero-event freeze
       // it's meant to catch, so onTurnStalled() would no-op. (handleEvent's later
@@ -986,6 +1006,10 @@ export class PanelAgent {
       this.turnWaiter = null;
       this.currentTurnMarker = 0;
       this.abandonedTurnMarker = 0;
+      // The #468 ack gate mirrors the marker reset: a fresh run re-learns whether
+      // this backend stamps, and no marker from the dead run can satisfy it.
+      this.turnEventTokensMarker = 0;
+      this.sawTurnMarkers = false;
       // Drop the prior session's last assistant UUID so a fork can't report a
       // stale (pre-fork) anchor for the first turn of the new session.
       this.lastAssistantUuid = null;
@@ -1215,6 +1239,10 @@ export class PanelAgent {
       );
       return;
     }
+    // Learn whether this backend stamps turn markers at all (#468 ack gate). Set
+    // from any surviving stamped event; a backend that never stamps leaves it
+    // false and keeps the pre-#468 ack behavior.
+    if (typeof ev.turn === "number") this.sawTurnMarkers = true;
     // Any event means the turn is alive — reset the idle watchdog. The `result`
     // case below disarms it entirely (turn ended). Placed before the switch so it
     // covers every event type without per-case bumps.
@@ -1341,7 +1369,19 @@ export class PanelAgent {
         // demonstrably reached the model's context. Ack them: the journal drops
         // them and settles their run tickets. This is the ONLY ack point; every
         // other exit from a turn hands the tokens back for replay.
-        if (this.turnEventTokens.length) {
+        //
+        // ACK GATE: only THIS turn's result may ack. On a marker-stamping
+        // backend an UNMARKED result is a traceless straggler (Claude emits one
+        // for a result it cannot match to a submitted turn) that the #728
+        // dead-letter deliberately lets through for gate liveness — it must not
+        // also retire a completion the CURRENT turn is carrying, or a turn that
+        // then stalls would have nothing left to hand back. A non-stamping
+        // backend has nothing to compare, so it keeps the previous behavior. The
+        // un-acked tokens are handed back at the next dispatch (see channel()).
+        const ackable =
+          !this.sawTurnMarkers ||
+          (typeof ev.turn === "number" && ev.turn === this.turnEventTokensMarker);
+        if (this.turnEventTokens.length && ackable) {
           const delivered = this.turnEventTokens;
           this.turnEventTokens = [];
           try {

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -436,12 +436,26 @@ export class PanelAgent {
 
   /** Queue a panel message and wake the streaming generator (the "channel in").
    *  `images` are ComfyUI refs delivered inline as image blocks (vision). */
-  send(text: string, opts?: { title?: string; images?: ImageRef[]; mid?: string; eventTokens?: string[] }): void {
+  send(
+    text: string,
+    opts?: {
+      title?: string;
+      images?: ImageRef[];
+      mid?: string;
+      eventTokens?: string[];
+      /** Re-delivery of an injected panel event (#468). MUST be preserved by every
+       *  carry-over path: an item that loses this marker is a completion the
+       *  detach logic can no longer remove from held mail, so its text survives
+       *  after its token has been replayed elsewhere — one completion, two turns. */
+      completionOnly?: boolean;
+    },
+  ): void {
     if (opts?.title) this.title = opts.title;
     this.queue.push({
       text,
       images: opts?.images,
       mid: opts?.mid,
+      ...(opts?.completionOnly ? { completionOnly: true } : {}),
       ...(opts?.eventTokens?.length ? { eventTokens: [...opts.eventTokens] } : {}),
     });
     const wake = this.waiting;
@@ -1867,7 +1881,10 @@ export class PanelAgentManager {
         mid: item.mid,
         // #468 — carry the run-completion tokens over so the replacement agent
         // acks the completion it inherited (rather than the journal replaying it
-        // as a second copy).
+        // as a second copy), AND the completionOnly marker with them: an item
+        // that loses it can no longer be removed from held mail later, so its
+        // text would outlive its token.
+        ...(item.completionOnly ? { completionOnly: true } : {}),
         ...(item.eventTokens?.length ? { eventTokens: item.eventTokens } : {}),
       });
     }
@@ -1933,6 +1950,10 @@ export class PanelAgentManager {
         agent.send(item.text, {
           images: item.images,
           mid: item.mid,
+          // #468 — preserve the completionOnly marker across EVERY re-delivery.
+          // A second consecutive failed start would otherwise return this item to
+          // held mail unmarked, making its text un-removable by a later detach.
+          ...(item.completionOnly ? { completionOnly: true } : {}),
           ...(item.eventTokens?.length ? { eventTokens: item.eventTokens } : {}),
         });
       }

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -2405,6 +2405,14 @@ export class PanelAgentManager {
   async stopAll(): Promise<void> {
     this.pendingEffortRestart.clear();
     this.pendingMcpRestart.clear();
+    // #468 — go through the same detach seam as reset()/retire() for EVERY key
+    // before dropping held mail. The journal is about to be reported on by the
+    // orchestrator's shutdown disclosure, and an entry still marked `handed_off`
+    // because its token died inside discarded held mail would be missed by the
+    // replay AND read as merely "in flight" rather than lost.
+    for (const key of [...this.heldMessages.keys()]) {
+      this.detachHeldCompletions(key, "shutdown");
+    }
     this.heldMessages.clear();
     await Promise.all([...this.agents.values()].map((a) => a.stop()));
     this.agents.clear();

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -285,6 +285,17 @@ export class PanelAgent {
   /** The turn marker `turnEventTokens` belongs to (#468). A completion is acked
    *  only by the result of the turn that CARRIED it — see the `result` case. */
   private turnEventTokensMarker = 0;
+  /**
+   * Has the backend produced ANY event for the turn currently in flight?
+   *
+   * This is what "carried" means for #468's bounded replay: the token is
+   * attached at DISPATCH, but the backend may not have consumed the yielded turn
+   * yet (Claude awaits output-image resolution before submitting it). Aborting
+   * in that window — a rewind, or the watchdog on a turn that produced nothing —
+   * means the completion never reached the model, so it must NOT count toward
+   * the settle bound. One event is proof of receipt. Reset at each dispatch.
+   */
+  private turnProducedEvents = false;
   /** True while a turn is in flight (working→done). Lets the manager defer a
    *  session-restarting option change (effort) until the turn finishes, instead
    *  of interrupting and silently dropping the in-flight reply. */
@@ -500,10 +511,11 @@ export class PanelAgent {
     // (#468).
     const rewoundTokens = this.turnEventTokens;
     this.turnEventTokens = [];
-    // CARRIED, for the same reason as the stall path: the turn was dispatched
-    // with the completion in it, and a rewind can repeat, so this release is
-    // bounded rather than an unbounded replay source.
-    this.releaseEventTokens(rewoundTokens, { carried: true });
+    // CARRIED only if the backend actually RECEIVED this turn. A rewind during
+    // the pre-submission window (Claude resolving output images) aborts a turn
+    // the model never saw, and counting that toward the settle bound could
+    // retire a completion nobody read.
+    this.releaseEventTokens(rewoundTokens, { carried: this.turnProducedEvents });
     // Break the current stream so start()'s loop re-enters and forks.
     void this.backend.interrupt().catch(() => {});
     const wake = this.waiting;
@@ -971,10 +983,9 @@ export class PanelAgent {
       if (this.turnEventTokens.length) {
         const stale = this.turnEventTokens;
         this.turnEventTokens = [];
-        // CARRIED: a turn genuinely dispatched with these and has now been
-        // superseded, so the agent read the text — this is the same unprovable-
-        // ack cycle as the result path and is bounded with it.
-        this.releaseEventTokens(stale, { carried: true });
+        // CARRIED only if that turn produced events (proof the backend received
+        // it) — the same rule as the result and abandon paths.
+        this.releaseEventTokens(stale, { carried: this.turnProducedEvents });
       }
       this.turnEventTokens = carriedTokens;
       this.inFlight = {
@@ -988,6 +999,7 @@ export class PanelAgent {
       // Nth turn the backend reads — its events carry marker N (#728 r3).
       this.currentTurnMarker += 1;
       this.turnEventTokensMarker = this.currentTurnMarker;
+      this.turnProducedEvents = false; // no proof of receipt yet (#468)
       // Mark the turn in flight AT DISPATCH (not on the first event). Without this
       // the watchdog's `busy` guard would be false for the exact zero-event freeze
       // it's meant to catch, so onTurnStalled() would no-op. (handleEvent's later
@@ -1254,11 +1266,13 @@ export class PanelAgent {
     // turn we just wrote off.
     const stalledTokens = this.turnEventTokens;
     this.turnEventTokens = [];
-    // CARRIED: the turn was DISPATCHED with the completion in it. The watchdog
-    // re-arms on every turn, so a backend that keeps freezing would otherwise
-    // replay the same completion forever — this release must count toward the
-    // MAX_CARRIED_RELEASES bound like the result path does.
-    this.releaseEventTokens(stalledTokens, { carried: true });
+    // CARRIED only if the backend produced at least one event for this turn —
+    // i.e. it demonstrably received the completion and then went silent. A turn
+    // that produced NOTHING never reached the model, so it must not count toward
+    // the settle bound (that freeze is bounded by the self-restart give-up
+    // machinery instead, which tears the agent down rather than quietly retiring
+    // a completion nobody saw).
+    this.releaseEventTokens(stalledTokens, { carried: this.turnProducedEvents });
     if (!alreadyReported) {
       this.deps.onSay(
         this.tabId,
@@ -1303,6 +1317,9 @@ export class PanelAgent {
       );
       return;
     }
+    // Proof the backend RECEIVED the in-flight turn (#468) — stragglers were
+    // already dead-lettered above, so anything reaching here belongs to it.
+    this.turnProducedEvents = true;
     // Any event means the turn is alive — reset the idle watchdog. The `result`
     // case below disarms it entirely (turn ended). Placed before the switch so it
     // covers every event type without per-case bumps.

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -2078,13 +2078,7 @@ export class PanelAgentManager {
         // agent's queue — including the one that triggered it. Capture them
         // (BEFORE stop(), which closes the agent) for re-delivery by the next
         // spawn on this key, so nothing dies silently with the doomed agent.
-        const orphaned = agent.takePending();
-        if (orphaned.length) {
-          this.heldMessages.set(key, [...(this.heldMessages.get(key) ?? []), ...orphaned]);
-          logger.warn(
-            `[panel-orchestrator] tab ${key.slice(0, 8)} holding ${orphaned.length} undelivered message(s) — re-delivered on the next successful start`,
-          );
-        }
+        this.holdOrphanedMail(key, agent.takePending(), "a failed start");
         // PER-TAB degradation (issue #250): a hard start failure is almost
         // always a tab-local configuration error — an invalid API key (the
         // endpoint 401s in prepare()), an unreachable base URL, a missing CLI
@@ -2112,13 +2106,7 @@ export class PanelAgentManager {
         // skips: no replay, ever. Capture the queue into held mail (its tokens
         // ride along, so a respawn re-delivers exactly once) and stop() the agent
         // so anything left over is handed back.
-        const orphaned = agent.takePending();
-        if (orphaned.length) {
-          this.heldMessages.set(key, [...(this.heldMessages.get(key) ?? []), ...orphaned]);
-          logger.warn(
-            `[panel-orchestrator] tab ${key.slice(0, 8)} holding ${orphaned.length} undelivered message(s) from an agent that gave up — re-delivered on the next successful start`,
-          );
-        }
+        this.holdOrphanedMail(key, agent.takePending(), "an agent that gave up");
         void agent.stop().catch(() => {});
         // Fatal signal: let the orchestrator self-exit + respawn.
         this.opts.onAgentFatal?.(key, "agent session kept dropping (self-restart gave up)");
@@ -2391,6 +2379,40 @@ export class PanelAgentManager {
    * must not count toward the journal's bounded replay cycle. Only a turn that
    * ran and ended is `carried`.
    */
+  /**
+   * Park a dead agent's unsent mail for the next spawn — but NEVER its injected
+   * completions (#468).
+   *
+   * Held mail is unbounded and the journal's revocation can only reach a LIVE
+   * agent's queue, so a completion parked here is a copy the journal can no
+   * longer count or cap: each failed-start/retry cycle would strand another
+   * capped batch in held mail, and the whole pile eventually drains into one
+   * turn. Completions are revocable by design and the JOURNAL is their record —
+   * so they are handed back instead, and replayed (bounded) into whatever agent
+   * comes next. Only the user's own messages are held.
+   */
+  private holdOrphanedMail(key: string, orphaned: QueueItem[], reason: string): void {
+    if (!orphaned.length) return;
+    const completions = orphaned.filter((it) => it.completionOnly);
+    const mail = orphaned.filter((it) => !it.completionOnly);
+    if (mail.length) {
+      this.heldMessages.set(key, [...(this.heldMessages.get(key) ?? []), ...mail]);
+      logger.warn(
+        `[panel-orchestrator] tab ${key.slice(0, 8)} holding ${mail.length} undelivered message(s) from ${reason} — re-delivered on the next successful start`,
+      );
+    }
+    const tokens = completions.flatMap((it) => it.eventTokens ?? []);
+    if (!tokens.length) return;
+    logger.warn(
+      `[panel-orchestrator] tab ${key.slice(0, 8)}: ${tokens.length} run completion(s) were queued on ${reason} — returned to the journal (never held) for bounded replay (#468)`,
+    );
+    try {
+      this.opts.onEventUndelivered?.(key, tokens);
+    } catch (err) {
+      logger.warn(`[panel-orchestrator] tab ${key.slice(0, 8)} returning orphaned completions: ${msgOf(err)}`);
+    }
+  }
+
   private detachHeldCompletions(key: string, reason: string): void {
     const held = this.heldMessages.get(key);
     if (!held?.length) return;

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -56,6 +56,7 @@ import { setComfyuiSecret, setAgentSecret, isAllowedAgentSecretKey } from "../se
 import { flattenUiWorkflow } from "../services/flatten-workflow.js";
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
 import { QueueMonitor } from "../services/queue-monitor.js";
+import { RunCompletions } from "./run-completion-journal.js";
 import {
   getClient,
   getObjectInfo,
@@ -4278,10 +4279,25 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           return typeof pid === "string" && pid ? pid : null;
         })();
         QueueMonitor.markSelfQueued(queuedId);
+        // #468 — open a run ticket so the render's completion can be CORRELATED
+        // to this exact call by prompt id. This is what lets the orchestrator
+        // journal an undelivered completion and replay it into the right run
+        // instead of losing it while the agent works through a goal.
+        const correlatable = RunCompletions.openRun(queuedId, {
+          tabId: ctx.tabId,
+          ...(typeof args.to_node_id === "number" ? { toNodeId: args.to_node_id } : {}),
+        });
         // Append anti-poll guidance: the agent should go idle after queuing so the
         // executed event auto-injects the output image, rather than busy-polling.
-        const note =
-          "\n\n[IMPORTANT] You will be notified automatically with the output image(s)/video when the render finishes — do NOT poll queue (action:\"list\"), get_history, or list_output_images. Just end your turn now and wait for the result to be delivered to you.";
+        //
+        // HONEST WHEN WE CAN'T PROMISE IT (#468): the anti-poll instruction is only
+        // safe because the completion is correlated by prompt id. Without one — the
+        // panel forwarded no `prompt_id` — a later completion can only be reported as
+        // UNDETERMINED, so telling the agent to idle and wait would park it on a
+        // promise we can't keep. Say so and point at the verification path instead.
+        const note = correlatable
+          ? "\n\n[IMPORTANT] You will be notified automatically with the output image(s)/video when the render finishes — do NOT poll queue (action:\"list\"), get_history, or list_output_images. Just end your turn now and wait for the result to be delivered to you."
+          : "\n\n[IMPORTANT] The run was queued, but the panel reported NO prompt id for it, so a completion event CANNOT be correlated back to this run — its outcome will be reported to you as UNDETERMINED. Do NOT simply idle and wait indefinitely: end your turn, and if nothing arrives, confirm the outcome with get_history before acting on it.";
         // Backpressure note. A backlog is only alarming when it's a job we did NOT
         // queue (possibly foreign/stuck). Deliberately batching renders — a sweep,
         // a multi-variant comparison — is a NORMAL workflow, so a queue made of our

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -391,7 +391,15 @@ export class RunCompletionJournalImpl {
         );
         return null;
       }
-      for (const entry of this.entries.values()) {
+      // COALESCE is an optimisation that ASSUMES the prompt id identifies one
+      // run — which is exactly the assumption `reused` voids. Merging there is a
+      // LOSS: B's real completion would overwrite A's entry and be returned as
+      // it, while the turn already queued still holds A's text; A's ack then
+      // removes the sole entry and B is never delivered. So for a reused id, do
+      // not coalesce at all — B gets its own entry, flagged UNDETERMINED like
+      // every other ambiguous case. Duplicate over loss, the same rule the
+      // suppression checks above follow.
+      for (const entry of idReused ? [] : this.entries.values()) {
         if (
           entry.key === key &&
           !entry.superseded && // a re-queued run never merges into the old one's entry
@@ -619,7 +627,17 @@ export class RunCompletionJournalImpl {
     // run's real completion.
     if (entry.superseded) return;
     if (entry.correlation.status !== "unidentified") {
-      this.memoDelivered(entry.key, entry.correlation.promptId);
+      // …and do not memoize a REUSED id either. DEFENSE IN DEPTH, not a live
+      // defect: `openRun` already clears the memo on every path, so no reachable
+      // sequence can let a stale one suppress a later legitimate completion (and
+      // therefore no test can fail on this line). It is here because writing a
+      // "we already reported this run" proof about an id that stands for MORE
+      // THAN ONE run is meaningless on its face, and a future caller that opens a
+      // ticket without going through openRun would inherit the trap.
+      const ticket = this.tickets.get(entry.correlation.promptId);
+      if (!(ticket?.reused === true && ticket.tabId === entry.key)) {
+        this.memoDelivered(entry.key, entry.correlation.promptId);
+      }
     } else if (entry.fingerprint) {
       // ID-LESS: memoize the CONTENT so a re-sent identical frame after the ack
       // doesn't produce a second turn. Windowed in record(), bounded here.

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -299,6 +299,38 @@ export class RunCompletionJournalImpl {
     this.reflush?.(entry.key);
   }
 
+  /**
+   * A NEW run has taken over `promptId`, so every completion already journaled
+   * under it belongs to an OLDER run. Retire them: superseded (so they can never
+   * be merged into, settle a ticket, or memoize a delivery), downgraded from
+   * `matched` to `foreign` (so they stop claiming to be the run now outstanding),
+   * and re-issued if their queued copy can still be pulled back and re-worded.
+   *
+   * Runs on BOTH openRun paths — a reopen AND a fresh ticket after the old one
+   * was evicted. Only doing it on the reopen left the eviction ordering able to
+   * present an older run's result as the newly queued one's.
+   */
+  private retireOlderEntriesFor(promptId: string): void {
+    for (const entry of this.entries.values()) {
+      if (
+        entry.correlation.status === "unidentified" ||
+        entry.correlation.promptId !== promptId ||
+        entry.superseded
+      ) {
+        continue;
+      }
+      entry.superseded = true;
+      if (entry.correlation.status === "matched") {
+        entry.correlation = { status: "foreign", promptId: entry.correlation.promptId };
+      }
+      logger.warn(
+        `[run-completions] prompt ${promptId} was queued again while an earlier completion for it was still undelivered — the older entry is superseded (and reported as undetermined) so it can no longer answer for the new run`,
+      );
+      entry.ambiguousId = true; // the id now stands for more than one run
+      this.reissueAfterDowngrade(entry);
+    }
+  }
+
   /** `panel_run` queued a render. Returns false when ComfyUI/the panel gave us
    *  no prompt id — the caller MUST then tell the agent its completion cannot be
    *  correlated rather than promising a notification it may not be able to
@@ -323,37 +355,7 @@ export class RunCompletionJournalImpl {
       // on is unattributable (see RunTicket.reused) — reported UNDETERMINED, and
       // never suppressed as a duplicate of the other generation.
       existing.reused = true;
-      // SUPERSEDE any entry still carrying the PREVIOUS run's completion for this
-      // id. Without this, the new run's completion merges into an entry that is
-      // already sitting in an agent queue holding the OLD completion's text: when
-      // that turn ends, ack() removes the shared entry and settles the REOPENED
-      // ticket — the old result is presented as the new run's, and the new run's
-      // real completion is never delivered. A superseded entry is skipped by the
-      // dedupe scan and can no longer settle a ticket or memoize a delivery.
-      for (const entry of this.entries.values()) {
-        if (
-          entry.correlation.status !== "unidentified" &&
-          entry.correlation.promptId === promptId &&
-          !entry.superseded
-        ) {
-          entry.superseded = true;
-          // DOWNGRADE it too (matched → foreign, the same one-way weakening
-          // closeRuns uses). Marking it superseded stops it settling the reopened
-          // ticket, but it would still have been DELIVERED saying "this is the run
-          // YOU queued" — presenting the OLD result as the newly queued run's
-          // awaited outcome. It is a real completion, so it is still delivered;
-          // it just can no longer claim to be the run now outstanding.
-          if (entry.correlation.status === "matched") {
-            entry.correlation = { status: "foreign", promptId: entry.correlation.promptId };
-          }
-          logger.warn(
-            `[run-completions] prompt ${promptId} was queued again while its previous completion was still undelivered — the older entry is superseded (and reported as undetermined) so it can no longer answer for the new run`,
-          );
-          // Its already-queued copy still SAYS "the run YOU queued". Pull it back
-          // if it hasn't been read yet and re-deliver the downgraded wording.
-          this.reissueAfterDowngrade(entry);
-        }
-      }
+      this.retireOlderEntriesFor(promptId);
       return true;
     }
     this.tickets.set(promptId, {
@@ -364,6 +366,11 @@ export class RunCompletionJournalImpl {
       ...(typeof meta.toNodeId === "number" ? { toNodeId: meta.toNodeId } : {}),
       settled: false,
     });
+    // …and on THIS branch too. A fresh ticket after the old one was evicted is
+    // still a NEW run for an id that already has journaled completions: without
+    // this, an older `matched` entry survives untouched and goes on telling the
+    // agent "this is the run YOU queued" for the id now outstanding.
+    this.retireOlderEntriesFor(promptId);
     this.trimTickets();
     return true;
   }
@@ -410,6 +417,9 @@ export class RunCompletionJournalImpl {
     let idlessRepeat = false;
     /** This id already stands for more than one run (see RunTicket.reused). */
     let idReused = false;
+    /** No provable identity for this completion — see the `unprovable` note in
+     *  the identified branch. Never merged into, never suppressed. */
+    let idUnprovable = false;
     /** Ticket generation this completion belongs to — the run identity (0 = no
      *  ticket, i.e. a run this tab never queued). */
     let gen = 0;
@@ -432,8 +442,19 @@ export class RunCompletionJournalImpl {
       // ticket after the old one was evicted): different generation, different
       // key, no match.
       gen = this.generationOf(key, correlation.promptId);
+      // UNPROVABLE identity — no dedupe of any kind is safe:
+      //  • `reused`: the id stands for more than one run (see RunTicket.reused).
+      //  • gen 0: this tab never ticketed the id, so there is NO generation to
+      //    tell one such completion from another. Every foreign completion would
+      //    share the key `(tab, id, 0)`, which is a bucket, not an identity —
+      //    two genuinely different external renders that reuse a prompt id (a
+      //    ComfyUI restart does exactly that) would merge, and the second would
+      //    be suppressed outright after the first was acked.
+      // Both cases fall back to the standing rule: duplicate over loss, each
+      // delivered on its own and labelled UNDETERMINED.
+      idUnprovable = idReused || gen === 0;
       if (
-        !idReused &&
+        !idUnprovable &&
         (this.delivered.has(deliveredKey(key, correlation.promptId, gen)) ||
           (settledTicket?.settled === true && settledTicket.tabId === key))
       ) {
@@ -464,7 +485,7 @@ export class RunCompletionJournalImpl {
       // still a DIFFERENT run: overwriting its payload would drop that run's
       // result and leave the survivor stamped with the wrong generation, so its
       // ack could settle neither. Same-state AND same-identity.
-      for (const entry of idReused ? [] : this.entries.values()) {
+      for (const entry of idUnprovable ? [] : this.entries.values()) {
         if (
           entry.key === key &&
           entry.state === "pending" && // never merge into text already committed to a turn
@@ -538,7 +559,7 @@ export class RunCompletionJournalImpl {
         ? { fingerprint: idlessFingerprint(key, payload), ...(idlessRepeat ? { possibleRepeat: true } : {}) }
         : {}),
       // Freeze the ambiguity onto the entry — see JournalEntry.ambiguousId.
-      ...(idReused ? { ambiguousId: true } : {}),
+      ...(idUnprovable ? { ambiguousId: true } : {}),
       // …and the GENERATION this completion belongs to, for EVERY identified
       // entry (not just matched ones): it is what keeps its ack, its memo and any
       // future merge bound to this run rather than to whatever the id means later.
@@ -707,7 +728,12 @@ export class RunCompletionJournalImpl {
       // THAN ONE run is meaningless on its face, and a future caller that opens a
       // ticket without going through openRun would inherit the trap.
       const ticket = this.tickets.get(entry.correlation.promptId);
-      if (!(ticket?.reused === true && ticket.tabId === entry.key)) {
+      // Only a REAL generation is a proof. Generation 0 means this tab never
+      // ticketed the id, so `(tab, id, 0)` is a bucket shared by every foreign
+      // completion for it — memoizing there would let one external render's
+      // delivery suppress a different one that happens to reuse the id.
+      const provable = (entry.ticketSeq ?? 0) > 0;
+      if (provable && !(ticket?.reused === true && ticket.tabId === entry.key)) {
         // Memoize against THIS entry's own generation, never the id's current
         // meaning: an older run's ack must not write a proof that then suppresses
         // the newer run which reused the id (or got a fresh ticket after the old

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -104,6 +104,9 @@ export interface JournalEntry {
   arrivedAt: number;
   attempts: number;
   state: EntryState;
+  /** Content fingerprint — set only for ID-LESS completions, which have no run
+   *  identity to dedupe on. See idlessFingerprint(). */
+  fingerprint?: string;
 }
 
 /** Runs tracked at once. Ample for any real batch; bounded so a long session
@@ -119,11 +122,39 @@ const MAX_ENTRIES_TOTAL = 96;
 const MAX_DELIVERED_MEMO = 256;
 /** Tabs whose evicted-completion counter is retained. */
 const MAX_DROPPED_KEYS = 64;
+/** How many times a completion may be handed to a LIVE agent without a provable
+ *  ack before the journal settles it anyway. Bounds the hand-off/release cycle
+ *  (see release()); each hand-off already put the text into a turn the agent
+ *  read, so settling risks a duplicate, never a loss. */
+const MAX_HANDOFFS = 3;
+/** How long an ID-LESS completion's content fingerprint suppresses an identical
+ *  repeat. Bounded on purpose: with no prompt id, identical content is the ONLY
+ *  evidence of sameness, and two genuinely distinct renders can eventually
+ *  produce identical filenames (ComfyUI reuses `ComfyUI_temp_*_00001_` after a
+ *  restart). Long enough to absorb a panel re-send burst, short enough that a
+ *  later real render is never mistaken for a repeat. */
+const IDLESS_DEDUPE_WINDOW_MS = 10 * 60_000;
 
 /** Memo key for an already-delivered (tab, run). "|" separates them; a ComfyUI
  *  prompt id is a fixed-format UUID, so the pair can't alias another. */
 function deliveredKey(key: string, promptId: string): string {
   return `${key}|${promptId}`;
+}
+
+/**
+ * Fingerprint for an ID-LESS completion (a panel that forwarded no `prompt_id`).
+ * With no run identity, content is all we have to tell "the panel re-sent the
+ * same frame" from "a second render finished": kind + note + error + the exact
+ * output list. Combined with IDLESS_DEDUPE_WINDOW_MS this collapses a repeat
+ * without letting a later, genuinely different render inherit the suppression.
+ * Filenames are NOT sorted — the panel emits them in output order, and a
+ * different order is a different batch.
+ */
+function idlessFingerprint(key: string, payload: CompletionPayload): string {
+  const files = (payload.images ?? [])
+    .map((i) => `${i.subfolder ?? ""}/${i.type ?? ""}/${i.filename}`)
+    .join(",");
+  return `${key}|~idless~|${payload.kind ?? ""}|${payload.note ?? ""}|${payload.error ?? ""}|${files}`;
 }
 
 export class RunCompletionJournalImpl {
@@ -137,6 +168,10 @@ export class RunCompletionJournalImpl {
    *  panel that re-sends the frame after the entry was removed can't produce a
    *  second delivery. */
   private delivered = new Set<string>();
+  /** Content fingerprint → delivery time, for ID-LESS completions (which have no
+   *  run identity to memoize). Bounded FIFO + a time window, so an identical
+   *  re-send is suppressed but a later genuinely-different render is not. */
+  private idlessSeen = new Map<string, number>();
   private seq = 0;
 
   /** `panel_run` queued a render. Returns false when ComfyUI/the panel gave us
@@ -187,11 +222,17 @@ export class RunCompletionJournalImpl {
   /**
    * Journal a completion addressed to `key`. Correlation is computed here, once.
    *
-   * DEDUPE: an identified completion (matched or foreign) collapses onto any
-   * existing undelivered entry for the same key + prompt id — one run can never
-   * produce two deliveries, however many times the panel re-sends it. An
-   * unidentified completion has nothing to dedupe on, so it is always a new
-   * entry (bounded by MAX_ENTRIES_PER_KEY).
+   * DEDUPE, in both directions:
+   *  • IDENTIFIED (matched or foreign) — collapses onto any existing undelivered
+   *    entry for the same key + prompt id, and is suppressed outright once that
+   *    (tab, run) has been acked. One run can never produce two deliveries,
+   *    however many times the panel re-sends it.
+   *  • ID-LESS — there is no run identity, so it dedupes on a CONTENT
+   *    fingerprint within IDLESS_DEDUPE_WINDOW_MS. That is enough to stop a
+   *    re-sent frame producing two turns (the agent double-reporting, or acting
+   *    twice on one output), while a later genuinely different render — or the
+   *    same content long afterwards — is still delivered.
+   * Returns null when the completion is a suppressed duplicate.
    */
   record(key: string, payload: CompletionPayload): JournalEntry | null {
     const correlation = this.correlate(key, payload);
@@ -221,6 +262,30 @@ export class RunCompletionJournalImpl {
           return entry;
         }
       }
+    } else {
+      const print = idlessFingerprint(key, payload);
+      const now = Date.now();
+      // Already delivered an identical id-less completion recently.
+      const seenAt = this.idlessSeen.get(print);
+      if (seenAt !== undefined && now - seenAt < IDLESS_DEDUPE_WINDOW_MS) {
+        logger.info(
+          `[run-completions] ignoring a re-sent id-less completion for tab ${key.slice(0, 8)} — identical content already delivered`,
+        );
+        return null;
+      }
+      if (seenAt !== undefined) this.idlessSeen.delete(print); // stale — let it through
+      // Or one is still journaled and undelivered.
+      for (const entry of this.entries.values()) {
+        if (
+          entry.key === key &&
+          entry.correlation.status === "unidentified" &&
+          entry.fingerprint === print &&
+          now - entry.arrivedAt < IDLESS_DEDUPE_WINDOW_MS
+        ) {
+          entry.payload = payload;
+          return entry;
+        }
+      }
     }
     const entry: JournalEntry = {
       token: `rc${++this.seq}`,
@@ -230,6 +295,9 @@ export class RunCompletionJournalImpl {
       arrivedAt: Date.now(),
       attempts: 0,
       state: "pending",
+      ...(correlation.status === "unidentified"
+        ? { fingerprint: idlessFingerprint(key, payload) }
+        : {}),
     };
     this.entries.set(entry.token, entry);
     this.trimEntries(key);
@@ -334,6 +402,15 @@ export class RunCompletionJournalImpl {
         if (oldest === undefined) break;
         this.delivered.delete(oldest);
       }
+    } else if (entry.fingerprint) {
+      // ID-LESS: memoize the CONTENT so a re-sent identical frame after the ack
+      // doesn't produce a second turn. Windowed in record(), bounded here.
+      this.idlessSeen.set(entry.fingerprint, Date.now());
+      while (this.idlessSeen.size > MAX_DELIVERED_MEMO) {
+        const oldest = this.idlessSeen.keys().next().value;
+        if (oldest === undefined) break;
+        this.idlessSeen.delete(oldest);
+      }
     }
     if (entry.correlation.status === "matched") {
       const ticket = this.tickets.get(entry.correlation.promptId);
@@ -341,11 +418,29 @@ export class RunCompletionJournalImpl {
     }
   }
 
-  /** An agent gave a hand-off back undelivered (it was stopped, or its turn was
-   *  abandoned before it could be read). Re-arm it for replay. */
+  /**
+   * An agent gave a hand-off back undelivered (it was stopped, its turn was
+   * abandoned, or the turn's result could not be proven to be its own). Re-arm
+   * it for replay.
+   *
+   * BOUNDED. `attempts` counts hand-offs to a LIVE agent — each one put the
+   * completion's text into a turn the agent actually read. A backend that
+   * declares turn markers but keeps emitting unmarked results would otherwise
+   * bounce the same entry between hand-off and release forever, re-delivering it
+   * on every turn. After MAX_HANDOFFS the evidence of delivery is overwhelming
+   * (the agent has seen it that many times), so we settle it rather than loop.
+   * This can only ever cause a duplicate, never a loss.
+   */
   release(token: string): void {
     const entry = this.entries.get(token);
     if (!entry) return;
+    if (entry.attempts >= MAX_HANDOFFS) {
+      logger.warn(
+        `[run-completions] ${describe(entry.correlation)} was handed to a live agent ${entry.attempts}× without a provable ack — settling it instead of replaying again`,
+      );
+      this.ack(token);
+      return;
+    }
     entry.state = "pending";
   }
 
@@ -376,6 +471,20 @@ export class RunCompletionJournalImpl {
       this.dropped.delete(from);
       this.dropped.set(to, (this.dropped.get(to) ?? 0) + lost);
     }
+    // The id-less content memo and every entry's fingerprint embed the tab key,
+    // so they must be re-keyed too or a post-migration re-send is delivered
+    // twice — the same defect as the delivered memo above.
+    const fromPrefix = `${from}|~idless~|`;
+    for (const [print, at] of [...this.idlessSeen]) {
+      if (!print.startsWith(fromPrefix)) continue;
+      this.idlessSeen.delete(print);
+      this.idlessSeen.set(`${to}|~idless~|${print.slice(fromPrefix.length)}`, at);
+    }
+    for (const entry of this.entries.values()) {
+      if (entry.fingerprint?.startsWith(fromPrefix)) {
+        entry.fingerprint = `${to}|~idless~|${entry.fingerprint.slice(fromPrefix.length)}`;
+      }
+    }
   }
 
   /**
@@ -404,6 +513,9 @@ export class RunCompletionJournalImpl {
     this.dropped.delete(key);
     for (const memo of [...this.delivered]) {
       if (memo.startsWith(`${key}|`)) this.delivered.delete(memo);
+    }
+    for (const print of [...this.idlessSeen.keys()]) {
+      if (print.startsWith(`${key}|~idless~|`)) this.idlessSeen.delete(print);
     }
   }
 
@@ -446,6 +558,7 @@ export class RunCompletionJournalImpl {
     this.entries.clear();
     this.dropped.clear();
     this.delivered.clear();
+    this.idlessSeen.clear();
     this.seq = 0;
   }
   droppedFor(key: string): number {

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -208,10 +208,17 @@ const MAX_CARRIED_RELEASES = 3;
 const IDLESS_COLLAPSE_MS = 30_000;
 const IDLESS_REPEAT_HINT_MS = 10 * 60_000;
 
-/** Memo key for an already-delivered (tab, run). "|" separates them; a ComfyUI
- *  prompt id is a fixed-format UUID, so the pair can't alias another. */
-function deliveredKey(key: string, promptId: string): string {
-  return `${key}|${promptId}`;
+/**
+ * Memo key for an already-delivered run: (tab, prompt id, TICKET GENERATION).
+ *
+ * The generation is what makes this an identity rather than a guess. A prompt id
+ * alone is not one — ComfyUI reuses ids, and a ticket can be evicted and
+ * recreated — so a memo keyed on the id would let run A's delivery suppress run
+ * B's real completion. `gen` is `RunTicket.seq`, or 0 when this tab has no
+ * ticket for the id at all (an unqueued, foreign run).
+ */
+function deliveredKey(key: string, promptId: string, gen: number): string {
+  return `${key}|${promptId}|${gen}`;
 }
 
 /**
@@ -248,6 +255,15 @@ export class RunCompletionJournalImpl {
   private seq = 0;
   /** Monotonic ticket-generation counter — see RunTicket.seq. */
   private ticketSeq = 0;
+
+  /** The generation this tab's ticket for `promptId` is currently on, or 0 when
+   *  it has none. THE run identity: every proof and every merge is keyed on it,
+   *  so an id reused (or a ticket evicted and recreated) can never let one run's
+   *  bookkeeping answer for another's. */
+  private generationOf(key: string, promptId: string): number {
+    const ticket = this.tickets.get(promptId);
+    return ticket && ticket.tabId === key ? ticket.seq : 0;
+  }
   /** Pull a still-queued completion back off its agent (see setRevoker). */
   private revoke: ((key: string, token: string) => boolean) | null = null;
   /** Re-deliver a tab's pending completions (after a revoke re-arms one). */
@@ -289,14 +305,11 @@ export class RunCompletionJournalImpl {
    *  attribute. */
   openRun(promptId: string | null | undefined, meta: { tabId: string; toNodeId?: number }): boolean {
     if (typeof promptId !== "string" || !promptId) return false;
-    // CLEAR the already-delivered memo for this (tab, run) FIRST, on EVERY path.
-    // The memo only ever means "we already reported THIS run", which queuing the
-    // id again makes false — and the memo outlives the ticket by design, so the
-    // reopen branch below is NOT the only way to reach a stale one: after 64
-    // later runs the old ticket is evicted, and a reuse of the id then takes the
-    // fresh-ticket path while the memo still stands. Leaving it would suppress
-    // the NEW run's real completion after `panel_run` promised to deliver it.
-    this.delivered.delete(deliveredKey(meta.tabId, promptId));
+    // NOTE: no memo clearing is needed here. The delivered memo is keyed by
+    // ticket GENERATION, and every path below either bumps the generation (a
+    // reopen) or mints a fresh one (a new ticket), so a newly queued run's memo
+    // key is unused by construction. This used to be a `delete` precisely because
+    // the key was generation-blind — the structural fix removed the need.
     const existing = this.tickets.get(promptId);
     if (existing) {
       // Same prompt id queued again (a re-run of an id ComfyUI reused, or a
@@ -397,6 +410,9 @@ export class RunCompletionJournalImpl {
     let idlessRepeat = false;
     /** This id already stands for more than one run (see RunTicket.reused). */
     let idReused = false;
+    /** Ticket generation this completion belongs to — the run identity (0 = no
+     *  ticket, i.e. a run this tab never queued). */
+    let gen = 0;
     if (correlation.status !== "unidentified") {
       // Already DELIVERED once (its carrying turn ended, so the entry is gone).
       // A panel that re-sends the frame must not produce a second delivery — the
@@ -411,9 +427,14 @@ export class RunCompletionJournalImpl {
       // the newer run's real result. A duplicate delivery (labelled UNDETERMINED)
       // is the correct trade here.
       idReused = settledTicket?.reused === true && settledTicket.tabId === key;
+      // The memo is keyed by GENERATION, so an older run's delivery can never
+      // suppress a newer one that merely reuses the id (or that got a fresh
+      // ticket after the old one was evicted): different generation, different
+      // key, no match.
+      gen = this.generationOf(key, correlation.promptId);
       if (
         !idReused &&
-        (this.delivered.has(deliveredKey(key, correlation.promptId)) ||
+        (this.delivered.has(deliveredKey(key, correlation.promptId, gen)) ||
           (settledTicket?.settled === true && settledTicket.tabId === key))
       ) {
         logger.info(
@@ -437,10 +458,17 @@ export class RunCompletionJournalImpl {
       // reason. The `reused`/`ambiguousId` checks below are now an OPTIMISATION
       // for better wording (an ambiguous run should read as UNDETERMINED rather
       // than merge at all), never the thing correctness rests on.
+      //
+      // The target must ALSO be the same GENERATION. A `pending` entry from an
+      // older run of the same id (its ticket evicted, the id then re-queued) is
+      // still a DIFFERENT run: overwriting its payload would drop that run's
+      // result and leave the survivor stamped with the wrong generation, so its
+      // ack could settle neither. Same-state AND same-identity.
       for (const entry of idReused ? [] : this.entries.values()) {
         if (
           entry.key === key &&
           entry.state === "pending" && // never merge into text already committed to a turn
+          (entry.ticketSeq ?? 0) === gen && // …nor across run generations
           !entry.superseded && // a re-queued run never merges into the old one's entry
           !entry.ambiguousId && // nor into one that arrived under a reused id
           entry.correlation.status !== "unidentified" &&
@@ -511,11 +539,10 @@ export class RunCompletionJournalImpl {
         : {}),
       // Freeze the ambiguity onto the entry — see JournalEntry.ambiguousId.
       ...(idReused ? { ambiguousId: true } : {}),
-      // …and the exact ticket GENERATION this matched, so its ack can never
-      // settle a later run that merely reuses the id (see RunTicket.seq).
-      ...(correlation.status === "matched"
-        ? { ticketSeq: this.tickets.get(correlation.promptId)?.seq }
-        : {}),
+      // …and the GENERATION this completion belongs to, for EVERY identified
+      // entry (not just matched ones): it is what keeps its ack, its memo and any
+      // future merge bound to this run rather than to whatever the id means later.
+      ...(correlation.status !== "unidentified" ? { ticketSeq: gen } : {}),
     };
     this.entries.set(entry.token, entry);
     this.trimEntries(key);
@@ -681,7 +708,11 @@ export class RunCompletionJournalImpl {
       // ticket without going through openRun would inherit the trap.
       const ticket = this.tickets.get(entry.correlation.promptId);
       if (!(ticket?.reused === true && ticket.tabId === entry.key)) {
-        this.memoDelivered(entry.key, entry.correlation.promptId);
+        // Memoize against THIS entry's own generation, never the id's current
+        // meaning: an older run's ack must not write a proof that then suppresses
+        // the newer run which reused the id (or got a fresh ticket after the old
+        // one was evicted).
+        this.memoDelivered(entry.key, entry.correlation.promptId, entry.ticketSeq ?? 0);
       }
     } else if (entry.fingerprint) {
       // ID-LESS: memoize the CONTENT so a re-sent identical frame after the ack
@@ -845,8 +876,8 @@ export class RunCompletionJournalImpl {
    *  frame is suppressed rather than delivered a second time. Bounded FIFO; the
    *  run TICKET's `settled` flag is the other record, and an evicted settled
    *  ticket feeds this one so neither expires before the other. */
-  private memoDelivered(key: string, promptId: string): void {
-    this.delivered.add(deliveredKey(key, promptId));
+  private memoDelivered(key: string, promptId: string, gen: number): void {
+    this.delivered.add(deliveredKey(key, promptId, gen));
     while (this.delivered.size > MAX_DELIVERED_MEMO) {
       const oldest = this.delivered.values().next().value;
       if (oldest === undefined) break;

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -85,6 +85,19 @@ export interface RunTicket {
   toNodeId?: number;
   /** True once a completion for this exact prompt id was acked as delivered. */
   settled: boolean;
+  /**
+   * This prompt id was queued MORE THAN ONCE, so it no longer identifies a
+   * single run.
+   *
+   * Nothing on the wire distinguishes generation A's completion from
+   * generation B's — the panel sends only the id — so once an id is reused, ANY
+   * completion for it is genuinely unattributable. It is therefore correlated as
+   * `foreign` (UNDETERMINED) rather than confidently matched, and the
+   * already-delivered proofs are disabled for it: a resend may be delivered
+   * twice, but B's real completion can never be suppressed as A's duplicate, and
+   * A's late resend can never be presented as B's awaited result.
+   */
+  reused?: boolean;
 }
 
 export type EntryState =
@@ -232,6 +245,10 @@ export class RunCompletionJournalImpl {
       existing.settled = false;
       existing.tabId = meta.tabId;
       existing.queuedAt = Date.now();
+      // The id no longer identifies ONE run. Every completion for it from here
+      // on is unattributable (see RunTicket.reused) — reported UNDETERMINED, and
+      // never suppressed as a duplicate of the other generation.
+      existing.reused = true;
       // SUPERSEDE any entry still carrying the PREVIOUS run's completion for this
       // id. Without this, the new run's completion merges into an entry that is
       // already sitting in an agent queue holding the OLD completion's text: when
@@ -287,7 +304,10 @@ export class RunCompletionJournalImpl {
     const pid = typeof payload.prompt_id === "string" ? payload.prompt_id.trim() : "";
     if (!pid) return { status: "unidentified" };
     const ticket = this.tickets.get(pid);
-    return ticket && ticket.tabId === key
+    // A REUSED id proves nothing: the panel sends only the id, so a completion
+    // for it could belong to either generation. Report it as foreign — real, but
+    // UNDETERMINED — rather than claiming it is the run now outstanding.
+    return ticket && ticket.tabId === key && !ticket.reused
       ? { status: "matched", promptId: pid }
       : { status: "foreign", promptId: pid };
   }
@@ -319,9 +339,15 @@ export class RunCompletionJournalImpl {
       // can age it out and then re-deliver a very late resend; the ticket outlives
       // it for any run this session actually queued. Either one is proof.
       const settledTicket = this.tickets.get(correlation.promptId);
+      // Both proofs are DISABLED for a reused id: neither can tell which
+      // generation a completion belongs to, so suppressing on them could swallow
+      // the newer run's real result. A duplicate delivery (labelled UNDETERMINED)
+      // is the correct trade here.
+      const idReused = settledTicket?.reused === true && settledTicket.tabId === key;
       if (
-        this.delivered.has(deliveredKey(key, correlation.promptId)) ||
-        (settledTicket?.settled === true && settledTicket.tabId === key)
+        !idReused &&
+        (this.delivered.has(deliveredKey(key, correlation.promptId)) ||
+          (settledTicket?.settled === true && settledTicket.tabId === key))
       ) {
         logger.info(
           `[run-completions] ignoring a re-sent completion for ${describe(correlation)} — already delivered to tab ${key.slice(0, 8)}`,

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -131,6 +131,17 @@ export interface JournalEntry {
    *  it belongs to the older run. Still delivered, but it can no longer be merged
    *  into, settle a ticket, or memoize a delivery. */
   superseded?: boolean;
+  /**
+   * This entry ARRIVED while its prompt id was already known to be reused, so
+   * the id cannot tell which run it belongs to.
+   *
+   * Stamped on the ENTRY, not read from the ticket, because tickets are
+   * evictable: 64 later runs drop the `reused` ticket, `idReused` goes false,
+   * and a subsequent ambiguous completion would coalesce into this one — the ack
+   * of one then removing the only entry and losing the other. The entry outlives
+   * the ticket, so the ambiguity does too.
+   */
+  ambiguousId?: boolean;
   /** Evicted-completion count this entry is carrying out on the tab's behalf, so
    *  the disclosure rides a real delivery instead of a side map that could be
    *  discarded before it is ever reported. */
@@ -367,6 +378,8 @@ export class RunCompletionJournalImpl {
   record(key: string, payload: CompletionPayload): JournalEntry | null {
     const correlation = this.correlate(key, payload);
     let idlessRepeat = false;
+    /** This id already stands for more than one run (see RunTicket.reused). */
+    let idReused = false;
     if (correlation.status !== "unidentified") {
       // Already DELIVERED once (its carrying turn ended, so the entry is gone).
       // A panel that re-sends the frame must not produce a second delivery — the
@@ -380,7 +393,7 @@ export class RunCompletionJournalImpl {
       // generation a completion belongs to, so suppressing on them could swallow
       // the newer run's real result. A duplicate delivery (labelled UNDETERMINED)
       // is the correct trade here.
-      const idReused = settledTicket?.reused === true && settledTicket.tabId === key;
+      idReused = settledTicket?.reused === true && settledTicket.tabId === key;
       if (
         !idReused &&
         (this.delivered.has(deliveredKey(key, correlation.promptId)) ||
@@ -403,6 +416,10 @@ export class RunCompletionJournalImpl {
         if (
           entry.key === key &&
           !entry.superseded && // a re-queued run never merges into the old one's entry
+          // …and never merge into one that ARRIVED under a reused id. The ticket
+          // that made `idReused` true above is evictable, so after 64 later runs
+          // the incoming side can no longer tell — but the entry still can.
+          !entry.ambiguousId &&
           entry.correlation.status !== "unidentified" &&
           entry.correlation.promptId === correlation.promptId
         ) {
@@ -471,6 +488,8 @@ export class RunCompletionJournalImpl {
       ...(correlation.status === "unidentified"
         ? { fingerprint: idlessFingerprint(key, payload), ...(idlessRepeat ? { possibleRepeat: true } : {}) }
         : {}),
+      // Freeze the ambiguity onto the entry — see JournalEntry.ambiguousId.
+      ...(idReused ? { ambiguousId: true } : {}),
     };
     this.entries.set(entry.token, entry);
     this.trimEntries(key);

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -107,8 +107,11 @@ export interface JournalEntry {
 /** Runs tracked at once. Ample for any real batch; bounded so a long session
  *  can't grow the map without limit. */
 const MAX_TICKETS = 64;
-/** Undelivered completions held per agent key. */
-const MAX_ENTRIES_PER_KEY = 16;
+/** Undelivered completions held per panel tab. */
+const MAX_ENTRIES_PER_KEY = 32;
+/** Undelivered completions held across ALL tabs — a global ceiling so a session
+ *  that opens and abandons many tabs can't grow the journal without limit. */
+const MAX_ENTRIES_TOTAL = 96;
 
 export class RunCompletionJournalImpl {
   /** prompt id → ticket. Keyed globally: ComfyUI prompt ids are UUIDs, so an
@@ -145,14 +148,23 @@ export class RunCompletionJournalImpl {
     return true;
   }
 
-  /** Classify a completion against the open runs. EXACT prompt-id equality only:
-   *  there is deliberately no "the newest outstanding run" fallback, because
-   *  attributing a completion to the wrong run is worse than not attributing it
-   *  at all. */
-  correlate(payload: CompletionPayload): RunCorrelation {
+  /**
+   * Classify a completion that arrived for panel tab `key` against the open runs.
+   *
+   * TWO conditions, both required: EXACT prompt-id equality AND the ticket must
+   * belong to THIS panel tab. There is deliberately no "the newest outstanding
+   * run" fallback and no cross-tab match, because attributing a completion to
+   * the wrong run — or to a different workflow's agent — is worse than not
+   * attributing it at all. A run whose ticket belongs to another tab reads as
+   * `foreign`, i.e. UNDETERMINED, which is the honest answer.
+   */
+  correlate(key: string, payload: CompletionPayload): RunCorrelation {
     const pid = typeof payload.prompt_id === "string" ? payload.prompt_id.trim() : "";
     if (!pid) return { status: "unidentified" };
-    return this.tickets.has(pid) ? { status: "matched", promptId: pid } : { status: "foreign", promptId: pid };
+    const ticket = this.tickets.get(pid);
+    return ticket && ticket.tabId === key
+      ? { status: "matched", promptId: pid }
+      : { status: "foreign", promptId: pid };
   }
 
   /**
@@ -165,7 +177,7 @@ export class RunCompletionJournalImpl {
    * entry (bounded by MAX_ENTRIES_PER_KEY).
    */
   record(key: string, payload: CompletionPayload): JournalEntry {
-    const correlation = this.correlate(payload);
+    const correlation = this.correlate(key, payload);
     if (correlation.status !== "unidentified") {
       for (const entry of this.entries.values()) {
         if (
@@ -173,10 +185,13 @@ export class RunCompletionJournalImpl {
           entry.correlation.status !== "unidentified" &&
           entry.correlation.promptId === correlation.promptId
         ) {
+          // Freshen the payload, but do NOT re-open a hand-off. The copy already
+          // sitting in an agent's queue cannot be recalled, so re-arming here
+          // would deliver the same completion twice (and the first ack would
+          // then drop the entry, leaving the second delivery untracked). If the
+          // hand-off fails, the release path re-arms it — that is the only way
+          // back to `pending`.
           entry.payload = payload;
-          // Re-open it for delivery: a re-send is the panel telling us the
-          // outcome again, and the previous hand-off is not proven consumed.
-          if (entry.state === "handed_off") entry.state = "pending";
           return entry;
         }
       }
@@ -194,6 +209,10 @@ export class RunCompletionJournalImpl {
     this.trimEntries(key);
     return entry;
   }
+
+  /** Completions this tab lost to an eviction and has not yet been told about.
+   *  Surfaced on the next delivery so a dropped completion is never silent. */
+  private dropped = new Map<string, number>();
 
   /** Entries awaiting a delivery attempt for this key, in arrival order. */
   pending(key: string): JournalEntry[] {
@@ -223,6 +242,10 @@ export class RunCompletionJournalImpl {
   ): { delivered: number; blockedOn: JournalEntry | null } {
     let delivered = 0;
     for (const entry of this.pending(key)) {
+      // Any completion this tab lost to an eviction rides out on the next one
+      // that DOES get through, so an evicted completion is reported rather than
+      // silently forgotten.
+      const lost = this.dropped.get(key) ?? 0;
       const payload: CompletionPayload = {
         ...entry.payload,
         run_correlation: entry.correlation.status,
@@ -232,10 +255,12 @@ export class RunCompletionJournalImpl {
         // Second and later attempts ARE re-deliveries — say so, so the agent
         // reads a replay as "this landed late", not as another render.
         ...(entry.attempts > 0 ? { replayed: true } : {}),
+        ...(lost > 0 ? { dropped_completions: lost } : {}),
       };
       const handedOff = inject(payload, entry.token);
       this.noteAttempt(entry.token, handedOff);
       if (!handedOff) return { delivered, blockedOn: entry };
+      if (lost > 0) this.dropped.delete(key);
       delivered += 1;
     }
     return { delivered, blockedOn: null };
@@ -275,18 +300,32 @@ export class RunCompletionJournalImpl {
     entry.state = "pending";
   }
 
-  /** Move every entry addressed to `from` onto `to` — a panel tab-id migration
-   *  re-keys the agent, and its undelivered completions must move WITH it. This
-   *  re-addresses, it never broadens: entries for other keys are untouched. */
+  /** Move every entry AND every open run ticket from `from` onto `to` — a panel
+   *  tab-id migration re-keys the agent, and both must move WITH it or a later
+   *  completion for a run queued under the old id reads as foreign. This
+   *  re-addresses, it never broadens: other tabs' state is untouched. */
   moveKey(from: string, to: string): void {
     if (from === to) return;
     for (const entry of this.entries.values()) {
       if (entry.key === from) entry.key = to;
     }
+    for (const ticket of this.tickets.values()) {
+      if (ticket.tabId === from) ticket.tabId = to;
+    }
   }
 
-  /** Drop everything addressed to a key that will never come back (tab closed).
-   *  Logs any completion that dies unacked — a loss must never be silent. */
+  /**
+   * Drop everything belonging to a tab that will never come back — a closed tab,
+   * or the workflow being switched AWAY from.
+   *
+   * Tickets go too, not just entries: a run queued under the old workflow that
+   * finishes AFTER the switch would otherwise still `correlate` as matched (the
+   * ticket map is global) and be delivered to the NEW workflow's agent as "the
+   * run YOU queued". Forgetting the ticket makes that completion read as
+   * foreign — i.e. UNDETERMINED — which is the honest answer.
+   *
+   * Logs every completion that dies unacked; a loss must never be silent.
+   */
   forget(key: string): void {
     for (const [token, entry] of [...this.entries]) {
       if (entry.key !== key) continue;
@@ -295,6 +334,10 @@ export class RunCompletionJournalImpl {
         `[run-completions] dropping an undelivered completion for ${describe(entry.correlation)} — its tab (${key.slice(0, 8)}) is gone`,
       );
     }
+    for (const [pid, ticket] of [...this.tickets]) {
+      if (ticket.tabId === key) this.tickets.delete(pid);
+    }
+    this.dropped.delete(key);
   }
 
   /** Test/diagnostic helpers. */
@@ -304,7 +347,11 @@ export class RunCompletionJournalImpl {
   reset(): void {
     this.tickets.clear();
     this.entries.clear();
+    this.dropped.clear();
     this.seq = 0;
+  }
+  droppedFor(key: string): number {
+    return this.dropped.get(key) ?? 0;
   }
 
   private trimTickets(): void {
@@ -325,16 +372,43 @@ export class RunCompletionJournalImpl {
     }
   }
 
+  /**
+   * Enforce the per-tab and global ceilings.
+   *
+   * EVICTION ORDER matters: an entry already HANDED OFF is sitting in a live
+   * agent's queue and will most likely be read, so it is the cheapest thing to
+   * forget; a still-PENDING entry has reached nobody, so evicting one is a real
+   * loss. Pending entries are therefore evicted last, logged at ERROR, and
+   * COUNTED — the count rides out on the next completion that does get through
+   * (`dropped_completions`), so the agent is told those runs are undetermined
+   * instead of the loss being silent.
+   */
   private trimEntries(key: string): void {
-    const mine = [...this.entries.values()].filter((e) => e.key === key);
-    while (mine.length > MAX_ENTRIES_PER_KEY) {
-      const victim = mine.shift();
-      if (!victim) return;
-      this.entries.delete(victim.token);
-      logger.error(
-        `[run-completions] journal for tab ${key.slice(0, 8)} exceeded ${MAX_ENTRIES_PER_KEY} undelivered completions — dropped the oldest (${describe(victim.correlation)})`,
-      );
-    }
+    const evict = (scope: (e: JournalEntry) => boolean, limit: number, label: string): void => {
+      let mine = [...this.entries.values()].filter(scope);
+      while (mine.length > limit) {
+        const victim =
+          mine.find((e) => e.state === "handed_off") ?? mine[0];
+        this.entries.delete(victim.token);
+        mine = mine.filter((e) => e !== victim);
+        if (victim.state === "pending") {
+          this.dropped.set(victim.key, (this.dropped.get(victim.key) ?? 0) + 1);
+          logger.error(
+            `[run-completions] ${label} — dropped an UNDELIVERED completion for ${describe(victim.correlation)}; the next delivery will report it as undetermined`,
+          );
+        } else {
+          logger.warn(
+            `[run-completions] ${label} — forgot an already-handed-off completion for ${describe(victim.correlation)}`,
+          );
+        }
+      }
+    };
+    evict(
+      (e) => e.key === key,
+      MAX_ENTRIES_PER_KEY,
+      `journal for tab ${key.slice(0, 8)} exceeded ${MAX_ENTRIES_PER_KEY} undelivered completions`,
+    );
+    evict(() => true, MAX_ENTRIES_TOTAL, `journal exceeded ${MAX_ENTRIES_TOTAL} undelivered completions overall`);
   }
 }
 

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -190,22 +190,12 @@ const MAX_DROPPED_KEYS = 64;
  *  so settling risks a duplicate, never a loss. */
 const MAX_CARRIED_RELEASES = 3;
 /**
- * ID-LESS completions have no run identity, so content is the only evidence of
- * sameness — and identical content is NOT proof: ComfyUI reuses temp output names
- * (`ComfyUI_temp_*_00001_`) after a restart, so two genuinely different renders
- * can look the same. The policy therefore splits by how much a mistake costs:
- *
- *  • STILL JOURNALED, UNDELIVERED, within IDLESS_COLLAPSE_MS — collapse onto the
- *    one entry. This is a transport-retry timescale, not a render timescale: two
- *    real renders finishing with byte-identical output lists AND both still
- *    undelivered inside 30s is not a case that occurs, while a panel re-sending a
- *    frame is. Collapsing here is what stops one output producing two turns.
- *  • ALREADY DELIVERED, within IDLESS_REPEAT_HINT_MS — do NOT suppress. Swallow
- *    the wrong one and a real render is silently lost, which is the failure this
- *    whole file exists to prevent. Deliver it FLAGGED as a possible repeat so the
- *    agent can decline to double-count it, and let the agent judge.
+ * How long an identical ID-LESS completion is still worth FLAGGING as a possible
+ * repeat. Content is the only evidence of sameness these have, and it is not
+ * proof — ComfyUI reuses temp output names (`ComfyUI_temp_*_00001_`) after a
+ * restart, so two genuinely different renders can look identical. Hence the flag
+ * is all it drives: nothing here ever merges or suppresses a completion.
  */
-const IDLESS_COLLAPSE_MS = 30_000;
 const IDLESS_REPEAT_HINT_MS = 10 * 60_000;
 
 /**
@@ -563,44 +553,33 @@ export class RunCompletionJournalImpl {
     } else {
       const print = idlessFingerprint(key, payload);
       const now = Date.now();
-      // COLLAPSE only onto a twin that is STILL PENDING — not yet handed to any
-      // agent. That is the whole safety argument: neither copy has reached
-      // anyone, so one delivery instead of two cannot lose news the agent
-      // already has. `handed_off` does NOT qualify: that copy is sitting unread
-      // in a busy agent's queue and will be acked when its turn ends, so merging
-      // a second real render into it would delete the second render outright —
-      // the exact silent swallow this design splits to avoid.
-      for (const entry of this.entries.values()) {
-        if (
-          entry.key === key &&
-          entry.state === "pending" &&
-          entry.correlation.status === "unidentified" &&
-          entry.fingerprint === print &&
-          now - entry.arrivedAt < IDLESS_COLLAPSE_MS
-        ) {
-          entry.payload = payload;
-          return entry;
-        }
-      }
-      // An identical twin that is already handed off (or delivered) falls
-      // through to a NEW entry below, flagged `possible_repeat` — never merged.
-      const twinInFlight = [...this.entries.values()].some(
+      // NEVER COLLAPSE AN ID-LESS COMPLETION.
+      //
+      // The collapse was the last surviving suppression, and it fails for the
+      // same reason all the others did — its premise is not establishable. For an
+      // identified run, "a twin nobody has seen yet" is a fact: same prompt id,
+      // same ticket generation. For an ID-LESS one there is no id, and ComfyUI
+      // reuses temp output names (this file says exactly that a few hundred lines
+      // up), so "same tab, same content, both pending, within 30s" is PRECISELY
+      // the state two genuinely different renders present. Merging there deletes
+      // one of them, silently.
+      //
+      // So every id-less completion gets its own entry. When an identical one is
+      // already journaled — in ANY state — or was delivered recently, the new one
+      // is FLAGGED `possible_repeat` and the agent decides. That is the same trade
+      // already accepted everywhere else: a duplicate turn beats a lost render,
+      // and a wording optimisation must never be load-bearing for correctness.
+      const twinJournaled = [...this.entries.values()].some(
         (e) =>
-          e.key === key &&
-          e.state === "handed_off" &&
-          e.correlation.status === "unidentified" &&
-          e.fingerprint === print,
+          e.key === key && e.correlation.status === "unidentified" && e.fingerprint === print,
       );
-      // Already DELIVERED an identical id-less completion recently. Deliberately
-      // NOT suppressed: identical content is not proof of identity, and swallowing
-      // a second real render is a silent loss. Deliver it flagged instead.
       const seenAt = this.idlessSeen.get(print);
       const repeatHint = seenAt !== undefined && now - seenAt < IDLESS_REPEAT_HINT_MS;
       if (seenAt !== undefined && !repeatHint) this.idlessSeen.delete(print); // stale
-      idlessRepeat = repeatHint || twinInFlight;
+      idlessRepeat = repeatHint || twinJournaled;
       if (idlessRepeat) {
         logger.info(
-          `[run-completions] tab ${key.slice(0, 8)}: an id-less completion with identical content was already delivered — forwarding it FLAGGED as a possible repeat (never suppressed: content is not identity)`,
+          `[run-completions] tab ${key.slice(0, 8)}: an id-less completion with identical content is already known — forwarding this one FLAGGED as a possible repeat (never merged, never suppressed: content is not identity)`,
         );
       }
     }

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -1047,6 +1047,15 @@ export class RunCompletionJournalImpl {
         const victim = mine.find((e) => e.state === "handed_off") ?? mine[0];
         this.entries.delete(victim.token);
         mine = mine.filter((e) => e !== victim);
+        // …and PULL ITS QUEUED COPY with it. The journal's cap bounds the
+        // journal; the agent's queue owns the actual payload, so evicting the
+        // record alone left the text queued forever. A panel resending in a tight
+        // loop would then grow that queue without limit while the journal stayed
+        // at 32 — and the whole backlog drains into ONE turn, which is how the
+        // genuine completion gets starved. Revoking keeps the two bounded
+        // together. (No-op once the carrying turn has started; that copy is
+        // already committed and is bounded by the turn instead.)
+        this.revoke?.(victim.key, victim.token);
         // Its own loss PLUS any disclosure it was carrying for the tab — moved to
         // whatever survives, so an eviction can never drop the disclosure itself.
         this.noteDropped(victim.key, 1 + (victim.disclose ?? 0));

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -292,12 +292,17 @@ export class RunCompletionJournalImpl {
     } else {
       const print = idlessFingerprint(key, payload);
       const now = Date.now();
-      // COLLAPSE only onto a still-journaled, undelivered twin from the same
-      // re-send burst. Safe: neither copy has reached anyone, so one delivery
-      // instead of two cannot lose news the agent already has.
+      // COLLAPSE only onto a twin that is STILL PENDING — not yet handed to any
+      // agent. That is the whole safety argument: neither copy has reached
+      // anyone, so one delivery instead of two cannot lose news the agent
+      // already has. `handed_off` does NOT qualify: that copy is sitting unread
+      // in a busy agent's queue and will be acked when its turn ends, so merging
+      // a second real render into it would delete the second render outright —
+      // the exact silent swallow this design splits to avoid.
       for (const entry of this.entries.values()) {
         if (
           entry.key === key &&
+          entry.state === "pending" &&
           entry.correlation.status === "unidentified" &&
           entry.fingerprint === print &&
           now - entry.arrivedAt < IDLESS_COLLAPSE_MS
@@ -306,14 +311,23 @@ export class RunCompletionJournalImpl {
           return entry;
         }
       }
+      // An identical twin that is already handed off (or delivered) falls
+      // through to a NEW entry below, flagged `possible_repeat` — never merged.
+      const twinInFlight = [...this.entries.values()].some(
+        (e) =>
+          e.key === key &&
+          e.state === "handed_off" &&
+          e.correlation.status === "unidentified" &&
+          e.fingerprint === print,
+      );
       // Already DELIVERED an identical id-less completion recently. Deliberately
       // NOT suppressed: identical content is not proof of identity, and swallowing
       // a second real render is a silent loss. Deliver it flagged instead.
       const seenAt = this.idlessSeen.get(print);
       const repeatHint = seenAt !== undefined && now - seenAt < IDLESS_REPEAT_HINT_MS;
       if (seenAt !== undefined && !repeatHint) this.idlessSeen.delete(print); // stale
-      idlessRepeat = repeatHint;
-      if (repeatHint) {
+      idlessRepeat = repeatHint || twinInFlight;
+      if (idlessRepeat) {
         logger.info(
           `[run-completions] tab ${key.slice(0, 8)}: an id-less completion with identical content was already delivered — forwarding it FLAGGED as a possible repeat (never suppressed: content is not identity)`,
         );

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -236,8 +236,17 @@ export class RunCompletionJournalImpl {
           !entry.superseded
         ) {
           entry.superseded = true;
+          // DOWNGRADE it too (matched → foreign, the same one-way weakening
+          // closeRuns uses). Marking it superseded stops it settling the reopened
+          // ticket, but it would still have been DELIVERED saying "this is the run
+          // YOU queued" — presenting the OLD result as the newly queued run's
+          // awaited outcome. It is a real completion, so it is still delivered;
+          // it just can no longer claim to be the run now outstanding.
+          if (entry.correlation.status === "matched") {
+            entry.correlation = { status: "foreign", promptId: entry.correlation.promptId };
+          }
           logger.warn(
-            `[run-completions] prompt ${promptId} was queued again while its previous completion was still undelivered — the older entry is superseded and can no longer answer for the new run`,
+            `[run-completions] prompt ${promptId} was queued again while its previous completion was still undelivered — the older entry is superseded (and reported as undetermined) so it can no longer answer for the new run`,
           );
         }
       }
@@ -472,8 +481,12 @@ export class RunCompletionJournalImpl {
       this.noteAttempt(entry.token, handedOff);
       if (!handedOff) return { delivered, blockedOn: entry };
       if (lost > 0) {
+        // CONSOLIDATE onto the entry; do NOT consider the disclosure spent yet.
+        // A hand-off is not consumption: if this agent is stopped before its turn
+        // runs, the entry is released and replayed, and the warning must go with
+        // it. Only `ack()` — the turn that carried it having ended — clears it.
+        entry.disclose = lost;
         this.dropped.delete(key);
-        delete entry.disclose;
       }
       delivered += 1;
     }
@@ -514,6 +527,10 @@ export class RunCompletionJournalImpl {
     const entry = this.entries.get(token);
     if (!entry) return;
     this.entries.delete(token);
+    // The turn that carried it ended, so any eviction disclosure it was carrying
+    // has now actually reached the agent — only here is it spent. (An entry
+    // evicted while still holding one passes it on; see trimEntries.)
+    delete entry.disclose;
     // A SUPERSEDED entry belongs to a run whose prompt id was queued again. It
     // was still delivered (its text reached the agent), but it must not settle
     // the REOPENED ticket — that would present the old result as the new run's —

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -361,6 +361,21 @@ export class RunCompletionJournalImpl {
     for (const ticket of this.tickets.values()) {
       if (ticket.tabId === from) ticket.tabId = to;
     }
+    // ALL per-tab state moves, not just the visible two. Leaving the delivered
+    // memo behind would let a post-migration re-send be delivered a SECOND time
+    // (its settled ticket moved, so it still correlates as matched); leaving the
+    // eviction counter behind would silently swallow the "these runs are
+    // undetermined" disclosure it exists to carry.
+    for (const memo of [...this.delivered]) {
+      if (!memo.startsWith(`${from}|`)) continue;
+      this.delivered.delete(memo);
+      this.delivered.add(`${to}|${memo.slice(from.length + 1)}`);
+    }
+    const lost = this.dropped.get(from);
+    if (lost !== undefined) {
+      this.dropped.delete(from);
+      this.dropped.set(to, (this.dropped.get(to) ?? 0) + lost);
+    }
   }
 
   /**
@@ -387,6 +402,9 @@ export class RunCompletionJournalImpl {
       if (ticket.tabId === key) this.tickets.delete(pid);
     }
     this.dropped.delete(key);
+    for (const memo of [...this.delivered]) {
+      if (memo.startsWith(`${key}|`)) this.delivered.delete(memo);
+    }
   }
 
   /**

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -310,7 +310,15 @@ export class RunCompletionJournalImpl {
       // Already DELIVERED once (its carrying turn ended, so the entry is gone).
       // A panel that re-sends the frame must not produce a second delivery — the
       // dedupe below can't see an entry that no longer exists.
-      if (this.delivered.has(deliveredKey(key, correlation.promptId))) {
+      // Two independent records of "already delivered": the bounded memo, and the
+      // run TICKET's own `settled` flag. The memo is FIFO-capped, so a busy tab
+      // can age it out and then re-deliver a very late resend; the ticket outlives
+      // it for any run this session actually queued. Either one is proof.
+      const settledTicket = this.tickets.get(correlation.promptId);
+      if (
+        this.delivered.has(deliveredKey(key, correlation.promptId)) ||
+        (settledTicket?.settled === true && settledTicket.tabId === key)
+      ) {
         logger.info(
           `[run-completions] ignoring a re-sent completion for ${describe(correlation)} — already delivered to tab ${key.slice(0, 8)}`,
         );
@@ -413,7 +421,13 @@ export class RunCompletionJournalImpl {
    */
   private noteDropped(key: string, count = 1): void {
     if (count <= 0) return;
-    const carrier = [...this.entries.values()].find((e) => e.key === key);
+    // The carrier must be an entry `deliverPending` will actually READ — i.e. a
+    // PENDING one. A handed-off entry's payload was already built and queued, so
+    // stamping the count on it would attach a warning to text nobody will ever
+    // see again, and `ack()` would then spend it: the eviction would be neither
+    // replayed nor disclosed. With no pending entry the count goes to the side
+    // map, where the next pending delivery for this tab picks it up.
+    const carrier = [...this.entries.values()].find((e) => e.key === key && e.state === "pending");
     if (carrier) {
       carrier.disclose = (carrier.disclose ?? 0) + count;
       return;

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -83,6 +83,16 @@ export interface RunTicket {
   tabId: string;
   queuedAt: number;
   toNodeId?: number;
+  /**
+   * Generation of THIS ticket. Bumped whenever the id is opened again (a fresh
+   * ticket after the old one was evicted, or a reopen), so a completion can only
+   * ever settle the exact ticket generation it was correlated against.
+   *
+   * Without it, `ack()` resolved the ticket by prompt id alone: run A's late
+   * completion would settle whatever ticket that id maps to NOW — i.e. run B's —
+   * marking B answered by A's result.
+   */
+  seq: number;
   /** True once a completion for this exact prompt id was acked as delivered. */
   settled: boolean;
   /**
@@ -142,6 +152,9 @@ export interface JournalEntry {
    * the ticket, so the ambiguity does too.
    */
   ambiguousId?: boolean;
+  /** Generation of the ticket this entry was MATCHED against, if any. `ack()`
+   *  settles only that exact generation — see RunTicket.seq. */
+  ticketSeq?: number;
   /** Evicted-completion count this entry is carrying out on the tab's behalf, so
    *  the disclosure rides a real delivery instead of a side map that could be
    *  discarded before it is ever reported. */
@@ -233,6 +246,8 @@ export class RunCompletionJournalImpl {
    *  re-send is suppressed but a later genuinely-different render is not. */
   private idlessSeen = new Map<string, number>();
   private seq = 0;
+  /** Monotonic ticket-generation counter — see RunTicket.seq. */
+  private ticketSeq = 0;
   /** Pull a still-queued completion back off its agent (see setRevoker). */
   private revoke: ((key: string, token: string) => boolean) | null = null;
   /** Re-deliver a tab's pending completions (after a revoke re-arms one). */
@@ -290,6 +305,7 @@ export class RunCompletionJournalImpl {
       existing.settled = false;
       existing.tabId = meta.tabId;
       existing.queuedAt = Date.now();
+      existing.seq = ++this.ticketSeq; // a NEW generation of this id
       // The id no longer identifies ONE run. Every completion for it from here
       // on is unattributable (see RunTicket.reused) — reported UNDETERMINED, and
       // never suppressed as a duplicate of the other generation.
@@ -330,6 +346,7 @@ export class RunCompletionJournalImpl {
     this.tickets.set(promptId, {
       promptId,
       tabId: meta.tabId,
+      seq: ++this.ticketSeq,
       queuedAt: Date.now(),
       ...(typeof meta.toNodeId === "number" ? { toNodeId: meta.toNodeId } : {}),
       settled: false,
@@ -404,31 +421,35 @@ export class RunCompletionJournalImpl {
         );
         return null;
       }
-      // COALESCE is an optimisation that ASSUMES the prompt id identifies one
-      // run — which is exactly the assumption `reused` voids. Merging there is a
-      // LOSS: B's real completion would overwrite A's entry and be returned as
-      // it, while the turn already queued still holds A's text; A's ack then
-      // removes the sole entry and B is never delivered. So for a reused id, do
-      // not coalesce at all — B gets its own entry, flagged UNDETERMINED like
-      // every other ambiguous case. Duplicate over loss, the same rule the
-      // suppression checks above follow.
+      // COALESCE ONLY ONTO A `pending` ENTRY. This is the correctness rule, and
+      // it is deliberately a property of the TARGET'S OWN CURRENT STATE — not of
+      // any history that could be evicted out from under it.
+      //
+      // Once an entry is `handed_off` its text is committed to a turn that will
+      // ack and DELETE it. Merging a newer completion into it means the newer one
+      // is never delivered: the queued turn still holds the older text, and its
+      // ack removes the single shared entry. That is a loss, and it is reachable
+      // by several orderings of prompt-id reuse vs. ticket eviction — chasing
+      // those one at a time is how this defect kept coming back, because reuse
+      // DETECTION needs the old ticket, and the ticket is evictable.
+      //
+      // The same predicate already governs the id-less collapse, for the same
+      // reason. The `reused`/`ambiguousId` checks below are now an OPTIMISATION
+      // for better wording (an ambiguous run should read as UNDETERMINED rather
+      // than merge at all), never the thing correctness rests on.
       for (const entry of idReused ? [] : this.entries.values()) {
         if (
           entry.key === key &&
+          entry.state === "pending" && // never merge into text already committed to a turn
           !entry.superseded && // a re-queued run never merges into the old one's entry
-          // …and never merge into one that ARRIVED under a reused id. The ticket
-          // that made `idReused` true above is evictable, so after 64 later runs
-          // the incoming side can no longer tell — but the entry still can.
-          !entry.ambiguousId &&
+          !entry.ambiguousId && // nor into one that arrived under a reused id
           entry.correlation.status !== "unidentified" &&
           entry.correlation.promptId === correlation.promptId
         ) {
-          // Freshen the payload, but do NOT re-open a hand-off. The copy already
-          // sitting in an agent's queue cannot be recalled, so re-arming here
-          // would deliver the same completion twice (and the first ack would
-          // then drop the entry, leaving the second delivery untracked). If the
-          // hand-off fails, the release path re-arms it — that is the only way
-          // back to `pending`.
+          // Safe by the predicate above: this entry is still `pending`, so
+          // nothing of it has been committed to a turn. Freshening its payload
+          // replaces a copy nobody has seen — one delivery instead of two, with
+          // no possibility that an older text acks and deletes the newer news.
           entry.payload = payload;
           return entry;
         }
@@ -490,6 +511,11 @@ export class RunCompletionJournalImpl {
         : {}),
       // Freeze the ambiguity onto the entry — see JournalEntry.ambiguousId.
       ...(idReused ? { ambiguousId: true } : {}),
+      // …and the exact ticket GENERATION this matched, so its ack can never
+      // settle a later run that merely reuses the id (see RunTicket.seq).
+      ...(correlation.status === "matched"
+        ? { ticketSeq: this.tickets.get(correlation.promptId)?.seq }
+        : {}),
     };
     this.entries.set(entry.token, entry);
     this.trimEntries(key);
@@ -669,7 +695,11 @@ export class RunCompletionJournalImpl {
     }
     if (entry.correlation.status === "matched") {
       const ticket = this.tickets.get(entry.correlation.promptId);
-      if (ticket) ticket.settled = true;
+      // ONLY the exact ticket generation this entry was matched against. Looking
+      // the ticket up by prompt id alone let a late completion for run A settle
+      // whatever ticket that id maps to NOW — run B's — marking B answered by A's
+      // result. See RunTicket.seq.
+      if (ticket && ticket.seq === entry.ticketSeq) ticket.settled = true;
     }
   }
 

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -212,7 +212,14 @@ export class RunCompletionJournalImpl {
       // duplicate reply): reopen it rather than stacking a second ticket, so one
       // prompt id always means one run.
       existing.settled = false;
+      existing.tabId = meta.tabId;
       existing.queuedAt = Date.now();
+      // …and CLEAR the already-delivered memo for it. Reopening the ticket while
+      // the memo stood meant the reopened run's completion was suppressed as a
+      // duplicate of the PREVIOUS run's: `panel_run` promised automatic delivery
+      // and the journal then swallowed it. The memo only ever means "we already
+      // reported THIS run", which a genuine re-queue makes false.
+      this.delivered.delete(deliveredKey(meta.tabId, promptId));
       return true;
     }
     this.tickets.set(promptId, {
@@ -360,9 +367,19 @@ export class RunCompletionJournalImpl {
   private noteDropped(key: string): void {
     this.dropped.set(key, (this.dropped.get(key) ?? 0) + 1);
     while (this.dropped.size > MAX_DROPPED_KEYS) {
-      const oldest = this.dropped.keys().next().value;
-      if (oldest === undefined) break;
-      this.dropped.delete(oldest);
+      // Discard a counter for a tab that has NOTHING left to carry the
+      // disclosure out on first — its next delivery (if any) is hypothetical.
+      // Only if every tracked tab still has entries do we drop the oldest, and
+      // that one is logged at ERROR because the disclosure dies with it.
+      const victim =
+        [...this.dropped.keys()].find((k) => ![...this.entries.values()].some((e) => e.key === k)) ??
+        this.dropped.keys().next().value;
+      if (victim === undefined) break;
+      const lost = this.dropped.get(victim) ?? 0;
+      this.dropped.delete(victim);
+      logger.error(
+        `[run-completions] discarding the undelivered-completion count (${lost}) for tab ${victim.slice(0, 8)} — over ${MAX_DROPPED_KEYS} tabs are tracking one; that tab will not be told`,
+      );
     }
   }
 
@@ -422,6 +439,14 @@ export class RunCompletionJournalImpl {
   /** All still-unacked entries for a key (pending OR handed off) — diagnostics. */
   outstanding(key: string): JournalEntry[] {
     return [...this.entries.values()].filter((e) => e.key === key);
+  }
+
+  /** Is ANY completion still undelivered anywhere? The orchestrator's
+   *  self-restart gate reads this: the journal is in-memory, so restarting while
+   *  an entry is outstanding would silently drop a render result the agent was
+   *  promised. */
+  hasOutstanding(): boolean {
+    return this.entries.size > 0;
   }
 
   /** Record the outcome of a delivery attempt. `handedOff` true = an agent took

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -75,9 +75,11 @@ export interface CompletionPayload {
 /** A run `panel_run` queued and is waiting on. */
 export interface RunTicket {
   promptId: string;
-  /** Panel tab the run was queued from (diagnostics only — correlation is by
-   *  prompt id, which ComfyUI makes globally unique, so a ctx.tabId rebind
-   *  between queue and completion cannot break the match). */
+  /** Panel tab the run was queued from. Part of the MATCH: a completion is only
+   *  "the run YOU queued" for the tab that queued it, so a workflow switch or a
+   *  cross-tab completion reads as foreign instead of being misattributed. A
+   *  proven tab-id migration moves it (moveKey) so the tab's own runs still
+   *  match. */
   tabId: string;
   queuedAt: number;
   toNodeId?: number;
@@ -112,6 +114,17 @@ const MAX_ENTRIES_PER_KEY = 32;
 /** Undelivered completions held across ALL tabs — a global ceiling so a session
  *  that opens and abandons many tabs can't grow the journal without limit. */
 const MAX_ENTRIES_TOTAL = 96;
+/** (tab, run) pairs remembered as already delivered, to suppress a re-sent frame
+ *  after its entry was acked and removed. */
+const MAX_DELIVERED_MEMO = 256;
+/** Tabs whose evicted-completion counter is retained. */
+const MAX_DROPPED_KEYS = 64;
+
+/** Memo key for an already-delivered (tab, run). "|" separates them; a ComfyUI
+ *  prompt id is a fixed-format UUID, so the pair can't alias another. */
+function deliveredKey(key: string, promptId: string): string {
+  return `${key}|${promptId}`;
+}
 
 export class RunCompletionJournalImpl {
   /** prompt id → ticket. Keyed globally: ComfyUI prompt ids are UUIDs, so an
@@ -120,6 +133,10 @@ export class RunCompletionJournalImpl {
   private tickets = new Map<string, RunTicket>();
   /** token → entry (insertion-ordered, which is also delivery order). */
   private entries = new Map<string, JournalEntry>();
+  /** (tab, run) pairs whose completion was ACKED — a bounded FIFO memo so a
+   *  panel that re-sends the frame after the entry was removed can't produce a
+   *  second delivery. */
+  private delivered = new Set<string>();
   private seq = 0;
 
   /** `panel_run` queued a render. Returns false when ComfyUI/the panel gave us
@@ -176,9 +193,18 @@ export class RunCompletionJournalImpl {
    * unidentified completion has nothing to dedupe on, so it is always a new
    * entry (bounded by MAX_ENTRIES_PER_KEY).
    */
-  record(key: string, payload: CompletionPayload): JournalEntry {
+  record(key: string, payload: CompletionPayload): JournalEntry | null {
     const correlation = this.correlate(key, payload);
     if (correlation.status !== "unidentified") {
+      // Already DELIVERED once (its carrying turn ended, so the entry is gone).
+      // A panel that re-sends the frame must not produce a second delivery — the
+      // dedupe below can't see an entry that no longer exists.
+      if (this.delivered.has(deliveredKey(key, correlation.promptId))) {
+        logger.info(
+          `[run-completions] ignoring a re-sent completion for ${describe(correlation)} — already delivered to tab ${key.slice(0, 8)}`,
+        );
+        return null;
+      }
       for (const entry of this.entries.values()) {
         if (
           entry.key === key &&
@@ -213,6 +239,18 @@ export class RunCompletionJournalImpl {
   /** Completions this tab lost to an eviction and has not yet been told about.
    *  Surfaced on the next delivery so a dropped completion is never silent. */
   private dropped = new Map<string, number>();
+
+  /** Count a lost completion for a tab, bounding the map so a churn of one-off
+   *  tabs can't grow it forever (the oldest unreported count is discarded — it
+   *  was already logged at ERROR when it happened). */
+  private noteDropped(key: string): void {
+    this.dropped.set(key, (this.dropped.get(key) ?? 0) + 1);
+    while (this.dropped.size > MAX_DROPPED_KEYS) {
+      const oldest = this.dropped.keys().next().value;
+      if (oldest === undefined) break;
+      this.dropped.delete(oldest);
+    }
+  }
 
   /** Entries awaiting a delivery attempt for this key, in arrival order. */
   pending(key: string): JournalEntry[] {
@@ -286,6 +324,17 @@ export class RunCompletionJournalImpl {
     const entry = this.entries.get(token);
     if (!entry) return;
     this.entries.delete(token);
+    if (entry.correlation.status !== "unidentified") {
+      // Remember (tab, run) so a later re-send of the same frame is suppressed
+      // rather than delivered a second time. Bounded FIFO — old ids age out; a
+      // re-send that late is not a real case.
+      this.delivered.add(deliveredKey(entry.key, entry.correlation.promptId));
+      while (this.delivered.size > MAX_DELIVERED_MEMO) {
+        const oldest = this.delivered.values().next().value;
+        if (oldest === undefined) break;
+        this.delivered.delete(oldest);
+      }
+    }
     if (entry.correlation.status === "matched") {
       const ticket = this.tickets.get(entry.correlation.promptId);
       if (ticket) ticket.settled = true;
@@ -340,6 +389,24 @@ export class RunCompletionJournalImpl {
     this.dropped.delete(key);
   }
 
+  /**
+   * The CONVERSATION that queued this tab's outstanding runs is gone — New chat,
+   * a switch to a historical session, or a workflow replaced in place.
+   *
+   * Drop the tab's run TICKETS but keep its journal entries. A render queued by
+   * the old conversation is still real and its completion is still delivered;
+   * it just can no longer be introduced to the replacement agent as "the run YOU
+   * queued" — it correlates as foreign, i.e. UNDETERMINED. Entries that already
+   * arrived keep the verdict frozen at THEIR arrival, so a completion the old
+   * conversation was owed is still reported to it correctly if it is still
+   * deliverable.
+   */
+  closeRuns(key: string): void {
+    for (const [pid, ticket] of [...this.tickets]) {
+      if (ticket.tabId === key) this.tickets.delete(pid);
+    }
+  }
+
   /** Test/diagnostic helpers. */
   ticketFor(promptId: string): RunTicket | undefined {
     return this.tickets.get(promptId);
@@ -348,6 +415,7 @@ export class RunCompletionJournalImpl {
     this.tickets.clear();
     this.entries.clear();
     this.dropped.clear();
+    this.delivered.clear();
     this.seq = 0;
   }
   droppedFor(key: string): number {
@@ -387,20 +455,18 @@ export class RunCompletionJournalImpl {
     const evict = (scope: (e: JournalEntry) => boolean, limit: number, label: string): void => {
       let mine = [...this.entries.values()].filter(scope);
       while (mine.length > limit) {
-        const victim =
-          mine.find((e) => e.state === "handed_off") ?? mine[0];
+        // Prefer an already-handed-off entry: it is at least sitting in a live
+        // agent's queue, so it is the likeliest to land anyway. But a hand-off is
+        // explicitly NOT proof of consumption, so an evicted hand-off is counted
+        // and reported exactly like an evicted pending one — evicting it removes
+        // our ability to replay it if that agent dies first.
+        const victim = mine.find((e) => e.state === "handed_off") ?? mine[0];
         this.entries.delete(victim.token);
         mine = mine.filter((e) => e !== victim);
-        if (victim.state === "pending") {
-          this.dropped.set(victim.key, (this.dropped.get(victim.key) ?? 0) + 1);
-          logger.error(
-            `[run-completions] ${label} — dropped an UNDELIVERED completion for ${describe(victim.correlation)}; the next delivery will report it as undetermined`,
-          );
-        } else {
-          logger.warn(
-            `[run-completions] ${label} — forgot an already-handed-off completion for ${describe(victim.correlation)}`,
-          );
-        }
+        this.noteDropped(victim.key);
+        logger.error(
+          `[run-completions] ${label} — dropped a ${victim.state === "pending" ? "still-undelivered" : "handed-off-but-unconfirmed"} completion for ${describe(victim.correlation)}; the next delivery will report it as undetermined`,
+        );
       }
     };
     evict(

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -114,6 +114,14 @@ export interface JournalEntry {
    *  the same frame re-sent. Delivered anyway (never swallowed) but FLAGGED, so
    *  the agent doesn't double-count it. */
   possibleRepeat?: boolean;
+  /** This entry's prompt id was queued AGAIN while it was still undelivered, so
+   *  it belongs to the older run. Still delivered, but it can no longer be merged
+   *  into, settle a ticket, or memoize a delivery. */
+  superseded?: boolean;
+  /** Evicted-completion count this entry is carrying out on the tab's behalf, so
+   *  the disclosure rides a real delivery instead of a side map that could be
+   *  discarded before it is ever reported. */
+  disclose?: number;
 }
 
 /** Runs tracked at once. Ample for any real batch; bounded so a long session
@@ -214,6 +222,25 @@ export class RunCompletionJournalImpl {
       existing.settled = false;
       existing.tabId = meta.tabId;
       existing.queuedAt = Date.now();
+      // SUPERSEDE any entry still carrying the PREVIOUS run's completion for this
+      // id. Without this, the new run's completion merges into an entry that is
+      // already sitting in an agent queue holding the OLD completion's text: when
+      // that turn ends, ack() removes the shared entry and settles the REOPENED
+      // ticket — the old result is presented as the new run's, and the new run's
+      // real completion is never delivered. A superseded entry is skipped by the
+      // dedupe scan and can no longer settle a ticket or memoize a delivery.
+      for (const entry of this.entries.values()) {
+        if (
+          entry.correlation.status !== "unidentified" &&
+          entry.correlation.promptId === promptId &&
+          !entry.superseded
+        ) {
+          entry.superseded = true;
+          logger.warn(
+            `[run-completions] prompt ${promptId} was queued again while its previous completion was still undelivered — the older entry is superseded and can no longer answer for the new run`,
+          );
+        }
+      }
       // …and CLEAR the already-delivered memo for it. Reopening the ticket while
       // the memo stood meant the reopened run's completion was suppressed as a
       // duplicate of the PREVIOUS run's: `panel_run` promised automatic delivery
@@ -283,6 +310,7 @@ export class RunCompletionJournalImpl {
       for (const entry of this.entries.values()) {
         if (
           entry.key === key &&
+          !entry.superseded && // a re-queued run never merges into the old one's entry
           entry.correlation.status !== "unidentified" &&
           entry.correlation.promptId === correlation.promptId
         ) {
@@ -364,21 +392,31 @@ export class RunCompletionJournalImpl {
   /** Count a lost completion for a tab, bounding the map so a churn of one-off
    *  tabs can't grow it forever (the oldest unreported count is discarded — it
    *  was already logged at ERROR when it happened). */
-  private noteDropped(key: string): void {
-    this.dropped.set(key, (this.dropped.get(key) ?? 0) + 1);
+  /**
+   * Record that a completion for `key` was destroyed by an eviction, so the next
+   * delivery to that tab can report it as UNDETERMINED.
+   *
+   * The count is stamped onto a SURVIVING entry for the same tab whenever one
+   * exists — it then rides out on a real delivery and cannot be discarded. The
+   * side map is only for a tab with nothing left to carry it, i.e. a tab whose
+   * next delivery is hypothetical anyway; that is the only thing the bound can
+   * ever discard, and it is logged.
+   */
+  private noteDropped(key: string, count = 1): void {
+    if (count <= 0) return;
+    const carrier = [...this.entries.values()].find((e) => e.key === key);
+    if (carrier) {
+      carrier.disclose = (carrier.disclose ?? 0) + count;
+      return;
+    }
+    this.dropped.set(key, (this.dropped.get(key) ?? 0) + count);
     while (this.dropped.size > MAX_DROPPED_KEYS) {
-      // Discard a counter for a tab that has NOTHING left to carry the
-      // disclosure out on first — its next delivery (if any) is hypothetical.
-      // Only if every tracked tab still has entries do we drop the oldest, and
-      // that one is logged at ERROR because the disclosure dies with it.
-      const victim =
-        [...this.dropped.keys()].find((k) => ![...this.entries.values()].some((e) => e.key === k)) ??
-        this.dropped.keys().next().value;
+      const victim = this.dropped.keys().next().value;
       if (victim === undefined) break;
       const lost = this.dropped.get(victim) ?? 0;
       this.dropped.delete(victim);
       logger.error(
-        `[run-completions] discarding the undelivered-completion count (${lost}) for tab ${victim.slice(0, 8)} — over ${MAX_DROPPED_KEYS} tabs are tracking one; that tab will not be told`,
+        `[run-completions] discarding the undelivered-completion count (${lost}) for tab ${victim.slice(0, 8)} — over ${MAX_DROPPED_KEYS} agentless tabs are tracking one; that tab will not be told`,
       );
     }
   }
@@ -414,7 +452,10 @@ export class RunCompletionJournalImpl {
       // Any completion this tab lost to an eviction rides out on the next one
       // that DOES get through, so an evicted completion is reported rather than
       // silently forgotten.
-      const lost = this.dropped.get(key) ?? 0;
+      // The tab's evicted-completion count: whatever this entry is carrying, plus
+      // anything stranded in the side map from a period when the tab had no entry
+      // to carry it.
+      const lost = (entry.disclose ?? 0) + (this.dropped.get(key) ?? 0);
       const payload: CompletionPayload = {
         ...entry.payload,
         run_correlation: entry.correlation.status,
@@ -430,7 +471,10 @@ export class RunCompletionJournalImpl {
       const handedOff = inject(payload, entry.token);
       this.noteAttempt(entry.token, handedOff);
       if (!handedOff) return { delivered, blockedOn: entry };
-      if (lost > 0) this.dropped.delete(key);
+      if (lost > 0) {
+        this.dropped.delete(key);
+        delete entry.disclose;
+      }
       delivered += 1;
     }
     return { delivered, blockedOn: null };
@@ -449,6 +493,12 @@ export class RunCompletionJournalImpl {
     return this.entries.size > 0;
   }
 
+  /** Every still-unacked entry, across all tabs — for the last-ditch disclosure
+   *  the orchestrator makes when a fatal self-exit is about to destroy them. */
+  allOutstanding(): JournalEntry[] {
+    return [...this.entries.values()];
+  }
+
   /** Record the outcome of a delivery attempt. `handedOff` true = an agent took
    *  it onto its queue (not yet proof it was read). */
   noteAttempt(token: string, handedOff: boolean): void {
@@ -464,6 +514,12 @@ export class RunCompletionJournalImpl {
     const entry = this.entries.get(token);
     if (!entry) return;
     this.entries.delete(token);
+    // A SUPERSEDED entry belongs to a run whose prompt id was queued again. It
+    // was still delivered (its text reached the agent), but it must not settle
+    // the REOPENED ticket — that would present the old result as the new run's —
+    // and must not memoize the id as delivered, which would then suppress the new
+    // run's real completion.
+    if (entry.superseded) return;
     if (entry.correlation.status !== "unidentified") {
       // Remember (tab, run) so a later re-send of the same frame is suppressed
       // rather than delivered a second time. Bounded FIFO — old ids age out; a
@@ -637,8 +693,13 @@ export class RunCompletionJournalImpl {
     this.idlessSeen.clear();
     this.seq = 0;
   }
+  /** Evicted completions this tab has not been told about yet — wherever the
+   *  count currently lives (riding an entry, or the agentless side map). */
   droppedFor(key: string): number {
-    return this.dropped.get(key) ?? 0;
+    const carried = [...this.entries.values()]
+      .filter((e) => e.key === key)
+      .reduce((n, e) => n + (e.disclose ?? 0), 0);
+    return carried + (this.dropped.get(key) ?? 0);
   }
 
   private trimTickets(): void {
@@ -682,7 +743,9 @@ export class RunCompletionJournalImpl {
         const victim = mine.find((e) => e.state === "handed_off") ?? mine[0];
         this.entries.delete(victim.token);
         mine = mine.filter((e) => e !== victim);
-        this.noteDropped(victim.key);
+        // Its own loss PLUS any disclosure it was carrying for the tab — moved to
+        // whatever survives, so an eviction can never drop the disclosure itself.
+        this.noteDropped(victim.key, 1 + (victim.disclose ?? 0));
         logger.error(
           `[run-completions] ${label} — dropped a ${victim.state === "pending" ? "still-undelivered" : "handed-off-but-unconfirmed"} completion for ${describe(victim.correlation)}; the next delivery will report it as undetermined`,
         );

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -446,9 +446,13 @@ export class RunCompletionJournalImpl {
    *    re-sent frame producing two turns (the agent double-reporting, or acting
    *    twice on one output), while a later genuinely different render — or the
    *    same content long afterwards — is still delivered.
-   * Returns null when the completion is a suppressed duplicate.
+   * NEVER returns null: a completion is always journaled and always delivered.
+   * The most this does is COLLAPSE onto a twin that nobody has seen yet, or FLAG
+   * one as a possible repeat. Suppression was the source of every loss this file
+   * kept re-growing, because each proof it rested on is bounded and any expiry at
+   * the wrong moment turned a new run's result into a discarded "duplicate".
    */
-  record(key: string, payload: CompletionPayload): JournalEntry | null {
+  record(key: string, payload: CompletionPayload): JournalEntry {
     const correlation = this.correlate(key, payload);
     let idlessRepeat = false;
     /** This id already stands for more than one run (see RunTicket.reused). */
@@ -459,6 +463,8 @@ export class RunCompletionJournalImpl {
     /** Ticket generation this completion belongs to — the run identity (0 = no
      *  ticket, i.e. a run this tab never queued). */
     let gen = 0;
+    /** A completion for this run was already delivered. A LABEL, not a veto. */
+    let alreadyDelivered = false;
     if (correlation.status !== "unidentified") {
       // Already DELIVERED once (its carrying turn ended, so the entry is gone).
       // A panel that re-sends the frame must not produce a second delivery — the
@@ -489,15 +495,30 @@ export class RunCompletionJournalImpl {
       // Both cases fall back to the standing rule: duplicate over loss, each
       // delivered on its own and labelled UNDETERMINED.
       idUnprovable = idReused || gen === 0;
+      // ALREADY-DELIVERED IS A LABEL, NEVER A VETO.
+      //
+      // This used to `return null` — suppressing the completion outright — and
+      // that single decision produced defect after defect, because every proof it
+      // rested on (the memo, the ticket's `settled` flag, the ticket's very
+      // existence) is BOUNDED. Whenever one expired at the wrong moment, a
+      // genuinely new run's completion was mistaken for an old one's resend and
+      // swallowed: exactly the failure this whole file exists to prevent, and the
+      // one the project's rules call worse than a duplicate.
+      //
+      // So the journal now NEVER suppresses an identified completion. It delivers
+      // it FLAGGED as a possible repeat and lets the agent — which can read the
+      // prompt id, see the outputs, and call get_history — decide. No expiry can
+      // turn that into a loss, and the honest failure mode is a second turn
+      // saying "this may be the same render", not silence.
       if (
         !idUnprovable &&
         (this.delivered.has(deliveredKey(key, correlation.promptId, gen)) ||
           (settledTicket?.settled === true && settledTicket.tabId === key))
       ) {
         logger.info(
-          `[run-completions] ignoring a re-sent completion for ${describe(correlation)} — already delivered to tab ${key.slice(0, 8)}`,
+          `[run-completions] a completion for ${describe(correlation)} was already delivered to tab ${key.slice(0, 8)} — forwarding this one FLAGGED as a possible repeat (never suppressed)`,
         );
-        return null;
+        alreadyDelivered = true;
       }
       // COALESCE ONLY ONTO A `pending` ENTRY. This is the correctness rule, and
       // it is deliberately a property of the TARGET'S OWN CURRENT STATE — not of
@@ -592,8 +613,11 @@ export class RunCompletionJournalImpl {
       attempts: 0,
       state: "pending",
       ...(correlation.status === "unidentified"
-        ? { fingerprint: idlessFingerprint(key, payload), ...(idlessRepeat ? { possibleRepeat: true } : {}) }
+        ? { fingerprint: idlessFingerprint(key, payload) }
         : {}),
+      // One flag, both paths: an identified run whose completion was already
+      // delivered, or an id-less one whose content matches a recent delivery.
+      ...(idlessRepeat || alreadyDelivered ? { possibleRepeat: true } : {}),
       // Freeze the ambiguity onto the entry — see JournalEntry.ambiguousId.
       ...(idUnprovable ? { ambiguousId: true } : {}),
       // …and the GENERATION this completion belongs to, for EVERY identified

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -222,6 +222,40 @@ export class RunCompletionJournalImpl {
    *  re-send is suppressed but a later genuinely-different render is not. */
   private idlessSeen = new Map<string, number>();
   private seq = 0;
+  /** Pull a still-queued completion back off its agent (see setRevoker). */
+  private revoke: ((key: string, token: string) => boolean) | null = null;
+  /** Re-deliver a tab's pending completions (after a revoke re-arms one). */
+  private reflush: ((key: string) => void) | null = null;
+
+  /**
+   * Wire the "unsend" hook (#468).
+   *
+   * A completion's WORDING is materialized when it is queued into an agent, so a
+   * correlation the journal later has to WEAKEN — a prompt id reused, a
+   * conversation replaced — would still reach the agent claiming "this is the run
+   * YOU queued". This lets the journal pull the stale copy back (only while it is
+   * still unread) and re-deliver the honest, downgraded version. Returns whether
+   * the item was actually removed.
+   */
+  setRevoker(revoke: (key: string, token: string) => boolean, reflush?: (key: string) => void): void {
+    this.revoke = revoke;
+    this.reflush = reflush ?? null;
+  }
+
+  /** Re-arm an entry whose correlation just weakened, if its already-queued copy
+   *  can still be pulled back. Once the carrying turn has started the text is in
+   *  the model's context and cannot be recalled — nothing to do but leave it. */
+  private reissueAfterDowngrade(entry: JournalEntry): void {
+    if (entry.state !== "handed_off") return;
+    if (!this.revoke?.(entry.key, entry.token)) return;
+    entry.state = "pending";
+    logger.info(
+      `[run-completions] pulled a queued completion back after its correlation weakened — re-delivering it as ${describe(entry.correlation)}`,
+    );
+    // Re-queue it immediately with the honest wording; a revoked entry left
+    // merely `pending` would wait for some unrelated later flush.
+    this.reflush?.(entry.key);
+  }
 
   /** `panel_run` queued a render. Returns false when ComfyUI/the panel gave us
    *  no prompt id — the caller MUST then tell the agent its completion cannot be
@@ -275,6 +309,9 @@ export class RunCompletionJournalImpl {
           logger.warn(
             `[run-completions] prompt ${promptId} was queued again while its previous completion was still undelivered — the older entry is superseded (and reported as undetermined) so it can no longer answer for the new run`,
           );
+          // Its already-queued copy still SAYS "the run YOU queued". Pull it back
+          // if it hasn't been read yet and re-deliver the downgraded wording.
+          this.reissueAfterDowngrade(entry);
         }
       }
       return true;
@@ -730,6 +767,9 @@ export class RunCompletionJournalImpl {
     for (const entry of this.entries.values()) {
       if (entry.key === key && entry.correlation.status === "matched") {
         entry.correlation = { status: "foreign", promptId: entry.correlation.promptId };
+        // Same as the reused-id downgrade: the queued copy still claims to be the
+        // run this (now-replaced) conversation queued. Recall it if we still can.
+        this.reissueAfterDowngrade(entry);
       }
     }
   }

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -331,6 +331,27 @@ export class RunCompletionJournalImpl {
     }
   }
 
+  /** Has this tab ALREADY seen a completion for this prompt id — delivered (a
+   *  memo from any generation) or still journaled? If so the id is not a fresh
+   *  identity, however long ago that was and whether or not its ticket survives.
+   *  Both stores are bounded, so this is a small scan. */
+  private hasHistoryFor(key: string, promptId: string): boolean {
+    const prefix = `${key}|${promptId}|`;
+    for (const memo of this.delivered) {
+      if (memo.startsWith(prefix)) return true;
+    }
+    for (const entry of this.entries.values()) {
+      if (
+        entry.key === key &&
+        entry.correlation.status !== "unidentified" &&
+        entry.correlation.promptId === promptId
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /** `panel_run` queued a render. Returns false when ComfyUI/the panel gave us
    *  no prompt id — the caller MUST then tell the agent its completion cannot be
    *  correlated rather than promising a notification it may not be able to
@@ -358,6 +379,15 @@ export class RunCompletionJournalImpl {
       this.retireOlderEntriesFor(promptId);
       return true;
     }
+    // A FRESH ticket is only a fresh IDENTITY if this tab has no history for the
+    // id. If it does — a delivered memo from an earlier generation, or an entry
+    // still journaled — then ComfyUI has REUSED the id and the ticket was merely
+    // evicted in between. Nothing on the wire separates "run A's late resend"
+    // from "run B's completion" in that state, so the new ticket is born
+    // ambiguous: had it been treated as a clean identity, A's resend would
+    // correlate as B, its ack would settle B, and B's real completion would then
+    // be suppressed by B's own settled flag — misattribution AND loss.
+    const hasHistory = this.hasHistoryFor(meta.tabId, promptId);
     this.tickets.set(promptId, {
       promptId,
       tabId: meta.tabId,
@@ -365,7 +395,13 @@ export class RunCompletionJournalImpl {
       queuedAt: Date.now(),
       ...(typeof meta.toNodeId === "number" ? { toNodeId: meta.toNodeId } : {}),
       settled: false,
+      ...(hasHistory ? { reused: true } : {}),
     });
+    if (hasHistory) {
+      logger.warn(
+        `[run-completions] prompt ${promptId} was queued again for tab ${meta.tabId.slice(0, 8)} after its ticket had been evicted — this tab already has history for that id, so it is treated as REUSED (every completion for it reported as undetermined)`,
+      );
+    }
     // …and on THIS branch too. A fresh ticket after the old one was evicted is
     // still a NEW run for an id that already has journaled completions: without
     // this, an older `matched` entry survives untouched and goes on telling the
@@ -855,6 +891,16 @@ export class RunCompletionJournalImpl {
     }
     for (const [pid, ticket] of [...this.tickets]) {
       if (ticket.tabId === key) this.tickets.delete(pid);
+    }
+    // An eviction disclosure this tab was still owed dies with it — the tab is
+    // gone, so there is no delivery left to carry it. Say so at ERROR rather than
+    // dropping it silently: the eviction path PROMISES the loss will be reported,
+    // and this is the one place that promise cannot be kept.
+    const owed = this.dropped.get(key) ?? 0;
+    if (owed > 0) {
+      logger.error(
+        `[run-completions] tab ${key.slice(0, 8)} is gone still owed a disclosure for ${owed} evicted completion(s) — it will never be told; treat those runs as UNDETERMINED`,
+      );
     }
     this.dropped.delete(key);
     for (const memo of [...this.delivered]) {

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -107,6 +107,13 @@ export interface JournalEntry {
   /** Content fingerprint — set only for ID-LESS completions, which have no run
    *  identity to dedupe on. See idlessFingerprint(). */
   fingerprint?: string;
+  /** How many turns carried this completion and then ended without a provable
+   *  ack. Bounds the replay loop — see release(). */
+  carriedReleases?: number;
+  /** ID-LESS only: an identical completion was delivered recently, so this may be
+   *  the same frame re-sent. Delivered anyway (never swallowed) but FLAGGED, so
+   *  the agent doesn't double-count it. */
+  possibleRepeat?: boolean;
 }
 
 /** Runs tracked at once. Ample for any real batch; bounded so a long session
@@ -122,18 +129,37 @@ const MAX_ENTRIES_TOTAL = 96;
 const MAX_DELIVERED_MEMO = 256;
 /** Tabs whose evicted-completion counter is retained. */
 const MAX_DROPPED_KEYS = 64;
-/** How many times a completion may be handed to a LIVE agent without a provable
- *  ack before the journal settles it anyway. Bounds the hand-off/release cycle
- *  (see release()); each hand-off already put the text into a turn the agent
- *  read, so settling risks a duplicate, never a loss. */
-const MAX_HANDOFFS = 3;
-/** How long an ID-LESS completion's content fingerprint suppresses an identical
- *  repeat. Bounded on purpose: with no prompt id, identical content is the ONLY
- *  evidence of sameness, and two genuinely distinct renders can eventually
- *  produce identical filenames (ComfyUI reuses `ComfyUI_temp_*_00001_` after a
- *  restart). Long enough to absorb a panel re-send burst, short enough that a
- *  later real render is never mistaken for a repeat. */
-const IDLESS_DEDUPE_WINDOW_MS = 10 * 60_000;
+/** How many times a completion may be CARRIED BY A TURN THAT THEN ENDED without a
+ *  provable ack before the journal settles it anyway.
+ *
+ *  Counts turns, NOT queue hand-offs. A hand-off only means the event was queued;
+ *  an agent torn down before it drained its queue never showed the text to
+ *  anyone, so counting those would settle — and lose — a completion that three
+ *  ordinary provider/session replacements had merely shuffled around. The only
+ *  cycle that needs bounding is "dispatched into a turn → that turn ended → its
+ *  result could not be proven to be its own → replay", which a backend that
+ *  declares turn markers but never stamps its results would otherwise repeat
+ *  forever. Each of THOSE put the completion's text into a turn the agent read,
+ *  so settling risks a duplicate, never a loss. */
+const MAX_CARRIED_RELEASES = 3;
+/**
+ * ID-LESS completions have no run identity, so content is the only evidence of
+ * sameness — and identical content is NOT proof: ComfyUI reuses temp output names
+ * (`ComfyUI_temp_*_00001_`) after a restart, so two genuinely different renders
+ * can look the same. The policy therefore splits by how much a mistake costs:
+ *
+ *  • STILL JOURNALED, UNDELIVERED, within IDLESS_COLLAPSE_MS — collapse onto the
+ *    one entry. This is a transport-retry timescale, not a render timescale: two
+ *    real renders finishing with byte-identical output lists AND both still
+ *    undelivered inside 30s is not a case that occurs, while a panel re-sending a
+ *    frame is. Collapsing here is what stops one output producing two turns.
+ *  • ALREADY DELIVERED, within IDLESS_REPEAT_HINT_MS — do NOT suppress. Swallow
+ *    the wrong one and a real render is silently lost, which is the failure this
+ *    whole file exists to prevent. Deliver it FLAGGED as a possible repeat so the
+ *    agent can decline to double-count it, and let the agent judge.
+ */
+const IDLESS_COLLAPSE_MS = 30_000;
+const IDLESS_REPEAT_HINT_MS = 10 * 60_000;
 
 /** Memo key for an already-delivered (tab, run). "|" separates them; a ComfyUI
  *  prompt id is a fixed-format UUID, so the pair can't alias another. */
@@ -236,6 +262,7 @@ export class RunCompletionJournalImpl {
    */
   record(key: string, payload: CompletionPayload): JournalEntry | null {
     const correlation = this.correlate(key, payload);
+    let idlessRepeat = false;
     if (correlation.status !== "unidentified") {
       // Already DELIVERED once (its carrying turn ended, so the entry is gone).
       // A panel that re-sends the frame must not produce a second delivery — the
@@ -265,26 +292,31 @@ export class RunCompletionJournalImpl {
     } else {
       const print = idlessFingerprint(key, payload);
       const now = Date.now();
-      // Already delivered an identical id-less completion recently.
-      const seenAt = this.idlessSeen.get(print);
-      if (seenAt !== undefined && now - seenAt < IDLESS_DEDUPE_WINDOW_MS) {
-        logger.info(
-          `[run-completions] ignoring a re-sent id-less completion for tab ${key.slice(0, 8)} — identical content already delivered`,
-        );
-        return null;
-      }
-      if (seenAt !== undefined) this.idlessSeen.delete(print); // stale — let it through
-      // Or one is still journaled and undelivered.
+      // COLLAPSE only onto a still-journaled, undelivered twin from the same
+      // re-send burst. Safe: neither copy has reached anyone, so one delivery
+      // instead of two cannot lose news the agent already has.
       for (const entry of this.entries.values()) {
         if (
           entry.key === key &&
           entry.correlation.status === "unidentified" &&
           entry.fingerprint === print &&
-          now - entry.arrivedAt < IDLESS_DEDUPE_WINDOW_MS
+          now - entry.arrivedAt < IDLESS_COLLAPSE_MS
         ) {
           entry.payload = payload;
           return entry;
         }
+      }
+      // Already DELIVERED an identical id-less completion recently. Deliberately
+      // NOT suppressed: identical content is not proof of identity, and swallowing
+      // a second real render is a silent loss. Deliver it flagged instead.
+      const seenAt = this.idlessSeen.get(print);
+      const repeatHint = seenAt !== undefined && now - seenAt < IDLESS_REPEAT_HINT_MS;
+      if (seenAt !== undefined && !repeatHint) this.idlessSeen.delete(print); // stale
+      idlessRepeat = repeatHint;
+      if (repeatHint) {
+        logger.info(
+          `[run-completions] tab ${key.slice(0, 8)}: an id-less completion with identical content was already delivered — forwarding it FLAGGED as a possible repeat (never suppressed: content is not identity)`,
+        );
       }
     }
     const entry: JournalEntry = {
@@ -296,7 +328,7 @@ export class RunCompletionJournalImpl {
       attempts: 0,
       state: "pending",
       ...(correlation.status === "unidentified"
-        ? { fingerprint: idlessFingerprint(key, payload) }
+        ? { fingerprint: idlessFingerprint(key, payload), ...(idlessRepeat ? { possibleRepeat: true } : {}) }
         : {}),
     };
     this.entries.set(entry.token, entry);
@@ -362,6 +394,7 @@ export class RunCompletionJournalImpl {
         // reads a replay as "this landed late", not as another render.
         ...(entry.attempts > 0 ? { replayed: true } : {}),
         ...(lost > 0 ? { dropped_completions: lost } : {}),
+        ...(entry.possibleRepeat ? { possible_repeat: true } : {}),
       };
       const handedOff = inject(payload, entry.token);
       this.noteAttempt(entry.token, handedOff);
@@ -419,27 +452,31 @@ export class RunCompletionJournalImpl {
   }
 
   /**
-   * An agent gave a hand-off back undelivered (it was stopped, its turn was
-   * abandoned, or the turn's result could not be proven to be its own). Re-arm
-   * it for replay.
+   * An agent gave a hand-off back undelivered. Re-arm it for replay.
    *
-   * BOUNDED. `attempts` counts hand-offs to a LIVE agent — each one put the
-   * completion's text into a turn the agent actually read. A backend that
-   * declares turn markers but keeps emitting unmarked results would otherwise
-   * bounce the same entry between hand-off and release forever, re-delivering it
-   * on every turn. After MAX_HANDOFFS the evidence of delivery is overwhelming
-   * (the agent has seen it that many times), so we settle it rather than loop.
-   * This can only ever cause a duplicate, never a loss.
+   * `carried` distinguishes the two causes, and ONLY the first is bounded:
+   *  • carried: true  — a turn actually DISPATCHED with this completion in it and
+   *    then ended, but its result could not be proven to be that turn's own. The
+   *    agent read the text. A backend that declares turn markers yet never stamps
+   *    its results would bounce the entry here on every single turn, so after
+   *    MAX_CARRIED_RELEASES we settle rather than loop: a duplicate at worst.
+   *  • carried: false — a teardown handed it back (agent stopped, held mail
+   *    discarded, session died). NOBODY read it. These must never count toward
+   *    the bound, or three ordinary provider/session replacements would settle —
+   *    and lose — a completion that was only ever shuffled between queues.
    */
-  release(token: string): void {
+  release(token: string, opts: { carried?: boolean } = {}): void {
     const entry = this.entries.get(token);
     if (!entry) return;
-    if (entry.attempts >= MAX_HANDOFFS) {
-      logger.warn(
-        `[run-completions] ${describe(entry.correlation)} was handed to a live agent ${entry.attempts}× without a provable ack — settling it instead of replaying again`,
-      );
-      this.ack(token);
-      return;
+    if (opts.carried) {
+      entry.carriedReleases = (entry.carriedReleases ?? 0) + 1;
+      if (entry.carriedReleases >= MAX_CARRIED_RELEASES) {
+        logger.warn(
+          `[run-completions] ${describe(entry.correlation)} was carried by ${entry.carriedReleases} turns that ended without a provable ack — settling it instead of replaying again`,
+        );
+        this.ack(token);
+        return;
+      }
     }
     entry.state = "pending";
   }

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -133,8 +133,10 @@ const MAX_ENTRIES_PER_KEY = 32;
  *  that opens and abandons many tabs can't grow the journal without limit. */
 const MAX_ENTRIES_TOTAL = 96;
 /** (tab, run) pairs remembered as already delivered, to suppress a re-sent frame
- *  after its entry was acked and removed. */
-const MAX_DELIVERED_MEMO = 256;
+ *  after its entry was acked and removed. Comfortably larger than MAX_TICKETS so
+ *  it outlives the tickets that feed it; a resend later than THIS is delivered
+ *  again, but as `foreign` — flagged UNDETERMINED, never as the awaited run. */
+const MAX_DELIVERED_MEMO = 512;
 /** Tabs whose evicted-completion counter is retained. */
 const MAX_DROPPED_KEYS = 64;
 /** How many times a completion may be CARRIED BY A TURN THAT THEN ENDED without a
@@ -552,15 +554,7 @@ export class RunCompletionJournalImpl {
     // run's real completion.
     if (entry.superseded) return;
     if (entry.correlation.status !== "unidentified") {
-      // Remember (tab, run) so a later re-send of the same frame is suppressed
-      // rather than delivered a second time. Bounded FIFO — old ids age out; a
-      // re-send that late is not a real case.
-      this.delivered.add(deliveredKey(entry.key, entry.correlation.promptId));
-      while (this.delivered.size > MAX_DELIVERED_MEMO) {
-        const oldest = this.delivered.values().next().value;
-        if (oldest === undefined) break;
-        this.delivered.delete(oldest);
-      }
+      this.memoDelivered(entry.key, entry.correlation.promptId);
     } else if (entry.fingerprint) {
       // ID-LESS: memoize the CONTENT so a re-sent identical frame after the ack
       // doesn't produce a second turn. Windowed in record(), bounded here.
@@ -712,6 +706,19 @@ export class RunCompletionJournalImpl {
     }
   }
 
+  /** Remember (tab, run) as already reported, so a later re-send of the same
+   *  frame is suppressed rather than delivered a second time. Bounded FIFO; the
+   *  run TICKET's `settled` flag is the other record, and an evicted settled
+   *  ticket feeds this one so neither expires before the other. */
+  private memoDelivered(key: string, promptId: string): void {
+    this.delivered.add(deliveredKey(key, promptId));
+    while (this.delivered.size > MAX_DELIVERED_MEMO) {
+      const oldest = this.delivered.values().next().value;
+      if (oldest === undefined) break;
+      this.delivered.delete(oldest);
+    }
+  }
+
   /** Test/diagnostic helpers. */
   ticketFor(promptId: string): RunTicket | undefined {
     return this.tickets.get(promptId);
@@ -747,6 +754,10 @@ export class RunCompletionJournalImpl {
       }
       if (!victim) victim = this.tickets.keys().next().value ?? null;
       if (!victim) return;
+      // Evicting a SETTLED ticket does not lose the "already reported" proof:
+      // ack() writes it to the delivered memo at the same moment it sets
+      // `settled`, and MAX_DELIVERED_MEMO is deliberately far larger than
+      // MAX_TICKETS so the memo always outlives the ticket that mirrors it.
       this.tickets.delete(victim);
     }
   }

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -1,0 +1,351 @@
+// Durable-across-the-turn delivery of a render COMPLETION to the panel agent
+// (issue #468).
+//
+// THE FAILURE. `panel_run` queues a render on the user's canvas and tells the
+// agent — in so many words — "end your turn, you WILL be notified when it
+// finishes". That promise is kept by exactly one mechanism: the panel's
+// `agent_event` frame → PanelAgentManager.injectEvent → PanelAgent.queue. That
+// path used to be fire-and-forget in three independent ways:
+//
+//   1. UNCORRELATED. The completion carried no run identity the orchestrator
+//      ever looked at. `panel_run` learns ComfyUI's `prompt_id` (it already
+//      hands it to QueueMonitor.markSelfQueued) but nothing downstream used it,
+//      so a completion could not be tied to the run that was outstanding — and
+//      an outstanding run could never be known to be unanswered.
+//   2. SILENTLY DROPPED with no live agent. injectEvent returns false for a
+//      missing/stopped agent and the caller only logged on success. Nothing
+//      recorded the loss.
+//   3. DIED WITH A QUEUED-BUT-UNREAD ITEM. The event is only really delivered
+//      when channel() splices it into a turn. Everything before that — a
+//      stop()/retire(), a stall-abandoned turn, a takePending() race — discards
+//      it.
+//
+// AUTOMATIC GOAL CONTINUATION is what turns those windows from theoretical into
+// routine. An ordinary single run ends the agent's turn and leaves it idle, so
+// the completion lands in an empty queue and is drained immediately. A
+// continuation keeps the agent BUSY for the whole render: the completion sits in
+// `queue` (window 3) for minutes, and the continuation's own turn churn is
+// exactly what fires the deferred session restarts (effort/model change,
+// comfyui-MCP-env respawn) that applyPendingRestarts defers "until idle" and the
+// self-restart loop — each of which tears the listener down (windows 2 and 3)
+// underneath the very render whose completion is in flight.
+//
+// THE CONTRACT HERE.
+//  • Runs are ticketed by ComfyUI's `prompt_id`, opened by `panel_run`.
+//  • Every completion is CORRELATED ONCE, AT ARRIVAL, by EXACT prompt-id
+//    equality against an open ticket — never by recency, never re-derived later.
+//  • An uncorrelatable completion is still delivered, labelled UNDETERMINED. It
+//    is never swallowed and never allowed to answer for a run it can't be proven
+//    to belong to.
+//  • Undelivered completions are JOURNALED and replayed at the next delivery
+//    opportunity (a fresh agent spawn, a later completion for the same tab).
+//  • An entry is cleared only on a positive ack — the turn that CARRIED it
+//    ended. Handed to an agent that then died, it comes back and is replayed.
+//
+// LOCAL trust domain: this is accidental-loss bookkeeping, not a defense against
+// a hostile panel. Everything is in-memory and process-scoped; an orchestrator
+// restart drops the journal along with the agents it was addressing.
+
+import { logger } from "../utils/logger.js";
+
+/** How a completion relates to the runs this session queued. Computed ONCE, at
+ *  arrival, and frozen onto the journal entry — a replay never re-correlates,
+ *  so a completion can never drift onto a run that started after it landed. */
+export type RunCorrelation =
+  /** Exact prompt-id match with a run `panel_run` queued from this session. */
+  | { status: "matched"; promptId: string }
+  /** Carries a prompt id, but no run this session queued has that id. Real, but
+   *  NOT ours — it must never satisfy an outstanding `panel_run`. */
+  | { status: "foreign"; promptId: string }
+  /** No prompt id at all. Unattributable in principle; reported as such. */
+  | { status: "unidentified" };
+
+/** The completion payload as it arrives from the panel (the `agent_event` frame
+ *  minus the routing fields). Kept loose on purpose — the panel is free to add
+ *  fields and we forward what we're given. */
+export interface CompletionPayload {
+  kind?: string;
+  images?: Array<{ filename: string; subfolder?: string; type?: string }>;
+  error?: string;
+  note?: string;
+  prompt_id?: string;
+  [k: string]: unknown;
+}
+
+/** A run `panel_run` queued and is waiting on. */
+export interface RunTicket {
+  promptId: string;
+  /** Panel tab the run was queued from (diagnostics only — correlation is by
+   *  prompt id, which ComfyUI makes globally unique, so a ctx.tabId rebind
+   *  between queue and completion cannot break the match). */
+  tabId: string;
+  queuedAt: number;
+  toNodeId?: number;
+  /** True once a completion for this exact prompt id was acked as delivered. */
+  settled: boolean;
+}
+
+export type EntryState =
+  /** Waiting for a delivery attempt. */
+  | "pending"
+  /** Handed to a live agent; not proven consumed yet. */
+  | "handed_off";
+
+export interface JournalEntry {
+  token: string;
+  /** Composite agent key this completion is addressed to. An entry is only ever
+   *  replayed to THIS key (moved wholesale by `moveKey` on a tab-id migration) —
+   *  it is never broadcast or re-targeted. */
+  key: string;
+  payload: CompletionPayload;
+  correlation: RunCorrelation;
+  arrivedAt: number;
+  attempts: number;
+  state: EntryState;
+}
+
+/** Runs tracked at once. Ample for any real batch; bounded so a long session
+ *  can't grow the map without limit. */
+const MAX_TICKETS = 64;
+/** Undelivered completions held per agent key. */
+const MAX_ENTRIES_PER_KEY = 16;
+
+export class RunCompletionJournalImpl {
+  /** prompt id → ticket. Keyed globally: ComfyUI prompt ids are UUIDs, so an
+   *  exact match is proof of identity on its own and survives a session's tab
+   *  id being rebound between the queue and the completion. */
+  private tickets = new Map<string, RunTicket>();
+  /** token → entry (insertion-ordered, which is also delivery order). */
+  private entries = new Map<string, JournalEntry>();
+  private seq = 0;
+
+  /** `panel_run` queued a render. Returns false when ComfyUI/the panel gave us
+   *  no prompt id — the caller MUST then tell the agent its completion cannot be
+   *  correlated rather than promising a notification it may not be able to
+   *  attribute. */
+  openRun(promptId: string | null | undefined, meta: { tabId: string; toNodeId?: number }): boolean {
+    if (typeof promptId !== "string" || !promptId) return false;
+    const existing = this.tickets.get(promptId);
+    if (existing) {
+      // Same prompt id queued again (a re-run of an id ComfyUI reused, or a
+      // duplicate reply): reopen it rather than stacking a second ticket, so one
+      // prompt id always means one run.
+      existing.settled = false;
+      existing.queuedAt = Date.now();
+      return true;
+    }
+    this.tickets.set(promptId, {
+      promptId,
+      tabId: meta.tabId,
+      queuedAt: Date.now(),
+      ...(typeof meta.toNodeId === "number" ? { toNodeId: meta.toNodeId } : {}),
+      settled: false,
+    });
+    this.trimTickets();
+    return true;
+  }
+
+  /** Classify a completion against the open runs. EXACT prompt-id equality only:
+   *  there is deliberately no "the newest outstanding run" fallback, because
+   *  attributing a completion to the wrong run is worse than not attributing it
+   *  at all. */
+  correlate(payload: CompletionPayload): RunCorrelation {
+    const pid = typeof payload.prompt_id === "string" ? payload.prompt_id.trim() : "";
+    if (!pid) return { status: "unidentified" };
+    return this.tickets.has(pid) ? { status: "matched", promptId: pid } : { status: "foreign", promptId: pid };
+  }
+
+  /**
+   * Journal a completion addressed to `key`. Correlation is computed here, once.
+   *
+   * DEDUPE: an identified completion (matched or foreign) collapses onto any
+   * existing undelivered entry for the same key + prompt id — one run can never
+   * produce two deliveries, however many times the panel re-sends it. An
+   * unidentified completion has nothing to dedupe on, so it is always a new
+   * entry (bounded by MAX_ENTRIES_PER_KEY).
+   */
+  record(key: string, payload: CompletionPayload): JournalEntry {
+    const correlation = this.correlate(payload);
+    if (correlation.status !== "unidentified") {
+      for (const entry of this.entries.values()) {
+        if (
+          entry.key === key &&
+          entry.correlation.status !== "unidentified" &&
+          entry.correlation.promptId === correlation.promptId
+        ) {
+          entry.payload = payload;
+          // Re-open it for delivery: a re-send is the panel telling us the
+          // outcome again, and the previous hand-off is not proven consumed.
+          if (entry.state === "handed_off") entry.state = "pending";
+          return entry;
+        }
+      }
+    }
+    const entry: JournalEntry = {
+      token: `rc${++this.seq}`,
+      key,
+      payload,
+      correlation,
+      arrivedAt: Date.now(),
+      attempts: 0,
+      state: "pending",
+    };
+    this.entries.set(entry.token, entry);
+    this.trimEntries(key);
+    return entry;
+  }
+
+  /** Entries awaiting a delivery attempt for this key, in arrival order. */
+  pending(key: string): JournalEntry[] {
+    const out: JournalEntry[] = [];
+    for (const entry of this.entries.values()) {
+      if (entry.key === key && entry.state === "pending") out.push(entry);
+    }
+    return out;
+  }
+
+  /**
+   * Deliver every pending entry for `key`, in ARRIVAL order, stopping at the
+   * first refusal so a newer completion can never overtake an older one that is
+   * still stuck.
+   *
+   * `inject` returns whether the agent TOOK the payload onto its queue — not
+   * that it was read. The entry stays journaled either way; only `ack` (the turn
+   * that carried it ended) removes it. That is the whole durability property:
+   * hand it to an agent that then dies and it comes back here.
+   *
+   * NOTHING is re-correlated: the payload is stamped with the verdict frozen at
+   * arrival, so a replay can never be re-attributed to a run that started later.
+   */
+  deliverPending(
+    key: string,
+    inject: (payload: CompletionPayload, token: string) => boolean,
+  ): { delivered: number; blockedOn: JournalEntry | null } {
+    let delivered = 0;
+    for (const entry of this.pending(key)) {
+      const payload: CompletionPayload = {
+        ...entry.payload,
+        run_correlation: entry.correlation.status,
+        ...(entry.correlation.status === "unidentified"
+          ? {}
+          : { prompt_id: entry.correlation.promptId }),
+        // Second and later attempts ARE re-deliveries — say so, so the agent
+        // reads a replay as "this landed late", not as another render.
+        ...(entry.attempts > 0 ? { replayed: true } : {}),
+      };
+      const handedOff = inject(payload, entry.token);
+      this.noteAttempt(entry.token, handedOff);
+      if (!handedOff) return { delivered, blockedOn: entry };
+      delivered += 1;
+    }
+    return { delivered, blockedOn: null };
+  }
+
+  /** All still-unacked entries for a key (pending OR handed off) — diagnostics. */
+  outstanding(key: string): JournalEntry[] {
+    return [...this.entries.values()].filter((e) => e.key === key);
+  }
+
+  /** Record the outcome of a delivery attempt. `handedOff` true = an agent took
+   *  it onto its queue (not yet proof it was read). */
+  noteAttempt(token: string, handedOff: boolean): void {
+    const entry = this.entries.get(token);
+    if (!entry) return;
+    entry.attempts += 1;
+    entry.state = handedOff ? "handed_off" : "pending";
+  }
+
+  /** The turn that CARRIED this completion ended — it genuinely reached the
+   *  agent. Drop the entry and settle its run. */
+  ack(token: string): void {
+    const entry = this.entries.get(token);
+    if (!entry) return;
+    this.entries.delete(token);
+    if (entry.correlation.status === "matched") {
+      const ticket = this.tickets.get(entry.correlation.promptId);
+      if (ticket) ticket.settled = true;
+    }
+  }
+
+  /** An agent gave a hand-off back undelivered (it was stopped, or its turn was
+   *  abandoned before it could be read). Re-arm it for replay. */
+  release(token: string): void {
+    const entry = this.entries.get(token);
+    if (!entry) return;
+    entry.state = "pending";
+  }
+
+  /** Move every entry addressed to `from` onto `to` — a panel tab-id migration
+   *  re-keys the agent, and its undelivered completions must move WITH it. This
+   *  re-addresses, it never broadens: entries for other keys are untouched. */
+  moveKey(from: string, to: string): void {
+    if (from === to) return;
+    for (const entry of this.entries.values()) {
+      if (entry.key === from) entry.key = to;
+    }
+  }
+
+  /** Drop everything addressed to a key that will never come back (tab closed).
+   *  Logs any completion that dies unacked — a loss must never be silent. */
+  forget(key: string): void {
+    for (const [token, entry] of [...this.entries]) {
+      if (entry.key !== key) continue;
+      this.entries.delete(token);
+      logger.warn(
+        `[run-completions] dropping an undelivered completion for ${describe(entry.correlation)} — its tab (${key.slice(0, 8)}) is gone`,
+      );
+    }
+  }
+
+  /** Test/diagnostic helpers. */
+  ticketFor(promptId: string): RunTicket | undefined {
+    return this.tickets.get(promptId);
+  }
+  reset(): void {
+    this.tickets.clear();
+    this.entries.clear();
+    this.seq = 0;
+  }
+
+  private trimTickets(): void {
+    while (this.tickets.size > MAX_TICKETS) {
+      // Prefer evicting a settled ticket; otherwise the oldest. An evicted OPEN
+      // ticket means a later completion for it correlates as "foreign" — i.e.
+      // UNDETERMINED, which is the honest reading once we've forgotten the run.
+      let victim: string | null = null;
+      for (const [pid, t] of this.tickets) {
+        if (t.settled) {
+          victim = pid;
+          break;
+        }
+      }
+      if (!victim) victim = this.tickets.keys().next().value ?? null;
+      if (!victim) return;
+      this.tickets.delete(victim);
+    }
+  }
+
+  private trimEntries(key: string): void {
+    const mine = [...this.entries.values()].filter((e) => e.key === key);
+    while (mine.length > MAX_ENTRIES_PER_KEY) {
+      const victim = mine.shift();
+      if (!victim) return;
+      this.entries.delete(victim.token);
+      logger.error(
+        `[run-completions] journal for tab ${key.slice(0, 8)} exceeded ${MAX_ENTRIES_PER_KEY} undelivered completions — dropped the oldest (${describe(victim.correlation)})`,
+      );
+    }
+  }
+}
+
+/** Short human label for a correlation, for logs. */
+export function describe(correlation: RunCorrelation): string {
+  return correlation.status === "unidentified"
+    ? "an unidentified run"
+    : `${correlation.status === "matched" ? "run" : "foreign run"} ${correlation.promptId}`;
+}
+
+/** Process-wide journal (mirrors the QueueMonitor singleton): `panel_run` opens
+ *  tickets from the tool layer while the orchestrator's panel-event handler
+ *  records and replays completions, with no ctx plumbing between them. */
+export const RunCompletions = new RunCompletionJournalImpl();

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -423,6 +423,18 @@ export class RunCompletionJournalImpl {
     for (const [pid, ticket] of [...this.tickets]) {
       if (ticket.tabId === key) this.tickets.delete(pid);
     }
+    // Entries still undelivered were addressed to the conversation that just
+    // went away, so their `matched` verdict no longer holds for whoever receives
+    // them next: DOWNGRADE to foreign. This does not violate "correlated once at
+    // arrival" — a correlation may only ever get WEAKER (matched → foreign),
+    // never stronger, and only in response to an explicit "that conversation is
+    // gone" event. Without it a completion journaled before New chat would be
+    // replayed to the replacement agent as "the run YOU queued".
+    for (const entry of this.entries.values()) {
+      if (entry.key === key && entry.correlation.status === "matched") {
+        entry.correlation = { status: "foreign", promptId: entry.correlation.promptId };
+      }
+    }
   }
 
   /** Test/diagnostic helpers. */

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -216,6 +216,14 @@ export class RunCompletionJournalImpl {
    *  attribute. */
   openRun(promptId: string | null | undefined, meta: { tabId: string; toNodeId?: number }): boolean {
     if (typeof promptId !== "string" || !promptId) return false;
+    // CLEAR the already-delivered memo for this (tab, run) FIRST, on EVERY path.
+    // The memo only ever means "we already reported THIS run", which queuing the
+    // id again makes false — and the memo outlives the ticket by design, so the
+    // reopen branch below is NOT the only way to reach a stale one: after 64
+    // later runs the old ticket is evicted, and a reuse of the id then takes the
+    // fresh-ticket path while the memo still stands. Leaving it would suppress
+    // the NEW run's real completion after `panel_run` promised to deliver it.
+    this.delivered.delete(deliveredKey(meta.tabId, promptId));
     const existing = this.tickets.get(promptId);
     if (existing) {
       // Same prompt id queued again (a re-run of an id ComfyUI reused, or a
@@ -252,12 +260,6 @@ export class RunCompletionJournalImpl {
           );
         }
       }
-      // …and CLEAR the already-delivered memo for it. Reopening the ticket while
-      // the memo stood meant the reopened run's completion was suppressed as a
-      // duplicate of the PREVIOUS run's: `panel_run` promised automatic delivery
-      // and the journal then swallowed it. The memo only ever means "we already
-      // reported THIS run", which a genuine re-queue makes false.
-      this.delivered.delete(deliveredKey(meta.tabId, promptId));
       return true;
     }
     this.tickets.set(promptId, {

--- a/src/orchestrator/session-store.ts
+++ b/src/orchestrator/session-store.ts
@@ -181,16 +181,27 @@ export function carryWorkflowCommandStamp(
 /** #570 — does the DESTINATION of a tab-id migration already hold state for a backend, so the
  *  incoming tab would inherit/leak it? Covers EVERY kind of per-backend state that must be reset
  *  before the source is rebound in: manager live/pending/held (`hasManagerState`), a dormant
- *  durable session (`hasDurableSession`), OR a RENDER-HELD queue (`renderHeldCount` — the
+ *  durable session (`hasDurableSession`), a RENDER-HELD queue (`renderHeldCount` — the
  *  orchestrator-level heldDuringGen, which manager.reset does NOT clear and which the source-held
  *  re-key would otherwise APPEND to, flushing the superseded tab's queued message into the incoming
- *  tab on render completion). Any of these ⇒ collision ⇒ reset + clear the destination's held. */
+ *  tab on render completion), OR a JOURNALED RUN COMPLETION (`journaledCompletionCount`, #468 — a
+ *  tab whose agent and session were already cleared (New chat) can still hold an undelivered
+ *  completion; without this it reads as UNOCCUPIED, the incoming source is rebound onto its id, and
+ *  the next flush delivers the DESTINATION tab's render into the SOURCE tab's conversation. A tab
+ *  holding a journal entry is not empty). Any of these ⇒ collision ⇒ reset + clear the
+ *  destination's held state. */
 export function destinationHasCollisionState(opts: {
   hasManagerState: boolean;
   hasDurableSession: boolean;
   renderHeldCount: number;
+  journaledCompletionCount?: number;
 }): boolean {
-  return opts.hasManagerState || opts.hasDurableSession || opts.renderHeldCount > 0;
+  return (
+    opts.hasManagerState ||
+    opts.hasDurableSession ||
+    opts.renderHeldCount > 0 ||
+    (opts.journaledCompletionCount ?? 0) > 0
+  );
 }
 
 /** #570 — does a connected SIBLING tab own the session behind a candidate stable key? A stable key

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -721,6 +721,18 @@ export class UiBridge {
    *  listener stays token-less so the local browser panel is unaffected. */
   private readonly extraServers: WebSocketServer[] = [];
   private conns = new Map<string, Conn>(); // tabId -> connection (canvas-owning primary)
+  /**
+   * EVERY accepted socket, from the moment it is accepted — including the ones
+   * still ANONYMOUS because no `hello` has named a tab id yet.
+   *
+   * `conns` is keyed by tab id, so it cannot see an anonymous socket at all.
+   * `stop()` used to close only `conns` and then await `wss.close()`, which waits
+   * for every open socket: one anonymous connection (a browser that opened the
+   * WebSocket and never sent hello, or was mid-handshake at shutdown) would hang
+   * teardown forever. Tracking from accept is what makes stop() actually able to
+   * close what it is about to wait on.
+   */
+  private sockets = new Set<BridgeSocket>();
   /** Incremented for every accepted panel hello; never reused during this bridge lifetime. */
   private nextHelloGeneration = 0;
   /** Mobile "mirror" viewers subscribed to a tab's live output (remote control):
@@ -1117,6 +1129,11 @@ export class UiBridge {
    *   connections. Bound to the tab so the reboot self-probe can trust which page it fronts.
    */
   private handleConnection(sock: BridgeSocket, local = false, serverOrigin?: string): void {
+    // Track from ACCEPT, not from hello: an anonymous socket is still a socket,
+    // and stop() must be able to close it (see `sockets`). Removed on close so
+    // the set never outgrows the live connections.
+    this.sockets.add(sock);
+    sock.on("close", () => this.sockets.delete(sock));
     // The connection is anonymous until its hello frame names a tab id.
     let tabId: string | null = null;
     // A socket's KIND (canvas-owning panel vs headless viewer) is pinned on its
@@ -2519,6 +2536,17 @@ export class UiBridge {
       }
     }
     this.conns.clear();
+    // …and every socket that never got as far as a hello. `wss.close()` below
+    // waits on EVERY open socket, so closing only the tab-keyed ones left an
+    // anonymous connection able to hang teardown indefinitely.
+    for (const sock of this.sockets) {
+      try {
+        sock.close();
+      } catch {
+        // Already gone.
+      }
+    }
+    this.sockets.clear();
     for (const s of this.extraServers.splice(0)) {
       try {
         s.close();


### PR DESCRIPTION
`panel_run` makes a promise: *"You will be notified automatically with the output image(s)/video when the render finishes — do NOT poll. Just end your turn now and wait."* This PR makes that promise keepable.

Closes #468

## Root cause — why *continuation* is what breaks it

The completion is delivered by exactly one mechanism: the panel's `agent_event` frame → `PanelAgentManager.injectEvent` → `PanelAgent.queue`. That path was fire-and-forget in three independent ways.

1. **Uncorrelated.** The completion carried no run identity anything downstream looked at. `panel_run` already learns ComfyUI's `prompt_id` (it hands it to `QueueMonitor.markSelfQueued`) but nothing used it, so a completion could not be tied to the run that was outstanding — and an outstanding run could never be known to be unanswered.
2. **Silently dropped with no live agent.** `manager.injectEvent` returns `false` for a missing/stopped agent and the caller only logged on success. Nothing recorded the loss. The event was gone with no line in the log.
3. **Died with a queued-but-unread item.** The event is only really delivered when `channel()` splices it into a turn. Everything before that — a `stop()`/`retire()`, a stall-abandoned turn, a `takePending()` race — discards it.

An **ordinary single run** ends the agent's turn and leaves it idle, so the completion lands in an empty queue and drains immediately; none of the above shows. **Automatic goal continuation** is what turns those windows from theoretical into routine:

- the agent is **busy for the entire render**, so the completion sits in `queue` (window 3) for minutes instead of microseconds;
- the continuation's own turn churn is exactly what fires the session restarts `applyPendingRestarts` defers "until idle" (effort/model change, comfyui-MCP-env respawn) plus the self-restart loop — each of which **tears the listener down** (windows 2 and 3) underneath the very render whose completion is in flight.

Nothing noticed, because there was no ack that the agent had consumed the event and no outstanding-run bookkeeping. A lost completion was indistinguishable from a slow render, so the agent simply waited.

## The fix — journal + replay, mirroring panel #514

New `src/orchestrator/run-completion-journal.ts`.

- **Run tickets.** `panel_run` opens one keyed by ComfyUI's `prompt_id` and the panel tab that queued it.
- **Correlated ONCE, at arrival**, by **exact** prompt-id equality **and** same tab. There is deliberately no "the newest outstanding run" fallback and no cross-tab match.
- **Journaled and replayed.** Every completion is recorded before delivery is attempted; a refused delivery is logged and retried at the next opportunity (a fresh agent spawn, a hand-back, a proven tab-id migration, a later completion for the same tab). Delivery preserves arrival order and stops at the first refusal.
- **Acked only by the turn that carried it.** `injectEvent` now takes an `eventToken` that rides the queue item and the in-flight turn. The entry leaves the journal only when *that turn's* `result` lands. Handed to an agent that then dies, it comes back and is replayed. Every other exit from a turn — stall-watchdog abandon, plain-Stop interrupt, rewind, session end with no result, `stop()`, a discarded held-mail `reset()` — hands the tokens **back**.

### Nothing is ever silently swallowed

- A completion that **can't be correlated** is still delivered, explicitly labelled: *"its origin is UNDETERMINED. Do NOT assume it is your run; verify yours with `get_history`."*
- A **replayed** one says so (`RE-DELIVERED`) so it reads as "this landed late", not as another render.
- A completion **evicted** by the journal's bounds is counted and reported on the next delivery that gets through.
- `panel_run` itself no longer over-promises: when the panel forwards **no `prompt_id`**, the anti-poll instruction is replaced with an honest one — the outcome will be UNDETERMINED, don't idle indefinitely, confirm with `get_history`.

### Never attributed to the wrong run

A completion on the wrong run is worse than a lost one, so:

- the verdict is **frozen at arrival** and never re-derived on replay — a stranded completion cannot drift onto a run that started after it landed;
- a correlation may only ever get **weaker** (`matched` → `foreign`), never stronger, and only on an explicit "that conversation is gone" event (`closeRuns`, wired into New chat, resume-session, and in-place workflow replacement);
- an entry is addressed to **one** panel tab and is only ever re-addressed (`moveKey` on a *proven* same-workflow tab-id migration — which carries the tickets, the delivered memo and the eviction counter with it), never broadcast; an unproven workflow switch **forgets** the old tab's entries *and* tickets instead of migrating them;
- a `matched` entry settles **only its own** ticket, and only on ack;
- **only the carrying turn's own `result` may ack.** #728 deliberately lets an *unmarked* result past the dead-letter guard for gate liveness; on a marker-stamping backend that result may belong to an abandoned earlier turn, so it is no longer allowed to retire a completion the current turn is holding. Leftovers are handed back at the next dispatch.
- dedupe on `(tab, run)` — including after the ack, via a bounded memo — so a re-sent frame can never produce a second delivery.

## Tests

`src/__tests__/orchestrator/run-completion-continuation.test.ts` (26). Delivered across a continuation while the agent is busy the whole render; journaled with no live agent and replayed to the right run; replayed after its carrying turn is abandoned; uncorrelatable and foreign completions reported as UNDETERMINED and never settling the awaited run; a replay never satisfying a different run; the held-mail/`reset()` path; the traceless-straggler ack gate (verified to fail without the gate); plus the journal's correlation, dedupe, eviction-disclosure, `moveKey`/`forget` and ordering invariants. `panel-tools.test.ts` gains the no-`prompt_id` honesty case.

`npm run build` clean; full suite **240 files / 4061 passed**, 2 skipped.

## Review

5 rounds of `gpt-5.6-terra` adversarial review, ending **PASS**. It found and drove out: the global-ticket workflow-switch misattribution (→ tab-scoped correlation + ticket-forgetting), silent eviction of undelivered completions (→ counted and disclosed), a re-arm that could double-deliver, a re-entrancy in the tab-collision path that flushed into the superseded tab's agent, held mail discarded without releasing its tokens, `moveKey` leaving the delivered memo and eviction counter behind, `matched` entries surviving a New chat, and the unmarked-straggler ack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
