### PR TITLE
fix(report-issue): poll past the worker's wall clock + surface root-cause clusters

### DIFF
--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -73,6 +73,13 @@ export interface TriageResult {
   recommend_upgrade?: boolean;
   agent_message?: string;
   possible_duplicate?: boolean;
+  /**
+   * Existing issues triage judged to share a root cause with this report
+   * (classification "related"). The created issue's body references them, so
+   * GitHub already cross-linked the cluster; surfaced so the agent can tell
+   * the user their report joined a known defect.
+   */
+  related_issues?: number[];
 }
 
 /**
@@ -129,8 +136,12 @@ export async function submitAndPoll(opts: {
 }): Promise<SubmitOutcome> {
   const doFetch = opts.fetchImpl ?? fetch;
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
-  // AI triage runs ~30-120s; poll patiently but bounded. ~40 * 3s ≈ 2 min.
-  const maxPolls = opts.maxPolls ?? 40;
+  // Poll past the WORKER's own wall-clock budget, not just the typical triage
+  // time — the worker allows itself up to 240 s (TRIAGE_WALL_CLOCK_MS) and a
+  // thorough dedup (several searches + candidate reads) now uses it. A shorter
+  // client budget returns "still triaging" for work that was about to finish,
+  // costing the reporter the fix-version/duplicate answer. ~95 * 3 s ≈ 285 s.
+  const maxPolls = opts.maxPolls ?? 95;
   const pollDelayMs = opts.pollDelayMs ?? 3000;
   const timeoutMs = opts.timeoutMs ?? 15000; // per-request cap (not the whole job)
 
@@ -267,6 +278,9 @@ function frameToResult(frame: StatusFrame): TriageResult | null {
     recommend_upgrade: p?.recommend_upgrade,
     agent_message: p?.agent_message,
     possible_duplicate: p?.possible_duplicate,
+    // Older workers omit this entirely — keep it absent rather than [] so the
+    // surface distinguishes "no cluster" from "worker predates clustering".
+    related_issues: Array.isArray(p?.related_issues) ? p.related_issues : undefined,
   };
 }
 
@@ -376,6 +390,9 @@ export function registerReportIssueTools(server: McpServer): void {
               fix_pr_url: r.fix_pr_url,
               recommend_upgrade: r.recommend_upgrade,
               possible_duplicate: r.possible_duplicate,
+              // Present (non-empty) when triage judged this a NEW symptom of an
+              // already-known defect; the issues are cross-linked on GitHub.
+              related_issues: r.related_issues?.length ? r.related_issues : undefined,
               versions: outcome.ack.versions,
               up_to_date: outcome.ack.up_to_date,
               upgrade_hint: outcome.ack.upgrade_hint,


### PR DESCRIPTION
Client half of the triage-clustering work shipped in comfyui-mcp-issue-worker@98b33c5 (already deployed).

## Why

Reports arrive in **clusters** — several symptoms of ONE defect, hours apart, worded differently — and triage had no way to say so. In the last 24h that produced 4 separate `panel_get_errors` stale-state issues and 7 separate graph-binding-desync issues, each filed as "new".

The worker now fixes the root cause (a `related` classification + a search-before-create dedup gate). This is the client side.

## Changes

**Poll past the worker's wall clock.** The client gave up at ~120 s while the worker allows itself 240 s (`TRIAGE_WALL_CLOCK_MS`). A thorough dedup — several search angles plus candidate reads, which the worker now *requires* before it may file — routinely runs past the old budget, so the reporter got "still triaging" for work that was about to produce the duplicate/fix-version answer. Now ~285 s, comfortably past the worker's ceiling.

**Surface `related_issues`.** Triage can now classify a report `related` (a NEW symptom of an already-known defect) and cross-link the cluster on GitHub. Kept *absent* rather than `[]` when the worker omits it, so the surface distinguishes "no cluster" from "worker predates clustering".

## Compatibility

No breaking change for older clients: `classification` is typed as a plain `string` and a `related` filing still carries an issue URL with `action_taken: "created"`, so an old client sees an ordinary successful filing.

## Verification

- `npm run lint`, `npm run build` clean
- `report-issue.test.ts`: 31/31 pass
- `asset-counts --check` and `check:vocabulary` gates pass
- Worker side: 167/167 pass, deployed (version `71be7c8f`)

Note: `src/__tests__/services/hello-retarget.test.ts` has an unrelated **uncommitted** WIP in the working tree (imports `comfyuiInstanceKey`, which the source does not export yet) — deliberately NOT included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)