### PR TITLE
docs: add a human-facing guide to calling tools, and real examples in the generated reference

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -44,6 +44,7 @@
             "pages": [
               "index",
               "quickstart",
+              "using-tools",
               "local-vs-comfy-cloud",
               "installation",
               "roadmap"

--- a/docs/tools/api-nodes.mdx
+++ b/docs/tools/api-nodes.mdx
@@ -6,6 +6,8 @@ icon: "cloud"
 
 <Info>3 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## list_api_nodes
 
 List hosted partner/API nodes available on the connected ComfyUI (e.g. Flux/BFL, Ideogram, Kling, Stability). These call external image/video providers and run server-side, requiring a Comfy account/API key configured on the ComfyUI server. Returns an empty list if the server has no API nodes (or they are disabled).
@@ -18,7 +20,7 @@ List hosted partner/API nodes available on the connected ComfyUI (e.g. Flux/BFL,
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -41,7 +43,7 @@ Return the input schema for a specific API/partner node from the connected Comfy
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -72,7 +74,7 @@ Build a minimal single-node workflow that runs a chosen API/partner node with th
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {

--- a/docs/tools/apps.mdx
+++ b/docs/tools/apps.mdx
@@ -6,6 +6,8 @@ icon: "layout-grid"
 
 <Info>1 tool. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## apps
 
 Micro-apps on this ComfyUI (panel Apps feature): named workflows packaged for one-click runs. Driven by the `action` parameter:
@@ -14,6 +16,8 @@ Micro-apps on this ComfyUI (panel Apps feature): named workflows packaged for on
 - action:"run" — Run one app: patches `values` (keys '&lt;nodeId&gt;.&lt;widget&gt;', e.g. &#123;"6.text": "a cat"&#125;) into the app's stored prompt snapshot and queues it on ComfyUI. Returns the prompt_id — poll action:"run_status". Only pass values for inputs listed in appMode.inputs; omitted inputs keep their conversion-time defaults.
 - action:"run_status" — Check one run by `app_id` + `prompt_id`: status (pending|running|done|unknown) plus the run's outputs (image/video file refs under each output node, text outputs). Read-only.
 - action:"import" — Install an app from the public registry: fetches the registry bundle (manifest + prompt snapshot [+ workflow unless hidden]) and creates it locally. The registry id becomes the local id, so re-importing reports an id conflict (already installed). Deps (models/custom nodes) are NOT installed — report the manifest's deps to the user so they can install them before running.
+
+<Tip>**In plain terms:** Micro-apps are workflows someone has already wired up and reduced to a few boxes to fill in — the closest thing here to a normal app. Handy on mobile, where there is no canvas to edit. One tool, several jobs, chosen with `action`.</Tip>
 
 ### Parameters
 
@@ -39,9 +43,9 @@ Micro-apps on this ComfyUI (panel Apps feature): named workflows packaged for on
   action:"import" — the registry version (recorded in local metadata).
 </ParamField>
 
-### Example
+### Examples
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** What one-click apps do I have?
 
 ```json
 {
@@ -51,5 +55,38 @@ Micro-apps on this ComfyUI (panel Apps feature): named workflows packaged for on
   }
 }
 ```
+
+**You get back:** Every installed app with its id, name and description. Read-only.
+
+**You say:** What do I need to fill in for the portrait one?
+
+```json
+{
+  "tool": "apps",
+  "arguments": {
+    "action": "get",
+    "app_id": "b1f4c2de-90a7-4c3e-9d21-5c8e2f7a13bb"
+  }
+}
+```
+
+**You get back:** That app's input form — each box with its label, type and default, and the key you set it by.
+
+**You say:** Run it with "a snow leopard on a rooftop".
+
+```json
+{
+  "tool": "apps",
+  "arguments": {
+    "action": "run",
+    "app_id": "b1f4c2de-90a7-4c3e-9d21-5c8e2f7a13bb",
+    "values": {
+      "6.text": "a snow leopard on a rooftop at dusk"
+    }
+  }
+}
+```
+
+**You get back:** A prompt_id immediately; the app renders in the background. Check on it with `action: "run_status"` and the same app_id plus that prompt_id. The odd-looking `"6.text"` key is nodeId.widget — the form from `action: "get"` tells you which keys exist.
 
 ---

--- a/docs/tools/assets-images.mdx
+++ b/docs/tools/assets-images.mdx
@@ -6,9 +6,13 @@ icon: "images"
 
 <Info>14 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## view_image
 
 Fetch a registered asset's bytes and return them as an inline image so the agent can see the result. Use this after enqueue_workflow completes (asset_id is included in the completion notification) to inspect, critique, or compare generated images. Only supports image mime types (PNG/JPEG/WebP); audio/video assets must be saved to disk via get_image.
+
+<Tip>**In plain terms:** Puts an image in front of the agent so it can actually look at it — for "is this any good?", "compare these two", "what is wrong with the hands".</Tip>
 
 ### Parameters
 
@@ -18,16 +22,18 @@ Fetch a registered asset's bytes and return them as an inline image so the agent
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Show me that one.
 
 ```json
 {
   "tool": "view_image",
   "arguments": {
-    "asset_id": "<asset_id>"
+    "asset_id": "asset_01HQ8Z3K7V"
   }
 }
 ```
+
+**You get back:** The image inline, visible to both of you. The asset id comes from the completion message of the run that made it.
 
 ---
 
@@ -52,16 +58,20 @@ Fetch a generated image from ComfyUI and return it as an inline image. Video/aud
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Save that render onto my desktop.
 
 ```json
 {
   "tool": "get_image",
   "arguments": {
-    "filename": "<filename>"
+    "filename": "portrait_00042_.png",
+    "type": "output",
+    "save_dir": "C:/Users/me/Desktop"
   }
 }
 ```
+
+**You get back:** The file copied to that folder, and the path it landed at. Use this rather than view_image for video and audio, which cannot be shown inline.
 
 ---
 
@@ -98,7 +108,7 @@ Re-encode a generated image to PNG, JPEG, or WebP and return it inline as an ima
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -141,7 +151,7 @@ Measure the color of a rendered image (not by eye): returns black/white points, 
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -170,7 +180,7 @@ Remove an image's background, returning a transparent (RGBA) cutout — the high
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -201,7 +211,7 @@ Upscale an image with an ESRGAN super-resolution model — the high-level entry 
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -238,7 +248,7 @@ Stage an EXISTING ComfyUI output (or temp/preview) as an INPUT so the next stage
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -269,7 +279,7 @@ Upload a generated ComfyUI output to cloud storage. Source can be asset_id or a 
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -297,7 +307,7 @@ Upload a local image file to the connected ComfyUI's input/ directory via the HT
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -325,7 +335,7 @@ Upload a local video file (.mp4, .mov, .webm, .avi, .mkv, .m4v) to the connected
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -353,7 +363,7 @@ Upload a local audio file (.wav, .mp3, .flac, .ogg, .m4a, .aac) to the connected
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -370,6 +380,8 @@ Upload a local audio file (.wav, .mp3, .flac, .ogg, .m4a, .aac) to the connected
 
 List recently generated image AND video files from ComfyUI's output/ directory, newest-first, with each file's kind ('image' | 'video'), subfolder, size, and modification time. Covers stills (.png/.jpg/.jpeg/.bmp) and video/animation outputs (.mp4/.webm/.mov/.mkv/.m4v/.avi/.gif/.webp). LOCAL ComfyUI (COMFYUI_PATH set): a RECURSIVE filesystem scan of output/ — includes subfolders like video/ that VHS/SaveVideo write to, and reports size + modification time. REMOTE ComfyUI: derives the list from /history over HTTP instead (size/modified are unavailable and omitted). It does NOT return the media bytes themselves — fetch those with get_image. USE THIS TO CONFIRM A VIDEO RENDER (e.g. VHS_VideoCombine / LTX / WAN output) when get_history shows the prompt done but lists no output: VHS-style video nodes write the file but often do NOT register in ComfyUI's /history, so the local filesystem scan is the reliable way to verify the .mp4 exists — then chain it with stage_output_as_input. Read-only.
 
+<Tip>**In plain terms:** What has ComfyUI actually written to disk lately. Worth knowing: video nodes often finish without registering in ComfyUI's history, so this is the reliable way to confirm a video really rendered.</Tip>
+
 ### Parameters
 
 <ParamField path="limit" type="integer">
@@ -382,16 +394,34 @@ List recently generated image AND video files from ComfyUI's output/ directory, 
   Response shape: markdown (default, human/agent-readable) or json (&#123;images:[&#123;filename,subfolder,kind,size,modified&#125;]&#125; — for app clients building pick grids). Options: `markdown`, `json`.
 </ParamField>
 
-### Example
+### Examples
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Show me the last few things I generated.
 
 ```json
 {
   "tool": "list_output_images",
-  "arguments": {}
+  "arguments": {
+    "limit": 10
+  }
 }
 ```
+
+**You get back:** The ten newest files, newest first, each with whether it is an image or a video, its folder, size and time. Not the pictures themselves — ask to see one and the agent fetches it.
+
+**You say:** Did that fox render ever come out?
+
+```json
+{
+  "tool": "list_output_images",
+  "arguments": {
+    "pattern": "fox",
+    "limit": 5
+  }
+}
+```
+
+**You get back:** Only files whose names contain "fox".
 
 ---
 
@@ -410,7 +440,7 @@ List recently generated assets, newest-first. Each call first reconciles ComfyUI
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -433,7 +463,7 @@ Get full provenance for a registered asset including the workflow snapshot that 
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {

--- a/docs/tools/comfy-cli.mdx
+++ b/docs/tools/comfy-cli.mdx
@@ -6,6 +6,8 @@ icon: "terminal"
 
 <Info>1 tool. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## comfy_cli
 
 Drive the official comfy-cli (envelope/1 JSON contract) for the selected ComfyUI environment. The MCP resolves `comfy` from COMFY_CLI_PATH, PATH, or the selected workspace's .venv/venv. Driven by the `action` parameter:
@@ -122,7 +124,7 @@ Drive the official comfy-cli (envelope/1 JSON contract) for the selected ComfyUI
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {

--- a/docs/tools/custom-nodes.mdx
+++ b/docs/tools/custom-nodes.mdx
@@ -6,6 +6,8 @@ icon: "puzzle"
 
 <Info>21 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## search_custom_nodes
 
 Search the public ComfyUI Registry (registry.comfy.org) for custom node packs by keyword. Read-only and network-only: queries the hosted registry over HTTP and does NOT require a running ComfyUI or COMFYUI_PATH. Returns a ranked list of packs with id, name, author, install count, and latest version. Use to discover packs to install; pass a returned id to get_node_pack_details for full info. This searches node PACKS, not models (use search_models) and not local installs (use list_local_models).
@@ -24,16 +26,19 @@ Search the public ComfyUI Registry (registry.comfy.org) for custom node packs by
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Is there a node pack for face detailing?
 
 ```json
 {
   "tool": "search_custom_nodes",
   "arguments": {
-    "query": "<query>"
+    "query": "face detailer",
+    "limit": 5
   }
 }
 ```
+
+**You get back:** Matching packs from the registry with their ids, authors and descriptions. The id is what install_custom_node wants.
 
 ---
 
@@ -49,7 +54,7 @@ Get full details for one ComfyUI custom node pack from the public ComfyUI Regist
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -92,16 +97,20 @@ Install a ComfyUI custom node pack by registry id, git URL, or name. Local insta
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Install the Impact Pack.
 
 ```json
 {
   "tool": "install_custom_node",
   "arguments": {
-    "id": "<id>"
+    "id": "comfyui-impact-pack"
   }
 }
 ```
+
+**You get back:** Progress, then confirmation. New nodes do not appear until ComfyUI restarts — the agent will normally offer to do that for you.
+
+<Warning>A custom node pack is third-party code that runs inside your ComfyUI. Install packs you have reason to trust, the same as any other plugin.</Warning>
 
 ---
 
@@ -126,7 +135,7 @@ Update an installed ComfyUI custom node pack, or pass 'all' to update every inst
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -163,7 +172,7 @@ Reinstall a ComfyUI custom node pack. Local operations prefer official comfy-cli
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -197,7 +206,7 @@ Repair a ComfyUI custom node pack's install and Python dependencies, or pass 'al
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -225,7 +234,7 @@ List installed ComfyUI custom node packs with their version and enabled/disabled
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -244,7 +253,7 @@ Reconcile the Python dependencies of all installed custom node packs through off
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -267,7 +276,7 @@ Analyze a ComfyUI workflow (API JSON) and determine which custom node packs it r
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -284,6 +293,8 @@ Analyze a ComfyUI workflow (API JSON) and determine which custom node packs it r
 
 Resolve and install the custom node packs a ComfyUI workflow requires via ComfyUI-Manager. Determines the missing packs, resets the Manager queue, queues the installs, starts the worker, and reports what was installed/already-present/unresolved. Runs server-side through ComfyUI-Manager on the connected instance (works against a local OR remote --comfyui-url target); a ComfyUI restart is typically needed before new nodes load. Mirrors `comfy-cli node install-deps`.
 
+<Tip>**In plain terms:** For a workflow someone sent you that is full of red nodes: this installs the node PACKS it needs. Missing model files are a different problem — that is resolve_missing_models.</Tip>
+
 ### Parameters
 
 <ParamField path="workflow" type="string | object" required>
@@ -292,16 +303,37 @@ Resolve and install the custom node packs a ComfyUI workflow requires via ComfyU
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Someone sent me this workflow and half the nodes are red. Fix it.
 
 ```json
 {
   "tool": "install_workflow_dependencies",
   "arguments": {
-    "workflow": "<workflow>"
+    "workflow": {
+      "4": {
+        "class_type": "CheckpointLoaderSimple",
+        "inputs": {
+          "ckpt_name": "sd_xl_base_1.0.safetensors"
+        }
+      },
+      "9": {
+        "class_type": "SaveImage",
+        "inputs": {
+          "filename_prefix": "portrait",
+          "images": [
+            "8",
+            0
+          ]
+        }
+      }
+    }
   }
 }
 ```
+
+<Note>Shortened for readability — two nodes of a real API-format graph are shown. In practice the agent passes the whole thing: the graph it just loaded with get_workflow, or the one it built for you.</Note>
+
+**You get back:** What it installed, what was already there, and anything it could not find. A restart is normally needed before the nodes load.
 
 ---
 
@@ -312,6 +344,8 @@ Custom-node snapshots via ComfyUI-Manager (mirrors `comfy node save-snapshot` / 
 - action:"save" — Save the current custom-node and version state. With no `name`, Manager assigns a timestamped snapshot (works against remote instances). Providing `name` writes a custom-named snapshot file, which requires a local ComfyUI install and is unavailable in remote (--comfyui-url) mode.
 - action:"restore" — Restore a previously saved snapshot by `name` (required). ComfyUI-Manager applies the custom-node changes on the next ComfyUI restart; use action:"list" to find available names.
 
+<Tip>**In plain terms:** A restore point for your installed node packs. Take one before a round of installing, and you have a way back if something breaks.</Tip>
+
 ### Parameters
 
 <ParamField path="action" type="enum" required>
@@ -321,18 +355,37 @@ Custom-node snapshots via ComfyUI-Manager (mirrors `comfy node save-snapshot` / 
   Snapshot name (no extension, no path separators). REQUIRED for action:"restore" (as shown by action:"list"). OPTIONAL for action:"save" — omit to let ComfyUI-Manager assign a timestamped name. Ignored by action:"list".
 </ParamField>
 
-### Example
+### Examples
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Save where my nodes are at before I start installing things.
 
 ```json
 {
   "tool": "node_snapshot",
   "arguments": {
-    "action": "list"
+    "action": "save",
+    "name": "before-impact-pack"
   }
 }
 ```
+
+**You get back:** Confirmation that the snapshot was recorded.
+
+**You say:** That broke everything. Put it back how it was.
+
+```json
+{
+  "tool": "node_snapshot",
+  "arguments": {
+    "action": "restore",
+    "name": "before-impact-pack"
+  }
+}
+```
+
+**You get back:** What it added, removed or re-pinned to match the snapshot.
+
+<Warning>Restoring rewrites your installed node packs to match the snapshot — anything installed since is uninstalled or downgraded.</Warning>
 
 ---
 
@@ -354,7 +407,7 @@ All actions are argument-free; `action` is the only parameter. `good`/`bad` requ
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -400,7 +453,7 @@ Generate a new ComfyUI custom-node pack from a template into &lt;COMFYUI_PATH&gt
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -432,7 +485,7 @@ Test that a custom-node pack actually loads in ComfyUI — the middle step of th
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -458,7 +511,7 @@ Publish a local custom-node pack to the public Comfy Registry (registry.comfy.or
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -487,7 +540,7 @@ List the files in one installed custom-node pack under &lt;COMFYUI_PATH&gt;/cust
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -521,7 +574,7 @@ Read a slice of one file inside a custom-node pack (read-only), with bounded out
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -558,7 +611,7 @@ Regex-search custom-node source under custom_nodes/ (read-only). Uses ripgrep wh
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -592,7 +645,7 @@ Create or overwrite one file inside a custom-node pack under custom_nodes/. Refu
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -618,7 +671,7 @@ Apply a unified diff to custom-node source under custom_nodes/. Every touched pa
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -655,7 +708,7 @@ Run a git operation inside one custom-node pack (status/diff/log/commit/push). R
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {

--- a/docs/tools/defaults-stats-skills.mdx
+++ b/docs/tools/defaults-stats-skills.mdx
@@ -6,6 +6,8 @@ icon: "sliders"
 
 <Info>7 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## get_defaults
 
 Return the merged view of generation defaults with per-source attribution. Precedence (lowest → highest): config file → COMFYUI_DEFAULT_* env vars → runtime overrides via set_defaults. Per-call MCP tool args always win over these defaults when consumed by a workflow-construction tool.
@@ -14,7 +16,7 @@ Return the merged view of generation defaults with per-source attribution. Prece
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** What settings do you use when I don't say?
 
 ```json
 {
@@ -23,11 +25,15 @@ Return the merged view of generation defaults with per-source attribution. Prece
 }
 ```
 
+**You get back:** The current fallback size, steps, cfg, sampler and checkpoint, and where each came from.
+
 ---
 
 ## set_defaults
 
 Update generation defaults. By default updates the in-memory runtime layer (lost on restart). Pass persist=true to also write the change into the config file (~/.config/comfyui-mcp/config.json by default). Use this to avoid repeating common values like width, height, steps, cfg, sampler, checkpoint.
+
+<Tip>**In plain terms:** Stop repeating yourself. Set the values you always want once, and leave them out of every later request.</Tip>
 
 ### Parameters
 
@@ -40,16 +46,23 @@ Update generation defaults. By default updates the in-memory runtime layer (lost
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Always use 1024 by 1024 and 30 steps, permanently.
 
 ```json
 {
   "tool": "set_defaults",
   "arguments": {
-    "values": "<values>"
+    "values": {
+      "width": 1024,
+      "height": 1024,
+      "steps": 30
+    },
+    "persist": true
   }
 }
 ```
+
+**You get back:** Confirmation of the new defaults. `persist: true` writes them to your config file so they survive a restart; without it they last only for this session.
 
 ---
 
@@ -68,7 +81,7 @@ Read the ComfyUI frontend's per-user UI settings (the Comfy.* ids the Settings p
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -94,7 +107,7 @@ Modify the ComfyUI user's persisted frontend UI setting by id. This writes Comfy
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -129,7 +142,7 @@ Recommend concrete, proven sampler/scheduler/steps/CFG (and denoise/shift/LoRA) 
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -152,7 +165,7 @@ Show statistics from this MCP server's local generation-history database (popula
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -181,7 +194,7 @@ Generate a Claude skill (SKILL.md) documenting a ComfyUI custom node pack: its n
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {

--- a/docs/tools/image-generation.mdx
+++ b/docs/tools/image-generation.mdx
@@ -6,9 +6,13 @@ icon: "image"
 
 <Info>7 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## generate_image
 
 Generate an image from a text prompt — the high-level entry point. Builds a txt2img workflow, filling any unspecified parameter from your configured defaults (set_defaults / COMFYUI_DEFAULT_* / config file), auto-selecting a local checkpoint when none is given. Returns the prompt_id immediately; the resulting asset_id arrives in the completion notification and can be passed to view_image or regenerate. For full control over the node graph, use create_workflow + enqueue_workflow instead.
+
+<Tip>**In plain terms:** The one-line way to get a picture. You do not need a workflow open, or any workflow at all — describe the image and this builds and runs a sensible graph for you. Everything except the prompt is optional and falls back to your saved defaults.</Tip>
 
 ### Parameters
 
@@ -46,18 +50,39 @@ Generate an image from a text prompt — the high-level entry point. Builds a tx
   Number of images to generate
 </ParamField>
 
-### Example
+### Examples
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Make me a picture of a red fox in the snow.
 
 ```json
 {
   "tool": "generate_image",
   "arguments": {
-    "prompt": "<prompt>"
+    "prompt": "a red fox in deep snow, golden hour, sharp focus"
   }
 }
 ```
+
+**You get back:** The finished image, inline in the conversation, plus the seed and settings that produced it so you can ask for the same thing again.
+
+**You say:** Same fox, but widescreen, more detail, and keep it repeatable.
+
+```json
+{
+  "tool": "generate_image",
+  "arguments": {
+    "prompt": "a red fox in deep snow, golden hour, sharp focus",
+    "negative_prompt": "blurry, watermark, text",
+    "width": 1344,
+    "height": 768,
+    "steps": 30,
+    "cfg": 4.5,
+    "seed": 12345
+  }
+}
+```
+
+**You get back:** The same fields plus the image. Because `seed` was pinned, running this again with the same settings gives the same picture — that is how you iterate on one image instead of rolling a new one each time.
 
 ---
 
@@ -109,7 +134,7 @@ Generate an image conditioned by a ControlNet preprocessed image (pose skeleton,
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -174,7 +199,7 @@ Generate an image guided by a reference image's style/subject via IP-Adapter, pl
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -206,7 +231,7 @@ Re-enqueue the workflow that produced an existing asset, optionally applying par
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -315,7 +340,7 @@ Generate audio from a text prompt — supports ACE Step 1.5 and Stable Audio 3 m
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -375,16 +400,21 @@ Generate a short video from a text prompt (text-to-video), or animate a start im
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Turn that fox picture into a short clip of it walking.
 
 ```json
 {
   "tool": "generate_video",
   "arguments": {
-    "prompt": "<prompt>"
+    "prompt": "a red fox walking through deep snow, camera slowly pushing in",
+    "seconds": 5,
+    "resolution": "832x480",
+    "fps": 16
   }
 }
 ```
+
+**You get back:** A path to the rendered video file plus the settings used. Video takes far longer than a still — minutes, not seconds — so the agent will usually tell you it has started and then report back.
 
 ---
 
@@ -415,7 +445,7 @@ Generate a 3D model (glb/obj/fbx) from a text prompt or an input image, using th
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {

--- a/docs/tools/install-environment.mdx
+++ b/docs/tools/install-environment.mdx
@@ -6,6 +6,8 @@ icon: "wrench"
 
 <Info>10 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## install_comfyui
 
 Install ComfyUI locally: git-clone it into a target directory, create a dedicated workspace virtualenv (&lt;target&gt;/.venv), and install Python requirements INTO that venv (never the Python running this MCP server) via pip or uv. ComfyUI-Manager is installed from manager_requirements.txt when present, else git-cloned as a fallback. Mirrors `comfy-cli install`. LOCAL, subprocess-only and independent of any remote --comfyui-url target; the target dir must be empty or non-existent (an existing install is never overwritten). Runs SYNCHRONOUSLY and can take several minutes (large git clone + full torch/dependency install); the call blocks until done. On success returns a JSON report &#123; installed, targetPath, venvPath, comfyuiUrl, managerInstalled, managerVia, version, pythonInstaller, steps[] &#125;. Does NOT start ComfyUI.
@@ -27,7 +29,7 @@ Install ComfyUI locally: git-clone it into a target directory, create a dedicate
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -48,7 +50,7 @@ Update the ComfyUI core install: runs `git pull` in the configured ComfyUI direc
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -67,7 +69,7 @@ Update ALL installed custom nodes via the ComfyUI-Manager HTTP API (queues updat
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -82,6 +84,8 @@ Update ALL installed custom nodes via the ComfyUI-Manager HTTP API (queues updat
 
 Install, update, reinstall, sync, pin, or report status of the ComfyUI sidebar panel ('comfyui-agent-panel' on the Comfy Registry; repo comfyui-mcp-panel) in the LOCAL ComfyUI's custom_nodes. Uses the same ComfyUI-Manager path as install_custom_node and always targets the 'nightly' (git-HEAD) channel. Local-only (no-op/refuses in remote/cloud mode) and NEVER modifies a dev install (a symlinked panel dir). After install/update/reinstall/sync, ComfyUI must be RESTARTED to load the new/updated node — this tool does not auto-restart. The panel is also auto-installed-if-missing when the MCP server loads. A version PIN (action='pin') holds the panel where it is: while a pin is set, install/update/reinstall/sync and the auto-install all refuse, and 'sync' only warns that a newer panel exists.
 
+<Tip>**In plain terms:** Installs and updates the Agent sidebar inside ComfyUI. This is the fix when a tool refuses with "this panel is too old".</Tip>
+
 ### Parameters
 
 <ParamField path="action" type="enum" default="status">
@@ -94,16 +98,33 @@ Install, update, reinstall, sync, pin, or report status of the ComfyUI sidebar p
   action='pin' only: why the user is pinning (stored with the pin).
 </ParamField>
 
-### Example
+### Examples
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** What version of the panel have I got?
 
 ```json
 {
   "tool": "install_panel",
-  "arguments": {}
+  "arguments": {
+    "action": "status"
+  }
 }
 ```
+
+**You get back:** The installed panel version, where it lives, and whether it is pinned. This action changes nothing.
+
+**You say:** It says my panel is too old — update it.
+
+```json
+{
+  "tool": "install_panel",
+  "arguments": {
+    "action": "update"
+  }
+}
+```
+
+**You get back:** The update result. Two more steps are yours: restart ComfyUI, then hard-refresh the ComfyUI browser tab (Ctrl+Shift+R). Without that refresh the tab keeps running the old cached panel code and the same refusal comes back.
 
 ---
 
@@ -117,16 +138,33 @@ Check or apply a self-update of the comfyui-mcp npm package against the npm regi
   status: report install mode + current vs latest version + dev-link note (never errors). update: update to the latest published version (refuses on a dev link; no-op when already up to date or for npx). Options: `status`, `update`.
 </ParamField>
 
-### Example
+### Examples
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Am I on the latest version?
 
 ```json
 {
   "tool": "self_update",
-  "arguments": {}
+  "arguments": {
+    "action": "status"
+  }
 }
 ```
+
+**You get back:** Your version, the latest published version, and whether they differ.
+
+**You say:** Update it.
+
+```json
+{
+  "tool": "self_update",
+  "arguments": {
+    "action": "update"
+  }
+}
+```
+
+**You get back:** The upgrade result. Your MCP client has to be restarted afterwards to pick up the new server.
 
 ---
 
@@ -145,7 +183,7 @@ Apply a ComfyUI setup manifest from an inline object or .json/.yaml/.yml file. C
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -163,6 +201,8 @@ Inspect and manage ComfyUI workspaces (local installs). Driven by the `action` p
 - action:"set_default" — Persist a default ComfyUI workspace path to the MCP config file (mirrors `comfy-cli set-default`). The value is stored under the OS config dir (e.g. ~/.config/comfyui-mcp/workspace.json) and reported by action:"get"/action:"list". Does NOT change the live API target. `path` is REQUIRED, e.g. &#123;action:"set_default", path:"/opt/ComfyUI"&#125;.
 - action:"list" — List known/auto-detected ComfyUI installations on this machine. Scans common install locations across macOS, Linux, and Windows and marks which one is active and which is the saved default.
 
+<Tip>**In plain terms:** Which ComfyUI installation everything else is talking about. One tool, three jobs, chosen with `action` — this is the tool the [consolidation note](/using-tools#one-tool-several-jobs) uses as its worked example.</Tip>
+
 ### Parameters
 
 <ParamField path="action" type="enum" required>
@@ -172,19 +212,34 @@ Inspect and manage ComfyUI workspaces (local installs). Driven by the `action` p
   action:"set_default" — REQUIRED absolute path to a ComfyUI installation directory to remember as the default workspace.
 </ParamField>
 
-### Example
+### Examples
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Which ComfyUI am I actually using?
+
+```json
+{
+  "tool": "workspace",
+  "arguments": {
+    "action": "get"
+  }
+}
+```
+
+**You get back:** The active install's path and how it was chosen — a flag, an environment variable, or the saved default.
+
+**You say:** Always use the one on my big drive from now on.
 
 ```json
 {
   "tool": "workspace",
   "arguments": {
     "action": "set_default",
-    "path": "/opt/ComfyUI"
+    "path": "D:/AI/ComfyUI"
   }
 }
 ```
+
+**You get back:** Confirmation, and it sticks across restarts. Later sessions target this install unless something overrides it.
 
 ---
 
@@ -196,7 +251,7 @@ Report ComfyUI environment info (mirrors `comfy-cli env`): the running instance 
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Tell me about my setup — useful when I'm reporting a bug.
 
 ```json
 {
@@ -204,6 +259,8 @@ Report ComfyUI environment info (mirrors `comfy-cli env`): the running instance 
   "arguments": {}
 }
 ```
+
+**You get back:** Where ComfyUI is installed, the Python and torch versions, the GPU, and which settings are in force. The first thing to paste into an issue.
 
 ---
 
@@ -222,7 +279,7 @@ Configure ComfyUI-Manager settings, mirroring `comfy-cli manager` subcommands. M
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -265,16 +322,20 @@ File or triage a GitHub issue for a bug/problem you hit (ComfyUI, a workflow, a 
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** This keeps crashing. File a bug about it.
 
 ```json
 {
   "tool": "report_issue",
   "arguments": {
-    "title": "<title>",
-    "body": "<body>"
+    "title": "Video render finishes but no file appears in outputs",
+    "body": "Running the WAN template completes and history shows success, but output/video/ is empty. Happens every time on 0.49.3."
   }
 }
 ```
+
+**You get back:** A GitHub issue on the project, with your environment details attached automatically, and a link to it.
+
+<Warning>This posts publicly. The environment block it attaches includes paths and versions from your machine — glance at what it drafted before agreeing to send it.</Warning>
 
 ---

--- a/docs/tools/models.mdx
+++ b/docs/tools/models.mdx
@@ -6,6 +6,8 @@ icon: "box"
 
 <Info>16 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## search_models
 
 Search HuggingFace Hub for models usable in ComfyUI (checkpoints, LoRAs, VAEs, ControlNets, etc.). Read-only and network-only: queries HuggingFace over HTTP, does NOT require a running ComfyUI or COMFYUI_PATH and does not download anything. Returns a ranked list with modelId, author, downloads, likes, and tags. Pick a result's download URL and pass it to download_model to install it locally. For CIVITAI searches ('find a Flux LoRA on Civitai') use search_civitai_models instead — it filters by type + base model and returns ids for download_civitai_model. For packs of custom nodes (not models) use search_custom_nodes.
@@ -24,16 +26,19 @@ Search HuggingFace Hub for models usable in ComfyUI (checkpoints, LoRAs, VAEs, C
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Find me a Flux model I can actually run.
 
 ```json
 {
   "tool": "search_models",
   "arguments": {
-    "query": "<query>"
+    "query": "flux schnell",
+    "limit": 5
   }
 }
 ```
+
+**You get back:** Matching models with their download URLs and file sizes. Nothing is downloaded — this is a search.
 
 ---
 
@@ -67,7 +72,7 @@ Search CivitAI by keyword for checkpoints, LoRAs, embeddings, VAEs, and ControlN
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -96,7 +101,7 @@ Find CivitAI CREATORS — THE tool for 'who are the top creators on Civitai' and
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -128,17 +133,21 @@ Download a model file to the connected ComfyUI's models directory from a URL (Hu
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Get that one.
 
 ```json
 {
   "tool": "download_model",
   "arguments": {
-    "url": "<url>",
-    "target_subfolder": "<target_subfolder>"
+    "url": "https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/flux1-schnell.safetensors",
+    "target_subfolder": "checkpoints"
   }
 }
 ```
+
+**You get back:** Live progress in the panel's download tray, and the path the file landed at. `target_subfolder` decides which ComfyUI dropdown it shows up in — checkpoints, loras, vae and so on.
+
+<Warning>Model files are large — many are 5-25 GB. Check you have the disk space before agreeing to a few of these.</Warning>
 
 ---
 
@@ -163,7 +172,7 @@ Download a model from CivitAI into the connected ComfyUI's models/ directory. Re
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -180,6 +189,8 @@ Download a model from CivitAI into the connected ComfyUI's models/ directory. Re
 
 Find the model files a workflow needs but this ComfyUI does NOT have, and search CivitAI + HuggingFace for installable candidates. THE tool for 'this Template says a model is missing — go get it'. Detects by comparing each model widget against the option list the server actually publishes, so it covers checkpoints, LoRAs, VAEs, ControlNets, UNets, CLIP and custom-pack model types without any per-node mapping. Each candidate reports size, source, precision/quantisation (fp16 / fp8 / GGUF Q4_K_M …) and whether it FITS this GPU's VRAM — so when the exact file is too big you can see the quantised variant that isn't. Read-only: it downloads nothing. Pass a chosen candidate to download_model (url) or download_civitai_model (id), using the reported directory as target_subfolder. For missing custom NODE PACKS (not models) use install_workflow_dependencies instead.
 
+<Tip>**In plain terms:** The answer to "this workflow says a model is missing". It works out what is actually absent and finds downloadable candidates, including smaller quantised versions when the full file will not fit your GPU.</Tip>
+
 ### Parameters
 
 <ParamField path="workflow" type="string | object" required>
@@ -191,16 +202,37 @@ Find the model files a workflow needs but this ComfyUI does NOT have, and search
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** This workflow won't run, it says something's missing. Find it for me.
 
 ```json
 {
   "tool": "resolve_missing_models",
   "arguments": {
-    "workflow": "<workflow>"
+    "workflow": {
+      "4": {
+        "class_type": "CheckpointLoaderSimple",
+        "inputs": {
+          "ckpt_name": "sd_xl_base_1.0.safetensors"
+        }
+      },
+      "9": {
+        "class_type": "SaveImage",
+        "inputs": {
+          "filename_prefix": "portrait",
+          "images": [
+            "8",
+            0
+          ]
+        }
+      }
+    }
   }
 }
 ```
+
+<Note>Shortened for readability — two nodes of a real API-format graph are shown. In practice the agent passes the whole thing: the graph it just loaded with get_workflow, or the one it built for you.</Note>
+
+**You get back:** Each missing file with candidate downloads, their sizes and precision, and whether each one fits your VRAM. It downloads nothing — you pick, then it fetches.
 
 ---
 
@@ -216,14 +248,18 @@ List model files available to the connected ComfyUI, grouped by type. Read-only.
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Which checkpoints do I already have?
 
 ```json
 {
   "tool": "list_local_models",
-  "arguments": {}
+  "arguments": {
+    "model_type": "checkpoints"
+  }
 }
 ```
+
+**You get back:** The model filenames in that folder — the exact strings a workflow needs. Omit `model_type` to see every folder at once.
 
 ---
 
@@ -242,7 +278,7 @@ Check on model downloads started by download_model. Reports each download's stat
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -265,7 +301,7 @@ Cancel ONE in-flight model download started by download_model / download_civitai
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -290,16 +326,20 @@ Delete a model file from the local ComfyUI models directories. Resolves the path
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Delete that old LoRA, I'm out of disk space.
 
 ```json
 {
   "tool": "remove_model",
   "arguments": {
-    "path": "<path>"
+    "path": "loras/old-character-v1.safetensors"
   }
 }
 ```
+
+**You get back:** Confirmation, and how much space came back.
+
+<Warning>This deletes the file. There is no undo and no recycle bin — you would have to download it again. Check the path is the one you mean.</Warning>
 
 ---
 
@@ -318,7 +358,7 @@ View ComfyUI extra search-path config for standalone/manual installs and ComfyUI
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -356,7 +396,7 @@ Add a directory to a ComfyUI extra search-path YAML config. Use this for model c
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -394,7 +434,7 @@ Remove a directory from a ComfyUI extra search-path YAML config. Matches the sto
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -416,7 +456,7 @@ List textual-inversion embeddings installed on the connected ComfyUI server (rea
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -442,7 +482,7 @@ Free GPU VRAM by unloading cached models from ComfyUI. Use this between generati
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -483,7 +523,7 @@ Curate a model file's embedded .safetensors metadata (Model Explorer). Driven by
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {

--- a/docs/tools/process-control.mdx
+++ b/docs/tools/process-control.mdx
@@ -6,6 +6,8 @@ icon: "power"
 
 <Info>3 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## start_comfyui
 
 Start ComfyUI using process info saved from a previous stop_comfyui call. Supports both Desktop app and manual Python installs. Polls the API for bounded readiness before reporting ready.
@@ -14,7 +16,7 @@ Start ComfyUI using process info saved from a previous stop_comfyui call. Suppor
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Start ComfyUI.
 
 ```json
 {
@@ -22,6 +24,8 @@ Start ComfyUI using process info saved from a previous stop_comfyui call. Suppor
   "arguments": {}
 }
 ```
+
+**You get back:** It launches the server and waits until it is answering, then tells you the URL. Only works for a ComfyUI on this machine.
 
 ---
 
@@ -33,7 +37,7 @@ Stop the running ComfyUI process. Captures process info so it can be restarted w
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Shut ComfyUI down, I need the VRAM.
 
 ```json
 {
@@ -42,17 +46,23 @@ Stop the running ComfyUI process. Captures process info so it can be restarted w
 }
 ```
 
+**You get back:** Confirmation that the process stopped.
+
+<Warning>Any running or queued render is lost.</Warning>
+
 ---
 
 ## restart_comfyui
 
 Restart ComfyUI: stops the running process (capturing its config), waits for the port to free, relaunches with the same arguments, and polls the API for bounded readiness. Also works against a REMOTE/tunnelled ComfyUI (via --comfyui-url) by rebooting through ComfyUI-Manager over HTTP and polling for it to come back (requires ComfyUI-Manager present and its security level permitting the reboot).
 
+<Tip>**In plain terms:** The standard next step after installing a node pack — new nodes are not loaded until ComfyUI starts again.</Tip>
+
 <Note>This tool takes no parameters.</Note>
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Restart it so the new nodes load.
 
 ```json
 {
@@ -60,5 +70,9 @@ Restart ComfyUI: stops the running process (capturing its config), waits for the
   "arguments": {}
 }
 ```
+
+**You get back:** The server stops and comes back up, and you are told when it is answering again.
+
+<Warning>Anything queued or rendering is lost. Check the queue is empty first if a long job is in flight.</Warning>
 
 ---

--- a/docs/tools/runpod.mdx
+++ b/docs/tools/runpod.mdx
@@ -6,6 +6,8 @@ icon: "server"
 
 <Info>11 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## runpod_pod_create
 
 Deploy a BRAND-NEW RunPod pod from our comfyui-mcp template (image with the panel + Manager + our nodes preinstalled), then it can be started/connected like any pod. One-tap alternative to the console deploy link for a user who already has a RunPod account + API key. Because our template is used, the agent can install the user's exact custom nodes/LoRAs + download models on it → full canvas parity. Tries several GPU types until one has capacity (on-demand availability fluctuates). NOTE: this bills GPU-time as soon as the pod boots — confirm with the user first, and stop it (runpod_pod_stop) when done. Created pods carry a DEAD-MAN SWITCH: if comfyui-mcp stops minding the pod (crash/offline), the pod STOPS ITSELF after a grace period so it can't bill forever — it uses the pod-scoped key RunPod auto-injects, so your account key never leaves this machine (disable with deadman:false). For onboarding a NEW RunPod user, prefer runpod_deploy_link so their signup credits our referral.
@@ -30,7 +32,7 @@ Deploy a BRAND-NEW RunPod pod from our comfyui-mcp template (image with the pane
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -53,7 +55,7 @@ Connect comfyui-mcp to a RunPod pod's ComfyUI so ALL the other comfyui tools (ge
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -74,7 +76,7 @@ Switch comfyui-mcp back to the LOCAL ComfyUI on this machine (the 'Local' half o
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -100,7 +102,7 @@ Start (resume) a stopped/exited RunPod pod by ID — RunPod re-attaches a GPU an
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -125,7 +127,7 @@ Stop a running RunPod pod by ID — releases the GPU and stops GPU-time billing 
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -150,7 +152,7 @@ Get the live state of a RunPod pod by ID: its desired status (RUNNING / EXITED /
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -171,7 +173,7 @@ List all RunPod pods on the account (id, name, status, GPU, cost). Use when the 
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -194,7 +196,7 @@ Diagnose why a RunPod pod isn't usable — call this when the pod 'won't connect
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -219,7 +221,7 @@ Start broadcasting a pod's LIVE status to the control panel (desktop + mobile) �
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -240,7 +242,7 @@ Stop broadcasting a pod's live status to the control panel (does NOT stop the po
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -259,7 +261,7 @@ Get the RunPod DEPLOY link for spinning up a NEW comfyui-mcp pod. Share this wit
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {

--- a/docs/tools/training.mdx
+++ b/docs/tools/training.mdx
@@ -6,6 +6,8 @@ icon: "graduation-cap"
 
 <Info>18 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## train_list_flows
 
 List the LoRA training flows and base models the local trainer supports (phase 1: character LoRA on FLUX.1-dev), with the default training params. Read-only — call this first to see what train_start accepts.
@@ -14,7 +16,7 @@ List the LoRA training flows and base models the local trainer supports (phase 1
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -33,7 +35,7 @@ Preflight the local trainer: docker daemon reachable, `--gpus all` GPU passthrou
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -56,7 +58,7 @@ Build the headless GPU trainer image (comfyui-mcp-trainer:latest) from docker/tr
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -82,7 +84,7 @@ Set up the NATIVE (dockerless) trainer on this machine or a pod: clone ai-toolki
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -111,7 +113,7 @@ Stage training images + captions into a dataset dir the trainer consumes. Each i
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -167,7 +169,7 @@ Start a LoRA training job: target 'local' builds the config and launches the GPU
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -193,7 +195,7 @@ Check training progress: pass an id for one job (step/total, loss, recent sample
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -216,7 +218,7 @@ Stop a running training job (docker stop) and mark it cancelled. Checkpoints alr
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -237,7 +239,7 @@ List staged training datasets (the dirs from train_prepare_dataset), newest-firs
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -260,7 +262,7 @@ Show one staged dataset: its dir (datasetPath — reusable as train_start's data
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -291,7 +293,7 @@ Edit a staged dataset: set/replace per-image captions and/or delete images (with
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -316,7 +318,7 @@ Delete a whole staged dataset (images + captions). Refuses while a running/queue
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -347,7 +349,7 @@ Caption ONE dataset/training image with the user's own Claude subscription (one 
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -381,7 +383,7 @@ Caption a whole staged dataset (or a subset) with the user's own Claude subscrip
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -406,7 +408,7 @@ Fetch an image under the training root (dataset image, job sample) as an inline 
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -431,7 +433,7 @@ Show the effective settings a training job ran with (steps/lr/rank/resolution/ba
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -465,7 +467,7 @@ Show the RAW ai-toolkit config.yml train_start would write for these settings (t
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -494,7 +496,7 @@ Delete an old training job's record (+ its output dir with checkpoints/samples u
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {

--- a/docs/tools/workflow-authoring.mdx
+++ b/docs/tools/workflow-authoring.mdx
@@ -6,6 +6,8 @@ icon: "pen-ruler"
 
 <Info>11 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## create_workflow
 
 Create a ready-to-run ComfyUI API-format workflow from a built-in template (txt2img, img2img, upscale, inpaint, controlnet, ip_adapter, ace_step_15, stable_audio_3, remove_background, ltx_video). Pure local generation — does not contact ComfyUI and has no side effects. Returns the complete workflow JSON; pass it to validate_workflow or enqueue_workflow. Unsupplied params fall back to template defaults, so the result may reference checkpoints/models that must exist on your ComfyUI server before it will execute.
@@ -21,7 +23,7 @@ Create a ready-to-run ComfyUI API-format workflow from a built-in template (txt2
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -49,7 +51,7 @@ Apply modification operations to an existing ComfyUI workflow. Supports: set_inp
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -78,16 +80,37 @@ Validate a ComfyUI workflow without executing it. Checks for missing node types,
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Will this run?
 
 ```json
 {
   "tool": "validate_workflow",
   "arguments": {
-    "workflow": "<workflow>"
+    "workflow": {
+      "4": {
+        "class_type": "CheckpointLoaderSimple",
+        "inputs": {
+          "ckpt_name": "sd_xl_base_1.0.safetensors"
+        }
+      },
+      "9": {
+        "class_type": "SaveImage",
+        "inputs": {
+          "filename_prefix": "portrait",
+          "images": [
+            "8",
+            0
+          ]
+        }
+      }
+    }
   }
 }
 ```
+
+<Note>Shortened for readability — two nodes of a real API-format graph are shown. In practice the agent passes the whole thing: the graph it just loaded with get_workflow, or the one it built for you.</Note>
+
+**You get back:** Either a clean bill of health or the specific problems, without queuing anything.
 
 ---
 
@@ -109,14 +132,18 @@ Query a running ComfyUI server's /object_info endpoint for installed node type d
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** What settings does the KSampler node have?
 
 ```json
 {
   "tool": "get_node_info",
-  "arguments": {}
+  "arguments": {
+    "node_type": "KSampler"
+  }
 }
 ```
+
+**You get back:** That node's inputs and outputs with their types. Dropdown options are summarised as a count by default, because a model-loader dropdown can be hundreds of kilobytes on its own.
 
 ---
 
@@ -132,7 +159,7 @@ Convert a ComfyUI API-format workflow into a compact, human/LLM-readable DSL —
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -157,7 +184,7 @@ Convert the compact workflow DSL (see workflow_to_dsl) back into executable Comf
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -188,7 +215,7 @@ DRAW a Mermaid flowchart DIAGRAM from workflow JSON you PASS IN (a JSON string o
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -225,7 +252,7 @@ SECTION a workflow JSON you PASS IN into a hierarchical Mermaid diagram — same
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -250,7 +277,7 @@ Convert a Mermaid flowchart diagram back into a ComfyUI workflow JSON. Parses no
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -275,7 +302,7 @@ Read Prompt Director's latest sanitized RUNTIME state after its nodes execute. R
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -337,7 +364,7 @@ QUERY a SAVED workflow FILE (or JSON you pass in) — NOT the live canvas, which
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {

--- a/docs/tools/workflow-execution.mdx
+++ b/docs/tools/workflow-execution.mdx
@@ -6,9 +6,13 @@ icon: "play"
 
 <Info>12 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## enqueue_workflow
 
 Submit a ComfyUI workflow for execution and return immediately with the prompt_id and queue position. Does not wait for completion. Use queue (action:"status") to check progress later, or get_history to retrieve results and images after completion.
+
+<Tip>**In plain terms:** Runs a workflow that the agent is holding in the conversation — one it just built or loaded from a file. If you want to run the graph you are LOOKING at in ComfyUI, that is the panel's run tool instead, and if you just want a picture, use generate_image.</Tip>
 
 ### Parameters
 
@@ -21,16 +25,37 @@ Submit a ComfyUI workflow for execution and return immediately with the prompt_i
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Run it.
 
 ```json
 {
   "tool": "enqueue_workflow",
   "arguments": {
-    "workflow": "<workflow>"
+    "workflow": {
+      "4": {
+        "class_type": "CheckpointLoaderSimple",
+        "inputs": {
+          "ckpt_name": "sd_xl_base_1.0.safetensors"
+        }
+      },
+      "9": {
+        "class_type": "SaveImage",
+        "inputs": {
+          "filename_prefix": "portrait",
+          "images": [
+            "8",
+            0
+          ]
+        }
+      }
+    }
   }
 }
 ```
+
+<Note>Shortened for readability — two nodes of a real API-format graph are shown. In practice the agent passes the whole thing: the graph it just loaded with get_workflow, or the one it built for you.</Note>
+
+**You get back:** A prompt_id straight away, then the finished images once the render completes.
 
 ---
 
@@ -52,7 +77,7 @@ Re-run the workflow behind a previous generation. Retrieves the prompt graph fro
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -71,7 +96,7 @@ Get system information from the connected ComfyUI server: GPU device(s), total/f
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** How much VRAM have I got left?
 
 ```json
 {
@@ -79,6 +104,8 @@ Get system information from the connected ComfyUI server: GPU device(s), total/f
   "arguments": {}
 }
 ```
+
+**You get back:** The GPU, its total and free VRAM, system RAM, and the ComfyUI and Python versions.
 
 ---
 
@@ -93,6 +120,8 @@ Inspect and manage the ComfyUI execution queue. Driven by the `action` parameter
 - action:"cancel" — Stop the CURRENTLY RUNNING job ROBUSTLY. Sends an interrupt, then WAITS and verifies the job actually stopped — ComfyUI only honors interrupts BETWEEN steps, so a long single step (e.g. a high-res video sampler) can ignore a plain cancel. If the interrupt isn't honored it escalates to freeing VRAM (POST /free) and re-checks; if it STILL won't die it reports the job as WEDGED and tells you to restart_comfyui (an HTTP cancel cannot kill a stuck step). Set clear_pending:true to also drop ALL pending jobs in the same call — the correct "reset the queue" action, since cancelling alone leaves pending jobs that would run next. The partial result is discarded. With `prompt_id` given, only interrupts the running job when its prompt_id matches; omit to interrupt whatever is currently running. Use action:"cancel_queued" to remove one specific PENDING job instead.
 - action:"cancel_queued" — Remove one specific PENDING job from the queue by prompt_id. Does not affect running jobs.
 - action:"clear" — Clear ALL pending jobs from the queue. Does not affect the currently running job.
+
+<Tip>**In plain terms:** One tool for everything to do with the job queue — see what is waiting, reorder it, cancel something. Which job it does is set by `action`. This is the shape most of the newer tools have; see [Using the tools](/using-tools) for why.</Tip>
 
 ### Parameters
 
@@ -118,9 +147,9 @@ Inspect and manage the ComfyUI execution queue. Driven by the `action` parameter
   action:"cancel" — also clear ALL pending jobs (recommended when resetting after a stuck/slow render, so a re-queue doesn't stack behind a backlog). Default false.
 </ParamField>
 
-### Example
+### Examples
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** What's still running?
 
 ```json
 {
@@ -130,6 +159,40 @@ Inspect and manage the ComfyUI execution queue. Driven by the `action` parameter
   }
 }
 ```
+
+**You get back:** The job currently rendering and everything queued behind it, each with its prompt_id — the receipt you use to ask about one job later.
+
+**You say:** Kill the one that's running, it's wrong.
+
+```json
+{
+  "tool": "queue",
+  "arguments": {
+    "action": "cancel",
+    "prompt_id": "8f3c1a02-6d4e-4b9a-9f21-77c0be5d1e44"
+  }
+}
+```
+
+**You get back:** Confirmation that the job was interrupted.
+
+<Warning>This stops work in progress and you do not get the partial result. If you share this ComfyUI with anyone else, make sure the job is yours.</Warning>
+
+**You say:** Clear the whole queue, I want to start over.
+
+```json
+{
+  "tool": "queue",
+  "arguments": {
+    "action": "clear",
+    "clear_pending": true
+  }
+}
+```
+
+**You get back:** Confirmation of how many jobs were dropped.
+
+<Warning>Destructive and not undoable — every waiting job is discarded, including any that someone else queued.</Warning>
 
 ---
 
@@ -145,14 +208,18 @@ Get execution history for a ComfyUI prompt: status, timing, cached nodes, and ou
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Did that finish? What did it produce?
 
 ```json
 {
   "tool": "get_history",
-  "arguments": {}
+  "arguments": {
+    "prompt_id": "8f3c1a02-6d4e-4b9a-9f21-77c0be5d1e44"
+  }
 }
 ```
+
+**You get back:** That run's outcome and the files it wrote. Omit `prompt_id` to get recent runs instead of one specific one.
 
 ---
 
@@ -171,7 +238,7 @@ Get ComfyUI server runtime logs. Useful for debugging execution errors, model lo
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -186,6 +253,8 @@ Get ComfyUI server runtime logs. Useful for debugging execution errors, model lo
 
 Pre-flight diagnostic for the connected ComfyUI: one call that aggregates the signals an agent should check before dispatching a batch. Reports ComfyUI version/Python/PyTorch, GPU name + VRAM free/total, system RAM free, queue depth (running + pending), per-category /models populations (catches empty dropdowns from a misconfigured extra_model_paths.yaml), and recent errors from /internal/logs. Read-only — no mutation. Use this when a job fails for an unexpected reason, before a long batch run, or to confirm a remote ComfyUI is healthy. Originally contributed by github.com/joaolvivas.
 
+<Tip>**In plain terms:** The first thing to try when something is not working. It answers "is ComfyUI actually up, and can it see my models?" in one call.</Tip>
+
 ### Parameters
 
 <ParamField path="model_categories" type="string[]">
@@ -195,9 +264,9 @@ Pre-flight diagnostic for the connected ComfyUI: one call that aggregates the si
   How many recent error/traceback lines to include from /internal/logs (default 20, max 200).
 </ParamField>
 
-### Example
+### Examples
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Is everything working?
 
 ```json
 {
@@ -205,6 +274,25 @@ Pre-flight diagnostic for the connected ComfyUI: one call that aggregates the si
   "arguments": {}
 }
 ```
+
+**You get back:** Whether the server is reachable, what it is running on, and whether the model folders have anything in them.
+
+**You say:** Check the setup, and tell me if any recent runs blew up.
+
+```json
+{
+  "tool": "health_check",
+  "arguments": {
+    "model_categories": [
+      "checkpoints",
+      "loras"
+    ],
+    "recent_errors": 5
+  }
+}
+```
+
+**You get back:** The same report, narrowed to the two model folders you asked about, with the last five errors from history attached.
 
 ---
 
@@ -238,7 +326,7 @@ spec="3 + 0*0.5\n3 + 1*0.5\n3 + 2*0.5\n3 + 3*0.5"
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -255,6 +343,8 @@ spec="3 + 0*0.5\n3 + 1*0.5\n3 + 2*0.5\n3 + 3*0.5"
 
 WHY DID MY RENDER FAIL / WHAT'S MISSING? Explains a failed run in ONE call, without needing a canvas — the headless counterpart to the panel's panel_get_errors ("why is this red?"), so mobile/remote sessions get the same answer. Returns: the failed node (id, type) with its `exception_type` + message and a trimmed traceback; **missing_models** (the exact model file that isn't installed and the widget holding it — feed the filename to search_civitai_models/download_model to fix it); **missing_node_types** (node classes this install lacks — feed to search_custom_nodes/install_custom_node); and any other per-input validation errors. Call this whenever a run fails, an enqueue is rejected, or the user asks what's missing — instead of guessing from raw logs. With no prompt_id it diagnoses the most recent FAILED run (falling back to the most recent run). Read-only.
 
+<Tip>**In plain terms:** For when a run failed and the error text does not mean anything to you. This reads the failure and tells you what to do about it.</Tip>
+
 ### Parameters
 
 <ParamField path="prompt_id" type="string">
@@ -263,14 +353,18 @@ WHY DID MY RENDER FAIL / WHAT'S MISSING? Explains a failed run in ONE call, with
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** That render failed and I don't understand the error.
 
 ```json
 {
   "tool": "diagnose_run",
-  "arguments": {}
+  "arguments": {
+    "prompt_id": "8f3c1a02-6d4e-4b9a-9f21-77c0be5d1e44"
+  }
 }
 ```
+
+**You get back:** A plain reading of what went wrong — a missing model, a bad connection, not enough VRAM — and the suggested fix. Omit `prompt_id` and it looks at the most recent failure.
 
 ---
 
@@ -286,16 +380,18 @@ Get a template's OVERRIDABLE run-time parameters (its 'slots') before running it
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** What can I change about the Flux template?
 
 ```json
 {
   "tool": "get_template_schema",
   "arguments": {
-    "template": "<template>"
+    "template": "flux_dev_full_text_to_image"
   }
 }
 ```
+
+**You get back:** The knobs that template exposes — prompt, size, steps, which model file — with their current values, so you know what to pass to run_template.
 
 ---
 
@@ -323,16 +419,22 @@ ONE-SHOT: run a named workflow template (a bundled pack from list_packs) with op
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Run the Flux template with my prompt and wait for it.
 
 ```json
 {
   "tool": "run_template",
   "arguments": {
-    "template": "<template>"
+    "template": "flux_dev_full_text_to_image",
+    "overrides": {
+      "prompt": "a lighthouse in a storm, dramatic sky"
+    },
+    "wait": true
   }
 }
 ```
+
+**You get back:** With `wait: true`, the finished result in one go. Leave it off and you get a prompt_id immediately and check back later.
 
 ---
 
@@ -371,7 +473,7 @@ Batch ids are durable — they survive server restarts.
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {

--- a/docs/tools/workflow-library.mdx
+++ b/docs/tools/workflow-library.mdx
@@ -6,15 +6,19 @@ icon: "folder-open"
 
 <Info>10 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
+<Tip>**You don't type these calls.** Ask your agent for what you want in ordinary English — it chooses the tool and fills in the arguments. The JSON on this page is what it sends. New here? Start with [Using the tools](/using-tools).</Tip>
+
 ## list_workflows
 
 List the filenames of workflows saved in the connected ComfyUI server's user library (the same workflows visible in the ComfyUI web UI). Requires a running ComfyUI server. Takes no parameters. Returns a numbered list of .json filenames; pass a filename to get_workflow or analyze_workflow to load one. Returns "No saved workflows found." when the library is empty.
+
+<Tip>**In plain terms:** The saved workflow FILES in your ComfyUI — the same list you see in the ComfyUI sidebar. Usually the first call in any "open my…" request.</Tip>
 
 <Note>This tool takes no parameters.</Note>
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** What workflows have I got saved?
 
 ```json
 {
@@ -23,11 +27,15 @@ List the filenames of workflows saved in the connected ComfyUI server's user lib
 }
 ```
 
+**You get back:** A numbered list of .json filenames. Pick one and hand it to analyze_workflow or get_workflow.
+
 ---
 
 ## get_workflow
 
 Return the full JSON of a SAVED workflow FILE, named from the library — a file on disk, NOT the graph open on the user's canvas (that is panel_graph_outline). Defaults to converted API format; pass format:'ui' for the raw on-disk UI JSON. Use analyze_workflow instead if you just need to understand the workflow — it returns a structured summary without flooding context with JSON. Use get_workflow only when you need the actual JSON for enqueue_workflow, modify_workflow, or save_workflow.
+
+<Tip>**In plain terms:** Reads a saved FILE, not the graph currently open on your canvas. Ask for this when the agent needs the actual JSON to change or run; if you only want to know what a workflow does, analyze_workflow is the shorter answer.</Tip>
 
 ### Parameters
 
@@ -38,18 +46,34 @@ Return the full JSON of a SAVED workflow FILE, named from the library — a file
   Output format: 'api' (default, recommended) converts to compact API format with named inputs, connection references, and _meta.mode flags for muted/bypassed nodes. 'ui' returns the raw UI format with layout positions and links arrays. Options: `ui`, `api`.
 </ParamField>
 
-### Example
+### Examples
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Open my portrait workflow so we can change the prompt.
 
 ```json
 {
   "tool": "get_workflow",
   "arguments": {
-    "filename": "<filename>"
+    "filename": "portrait-flux.json"
   }
 }
 ```
+
+**You get back:** The full workflow as runnable API-format JSON. This is a big response — it is meant for the agent to work on, not for you to read.
+
+**You say:** Give me the raw file exactly as ComfyUI saved it.
+
+```json
+{
+  "tool": "get_workflow",
+  "arguments": {
+    "filename": "portrait-flux.json",
+    "format": "ui"
+  }
+}
+```
+
+**You get back:** The on-disk UI format, including node positions and colours — what you want if the file is going to be loaded back into the canvas rather than executed.
 
 ---
 
@@ -71,7 +95,7 @@ Read (and optionally execute) a shared ComfyUI workflow from a URL. Fetches the 
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -105,7 +129,7 @@ Strip a workflow to a clean, flat API graph — resolving Get/Set buses, Reroute
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -137,7 +161,7 @@ Slice ONE pipeline out of a toggle-template workflow — the kind built with rgt
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -165,23 +189,48 @@ Save a workflow JSON to the connected ComfyUI server's user library so it appear
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** Save that as a new file so I don't lose the original.
 
 ```json
 {
   "tool": "save_workflow",
   "arguments": {
-    "filename": "<filename>",
-    "workflow": "<workflow>"
+    "filename": "portrait-flux-v2.json",
+    "workflow": {
+      "4": {
+        "class_type": "CheckpointLoaderSimple",
+        "inputs": {
+          "ckpt_name": "sd_xl_base_1.0.safetensors"
+        }
+      },
+      "9": {
+        "class_type": "SaveImage",
+        "inputs": {
+          "filename_prefix": "portrait",
+          "images": [
+            "8",
+            0
+          ]
+        }
+      }
+    }
   }
 }
 ```
+
+<Note>Shortened for readability — two nodes of a real API-format graph are shown. In practice the agent passes the whole thing: the graph it just loaded with get_workflow, or the one it built for you.</Note>
+
+**You get back:** Confirmation and the path it was written to.
+
+<Warning>Writing to a filename that already exists replaces that file. Ask for a new name — as above — when you want to keep the original.</Warning>
 
 ---
 
 ## analyze_workflow
 
 SUMMARIZE a SAVED workflow FILE named from the library — sections, node settings, connections, and data flow. It reads a file from the library, NOT the graph open on the user's canvas (that is panel_graph_outline). Use this to understand a saved workflow before modifying or executing it. Returns a concise text summary (not raw JSON) optimized for AI reasoning. Prefer this over get_workflow unless you need the raw JSON for enqueue_workflow or modify_workflow.
+
+<Tip>**In plain terms:** "Explain this workflow to me." Cheaper and far more readable than get_workflow when you just want to understand what a file does.</Tip>
 
 ### Parameters
 
@@ -195,18 +244,34 @@ SUMMARIZE a SAVED workflow FILE named from the library — sections, node settin
   Section name for detail view. Use view='list' first to see available section names.
 </ParamField>
 
-### Example
+### Examples
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+**You say:** What does my portrait workflow actually do?
 
 ```json
 {
   "tool": "analyze_workflow",
   "arguments": {
-    "filename": "<filename>"
+    "filename": "portrait-flux.json"
   }
 }
 ```
+
+**You get back:** A short summary: the model it loads, the prompts, the sampler settings, and what it saves.
+
+**You say:** Is that workflow going to run, or is something missing?
+
+```json
+{
+  "tool": "analyze_workflow",
+  "arguments": {
+    "filename": "portrait-flux.json",
+    "view": "health"
+  }
+}
+```
+
+**You get back:** Problems only — missing models, unconnected inputs, nodes whose packs are not installed.
 
 ---
 
@@ -222,7 +287,7 @@ Extract embedded ComfyUI workflow metadata from a PNG file. ComfyUI stores the f
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -247,7 +312,7 @@ Capture a provenance lock for a saved workflow so it can be exactly reproduced l
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {
@@ -272,7 +337,7 @@ Compare a saved workflow's lock file against the current state of the local inst
 
 ### Example
 
-<Note>Example coming soon — the call below is a generated skeleton.</Note>
+<Note>No worked example yet — the call below is a skeleton generated from the required parameters. Real examples live in `scripts/tool-doc-examples.ts`; contributions welcome.</Note>
 
 ```json
 {

--- a/docs/using-tools.mdx
+++ b/docs/using-tools.mdx
@@ -1,0 +1,228 @@
+---
+title: "Using the tools"
+description: "What the tools are, why you never call one yourself, and what to do when one says no. Written for people, not for engineers."
+icon: "hand-pointer"
+---
+
+The [Tool Reference](/tools/image-generation) lists everything this project can do, in the form the AI reads it. This page is the version for you.
+
+<Note>
+  Nothing here requires you to write code, type JSON, or learn an API. If you have
+  ever asked a person to "open my portrait workflow and bump the steps to 30",
+  you already know the interface.
+</Note>
+
+## A tool is a thing the agent can do, not a thing you type
+
+On its own, a chat model can only produce text. It can describe a workflow; it cannot open one.
+
+A **tool** is a specific, named action we hand the model so it can actually reach your ComfyUI — load a file, queue a render, install a node pack, look at the picture that came out. The model does not get to invent these. It gets a fixed menu, and each item on the menu says exactly what it needs.
+
+**You never pick from that menu.** You say what you want, in whatever words come naturally, and the agent chooses.
+
+| You say | It quietly runs |
+| --- | --- |
+| "What have I got saved?" | `list_workflows` |
+| "Open the portrait one and tell me what it does" | `list_workflows`, then `analyze_workflow` |
+| "Make me a red fox in the snow" | `generate_image` |
+| "Is it done yet?" | `queue` (the `list` job) |
+| "That failed and I don't understand why" | `diagnose_run` |
+| "Half the nodes are red" | `install_workflow_dependencies` |
+| "I'm out of disk space, what's big?" | `list_local_models` |
+
+Notice the second row: one sentence, two tools, in an order you did not have to know. That is the point of the whole arrangement. You are not expected to know that finding a file and reading a file are separate operations.
+
+<Tip>
+  You can be as vague as you like. "Something's broken" is a perfectly good
+  opening — the agent will start with `health_check` and narrow down. Being
+  specific gets you there faster, but it is never required.
+</Tip>
+
+### So what is all that JSON in the reference pages?
+
+Every tool page shows a block like this:
+
+```json
+{
+  "tool": "generate_image",
+  "arguments": {
+    "prompt": "a red fox in deep snow, golden hour, sharp focus",
+    "steps": 30
+  }
+}
+```
+
+That is a transcript of what the agent sent, not an instruction to you. You said "make me a red fox in the snow, and put a bit more detail into it"; that is what came out the other end.
+
+It is worth being able to read one, for two reasons: when you want to check the agent understood you, and when something goes wrong and you are describing it to someone else. It is not worth memorising.
+
+## Two places tools come from
+
+There are two surfaces, and they exist because they answer different questions.
+
+<CardGroup cols={2}>
+  <Card title="The sidebar panel" icon="window-maximize">
+    Lives **inside ComfyUI**, in the Agent tab. Its tools (`panel_*`) act on the
+    graph you are looking at right now — the actual canvas, with your unsaved
+    changes on it.
+  </Card>
+  <Card title="An outside client" icon="terminal">
+    Claude Desktop, Claude Code, an editor, your phone. Its tools act on the
+    **server**: files on disk, the job queue, models, node packs, the ComfyUI
+    process itself.
+  </Card>
+</CardGroup>
+
+The split is really about the word "this". When you say "add a LoRA to **this**", the panel knows what "this" is, because it can see your screen. An outside client cannot — it has to be told a filename.
+
+So the panel handles things like:
+
+- reading the graph in front of you (`panel_graph_outline`)
+- running it, exactly as if you had hit Queue Prompt yourself (`panel_run`)
+- wiring a node in, changing a widget, telling you why a node went red (`panel_add_node`, `panel_set_widget`, `panel_get_errors`)
+- loading a whole workflow onto the canvas, or saving what is there (`panel_load_workflow`, `panel_save_workflow`)
+
+And an outside client handles things like generating an image from scratch, managing models and node packs, working through saved files, and restarting ComfyUI.
+
+<Tip>
+  **If you are new, use the panel.** It is one install, it is right there next to
+  your graph, and it does not need a separate app. See
+  [the panel guide](/panel) to set it up. Add an outside client later, when you
+  want the agent involved in things that are not a canvas.
+</Tip>
+
+They are not rivals — the panel talks to the same server underneath, and a session can use both. Someone editing a graph on their desktop while a phone drives the same session is a supported thing, not a hack.
+
+## One tool, several jobs
+
+You will notice some tools take an `action`:
+
+```json
+{ "tool": "workspace", "arguments": { "action": "get" } }
+```
+
+This looks cryptic and is not. `workspace` is a topic — *which ComfyUI installation are we talking about* — and `action` says which question you are asking about that topic: read it, change the default, list what is available.
+
+It reads exactly like ordinary speech, where the verb and the object are separate words:
+
+| You say | Action |
+| --- | --- |
+| "Which ComfyUI am I using?" | `get` |
+| "Always use the one on my D drive" | `set_default` |
+| "What installations can you see?" | `list` |
+
+### Nothing was removed
+
+This shape is new-ish, and it is easy to read it as capability being cut. It isn't, and the confusion is worth heading off directly, because it has already come up.
+
+There used to be one tool per question — a separate name for reading a workspace, another for setting it, another for listing them. Those names are gone, and if you watch the tool count you will see it falling, sharply.
+
+What actually happened is that related tools were **merged**, not deleted:
+
+| The old name | The same thing today |
+| --- | --- |
+| `get_workspace` | `workspace` with `action: "get"` |
+| `get_queue` | `queue` with `action: "list"` |
+| `apps_run_status` | `apps` with `action: "run_status"` |
+
+Same code underneath, same behaviour, same answers. Only the label on the front changed.
+
+The reason is that the menu got long enough to hurt. Every tool's full description has to be handed to the model before it can choose, and past a certain size the choosing itself degrades — smaller models in particular start picking a plausible-looking neighbour instead of the right one. Fewer, broader tools with a clear `action` measurably fixes that. It also means the model spends its attention on your request instead of on reading a catalogue.
+
+You should not notice any of this. You never typed the old name either; you said "which ComfyUI am I on?", and that still works.
+
+<Note>
+  If some older guide or a model's own memory reaches for a name that no longer
+  exists, you get a specific error naming the replacement rather than a blank
+  "unknown tool" — for example: *removed in 0.49.0. Call workspace (action:"get")
+  instead.* The agent can usually correct itself and retry without you doing
+  anything.
+</Note>
+
+## When it says no
+
+A tool refusing is not usually a bug. Most refusals are a guard that fired because the call would have done something you did not ask for.
+
+### "It refused and I don't know why"
+
+You will see plain-language text rather than a stack trace — something naming what it would not do and what to do instead. Read it as the agent being careful, not stuck. Common honest refusals:
+
+- **It cannot tell which workflow you mean.** More than one tab is open, or the graph has no saved identity yet. Save it, or say which one.
+- **It would overwrite something.** Ask for a new filename and it will proceed.
+- **The thing genuinely is not there.** A model file, a node pack, a running server.
+
+If a refusal reads as nonsense rather than caution, that is worth reporting — ask the agent to file it, and it will attach your setup details for you.
+
+### "This panel is too old"
+
+The most common refusal with a real fix. It reads roughly like:
+
+> This ComfyUI-MCP panel is too old for *"…"* — update the ComfyUI-MCP panel, then reconnect.
+
+The sidebar panel and this server are separate pieces that ship separately, so one can lag the other. When the server asks for something the installed panel cannot do safely, it declines rather than guessing — an old panel that cannot confirm *which* workflow a command lands on could apply your edit to the wrong tab, so it is held to reads until it is updated.
+
+The fix is three steps, and **the third is the one people skip**:
+
+<Steps>
+  <Step title="Update the panel">
+    Ask the agent to update it (`install_panel` with `action: "update"`), or do it
+    from ComfyUI Manager, where it is listed as the comfyui-mcp panel.
+  </Step>
+  <Step title="Restart ComfyUI">
+    The update does not restart anything on its own. Ask the agent, or restart it
+    yourself.
+  </Step>
+  <Step title="Hard-refresh the ComfyUI browser tab">
+    **Ctrl+Shift+R** (**Cmd+Shift+R** on a Mac). Your browser has the old panel
+    code cached, and a restart alone will not shake it loose. Skip this and the
+    same message comes straight back, which is why it looks like the update
+    failed when it did not.
+  </Step>
+</Steps>
+
+### "No panel connected"
+
+Different problem, similar-looking message. This means the outside agent cannot find your ComfyUI browser tab. Nearly always it is one of:
+
+- ComfyUI is not open in a browser at all — open it and look at the Agent tab in the sidebar.
+- ComfyUI was just restarted, or you reloaded the tab. That drops the connection. **Reload the ComfyUI tab** and it comes straight back.
+- The panel is not installed yet. See [the panel guide](/panel).
+
+The message itself will tell you which — it distinguishes "never connected" from "connected earlier and dropped", and the second one is always just a reload.
+
+## If you run a small local model
+
+Handing the entire menu to a model costs a lot of reading before it says a word. On a large hosted model that is fine. On a small model running on your own machine it is often the difference between working and not.
+
+So by default the agent gets **three** tools instead of the full set: one to browse the catalogue, one to look up a single tool in detail, and one to run it. It fetches what it needs, when it needs it, rather than reading everything up front.
+
+You do not have to do anything to get this — it is the default. The controls exist if you want them:
+
+```bash
+# force the small three-tool mode
+npx -y comfyui-mcp --compact
+
+# or hand the model everything at once
+npx -y comfyui-mcp --full
+```
+
+Either can also be set with `COMFYUI_MCP_TOOL_MODE=compact` or `COMFYUI_MCP_TOOL_MODE=full`.
+
+The trade is a couple of extra round-trips before the first real action, in exchange for a model that has room left to think. Big models are usually happier with `--full`. See [local LLMs](/local-llms) for which models cope with which.
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Install it and generate your first image.
+  </Card>
+  <Card title="The sidebar panel" icon="window-maximize" href="/panel">
+    The in-ComfyUI agent, and what it can do to your canvas.
+  </Card>
+  <Card title="Tool Reference" icon="book" href="/tools/image-generation">
+    Every tool, with worked examples of what a real call looks like.
+  </Card>
+  <Card title="Troubleshooting" icon="wrench" href="/troubleshooting">
+    When it is not a refusal and something is actually broken.
+  </Card>
+</CardGroup>

--- a/scripts/gen-tool-docs.ts
+++ b/scripts/gen-tool-docs.ts
@@ -25,6 +25,7 @@ import { fileURLToPath } from "node:url";
 import { z } from "zod";
 // zod 4 ships JSON Schema conversion natively (z.toJSONSchema) — no zod-to-json-schema.
 import { registerAllTools } from "../src/tools/index.js";
+import { TOOL_DOC_EXAMPLES, type ToolDocEntry } from "./tool-doc-examples.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, "..");
@@ -351,6 +352,116 @@ function firstSentence(desc: string): string {
   return (m ? m[0] : desc).trim();
 }
 
+/**
+ * Validate every curated example in scripts/tool-doc-examples.ts against the
+ * tool's REAL zod schema, and fail generation if any of them is wrong.
+ *
+ * This exists because a documented call that does not typecheck is worse than no
+ * example at all: a reader copies it, it 400s, and they conclude the tool is
+ * broken. Prose cannot be unit-tested, so this is where examples get tested.
+ *
+ * Three distinct failures, each caught deliberately:
+ *
+ * 1. A key for a tool that no longer exists. During the consolidation tools are
+ *    being renamed and folded together; an example still keyed by a retired name
+ *    must become a loud failure, not a silently-ignored map entry.
+ *
+ * 2. A field that is not in the schema. zod objects STRIP unknown keys by
+ *    default, so `safeParse` alone happily accepts `{"filenmae": "x"}` and
+ *    reports success — the misspelling would ship. Hence the explicit key check
+ *    against the JSON Schema's properties, before parsing.
+ *
+ * 3. A field with the wrong type or a missing required one. That is what
+ *    `safeParse` is for, run against the same shape the MCP SDK advertises.
+ */
+function validateExamples(byName: Map<string, CapturedTool>): void {
+  const problems: string[] = [];
+
+  for (const [toolName, entry] of Object.entries(TOOL_DOC_EXAMPLES)) {
+    const tool = byName.get(toolName);
+    if (!tool) {
+      problems.push(
+        `${toolName}: no such tool is registered — it was probably renamed or ` +
+          `consolidated. Update or remove its entry in scripts/tool-doc-examples.ts.`,
+      );
+      continue;
+    }
+    const schema = z.object(tool.shape);
+    const json = z.toJSONSchema(schema, { reused: "inline", io: "input" }) as unknown as JsonSchema;
+    const known = new Set(Object.keys(json.properties ?? {}));
+
+    entry.examples.forEach((ex, i) => {
+      const where = `${toolName} example #${i + 1} ("${ex.ask}")`;
+      const unknownKeys = Object.keys(ex.args).filter((k) => !known.has(k));
+      if (unknownKeys.length > 0) {
+        problems.push(
+          `${where}: field(s) ${unknownKeys.map((k) => `\`${k}\``).join(", ")} ` +
+            `do not exist on this tool. Known fields: ${[...known].join(", ") || "(none)"}.`,
+        );
+        // Still parse below: a typo'd key is stripped, so the parse would pass
+        // and hide any OTHER problem in the same example.
+      }
+      const parsed = schema.safeParse(ex.args);
+      if (!parsed.success) {
+        const detail = parsed.error.issues
+          .map((iss) => `${iss.path.join(".") || "(root)"}: ${iss.message}`)
+          .join("; ");
+        problems.push(`${where}: does not satisfy the tool's schema — ${detail}`);
+      }
+    });
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `[gen-tool-docs] ${problems.length} documented example(s) do not match the live tool ` +
+        `schemas:\n  ${problems.join("\n  ")}\n` +
+        `Fix the example in scripts/tool-doc-examples.ts — do NOT relax this check. ` +
+        `An example that does not typecheck will be copied by a reader and will fail.`,
+    );
+  }
+}
+
+/** Render the curated examples for one tool, or the generated skeleton if it has none. */
+function renderExamples(t: CapturedTool, json: JsonSchema, entry?: ToolDocEntry): string[] {
+  const lines: string[] = [];
+
+  if (!entry || entry.examples.length === 0) {
+    lines.push("### Example", "");
+    lines.push(
+      "<Note>No worked example yet — the call below is a skeleton generated from the " +
+        "required parameters. Real examples live in `scripts/tool-doc-examples.ts`; " +
+        "contributions welcome.</Note>",
+      "",
+    );
+    lines.push(
+      "```json",
+      JSON.stringify({ tool: t.name, arguments: exampleArgs(t.name, json) }, null, 2),
+      "```",
+      "",
+    );
+    return lines;
+  }
+
+  lines.push(entry.examples.length === 1 ? "### Example" : "### Examples", "");
+  for (const ex of entry.examples) {
+    // The ASK comes first on purpose. The audience for this page mostly does not
+    // type JSON at anything — they say a sentence to an agent and it makes the
+    // call. Leading with the sentence shows which request reaches this tool;
+    // leading with the JSON implies a calling convention they will never use.
+    lines.push(`**You say:** ${esc(ex.ask)}`, "");
+    lines.push(
+      "```json",
+      JSON.stringify({ tool: t.name, arguments: ex.args }, null, 2),
+      "```",
+      "",
+    );
+    if (ex.argsNote) lines.push(`<Note>${esc(ex.argsNote)}</Note>`, "");
+    lines.push(`**You get back:** ${esc(ex.returns)}`, "");
+    if (ex.caution) lines.push(`<Warning>${esc(ex.caution)}</Warning>`, "");
+  }
+  return lines;
+}
+
 function renderTool(t: CapturedTool): string {
   // `io: "input"` matches what the MCP SDK advertises to clients
   // (sdk/server/zod-json-schema-compat.js defaults pipeStrategy to 'input').
@@ -371,9 +482,20 @@ function renderTool(t: CapturedTool): string {
   const required = new Set(json.required ?? []);
   const paramNames = Object.keys(props);
 
+  const entry = TOOL_DOC_EXAMPLES[t.name];
+
   const lines: string[] = [];
   lines.push(`## ${t.name}`, "");
   lines.push(esc(t.description), "");
+
+  // The gloss is ADDITIVE. The description above is written for model dispatch —
+  // it disambiguates this tool from its neighbours in the terms a model needs,
+  // which is why it talks about context cost and about which tool NOT to pick.
+  // Rewriting it for readability measurably degrades tool choice (#557/#654), so
+  // a human-facing sentence goes here, next to it, instead of over it.
+  if (entry?.gloss) {
+    lines.push(`<Tip>**In plain terms:** ${esc(entry.gloss)}</Tip>`, "");
+  }
 
   if (paramNames.length > 0) {
     lines.push("### Parameters", "");
@@ -385,10 +507,7 @@ function renderTool(t: CapturedTool): string {
     lines.push("<Note>This tool takes no parameters.</Note>", "");
   }
 
-  lines.push("### Example", "");
-  lines.push("<Note>Example coming soon — the call below is a generated skeleton.</Note>", "");
-  const args = exampleArgs(t.name, json);
-  lines.push("```json", JSON.stringify({ tool: t.name, arguments: args }, null, 2), "```", "");
+  lines.push(...renderExamples(t, json, entry));
   lines.push("---", "");
   return lines.join("\n");
 }
@@ -408,6 +527,11 @@ async function main() {
   await registerAllTools(mockServer as never);
 
   const byName = new Map(captured.map((t) => [t.name, t]));
+
+  // Before ANY page is rendered — a bad example must abort the run, not be
+  // written into 16 files and then reported.
+  validateExamples(byName);
+
   const mapped = new Set<string>();
   mkdirSync(toolsDir, { recursive: true });
 
@@ -432,6 +556,16 @@ async function main() {
     page.push("---");
     page.push("");
     page.push(`<Info>${present.length} tool${present.length === 1 ? "" : "s"}. Generated from the live MCP tool schemas — do not edit by hand; run \`npm run docs:gen\`.</Info>`);
+    page.push("");
+    // Every page carries this. The JSON below is what the AGENT sends; readers
+    // arriving from a search result were being shown a calling convention they
+    // will never type, with nothing on the page to say so.
+    page.push(
+      "<Tip>**You don't type these calls.** Ask your agent for what you want in " +
+        "ordinary English — it chooses the tool and fills in the arguments. The JSON " +
+        "on this page is what it sends. New here? Start with " +
+        "[Using the tools](/using-tools).</Tip>",
+    );
     page.push("");
     for (const name of present) page.push(renderTool(byName.get(name)!));
 

--- a/scripts/tool-doc-examples.ts
+++ b/scripts/tool-doc-examples.ts
@@ -1,0 +1,794 @@
+/**
+ * Curated, human-facing examples for the generated Tool Reference.
+ *
+ * WHY THIS FILE EXISTS. Every page under docs/tools/ is generated from the live
+ * zod schemas by scripts/gen-tool-docs.ts, and for a long time every single one
+ * of them ended in "Example coming soon — the call below is a generated
+ * skeleton" followed by `{"filename": "<filename>"}`. That skeleton is derived
+ * mechanically from the required fields, so it is never WRONG — it is just never
+ * useful either. A reader learns the parameter exists, which the parameter table
+ * already told them, and nothing about what a real value looks like.
+ *
+ * Hand-editing the .mdx is not an option: the next `npm run docs:gen` overwrites
+ * it, and CI runs docs:gen and fails if the tree changes. So the examples live
+ * HERE, as data, and the generator renders them.
+ *
+ * THE RULE FOR ADDING ONE: every `args` object is validated against the tool's
+ * real zod schema at generation time (see validateExamples in gen-tool-docs.ts).
+ * A field that does not exist, or has the wrong type, fails the build rather
+ * than shipping. Do not disable that check to make an example fit — if the
+ * example does not typecheck, the example is wrong. A confidently wrong example
+ * is worse than the skeleton it replaced, because a reader will copy it.
+ *
+ * WHAT MAKES A GOOD ENTRY:
+ *  - `ask` is what a PERSON says out loud, not a restatement of the tool name.
+ *    Nobody says "call list_workflows"; they say "what have I got saved?".
+ *  - `args` uses plausible real values — a real filename, a real prompt, a real
+ *    HuggingFace URL — not `<placeholder>` echoes of the field name.
+ *  - `returns` says what lands back in the conversation, in a sentence.
+ *  - `caution` is REQUIRED wherever the call deletes, overwrites, costs money,
+ *    or interrupts work someone else may be waiting on.
+ *
+ * WHAT THIS FILE MUST NOT DO: rewrite the tool DESCRIPTIONS. Those are tuned for
+ * model dispatch and a readability edit there is a regression in tool-choice
+ * accuracy, not an improvement (#557/#654). When a description reads badly to a
+ * human, add a `gloss` here — it renders ALONGSIDE the description, leaving the
+ * model-facing text untouched.
+ *
+ * COVERAGE IS DELIBERATELY PARTIAL. The beginner path is covered end to end;
+ * expert surfaces (training, RunPod, comfy-cli's 26 actions, node authoring) are
+ * left on the skeleton until someone writes examples worth reading. A missing
+ * example is an honest gap; a made-up one is a bug.
+ */
+
+export interface ToolDocExample {
+  /** What a person actually says to the agent, in plain English. */
+  ask: string;
+  /**
+   * The call the agent then makes. Validated against the tool's real zod schema
+   * at generation time — an unknown or mistyped field fails `npm run docs:gen`.
+   */
+  args: Record<string, unknown>;
+  /** What comes back, in a sentence or two. */
+  returns: string;
+  /**
+   * Rendered under the JSON when the arguments are shown in shortened form —
+   * used for the graph-shaped parameters, where pasting a complete 40-node
+   * workflow would bury the point. Say plainly what was left out.
+   */
+  argsNote?: string;
+  /** Rendered as a warning. Required when the call destroys or costs something. */
+  caution?: string;
+}
+
+export interface ToolDocEntry {
+  /**
+   * A plain-language gloss shown ALONGSIDE (never instead of) the model-facing
+   * description. For tools whose description is written in terms a human reader
+   * has no reason to care about — context budgets, dispatch disambiguation.
+   */
+  gloss?: string;
+  examples: ToolDocExample[];
+}
+
+/**
+ * An abbreviated but structurally REAL API-format graph, for the tools that take
+ * a whole workflow. Two genuine nodes rather than a fake one-liner: a reader
+ * should come away knowing that API format is an object keyed by node id, each
+ * value having `class_type` and `inputs`, and that a link is `[nodeId, slot]`.
+ * Every entry that uses it also carries an `argsNote` saying it is shortened.
+ */
+const WORKFLOW_FRAGMENT = {
+  "4": {
+    class_type: "CheckpointLoaderSimple",
+    inputs: { ckpt_name: "sd_xl_base_1.0.safetensors" },
+  },
+  "9": {
+    class_type: "SaveImage",
+    inputs: { filename_prefix: "portrait", images: ["8", 0] },
+  },
+} as const;
+
+const FRAGMENT_NOTE =
+  "Shortened for readability — two nodes of a real API-format graph are shown. " +
+  "In practice the agent passes the whole thing: the graph it just loaded with " +
+  "get_workflow, or the one it built for you.";
+
+export const TOOL_DOC_EXAMPLES: Readonly<Record<string, ToolDocEntry>> = {
+  // -------------------------------------------------------------------------
+  // Image & Audio Generation
+  // -------------------------------------------------------------------------
+  generate_image: {
+    gloss:
+      "The one-line way to get a picture. You do not need a workflow open, or " +
+      "any workflow at all — describe the image and this builds and runs a " +
+      "sensible graph for you. Everything except the prompt is optional and " +
+      "falls back to your saved defaults.",
+    examples: [
+      {
+        ask: "Make me a picture of a red fox in the snow.",
+        args: { prompt: "a red fox in deep snow, golden hour, sharp focus" },
+        returns:
+          "The finished image, inline in the conversation, plus the seed and " +
+          "settings that produced it so you can ask for the same thing again.",
+      },
+      {
+        ask: "Same fox, but widescreen, more detail, and keep it repeatable.",
+        args: {
+          prompt: "a red fox in deep snow, golden hour, sharp focus",
+          negative_prompt: "blurry, watermark, text",
+          width: 1344,
+          height: 768,
+          steps: 30,
+          cfg: 4.5,
+          seed: 12345,
+        },
+        returns:
+          "The same fields plus the image. Because `seed` was pinned, running " +
+          "this again with the same settings gives the same picture — that is " +
+          "how you iterate on one image instead of rolling a new one each time.",
+      },
+    ],
+  },
+  generate_video: {
+    examples: [
+      {
+        ask: "Turn that fox picture into a short clip of it walking.",
+        args: {
+          prompt: "a red fox walking through deep snow, camera slowly pushing in",
+          seconds: 5,
+          resolution: "832x480",
+          fps: 16,
+        },
+        returns:
+          "A path to the rendered video file plus the settings used. Video takes " +
+          "far longer than a still — minutes, not seconds — so the agent will " +
+          "usually tell you it has started and then report back.",
+      },
+    ],
+  },
+
+  // -------------------------------------------------------------------------
+  // Workflow Execution
+  // -------------------------------------------------------------------------
+  health_check: {
+    gloss:
+      "The first thing to try when something is not working. It answers \"is " +
+      "ComfyUI actually up, and can it see my models?\" in one call.",
+    examples: [
+      {
+        ask: "Is everything working?",
+        args: {},
+        returns:
+          "Whether the server is reachable, what it is running on, and whether " +
+          "the model folders have anything in them.",
+      },
+      {
+        ask: "Check the setup, and tell me if any recent runs blew up.",
+        args: { model_categories: ["checkpoints", "loras"], recent_errors: 5 },
+        returns:
+          "The same report, narrowed to the two model folders you asked about, " +
+          "with the last five errors from history attached.",
+      },
+    ],
+  },
+  queue: {
+    gloss:
+      "One tool for everything to do with the job queue — see what is waiting, " +
+      "reorder it, cancel something. Which job it does is set by `action`. This " +
+      "is the shape most of the newer tools have; see " +
+      "[Using the tools](/using-tools) for why.",
+    examples: [
+      {
+        ask: "What's still running?",
+        args: { action: "list" },
+        returns:
+          "The job currently rendering and everything queued behind it, each " +
+          "with its prompt_id — the receipt you use to ask about one job later.",
+      },
+      {
+        ask: "Kill the one that's running, it's wrong.",
+        args: { action: "cancel", prompt_id: "8f3c1a02-6d4e-4b9a-9f21-77c0be5d1e44" },
+        returns: "Confirmation that the job was interrupted.",
+        caution:
+          "This stops work in progress and you do not get the partial result. " +
+          "If you share this ComfyUI with anyone else, make sure the job is yours.",
+      },
+      {
+        ask: "Clear the whole queue, I want to start over.",
+        args: { action: "clear", clear_pending: true },
+        returns: "Confirmation of how many jobs were dropped.",
+        caution:
+          "Destructive and not undoable — every waiting job is discarded, " +
+          "including any that someone else queued.",
+      },
+    ],
+  },
+  get_history: {
+    examples: [
+      {
+        ask: "Did that finish? What did it produce?",
+        args: { prompt_id: "8f3c1a02-6d4e-4b9a-9f21-77c0be5d1e44" },
+        returns:
+          "That run's outcome and the files it wrote. Omit `prompt_id` to get " +
+          "recent runs instead of one specific one.",
+      },
+    ],
+  },
+  diagnose_run: {
+    gloss:
+      "For when a run failed and the error text does not mean anything to you. " +
+      "This reads the failure and tells you what to do about it.",
+    examples: [
+      {
+        ask: "That render failed and I don't understand the error.",
+        args: { prompt_id: "8f3c1a02-6d4e-4b9a-9f21-77c0be5d1e44" },
+        returns:
+          "A plain reading of what went wrong — a missing model, a bad " +
+          "connection, not enough VRAM — and the suggested fix. Omit " +
+          "`prompt_id` and it looks at the most recent failure.",
+      },
+    ],
+  },
+  get_system_stats: {
+    examples: [
+      {
+        ask: "How much VRAM have I got left?",
+        args: {},
+        returns:
+          "The GPU, its total and free VRAM, system RAM, and the ComfyUI and " +
+          "Python versions.",
+      },
+    ],
+  },
+  enqueue_workflow: {
+    gloss:
+      "Runs a workflow that the agent is holding in the conversation — one it " +
+      "just built or loaded from a file. If you want to run the graph you are " +
+      "LOOKING at in ComfyUI, that is the panel's run tool instead, and if you " +
+      "just want a picture, use generate_image.",
+    examples: [
+      {
+        ask: "Run it.",
+        args: { workflow: WORKFLOW_FRAGMENT },
+        argsNote: FRAGMENT_NOTE,
+        returns:
+          "A prompt_id straight away, then the finished images once the render " +
+          "completes.",
+      },
+    ],
+  },
+  get_template_schema: {
+    examples: [
+      {
+        ask: "What can I change about the Flux template?",
+        args: { template: "flux_dev_full_text_to_image" },
+        returns:
+          "The knobs that template exposes — prompt, size, steps, which model " +
+          "file — with their current values, so you know what to pass to " +
+          "run_template.",
+      },
+    ],
+  },
+  run_template: {
+    examples: [
+      {
+        ask: "Run the Flux template with my prompt and wait for it.",
+        args: {
+          template: "flux_dev_full_text_to_image",
+          overrides: { prompt: "a lighthouse in a storm, dramatic sky" },
+          wait: true,
+        },
+        returns:
+          "With `wait: true`, the finished result in one go. Leave it off and " +
+          "you get a prompt_id immediately and check back later.",
+      },
+    ],
+  },
+
+  // -------------------------------------------------------------------------
+  // Workflow Library
+  // -------------------------------------------------------------------------
+  list_workflows: {
+    gloss:
+      "The saved workflow FILES in your ComfyUI — the same list you see in the " +
+      "ComfyUI sidebar. Usually the first call in any \"open my…\" request.",
+    examples: [
+      {
+        ask: "What workflows have I got saved?",
+        args: {},
+        returns:
+          "A numbered list of .json filenames. Pick one and hand it to " +
+          "analyze_workflow or get_workflow.",
+      },
+    ],
+  },
+  get_workflow: {
+    gloss:
+      "Reads a saved FILE, not the graph currently open on your canvas. Ask for " +
+      "this when the agent needs the actual JSON to change or run; if you only " +
+      "want to know what a workflow does, analyze_workflow is the shorter answer.",
+    examples: [
+      {
+        ask: "Open my portrait workflow so we can change the prompt.",
+        args: { filename: "portrait-flux.json" },
+        returns:
+          "The full workflow as runnable API-format JSON. This is a big " +
+          "response — it is meant for the agent to work on, not for you to read.",
+      },
+      {
+        ask: "Give me the raw file exactly as ComfyUI saved it.",
+        args: { filename: "portrait-flux.json", format: "ui" },
+        returns:
+          "The on-disk UI format, including node positions and colours — what " +
+          "you want if the file is going to be loaded back into the canvas " +
+          "rather than executed.",
+      },
+    ],
+  },
+  analyze_workflow: {
+    gloss:
+      "\"Explain this workflow to me.\" Cheaper and far more readable than " +
+      "get_workflow when you just want to understand what a file does.",
+    examples: [
+      {
+        ask: "What does my portrait workflow actually do?",
+        args: { filename: "portrait-flux.json" },
+        returns:
+          "A short summary: the model it loads, the prompts, the sampler " +
+          "settings, and what it saves.",
+      },
+      {
+        ask: "Is that workflow going to run, or is something missing?",
+        args: { filename: "portrait-flux.json", view: "health" },
+        returns:
+          "Problems only — missing models, unconnected inputs, nodes whose " +
+          "packs are not installed.",
+      },
+    ],
+  },
+  save_workflow: {
+    examples: [
+      {
+        ask: "Save that as a new file so I don't lose the original.",
+        args: { filename: "portrait-flux-v2.json", workflow: WORKFLOW_FRAGMENT },
+        argsNote: FRAGMENT_NOTE,
+        returns: "Confirmation and the path it was written to.",
+        caution:
+          "Writing to a filename that already exists replaces that file. Ask " +
+          "for a new name — as above — when you want to keep the original.",
+      },
+    ],
+  },
+
+  // -------------------------------------------------------------------------
+  // Workflow Authoring
+  // -------------------------------------------------------------------------
+  get_node_info: {
+    examples: [
+      {
+        ask: "What settings does the KSampler node have?",
+        args: { node_type: "KSampler" },
+        returns:
+          "That node's inputs and outputs with their types. Dropdown options are " +
+          "summarised as a count by default, because a model-loader dropdown can " +
+          "be hundreds of kilobytes on its own.",
+      },
+    ],
+  },
+  validate_workflow: {
+    examples: [
+      {
+        ask: "Will this run?",
+        args: { workflow: WORKFLOW_FRAGMENT },
+        argsNote: FRAGMENT_NOTE,
+        returns:
+          "Either a clean bill of health or the specific problems, without " +
+          "queuing anything.",
+      },
+    ],
+  },
+
+  // -------------------------------------------------------------------------
+  // Assets & Images
+  // -------------------------------------------------------------------------
+  list_output_images: {
+    gloss:
+      "What has ComfyUI actually written to disk lately. Worth knowing: video " +
+      "nodes often finish without registering in ComfyUI's history, so this is " +
+      "the reliable way to confirm a video really rendered.",
+    examples: [
+      {
+        ask: "Show me the last few things I generated.",
+        args: { limit: 10 },
+        returns:
+          "The ten newest files, newest first, each with whether it is an image " +
+          "or a video, its folder, size and time. Not the pictures themselves — " +
+          "ask to see one and the agent fetches it.",
+      },
+      {
+        ask: "Did that fox render ever come out?",
+        args: { pattern: "fox", limit: 5 },
+        returns: "Only files whose names contain \"fox\".",
+      },
+    ],
+  },
+  view_image: {
+    gloss:
+      "Puts an image in front of the agent so it can actually look at it — for " +
+      "\"is this any good?\", \"compare these two\", \"what is wrong with the hands\".",
+    examples: [
+      {
+        ask: "Show me that one.",
+        args: { asset_id: "asset_01HQ8Z3K7V" },
+        returns:
+          "The image inline, visible to both of you. The asset id comes from " +
+          "the completion message of the run that made it.",
+      },
+    ],
+  },
+  get_image: {
+    examples: [
+      {
+        ask: "Save that render onto my desktop.",
+        args: {
+          filename: "portrait_00042_.png",
+          type: "output",
+          save_dir: "C:/Users/me/Desktop",
+        },
+        returns:
+          "The file copied to that folder, and the path it landed at. Use this " +
+          "rather than view_image for video and audio, which cannot be shown " +
+          "inline.",
+      },
+    ],
+  },
+
+  // -------------------------------------------------------------------------
+  // Models
+  // -------------------------------------------------------------------------
+  search_models: {
+    examples: [
+      {
+        ask: "Find me a Flux model I can actually run.",
+        args: { query: "flux schnell", limit: 5 },
+        returns:
+          "Matching models with their download URLs and file sizes. Nothing is " +
+          "downloaded — this is a search.",
+      },
+    ],
+  },
+  download_model: {
+    examples: [
+      {
+        ask: "Get that one.",
+        args: {
+          url: "https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/flux1-schnell.safetensors",
+          target_subfolder: "checkpoints",
+        },
+        returns:
+          "Live progress in the panel's download tray, and the path the file " +
+          "landed at. `target_subfolder` decides which ComfyUI dropdown it shows " +
+          "up in — checkpoints, loras, vae and so on.",
+        caution:
+          "Model files are large — many are 5-25 GB. Check you have the disk " +
+          "space before agreeing to a few of these.",
+      },
+    ],
+  },
+  list_local_models: {
+    examples: [
+      {
+        ask: "Which checkpoints do I already have?",
+        args: { model_type: "checkpoints" },
+        returns:
+          "The model filenames in that folder — the exact strings a workflow " +
+          "needs. Omit `model_type` to see every folder at once.",
+      },
+    ],
+  },
+  resolve_missing_models: {
+    gloss:
+      "The answer to \"this workflow says a model is missing\". It works out " +
+      "what is actually absent and finds downloadable candidates, including " +
+      "smaller quantised versions when the full file will not fit your GPU.",
+    examples: [
+      {
+        ask: "This workflow won't run, it says something's missing. Find it for me.",
+        args: { workflow: WORKFLOW_FRAGMENT },
+        argsNote: FRAGMENT_NOTE,
+        returns:
+          "Each missing file with candidate downloads, their sizes and " +
+          "precision, and whether each one fits your VRAM. It downloads nothing " +
+          "— you pick, then it fetches.",
+      },
+    ],
+  },
+  remove_model: {
+    examples: [
+      {
+        ask: "Delete that old LoRA, I'm out of disk space.",
+        args: { path: "loras/old-character-v1.safetensors" },
+        returns: "Confirmation, and how much space came back.",
+        caution:
+          "This deletes the file. There is no undo and no recycle bin — you " +
+          "would have to download it again. Check the path is the one you mean.",
+      },
+    ],
+  },
+
+  // -------------------------------------------------------------------------
+  // Custom Nodes
+  // -------------------------------------------------------------------------
+  search_custom_nodes: {
+    examples: [
+      {
+        ask: "Is there a node pack for face detailing?",
+        args: { query: "face detailer", limit: 5 },
+        returns:
+          "Matching packs from the registry with their ids, authors and " +
+          "descriptions. The id is what install_custom_node wants.",
+      },
+    ],
+  },
+  install_custom_node: {
+    examples: [
+      {
+        ask: "Install the Impact Pack.",
+        args: { id: "comfyui-impact-pack" },
+        returns:
+          "Progress, then confirmation. New nodes do not appear until ComfyUI " +
+          "restarts — the agent will normally offer to do that for you.",
+        caution:
+          "A custom node pack is third-party code that runs inside your " +
+          "ComfyUI. Install packs you have reason to trust, the same as any " +
+          "other plugin.",
+      },
+    ],
+  },
+  install_workflow_dependencies: {
+    gloss:
+      "For a workflow someone sent you that is full of red nodes: this installs " +
+      "the node PACKS it needs. Missing model files are a different problem — " +
+      "that is resolve_missing_models.",
+    examples: [
+      {
+        ask: "Someone sent me this workflow and half the nodes are red. Fix it.",
+        args: { workflow: WORKFLOW_FRAGMENT },
+        argsNote: FRAGMENT_NOTE,
+        returns:
+          "What it installed, what was already there, and anything it could not " +
+          "find. A restart is normally needed before the nodes load.",
+      },
+    ],
+  },
+  node_snapshot: {
+    gloss:
+      "A restore point for your installed node packs. Take one before a round " +
+      "of installing, and you have a way back if something breaks.",
+    examples: [
+      {
+        ask: "Save where my nodes are at before I start installing things.",
+        args: { action: "save", name: "before-impact-pack" },
+        returns: "Confirmation that the snapshot was recorded.",
+      },
+      {
+        ask: "That broke everything. Put it back how it was.",
+        args: { action: "restore", name: "before-impact-pack" },
+        returns: "What it added, removed or re-pinned to match the snapshot.",
+        caution:
+          "Restoring rewrites your installed node packs to match the snapshot — " +
+          "anything installed since is uninstalled or downgraded.",
+      },
+    ],
+  },
+
+  // -------------------------------------------------------------------------
+  // Install & Environment
+  // -------------------------------------------------------------------------
+  workspace: {
+    gloss:
+      "Which ComfyUI installation everything else is talking about. One tool, " +
+      "three jobs, chosen with `action` — this is the tool the " +
+      "[consolidation note](/using-tools#one-tool-several-jobs) uses as its " +
+      "worked example.",
+    examples: [
+      {
+        ask: "Which ComfyUI am I actually using?",
+        args: { action: "get" },
+        returns:
+          "The active install's path and how it was chosen — a flag, an " +
+          "environment variable, or the saved default.",
+      },
+      {
+        ask: "Always use the one on my big drive from now on.",
+        args: { action: "set_default", path: "D:/AI/ComfyUI" },
+        returns:
+          "Confirmation, and it sticks across restarts. Later sessions target " +
+          "this install unless something overrides it.",
+      },
+    ],
+  },
+  install_panel: {
+    gloss:
+      "Installs and updates the Agent sidebar inside ComfyUI. This is the fix " +
+      "when a tool refuses with \"this panel is too old\".",
+    examples: [
+      {
+        ask: "What version of the panel have I got?",
+        args: { action: "status" },
+        returns:
+          "The installed panel version, where it lives, and whether it is " +
+          "pinned. This action changes nothing.",
+      },
+      {
+        ask: "It says my panel is too old — update it.",
+        args: { action: "update" },
+        returns:
+          "The update result. Two more steps are yours: restart ComfyUI, then " +
+          "hard-refresh the ComfyUI browser tab (Ctrl+Shift+R). Without that " +
+          "refresh the tab keeps running the old cached panel code and the same " +
+          "refusal comes back.",
+      },
+    ],
+  },
+  get_environment: {
+    examples: [
+      {
+        ask: "Tell me about my setup — useful when I'm reporting a bug.",
+        args: {},
+        returns:
+          "Where ComfyUI is installed, the Python and torch versions, the GPU, " +
+          "and which settings are in force. The first thing to paste into an " +
+          "issue.",
+      },
+    ],
+  },
+  self_update: {
+    examples: [
+      {
+        ask: "Am I on the latest version?",
+        args: { action: "status" },
+        returns: "Your version, the latest published version, and whether they differ.",
+      },
+      {
+        ask: "Update it.",
+        args: { action: "update" },
+        returns:
+          "The upgrade result. Your MCP client has to be restarted afterwards " +
+          "to pick up the new server.",
+      },
+    ],
+  },
+  report_issue: {
+    examples: [
+      {
+        ask: "This keeps crashing. File a bug about it.",
+        args: {
+          title: "Video render finishes but no file appears in outputs",
+          body:
+            "Running the WAN template completes and history shows success, but " +
+            "output/video/ is empty. Happens every time on 0.49.3.",
+        },
+        returns:
+          "A GitHub issue on the project, with your environment details " +
+          "attached automatically, and a link to it.",
+        caution:
+          "This posts publicly. The environment block it attaches includes " +
+          "paths and versions from your machine — glance at what it drafted " +
+          "before agreeing to send it.",
+      },
+    ],
+  },
+
+  // -------------------------------------------------------------------------
+  // Process Control
+  // -------------------------------------------------------------------------
+  start_comfyui: {
+    examples: [
+      {
+        ask: "Start ComfyUI.",
+        args: {},
+        returns:
+          "It launches the server and waits until it is answering, then tells " +
+          "you the URL. Only works for a ComfyUI on this machine.",
+      },
+    ],
+  },
+  restart_comfyui: {
+    gloss:
+      "The standard next step after installing a node pack — new nodes are not " +
+      "loaded until ComfyUI starts again.",
+    examples: [
+      {
+        ask: "Restart it so the new nodes load.",
+        args: {},
+        returns:
+          "The server stops and comes back up, and you are told when it is " +
+          "answering again.",
+        caution:
+          "Anything queued or rendering is lost. Check the queue is empty first " +
+          "if a long job is in flight.",
+      },
+    ],
+  },
+  stop_comfyui: {
+    examples: [
+      {
+        ask: "Shut ComfyUI down, I need the VRAM.",
+        args: {},
+        returns: "Confirmation that the process stopped.",
+        caution: "Any running or queued render is lost.",
+      },
+    ],
+  },
+
+  // -------------------------------------------------------------------------
+  // Defaults
+  // -------------------------------------------------------------------------
+  get_defaults: {
+    examples: [
+      {
+        ask: "What settings do you use when I don't say?",
+        args: {},
+        returns:
+          "The current fallback size, steps, cfg, sampler and checkpoint, and " +
+          "where each came from.",
+      },
+    ],
+  },
+  set_defaults: {
+    gloss:
+      "Stop repeating yourself. Set the values you always want once, and leave " +
+      "them out of every later request.",
+    examples: [
+      {
+        ask: "Always use 1024 by 1024 and 30 steps, permanently.",
+        args: { values: { width: 1024, height: 1024, steps: 30 }, persist: true },
+        returns:
+          "Confirmation of the new defaults. `persist: true` writes them to your " +
+          "config file so they survive a restart; without it they last only for " +
+          "this session.",
+      },
+    ],
+  },
+
+  // -------------------------------------------------------------------------
+  // Apps (micro-apps)
+  // -------------------------------------------------------------------------
+  apps: {
+    gloss:
+      "Micro-apps are workflows someone has already wired up and reduced to a " +
+      "few boxes to fill in — the closest thing here to a normal app. Handy on " +
+      "mobile, where there is no canvas to edit. One tool, several jobs, chosen " +
+      "with `action`.",
+    examples: [
+      {
+        ask: "What one-click apps do I have?",
+        args: { action: "list" },
+        returns:
+          "Every installed app with its id, name and description. Read-only.",
+      },
+      {
+        ask: "What do I need to fill in for the portrait one?",
+        args: { action: "get", app_id: "b1f4c2de-90a7-4c3e-9d21-5c8e2f7a13bb" },
+        returns:
+          "That app's input form — each box with its label, type and default, " +
+          "and the key you set it by.",
+      },
+      {
+        ask: "Run it with \"a snow leopard on a rooftop\".",
+        args: {
+          action: "run",
+          app_id: "b1f4c2de-90a7-4c3e-9d21-5c8e2f7a13bb",
+          values: { "6.text": "a snow leopard on a rooftop at dusk" },
+        },
+        returns:
+          "A prompt_id immediately; the app renders in the background. Check on " +
+          "it with `action: \"run_status\"` and the same app_id plus that " +
+          "prompt_id. The odd-looking `\"6.text\"` key is nodeId.widget — the " +
+          "form from `action: \"get\"` tells you which keys exist.",
+      },
+    ],
+  },
+};

--- a/src/tools/vocabulary.ts
+++ b/src/tools/vocabulary.ts
@@ -382,6 +382,13 @@ export const DEAD_NAMES: readonly DeadName[] = [
     name: "get_workspace",
     since: "0.49.0",
     replacement: 'workspace (action:"get")',
+    allowedIn: [
+      {
+        path: "docs/using-tools.mdx",
+        context: "| `get_workspace` | `workspace` with `action: \"get\"` |",
+        why: "The old-name → new-form migration table on the human-facing tools guide. A community reader (#660-adjacent confusion) read the 0.49.0 consolidation as capability being REMOVED; the table exists to show the same behaviour under a new label, so the left column must spell the retired name. It is a mapping AWAY from the name, never an instruction to call it.",
+      },
+    ],
   },
   {
     name: "set_default_workspace",
@@ -420,6 +427,13 @@ export const DEAD_NAMES: readonly DeadName[] = [
     name: "get_queue",
     since: "0.49.0",
     replacement: 'queue (action:"list")',
+    allowedIn: [
+      {
+        path: "docs/using-tools.mdx",
+        context: "| `get_queue` | `queue` with `action: \"list\"` |",
+        why: "Same migration table as get_workspace above — the retired name appears only in the left column, mapped to its live replacement on the right.",
+      },
+    ],
   },
   {
     name: "get_queued_workflow",
@@ -591,6 +605,13 @@ export const DEAD_NAMES: readonly DeadName[] = [
     name: "apps_run_status",
     since: "0.49.0",
     replacement: 'apps (action:"run_status")',
+    allowedIn: [
+      {
+        path: "docs/using-tools.mdx",
+        context: "| `apps_run_status` | `apps` with `action: \"run_status\"` |",
+        why: "Same migration table as get_workspace above. Included as the third row because it is from a DIFFERENT consolidation slice, showing the reader that the pattern is general rather than one tool's quirk.",
+      },
+    ],
   },
   {
     name: "apps_import",


### PR DESCRIPTION
> "make sure we're making detailed updates to the docs on how to use and call these tools for the non AI types."

The Tool Reference was accurate and unusable for exactly those people.

- **Every example was a placeholder.** All 16 generated pages ended in *"Example coming soon — the call below is a generated skeleton"* followed by a stub echoing the field name back (`{"filename": "<filename>"}`). Not one worked example in the entire reference.
- **The prose was the model-facing dispatch text verbatim.** A human reading `get_workflow` learned it avoids "flooding context with JSON" — a real concern, but not theirs.
- **The mental model was wrong.** Every page showed a `{"tool": …, "arguments": …}` block. The audience this was written for never types that. They talk to the agent in the ComfyUI sidebar, in English.

Related: **#660** (the docker-compose docs gap) — same root cause, docs written for the wrong audience.

## 1. A new page for humans — `docs/using-tools.mdx`

Added to **Getting Started**, right after Quickstart.

- **A tool is a thing the agent can do, not a thing you type** — with a side-by-side "you say / it quietly runs" table. One row deliberately maps one sentence to *two* tools in an order the reader never had to know.
- **What all that JSON is** — a transcript of what the agent sent, worth being able to read, not worth memorising.
- **Two places tools come from** — the sidebar panel (`panel_*`, drives the canvas you are looking at) vs. an outside client (drives the server). Framed around the word *"this"*: when you say "add a LoRA to **this**", the panel knows what "this" is because it can see your screen. Beginners are pointed at the panel.
- **One tool, several jobs** — the action-parameterized pattern in human terms, with a **"Nothing was removed"** subsection. This is live confusion: a community member read the 0.49.0 consolidation as capability being *cut*. It isn't, and the page says so with a migration table and the actual reason (tool-choice accuracy degrades past a certain menu size).
- **When it says no** — that a refusal is usually a guard, not a bug; the *"panel is too old"* fix as a 3-step `<Steps>` block with the **hard-refresh** step called out as the one everyone skips (skip it and the same message returns, which reads as the update having failed); and "no panel connected", which is nearly always just a tab reload.
- **If you run a small local model** — the 3-tool compact facade, that it is already the default, and the `--compact` / `--full` / `COMFYUI_MCP_TOOL_MODE` controls.

Teaches the *pattern* throughout and avoids hard-coding lists of names or any tool count, so it survives the consolidation to ~32.

## 2. Real examples — through the generator, not by hand

Hand-edited `.mdx` gets destroyed by the next `npm run docs:gen`, and CI fails on the drift. So examples are a new data source the generator reads: **`scripts/tool-doc-examples.ts`**.

**55 worked examples and 18 plain-English glosses across 12 of 16 pages.** Each example carries what a person would actually say, realistic arguments, what comes back, and a `<Warning>` wherever the call deletes, overwrites, costs money, or interrupts a render someone may be waiting on — `queue action:"clear"`, `remove_model`, `restart_comfyui`, `install_custom_node`, `node_snapshot action:"restore"`, `report_issue`.

```
**You say:** Kill the one that's running, it's wrong.

{ "tool": "queue", "arguments": { "action": "cancel", "prompt_id": "8f3c1a02-…" } }

**You get back:** Confirmation that the job was interrupted.

⚠ This stops work in progress and you do not get the partial result. If you
  share this ComfyUI with anyone else, make sure the job is yours.
```

Every generated page also gained a banner saying the JSON is what the *agent* sends, linking to the new guide — which fixes the wrong-mental-model problem across all 16 pages at once.

### Examples are validated against the live zod schemas

A wrong example is worse than a missing one, because a reader copies it. So `docs:gen` now fails, before writing a single page, on:

1. **An unknown field.** zod objects *strip* unknown keys, so `safeParse` alone happily accepts `{"filenmae": …}` and reports success — the typo would ship. Checked explicitly against the schema's properties.
2. **A wrong type or missing required field** — `safeParse` against the same shape the MCP SDK advertises (`io: "input"`).
3. **A key naming a tool that no longer exists** — during the consolidation this must be loud, not a silently-ignored map entry.

Verified by deliberately breaking one:

```
[gen-tool-docs] 2 documented example(s) do not match the live tool schemas:
  get_workflow example #1 (…): field(s) `filenmae`, `steps` do not exist on this tool.
      Known fields: filename, format.
  get_workflow example #1 (…): does not satisfy the tool's schema —
      filename: Invalid input: expected string, received undefined
```

## 3. Model-facing descriptions untouched

They are tuned for LLM dispatch and were the subject of a real bug (#557/#654, where 7/7 local models picked the wrong tool). A readability edit there is a regression in tool choice, not an improvement. Where a description reads badly to a human, a **gloss renders alongside it** — the dispatch text is never rewritten.

## Coverage

**Covered** (beginner path, end to end): workflow library (list/get/analyze/save), image + video generation, execution (health, queue, history, diagnose, stats, enqueue, templates), assets (list/view/get), models (search/download/list/resolve/remove), custom nodes (search/install/deps/snapshot), install + environment (workspace, panel, environment, self-update, report issue), process control, defaults, apps.

**Deliberately left on the skeleton:** RunPod, LoRA training, comfy-cli (26 actions), API nodes, node authoring — expert surfaces where a beginner is not the reader. The skeleton note now says examples are welcome and where they live, rather than "coming soon". A missing example is an honest gap; a made-up one is a bug.

## Notes

The three retired names in the migration table are exempted **per-occurrence** via `allowedIn` in the vocabulary ledger — the sanctioned append-only mechanism for history that is not rot, matching the existing precedent for the TDQS case study. Nothing was deleted from the ledger.

The vocabulary gate earned its keep here: it caught two mentions I had missed, **one of them in my own code comment** in `gen-tool-docs.ts`. Both were reworded rather than exempted.

## Verification

- `npm run build`, `npm run lint` — clean
- `npm test` — **239 files, 4039 passed**, 2 skipped
- `npm run check:vocabulary` — OK (1049 files, 41 dead names, no live references)
- `npm run vocab:export -- --check` — OK
- `node scripts/asset-counts.mjs --check` — OK (no counts stated in the new page)
- `npm run docs:gen` — **idempotent**; second run produces an empty diff
- `git diff --numstat` — real line counts on every file, no binary/NUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
