### PR TITLE
fix(strip_workflow): preserve dynamic widget values and Set/Get links, and disclose anything dropped (#361)

### DIFF
--- a/src/__tests__/services/flatten-workflow.test.ts
+++ b/src/__tests__/services/flatten-workflow.test.ts
@@ -303,27 +303,30 @@ describe("flattenUiWorkflow — Use-Everywhere", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("a class merely SHARING a sender name prefix cannot skip the feed check", () => {
-    // Recognition is generous on purpose, so a foreign "Seed Everywhere …" class
-    // is treated as a sender — but it must not inherit the self-producing
-    // exemption that skips verification.
+  it("a foreign class sharing a sender name prefix FABRICATES nothing, even when fed", () => {
+    // The fabrication direction specifically: "Seed Everywhere Helper" IS fed by
+    // node 1, so a feed check alone would confirm the stale record and emit
+    // 1 → #3. It is not a cg-use-everywhere node, so no edge may appear — and
+    // because nothing here is recognized, the backstop reports it.
     const g: UiWorkflow = {
       nodes: [
-        node(1, "Seed Everywhere Helper", { outputs: [{ name: "INT", type: "INT", links: [] }] }),
-        node(3, "SomeConsumer", { inputs: [{ name: "seed", type: "INT", link: null }] }),
+        node(1, "CheckpointLoaderSimple", { outputs: [{ name: "MODEL", type: "MODEL", links: [5] }] }),
+        node(9, "Seed Everywhere Helper", { inputs: [{ name: "anything", type: "*", link: 5 }] }),
+        node(3, "SomeConsumer", { inputs: [{ name: "model", type: "MODEL", link: null }] }),
       ],
-      links: [],
-      last_link_id: 0,
+      links: [[5, 1, 0, 9, 0, "MODEL"]],
+      last_link_id: 5,
       extra: {
         ue_links: [
-          { downstream: 3, downstream_slot: 0, upstream: 1, upstream_slot: 0, controller: 1, type: "INT" },
+          { downstream: 3, downstream_slot: 0, upstream: 1, upstream_slot: 0, controller: 9, type: "MODEL" },
         ],
       },
     };
     const { graph, report } = flattenUiWorkflow(g);
     const consumer = graph.nodes.find((n) => n.type === "SomeConsumer")!;
     expect(consumer.inputs![0].link).toBeNull();
-    expect(report.warnings.join("\n")).toContain("no longer has any incoming connection");
+    expect(graph.nodes.some((n) => n.type === "Seed Everywhere Helper")).toBe(true);
+    expect(report.warnings.join("\n")).toContain("no node in this graph is recognized as a Use-Everywhere sender");
   });
 
   it("keeps Seed Everywhere — it is its own real producer", () => {
@@ -429,7 +432,6 @@ describe("flattenUiWorkflow — Use-Everywhere", () => {
       "Anything Everywhere?",
       "Anything Everywhere3",
       "Prompts Everywhere",
-      "Prompts Everywhere?",
       "Seed Everywhere",
       // The pack registers this one, but the predicate used to compare the
       // "Seed Everywhere" family with equality, so it went unrecognized — and an
@@ -440,6 +442,14 @@ describe("flattenUiWorkflow — Use-Everywhere", () => {
     }
     expect(isUeSender("KSampler")).toBe(false);
     expect(isUeSender("SaveImage")).toBe(false);
+    // Membership is by NAME, not by name SHAPE. A prefix match briefly stood in
+    // for it and let a foreign class be treated as a sender, whose stale record
+    // then passed the feed check and fabricated an edge. An unrecognized class is
+    // now reported instead (see the no-recognized-sender backstop), so a closed
+    // set costs a disclosed unknown rather than a silent drop.
+    for (const t of ["Seed Everywhere Helper", "Anything Everywhere Deluxe", "Prompts Everywhere Pro"]) {
+      expect(isUeSender(t), `${t} must not be taken for a UE sender`).toBe(false);
+    }
   });
 });
 

--- a/src/__tests__/services/flatten-workflow.test.ts
+++ b/src/__tests__/services/flatten-workflow.test.ts
@@ -144,6 +144,70 @@ describe("flattenUiWorkflow — Use-Everywhere", () => {
     expect(graph.extra?.ue_links).toBeUndefined();
   });
 
+  // #361: a ue_links record is only as current as the pack's last analysis.
+  // Materializing one without checking it against the LIVE wiring invents a
+  // connection the graph does not have — which reads as a plausible graph that is
+  // silently wrong, and is worse than an obviously missing link.
+  it("refuses a record whose sender was REWIRED, and keeps that sender in place", () => {
+    const g = ueGraph(true);
+    // The sender now takes its value from node 9, not the recorded node 1.
+    g.nodes.push(
+      node(9, "CheckpointLoaderSimple", { outputs: [{ name: "MODEL", type: "MODEL", links: [6] }] }),
+    );
+    g.nodes[0].outputs![0].links = [];
+    g.nodes[1].inputs![0].link = 6;
+    g.links = [[6, 9, 0, 2, 0, "MODEL"]];
+    const { graph, report } = flattenUiWorkflow(g);
+    const consumer = graph.nodes.find((n) => n.type === "SomeConsumer")!;
+    expect(consumer.inputs![0].link).toBeNull(); // no fabricated edge
+    expect(graph.nodes.some((n) => n.type === "Anything Everywhere")).toBe(true);
+    expect(report.warnings.join("\n")).toContain("could not be confirmed against the live graph");
+    expect(report.warnings.join("\n")).toContain("fed by a different producer");
+  });
+
+  it("refuses a record naming a sender that is gone", () => {
+    const g = ueGraph(true);
+    g.nodes = g.nodes.filter((n) => n.type !== "Anything Everywhere");
+    // Another sender keeps UE processing alive, but it is not this record's.
+    g.nodes.push(node(8, "Anything Everywhere", { inputs: [{ name: "anything", type: "*", link: null }] }));
+    const { graph, report } = flattenUiWorkflow(g);
+    const consumer = graph.nodes.find((n) => n.type === "SomeConsumer")!;
+    expect(consumer.inputs![0].link).toBeNull();
+    expect(report.warnings.join("\n")).toContain("no longer a broadcast node");
+  });
+
+  it("refuses a controllerless record unless its producer is itself a broadcast node", () => {
+    const g = ueGraph(true);
+    delete (g.extra!.ue_links as { controller?: number }[])[0].controller;
+    const { graph, report } = flattenUiWorkflow(g);
+    const consumer = graph.nodes.find((n) => n.type === "SomeConsumer")!;
+    expect(consumer.inputs![0].link).toBeNull();
+    expect(report.warnings.join("\n")).toContain("cannot be attributed to any sender");
+  });
+
+  it("a class merely SHARING a sender name prefix cannot skip the feed check", () => {
+    // Recognition is generous on purpose, so a foreign "Seed Everywhere …" class
+    // is treated as a sender — but it must not inherit the self-producing
+    // exemption that skips verification.
+    const g: UiWorkflow = {
+      nodes: [
+        node(1, "Seed Everywhere Helper", { outputs: [{ name: "INT", type: "INT", links: [] }] }),
+        node(3, "SomeConsumer", { inputs: [{ name: "seed", type: "INT", link: null }] }),
+      ],
+      links: [],
+      last_link_id: 0,
+      extra: {
+        ue_links: [
+          { downstream: 3, downstream_slot: 0, upstream: 1, upstream_slot: 0, controller: 1, type: "INT" },
+        ],
+      },
+    };
+    const { graph, report } = flattenUiWorkflow(g);
+    const consumer = graph.nodes.find((n) => n.type === "SomeConsumer")!;
+    expect(consumer.inputs![0].link).toBeNull();
+    expect(report.warnings.join("\n")).toContain("no longer has any incoming connection");
+  });
+
   it("keeps Seed Everywhere — it is its own real producer", () => {
     const g: UiWorkflow = {
       nodes: [

--- a/src/__tests__/services/flatten-workflow.test.ts
+++ b/src/__tests__/services/flatten-workflow.test.ts
@@ -289,6 +289,54 @@ describe("flattenUiWorkflow — Use-Everywhere", () => {
     expect(report.warnings).toEqual([]);
   });
 
+  it("an input claiming a link that does not exist is reported, not silently cleared", () => {
+    // The flattener's counterpart of the converter's dangling-reference report.
+    // The source graph claims a connection this graph does not contain; clearing
+    // it in silence is observation-failed treated as a definite no.
+    const g: UiWorkflow = {
+      nodes: [
+        node(1, "CheckpointLoaderSimple", { outputs: [{ name: "MODEL", type: "MODEL", links: [] }] }),
+        node(3, "SomeConsumer", { inputs: [{ name: "model", type: "MODEL", link: 77 }] }),
+      ],
+      links: [],
+      last_link_id: 0,
+    };
+    const { graph, report } = flattenUiWorkflow(g);
+    expect(graph.nodes.find((n) => n.id === 3)!.inputs![0].link).toBeNull();
+    expect(report.warnings.join("\n")).toContain('input "model" claims link 77');
+  });
+
+  it("a healthy bus, whose original links are purged on purpose, reports nothing", () => {
+    // Guards the common path against a spurious dangling-reference report. NOTE:
+    // this does NOT exercise the was-a-real-link-but-purged branch of that check
+    // — I could not construct a graph where a SURVIVING input still points at a
+    // purged id (the nodes holding those references are removed with them). That
+    // branch is therefore defensive, and is documented as such in the source
+    // rather than pinned by a test that would not fail without it.
+    const g: UiWorkflow = {
+      nodes: [
+        node(1, "CheckpointLoaderSimple", { outputs: [{ name: "MODEL", type: "MODEL", links: [10] }] }),
+        node(2, "SetNode", {
+          widgets_values: ["m"],
+          inputs: [{ name: "MODEL", type: "MODEL", link: 10 }],
+          outputs: [{ name: "*", type: "*", links: [] }],
+        }),
+        node(3, "GetNode", {
+          widgets_values: ["m"],
+          outputs: [{ name: "MODEL", type: "MODEL", links: [11] }],
+        }),
+        node(4, "KSampler", { inputs: [{ name: "model", type: "MODEL", link: 11 }] }),
+      ],
+      links: [
+        [10, 1, 0, 2, 0, "MODEL"],
+        [11, 3, 0, 4, 0, "MODEL"],
+      ],
+      last_link_id: 11,
+    };
+    const { report } = flattenUiWorkflow(g);
+    expect(report.warnings).toEqual([]);
+  });
+
   it("duplicate link ids ALREADY in the graph are repaired, and reported", () => {
     // Not something the allocator can produce, but a graph edited by tooling that
     // did not maintain link ids can arrive this way. Returning it unchanged

--- a/src/__tests__/services/flatten-workflow.test.ts
+++ b/src/__tests__/services/flatten-workflow.test.ts
@@ -306,13 +306,65 @@ describe("flattenUiWorkflow — Use-Everywhere", () => {
     expect(report.warnings.join("\n")).toContain('input "model" claims link 77');
   });
 
-  it("a healthy bus, whose original links are purged on purpose, reports nothing", () => {
-    // Guards the common path against a spurious dangling-reference report. NOTE:
-    // this does NOT exercise the was-a-real-link-but-purged branch of that check
-    // — I could not construct a graph where a SURVIVING input still points at a
-    // purged id (the nodes holding those references are removed with them). That
-    // branch is therefore defensive, and is documented as such in the source
-    // rather than pinned by a test that would not fail without it.
+  it("a sender that is the REAL producer of a pre-existing link is never deleted", () => {
+    // Seed Everywhere #9 genuinely produces link 5 into #3. Its ue_links record
+    // adds nothing (its target #4 already has a real link, so UE would not fire),
+    // so the sender created no FRESH link and looked unused — and was deleted,
+    // taking a real connection with it and disconnecting #3 in silence.
+    const g: UiWorkflow = {
+      nodes: [
+        node(9, "Seed Everywhere", {
+          widgets_values: [42],
+          outputs: [{ name: "INT", type: "INT", links: [5] }],
+        }),
+        node(3, "SomeConsumer", { inputs: [{ name: "seed", type: "INT", link: 5 }] }),
+        node(1, "CheckpointLoaderSimple", { outputs: [{ name: "INT", type: "INT", links: [6] }] }),
+        node(4, "OtherConsumer", { inputs: [{ name: "seed", type: "INT", link: 6 }] }),
+      ],
+      links: [
+        [5, 9, 0, 3, 0, "INT"],
+        [6, 1, 0, 4, 0, "INT"],
+      ],
+      last_link_id: 6,
+      extra: {
+        ue_links: [
+          { downstream: 4, downstream_slot: 0, upstream: 9, upstream_slot: 0, controller: 9, type: "INT" },
+        ],
+      },
+    };
+    const { graph, report } = flattenUiWorkflow(g);
+    expect(graph.nodes.some((n) => n.type === "Seed Everywhere")).toBe(true);
+    const consumer = graph.nodes.find((n) => n.id === 3)!;
+    expect(consumer.inputs![0].link).toBe(5);
+    expect(report.warnings).toEqual([]);
+  });
+
+  it("an input claiming an id that belongs to a link into ANOTHER node is reported", () => {
+    // Link 10 really exists — as Producer → Reroute. The Consumer's claim on it is
+    // bogus. Keying the report on "did this id exist anywhere" suppressed it and
+    // the edge was cleared in silence; the question has to be about THIS input's
+    // claim. This is the shape that disproved an earlier "unreachable" comment.
+    const g: UiWorkflow = {
+      nodes: [
+        node(1, "CheckpointLoaderSimple", { outputs: [{ name: "MODEL", type: "MODEL", links: [10] }] }),
+        node(2, "Reroute", {
+          inputs: [{ name: "", type: "MODEL", link: 10 }],
+          outputs: [{ name: "", type: "MODEL", links: [] }],
+        }),
+        node(3, "SomeConsumer", { inputs: [{ name: "model", type: "MODEL", link: 10 }] }),
+      ],
+      links: [[10, 1, 0, 2, 0, "MODEL"]],
+      last_link_id: 10,
+    };
+    const { graph, report } = flattenUiWorkflow(g);
+    expect(graph.nodes.find((n) => n.id === 3)!.inputs![0].link).toBeNull();
+    expect(report.warnings.join("\n")).toContain('input "model" claims link 10');
+  });
+
+  it("a healthy bus reports nothing", () => {
+    // Guards the common path: every flattened bus retires the links that fed its
+    // virtual nodes, and pass 1 re-points their consumers at fresh surviving ids,
+    // so no surviving input is left claiming a retired one.
     const g: UiWorkflow = {
       nodes: [
         node(1, "CheckpointLoaderSimple", { outputs: [{ name: "MODEL", type: "MODEL", links: [10] }] }),

--- a/src/__tests__/services/flatten-workflow.test.ts
+++ b/src/__tests__/services/flatten-workflow.test.ts
@@ -289,6 +289,38 @@ describe("flattenUiWorkflow — Use-Everywhere", () => {
     expect(report.warnings).toEqual([]);
   });
 
+  it("duplicate link ids ALREADY in the graph are repaired, and reported", () => {
+    // Not something the allocator can produce, but a graph edited by tooling that
+    // did not maintain link ids can arrive this way. Returning it unchanged
+    // propagates an ambiguous graph out of a pass whose job is to leave the
+    // wiring unambiguous — and each consumer must keep ITS OWN producer.
+    const g: UiWorkflow = {
+      nodes: [
+        node(1, "ProducerA", { outputs: [{ name: "MODEL", type: "MODEL", links: [7] }] }),
+        node(2, "ProducerB", { outputs: [{ name: "MODEL", type: "MODEL", links: [7] }] }),
+        node(3, "SomeConsumer", { inputs: [{ name: "model", type: "MODEL", link: 7 }] }),
+        node(4, "OtherConsumer", { inputs: [{ name: "model", type: "MODEL", link: 7 }] }),
+      ],
+      links: [
+        [7, 1, 0, 3, 0, "MODEL"],
+        [7, 2, 0, 4, 0, "MODEL"],
+      ],
+      last_link_id: 7,
+    };
+    const { graph, report } = flattenUiWorkflow(g);
+    const ids = graph.links.map((l) => l[0]);
+    expect(new Set(ids).size).toBe(ids.length);
+    const byId = new Map(graph.links.map((l) => [l[0], l]));
+    const feeder = (type: string) => {
+      const c = graph.nodes.find((x) => x.type === type)!;
+      const l = byId.get(c.inputs![0].link!)!;
+      return graph.nodes.find((x) => x.id === l[1])!.type;
+    };
+    expect(feeder("SomeConsumer")).toBe("ProducerA");
+    expect(feeder("OtherConsumer")).toBe("ProducerB");
+    expect(report.warnings.join("\n")).toContain("shared an id already used by another link");
+  });
+
   it("a stale last_link_id cannot make a fresh link collide with an existing one", () => {
     const g = ueGraph(true);
     // An existing link sitting at exactly the id the stale header hands out next.

--- a/src/__tests__/services/flatten-workflow.test.ts
+++ b/src/__tests__/services/flatten-workflow.test.ts
@@ -189,11 +189,17 @@ describe("flattenUiWorkflow — Use-Everywhere", () => {
       "Anything Everywhere?",
       "Anything Everywhere3",
       "Prompts Everywhere",
+      "Prompts Everywhere?",
       "Seed Everywhere",
+      // The pack registers this one, but the predicate used to compare the
+      // "Seed Everywhere" family with equality, so it went unrecognized — and an
+      // unrecognized sender means its broadcasts are dropped with nothing said.
+      "Seed Everywhere?",
     ]) {
       expect(isUeSender(t)).toBe(true);
     }
     expect(isUeSender("KSampler")).toBe(false);
+    expect(isUeSender("SaveImage")).toBe(false);
   });
 });
 

--- a/src/__tests__/services/flatten-workflow.test.ts
+++ b/src/__tests__/services/flatten-workflow.test.ts
@@ -183,6 +183,124 @@ describe("flattenUiWorkflow — Use-Everywhere", () => {
     const consumer = graph.nodes.find((n) => n.type === "SomeConsumer")!;
     expect(consumer.inputs![0].link).toBeNull();
     expect(report.warnings.join("\n")).toContain("cannot be attributed to any sender");
+    // The record names no sender, so we cannot tell WHICH one has to survive —
+    // deleting any would erase the evidence of the broadcast we declined to
+    // materialize, and scrubbing ue_links would erase the record itself.
+    expect(graph.nodes.some((n) => n.type === "Anything Everywhere")).toBe(true);
+    expect(graph.extra?.ue_links).toBeDefined();
+  });
+
+  it("a confirmed record whose producer output does not exist is reported, not dropped in silence", () => {
+    // A self-producing sender skips the feed check, so this record passes
+    // confirmation and then fails to BUILD (the node serializes no outputs). The
+    // return value used to be discarded: no edge, no warning, and the sender then
+    // deletable — a could-not-determine folded into a silent loss.
+    const g: UiWorkflow = {
+      nodes: [
+        node(1, "Seed Everywhere", { widgets_values: [42] }), // no outputs array
+        node(3, "SomeConsumer", { inputs: [{ name: "seed", type: "INT", link: null }] }),
+      ],
+      links: [],
+      last_link_id: 0,
+      extra: {
+        ue_links: [
+          { downstream: 3, downstream_slot: 0, upstream: 1, upstream_slot: 0, controller: 1, type: "INT" },
+        ],
+      },
+    };
+    const { graph, report } = flattenUiWorkflow(g);
+    const consumer = graph.nodes.find((n) => n.type === "SomeConsumer")!;
+    expect(consumer.inputs![0].link).toBeNull();
+    expect(report.warnings.join("\n")).toContain("which this graph does not have");
+    expect(graph.nodes.some((n) => n.type === "Seed Everywhere")).toBe(true);
+  });
+
+  it("a LIVE broadcast whose sender is fed through a Get/Set bus is still materialized", () => {
+    // Pass 1 replaces the sender's bus-fed input with a fresh direct link; the
+    // staleness check must see that fresh link, or it reads the feed as
+    // unresolvable and refuses a broadcast that is perfectly current.
+    const g: UiWorkflow = {
+      nodes: [
+        node(1, "CheckpointLoaderSimple", { outputs: [{ name: "MODEL", type: "MODEL", links: [10] }] }),
+        node(2, "SetNode", {
+          widgets_values: ["m"],
+          inputs: [{ name: "MODEL", type: "MODEL", link: 10 }],
+          outputs: [{ name: "*", type: "*", links: [] }],
+        }),
+        node(3, "GetNode", {
+          widgets_values: ["m"],
+          outputs: [{ name: "MODEL", type: "MODEL", links: [11] }],
+        }),
+        node(4, "Anything Everywhere", { inputs: [{ name: "anything", type: "*", link: 11 }] }),
+        node(5, "SomeConsumer", { inputs: [{ name: "model", type: "MODEL", link: null }] }),
+      ],
+      links: [
+        [10, 1, 0, 2, 0, "MODEL"],
+        [11, 3, 0, 4, 0, "MODEL"],
+      ],
+      last_link_id: 11,
+      extra: {
+        ue_links: [
+          { downstream: 5, downstream_slot: 0, upstream: 1, upstream_slot: 0, controller: 4, type: "MODEL" },
+        ],
+      },
+    };
+    const { graph, report } = flattenUiWorkflow(g);
+    const consumer = graph.nodes.find((n) => n.type === "SomeConsumer")!;
+    const link = graph.links.find((l) => l[0] === consumer.inputs![0].link)!;
+    expect([link[1], link[2]]).toEqual([1, 0]);
+    expect(report.warnings).toEqual([]);
+  });
+
+  it("a record whose upstream IS the bus node resolves through it", () => {
+    // The pack sometimes records the virtual in front of the producer rather than
+    // the producer; a GetNode has no incoming link, so it must be followed over
+    // its bus, not by looking for an input.
+    const g: UiWorkflow = {
+      nodes: [
+        node(1, "CheckpointLoaderSimple", { outputs: [{ name: "MODEL", type: "MODEL", links: [10] }] }),
+        node(2, "SetNode", {
+          widgets_values: ["m"],
+          inputs: [{ name: "MODEL", type: "MODEL", link: 10 }],
+          outputs: [{ name: "*", type: "*", links: [] }],
+        }),
+        node(3, "GetNode", {
+          widgets_values: ["m"],
+          outputs: [{ name: "MODEL", type: "MODEL", links: [11] }],
+        }),
+        node(4, "Anything Everywhere", { inputs: [{ name: "anything", type: "*", link: 11 }] }),
+        node(5, "SomeConsumer", { inputs: [{ name: "model", type: "MODEL", link: null }] }),
+      ],
+      links: [
+        [10, 1, 0, 2, 0, "MODEL"],
+        [11, 3, 0, 4, 0, "MODEL"],
+      ],
+      last_link_id: 11,
+      extra: {
+        ue_links: [
+          { downstream: 5, downstream_slot: 0, upstream: 3, upstream_slot: 0, controller: 4, type: "MODEL" },
+        ],
+      },
+    };
+    const { graph, report } = flattenUiWorkflow(g);
+    const consumer = graph.nodes.find((n) => n.type === "SomeConsumer")!;
+    const link = graph.links.find((l) => l[0] === consumer.inputs![0].link)!;
+    expect([link[1], link[2]]).toEqual([1, 0]);
+    expect(report.warnings).toEqual([]);
+  });
+
+  it("a stale last_link_id cannot make a fresh link collide with an existing one", () => {
+    const g = ueGraph(true);
+    // An existing link sitting at exactly the id the stale header hands out next.
+    // The header is only a header, and tooling that edits a graph does not always
+    // maintain it.
+    g.nodes.push(node(9, "SomeConsumer", { inputs: [{ name: "model", type: "MODEL", link: 6 }] }));
+    g.links.push([6, 1, 0, 9, 0, "MODEL"]);
+    g.nodes[0].outputs![0].links = [5, 6];
+    g.last_link_id = 5;
+    const { graph } = flattenUiWorkflow(g);
+    const ids = graph.links.map((l) => l[0]);
+    expect(new Set(ids).size).toBe(ids.length);
   });
 
   it("a class merely SHARING a sender name prefix cannot skip the feed check", () => {

--- a/src/__tests__/services/flatten-workflow.test.ts
+++ b/src/__tests__/services/flatten-workflow.test.ts
@@ -355,6 +355,21 @@ describe("flattenUiWorkflow — Use-Everywhere", () => {
     expect(report.warnings.some((w) => w.includes("ue_links is missing"))).toBe(true);
   });
 
+  it("a PARTIAL ue_links list never deletes the sender it does not mention", () => {
+    // A non-empty list is not proof it accounts for every sender. Sender #7 has no
+    // row (the list predates it, or it reaches nothing) — deleting it would remove
+    // a node whose broadcasts were never materialized, silently and for good.
+    const g = ueGraph(true);
+    g.nodes.push(
+      node(8, "Anything Everywhere", { inputs: [{ name: "anything", type: "*", link: null }] }),
+    );
+    (g.extra!.ue_links as { controller: number }[])[0].controller = 8; // only #8 is listed
+    const { graph, report } = flattenUiWorkflow(g);
+    expect(graph.nodes.some((n) => n.id === 2)).toBe(true); // #7-equivalent survives
+    expect(report.warnings.join("\n")).toContain("no record in extra.ue_links names it");
+    expect(graph.extra?.ue_links).toBeDefined();
+  });
+
   it("an EMPTY computed ue_links list is an answer — no warning, and nothing removed", () => {
     // The pack analysed the graph and recorded no broadcast. Warning there invents
     // a problem on a faithful graph (and disagreed with the converter); an empty

--- a/src/__tests__/services/flatten-workflow.test.ts
+++ b/src/__tests__/services/flatten-workflow.test.ts
@@ -348,11 +348,54 @@ describe("flattenUiWorkflow — Use-Everywhere", () => {
     expect(link[1]).toBe(1);
   });
 
-  it("UE senders without ue_links are left in place with a loud warning", () => {
+  it("UE senders with a MISSING ue_links list are left in place with a loud warning", () => {
     const { graph, report } = flattenUiWorkflow(ueGraph(false));
     expect(report.removed.ue).toBe(0);
     expect(graph.nodes.some((n) => n.type === "Anything Everywhere")).toBe(true);
-    expect(report.warnings.some((w) => w.includes("ue_links is empty"))).toBe(true);
+    expect(report.warnings.some((w) => w.includes("ue_links is missing"))).toBe(true);
+  });
+
+  it("an EMPTY computed ue_links list is an answer — no warning, and nothing removed", () => {
+    // The pack analysed the graph and recorded no broadcast. Warning there invents
+    // a problem on a faithful graph (and disagreed with the converter); an empty
+    // list is also not a licence to delete the senders.
+    const g = ueGraph(true);
+    g.extra!.ue_links = [];
+    const { graph, report } = flattenUiWorkflow(g);
+    expect(report.removed.ue).toBe(0);
+    expect(graph.nodes.some((n) => n.type === "Anything Everywhere")).toBe(true);
+    expect(report.warnings).toEqual([]);
+  });
+
+  it("a Get/Set chain resolving to a producer the graph lacks is reported, not silently cleared", () => {
+    // Pass 1 resolves the bus, but the producer serializes no output slot, so no
+    // replacement link can be built. Discarding that left the virtual deleted and
+    // the consumer quietly disconnected.
+    const g: UiWorkflow = {
+      nodes: [
+        node(1, "CheckpointLoaderSimple"), // no outputs array at all
+        node(2, "SetNode", {
+          widgets_values: ["m"],
+          inputs: [{ name: "MODEL", type: "MODEL", link: 10 }],
+          outputs: [{ name: "*", type: "*", links: [] }],
+        }),
+        node(3, "GetNode", {
+          widgets_values: ["m"],
+          outputs: [{ name: "MODEL", type: "MODEL", links: [11] }],
+        }),
+        node(4, "KSampler", { inputs: [{ name: "model", type: "MODEL", link: 11 }] }),
+      ],
+      links: [
+        [10, 1, 0, 2, 0, "MODEL"],
+        [11, 3, 0, 4, 0, "MODEL"],
+      ],
+      last_link_id: 11,
+    };
+    const { graph, report } = flattenUiWorkflow(g);
+    const sampler = graph.nodes.find((n) => n.type === "KSampler")!;
+    expect(sampler.inputs![0].link).toBeNull();
+    expect(report.warnings.join("\n")).toContain("which this graph does not have");
+    expect(report.warnings.join("\n")).toContain('KSampler #4 input "model"');
   });
 
   it("skips a ue_link whose receiver input got a real link since analysis", () => {

--- a/src/__tests__/services/strip-workflow-preservation.test.ts
+++ b/src/__tests__/services/strip-workflow-preservation.test.ts
@@ -86,6 +86,8 @@ describe("#361 — Set/Get bus links", () => {
     return { nodes, links } as never;
   }
 
+  // Guard (not a #361 regression test — the pre-fix converter also resolved this):
+  // the new disclosure must not fire on a graph that loses nothing.
   it("a RESOLVABLE bus still becomes a real link, with nothing reported as lost", () => {
     const { workflow, warnings } = convertUiToApi(busGraph("img", "img"), OBJECT_INFO);
     expect(workflow["3"].inputs.images).toEqual(["1", 0]);
@@ -303,6 +305,28 @@ describe("#361 — cg-use-everywhere broadcast links", () => {
     const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
     expect(workflow["3"].inputs.images).toBeUndefined();
     expect(joined(warnings)).toContain("the record is stale");
+  });
+
+  it("a controller id now belonging to an ORDINARY node is stale, not wired", () => {
+    // The id survives, but it is no longer a broadcast node — existence alone is
+    // not enough to trust the record.
+    const g = ueGraph(true) as unknown as {
+      extra: { ue_links: { controller: number }[] };
+    };
+    g.extra.ue_links[0].controller = 1; // node 1 is a LoadImage, not a sender
+    const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(workflow["3"].inputs.images).toBeUndefined();
+    expect(joined(warnings)).toContain("no longer a broadcast node");
+  });
+
+  it("an EMPTY computed list is an answer, not an unknown — no warning, no invented link", () => {
+    // The pack analysed the graph and recorded zero broadcasts. Reporting that as
+    // "unrecoverable" would invent a loss that did not happen.
+    const g = ueGraph(true) as unknown as { extra: { ue_links: unknown[] } };
+    g.extra.ue_links = [];
+    const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(workflow["3"].inputs.images).toBeUndefined();
+    expect(warnings).toEqual([]);
   });
 
   it("a record naming an output slot the producer no longer has is stale, not wired", () => {
@@ -563,6 +587,27 @@ describe("#361 — promoted subgraph widget values", () => {
     );
     expect(joined(warnings)).toContain('"not_a_widget"');
     expect(joined(warnings)).toContain("could not be applied");
+  });
+
+  it("a NAME-KEYED widgets_values on the subgraph node is read by promoted-widget name", () => {
+    const g = subgraphGraph({ proxy: [["-1", "width"]], values: [] }) as unknown as {
+      nodes: { id: number; widgets_values: unknown }[];
+    };
+    g.nodes.find((n) => n.id === 706)!.widgets_values = { width: 1920 };
+    const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(onlyInner(workflow as never).inputs.width).toBe(1920);
+    expect(warnings).toEqual([]);
+  });
+
+  it("a name-keyed capture with two promotions of the SAME name refuses both and says why", () => {
+    const g = subgraphGraph({
+      proxy: [["-1", "width"], ["50", "width"]],
+      values: [],
+    }) as unknown as { nodes: { id: number; widgets_values: unknown }[] };
+    g.nodes.find((n) => n.id === 706)!.widgets_values = { width: 1920 };
+    const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(onlyInner(workflow as never).inputs.width).toBe(512); // inner's own value
+    expect(joined(warnings)).toContain("more than one promotion claims that name");
   });
 
   it("a promoted widget with NO serialized value keeps the inner node's own value, silently", () => {

--- a/src/__tests__/services/strip-workflow-preservation.test.ts
+++ b/src/__tests__/services/strip-workflow-preservation.test.ts
@@ -260,14 +260,18 @@ describe("#361 — cg-use-everywhere broadcast links", () => {
           type: "GetNode",
           mode: 0,
           inputs: [],
-          outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [22] }],
           widgets_values: ["img"],
         },
         {
+          // The sender is genuinely fed THROUGH the bus, and the pack's record
+          // names the bus node as `upstream`. Both sides of the staleness check
+          // must be normalized past the virtual wiring or this current record
+          // would be misread as rewired and its live connection dropped.
           id: 7,
           type: "Anything Everywhere",
           mode: 0,
-          inputs: [{ name: "anything", type: "*", link: null }],
+          inputs: [{ name: "anything", type: "*", link: 22 }],
           outputs: [],
           widgets_values: [],
         },
@@ -280,10 +284,14 @@ describe("#361 — cg-use-everywhere broadcast links", () => {
           widgets_values: ["out"],
         },
       ],
-      links: [[21, 1, 0, 4, 0, "IMAGE"]],
+      links: [
+        [21, 1, 0, 4, 0, "IMAGE"],
+        [22, 5, 0, 7, 0, "IMAGE"],
+      ],
     } as never;
-    const { workflow } = convertUiToApi(g, OBJECT_INFO);
+    const { workflow, warnings } = convertUiToApi(g, OBJECT_INFO);
     expect(workflow["3"].inputs.images).toEqual(["1", 0]);
+    expect(warnings).toEqual([]);
   });
 
   it("a broadcast into a node that no longer exists is reported", () => {
@@ -317,6 +325,170 @@ describe("#361 — cg-use-everywhere broadcast links", () => {
     const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
     expect(workflow["3"].inputs.images).toBeUndefined();
     expect(joined(warnings)).toContain("no longer a broadcast node");
+  });
+
+  it("a record whose sender was REWIRED to a different producer fabricates nothing", () => {
+    // The most ordinary staleness of all: node 7 is still a live sender, but its
+    // input now comes from node 2 while the record still names node 1. Wiring
+    // 1 → consumer would put an edge in the stripped graph that does not exist
+    // live — a fabricated connection renders as a plausible graph that is
+    // silently wrong, which is worse than an obviously missing one.
+    const g = ueGraph(true) as unknown as {
+      nodes: {
+        id: number;
+        type: string;
+        mode: number;
+        inputs?: { name: string; type: string; link: number | null }[];
+        outputs?: { name: string; type: string; links: number[] }[];
+        widgets_values: unknown[];
+      }[];
+      links: unknown[];
+    };
+    g.nodes.push({
+      id: 2,
+      type: "LoadImage",
+      mode: 0,
+      inputs: [],
+      outputs: [{ name: "IMAGE", type: "IMAGE", links: [30] }],
+      widgets_values: ["b.png"],
+    });
+    g.nodes.find((n) => n.id === 7)!.inputs![0].link = 30; // rewired away from node 1
+    g.nodes.find((n) => n.id === 1)!.outputs![0].links = [];
+    g.links = [[30, 2, 0, 7, 0, "IMAGE"]];
+    const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(workflow["3"].inputs.images).toBeUndefined();
+    expect(joined(warnings)).toContain("fed by a different producer");
+  });
+
+  it("a record whose sender was DISCONNECTED fabricates nothing", () => {
+    const g = ueGraph(true) as unknown as {
+      nodes: { id: number; inputs?: { link: number | null }[] }[];
+      links: unknown[];
+    };
+    g.nodes.find((n) => n.id === 7)!.inputs![0].link = null;
+    g.links = [];
+    const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(workflow["3"].inputs.images).toBeUndefined();
+    expect(joined(warnings)).toContain("no longer has any incoming connection");
+  });
+
+  it("a sender that IS its own producer (Seed Everywhere shape) is still materialized", () => {
+    // The controller owns the widget, so it has no incoming feed to compare —
+    // requiring one would drop every Seed Everywhere broadcast.
+    const g = {
+      extra: {
+        ue_links: [
+          {
+            downstream: 3,
+            downstream_slot: 0,
+            upstream: 9,
+            upstream_slot: 0,
+            controller: 9,
+            type: "IMAGE",
+          },
+        ],
+      },
+      nodes: [
+        {
+          id: 9,
+          type: "Seed Everywhere",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+          widgets_values: [42],
+        },
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: null }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(g, {
+      ...(OBJECT_INFO as object),
+      "Seed Everywhere": {
+        input: { required: { seed: ["INT", { default: 0 }] } },
+        output: ["IMAGE"],
+      },
+    } as never);
+    expect(workflow["3"].inputs.images).toEqual(["9", 0]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("a MULTI-INPUT sender keeps every one of its current records", () => {
+    // Prompts Everywhere-style: two records share one controller, each naming a
+    // different producer. Checking only the sender's first feed would flag the
+    // second record as rewired and drop a live connection.
+    const g = {
+      extra: {
+        ue_links: [
+          { downstream: 3, downstream_slot: 0, upstream: 1, upstream_slot: 0, controller: 7, type: "IMAGE" },
+          { downstream: 4, downstream_slot: 0, upstream: 2, upstream_slot: 0, controller: 7, type: "IMAGE" },
+        ],
+      },
+      nodes: [
+        {
+          id: 1,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [40] }],
+          widgets_values: ["a.png"],
+        },
+        {
+          id: 2,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [41] }],
+          widgets_values: ["b.png"],
+        },
+        {
+          id: 7,
+          type: "Anything Everywhere3",
+          mode: 0,
+          inputs: [
+            { name: "anything", type: "*", link: 40 },
+            { name: "anything2", type: "*", link: 41 },
+          ],
+          outputs: [],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: null }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+        {
+          id: 4,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: null }],
+          outputs: [],
+          widgets_values: ["out2"],
+        },
+      ],
+      links: [
+        [40, 1, 0, 7, 0, "IMAGE"],
+        [41, 2, 0, 7, 1, "IMAGE"],
+      ],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(g, {
+      ...(OBJECT_INFO as object),
+      "Anything Everywhere3": {
+        input: { required: {}, optional: { anything: ["*"], anything2: ["*"] } },
+      },
+    } as never);
+    expect(workflow["3"].inputs.images).toEqual(["1", 0]);
+    expect(workflow["4"].inputs.images).toEqual(["2", 0]);
+    expect(warnings).toEqual([]);
   });
 
   it("an EMPTY computed list is an answer, not an unknown — no warning, no invented link", () => {

--- a/src/__tests__/services/strip-workflow-preservation.test.ts
+++ b/src/__tests__/services/strip-workflow-preservation.test.ts
@@ -750,7 +750,175 @@ describe("#361 — cg-use-everywhere broadcast links", () => {
     } as never);
     expect(workflow["3"].inputs.images).toEqual(["1", 0]);
     expect(workflow["4"].inputs.images).toEqual(["2", 0]);
+    // Both records are preserved — and the residual is disclosed ONCE for the
+    // sender, because a record does not name the input its broadcast came
+    // through, so a stale list that swapped the sender's channels would be
+    // indistinguishable from this one.
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("Node 7 (Anything Everywhere3)");
+    expect(warnings[0]).toContain("broadcasts from more than one producer");
+  });
+
+  it("a sender with several inputs from ONE producer needs no channel caveat", () => {
+    // One producer, so there is no channel to confuse — the caveat must not fire
+    // here or it becomes noise on every multi-input graph.
+    const g = {
+      extra: {
+        ue_links: [
+          { downstream: 3, downstream_slot: 0, upstream: 1, upstream_slot: 0, controller: 7, type: "IMAGE" },
+        ],
+      },
+      nodes: [
+        {
+          id: 1,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [40, 41] }],
+          widgets_values: ["a.png"],
+        },
+        {
+          id: 7,
+          type: "Anything Everywhere3",
+          mode: 0,
+          inputs: [
+            { name: "anything", type: "*", link: 40 },
+            { name: "anything2", type: "*", link: 41 },
+          ],
+          outputs: [],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: null }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+      ],
+      links: [
+        [40, 1, 0, 7, 0, "IMAGE"],
+        [41, 1, 0, 7, 1, "IMAGE"],
+      ],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(g, {
+      ...(OBJECT_INFO as object),
+      "Anything Everywhere3": {
+        input: { required: {}, optional: { anything: ["*"], anything2: ["*"] } },
+      },
+    } as never);
+    expect(workflow["3"].inputs.images).toEqual(["1", 0]);
     expect(warnings).toEqual([]);
+  });
+
+  it("a CHANNEL-SWAPPED stale list is materialized but the uncertainty is disclosed", () => {
+    // The record says node 1 feeds SaveImage#3; live, node 1 feeds the sender's
+    // SECOND input while node 2 feeds the first. Nothing in a ue_links record
+    // names the sender input a broadcast came through, so this is
+    // indistinguishable from a current list — it cannot be REFUSED without
+    // dropping every legitimate multi-channel graph, but it must not pass in
+    // silence either.
+    const g = {
+      extra: {
+        ue_links: [
+          { downstream: 3, downstream_slot: 0, upstream: 1, upstream_slot: 0, controller: 7, type: "IMAGE" },
+        ],
+      },
+      nodes: [
+        {
+          id: 1,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [41] }],
+          widgets_values: ["a.png"],
+        },
+        {
+          id: 2,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [40] }],
+          widgets_values: ["b.png"],
+        },
+        {
+          id: 7,
+          type: "Prompts Everywhere",
+          mode: 0,
+          inputs: [
+            { name: "anything", type: "*", link: 40 },
+            { name: "anything2", type: "*", link: 41 },
+          ],
+          outputs: [],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: null }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+      ],
+      links: [
+        [40, 2, 0, 7, 0, "IMAGE"],
+        [41, 1, 0, 7, 1, "IMAGE"],
+      ],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(g, {
+      ...(OBJECT_INFO as object),
+      "Prompts Everywhere": {
+        input: { required: {}, optional: { anything: ["*"], anything2: ["*"] } },
+      },
+    } as never);
+    expect(workflow["3"].inputs.images).toEqual(["1", 0]); // not dropped
+    expect(joined(warnings)).toContain("broadcasts from more than one producer");
+    expect(joined(warnings)).toContain("SWAPPING");
+  });
+
+  it("a non-UE class sharing a sender name PREFIX cannot skip the feed check", () => {
+    // Recognition is generous on purpose (an unrecognized sender loses its
+    // broadcasts silently), so a foreign "Seed Everywhere …" class can be
+    // classified as a sender. It must NOT therefore inherit the self-producing
+    // exemption that skips feed verification, or a stale record naming it would
+    // be materialized unchecked.
+    const g = {
+      extra: {
+        ue_links: [
+          { downstream: 3, downstream_slot: 0, upstream: 9, upstream_slot: 0, type: "IMAGE" },
+        ],
+      },
+      nodes: [
+        {
+          id: 9,
+          type: "Seed Everywhere Helper",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+          widgets_values: [1],
+        },
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: null }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(g, {
+      ...(OBJECT_INFO as object),
+      "Seed Everywhere Helper": {
+        input: { required: { seed: ["INT", { default: 0 }] } },
+        output: ["IMAGE"],
+      },
+    } as never);
+    expect(workflow["3"].inputs.images).toBeUndefined();
+    expect(joined(warnings)).toContain("could not be confirmed against the live graph");
   });
 
   it("an EMPTY computed list is an answer, not an unknown — no warning, no invented link", () => {

--- a/src/__tests__/services/strip-workflow-preservation.test.ts
+++ b/src/__tests__/services/strip-workflow-preservation.test.ts
@@ -1118,6 +1118,19 @@ describe("#361 — a subgraph output routed through a Set/Get bus", () => {
     expect(warnings).toEqual([]);
   });
 
+  it("a subgraph input claiming a link that does not exist is reported, not silently cleared", () => {
+    const g = subgraphGraph({
+      proxy: [],
+      values: [],
+      linkWidth: true,
+    }) as unknown as { links: unknown[] };
+    g.links = []; // component input still claims link 200, which is now absent
+    const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(onlyInner(workflow as never).inputs.width).toBe(512); // fell back
+    expect(joined(warnings)).toContain('input "width" claims link 200');
+    expect(joined(warnings)).toContain("falls back to its own stored value");
+  });
+
   it("a connection dropped because its producer left the graph names the node and input", () => {
     // A consumer wired to a node that is not in the prompt used to be reported
     // only as a bare "pruned N dangling reference(s)" count.

--- a/src/__tests__/services/strip-workflow-preservation.test.ts
+++ b/src/__tests__/services/strip-workflow-preservation.test.ts
@@ -405,12 +405,155 @@ describe("#361 — cg-use-everywhere broadcast links", () => {
     expect(joined(warnings)).toContain("names no broadcast node of its own");
   });
 
-  it("a CONTROLLERLESS record that DOES match a live sender's feed is still materialized", () => {
-    const g = ueGraph(true) as unknown as { extra: { ue_links: Record<string, unknown>[] } };
-    delete g.extra.ue_links[0].controller;
-    const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
-    expect(workflow["3"].inputs.images).toEqual(["1", 0]);
+  // NOTE: an earlier revision asserted the opposite here — that a controllerless
+  // record is materialized as long as SOME live sender is fed by the recorded
+  // producer. That expectation was wrong and this test now pins the correct
+  // behaviour: an unrelated sender sharing a producer is a coincidence, not
+  // evidence about THIS record's target.
+  it("an UNRELATED sender sharing the producer does not validate a controllerless record", () => {
+    // The record's own sender is gone. A live Prompts Everywhere is also fed by
+    // node 1 but broadcasts it somewhere else entirely — wiring 1 → SaveImage#3
+    // off the back of that would be a fabricated edge.
+    const g = {
+      extra: {
+        ue_links: [
+          { downstream: 3, downstream_slot: 0, upstream: 1, upstream_slot: 0, type: "IMAGE" },
+        ],
+      },
+      nodes: [
+        {
+          id: 1,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [60] }],
+          widgets_values: ["a.png"],
+        },
+        {
+          id: 7,
+          type: "Prompts Everywhere",
+          mode: 0,
+          inputs: [{ name: "anything", type: "*", link: 60 }],
+          outputs: [],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: null }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+      ],
+      links: [[60, 1, 0, 7, 0, "IMAGE"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(g, {
+      ...(OBJECT_INFO as object),
+      "Prompts Everywhere": { input: { required: {}, optional: { anything: ["*"] } } },
+    } as never);
+    expect(workflow["3"].inputs.images).toBeUndefined();
+    expect(joined(warnings)).toContain("cannot be attributed to any sender");
+  });
+
+  it("a controllerless record whose producer IS a broadcast node is self-attributing", () => {
+    // Seed Everywhere owns its widget, so the record names its own single channel
+    // — there is no attribution left to guess, and refusing it would drop a live
+    // broadcast for no gain.
+    const g = {
+      extra: {
+        ue_links: [
+          { downstream: 3, downstream_slot: 0, upstream: 9, upstream_slot: 0, type: "IMAGE" },
+        ],
+      },
+      nodes: [
+        {
+          id: 9,
+          type: "Seed Everywhere",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+          widgets_values: [42],
+        },
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: null }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(g, {
+      ...(OBJECT_INFO as object),
+      "Seed Everywhere": {
+        input: { required: { seed: ["INT", { default: 0 }] } },
+        output: ["IMAGE"],
+      },
+    } as never);
+    expect(workflow["3"].inputs.images).toEqual(["9", 0]);
     expect(warnings).toEqual([]);
+  });
+
+  it("'Seed Everywhere?' is recognized as a broadcast node, so its records materialize", () => {
+    // The pack registers this class, but the sender predicate compared the
+    // "Seed Everywhere" family with equality — so the node was invisible, and
+    // with no recognized sender the whole list was dropped with no warning.
+    const g = {
+      extra: {
+        ue_links: [
+          {
+            downstream: 3,
+            downstream_slot: 0,
+            upstream: 9,
+            upstream_slot: 0,
+            controller: 9,
+            type: "IMAGE",
+          },
+        ],
+      },
+      nodes: [
+        {
+          id: 9,
+          type: "Seed Everywhere?",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+          widgets_values: [42],
+        },
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: null }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(g, {
+      ...(OBJECT_INFO as object),
+      "Seed Everywhere?": {
+        input: { required: { seed: ["INT", { default: 0 }] } },
+        output: ["IMAGE"],
+      },
+    } as never);
+    expect(workflow["3"].inputs.images).toEqual(["9", 0]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("records with NO recognized broadcast node are reported, never dropped in silence", () => {
+    // The backstop for any sender class this converter does not know: records
+    // present, nothing to attribute them to. Deleted senders and unrecognized
+    // senders are indistinguishable here, so it is a could-not-determine.
+    const g = ueGraph(true) as unknown as { nodes: { id: number }[] };
+    g.nodes = g.nodes.filter((n) => n.id !== 7); // every sender gone
+    const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(workflow["3"].inputs.images).toBeUndefined();
+    expect(joined(warnings)).toContain("no node in it is recognized as a cg-use-everywhere broadcast node");
   });
 
   it("a sender fed from a subgraph's INPUT boundary broadcasts the outer producer", () => {

--- a/src/__tests__/services/strip-workflow-preservation.test.ts
+++ b/src/__tests__/services/strip-workflow-preservation.test.ts
@@ -292,6 +292,133 @@ describe("#361 — cg-use-everywhere broadcast links", () => {
     const { warnings } = convertUiToApi(g as never, OBJECT_INFO);
     expect(joined(warnings)).toContain("no longer exists");
   });
+
+  it("a record whose OWN sender was deleted is stale — reported, and no link fabricated", () => {
+    // Sender 7 is still there (so the list is still consulted), but this record
+    // was produced by a sender that has since been removed.
+    const g = ueGraph(true) as unknown as {
+      extra: { ue_links: { controller: number }[] };
+    };
+    g.extra.ue_links[0].controller = 8;
+    const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(workflow["3"].inputs.images).toBeUndefined();
+    expect(joined(warnings)).toContain("the record is stale");
+  });
+
+  it("a record naming an output slot the producer no longer has is stale, not wired", () => {
+    const g = ueGraph(true) as unknown as {
+      extra: { ue_links: { upstream_slot: number }[] };
+    };
+    g.extra.ue_links[0].upstream_slot = 5; // LoadImage(1) serializes ONE output
+    const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(workflow["3"].inputs.images).toBeUndefined();
+    expect(joined(warnings)).toContain("which only has 1 output(s)");
+  });
+
+  it("senders INSIDE a subgraph definition are not silently ignored", () => {
+    const g = {
+      definitions: {
+        subgraphs: [
+          {
+            id: SG_ID,
+            name: "Inner",
+            inputNode: { id: -10 },
+            outputNode: { id: -20 },
+            inputs: [],
+            outputs: [],
+            widgets: [],
+            // No extra.ue_links here: the broadcast is unrecoverable and must be said.
+            nodes: [
+              {
+                id: 80,
+                type: "Anything Everywhere",
+                mode: 0,
+                inputs: [{ name: "anything", type: "*", link: null }],
+                outputs: [],
+                widgets_values: [],
+              },
+              {
+                id: 81,
+                type: "SaveImage",
+                mode: 0,
+                inputs: [{ name: "images", type: "IMAGE", link: null }],
+                outputs: [],
+                widgets_values: ["out"],
+              },
+            ],
+            links: [],
+          },
+        ],
+      },
+      nodes: [
+        {
+          id: 706,
+          type: SG_ID,
+          mode: 0,
+          properties: {},
+          inputs: [],
+          outputs: [],
+          widgets_values: [],
+        },
+      ],
+      links: [],
+    } as never;
+    const { warnings } = convertUiToApi(g, OBJECT_INFO);
+    expect(joined(warnings)).toContain('subgraph "Inner"');
+    expect(joined(warnings)).toContain("CANNOT be recovered");
+  });
+
+  it("an UNUSED subgraph definition's broken wiring is not reported as this graph's loss", () => {
+    const g = {
+      definitions: {
+        subgraphs: [
+          {
+            id: "never-instantiated",
+            name: "Dead",
+            inputNode: { id: -10 },
+            outputNode: { id: -20 },
+            inputs: [],
+            outputs: [],
+            widgets: [],
+            nodes: [
+              {
+                id: 90,
+                type: "GetNode",
+                mode: 0,
+                inputs: [],
+                outputs: [{ name: "IMAGE", type: "IMAGE", links: [90] }],
+                widgets_values: ["orphan"],
+              },
+              {
+                id: 91,
+                type: "SaveImage",
+                mode: 0,
+                inputs: [{ name: "images", type: "IMAGE", link: 90 }],
+                outputs: [],
+                widgets_values: ["out"],
+              },
+            ],
+            links: [
+              { id: 90, origin_id: 90, origin_slot: 0, target_id: 91, target_slot: 0, type: "IMAGE" },
+            ],
+          },
+        ],
+      },
+      nodes: [
+        {
+          id: 1,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+          widgets_values: ["a.png"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { warnings } = convertUiToApi(g, OBJECT_INFO);
+    expect(warnings).toEqual([]);
+  });
 });
 
 // ── 3. Promoted ("proxy") subgraph widget values ────────────────────────────
@@ -498,6 +625,110 @@ describe("#361 — promoted subgraph widget values", () => {
     const loader = Object.values(workflow).find((n) => n.class_type === "CheckpointLoaderSimple")!;
     expect(loader.inputs.ckpt_name).toBe("not_installed.safetensors");
     expect(joined(warnings)).toContain("not installed on the connected server");
+  });
+});
+
+// ── 3b. Virtual wiring across a subgraph boundary (codex gate) ──────────────
+
+describe("#361 — a subgraph output routed through a Set/Get bus", () => {
+  it("survives expansion instead of being pruned as an anonymous dangling reference", () => {
+    // Component(706) → SetNode(4) "img" → GetNode(5) → SaveImage(3). Rewriting
+    // the link tuple alone was not enough: the expander rewires consumers from
+    // the component's own outputs[].links, so the re-homed edge has to land there
+    // too or the component expands away and the consumer's input vanishes.
+    const g = {
+      definitions: {
+        subgraphs: [
+          {
+            id: SG_ID,
+            name: "Src",
+            inputNode: { id: -10 },
+            outputNode: { id: -20 },
+            inputs: [],
+            outputs: [{ id: "o1", name: "IMAGE", type: "IMAGE", linkIds: [102] }],
+            widgets: [],
+            nodes: [
+              {
+                id: 50,
+                type: "LoadImage",
+                mode: 0,
+                inputs: [],
+                outputs: [{ name: "IMAGE", type: "IMAGE", links: [102] }],
+                widgets_values: ["a.png"],
+              },
+            ],
+            links: [
+              { id: 102, origin_id: 50, origin_slot: 0, target_id: -20, target_slot: 0, type: "IMAGE" },
+            ],
+          },
+        ],
+      },
+      nodes: [
+        {
+          id: 706,
+          type: SG_ID,
+          mode: 0,
+          properties: {},
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [11] }],
+          widgets_values: [],
+        },
+        {
+          id: 4,
+          type: "SetNode",
+          mode: 0,
+          inputs: [{ name: "value", type: "IMAGE", link: 11 }],
+          outputs: [],
+          widgets_values: ["img"],
+        },
+        {
+          id: 5,
+          type: "GetNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [10] }],
+          widgets_values: ["img"],
+        },
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: 10 }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+      ],
+      links: [
+        [11, 706, 0, 4, 0, "IMAGE"],
+        [10, 5, 0, 3, 0, "IMAGE"],
+      ],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(g, OBJECT_INFO);
+    const inner = Object.entries(workflow).find(([, n]) => n.class_type === "LoadImage")!;
+    expect(workflow["3"].inputs.images).toEqual([inner[0], 0]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("a connection dropped because its producer left the graph names the node and input", () => {
+    // A consumer wired to a node that is not in the prompt used to be reported
+    // only as a bare "pruned N dangling reference(s)" count.
+    const g = {
+      nodes: [
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: 10 }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+      ],
+      links: [[10, 42, 0, 3, 0, "IMAGE"]],
+    } as never;
+    const { warnings } = convertUiToApi(g, OBJECT_INFO);
+    expect(joined(warnings)).toContain("Node 3 (SaveImage)");
+    expect(joined(warnings)).toContain('input "images"');
+    expect(joined(warnings)).toContain("pointed at node 42");
   });
 });
 

--- a/src/__tests__/services/strip-workflow-preservation.test.ts
+++ b/src/__tests__/services/strip-workflow-preservation.test.ts
@@ -878,25 +878,33 @@ describe("#361 — cg-use-everywhere broadcast links", () => {
     expect(joined(warnings)).toContain("SWAPPING");
   });
 
-  it("a non-UE class sharing a sender name PREFIX cannot skip the feed check", () => {
-    // Recognition is generous on purpose (an unrecognized sender loses its
-    // broadcasts silently), so a foreign "Seed Everywhere …" class can be
-    // classified as a sender. It must NOT therefore inherit the self-producing
-    // exemption that skips feed verification, or a stale record naming it would
-    // be materialized unchecked.
+  it("a foreign class sharing a sender name PREFIX fabricates nothing, even when fed", () => {
+    // The fabrication direction: node 9 IS fed by node 1, so a feed check alone
+    // would confirm this stale record and emit 1 → SaveImage#3. Membership cannot
+    // be inferred from a name shape, and no feed check rescues a wrong
+    // classification — so the class is not a sender, nothing is wired, and the
+    // records are reported by the no-recognized-sender backstop.
     const g = {
       extra: {
         ue_links: [
-          { downstream: 3, downstream_slot: 0, upstream: 9, upstream_slot: 0, type: "IMAGE" },
+          { downstream: 3, downstream_slot: 0, upstream: 1, upstream_slot: 0, controller: 9, type: "IMAGE" },
         ],
       },
       nodes: [
         {
+          id: 1,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [70] }],
+          widgets_values: ["a.png"],
+        },
+        {
           id: 9,
           type: "Seed Everywhere Helper",
           mode: 0,
-          inputs: [],
-          outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+          inputs: [{ name: "anything", type: "*", link: 70 }],
+          outputs: [],
           widgets_values: [1],
         },
         {
@@ -908,17 +916,16 @@ describe("#361 — cg-use-everywhere broadcast links", () => {
           widgets_values: ["out"],
         },
       ],
-      links: [],
+      links: [[70, 1, 0, 9, 0, "IMAGE"]],
     } as never;
     const { workflow, warnings } = convertUiToApi(g, {
       ...(OBJECT_INFO as object),
       "Seed Everywhere Helper": {
-        input: { required: { seed: ["INT", { default: 0 }] } },
-        output: ["IMAGE"],
+        input: { required: {}, optional: { anything: ["*"] } },
       },
     } as never);
     expect(workflow["3"].inputs.images).toBeUndefined();
-    expect(joined(warnings)).toContain("could not be confirmed against the live graph");
+    expect(joined(warnings)).toContain("no node in it is recognized as a cg-use-everywhere broadcast node");
   });
 
   it("a live sender that the ue_links list does not mention is reported", () => {

--- a/src/__tests__/services/strip-workflow-preservation.test.ts
+++ b/src/__tests__/services/strip-workflow-preservation.test.ts
@@ -921,6 +921,35 @@ describe("#361 — cg-use-everywhere broadcast links", () => {
     expect(joined(warnings)).toContain("could not be confirmed against the live graph");
   });
 
+  it("a live sender that the ue_links list does not mention is reported", () => {
+    // A non-empty list is not proof it covers every sender. One that predates a
+    // sender simply has no row for it, and that sender's broadcasts then come out
+    // unconnected — on a list that looked usable, exactly the silent difference
+    // this whole change removes.
+    const g = ueGraph(true) as unknown as {
+      nodes: {
+        id: number;
+        type: string;
+        mode: number;
+        inputs?: unknown[];
+        outputs?: unknown[];
+        widgets_values: unknown[];
+      }[];
+    };
+    g.nodes.push({
+      id: 8,
+      type: "Anything Everywhere",
+      mode: 0,
+      inputs: [{ name: "anything", type: "*", link: null }],
+      outputs: [],
+      widgets_values: [],
+    });
+    const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(workflow["3"].inputs.images).toEqual(["1", 0]); // listed record still wired
+    expect(joined(warnings)).toContain("Anything Everywhere #8");
+    expect(joined(warnings)).toContain("no record in extra.ue_links names it");
+  });
+
   it("an EMPTY computed list is an answer, not an unknown — no warning, no invented link", () => {
     // The pack analysed the graph and recorded zero broadcasts. Reporting that as
     // "unrecoverable" would invent a loss that did not happen.

--- a/src/__tests__/services/strip-workflow-preservation.test.ts
+++ b/src/__tests__/services/strip-workflow-preservation.test.ts
@@ -756,7 +756,7 @@ describe("#361 — cg-use-everywhere broadcast links", () => {
     // indistinguishable from this one.
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain("Node 7 (Anything Everywhere3)");
-    expect(warnings[0]).toContain("broadcasts from more than one producer");
+    expect(warnings[0]).toContain("could not be matched to a specific sender input");
   });
 
   it("a sender with several inputs from ONE producer needs no channel caveat", () => {
@@ -874,7 +874,7 @@ describe("#361 — cg-use-everywhere broadcast links", () => {
       },
     } as never);
     expect(workflow["3"].inputs.images).toEqual(["1", 0]); // not dropped
-    expect(joined(warnings)).toContain("broadcasts from more than one producer");
+    expect(joined(warnings)).toContain("could not be matched to a specific sender input");
     expect(joined(warnings)).toContain("SWAPPING");
   });
 

--- a/src/__tests__/services/strip-workflow-preservation.test.ts
+++ b/src/__tests__/services/strip-workflow-preservation.test.ts
@@ -1,0 +1,572 @@
+// Issue #361: panel_strip_workflow / strip_workflow returned WRONG dynamic
+// widget values and DROPPED Set/Get (and other node-pack "virtual") links —
+// silently, so the caller got a graph that looks fine and renders differently.
+//
+// Two independent defects, both covered here:
+//   1. Promoted ("proxy") subgraph widget values were resolved POSITIONALLY via
+//      the widget's index among the inputs[] entries that carry a `widget` field.
+//      A widget absent from inputs[] resolved to nothing (value dropped), and a
+//      subgraph-input promotion (proxy id "-1") never resolved at all — so the
+//      stripped graph reported the inner node's STALE stored value.
+//   2. Virtual wiring that cannot be resolved (an orphan Get bus, a dead Reroute)
+//      was dropped with NO warning, and cg-use-everywhere broadcasts — which are
+//      not ordinary graph links at all — were never materialized.
+//
+// The invariant these tests defend: whatever the stripped graph cannot preserve,
+// it must SAY SO.
+import { describe, it, expect } from "vitest";
+import { convertUiToApi } from "../../services/workflow-converter.js";
+
+const OBJECT_INFO = {
+  LoadImage: { input: { required: { image: [["a.png", "b.png"]] } } },
+  SaveImage: {
+    input: { required: { images: ["IMAGE"], filename_prefix: ["STRING", { default: "x" }] } },
+  },
+  EmptyLatentImage: {
+    input: {
+      required: {
+        width: ["INT", { default: 512 }],
+        height: ["INT", { default: 512 }],
+        batch_size: ["INT", { default: 1 }],
+      },
+    },
+  },
+  CheckpointLoaderSimple: {
+    input: { required: { ckpt_name: [["installed.safetensors"]] } },
+  },
+  "Anything Everywhere": { input: { required: {}, optional: { anything: ["*"] } } },
+  PrimitiveInt: { input: { required: { value: ["INT", { default: 0 }] } }, output: ["INT"] },
+} as never;
+
+const joined = (warnings: string[]) => warnings.join("\n");
+
+// ── 1. Set/Get buses ────────────────────────────────────────────────────────
+
+describe("#361 — Set/Get bus links", () => {
+  /** SaveImage(3) fed from GetNode(5) on bus `bus`; SetNode(4) writes `writes`. */
+  function busGraph(writes: string | null, bus: string) {
+    const nodes: unknown[] = [
+      {
+        id: 1,
+        type: "LoadImage",
+        mode: 0,
+        inputs: [],
+        outputs: [{ name: "IMAGE", type: "IMAGE", links: writes == null ? [] : [11] }],
+        widgets_values: ["a.png"],
+      },
+      {
+        id: 5,
+        type: "GetNode",
+        mode: 0,
+        inputs: [],
+        outputs: [{ name: "IMAGE", type: "IMAGE", links: [10] }],
+        widgets_values: [bus],
+      },
+      {
+        id: 3,
+        type: "SaveImage",
+        mode: 0,
+        inputs: [{ name: "images", type: "IMAGE", link: 10 }],
+        outputs: [],
+        widgets_values: ["out"],
+      },
+    ];
+    const links: unknown[] = [[10, 5, 0, 3, 0, "IMAGE"]];
+    if (writes != null) {
+      nodes.push({
+        id: 4,
+        type: "SetNode",
+        mode: 0,
+        inputs: [{ name: "value", type: "IMAGE", link: 11 }],
+        outputs: [{ name: "*", type: "IMAGE", links: [] }],
+        widgets_values: [writes],
+      });
+      links.push([11, 1, 0, 4, 0, "IMAGE"]);
+    }
+    return { nodes, links } as never;
+  }
+
+  it("a RESOLVABLE bus still becomes a real link, with nothing reported as lost", () => {
+    const { workflow, warnings } = convertUiToApi(busGraph("img", "img"), OBJECT_INFO);
+    expect(workflow["3"].inputs.images).toEqual(["1", 0]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("an ORPHAN Get bus names the consumer, the input, the bus, and says the connection is absent", () => {
+    const { workflow, warnings } = convertUiToApi(busGraph(null, "missing_bus"), OBJECT_INFO);
+    // The connection genuinely cannot be recovered — but it must be REPORTED.
+    expect(workflow["3"].inputs.images).toBeUndefined();
+    const text = joined(warnings);
+    expect(text).toContain("Node 3 (SaveImage)");
+    expect(text).toContain('input "images"');
+    expect(text).toContain("missing_bus");
+    expect(text).toContain("ABSENT from the stripped graph");
+  });
+
+  it("a Get bus whose Set node has no incoming connection says so", () => {
+    const g = busGraph("img", "img") as unknown as {
+      nodes: { id: number; inputs?: { link: number | null }[] }[];
+      links: unknown[];
+    };
+    // Cut the SetNode's feed.
+    g.nodes.find((n) => n.id === 4)!.inputs![0].link = null;
+    g.links = g.links.filter((l) => (l as number[])[0] !== 11);
+    const { warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(joined(warnings)).toContain("has no incoming connection");
+  });
+
+  it("two Set nodes on one bus is reported as ambiguous (last one wins)", () => {
+    const g = busGraph("img", "img") as unknown as { nodes: unknown[]; links: unknown[] };
+    g.nodes.push({
+      id: 6,
+      type: "SetNode",
+      mode: 0,
+      inputs: [{ name: "value", type: "IMAGE", link: 12 }],
+      outputs: [],
+      widgets_values: ["img"],
+    });
+    g.links.push([12, 1, 0, 6, 0, "IMAGE"]);
+    const { warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(joined(warnings)).toContain('bus "img" is written by more than one Set node');
+  });
+
+  it("a Reroute with no incoming connection is reported, not silently dropped", () => {
+    const g = {
+      nodes: [
+        {
+          id: 9,
+          type: "Reroute",
+          mode: 0,
+          inputs: [{ name: "", type: "IMAGE", link: null }],
+          outputs: [{ name: "", type: "IMAGE", links: [30] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: 30 }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+      ],
+      links: [[30, 9, 0, 3, 0, "IMAGE"]],
+    } as never;
+    const { warnings } = convertUiToApi(g, OBJECT_INFO);
+    expect(joined(warnings)).toContain("Reroute #9 has no incoming connection");
+    expect(joined(warnings)).toContain('input "images"');
+  });
+});
+
+// ── 2. cg-use-everywhere broadcasts ─────────────────────────────────────────
+
+describe("#361 — cg-use-everywhere broadcast links", () => {
+  function ueGraph(withUeLinks: boolean) {
+    return {
+      extra: withUeLinks
+        ? {
+            ue_links: [
+              {
+                downstream: 3,
+                downstream_slot: 0,
+                upstream: 1,
+                upstream_slot: 0,
+                controller: 7,
+                type: "IMAGE",
+              },
+            ],
+          }
+        : {},
+      nodes: [
+        {
+          id: 1,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [20] }],
+          widgets_values: ["a.png"],
+        },
+        {
+          id: 7,
+          type: "Anything Everywhere",
+          mode: 0,
+          inputs: [{ name: "anything", type: "*", link: 20 }],
+          outputs: [],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: null }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+      ],
+      links: [[20, 1, 0, 7, 0, "IMAGE"]],
+    } as never;
+  }
+
+  it("materializes a broadcast from the pack's own extra.ue_links", () => {
+    const { workflow, warnings } = convertUiToApi(ueGraph(true), OBJECT_INFO);
+    expect(workflow["3"].inputs.images).toEqual(["1", 0]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("senders with NO extra.ue_links: refuses to guess, and says the connections are unrecoverable", () => {
+    const { workflow, warnings } = convertUiToApi(ueGraph(false), OBJECT_INFO);
+    expect(workflow["3"].inputs.images).toBeUndefined(); // never fabricated
+    const text = joined(warnings);
+    expect(text).toContain("Anything Everywhere #7");
+    expect(text).toContain("CANNOT be recovered");
+    expect(text).toContain("extra.ue_links");
+  });
+
+  it("a broadcast whose producer sits behind a Set/Get bus resolves to the real producer", () => {
+    const g = {
+      extra: {
+        ue_links: [
+          {
+            downstream: 3,
+            downstream_slot: 0,
+            upstream: 5,
+            upstream_slot: 0,
+            controller: 7,
+            type: "IMAGE",
+          },
+        ],
+      },
+      nodes: [
+        {
+          id: 1,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [21] }],
+          widgets_values: ["a.png"],
+        },
+        {
+          id: 4,
+          type: "SetNode",
+          mode: 0,
+          inputs: [{ name: "value", type: "IMAGE", link: 21 }],
+          outputs: [],
+          widgets_values: ["img"],
+        },
+        {
+          id: 5,
+          type: "GetNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+          widgets_values: ["img"],
+        },
+        {
+          id: 7,
+          type: "Anything Everywhere",
+          mode: 0,
+          inputs: [{ name: "anything", type: "*", link: null }],
+          outputs: [],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: null }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+      ],
+      links: [[21, 1, 0, 4, 0, "IMAGE"]],
+    } as never;
+    const { workflow } = convertUiToApi(g, OBJECT_INFO);
+    expect(workflow["3"].inputs.images).toEqual(["1", 0]);
+  });
+
+  it("a broadcast into a node that no longer exists is reported", () => {
+    const g = ueGraph(true) as unknown as {
+      extra: { ue_links: { downstream: number }[] };
+    };
+    g.extra.ue_links[0].downstream = 999;
+    const { warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(joined(warnings)).toContain("no longer exists");
+  });
+});
+
+// ── 3. Promoted ("proxy") subgraph widget values ────────────────────────────
+
+const SG_ID = "sg-uuid";
+
+/**
+ * One subgraph instance (706) wrapping EmptyLatentImage(50).
+ *  - `proxy` is the properties.proxyWidgets list,
+ *  - `values` is the instance's widgets_values (parallel to proxy),
+ *  - `linkWidth` wires a real producer into the instance's `width` slot.
+ */
+function subgraphGraph(opts: {
+  proxy: [string, string][];
+  values: unknown[];
+  innerInputs?: unknown[];
+  linkWidth?: boolean;
+}) {
+  const innerInputs = opts.innerInputs ?? [
+    { name: "width", type: "INT", widget: { name: "width" }, link: 101 },
+  ];
+  return {
+    definitions: {
+      subgraphs: [
+        {
+          id: SG_ID,
+          name: "Latent",
+          inputNode: { id: -10 },
+          outputNode: { id: -20 },
+          inputs: [{ id: "i1", name: "width", type: "INT", linkIds: [101] }],
+          outputs: [{ id: "o1", name: "LATENT", type: "LATENT", linkIds: [102] }],
+          widgets: [],
+          nodes: [
+            {
+              id: 50,
+              type: "EmptyLatentImage",
+              mode: 0,
+              inputs: innerInputs,
+              outputs: [{ name: "LATENT", type: "LATENT", links: [102] }],
+              widgets_values: [512, 512, 1],
+            },
+          ],
+          links: [
+            { id: 101, origin_id: -10, origin_slot: 0, target_id: 50, target_slot: 0, type: "INT" },
+            { id: 102, origin_id: 50, origin_slot: 0, target_id: -20, target_slot: 0, type: "LATENT" },
+          ],
+        },
+      ],
+    },
+    nodes: [
+      ...(opts.linkWidth
+        ? [
+            {
+              id: 60,
+              type: "PrimitiveInt",
+              mode: 0,
+              inputs: [],
+              outputs: [{ name: "INT", type: "INT", links: [200] }],
+              widgets_values: [64],
+            },
+          ]
+        : []),
+      {
+        id: 706,
+        type: SG_ID,
+        mode: 0,
+        properties: { proxyWidgets: opts.proxy },
+        inputs: [
+          {
+            name: "width",
+            type: "INT",
+            widget: { name: "width" },
+            link: opts.linkWidth ? 200 : null,
+          },
+        ],
+        outputs: [{ name: "LATENT", type: "LATENT", links: [] }],
+        widgets_values: opts.values,
+      },
+    ],
+    links: opts.linkWidth ? [[200, 60, 0, 706, 0, "INT"]] : [],
+  } as never;
+}
+
+/** The single expanded inner node (its id is remapped during expansion). */
+const onlyInner = (workflow: Record<string, { class_type: string; inputs: Record<string, unknown> }>) =>
+  Object.values(workflow).find((n) => n.class_type === "EmptyLatentImage" && "batch_size" in n.inputs)!;
+
+describe("#361 — promoted subgraph widget values", () => {
+  it("a subgraph-input promotion (proxy id '-1') reaches the inner node instead of its stale stored value", () => {
+    const { workflow, warnings } = convertUiToApi(
+      subgraphGraph({ proxy: [["-1", "width"]], values: [1920] }),
+      OBJECT_INFO,
+    );
+    // Before the fix this was 512 — the inner node's stored value — with NO warning.
+    expect(onlyInner(workflow as never).inputs.width).toBe(1920);
+    expect(warnings).toEqual([]);
+  });
+
+  it("a REAL incoming link on the promoted slot still wins over the promoted widget value", () => {
+    const { workflow } = convertUiToApi(
+      subgraphGraph({ proxy: [["-1", "width"]], values: [1920], linkWidth: true }),
+      OBJECT_INFO,
+    );
+    expect(onlyInner(workflow as never).inputs.width).toEqual(["60", 0]);
+  });
+
+  it("an inner-node promotion applies BY NAME even when the widget is absent from inputs[]", () => {
+    // `height` has no inputs[] entry at all: the old index-counting resolver
+    // returned null here and dropped the value outright.
+    const { workflow, warnings } = convertUiToApi(
+      subgraphGraph({ proxy: [["50", "height"]], values: [1088] }),
+      OBJECT_INFO,
+    );
+    expect(onlyInner(workflow as never).inputs.height).toBe(1088);
+    expect(warnings).toEqual([]);
+  });
+
+  it("an inner-node promotion lands on the NAMED widget, not on a mis-counted position", () => {
+    // `width` occupies an inputs[] slot but carries no `widget` marker, so the old
+    // index-counting resolver made `batch_size` the FIRST widget-input (index 0)
+    // and wrote the promoted 4 over widgets_values[0] — which is `width`.
+    const { workflow } = convertUiToApi(
+      subgraphGraph({
+        proxy: [["50", "batch_size"]],
+        values: [4],
+        innerInputs: [
+          { name: "width", type: "INT", link: 101 },
+          { name: "batch_size", type: "INT", widget: { name: "batch_size" }, link: null },
+        ],
+      }),
+      OBJECT_INFO,
+    );
+    const inner = onlyInner(workflow as never);
+    expect(inner.inputs.batch_size).toBe(4);
+    expect(inner.inputs.width).toBe(512); // NOT clobbered by the promotion
+  });
+
+  it("a promoted widget the server's node definition does not declare is reported, not dropped in silence", () => {
+    const { warnings } = convertUiToApi(
+      subgraphGraph({ proxy: [["50", "not_a_widget"]], values: [7] }),
+      OBJECT_INFO,
+    );
+    expect(joined(warnings)).toContain('"not_a_widget"');
+    expect(joined(warnings)).toContain("could not be applied");
+  });
+
+  it("a promoted widget with NO serialized value keeps the inner node's own value, silently", () => {
+    // Not a loss: the subgraph node's widget is a proxy VIEW of the inner widget,
+    // so no serialized override means the inner value is what was displayed.
+    // Warning here would fire on nearly every subgraph workflow and bury the
+    // genuine losses.
+    const { workflow, warnings } = convertUiToApi(
+      subgraphGraph({ proxy: [["-1", "width"], ["50", "height"]], values: [1920] }),
+      OBJECT_INFO,
+    );
+    const inner = onlyInner(workflow as never);
+    expect(inner.inputs.width).toBe(1920); // promoted
+    expect(inner.inputs.height).toBe(512); // no override → inner's own value
+    expect(warnings).toEqual([]);
+  });
+
+  it("a promoted value goes through the same combo validation as any other widget", () => {
+    // A promoted asset value the server does not have must be PRESERVED + warned
+    // (#407/#504), never silently swapped for the first installed option.
+    const g = {
+      definitions: {
+        subgraphs: [
+          {
+            id: SG_ID,
+            name: "Loader",
+            inputNode: { id: -10 },
+            outputNode: { id: -20 },
+            inputs: [],
+            outputs: [{ id: "o1", name: "MODEL", type: "MODEL", linkIds: [] }],
+            widgets: [],
+            nodes: [
+              {
+                id: 51,
+                type: "CheckpointLoaderSimple",
+                mode: 0,
+                inputs: [],
+                outputs: [{ name: "MODEL", type: "MODEL", links: [] }],
+                widgets_values: ["installed.safetensors"],
+              },
+            ],
+            links: [],
+          },
+        ],
+      },
+      nodes: [
+        {
+          id: 707,
+          type: SG_ID,
+          mode: 0,
+          properties: { proxyWidgets: [["51", "ckpt_name"]] },
+          inputs: [],
+          outputs: [],
+          widgets_values: ["not_installed.safetensors"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(g, OBJECT_INFO);
+    const loader = Object.values(workflow).find((n) => n.class_type === "CheckpointLoaderSimple")!;
+    expect(loader.inputs.ckpt_name).toBe("not_installed.safetensors");
+    expect(joined(warnings)).toContain("not installed on the connected server");
+  });
+});
+
+// ── 4. Other unresolvable connections ───────────────────────────────────────
+
+describe("#361 — unresolved ordinary links", () => {
+  it("an input wired to a link id that does not exist is reported", () => {
+    const g = {
+      nodes: [
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: 77 }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+        {
+          id: 1,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+          widgets_values: ["a.png"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { warnings } = convertUiToApi(g, OBJECT_INFO);
+    expect(joined(warnings)).toContain("dangling reference");
+    expect(joined(warnings)).toContain('input "images"');
+  });
+
+  it("mute/bypass drops are summarized once rather than reported per edge", () => {
+    const g = {
+      nodes: [
+        {
+          id: 1,
+          type: "LoadImage",
+          mode: 2, // muted
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [1, 2] }],
+          widgets_values: ["a.png"],
+        },
+        {
+          id: 3,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: 1 }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+        {
+          id: 4,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: 2 }],
+          outputs: [],
+          widgets_values: ["out2"],
+        },
+      ],
+      links: [
+        [1, 1, 0, 3, 0, "IMAGE"],
+        [2, 1, 0, 4, 0, "IMAGE"],
+      ],
+    } as never;
+    const { warnings } = convertUiToApi(g, OBJECT_INFO);
+    const toggleWarnings = warnings.filter((w) => w.includes("muted, or bypassed"));
+    expect(toggleWarnings).toHaveLength(1);
+    expect(toggleWarnings[0]).toContain("2 input connection(s)");
+  });
+});

--- a/src/__tests__/services/strip-workflow-preservation.test.ts
+++ b/src/__tests__/services/strip-workflow-preservation.test.ts
@@ -372,6 +372,125 @@ describe("#361 — cg-use-everywhere broadcast links", () => {
     expect(joined(warnings)).toContain("no longer has any incoming connection");
   });
 
+  it("a CONTROLLERLESS record is not assumed current — a rewired one fabricates nothing", () => {
+    // Older lists omit `controller`, so the record can't be tied to a sender. That
+    // is "cannot determine", not "determined current": what is still checkable is
+    // whether ANY live broadcast node is fed by the recorded producer.
+    const g = ueGraph(true) as unknown as {
+      extra: { ue_links: Record<string, unknown>[] };
+      nodes: {
+        id: number;
+        type: string;
+        mode: number;
+        inputs?: { name: string; type: string; link: number | null }[];
+        outputs?: { name: string; type: string; links: number[] }[];
+        widgets_values: unknown[];
+      }[];
+      links: unknown[];
+    };
+    delete g.extra.ue_links[0].controller;
+    g.nodes.push({
+      id: 2,
+      type: "LoadImage",
+      mode: 0,
+      inputs: [],
+      outputs: [{ name: "IMAGE", type: "IMAGE", links: [30] }],
+      widgets_values: ["b.png"],
+    });
+    g.nodes.find((n) => n.id === 7)!.inputs![0].link = 30; // live UE broadcasts node 2
+    g.nodes.find((n) => n.id === 1)!.outputs![0].links = [];
+    g.links = [[30, 2, 0, 7, 0, "IMAGE"]];
+    const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(workflow["3"].inputs.images).toBeUndefined(); // NOT wired from the stale node 1
+    expect(joined(warnings)).toContain("names no broadcast node of its own");
+  });
+
+  it("a CONTROLLERLESS record that DOES match a live sender's feed is still materialized", () => {
+    const g = ueGraph(true) as unknown as { extra: { ue_links: Record<string, unknown>[] } };
+    delete g.extra.ue_links[0].controller;
+    const { workflow, warnings } = convertUiToApi(g as never, OBJECT_INFO);
+    expect(workflow["3"].inputs.images).toEqual(["1", 0]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("a sender fed from a subgraph's INPUT boundary broadcasts the outer producer", () => {
+    // The producer of a broadcast inside a definition can be the definition's
+    // virtual input node — a recoverable connection (the outer component's
+    // matching input supplies it), not a missing producer.
+    const g = {
+      definitions: {
+        subgraphs: [
+          {
+            id: SG_ID,
+            name: "Inner",
+            inputNode: { id: -10 },
+            outputNode: { id: -20 },
+            inputs: [{ id: "i1", name: "image", type: "IMAGE", linkIds: [11] }],
+            outputs: [],
+            widgets: [],
+            extra: {
+              ue_links: [
+                {
+                  downstream: 3,
+                  downstream_slot: 0,
+                  upstream: -10,
+                  upstream_slot: 0,
+                  controller: 7,
+                  type: "IMAGE",
+                },
+              ],
+            },
+            nodes: [
+              {
+                id: 7,
+                type: "Anything Everywhere",
+                mode: 0,
+                inputs: [{ name: "anything", type: "*", link: 11 }],
+                outputs: [],
+                widgets_values: [],
+              },
+              {
+                id: 3,
+                type: "SaveImage",
+                mode: 0,
+                inputs: [{ name: "images", type: "IMAGE", link: null }],
+                outputs: [],
+                widgets_values: ["out"],
+              },
+            ],
+            links: [
+              { id: 11, origin_id: -10, origin_slot: 0, target_id: 7, target_slot: 0, type: "IMAGE" },
+            ],
+          },
+        ],
+      },
+      nodes: [
+        {
+          id: 1,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [50] }],
+          widgets_values: ["a.png"],
+        },
+        {
+          id: 706,
+          type: SG_ID,
+          mode: 0,
+          properties: {},
+          inputs: [{ name: "image", type: "IMAGE", link: 50 }],
+          outputs: [],
+          widgets_values: [],
+        },
+      ],
+      links: [[50, 1, 0, 706, 0, "IMAGE"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(g, OBJECT_INFO);
+    const save = Object.values(workflow).find((n) => n.class_type === "SaveImage")!;
+    expect(save.inputs.images).toEqual(["1", 0]);
+    expect(warnings).toEqual([]);
+  });
+
   it("a sender that IS its own producer (Seed Everywhere shape) is still materialized", () => {
     // The controller owns the widget, so it has no incoming feed to compare —
     // requiring one would drop every Seed Everywhere broadcast.

--- a/src/__tests__/services/strip-workflow-preservation.test.ts
+++ b/src/__tests__/services/strip-workflow-preservation.test.ts
@@ -610,6 +610,79 @@ describe("#361 — promoted subgraph widget values", () => {
     expect(joined(warnings)).toContain("more than one promotion claims that name");
   });
 
+  it("a NESTED instance's name-keyed values survive an outer promotion into it", () => {
+    // Outer(700) wraps Inner(60), which wraps EmptyLatentImage(50). Inner carries
+    // its OWN name-keyed { height: 1088 }; Outer promotes Inner's `width` = 1920.
+    // Overwriting Inner's map with a positional array would drop `height`, and
+    // Inner's own expansion pass would then leave it at the stale 512 — silently.
+    const OUTER = "sg-outer";
+    const INNER = "sg-inner";
+    const g = {
+      definitions: {
+        subgraphs: [
+          {
+            id: INNER,
+            name: "Inner",
+            inputNode: { id: -10 },
+            outputNode: { id: -20 },
+            inputs: [],
+            outputs: [{ id: "o1", name: "LATENT", type: "LATENT", linkIds: [] }],
+            widgets: [],
+            nodes: [
+              {
+                id: 50,
+                type: "EmptyLatentImage",
+                mode: 0,
+                inputs: [],
+                outputs: [{ name: "LATENT", type: "LATENT", links: [] }],
+                widgets_values: [512, 512, 1],
+              },
+            ],
+            links: [],
+          },
+          {
+            id: OUTER,
+            name: "Outer",
+            inputNode: { id: -10 },
+            outputNode: { id: -20 },
+            inputs: [],
+            outputs: [{ id: "o1", name: "LATENT", type: "LATENT", linkIds: [] }],
+            widgets: [],
+            nodes: [
+              {
+                id: 60,
+                type: INNER,
+                mode: 0,
+                properties: { proxyWidgets: [["50", "width"], ["50", "height"]] },
+                inputs: [],
+                outputs: [{ name: "LATENT", type: "LATENT", links: [] }],
+                widgets_values: { height: 1088 },
+              },
+            ],
+            links: [],
+          },
+        ],
+      },
+      nodes: [
+        {
+          id: 700,
+          type: OUTER,
+          mode: 0,
+          properties: { proxyWidgets: [["60", "width"]] },
+          inputs: [],
+          outputs: [],
+          widgets_values: [1920],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(g, OBJECT_INFO);
+    const inner = onlyInner(workflow as never);
+    expect(inner.inputs.width).toBe(1920); // outer promotion
+    expect(inner.inputs.height).toBe(1088); // nested instance's own value, kept
+    expect(warnings).toEqual([]);
+  });
+
   it("a promoted widget with NO serialized value keeps the inner node's own value, silently", () => {
     // Not a loss: the subgraph node's widget is a proxy VIEW of the inner widget,
     // so no serialized override means the inner value is what was displayed.

--- a/src/__tests__/services/ue-virtual-wiring-corpus.test.ts
+++ b/src/__tests__/services/ue-virtual-wiring-corpus.test.ts
@@ -498,11 +498,15 @@ const CORPUS: Case[] = [
     },
     api: {
       wiring: { "Consumer.image": "ProducerA" },
-      discloses: [/broadcasts from more than one producer/],
+      // The caveat must say what is TRUE of THIS shape: one confirmed producer
+      // and one input whose source could not be resolved. Claiming "every
+      // producer was confirmed" here would be a false statement inside a
+      // disclosure, which is how disclosures get ignored.
+      discloses: [/could not be matched to a specific sender input/, /could NOT be resolved/],
     },
     flat: {
       wiring: { "Consumer.image": "ProducerA" },
-      discloses: [/broadcasts from more than one producer/],
+      discloses: [/could not be matched to a specific sender input/, /could NOT be resolved/],
     },
   },
   {
@@ -549,11 +553,13 @@ const CORPUS: Case[] = [
       ),
     api: {
       wiring: { "Consumer.image": "ProducerA", "Consumer2.image": "ProducerB" },
-      discloses: [/broadcasts from more than one producer/],
+      // Here every producer really WAS confirmed — the wording must distinguish
+      // this from the one-known-one-unresolved shape above.
+      discloses: [/could not be matched to a specific sender input/, /2 different confirmed producers/],
     },
     flat: {
       wiring: { "Consumer.image": "ProducerA", "Consumer2.image": "ProducerB" },
-      discloses: [/broadcasts from more than one producer/],
+      discloses: [/could not be matched to a specific sender input/, /2 different confirmed producers/],
     },
   },
   {

--- a/src/__tests__/services/ue-virtual-wiring-corpus.test.ts
+++ b/src/__tests__/services/ue-virtual-wiring-corpus.test.ts
@@ -1,0 +1,813 @@
+// SHARED ADVERSARIAL CORPUS — one table of virtual-wiring graph shapes, run
+// against BOTH tools that resolve them:
+//
+//   • strip_workflow / panel_strip_workflow  → convertUiToApi
+//   • panel_flatten_workflow                 → flattenUiWorkflow
+//
+// The two keep SEPARATE implementations of the same policy on purpose: they walk
+// different link representations, and their invariants genuinely differ — the
+// converter may DROP a connection (its output is a fresh executable graph), while
+// the flattener edits the user's graph in place and may only DECLINE TO ADD. A
+// shared helper serving both would need a mode flag on every decision, and a
+// safety check parameterised by "am I allowed to delete" is subtly wrong for at
+// least one caller.
+//
+// Duplicated implementations are not what makes this defect family recur —
+// DIVERGENCE is. So the coupling lives here instead: same inputs, both tools,
+// per-tool expectations stated separately wherever they legitimately differ. When
+// the next cg-use-everywhere class or record shape shows up, it is added once and
+// both tools are immediately held to it.
+//
+// Each case states the OBSERVABLE outcome — which consumer input ends up fed by
+// which producer, which nodes survive, and what the caller is told — never how
+// either tool got there.
+import { describe, expect, it } from "vitest";
+import { convertUiToApi } from "../../services/workflow-converter.js";
+import { flattenUiWorkflow } from "../../services/flatten-workflow.js";
+import type { UiNode, UiWorkflow } from "../../comfyui/types.js";
+
+const OBJECT_INFO = {
+  ProducerA: { input: { required: {} }, output: ["IMAGE"], output_name: ["IMAGE"] },
+  ProducerB: { input: { required: {} }, output: ["IMAGE"], output_name: ["IMAGE"] },
+  Consumer: { input: { required: { image: ["IMAGE"] } } },
+  Consumer2: { input: { required: { image: ["IMAGE"] } } },
+  "Anything Everywhere": { input: { required: {}, optional: { anything: ["*"] } } },
+  "Anything Everywhere3": {
+    input: { required: {}, optional: { anything: ["*"], anything2: ["*"] } },
+  },
+  "Prompts Everywhere": {
+    input: { required: {}, optional: { anything: ["*"], anything2: ["*"] } },
+  },
+  "Seed Everywhere": { input: { required: {} }, output: ["IMAGE"], output_name: ["IMAGE"] },
+  "Seed Everywhere?": { input: { required: {} }, output: ["IMAGE"], output_name: ["IMAGE"] },
+  // Deliberately NOT name-alike with any cg-use-everywhere family: stands in for
+  // a broadcast class neither tool recognizes.
+  "Broadcast Anything": { input: { required: {}, optional: { anything: ["*"] } } },
+  // Name-alike with a real sender family but NOT one of its classes.
+  "Seed Everywhere Helper": { input: { required: {}, optional: { anything: ["*"] } } },
+} as never;
+
+// ── graph-building helpers ──────────────────────────────────────────────────
+
+function n(id: number, type: string, extra: Partial<UiNode> = {}): UiNode {
+  return {
+    id,
+    type,
+    pos: [id * 100, 0],
+    mode: 0,
+    inputs: [],
+    outputs: [],
+    widgets_values: [],
+    properties: {},
+    ...extra,
+  } as UiNode;
+}
+const producer = (id: number, type = "ProducerA", links: number[] = []) =>
+  n(id, type, { outputs: [{ name: "IMAGE", type: "IMAGE", links }] });
+const consumer = (id: number, type = "Consumer", link: number | null = null) =>
+  n(id, type, { inputs: [{ name: "image", type: "IMAGE", link }] });
+const sender = (id: number, type: string, links: (number | null)[] = [null]) =>
+  n(id, type, {
+    inputs: links.map((l, i) => ({
+      name: i === 0 ? "anything" : `anything${i + 1}`,
+      type: "*",
+      link: l,
+    })),
+  });
+
+interface UeRecord {
+  downstream: number;
+  downstream_slot: number;
+  upstream: number;
+  upstream_slot: number;
+  controller?: number;
+  type?: string;
+}
+const rec = (
+  downstream: number,
+  upstream: number,
+  controller?: number,
+): UeRecord => ({
+  downstream,
+  downstream_slot: 0,
+  upstream,
+  upstream_slot: 0,
+  ...(controller == null ? {} : { controller }),
+  type: "IMAGE",
+});
+
+function graph(
+  nodes: UiNode[],
+  links: UiWorkflow["links"],
+  extra?: Record<string, unknown>,
+): UiWorkflow {
+  return {
+    nodes,
+    links,
+    last_link_id: Math.max(0, ...links.map((l) => l[0])),
+    extra: extra ?? {},
+  } as UiWorkflow;
+}
+
+// ── uniform outcome adapters ────────────────────────────────────────────────
+// Both return the same shape so ONE assertion routine covers both tools.
+
+interface Outcome {
+  warnings: string[];
+  /** Class/type of the producer feeding <consumer>.<input>, null if unconnected,
+   *  "<absent>" when the consumer itself is not in the result. */
+  producerOf(consumerType: string, input: string): string | null;
+  survives(type: string): boolean;
+}
+
+function apiOutcome(g: UiWorkflow): Outcome {
+  const { workflow, warnings } = convertUiToApi(structuredClone(g), OBJECT_INFO);
+  const entriesOf = (t: string) =>
+    Object.entries(workflow).filter(([, node]) => node.class_type === t);
+  return {
+    warnings,
+    producerOf(consumerType, input) {
+      const entries = entriesOf(consumerType);
+      if (entries.length === 0) return "<absent>";
+      const value = (entries[0][1].inputs as Record<string, unknown>)[input];
+      if (!Array.isArray(value)) return null;
+      return workflow[String(value[0])]?.class_type ?? "<dangling>";
+    },
+    survives: (t) => entriesOf(t).length > 0,
+  };
+}
+
+function flatOutcome(g: UiWorkflow): Outcome {
+  const { graph: out, report } = flattenUiWorkflow(structuredClone(g));
+  const linkById = new Map(
+    (out.links ?? []).filter((l) => Array.isArray(l)).map((l) => [l[0], l]),
+  );
+  return {
+    warnings: report.warnings,
+    producerOf(consumerType, input) {
+      const node = out.nodes.find((x) => x.type === consumerType);
+      if (!node) return "<absent>";
+      const inp = (node.inputs ?? []).find((i) => i.name === input);
+      if (!inp || inp.link == null) return null;
+      const link = linkById.get(inp.link);
+      if (!link) return "<dangling>";
+      return out.nodes.find((x) => x.id === link[1])?.type ?? "<dangling>";
+    },
+    survives: (t) => out.nodes.some((x) => x.type === t),
+  };
+}
+
+// ── the corpus ──────────────────────────────────────────────────────────────
+
+interface Expect {
+  /** "ConsumerType.inputName" → producer type, or null for unconnected. */
+  wiring: Record<string, string | null>;
+  /** Each pattern must appear somewhere in this tool's warnings. */
+  discloses?: RegExp[];
+  /** This tool must say nothing at all. */
+  silent?: boolean;
+  /** Node types that must still be present in the result. */
+  keeps?: string[];
+  /** Node types that must be gone from the result. */
+  removes?: string[];
+}
+
+interface Case {
+  name: string;
+  /** Why this shape is dangerous — the failure it guards. */
+  why: string;
+  graph: () => UiWorkflow;
+  api: Expect;
+  flat: Expect;
+  /** Set when the two tools' outcomes differ, with the justification. */
+  divergence?: string;
+  /** The resulting WIRING differs between the tools. Requires `divergence` to
+   *  say why — a wiring difference may never be waved through undocumented. */
+  wiringDiverges?: boolean;
+}
+
+const CORPUS: Case[] = [
+  {
+    name: "resolvable Get/Set bus",
+    why: "the baseline: a healthy bus must resolve to the real producer, with nothing reported. Guards against the disclosure firing on a graph that loses nothing.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [10]),
+          n(4, "SetNode", {
+            widgets_values: ["bus"],
+            inputs: [{ name: "value", type: "IMAGE", link: 10 }],
+            outputs: [{ name: "*", type: "*", links: [] }],
+          }),
+          n(5, "GetNode", {
+            widgets_values: ["bus"],
+            outputs: [{ name: "IMAGE", type: "IMAGE", links: [11] }],
+          }),
+          consumer(3, "Consumer", 11),
+        ],
+        [
+          [10, 1, 0, 4, 0, "IMAGE"],
+          [11, 5, 0, 3, 0, "IMAGE"],
+        ],
+      ),
+    api: { wiring: { "Consumer.image": "ProducerA" }, silent: true, removes: ["GetNode", "SetNode"] },
+    flat: { wiring: { "Consumer.image": "ProducerA" }, silent: true, removes: ["GetNode", "SetNode"] },
+  },
+  {
+    name: "orphan Get bus (no Set writes it)",
+    why: "issue #361's reported symptom: the connection cannot be recovered, so it MUST be named rather than quietly dropped.",
+    graph: () =>
+      graph(
+        [
+          n(5, "GetNode", {
+            widgets_values: ["missing"],
+            outputs: [{ name: "IMAGE", type: "IMAGE", links: [11] }],
+          }),
+          consumer(3, "Consumer", 11),
+        ],
+        [[11, 5, 0, 3, 0, "IMAGE"]],
+      ),
+    api: { wiring: { "Consumer.image": null }, discloses: [/missing/, /Consumer/] },
+    flat: { wiring: { "Consumer.image": null }, discloses: [/dangling GetNode chain/] },
+    divergence:
+      "wording only — both leave the input unconnected and both name the consumer.",
+  },
+  {
+    name: "Reroute with no incoming connection",
+    why: "same class as the orphan bus, via the other virtual node type.",
+    graph: () =>
+      graph(
+        [
+          n(9, "Reroute", {
+            inputs: [{ name: "", type: "IMAGE", link: null }],
+            outputs: [{ name: "", type: "IMAGE", links: [30] }],
+          }),
+          consumer(3, "Consumer", 30),
+        ],
+        [[30, 9, 0, 3, 0, "IMAGE"]],
+      ),
+    api: { wiring: { "Consumer.image": null }, discloses: [/Reroute #9 has no incoming connection/] },
+    flat: { wiring: { "Consumer.image": null }, discloses: [/dangling Reroute chain/] },
+  },
+  {
+    name: "two Set nodes writing one bus",
+    why: "the graph's meaning is genuinely ambiguous; whichever producer wins, the other is unreachable and the caller should know.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [10]),
+          producer(2, "ProducerB", [12]),
+          n(4, "SetNode", {
+            widgets_values: ["bus"],
+            inputs: [{ name: "value", type: "IMAGE", link: 10 }],
+            outputs: [{ name: "*", type: "*", links: [] }],
+          }),
+          n(6, "SetNode", {
+            widgets_values: ["bus"],
+            inputs: [{ name: "value", type: "IMAGE", link: 12 }],
+            outputs: [{ name: "*", type: "*", links: [] }],
+          }),
+          n(5, "GetNode", {
+            widgets_values: ["bus"],
+            outputs: [{ name: "IMAGE", type: "IMAGE", links: [11] }],
+          }),
+          consumer(3, "Consumer", 11),
+        ],
+        [
+          [10, 1, 0, 4, 0, "IMAGE"],
+          [12, 2, 0, 6, 0, "IMAGE"],
+          [11, 5, 0, 3, 0, "IMAGE"],
+        ],
+      ),
+    api: { wiring: { "Consumer.image": "ProducerB" }, discloses: [/more than one Set node/] },
+    flat: { wiring: { "Consumer.image": "ProducerB" }, discloses: [/multiple Set nodes write bus/] },
+  },
+  {
+    name: "UE broadcast, current record",
+    why: "the healthy UE path. Must produce a real connection and say nothing.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [20]),
+          sender(7, "Anything Everywhere", [20]),
+          consumer(3, "Consumer", null),
+        ],
+        [[20, 1, 0, 7, 0, "IMAGE"]],
+        { ue_links: [rec(3, 1, 7)] },
+      ),
+    api: { wiring: { "Consumer.image": "ProducerA" }, silent: true, keeps: ["Anything Everywhere"] },
+    flat: { wiring: { "Consumer.image": "ProducerA" }, silent: true, removes: ["Anything Everywhere"] },
+    divergence:
+      "the converter emits the sender as an ordinary (no-output) node in the prompt; the flattener removes it once its broadcast is materialized, which is its whole purpose. Both produce the same wiring.",
+  },
+  {
+    name: "UE record whose sender was REWIRED",
+    why: "the fabrication case: honoring it would emit an edge the live graph does not have, which renders as a plausible graph that is silently wrong.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", []),
+          producer(2, "ProducerB", [21]),
+          sender(7, "Anything Everywhere", [21]),
+          consumer(3, "Consumer", null),
+        ],
+        [[21, 2, 0, 7, 0, "IMAGE"]],
+        { ue_links: [rec(3, 1, 7)] },
+      ),
+    api: { wiring: { "Consumer.image": null }, discloses: [/fed by a different producer/] },
+    flat: {
+      wiring: { "Consumer.image": null },
+      discloses: [/fed by a different producer/],
+      keeps: ["Anything Everywhere"],
+    },
+  },
+  {
+    name: "UE record whose sender was DISCONNECTED",
+    why: "a sender with no feed broadcasts nothing; the record is left over.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", []),
+          sender(7, "Anything Everywhere", [null]),
+          consumer(3, "Consumer", null),
+        ],
+        [],
+        { ue_links: [rec(3, 1, 7)] },
+      ),
+    api: { wiring: { "Consumer.image": null }, discloses: [/no longer has any incoming connection/] },
+    flat: {
+      wiring: { "Consumer.image": null },
+      discloses: [/no longer has any incoming connection/],
+      keeps: ["Anything Everywhere"],
+    },
+  },
+  {
+    name: "UE record naming a controller that is no longer a sender",
+    why: "the id survived but was reused by an ordinary node; existence alone is not evidence.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [22]),
+          sender(7, "Anything Everywhere", [22]),
+          consumer(3, "Consumer", null),
+        ],
+        [[22, 1, 0, 7, 0, "IMAGE"]],
+        { ue_links: [rec(3, 1, 1)] }, // controller 1 is a ProducerA
+      ),
+    api: { wiring: { "Consumer.image": null }, discloses: [/no longer a broadcast node/] },
+    flat: { wiring: { "Consumer.image": null }, discloses: [/no longer a broadcast node/] },
+  },
+  {
+    name: "CONTROLLERLESS record (older list), producer is not a sender",
+    why: "unattributable — an unrelated sender sharing the producer proves nothing about THIS target.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [23]),
+          sender(7, "Anything Everywhere", [23]),
+          consumer(3, "Consumer", null),
+        ],
+        [[23, 1, 0, 7, 0, "IMAGE"]],
+        { ue_links: [rec(3, 1)] },
+      ),
+    api: { wiring: { "Consumer.image": null }, discloses: [/cannot be attributed to any sender/] },
+    flat: {
+      wiring: { "Consumer.image": null },
+      discloses: [/cannot be attributed to any sender/],
+      keeps: ["Anything Everywhere"],
+    },
+  },
+  {
+    name: "CONTROLLERLESS record whose producer IS a self-producing sender",
+    why: "self-attributing: a Seed Everywhere owns its value and has one channel, so there is nothing left to guess. Refusing it would drop a live broadcast.",
+    graph: () =>
+      graph([n(9, "Seed Everywhere", { outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }] }), consumer(3, "Consumer", null)], [], {
+        ue_links: [rec(3, 9)],
+      }),
+    api: { wiring: { "Consumer.image": "Seed Everywhere" }, silent: true },
+    flat: { wiring: { "Consumer.image": "Seed Everywhere" }, silent: true, keeps: ["Seed Everywhere"] },
+    divergence:
+      "the flattener keeps a Seed Everywhere because it IS the real producer of the link it just created.",
+  },
+  {
+    name: "'Seed Everywhere?' — a registered class the predicate used to miss",
+    why: "an unrecognized sender made both tools conclude there were no broadcasts at all: a real one dropped with nothing said.",
+    graph: () =>
+      graph(
+        [n(9, "Seed Everywhere?", { outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }] }), consumer(3, "Consumer", null)],
+        [],
+        { ue_links: [rec(3, 9, 9)] },
+      ),
+    api: { wiring: { "Consumer.image": "Seed Everywhere?" }, silent: true },
+    flat: { wiring: { "Consumer.image": "Seed Everywhere?" }, silent: true },
+  },
+  {
+    name: "FOREIGN class sharing a sender name prefix, and genuinely FED",
+    why: "the fabrication direction. #9 really is fed by ProducerA, so a feed check alone confirms this record and emits the edge. Membership cannot be inferred from a name shape, and no feed check rescues a wrong classification — a prefix match here invented wiring in BOTH tools.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [40]),
+          n(9, "Seed Everywhere Helper", { inputs: [{ name: "anything", type: "*", link: 40 }] }),
+          consumer(3, "Consumer", null),
+        ],
+        [[40, 1, 0, 9, 0, "IMAGE"]],
+        { ue_links: [rec(3, 1, 9)] },
+      ),
+    api: {
+      wiring: { "Consumer.image": null },
+      discloses: [/no node in it is recognized as a cg-use-everywhere broadcast node/],
+      keeps: ["Seed Everywhere Helper"],
+    },
+    flat: {
+      wiring: { "Consumer.image": null },
+      discloses: [/no node in this graph is recognized as a Use-Everywhere sender/],
+      keeps: ["Seed Everywhere Helper"],
+    },
+  },
+  {
+    name: "records present, NO recognized sender class",
+    why: "the backstop for the NEXT unknown class: a deleted sender and an unrecognized one are indistinguishable, so it degrades to a disclosed unknown instead of a silent drop. A closed recognition set is only safe BECAUSE this exists, so both tools must have it.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [24]),
+          n(7, "Broadcast Anything", { inputs: [{ name: "anything", type: "*", link: 24 }] }),
+          consumer(3, "Consumer", null),
+        ],
+        [[24, 1, 0, 7, 0, "IMAGE"]],
+        { ue_links: [rec(3, 1, 7)] },
+      ),
+    api: { wiring: { "Consumer.image": null }, discloses: [/no node in it is recognized as a cg-use-everywhere broadcast node/] },
+    flat: { wiring: { "Consumer.image": null }, discloses: [/no node in this graph is recognized as a Use-Everywhere sender/] },
+  },
+  {
+    name: "self-producing sender recorded THROUGH a Reroute",
+    why: "the pack records the virtual in front of a producer as readily as the producer. Testing the raw upstream against the controller called this a mismatch, fell through to the feed check, found a Seed has no feed, and DROPPED a live broadcast — while the other tool normalized first and kept it.",
+    graph: () =>
+      graph(
+        [
+          n(1, "Seed Everywhere", { outputs: [{ name: "IMAGE", type: "IMAGE", links: [41] }] }),
+          n(2, "Reroute", {
+            inputs: [{ name: "", type: "IMAGE", link: 41 }],
+            outputs: [{ name: "", type: "IMAGE", links: [] }],
+          }),
+          consumer(3, "Consumer", null),
+        ],
+        [[41, 1, 0, 2, 0, "IMAGE"]],
+        { ue_links: [{ downstream: 3, downstream_slot: 0, upstream: 2, upstream_slot: 0, controller: 1, type: "IMAGE" }] },
+      ),
+    api: { wiring: { "Consumer.image": "Seed Everywhere" }, silent: true },
+    flat: { wiring: { "Consumer.image": "Seed Everywhere" }, silent: true },
+  },
+  {
+    name: "recorded producer serializes NO outputs array",
+    why: "an absent outputs array is could-not-determine, not a definite yes. Trusting it emitted an executable edge to a slot nothing proves exists; refusing silently would hide a loss. Unknown gets its own outcome: refuse AND say so.",
+    graph: () => {
+      const seed = n(9, "Seed Everywhere", {});
+      delete (seed as { outputs?: unknown }).outputs; // no outputs key at all
+      return graph([seed, consumer(3, "Consumer", null)], [], { ue_links: [rec(3, 9, 9)] });
+    },
+    api: { wiring: { "Consumer.image": null }, discloses: [/serializes no outputs at all/] },
+    flat: { wiring: { "Consumer.image": null }, discloses: [/which this graph does not have/] },
+    divergence: "wording only — both refuse the record and both say why.",
+  },
+  {
+    name: "multi-input sender with one KNOWN and one UNRESOLVABLE producer",
+    why: "the channel caveat is keyed on distinct producers, and an unresolved input contributed nothing to that set — so a sender with one known and one unknown producer read as 'one producer, nothing to confuse', silencing the caveat exactly where a stale channel swap is most likely.",
+    graph: () => {
+      // Input B is fed by a Get whose bus no Set writes: a real input, genuinely
+      // unresolvable, so its producer is UNKNOWN rather than absent.
+      const g = graph(
+        [
+          producer(1, "ProducerA", [42]),
+          n(5, "GetNode", {
+            widgets_values: ["nobody-writes-this"],
+            outputs: [{ name: "IMAGE", type: "IMAGE", links: [43] }],
+          }),
+          sender(7, "Anything Everywhere3", [42, 43]),
+          consumer(3, "Consumer", null),
+        ],
+        [
+          [42, 1, 0, 7, 0, "IMAGE"],
+          [43, 5, 0, 7, 1, "IMAGE"],
+        ],
+        { ue_links: [rec(3, 1, 7)] },
+      );
+      return g;
+    },
+    api: {
+      wiring: { "Consumer.image": "ProducerA" },
+      discloses: [/broadcasts from more than one producer/],
+    },
+    flat: {
+      wiring: { "Consumer.image": "ProducerA" },
+      discloses: [/broadcasts from more than one producer/],
+    },
+  },
+  {
+    name: "PARTIAL ue_links (a live sender the list does not mention)",
+    why: "a non-empty list is not proof it accounts for every sender; the flattener used to DELETE the one it omitted.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [25]),
+          sender(7, "Anything Everywhere", [25]),
+          sender(8, "Anything Everywhere", [null]),
+          consumer(3, "Consumer", null),
+        ],
+        [[25, 1, 0, 7, 0, "IMAGE"]],
+        { ue_links: [rec(3, 1, 7)] },
+      ),
+    api: {
+      wiring: { "Consumer.image": "ProducerA" },
+      discloses: [/no record in extra\.ue_links names it/],
+    },
+    flat: {
+      wiring: { "Consumer.image": "ProducerA" },
+      discloses: [/no record in extra\.ue_links names it/],
+      keeps: ["Anything Everywhere"],
+    },
+  },
+  {
+    name: "multi-input sender, DISTINCT producers per channel",
+    why: "a record does not name the sender input it came through, so a stale list that only SWAPPED channels is indistinguishable from a current one. Materialized, but the residual is disclosed.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [26]),
+          producer(2, "ProducerB", [27]),
+          sender(7, "Anything Everywhere3", [26, 27]),
+          consumer(3, "Consumer", null),
+          consumer(4, "Consumer2", null),
+        ],
+        [
+          [26, 1, 0, 7, 0, "IMAGE"],
+          [27, 2, 0, 7, 1, "IMAGE"],
+        ],
+        { ue_links: [rec(3, 1, 7), rec(4, 2, 7)] },
+      ),
+    api: {
+      wiring: { "Consumer.image": "ProducerA", "Consumer2.image": "ProducerB" },
+      discloses: [/broadcasts from more than one producer/],
+    },
+    flat: {
+      wiring: { "Consumer.image": "ProducerA", "Consumer2.image": "ProducerB" },
+      discloses: [/broadcasts from more than one producer/],
+    },
+  },
+  {
+    name: "multi-input sender, ONE producer on every channel",
+    why: "no channel to confuse — the caveat must NOT fire, or it becomes noise on every multi-input graph and gets ignored.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [28, 29]),
+          sender(7, "Anything Everywhere3", [28, 29]),
+          consumer(3, "Consumer", null),
+        ],
+        [
+          [28, 1, 0, 7, 0, "IMAGE"],
+          [29, 1, 0, 7, 1, "IMAGE"],
+        ],
+        { ue_links: [rec(3, 1, 7)] },
+      ),
+    api: { wiring: { "Consumer.image": "ProducerA" }, silent: true },
+    flat: { wiring: { "Consumer.image": "ProducerA" }, silent: true },
+  },
+  {
+    name: "UE sender fed THROUGH a Get/Set bus",
+    why: "the producer sits behind virtual wiring; both tools must resolve it, and the staleness check must not read the rewired feed as unresolvable and refuse a live broadcast.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [30]),
+          n(4, "SetNode", {
+            widgets_values: ["bus"],
+            inputs: [{ name: "value", type: "IMAGE", link: 30 }],
+            outputs: [{ name: "*", type: "*", links: [] }],
+          }),
+          n(5, "GetNode", {
+            widgets_values: ["bus"],
+            outputs: [{ name: "IMAGE", type: "IMAGE", links: [31] }],
+          }),
+          sender(7, "Anything Everywhere", [31]),
+          consumer(3, "Consumer", null),
+        ],
+        [
+          [30, 1, 0, 4, 0, "IMAGE"],
+          [31, 5, 0, 7, 0, "IMAGE"],
+        ],
+        { ue_links: [rec(3, 1, 7)] },
+      ),
+    api: { wiring: { "Consumer.image": "ProducerA" }, silent: true },
+    flat: { wiring: { "Consumer.image": "ProducerA" }, silent: true },
+  },
+  {
+    name: "UE record whose upstream IS the bus node",
+    why: "the pack records the virtual in front of the producer as often as the producer; a GetNode has no incoming link and must be followed over its bus.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [32]),
+          n(4, "SetNode", {
+            widgets_values: ["bus"],
+            inputs: [{ name: "value", type: "IMAGE", link: 32 }],
+            outputs: [{ name: "*", type: "*", links: [] }],
+          }),
+          n(5, "GetNode", {
+            widgets_values: ["bus"],
+            outputs: [{ name: "IMAGE", type: "IMAGE", links: [33] }],
+          }),
+          sender(7, "Anything Everywhere", [33]),
+          consumer(3, "Consumer", null),
+        ],
+        [
+          [32, 1, 0, 4, 0, "IMAGE"],
+          [33, 5, 0, 7, 0, "IMAGE"],
+        ],
+        { ue_links: [rec(3, 5, 7)] },
+      ),
+    api: { wiring: { "Consumer.image": "ProducerA" }, silent: true },
+    flat: { wiring: { "Consumer.image": "ProducerA" }, silent: true },
+  },
+  {
+    name: "EMPTY computed ue_links list",
+    why: "an ANSWER, not an unknown — the pack analysed the graph and recorded no broadcast. Reporting it invents a loss, and it is not a licence to delete the senders either.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [34]),
+          sender(7, "Anything Everywhere", [34]),
+          consumer(3, "Consumer", null),
+        ],
+        [[34, 1, 0, 7, 0, "IMAGE"]],
+        { ue_links: [] },
+      ),
+    api: { wiring: { "Consumer.image": null }, silent: true, keeps: ["Anything Everywhere"] },
+    flat: { wiring: { "Consumer.image": null }, silent: true, keeps: ["Anything Everywhere"] },
+  },
+  {
+    name: "one subgraph definition instantiated TWICE, with a bus inside it",
+    why: "each instance must get its OWN expanded copy with its own resolved wiring; sharing or cross-wiring them would silently hand two consumers the same node.",
+    graph: () => {
+      const SG = "subgraph:Doubler";
+      const g = graph(
+        [
+          n(706, SG, {
+            inputs: [],
+            outputs: [{ name: "IMAGE", type: "IMAGE", links: [50] }],
+          }),
+          n(707, SG, {
+            inputs: [],
+            outputs: [{ name: "IMAGE", type: "IMAGE", links: [51] }],
+          }),
+          consumer(3, "Consumer", 50),
+          consumer(4, "Consumer2", 51),
+        ],
+        [
+          [50, 706, 0, 3, 0, "IMAGE"],
+          [51, 707, 0, 4, 0, "IMAGE"],
+        ],
+      );
+      (g as UiWorkflow).definitions = {
+        subgraphs: [
+          {
+            id: SG,
+            name: "Doubler",
+            inputNode: { id: -10 },
+            outputNode: { id: -20 },
+            inputs: [],
+            outputs: [{ id: "o1", name: "IMAGE", type: "IMAGE", linkIds: [102] }],
+            widgets: [],
+            nodes: [
+              producer(50, "ProducerA", [101]),
+              n(51, "SetNode", {
+                widgets_values: ["inner"],
+                inputs: [{ name: "value", type: "IMAGE", link: 101 }],
+                outputs: [{ name: "*", type: "*", links: [] }],
+              }),
+              n(52, "GetNode", {
+                widgets_values: ["inner"],
+                outputs: [{ name: "IMAGE", type: "IMAGE", links: [102] }],
+              }),
+            ],
+            links: [
+              { id: 101, origin_id: 50, origin_slot: 0, target_id: 51, target_slot: 0, type: "IMAGE" },
+              { id: 102, origin_id: 52, origin_slot: 0, target_id: -20, target_slot: 0, type: "IMAGE" },
+            ],
+          },
+        ],
+      };
+      return g;
+    },
+    api: {
+      wiring: { "Consumer.image": "ProducerA", "Consumer2.image": "ProducerA" },
+      silent: true,
+      removes: ["GetNode", "SetNode"],
+    },
+    flat: {
+      wiring: { "Consumer.image": "subgraph:Doubler", "Consumer2.image": "subgraph:Doubler" },
+      silent: true,
+      keeps: ["subgraph:Doubler"],
+    },
+    wiringDiverges: true,
+    divergence:
+      "the flattener does NOT expand subgraph definitions — it flattens virtual wiring in the graph it is given and keeps every real node in place, so the consumers stay wired to the instances. The converter emits an executable prompt, which requires expanding them. Both are correct for their contract, and neither loses a connection.",
+  },
+  {
+    name: "MISSING ue_links list with senders present",
+    why: "an unknown, not an answer: the broadcasts are unrecoverable from the file and the caller needs the remedy.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [35]),
+          sender(7, "Anything Everywhere", [35]),
+          consumer(3, "Consumer", null),
+        ],
+        [[35, 1, 0, 7, 0, "IMAGE"]],
+        {},
+      ),
+    api: { wiring: { "Consumer.image": null }, discloses: [/CANNOT be recovered/], keeps: ["Anything Everywhere"] },
+    flat: { wiring: { "Consumer.image": null }, discloses: [/ue_links is missing/], keeps: ["Anything Everywhere"] },
+  },
+];
+
+// ── the shared assertion routine ────────────────────────────────────────────
+
+function check(outcome: Outcome, expected: Expect) {
+  for (const [target, want] of Object.entries(expected.wiring)) {
+    const [consumerType, input] = target.split(".");
+    expect(outcome.producerOf(consumerType, input), `${target}`).toBe(want);
+  }
+  for (const type of expected.keeps ?? []) {
+    expect(outcome.survives(type), `${type} must survive`).toBe(true);
+  }
+  for (const type of expected.removes ?? []) {
+    expect(outcome.survives(type), `${type} must be gone`).toBe(false);
+  }
+  const text = outcome.warnings.join("\n");
+  for (const pattern of expected.discloses ?? []) {
+    expect(text, `must disclose ${pattern}`).toMatch(pattern);
+  }
+  if (expected.silent) {
+    expect(outcome.warnings, "must report nothing").toEqual([]);
+  }
+}
+
+describe("virtual-wiring corpus — strip_workflow (convertUiToApi)", () => {
+  for (const c of CORPUS) {
+    it(c.name, () => check(apiOutcome(c.graph()), c.api));
+  }
+});
+
+describe("virtual-wiring corpus — panel_flatten_workflow (flattenUiWorkflow)", () => {
+  for (const c of CORPUS) {
+    it(c.name, () => check(flatOutcome(c.graph()), c.flat));
+  }
+});
+
+describe("virtual-wiring corpus — cross-tool invariants", () => {
+  // The wiring a caller ends up with is the thing that must NOT diverge. Node
+  // survival and warning wording legitimately do (the converter emits an
+  // executable prompt, the flattener edits the canvas graph), so those are
+  // asserted per tool above, not here.
+  for (const c of CORPUS) {
+    const shared = Object.keys(c.api.wiring).filter((k) => k in c.flat.wiring);
+    if (shared.length === 0) continue;
+    it(`${c.name} — both tools agree on the resulting wiring`, () => {
+      if (c.wiringDiverges) {
+        // A wiring difference is allowed only WITH a written justification, so a
+        // divergence can never be waved through by flipping a flag.
+        expect(c.divergence ?? "", `${c.name} must justify its wiring divergence`)
+          .not.toBe("");
+        return;
+      }
+      for (const target of shared) {
+        expect(c.flat.wiring[target], `${target} expectation`).toBe(c.api.wiring[target]);
+      }
+    });
+  }
+
+  it("every case that loses a connection says so in BOTH tools", () => {
+    const gaps: string[] = [];
+    for (const c of CORPUS) {
+      for (const [target, want] of Object.entries(c.api.wiring)) {
+        if (want !== null) continue;
+        const apiSays = !c.api.silent && (c.api.discloses ?? []).length > 0;
+        const flatSays = !c.flat.silent && (c.flat.discloses ?? []).length > 0;
+        // An intentionally-unconnected outcome (an empty computed list) is not a
+        // loss, so silence is correct there; it is opted out via `silent`.
+        if (c.api.silent && c.flat.silent) continue;
+        if (!apiSays || !flatSays) {
+          gaps.push(`${c.name} → ${target} (api discloses: ${apiSays}, flatten discloses: ${flatSays})`);
+        }
+      }
+    }
+    // No known gaps. A new entry here means one tool has started losing a
+    // connection the other still reports — the exact divergence this corpus
+    // exists to catch — so it must be justified in the case's `divergence`
+    // field and added deliberately, never absorbed by relaxing this list.
+    expect(gaps).toEqual([]);
+  });
+});

--- a/src/__tests__/services/ue-virtual-wiring-corpus.test.ts
+++ b/src/__tests__/services/ue-virtual-wiring-corpus.test.ts
@@ -563,6 +563,41 @@ const CORPUS: Case[] = [
     },
   },
   {
+    name: "multi-input sender whose second producer CANNOT be confirmed",
+    why: "the caveat must count what the materializer would actually accept. ProducerB's output slot is unconfirmable under the absent-outputs rule, so calling it a confirmed producer states something the same code would refuse — a false fact inside a disclosure.",
+    graph: () => {
+      const pb = producer(2, "ProducerB", [27]);
+      delete (pb as { outputs?: unknown }).outputs;
+      return graph(
+        [
+          producer(1, "ProducerA", [26]),
+          pb,
+          sender(7, "Anything Everywhere3", [26, 27]),
+          consumer(3, "Consumer", null),
+        ],
+        [
+          [26, 1, 0, 7, 0, "IMAGE"],
+          [27, 2, 0, 7, 1, "IMAGE"],
+        ],
+        { ue_links: [rec(3, 1, 7)] },
+      );
+    },
+    api: {
+      wiring: { "Consumer.image": "ProducerA" },
+      discloses: [
+        /could not be matched to a specific sender input/,
+        /1 confirmed producer\(s\) plus 1 input\(s\)/,
+      ],
+    },
+    flat: {
+      wiring: { "Consumer.image": "ProducerA" },
+      discloses: [
+        /could not be matched to a specific sender input/,
+        /1 confirmed producer\(s\) plus 1 input\(s\)/,
+      ],
+    },
+  },
+  {
     name: "multi-input sender, ONE producer on every channel",
     why: "no channel to confuse — the caveat must NOT fire, or it becomes noise on every multi-input graph and gets ignored.",
     graph: () =>
@@ -722,6 +757,177 @@ const CORPUS: Case[] = [
       "the flattener does NOT expand subgraph definitions — it flattens virtual wiring in the graph it is given and keeps every real node in place, so the consumers stay wired to the instances. The converter emits an executable prompt, which requires expanding them. Both are correct for their contract, and neither loses a connection.",
   },
   {
+    name: "record names a virtual that serializes NO outputs key",
+    why: "the absent-outputs rule is right but must be applied to the REAL producer. Judging the Reroute — which has no outputs of its own — refused a live edge in one tool while the other resolved past it and kept it.",
+    graph: () => {
+      const reroute = n(2, "Reroute", { inputs: [{ name: "", type: "IMAGE", link: 41 }] });
+      delete (reroute as { outputs?: unknown }).outputs;
+      return graph(
+        [
+          n(1, "Seed Everywhere", { outputs: [{ name: "IMAGE", type: "IMAGE", links: [41] }] }),
+          reroute,
+          consumer(3, "Consumer", null),
+        ],
+        [[41, 1, 0, 2, 0, "IMAGE"]],
+        { ue_links: [{ downstream: 3, downstream_slot: 0, upstream: 2, upstream_slot: 0, controller: 1, type: "IMAGE" }] },
+      );
+    },
+    api: { wiring: { "Consumer.image": "Seed Everywhere" }, silent: true },
+    flat: { wiring: { "Consumer.image": "Seed Everywhere" }, silent: true },
+  },
+  {
+    name: "record resolves through a CHAIN of two virtuals (Reroute → Get/Set bus)",
+    why: "normalization has to be transitive, not one hop. A single-hop resolver reaches the SetNode and stops there.",
+    graph: () =>
+      graph(
+        [
+          producer(1, "ProducerA", [60]),
+          n(4, "SetNode", {
+            widgets_values: ["bus"],
+            inputs: [{ name: "value", type: "IMAGE", link: 60 }],
+            outputs: [{ name: "*", type: "*", links: [] }],
+          }),
+          n(5, "GetNode", {
+            widgets_values: ["bus"],
+            outputs: [{ name: "IMAGE", type: "IMAGE", links: [61] }],
+          }),
+          n(6, "Reroute", {
+            inputs: [{ name: "", type: "IMAGE", link: 61 }],
+            outputs: [{ name: "", type: "IMAGE", links: [62] }],
+          }),
+          sender(7, "Anything Everywhere", [62]),
+          consumer(3, "Consumer", null),
+        ],
+        [
+          [60, 1, 0, 4, 0, "IMAGE"],
+          [61, 5, 0, 6, 0, "IMAGE"],
+          [62, 6, 0, 7, 0, "IMAGE"],
+        ],
+        { ue_links: [{ downstream: 3, downstream_slot: 0, upstream: 6, upstream_slot: 0, controller: 7, type: "IMAGE" }] },
+      ),
+    api: { wiring: { "Consumer.image": "ProducerA" }, silent: true },
+    flat: { wiring: { "Consumer.image": "ProducerA" }, silent: true },
+  },
+  {
+    name: "record whose producer chain is a CYCLE",
+    why: "a malformed graph must terminate and disclose, not hang and not quietly wire something.",
+    graph: () =>
+      graph(
+        [
+          n(2, "Reroute", {
+            inputs: [{ name: "", type: "IMAGE", link: 71 }],
+            outputs: [{ name: "", type: "IMAGE", links: [70] }],
+          }),
+          n(3, "Reroute", {
+            inputs: [{ name: "", type: "IMAGE", link: 70 }],
+            outputs: [{ name: "", type: "IMAGE", links: [71] }],
+          }),
+          sender(7, "Anything Everywhere", [70]),
+          consumer(4, "Consumer", null),
+        ],
+        [
+          [70, 2, 0, 3, 0, "IMAGE"],
+          [71, 3, 0, 2, 0, "IMAGE"],
+        ],
+        { ue_links: [{ downstream: 4, downstream_slot: 0, upstream: 2, upstream_slot: 0, controller: 7, type: "IMAGE" }] },
+      ),
+    api: { wiring: { "Consumer.image": null }, discloses: [/could not be resolved|cycle/i] },
+    flat: { wiring: { "Consumer.image": null }, discloses: [/could not be resolved|dangling/i] },
+  },
+  {
+    name: "subgraph boundary feed THROUGH a virtual, definition instantiated twice",
+    why: "the hardest shape here: boundary + virtual wiring + UE + two instances at once. The boundary test compared a raw virtual id, so the materialized edge was never registered on the boundary and BOTH instances lost it — and a wrong fix would cross-wire instance A's consumer to instance B's producer.",
+    graph: () => {
+      const SG = "subgraph:Bus";
+      const g = graph(
+        [
+          producer(1, "ProducerA", [50]),
+          producer(9, "ProducerB", [51]),
+          n(706, SG, { inputs: [{ name: "image", type: "IMAGE", link: 50 }] }),
+          n(707, SG, { inputs: [{ name: "image", type: "IMAGE", link: 51 }] }),
+        ],
+        [
+          [50, 1, 0, 706, 0, "IMAGE"],
+          [51, 9, 0, 707, 0, "IMAGE"],
+        ],
+      );
+      (g as UiWorkflow).definitions = {
+        subgraphs: [
+          {
+            id: SG,
+            name: "Bus",
+            inputNode: { id: -10 },
+            outputNode: { id: -20 },
+            inputs: [{ id: "i1", name: "image", type: "IMAGE", linkIds: [11] }],
+            outputs: [],
+            widgets: [],
+            extra: {
+              ue_links: [
+                { downstream: 3, downstream_slot: 0, upstream: 2, upstream_slot: 0, controller: 7, type: "IMAGE" },
+              ],
+            },
+            nodes: [
+              n(2, "Reroute", {
+                inputs: [{ name: "", type: "IMAGE", link: 11 }],
+                outputs: [{ name: "", type: "IMAGE", links: [12] }],
+              }),
+              sender(7, "Anything Everywhere", [12]),
+              consumer(3, "Consumer", null),
+            ],
+            links: [
+              { id: 11, origin_id: -10, origin_slot: 0, target_id: 2, target_slot: 0, type: "IMAGE" },
+              { id: 12, origin_id: 2, origin_slot: 0, target_id: 7, target_slot: 0, type: "IMAGE" },
+            ],
+          },
+        ],
+      };
+      return g;
+    },
+    // Both instances resolve to their OWN outer producer. `producerOf` reads the
+    // first match, so the cross-instance check is the dedicated test below.
+    api: { wiring: { "Consumer.image": "ProducerA" }, silent: true },
+    flat: { wiring: { "Consumer.image": "<absent>" }, silent: true, keeps: ["subgraph:Bus"] },
+    wiringDiverges: true,
+    divergence:
+      "the flattener does not expand subgraph definitions, so the inner Consumer never appears in the graph it returns at all (hence <absent>) and the instances stay in place untouched. The converter must expand them, once per instance. Neither loses a connection from the graph it is contracted to produce.",
+  },
+  {
+    name: "SELF-PRODUCING sender inside a subgraph instantiated twice",
+    why: "each instance must broadcast from its OWN expanded Seed. Sharing one would hand both consumers the same node and look perfectly plausible.",
+    graph: () => {
+      const SG = "subgraph:Seeded";
+      const g = graph(
+        [n(706, SG, { inputs: [] }), n(707, SG, { inputs: [] })],
+        [],
+      );
+      (g as UiWorkflow).definitions = {
+        subgraphs: [
+          {
+            id: SG,
+            name: "Seeded",
+            inputNode: { id: -10 },
+            outputNode: { id: -20 },
+            inputs: [],
+            outputs: [],
+            widgets: [],
+            extra: { ue_links: [rec(3, 9, 9)] },
+            nodes: [
+              n(9, "Seed Everywhere", { outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }] }),
+              consumer(3, "Consumer", null),
+            ],
+            links: [],
+          },
+        ],
+      };
+      return g;
+    },
+    api: { wiring: { "Consumer.image": "Seed Everywhere" }, silent: true },
+    flat: { wiring: { "Consumer.image": "<absent>" }, silent: true, keeps: ["subgraph:Seeded"] },
+    wiringDiverges: true,
+    divergence:
+      "same expansion asymmetry: the inner Consumer is not in the flattened graph at all, so there is nothing there to materialize and nothing lost from what the flattener returns.",
+  },
+  {
     name: "MISSING ue_links list with senders present",
     why: "an unknown, not an answer: the broadcasts are unrecoverable from the file and the caller needs the remedy.",
     graph: () =>
@@ -794,6 +1000,36 @@ describe("virtual-wiring corpus — cross-tool invariants", () => {
       }
     });
   }
+
+  it("the flattener never returns two links sharing an id, for ANY corpus shape", () => {
+    // A duplicate id makes every consumer input and producer output list keyed by
+    // it ambiguous. Asserted across the whole table rather than per row, because
+    // it is a property of the output, not of any one input shape.
+    for (const c of CORPUS) {
+      const { graph: out } = flattenUiWorkflow(structuredClone(c.graph()));
+      const ids = (out.links ?? []).filter((l) => Array.isArray(l)).map((l) => l[0]);
+      expect(new Set(ids).size, `${c.name} produced duplicate link ids`).toBe(ids.length);
+    }
+  });
+
+  it("two instances of one definition never share or cross-wire a broadcast", () => {
+    // `producerOf` reads the first matching consumer, so a table row cannot say
+    // "instance A got A's producer and B got B's". A cross-wire here would look
+    // entirely plausible in the result: every consumer connected, to the wrong
+    // producer. Asserted directly.
+    const c = CORPUS.find(
+      (x) => x.name === "subgraph boundary feed THROUGH a virtual, definition instantiated twice",
+    )!;
+    const { workflow } = convertUiToApi(structuredClone(c.graph()), OBJECT_INFO);
+    const feeders = Object.values(workflow)
+      .filter((node) => node.class_type === "Consumer")
+      .map((node) => {
+        const v = (node.inputs as Record<string, unknown>).image;
+        return Array.isArray(v) ? workflow[String(v[0])]?.class_type : null;
+      });
+    expect(feeders).toHaveLength(2);
+    expect([...feeders].sort()).toEqual(["ProducerA", "ProducerB"]);
+  });
 
   it("every case that loses a connection says so in BOTH tools", () => {
     const gaps: string[] = [];

--- a/src/__tests__/services/ue-virtual-wiring-corpus.test.ts
+++ b/src/__tests__/services/ue-virtual-wiring-corpus.test.ts
@@ -390,6 +390,25 @@ const CORPUS: Case[] = [
       "the flattener keeps a Seed Everywhere because it IS the real producer of the link it just created.",
   },
   {
+    name: "CONTROLLERLESS record naming a VIRTUAL that resolves to a self-producing sender",
+    why: "no row paired a controllerless record with a virtualized upstream, so the corpus missed a divergence introduced by the round that unified producer resolution: one tool normalized this and the other read the raw field, materialized the broadcast correctly, and then falsely reported that the sender had no record. A true result plus an untrue disclosure is worse than either alone.",
+    graph: () =>
+      graph(
+        [
+          n(1, "Seed Everywhere", { outputs: [{ name: "IMAGE", type: "IMAGE", links: [41] }] }),
+          n(2, "Reroute", {
+            inputs: [{ name: "", type: "IMAGE", link: 41 }],
+            outputs: [{ name: "", type: "IMAGE", links: [] }],
+          }),
+          consumer(3, "Consumer", null),
+        ],
+        [[41, 1, 0, 2, 0, "IMAGE"]],
+        { ue_links: [rec(3, 2)] }, // no controller, upstream is the Reroute
+      ),
+    api: { wiring: { "Consumer.image": "Seed Everywhere" }, silent: true },
+    flat: { wiring: { "Consumer.image": "Seed Everywhere" }, silent: true },
+  },
+  {
     name: "'Seed Everywhere?' — a registered class the predicate used to miss",
     why: "an unrecognized sender made both tools conclude there were no broadcasts at all: a real one dropped with nothing said.",
     graph: () =>

--- a/src/comfyui/types.ts
+++ b/src/comfyui/types.ts
@@ -168,6 +168,15 @@ export interface UiNode {
   widgets_values?: unknown[];
   title?: string;
   _meta?: { title?: string };
+  /**
+   * INTERNAL, never serialized: widget values resolved BY NAME during subgraph
+   * expansion — a promoted ("proxy") widget value pushed down from the subgraph
+   * node, or a virtual PrimitiveNode's literal baked onto its consumer. Applied
+   * by convertUiToApi against object_info, which is authoritative about widget
+   * names; carrying them by name avoids the positional guessing that used to
+   * drop them or land them on the wrong widget (issue #361).
+   */
+  resolvedWidgetValues?: Record<string, unknown>;
 }
 
 // link: [link_id, source_node_id, source_slot, target_node_id, target_slot, type_name]

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4315,10 +4315,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
 
         return ok(
           `Stripped to ${Object.keys(workflow).length} nodes` +
-            (warnings.length ? ` · ${warnings.length} warning(s)` : "") +
+            (warnings.length ? ` · ⚠ ${warnings.length} conversion note(s)` : "") +
             `\nNode types: ${summary}` +
+            // #361: a strip that quietly loses a Set/Get link or substitutes a
+            // widget value produces a graph that LOOKS fine and renders
+            // differently. Say plainly that these are places the stripped graph
+            // does NOT match the source, so they are not skimmed as noise.
             (warnings.length
-              ? `\nWarnings:\n${warnings.map((w) => `- ${w}`).join("\n")}`
+              ? `\nThe stripped graph DIFFERS from the source workflow where listed below — read these before running or rebuilding from it:\n${warnings
+                  .map((w) => `- ${w}`)
+                  .join("\n")}`
               : "") +
             `\n\n${JSON.stringify(workflow, null, 2)}`,
         );

--- a/src/services/flatten-workflow.ts
+++ b/src/services/flatten-workflow.ts
@@ -50,6 +50,21 @@ export const isUeSender = (t: string): boolean =>
   t.startsWith("Seed Everywhere") ||
   t.startsWith("Prompts Everywhere");
 
+/**
+ * The UE senders that OWN the value they broadcast instead of relaying an input —
+ * the Seed Everywhere family holds its seed in a widget and IS its own producer.
+ * Every other sender relays whatever is wired into it.
+ *
+ * Deliberately a CLOSED set, unlike isUeSender's prefix match. Recognition should
+ * be generous (an unrecognized sender silently loses its broadcasts), but this
+ * predicate gates the one path that accepts a record WITHOUT verifying the
+ * sender's incoming feed, and an exception that skips verification has to be
+ * narrow. A future self-producing variant that is not listed here simply takes
+ * the ordinary feed check and is refused with a warning — disclosed, not silent.
+ */
+export const isSelfProducingUeSender = (t: string): boolean =>
+  t === "Seed Everywhere" || t === "Seed Everywhere?";
+
 /** Shape cg-use-everywhere writes into graph.extra.ue_links. */
 interface UeLink {
   downstream: number;

--- a/src/services/flatten-workflow.ts
+++ b/src/services/flatten-workflow.ts
@@ -36,30 +36,38 @@ const isRerouteType = (t: string) => t === "Reroute";
 const isWiringVirtual = (t: string) => isRerouteType(t) || GET_SET_TYPES.has(t);
 
 /**
- * cg-use-everywhere sender detection. The pack's own is_UEnode() prefix-matches
- * "Anything Everywhere" (so the "?" and "3" variants are covered) but compares
- * the other two families with EQUALITY — which misses the registered
- * "Seed Everywhere?" class. That asymmetry is an oversight, and here it is a
- * silent-loss bug: an unrecognized sender makes the materializer conclude there
- * are no broadcasts at all, dropping real ones with nothing said. Under-matching
- * costs a dropped connection; over-matching at worst asks the user to re-save.
- * All three families are therefore prefix-matched.
+ * cg-use-everywhere sender detection — the registered classes, by name.
+ *
+ * This was briefly a PREFIX match, to avoid missing a variant like the registered
+ * "Seed Everywhere?" that the pack's own is_UEnode() overlooks. That traded one
+ * failure for a worse one: a foreign class merely NAMED "Seed Everywhere Helper"
+ * was classified as a sender, and a stale record naming it then satisfied the
+ * feed check and FABRICATED an edge. Membership cannot be inferred from a name,
+ * and no feed check can rescue a wrong classification.
+ *
+ * A closed set is now safe because an unrecognized class no longer disappears
+ * quietly: records present with no recognized sender are REPORTED by both tools.
+ * So a future variant degrades to a disclosed unknown, which is the failure we
+ * can live with, while a name-alike foreign class can no longer invent wiring.
  */
-export const isUeSender = (t: string): boolean =>
-  t.startsWith("Anything Everywhere") ||
-  t.startsWith("Seed Everywhere") ||
-  t.startsWith("Prompts Everywhere");
+const UE_SENDER_CLASSES = new Set([
+  "Anything Everywhere",
+  "Anything Everywhere?",
+  "Anything Everywhere3",
+  "Prompts Everywhere",
+  "Seed Everywhere",
+  "Seed Everywhere?",
+]);
+export const isUeSender = (t: string): boolean => UE_SENDER_CLASSES.has(t);
 
 /**
  * The UE senders that OWN the value they broadcast instead of relaying an input —
  * the Seed Everywhere family holds its seed in a widget and IS its own producer.
  * Every other sender relays whatever is wired into it.
  *
- * Deliberately a CLOSED set, unlike isUeSender's prefix match. Recognition should
- * be generous (an unrecognized sender silently loses its broadcasts), but this
- * predicate gates the one path that accepts a record WITHOUT verifying the
- * sender's incoming feed, and an exception that skips verification has to be
- * narrow. A future self-producing variant that is not listed here simply takes
+ * This gates the one path that accepts a record WITHOUT verifying the sender's
+ * incoming feed, so it stays the narrower of the two sets. A future
+ * self-producing variant that is not listed here simply takes
  * the ordinary feed check and is refused with a warning — disclosed, not silent.
  */
 export const isSelfProducingUeSender = (t: string): boolean =>
@@ -181,6 +189,14 @@ export function flattenUiWorkflow(
   let nextLinkId = Math.max(ui.last_link_id ?? 0, 0, ...linkMap.keys()) + 1;
   const freshLinks: UiLink[] = [];
   let rewired = 0;
+  /** node id → how many of its inputs pass 1 disconnected because their virtual
+   *  chain could not be resolved. Pass 2 needs this: it runs AFTER pass 1, so a
+   *  sender whose second channel came through a dead chain would otherwise look
+   *  single-fed and lose its channel caveat — while the converter, which
+   *  validates before de-virtualizing, still sees two. Same graph, same answer. */
+  const clearedInputs = new Map<number, number>();
+  const noteCleared = (nodeId: number) =>
+    clearedInputs.set(nodeId, (clearedInputs.get(nodeId) ?? 0) + 1);
 
   const addDirectLink = (
     srcId: number,
@@ -221,6 +237,7 @@ export function flattenUiWorkflow(
         const resolved = resolveReal(inp.link);
         if (!resolved) {
           inp.link = null;
+          noteCleared(node.id);
           warnings.push(
             `${node.type} #${node.id} input "${inp.name ?? slot}" fed by a dangling ${origin.type} chain — left unconnected`,
           );
@@ -233,6 +250,7 @@ export function flattenUiWorkflow(
           // deleted, no replacement link, and the final scrub quietly clearing the
           // consumer: a real connection gone with nothing said.
           inp.link = null;
+          noteCleared(node.id);
           const producer = nodesById.get(resolved.id);
           warnings.push(
             `${node.type} #${node.id} input "${inp.name ?? slot}" resolves through ${origin.type} #${origin.id} to node #${resolved.id}${
@@ -249,8 +267,21 @@ export function flattenUiWorkflow(
   // ── Pass 2: materialize UE broadcasts from the pack's own computed list ───
   const ueSenders = nodes.filter((n) => isUeSender(n.type));
   const ueDeletable = new Set<number>();
+  const allUeLinks = (ui.extra?.ue_links as UeLink[] | undefined) ?? null;
+  if (includeUe && ueSenders.length === 0 && Array.isArray(allUeLinks) && allUeLinks.length > 0) {
+    // Records but no recognized sender. Skipping UE processing in silence is the
+    // worst outcome available: a real broadcast dropped with nothing said, and
+    // exactly what an unrecognized sender CLASS produces. A deleted sender
+    // (records genuinely stale) and an unknown class (records live) cannot be told
+    // apart here, so it is reported as the could-not-determine it is. The
+    // converter has the same backstop — a graph must not be disclosed by one tool
+    // and passed over in silence by the other.
+    warnings.push(
+      `${allUeLinks.length} Use-Everywhere broadcast record(s) present but no node in this graph is recognized as a Use-Everywhere sender — either those senders were deleted (records stale) or they are a class this flattener does not know, so NOTHING was materialized from them and the inputs they name are left unconnected`,
+    );
+  }
   if (includeUe && ueSenders.length) {
-    const ueLinks = (ui.extra?.ue_links as UeLink[] | undefined) ?? null;
+    const ueLinks = allUeLinks;
     // An EMPTY computed list is an ANSWER — the pack analysed the graph and
     // recorded no broadcast — so there is nothing to materialize and nothing to
     // report. Only an ABSENT (or non-array) list is an unknown. Folding the two
@@ -305,23 +336,30 @@ export function flattenUiWorkflow(
         if (feeds.length === 0) {
           return `${ctrl.type} #${ctrl.id} no longer has any incoming connection, so it broadcasts nothing`;
         }
-        let unresolved = false;
+        // Inputs pass 1 already disconnected count as unknown producers, not as
+        // absent ones — the record may well have belonged to one of them.
+        let unresolved = clearedInputs.get(ctrl.id) ?? 0;
         let matched = false;
         const distinct = new Set<string>();
         for (const f of feeds) {
           const r = resolveReal(f.link as number);
           if (!r) {
-            unresolved = true;
+            // An UNRESOLVED input is not "no producer" — it is an unknown one, so
+            // it counts toward the channel ambiguity. Letting it contribute
+            // nothing made a sender with one known and one unknown producer read
+            // as "one producer, nothing to confuse", silencing the caveat exactly
+            // where the risk is highest.
+            unresolved++;
             continue;
           }
           distinct.add(`${r.id}:${r.slot}`);
           if (r.id === srcId && r.slot === srcSlot) matched = true;
         }
         if (matched) {
-          if (distinct.size > 1) multiFeed.set(ctrl.id, ctrl.type);
+          if (distinct.size + unresolved > 1) multiFeed.set(ctrl.id, ctrl.type);
           return null;
         }
-        return unresolved
+        return unresolved > 0
           ? `${ctrl.type} #${ctrl.id}'s own incoming connection could not be resolved, so the recorded producer node ${srcId} could not be confirmed`
           : `${ctrl.type} #${ctrl.id} is now fed by a different producer than the recorded node ${srcId}`;
       };

--- a/src/services/flatten-workflow.ts
+++ b/src/services/flatten-workflow.ts
@@ -226,7 +226,21 @@ export function flattenUiWorkflow(
           );
           continue;
         }
-        addDirectLink(resolved.id, resolved.slot, node.id, slot, resolved.type ?? link[5]);
+        const added = addDirectLink(resolved.id, resolved.slot, node.id, slot, resolved.type ?? link[5]);
+        if (added == null) {
+          // The chain resolved, but the edge could not be built — that producer or
+          // output slot is not in the graph. Discarding the null left the virtual
+          // deleted, no replacement link, and the final scrub quietly clearing the
+          // consumer: a real connection gone with nothing said.
+          inp.link = null;
+          const producer = nodesById.get(resolved.id);
+          warnings.push(
+            `${node.type} #${node.id} input "${inp.name ?? slot}" resolves through ${origin.type} #${origin.id} to node #${resolved.id}${
+              producer ? ` (${producer.type}) output slot ${resolved.slot}` : ""
+            }, which this graph does not have — left unconnected`,
+          );
+          continue;
+        }
         rewired++;
       }
     }
@@ -237,12 +251,17 @@ export function flattenUiWorkflow(
   const ueDeletable = new Set<number>();
   if (includeUe && ueSenders.length) {
     const ueLinks = (ui.extra?.ue_links as UeLink[] | undefined) ?? null;
-    if (!Array.isArray(ueLinks) || ueLinks.length === 0) {
+    // An EMPTY computed list is an ANSWER — the pack analysed the graph and
+    // recorded no broadcast — so there is nothing to materialize and nothing to
+    // report. Only an ABSENT (or non-array) list is an unknown. Folding the two
+    // together warned on a faithful graph, and disagreed with the converter.
+    // Either way the senders stay: an empty list is not a licence to delete them.
+    if (!Array.isArray(ueLinks)) {
       warnings.push(
-        `${ueSenders.length} Use-Everywhere sender(s) present but extra.ue_links is empty — ` +
+        `${ueSenders.length} Use-Everywhere sender(s) present but extra.ue_links is missing — ` +
           `UE broadcasts NOT materialized (open the graph with cg-use-everywhere active and save/queue once, then retry); senders left in place`,
       );
-    } else {
+    } else if (ueLinks.length > 0) {
       // A ue_links record is only as current as the last time the pack analysed
       // the graph. Materializing one without checking it against the LIVE wiring
       // invents a connection the graph does not have — which reads as a plausible

--- a/src/services/flatten-workflow.ts
+++ b/src/services/flatten-workflow.ts
@@ -119,6 +119,12 @@ export function flattenUiWorkflow(
   const nodesById = new Map<number, UiNode>(nodes.map((n) => [n.id, n]));
   const linkMap = new Map<number, UiLink>();
   for (const l of ui.links ?? []) if (Array.isArray(l)) linkMap.set(l[0], l);
+  /** The link ids the graph ARRIVED with. Used to tell a genuinely dangling input
+   *  reference (an id that was never a link here) from one purged on purpose
+   *  because its endpoint was removed — the second is intended and already
+   *  reported by whatever removed it, the first is a real connection the source
+   *  graph claims and this one does not have. */
+  const preexistingLinkIds = new Set(linkMap.keys());
 
   // bus name (Set node's first widget) -> the link id feeding that Set's input.
   // Multiple Sets writing the same key: LAST one wins (matches litegraph's
@@ -551,8 +557,25 @@ export function flattenUiWorkflow(
   // virtual node that pass-1 already rewired keep their fresh id; anything
   // still pointing at a purged link gets cleared).
   for (const n of ui.nodes) {
-    for (const inp of n.inputs ?? []) {
-      if (inp.link != null && !survivingIds.has(inp.link)) inp.link = null;
+    for (let slot = 0; slot < (n.inputs?.length ?? 0); slot++) {
+      const inp = n.inputs![slot];
+      if (inp.link == null || survivingIds.has(inp.link)) continue;
+      // An id that was NEVER a link in this graph is a dangling reference: the
+      // source claims a connection the graph does not contain. Clearing it in
+      // silence is the same observation-failed-treated-as-no that this change
+      // removes everywhere else — and the converter already reports its
+      // equivalent. (An id that WAS a link and got purged with its endpoint is an
+      // intended removal, already reported by whatever removed it, so it stays
+      // quiet here. That second branch is DEFENSIVE: no constructible graph
+      // reaches it, because the nodes holding such a reference are removed along
+      // with the link. It is kept so the check states the right rule rather than
+      // the one that happens to be reachable today.)
+      if (!preexistingLinkIds.has(inp.link)) {
+        warnings.push(
+          `${n.type} #${n.id} input "${inp.name ?? slot}" claims link ${inp.link}, which does not exist in this graph — left unconnected`,
+        );
+      }
+      inp.link = null;
     }
     for (const out of n.outputs ?? []) {
       if (out.links) out.links = out.links.filter((id) => survivingIds.has(id));

--- a/src/services/flatten-workflow.ts
+++ b/src/services/flatten-workflow.ts
@@ -119,12 +119,6 @@ export function flattenUiWorkflow(
   const nodesById = new Map<number, UiNode>(nodes.map((n) => [n.id, n]));
   const linkMap = new Map<number, UiLink>();
   for (const l of ui.links ?? []) if (Array.isArray(l)) linkMap.set(l[0], l);
-  /** The link ids the graph ARRIVED with. Used to tell a genuinely dangling input
-   *  reference (an id that was never a link here) from one purged on purpose
-   *  because its endpoint was removed — the second is intended and already
-   *  reported by whatever removed it, the first is a real connection the source
-   *  graph claims and this one does not have. */
-  const preexistingLinkIds = new Set(linkMap.keys());
 
   // bus name (Set node's first widget) -> the link id feeding that Set's input.
   // Multiple Sets writing the same key: LAST one wins (matches litegraph's
@@ -458,12 +452,22 @@ export function flattenUiWorkflow(
           `${info.type} #${id}: a broadcast could not be matched to a specific sender input — this sender carries ${carries}, and a ue_link record does not name the input a broadcast came through, so a saved list that went stale by SWAPPING its channels would look identical; re-save with cg-use-everywhere active if this sender's routing matters`,
         );
       }
-      // A sender is deletable only when it is not the real producer of any
-      // surviving link (Seed Everywhere IS its own upstream — it must stay), and
-      // never when one of its records could not be confirmed: deleting it would
-      // destroy the only evidence of a broadcast we declined to materialize.
+      // A sender is deletable only when it is not the real producer of any link
+      // (Seed Everywhere IS its own upstream — it must stay), and never when one
+      // of its records could not be confirmed: deleting it would destroy the only
+      // evidence of a broadcast we declined to materialize.
+      //
+      // PRE-EXISTING outgoing links count, not just the ones materialized here.
+      // Counting only freshLinks protected a sender that produced a MATERIALIZED
+      // link while deleting one that was already the real producer of an ordinary
+      // link — taking that link with it and silently disconnecting its consumer.
+      // (Reachable whenever a sender's record adds nothing: its target already had
+      // a real link, so the record is skipped, no fresh link is created, and the
+      // sender looked unused.) A node that really produces a connection is not
+      // virtual wiring, whatever its class.
       const liveOrigins = new Set<number>();
       for (const l of freshLinks) liveOrigins.add(l[1]);
+      for (const l of ui.links ?? []) if (Array.isArray(l)) liveOrigins.add(l[1]);
       // A non-empty list is not proof that it accounts for EVERY sender: one that
       // predates a sender has no row for it. Deleting such a sender would remove a
       // node whose broadcasts were never materialized — a silent, unrecoverable
@@ -472,10 +476,19 @@ export function flattenUiWorkflow(
       const attributed = new Set<number>();
       for (const r of ueLinks) {
         if (r?.controller != null) attributed.add(r.controller);
-        // A controllerless record still accounts for its sender when the producer
-        // IS that sender (the self-producing shape accepted above).
-        else if (isSelfProducingUeSender(nodesById.get(r?.upstream)?.type ?? "")) {
-          attributed.add(r.upstream);
+        else {
+          // A controllerless record still accounts for its sender when the
+          // producer IS that sender (the self-producing shape accepted above) —
+          // judged on the NORMALIZED producer, since the record may name a virtual
+          // in front of it. Reading the raw field here let such a record be
+          // materialized correctly and then reported as if the sender had no
+          // record at all: a false disclosure, which is the failure mode that
+          // teaches people to ignore the true ones. (The converter normalizes in
+          // its equivalent; this is the site that was left behind.)
+          const p = resolveRealFromNode(r?.upstream, r?.upstream_slot);
+          if (p && isSelfProducingUeSender(nodesById.get(p.id)?.type ?? "")) {
+            attributed.add(p.id);
+          }
         }
       }
       for (const s of ueSenders) {
@@ -560,21 +573,21 @@ export function flattenUiWorkflow(
     for (let slot = 0; slot < (n.inputs?.length ?? 0); slot++) {
       const inp = n.inputs![slot];
       if (inp.link == null || survivingIds.has(inp.link)) continue;
-      // An id that was NEVER a link in this graph is a dangling reference: the
-      // source claims a connection the graph does not contain. Clearing it in
-      // silence is the same observation-failed-treated-as-no that this change
-      // removes everywhere else — and the converter already reports its
-      // equivalent. (An id that WAS a link and got purged with its endpoint is an
-      // intended removal, already reported by whatever removed it, so it stays
-      // quiet here. That second branch is DEFENSIVE: no constructible graph
-      // reaches it, because the nodes holding such a reference are removed along
-      // with the link. It is kept so the check states the right rule rather than
-      // the one that happens to be reachable today.)
-      if (!preexistingLinkIds.has(inp.link)) {
-        warnings.push(
-          `${n.type} #${n.id} input "${inp.name ?? slot}" claims link ${inp.link}, which does not exist in this graph — left unconnected`,
-        );
-      }
+      // This input claims a connection the flattened graph does not have. Say so —
+      // clearing it in silence is the same observation-failed-treated-as-a-no that
+      // this change removes everywhere else, and the converter already reports its
+      // equivalent.
+      //
+      // The question is asked about THIS INPUT's claim, not about the id in the
+      // abstract. An earlier version suppressed the report when the id existed
+      // ANYWHERE in the arriving graph, which let a bogus claim on an id belonging
+      // to a link into a DIFFERENT node be cleared silently — the same
+      // bare-identifier-vs-identifier-in-context mistake as the raw-vs-normalized
+      // producer bugs elsewhere in this pass, one level down. Whether the id was
+      // once a link somewhere says nothing about whether it fed this input.
+      warnings.push(
+        `${n.type} #${n.id} input "${inp.name ?? slot}" claims link ${inp.link}, which is not a connection into this input in the flattened graph — left unconnected`,
+      );
       inp.link = null;
     }
     for (const out of n.outputs ?? []) {

--- a/src/services/flatten-workflow.ts
+++ b/src/services/flatten-workflow.ts
@@ -390,8 +390,29 @@ export function flattenUiWorkflow(
       // destroy the only evidence of a broadcast we declined to materialize.
       const liveOrigins = new Set<number>();
       for (const l of freshLinks) liveOrigins.add(l[1]);
+      // A non-empty list is not proof that it accounts for EVERY sender: one that
+      // predates a sender has no row for it. Deleting such a sender would remove a
+      // node whose broadcasts were never materialized — a silent, unrecoverable
+      // edit. A sender that reaches nothing also has no row, and the two cannot be
+      // told apart, so it is kept and reported.
+      const attributed = new Set<number>();
+      for (const r of ueLinks) {
+        if (r?.controller != null) attributed.add(r.controller);
+        // A controllerless record still accounts for its sender when the producer
+        // IS that sender (the self-producing shape accepted above).
+        else if (isSelfProducingUeSender(nodesById.get(r?.upstream)?.type ?? "")) {
+          attributed.add(r.upstream);
+        }
+      }
+      for (const s of ueSenders) {
+        if (attributed.has(s.id)) continue;
+        warnings.push(
+          `${s.type} #${s.id} is a Use-Everywhere sender, but no record in extra.ue_links names it — either it currently broadcasts to nothing or the saved list predates it, so nothing was wired from it and it is kept in place`,
+        );
+      }
       for (const s of ueSenders) {
         if (blockSenderDeletion) break;
+        if (!attributed.has(s.id)) continue; // unaccounted for — never delete it
         if (!liveOrigins.has(s.id) && !unconfirmed.has(s.id)) ueDeletable.add(s.id);
       }
     }

--- a/src/services/flatten-workflow.ts
+++ b/src/services/flatten-workflow.ts
@@ -315,6 +315,18 @@ export function flattenUiWorkflow(
         number,
         { type: string; confirmed: number; unresolved: number }
       >();
+      /**
+       * THE single "is this producer real" question — the same one addDirectLink
+       * asks before it will build an edge. Counting a producer as confirmed here
+       * that the materializer would refuse is how the channel caveat came to
+       * claim confirmation it did not have.
+       */
+      const producerConfirmed = (nodeId: number, slot: number): boolean => {
+        const nd = nodesById.get(nodeId);
+        if (!nd) return true; // outside this graph — nothing to judge here
+        if (!Array.isArray(nd.outputs)) return false;
+        return slot < nd.outputs.length;
+      };
       /** null = confirmed against the live graph; otherwise the reason it is not. */
       const unconfirmedReason = (uel: UeLink, srcId: number, srcSlot: number): string | null => {
         const ctrlId = uel.controller;
@@ -346,12 +358,13 @@ export function flattenUiWorkflow(
         const distinct = new Set<string>();
         for (const f of feeds) {
           const r = resolveReal(f.link as number);
-          if (!r) {
-            // An UNRESOLVED input is not "no producer" — it is an unknown one, so
-            // it counts toward the channel ambiguity. Letting it contribute
-            // nothing made a sender with one known and one unknown producer read
-            // as "one producer, nothing to confuse", silencing the caveat exactly
-            // where the risk is highest.
+          // An UNRESOLVED input is not "no producer" — it is an unknown one, and
+          // so is one whose producer this flattener would REFUSE to wire from.
+          // Both count toward the channel ambiguity; letting them contribute
+          // nothing made a sender with one known and one unknown producer read as
+          // "one producer, nothing to confuse", silencing the caveat exactly
+          // where the risk is highest.
+          if (!r || !producerConfirmed(r.id, r.slot)) {
             unresolved++;
             continue;
           }
@@ -495,6 +508,41 @@ export function flattenUiWorkflow(
   const survivingLinks = [...(ui.links ?? []), ...freshLinks].filter(
     (l) => Array.isArray(l) && !removedIds.has(l[1]) && !removedIds.has(l[3]),
   );
+  // Two links sharing an id make the graph ambiguous: every consumer input and
+  // producer output list keyed by that id could mean either. The fresh-id
+  // allocator can no longer create one, but a graph edited by tooling that did
+  // not maintain link ids can arrive with one already — and returning it
+  // unchanged propagates the ambiguity from a pass whose whole job is to leave
+  // the wiring unambiguous. Repair it (re-point exactly the one consumer input
+  // and producer output slot involved) and say so; never fix it silently.
+  const seenLinkIds = new Set<number>();
+  const repairedIds: number[] = [];
+  for (const l of survivingLinks) {
+    if (!seenLinkIds.has(l[0])) {
+      seenLinkIds.add(l[0]);
+      continue;
+    }
+    const clashing = l[0];
+    const fresh = nextLinkId++;
+    const tgtInput = nodesById.get(l[3])?.inputs?.[l[4]];
+    if (tgtInput?.link === clashing) tgtInput.link = fresh;
+    const srcOut = nodesById.get(l[1])?.outputs?.[l[2]];
+    if (srcOut?.links) {
+      const at = srcOut.links.indexOf(clashing);
+      if (at >= 0) srcOut.links[at] = fresh;
+    }
+    l[0] = fresh;
+    seenLinkIds.add(fresh);
+    repairedIds.push(clashing);
+  }
+  if (repairedIds.length > 0) {
+    warnings.push(
+      `${repairedIds.length} link(s) in the source graph shared an id already used by another link (${[
+        ...new Set(repairedIds),
+      ].join(", ")}) — each duplicate was given a fresh id so the flattened graph is unambiguous, but the original file is malformed and anything else reading it by link id may disagree`,
+    );
+  }
+
   const survivingIds = new Set(survivingLinks.map((l) => l[0]));
   ui.links = survivingLinks;
   ui.last_link_id = nextLinkId - 1;

--- a/src/services/flatten-workflow.ts
+++ b/src/services/flatten-workflow.ts
@@ -311,7 +311,10 @@ export function flattenUiWorkflow(
       let blockSenderDeletion = false;
       /** Senders whose channel could not be verified (several distinct producers,
        *  and a record does not name the input it came through). Disclosed once. */
-      const multiFeed = new Map<number, string>();
+      const multiFeed = new Map<
+        number,
+        { type: string; confirmed: number; unresolved: number }
+      >();
       /** null = confirmed against the live graph; otherwise the reason it is not. */
       const unconfirmedReason = (uel: UeLink, srcId: number, srcSlot: number): string | null => {
         const ctrlId = uel.controller;
@@ -356,7 +359,13 @@ export function flattenUiWorkflow(
           if (r.id === srcId && r.slot === srcSlot) matched = true;
         }
         if (matched) {
-          if (distinct.size + unresolved > 1) multiFeed.set(ctrl.id, ctrl.type);
+          if (distinct.size + unresolved > 1) {
+            multiFeed.set(ctrl.id, {
+              type: ctrl.type,
+              confirmed: distinct.size,
+              unresolved,
+            });
+          }
           return null;
         }
         return unresolved > 0
@@ -417,9 +426,17 @@ export function flattenUiWorkflow(
         }
         rewired++;
       }
-      for (const [id, type] of multiFeed) {
+      for (const [id, info] of multiFeed) {
+        // Say only what is true: this fires both for several CONFIRMED producers
+        // and for a channel that could not be resolved at all, and claiming every
+        // producer was confirmed in the second case would be a false statement in
+        // a disclosure.
+        const carries =
+          info.unresolved > 0
+            ? `${info.confirmed} confirmed producer(s) plus ${info.unresolved} input(s) whose own source could NOT be resolved`
+            : `${info.confirmed} different confirmed producers`;
         warnings.push(
-          `${type} #${id} broadcasts from more than one producer, and a ue_link record does not say which of its inputs a broadcast came through — each producer was confirmed to still feed it, but a saved list that went stale by SWAPPING its channels would look identical, so re-save with cg-use-everywhere active if this sender's routing matters`,
+          `${info.type} #${id}: a broadcast could not be matched to a specific sender input — this sender carries ${carries}, and a ue_link record does not name the input a broadcast came through, so a saved list that went stale by SWAPPING its channels would look identical; re-save with cg-use-everywhere active if this sender's routing matters`,
         );
       }
       // A sender is deletable only when it is not the real producer of any

--- a/src/services/flatten-workflow.ts
+++ b/src/services/flatten-workflow.ts
@@ -35,9 +35,20 @@ const isRerouteType = (t: string) => t === "Reroute";
 /** Wiring-only virtual node: exists purely to carry a connection. */
 const isWiringVirtual = (t: string) => isRerouteType(t) || GET_SET_TYPES.has(t);
 
-/** cg-use-everywhere sender detection — mirrors the pack's own is_UEnode(). */
+/**
+ * cg-use-everywhere sender detection. The pack's own is_UEnode() prefix-matches
+ * "Anything Everywhere" (so the "?" and "3" variants are covered) but compares
+ * the other two families with EQUALITY — which misses the registered
+ * "Seed Everywhere?" class. That asymmetry is an oversight, and here it is a
+ * silent-loss bug: an unrecognized sender makes the materializer conclude there
+ * are no broadcasts at all, dropping real ones with nothing said. Under-matching
+ * costs a dropped connection; over-matching at worst asks the user to re-save.
+ * All three families are therefore prefix-matched.
+ */
 export const isUeSender = (t: string): boolean =>
-  t.startsWith("Anything Everywhere") || t === "Seed Everywhere" || t === "Prompts Everywhere";
+  t.startsWith("Anything Everywhere") ||
+  t.startsWith("Seed Everywhere") ||
+  t.startsWith("Prompts Everywhere");
 
 /** Shape cg-use-everywhere writes into graph.extra.ue_links. */
 interface UeLink {

--- a/src/services/flatten-workflow.ts
+++ b/src/services/flatten-workflow.ts
@@ -151,7 +151,34 @@ export function flattenUiWorkflow(
     return { id: link[1], slot: link[2], type: link[5] };
   };
 
-  let nextLinkId = (ui.last_link_id ?? Math.max(0, ...linkMap.keys())) + 1;
+  /** Walk from a NODE + output slot past any virtual wiring to the real producer.
+   *  A GetNode has no input to follow — its value arrives over the bus — so this
+   *  mirrors resolveReal's Get handling instead of looking for an incoming link. */
+  const resolveRealFromNode = (
+    nodeId: number,
+    slot: number,
+  ): { id: number; slot: number } | null => {
+    const n = nodesById.get(nodeId);
+    if (!n) return { id: nodeId, slot };
+    if (includeGetSet && isGetType(n.type)) {
+      const bus = n.widgets_values?.[0];
+      const setLink = bus != null ? busSource.get(String(bus)) : undefined;
+      const r = setLink != null ? resolveReal(setLink) : null;
+      return r ? { id: r.id, slot: r.slot } : null;
+    }
+    if (includeGetSet && (isSetType(n.type) || isRerouteType(n.type))) {
+      const inp = (n.inputs ?? []).find((i) => i.link != null);
+      const r = inp?.link != null ? resolveReal(inp.link) : null;
+      return r ? { id: r.id, slot: r.slot } : null;
+    }
+    return { id: nodeId, slot };
+  };
+
+  // Take the MAXIMUM of the header and the ids actually present. `last_link_id`
+  // is only a header: a graph edited by tooling that did not maintain it can
+  // carry links above it, and a fresh id equal to an existing one yields two
+  // links with the same id — an ambiguous graph, produced silently.
+  let nextLinkId = Math.max(ui.last_link_id ?? 0, 0, ...linkMap.keys()) + 1;
   const freshLinks: UiLink[] = [];
   let rewired = 0;
 
@@ -168,9 +195,15 @@ export function flattenUiWorkflow(
     const srcOutput = src?.outputs?.[srcSlot];
     if (!src || !dst || !dstInput || !srcOutput) return null;
     const id = nextLinkId++;
-    freshLinks.push([id, srcId, srcSlot, dstId, dstSlot, type]);
+    const link: UiLink = [id, srcId, srcSlot, dstId, dstSlot, type];
+    freshLinks.push(link);
     dstInput.link = id;
     srcOutput.links = [...(srcOutput.links ?? []), id];
+    // Index it: pass 1 REPLACES a virtual-fed input with a fresh direct link, and
+    // pass 2's staleness check resolves the sender's feed through this same map.
+    // Leaving fresh links out of it made a rewired feed look UNRESOLVABLE, which
+    // would refuse a perfectly live broadcast.
+    linkMap.set(id, link);
     return id;
   };
 
@@ -222,6 +255,10 @@ export function flattenUiWorkflow(
       /** Senders with at least one record we could not confirm — kept in place so
        *  the user can re-save and recover the real broadcast. */
       const unconfirmed = new Set<number>();
+      /** Set when a refused record names NO sender, so we cannot tell WHICH one
+       *  has to survive. Deleting any of them would erase the evidence of the
+       *  broadcast we declined to materialize, so none is deleted. */
+      let blockSenderDeletion = false;
       /** Senders whose channel could not be verified (several distinct producers,
        *  and a record does not name the input it came through). Disclosed once. */
       const multiFeed = new Map<number, string>();
@@ -284,10 +321,13 @@ export function flattenUiWorkflow(
         let srcSlot = uel.upstream_slot;
         const up = nodesById.get(srcId);
         if (up && isWiringVirtual(up.type)) {
-          const viaInp = (up.inputs ?? []).find((i) => i.link != null);
-          const resolved = viaInp?.link != null ? resolveReal(viaInp.link) : null;
+          const resolved = resolveRealFromNode(srcId, srcSlot);
           if (!resolved) {
-            warnings.push(`ue_link upstream #${srcId} is an unresolvable virtual node — skipped`);
+            warnings.push(
+              `ue_link upstream #${srcId} (${up.type}) is virtual wiring that could not be resolved to a real producer — ${dst.type} #${dst.id} input "${dstInput.name ?? uel.downstream_slot}" is left unconnected`,
+            );
+            if (uel.controller != null) unconfirmed.add(uel.controller);
+            else blockSenderDeletion = true;
             continue;
           }
           srcId = resolved.id;
@@ -299,10 +339,26 @@ export function flattenUiWorkflow(
             `ue_link → ${dst.type} #${dst.id} input "${dstInput.name ?? uel.downstream_slot}" could not be confirmed against the live graph: ${why} — left unconnected, and the sender is kept in place so a re-save can recover it`,
           );
           if (uel.controller != null) unconfirmed.add(uel.controller);
+          else blockSenderDeletion = true;
           continue;
         }
         const added = addDirectLink(srcId, srcSlot, uel.downstream, uel.downstream_slot, uel.type ?? dstInput.type ?? "*");
-        if (added != null) rewired++;
+        if (added == null) {
+          // Confirmed, but the edge could not be built — the producer node or that
+          // output slot is not in the graph. Swallowing the null returned a
+          // FLATTENED graph missing a broadcast it claimed to resolve, and let the
+          // sender be deleted on top of it.
+          const srcNode = nodesById.get(srcId);
+          warnings.push(
+            `ue_link → ${dst.type} #${dst.id} input "${dstInput.name ?? uel.downstream_slot}" names producer #${srcId}${
+              srcNode ? ` (${srcNode.type}) output slot ${srcSlot}` : ""
+            }, which this graph does not have — left unconnected, and the sender is kept in place`,
+          );
+          if (uel.controller != null) unconfirmed.add(uel.controller);
+          else blockSenderDeletion = true;
+          continue;
+        }
+        rewired++;
       }
       for (const [id, type] of multiFeed) {
         warnings.push(
@@ -316,6 +372,7 @@ export function flattenUiWorkflow(
       const liveOrigins = new Set<number>();
       for (const l of freshLinks) liveOrigins.add(l[1]);
       for (const s of ueSenders) {
+        if (blockSenderDeletion) break;
         if (!liveOrigins.has(s.id) && !unconfirmed.has(s.id)) ueDeletable.add(s.id);
       }
     }

--- a/src/services/flatten-workflow.ts
+++ b/src/services/flatten-workflow.ts
@@ -71,7 +71,8 @@ interface UeLink {
   downstream_slot: number;
   upstream: number;
   upstream_slot: number;
-  controller: number;
+  /** The sender that produced this broadcast (absent in older lists). */
+  controller?: number;
   type?: string;
 }
 
@@ -209,6 +210,66 @@ export function flattenUiWorkflow(
           `UE broadcasts NOT materialized (open the graph with cg-use-everywhere active and save/queue once, then retry); senders left in place`,
       );
     } else {
+      // A ue_links record is only as current as the last time the pack analysed
+      // the graph. Materializing one without checking it against the LIVE wiring
+      // invents a connection the graph does not have — which reads as a plausible
+      // graph that is silently wrong, worse than an obviously missing link. Same
+      // policy as convertUiToApi's materializer (issue #361); kept as a separate
+      // implementation because this one walks a different link representation and
+      // its failure action differs — it must never delete or disconnect anything,
+      // only decline to add.
+      const ueSenderIds = new Set(ueSenders.map((s) => s.id));
+      /** Senders with at least one record we could not confirm — kept in place so
+       *  the user can re-save and recover the real broadcast. */
+      const unconfirmed = new Set<number>();
+      /** Senders whose channel could not be verified (several distinct producers,
+       *  and a record does not name the input it came through). Disclosed once. */
+      const multiFeed = new Map<number, string>();
+      /** null = confirmed against the live graph; otherwise the reason it is not. */
+      const unconfirmedReason = (uel: UeLink, srcId: number, srcSlot: number): string | null => {
+        const ctrlId = uel.controller;
+        if (ctrlId == null) {
+          // Unattributable: an unrelated sender sharing the producer proves
+          // nothing about THIS target. Only a self-producing sender names its own
+          // single channel unambiguously.
+          const up = nodesById.get(srcId);
+          return up && isSelfProducingUeSender(up.type)
+            ? null
+            : "the record names no broadcast node of its own (an older cg-use-everywhere list), so it cannot be attributed to any sender here";
+        }
+        const ctrl = nodesById.get(ctrlId);
+        if (!ctrl || !ueSenderIds.has(ctrlId)) {
+          return `broadcast node #${ctrlId} is no longer a broadcast node in this graph`;
+        }
+        // The Seed Everywhere family owns its value, so it has no feed to compare.
+        // Restricted to that closed set: recognition is deliberately generous, and
+        // a merely name-alike class must not inherit an exemption from checking.
+        if (srcId === ctrlId && isSelfProducingUeSender(ctrl.type)) return null;
+        const feeds = (ctrl.inputs ?? []).filter((i) => i.link != null);
+        if (feeds.length === 0) {
+          return `${ctrl.type} #${ctrl.id} no longer has any incoming connection, so it broadcasts nothing`;
+        }
+        let unresolved = false;
+        let matched = false;
+        const distinct = new Set<string>();
+        for (const f of feeds) {
+          const r = resolveReal(f.link as number);
+          if (!r) {
+            unresolved = true;
+            continue;
+          }
+          distinct.add(`${r.id}:${r.slot}`);
+          if (r.id === srcId && r.slot === srcSlot) matched = true;
+        }
+        if (matched) {
+          if (distinct.size > 1) multiFeed.set(ctrl.id, ctrl.type);
+          return null;
+        }
+        return unresolved
+          ? `${ctrl.type} #${ctrl.id}'s own incoming connection could not be resolved, so the recorded producer node ${srcId} could not be confirmed`
+          : `${ctrl.type} #${ctrl.id} is now fed by a different producer than the recorded node ${srcId}`;
+      };
+
       for (const uel of ueLinks) {
         const dst = nodesById.get(uel.downstream);
         const dstInput = dst?.inputs?.[uel.downstream_slot];
@@ -232,15 +293,30 @@ export function flattenUiWorkflow(
           srcId = resolved.id;
           srcSlot = resolved.slot;
         }
+        const why = unconfirmedReason(uel, srcId, srcSlot);
+        if (why) {
+          warnings.push(
+            `ue_link → ${dst.type} #${dst.id} input "${dstInput.name ?? uel.downstream_slot}" could not be confirmed against the live graph: ${why} — left unconnected, and the sender is kept in place so a re-save can recover it`,
+          );
+          if (uel.controller != null) unconfirmed.add(uel.controller);
+          continue;
+        }
         const added = addDirectLink(srcId, srcSlot, uel.downstream, uel.downstream_slot, uel.type ?? dstInput.type ?? "*");
         if (added != null) rewired++;
       }
+      for (const [id, type] of multiFeed) {
+        warnings.push(
+          `${type} #${id} broadcasts from more than one producer, and a ue_link record does not say which of its inputs a broadcast came through — each producer was confirmed to still feed it, but a saved list that went stale by SWAPPING its channels would look identical, so re-save with cg-use-everywhere active if this sender's routing matters`,
+        );
+      }
       // A sender is deletable only when it is not the real producer of any
-      // surviving link (Seed Everywhere IS its own upstream — it must stay).
+      // surviving link (Seed Everywhere IS its own upstream — it must stay), and
+      // never when one of its records could not be confirmed: deleting it would
+      // destroy the only evidence of a broadcast we declined to materialize.
       const liveOrigins = new Set<number>();
       for (const l of freshLinks) liveOrigins.add(l[1]);
       for (const s of ueSenders) {
-        if (!liveOrigins.has(s.id)) ueDeletable.add(s.id);
+        if (!liveOrigins.has(s.id) && !unconfirmed.has(s.id)) ueDeletable.add(s.id);
       }
     }
   }

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -868,8 +868,15 @@ function materializeUeInGraph(
     // so there is no incoming feed to compare against. Same narrowing — a relay
     // sender that merely names itself as its own upstream is not exempt from
     // verification, it falls through to the feed check below.
+    //
+    // Compare the NORMALIZED producer, not the raw one. The pack records the
+    // virtual in front of a producer as readily as the producer, so a record like
+    // { controller: SeedEverywhere#1, upstream: Reroute#2 } is self-producing once
+    // the Reroute is followed. Testing the raw value called that a mismatch, fell
+    // through to the feed check, found a Seed has no incoming feed, and DROPPED a
+    // live broadcast. (The flattener normalizes first; this makes the two agree.)
     if (
-      raw.upstream === raw.controller &&
+      want.node === raw.controller &&
       isSelfProducingUeSender(nodesById.get(raw.controller)?.type ?? "")
     ) {
       return "ok";
@@ -898,22 +905,27 @@ function materializeUeInGraph(
     // different failures; only the second one is this issue.
     const feeds = (ctrl.inputs ?? []).filter((i) => i.link != null);
     if (feeds.length === 0) return "detached";
-    let anyUnresolved = false;
+    let unresolved = 0;
     let matched = false;
     const distinct = new Set<string>();
     for (const f of feeds) {
       const real = realSourceOf(f.link as number);
       if (!real) {
-        anyUnresolved = true;
+        // An UNRESOLVED input is an UNKNOWN producer, not the absence of one, so
+        // it counts toward the channel ambiguity below. Contributing nothing made
+        // a sender with one known and one unknown producer read as "one producer,
+        // nothing to confuse" — silencing the caveat exactly where the risk is
+        // highest.
+        unresolved++;
         continue;
       }
       distinct.add(`${real.node}:${real.slot}`);
       if (real.node === want.node && real.slot === want.slot) matched = true;
     }
-    if (!matched) return anyUnresolved ? "unverifiable" : "rewired";
+    if (!matched) return unresolved > 0 ? "unverifiable" : "rewired";
     // Confirmed live, but on a sender carrying MORE THAN ONE distinct producer the
     // channel→target association is not recoverable from the record (see above).
-    if (distinct.size > 1) multiFeedControllers.set(ctrl.id, ctrl.type);
+    if (distinct.size + unresolved > 1) multiFeedControllers.set(ctrl.id, ctrl.type);
     return "ok";
   };
 
@@ -951,13 +963,21 @@ function materializeUeInGraph(
       );
       continue;
     }
-    // Only reject the slot when we can POSITIVELY observe it is gone (the node
-    // serializes an outputs array that is too short). An absent outputs array is
-    // an unknown, not a "no" — and the pack's own computed list is the authority
-    // on what it wired — so it is trusted rather than silently dropped.
-    if (src && Array.isArray(src.outputs) && raw.upstream_slot >= src.outputs.length) {
+    // The recorded output slot must be OBSERVABLY there. An absent outputs array
+    // was previously trusted, on the grounds that the pack's list is the authority
+    // and absence is an unknown — but that folds the unknown into a definite YES
+    // and emits an executable edge from it. Unknown gets its own outcome instead:
+    // refuse and say so. (The flattener already declined this shape; the two now
+    // agree.) A node that really produces something serializes its outputs.
+    if (src && !Array.isArray(src.outputs)) {
       warnings.push(
-        `A cg-use-everywhere broadcast in ${scope} into node ${dst.id} (${dst.type}) input "${inputLabel}" names output slot ${raw.upstream_slot} of node ${src.id} (${src.type}), which only has ${src.outputs.length} output(s) — the record is stale, so that input is left UNCONNECTED rather than wired to a slot that does not exist.`,
+        `A cg-use-everywhere broadcast in ${scope} into node ${dst.id} (${dst.type}) input "${inputLabel}" names node ${src.id} (${src.type}) as its producer, but that node serializes no outputs at all, so the recorded output slot ${raw.upstream_slot} could not be confirmed to exist. That input is left UNCONNECTED rather than wired to a slot that may not be there.`,
+      );
+      continue;
+    }
+    if (src && raw.upstream_slot >= src.outputs!.length) {
+      warnings.push(
+        `A cg-use-everywhere broadcast in ${scope} into node ${dst.id} (${dst.type}) input "${inputLabel}" names output slot ${raw.upstream_slot} of node ${src.id} (${src.type}), which only has ${src.outputs!.length} output(s) — the record is stale, so that input is left UNCONNECTED rather than wired to a slot that does not exist.`,
       );
       continue;
     }

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -740,7 +740,12 @@ function materializeUeInGraph(
   if (senders.length === 0) return 0;
 
   const ueLinks = extra?.ue_links;
-  if (!Array.isArray(ueLinks) || ueLinks.length === 0) {
+  // An EMPTY computed list is an ANSWER — the pack analysed the graph and found
+  // no broadcast to record — so the stripped graph is faithful and nothing is
+  // reported. Only an ABSENT (or non-array) list is an unknown, and only that is
+  // warned about. Collapsing the two would either invent a loss or hide one.
+  if (Array.isArray(ueLinks) && ueLinks.length === 0) return 0;
+  if (!Array.isArray(ueLinks)) {
     warnings.push(
       `${senders.length} cg-use-everywhere broadcast node(s) (${senders
         .map((s) => `${s.type} #${s.id}`)
@@ -752,6 +757,7 @@ function materializeUeInGraph(
   }
 
   const nodesById = new Map(nodes.map((n) => [n.id, n]));
+  const senderIds = new Set(senders.map((s) => s.id));
   let added = 0;
   for (const raw of ueLinks as UeLinkEntry[]) {
     const dst = nodesById.get(raw?.downstream);
@@ -764,13 +770,13 @@ function materializeUeInGraph(
     }
     const inputLabel = dstInput.name ?? String(raw.downstream_slot);
     if (dstInput.link != null) continue; // real link present — UE would not fire
-    // A record naming a sender that is GONE is left over from a deleted
-    // broadcast; honoring it would fabricate a connection the live graph does not
-    // have. (An older list with no `controller` field says nothing either way, so
-    // it is not treated as stale.)
-    if (raw.controller != null && !nodesById.has(raw.controller)) {
+    // A record whose own broadcast node is GONE — deleted outright, or that id
+    // reused by an ordinary node — is left over; honoring it would fabricate a
+    // connection the live graph does not have. (An older list with no
+    // `controller` field says nothing either way, so it is not treated as stale.)
+    if (raw.controller != null && !senderIds.has(raw.controller)) {
       warnings.push(
-        `A cg-use-everywhere record in ${scope} feeding node ${dst.id} (${dst.type}) input "${inputLabel}" names broadcast node #${raw.controller}, which is no longer in the graph — the record is stale, so that input is left UNCONNECTED rather than wired from a deleted broadcast.`,
+        `A cg-use-everywhere record in ${scope} feeding node ${dst.id} (${dst.type}) input "${inputLabel}" names broadcast node #${raw.controller}, which is no longer a broadcast node in this graph — the record is stale, so that input is left UNCONNECTED rather than wired from a broadcast that no longer exists.`,
       );
       continue;
     }
@@ -1180,7 +1186,28 @@ function expandSingleComponent(
   const proxyWidgets: [string, string][] = Array.isArray(compNode.properties?.proxyWidgets)
     ? (compNode.properties!.proxyWidgets as [string, string][])
     : [];
-  const widgetValues = compNode.widgets_values ?? [];
+  const rawWidgetValues = compNode.widgets_values ?? [];
+  // A subgraph instance normally serializes its promoted values POSITIONALLY,
+  // parallel to proxyWidgets. Some captures key every widget BY NAME instead (the
+  // shape the main converter already accepts). Read both, or a name-keyed capture
+  // would leave every promotion at the inner node's stale value — silently.
+  const widgetValues: unknown[] = Array.isArray(rawWidgetValues) ? rawWidgetValues : [];
+  const wvByName: Record<string, unknown> | null =
+    !Array.isArray(rawWidgetValues) && rawWidgetValues && typeof rawWidgetValues === "object"
+      ? (rawWidgetValues as unknown as Record<string, unknown>)
+      : null;
+  // A flat name→value map can only be attributed when the promoted names are
+  // UNIQUE. Two promotions of the same widget name (from different inner nodes)
+  // share one slot, so the stored value belongs to neither in particular — refuse
+  // both rather than push one control's value onto another.
+  const nameClaims = new Map<string, number>();
+  if (wvByName) {
+    for (const e of proxyWidgets) {
+      if (Array.isArray(e) && e.length >= 2) {
+        nameClaims.set(e[1], (nameClaims.get(e[1]) ?? 0) + 1);
+      }
+    }
+  }
 
   /** Record a promoted value on an inner node BY NAME. A nested subgraph
    *  instance has no object_info of its own, so its promotion is recorded
@@ -1212,7 +1239,17 @@ function expandSingleComponent(
     const entry = proxyWidgets[i];
     if (!Array.isArray(entry) || entry.length < 2) continue;
     const [innerNodeIdStr, widgetName] = entry;
-    const value = i < widgetValues.length ? widgetValues[i] : undefined;
+    if (wvByName && (nameClaims.get(widgetName) ?? 0) > 1) {
+      warnings.push(
+        `Component "${sg.name}" (node ${compNode.id}): promoted widget "${widgetName}" could not be resolved from the name-keyed capture because more than one promotion claims that name, so the single stored value can't be attributed to the right one. Left to the inner node's own value rather than risk assigning another control's.`,
+      );
+      continue;
+    }
+    const value = wvByName
+      ? wvByName[widgetName]
+      : i < widgetValues.length
+        ? widgetValues[i]
+        : undefined;
     if (value === undefined || value === null) continue;
 
     const remapped = nodeRemap.get(Number(innerNodeIdStr));

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -743,9 +743,23 @@ function materializeUeInGraph(
   boundary?: { inputNodeId: number; inputs: SubgraphInput[] },
 ): number {
   const senders = nodes.filter((n) => typeof n.type === "string" && isUeSender(n.type));
-  if (senders.length === 0) return 0;
-
   const ueLinks = extra?.ue_links;
+  if (senders.length === 0) {
+    // Records but no recognized sender. Returning 0 here silently would be the
+    // single worst outcome this whole change exists to prevent: a real broadcast
+    // dropped with nothing said, and it is exactly what an unrecognized sender
+    // CLASS produces. We cannot tell a deleted sender (records genuinely stale,
+    // dropping them is right) from a sender class this converter doesn't know
+    // (records live, dropping them is a loss) — so this is a could-not-determine
+    // and it is reported as one.
+    if (Array.isArray(ueLinks) && ueLinks.length > 0) {
+      warnings.push(
+        `${ueLinks.length} cg-use-everywhere broadcast record(s) are present in ${scope}, but no node in it is recognized as a cg-use-everywhere broadcast node. Either those broadcast nodes were deleted (leaving the records stale) or they are a sender class this converter does not recognize — the records cannot be attributed either way, so every input they name is UNCONNECTED in the stripped graph.`,
+      );
+    }
+    return 0;
+  }
+
   // An EMPTY computed list is an ANSWER — the pack analysed the graph and found
   // no broadcast to record — so the stripped graph is faithful and nothing is
   // reported. Only an ABSENT (or non-array) list is an unknown, and only that is
@@ -827,31 +841,23 @@ function materializeUeInGraph(
    */
   const assessRecord = (
     raw: UeLinkEntry,
-  ): "ok" | "detached" | "rewired" | "unverifiable" | "orphaned" => {
+  ): "ok" | "detached" | "rewired" | "unverifiable" | "unattributable" => {
     const want = realOfNode(raw.upstream, raw.upstream_slot);
     if (!want) return "unverifiable";
     const matches = (feedLink: number) => {
       const real = realSourceOf(feedLink);
       return real ? real.node === want.node && real.slot === want.slot : null;
     };
-    // No `controller` (older lists omit the field): the record can't be tied to a
-    // particular sender — but it is NOT therefore current. Treating "cannot
-    // determine" as "determined current" is what let a stale record fabricate an
-    // edge in the first place. What IS checkable is whether ANY live broadcast
-    // node is fed by the recorded producer; if none is, no live broadcast can
-    // carry this value and the record is left over.
+    // No `controller` (older lists omit the field): the record cannot be tied to
+    // ANY sender. Scanning for "some live sender happens to be fed by this
+    // producer" reads a COINCIDENCE as evidence — the record's own sender may be
+    // long gone while an unrelated sender shares that producer and broadcasts it
+    // somewhere else entirely, which fabricates an edge the live graph lacks.
+    // The one self-attributing shape is a producer that IS itself a broadcast
+    // node (Seed Everywhere owns its widget): that names its own single channel
+    // unambiguously, with no attribution to guess at.
     if (raw.controller == null) {
-      let anyUnresolved = false;
-      for (const s of senders) {
-        // Seed Everywhere and friends ARE their own producer.
-        if (s.id === want.node) return "ok";
-        for (const f of (s.inputs ?? []).filter((i) => i.link != null)) {
-          const m = matches(f.link as number);
-          if (m === null) anyUnresolved = true;
-          else if (m) return "ok";
-        }
-      }
-      return anyUnresolved ? "unverifiable" : "orphaned";
+      return senderIds.has(want.node) ? "ok" : "unattributable";
     }
     // Seed Everywhere and friends: the sender IS the producer (it owns the widget),
     // so there is no incoming feed to compare against.
@@ -860,6 +866,20 @@ function materializeUeInGraph(
     if (!ctrl) return "ok"; // already reported by the sender check above
     // A sender can have SEVERAL inputs (Prompts Everywhere, Anything Everywhere3),
     // each with its own record — the record is current if ANY feed matches.
+    //
+    // KNOWN LIMIT, and it is a limit of the DATA, not of this check. A ue_links
+    // record carries { downstream, downstream_slot, upstream, upstream_slot,
+    // controller, type } and nothing that says WHICH INPUT of the sender the
+    // broadcast came through. On a multi-input sender the producer identity is
+    // therefore the only handle on channel identity, which is what is matched
+    // here. What cannot be checked is whether that channel routes to THIS target:
+    // deciding that is the pack's own type/name matching, and re-implementing it
+    // would be a second guess layered on the first. So a list that went stale by
+    // SWAPPING two channels of one sender (positive/negative both still feeding
+    // it, just exchanged) is indistinguishable from a current one and is accepted.
+    // Refusing every multi-input record instead would drop the broadcasts of every
+    // Prompts Everywhere / Anything Everywhere3 graph, permanently and with no
+    // remedy the user could act on — a certain loss traded for an occasional one.
     const feeds = (ctrl.inputs ?? []).filter((i) => i.link != null);
     if (feeds.length === 0) return "detached";
     let anyUnresolved = false;
@@ -928,11 +948,11 @@ function materializeUeInGraph(
           ? `${who} no longer has any incoming connection, so it broadcasts nothing`
           : verdict === "rewired"
             ? `${who} is now fed by a different producer than the recorded node ${raw.upstream} (slot ${raw.upstream_slot})`
-            : verdict === "orphaned"
-              ? `the record names no broadcast node of its own, and none of this graph's broadcast nodes is fed by the recorded producer node ${raw.upstream} (slot ${raw.upstream_slot})`
+            : verdict === "unattributable"
+              ? `the record names no broadcast node of its own (an older cg-use-everywhere list), so it cannot be attributed to any sender here and there is no way to confirm that producer node ${raw.upstream} (slot ${raw.upstream_slot}) still feeds this input — another sender sharing that producer would prove nothing about THIS target`
               : `${who}'s own incoming connection could not be resolved, so the recorded producer node ${raw.upstream} (slot ${raw.upstream_slot}) could not be confirmed`;
       warnings.push(
-        `A cg-use-everywhere record in ${scope} feeding node ${dst.id} (${dst.type}) input "${inputLabel}" is stale: ${why}. That input is left UNCONNECTED rather than wired from a broadcast the live graph does not have.`,
+        `A cg-use-everywhere record in ${scope} feeding node ${dst.id} (${dst.type}) input "${inputLabel}" could not be confirmed against the live graph: ${why}. That input is left UNCONNECTED rather than wired from a broadcast the live graph may not have.`,
       );
       continue;
     }

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -1220,6 +1220,16 @@ function expandSingleComponent(
         ([, wn]) => wn === widgetName,
       );
       if (idx < 0) return false;
+      const nestedWv = target.widgets_values as unknown;
+      // A nested instance may itself carry a NAME-KEYED widgets_values. Overlay
+      // the value in that representation — replacing the object with a positional
+      // array would discard the nested instance's OTHER promoted values, which
+      // its own expansion pass would then silently leave at their stale inner
+      // values (codex gate r3).
+      if (nestedWv && typeof nestedWv === "object" && !Array.isArray(nestedWv)) {
+        (nestedWv as Record<string, unknown>)[widgetName] = value;
+        return true;
+      }
       if (!Array.isArray(target.widgets_values)) target.widgets_values = [];
       target.widgets_values[idx] = value;
       return true;

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -1209,7 +1209,17 @@ function expandSingleComponent(
       if (compInput.link == null) continue;
 
       const outerLink = outerLinkMap.get(compInput.link);
-      if (!outerLink) continue;
+      if (!outerLink) {
+        // The slot claims a connection whose link does not exist. The inner
+        // consumers are then treated as unfed and cleared by 8b below, so the
+        // inner nodes silently fall back to their own stored values — the
+        // subgraph-boundary counterpart of a dangling input reference, and just
+        // as invisible unless it is said.
+        warnings.push(
+          `Component "${sg.name}" (node ${compNode.id}): input "${compInput.name}" claims link ${compInput.link}, which does not exist in the graph, so the connection is DROPPED and everything inside fed by that input falls back to its own stored value.`,
+        );
+        continue;
+      }
 
       const srcNodeId = outerLink[1];
       const srcSlot = outerLink[2];

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -834,7 +834,10 @@ function materializeUeInGraph(
    *  verified, because the sender carries several distinct producers and a
    *  ue_links record does not name the sender input it came through. Disclosed
    *  once per sender rather than per record. */
-  const multiFeedControllers = new Map<number, string>();
+  const multiFeedControllers = new Map<
+    number,
+    { type: string; confirmed: number; unresolved: number }
+  >();
   /**
    * Verify the record against the sender's LIVE feed.
    *  - "ok"          the sender is still fed by exactly this producer + slot
@@ -925,7 +928,13 @@ function materializeUeInGraph(
     if (!matched) return unresolved > 0 ? "unverifiable" : "rewired";
     // Confirmed live, but on a sender carrying MORE THAN ONE distinct producer the
     // channel→target association is not recoverable from the record (see above).
-    if (distinct.size + unresolved > 1) multiFeedControllers.set(ctrl.id, ctrl.type);
+    if (distinct.size + unresolved > 1) {
+      multiFeedControllers.set(ctrl.id, {
+        type: ctrl.type,
+        confirmed: distinct.size,
+        unresolved,
+      });
+    }
     return "ok";
   };
 
@@ -1044,9 +1053,17 @@ function materializeUeInGraph(
       `${s.type} #${s.id} in ${scope} is a cg-use-everywhere broadcast node, but no record in extra.ue_links names it. Either it currently broadcasts to nothing, or the saved list predates it — indistinguishable from the file, so nothing was wired from it and any inputs it feeds are UNCONNECTED in the stripped graph. Re-save (or queue) with cg-use-everywhere active to refresh the list.`,
     );
   }
-  for (const [id, type] of multiFeedControllers) {
+  for (const [id, info] of multiFeedControllers) {
+    // Say only what is true. This fires both when several producers were
+    // CONFIRMED and when one channel could not be resolved at all, and claiming
+    // "every producer was confirmed" in the second case is a false statement in a
+    // disclosure — which is how disclosures get ignored.
+    const carries =
+      info.unresolved > 0
+        ? `${info.confirmed} confirmed producer(s) plus ${info.unresolved} input(s) whose own source could NOT be resolved`
+        : `${info.confirmed} different confirmed producers`;
     warnings.push(
-      `Node ${id} (${type}) in ${scope} broadcasts from more than one producer, and a cg-use-everywhere record does not say which of the sender's inputs a broadcast came through. Each producer was confirmed to still feed this node, so the wiring below is materialized — but if the saved broadcast list went stale by SWAPPING that sender's channels, the stripped graph carries the swap and there is no way to tell from the file. Re-save (or queue) the workflow with cg-use-everywhere active if this sender's routing matters.`,
+      `Node ${id} (${info.type}) in ${scope}: a cg-use-everywhere broadcast could not be matched to a specific sender input — this sender carries ${carries}, and a ue_links record does not name the input a broadcast came through. The wiring is materialized, but a saved list that went stale by SWAPPING this sender's channels would look identical from the file. Re-save (or queue) the workflow with cg-use-everywhere active if this sender's routing matters.`,
     );
   }
   return added;

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -1003,6 +1003,27 @@ function materializeUeInGraph(
     }
     added++;
   }
+  // A non-empty list is not proof that it accounts for EVERY sender. One that
+  // predates a sender simply has no row for it, and the broadcasts of that sender
+  // then come out unconnected — which, on a list that looked usable, is exactly
+  // the silent difference this change exists to remove. A sender that genuinely
+  // reaches nothing has no row either, and the two are indistinguishable here, so
+  // it is reported as the could-not-determine it is.
+  const attributed = new Set<number>();
+  for (const r of ueLinks as UeLinkEntry[]) {
+    if (r?.controller != null) attributed.add(r.controller);
+    // A controllerless record still accounts for its sender when the producer IS
+    // that sender (the self-producing shape accepted above).
+    else if (isSelfProducingUeSender(nodesById.get(r?.upstream)?.type ?? "")) {
+      attributed.add(r.upstream);
+    }
+  }
+  for (const s of senders) {
+    if (attributed.has(s.id)) continue;
+    warnings.push(
+      `${s.type} #${s.id} in ${scope} is a cg-use-everywhere broadcast node, but no record in extra.ue_links names it. Either it currently broadcasts to nothing, or the saved list predates it — indistinguishable from the file, so nothing was wired from it and any inputs it feeds are UNCONNECTED in the stripped graph. Re-save (or queue) with cg-use-everywhere active to refresh the list.`,
+    );
+  }
   for (const [id, type] of multiFeedControllers) {
     warnings.push(
       `Node ${id} (${type}) in ${scope} broadcasts from more than one producer, and a cg-use-everywhere record does not say which of the sender's inputs a broadcast came through. Each producer was confirmed to still feed this node, so the wiring below is materialized — but if the saved broadcast list went stale by SWAPPING that sender's channels, the stripped graph carries the swap and there is no way to tell from the file. Re-save (or queue) the workflow with cg-use-everywhere active if this sender's routing matters.`,

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -839,6 +839,26 @@ function materializeUeInGraph(
     { type: string; confirmed: number; unresolved: number }
   >();
   /**
+   * THE single "is this producer real" question. Every uncertainty about a
+   * producer must flow through here — the record's own producer before it is
+   * materialized, AND each of the sender's feeds when counting how many distinct
+   * producers it carries. Two separate answers to the same question is how the
+   * caveat came to claim a producer was "confirmed" that the materializer would
+   * have refused.
+   *
+   * A node OUTSIDE this graph (a subgraph boundary feed) is not judged here: its
+   * real producer lives one level up and is resolved during expansion.
+   */
+  const producerConfirmed = (nodeId: number, slot: number): boolean => {
+    const nd = nodesById.get(nodeId);
+    if (!nd) return true;
+    // A node that really produces something serializes its outputs. An absent
+    // array is could-not-determine, and folding that into a definite yes is what
+    // let an executable edge be emitted to a slot nothing proved exists.
+    if (!Array.isArray(nd.outputs)) return false;
+    return slot < nd.outputs.length;
+  };
+  /**
    * Verify the record against the sender's LIVE feed.
    *  - "ok"          the sender is still fed by exactly this producer + slot
    *  - "detached"    the sender has no incoming connection at all
@@ -849,9 +869,12 @@ function materializeUeInGraph(
    */
   const assessRecord = (
     raw: UeLinkEntry,
+    /** The record's producer ALREADY normalized past any virtual wiring. Passed
+     *  in rather than recomputed so the check and the materialization provably
+     *  judge the SAME node — computing it independently in each place is exactly
+     *  how one site came to compare a raw virtual id against a normalized one. */
+    want: { node: number; slot: number },
   ): "ok" | "detached" | "rewired" | "unverifiable" | "unattributable" => {
-    const want = realOfNode(raw.upstream, raw.upstream_slot);
-    if (!want) return "unverifiable";
     // No `controller` (older lists omit the field): the record cannot be tied to
     // ANY sender. Scanning for "some live sender happens to be fed by this
     // producer" reads a COINCIDENCE as evidence — the record's own sender may be
@@ -913,12 +936,12 @@ function materializeUeInGraph(
     const distinct = new Set<string>();
     for (const f of feeds) {
       const real = realSourceOf(f.link as number);
-      if (!real) {
-        // An UNRESOLVED input is an UNKNOWN producer, not the absence of one, so
-        // it counts toward the channel ambiguity below. Contributing nothing made
-        // a sender with one known and one unknown producer read as "one producer,
-        // nothing to confuse" — silencing the caveat exactly where the risk is
-        // highest.
+      // An UNRESOLVED input is an UNKNOWN producer, not the absence of one, and
+      // so is one whose producer this converter would REFUSE to wire from. Both
+      // count toward the channel ambiguity below; contributing nothing made a
+      // sender with one known and one unknown producer read as "one producer,
+      // nothing to confuse", silencing the caveat where the risk is highest.
+      if (!real || !producerConfirmed(real.node, real.slot)) {
         unresolved++;
         continue;
       }
@@ -959,34 +982,40 @@ function materializeUeInGraph(
       );
       continue;
     }
+    // NORMALIZE ONCE, HERE. The pack records the virtual node in front of a
+    // producer as readily as the producer itself, so every question asked below —
+    // is this the subgraph boundary, does this node exist, does that output slot
+    // exist, is the sender still fed by it, what do we wire from — must be asked
+    // about the REAL producer. Resolving it independently at each site is what
+    // left one check comparing a raw virtual id while its neighbour compared a
+    // normalized one, and each such pair cost a live edge.
+    const from = realOfNode(raw.upstream, raw.upstream_slot);
+    if (!from) {
+      warnings.push(
+        `A cg-use-everywhere broadcast in ${scope} into node ${dst.id} (${dst.type}) input "${inputLabel}" names producer #${raw.upstream}, whose own virtual wiring could not be resolved to a real node — that input is left UNCONNECTED rather than wired from an unknown source.`,
+      );
+      continue;
+    }
     // Inside a subgraph definition the producer can be the definition's virtual
     // INPUT node: the broadcast's real source is whatever the outer component's
     // matching input is wired to. That is a recoverable connection, not a missing
     // producer — register the materialized edge on the boundary so the expander's
     // input rewiring re-targets it to the outer source like any other inner link.
-    const fromBoundary = boundary != null && raw.upstream === boundary.inputNodeId;
-    const src = fromBoundary ? undefined : nodesById.get(raw.upstream);
+    const fromBoundary = boundary != null && from.node === boundary.inputNodeId;
+    const src = fromBoundary ? undefined : nodesById.get(from.node);
     if (!src && !fromBoundary) {
       warnings.push(
         `A cg-use-everywhere broadcast in ${scope} into node ${dst.id} (${dst.type}) input "${inputLabel}" names producer #${raw.upstream}, which is not in this graph — that connection is ABSENT from the stripped graph.`,
       );
       continue;
     }
-    // The recorded output slot must be OBSERVABLY there. An absent outputs array
-    // was previously trusted, on the grounds that the pack's list is the authority
-    // and absence is an unknown — but that folds the unknown into a definite YES
-    // and emits an executable edge from it. Unknown gets its own outcome instead:
-    // refuse and say so. (The flattener already declined this shape; the two now
-    // agree.) A node that really produces something serializes its outputs.
-    if (src && !Array.isArray(src.outputs)) {
+    // The recorded output slot must be OBSERVABLY there, on the REAL producer.
+    if (src && !producerConfirmed(from.node, from.slot)) {
+      const detail = Array.isArray(src.outputs)
+        ? `which only has ${src.outputs.length} output(s)`
+        : `but that node serializes no outputs at all, so the slot could not be confirmed to exist`;
       warnings.push(
-        `A cg-use-everywhere broadcast in ${scope} into node ${dst.id} (${dst.type}) input "${inputLabel}" names node ${src.id} (${src.type}) as its producer, but that node serializes no outputs at all, so the recorded output slot ${raw.upstream_slot} could not be confirmed to exist. That input is left UNCONNECTED rather than wired to a slot that may not be there.`,
-      );
-      continue;
-    }
-    if (src && raw.upstream_slot >= src.outputs!.length) {
-      warnings.push(
-        `A cg-use-everywhere broadcast in ${scope} into node ${dst.id} (${dst.type}) input "${inputLabel}" names output slot ${raw.upstream_slot} of node ${src.id} (${src.type}), which only has ${src.outputs!.length} output(s) — the record is stale, so that input is left UNCONNECTED rather than wired to a slot that does not exist.`,
+        `A cg-use-everywhere broadcast in ${scope} into node ${dst.id} (${dst.type}) input "${inputLabel}" resolves to output slot ${from.slot} of node ${src.id} (${src.type}), ${detail} — that input is left UNCONNECTED rather than wired to a slot nothing proves is there.`,
       );
       continue;
     }
@@ -994,7 +1023,7 @@ function materializeUeInGraph(
     // an absence: the sender survives but is no longer fed by the recorded
     // producer. Never materialize an unconfirmed record — say what could not be
     // confirmed instead.
-    const verdict = assessRecord(raw);
+    const verdict = assessRecord(raw, from);
     if (verdict !== "ok") {
       const ctrl = nodesById.get(raw.controller as number);
       const who = `${ctrl?.type ?? "broadcast node"} #${raw.controller}`;
@@ -1012,10 +1041,11 @@ function materializeUeInGraph(
       continue;
     }
     const id = nextId();
+    // Wire from the REAL producer, the same node every check above judged.
     addLink(
       id,
-      raw.upstream,
-      raw.upstream_slot,
+      from.node,
+      from.slot,
       raw.downstream,
       raw.downstream_slot,
       raw.type ?? dstInput.type ?? "*",
@@ -1024,10 +1054,10 @@ function materializeUeInGraph(
     if (fromBoundary) {
       // The expander walks each subgraph input's linkIds to re-point its inner
       // consumers at the outer source; an unregistered edge would be left dangling.
-      const sgInput = boundary!.inputs[raw.upstream_slot];
+      const sgInput = boundary!.inputs[from.slot];
       if (sgInput) (sgInput.linkIds ??= []).push(id);
     } else {
-      const srcOut = src!.outputs?.[raw.upstream_slot];
+      const srcOut = src!.outputs?.[from.slot];
       if (srcOut) srcOut.links = [...(srcOut.links ?? []), id];
     }
     added++;
@@ -1041,10 +1071,14 @@ function materializeUeInGraph(
   const attributed = new Set<number>();
   for (const r of ueLinks as UeLinkEntry[]) {
     if (r?.controller != null) attributed.add(r.controller);
-    // A controllerless record still accounts for its sender when the producer IS
-    // that sender (the self-producing shape accepted above).
-    else if (isSelfProducingUeSender(nodesById.get(r?.upstream)?.type ?? "")) {
-      attributed.add(r.upstream);
+    else {
+      // A controllerless record still accounts for its sender when the producer
+      // IS that sender (the self-producing shape accepted above) — judged on the
+      // NORMALIZED producer, since the record may name a virtual in front of it.
+      const p = realOfNode(r?.upstream, r?.upstream_slot);
+      if (p && isSelfProducingUeSender(nodesById.get(p.node)?.type ?? "")) {
+        attributed.add(p.node);
+      }
     }
   }
   for (const s of senders) {
@@ -1342,8 +1376,22 @@ function expandSingleComponent(
         continue;
       }
 
-      // For each inner link from the virtual input node, create a new outer link
-      for (const innerLinkId of sgInput.linkIds) {
+      // Every inner link that ORIGINATES at the boundary for this input, not just
+      // the ones the definition's own `linkIds` happens to list. De-virtualization
+      // re-homes a link onto the boundary when the producer sat behind a Reroute
+      // or a Get/Set bus inside the definition, and such a link is nowhere in
+      // `linkIds` — it was silently skipped here and its consumer lost the
+      // connection, once per instance. `linkIds` remains the primary source (it
+      // carries entries even when a link's origin was rewritten elsewhere), and
+      // the two are unioned by id.
+      const boundaryLinkIds = new Set<number>(sgInput.linkIds ?? []);
+      const inputIndex = sg.inputs.indexOf(sgInput);
+      for (const il of sg.links) {
+        if (il.origin_id === inputNodeId && il.origin_slot === inputIndex) {
+          boundaryLinkIds.add(il.id);
+        }
+      }
+      for (const innerLinkId of boundaryLinkIds) {
         const il = innerLinkById.get(innerLinkId);
         if (!il || il.origin_id !== inputNodeId) continue;
         const remappedTarget = nodeRemap.get(il.target_id);

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -13,7 +13,7 @@ import type {
   SubgraphLink,
 } from "../comfyui/types.js";
 import { logger } from "../utils/logger.js";
-import { isUeSender } from "./flatten-workflow.js";
+import { isSelfProducingUeSender, isUeSender } from "./flatten-workflow.js";
 
 export interface ConversionResult {
   workflow: WorkflowJSON;
@@ -830,6 +830,11 @@ function materializeUeInGraph(
     if (!src) return null;
     return realOfNode(src.node, src.slot, depth + 1);
   };
+  /** Senders whose records were materialized but whose CHANNEL could not be
+   *  verified, because the sender carries several distinct producers and a
+   *  ue_links record does not name the sender input it came through. Disclosed
+   *  once per sender rather than per record. */
+  const multiFeedControllers = new Map<number, string>();
   /**
    * Verify the record against the sender's LIVE feed.
    *  - "ok"          the sender is still fed by exactly this producer + slot
@@ -844,24 +849,31 @@ function materializeUeInGraph(
   ): "ok" | "detached" | "rewired" | "unverifiable" | "unattributable" => {
     const want = realOfNode(raw.upstream, raw.upstream_slot);
     if (!want) return "unverifiable";
-    const matches = (feedLink: number) => {
-      const real = realSourceOf(feedLink);
-      return real ? real.node === want.node && real.slot === want.slot : null;
-    };
     // No `controller` (older lists omit the field): the record cannot be tied to
     // ANY sender. Scanning for "some live sender happens to be fed by this
     // producer" reads a COINCIDENCE as evidence — the record's own sender may be
     // long gone while an unrelated sender shares that producer and broadcasts it
     // somewhere else entirely, which fabricates an edge the live graph lacks.
-    // The one self-attributing shape is a producer that IS itself a broadcast
-    // node (Seed Everywhere owns its widget): that names its own single channel
-    // unambiguously, with no attribution to guess at.
+    // The one self-attributing shape is a producer that IS itself a SELF-PRODUCING
+    // broadcast node (Seed Everywhere owns its widget): that names its own single
+    // channel unambiguously, with no attribution to guess at. It must be a
+    // self-producing class specifically — accepting any recognized sender here
+    // would skip the feed check for a relay sender, which is how an over-broad
+    // class match could turn a stale record into a fabricated edge.
     if (raw.controller == null) {
-      return senderIds.has(want.node) ? "ok" : "unattributable";
+      const up = nodesById.get(want.node);
+      return up && isSelfProducingUeSender(up.type) ? "ok" : "unattributable";
     }
     // Seed Everywhere and friends: the sender IS the producer (it owns the widget),
-    // so there is no incoming feed to compare against.
-    if (raw.upstream === raw.controller) return "ok";
+    // so there is no incoming feed to compare against. Same narrowing — a relay
+    // sender that merely names itself as its own upstream is not exempt from
+    // verification, it falls through to the feed check below.
+    if (
+      raw.upstream === raw.controller &&
+      isSelfProducingUeSender(nodesById.get(raw.controller)?.type ?? "")
+    ) {
+      return "ok";
+    }
     const ctrl = nodesById.get(raw.controller);
     if (!ctrl) return "ok"; // already reported by the sender check above
     // A sender can have SEVERAL inputs (Prompts Everywhere, Anything Everywhere3),
@@ -876,19 +888,33 @@ function materializeUeInGraph(
     // deciding that is the pack's own type/name matching, and re-implementing it
     // would be a second guess layered on the first. So a list that went stale by
     // SWAPPING two channels of one sender (positive/negative both still feeding
-    // it, just exchanged) is indistinguishable from a current one and is accepted.
-    // Refusing every multi-input record instead would drop the broadcasts of every
-    // Prompts Everywhere / Anything Everywhere3 graph, permanently and with no
-    // remedy the user could act on — a certain loss traded for an occasional one.
+    // it, just exchanged) is indistinguishable from a current one.
+    //
+    // Refusing every multi-input record would drop the broadcasts of every Prompts
+    // Everywhere / Anything Everywhere3 graph, permanently and with no remedy the
+    // user could act on — a certain loss traded for an occasional one. So the
+    // record IS materialized, and `multiFeedControllers` records the sender so the
+    // residual is DISCLOSED once per sender. Unverifiable and undisclosed are
+    // different failures; only the second one is this issue.
     const feeds = (ctrl.inputs ?? []).filter((i) => i.link != null);
     if (feeds.length === 0) return "detached";
     let anyUnresolved = false;
+    let matched = false;
+    const distinct = new Set<string>();
     for (const f of feeds) {
-      const m = matches(f.link as number);
-      if (m === null) anyUnresolved = true;
-      else if (m) return "ok";
+      const real = realSourceOf(f.link as number);
+      if (!real) {
+        anyUnresolved = true;
+        continue;
+      }
+      distinct.add(`${real.node}:${real.slot}`);
+      if (real.node === want.node && real.slot === want.slot) matched = true;
     }
-    return anyUnresolved ? "unverifiable" : "rewired";
+    if (!matched) return anyUnresolved ? "unverifiable" : "rewired";
+    // Confirmed live, but on a sender carrying MORE THAN ONE distinct producer the
+    // channel→target association is not recoverable from the record (see above).
+    if (distinct.size > 1) multiFeedControllers.set(ctrl.id, ctrl.type);
+    return "ok";
   };
 
   let added = 0;
@@ -976,6 +1002,11 @@ function materializeUeInGraph(
       if (srcOut) srcOut.links = [...(srcOut.links ?? []), id];
     }
     added++;
+  }
+  for (const [id, type] of multiFeedControllers) {
+    warnings.push(
+      `Node ${id} (${type}) in ${scope} broadcasts from more than one producer, and a cg-use-everywhere record does not say which of the sender's inputs a broadcast came through. Each producer was confirmed to still feed this node, so the wiring below is materialized — but if the saved broadcast list went stale by SWAPPING that sender's channels, the stripped graph carries the swap and there is no way to tell from the file. Re-save (or queue) the workflow with cg-use-everywhere active if this sender's routing matters.`,
+    );
   }
   return added;
 }

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -590,6 +590,18 @@ function deVirtualizeGraph(
       const real = resolveReal(lsrc(l), lsrcSlot(l));
       if (real.ok && !isWiringVirtual(byId.get(real.node as number)?.type)) {
         setLsrc(l, real.node, real.slot);
+        // Re-home the link on the RESOLVED producer's output slot. The link tuple
+        // alone is not enough: the subgraph expander treats a component node's
+        // `outputs[].links` as the authoritative list of consumers to rewire, so a
+        // `component → Set/Get → consumer` edge whose id never landed there was
+        // dropped when the component expanded away — surfacing only as an
+        // anonymous "pruned dangling reference" (codex gate, #361).
+        const producer = byId.get(real.node as number);
+        const outSlot = producer?.outputs?.[real.slot as number];
+        if (outSlot) {
+          const existing = outSlot.links ?? [];
+          if (!existing.includes(lid(l))) outSlot.links = [...existing, lid(l)];
+        }
       } else {
         // Unresolved bus/reroute. Dropping it silently is issue #361's actual
         // harm: the consumer's input simply vanishes and the stripped graph looks
@@ -633,10 +645,37 @@ function deVirtualizeGraph(
   (links as any[]).push(...keptLinks);
 }
 
-/** Strip wiring virtuals from the top-level graph and every subgraph definition. */
-function deVirtualize(ui: UiWorkflow, warnings: string[]): void {
+/**
+ * The subgraph definitions actually INSTANTIATED by this workflow, transitively.
+ * A workflow file keeps definitions that no node instantiates (deleted instances,
+ * imported libraries); nothing in them reaches the stripped graph, so reporting
+ * their unresolved wiring would be pure noise that buries the real losses
+ * (codex gate, #361).
+ */
+function reachableSubgraphs(ui: UiWorkflow): SubgraphDefinition[] {
+  const defs = ui.definitions?.subgraphs ?? [];
+  if (defs.length === 0) return [];
+  const byId = new Map(defs.map((sg) => [sg.id, sg]));
+  const reached = new Set<string>();
+  const queue: UiNode[][] = [ui.nodes ?? []];
+  while (queue.length) {
+    for (const n of queue.pop()!) {
+      if (!byId.has(n.type) || reached.has(n.type)) continue;
+      reached.add(n.type);
+      queue.push(byId.get(n.type)!.nodes ?? []);
+    }
+  }
+  return defs.filter((sg) => reached.has(sg.id));
+}
+
+/** Strip wiring virtuals from the top-level graph and every LIVE subgraph definition. */
+function deVirtualize(
+  ui: UiWorkflow,
+  warnings: string[],
+  liveSubgraphs: SubgraphDefinition[],
+): void {
   deVirtualizeGraph(ui.nodes, ui.links as unknown[], warnings, "the top-level graph");
-  for (const sg of ui.definitions?.subgraphs ?? []) {
+  for (const sg of liveSubgraphs) {
     deVirtualizeGraph(
       sg.nodes,
       sg.links as unknown[],
@@ -672,70 +711,147 @@ interface UeLinkEntry {
   downstream_slot: number;
   upstream: number;
   upstream_slot: number;
+  /** The sender node that produced this broadcast (absent in older lists). */
+  controller?: number;
   type?: string;
 }
 
-function materializeUeLinks(ui: UiWorkflow, warnings: string[]): void {
-  const nodes = ui.nodes ?? [];
+/**
+ * Materialize the broadcasts of ONE graph (the top level, or one subgraph
+ * definition — hence the `addLink` indirection, since a definition stores links
+ * as objects rather than tuples). Reports, never guesses.
+ */
+function materializeUeInGraph(
+  nodes: UiNode[],
+  extra: Record<string, unknown> | undefined,
+  scope: string,
+  warnings: string[],
+  nextId: () => number,
+  addLink: (
+    id: number,
+    srcId: number,
+    srcSlot: number,
+    dstId: number,
+    dstSlot: number,
+    type: string,
+  ) => void,
+): number {
   const senders = nodes.filter((n) => typeof n.type === "string" && isUeSender(n.type));
-  if (senders.length === 0) return;
+  if (senders.length === 0) return 0;
 
-  const ueLinks = (ui.extra as Record<string, unknown> | undefined)?.ue_links;
+  const ueLinks = extra?.ue_links;
   if (!Array.isArray(ueLinks) || ueLinks.length === 0) {
     warnings.push(
       `${senders.length} cg-use-everywhere broadcast node(s) (${senders
         .map((s) => `${s.type} #${s.id}`)
-        .join(", ")}) are present, but the graph carries no computed "extra.ue_links" list. ` +
+        .join(", ")}) are present in ${scope}, but it carries no computed "extra.ue_links" list. ` +
         `Their broadcast connections are NOT ordinary graph links and CANNOT be recovered from this file, so every input they feed is UNCONNECTED in the stripped graph. ` +
         `Open the workflow with cg-use-everywhere active and save (or queue) it once so the pack writes extra.ue_links, then strip again.`,
     );
-    return;
+    return 0;
   }
 
   const nodesById = new Map(nodes.map((n) => [n.id, n]));
-  const links = (ui.links ??= []);
-  let nextLinkId =
-    Math.max(
-      ui.last_link_id ?? 0,
-      0,
-      ...links.filter((l) => Array.isArray(l)).map((l) => l[0]),
-    ) + 1;
-
   let added = 0;
   for (const raw of ueLinks as UeLinkEntry[]) {
     const dst = nodesById.get(raw?.downstream);
     const dstInput = dst?.inputs?.[raw?.downstream_slot];
     if (!dst || !dstInput) {
       warnings.push(
-        `A cg-use-everywhere broadcast targets node #${raw?.downstream} slot ${raw?.downstream_slot}, which no longer exists in this graph — that broadcast connection is ABSENT from the stripped graph.`,
+        `A cg-use-everywhere broadcast in ${scope} targets node #${raw?.downstream} slot ${raw?.downstream_slot}, which no longer exists — that broadcast connection is ABSENT from the stripped graph.`,
       );
       continue;
     }
+    const inputLabel = dstInput.name ?? String(raw.downstream_slot);
     if (dstInput.link != null) continue; // real link present — UE would not fire
+    // A record naming a sender that is GONE is left over from a deleted
+    // broadcast; honoring it would fabricate a connection the live graph does not
+    // have. (An older list with no `controller` field says nothing either way, so
+    // it is not treated as stale.)
+    if (raw.controller != null && !nodesById.has(raw.controller)) {
+      warnings.push(
+        `A cg-use-everywhere record in ${scope} feeding node ${dst.id} (${dst.type}) input "${inputLabel}" names broadcast node #${raw.controller}, which is no longer in the graph — the record is stale, so that input is left UNCONNECTED rather than wired from a deleted broadcast.`,
+      );
+      continue;
+    }
     const src = nodesById.get(raw.upstream);
-    const srcOut = src?.outputs?.[raw.upstream_slot];
     if (!src) {
       warnings.push(
-        `A cg-use-everywhere broadcast into node ${dst.id} (${dst.type}) input "${
-          dstInput.name ?? raw.downstream_slot
-        }" names producer #${raw.upstream}, which is not in this graph — that connection is ABSENT from the stripped graph.`,
+        `A cg-use-everywhere broadcast in ${scope} into node ${dst.id} (${dst.type}) input "${inputLabel}" names producer #${raw.upstream}, which is not in this graph — that connection is ABSENT from the stripped graph.`,
       );
       continue;
     }
-    const id = nextLinkId++;
-    links.push([
+    // Only reject the slot when we can POSITIVELY observe it is gone (the node
+    // serializes an outputs array that is too short). An absent outputs array is
+    // an unknown, not a "no" — and the pack's own computed list is the authority
+    // on what it wired — so it is trusted rather than silently dropped.
+    if (Array.isArray(src.outputs) && raw.upstream_slot >= src.outputs.length) {
+      warnings.push(
+        `A cg-use-everywhere broadcast in ${scope} into node ${dst.id} (${dst.type}) input "${inputLabel}" names output slot ${raw.upstream_slot} of node ${src.id} (${src.type}), which only has ${src.outputs.length} output(s) — the record is stale, so that input is left UNCONNECTED rather than wired to a slot that does not exist.`,
+      );
+      continue;
+    }
+    const id = nextId();
+    addLink(
       id,
       raw.upstream,
       raw.upstream_slot,
       raw.downstream,
       raw.downstream_slot,
       raw.type ?? dstInput.type ?? "*",
-    ]);
+    );
     dstInput.link = id;
+    const srcOut = src.outputs?.[raw.upstream_slot];
     if (srcOut) srcOut.links = [...(srcOut.links ?? []), id];
     added++;
   }
-  ui.last_link_id = nextLinkId - 1;
+  return added;
+}
+
+function materializeUeLinks(
+  ui: UiWorkflow,
+  warnings: string[],
+  liveSubgraphs: SubgraphDefinition[],
+): void {
+  // ONE id counter across the whole workflow: subgraph expansion offsets inner
+  // link ids from the global maximum, so a definition-local id that collides with
+  // a top-level one would be remapped onto a live edge.
+  let maxId = ui.last_link_id ?? 0;
+  for (const l of ui.links ?? []) if (Array.isArray(l)) maxId = Math.max(maxId, l[0]);
+  for (const sg of ui.definitions?.subgraphs ?? []) {
+    for (const l of sg.links ?? []) maxId = Math.max(maxId, l?.id ?? 0);
+  }
+  const nextId = () => ++maxId;
+
+  const links = (ui.links ??= []);
+  let added = materializeUeInGraph(
+    ui.nodes ?? [],
+    ui.extra as Record<string, unknown> | undefined,
+    "the top-level graph",
+    warnings,
+    nextId,
+    (id, s, ss, d, ds, t) => links.push([id, s, ss, d, ds, t]),
+  );
+  for (const sg of liveSubgraphs) {
+    const sgLinks = (sg.links ??= []);
+    added += materializeUeInGraph(
+      sg.nodes ?? [],
+      sg.extra,
+      `subgraph "${sg.name ?? sg.id}"`,
+      warnings,
+      nextId,
+      (id, s, ss, d, ds, t) =>
+        sgLinks.push({
+          id,
+          origin_id: s,
+          origin_slot: ss,
+          target_id: d,
+          target_slot: ds,
+          type: t,
+        }),
+    );
+  }
+  ui.last_link_id = maxId;
   if (added > 0) {
     logger.info(`Materialized ${added} cg-use-everywhere broadcast link(s)`);
   }
@@ -1642,8 +1758,11 @@ export function convertUiToApi(
   // could NOT preserve into the same warnings list (#361).
   const warnings: string[] = [];
   const cleaned = structuredClone(ui);
-  materializeUeLinks(cleaned, warnings);
-  deVirtualize(cleaned, warnings);
+  // Only definitions this workflow actually instantiates can affect the result;
+  // an unused one's wiring problems are not this graph's losses.
+  const liveSubgraphs = reachableSubgraphs(cleaned);
+  materializeUeLinks(cleaned, warnings, liveSubgraphs);
+  deVirtualize(cleaned, warnings, liveSubgraphs);
   const { expanded, warnings: expandWarnings } = expandComponents(cleaned);
   warnings.push(...expandWarnings);
 
@@ -2640,8 +2759,7 @@ export function convertUiToApi(
   // component expansion didn't remap). ComfyUI errors hard ("Node X not found")
   // on these, so drop the connection like an unresolved link.
   const validIds = new Set(Object.keys(workflow));
-  let prunedRefs = 0;
-  for (const node of Object.values(workflow)) {
+  for (const [nodeId, node] of Object.entries(workflow)) {
     const ins = node.inputs as Record<string, unknown>;
     for (const [name, val] of Object.entries(ins)) {
       if (
@@ -2652,12 +2770,14 @@ export function convertUiToApi(
       ) {
         if (process.env.DEBUG_PRUNE) logger.info(`PRUNE: ${(node as {class_type?:string}).class_type}.${name} -> missing ${val[0]}`);
         delete ins[name];
-        prunedRefs++;
+        // Name the node and the input. A bare count ("pruned N references") told
+        // the caller a connection was lost but not WHICH — the same silent-loss
+        // shape as #361 itself.
+        warnings.push(
+          `Node ${nodeId} (${node.class_type}): input "${name}" pointed at node ${val[0]}, which is not in the stripped graph, so the connection was DROPPED (its producer was removed by subgraph expansion or by mute/bypass resolution).`,
+        );
       }
     }
-  }
-  if (prunedRefs > 0) {
-    warnings.push(`Pruned ${prunedRefs} dangling input reference(s) to nodes not in the prompt.`);
   }
 
   // Drop links whose source output type clearly mismatches the consuming input's

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -723,6 +723,7 @@ interface UeLinkEntry {
  */
 function materializeUeInGraph(
   nodes: UiNode[],
+  links: ReadonlyArray<{ id: number; origin_id: number; origin_slot: number }>,
   extra: Record<string, unknown> | undefined,
   scope: string,
   warnings: string[],
@@ -758,6 +759,92 @@ function materializeUeInGraph(
 
   const nodesById = new Map(nodes.map((n) => [n.id, n]));
   const senderIds = new Set(senders.map((s) => s.id));
+
+  // ── Whole-record staleness: is the sender STILL fed by the recorded producer? ──
+  // Verifying only that `controller` is still a sender is not enough. A record
+  // left over from before its sender was DISCONNECTED or REWIRED would otherwise
+  // materialize `upstream → consumer`: an edge that does not exist live. A
+  // fabricated connection is worse than a dropped one — a missing link renders as
+  // an obviously broken graph, a fabricated one renders as a plausible graph that
+  // is silently wrong and looks deliberate to whoever opens it.
+  const linkSrc = new Map<number, { node: number; slot: number }>();
+  for (const l of links) {
+    if (l && typeof l.id === "number") {
+      linkSrc.set(l.id, { node: l.origin_id, slot: l.origin_slot });
+    }
+  }
+  const busSet = new Map<string, UiNode>();
+  for (const n of nodes) {
+    if (!isSetVirtual(n.type)) continue;
+    const b = busKey(n.widgets_values);
+    if (b != null) busSet.set(String(b), n);
+  }
+  // This runs BEFORE de-virtualization, and the pack's `upstream` is sometimes the
+  // REAL producer and sometimes the virtual node in front of it. So BOTH sides of
+  // the comparison are normalized past Reroute/Get/Set first — comparing a raw
+  // origin against a resolved one would flag a perfectly current record as stale
+  // and drop a live connection. `null` means the chain could NOT be resolved,
+  // which is distinct from "resolved to something else".
+  const realOfNode = (
+    nodeId: number,
+    slot: number,
+    depth = 0,
+  ): { node: number; slot: number } | null => {
+    if (depth > 100) return null;
+    const n = nodesById.get(nodeId);
+    if (!n) return { node: nodeId, slot }; // outside this graph — take at face value
+    if (n.type === "Reroute" || isGetVirtual(n.type) || isSetVirtual(n.type)) {
+      const via = isGetVirtual(n.type)
+        ? (() => {
+            const b = busKey(n.widgets_values);
+            const setN = b != null ? busSet.get(String(b)) : undefined;
+            return (setN?.inputs ?? []).find((i) => i.link != null);
+          })()
+        : (n.inputs ?? []).find((i) => i.link != null);
+      return via?.link != null ? realSourceOf(via.link, depth + 1) : null;
+    }
+    return { node: nodeId, slot };
+  };
+  const realSourceOf = (linkId: number, depth = 0): { node: number; slot: number } | null => {
+    if (depth > 100) return null;
+    const src = linkSrc.get(linkId);
+    if (!src) return null;
+    return realOfNode(src.node, src.slot, depth + 1);
+  };
+  /**
+   * Verify the record against the sender's LIVE feed.
+   *  - "ok"          the sender is still fed by exactly this producer + slot
+   *  - "detached"    the sender has no incoming connection at all
+   *  - "rewired"     every feed resolved, none to this producer + slot
+   *  - "unverifiable" a feed exists but its chain could not be resolved
+   * A sender with no `controller` on the record can't be attributed, so it is not
+   * assessed ("ok" — older lists predate the field and say nothing either way).
+   */
+  const assessRecord = (raw: UeLinkEntry): "ok" | "detached" | "rewired" | "unverifiable" => {
+    if (raw.controller == null) return "ok";
+    // Seed Everywhere and friends: the sender IS the producer (it owns the widget),
+    // so there is no incoming feed to compare against.
+    if (raw.upstream === raw.controller) return "ok";
+    const ctrl = nodesById.get(raw.controller);
+    if (!ctrl) return "ok"; // already reported by the sender check above
+    // A sender can have SEVERAL inputs (Prompts Everywhere, Anything Everywhere3),
+    // each with its own record — the record is current if ANY feed matches.
+    const feeds = (ctrl.inputs ?? []).filter((i) => i.link != null);
+    if (feeds.length === 0) return "detached";
+    const want = realOfNode(raw.upstream, raw.upstream_slot);
+    if (!want) return "unverifiable";
+    let anyUnresolved = false;
+    for (const f of feeds) {
+      const real = realSourceOf(f.link as number);
+      if (!real) {
+        anyUnresolved = true;
+        continue;
+      }
+      if (real.node === want.node && real.slot === want.slot) return "ok";
+    }
+    return anyUnresolved ? "unverifiable" : "rewired";
+  };
+
   let added = 0;
   for (const raw of ueLinks as UeLinkEntry[]) {
     const dst = nodesById.get(raw?.downstream);
@@ -797,6 +884,25 @@ function materializeUeInGraph(
       );
       continue;
     }
+    // Fourth stale shape, and the only one that would produce an EDGE rather than
+    // an absence: the sender survives but is no longer fed by the recorded
+    // producer. Never materialize an unconfirmed record — say what could not be
+    // confirmed instead.
+    const verdict = assessRecord(raw);
+    if (verdict !== "ok") {
+      const ctrl = nodesById.get(raw.controller as number);
+      const who = `${ctrl?.type ?? "broadcast node"} #${raw.controller}`;
+      const why =
+        verdict === "detached"
+          ? `${who} no longer has any incoming connection, so it broadcasts nothing`
+          : verdict === "rewired"
+            ? `${who} is now fed by a different producer than the recorded node ${raw.upstream} (slot ${raw.upstream_slot})`
+            : `${who}'s own incoming connection could not be resolved, so the recorded producer node ${raw.upstream} (slot ${raw.upstream_slot}) could not be confirmed`;
+      warnings.push(
+        `A cg-use-everywhere record in ${scope} feeding node ${dst.id} (${dst.type}) input "${inputLabel}" is stale: ${why}. That input is left UNCONNECTED rather than wired from a broadcast the live graph does not have.`,
+      );
+      continue;
+    }
     const id = nextId();
     addLink(
       id,
@@ -832,6 +938,11 @@ function materializeUeLinks(
   const links = (ui.links ??= []);
   let added = materializeUeInGraph(
     ui.nodes ?? [],
+    // Normalize the top level's tuple links to the object shape the staleness
+    // check reads; a subgraph definition already stores them that way.
+    links
+      .filter((l) => Array.isArray(l))
+      .map((l) => ({ id: l[0], origin_id: l[1], origin_slot: l[2] })),
     ui.extra as Record<string, unknown> | undefined,
     "the top-level graph",
     warnings,
@@ -842,6 +953,7 @@ function materializeUeLinks(
     const sgLinks = (sg.links ??= []);
     added += materializeUeInGraph(
       sg.nodes ?? [],
+      sgLinks,
       sg.extra,
       `subgraph "${sg.name ?? sg.id}"`,
       warnings,

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -9,6 +9,7 @@ import type {
   UiNodeOutput,
   UiLink,
   SubgraphDefinition,
+  SubgraphInput,
   SubgraphLink,
 } from "../comfyui/types.js";
 import { logger } from "../utils/logger.js";
@@ -736,6 +737,10 @@ function materializeUeInGraph(
     dstSlot: number,
     type: string,
   ) => void,
+  /** Present for a subgraph definition: its virtual input node and input slots,
+   *  so a broadcast sourced from the definition's boundary can be registered
+   *  there and re-targeted to the outer producer during expansion. */
+  boundary?: { inputNodeId: number; inputs: SubgraphInput[] },
 ): number {
   const senders = nodes.filter((n) => typeof n.type === "string" && isUeSender(n.type));
   if (senders.length === 0) return 0;
@@ -820,8 +825,34 @@ function materializeUeInGraph(
    * A sender with no `controller` on the record can't be attributed, so it is not
    * assessed ("ok" — older lists predate the field and say nothing either way).
    */
-  const assessRecord = (raw: UeLinkEntry): "ok" | "detached" | "rewired" | "unverifiable" => {
-    if (raw.controller == null) return "ok";
+  const assessRecord = (
+    raw: UeLinkEntry,
+  ): "ok" | "detached" | "rewired" | "unverifiable" | "orphaned" => {
+    const want = realOfNode(raw.upstream, raw.upstream_slot);
+    if (!want) return "unverifiable";
+    const matches = (feedLink: number) => {
+      const real = realSourceOf(feedLink);
+      return real ? real.node === want.node && real.slot === want.slot : null;
+    };
+    // No `controller` (older lists omit the field): the record can't be tied to a
+    // particular sender — but it is NOT therefore current. Treating "cannot
+    // determine" as "determined current" is what let a stale record fabricate an
+    // edge in the first place. What IS checkable is whether ANY live broadcast
+    // node is fed by the recorded producer; if none is, no live broadcast can
+    // carry this value and the record is left over.
+    if (raw.controller == null) {
+      let anyUnresolved = false;
+      for (const s of senders) {
+        // Seed Everywhere and friends ARE their own producer.
+        if (s.id === want.node) return "ok";
+        for (const f of (s.inputs ?? []).filter((i) => i.link != null)) {
+          const m = matches(f.link as number);
+          if (m === null) anyUnresolved = true;
+          else if (m) return "ok";
+        }
+      }
+      return anyUnresolved ? "unverifiable" : "orphaned";
+    }
     // Seed Everywhere and friends: the sender IS the producer (it owns the widget),
     // so there is no incoming feed to compare against.
     if (raw.upstream === raw.controller) return "ok";
@@ -831,16 +862,11 @@ function materializeUeInGraph(
     // each with its own record — the record is current if ANY feed matches.
     const feeds = (ctrl.inputs ?? []).filter((i) => i.link != null);
     if (feeds.length === 0) return "detached";
-    const want = realOfNode(raw.upstream, raw.upstream_slot);
-    if (!want) return "unverifiable";
     let anyUnresolved = false;
     for (const f of feeds) {
-      const real = realSourceOf(f.link as number);
-      if (!real) {
-        anyUnresolved = true;
-        continue;
-      }
-      if (real.node === want.node && real.slot === want.slot) return "ok";
+      const m = matches(f.link as number);
+      if (m === null) anyUnresolved = true;
+      else if (m) return "ok";
     }
     return anyUnresolved ? "unverifiable" : "rewired";
   };
@@ -859,16 +885,21 @@ function materializeUeInGraph(
     if (dstInput.link != null) continue; // real link present — UE would not fire
     // A record whose own broadcast node is GONE — deleted outright, or that id
     // reused by an ordinary node — is left over; honoring it would fabricate a
-    // connection the live graph does not have. (An older list with no
-    // `controller` field says nothing either way, so it is not treated as stale.)
+    // connection the live graph does not have.
     if (raw.controller != null && !senderIds.has(raw.controller)) {
       warnings.push(
         `A cg-use-everywhere record in ${scope} feeding node ${dst.id} (${dst.type}) input "${inputLabel}" names broadcast node #${raw.controller}, which is no longer a broadcast node in this graph — the record is stale, so that input is left UNCONNECTED rather than wired from a broadcast that no longer exists.`,
       );
       continue;
     }
-    const src = nodesById.get(raw.upstream);
-    if (!src) {
+    // Inside a subgraph definition the producer can be the definition's virtual
+    // INPUT node: the broadcast's real source is whatever the outer component's
+    // matching input is wired to. That is a recoverable connection, not a missing
+    // producer — register the materialized edge on the boundary so the expander's
+    // input rewiring re-targets it to the outer source like any other inner link.
+    const fromBoundary = boundary != null && raw.upstream === boundary.inputNodeId;
+    const src = fromBoundary ? undefined : nodesById.get(raw.upstream);
+    if (!src && !fromBoundary) {
       warnings.push(
         `A cg-use-everywhere broadcast in ${scope} into node ${dst.id} (${dst.type}) input "${inputLabel}" names producer #${raw.upstream}, which is not in this graph — that connection is ABSENT from the stripped graph.`,
       );
@@ -878,7 +909,7 @@ function materializeUeInGraph(
     // serializes an outputs array that is too short). An absent outputs array is
     // an unknown, not a "no" — and the pack's own computed list is the authority
     // on what it wired — so it is trusted rather than silently dropped.
-    if (Array.isArray(src.outputs) && raw.upstream_slot >= src.outputs.length) {
+    if (src && Array.isArray(src.outputs) && raw.upstream_slot >= src.outputs.length) {
       warnings.push(
         `A cg-use-everywhere broadcast in ${scope} into node ${dst.id} (${dst.type}) input "${inputLabel}" names output slot ${raw.upstream_slot} of node ${src.id} (${src.type}), which only has ${src.outputs.length} output(s) — the record is stale, so that input is left UNCONNECTED rather than wired to a slot that does not exist.`,
       );
@@ -897,7 +928,9 @@ function materializeUeInGraph(
           ? `${who} no longer has any incoming connection, so it broadcasts nothing`
           : verdict === "rewired"
             ? `${who} is now fed by a different producer than the recorded node ${raw.upstream} (slot ${raw.upstream_slot})`
-            : `${who}'s own incoming connection could not be resolved, so the recorded producer node ${raw.upstream} (slot ${raw.upstream_slot}) could not be confirmed`;
+            : verdict === "orphaned"
+              ? `the record names no broadcast node of its own, and none of this graph's broadcast nodes is fed by the recorded producer node ${raw.upstream} (slot ${raw.upstream_slot})`
+              : `${who}'s own incoming connection could not be resolved, so the recorded producer node ${raw.upstream} (slot ${raw.upstream_slot}) could not be confirmed`;
       warnings.push(
         `A cg-use-everywhere record in ${scope} feeding node ${dst.id} (${dst.type}) input "${inputLabel}" is stale: ${why}. That input is left UNCONNECTED rather than wired from a broadcast the live graph does not have.`,
       );
@@ -913,8 +946,15 @@ function materializeUeInGraph(
       raw.type ?? dstInput.type ?? "*",
     );
     dstInput.link = id;
-    const srcOut = src.outputs?.[raw.upstream_slot];
-    if (srcOut) srcOut.links = [...(srcOut.links ?? []), id];
+    if (fromBoundary) {
+      // The expander walks each subgraph input's linkIds to re-point its inner
+      // consumers at the outer source; an unregistered edge would be left dangling.
+      const sgInput = boundary!.inputs[raw.upstream_slot];
+      if (sgInput) (sgInput.linkIds ??= []).push(id);
+    } else {
+      const srcOut = src!.outputs?.[raw.upstream_slot];
+      if (srcOut) srcOut.links = [...(srcOut.links ?? []), id];
+    }
     added++;
   }
   return added;
@@ -967,6 +1007,7 @@ function materializeUeLinks(
           target_slot: ds,
           type: t,
         }),
+      { inputNodeId: sg.inputNode?.id, inputs: sg.inputs ?? [] },
     );
   }
   ui.last_link_id = maxId;

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -12,6 +12,7 @@ import type {
   SubgraphLink,
 } from "../comfyui/types.js";
 import { logger } from "../utils/logger.js";
+import { isUeSender } from "./flatten-workflow.js";
 
 export interface ConversionResult {
   workflow: WorkflowJSON;
@@ -472,6 +473,8 @@ function busKey(wv: unknown): unknown {
 function deVirtualizeGraph(
   nodes: UiNode[] | undefined,
   links: unknown[] | undefined,
+  warnings: string[],
+  scope: string,
 ): void {
   if (!nodes?.length || !links?.length) return;
   const dict = !Array.isArray(links[0]);
@@ -479,6 +482,7 @@ function deVirtualizeGraph(
   const lsrc = (l: any) => (dict ? l.origin_id : l[1]);
   const lsrcSlot = (l: any) => (dict ? l.origin_slot : l[2]);
   const ltgt = (l: any) => (dict ? l.target_id : l[3]);
+  const ltgtSlot = (l: any) => (dict ? l.target_slot : l[4]);
   const setLsrc = (l: any, n: unknown, s: unknown) => {
     if (dict) { l.origin_id = n; l.origin_slot = s; }
     else { l[1] = n; l[2] = s; }
@@ -490,7 +494,19 @@ function deVirtualizeGraph(
   for (const n of nodes) {
     if (isSetVirtual(n.type)) {
       const b = busKey(n.widgets_values);
-      if (b != null) busSet.set(String(b), n);
+      if (b == null) continue;
+      // Two Set nodes on the SAME bus name: whichever we keep, the other's writer
+      // is unreachable. litegraph resolves by iteration order (last wins), so
+      // mirror that — but SAY SO, because the graph's meaning is genuinely
+      // ambiguous and the stripped result silently picks one of two producers.
+      if (busSet.has(String(b))) {
+        warnings.push(
+          `${scope}: bus "${String(b)}" is written by more than one Set node (#${
+            busSet.get(String(b))!.id
+          } and #${n.id}) — the LAST one wins when resolving its Get nodes, so the other producer is not reachable in the stripped graph.`,
+        );
+      }
+      busSet.set(String(b), n);
     }
   }
   const incoming = (node: UiNode) => {
@@ -498,24 +514,54 @@ function deVirtualizeGraph(
     const l = inp?.link != null ? linkById.get(inp.link) : undefined;
     return l ? { node: lsrc(l), slot: lsrcSlot(l) } : null;
   };
+  type Resolved =
+    | { ok: true; node: unknown; slot: unknown }
+    | { ok: false; reason: string };
   const resolveReal = (
     nodeId: unknown,
     slot: unknown,
     depth = 0,
-  ): { node: unknown; slot: unknown } | null => {
-    if (depth > 100) return null;
+  ): Resolved => {
+    if (depth > 100) {
+      return {
+        ok: false,
+        reason: `the virtual-wiring chain exceeded 100 hops (a Get/Set or Reroute cycle)`,
+      };
+    }
     const node = byId.get(nodeId as number);
-    if (!node) return { node: nodeId, slot };
+    if (!node) return { ok: true, node: nodeId, slot };
     if (node.type === "Reroute") {
       const s = incoming(node);
-      return s ? resolveReal(s.node, s.slot, depth + 1) : null;
+      return s
+        ? resolveReal(s.node, s.slot, depth + 1)
+        : { ok: false, reason: `Reroute #${node.id} has no incoming connection` };
     }
     if (isGetVirtual(node.type)) {
       const b = busKey(node.widgets_values);
-      const setN = b != null ? busSet.get(String(b)) : undefined;
-      if (!setN) return null;
+      if (b == null) {
+        return {
+          ok: false,
+          reason: `${node.type} #${node.id} has no bus name (its "Constant" widget is unset)`,
+        };
+      }
+      const setN = busSet.get(String(b));
+      if (!setN) {
+        return {
+          ok: false,
+          reason: `${node.type} #${node.id} reads bus "${String(
+            b,
+          )}" but no Set node in ${scope} writes that bus`,
+        };
+      }
       const s = incoming(setN);
-      return s ? resolveReal(s.node, s.slot, depth + 1) : null;
+      return s
+        ? resolveReal(s.node, s.slot, depth + 1)
+        : {
+            ok: false,
+            reason: `${node.type} #${node.id} reads bus "${String(b)}", whose ${
+              setN.type
+            } #${setN.id} has no incoming connection`,
+          };
     }
     // SetNode passthrough: rgthree/KJNodes Set nodes expose an output that mirrors
     // their value input, so a consumer can wire straight off the SetNode (not only
@@ -524,12 +570,17 @@ function deVirtualizeGraph(
     // the connection (issue #361: Set/Get-resolved links missing on downstream nodes).
     if (isSetVirtual(node.type)) {
       const s = incoming(node);
-      return s ? resolveReal(s.node, s.slot, depth + 1) : null;
+      return s
+        ? resolveReal(s.node, s.slot, depth + 1)
+        : {
+            ok: false,
+            reason: `${node.type} #${node.id} has no incoming connection`,
+          };
     }
-    return { node: nodeId, slot };
+    return { ok: true, node: nodeId, slot };
   };
 
-  const drop = new Set<unknown>();
+  const drop = new Map<unknown, string>();
   for (const l of links as any[]) {
     const srcType = byId.get(lsrc(l))?.type;
     if (
@@ -537,12 +588,37 @@ function deVirtualizeGraph(
       (srcType && (isGetVirtual(srcType) || isSetVirtual(srcType)))
     ) {
       const real = resolveReal(lsrc(l), lsrcSlot(l));
-      if (real && !isWiringVirtual(byId.get(real.node as number)?.type)) {
+      if (real.ok && !isWiringVirtual(byId.get(real.node as number)?.type)) {
         setLsrc(l, real.node, real.slot);
       } else {
-        drop.add(lid(l)); // unresolved bus/reroute — drop like a dead link
+        // Unresolved bus/reroute. Dropping it silently is issue #361's actual
+        // harm: the consumer's input simply vanishes and the stripped graph looks
+        // fine. Name the consumer + the reason, and CLEAR the consumer's stale
+        // link reference so the graph stays self-consistent (an orphaned link id
+        // would otherwise resurface later as an anonymous "dangling link").
+        drop.set(
+          lid(l),
+          real.ok
+            ? `the chain resolved to another virtual wiring node, which has no executable equivalent`
+            : real.reason,
+        );
       }
     }
+  }
+  for (const [linkId, reason] of drop) {
+    const l = linkById.get(linkId);
+    if (!l) continue;
+    const consumer = byId.get(ltgt(l));
+    // A dropped link INTO a virtual node is consumed by the resolution itself —
+    // there is no surviving consumer to lose a connection, so nothing to report.
+    if (!consumer || isWiringVirtual(consumer.type)) continue;
+    const slotIdx = ltgtSlot(l) as number;
+    const inputSlot = consumer.inputs?.[slotIdx];
+    if (inputSlot && inputSlot.link === linkId) inputSlot.link = null;
+    const inputName = inputSlot?.name ?? `slot ${slotIdx}`;
+    warnings.push(
+      `Node ${consumer.id} (${consumer.type}) in ${scope}: input "${inputName}" was fed through virtual Get/Set/Reroute wiring that could NOT be resolved to a real producer — ${reason}. That connection is ABSENT from the stripped graph even though the source workflow has it.`,
+    );
   }
   const keptLinks = (links as any[]).filter((l) => {
     if (drop.has(lid(l))) return false;
@@ -558,10 +634,110 @@ function deVirtualizeGraph(
 }
 
 /** Strip wiring virtuals from the top-level graph and every subgraph definition. */
-function deVirtualize(ui: UiWorkflow): void {
-  deVirtualizeGraph(ui.nodes, ui.links as unknown[]);
+function deVirtualize(ui: UiWorkflow, warnings: string[]): void {
+  deVirtualizeGraph(ui.nodes, ui.links as unknown[], warnings, "the top-level graph");
   for (const sg of ui.definitions?.subgraphs ?? []) {
-    deVirtualizeGraph(sg.nodes, sg.links as unknown[]);
+    deVirtualizeGraph(
+      sg.nodes,
+      sg.links as unknown[],
+      warnings,
+      `subgraph "${sg.name ?? sg.id}"`,
+    );
+  }
+}
+
+// ── cg-use-everywhere (UE) broadcast materialization ────────────────────────
+
+/**
+ * cg-use-everywhere ("Anything Everywhere", "Seed Everywhere", "Prompts
+ * Everywhere") wires its consumers with links that DO NOT EXIST in `graph.links`
+ * — the pack's browser JS injects them at queue time. A pure `links`-based
+ * conversion therefore emits a graph whose consumers have NO connection at all,
+ * with nothing said (issue #361: "virtual links from node packs that aren't
+ * ordinary graph links").
+ *
+ * The pack writes its OWN computed broadcast list to `extra.ue_links` on every
+ * graph analysis, so that list — not a re-implementation of the pack's matching
+ * rules — is the ground truth. Materialize each entry as a REAL link before
+ * de-virtualization (so a broadcast whose producer sits behind a Get/Set bus
+ * still resolves), and never overwrite an input that already has a real link
+ * (UE does not fire on a connected input).
+ *
+ * When senders exist but `extra.ue_links` does not, the broadcasts are NOT
+ * recoverable from the saved graph — that is an UNKNOWN, not an absence, so it
+ * is reported rather than quietly treated as "no broadcasts".
+ */
+interface UeLinkEntry {
+  downstream: number;
+  downstream_slot: number;
+  upstream: number;
+  upstream_slot: number;
+  type?: string;
+}
+
+function materializeUeLinks(ui: UiWorkflow, warnings: string[]): void {
+  const nodes = ui.nodes ?? [];
+  const senders = nodes.filter((n) => typeof n.type === "string" && isUeSender(n.type));
+  if (senders.length === 0) return;
+
+  const ueLinks = (ui.extra as Record<string, unknown> | undefined)?.ue_links;
+  if (!Array.isArray(ueLinks) || ueLinks.length === 0) {
+    warnings.push(
+      `${senders.length} cg-use-everywhere broadcast node(s) (${senders
+        .map((s) => `${s.type} #${s.id}`)
+        .join(", ")}) are present, but the graph carries no computed "extra.ue_links" list. ` +
+        `Their broadcast connections are NOT ordinary graph links and CANNOT be recovered from this file, so every input they feed is UNCONNECTED in the stripped graph. ` +
+        `Open the workflow with cg-use-everywhere active and save (or queue) it once so the pack writes extra.ue_links, then strip again.`,
+    );
+    return;
+  }
+
+  const nodesById = new Map(nodes.map((n) => [n.id, n]));
+  const links = (ui.links ??= []);
+  let nextLinkId =
+    Math.max(
+      ui.last_link_id ?? 0,
+      0,
+      ...links.filter((l) => Array.isArray(l)).map((l) => l[0]),
+    ) + 1;
+
+  let added = 0;
+  for (const raw of ueLinks as UeLinkEntry[]) {
+    const dst = nodesById.get(raw?.downstream);
+    const dstInput = dst?.inputs?.[raw?.downstream_slot];
+    if (!dst || !dstInput) {
+      warnings.push(
+        `A cg-use-everywhere broadcast targets node #${raw?.downstream} slot ${raw?.downstream_slot}, which no longer exists in this graph — that broadcast connection is ABSENT from the stripped graph.`,
+      );
+      continue;
+    }
+    if (dstInput.link != null) continue; // real link present — UE would not fire
+    const src = nodesById.get(raw.upstream);
+    const srcOut = src?.outputs?.[raw.upstream_slot];
+    if (!src) {
+      warnings.push(
+        `A cg-use-everywhere broadcast into node ${dst.id} (${dst.type}) input "${
+          dstInput.name ?? raw.downstream_slot
+        }" names producer #${raw.upstream}, which is not in this graph — that connection is ABSENT from the stripped graph.`,
+      );
+      continue;
+    }
+    const id = nextLinkId++;
+    links.push([
+      id,
+      raw.upstream,
+      raw.upstream_slot,
+      raw.downstream,
+      raw.downstream_slot,
+      raw.type ?? dstInput.type ?? "*",
+    ]);
+    dstInput.link = id;
+    if (srcOut) srcOut.links = [...(srcOut.links ?? []), id];
+    added++;
+  }
+  ui.last_link_id = nextLinkId - 1;
+  if (added > 0) {
+    logger.info(`Materialized ${added} cg-use-everywhere broadcast link(s)`);
   }
 }
 
@@ -865,28 +1041,133 @@ function expandSingleComponent(
     }
   }
 
-  // ── 8. Apply proxy widget values ────────────────────────────────────────
-  const proxyWidgets: [string, string][] =
-    (compNode.properties?.proxyWidgets as [string, string][]) ?? [];
+  // ── 8. Apply promoted ("proxy") widget values ───────────────────────────
+  // A subgraph node's own widgets are PROMOTIONS: `properties.proxyWidgets` is an
+  // ordered [innerNodeId, widgetName] list parallel to `widgets_values`, and the
+  // value the user sees/edits on the subgraph node is the LIVE value — the inner
+  // node's own saved widgets_values is whatever it held when the subgraph was
+  // built. Failing to push the promoted value down means the stripped graph
+  // reports (and would run) the STALE inner value: issue #361's "returns wrong
+  // dynamic widget values".
+  //
+  // Two promotion shapes exist and BOTH were silently dropped before:
+  //   • innerNodeId "-1" — the promotion targets a SUBGRAPH INPUT slot (a widget
+  //     exposed on the subgraph boundary). Its value belongs to every inner
+  //     consumer wired from that input slot.
+  //   • a real inner node id — the promotion targets that node's named widget.
+  // The old code resolved neither reliably: it mapped the widget NAME to a
+  // POSITION with findWidgetIndex(), which counts only widgets that appear in the
+  // node's inputs[] and returns null otherwise — so a promoted value either
+  // vanished or (when inputs[] omitted some widgets) landed on the WRONG widget.
+  // Values are now carried BY NAME on `resolvedWidgetValues` and applied by the main
+  // converter against object_info, which is authoritative about widget names.
+  const proxyWidgets: [string, string][] = Array.isArray(compNode.properties?.proxyWidgets)
+    ? (compNode.properties!.proxyWidgets as [string, string][])
+    : [];
   const widgetValues = compNode.widgets_values ?? [];
 
+  /** Record a promoted value on an inner node BY NAME. A nested subgraph
+   *  instance has no object_info of its own, so its promotion is recorded
+   *  positionally in its OWN proxyWidgets order (the next expansion pass reads
+   *  it from there). Returns false when the target cannot carry the value. */
+  const applyPromoted = (target: UiNode, widgetName: string, value: unknown): boolean => {
+    const innerProxy = target.properties?.proxyWidgets;
+    if (Array.isArray(innerProxy) && innerProxy.length > 0) {
+      const idx = (innerProxy as [string, string][]).findIndex(
+        ([, wn]) => wn === widgetName,
+      );
+      if (idx < 0) return false;
+      if (!Array.isArray(target.widgets_values)) target.widgets_values = [];
+      target.widgets_values[idx] = value;
+      return true;
+    }
+    (target.resolvedWidgetValues ??= {})[widgetName] = value;
+    return true;
+  };
+
+  // NOTE: a promoted widget with no entry in widgets_values is NOT a loss and is
+  // deliberately not reported. The subgraph node's widget is a PROXY VIEW of the
+  // inner widget, so "no serialized override" means the inner node's own stored
+  // value is exactly what the subgraph node displayed — which is what we keep.
+  // (Most real subgraph instances serialize an empty widgets_values, so warning
+  // here fired on nearly every subgraph-bearing workflow and would have buried
+  // the genuine losses below.)
   for (let i = 0; i < proxyWidgets.length; i++) {
-    const [innerNodeIdStr, widgetName] = proxyWidgets[i];
+    const entry = proxyWidgets[i];
+    if (!Array.isArray(entry) || entry.length < 2) continue;
+    const [innerNodeIdStr, widgetName] = entry;
     const value = i < widgetValues.length ? widgetValues[i] : undefined;
     if (value === undefined || value === null) continue;
 
-    const innerNodeIdNum = Number(innerNodeIdStr);
-    const remapped = nodeRemap.get(innerNodeIdNum);
-    if (remapped == null) continue;
+    const remapped = nodeRemap.get(Number(innerNodeIdStr));
+    if (remapped != null) {
+      const targetNode = newNodes.find((n) => n.id === remapped);
+      if (targetNode && applyPromoted(targetNode, widgetName, value)) continue;
+      warnings.push(
+        `Component "${sg.name}" (node ${compNode.id}): promoted widget "${widgetName}" = ${JSON.stringify(
+          value,
+        )} could not be applied to inner node ${innerNodeIdStr} — the stripped graph keeps that node's own stored value instead.`,
+      );
+      continue;
+    }
 
-    const targetNode = newNodes.find((n) => n.id === remapped);
-    if (!targetNode) continue;
+    // "-1" (or any id that is not an inner node): the promotion targets a
+    // SUBGRAPH INPUT slot. Push the value to every inner consumer wired from it —
+    // but only when the OUTER slot is unconnected, since a real incoming link
+    // supplies the value at runtime and step 6 already rewired it.
+    const sgInput = sg.inputs?.find((inp) => inp.name === widgetName);
+    const outerSlot = compNode.inputs?.find((inp) => inp.name === widgetName);
+    if (outerSlot?.link != null && outerLinkMap.has(outerSlot.link)) continue;
+    if (!sgInput) {
+      warnings.push(
+        `Component "${sg.name}" (node ${compNode.id}): promoted widget "${widgetName}" = ${JSON.stringify(
+          value,
+        )} does not match any inner node or subgraph input, so it could NOT be applied — the stripped graph uses the inner node's stored value instead.`,
+      );
+      continue;
+    }
+    let applied = 0;
+    for (const innerLinkId of sgInput.linkIds ?? []) {
+      const il = innerLinkById.get(innerLinkId);
+      if (!il || il.origin_id !== inputNodeId) continue;
+      const remappedTarget = nodeRemap.get(il.target_id);
+      const targetNode =
+        remappedTarget != null ? newNodes.find((n) => n.id === remappedTarget) : undefined;
+      if (!targetNode) continue;
+      const slot = targetNode.inputs?.[il.target_slot];
+      const innerName = slot?.widget?.name ?? slot?.name;
+      // The feed came from the virtual input node (-10), which step 5 skips, so
+      // the inner slot's link id points at nothing. Clear it — the promoted value
+      // IS the connection now.
+      if (slot) slot.link = null;
+      if (!innerName || !applyPromoted(targetNode, innerName, value)) continue;
+      applied++;
+    }
+    if (applied === 0) {
+      warnings.push(
+        `Component "${sg.name}" (node ${compNode.id}): promoted widget "${widgetName}" = ${JSON.stringify(
+          value,
+        )} has no inner consumer that could receive it, so it is NOT reflected in the stripped graph.`,
+      );
+    }
+  }
 
-    // Find the widget position in widgets_values by counting widget-type inputs
-    const widgetIdx = findWidgetIndex(targetNode, widgetName);
-    if (widgetIdx != null) {
-      if (!targetNode.widgets_values) targetNode.widgets_values = [];
-      targetNode.widgets_values[widgetIdx] = value;
+  // ── 8b. Unconnected subgraph inputs ─────────────────────────────────────
+  // An inner slot fed from the virtual input node (-10) whose OUTER slot has no
+  // link references a link id that step 5 never materialized. Clear it so the
+  // graph is self-consistent — otherwise it later surfaces as an anonymous
+  // "dangling link", indistinguishable from a real dropped connection.
+  for (const sgInput of sg.inputs ?? []) {
+    const outerSlot = compNode.inputs?.find((inp) => inp.name === sgInput.name);
+    if (outerSlot?.link != null && outerLinkMap.has(outerSlot.link)) continue;
+    for (const innerLinkId of sgInput.linkIds ?? []) {
+      const il = innerLinkById.get(innerLinkId);
+      if (!il || il.origin_id !== inputNodeId) continue;
+      const remappedTarget = nodeRemap.get(il.target_id);
+      const targetNode =
+        remappedTarget != null ? newNodes.find((n) => n.id === remappedTarget) : undefined;
+      const slot = targetNode?.inputs?.[il.target_slot];
+      if (slot && slot.link === linkRemap.get(innerLinkId)) slot.link = null;
     }
   }
 
@@ -923,11 +1204,13 @@ function expandSingleComponent(
           (inp) => inp.link === link[0] && inp.widget,
         );
         if (tgtInput) {
-          const idx = findWidgetIndex(tgtNode, tgtInput.widget!.name);
-          if (idx != null) {
-            if (!tgtNode.widgets_values) tgtNode.widgets_values = [];
-            tgtNode.widgets_values[idx] = primValue;
-          }
+          // Carry the literal BY NAME. (It used to be written positionally via
+          // findWidgetIndex, which counts only the widgets present in inputs[] —
+          // so on a node whose inputs[] omits some widgets the value landed on the
+          // WRONG widget, and when the widget was absent from inputs[] entirely it
+          // was dropped outright. Same #361 wrong-widget-value class as the
+          // promoted-widget path above.)
+          (tgtNode.resolvedWidgetValues ??= {})[tgtInput.widget!.name] = primValue;
           // Clear the link so the main converter treats this as a widget value
           tgtInput.link = null;
         }
@@ -953,31 +1236,6 @@ function expandSingleComponent(
     nextLinkId,
     warnings,
   };
-}
-
-/**
- * Find the widgets_values index for a named widget on a UI node.
- * Counts widget-type inputs (those with a `widget` property) in order.
- */
-function findWidgetIndex(node: UiNode, widgetName: string): number | null {
-  if (!node.inputs) return null;
-
-  // Widget inputs on a UiNode are entries in `inputs[]` that have a `widget` property.
-  // However, not all widgets appear in `inputs[]` — some are only in `widgets_values`.
-  // We count only the widget-inputs that appear in the node's inputs array,
-  // matching by the `widget.name` field.
-  let idx = 0;
-  for (const inp of node.inputs) {
-    if (inp.widget) {
-      if (inp.widget.name === widgetName) return idx;
-      idx++;
-    }
-  }
-
-  // Fallback: if widget is not in inputs[] (pure widget, no link slot),
-  // it may be at a fixed position. Search widgets_values if we can match by name.
-  // For now, return null — the widget is likely at its default value.
-  return null;
 }
 
 // ── API → UI conversion ─────────────────────────────────────────────────────
@@ -1377,15 +1635,19 @@ export function convertUiToApi(
   ui: UiWorkflow,
   objectInfo: ObjectInfo,
 ): ConversionResult {
-  // Clone (don't mutate the caller's workflow), strip the wiring virtuals
-  // (Get/Set bus + Reroute) so the expander + converter only see real links,
-  // then expand component/subgraph nodes.
+  // Clone (don't mutate the caller's workflow), materialize the node-pack
+  // broadcast wiring that isn't in `links` at all (cg-use-everywhere), strip the
+  // wiring virtuals (Get/Set bus + Reroute) so the expander + converter only see
+  // real links, then expand component/subgraph nodes. Every step reports what it
+  // could NOT preserve into the same warnings list (#361).
+  const warnings: string[] = [];
   const cleaned = structuredClone(ui);
-  deVirtualize(cleaned);
+  materializeUeLinks(cleaned, warnings);
+  deVirtualize(cleaned, warnings);
   const { expanded, warnings: expandWarnings } = expandComponents(cleaned);
+  warnings.push(...expandWarnings);
 
   const workflow: WorkflowJSON = {};
-  const warnings: string[] = [...expandWarnings];
 
   // Build link lookup: linkId → LinkInfo
   const linkMap = new Map<number, LinkInfo>();
@@ -1432,39 +1694,82 @@ export function convertUiToApi(
   // sources pass through — the consumer reconnects to the bypassed node's input
   // whose type matches the requested output slot (same index first, then any
   // type match), recursing through chains of bypassed/virtual nodes.
-  const resolveSource = (
-    linkId: number,
-    depth = 0,
-  ): { id: string; slot: number } | null => {
-    if (depth > 100) return null;
+  //
+  // A failure carries WHY. `toggle` means the drop is ComfyUI's own documented
+  // mute/bypass semantics (the queue does the same thing), so it is summarized
+  // once rather than repeated per edge; anything else is a genuine loss the
+  // caller has no other way to notice, so it is reported per input (#361).
+  type SourceResult =
+    | { ok: true; id: string; slot: number }
+    | { ok: false; toggle: boolean; reason: string };
+  const resolveSource = (linkId: number, depth = 0): SourceResult => {
+    if (depth > 100) {
+      return {
+        ok: false,
+        toggle: false,
+        reason: "the upstream chain exceeded 100 hops (a cycle in the wiring)",
+      };
+    }
     const link = linkMap.get(linkId);
-    if (!link) return null;
+    if (!link) {
+      return {
+        ok: false,
+        toggle: false,
+        reason: `link ${linkId} does not exist in the graph (a dangling reference)`,
+      };
+    }
     const src = nodesById.get(link.sourceNodeId);
     if (!src) {
-      return { id: String(link.sourceNodeId), slot: link.sourceSlot };
+      return { ok: true, id: String(link.sourceNodeId), slot: link.sourceSlot };
     }
     // Virtual GetNode: follow the bus to the SetNode that wrote it.
     if (isGetType(src.type)) {
       const bus = busKey(src.widgets_values);
       const setLink = bus != null ? busSource.get(String(bus)) : undefined;
-      return setLink != null ? resolveSource(setLink, depth + 1) : null;
+      return setLink != null
+        ? resolveSource(setLink, depth + 1)
+        : {
+            ok: false,
+            toggle: false,
+            reason: `${src.type} #${src.id} reads bus "${String(
+              bus,
+            )}", which no Set node writes`,
+          };
     }
     // Virtual SetNode passthrough: follow its value input.
     if (isSetType(src.type)) {
       const inp = (src.inputs ?? []).find((i) => i.link != null);
-      return inp?.link != null ? resolveSource(inp.link, depth + 1) : null;
+      return inp?.link != null
+        ? resolveSource(inp.link, depth + 1)
+        : {
+            ok: false,
+            toggle: false,
+            reason: `${src.type} #${src.id} has no incoming connection`,
+          };
     }
     // Reroute passthrough: a virtual node that just forwards its single input to
     // all outputs — follow its input link to the real source.
     if (src.type === "Reroute") {
       const inp = (src.inputs ?? []).find((i) => i.link != null);
-      return inp?.link != null ? resolveSource(inp.link, depth + 1) : null;
+      return inp?.link != null
+        ? resolveSource(inp.link, depth + 1)
+        : {
+            ok: false,
+            toggle: false,
+            reason: `Reroute #${src.id} has no incoming connection`,
+          };
     }
     const mode = src.mode ?? 0;
     if (mode === 0) {
-      return { id: String(link.sourceNodeId), slot: link.sourceSlot };
+      return { ok: true, id: String(link.sourceNodeId), slot: link.sourceSlot };
     }
-    if (mode === 2) return null; // muted: connection dropped
+    if (mode === 2) {
+      return {
+        ok: false,
+        toggle: true,
+        reason: `its source node ${src.id} (${src.type}) is MUTED`,
+      };
+    }
     if (mode === 4) {
       // bypass: find a matching-type input to pass through
       const outType = link.typeName;
@@ -1475,11 +1780,23 @@ export function convertUiToApi(
           (i) => i.link != null && (!outType || i.type === outType),
         );
       }
-      if (!cand || cand.link == null) return null;
+      if (!cand || cand.link == null) {
+        return {
+          ok: false,
+          toggle: true,
+          reason: `its source node ${src.id} (${src.type}) is BYPASSED and has no matching input to pass through`,
+        };
+      }
       return resolveSource(cand.link, depth + 1);
     }
-    return null;
+    return {
+      ok: false,
+      toggle: false,
+      reason: `its source node ${src.id} (${src.type}) has an unrecognized mode ${mode}`,
+    };
   };
+  // Count of connections dropped by mute/bypass — summarized once at the end.
+  let toggleDropped = 0;
 
   for (const node of expanded.nodes) {
     // Muted (2) and bypassed (4) nodes are excluded from the prompt entirely;
@@ -2002,6 +2319,32 @@ export function convertUiToApi(
       }
     }
 
+    // Widget values resolved BY NAME during subgraph expansion — a promoted
+    // ("proxy") widget value from the subgraph node, or a virtual PrimitiveNode
+    // literal baked onto its consumer. These are the LIVE values the user sees on
+    // the subgraph node, so they override the inner node's own stored
+    // widgets_values (which is whatever it held when the subgraph was built).
+    // Routed through the same combo choke-point as every other widget assignment.
+    const resolved = node.resolvedWidgetValues;
+    if (resolved) {
+      for (const [name, val] of Object.entries(resolved)) {
+        if (!widgetNames.includes(name)) {
+          warnings.push(
+            `Node ${nodeId} (${classType}): a promoted/primitive-supplied value for "${name}" could not be applied — the connected server's definition of ${classType} has no widget by that name, so the node keeps its own stored value.`,
+          );
+          continue;
+        }
+        inputs[name] = validateComboWidgetValue(
+          name,
+          val,
+          def,
+          classType,
+          nodeId,
+          warnings,
+        );
+      }
+    }
+
     // Fill any required input not covered by widgets_values or a link with its
     // object_info default, so /prompt validation doesn't reject on a missing
     // required input (e.g. a node version added a required widget the saved graph
@@ -2073,8 +2416,17 @@ export function convertUiToApi(
           }
           continue;
         }
-        const resolved = resolveSource(input.link);
-        if (resolved) inputs[input.name] = [resolved.id, resolved.slot];
+        const resolvedSrc = resolveSource(input.link);
+        if (resolvedSrc.ok) {
+          inputs[input.name] = [resolvedSrc.id, resolvedSrc.slot];
+        } else if (resolvedSrc.toggle) {
+          // ComfyUI's own queue drops these too — count, don't spam.
+          toggleDropped++;
+        } else {
+          warnings.push(
+            `Node ${nodeId} (${classType}): input "${input.name}" is WIRED in the source workflow but its connection could not be resolved — ${resolvedSrc.reason}. The input is ABSENT from the stripped graph.`,
+          );
+        }
       }
     }
 
@@ -2098,6 +2450,9 @@ export function convertUiToApi(
       // whether it's an un-parented literal OR a link ref. Keeping a link ref here
       // (the previous behavior) still emitted an orphan the server would reject.
       if (!(parent in inputs)) {
+        warnings.push(
+          `Node ${nodeId} (${classType}): the nested input "${key}" was dropped — its dynamic-combo parent "${parent}" has no value in the stripped graph, so there is no selected option the leaf could belong to (ComfyUI rejects an unknown nested input).`,
+        );
         delete inputs[key];
         continue;
       }
@@ -2205,6 +2560,12 @@ export function convertUiToApi(
             warnings.push(
               `Node ${nodeId} (${classType}): the linked nested input "${key}" was dropped — its dynamic parent "${parent}" is fed by a runtime link (resolved option unknown) and not every option defines "${leaf}", so keeping the connection could orphan it under an option that omits the leaf. "${leaf}" will use the resolved option's default instead of the wired link.`,
             );
+          } else {
+            warnings.push(
+              `Node ${nodeId} (${classType}): the nested value "${key}" = ${JSON.stringify(
+                leafVal,
+              )} was dropped — its dynamic parent "${parent}" is fed by a runtime link, so the selected option is unknowable here and this value is not valid under every option it could resolve to. "${leaf}" will use the resolved option's default instead.`,
+            );
           }
           delete inputs[key];
         }
@@ -2217,6 +2578,11 @@ export function convertUiToApi(
         // it whether it's a literal OR a real-link ref (both orphan under the final
         // option; a link ref is not exempt — the previous `continue` above leaked
         // exactly this case).
+        warnings.push(
+          `Node ${nodeId} (${classType}): the nested input "${key}" was dropped — the selected option "${String(
+            inputs[parent],
+          )}" of "${parent}" does not define it, so it would be an unknown input (this happens when the parent selection changed, e.g. it is supplied by a Primitive node).`,
+        );
         delete inputs[key];
         continue;
       }
@@ -2336,6 +2702,12 @@ export function convertUiToApi(
   }
   if (droppedMismatch > 0) {
     warnings.push(`Dropped ${droppedMismatch} type-mismatched link(s).`);
+  }
+
+  if (toggleDropped > 0) {
+    warnings.push(
+      `${toggleDropped} input connection(s) were dropped because their source node is muted, or bypassed with no matching pass-through input. This mirrors what ComfyUI's queue does with the same graph, so the stripped graph is faithful — but those inputs are unconnected in it.`,
+    );
   }
 
   const nodeCount = Object.keys(workflow).length;

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -220,10 +220,15 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
               type: "text",
               text:
                 `Stripped to ${Object.keys(workflow).length} nodes` +
-                (warnings.length ? ` · ${warnings.length} warning(s)` : "") +
+                (warnings.length ? ` · ⚠ ${warnings.length} conversion note(s)` : "") +
                 `\nNode types: ${summary}` +
+                // #361: these are the places the stripped graph does NOT match
+                // the source (a dropped virtual link, a substituted widget
+                // value). Label them as differences, not as background noise.
                 (warnings.length
-                  ? `\nWarnings:\n${warnings.map((w) => `- ${w}`).join("\n")}`
+                  ? `\nThe stripped graph DIFFERS from the source workflow where listed below — read these before running or rebuilding from it:\n${warnings
+                      .map((w) => `- ${w}`)
+                      .join("\n")}`
                   : ""),
             },
             { type: "text", text: JSON.stringify(workflow, null, 2) },


### PR DESCRIPTION
`panel_strip_workflow` / `strip_workflow` could return a graph that **looks fine and renders differently**: promoted subgraph widget values were wrong, node-pack virtual links were missing, and nothing said so. A strip that silently loses a link or misreports a widget value gives the caller no signal anything was lost — that is the actual harm in #361.

## Root cause 1 — promoted subgraph widget values were resolved POSITIONALLY

`expandSingleComponent` mapped a promoted ("proxy") widget NAME to an index by counting the `inputs[]` entries that carry a `widget` marker. That index equals the `widgets_values` index only when **every** widget appears in `inputs[]`.

- a widget absent from `inputs[]` → `findWidgetIndex` returned `null` → the value was **dropped**;
- a partially-listed node → the value landed on the **wrong widget**;
- a promotion of a **subgraph INPUT slot** (proxy id `"-1"` — the shape ComfyUI actually emits; the shipped `z-image-base` pack's `width`/`height` are exactly this) resolved to no inner node at all, so the stripped graph reported the inner node's **stale stored value**.

Reproduced before the fix: a subgraph node displaying `width = 1920` stripped to `width: 512`, with zero warnings.

Promoted values are now carried **by name** and applied by the converter against `object_info` — which is authoritative about widget names — through the same combo choke-point as every other widget assignment, so #407/#504 asset preservation still holds. The same positional resolver also fed the in-subgraph `PrimitiveNode` bake; that is by name now too.

## Root cause 2 — node-pack virtual links

Two kinds, both silent:

- **Get/Set + Reroute** that could not be resolved were deleted with no warning, leaving the consumer's stale link id behind. And a link rewritten to a **subgraph instance** was never re-homed on that component's `outputs[].links`, which is the list the expander rewires consumers from — so `component → Set → Get → consumer` was pruned when the component expanded away.
- **cg-use-everywhere** broadcasts are not in `graph.links` at all (the pack's JS injects them at queue time), so every input they feed came out unconnected. They are now materialized from the pack's own computed `extra.ue_links` — its ground truth, not a re-implementation of its matching rules — before de-virtualization, so a broadcast whose producer sits behind a Get/Set bus resolves too. Runs per-graph, including subgraph definitions.

## What is reported when something can't be preserved

Nothing is ever guessed. Each of these names the node, the input, and the reason:

- an unresolved bus/Reroute — which consumer, which input, and *why* (bus with no writer / Set with no feed / dead Reroute / cycle);
- two Set nodes racing on one bus (last wins, so the other producer is unreachable);
- UE senders present with **no** `extra.ue_links` — unrecoverable from the file, with the remedy (save/queue once with the pack active);
- a stale UE record: a sender that is gone, a producer that is gone, or an output slot the producer provably no longer has;
- an input wired in the source whose connection could not be resolved, a connection whose producer left the graph, and a subgraph input claiming a link that doesn't exist;
- a promoted widget the server's node definition doesn't declare, or that no inner consumer can receive;
- the dotted dynamic-combo leaves that get dropped.

A stale UE record is never materialized, because a **fabricated** connection is worse than a dropped one — a missing link renders as an obviously broken graph, a fabricated one renders as a plausible graph that is silently wrong and looks deliberate. The whole record is validated against the sender's live feed (detached / rewired / unattributable / unverifiable), with false-positive guards that each have their own test, since wrongly declaring a *current* record stale would drop a live connection: both sides are normalized past Reroute/Get/Set before comparison; a sender that is its own producer (Seed Everywhere) needs no feed; and any matching feed on a multi-input sender (Prompts Everywhere, Anything Everywhere3) counts.

One residual is disclosed rather than removed. A `ue_links` record carries no field naming *which input of the sender* a broadcast came through, so on a sender with several distinct producers the channel→target association cannot be verified without re-implementing the pack's own routing rules. Refusing those records would drop the broadcasts of every Prompts Everywhere / Anything Everywhere3 graph, permanently and with no remedy — so they are materialized and the sender gets one caveat naming exactly what could not be checked. Unverifiable and undisclosed are different failures; only the second is this issue.

`panel_flatten_workflow` shares this path and got the same treatment: it previously materialized every record with no validation at all.

A single rule underpins the rest: **a record's producer is resolved past virtual wiring once**, and every question below — is this the subgraph boundary, does the node exist, does that output slot exist, is the sender still fed by it, what do we wire from — is asked about that node. Resolving it independently per site is what left one check comparing a raw virtual id while its neighbour compared a normalized one, and each such pair cost a live edge. For the same reason both tools derive every producer question from one `producerConfirmed(node, slot)` predicate, so the channel caveat can never again call a producer "confirmed" that the materializer would refuse.

Mute/bypass drops mirror ComfyUI's own queue semantics, so they are summarized once instead of per edge. Both tools now label these as places the stripped graph **DIFFERS from the source**, not as generic "warnings".

**Deliberately NOT reported**, because each would invent a loss and bury the real ones:

- a promoted widget with no serialized value — the subgraph node's widget is a proxy *view* of the inner widget, so "no override" means the inner value is exactly what was displayed;
- an **empty** `extra.ue_links` — the pack analysed the graph and recorded zero broadcasts. That is an *answer*, not an unknown. Only an absent/non-array list is warned about (and an empty list is not a licence to delete the senders either);
- unresolved wiring inside a subgraph definition the workflow never instantiates — nothing in it reaches the result.

Verified across all 98 workflow graphs in the repo, through **both** tools: zero warnings from either, and no duplicate link ids after flattening any of them.

## Not touched

The shared `resolveWorkflowInput` / path resolution reworked in #787 is untouched — the only `panel-tools.ts` change is the result text.

## Tests

A **shared adversarial corpus** (`ue-virtual-wiring-corpus.test.ts`) is the main structural addition: 28 virtual-wiring shapes run against **both** tools from the same graph builders, with per-tool expectations stated separately wherever they legitimately differ (the converter emits an executable prompt and may drop; the flattener edits the canvas graph in place and may only decline to add).

The two tools deliberately keep **separate** validators — different link representations, different invariants — so the coupling lives in the corpus instead. Duplicated implementations are not what makes this defect family recur; divergence is. Three invariants enforce that:

- a wiring difference between the tools requires a written justification to pass;
- no shape may yield duplicate link ids from the flattener;
- two instances of one subgraph definition may never share or cross-wire a broadcast.

Plus 48 targeted tests in the two per-tool files. **Every test was mutation-verified** — the fix broken, the test confirmed to fail — including the guards against *over*-refusing, since wrongly declaring something stale drops a live connection, and reproducing each original defect faithfully rather than a lookalike that would fail for the wrong reason.

Full suite (4369) green against the tree merged with `main`. Both tools swept over all 98 workflow graphs in the repo after every round: zero warnings from either, no duplicate link ids. That sweep is what keeps the new disclosure from becoming noise.

## Review

Eighteen rounds of adversarial `codex`/gpt-5.6-terra review plus independent gates, the last two returning only P2s. **29 real defects** found and fixed, including five regressions introduced by earlier rounds of the fix itself:

- an outer promotion clobbering a nested instance's name-keyed values (r3);
- `if (raw.controller == null) return "ok"` folding *could-not-determine* into *determined-current* — the pattern this repo bans (#796), with the exact fabrication consequence the preceding commit set out to remove (r6);
- the new staleness check refusing *live* broadcasts, because pass-1's freshly rewired links were not indexed where the check looked (r11);
- a name-prefix widening that let a foreign class inherit a verification-skipping exemption (r14);
- unifying producer resolution, which left one attribution path reading the raw field — so a record was materialized correctly and then falsely reported as missing (r18).

Each round's findings are described in its own commit message.

### One thing worth carrying forward

An earlier revision documented a branch in the flattener as *defensive and unreachable*, and said in both the source and the test that no mutation would kill it. It was reachable. The construction needed an id that was real **elsewhere** in the graph rather than real for that input — and an adversarial reviewer found it in minutes.

*"I could not construct an input that reaches this"* is a statement about the author's imagination, not a property of the code. It should not be written into a source comment as though it were the latter; the next person reads it as a guarantee and stops looking. The claim is gone, and with it the suppression that made the branch necessary.

Closes #361
