### PR TITLE
release: 0.49.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.49.4] - 2026-08-03
+
+### MCP
+
+#### Fixed
+- poll past the worker's wall clock + surface root-cause clusters (#799)
+- make the completion event durable across automatic goal continuation (#468) (#786)
+- resolve panel_load_workflow relative paths against the live user directory (#202) (#787)
+- resolve the destination from the live server and verify it on disk (#369) (#794)
+- stop root icon requests becoming logged 404s (#783)
+- distinguish watchdog stalls from user cancellations (#782)
+- make stale panel-lock recovery fail closed (#779)
+- list reachable local extra paths without argv main.py (#781)
+- retain stale persisted downloads (#761) (#780)
+- gate the hello retarget on the server-observed origin — never trust the spoofable claim (codex gate)
+- hello veto protects only a healthy target — a ComfyUI restart can no longer pin stale remote state
+- do not capability-mark the no-trusted-identity refusal (codex gate)
+- type the capability refusal; full tab id + hard-refresh recovery
+
+
 ## [0.49.3] - 2026-08-03
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.49.1",
+  "version": "0.49.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.49.1",
+      "version": "0.49.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.49.3",
+  "version": "0.49.4",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the `v0.49.4` version bump + changelog onto protected `main`. The tag is already pushed and **published to npm as 0.49.4**; this PR only carries the `package.json` bump and generated `CHANGELOG.md`.

Ships 13 commits since v0.49.3, including the client half of the triage-clustering work (#799) whose worker side is already deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)