### PR TITLE
fix(panel): resolve panel_load_workflow relative paths against the live user directory (#202)

### DIFF
--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -413,34 +413,42 @@ describe("readWorkflowFromPath: a refusal is never mistaken for an unreachable s
     }
   });
 
-  it("refuses a backslash name rather than letting Windows resolve() reinterpret it", async () => {
-    // The local fallback passes the store key straight to resolve(). On Windows
-    // that turns "recipes\foo.json" — one literal segment in the server's key
-    // space — into the folder path recipes/foo.json, so the two branches would
-    // open different files from the same input (codex MAJOR).
+  it("does NOT consult a local file when a backslash name is absent under BOTH spellings", async () => {
+    // A backslash name is asked for literally first (the server's key space is
+    // "/"-separated, and on POSIX a backslash is a legal filename character), then
+    // as the Windows-style folder path. Once the server has answered "no" to both,
+    // it has spoken — the colliding local file is never consulted, and the refusal
+    // names both keys it tried.
     const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
     try {
       const nested = join(root, "user", "default", "workflows", "recipes");
       mkdirSync(nested, { recursive: true });
       writeFileSync(
         join(nested, "foo.json"),
-        JSON.stringify({ nodes: [{ id: 1, type: "ReinterpretedNode" }], links: [] }),
+        JSON.stringify({ nodes: [{ id: 1, type: "LocalRecipeNode" }], links: [] }),
         "utf8",
       );
       process.env.COMFYUI_PATH = root;
 
-      fetchApi.mockRejectedValue(new Error("ECONNREFUSED"));
+      fetchApi.mockImplementation(async (route: string) =>
+        route.startsWith("/api/userdata?")
+          ? { ok: true, status: 200, json: async () => [] }
+          : { ok: false, status: 404, json: async () => ({}) },
+      );
 
       const { ctx, calls } = makeCtx();
       const res = await loadWorkflow().handler({ path: "recipes\\foo.json" }, ctx);
 
       expect(res.isError).toBe(true);
-      expect(calls).toHaveLength(0); // resolve() never got to reinterpret the name
-      expect(JSON.stringify(res)).toMatch(/forward slashes/i);
+      expect(calls).toHaveLength(0); // the local recipes/foo.json was NOT loaded
+      const text = JSON.stringify(res);
+      expect(text).toMatch(/recipes\\\\foo\.json/); // the literal spelling
+      expect(text).toMatch(/recipes\/foo\.json/); // and the normalized one
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
 
   it("refuses when an unreachable server leaves TWO different local candidates", async () => {
     // Both reconstructed layouts (user/default/workflows and user/workflows) hold a
@@ -531,27 +539,53 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     expect(fetchApi).toHaveBeenCalledWith(`/api/userdata/${encodeURIComponent(`workflows/${nfd}`)}`);
   });
 
-  it("uses the server's key verbatim when the listing already carries the workflows/ prefix", async () => {
-    // Some listings report the FULL store key. The caller's spelling must miss
-    // first (otherwise the listing branch is never entered), and the retry must
-    // then send the listed key without nesting a second workflows/ segment.
+  it("a nested folder named `workflows` can NOT satisfy a request for a ROOT file", async () => {
+    // The recursive listing reports the file workflows/workflows/name.json as the
+    // entry "workflows/name.json" — textually identical to what a root entry would
+    // look like if entries carried the library prefix. Stripping that prefix from
+    // an entry made the nested file collide with the ROOT file of the same name, so
+    // a bare request matched the nested entry and then fetched the DIFFERENT root
+    // file (gate MAJOR). Entries are store-relative and are compared verbatim, so
+    // depth is preserved and this must refuse.
     const nfc = "caf\u00e9.json";
     const nfd = "cafe\u0301.json";
-    const graph = { nodes: [{ id: 11, type: "PrefixedListingNode" }], links: [] };
-    routeMock([`workflows/${nfc}`], { [`workflows/${nfc}`]: graph });
+    routeMock([`workflows/${nfc}`], {
+      // The ROOT file exists and is servable — it is exactly what must not be sent.
+      [`workflows/${nfc}`]: { nodes: [{ id: 61, type: "RootFileNode" }], links: [] },
+    });
 
     const { ctx, calls } = makeCtx();
     const res = await loadWorkflow().handler({ path: nfd }, ctx);
 
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    // The root file's key was requested ONCE (the caller's own NFD spelling missed);
+    // the nested entry must never have been turned into a request for it.
+    expect(fetchApi).not.toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent(`workflows/${nfc}`)}`,
+    );
+  });
+
+  it("resolves an EXPLICIT request for a file inside a nested `workflows` folder", async () => {
+    // The flip side: asking for it by its real depth works, and the store key nests
+    // the folder rather than collapsing it.
+    const nfc = "caf\u00e9.json";
+    const nfd = "cafe\u0301.json";
+    const graph = { nodes: [{ id: 62, type: "NestedWorkflowsFolderNode" }], links: [] };
+    routeMock([`workflows/${nfc}`], { [`workflows/workflows/${nfc}`]: graph });
+
+    const { ctx, calls } = makeCtx();
+    // One "workflows/" is the library prefix a caller may paste (#414); the second
+    // is the real subfolder.
+    const res = await loadWorkflow().handler({ path: `workflows/workflows/${nfd}` }, ctx);
+
     expect(res.isError).toBeUndefined();
     expect(calls[0].graph).toMatchObject(graph);
-    // The listing branch WAS used: the caller's spelling 404'd, the listed key served.
-    expect(fetchApi).toHaveBeenCalledWith(`/api/userdata/${encodeURIComponent(`workflows/${nfd}`)}`);
-    expect(fetchApi).toHaveBeenCalledWith(`/api/userdata/${encodeURIComponent(`workflows/${nfc}`)}`);
-    expect(fetchApi).not.toHaveBeenCalledWith(
+    expect(fetchApi).toHaveBeenCalledWith(
       `/api/userdata/${encodeURIComponent(`workflows/workflows/${nfc}`)}`,
     );
   });
+
 
   it("does NOT treat a backslash as a path separator when matching (POSIX aliasing)", async () => {
     // On POSIX a file literally named "dir\\foo.json" is a DIFFERENT file from
@@ -655,23 +689,47 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     );
   });
 
-  it("REFUSES a relative name containing a backslash, before any request", async () => {
-    // "workflows\foo.json" would mean a single literal segment to the server's
-    // "/"-keyed library and a folder separator to Windows resolve(). One input,
-    // two different files — so it is refused rather than read either way.
-    routeMock(["foo.json"], {
-      "workflows/foo.json": { nodes: [{ id: 1, type: "DifferentGraphNode" }], links: [] },
+  it("asks for a backslash name LITERALLY first, then as a folder path", async () => {
+    // On POSIX "recipes\name.json" is a legal single filename, so the literal key
+    // must be asked for before the Windows-style reading — the server is the
+    // authority on which of the two exists. Only after it disproves the literal one
+    // is the folder path tried, so nothing is substituted while the literally-named
+    // file might still exist (gate MEDIUM).
+    const graph = { nodes: [{ id: 71, type: "WindowsPathNode" }], links: [] };
+    routeMock(["recipes/foo.json"], { "workflows/recipes/foo.json": graph });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "recipes\\foo.json" }, ctx);
+
+    expect(res.isError).toBeUndefined();
+    expect(calls[0].graph).toMatchObject(graph);
+    const keys = fetchApi.mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .filter((u: string) => u.startsWith("/api/userdata/"))
+      .map((u: string) => decodeURIComponent(u.replace("/api/userdata/", "")));
+    expect(keys[0]).toBe("workflows/recipes\\foo.json"); // literal first
+    expect(keys[1]).toBe("workflows/recipes/foo.json"); // folder path second
+  });
+
+  it("prefers a LITERAL backslash filename over the folder-path reading", async () => {
+    // Both exist on the server. The literally-named one is what was asked for, so
+    // it wins and the folder path is never requested.
+    const literal = { nodes: [{ id: 72, type: "LiteralBackslashNode" }], links: [] };
+    routeMock(["recipes\\foo.json", "recipes/foo.json"], {
+      "workflows/recipes\\foo.json": literal,
+      "workflows/recipes/foo.json": { nodes: [{ id: 73, type: "FolderPathNode" }], links: [] },
     });
 
     const { ctx, calls } = makeCtx();
-    const res = await loadWorkflow().handler({ path: "workflows\\foo.json" }, ctx);
+    const res = await loadWorkflow().handler({ path: "recipes\\foo.json" }, ctx);
 
-    expect(res.isError).toBe(true);
-    expect(calls).toHaveLength(0);
-    // Refused up front — "workflows/foo.json" exists and was never even asked for.
-    expect(fetchApi).not.toHaveBeenCalled();
-    expect(JSON.stringify(res)).toMatch(/forward slashes/i);
+    expect(res.isError).toBeUndefined();
+    expect(calls[0].graph).toMatchObject(literal);
+    expect(fetchApi).not.toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent("workflows/recipes/foo.json")}`,
+    );
   });
+
 
   it("a retry that cannot be completed REFUSES — it does not reopen the local fallback", async () => {
     // The server already answered (404 + a readable listing). A transport failure

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -479,6 +479,25 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     expect(JSON.stringify(res)).toMatch(/path separator/i);
   });
 
+  it("does NOT collapse a repeated slash after the workflows/ prefix", async () => {
+    // "workflows//foo.json" is the key "/foo.json" under the library, which is a
+    // different key from "foo.json". Collapsing the run of slashes would alias one
+    // onto the other (codex MAJOR).
+    routeMock(["foo.json"], {
+      "workflows/foo.json": { nodes: [{ id: 41, type: "BareNameNode" }], links: [] },
+    });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "workflows//foo.json" }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    // The bare-name key exists and would have loaded had the slashes collapsed.
+    expect(fetchApi).not.toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent("workflows/foo.json")}`,
+    );
+  });
+
   it("does NOT fold a LEADING-SLASH listing entry onto the bare name", async () => {
     // "/name.json" and "name.json" are different store keys. Folding them in the
     // match let a match on the listed "/name.json" be RETRIED as

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -479,6 +479,26 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     expect(JSON.stringify(res)).toMatch(/path separator/i);
   });
 
+  it("does NOT treat a DIFFERENTLY-CASED workflows/ as the library prefix", async () => {
+    // "WORKFLOWS" can be a real subfolder inside the library on a case-sensitive
+    // host. Stripping it would turn "WORKFLOWS/foo.json" into a request for the
+    // root "foo.json" — a different file (codex MAJOR).
+    const nested = { nodes: [{ id: 21, type: "NestedNode" }], links: [] };
+    routeMock(["WORKFLOWS/foo.json"], {
+      "workflows/WORKFLOWS/foo.json": nested,
+      "workflows/foo.json": { nodes: [{ id: 22, type: "RootNode" }], links: [] },
+    });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "WORKFLOWS/foo.json" }, ctx);
+
+    expect(res.isError).toBeUndefined();
+    expect(calls[0].graph).toMatchObject(nested); // the NESTED file, not the root one
+    expect(fetchApi).not.toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent("workflows/foo.json")}`,
+    );
+  });
+
   it("does NOT treat a BACKSLASH-spelled workflows/ prefix as the library prefix", async () => {
     // On POSIX "workflows\foo.json" is a legal LITERAL filename, not a prefixed
     // spelling of "foo.json". Stripping it would turn a request for that literal
@@ -636,6 +656,9 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     // pass even if the near-miss lookup had been dropped entirely.
     expect(fetchApi).toHaveBeenCalledWith("/api/userdata?dir=workflows");
     expect(JSON.stringify(res)).toMatch(/list_workflows/);
+    // And the refusal admits the listing was unreadable rather than implying the
+    // library was fully checked.
+    expect(JSON.stringify(res)).toMatch(/listing could not be read/i);
   });
 });
 

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -597,10 +597,12 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
   });
 
   it("holds the invariant that no request key ever carries a traversal segment", async () => {
-    // This asserts the INVARIANT, not one mechanism. Two things currently uphold
-    // it — the caller-side traversal guard and the listing filter — so the test
-    // cannot attribute a pass to either. It is here to fail if a future change
-    // lets a server-supplied string reach the request key.
+    // This asserts the INVARIANT, not one mechanism, and it cannot attribute a
+    // pass to either the caller-side traversal guard or the listing filter — under
+    // NFC-only matching a "../" entry can never match a clean requested name, so
+    // the listing filter is unreachable today and is forward defense. The test is
+    // here to fail if a future change lets a server-supplied string reach the
+    // request key.
     routeMock(["../../secret.json", "..\\secret.json"], {});
 
     const { ctx, calls } = makeCtx();

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -15,7 +15,7 @@
 // default layout working — and "no answer" means no HTTP Response object exists,
 // not merely a reply we could not decode.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -387,6 +387,92 @@ describe("readWorkflowFromPath: a refusal is never mistaken for an unreachable s
     expect(fetchInit).toHaveBeenCalledWith(
       expect.objectContaining({ headers: expect.objectContaining({ "Comfy-User": "default" }) }),
     );
+  });
+
+  it("the local fallback will not load a file whose on-disk name is spelled differently", async () => {
+    // resolve() answers in the filesystem's terms: on a case-insensitive volume
+    // "foo.json" opens an on-disk "Foo.json", which is exactly the substitution the
+    // server path refuses. With ComfyUI unreachable there is no authority to say
+    // the two names are the same file, so the local branch must apply the same
+    // rule (codex MAJOR) — every segment has to appear verbatim in its directory.
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      writeFileSync(
+        join(defaultDir, "Foo.json"),
+        JSON.stringify({ nodes: [{ id: 81, type: "DifferentlyCasedNode" }], links: [] }),
+        "utf8",
+      );
+      process.env.COMFYUI_PATH = root;
+
+      fetchApi.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      // Only a case-INSENSITIVE volume can even offer the wrong file here; on a
+      // case-sensitive one there is simply no candidate. Both must refuse, but only
+      // the former can name the near miss.
+      const caseInsensitiveVolume = existsSync(join(defaultDir, "foo.json"));
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "foo.json" }, ctx);
+
+      expect(res.isError).toBe(true);
+      expect(calls).toHaveLength(0);
+      if (caseInsensitiveVolume) {
+        // The differently-cased file is NAMED so the caller can retype it.
+        expect(JSON.stringify(res)).toMatch(/not spelled the way you asked/i);
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("the local fallback does not let resolve() collapse a repeated separator", async () => {
+    // "recipes//foo.json" is a distinct key everywhere else in this resolver, but
+    // resolve() collapses the run and would open recipes/foo.json.
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const nested = join(root, "user", "default", "workflows", "recipes");
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(
+        join(nested, "foo.json"),
+        JSON.stringify({ nodes: [{ id: 82, type: "CollapsedSeparatorNode" }], links: [] }),
+        "utf8",
+      );
+      process.env.COMFYUI_PATH = root;
+
+      fetchApi.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "recipes//foo.json" }, ctx);
+
+      expect(res.isError).toBe(true);
+      expect(calls).toHaveLength(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("a nested EXACT name still loads from the reconstructed dir when unreachable", async () => {
+    // The strictness must not break the ordinary nested case it is guarding.
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const nested = join(root, "user", "default", "workflows", "recipes");
+      mkdirSync(nested, { recursive: true });
+      const staged = { nodes: [{ id: 83, type: "ExactNestedNode" }], links: [] };
+      writeFileSync(join(nested, "foo.json"), JSON.stringify(staged), "utf8");
+      process.env.COMFYUI_PATH = root;
+
+      fetchApi.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "recipes/foo.json" }, ctx);
+
+      expect(res.isError).toBeUndefined();
+      expect(calls[0].graph).toMatchObject(staged);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("a statusless transport error still allows the reconstructed local dir (default layout)", async () => {

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -479,6 +479,27 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     expect(JSON.stringify(res)).toMatch(/path separator/i);
   });
 
+  it("does NOT fold a LEADING-SLASH listing entry onto the bare name", async () => {
+    // "/name.json" and "name.json" are different store keys. Folding them in the
+    // match let a match on the listed "/name.json" be RETRIED as
+    // "workflows/name.json" — a key the server never listed (codex MAJOR).
+    const nfc = "caf\u00e9.json";
+    const nfd = "cafe\u0301.json";
+    routeMock([`/${nfc}`], {
+      [`workflows/${nfc}`]: { nodes: [{ id: 31, type: "UnlistedNode" }], links: [] },
+    });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: nfd }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    // The unlisted key exists and would have loaded had the slash been folded.
+    expect(fetchApi).not.toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent(`workflows/${nfc}`)}`,
+    );
+  });
+
   it("does NOT treat a DIFFERENTLY-CASED workflows/ as the library prefix", async () => {
     // "WORKFLOWS" can be a real subfolder inside the library on a case-sensitive
     // host. Stripping it would turn "WORKFLOWS/foo.json" into a request for the
@@ -556,11 +577,11 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     }
   });
 
-  it("never echoes a traversal entry from a hostile listing back as a request key", async () => {
-    // Defense in depth. With exact (normalization-only) matching a listed key
-    // containing ".." can never equal a caller name that passed the traversal
-    // guard, so this filter is unreachable today — it exists so that any future
-    // loosening of the match cannot turn a server-supplied string into an escape.
+  it("holds the invariant that no request key ever carries a traversal segment", async () => {
+    // This asserts the INVARIANT, not one mechanism. Two things currently uphold
+    // it — the caller-side traversal guard and the listing filter — so the test
+    // cannot attribute a pass to either. It is here to fail if a future change
+    // lets a server-supplied string reach the request key.
     routeMock(["../../secret.json", "..\\secret.json"], {});
 
     const { ctx, calls } = makeCtx();

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -1,12 +1,18 @@
-// panel_load_workflow — relative names resolve through the connected ComfyUI's
-// userdata API when the guessed local disk path misses (#202).
+// panel_load_workflow — relative names are resolved by the CONNECTED ComfyUI,
+// which is the only authority on its own `--user-directory` (panel #202).
 //
-// Root cause: comfyWorkflowsDirs() hardcodes COMFYUI_PATH/user/default/workflows
-// (and user/workflows), so a ComfyUI launched with a CUSTOM --user-directory
-// keeps its workflows somewhere the orchestrator can't guess — a relative
-// panel_load_workflow name then fell through to a "no workflow file" error even
-// though list_workflows/panel_open_workflow (which read the userdata API) could
-// see it. readWorkflowFromPath now falls back to that same userdata API.
+// Root cause: comfyWorkflowsDirs() RECONSTRUCTS COMFYUI_PATH/user/default/workflows
+// (and user/workflows), so a ComfyUI launched with a CUSTOM --user-directory keeps
+// its workflows somewhere the orchestrator cannot guess. A relative name either
+// failed outright — even though list_workflows/panel_open_workflow could see it —
+// or, worse, matched a same-named file under the reconstructed path and loaded a
+// DIFFERENT graph for the agent to edit.
+//
+// The resolver now asks the server first and, when the server answers, defers to
+// that answer completely: it refuses instead of falling back to a reconstructed
+// path, and refuses instead of picking between several candidates. Only a server
+// that gives NO answer at all (a statusless transport error) re-enables the
+// best-effort local read that keeps the default layout working.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -92,7 +98,7 @@ describe("panel_load_workflow: userdata fallback for a custom --user-directory (
     expect(res.isError).toBe(true);
     expect(calls).toHaveLength(0);
     const text = JSON.stringify(res);
-    expect(text).toMatch(/userdata library/i);
+    expect(text).toMatch(/workflow library/i);
     expect(text).toMatch(/panel_list_workflows/);
   });
 
@@ -190,33 +196,136 @@ describe("panel_load_workflow: userdata fallback for a custom --user-directory (
     }
   });
 
-  it("treats an EMPTY 200 body as absence and falls back to the local disk file", async () => {
+  it("treats an EMPTY 200 body as an AUTHORITATIVE absence and refuses (never the local file)", async () => {
     // ComfyUI's "200 + empty body = file does not exist" convention (some builds)
-    // must be an ABSENCE (local fallback), NOT a malformed error (#202).
+    // is an ABSENCE, not a malformed error — and an absence reported by the server
+    // is AUTHORITATIVE: it resolved the name under its own --user-directory. Any
+    // file still findable under the orchestrator's RECONSTRUCTED default-layout
+    // path is therefore a DIFFERENT file, so loading it is the wrong-graph hazard
+    // (#202). Refuse instead.
     const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
     try {
       const defaultDir = join(root, "user", "default", "workflows");
       mkdirSync(defaultDir, { recursive: true });
-      const staged = { nodes: [{ id: 5, type: "EmptyBodyFallbackNode" }], links: [] };
-      writeFileSync(join(defaultDir, "foo.json"), JSON.stringify(staged), "utf8");
+      const other = { nodes: [{ id: 5, type: "DifferentFileNode" }], links: [] };
+      writeFileSync(join(defaultDir, "foo.json"), JSON.stringify(other), "utf8");
       process.env.COMFYUI_PATH = root;
 
-      fetchApi.mockResolvedValue({ ok: true, status: 200, text: async () => "   " });
+      fetchApi.mockImplementation(async (route: string) =>
+        route.startsWith("/api/userdata?")
+          ? { ok: true, status: 200, json: async () => [] }
+          : { ok: true, status: 200, text: async () => "   " },
+      );
 
       const { ctx, calls } = makeCtx();
       const res = await loadWorkflow().handler({ path: "foo.json" }, ctx);
 
-      expect(res.isError).toBeUndefined();
-      expect(calls).toHaveLength(1);
-      expect(calls[0].graph).toMatchObject(staged); // local fallback loaded it
+      expect(res.isError).toBe(true);
+      expect(calls).toHaveLength(0); // the DIFFERENT local foo.json was never loaded
+      expect(JSON.stringify(res)).toMatch(/user directory|--user-directory/i);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
   });
 
-  it("falls back to the local disk file when the server doesn't have the name (404)", async () => {
-    // A file staged straight to the default workflows dir, absent from the
-    // runtime userdata library → the local fallback still opens it.
+  it("REFUSES rather than loading a same-named local file when the server 404s the name (#202)", async () => {
+    // The core hazard: ComfyUI runs a custom --user-directory, so the guessed
+    // COMFYUI_PATH/user/default/workflows is the WRONG directory. A same-named
+    // file there is a different graph; loading it would hand the agent the wrong
+    // workflow to edit. The refusal must name what was tried.
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      const wrong = { nodes: [{ id: 7, type: "WrongDirNode" }], links: [] };
+      writeFileSync(join(defaultDir, "staged.json"), JSON.stringify(wrong), "utf8");
+      process.env.COMFYUI_PATH = root;
+
+      fetchApi.mockImplementation(async (route: string) =>
+        route.startsWith("/api/userdata?")
+          ? { ok: true, status: 200, json: async () => ["other.json"] }
+          : { ok: false, status: 404, json: async () => ({}) },
+      );
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "staged.json" }, ctx);
+
+      expect(res.isError).toBe(true);
+      expect(calls).toHaveLength(0);
+      const text = JSON.stringify(res);
+      expect(text).toMatch(/staged\.json/); // names what it tried
+      expect(text).toMatch(/panel_list_workflows/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// #202 — the connected ComfyUI's real fetch client (@stable-canvas/comfyui-client)
+// THROWS an HttpError {status} for every non-2xx; it never returns a non-ok
+// Response. Classifying only `res.status` therefore turned every 401/403/5xx into
+// "unreachable", which re-enabled the guessed-local-directory fallback for a
+// server that had REFUSED — the wrong-file path this resolver exists to close.
+describe("readWorkflowFromPath: HTTP status is recovered from a THROWN client error (#202)", () => {
+  class HttpError extends Error {
+    constructor(message: string, readonly status: number) {
+      super(message);
+    }
+  }
+
+  it("a THROWN 403 is a refusal — never a fallback to a colliding local file", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      writeFileSync(
+        join(defaultDir, "foo.json"),
+        JSON.stringify({ nodes: [{ id: 1, type: "CollidingLocalNode" }], links: [] }),
+        "utf8",
+      );
+      process.env.COMFYUI_PATH = root;
+
+      fetchApi.mockRejectedValue(new HttpError("Endpoint Bad Request (403 Forbidden)", 403));
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "foo.json" }, ctx);
+
+      expect(res.isError).toBe(true);
+      expect(calls).toHaveLength(0); // the colliding local file was NOT loaded
+      expect(JSON.stringify(res)).toMatch(/HTTP 403/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("a THROWN 404 is an authoritative absence — refused, not silently substituted", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      writeFileSync(
+        join(defaultDir, "foo.json"),
+        JSON.stringify({ nodes: [{ id: 1, type: "CollidingLocalNode" }], links: [] }),
+        "utf8",
+      );
+      process.env.COMFYUI_PATH = root;
+
+      fetchApi.mockRejectedValue(new HttpError("Endpoint Bad Request (404 Not Found)", 404));
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "foo.json" }, ctx);
+
+      expect(res.isError).toBe(true);
+      expect(calls).toHaveLength(0);
+      expect(JSON.stringify(res)).toMatch(/404/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("a statusless transport error still allows the reconstructed local dir (default layout)", async () => {
+    // No HTTP status at all → no authority to defer to → the pre-existing
+    // best-effort local read is preserved so the DEFAULT layout keeps working.
     const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
     try {
       const defaultDir = join(root, "user", "default", "workflows");
@@ -225,7 +334,7 @@ describe("panel_load_workflow: userdata fallback for a custom --user-directory (
       writeFileSync(join(defaultDir, "staged.json"), JSON.stringify(staged), "utf8");
       process.env.COMFYUI_PATH = root;
 
-      fetchApi.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+      fetchApi.mockRejectedValue(new Error("ECONNREFUSED"));
 
       const { ctx, calls } = makeCtx();
       const res = await loadWorkflow().handler({ path: "staged.json" }, ctx);
@@ -236,6 +345,111 @@ describe("panel_load_workflow: userdata fallback for a custom --user-directory (
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("refuses when an unreachable server leaves TWO different local candidates", async () => {
+    // Both reconstructed layouts (user/default/workflows and user/workflows) hold a
+    // DIFFERENT file of the same name. With no server to arbitrate, picking the
+    // first is a coin flip over which graph the agent edits — refuse instead.
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const a = join(root, "user", "default", "workflows");
+      const b = join(root, "user", "workflows");
+      mkdirSync(a, { recursive: true });
+      mkdirSync(b, { recursive: true });
+      writeFileSync(join(a, "dup.json"), JSON.stringify({ nodes: [{ id: 1, type: "A" }] }), "utf8");
+      writeFileSync(join(b, "dup.json"), JSON.stringify({ nodes: [{ id: 2, type: "B" }] }), "utf8");
+      process.env.COMFYUI_PATH = root;
+
+      fetchApi.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "dup.json" }, ctx);
+
+      expect(res.isError).toBe(true);
+      expect(calls).toHaveLength(0);
+      expect(JSON.stringify(res)).toMatch(/ambiguous/i);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// #202 — a name that IS in the connected ComfyUI's library but whose bytes differ
+// (Unicode NFC/NFD, or letter case) used to 404 and die, even though
+// panel_list_workflows plainly showed it. The resolver asks the SERVER for its own
+// listing and retries the SERVER's exact key — it never reconstructs a path — and
+// refuses outright when more than one listed key could be meant.
+describe("readWorkflowFromPath: near-miss names resolve via the server's OWN listing (#202)", () => {
+  const routeMock = (listing: unknown[], files: Record<string, unknown>) =>
+    fetchApi.mockImplementation(async (route: string) => {
+      if (route.startsWith("/api/userdata?")) {
+        return { ok: true, status: 200, json: async () => listing };
+      }
+      const key = decodeURIComponent(route.replace("/api/userdata/", ""));
+      const hit = files[key];
+      if (hit === undefined) return { ok: false, status: 404, json: async () => ({}) };
+      return { ok: true, status: 200, text: async () => JSON.stringify(hit) };
+    });
+
+  it("resolves an NFD-typed name to the library's NFC key and loads THAT file", async () => {
+    // "cafe.json" with an acute accent: the library key is COMPOSED (NFC, U+00E9),
+    // the caller typed the DECOMPOSED form (NFD, "e" + U+0301). Byte-different,
+    // same file name. Written as escapes so no editor/formatter can re-normalize
+    // the literals and quietly void the test.
+    const nfc = "café.json";
+    const nfd = "café.json";
+    const graph = { nodes: [{ id: 1, type: "KSampler" }], links: [] };
+    routeMock([nfc], { [`workflows/${nfc}`]: graph });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: nfd }, ctx);
+
+    expect(res.isError).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].graph).toMatchObject(graph);
+    // It fetched the SERVER's key, not a locally reconstructed path.
+    expect(fetchApi).toHaveBeenCalledWith(`/api/userdata/${encodeURIComponent(`workflows/${nfc}`)}`);
+  });
+
+  it("REFUSES when two listed workflows differ only by case (ambiguous, no guess)", async () => {
+    routeMock(["Foo.json", "foo.json"], {});
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "FOO.json" }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    const text = JSON.stringify(res);
+    expect(text).toMatch(/ambiguous/i);
+    expect(text).toMatch(/Foo\.json/);
+    expect(text).toMatch(/foo\.json/);
+  });
+
+  it("says so when the library LISTS the name but will not serve it", async () => {
+    routeMock(["ghost.json"], {}); // listed, but every GET 404s
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "ghost.json" }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    expect(JSON.stringify(res)).toMatch(/DOES list/i);
+  });
+
+  it("an unreadable listing does not invent a match — it still refuses honestly", async () => {
+    fetchApi.mockImplementation(async (route: string) =>
+      route.startsWith("/api/userdata?")
+        ? { ok: false, status: 500, json: async () => ({}) }
+        : { ok: false, status: 404, json: async () => ({}) },
+    );
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "whatever.json" }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    expect(JSON.stringify(res)).toMatch(/panel_list_workflows/);
   });
 });
 
@@ -288,9 +502,10 @@ describe("readWorkflowFromPath: a list-style 'workflows/…' path is not double-
       writeFileSync(join(defaultDir, "Foo.json"), JSON.stringify(staged), "utf8");
       process.env.COMFYUI_PATH = root;
 
-      // Server 404s the name → local fallback. rel ("Foo.json") must join the
+      // Server unreachable (statusless transport error) → the local fallback is
+      // the only branch that still reads disk. rel ("Foo.json") must join the
       // workflows dir directly, not as workflows/workflows/Foo.json.
-      fetchApi.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+      fetchApi.mockRejectedValue(new Error("ECONNREFUSED"));
 
       const { ctx, calls } = makeCtx();
       const res = await loadWorkflow().handler({ path: "workflows/Foo.json" }, ctx);
@@ -364,7 +579,9 @@ describe("readWorkflowFromPath: refuses a '..' traversal segment (#414 hardening
         return; // unprivileged symlink creation — skip on this platform
       }
       process.env.COMFYUI_PATH = root;
-      fetchApi.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+      // Unreachable server → the local fallback is reached, so the realpath
+      // containment check is the thing actually under test here.
+      fetchApi.mockRejectedValue(new Error("ECONNREFUSED"));
 
       const { ctx, calls } = makeCtx();
       const res = await loadWorkflow().handler({ path: "linked/secret.json" }, ctx);
@@ -372,7 +589,7 @@ describe("readWorkflowFromPath: refuses a '..' traversal segment (#414 hardening
       // The escaping file must NOT be loaded — surfaces the honest not-found error.
       expect(calls).toHaveLength(0);
       expect(res.isError).toBe(true);
-      expect(JSON.stringify(res)).toMatch(/No workflow file at|userdata/i);
+      expect(JSON.stringify(res)).toMatch(/No workflow file at/i);
     } finally {
       rmSync(root, { recursive: true, force: true });
       rmSync(external, { recursive: true, force: true });

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -413,6 +413,35 @@ describe("readWorkflowFromPath: a refusal is never mistaken for an unreachable s
     }
   });
 
+  it("refuses a backslash name rather than letting Windows resolve() reinterpret it", async () => {
+    // The local fallback passes the store key straight to resolve(). On Windows
+    // that turns "recipes\foo.json" — one literal segment in the server's key
+    // space — into the folder path recipes/foo.json, so the two branches would
+    // open different files from the same input (codex MAJOR).
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const nested = join(root, "user", "default", "workflows", "recipes");
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(
+        join(nested, "foo.json"),
+        JSON.stringify({ nodes: [{ id: 1, type: "ReinterpretedNode" }], links: [] }),
+        "utf8",
+      );
+      process.env.COMFYUI_PATH = root;
+
+      fetchApi.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "recipes\\foo.json" }, ctx);
+
+      expect(res.isError).toBe(true);
+      expect(calls).toHaveLength(0); // resolve() never got to reinterpret the name
+      expect(JSON.stringify(res)).toMatch(/forward slashes/i);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("refuses when an unreachable server leaves TWO different local candidates", async () => {
     // Both reconstructed layouts (user/default/workflows and user/workflows) hold a
     // DIFFERENT file of the same name. With no server to arbitrate, picking the
@@ -626,10 +655,10 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     );
   });
 
-  it("does NOT treat a BACKSLASH-spelled workflows/ prefix as the library prefix", async () => {
-    // On POSIX "workflows\foo.json" is a legal LITERAL filename, not a prefixed
-    // spelling of "foo.json". Stripping it would turn a request for that literal
-    // file into a request for a different graph (codex MAJOR).
+  it("REFUSES a relative name containing a backslash, before any request", async () => {
+    // "workflows\foo.json" would mean a single literal segment to the server's
+    // "/"-keyed library and a folder separator to Windows resolve(). One input,
+    // two different files — so it is refused rather than read either way.
     routeMock(["foo.json"], {
       "workflows/foo.json": { nodes: [{ id: 1, type: "DifferentGraphNode" }], links: [] },
     });
@@ -639,12 +668,9 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
 
     expect(res.isError).toBe(true);
     expect(calls).toHaveLength(0);
-    // "workflows/foo.json" exists and would have loaded had the prefix been stripped.
-    expect(fetchApi).not.toHaveBeenCalledWith(
-      `/api/userdata/${encodeURIComponent("workflows/foo.json")}`,
-    );
-    // The close match is still surfaced so the caller can retype it.
-    expect(JSON.stringify(res)).toMatch(/path separator/i);
+    // Refused up front — "workflows/foo.json" exists and was never even asked for.
+    expect(fetchApi).not.toHaveBeenCalled();
+    expect(JSON.stringify(res)).toMatch(/forward slashes/i);
   });
 
   it("a retry that cannot be completed REFUSES — it does not reopen the local fallback", async () => {

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -376,10 +376,15 @@ describe("readWorkflowFromPath: HTTP status is recovered from a THROWN client er
 });
 
 // #202 — a name that IS in the connected ComfyUI's library but whose bytes differ
-// (Unicode NFC/NFD, or letter case) used to 404 and die, even though
-// panel_list_workflows plainly showed it. The resolver asks the SERVER for its own
-// listing and retries the SERVER's exact key — it never reconstructs a path — and
-// refuses outright when more than one listed key could be meant.
+// by Unicode normalization used to 404 and die, even though panel_list_workflows
+// plainly showed it. The resolver asks the SERVER for its own listing and retries
+// the SERVER's exact key — it never reconstructs a path — and refuses outright
+// when more than one listed key normalizes to the requested name.
+//
+// Normalization is the ONLY accepted equivalence: NFC/NFD are two spellings of the
+// same character sequence. Letter case is NOT — on a case-sensitive filesystem
+// "Foo.json" and "foo.json" are different files, so a case-only near miss is named
+// in the refusal and never substituted.
 describe("readWorkflowFromPath: near-miss names resolve via the server's OWN listing (#202)", () => {
   const routeMock = (listing: unknown[], files: Record<string, unknown>) =>
     fetchApi.mockImplementation(async (route: string) => {
@@ -397,8 +402,8 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     // the caller typed the DECOMPOSED form (NFD, "e" + U+0301). Byte-different,
     // same file name. Written as escapes so no editor/formatter can re-normalize
     // the literals and quietly void the test.
-    const nfc = "café.json";
-    const nfd = "café.json";
+    const nfc = "caf\u00e9.json";
+    const nfd = "cafe\u0301.json";
     const graph = { nodes: [{ id: 1, type: "KSampler" }], links: [] };
     routeMock([nfc], { [`workflows/${nfc}`]: graph });
 
@@ -412,8 +417,26 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     expect(fetchApi).toHaveBeenCalledWith(`/api/userdata/${encodeURIComponent(`workflows/${nfc}`)}`);
   });
 
-  it("REFUSES when two listed workflows differ only by case (ambiguous, no guess)", async () => {
-    routeMock(["Foo.json", "foo.json"], {});
+  it("REFUSES when two listed keys NORMALIZE to the requested name (ambiguous, no guess)", async () => {
+    // Two library keys, one NFC and one NFD, both spelling the same name. A
+    // case-sensitive store can hold both; picking either would be a coin flip over
+    // which graph the agent edits.
+    const nfc = "caf\u00e9.json";
+    const nfd = "cafe\u0301.json";
+    routeMock([nfc, nfd], {});
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: nfd }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    expect(JSON.stringify(res)).toMatch(/ambiguous/i);
+  });
+
+  it("NEVER substitutes a case-only near miss — it names it and refuses", async () => {
+    // "FOO.json" is not in the library; "Foo.json" is a DIFFERENT file on a
+    // case-sensitive filesystem. Loading it would be the wrong graph.
+    routeMock(["Foo.json"], { "workflows/Foo.json": { nodes: [{ id: 1, type: "WrongCaseNode" }] } });
 
     const { ctx, calls } = makeCtx();
     const res = await loadWorkflow().handler({ path: "FOO.json" }, ctx);
@@ -421,9 +444,33 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     expect(res.isError).toBe(true);
     expect(calls).toHaveLength(0);
     const text = JSON.stringify(res);
-    expect(text).toMatch(/ambiguous/i);
+    expect(text).toMatch(/letter case/i);
     expect(text).toMatch(/Foo\.json/);
-    expect(text).toMatch(/foo\.json/);
+    // The differently-cased key was never fetched.
+    expect(fetchApi).not.toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent("workflows/Foo.json")}`,
+    );
+  });
+
+  it("an NFC-exact match still wins when a case-variant sibling exists", async () => {
+    // The caller's name matches "café.json" character-for-character once
+    // normalized; "CAFÉ.json" differs in case and is a different name. The exact
+    // match is not a guess, so it resolves — and the case sibling is not fetched.
+    const nfc = "caf\u00e9.json";
+    const nfd = "cafe\u0301.json";
+    const upper = "CAF\u00c9.json";
+    const graph = { nodes: [{ id: 4, type: "ExactMatchNode" }], links: [] };
+    routeMock([upper, nfc], { [`workflows/${nfc}`]: graph });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: nfd }, ctx);
+
+    expect(res.isError).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].graph).toMatchObject(graph);
+    expect(fetchApi).not.toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent(`workflows/${upper}`)}`,
+    );
   });
 
   it("says so when the library LISTS the name but will not serve it", async () => {
@@ -449,7 +496,47 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
 
     expect(res.isError).toBe(true);
     expect(calls).toHaveLength(0);
+    // The listing WAS consulted (and its 500 swallowed) — otherwise this test would
+    // pass even if the near-miss lookup had been dropped entirely.
+    expect(fetchApi).toHaveBeenCalledWith("/api/userdata?dir=workflows");
     expect(JSON.stringify(res)).toMatch(/panel_list_workflows/);
+  });
+});
+
+// #202 (codex MAJOR) — a 2xx whose BODY read aborts is still an answer from the
+// server. Letting that fall out as a statusless error classified it "unreachable"
+// and re-opened the reconstructed-local-dir fallback, so a mid-body network drop
+// could load a colliding local file.
+describe("readWorkflowFromPath: a 2xx with an unreadable body is a refusal, not a fallback (#202)", () => {
+  it("does not load a colliding local file when the response body fails mid-read", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      writeFileSync(
+        join(defaultDir, "foo.json"),
+        JSON.stringify({ nodes: [{ id: 1, type: "CollidingLocalNode" }], links: [] }),
+        "utf8",
+      );
+      process.env.COMFYUI_PATH = root;
+
+      fetchApi.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => {
+          throw new Error("terminated");
+        },
+      });
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "foo.json" }, ctx);
+
+      expect(res.isError).toBe(true);
+      expect(calls).toHaveLength(0); // the colliding local file was NOT loaded
+      expect(JSON.stringify(res)).toMatch(/body could not be read/i);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -437,19 +437,46 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
   });
 
   it("uses the server's key verbatim when the listing already carries the workflows/ prefix", async () => {
-    // Some listings report the full store key. It must not be double-prefixed, and
-    // it must not be rewritten.
+    // Some listings report the FULL store key. The caller's spelling must miss
+    // first (otherwise the listing branch is never entered), and the retry must
+    // then send the listed key without nesting a second workflows/ segment.
+    const nfc = "caf\u00e9.json";
+    const nfd = "cafe\u0301.json";
     const graph = { nodes: [{ id: 11, type: "PrefixedListingNode" }], links: [] };
-    routeMock(["workflows/Prefixed Name.json"], { "workflows/Prefixed Name.json": graph });
+    routeMock([`workflows/${nfc}`], { [`workflows/${nfc}`]: graph });
 
     const { ctx, calls } = makeCtx();
-    const res = await loadWorkflow().handler({ path: "Prefixed Name.json" }, ctx);
+    const res = await loadWorkflow().handler({ path: nfd }, ctx);
 
     expect(res.isError).toBeUndefined();
     expect(calls[0].graph).toMatchObject(graph);
+    // The listing branch WAS used: the caller's spelling 404'd, the listed key served.
+    expect(fetchApi).toHaveBeenCalledWith(`/api/userdata/${encodeURIComponent(`workflows/${nfd}`)}`);
+    expect(fetchApi).toHaveBeenCalledWith(`/api/userdata/${encodeURIComponent(`workflows/${nfc}`)}`);
     expect(fetchApi).not.toHaveBeenCalledWith(
-      `/api/userdata/${encodeURIComponent("workflows/workflows/Prefixed Name.json")}`,
+      `/api/userdata/${encodeURIComponent(`workflows/workflows/${nfc}`)}`,
     );
+  });
+
+  it("does NOT treat a backslash as a path separator when matching (POSIX aliasing)", async () => {
+    // On POSIX a file literally named "dir\\foo.json" is a DIFFERENT file from
+    // "dir/foo.json". Folding separators in the match would substitute one for the
+    // other (codex MAJOR). It must refuse and never fetch the backslash key.
+    const backslashKey = "dir\\foo.json";
+    routeMock([backslashKey], {
+      [`workflows/${backslashKey}`]: { nodes: [{ id: 1, type: "WrongSeparatorNode" }], links: [] },
+    });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "dir/foo.json" }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    expect(fetchApi).not.toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent(`workflows/${backslashKey}`)}`,
+    );
+    // But it IS named as a near miss so the user can retype it.
+    expect(JSON.stringify(res)).toMatch(/path separator/i);
   });
 
   it("never echoes a traversal entry from a hostile listing back as a request key", async () => {

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -372,9 +372,12 @@ describe("readWorkflowFromPath: a refusal is never mistaken for an unreachable s
     });
   });
 
-  it("applies the client's own request headers", async () => {
-    // The direct fetch must not drop what fetchApi used to add (Comfy-User, Accept,
-    // and the injected COMFYUI_AUTH_* handling that lives in the client's fetch).
+  it("passes the client's own apiHeaders() to the client's own fetch", async () => {
+    // Bypassing fetchApi must not drop what it used to assemble. What this asserts
+    // is exactly that: the headers the CLIENT produced reach the fetch the CLIENT
+    // was configured with. COMFYUI_AUTH_* injection is not exercised here — it
+    // lives inside that configured fetch (comfyuiFetch), so calling the client's
+    // own `fetch` is what preserves it, and that is what is checked.
     fetchApi.mockResolvedValue({
       ok: true,
       status: 200,

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -479,7 +479,68 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     expect(JSON.stringify(res)).toMatch(/path separator/i);
   });
 
+  it("does NOT treat a BACKSLASH-spelled workflows/ prefix as the library prefix", async () => {
+    // On POSIX "workflows\foo.json" is a legal LITERAL filename, not a prefixed
+    // spelling of "foo.json". Stripping it would turn a request for that literal
+    // file into a request for a different graph (codex MAJOR).
+    routeMock(["foo.json"], {
+      "workflows/foo.json": { nodes: [{ id: 1, type: "DifferentGraphNode" }], links: [] },
+    });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "workflows\\foo.json" }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    // "workflows/foo.json" exists and would have loaded had the prefix been stripped.
+    expect(fetchApi).not.toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent("workflows/foo.json")}`,
+    );
+    // The close match is still surfaced so the caller can retype it.
+    expect(JSON.stringify(res)).toMatch(/path separator/i);
+  });
+
+  it("a retry that cannot be completed REFUSES — it does not reopen the local fallback", async () => {
+    // The server already answered (404 + a readable listing). A transport failure
+    // on the follow-up read must not be reclassified as "unreachable", which would
+    // hand the reconstructed local dir back its veto (codex MAJOR).
+    const nfc = "caf\u00e9.json";
+    const nfd = "cafe\u0301.json";
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      writeFileSync(
+        join(defaultDir, nfd),
+        JSON.stringify({ nodes: [{ id: 1, type: "StaleLocalNode" }], links: [] }),
+        "utf8",
+      );
+      process.env.COMFYUI_PATH = root;
+
+      fetchApi.mockImplementation(async (route: string) => {
+        if (route.startsWith("/api/userdata?")) return { ok: true, status: 200, json: async () => [nfc] };
+        if (route === `/api/userdata/${encodeURIComponent(`workflows/${nfc}`)}`) {
+          throw new Error("ECONNRESET"); // statusless failure on the retry
+        }
+        return { ok: false, status: 404, json: async () => ({}) };
+      });
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: nfd }, ctx);
+
+      expect(res.isError).toBe(true);
+      expect(calls).toHaveLength(0); // the stale local file was NOT loaded
+      expect(JSON.stringify(res)).toMatch(/re-reading it failed/i);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("never echoes a traversal entry from a hostile listing back as a request key", async () => {
+    // Defense in depth. With exact (normalization-only) matching a listed key
+    // containing ".." can never equal a caller name that passed the traversal
+    // guard, so this filter is unreachable today — it exists so that any future
+    // loosening of the match cannot turn a server-supplied string into an escape.
     routeMock(["../../secret.json", "..\\secret.json"], {});
 
     const { ctx, calls } = makeCtx();

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -11,8 +11,9 @@
 // The resolver now asks the server first and, when the server answers, defers to
 // that answer completely: it refuses instead of falling back to a reconstructed
 // path, and refuses instead of picking between several candidates. Only a server
-// that gives NO answer at all (a statusless transport error) re-enables the
-// best-effort local read that keeps the default layout working.
+// that gives NO answer at all re-enables the best-effort local read that keeps the
+// default layout working — and "no answer" means no HTTP Response object exists,
+// not merely a reply we could not decode.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -21,12 +22,28 @@ import { join } from "node:path";
 // Stub ONLY getClient so no real ComfyUI connection is attempted; every other
 // client export keeps its real implementation (panel-tools' module graph uses
 // several of them at import time).
+//
+// The resolver builds its request from the client's `apiURL` + `apiHeaders` and
+// calls `fetch` directly, rather than the throw-on-non-2xx `fetchApi` wrapper —
+// that is what lets it tell a refusal apart from an unreachable server. `apiURL`
+// is the identity here so assertions keep naming the plain route, and the mock
+// `fetch` records only the URL so single-argument assertions stay readable; the
+// init object is captured separately in `fetchInit` for the one test that checks
+// the client's headers are still applied.
 const fetchApi = vi.fn();
+const fetchInit = vi.fn();
 vi.mock("../../comfyui/client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../comfyui/client.js")>();
   return {
     ...actual,
-    getClient: () => ({ fetchApi: (...a: unknown[]) => fetchApi(...a) }),
+    getClient: () => ({
+      apiURL: (route: string) => route,
+      apiHeaders: () => ({ "Comfy-User": "default", Accept: "*/*" }),
+      fetch: (url: string, init?: unknown) => {
+        fetchInit(init);
+        return fetchApi(url);
+      },
+    }),
   };
 });
 
@@ -57,6 +74,7 @@ function loadWorkflow() {
 let savedComfyPath: string | undefined;
 beforeEach(() => {
   fetchApi.mockReset();
+  fetchInit.mockReset();
   savedComfyPath = process.env.COMFYUI_PATH;
   // No local COMFYUI_PATH → the guessed workflows dirs are empty, so a relative
   // name misses on disk and MUST fall through to the userdata API.
@@ -261,19 +279,21 @@ describe("panel_load_workflow: userdata fallback for a custom --user-directory (
   });
 });
 
-// #202 — the connected ComfyUI's real fetch client (@stable-canvas/comfyui-client)
-// THROWS an HttpError {status} for every non-2xx; it never returns a non-ok
-// Response. Classifying only `res.status` therefore turned every 401/403/5xx into
-// "unreachable", which re-enabled the guessed-local-directory fallback for a
-// server that had REFUSED — the wrong-file path this resolver exists to close.
-describe("readWorkflowFromPath: HTTP status is recovered from a THROWN client error (#202)", () => {
-  class HttpError extends Error {
-    constructor(message: string, readonly status: number) {
-      super(message);
-    }
-  }
-
-  it("a THROWN 403 is a refusal — never a fallback to a colliding local file", async () => {
+// #202 (gate MAJOR) — the client's own `fetchApi` throws for every non-2xx AND
+// calls `response.json()` while building that error, so a refusal with a NON-JSON
+// body (a `403 text/plain` from a proxy, an HTML 502) rejected with a STATUSLESS
+// SyntaxError. Classifying that as "unreachable" re-opened the guessed-local-dir
+// fallback for a server that had explicitly REFUSED, and loaded a different graph.
+//
+// The resolver now issues the request itself and keeps the raw Response, so the
+// split is categorical: a Response means the server answered (classify by status,
+// whatever the body turns out to be), and a throw means no Response exists at all.
+describe("readWorkflowFromPath: a refusal is never mistaken for an unreachable server (#202)", () => {
+  /** A workflows dir holding a DIFFERENT graph of the same name — the file that
+   *  must never be substituted when the server refuses. */
+  const withCollidingLocalFile = async (
+    run: (path: string) => Promise<void>,
+  ): Promise<void> => {
     const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
     try {
       const defaultDir = join(root, "user", "default", "workflows");
@@ -284,43 +304,89 @@ describe("readWorkflowFromPath: HTTP status is recovered from a THROWN client er
         "utf8",
       );
       process.env.COMFYUI_PATH = root;
+      await run("foo.json");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  };
 
-      fetchApi.mockRejectedValue(new HttpError("Endpoint Bad Request (403 Forbidden)", 403));
+  it("a 403 whose body is NOT JSON refuses — the resolver never parses the error body", async () => {
+    // The exact reported shape: a plain-text 403. Both decoders throw, proving the
+    // classification never depends on reading the body of a refusal.
+    await withCollidingLocalFile(async (path) => {
+      fetchApi.mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => {
+          throw new SyntaxError("Unexpected token 'F', \"Forbidden\" is not valid JSON");
+        },
+        text: async () => {
+          throw new SyntaxError("body already consumed");
+        },
+      });
 
       const { ctx, calls } = makeCtx();
-      const res = await loadWorkflow().handler({ path: "foo.json" }, ctx);
+      const res = await loadWorkflow().handler({ path }, ctx);
 
       expect(res.isError).toBe(true);
       expect(calls).toHaveLength(0); // the colliding local file was NOT loaded
       expect(JSON.stringify(res)).toMatch(/HTTP 403/);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+      // Classified as a refusal, NOT as an unreachable server.
+      expect(JSON.stringify(res)).not.toMatch(/could not be reached/i);
+    });
   });
 
-  it("a THROWN 404 is an authoritative absence — refused, not silently substituted", async () => {
-    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
-    try {
-      const defaultDir = join(root, "user", "default", "workflows");
-      mkdirSync(defaultDir, { recursive: true });
-      writeFileSync(
-        join(defaultDir, "foo.json"),
-        JSON.stringify({ nodes: [{ id: 1, type: "CollidingLocalNode" }], links: [] }),
-        "utf8",
-      );
-      process.env.COMFYUI_PATH = root;
-
-      fetchApi.mockRejectedValue(new HttpError("Endpoint Bad Request (404 Not Found)", 404));
+  it("a 500 with an HTML body refuses rather than substituting the local file", async () => {
+    await withCollidingLocalFile(async (path) => {
+      fetchApi.mockResolvedValue({
+        ok: false,
+        status: 502,
+        json: async () => {
+          throw new SyntaxError("Unexpected token '<'");
+        },
+      });
 
       const { ctx, calls } = makeCtx();
-      const res = await loadWorkflow().handler({ path: "foo.json" }, ctx);
+      const res = await loadWorkflow().handler({ path }, ctx);
+
+      expect(res.isError).toBe(true);
+      expect(calls).toHaveLength(0);
+      expect(JSON.stringify(res)).toMatch(/HTTP 502/);
+    });
+  });
+
+  it("a 404 Response is an authoritative absence — refused, not silently substituted", async () => {
+    await withCollidingLocalFile(async (path) => {
+      fetchApi.mockImplementation(async (route: string) =>
+        route.startsWith("/api/userdata?")
+          ? { ok: true, status: 200, json: async () => [] }
+          : { ok: false, status: 404, json: async () => ({}) },
+      );
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path }, ctx);
 
       expect(res.isError).toBe(true);
       expect(calls).toHaveLength(0);
       expect(JSON.stringify(res)).toMatch(/404/);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
+  });
+
+  it("applies the client's own request headers", async () => {
+    // The direct fetch must not drop what fetchApi used to add (Comfy-User, Accept,
+    // and the injected COMFYUI_AUTH_* handling that lives in the client's fetch).
+    fetchApi.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ nodes: [], links: [] }),
+    });
+
+    const { ctx } = makeCtx();
+    await loadWorkflow().handler({ path: "headers.json" }, ctx);
+
+    expect(fetchInit).toHaveBeenCalledWith(
+      expect.objectContaining({ headers: expect.objectContaining({ "Comfy-User": "default" }) }),
+    );
   });
 
   it("a statusless transport error still allows the reconstructed local dir (default layout)", async () => {
@@ -477,6 +543,27 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     );
     // But it IS named as a near miss so the user can retype it.
     expect(JSON.stringify(res)).toMatch(/path separator/i);
+  });
+
+  it("resolves a normalization near-miss for a workflow in a SUBFOLDER", async () => {
+    // The listing is requested with recurse=true, which is VERIFIED against the
+    // installed ComfyUI (0.29.2): a nested workflow is absent from the plain
+    // listing and present as "sub/name.json" under recurse. Without it a nested
+    // NFD/NFC near-miss had no listing entry to match and was refused.
+    const nfc = "caf\u00e9.json";
+    const nfd = "cafe\u0301.json";
+    const graph = { nodes: [{ id: 51, type: "NestedRecipeNode" }], links: [] };
+    routeMock([`recipes/${nfc}`], { [`workflows/recipes/${nfc}`]: graph });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: `recipes/${nfd}` }, ctx);
+
+    expect(res.isError).toBeUndefined();
+    expect(calls[0].graph).toMatchObject(graph);
+    expect(fetchApi).toHaveBeenCalledWith("/api/userdata?dir=workflows&recurse=true");
+    expect(fetchApi).toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent(`workflows/recipes/${nfc}`)}`,
+    );
   });
 
   it("does NOT collapse a repeated slash after the workflows/ prefix", async () => {
@@ -696,7 +783,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     expect(calls).toHaveLength(0);
     // The listing WAS consulted (and its 500 swallowed) — otherwise this test would
     // pass even if the near-miss lookup had been dropped entirely.
-    expect(fetchApi).toHaveBeenCalledWith("/api/userdata?dir=workflows");
+    expect(fetchApi).toHaveBeenCalledWith("/api/userdata?dir=workflows&recurse=true");
     expect(JSON.stringify(res)).toMatch(/list_workflows/);
     // And the refusal admits the listing was unreadable rather than implying the
     // library was fully checked.

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -99,7 +99,7 @@ describe("panel_load_workflow: userdata fallback for a custom --user-directory (
     expect(calls).toHaveLength(0);
     const text = JSON.stringify(res);
     expect(text).toMatch(/workflow library/i);
-    expect(text).toMatch(/panel_list_workflows/);
+    expect(text).toMatch(/list_workflows/);
   });
 
   it("surfaces an honest error (no graph_load) when the userdata file is not a UI workflow", async () => {
@@ -254,7 +254,7 @@ describe("panel_load_workflow: userdata fallback for a custom --user-directory (
       expect(calls).toHaveLength(0);
       const text = JSON.stringify(res);
       expect(text).toMatch(/staged\.json/); // names what it tried
-      expect(text).toMatch(/panel_list_workflows/);
+      expect(text).toMatch(/list_workflows/);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -417,6 +417,54 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     expect(fetchApi).toHaveBeenCalledWith(`/api/userdata/${encodeURIComponent(`workflows/${nfc}`)}`);
   });
 
+  it("resolves the REVERSE direction too — an NFC name against a DECOMPOSED library key", async () => {
+    // The mirror of the test above, and the one that catches a retry which
+    // re-derives the key instead of echoing the server's bytes (codex MAJOR): if
+    // the retry NFC-normalized the listed key it would re-send the caller's own
+    // spelling — the key that just 404'd — and refuse a uniquely listed workflow.
+    const nfc = "caf\u00e9.json";
+    const nfd = "cafe\u0301.json";
+    const graph = { nodes: [{ id: 9, type: "DecomposedLibraryNode" }], links: [] };
+    routeMock([nfd], { [`workflows/${nfd}`]: graph });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: nfc }, ctx);
+
+    expect(res.isError).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].graph).toMatchObject(graph);
+    expect(fetchApi).toHaveBeenCalledWith(`/api/userdata/${encodeURIComponent(`workflows/${nfd}`)}`);
+  });
+
+  it("uses the server's key verbatim when the listing already carries the workflows/ prefix", async () => {
+    // Some listings report the full store key. It must not be double-prefixed, and
+    // it must not be rewritten.
+    const graph = { nodes: [{ id: 11, type: "PrefixedListingNode" }], links: [] };
+    routeMock(["workflows/Prefixed Name.json"], { "workflows/Prefixed Name.json": graph });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "Prefixed Name.json" }, ctx);
+
+    expect(res.isError).toBeUndefined();
+    expect(calls[0].graph).toMatchObject(graph);
+    expect(fetchApi).not.toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent("workflows/workflows/Prefixed Name.json")}`,
+    );
+  });
+
+  it("never echoes a traversal entry from a hostile listing back as a request key", async () => {
+    routeMock(["../../secret.json", "..\\secret.json"], {});
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "secret.json" }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    for (const call of fetchApi.mock.calls) {
+      expect(String(call[0])).not.toMatch(/%2E%2E|\.\./i);
+    }
+  });
+
   it("REFUSES when two listed keys NORMALIZE to the requested name (ambiguous, no guess)", async () => {
     // Two library keys, one NFC and one NFD, both spelling the same name. A
     // case-sensitive store can hold both; picking either would be a coin flip over
@@ -499,7 +547,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     // The listing WAS consulted (and its 500 swallowed) — otherwise this test would
     // pass even if the near-miss lookup had been dropped entirely.
     expect(fetchApi).toHaveBeenCalledWith("/api/userdata?dir=workflows");
-    expect(JSON.stringify(res)).toMatch(/panel_list_workflows/);
+    expect(JSON.stringify(res)).toMatch(/list_workflows/);
   });
 });
 
@@ -644,7 +692,7 @@ describe("readWorkflowFromPath: refuses a '..' traversal segment (#414 hardening
     expect(JSON.stringify(res)).toMatch(/not a valid workflow name/i);
   });
 
-  it("does NOT read a file via a symlink under the workflows dir that escapes the root", async () => {
+  it("does NOT read a file via a symlink under the workflows dir that escapes the root", async (t) => {
     // A lexically-clean name ("linked/secret.json") where `linked` is a symlink to
     // an EXTERNAL dir would, without realpath containment, be read on the local
     // fallback. The realpath check rejects it. (Skipped where the OS denies
@@ -663,7 +711,11 @@ describe("readWorkflowFromPath: refuses a '..' traversal segment (#414 hardening
       try {
         symlinkSync(external, join(defaultDir, "linked"), "junction");
       } catch {
-        return; // unprivileged symlink creation — skip on this platform
+        // Unprivileged symlink creation (stock Windows). Mark the test SKIPPED
+        // rather than returning — a bare return reports a green test that never
+        // ran its assertion (codex).
+        t.skip();
+        return;
       }
       process.env.COMFYUI_PATH = root;
       // Unreachable server → the local fallback is reached, so the realpath

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -17,7 +17,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 
 // Stub ONLY getClient so no real ComfyUI connection is attempted; every other
 // client export keeps its real implementation (panel-tools' module graph uses
@@ -420,7 +420,7 @@ describe("readWorkflowFromPath: a refusal is never mistaken for an unreachable s
       expect(calls).toHaveLength(0);
       if (caseInsensitiveVolume) {
         // The differently-cased file is NAMED so the caller can retype it.
-        expect(JSON.stringify(res)).toMatch(/not spelled the way you asked/i);
+        expect(JSON.stringify(res)).toMatch(/not how you spelled it/i);
       }
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -448,6 +448,39 @@ describe("readWorkflowFromPath: a refusal is never mistaken for an unreachable s
 
       expect(res.isError).toBe(true);
       expect(calls).toHaveLength(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reads a backslash name the way the LOCAL platform would, or not at all", async () => {
+    // With no server there is no authority to disprove the literal reading, so the
+    // local branch may only apply the platform's own semantics (codex MAJOR):
+    //   - Windows: a file named "recipes\foo.json" cannot exist, so the folder
+    //     reading is the ONLY reading and resolve() is right to take it.
+    //   - POSIX: the backslash is an ordinary filename character, so resolve()
+    //     produces the LITERAL path; the folder reading was never authorised and
+    //     must not be substituted.
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const nested = join(root, "user", "default", "workflows", "recipes");
+      mkdirSync(nested, { recursive: true });
+      const staged = { nodes: [{ id: 84, type: "PlatformSeparatorNode" }], links: [] };
+      writeFileSync(join(nested, "foo.json"), JSON.stringify(staged), "utf8");
+      process.env.COMFYUI_PATH = root;
+
+      fetchApi.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "recipes\\foo.json" }, ctx);
+
+      if (sep === "\\") {
+        expect(res.isError).toBeUndefined();
+        expect(calls[0].graph).toMatchObject(staged);
+      } else {
+        expect(res.isError).toBe(true);
+        expect(calls).toHaveLength(0);
+      }
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2187,7 +2187,21 @@ function readPackWorkflow(packName: string): Record<string, unknown> {
 // ComfyUI whose files the orchestrator can't see — use the inline `graph` option
 // for that.
 
-/** Candidate ComfyUI workflows directories (where the frontend saves/stages files). */
+/**
+ * Candidate ComfyUI workflows directories, RECONSTRUCTED from COMFYUI_PATH.
+ *
+ * These are GUESSES at the DEFAULT layout. ComfyUI's `--user-directory` moves the
+ * whole user tree somewhere unguessable, so a hit under one of these dirs is only
+ * ever the file the caller meant when the server happens to run the default
+ * layout. They are therefore a LAST resort, used only when the connected ComfyUI
+ * could not be asked at all (#202).
+ *
+ * `process.cwd()` is deliberately NOT in this list: resolving a library name
+ * against whatever directory the orchestrator happened to be launched from can
+ * only ever produce a file that is not the named library workflow — the
+ * load-the-wrong-graph hazard. Callers who mean a file outside the library pass
+ * an absolute path.
+ */
 function comfyWorkflowsDirs(): string[] {
   const base = process.env.COMFYUI_PATH;
   if (!base) return [];
@@ -2195,6 +2209,66 @@ function comfyWorkflowsDirs(): string[] {
     join(base, "user", "default", "workflows"),
     join(base, "user", "workflows"),
   ];
+}
+
+/**
+ * The HTTP status behind a failed `client.fetchApi` call, or undefined when the
+ * failure carried no status (a genuine transport error).
+ *
+ * WHY THIS EXISTS: `@stable-canvas/comfyui-client`'s `fetchApi` THROWS an
+ * `HttpError {status, json}` for every status outside 2xx/3xx — it never returns
+ * a non-ok Response. Code that only inspected `res.status` therefore classified
+ * EVERY 401/403/404/5xx as a transport failure, which silently enabled the
+ * guessed-local-directory fallback for a server that was reachable and had
+ * REFUSED. That is precisely how a different same-named workflow gets loaded
+ * (#202). The returned-non-ok shape is still handled by the caller for older
+ * clients and for tests that stub a plain Response.
+ *
+ * A 4xx/5xx whose body is not JSON makes the library's own `await res.json()`
+ * reject, so the status is genuinely unrecoverable there — those fall through to
+ * `undefined` (treated as "no authority", never as "the server said no").
+ */
+function httpStatusOfError(err: unknown): number | undefined {
+  const status = (err as { status?: unknown } | null | undefined)?.status;
+  return typeof status === "number" && Number.isFinite(status) ? status : undefined;
+}
+
+/** Compare two userdata store keys the way a filesystem does: one path-separator
+ *  flavour, one Unicode normal form. A name copied out of a listing (or typed on
+ *  a different OS) can carry the SAME characters in a different normalization —
+ *  NFD "é" vs NFC "é" are byte-different but the same file name, and a raw
+ *  byte comparison 404s on a workflow that visibly exists in the library. */
+const normalizeStoreKey = (key: string): string =>
+  key.replace(/\\/g, "/").replace(/^\/+/, "").replace(/^workflows\/+/i, "").normalize("NFC");
+
+/**
+ * The connected ComfyUI's OWN list of saved workflow store keys, or null when the
+ * listing could not be read. This is the same source panel_list_workflows /
+ * list_workflows report, so it reflects the server's runtime `--user-directory`
+ * — it is asked, never reconstructed. Used only to turn an authoritative
+ * "no such name" into either the server's EXACT key or an explicit refusal.
+ * Never throws: an unreadable listing simply means "no extra information".
+ */
+async function listUserdataWorkflowKeys(): Promise<string[] | null> {
+  try {
+    const res = await getClient().fetchApi("/api/userdata?dir=workflows");
+    if (!res.ok) return null;
+    const body: unknown = await res.json();
+    if (!Array.isArray(body)) return null;
+    // Tolerate both shapes ComfyUI builds return: bare strings, and richer
+    // entries ({path}/{name}) from full-info-style responses.
+    return body
+      .map((entry) => {
+        if (typeof entry === "string") return entry;
+        const rec = entry as { path?: unknown; name?: unknown } | null;
+        if (rec && typeof rec.path === "string") return rec.path;
+        if (rec && typeof rec.name === "string") return rec.name;
+        return null;
+      })
+      .filter((k): k is string => typeof k === "string" && k.length > 0);
+  } catch {
+    return null;
+  }
 }
 
 /** Validate a parsed value is a UI/litegraph workflow (a top-level `nodes`
@@ -2212,16 +2286,33 @@ function assertUiWorkflow(parsed: unknown, sourceLabel: string): Record<string, 
   return parsed as Record<string, unknown>;
 }
 
-/** Read + parse a UI workflow JSON by path. Resolves an ABSOLUTE path off the
- *  orchestrator's disk, or a RELATIVE name authoritatively through the CONNECTED
- *  ComfyUI's userdata API — which resolves under the server's RUNTIME
- *  `--user-directory` (custom or default), so the RIGHT file always wins and a
- *  stale same-named file under the guessed default dir can never shadow it
- *  (#202). Only when the server can't serve the name (404 / unreachable) does it
- *  fall back to the orchestrator's guessed local workflows dirs, so a
- *  disk-staged file still opens. Guards: must be .json and must parse to a UI
- *  workflow (a top-level `nodes` array). Fails loudly (never loads the wrong
- *  file) when the name resolves nowhere. */
+/**
+ * Read + parse a UI workflow JSON by path.
+ *
+ * An ABSOLUTE path is read off the orchestrator's own disk, unchanged.
+ *
+ * A RELATIVE name is resolved AUTHORITATIVELY by the CONNECTED ComfyUI's userdata
+ * API — the same source panel_list_workflows / panel_open_workflow read. That
+ * server resolves the name under its RUNTIME `--user-directory`, so a custom user
+ * directory just works and a same-named file under a reconstructed default-layout
+ * path can never shadow it (#202).
+ *
+ * The governing rule is that loading the WRONG graph is worse than loading none,
+ * so the resolver never guesses:
+ *   - server serves the file            → load it
+ *   - server refuses (401/403/5xx)      → error, no local fallback
+ *   - server says it has no such name   → retry the server's OWN exact key if the
+ *                                         listing has a single normalization/case
+ *                                         match, otherwise REFUSE (an absence from
+ *                                         the authority means any local hit is a
+ *                                         DIFFERENT file)
+ *   - name matches several library keys → REFUSE as ambiguous, naming them
+ *   - server unreachable (no answer)    → best-effort reconstructed local dirs,
+ *                                         and REFUSE if more than one file matches
+ *
+ * Guards: must be .json and must parse to a UI workflow (a top-level `nodes`
+ * array). Every failure names exactly what was tried.
+ */
 async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unknown>> {
   const p = (rawPath ?? "").trim();
   if (!p) throw new Error("Provide a non-empty `path` to a workflow .json file.");
@@ -2259,10 +2350,10 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
   // own honest error rather than silently loading a possibly-stale local file.
   type Outcome =
     | { kind: "found"; parsed: unknown }
-    | { kind: "malformed"; detail: string } // 2xx but bad JSON → error, no fallback
-    | { kind: "refused"; detail: string } // non-404 HTTP error → error, no fallback
-    | { kind: "absent"; detail: string } // 404 → local fallback allowed
-    | { kind: "unreachable"; detail: string }; // transport failure → local fallback allowed
+    | { kind: "malformed"; detail: string } // 2xx but bad JSON → error, no guessing
+    | { kind: "refused"; detail: string } // non-404 HTTP status → error, no guessing
+    | { kind: "absent"; detail: string } // server ANSWERED "no such name" → authoritative
+    | { kind: "unreachable"; detail: string }; // no answer at all → no authority
   // #414: panel_list_workflows reports each workflow's userdata STORE KEY, which
   // already carries the "workflows/" prefix (e.g. "workflows/Daily Anime.json").
   // Feeding that exact value back here double-prefixed it to
@@ -2290,36 +2381,87 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
         `workflows folder (no "..", drive letters, or absolute paths), or an absolute path.`,
     );
   }
-  let outcome: Outcome;
-  try {
-    const client = getClient();
-    const encoded = encodeURIComponent(`workflows/${rel}`);
-    const res = await client.fetchApi(`/api/userdata/${encoded}`);
-    if (res.ok) {
-      // Read the body as TEXT and classify HERE so a malformed 2xx surfaces its
-      // OWN error (no fallback), while ComfyUI's "200 + EMPTY body = file does
-      // not exist" convention (some builds; see parseWorkflowLock) is treated as
-      // an ABSENCE that DOES allow the local fallback — not a malformed error.
-      const body = (await res.text()).trim();
-      if (body === "") {
-        outcome = { kind: "absent", detail: "was not in the ComfyUI userdata library (empty 200 response)" };
-      } else {
+  // One userdata GET, classified. `key` is the STORE key (already "workflows/…").
+  // The status must be recovered from a THROWN HttpError as well as from a
+  // returned non-ok Response — see httpStatusOfError: the real client never
+  // returns a non-ok Response, so reading only `res.status` made every refusal
+  // look like a transport failure.
+  const fetchUserdataKey = async (key: string): Promise<Outcome> => {
+    try {
+      const client = getClient();
+      const res = await client.fetchApi(`/api/userdata/${encodeURIComponent(key)}`);
+      if (res.ok) {
+        // Read the body as TEXT and classify HERE so a malformed 2xx surfaces its
+        // OWN error, while ComfyUI's "200 + EMPTY body = file does not exist"
+        // convention (some builds; see parseWorkflowLock) is an ABSENCE — an
+        // authoritative "no such name", not a malformed file.
+        const body = (await res.text()).trim();
+        if (body === "") {
+          return { kind: "absent", detail: `is not in the connected ComfyUI's workflow library (empty 200 response for "${key}")` };
+        }
         try {
-          outcome = { kind: "found", parsed: JSON.parse(body) };
+          return { kind: "found", parsed: JSON.parse(body) };
         } catch (err) {
-          outcome = { kind: "malformed", detail: err instanceof Error ? err.message : String(err) };
+          return { kind: "malformed", detail: err instanceof Error ? err.message : String(err) };
         }
       }
-    } else if (res.status === 404) {
-      outcome = { kind: "absent", detail: "was not in the ComfyUI userdata library (HTTP 404)" };
-    } else {
-      outcome = { kind: "refused", detail: `ComfyUI userdata library returned HTTP ${res.status}` };
+      if (res.status === 404) {
+        return { kind: "absent", detail: `is not in the connected ComfyUI's workflow library (HTTP 404 for "${key}")` };
+      }
+      return { kind: "refused", detail: `ComfyUI userdata library returned HTTP ${res.status} for "${key}"` };
+    } catch (err) {
+      const status = httpStatusOfError(err);
+      if (status === 404) {
+        return { kind: "absent", detail: `is not in the connected ComfyUI's workflow library (HTTP 404 for "${key}")` };
+      }
+      if (status !== undefined) {
+        return { kind: "refused", detail: `ComfyUI userdata library returned HTTP ${status} for "${key}"` };
+      }
+      return {
+        kind: "unreachable",
+        detail: `the connected ComfyUI's workflow library could not be reached (${err instanceof Error ? err.message : String(err)})`,
+      };
     }
-  } catch (err) {
-    outcome = {
-      kind: "unreachable",
-      detail: `ComfyUI userdata library was unreachable (${err instanceof Error ? err.message : String(err)})`,
-    };
+  };
+
+  const requestedKey = `workflows/${rel}`;
+  let outcome = await fetchUserdataKey(requestedKey);
+
+  // The server ANSWERED "no such name". Before giving up, ask it for its OWN
+  // listing and look for the same name in a different Unicode normal form or
+  // letter case — a name pasted from a listing (or produced on another OS) can be
+  // byte-different yet denote the same file, which is how a workflow that
+  // panel_list_workflows plainly shows still 404s here. Only the SERVER's exact
+  // key is retried, so this resolves the name the connected ComfyUI itself
+  // reports — it never reconstructs a path. More than one match is AMBIGUOUS and
+  // is refused rather than guessed at.
+  let listedButUnserved: string | null = null;
+  if (outcome.kind === "absent") {
+    const listed = await listUserdataWorkflowKeys();
+    if (listed) {
+      const want = normalizeStoreKey(rel);
+      const exact = listed.filter((k) => normalizeStoreKey(k) === want);
+      const matches = exact.length
+        ? exact
+        : listed.filter((k) => normalizeStoreKey(k).toLowerCase() === want.toLowerCase());
+      if (matches.length > 1) {
+        throw new Error(
+          `"${p}" is ambiguous in the connected ComfyUI's workflow library — it matches ` +
+            `${matches.length} saved workflows (${matches.map((k) => `"${k}"`).join(", ")}). ` +
+            `Refusing to guess which one you meant: pass the exact name from panel_list_workflows, ` +
+            `or an absolute path.`,
+        );
+      }
+      if (matches.length === 1) {
+        if (normalizeStoreKey(matches[0]) !== rel.replace(/\\/g, "/")) {
+          outcome = await fetchUserdataKey(`workflows/${normalizeStoreKey(matches[0])}`);
+        }
+        // Still absent after retrying the server's OWN key: the library lists the
+        // name but will not serve it. Say so — that is a server-side condition the
+        // user must see, not a cue to go hunting for a local file.
+        if (outcome.kind === "absent") listedButUnserved = matches[0];
+      }
+    }
   }
 
   if (outcome.kind === "found") {
@@ -2331,25 +2473,44 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
   }
   if (outcome.kind === "refused") {
     // Server is reachable but did not serve the file — do NOT fall back to a
-    // possibly-stale local file; report the status honestly.
+    // possibly-different local file; report the status honestly.
     throw new Error(
       `Could not read "${p}" from the connected ComfyUI: ${outcome.detail}. ` +
         `Pass an absolute path, or a name shown by panel_list_workflows.`,
     );
   }
+  if (outcome.kind === "absent") {
+    // AUTHORITATIVE absence. The connected ComfyUI resolved the name under its own
+    // runtime `--user-directory` and said it has no such workflow — so any file the
+    // orchestrator could still find by RECONSTRUCTING a default-layout path is, by
+    // construction, a DIFFERENT file from the one the caller named. Loading it
+    // would hand the agent the wrong graph to edit, which is worse than failing
+    // (#202). Refuse, naming exactly what was tried.
+    throw new Error(
+      `No workflow named "${p}" — it ${outcome.detail}.` +
+        (listedButUnserved
+          ? ` Its library DOES list "${listedButUnserved}", but the server would not serve that key —` +
+            ` the file may have been removed or be unreadable on the ComfyUI machine.`
+          : "") +
+        ` The connected ComfyUI is the authority on its own user directory (it may have been started` +
+        ` with --user-directory), so the orchestrator will NOT guess at a local path that could be a` +
+        ` different file. Use a name exactly as shown by panel_list_workflows, or pass an absolute path.`,
+    );
+  }
 
-  // outcome.kind is "absent" (404) or "unreachable" — fall back to the
-  // orchestrator's guessed local workflows dirs (best-effort; only meaningful on
-  // a same-machine ComfyUI whose user-dir matches the default layout, or a file
-  // staged straight to disk).
+  // outcome.kind is "unreachable": the connected ComfyUI gave no answer at all, so
+  // there is no authority to defer to. Only here does the orchestrator fall back to
+  // the RECONSTRUCTED default-layout workflows dirs — best-effort, and only when
+  // the name resolves to exactly ONE file (two hits mean two different candidate
+  // graphs, which is refused rather than guessed at).
   // Each candidate is the store-relative name resolved UNDER a base dir. Only the
   // NORMALIZED `rel` is used (never the raw `workflows/…` key), so nothing nests a
   // second workflows/ (codex P1/P2). Belt-and-suspenders containment: an existing
   // candidate is only accepted if its REAL path (symlinks/junctions resolved)
   // stays beneath the base's REAL path — so a link under the workflows dir that
-  // targets an external directory can't be read on the 404/unreachable fallback
-  // (codex). Canonicalizing BOTH sides keeps a legitimately-symlinked workflows
-  // dir working (its base resolves too), while blocking a per-file escape.
+  // targets an external directory can't be read on the fallback (codex).
+  // Canonicalizing BOTH sides keeps a legitimately-symlinked workflows dir working
+  // (its base resolves too), while blocking a per-file escape.
   const realBaseUnder = (base: string, candidate: string): boolean => {
     try {
       const rb = realpathSync(base);
@@ -2359,17 +2520,26 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
       return false;
     }
   };
-  const localBases = [...comfyWorkflowsDirs(), process.cwd()];
-  const local = localBases
+  const hits = comfyWorkflowsDirs()
     .map((dir) => ({ dir, path: resolve(dir, rel) }))
     .filter(({ path }) => existsSync(path) && statSync(path).isFile())
     .filter(({ dir, path }) => realBaseUnder(dir, path))
-    .map(({ path }) => path)[0];
-  if (local) return readLocal(local);
+    .map(({ path }) => path);
+  // De-duplicate by REAL path: the two guessed layouts can be the same directory
+  // (a symlink/junction), which is one candidate, not an ambiguity.
+  const distinct = [...new Set(hits.map((h) => { try { return realpathSync(h); } catch { return h; } }))];
+  if (distinct.length > 1) {
+    throw new Error(
+      `"${p}" is ambiguous: the connected ComfyUI could not be reached, and the name matches ` +
+        `${distinct.length} different local files (${distinct.map((f) => `"${f}"`).join(", ")}). ` +
+        `Refusing to guess which one you meant — pass an absolute path.`,
+    );
+  }
+  if (distinct.length === 1) return readLocal(distinct[0]);
 
   throw new Error(
-    `No workflow file at "${p}". It ${outcome.detail}, and it is not under the orchestrator's workflows ` +
-      `dir (${comfyWorkflowsDirs().join(" or ") || "COMFYUI_PATH not set"}). ` +
+    `No workflow file at "${p}". It ${outcome.detail}, and it is not under the orchestrator's ` +
+      `reconstructed workflows dir (${comfyWorkflowsDirs().join(" or ") || "COMFYUI_PATH not set"}). ` +
       `Pass an absolute path, or a name shown by panel_list_workflows.`,
   );
 }
@@ -4004,7 +4174,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         path: z
           .string()
           .optional()
-          .describe("Path to a workflow .json on the ComfyUI machine's disk — absolute, or relative to the ComfyUI workflows folder (user/default/workflows). Read + parsed server-side and loaded onto the canvas (keeps a large JSON out of chat). Local ComfyUI only."),
+          .describe("Path to a workflow .json — an ABSOLUTE path on the ComfyUI machine's disk, or a name from panel_list_workflows, which is looked up in the connected ComfyUI's own workflow library (so a custom --user-directory resolves correctly). Read + parsed server-side and loaded onto the canvas (keeps a large JSON out of chat). A name the library does not have is REFUSED rather than guessed at from a local path."),
         graph: z
           .union([z.string(), z.record(z.string(), z.unknown())])
           .optional()

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -25,7 +25,7 @@
 
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { extname, isAbsolute, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { comfyuiFetch } from "../comfyui/fetch.js";
@@ -2712,10 +2712,51 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
       return false;
     }
   };
+  /**
+   * Is `rel` the name the file on disk ACTUALLY has, segment for segment?
+   *
+   * `resolve(dir, rel)` answers in the filesystem's terms, not the store's (codex
+   * MAJOR). It collapses repeated separators, so "recipes//foo.json" — a distinct
+   * key everywhere else in this resolver — silently opens recipes/foo.json; and on
+   * a case-insensitive volume `foo.json` opens an on-disk `Foo.json`, the very
+   * substitution the server path refuses. That left the two branches applying
+   * different rules to the same input depending only on whether ComfyUI happened
+   * to answer.
+   *
+   * Walking the directory entries restores one rule: every segment must appear
+   * VERBATIM in its parent listing. An empty segment (from a repeated separator)
+   * can never match, and a case- or normalization-different on-disk name is
+   * refused exactly as it would be against the server.
+   */
+  const localNameIsExact = (base: string, name: string): boolean => {
+    // Split on BOTH separators: Windows resolve() honours either, so the check has
+    // to see the same segmentation the read would.
+    const segs = name.split(/[\\/]/);
+    let dir = base;
+    for (const seg of segs) {
+      let entries: string[];
+      try {
+        entries = readdirSync(dir);
+      } catch {
+        return false;
+      }
+      if (!entries.includes(seg)) return false;
+      dir = join(dir, seg);
+    }
+    return true;
+  };
+  // Spellings that exist on disk but are NOT what was asked for — reported so the
+  // refusal is actionable, never loaded.
+  const misspelled: string[] = [];
   const hits = comfyWorkflowsDirs()
     .map((dir) => ({ dir, path: resolve(dir, rel) }))
     .filter(({ path }) => existsSync(path) && statSync(path).isFile())
     .filter(({ dir, path }) => realBaseUnder(dir, path))
+    .filter(({ dir, path }) => {
+      if (localNameIsExact(dir, rel)) return true;
+      misspelled.push(path);
+      return false;
+    })
     .map(({ path }) => path);
   // De-duplicate by REAL path: the two guessed layouts can be the same directory
   // (a symlink/junction), which is one candidate, not an ambiguity.
@@ -2731,8 +2772,14 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
 
   throw new Error(
     `No workflow file at "${p}". It ${outcome.detail}, and it is not under the orchestrator's ` +
-      `reconstructed workflows dir (${comfyWorkflowsDirs().join(" or ") || "COMFYUI_PATH not set"}). ` +
-      `Pass an absolute path, or a name shown by list_workflows.`,
+      `reconstructed workflows dir (${comfyWorkflowsDirs().join(" or ") || "COMFYUI_PATH not set"}).` +
+      (misspelled.length
+        ? ` A file exists at ${misspelled.map((f) => `"${f}"`).join(", ")}, but its name on disk is` +
+          ` not spelled the way you asked (letter case, repeated separator, or Unicode` +
+          ` normalization), and with ComfyUI unreachable there is no authority to confirm they are` +
+          ` the same file — so it was NOT loaded. Retype the name exactly, or pass an absolute path.`
+        : "") +
+      ` Pass an absolute path, or a name shown by list_workflows.`,
   );
 }
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2241,9 +2241,15 @@ function httpStatusOfError(err: unknown): number | undefined {
  *  one — while on POSIX it is a perfectly legal LITERAL filename. Accepting the
  *  backslash spelling would silently rewrite a request for that literal file into
  *  a request for `workflows/foo.json`, i.e. a different graph. A caller who types
- *  the backslash form gets a refusal that names the close match instead. */
+ *  the backslash form gets a refusal that names the close match instead.
+ *
+ *  The match is also case-SENSITIVE (codex MAJOR). ComfyUI's store key is the
+ *  literal lowercase "workflows/"; a library that contains a subfolder named
+ *  "WORKFLOWS" is a real, different location on a case-sensitive host, and
+ *  stripping it would turn "WORKFLOWS/foo.json" into a request for the root
+ *  "foo.json". */
 const stripLibraryPrefix = (key: string): string =>
-  key.replace(/^\/+/, "").replace(/^workflows\/+/i, "");
+  key.replace(/^\/+/, "").replace(/^workflows\/+/, "");
 
 /** The form two userdata store keys are compared in when deciding they are the
  *  SAME NAME. Unicode normalization is the only equivalence applied: NFD "é" and
@@ -2483,15 +2489,20 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
   // key that just 404'd — and a uniquely listed workflow would be refused. Only a
   // missing "workflows/" prefix is added.
   const storeKeyForListed = (listedKey: string): string => {
-    const trimmed = listedKey.replace(/^[\\/]+/, "");
-    return /^workflows[\\/]/i.test(trimmed) ? trimmed : `workflows/${trimmed}`;
+    // Same strictness as stripLibraryPrefix: only the literal lowercase,
+    // forward-slash "workflows/" counts as an already-prefixed key. Anything else
+    // is part of the NAME and must stay under the library root.
+    const trimmed = listedKey.replace(/^\/+/, "");
+    return /^workflows\//.test(trimmed) ? trimmed : `workflows/${trimmed}`;
   };
 
   let listedButUnserved: string | null = null;
   let nearMisses: string[] = [];
+  let listingUnreadable = false;
   let resolvedKey = requestedKey;
   if (outcome.kind === "absent") {
     const rawListed = await listUserdataWorkflowKeys();
+    listingUnreadable = rawListed === null;
     // A listing entry is server-supplied data, so it gets the SAME escape guard as
     // caller input before it is echoed back as a request key. The split is
     // deliberately liberal about separators — that is a REJECTION rule, where being
@@ -2586,6 +2597,9 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
     // (#202). Refuse, naming exactly what was tried.
     throw new Error(
       `No workflow named "${p}" — it ${outcome.detail}.` +
+        (listingUnreadable
+          ? ` Its workflow listing could not be read either, so no close match could be checked.`
+          : "") +
         (listedButUnserved
           ? ` Its library DOES list "${listedButUnserved}", but the server would not serve that key —` +
             ` the file may have been removed or be unreadable on the ComfyUI machine.`

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2212,25 +2212,27 @@ function comfyWorkflowsDirs(): string[] {
 }
 
 /**
- * The HTTP status behind a failed `client.fetchApi` call, or undefined when the
- * failure carried no status (a genuine transport error).
+ * Issue ONE userdata GET and hand back the raw Response.
  *
- * WHY THIS EXISTS: `@stable-canvas/comfyui-client`'s `fetchApi` THROWS an
- * `HttpError {status, json}` for every status outside 2xx/3xx — it never returns
- * a non-ok Response. Code that only inspected `res.status` therefore classified
- * EVERY 401/403/404/5xx as a transport failure, which silently enabled the
- * guessed-local-directory fallback for a server that was reachable and had
- * REFUSED. That is precisely how a different same-named workflow gets loaded
- * (#202). The returned-non-ok shape is still handled by the caller for older
- * clients and for tests that stub a plain Response.
+ * This deliberately bypasses the client's own `fetchApi` (codex/gate MAJOR).
+ * `fetchApi` throws for every non-2xx AND calls `response.json()` while building
+ * that error — so a refusal with a non-JSON body (a `403 text/plain` from a proxy,
+ * an HTML 502) rejects with a STATUSLESS SyntaxError. There is then no way to tell
+ * "the server refused" from "the server was never reached", and the resolver's
+ * local fallback would re-open for a server that had explicitly refused, loading a
+ * different graph (#202).
  *
- * A 4xx/5xx whose body is not JSON makes the library's own `await res.json()`
- * reject, so the status is genuinely unrecoverable there — those fall through to
- * `undefined` (treated as "no authority", never as "the server said no").
+ * Building the request from the client's own `apiURL` + `apiHeaders` keeps every
+ * transport concern identical (host, ssl, base path, clientId, Comfy-User, the
+ * injected COMFYUI_AUTH_* fetch) while making the outcome unambiguous:
+ *   - a returned Response  = the server ANSWERED; classify by status, decode later
+ *   - a thrown error       = no Response exists, so the request never got one
+ * Nothing here reads a body, so a body that cannot be decoded can never be
+ * mistaken for a transport failure.
  */
-function httpStatusOfError(err: unknown): number | undefined {
-  const status = (err as { status?: unknown } | null | undefined)?.status;
-  return typeof status === "number" && Number.isFinite(status) ? status : undefined;
+async function userdataFetch(route: string): Promise<Response> {
+  const client = getClient();
+  return await client.fetch(client.apiURL(route), { headers: client.apiHeaders() });
 }
 
 /** Drop the one leading "workflows/" segment, leaving a store-RELATIVE key.
@@ -2284,19 +2286,29 @@ const looseStoreKey = (key: string): string =>
  * The connected ComfyUI's OWN list of saved workflow store keys, or null when the
  * listing could not be read. This is the same source list_workflows reports (the
  * SAVED library, not the open tabs), so it reflects the server's runtime
- * `--user-directory`
- * — it is asked, never reconstructed. Used only to turn an authoritative
- * "no such name" into either the server's EXACT key or an explicit refusal.
- * Never throws: an unreadable listing simply means "no extra information".
+ * `--user-directory` — it is asked, never reconstructed. Used only to turn an
+ * authoritative "no such name" into either the server's EXACT key or an explicit
+ * refusal. Never throws: an unreadable listing simply means "no extra
+ * information", and the refusal says the listing could not be read.
+ *
+ * `recurse=true` is VERIFIED against the installed ComfyUI (0.29.2): a workflow in
+ * a SUBFOLDER is absent from the plain listing and present as "sub/name.json"
+ * under recurse, while root entries stay bare. Without it, a nested name that
+ * differs only by Unicode normalization has no listing entry to match and is
+ * refused. The parameter is safe on builds that do not implement it — an unknown
+ * query arg is ignored and the flat list comes back, which is exactly the
+ * pre-existing behaviour (over-refusal of nested near-misses, never a wrong file),
+ * so this needs no version gate.
  */
 async function listUserdataWorkflowKeys(): Promise<string[] | null> {
   try {
-    const res = await getClient().fetchApi("/api/userdata?dir=workflows");
+    const res = await userdataFetch("/api/userdata?dir=workflows&recurse=true");
     if (!res.ok) return null;
     const body: unknown = await res.json();
     if (!Array.isArray(body)) return null;
-    // Tolerate both shapes ComfyUI builds return: bare strings, and richer
-    // entries ({path}/{name}) from full-info-style responses.
+    // Tolerate both shapes ComfyUI builds return: bare strings (the default on
+    // 0.29.2), and {path} objects (what full_info=true emits, in case a build
+    // returns that shape by default).
     return body
       .map((entry) => {
         if (typeof entry === "string") return entry;
@@ -2348,8 +2360,13 @@ function assertUiWorkflow(parsed: unknown, sourceLabel: string): Record<string, 
  *                                         REFUSE — an absence from the authority
  *                                         means any local hit is a DIFFERENT file
  *   - name matches several library keys → REFUSE as ambiguous, naming them
- *   - server unreachable (no answer)    → best-effort reconstructed local dirs,
+ *   - NO HTTP RESPONSE AT ALL           → best-effort reconstructed local dirs,
  *                                         and REFUSE if more than one file matches
+ *
+ * That last line is the only branch that guesses, and it is deliberately narrow: a
+ * reply that ARRIVED but could not be decoded is a refusal, not an absence of
+ * authority. See userdataFetch for why the request bypasses the client's
+ * throw-on-non-2xx wrapper to make that distinction sound.
  *
  * Guards: must be .json and must parse to a UI workflow (a top-level `nodes`
  * array). Every failure names exactly what was tried.
@@ -2423,61 +2440,57 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
     );
   }
   // One userdata GET, classified. `key` is the STORE key (already "workflows/…").
-  // The status must be recovered from a THROWN HttpError as well as from a
-  // returned non-ok Response — see httpStatusOfError: the real client never
-  // returns a non-ok Response, so reading only `res.status` made every refusal
-  // look like a transport failure.
+  //
+  // The request goes through userdataFetch, which returns the raw Response instead
+  // of the client's throw-on-non-2xx wrapper. That is what makes this split sound
+  // (gate MAJOR): the ONLY way to land in the catch is for no Response to exist at
+  // all, so "the server refused with a body we could not decode" can never be
+  // mistaken for "the server was never reached" and re-open the local fallback.
   const fetchUserdataKey = async (key: string): Promise<Outcome> => {
+    let res: Response;
     try {
-      const client = getClient();
-      const res = await client.fetchApi(`/api/userdata/${encodeURIComponent(key)}`);
-      if (res.ok) {
-        // Read the body as TEXT and classify HERE so a malformed 2xx surfaces its
-        // OWN error, while ComfyUI's "200 + EMPTY body = file does not exist"
-        // convention (some builds; see parseWorkflowLock) is an ABSENCE — an
-        // authoritative "no such name", not a malformed file.
-        //
-        // The body read gets its OWN try/catch (codex MAJOR): a stream that aborts
-        // MID-BODY would otherwise fall out to the outer catch as a statusless
-        // error and be classified "unreachable", re-opening the reconstructed
-        // local fallback for a server that had in fact ANSWERED — the wrong-file
-        // path again. The server answered, so this is a refusal, not an absence.
-        let body: string;
-        try {
-          body = (await res.text()).trim();
-        } catch (err) {
-          return {
-            kind: "refused",
-            detail:
-              `ComfyUI answered ${res.status} for "${key}" but the response body could not be read ` +
-              `(${err instanceof Error ? err.message : String(err)})`,
-          };
-        }
-        if (body === "") {
-          return { kind: "absent", detail: `is not in the connected ComfyUI's workflow library (empty 200 response for "${key}")` };
-        }
-        try {
-          return { kind: "found", parsed: JSON.parse(body) };
-        } catch (err) {
-          return { kind: "malformed", detail: err instanceof Error ? err.message : String(err) };
-        }
-      }
-      if (res.status === 404) {
-        return { kind: "absent", detail: `is not in the connected ComfyUI's workflow library (HTTP 404 for "${key}")` };
-      }
-      return { kind: "refused", detail: `ComfyUI userdata library returned HTTP ${res.status} for "${key}"` };
+      res = await userdataFetch(`/api/userdata/${encodeURIComponent(key)}`);
     } catch (err) {
-      const status = httpStatusOfError(err);
-      if (status === 404) {
-        return { kind: "absent", detail: `is not in the connected ComfyUI's workflow library (HTTP 404 for "${key}")` };
-      }
-      if (status !== undefined) {
-        return { kind: "refused", detail: `ComfyUI userdata library returned HTTP ${status} for "${key}"` };
-      }
+      // No Response object exists — the request never received an answer
+      // (connection refused, DNS, TLS, timeout), or no client could be built at
+      // all. This is the ONLY outcome that leaves the orchestrator without an
+      // authority to defer to.
       return {
         kind: "unreachable",
         detail: `the connected ComfyUI's workflow library could not be reached (${err instanceof Error ? err.message : String(err)})`,
       };
+    }
+    // From here the server ANSWERED. Every remaining outcome is authoritative, and
+    // none of them may fall back to a reconstructed local path.
+    if (!res.ok) {
+      if (res.status === 404) {
+        return { kind: "absent", detail: `is not in the connected ComfyUI's workflow library (HTTP 404 for "${key}")` };
+      }
+      return { kind: "refused", detail: `ComfyUI userdata library returned HTTP ${res.status} for "${key}"` };
+    }
+    // Read the body as TEXT and classify HERE so a malformed 2xx surfaces its OWN
+    // error, while ComfyUI's "200 + EMPTY body = file does not exist" convention
+    // (some builds; see parseWorkflowLock) is an ABSENCE — an authoritative "no
+    // such name", not a malformed file. A body that cannot be read is a REFUSAL:
+    // the server answered, we simply could not decode it.
+    let body: string;
+    try {
+      body = (await res.text()).trim();
+    } catch (err) {
+      return {
+        kind: "refused",
+        detail:
+          `ComfyUI answered ${res.status} for "${key}" but the response body could not be read ` +
+          `(${err instanceof Error ? err.message : String(err)})`,
+      };
+    }
+    if (body === "") {
+      return { kind: "absent", detail: `is not in the connected ComfyUI's workflow library (empty 200 response for "${key}")` };
+    }
+    try {
+      return { kind: "found", parsed: JSON.parse(body) };
+    } catch (err) {
+      return { kind: "malformed", detail: err instanceof Error ? err.message : String(err) };
     }
   };
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2233,8 +2233,13 @@ function httpStatusOfError(err: unknown): number | undefined {
   return typeof status === "number" && Number.isFinite(status) ? status : undefined;
 }
 
-/** Drop the leading slashes and the one leading "workflows/" segment, leaving a
- *  store-RELATIVE key.
+/** Drop the one leading "workflows/" segment, leaving a store-RELATIVE key.
+ *
+ *  Nothing else is stripped. In particular a leading "/" is NOT removed (codex
+ *  MAJOR): caller input can never reach here with one (that is an absolute path,
+ *  handled earlier), so the only strings it would affect are LISTING entries —
+ *  where "/name.json" and "name.json" are two different keys, and folding them
+ *  would let a match on one be fetched as the other.
  *
  *  Only the FORWARD-slash spelling counts as the library prefix (codex MAJOR).
  *  ComfyUI store keys are always "/"-separated, so `workflows\foo.json` was never
@@ -2249,7 +2254,7 @@ function httpStatusOfError(err: unknown): number | undefined {
  *  stripping it would turn "WORKFLOWS/foo.json" into a request for the root
  *  "foo.json". */
 const stripLibraryPrefix = (key: string): string =>
-  key.replace(/^\/+/, "").replace(/^workflows\/+/, "");
+  key.replace(/^workflows\/+/, "");
 
 /** The form two userdata store keys are compared in when deciding they are the
  *  SAME NAME. Unicode normalization is the only equivalence applied: NFD "é" and
@@ -2490,10 +2495,10 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
   // missing "workflows/" prefix is added.
   const storeKeyForListed = (listedKey: string): string => {
     // Same strictness as stripLibraryPrefix: only the literal lowercase,
-    // forward-slash "workflows/" counts as an already-prefixed key. Anything else
-    // is part of the NAME and must stay under the library root.
-    const trimmed = listedKey.replace(/^\/+/, "");
-    return /^workflows\//.test(trimmed) ? trimmed : `workflows/${trimmed}`;
+    // forward-slash "workflows/" counts as an already-prefixed key, and nothing
+    // else about the key is rewritten. Anything else is part of the NAME and must
+    // stay under the library root.
+    return /^workflows\//.test(listedKey) ? listedKey : `workflows/${listedKey}`;
   };
 
   let listedButUnserved: string | null = null;

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2439,6 +2439,22 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
         `workflows folder (no "..", drive letters, or absolute paths), or an absolute path.`,
     );
   }
+  // A BACKSLASH in a relative name is refused outright (codex MAJOR), because the
+  // two branches below would disagree about what it means. The userdata key space
+  // is "/"-separated, so "recipes\foo.json" is sent to the server as a single
+  // literal segment — but Windows `resolve()` treats "\" as a separator, so the
+  // local fallback would happily open user/default/workflows/recipes/foo.json.
+  // One input, two different files. Since neither reading is authoritative, this
+  // refuses instead of picking: forward slashes are what the library actually uses,
+  // and a real Windows path belongs in the absolute-path branch.
+  if (rel.includes("\\")) {
+    throw new Error(
+      `"${p}" is not a valid workflow name — the ComfyUI workflow library separates ` +
+        `folders with "/", so a "\\" would mean a literal character to the server and a ` +
+        `folder separator to the local filesystem. Use forward slashes (e.g. ` +
+        `"recipes/name.json"), or pass an absolute path.`,
+    );
+  }
   // One userdata GET, classified. `key` is the STORE key (already "workflows/…").
   //
   // The request goes through userdataFetch, which returns the raw Response instead

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2713,37 +2713,56 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
     }
   };
   /**
-   * Is `rel` the name the file on disk ACTUALLY has, segment for segment?
+   * Is `name` the name the file on disk ACTUALLY has, segment for segment? When it
+   * is not, report the on-disk spelling that came closest so the refusal can name
+   * it.
    *
-   * `resolve(dir, rel)` answers in the filesystem's terms, not the store's (codex
+   * `resolve(dir, name)` answers in the FILESYSTEM's terms, not the store's (codex
    * MAJOR). It collapses repeated separators, so "recipes//foo.json" — a distinct
    * key everywhere else in this resolver — silently opens recipes/foo.json; and on
    * a case-insensitive volume `foo.json` opens an on-disk `Foo.json`, the very
    * substitution the server path refuses. That left the two branches applying
-   * different rules to the same input depending only on whether ComfyUI happened
-   * to answer.
+   * different rules to the same input depending only on whether ComfyUI answered.
    *
    * Walking the directory entries restores one rule: every segment must appear
    * VERBATIM in its parent listing. An empty segment (from a repeated separator)
-   * can never match, and a case- or normalization-different on-disk name is
-   * refused exactly as it would be against the server.
+   * can never match, and a case- or normalization-different on-disk name is refused
+   * exactly as it would be against the server.
+   *
+   * The segmentation follows the PLATFORM, matching whatever `resolve()` just did
+   * (codex MAJOR). On Windows a backslash is a separator — and a file literally
+   * named `recipes\foo.json` cannot exist — so the folder reading is the only
+   * reading. On POSIX a backslash is an ordinary filename character, `resolve()`
+   * produces the LITERAL path, and this must too: splitting it there would bless a
+   * folder reading that the server-first rule never authorised, letting an
+   * unreachable server's `recipes/foo.json` stand in for a literal
+   * `recipes\foo.json` that may well exist.
    */
-  const localNameIsExact = (base: string, name: string): boolean => {
-    // Split on BOTH separators: Windows resolve() honours either, so the check has
-    // to see the same segmentation the read would.
-    const segs = name.split(/[\\/]/);
+  const platformSegments = (name: string): string[] =>
+    name.split(sep === "\\" ? /[\\/]/ : /\//);
+  const localSpelling = (
+    base: string,
+    name: string,
+  ): { exact: true } | { exact: false; onDisk?: string } => {
     let dir = base;
-    for (const seg of segs) {
+    const segs = platformSegments(name);
+    for (let i = 0; i < segs.length; i++) {
       let entries: string[];
       try {
         entries = readdirSync(dir);
       } catch {
-        return false;
+        return { exact: false };
       }
-      if (!entries.includes(seg)) return false;
-      dir = join(dir, seg);
+      if (entries.includes(segs[i])) {
+        dir = join(dir, segs[i]);
+        continue;
+      }
+      // Not spelled the way it was asked for. Name the entry it would have been, so
+      // the caller can retype it — reported only, never loaded.
+      const near = entries.find((e) => looseName(e) === looseName(segs[i]));
+      return { exact: false, onDisk: near ? join(dir, near, ...segs.slice(i + 1)) : undefined };
     }
-    return true;
+    return { exact: true };
   };
   // Spellings that exist on disk but are NOT what was asked for — reported so the
   // refusal is actionable, never loaded.
@@ -2752,9 +2771,10 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
     .map((dir) => ({ dir, path: resolve(dir, rel) }))
     .filter(({ path }) => existsSync(path) && statSync(path).isFile())
     .filter(({ dir, path }) => realBaseUnder(dir, path))
-    .filter(({ dir, path }) => {
-      if (localNameIsExact(dir, rel)) return true;
-      misspelled.push(path);
+    .filter(({ dir }) => {
+      const spelling = localSpelling(dir, rel);
+      if (spelling.exact) return true;
+      if (spelling.onDisk) misspelled.push(spelling.onDisk);
       return false;
     })
     .map(({ path }) => path);
@@ -2774,8 +2794,8 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
     `No workflow file at "${p}". It ${outcome.detail}, and it is not under the orchestrator's ` +
       `reconstructed workflows dir (${comfyWorkflowsDirs().join(" or ") || "COMFYUI_PATH not set"}).` +
       (misspelled.length
-        ? ` A file exists at ${misspelled.map((f) => `"${f}"`).join(", ")}, but its name on disk is` +
-          ` not spelled the way you asked (letter case, repeated separator, or Unicode` +
+        ? ` A file exists on disk as ${misspelled.map((f) => `"${f}"`).join(", ")}, which is` +
+          ` not how you spelled it (letter case, repeated separator, or Unicode` +
           ` normalization), and with ComfyUI unreachable there is no authority to confirm they are` +
           ` the same file — so it was NOT loaded. Retype the name exactly, or pass an absolute path.`
         : "") +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2243,8 +2243,9 @@ const normalizeStoreKey = (key: string): string =>
 
 /**
  * The connected ComfyUI's OWN list of saved workflow store keys, or null when the
- * listing could not be read. This is the same source panel_list_workflows /
- * list_workflows report, so it reflects the server's runtime `--user-directory`
+ * listing could not be read. This is the same source list_workflows reports (the
+ * SAVED library, not the open tabs), so it reflects the server's runtime
+ * `--user-directory`
  * — it is asked, never reconstructed. Used only to turn an authoritative
  * "no such name" into either the server's EXACT key or an explicit refusal.
  * Never throws: an unreadable listing simply means "no extra information".
@@ -2292,7 +2293,7 @@ function assertUiWorkflow(parsed: unknown, sourceLabel: string): Record<string, 
  * An ABSOLUTE path is read off the orchestrator's own disk, unchanged.
  *
  * A RELATIVE name is resolved AUTHORITATIVELY by the CONNECTED ComfyUI's userdata
- * API — the same source panel_list_workflows / panel_open_workflow read. That
+ * API — the same source list_workflows / panel_open_workflow read. That
  * server resolves the name under its RUNTIME `--user-directory`, so a custom user
  * directory just works and a same-named file under a reconstructed default-layout
  * path can never shadow it (#202).
@@ -2447,14 +2448,31 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
   // listing and look for the same name in a different Unicode normal form or
   // letter case — a name pasted from a listing (or produced on another OS) can be
   // byte-different yet denote the same file, which is how a workflow that
-  // panel_list_workflows plainly shows still 404s here. Only the SERVER's exact
+  // list_workflows plainly shows still 404s here. Only the SERVER's exact
   // key is retried, so this resolves the name the connected ComfyUI itself
   // reports — it never reconstructs a path. More than one match is AMBIGUOUS and
   // is refused rather than guessed at.
+  // Turn a RAW key from the server's listing into the store key to request. The
+  // server's own bytes are preserved (codex MAJOR): re-deriving the key through
+  // normalizeStoreKey would NFC-normalize it, so a library that stores the
+  // DECOMPOSED spelling would be re-asked with the COMPOSED one — i.e. the exact
+  // key that just 404'd — and a uniquely listed workflow would be refused. Only a
+  // missing "workflows/" prefix is added.
+  const storeKeyForListed = (listedKey: string): string => {
+    const trimmed = listedKey.replace(/^[\\/]+/, "");
+    return /^workflows[\\/]/i.test(trimmed) ? trimmed : `workflows/${trimmed}`;
+  };
+
   let listedButUnserved: string | null = null;
   let caseNearMisses: string[] = [];
   if (outcome.kind === "absent") {
-    const listed = await listUserdataWorkflowKeys();
+    const rawListed = await listUserdataWorkflowKeys();
+    // A listing entry is server-supplied data, so it gets the SAME escape guard as
+    // caller input before it is echoed back as a request key.
+    const listed = rawListed?.filter((k) => {
+      const segs = normalizeStoreKey(k).split("/");
+      return !segs.includes("..") && !segs.some((s) => /^[A-Za-z]:/.test(s));
+    });
     if (listed) {
       const want = normalizeStoreKey(rel);
       // The ONLY accepted equivalence is Unicode normalization. NFC "é" and NFD
@@ -2473,14 +2491,15 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
         throw new Error(
           `"${p}" is ambiguous in the connected ComfyUI's workflow library — it matches ` +
             `${matches.length} saved workflows (${matches.map((k) => `"${k}"`).join(", ")}). ` +
-            `Refusing to guess which one you meant: pass the exact name from panel_list_workflows, ` +
+            `Refusing to guess which one you meant: pass the exact name from list_workflows, ` +
             `or an absolute path.`,
         );
       }
       if (matches.length === 1) {
-        if (normalizeStoreKey(matches[0]) !== rel.replace(/\\/g, "/")) {
-          outcome = await fetchUserdataKey(`workflows/${normalizeStoreKey(matches[0])}`);
-        }
+        const retryKey = storeKeyForListed(matches[0]);
+        // Only re-ask when the server's spelling actually differs from what was
+        // already sent — otherwise this would repeat the request that just failed.
+        if (retryKey !== requestedKey) outcome = await fetchUserdataKey(retryKey);
         // Still absent after retrying the server's OWN key: the library lists the
         // name but will not serve it. Say so — that is a server-side condition the
         // user must see, not a cue to go hunting for a local file.
@@ -2505,7 +2524,7 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
     // possibly-different local file; report the status honestly.
     throw new Error(
       `Could not read "${p}" from the connected ComfyUI: ${outcome.detail}. ` +
-        `Pass an absolute path, or a name shown by panel_list_workflows.`,
+        `Pass an absolute path, or a name shown by list_workflows.`,
     );
   }
   if (outcome.kind === "absent") {
@@ -2528,7 +2547,8 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
           : "") +
         ` The connected ComfyUI is the authority on its own user directory (it may have been started` +
         ` with --user-directory), so the orchestrator will NOT guess at a local path that could be a` +
-        ` different file. Use a name exactly as shown by panel_list_workflows, or pass an absolute path.`,
+        ` different file. Use a name exactly as shown by list_workflows (which reads the same library),` +
+        ` or pass an absolute path.`,
     );
   }
 
@@ -2574,7 +2594,7 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
   throw new Error(
     `No workflow file at "${p}". It ${outcome.detail}, and it is not under the orchestrator's ` +
       `reconstructed workflows dir (${comfyWorkflowsDirs().join(" or ") || "COMFYUI_PATH not set"}). ` +
-      `Pass an absolute path, or a name shown by panel_list_workflows.`,
+      `Pass an absolute path, or a name shown by list_workflows.`,
   );
 }
 
@@ -4208,7 +4228,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         path: z
           .string()
           .optional()
-          .describe("Path to a workflow .json — an ABSOLUTE path on the ComfyUI machine's disk, or a name from panel_list_workflows, which is looked up in the connected ComfyUI's own workflow library (so a custom --user-directory resolves correctly). Read + parsed server-side and loaded onto the canvas (keeps a large JSON out of chat). A name the library does not have is REFUSED rather than guessed at from a local path."),
+          .describe("Path to a workflow .json — an ABSOLUTE path on the ComfyUI machine's disk, or a name from list_workflows, which is looked up in the connected ComfyUI's own saved-workflow library (so a custom --user-directory resolves correctly). Read + parsed server-side and loaded onto the canvas (keeps a large JSON out of chat). A name the library does not have is REFUSED rather than guessed at from a local path."),
         graph: z
           .union([z.string(), z.record(z.string(), z.unknown())])
           .optional()

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2235,53 +2235,59 @@ async function userdataFetch(route: string): Promise<Response> {
   return await client.fetch(client.apiURL(route), { headers: client.apiHeaders() });
 }
 
-/** Drop the one leading "workflows/" segment, leaving a store-RELATIVE key.
+/**
+ * Drop the one leading "workflows/" segment from CALLER input, leaving a key that
+ * is relative to the workflow store root.
  *
- *  EXACTLY one separator is consumed (codex MAJOR). "workflows//foo.json" keeps
- *  its second slash and stays "/foo.json" — collapsing runs of slashes would make
- *  it an alias for the different key "foo.json".
+ * This exists only because panel_list_workflows reports store keys that already
+ * carry the prefix (#414), so a caller may legitimately paste either spelling. It
+ * is applied EXACTLY ONCE, to the caller's `path`, and NEVER to an entry from the
+ * server's listing — those are already store-relative and stripping them again is
+ * what let a nested folder named `workflows` impersonate the store root (gate
+ * MAJOR); see matchName.
  *
- *  Nothing else is stripped. In particular a leading "/" is NOT removed (codex
- *  MAJOR): caller input can never reach here with one (that is an absolute path,
- *  handled earlier), so the only strings it would affect are LISTING entries —
- *  where "/name.json" and "name.json" are two different keys, and folding them
- *  would let a match on one be fetched as the other.
+ * Exactly one separator is consumed (codex MAJOR). "workflows//foo.json" keeps its
+ * second slash and stays "/foo.json" — collapsing runs of slashes would make it an
+ * alias for the different key "foo.json". A leading "/" is not removed either;
+ * caller input can never reach here with one (that is an absolute path, handled
+ * earlier).
  *
- *  Only the FORWARD-slash spelling counts as the library prefix (codex MAJOR).
- *  ComfyUI store keys are always "/"-separated, so `workflows\foo.json` was never
- *  one — while on POSIX it is a perfectly legal LITERAL filename. Accepting the
- *  backslash spelling would silently rewrite a request for that literal file into
- *  a request for `workflows/foo.json`, i.e. a different graph. A caller who types
- *  the backslash form gets a refusal that names the close match instead.
- *
- *  The match is also case-SENSITIVE (codex MAJOR). ComfyUI's store key is the
- *  literal lowercase "workflows/"; a library that contains a subfolder named
- *  "WORKFLOWS" is a real, different location on a case-sensitive host, and
- *  stripping it would turn "WORKFLOWS/foo.json" into a request for the root
- *  "foo.json". */
-const stripLibraryPrefix = (key: string): string =>
-  key.replace(/^workflows\//, "");
+ * Only the literal lowercase FORWARD-slash spelling counts (codex MAJOR). ComfyUI
+ * store keys are always "/"-separated and lowercase here, so `workflowsoo.json`
+ * and `WORKFLOWS/foo.json` are ordinary names — a real subfolder on a
+ * case-sensitive host, or a legal literal filename on POSIX — and stripping either
+ * would rewrite a request into one for a different graph.
+ */
+const stripLibraryPrefix = (key: string): string => key.replace(/^workflows\//, "");
 
-/** The form two userdata store keys are compared in when deciding they are the
- *  SAME NAME. Unicode normalization is the only equivalence applied: NFD "é" and
- *  NFC "é" are one character sequence written two ways, so a name pasted from a
- *  listing (or produced on another OS) can be byte-different yet denote the same
- *  file, and a raw byte comparison 404s on a workflow that visibly exists.
+/**
+ * The form two store-relative names are compared in when deciding they are the
+ * SAME NAME. Unicode normalization is the only equivalence applied: NFD "é" and
+ * NFC "é" are one character sequence written two ways, so a name pasted from a
+ * listing (or produced on another OS) can be byte-different yet denote the same
+ * file, and a raw byte comparison 404s on a workflow that visibly exists.
  *
- *  Path separators are deliberately NOT folded (codex MAJOR): on POSIX a file
- *  literally named `dir\foo.json` is a DIFFERENT file from `dir/foo.json`, so
- *  treating `\` as `/` here would let a request for one resolve to the other. Case
- *  is not folded either, for the same reason. Both of those are instead reported
- *  as near misses in the refusal. */
-const matchStoreKey = (key: string): string => stripLibraryPrefix(key).normalize("NFC");
+ * Nothing is STRIPPED here, which is what keeps request depth matched to entry
+ * depth (gate MAJOR). A recursive listing reports the root file "x.json" bare and
+ * the nested file workflows/workflows/x.json as "workflows/x.json"; stripping a
+ * prefix from the entry made those two collide, so a bare request could match the
+ * nested entry and then fetch the DIFFERENT root file. Compared verbatim, a
+ * depth-0 request can only ever match a depth-0 entry, and a request naming a
+ * subfolder matches only that exact path.
+ *
+ * Path separators are deliberately NOT folded (codex MAJOR): on POSIX a file
+ * literally named `diroo.json` is a DIFFERENT file from `dir/foo.json`. Case is
+ * not folded either, for the same reason. Both are reported as near misses instead.
+ */
+const matchName = (name: string): string => name.normalize("NFC");
 
 /** The looser form used ONLY to describe a near miss in an error message — never
  *  to select a file to load. Folds the equivalences that hold on some filesystems
- *  and not others: separator flavour (including a backslash-spelled library
- *  prefix) and letter case. */
-const looseStoreKey = (key: string): string =>
-  stripLibraryPrefix(key.replace(/\\/g, "/")).normalize("NFC").toLowerCase();
-
+ *  and not others: separator flavour, letter case and normalization. Like matchName
+ *  it strips nothing, so it cannot report a nested entry as a near miss for a root
+ *  name. */
+const looseName = (name: string): string =>
+  name.replace(/\\/g, "/").normalize("NFC").toLowerCase();
 /**
  * The connected ComfyUI's OWN list of saved workflow store keys, or null when the
  * listing could not be read. This is the same source list_workflows reports (the
@@ -2439,22 +2445,6 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
         `workflows folder (no "..", drive letters, or absolute paths), or an absolute path.`,
     );
   }
-  // A BACKSLASH in a relative name is refused outright (codex MAJOR), because the
-  // two branches below would disagree about what it means. The userdata key space
-  // is "/"-separated, so "recipes\foo.json" is sent to the server as a single
-  // literal segment — but Windows `resolve()` treats "\" as a separator, so the
-  // local fallback would happily open user/default/workflows/recipes/foo.json.
-  // One input, two different files. Since neither reading is authoritative, this
-  // refuses instead of picking: forward slashes are what the library actually uses,
-  // and a real Windows path belongs in the absolute-path branch.
-  if (rel.includes("\\")) {
-    throw new Error(
-      `"${p}" is not a valid workflow name — the ComfyUI workflow library separates ` +
-        `folders with "/", so a "\\" would mean a literal character to the server and a ` +
-        `folder separator to the local filesystem. Use forward slashes (e.g. ` +
-        `"recipes/name.json"), or pass an absolute path.`,
-    );
-  }
   // One userdata GET, classified. `key` is the STORE key (already "workflows/…").
   //
   // The request goes through userdataFetch, which returns the raw Response instead
@@ -2512,33 +2502,81 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
 
   const requestedKey = `workflows/${rel}`;
   let outcome = await fetchUserdataKey(requestedKey);
+  let resolvedKey = requestedKey;
+  // Every store key this call asked for, in order, so a refusal can name them all.
+  const attempted: string[] = [requestedKey];
 
-  // The server ANSWERED "no such name". Before giving up, ask it for its OWN
-  // listing and look for the same name in a different Unicode normal form or
-  // letter case — a name pasted from a listing (or produced on another OS) can be
-  // byte-different yet denote the same file, which is how a workflow that
-  // list_workflows plainly shows still 404s here. Only the SERVER's exact
-  // key is retried, so this resolves the name the connected ComfyUI itself
-  // reports — it never reconstructs a path. More than one match is AMBIGUOUS and
-  // is refused rather than guessed at.
-  // Turn a RAW key from the server's listing into the store key to request. The
-  // server's own bytes are preserved (codex MAJOR): re-deriving the key through
-  // normalizeStoreKey would NFC-normalize it, so a library that stores the
-  // DECOMPOSED spelling would be re-asked with the COMPOSED one — i.e. the exact
-  // key that just 404'd — and a uniquely listed workflow would be refused. Only a
-  // missing "workflows/" prefix is added.
-  const storeKeyForListed = (listedKey: string): string => {
-    // Same strictness as stripLibraryPrefix: only the literal lowercase,
-    // forward-slash "workflows/" counts as an already-prefixed key, and nothing
-    // else about the key is rewritten. Anything else is part of the NAME and must
-    // stay under the library root.
-    return /^workflows\//.test(listedKey) ? listedKey : `workflows/${listedKey}`;
+  /** Re-ask the server under a different spelling of the SAME name, without letting
+   *  the follow-up weaken what the server already told us. Returns true when the
+   *  retry settled the outcome (i.e. produced something other than another
+   *  authoritative absence). */
+  const reask = async (key: string, onUnreachable: (detail: string) => string): Promise<boolean> => {
+    attempted.push(key);
+    const retry = await fetchUserdataKey(key);
+    if (retry.kind === "unreachable") {
+      // The server ALREADY answered. A transport blip on the follow-up does not
+      // un-answer that (codex MAJOR): letting it become "unreachable" would re-open
+      // the reconstructed-local-dir fallback after the authority had spoken.
+      outcome = { kind: "refused", detail: onUnreachable(retry.detail) };
+      return true;
+    }
+    outcome = retry;
+    if (retry.kind !== "absent") {
+      // Remember which key was actually read, so a malformed / non-UI file names the
+      // file that was consulted rather than the caller's spelling.
+      resolvedKey = key;
+      return true;
+    }
+    return false;
   };
+
+  // SEPARATOR SPELLING, asked SERVER-FIRST (gate MEDIUM). The store key space is
+  // "/"-separated, so a backslash in the name is ONE literal character to the server
+  // — and on POSIX that is a legal filename — so the literal spelling must be asked
+  // for FIRST. Only once the server has authoritatively said it has no such file is
+  // the Windows-style reading tried, and both attempts are named in any refusal.
+  //
+  // That keeps a Windows caller's "recipes\name.json" working: it used to resolve
+  // through the local fallback, so refusing it outright was a regression on a path
+  // that worked, for panel_strip_workflow as much as panel_load_workflow. And it
+  // never substitutes a file while the literally-named one might still exist,
+  // because the literal key is disproved by the authority before the retry happens.
+  let matchRel = rel;
+  if (outcome.kind === "absent" && rel.includes("\\")) {
+    const slashRel = rel.replace(/\\/g, "/");
+    const slashKey = `workflows/${slashRel}`;
+    if (slashKey !== requestedKey) {
+      const settled = await reask(
+        slashKey,
+        (d) => `"${rel}" is not in the library, and re-reading it as "${slashRel}" failed: ${d}`,
+      );
+      // Absent under BOTH spellings: the literal reading is disproved, so the
+      // forward-slash reading is the only one left for the listing lookup below.
+      if (!settled) matchRel = slashRel;
+    }
+  }
+
+  // The server ANSWERED "no such name". Before giving up, ask it for its OWN listing
+  // and look for the same name in a different Unicode normal form — a name pasted
+  // from a listing (or produced on another OS) can be byte-different yet denote the
+  // same file, which is how a workflow that list_workflows plainly shows still 404s
+  // here. Only the SERVER's own entry is retried, so this resolves the name the
+  // connected ComfyUI itself reports; it never reconstructs a path. More than one
+  // match is AMBIGUOUS and is refused rather than guessed at.
+  //
+  // Listing entries are store-RELATIVE and carry NO prefix — verified on 0.29.2,
+  // where root files come back bare and nested ones as "sub/name.json" — so the
+  // store key is simply the entry under the library root, and nothing about the
+  // entry is rewritten (gate MAJOR). Stripping a "workflows/" prefix from an entry
+  // was how a subfolder literally named `workflows` came to impersonate the store
+  // root: its file lists as "workflows/x.json", which stripped to "x.json" and
+  // collided with the ROOT file of that name, so a bare request matched the nested
+  // entry and then fetched the different root file.
+  const storeKeyForListed = (listedKey: string): string => `workflows/${listedKey}`;
 
   let listedButUnserved: string | null = null;
   let nearMisses: string[] = [];
   let listingUnreadable = false;
-  let resolvedKey = requestedKey;
   if (outcome.kind === "absent") {
     const rawListed = await listUserdataWorkflowKeys();
     listingUnreadable = rawListed === null;
@@ -2547,23 +2585,18 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
     // deliberately liberal about separators — that is a REJECTION rule, where being
     // over-inclusive can only refuse more, never resolve to another file.
     const listed = rawListed?.filter((k) => {
-      const segs = stripLibraryPrefix(k.replace(/\\/g, "/")).split("/");
+      const segs = k.split(/[\\/]+/);
       return !segs.includes("..") && !segs.some((s) => /^[A-Za-z]:/.test(s));
     });
     if (listed) {
-      const want = matchStoreKey(rel);
-      // The ONLY accepted equivalence is Unicode normalization. NFC "é" and NFD
-      // "e"+U+0301 are the SAME character sequence written two ways — the same
-      // name, not a similar one — so retrying the server's form of it resolves
-      // the caller's name rather than substituting another.
-      //
-      // Letter case is deliberately NOT an accepted equivalence (codex MAJOR).
-      // On a case-insensitive filesystem the server's first GET already succeeds,
-      // so case never reaches here; on a case-sensitive one "Foo.json" and
-      // "foo.json" are two DIFFERENT files, and silently serving the other one is
-      // exactly the wrong-graph substitution this resolver must not make. A
-      // case-only near miss is instead NAMED in the refusal below.
-      const matches = listed.filter((k) => matchStoreKey(k) === want);
+      // Compared VERBATIM apart from Unicode normalization, which is what keeps
+      // request depth matched to entry depth: a name with no separator can only
+      // equal a depth-0 entry, and a name that includes a subfolder can only equal
+      // that exact path. Letter case and separator flavour are deliberately not
+      // folded — on a case-sensitive host "Foo.json" and "foo.json" are two
+      // different files — so those are NAMED as near misses below, never served.
+      const want = matchName(matchRel);
+      const matches = listed.filter((k) => matchName(k) === want);
       if (matches.length > 1) {
         throw new Error(
           `"${p}" is ambiguous in the connected ComfyUI's workflow library — it matches ` +
@@ -2574,34 +2607,23 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
       }
       if (matches.length === 1) {
         const retryKey = storeKeyForListed(matches[0]);
-        // Only re-ask when the server's spelling actually differs from what was
-        // already sent — otherwise this would repeat the request that just failed.
-        if (retryKey !== requestedKey) {
-          const retry = await fetchUserdataKey(retryKey);
-          if (retry.kind === "unreachable") {
-            // The server ALREADY answered — a 404 plus a readable listing. A
-            // transport blip on the follow-up does not un-answer that (codex
-            // MAJOR): letting it become "unreachable" would re-open the
-            // reconstructed-local-dir fallback after the authority had spoken.
-            outcome = {
-              kind: "refused",
-              detail: `the library lists "${matches[0]}", but re-reading it failed: ${retry.detail}`,
-            };
-          } else {
-            outcome = retry;
-            // Remember which key was actually read, so a malformed / non-UI file
-            // names the file that was consulted rather than the caller's spelling.
-            if (retry.kind !== "absent") resolvedKey = retryKey;
-          }
+        // Only re-ask when the server's spelling actually differs from every key
+        // already sent — otherwise this repeats a request that just failed.
+        if (!attempted.includes(retryKey)) {
+          await reask(
+            retryKey,
+            (d) => `the library lists "${matches[0]}", but re-reading it failed: ${d}`,
+          );
         }
-        // Still absent after retrying the server's OWN key: the library lists the
+        // Still absent after retrying the server's OWN entry: the library lists the
         // name but will not serve it. Say so — that is a server-side condition the
         // user must see, not a cue to go hunting for a local file.
         if (outcome.kind === "absent") listedButUnserved = matches[0];
       } else {
-        // Reported only. A key that differs by separator flavour or letter case is
-        // a DIFFERENT file on some filesystems, so it is never substituted.
-        nearMisses = listed.filter((k) => looseStoreKey(k) === looseStoreKey(rel));
+        // Reported only. A key that differs by separator flavour, letter case or
+        // normalization is a DIFFERENT file on some filesystems, so it is never
+        // substituted.
+        nearMisses = listed.filter((k) => looseName(k) === looseName(matchRel));
       }
     }
   }
@@ -2636,6 +2658,9 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
     // (#202). Refuse, naming exactly what was tried.
     throw new Error(
       `No workflow named "${p}" — it ${outcome.detail}.` +
+        (attempted.length > 1
+          ? ` Asked for ${attempted.map((k) => `"${k}"`).join(" and then ")}.`
+          : "") +
         (listingUnreadable
           ? ` Its workflow listing could not be read either, so no close match could be checked.`
           : "") +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2234,10 +2234,16 @@ function httpStatusOfError(err: unknown): number | undefined {
 }
 
 /** Drop the leading slashes and the one leading "workflows/" segment, leaving a
- *  store-RELATIVE key. Both separators are accepted here because either can spell
- *  that prefix, whichever OS produced the string. */
+ *  store-RELATIVE key.
+ *
+ *  Only the FORWARD-slash spelling counts as the library prefix (codex MAJOR).
+ *  ComfyUI store keys are always "/"-separated, so `workflows\foo.json` was never
+ *  one — while on POSIX it is a perfectly legal LITERAL filename. Accepting the
+ *  backslash spelling would silently rewrite a request for that literal file into
+ *  a request for `workflows/foo.json`, i.e. a different graph. A caller who types
+ *  the backslash form gets a refusal that names the close match instead. */
 const stripLibraryPrefix = (key: string): string =>
-  key.replace(/^[\\/]+/, "").replace(/^workflows[\\/]+/i, "");
+  key.replace(/^\/+/, "").replace(/^workflows\/+/i, "");
 
 /** The form two userdata store keys are compared in when deciding they are the
  *  SAME NAME. Unicode normalization is the only equivalence applied: NFD "é" and
@@ -2253,10 +2259,11 @@ const stripLibraryPrefix = (key: string): string =>
 const matchStoreKey = (key: string): string => stripLibraryPrefix(key).normalize("NFC");
 
 /** The looser form used ONLY to describe a near miss in an error message — never
- *  to select a file to load. Folds the two equivalences that are real on some
- *  filesystems and not on others: separator flavour and letter case. */
+ *  to select a file to load. Folds the equivalences that hold on some filesystems
+ *  and not others: separator flavour (including a backslash-spelled library
+ *  prefix) and letter case. */
 const looseStoreKey = (key: string): string =>
-  matchStoreKey(key).replace(/\\/g, "/").toLowerCase();
+  stripLibraryPrefix(key.replace(/\\/g, "/")).normalize("NFC").toLowerCase();
 
 /**
  * The connected ComfyUI's OWN list of saved workflow store keys, or null when the
@@ -2381,7 +2388,7 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
   // path all normalize to the same store-relative name. (A genuinely absolute path
   // — including a Windows leading-slash path — was already handled and returned
   // above, so it never reaches this relative-name normalization.)
-  const rel = p.replace(/^[\\/]+/, "").replace(/^workflows[\\/]+/i, "");
+  const rel = stripLibraryPrefix(p);
   // Refuse traversal / drive-relative escapes (codex): a real workflow name is a
   // plain relative path whose segments are filenames/subfolders. Stripping the
   // "workflows/" prefix must never turn the input into something that ESCAPES the
@@ -2490,7 +2497,7 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
     // deliberately liberal about separators — that is a REJECTION rule, where being
     // over-inclusive can only refuse more, never resolve to another file.
     const listed = rawListed?.filter((k) => {
-      const segs = stripLibraryPrefix(k).split(/[\/]+/);
+      const segs = stripLibraryPrefix(k.replace(/\\/g, "/")).split("/");
       return !segs.includes("..") && !segs.some((s) => /^[A-Za-z]:/.test(s));
     });
     if (listed) {
@@ -2520,10 +2527,22 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
         // Only re-ask when the server's spelling actually differs from what was
         // already sent — otherwise this would repeat the request that just failed.
         if (retryKey !== requestedKey) {
-          outcome = await fetchUserdataKey(retryKey);
-          // Remember which key was actually read, so a malformed / non-UI file
-          // names the file that was consulted rather than the caller's spelling.
-          if (outcome.kind !== "absent") resolvedKey = retryKey;
+          const retry = await fetchUserdataKey(retryKey);
+          if (retry.kind === "unreachable") {
+            // The server ALREADY answered — a 404 plus a readable listing. A
+            // transport blip on the follow-up does not un-answer that (codex
+            // MAJOR): letting it become "unreachable" would re-open the
+            // reconstructed-local-dir fallback after the authority had spoken.
+            outcome = {
+              kind: "refused",
+              detail: `the library lists "${matches[0]}", but re-reading it failed: ${retry.detail}`,
+            };
+          } else {
+            outcome = retry;
+            // Remember which key was actually read, so a malformed / non-UI file
+            // names the file that was consulted rather than the caller's spelling.
+            if (retry.kind !== "absent") resolvedKey = retryKey;
+          }
         }
         // Still absent after retrying the server's OWN key: the library lists the
         // name but will not serve it. Say so — that is a server-side condition the

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2395,7 +2395,23 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
         // OWN error, while ComfyUI's "200 + EMPTY body = file does not exist"
         // convention (some builds; see parseWorkflowLock) is an ABSENCE — an
         // authoritative "no such name", not a malformed file.
-        const body = (await res.text()).trim();
+        //
+        // The body read gets its OWN try/catch (codex MAJOR): a stream that aborts
+        // MID-BODY would otherwise fall out to the outer catch as a statusless
+        // error and be classified "unreachable", re-opening the reconstructed
+        // local fallback for a server that had in fact ANSWERED — the wrong-file
+        // path again. The server answered, so this is a refusal, not an absence.
+        let body: string;
+        try {
+          body = (await res.text()).trim();
+        } catch (err) {
+          return {
+            kind: "refused",
+            detail:
+              `ComfyUI answered ${res.status} for "${key}" but the response body could not be read ` +
+              `(${err instanceof Error ? err.message : String(err)})`,
+          };
+        }
         if (body === "") {
           return { kind: "absent", detail: `is not in the connected ComfyUI's workflow library (empty 200 response for "${key}")` };
         }
@@ -2436,14 +2452,23 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
   // reports — it never reconstructs a path. More than one match is AMBIGUOUS and
   // is refused rather than guessed at.
   let listedButUnserved: string | null = null;
+  let caseNearMisses: string[] = [];
   if (outcome.kind === "absent") {
     const listed = await listUserdataWorkflowKeys();
     if (listed) {
       const want = normalizeStoreKey(rel);
-      const exact = listed.filter((k) => normalizeStoreKey(k) === want);
-      const matches = exact.length
-        ? exact
-        : listed.filter((k) => normalizeStoreKey(k).toLowerCase() === want.toLowerCase());
+      // The ONLY accepted equivalence is Unicode normalization. NFC "é" and NFD
+      // "e"+U+0301 are the SAME character sequence written two ways — the same
+      // name, not a similar one — so retrying the server's form of it resolves
+      // the caller's name rather than substituting another.
+      //
+      // Letter case is deliberately NOT an accepted equivalence (codex MAJOR).
+      // On a case-insensitive filesystem the server's first GET already succeeds,
+      // so case never reaches here; on a case-sensitive one "Foo.json" and
+      // "foo.json" are two DIFFERENT files, and silently serving the other one is
+      // exactly the wrong-graph substitution this resolver must not make. A
+      // case-only near miss is instead NAMED in the refusal below.
+      const matches = listed.filter((k) => normalizeStoreKey(k) === want);
       if (matches.length > 1) {
         throw new Error(
           `"${p}" is ambiguous in the connected ComfyUI's workflow library — it matches ` +
@@ -2460,6 +2485,10 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
         // name but will not serve it. Say so — that is a server-side condition the
         // user must see, not a cue to go hunting for a local file.
         if (outcome.kind === "absent") listedButUnserved = matches[0];
+      } else {
+        caseNearMisses = listed.filter(
+          (k) => normalizeStoreKey(k).toLowerCase() === want.toLowerCase(),
+        );
       }
     }
   }
@@ -2491,6 +2520,11 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
         (listedButUnserved
           ? ` Its library DOES list "${listedButUnserved}", but the server would not serve that key —` +
             ` the file may have been removed or be unreadable on the ComfyUI machine.`
+          : "") +
+        (caseNearMisses.length
+          ? ` The library does list ${caseNearMisses.map((k) => `"${k}"`).join(", ")}, which differs` +
+            ` only in letter case — a different file on a case-sensitive filesystem, so it was NOT` +
+            ` substituted. Retype the name exactly if that is the one you meant.`
           : "") +
         ` The connected ComfyUI is the authority on its own user directory (it may have been started` +
         ` with --user-directory), so the orchestrator will NOT guess at a local path that could be a` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2233,13 +2233,30 @@ function httpStatusOfError(err: unknown): number | undefined {
   return typeof status === "number" && Number.isFinite(status) ? status : undefined;
 }
 
-/** Compare two userdata store keys the way a filesystem does: one path-separator
- *  flavour, one Unicode normal form. A name copied out of a listing (or typed on
- *  a different OS) can carry the SAME characters in a different normalization —
- *  NFD "é" vs NFC "é" are byte-different but the same file name, and a raw
- *  byte comparison 404s on a workflow that visibly exists in the library. */
-const normalizeStoreKey = (key: string): string =>
-  key.replace(/\\/g, "/").replace(/^\/+/, "").replace(/^workflows\/+/i, "").normalize("NFC");
+/** Drop the leading slashes and the one leading "workflows/" segment, leaving a
+ *  store-RELATIVE key. Both separators are accepted here because either can spell
+ *  that prefix, whichever OS produced the string. */
+const stripLibraryPrefix = (key: string): string =>
+  key.replace(/^[\\/]+/, "").replace(/^workflows[\\/]+/i, "");
+
+/** The form two userdata store keys are compared in when deciding they are the
+ *  SAME NAME. Unicode normalization is the only equivalence applied: NFD "é" and
+ *  NFC "é" are one character sequence written two ways, so a name pasted from a
+ *  listing (or produced on another OS) can be byte-different yet denote the same
+ *  file, and a raw byte comparison 404s on a workflow that visibly exists.
+ *
+ *  Path separators are deliberately NOT folded (codex MAJOR): on POSIX a file
+ *  literally named `dir\foo.json` is a DIFFERENT file from `dir/foo.json`, so
+ *  treating `\` as `/` here would let a request for one resolve to the other. Case
+ *  is not folded either, for the same reason. Both of those are instead reported
+ *  as near misses in the refusal. */
+const matchStoreKey = (key: string): string => stripLibraryPrefix(key).normalize("NFC");
+
+/** The looser form used ONLY to describe a near miss in an error message — never
+ *  to select a file to load. Folds the two equivalences that are real on some
+ *  filesystems and not on others: separator flavour and letter case. */
+const looseStoreKey = (key: string): string =>
+  matchStoreKey(key).replace(/\\/g, "/").toLowerCase();
 
 /**
  * The connected ComfyUI's OWN list of saved workflow store keys, or null when the
@@ -2464,17 +2481,20 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
   };
 
   let listedButUnserved: string | null = null;
-  let caseNearMisses: string[] = [];
+  let nearMisses: string[] = [];
+  let resolvedKey = requestedKey;
   if (outcome.kind === "absent") {
     const rawListed = await listUserdataWorkflowKeys();
     // A listing entry is server-supplied data, so it gets the SAME escape guard as
-    // caller input before it is echoed back as a request key.
+    // caller input before it is echoed back as a request key. The split is
+    // deliberately liberal about separators — that is a REJECTION rule, where being
+    // over-inclusive can only refuse more, never resolve to another file.
     const listed = rawListed?.filter((k) => {
-      const segs = normalizeStoreKey(k).split("/");
+      const segs = stripLibraryPrefix(k).split(/[\/]+/);
       return !segs.includes("..") && !segs.some((s) => /^[A-Za-z]:/.test(s));
     });
     if (listed) {
-      const want = normalizeStoreKey(rel);
+      const want = matchStoreKey(rel);
       // The ONLY accepted equivalence is Unicode normalization. NFC "é" and NFD
       // "e"+U+0301 are the SAME character sequence written two ways — the same
       // name, not a similar one — so retrying the server's form of it resolves
@@ -2486,7 +2506,7 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
       // "foo.json" are two DIFFERENT files, and silently serving the other one is
       // exactly the wrong-graph substitution this resolver must not make. A
       // case-only near miss is instead NAMED in the refusal below.
-      const matches = listed.filter((k) => normalizeStoreKey(k) === want);
+      const matches = listed.filter((k) => matchStoreKey(k) === want);
       if (matches.length > 1) {
         throw new Error(
           `"${p}" is ambiguous in the connected ComfyUI's workflow library — it matches ` +
@@ -2499,25 +2519,36 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
         const retryKey = storeKeyForListed(matches[0]);
         // Only re-ask when the server's spelling actually differs from what was
         // already sent — otherwise this would repeat the request that just failed.
-        if (retryKey !== requestedKey) outcome = await fetchUserdataKey(retryKey);
+        if (retryKey !== requestedKey) {
+          outcome = await fetchUserdataKey(retryKey);
+          // Remember which key was actually read, so a malformed / non-UI file
+          // names the file that was consulted rather than the caller's spelling.
+          if (outcome.kind !== "absent") resolvedKey = retryKey;
+        }
         // Still absent after retrying the server's OWN key: the library lists the
         // name but will not serve it. Say so — that is a server-side condition the
         // user must see, not a cue to go hunting for a local file.
         if (outcome.kind === "absent") listedButUnserved = matches[0];
       } else {
-        caseNearMisses = listed.filter(
-          (k) => normalizeStoreKey(k).toLowerCase() === want.toLowerCase(),
-        );
+        // Reported only. A key that differs by separator flavour or letter case is
+        // a DIFFERENT file on some filesystems, so it is never substituted.
+        nearMisses = listed.filter((k) => looseStoreKey(k) === looseStoreKey(rel));
       }
     }
   }
 
   if (outcome.kind === "found") {
     // A found-but-non-UI file must surface its own honest error, not silence.
-    return assertUiWorkflow(outcome.parsed, `The workflow "${p}" from the ComfyUI userdata library`);
+    return assertUiWorkflow(
+      outcome.parsed,
+      `The workflow "${p}" from the ComfyUI userdata library (read as "${resolvedKey}")`,
+    );
   }
   if (outcome.kind === "malformed") {
-    throw new Error(`The workflow "${p}" in the ComfyUI userdata library is not valid JSON: ${outcome.detail}`);
+    throw new Error(
+      `The workflow "${p}" in the ComfyUI userdata library (read as "${resolvedKey}") is not ` +
+        `valid JSON: ${outcome.detail}`,
+    );
   }
   if (outcome.kind === "refused") {
     // Server is reachable but did not serve the file — do NOT fall back to a
@@ -2540,9 +2571,9 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
           ? ` Its library DOES list "${listedButUnserved}", but the server would not serve that key —` +
             ` the file may have been removed or be unreadable on the ComfyUI machine.`
           : "") +
-        (caseNearMisses.length
-          ? ` The library does list ${caseNearMisses.map((k) => `"${k}"`).join(", ")}, which differs` +
-            ` only in letter case — a different file on a case-sensitive filesystem, so it was NOT` +
+        (nearMisses.length
+          ? ` The library does list ${nearMisses.map((k) => `"${k}"`).join(", ")}, which differs only` +
+            ` in letter case or path separator — a DIFFERENT file on some filesystems, so it was NOT` +
             ` substituted. Retype the name exactly if that is the one you meant.`
           : "") +
         ` The connected ComfyUI is the authority on its own user directory (it may have been started` +
@@ -2565,6 +2596,15 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
   // targets an external directory can't be read on the fallback (codex).
   // Canonicalizing BOTH sides keeps a legitimately-symlinked workflows dir working
   // (its base resolves too), while blocking a per-file escape.
+  //
+  // KNOWN AND ACCEPTED: this check is check-then-open, so it does not survive a
+  // concurrent swap of the checked file for a symlink between the realpath and the
+  // read (codex MAJOR). Closing that needs an fd-based open + fstat, and the threat
+  // it defends against is another process on the user's OWN machine racing their
+  // own workflow load — outside this project's trust model, where the orchestrator,
+  // the panel and the user are one trust domain. The check remains as a guard
+  // against a statically mis-linked workflows dir, which is the accidental case
+  // that actually happens.
   const realBaseUnder = (base: string, candidate: string): boolean => {
     try {
       const rb = realpathSync(base);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2341,11 +2341,12 @@ function assertUiWorkflow(parsed: unknown, sourceLabel: string): Record<string, 
  * so the resolver never guesses:
  *   - server serves the file            → load it
  *   - server refuses (401/403/5xx)      → error, no local fallback
- *   - server says it has no such name   → retry the server's OWN exact key if the
- *                                         listing has a single normalization/case
- *                                         match, otherwise REFUSE (an absence from
- *                                         the authority means any local hit is a
- *                                         DIFFERENT file)
+ *   - server says it has no such name   → retry the server's OWN exact key if its
+ *                                         listing has a single UNICODE-NORMALIZATION
+ *                                         match (case and separator differences are
+ *                                         named, never substituted), otherwise
+ *                                         REFUSE — an absence from the authority
+ *                                         means any local hit is a DIFFERENT file
  *   - name matches several library keys → REFUSE as ambiguous, naming them
  *   - server unreachable (no answer)    → best-effort reconstructed local dirs,
  *                                         and REFUSE if more than one file matches

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2235,6 +2235,10 @@ function httpStatusOfError(err: unknown): number | undefined {
 
 /** Drop the one leading "workflows/" segment, leaving a store-RELATIVE key.
  *
+ *  EXACTLY one separator is consumed (codex MAJOR). "workflows//foo.json" keeps
+ *  its second slash and stays "/foo.json" — collapsing runs of slashes would make
+ *  it an alias for the different key "foo.json".
+ *
  *  Nothing else is stripped. In particular a leading "/" is NOT removed (codex
  *  MAJOR): caller input can never reach here with one (that is an absolute path,
  *  handled earlier), so the only strings it would affect are LISTING entries —
@@ -2254,7 +2258,7 @@ function httpStatusOfError(err: unknown): number | undefined {
  *  stripping it would turn "WORKFLOWS/foo.json" into a request for the root
  *  "foo.json". */
 const stripLibraryPrefix = (key: string): string =>
-  key.replace(/^workflows\/+/, "");
+  key.replace(/^workflows\//, "");
 
 /** The form two userdata store keys are compared in when deciding they are the
  *  SAME NAME. Unicode normalization is the only equivalence applied: NFD "é" and

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2645,8 +2645,9 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
           : "") +
         (nearMisses.length
           ? ` The library does list ${nearMisses.map((k) => `"${k}"`).join(", ")}, which differs only` +
-            ` in letter case or path separator — a DIFFERENT file on some filesystems, so it was NOT` +
-            ` substituted. Retype the name exactly if that is the one you meant.`
+            ` in letter case, path separator, or Unicode normalization — a DIFFERENT file on some` +
+            ` filesystems, so it was NOT substituted. Retype the name exactly if that is the one` +
+            ` you meant.`
           : "") +
         ` The connected ComfyUI is the authority on its own user directory (it may have been started` +
         ` with --user-directory), so the orchestrator will NOT guess at a local path that could be a` +


### PR DESCRIPTION
Closes artokun/comfyui-mcp-panel#202

> **Repo note:** panel #202 reports a `panel_load_workflow` bug, but that tool's path resolution lives here in `src/orchestrator/panel-tools.ts` — the panel repo has no path resolver at all. So the fix ships from this repo, and the closing reference is owner-qualified. A bare `Closes #202` here would target comfyui-mcp#202, an unrelated already-merged PR.

## What was wrong

A relative `path` is a name in the connected ComfyUI's workflow library. That server is the only authority on where the library lives — `--user-directory` moves it somewhere the orchestrator cannot reconstruct. The resolver asked the server first, but then quietly second-guessed it. Each of these could hand the agent the **wrong graph to edit**:

1. **A refusal was indistinguishable from an unreachable server.** The client's `fetchApi` throws for every non-2xx *and* calls `response.json()` while building that error — so a refusal with a non-JSON body (a `403 text/plain` from a proxy, an HTML 502) rejected with a **statusless `SyntaxError`**. That was classified `unreachable`, which re-enabled the guessed-local-directory fallback *for a server that had explicitly refused*.
2. **An authoritative absence fell through to a guess.** When the server answered "no such name", the resolver still resolved it under `COMFYUI_PATH/user/default/workflows`. Under a custom `--user-directory` that is by construction the wrong directory.
3. **`process.cwd()` was a fallback base** — it cannot produce the named library workflow.
4. **Several key spellings aliased two different files**, in both the server key space and the local filesystem.

## What it does now

The governing rule is that loading the wrong graph is worse than loading none.

The resolver issues its own request via the client's `apiURL` + `apiHeaders` + `fetch` and keeps the raw `Response`, instead of the throw-on-non-2xx wrapper. That makes the central distinction **categorical rather than a heuristic**:

- **a `Response` exists** → the server *answered*. Classify by status, whatever the body turns out to be. Never fall back.
- **a throw** → no `Response` object exists at all (connect refused, DNS, TLS, timeout). This is the only state with no authority to defer to.

No body is read to decide reachability, so a reply that cannot be decoded can never masquerade as silence.

| Server response | Behaviour |
| --- | --- |
| serves the file | load it |
| refuses (401/403/5xx, or a 2xx whose body cannot be read) | error — no local fallback |
| says it has no such name | retry the server's **own listed key** when its listing has a single Unicode-normalization match; otherwise **refuse** |
| several listed keys match | **refuse** as ambiguous, naming them |
| no HTTP response at all | best-effort reconstructed local dirs, refusing when more than one file matches |

Refusals name exactly what was tried: the userdata key, whether the listing was readable, any near miss differing only in case / separator / normalization (named, never substituted), and the reconstructed directories. Discovery guidance points at `list_workflows` (the saved library) rather than `panel_list_workflows` (open tabs only).

The reported symptom — a workflow the library plainly lists still 404ing — is handled without guessing: on an absence the resolver asks the server for its own listing and re-asks with the server's **verbatim** key when exactly one entry matches after NFC normalization. NFC and NFD are two spellings of one character sequence; case and separator are not, and are never substituted.

## Verified against the live rig (ComfyUI 0.29.2)

The listing is fetched with `recurse=true`, **verified by probe** with a throwaway nested workflow (created and deleted):

- `?dir=workflows` → flat list of bare filename strings; the nested file is **absent**
- `?dir=workflows&recurse=true` → same list **plus** `"sub/name.json"`; root entries stay bare
- `?dir=workflows&full_info=true` → `[{path, size, modified, created}]`

Without it, a workflow in a subfolder whose name differs only by normalization had no listing entry to match and was refused. No version gate is needed: a build that does not implement the parameter ignores it and returns the flat list — exactly the previous behaviour (over-refusal of a nested near-miss, never a wrong file). That reasoning is recorded at the call site.

Adding it initially **caused a wrong-file load**, which is worth recording. Listing entries are relative to the store root, but the resolver was running caller-side normalization over them and stripping a leading `workflows/`. A library holding a subfolder literally named `workflows` lists its file as `"workflows/name.json"` - textually identical to what a prefixed root entry would look like. Stripped, it collided with the **root** file of that name, so a bare request matched the nested entry and the retry fetched the different root file. Entries are now compared and requested verbatim, so request depth must equal entry depth: a name with no separator can only match a depth-0 entry, and a name that includes a subfolder can only match that exact path.

## Not regressed

The default layout resolves through the userdata API exactly as before. The reconstructed-local-dir read still works when the server gives no answer at all, so a same-machine default-layout install keeps working during an outage.

## Deliberate behaviour changes

- A **reachable** server that 404s a name no longer falls back to a local file. A file staged into a *correctly guessed* dir would have been served by the server anyway; the only case this removes is the one where the guess was wrong.
- `process.cwd()` is gone as a resolution base. Pass an absolute path for a file outside the library.
- A relative name containing a **backslash** is asked for **literally first**. The library keys with `/`, and on POSIX a backslash is a legal filename character, so the server - the authority - is asked about the literal name before the Windows-style folder reading is tried. Both attempts are named in any refusal. (An earlier revision refused every backslash name outright; that regressed a path that worked, since a Windows caller's `recipes\name.json` used to resolve through the local fallback, for `panel_strip_workflow` as much as `panel_load_workflow`.)
- The **local fallback now enforces the same spelling rule as the server path**. `resolve()` answers in the filesystem's terms - collapsing repeated separators, and matching case-insensitively on Windows and macOS - so the unreachable-server branch was looser than everything else here. Every segment must now appear verbatim in its parent directory listing, and a file that exists under a different spelling is named in the refusal rather than loaded.
- Only one literal lowercase `workflows/` prefix is stripped — not a backslash spelling, a different case, a repeated slash, or a leading slash. Each was a wrong-file alias.

## Tests

`src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts` - 45 tests, up from 12. Custom user directory resolves; default layout unchanged; nested normalization near-miss resolves via the recursive listing; a nested `workflows` folder cannot satisfy a root request, and an explicit request for it does resolve; a backslash name is asked literally first, and a literal filename wins over the folder reading; refusals for a non-JSON 403, an HTML 502, a reachable 404 with a colliding local file, a 2xx with a failing body read, two normalizing library keys, two local candidates, a case-only near miss, and a retry that cannot be completed; and the local fallback refuses a case-different on-disk name and a collapsed repeated separator.

The two depth tests and the two local-spelling tests were each confirmed to **fail** against a deliberately reintroduced bug, so they are not vacuous. The platform-separator test asserts the load on Windows and the refusal on POSIX, so it is meaningful on either CI host.

Full suite: 4069 passed, 2 skipped. `tsc --noEmit` clean. `npm run check:vocabulary` passes.

## Adversarial review

Thirteen rounds of `codex exec` (`gpt-5.6-terra`) plus two external gate passes, final verdict **PASS**. Thirteen MAJORs found and fixed, each with a regression test:

- a refusal with a non-JSON body was classified as unreachable, re-opening the local fallback *(found by the external gate after nine of my own rounds passed it — the root cause of the original bug class, and the reason the request no longer goes through `fetchApi`)*
- a 2xx whose body read aborts was reclassified `unreachable`
- case-insensitive matching substituted a differently-cased file
- the retry re-derived the key instead of echoing the server's, so a decomposed-key library refused a uniquely listed workflow
- separator folding aliased `dir\foo.json` onto `dir/foo.json` (different files on POSIX)
- a backslash-spelled `workflows\` prefix was stripped, rewriting a literal filename into another key
- a statusless failure on the *retry* downgraded the server's authoritative absence
- case-insensitive, leading-slash, and repeated-slash prefix handling each aliased two distinct keys
- Windows `resolve()` reinterpreted a backslash in the store key, so the server branch and the local branch disagreed about what one name meant
- adding `recurse=true` let a nested folder named `workflows` impersonate the store root, so a bare request could fetch a different root file *(found by the external gate)*
- the unreachable-server local fallback was looser than the server path: `resolve()` collapsed repeated separators and matched case-insensitively, substituting a differently-spelled file
- with no server to disprove the literal reading, a backslash name still took the folder reading on POSIX, where a literal backslash filename can genuinely exist

**One finding accepted rather than fixed:** the local-fallback realpath containment check is check-then-open and does not survive a concurrent symlink swap. Closing it needs fd-based `open` + `fstat`, and the threat is another process on the user's own machine racing their own workflow load — outside this project's single-trust-domain model. Documented at the check.

## Needs human rig verification

The listing shape and `recurse=true` questions are now answered by probe. What remains is behavioural, on a machine actually running a custom user directory:

1. **The reported case end to end** — ComfyUI started with `--user-directory D:\user`, then `panel_load_workflow` with a bare saved-workflow name, and with a non-ASCII name such as the one in the recurrence report. This is the point of the fix and has never been exercised against a real custom user dir.
2. **No regression in the default layout** on a normal install: `panel_load_workflow` by name, and `panel_strip_workflow` (which shares this resolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
