### PR TITLE
fix(panel): rebind the agent tab across id migration and keep the release fallback starvation-free (#568)

### DIFF
--- a/src/__tests__/orchestrator/interrupt-storm.test.ts
+++ b/src/__tests__/orchestrator/interrupt-storm.test.ts
@@ -22,9 +22,10 @@ import type {
 import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
 
 let PanelAgent: typeof import("../../orchestrator/panel-agent.js").PanelAgent;
+let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
 
 beforeAll(async () => {
-  ({ PanelAgent } = await import("../../orchestrator/panel-agent.js"));
+  ({ PanelAgent, PanelAgentManager } = await import("../../orchestrator/panel-agent.js"));
 });
 
 /** A WEDGED backend: each turn hangs, and an interrupt breaks the hang (so the
@@ -133,5 +134,74 @@ describe("interrupt storm does not starve the release fallback (#568 Defect 2)",
     expect(backend.turns.join("\n\n")).toContain("the follow-up");
 
     await agent.stop();
+  });
+
+  // The property that makes the net starvation-free rather than merely "eventually
+  // scheduled": the deadline set by the FIRST interrupt of an unsettled burst is an
+  // ABSOLUTE ceiling. Later interrupts refresh the guard (so it keeps naming the
+  // still-stuck turn) but must never push the deadline out. Timing it — not just
+  // "does a turn eventually start" — is what distinguishes the two: a re-arming net
+  // still fires eventually once the storm stops, so a generous bound passes in BOTH
+  // states.
+  it("releases within ONE window of the FIRST interrupt, however many follow", async () => {
+    const backend = new WedgedBackend();
+    const agent = new PanelAgent("tab-ceiling", makeDeps() as never, backend);
+    void agent.start();
+
+    agent.send("wedged first");
+    await waitFor(() => backend.turns.length === 1);
+    agent.send("the follow-up");
+
+    const firstInterruptAt = Date.now();
+    void agent.interrupt({ requeueInFlight: true });
+    // Keep hammering INSIDE the window (50ms < 150ms) — each one is a chance to
+    // postpone the net.
+    const storm = setInterval(() => {
+      void agent.interrupt({ requeueInFlight: true });
+    }, 50);
+    try {
+      await waitFor(() => backend.turns.length >= 2, 1200);
+    } finally {
+      clearInterval(storm);
+    }
+    const elapsed = Date.now() - firstInterruptAt;
+
+    // One 150ms window plus scheduling slack. A net that any later interrupt could
+    // re-arm would land far beyond this (the storm ran for the whole wait).
+    expect(elapsed).toBeLessThan(600);
+
+    await agent.stop();
+  });
+});
+
+// #568 — the two defects compound: a stale identity means the interrupt reaches no
+// live agent at all, and an interrupt that reaches nothing arms NO recovery (no turn
+// gate is held for it, no release fallback is scheduled). Reporting that as a
+// completed cancellation is a could-not/did-not conflation, and it is what left the
+// user hammering "send now" at a tab with nothing behind it. The outcome must be
+// distinguishable.
+describe("interrupt reports whether a live agent actually took it (#568)", () => {
+  it("false when the key has no agent, true once one exists", async () => {
+    const backend = new WedgedBackend();
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      makeBackend: () => backend,
+    } as never);
+
+    const key = "tmp:no-agent::claude";
+    expect(manager.hasLiveAgent(key)).toBe(false);
+    // Nothing was cancelled — and, critically, nothing was scheduled to recover either.
+    await expect(manager.interrupt(key, { requeueInFlight: true })).resolves.toBe(false);
+
+    manager.send(key, "spawns the agent");
+    await waitFor(() => backend.turns.length === 1);
+    expect(manager.hasLiveAgent(key)).toBe(true);
+    await expect(manager.interrupt(key, { requeueInFlight: true })).resolves.toBe(true);
+
+    await manager.stopAll();
   });
 });

--- a/src/__tests__/orchestrator/interrupt-storm.test.ts
+++ b/src/__tests__/orchestrator/interrupt-storm.test.ts
@@ -64,6 +64,41 @@ class WedgedBackend implements AgentBackend {
   }
 }
 
+/** A backend whose interrupt() HANGS until released — so stopAll()'s awaited stop()
+ *  never resolves and the closed agent stays in the manager's map indefinitely. That
+ *  unbounded window is the one where map presence and liveness diverge. */
+class HangingStopBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turns: string[] = [];
+  private release: (() => void) | null = null;
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    yield { type: "session", sessionId: "sess-hang" };
+    for await (const turn of opts.channel) {
+      this.turns.push(turn.text);
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+
+  async interrupt(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      this.release = resolve;
+    });
+  }
+
+  /** Let the pending stop() finish so the test doesn't leave it dangling. */
+  releaseStop(): void {
+    const r = this.release;
+    this.release = null;
+    r?.();
+  }
+
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
 function makeDeps() {
   return {
     mcpServers: {},
@@ -203,5 +238,41 @@ describe("interrupt reports whether a live agent actually took it (#568)", () =>
     await expect(manager.interrupt(key, { requeueInFlight: true })).resolves.toBe(true);
 
     await manager.stopAll();
+  });
+
+  // MAP PRESENCE IS NOT LIVENESS. reset()/retire() unmap before stopping, but
+  // stopAll() sets `closed` on every agent synchronously and keeps them MAPPED until
+  // each awaited stop() resolves — and stop() awaits the backend, which can hang. The
+  // bridge is still serving the panel throughout that window, so an interrupt can land
+  // in it. Reporting it as taken would fabricate exactly the success this reporting
+  // exists to stop fabricating — the "agent exists but is closed" case one step over
+  // from "no agent at all".
+  it("reports NOT interrupted inside the shutdown window, even while still mapped", async () => {
+    const backend = new HangingStopBackend();
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      makeBackend: () => backend,
+    } as never);
+
+    const key = "tmp:shutting-down::claude";
+    manager.send(key, "a turn");
+    await waitFor(() => backend.turns.length === 1);
+    expect(manager.hasLiveAgent(key)).toBe(true);
+
+    // Shutdown begins but does NOT complete: this backend's interrupt never settles,
+    // so the agent stays in the map indefinitely with `closed` already true.
+    const stopping = manager.stopAll();
+    expect(manager.hasLiveAgent(key)).toBe(false);
+
+    // Must answer FALSE, and must answer AT ALL — a hung backend.interrupt() cannot be
+    // allowed to stall it, which is why the predicate short-circuits before the await.
+    await expect(manager.interrupt(key, { requeueInFlight: true })).resolves.toBe(false);
+
+    backend.releaseStop();
+    await stopping;
   });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1148,6 +1148,27 @@ describe("UiBridge (multi-tab)", () => {
       sockA.close();
       sockB.close();
     });
+
+    it("follows a migration CHAIN, and a revoke of a superseded hop is inert", async () => {
+      const { sockA, sockB } = await twoTabsWithAActive();
+      // wf:aaa → tmp:mid → wf:ccc, all on the SAME socket (the reported id-scheme chain).
+      sockA.send(JSON.stringify({ type: "hello", tab_id: "tmp:mid" }));
+      await vi.waitFor(() => expect(bridge.resolveActiveTabId()).toBe("tmp:mid"));
+      sockA.send(JSON.stringify({ type: "hello", tab_id: "wf:ccc" }));
+      await vi.waitFor(() => expect(bridge.resolveActiveTabId()).toBe("wf:ccc"));
+
+      // Revoking the FIRST (already superseded) hop must not touch the live selection:
+      // the carry it recorded was overwritten by the second hop, and only the write
+      // SEQUENCE distinguishes "my carry is still current" from "it was superseded".
+      bridge.revokeTabMigration("wf:aaa");
+      expect(bridge.resolveActiveTabId()).toBe("wf:ccc");
+
+      // Revoking the hop that actually produced the live selection DOES clear it.
+      bridge.revokeTabMigration("tmp:mid");
+      expect(() => bridge.resolveActiveTabId()).toThrow(/none is "last active"/);
+      sockA.close();
+      sockB.close();
+    });
   });
 
   it("follows MIGRATION CHAINS: uuid → tmp: → wf: (the exact #210 field sequence)", async () => {

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1070,6 +1070,86 @@ describe("UiBridge (multi-tab)", () => {
     sockB.close();
   });
 
+  // #568 — the last-active SELECTION is per-tab identity state and must move with a
+  // same-socket tab-id migration. Left on the retiring id it names a tab that no longer
+  // exists, so with 2+ tabs connected every no-tabId resolution reports "none is last
+  // active" and panel_set_workflow_target({mode:"current"}) — the one documented escape
+  // hatch for a stale binding — can no longer recover. That is the reported wedge:
+  // save-as with two tabs open, then nothing can rebind.
+  describe("last-active selection across a tab-id migration (#568)", () => {
+    /** Two live tabs; A has the last-active selection. Returns both sockets. */
+    async function twoTabsWithAActive(): Promise<{ sockA: WebSocket; sockB: WebSocket }> {
+      const sockA = await connectPanel();
+      autoReply(sockA, "A");
+      sockA.send(JSON.stringify({ type: "hello", tab_id: "wf:aaa" }));
+      const sockB = await connectPanel();
+      autoReply(sockB, "B");
+      sockB.send(JSON.stringify({ type: "hello", tab_id: "wf:bbb" }));
+      await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(2));
+      // The user typed in A — that is what makes A the last-active tab.
+      sockA.send(JSON.stringify({ type: "user_message", text: "hi" }));
+      await vi.waitFor(() => expect(bridge.resolveActiveTabId()).toBe("wf:aaa"));
+      return { sockA, sockB };
+    }
+
+    it("a PROVEN same-socket migration moves it, so the explicit rebind still resolves", async () => {
+      const { sockA, sockB } = await twoTabsWithAActive();
+
+      // Save-as: the SAME socket re-hellos under a new wf: id. The retiring id is removed.
+      sockA.send(JSON.stringify({ type: "hello", tab_id: "wf:ccc" }));
+      await vi.waitFor(() => expect(bridge.tabs().map((t) => t.tab_id).sort()).toEqual(["wf:bbb", "wf:ccc"]));
+
+      // The selection followed the SAME BROWSER TAB onto its new id — not a guess among the
+      // live tabs, and emphatically not the unrelated wf:bbb. Without the carry this throws.
+      expect(bridge.resolveActiveTabId()).toBe("wf:ccc");
+      expect(bridge.status()).toContain("wf:ccc");
+      sockA.close();
+      sockB.close();
+    });
+
+    it("an UNPROVEN switch (revoked migration) REFUSES — it never names the switched-to tab", async () => {
+      const { sockA, sockB } = await twoTabsWithAActive();
+      sockA.send(JSON.stringify({ type: "hello", tab_id: "wf:ccc" }));
+      await vi.waitFor(() => expect(bridge.tabs().map((t) => t.tab_id).sort()).toEqual(["wf:bbb", "wf:ccc"]));
+
+      // The orchestrator classified the re-hello as a switch to a DIFFERENT workflow.
+      bridge.revokeTabMigration("wf:aaa");
+
+      // UNKNOWN gets its own answer: refuse. The distinguishing assertion is that the
+      // resolution does NOT come back as the switched-to tab — asserting only "throws"
+      // would also pass if the selection had been cleared for the wrong reason, and
+      // asserting only the tab COUNT passes in both the fixed and broken states.
+      let resolved: string | null = null;
+      try {
+        resolved = bridge.resolveActiveTabId();
+      } catch {
+        resolved = null;
+      }
+      expect(resolved).not.toBe("wf:ccc");
+      expect(resolved).toBeNull();
+      expect(() => bridge.resolveActiveTabId()).toThrow(/none is "last active"/);
+      sockA.close();
+      sockB.close();
+    });
+
+    it("does NOT revert a selection the user made in the destination after the migration", async () => {
+      const { sockA, sockB } = await twoTabsWithAActive();
+      sockA.send(JSON.stringify({ type: "hello", tab_id: "wf:ccc" }));
+      await vi.waitFor(() => expect(bridge.resolveActiveTabId()).toBe("wf:ccc"));
+
+      // The user then typed in the (switched-to) tab: a fresh, genuine selection that
+      // happens to hold the SAME value the carry wrote, so only the write SEQUENCE can
+      // tell them apart. The revoke must undo the carry, never this.
+      sockA.send(JSON.stringify({ type: "user_message", text: "typed after the switch" }));
+      await new Promise((r) => setTimeout(r, 30));
+      bridge.revokeTabMigration("wf:aaa");
+
+      expect(bridge.resolveActiveTabId()).toBe("wf:ccc");
+      sockA.close();
+      sockB.close();
+    });
+  });
+
   it("follows MIGRATION CHAINS: uuid → tmp: → wf: (the exact #210 field sequence)", async () => {
     // The reported failure re-helloed TWICE: legacy random UUID, then the
     // unsaved-tab tmp:<uuid> id, then the saved wf:<hash> id. The ORIGINAL id

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -4180,11 +4180,29 @@ export async function runPanelOrchestrator(): Promise<void> {
       // interrupted turn so BOTH messages get answered; a plain Stop/Ctrl+C/Esc
       // sends a bare interrupt and must NOT re-run the stopped turn.
       const requeueInFlight = (event as { requeue?: boolean }).requeue === true;
+      // #568 — report what actually happened. An interrupt addressed to a key with no
+      // live agent (the tab's agent was retired by an unprovable workflow switch, or the
+      // panel is still driving a pre-migration id) reaches nothing: no turn gate is held
+      // for it and no release fallback is armed, so nothing will ever "finish". Acking it
+      // as a plain success is exactly the could-not/did-not conflation that made the wedge
+      // unreadable — the user keeps pressing "send now" against a tab that has no agent.
+      // `ok` stays true (the orchestrator DID handle the frame); `interrupted` carries the
+      // outcome, and a miss is logged loudly rather than silently.
+      // Read the outcome SYNCHRONOUSLY (the manager resolves the key before its first
+      // await), so the ack still goes out immediately — a hung backend.interrupt() must
+      // never be able to withhold it.
+      const reached = manager.hasLiveAgent(agentKeyFor(tabId));
       void manager.interrupt(agentKeyFor(tabId), { requeueInFlight });
-      bridge.push({ type: "ack", ok: true, kind: "interrupt" }, tabId);
-      logger.info(
-        `[panel-orchestrator] tab ${tabId.slice(0, 8)} interrupted${requeueInFlight ? " (send-now: re-queue)" : ""}`,
-      );
+      bridge.push({ type: "ack", ok: true, kind: "interrupt", interrupted: reached }, tabId);
+      if (reached) {
+        logger.info(
+          `[panel-orchestrator] tab ${tabId.slice(0, 8)} interrupted${requeueInFlight ? " (send-now: re-queue)" : ""}`,
+        );
+      } else {
+        logger.warn(
+          `[panel-orchestrator] tab ${tabId.slice(0, 8)} interrupt reached NO live agent — nothing was cancelled and no recovery is armed (the tab's agent was retired, or the panel is still driving a pre-migration tab id); the next message will spawn a fresh agent`,
+        );
+      }
       return;
     }
 

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -886,6 +886,16 @@ export class PanelAgent {
     this.interruptReleaseTimer.unref?.();
   }
 
+  /** INVARIANT that makes the net starvation-free rather than merely eventually-
+   *  scheduled, and the reason every clear lives behind this one seam: the fallback is
+   *  only ever cleared at a point where the gate is (or is about to be) OPEN —
+   *  completeTurn() and releaseTurns() both open it, and start()'s session-ended clear
+   *  is followed by a counter reset on the next loop iteration. So "an interrupt
+   *  happened and the gate is still closed" implies a timer is armed, and that timer's
+   *  deadline was set by the FIRST interrupt of the burst (arm coalesces) while its
+   *  guard tracks the LATEST interrupt's still-stuck turn. A storm can therefore neither
+   *  postpone the release nor aim it at the wrong turn. Any new clear site must preserve
+   *  this — clearing while the gate stays shut re-creates the #568 wedge. */
   private clearInterruptReleaseFallback(): void {
     if (this.interruptReleaseTimer) {
       clearTimeout(this.interruptReleaseTimer);
@@ -1879,7 +1889,9 @@ export class PanelAgentManager {
   }
 
   /** Whether a live agent (session) exists for this composite key — used to flag
-   *  the mobile mirror picker's "session attached" dot. */
+   *  the mobile mirror picker's "session attached" dot, and as the SYNCHRONOUS half
+   *  of {@link interrupt}'s outcome for callers that must report it without waiting
+   *  on the backend's (possibly slow, possibly hung) interrupt round-trip (#568). */
   hasLiveAgent(key: string): boolean {
     return this.agents.has(key);
   }
@@ -2573,8 +2585,17 @@ export class PanelAgentManager {
     );
   }
 
-  async interrupt(tabId: string, opts: { requeueInFlight?: boolean } = {}): Promise<void> {
-    await this.agents.get(tabId)?.interrupt(opts);
+  /** Interrupt a tab's live agent. Returns whether a live agent actually TOOK the
+   *  interrupt — an interrupt addressed to a key with no agent is a silent no-op that
+   *  arms NO recovery at all (no turn gate is held, no release fallback is scheduled),
+   *  so the caller must not report it as a completed cancellation. Reporting "done"
+   *  for an interrupt nothing received is the same could-not/did-not conflation that
+   *  made #568 look like a wedge nobody could explain. */
+  async interrupt(tabId: string, opts: { requeueInFlight?: boolean } = {}): Promise<boolean> {
+    const agent = this.agents.get(tabId);
+    if (!agent) return false;
+    await agent.interrupt(opts);
+    return true;
   }
 
   async stopAll(): Promise<void> {

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1891,9 +1891,16 @@ export class PanelAgentManager {
   /** Whether a live agent (session) exists for this composite key — used to flag
    *  the mobile mirror picker's "session attached" dot, and as the SYNCHRONOUS half
    *  of {@link interrupt}'s outcome for callers that must report it without waiting
-   *  on the backend's (possibly slow, possibly hung) interrupt round-trip (#568). */
+   *  on the backend's (possibly slow, possibly hung) interrupt round-trip (#568).
+   *
+   *  LIVE means live, not merely mapped. reset()/retire() unmap through unbindAgent()
+   *  BEFORE stopping, but stopAll() sets `closed` on every agent and keeps them mapped
+   *  until each awaited stop() resolves — an unbounded window when a backend hangs.
+   *  A closed agent takes no message, runs no turn and accepts no interrupt, so every
+   *  caller of this ("is there an agent I can act on?") must see through that window. */
   hasLiveAgent(key: string): boolean {
-    return this.agents.has(key);
+    const agent = this.agents.get(key);
+    return !!agent && !agent.isStopped;
   }
 
   /** #570 P0 — true when this key holds ANY per-tab live/queued state that reset() would
@@ -2593,7 +2600,13 @@ export class PanelAgentManager {
    *  made #568 look like a wedge nobody could explain. */
   async interrupt(tabId: string, opts: { requeueInFlight?: boolean } = {}): Promise<boolean> {
     const agent = this.agents.get(tabId);
-    if (!agent) return false;
+    // MAP PRESENCE IS NOT LIVENESS. stopAll() sets `closed` synchronously on every
+    // agent but keeps them MAPPED until each awaited stop() resolves — and stop()
+    // awaits the backend, which can hang. An interrupt arriving in that window has
+    // nothing that can take it, so returning true here would fabricate exactly the
+    // success this method exists to stop fabricating. Bail without awaiting, too: a
+    // hung backend.interrupt() must not be able to stall the answer.
+    if (!agent || agent.isStopped) return false;
     await agent.interrupt(opts);
     return true;
   }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -769,7 +769,16 @@ export class UiBridge {
    *  MOVED sockets are undone, so B's OWN pre-existing viewers are untouched. */
   private migratedMirror = new Map<
     string,
-    { to: string; viewers: Set<BridgeSocket>; subs: Set<BridgeSocket> }
+    {
+      to: string;
+      viewers: Set<BridgeSocket>;
+      subs: Set<BridgeSocket>;
+      /** The `lastActiveSeq` value this migration's last-active carry produced, or
+       *  null when nothing was carried. The undo compares it so a FRESH selection
+       *  made after the carry (a user_message from the destination) is never
+       *  reverted — value equality alone cannot tell the two apart (#568). */
+      lastActiveSeq: number | null;
+    }
   >();
   /** Injected by the orchestrator: does this tabId have a live agent session?
    *  (SessionStore/PanelAgentManager live there.) Flags desktopTabs() for the
@@ -856,8 +865,13 @@ export class UiBridge {
    *  is allowed ONLY together with a token — panel #54: browsers on OTHER
    *  machines reaching a 24/7 server-side orchestrator. */
   private host: string;
-  /** Tab the user most recently typed in — the default command target. */
+  /** Tab the user most recently typed in — the default command target. Always
+   *  written through {@link setLastActiveTab} so {@link lastActiveSeq} stays in step. */
   private lastActiveTabId: string | null = null;
+  /** Monotonic counter bumped on every last-active write. Lets the tab-id-migration
+   *  undo tell "the value I carried is still the current selection" from "the same
+   *  value was re-selected since" — the two are indistinguishable by value (#568). */
+  private lastActiveSeq = 0;
   /** Resolves true once the port is bound, false if binding ultimately fails. */
   private readyPromise: Promise<boolean> | null = null;
   private readyResolve: ((ok: boolean) => void) | null = null;
@@ -1197,6 +1211,19 @@ export class UiBridge {
           // destination's own session ownership to trigger the undo).
           const movedViewers = new Set<BridgeSocket>();
           const movedSubs = new Set<BridgeSocket>();
+          // #568 — the LAST-ACTIVE selection is per-TAB identity state, so it has to move
+          // with the tab id exactly like the mirror sets below. Left pointing at the id
+          // being retired it names a tab that no longer exists, and with 2+ tabs connected
+          // resolveTarget()/resolveActiveTabId() then report "none is last active" — which
+          // disables panel_set_workflow_target({mode:"current"}), the ONE documented escape
+          // hatch for a session whose binding went stale. The reported wedge (save-as with
+          // two tabs open) is exactly that: the retiring id is removed, the selection is
+          // left on it, and nothing can rebind. Moving it is not a guess — the same SOCKET
+          // re-helloed, which is the server-observed proof that the new id and the old id
+          // are the same browser tab. OPTIMISTIC like the mirror move (the orchestrator
+          // classifies proven-vs-switch only afterwards); revokeTabMigration() undoes it.
+          const movedLastActiveSeq =
+            this.lastActiveTabId === tabId ? this.setLastActiveTab(msg.tab_id as string) : null;
           const migSubs = this.subscribers.get(tabId);
           if (migSubs) {
             this.subscribers.delete(tabId);
@@ -1215,11 +1242,12 @@ export class UiBridge {
               movedViewers.add(s);
             }
           }
-          if (movedViewers.size || movedSubs.size) {
+          if (movedViewers.size || movedSubs.size || movedLastActiveSeq !== null) {
             this.migratedMirror.set(tabId, {
               to: msg.tab_id as string,
               viewers: movedViewers,
               subs: movedSubs,
+              lastActiveSeq: movedLastActiveSeq,
             });
           }
         }
@@ -1495,7 +1523,7 @@ export class UiBridge {
         if (effectiveTab) {
           msg.tab_id = effectiveTab;
           msg.title = this.conns.get(effectiveTab)?.title;
-          if (msg.type === "user_message") this.lastActiveTabId = effectiveTab;
+          if (msg.type === "user_message") this.setLastActiveTab(effectiveTab);
         }
         this.onPanelMessage?.(msg as PanelEvent);
       }
@@ -1523,7 +1551,7 @@ export class UiBridge {
       if (tabId && this.conns.get(tabId)?.sock === sock) {
         wasPrimary = true;
         this.conns.delete(tabId);
-        if (this.lastActiveTabId === tabId) this.lastActiveTabId = null;
+        if (this.lastActiveTabId === tabId) this.setLastActiveTab(null);
         // The mirrored desktop tab is gone — detach its viewers so their input
         // reverts to their OWN session instead of routing into a dead id (and its
         // output isn't silently buffered forever). They can re-attach if it returns.
@@ -1549,6 +1577,15 @@ export class UiBridge {
         }
       }
     });
+  }
+
+  /** The ONLY writer of {@link lastActiveTabId}. Returns the sequence number this
+   *  write produced so a caller (the tab-id-migration carry) can later prove that
+   *  its own write is still the current selection before undoing it (#568). */
+  private setLastActiveTab(tabId: string | null): number {
+    this.lastActiveTabId = tabId;
+    this.lastActiveSeq += 1;
+    return this.lastActiveSeq;
   }
 
   connected(): boolean {
@@ -1706,6 +1743,17 @@ export class UiBridge {
         // Only revert a viewer we moved that is STILL pointed at this destination (it may have
         // since re-attached elsewhere, which we must not clobber).
         if (this.mirrorViewers.get(s) === moved.to) this.mirrorViewers.delete(s);
+      }
+      // #568 — undo the optimistic last-active carry too. This re-hello turned out to be a
+      // switch to a DIFFERENT workflow, so the destination is NOT the successor of the tab
+      // the selection named. Do NOT hand it back to fromId either: that id is retired. UNKNOWN
+      // gets its OWN representation (null) rather than being folded into either answer, so
+      // resolveTarget() refuses with "none is last active — pass tab_id" and an orphaned
+      // session's explicit rebind FAILS instead of silently retargeting onto a DIFFERENT
+      // workflow's canvas. Undo ONLY the exact write we made: a user_message from the
+      // destination since then is a fresh, genuine selection (same value, newer seq) and stands.
+      if (moved.lastActiveSeq !== null && this.lastActiveSeq === moved.lastActiveSeq) {
+        this.setLastActiveTab(null);
       }
     }
   }


### PR DESCRIPTION
Closes #568

Both halves of #568 got a first-pass fix in 4e8888b (already on main). The issue
stayed open because of the recurrence reported on **0.49.3 / panel 0.11.38**: with two
panel tabs connected, saving the active workflow under a new name migrates the tab id,
"the retiring id is removed, but the last-active selection remains the retired id", and
`panel_set_workflow_target({mode:"current"})` "cannot recover because neither of the two
live tabs is selected as last active". This finishes it.

## Root cause (a) — the migration carried everything about the tab except which tab was selected

A same-socket tab-id migration already moves a great deal: the agent and its own
`tabId`, the bound panel MCP server, the run-completion journal (`moveKey`), pinned
workflow targets, held mail, the stable resume key, mirror viewers and subscribers. It
did **not** move the bridge's `lastActiveTabId`.

Left on the id being retired, that selection names a tab that no longer exists. With
2+ tabs connected, `resolveTarget()`'s no-tabId path and `resolveActiveTabId()` both
fall through to "none is last active" — which disables
`panel_set_workflow_target({mode:"current"})`, the one documented escape hatch for a
stale binding. So the session cannot be recovered from the agent side at all, which is
exactly the reported symptom.

**The correct id is recoverable, not guessable.** The migration is a *same-socket*
re-hello, and the socket is server-observed — that is the proof that the new id and the
old id are the same browser tab. The selection now moves with it.

Like the mirror move it sits beside, the carry is **optimistic** (the orchestrator
classifies proven-vs-switch only afterwards), so `revokeTabMigration()` undoes it —
the same proven-carries / unproven-forgets split PR #786's `moveKey` established.

The undo compares a write **sequence**, not a value. A `user_message` from the
destination after the carry writes the same id, and value equality alone would revert a
genuine selection.

## What happens when the correct tab cannot be established

It **refuses, and stays refused.** On an unproven switch the undo sets the selection to
`null` — it does **not** hand it back to the retired id, and it does **not** leave it
pointing at the switched-to workflow. Unknown gets its own representation, so
`resolveTarget()` raises `Multiple panel tabs are connected and none is "last active" —
pass tab_id` and an orphaned session's rebind fails rather than silently retargeting
onto a different workflow's canvas. Un-wedging by binding to whatever tab happens to be
live would be worse than staying wedged; a test asserts specifically that the
resolution does **not** come back as the switched-to tab.

The silent auto-heal (`ensureReachable`) is untouched: it stays strict-single and never
consults the last-active selection at all.

## Root cause (b) — the release fallback, and what is actually still reachable

The reported starvation (`clearTimeout` + re-arm on *every* interrupt, so a burst
spaced under the window kept cancelling the net) was fixed in 4e8888b. I re-derived it
rather than taking it on trust, and it holds: the arm **coalesces**, so the deadline set
by the first interrupt of an unsettled burst is an absolute ceiling, while
`interruptGuardTurn` is refreshed by every interrupt so it keeps naming the still-stuck
turn. A storm can neither postpone the release nor aim it at the wrong turn.

The invariant that makes that starvation-free rather than merely eventually-scheduled is
now written down at its single seam: **the fallback is only ever cleared at a point
where the gate is (or is about to be) open**, so "an interrupt happened and the gate is
still closed" implies a timer is armed. Any future clear site has to preserve it.

The existing regression test asserted only "a turn eventually starts", which passes in
both the fixed and the broken state once the storm stops. It is now **timed**: the
release must land within one window of the *first* interrupt while interrupts are still
arriving.

What is still reachable in production is the compounding the issue itself describes
("the second is only reachable in practice via the first"): an interrupt addressed to a
key with **no live agent** reaches nothing — no turn gate is held for it, and no release
fallback is scheduled. A recovery path that is never armed cannot be starved; it simply
does not exist. That was acked to the panel as a plain success, so the user keeps
pressing "send now" at a tab with nothing behind it. The outcome is now reported
(`interrupted` on the ack, read synchronously via `hasLiveAgent` so a hung
`backend.interrupt()` cannot withhold the ack) and a miss is logged loudly.

## Tests

All mutation-verified — the fix was broken each way and the test confirmed to fail:

| Test | Mutation that must break it |
| --- | --- |
| proven migration moves the selection; the explicit rebind resolves to the successor | drop the carry |
| unproven switch refuses and never names the switched-to tab | drop the undo |
| a fresh selection in the destination is not reverted | value-only compare instead of the sequence |
| a migration CHAIN follows; revoking a superseded hop is inert | drop the sequence guard |
| release lands within one window of the FIRST interrupt, however many follow | restore cancel-and-re-arm |
| interrupt reports whether a live agent took it | always return true |

Note the trap: for the refusal test, asserting only "throws" or only the tab count
passes in both states — the distinguishing assertion is that the resolution does not
come back as `wf:ccc`.

4212 tests pass, rebased on `origin/main` and re-run against the merged tree.

## Codex gate

`gpt-5.6-terra`, read-only, scoped to the three questions (wrong-tab binding, wedge with
no recovery, starvable release) plus chains, destination collisions and the
could-not/determined-not class. **PASS with no P0/P1/P2.** It confirmed the chain and
collision paths and that no unknown→none conflation was introduced; it could not run the
test suite in its sandbox (Vite child-process `EPERM`), so its verdict is a static audit
— the mutation testing above is mine.

## Deliberately out of scope

- **Identity-matched rebinding.** With 2+ live tabs, `rebindToActiveTab()` still binds to
  the last-active tab. That is the explicit, documented "use what's live now" consent
  signal, and this change only makes the selection it reads *correct*. Gating it on a
  workflow-identity match would need the identity of a tab id that has already been
  deleted from the live maps — i.e. it would have to treat "cannot determine" as
  "does not match" and refuse the legitimate reconnect recoveries (#322/#331/#332) the
  path exists for. That is the #796 bug in the other direction.
- **The panel-side PENDING tray.** The reporter's tray not draining is partly panel
  behavior (comfyui-mcp-panel); this PR makes the orchestrator's half of that signal
  honest but does not change the panel.
- **The Codex HTTP MCP session URL** (`/<tabId>`) still carries the pre-migration id and
  relies on the bridge's socket-scoped alias. That is the existing documented design
  (see `session-store.ts`'s proven-migration carry) and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
