### PR TITLE
fix(panel_ask): make a validated response durable across a tool timeout (#486)

### DIFF
--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -765,6 +765,22 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     const block = src.slice(start, src.indexOf("\n      return;", start));
     expect(block, "rewind must retire ask state").toContain("AskAnswers.closeAsks(");
 
+    // A PROVIDER SWITCH is a boundary for questions even though #468 deliberately
+    // re-addresses renders across it: a finished render is useful to whoever is
+    // on the tab now, an answer to a card the new conversation never put up is
+    // not. Both switch paths must retire the asks.
+    for (const guard of [
+      "if (providerSwitched) flushRunCompletions(panelTab);",
+      "if (prev !== reqBackend) flushRunCompletions(panelTab);",
+    ]) {
+      const at = src.indexOf(guard);
+      expect(at, `provider-switch site not found: ${guard}`).toBeGreaterThan(-1);
+      expect(
+        src.slice(at, at + 900),
+        `${guard} must retire ask state`,
+      ).toContain("AskAnswers.closeAsks(panelTab)");
+    }
+
     // The unsend hook must actually be wired, or closeAsks silently degrades to
     // "leave the stale copy queued".
     expect(src).toContain("AskAnswers.setRevoker(");

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -3,6 +3,7 @@ import {
   AskAnswers,
   askFingerprint,
   ASK_RECOVER_MAX_AGE_MS,
+  PANEL_ASK_ID_PREFIX,
   type AskAnswerEvent,
 } from "../../orchestrator/ask-answer-journal.js";
 
@@ -47,7 +48,7 @@ beforeEach(() => {
 
 describe("ask-answer journal — an answer survives its tool call (#486)", () => {
   it("journals an answer that arrives with NO handler waiting, and arms it for delivery", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     const entries = AskAnswers.entriesFor(TAB);
     expect(entries).toHaveLength(1);
     expect(entries[0].answer).toBe("dpmpp_2m");
@@ -58,7 +59,7 @@ describe("ask-answer journal — an answer survives its tool call (#486)", () =>
   });
 
   it("recovers it for a re-ask of the IDENTICAL question", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
     expect(rec.status).toBe("recovered");
     if (rec.status !== "recovered") return;
@@ -67,7 +68,7 @@ describe("ask-answer journal — an answer survives its tool call (#486)", () =>
   });
 
   it("hands the SAME answer over only once", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     const first = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
     expect(first.status).toBe("recovered");
     if (first.status !== "recovered") return;
@@ -79,14 +80,14 @@ describe("ask-answer journal — an answer survives its tool call (#486)", () =>
     // The ordinary success path: the handler got the answer and returned it. It
     // may have gone into a dead request (unobservable), so it stays journaled —
     // but it must not ALSO be announced to the agent, or every ask would double.
-    AskAnswers.openAsk("ask-1", {
+    AskAnswers.openAsk("pa-ask-1", {
       tabId: TAB,
       fingerprint: askFingerprint(SAMPLER),
       question: SAMPLER.question,
     });
-    AskAnswers.record("ask-1", "euler", { tabId: TAB });
-    AskAnswers.markReturned("ask-1");
-    AskAnswers.closeAsk("ask-1");
+    AskAnswers.record("pa-ask-1", "euler", { tabId: TAB });
+    AskAnswers.markReturned("pa-ask-1");
+    AskAnswers.closeAsk("pa-ask-1");
     expect(AskAnswers.hasOutstanding()).toBe(false);
     expect(AskAnswers.orphansFor(TAB)).toHaveLength(0);
     expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("recovered");
@@ -95,7 +96,7 @@ describe("ask-answer journal — an answer survives its tool call (#486)", () =>
 
 describe("ask-answer journal — cross-question misattribution guard (#486)", () => {
   it("a journaled answer NEVER satisfies a different question", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     const rec = AskAnswers.recover(TAB, askFingerprint(SCHEDULER));
     // Not "recovered", and not silently "none" either: the answer exists and is
     // handed back for DISCLOSURE, quoted with its own question.
@@ -153,12 +154,12 @@ describe("ask-answer journal — cross-question misattribution guard (#486)", ()
   });
 
   it("an answer given on ANOTHER tab never satisfies this tab's question", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m", { tabId: OTHER_TAB });
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m", { tabId: OTHER_TAB });
     expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("none");
   });
 
   it("an answer too old to be presented as fresh is disclosed, never returned", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     const entry = AskAnswers.entriesFor(TAB)[0];
     entry.answeredAt = Date.now() - ASK_RECOVER_MAX_AGE_MS - 1000;
     const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
@@ -168,7 +169,7 @@ describe("ask-answer journal — cross-question misattribution guard (#486)", ()
   });
 
   it("a replaced conversation revokes the licence to satisfy a re-ask, but keeps the answer", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     AskAnswers.closeAsks(TAB); // New chat / resume of a historical session
     const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
     expect(rec.status).toBe("unattributed");
@@ -180,7 +181,7 @@ describe("ask-answer journal — cross-question misattribution guard (#486)", ()
   });
 
   it("an answer whose ask id this session never opened is UNATTRIBUTED, never matched", () => {
-    AskAnswers.record("never-opened", "dpmpp_2m", { tabId: TAB });
+    AskAnswers.record("pa-never-opened", "dpmpp_2m", { tabId: TAB });
     const entry = AskAnswers.entriesFor(TAB)[0];
     expect(entry.correlation.status).toBe("foreign");
     expect(entry.fingerprint).toBeNull();
@@ -202,7 +203,7 @@ describe("ask-answer journal — durable delivery (#486, mirroring #468)", () =>
   }
 
   it("delivers the answer WITH the question that it answers", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     const [ev] = drain(TAB);
     expect(ev.ask_answer).toBe("dpmpp_2m");
     expect(ev.ask_question).toBe(SAMPLER.question);
@@ -210,7 +211,7 @@ describe("ask-answer journal — durable delivery (#486, mirroring #468)", () =>
   });
 
   it("an answer handed to an agent that then DIES comes back and is replayed", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     const token = AskAnswers.entriesFor(TAB)[0].token;
     drain(TAB);
     expect(AskAnswers.pending(TAB)).toHaveLength(0);
@@ -223,7 +224,7 @@ describe("ask-answer journal — durable delivery (#486, mirroring #468)", () =>
   });
 
   it("teardown handbacks are UNBOUNDED; only turns that carried it are counted", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     const token = AskAnswers.entriesFor(TAB)[0].token;
     for (let i = 0; i < 10; i += 1) {
       drain(TAB);
@@ -240,7 +241,7 @@ describe("ask-answer journal — durable delivery (#486, mirroring #468)", () =>
   });
 
   it("the turn that carried it ending clears the push but keeps it recoverable", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     const token = AskAnswers.entriesFor(TAB)[0].token;
     drain(TAB);
     AskAnswers.ack(token);
@@ -250,14 +251,14 @@ describe("ask-answer journal — durable delivery (#486, mirroring #468)", () =>
   });
 
   it("a tab that goes away drops its answers and its tickets", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     AskAnswers.forget(TAB);
     expect(AskAnswers.entriesFor(TAB)).toHaveLength(0);
     expect(AskAnswers.hasOutstanding()).toBe(false);
   });
 
   it("a tab-id migration re-addresses the answer instead of stranding it", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     AskAnswers.moveKey(TAB, OTHER_TAB);
     expect(AskAnswers.entriesFor(TAB)).toHaveLength(0);
     expect(AskAnswers.pending(OTHER_TAB)).toHaveLength(1);
@@ -268,19 +269,19 @@ describe("ask-answer journal — durable delivery (#486, mirroring #468)", () =>
     const flushed: string[] = [];
     AskAnswers.setFlusher((k) => flushed.push(k));
     // Landed with no handler waiting → pushed immediately.
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     expect(flushed).toContain(TAB);
     flushed.length = 0;
     // …and an answer that lands WHILE the handler is running is that handler's to
     // return, so it is not announced until the handler unwinds without it.
-    AskAnswers.openAsk("ask-2", {
+    AskAnswers.openAsk("pa-ask-2", {
       tabId: TAB,
       fingerprint: askFingerprint(SCHEDULER),
       question: SCHEDULER.question,
     });
-    AskAnswers.record("ask-2", "karras", { tabId: TAB });
+    AskAnswers.record("pa-ask-2", "karras", { tabId: TAB });
     expect(flushed).toHaveLength(0);
-    AskAnswers.closeAsk("ask-2");
+    AskAnswers.closeAsk("pa-ask-2");
     expect(flushed).toContain(TAB);
   });
 });
@@ -290,7 +291,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     // 16 answers fit per tab; the 17th evicts one. Every one of these reached
     // nobody, so the eviction is a real loss and must be reported.
     for (let i = 0; i < 20; i += 1) {
-      openAndAnswer(`ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
+      openAndAnswer(`pa-ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
     }
     expect(AskAnswers.droppedFor(TAB)).toBeGreaterThan(0);
     const seen: AskAnswerEvent[] = [];
@@ -303,7 +304,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
 
   it("an eviction disclosure is NOT spent by a hand-off that is later given back", () => {
     for (let i = 0; i < 20; i += 1) {
-      openAndAnswer(`ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
+      openAndAnswer(`pa-ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
     }
     const carrier = AskAnswers.pending(TAB)[0];
     AskAnswers.deliverPending(TAB, () => true);
@@ -322,14 +323,14 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     openAndAnswer("orphan", SAMPLER, "dpmpp_2m");
     for (let i = 0; i < 30; i += 1) {
       const ask = { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] };
-      AskAnswers.openAsk(`ret-${i}`, {
+      AskAnswers.openAsk(`pa-ret-${i}`, {
         tabId: TAB,
         fingerprint: askFingerprint(ask),
         question: ask.question,
       });
-      AskAnswers.record(`ret-${i}`, `A${i}`, { tabId: TAB });
-      AskAnswers.markReturned(`ret-${i}`);
-      AskAnswers.closeAsk(`ret-${i}`);
+      AskAnswers.record(`pa-ret-${i}`, `A${i}`, { tabId: TAB });
+      AskAnswers.markReturned(`pa-ret-${i}`);
+      AskAnswers.closeAsk(`pa-ret-${i}`);
     }
     expect(AskAnswers.droppedFor(TAB)).toBe(0);
     // The orphan is still there — it was never a candidate for a quiet eviction.
@@ -340,45 +341,45 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     // `tracks()` is what the bridge sink filters on. If it were answered from the
     // (bounded) ticket map, an eviction would make a validated answer vanish —
     // a bounded store protecting against a bounded store.
-    AskAnswers.openAsk("ask-old", {
+    AskAnswers.openAsk("pa-ask-old", {
       tabId: TAB,
       fingerprint: askFingerprint(SAMPLER),
       question: SAMPLER.question,
     });
-    AskAnswers.closeAsk("ask-old"); // its tool call died; the ticket is evictable
+    AskAnswers.closeAsk("pa-ask-old"); // its tool call died; the ticket is evictable
     for (let i = 0; i < 200; i += 1) {
       const ask = { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] };
-      AskAnswers.openAsk(`ask-${i}`, {
+      AskAnswers.openAsk(`pa-ask-${i}`, {
         tabId: TAB,
         fingerprint: askFingerprint(ask),
         question: ask.question,
       });
-      AskAnswers.closeAsk(`ask-${i}`);
+      AskAnswers.closeAsk(`pa-ask-${i}`);
     }
-    expect(AskAnswers.ticketFor("ask-old")).toBeUndefined(); // ticket trimmed away
-    expect(AskAnswers.tracks("ask-old")).toBe(true); // …but still one of ours
-    AskAnswers.record("ask-old", "dpmpp_2m", { tabId: TAB });
-    const entry = AskAnswers.entriesFor(TAB).find((e) => e.askId === "ask-old");
+    expect(AskAnswers.ticketFor("pa-ask-old")).toBeUndefined(); // ticket trimmed away
+    expect(AskAnswers.tracks("pa-ask-old")).toBe(true); // …but still one of ours
+    AskAnswers.record("pa-ask-old", "dpmpp_2m", { tabId: TAB });
+    const entry = AskAnswers.entriesFor(TAB).find((e) => e.askId === "pa-ask-old");
     expect(entry?.answer).toBe("dpmpp_2m");
     expect(entry?.correlation.status).toBe("foreign"); // weakened, not lost
   });
 
   it("the same answer observed twice collapses to one entry (identity, not suppression)", () => {
     // The grace poll and the bridge sink can both see one card's reply.
-    AskAnswers.openAsk("ask-1", {
+    AskAnswers.openAsk("pa-ask-1", {
       tabId: TAB,
       fingerprint: askFingerprint(SAMPLER),
       question: SAMPLER.question,
     });
-    const a = AskAnswers.record("ask-1", "dpmpp_2m", { tabId: TAB });
-    const b = AskAnswers.record("ask-1", "dpmpp_2m", { tabId: TAB });
+    const a = AskAnswers.record("pa-ask-1", "dpmpp_2m", { tabId: TAB });
+    const b = AskAnswers.record("pa-ask-1", "dpmpp_2m", { tabId: TAB });
     expect(b.token).toBe(a.token);
     expect(AskAnswers.entriesFor(TAB)).toHaveLength(1);
   });
 
   it("two DIFFERENT answers are never merged, however alike", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
-    openAndAnswer("ask-2", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-2", SAMPLER, "dpmpp_2m");
     expect(AskAnswers.entriesFor(TAB)).toHaveLength(2);
   });
 
@@ -388,7 +389,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
   // answer was recovered. The debt belongs to the TAB, not to its carrier.
   it("a recovery that consumes the disclosure's carrier re-homes the debt", () => {
     for (let i = 0; i < 20; i += 1) {
-      openAndAnswer(`ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
+      openAndAnswer(`pa-ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
     }
     const owed = AskAnswers.droppedFor(TAB);
     expect(owed).toBeGreaterThan(0);
@@ -402,20 +403,20 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
   // recovery window. "It went into a ToolResult" is exactly the thing that is not
   // provable here — that IS #486 — so nothing may be dropped on that basis.
   it("nothing is ever expired by age — only recovery, eviction or a gone tab remove an answer", () => {
-    AskAnswers.openAsk("ask-1", {
+    AskAnswers.openAsk("pa-ask-1", {
       tabId: TAB,
       fingerprint: askFingerprint(SAMPLER),
       question: SAMPLER.question,
     });
-    AskAnswers.record("ask-1", "dpmpp_2m", { tabId: TAB });
-    AskAnswers.markReturned("ask-1");
-    AskAnswers.closeAsk("ask-1");
+    AskAnswers.record("pa-ask-1", "dpmpp_2m", { tabId: TAB });
+    AskAnswers.markReturned("pa-ask-1");
+    AskAnswers.closeAsk("pa-ask-1");
     const entry = AskAnswers.entriesFor(TAB)[0];
     entry.answeredAt = Date.now() - ASK_RECOVER_MAX_AGE_MS * 10;
     // Any number of later journal operations must not sweep it away.
-    openAndAnswer("ask-2", SCHEDULER, "karras");
+    openAndAnswer("pa-ask-2", SCHEDULER, "karras");
     AskAnswers.recover(TAB, askFingerprint(SCHEDULER));
-    expect(AskAnswers.entriesFor(TAB).some((e) => e.askId === "ask-1")).toBe(true);
+    expect(AskAnswers.entriesFor(TAB).some((e) => e.askId === "pa-ask-1")).toBe(true);
     // Too old to be presented as a fresh decision, but still REPORTABLE.
     const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
     expect(rec.status).toBe("unattributed");
@@ -428,15 +429,15 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
   // same tab, and PUSHED into the replacement conversation — an unsolicited turn
   // about a decision that conversation never asked for.
   it("an answer to a card whose conversation was replaced is never announced to the new one", () => {
-    AskAnswers.openAsk("ask-1", {
+    AskAnswers.openAsk("pa-ask-1", {
       tabId: TAB,
       fingerprint: askFingerprint(SAMPLER),
       question: SAMPLER.question,
     });
-    AskAnswers.closeAsk("ask-1");
+    AskAnswers.closeAsk("pa-ask-1");
     AskAnswers.closeAsks(TAB); // New chat / resume of a historical session
     // The user clicks the still-rendered old card.
-    const entry = AskAnswers.record("ask-1", "dpmpp_2m", { tabId: TAB });
+    const entry = AskAnswers.record("pa-ask-1", "dpmpp_2m", { tabId: TAB });
     expect(entry.delivery).toBe("none");
     expect(AskAnswers.pending(TAB)).toHaveLength(0);
     expect(AskAnswers.hasOutstanding()).toBe(false);
@@ -449,7 +450,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
   });
 
   it("an already-journaled answer stops being pushed when its conversation is replaced", () => {
-    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     expect(AskAnswers.pending(TAB)).toHaveLength(1);
     AskAnswers.closeAsks(TAB);
     expect(AskAnswers.pending(TAB)).toHaveLength(0);
@@ -457,21 +458,21 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
   });
 
   it("a late answer for a tab that is GONE is never armed for a doomed push", () => {
-    AskAnswers.openAsk("ask-1", {
+    AskAnswers.openAsk("pa-ask-1", {
       tabId: TAB,
       fingerprint: askFingerprint(SAMPLER),
       question: SAMPLER.question,
     });
-    AskAnswers.closeAsk("ask-1");
+    AskAnswers.closeAsk("pa-ask-1");
     AskAnswers.forget(TAB); // workflow switched away / tab closed
-    const entry = AskAnswers.record("ask-1", "dpmpp_2m", { tabId: TAB });
+    const entry = AskAnswers.record("pa-ask-1", "dpmpp_2m", { tabId: TAB });
     expect(entry.delivery).toBe("none");
     expect(AskAnswers.hasOutstanding()).toBe(false);
   });
 
   it("takeDropped reports the un-carried debt once, and leaves entry-carried debt to its push", () => {
     for (let i = 0; i < 20; i += 1) {
-      openAndAnswer(`ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
+      openAndAnswer(`pa-ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
     }
     // Move all the debt into the side map by consuming every carrier.
     for (const e of AskAnswers.entriesFor(TAB).filter((x) => (x.disclose ?? 0) > 0)) {
@@ -489,11 +490,101 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(AskAnswers.takeDropped(TAB)).toBe(0); // said once
   });
 
+  // codex round 2, P0: ownership of an ask id used to be answered from a BOUNDED
+  // set of remembered ids, so an eviction made the bridge's sink ignore — and
+  // therefore silently drop — a validated answer. It is now syntactic: a
+  // property of the id itself, which cannot expire, evict, or be raced.
+  it("ownership of an ask id is syntactic, so no bound can make an answer vanish", () => {
+    expect(AskAnswers.tracks(`${PANEL_ASK_ID_PREFIX}anything-at-all`)).toBe(true);
+    // Never opened, never remembered, journal completely empty — still ours.
+    AskAnswers.reset();
+    expect(AskAnswers.tracks(`${PANEL_ASK_ID_PREFIX}${"x".repeat(40)}`)).toBe(true);
+    // A confirm / 18+ consent / secret card's plain id is NOT ours: those cards
+    // have deliberately non-recoverable paths (a recovered "Yes, go ahead" must
+    // never authorise a different destructive operation).
+    expect(AskAnswers.tracks("b6f0a2c8-0000-4000-8000-000000000000")).toBe(false);
+  });
+
+  // codex round 2, P0: reopening an ask id overwrote the ticket's question and
+  // fingerprint, so the FIRST card's late click would be frozen with the SECOND
+  // question's identity and could be recovered as its answer.
+  it("a REUSED ask id can never satisfy a question — either question", () => {
+    AskAnswers.openAsk("pa-dup", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-dup");
+    // The same id opened again, now for a DIFFERENT question.
+    AskAnswers.openAsk("pa-dup", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SCHEDULER),
+      question: SCHEDULER.question,
+    });
+    AskAnswers.closeAsk("pa-dup");
+    // The first card is clicked. Nothing on the wire says which card it was.
+    const entry = AskAnswers.record("pa-dup", "dpmpp_2m", { tabId: TAB });
+    expect(entry.correlation.status).toBe("foreign");
+    expect(entry.fingerprint).toBeNull();
+    expect(AskAnswers.recover(TAB, askFingerprint(SCHEDULER)).status).toBe("unattributed");
+    expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("unattributed");
+    // …but it is still delivered, labelled UNDETERMINED.
+    expect(entry.delivery).toBe("pending");
+  });
+
+  // codex round 2, P0: the eviction DEBT is destroyed by a teardown exactly as an
+  // entry is, so a restart while one is owed turns a disclosed loss back into a
+  // silent one. It must hold the restart gate and appear in the exit disclosure.
+  it("an owed eviction disclosure keeps the journal 'outstanding' and is named on exit", () => {
+    for (let i = 0; i < 20; i += 1) {
+      openAndAnswer(`pa-ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
+    }
+    expect(AskAnswers.droppedFor(TAB)).toBeGreaterThan(0);
+    // Every surviving answer is recovered away (each consume re-homes the debt),
+    // so all that is left of the eviction is a COUNTER with no carrier.
+    for (const e of AskAnswers.entriesFor(TAB)) AskAnswers.consume(e.token);
+    expect(AskAnswers.entriesFor(TAB)).toHaveLength(0);
+    expect(AskAnswers.hasOutstanding()).toBe(true); // the debt still holds the gate
+    const debt = AskAnswers.outstandingDebt();
+    expect(debt.some((d) => d.key === TAB && d.count > 0)).toBe(true);
+  });
+
+  it("a debt that a turn actually CARRIED is spent, and stops holding the gate", () => {
+    for (let i = 0; i < 20; i += 1) {
+      openAndAnswer(`pa-ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
+    }
+    expect(AskAnswers.droppedFor(TAB)).toBeGreaterThan(0);
+    AskAnswers.deliverPending(TAB, () => true);
+    for (const e of AskAnswers.entriesFor(TAB)) AskAnswers.ack(e.token);
+    expect(AskAnswers.hasOutstanding()).toBe(false);
+    expect(AskAnswers.outstandingDebt()).toHaveLength(0);
+  });
+
+  // codex round 2, P0: a RETURNED answer inside the recovery window is still the
+  // only copy of a decision that may never have reached the model, so a fatal
+  // exit must name it even though a restart does not wait for it.
+  it("a recently-returned answer is named by the exit disclosure, but does not block a restart", () => {
+    AskAnswers.openAsk("pa-ask-1", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.record("pa-ask-1", "dpmpp_2m", { tabId: TAB });
+    AskAnswers.markReturned("pa-ask-1");
+    AskAnswers.closeAsk("pa-ask-1");
+    expect(AskAnswers.hasOutstanding()).toBe(false); // restarts are not stalled
+    expect(AskAnswers.allOutstanding().map((e) => e.answer)).toContain("dpmpp_2m");
+    // …and once it is far outside the recovery window there is nothing left to
+    // claim, so it stops being reported.
+    AskAnswers.entriesFor(TAB)[0].answeredAt = Date.now() - ASK_RECOVER_MAX_AGE_MS * 2;
+    expect(AskAnswers.allOutstanding()).toHaveLength(0);
+  });
+
   it("never throws when the flusher does", () => {
     AskAnswers.setFlusher(() => {
       throw new Error("no agent");
     });
-    expect(() => openAndAnswer("ask-1", SAMPLER, "dpmpp_2m")).toThrow();
+    expect(() => openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m")).toThrow();
     // The entry is journaled regardless — the throw happens after the record.
     expect(AskAnswers.entriesFor(TAB)).toHaveLength(1);
     vi.restoreAllMocks();

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -62,6 +62,10 @@ function strandEvictionDebt(): void {
   AskAnswers.record("pa-live", "dpmpp_2m", { tabId: TAB }); // still awaiting -> "none"
 }
 
+/** The agent instance the test's turns belong to. The journal refuses an ack
+ *  from anything else, so tests have to name who is acking. */
+const TURN = "pa-test-turn";
+
 /** An ordinary successful ask: answered, handed back in a tool result, and the
  *  turn that carried it produced its own result — the ACK. This is the common
  *  path, and the only one allowed to be forgotten quietly. */
@@ -78,13 +82,14 @@ function ordinaryAckedAsk(
   const token = AskAnswers.record(askId, answer, { tabId: TAB }).token;
   AskAnswers.markReturned(token);
   AskAnswers.closeAsk(askId);
-  AskAnswers.ack(token); // the turn's own result landed
+  AskAnswers.ack(token, { carrier: TURN }); // the turn's own result landed
 }
 
 beforeEach(() => {
   AskAnswers.reset();
   AskAnswers.setFlusher(() => {});
   AskAnswers.setRevoker(() => false); // nothing queued unless a test says so
+  AskAnswers.setTurnAttacher(() => TURN); // a live turn, unless a test says otherwise
 });
 
 describe("ask-answer journal — an answer survives its tool call (#486)", () => {
@@ -486,7 +491,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     const carried: string[] = [];
     AskAnswers.setTurnAttacher((_key, token) => {
       carried.push(token);
-      return true;
+      return TURN;
     });
     AskAnswers.openAsk("pa-attach", {
       tabId: TAB,
@@ -495,7 +500,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     });
     const token = AskAnswers.markReturnedForTest("pa-attach", "dpmpp_2m", TAB);
     expect(carried).toEqual([token]);
-    AskAnswers.setTurnAttacher(() => false);
+    expect(AskAnswers.entriesFor(TAB)[0].carrier).toBe(TURN);
   });
 
   it("a trimmed TICKET can only weaken a correlation, never drop the answer", () => {
@@ -646,7 +651,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(owed).toBeGreaterThan(0);
 
     // No live turn to ride: nothing is retired, however many results carry it.
-    AskAnswers.setTurnAttacher(() => false);
+    AskAnswers.setTurnAttacher(() => null);
     for (let i = 0; i < 10; i += 1) expect(AskAnswers.reportDropped(TAB)).toBe(owed);
     expect(AskAnswers.hasOutstanding()).toBe(true);
 
@@ -654,20 +659,20 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     const tokens: string[] = [];
     AskAnswers.setTurnAttacher((_key, token) => {
       tokens.push(token);
-      return true;
+      return TURN;
     });
     expect(AskAnswers.reportDropped(TAB)).toBe(owed);
     AskAnswers.release(tokens[0], { carried: true });
     // …and a turn that HANDED THE WARNING BACK can never settle it afterwards:
     // its token is spent, so a late ack for it must be a no-op rather than a
     // retroactive claim that the tab was told.
-    AskAnswers.ack(tokens[0]);
+    AskAnswers.ack(tokens[0], { carrier: TURN });
     expect(AskAnswers.droppedFor(TAB)).toBe(owed);
     expect(AskAnswers.reportDropped(TAB)).toBe(owed);
     expect(AskAnswers.droppedFor(TAB)).toBe(owed);
 
     // …and only that turn's own result settles it.
-    AskAnswers.ack(tokens[tokens.length - 1]);
+    AskAnswers.ack(tokens[tokens.length - 1], { carrier: TURN });
     expect(AskAnswers.droppedFor(TAB)).toBe(0);
     expect(AskAnswers.reportDropped(TAB)).toBe(0);
     expect(AskAnswers.outstandingDebt().some((x) => x.key === TAB)).toBe(false);
@@ -778,9 +783,16 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     AskAnswers.closeAsk("pa-ask-1");
     expect(AskAnswers.hasOutstanding()).toBe(false); // restarts are not stalled
     expect(AskAnswers.allOutstanding().map((e) => e.answer)).toContain("dpmpp_2m");
-    // …and once it is far outside the recovery window there is nothing left to
-    // claim, so it stops being reported.
-    AskAnswers.entriesFor(TAB)[0].answeredAt = Date.now() - ASK_RECOVER_MAX_AGE_MS * 2;
+    // Coordinator gate P0-1: it stays reported NO MATTER HOW OLD it is. An
+    // earlier draft dropped it out of the exit disclosure once the recovery
+    // window lapsed, which quietly undid the whole returned/acked split — past
+    // ten minutes the answer was neither pending nor debt-bearing, so a fatal
+    // exit said nothing at all. Unacked means unproven, and time does not turn
+    // unproven into delivered.
+    AskAnswers.entriesFor(TAB)[0].answeredAt = Date.now() - ASK_RECOVER_MAX_AGE_MS * 100;
+    expect(AskAnswers.allOutstanding().map((e) => e.answer)).toContain("dpmpp_2m");
+    // …and the moment it IS proven read, it stops being news.
+    AskAnswers.ack(AskAnswers.entriesFor(TAB)[0].token, { carrier: TURN });
     expect(AskAnswers.allOutstanding()).toHaveLength(0);
   });
 
@@ -964,6 +976,13 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(src).toContain("AskAnswers.setFlusher(");
     expect(src).toContain("AskAnswers.setTurnAttacher(");
     expect(src).toContain("manager.attachTurnToken(");
+    // …and the debt's lifecycle end must be wired, or removing its ceiling just
+    // trades a silent loss for unbounded growth.
+    expect(src).toContain("bridge.setTabGoneListener(");
+    expect(src).toContain("AskAnswers.retireDebt(");
+    // The ack must carry WHO is acking, or a switched provider can certify the
+    // previous conversation's answer.
+    expect(src).toMatch(/AskAnswers\.ack\(token, from\)/);
 
     // The fatal-exit disclosure must keep RENDERS and ANSWERS apart. A lost
     // answer is not a ComfyUI run and will NEVER be in history, so pointing the
@@ -1149,7 +1168,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     const carrier = AskAnswers.entriesFor(TAB).find((e) => (e.disclose ?? 0) > 0);
     expect(carrier).toBeDefined();
     AskAnswers.markSurfaced(carrier!.token); // a recovery handed it over
-    AskAnswers.ack(carrier!.token); // …and that turn completed
+    AskAnswers.ack(carrier!.token, { carrier: TURN }); // …and that turn completed
     expect(carrier!.acked).toBe(true); // now the preferred eviction victim
     // More answers arrive, all of them ACKED, so every eviction they cause takes
     // the quiet path and creates NO new debt — leaving the carrier's count as the
@@ -1232,6 +1251,38 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(AskAnswers.reportDropped(FIRST)).toBe(still);
     expect(AskAnswers.hasOutstanding()).toBe(true);
     expect(AskAnswers.outstandingDebt().some((x) => x.key === FIRST && x.count > 0)).toBe(true);
+  });
+
+  // Coordinator gate P1-2: removing the ceiling was right, but a debt then needs
+  // a LIFECYCLE end or it accumulates for every temporary tab that never
+  // reconnects. It must end because it was SURFACED or its tab went away — never
+  // because a counter filled up and picked a victim.
+  it("a tab leaving the bridge surfaces and retires its debt, keeping its answers", () => {
+    strandEvictionDebt();
+    expect(AskAnswers.droppedFor(TAB)).toBeGreaterThan(0);
+    const answersBefore = AskAnswers.entriesFor(TAB).length;
+    expect(answersBefore).toBeGreaterThan(0);
+
+    AskAnswers.retireDebt(TAB); // what the bridge's tab-gone listener calls
+
+    expect(AskAnswers.droppedFor(TAB)).toBe(0);
+    expect(AskAnswers.outstandingDebt().some((x) => x.key === TAB)).toBe(false);
+    // A disconnect is usually a reload — the ANSWERS are still deliverable.
+    expect(AskAnswers.entriesFor(TAB)).toHaveLength(answersBefore);
+  });
+
+  it("debt does not accumulate across many short-lived tabs", () => {
+    // Each short-lived tab strands a debt and then goes away. ONLY the tab-gone
+    // wire may clear it — no `forget`, no ceiling — so if the wire is missing the
+    // map grows without limit, which is the cost of removing the ceiling.
+    for (let t = 0; t < 300; t += 1) {
+      const tab = `tab-ephemeral-${t}`;
+      AskAnswers.noteDroppedForTest(tab, 1);
+      AskAnswers.retireDebt(tab);
+    }
+    expect(AskAnswers.outstandingDebt()).toHaveLength(0);
+    expect(AskAnswers.droppedFor("tab-ephemeral-0")).toBe(0);
+    expect(AskAnswers.droppedFor("tab-ephemeral-299")).toBe(0);
   });
 
   it("never throws when the flusher does", () => {

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -1337,6 +1337,56 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(AskAnswers.droppedFor(TAB)).toBe(0);
   });
 
+  // Coordinator gate: a warning names a NUMBER, and only that number is settled
+  // when its turn ends. The token used to record only the tab, so an eviction
+  // that landed AFTER the warning was rendered — while its turn was still
+  // running — was wiped by an ack that never mentioned it.
+  it("an ack settles only what its warning showed, not evictions that landed after", () => {
+    AskAnswers.noteDroppedForTest(TAB, 2);
+    const tokens: string[] = [];
+    AskAnswers.setTurnAttacher((_key, token) => {
+      tokens.push(token);
+      return TURN;
+    });
+    expect(AskAnswers.reportDropped(TAB)).toBe(2); // the warning says "2"
+
+    // While that turn is still running, two MORE answers are evicted.
+    AskAnswers.noteDroppedForTest(TAB, 3);
+
+    // The turn completes. It showed 2, so it settles 2 — never the 3 it never saw.
+    AskAnswers.ack(tokens[0], { carrier: TURN });
+    expect(AskAnswers.droppedFor(TAB)).toBe(3);
+    expect(AskAnswers.hasOutstanding()).toBe(true);
+    expect(AskAnswers.outstandingDebt().some((x) => x.key === TAB && x.count === 3)).toBe(true);
+
+    // The next result reports the remainder, and settling THAT clears the tab.
+    expect(AskAnswers.reportDropped(TAB)).toBe(3);
+    AskAnswers.ack(tokens[1], { carrier: TURN });
+    expect(AskAnswers.droppedFor(TAB)).toBe(0);
+    expect(AskAnswers.outstandingDebt()).toHaveLength(0);
+  });
+
+  it("two results reporting the SAME debt settle it once, not twice", () => {
+    AskAnswers.noteDroppedForTest(TAB, 2);
+    const tokens: string[] = [];
+    AskAnswers.setTurnAttacher((_key, token) => {
+      tokens.push(token);
+      return TURN;
+    });
+    // Two separate results each carry the same warning ("2 answers dropped").
+    expect(AskAnswers.reportDropped(TAB)).toBe(2);
+    expect(AskAnswers.reportDropped(TAB)).toBe(2);
+    // Three more answers are evicted before either turn finishes.
+    AskAnswers.noteDroppedForTest(TAB, 3);
+
+    // Both turns complete. Between them they showed 2 — not 4 — so 3 remain
+    // owed. A count that added instead of watermarking would swallow two of them.
+    AskAnswers.ack(tokens[0], { carrier: TURN });
+    AskAnswers.ack(tokens[1], { carrier: TURN });
+    expect(AskAnswers.droppedFor(TAB)).toBe(3);
+    expect(AskAnswers.hasOutstanding()).toBe(true);
+  });
+
   it("never throws when the flusher does", () => {
     AskAnswers.setFlusher(() => {
       throw new Error("no agent");

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -1065,6 +1065,37 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(b.recoverable).toBe(false);
   });
 
+  // Coordinator gate: the collapse guard read `ticket?.reused`, which is an
+  // EVICTABLE store — once the reused ticket was trimmed the guard silently
+  // switched back on and the second card's validated answer was discarded before
+  // it ever had an entry. The ambiguity now lives on the ENTRY, which outlives
+  // the ticket.
+  it("a trimmed reused TICKET does not re-enable the identical-answer collapse", () => {
+    AskAnswers.openAsk("pa-evicted", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-evicted");
+    const a = AskAnswers.record("pa-evicted", "euler", { tabId: TAB });
+    // A second card reuses the id, for a different question…
+    AskAnswers.openAsk("pa-evicted", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SCHEDULER),
+      question: SCHEDULER.question,
+    });
+    expect(a.ambiguousId).toBe(true); // frozen on the entry at reopen
+    // …and then the ticket ceiling bites.
+    AskAnswers.dropTicketForTest("pa-evicted");
+    expect(AskAnswers.ticketFor("pa-evicted")).toBeUndefined();
+    // The user answers the SECOND card with the same text.
+    const b = AskAnswers.record("pa-evicted", "euler", { tabId: TAB });
+    expect(b.token).not.toBe(a.token); // kept, not collapsed away
+    expect(AskAnswers.entriesFor(TAB)).toHaveLength(2);
+    expect(b.recoverable).toBe(false);
+    expect(a.recoverable).toBe(false);
+  });
+
   it("…but one observation seen twice is still ONE answer", () => {
     // The grace poll and the bridge sink can both see a single card's reply. The
     // id is not reused there, so the collapse is identity, not suppression.

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -501,11 +501,45 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(AskAnswers.hasOutstanding()).toBe(false);
   });
 
-  it("takeDropped reports the un-carried debt once", () => {
+  // codex round 4, P0: the ask path used to TAKE the debt, i.e. spend it on the
+  // first tool result — which is a hand-off, not a receipt, so an abandoned call
+  // carried the "N answers were lost" disclosure away with it. It is now spent by
+  // a COUNT of reports (the same trade MAX_CARRIED_RELEASES makes for a push):
+  // repeated at worst, never swallowed, and it cannot repeat forever.
+  it("an eviction debt survives a hand-off and is retired only after several reports", () => {
     strandEvictionDebt();
-    const owed = AskAnswers.takeDropped(TAB);
-    expect(owed).toBeGreaterThan(0);
-    expect(AskAnswers.takeDropped(TAB)).toBe(0); // said once
+    const first = AskAnswers.reportDropped(TAB);
+    expect(first).toBeGreaterThan(0);
+    // A second tool result still carries it — the first may never have landed.
+    expect(AskAnswers.reportDropped(TAB)).toBe(first);
+    expect(AskAnswers.hasOutstanding()).toBe(true);
+    // …but it does not repeat for ever.
+    expect(AskAnswers.reportDropped(TAB)).toBe(first);
+    expect(AskAnswers.reportDropped(TAB)).toBe(0);
+    expect(AskAnswers.droppedFor(TAB)).toBe(0);
+  });
+
+  // codex round 4, P0: `record` collapsed onto ANY existing entry for the ask id,
+  // so a genuinely different validated answer under a reused id was silently
+  // discarded. Only an IDENTICAL observation may collapse.
+  it("a DIFFERENT answer under the same ask id is kept, and both become undetermined", () => {
+    AskAnswers.openAsk("pa-two", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-two");
+    const a = AskAnswers.record("pa-two", "euler", { tabId: TAB });
+    // The same observation seen twice is ONE answer.
+    expect(AskAnswers.record("pa-two", "euler", { tabId: TAB }).token).toBe(a.token);
+    // A different pick is a different answer and must not vanish.
+    const b = AskAnswers.record("pa-two", "dpmpp_2m", { tabId: TAB });
+    expect(b.token).not.toBe(a.token);
+    expect(AskAnswers.entriesFor(TAB).map((e) => e.answer).sort()).toEqual(["dpmpp_2m", "euler"]);
+    // Neither may satisfy a question — nothing says which card either came from.
+    expect(a.recoverable).toBe(false);
+    expect(b.recoverable).toBe(false);
+    expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("unattributed");
   });
 
   // codex round 2, P0: ownership of an ask id used to be answered from a BOUNDED

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -1498,6 +1498,100 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     AskAnswers.setIncarnationResolver(() => OCCUPANT);
   });
 
+  // Coordinator gate P0: the debt BUCKET was keyed by incarnation but the code
+  // WRITING into it still derived an owner from the tab key. So an eviction of
+  // A's entry after B took the key filed A's loss under B — B was pushed
+  // `dropped_answers`, B's ack cleared it, and A's own lifecycle callback (which
+  // retires A's bucket) found nothing left to disclose.
+  // Coordinator gate P0: the debt BUCKET was keyed by incarnation but the code
+  // WRITING into it still derived an owner from the tab key. So an eviction of
+  // A's entry after B took the key filed A's loss under B — B was pushed
+  // `dropped_answers`, B's ack cleared it, and A's own lifecycle callback (which
+  // retires A's bucket) found nothing left to disclose.
+  // Coordinator gate P0: the debt BUCKET was keyed by incarnation but the code
+  // WRITING into it still derived an owner from the tab key — so an eviction of
+  // A's entry after B took the key filed A's loss under B. B was pushed
+  // `dropped_answers`, B's ack cleared it, and A's own lifecycle callback (which
+  // retires A's bucket) found nothing left to disclose.
+  //
+  // The arrangement matters: A's surviving entries are all HANDED OFF, so the
+  // only `pending` entry on the key is B's. That is what makes a writer that
+  // picks "any pending entry on this key" reach for B's, and a writer that files
+  // into "whoever holds the key now" reach for B's bucket.
+  it("A's eviction after B takes the key lands on A, not on the newcomer", () => {
+    let holder: string | undefined = "browser-tab-A";
+    AskAnswers.setIncarnationResolver(() => holder);
+
+    // A fills its tab to the ceiling, then everything of A's is handed off.
+    for (let i = 0; i < 48; i += 1) {
+      openAndAnswer(`pa-a-${i}`, { question: `A${i}?`, options: [{ label: "x" }, { label: "y" }] }, `A${i}`);
+    }
+    AskAnswers.deliverPending(TAB, () => true);
+    expect(AskAnswers.pending(TAB)).toHaveLength(0);
+    expect(AskAnswers.droppedFor(TAB)).toBe(0); // nothing evicted yet
+
+    // A different browser tab takes the recurring key over and asks. Its answer
+    // is the ONLY pending entry — and recording it pushes the tab over the
+    // ceiling, evicting one of A's.
+    holder = "browser-tab-B";
+    openAndAnswer("pa-b-1", SCHEDULER, "karras");
+    const bEntry = AskAnswers.entriesFor(TAB).find((e) => e.incarnation === "browser-tab-B");
+    expect(bEntry).toBeDefined();
+
+    // A's loss was NOT stamped onto B's entry…
+    expect(bEntry!.disclose ?? 0).toBe(0);
+    // …and B's delivery does not carry it.
+    const toB: AskAnswerEvent[] = [];
+    AskAnswers.deliverPending(TAB, (payload) => {
+      toB.push(payload);
+      return true;
+    });
+    expect(toB).toHaveLength(1);
+    expect(toB[0].ask_answer).toBe("karras");
+    expect(toB[0].dropped_answers).toBeUndefined();
+    // …nor is B owed anything it could report or settle.
+    expect(AskAnswers.reportDropped(TAB)).toBe(0);
+
+    // A is owed it, and only A.
+    holder = "browser-tab-A";
+    expect(AskAnswers.reportDropped(TAB)).toBeGreaterThan(0);
+    expect(AskAnswers.hasOutstanding()).toBe(true);
+    AskAnswers.setIncarnationResolver(() => OCCUPANT);
+  });
+
+  // …and the lifecycle half: a bare counter owed to A survives B entirely, and
+  // only A's own departure retires it.
+  it("a bare counter owed to A is invisible to B and retired by A's own callback", () => {
+    let holder: string | undefined = "browser-tab-A";
+    AskAnswers.setIncarnationResolver(() => holder);
+    const tokens: string[] = [];
+    AskAnswers.setTurnAttacher((_key, token) => {
+      tokens.push(token);
+      return TURN;
+    });
+
+    // The loss is A's, but it is RECORDED WHILE B HOLDS THE KEY — which is the
+    // real shape (an eviction of A's entry after the takeover). A writer that
+    // files into "whoever holds the key now" would put it in B's bucket here.
+    holder = "browser-tab-B";
+    AskAnswers.noteDroppedForTest(TAB, 4, "browser-tab-A");
+    expect(AskAnswers.droppedFor(TAB)).toBe(4); // the TAB is owed it, either way
+
+    // …but B is owed nothing and can settle nothing.
+    expect(AskAnswers.reportDropped(TAB)).toBe(0);
+    expect(tokens).toHaveLength(0); // no warning minted, so nothing for B to ack
+
+    // A is still owed it, is told, and only A's own retirement clears it.
+    holder = "browser-tab-A";
+    expect(AskAnswers.reportDropped(TAB)).toBe(4);
+    expect(AskAnswers.hasOutstanding()).toBe(true);
+    AskAnswers.retireDebt(TAB, "browser-tab-B"); // B's departure settles nothing of A's
+    expect(AskAnswers.reportDropped(TAB)).toBe(4);
+    AskAnswers.retireDebt(TAB, "browser-tab-A");
+    expect(AskAnswers.droppedFor(TAB)).toBe(0);
+    AskAnswers.setIncarnationResolver(() => OCCUPANT);
+  });
+
   it("retiring one incarnation's debt leaves the other's alone", () => {
     let holder: string | undefined = "browser-tab-A";
     AskAnswers.setIncarnationResolver(() => holder);

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -944,6 +944,33 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(AskAnswers.droppedFor(TAB)).toBe(owed);
   });
 
+  // codex round 12, P0: the ticket map is global, so a REUSED id can name a
+  // ticket opened by a DIFFERENT tab. Taking that ticket's tab re-addressed the
+  // answer to a conversation that never rendered the card — labelled `foreign`
+  // so it could satisfy nothing, but still delivered to the wrong place.
+  it("an unattributable answer is addressed to the tab that PROVABLY sent it", () => {
+    AskAnswers.openAsk("pa-shared", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-shared");
+    // The other tab accidentally dispatches a card with the same id.
+    AskAnswers.openAsk("pa-shared", {
+      tabId: OTHER_TAB,
+      fingerprint: askFingerprint(SCHEDULER),
+      question: SCHEDULER.question,
+    });
+    AskAnswers.closeAsk("pa-shared");
+    expect(AskAnswers.ticketFor("pa-shared")?.tabId).toBe(OTHER_TAB);
+    // The reply comes back from the FIRST tab — the bridge routed it, so that is
+    // proven, unlike anything the shared id can say.
+    const entry = AskAnswers.record("pa-shared", "dpmpp_2m", { tabId: TAB });
+    expect(entry.key).toBe(TAB);
+    expect(entry.correlation.status).toBe("foreign");
+    expect(AskAnswers.entriesFor(OTHER_TAB)).toHaveLength(0);
+  });
+
   it("never throws when the flusher does", () => {
     AskAnswers.setFlusher(() => {
       throw new Error("no agent");

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -234,10 +234,15 @@ describe("ask-answer journal — cross-question misattribution guard (#486)", ()
     const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
     expect(rec.status).toBe("unattributed");
     if (rec.status !== "unattributed") return;
-    // Still reported, still quoted with its question — downgraded, not deleted.
-    expect(rec.others[0].answer).toBe("dpmpp_2m");
-    expect(rec.others[0].question).toBe(SAMPLER.question);
-    expect(rec.others[0].correlation.status).toBe("foreign");
+    // WITHHELD, not shown: its content belongs to a conversation/tab that is no
+    // longer here, and rendering the chosen option into this conversation's
+    // result is the leak the boundary exists to stop. The COUNT is the
+    // disclosure; the text stays journaled and in the durable log.
+    expect(rec.withheld).toBeGreaterThan(0);
+    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(false);
+    expect(AskAnswers.entriesFor(TAB).some((e) => e.answer === "dpmpp_2m")).toBe(true);
+    expect(AskAnswers.entriesFor(TAB)[0].question).toBe(SAMPLER.question);
+    expect(AskAnswers.entriesFor(TAB)[0].correlation.status).toBe("foreign");
   });
 
   it("an answer whose ask id this session never opened is UNATTRIBUTED, never matched", () => {
@@ -592,6 +597,10 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
     expect(rec.status).toBe("unattributed");
     if (rec.status !== "unattributed") return;
+    // This one is NOT retired and NOT another tab's — it is this conversation's
+    // own earlier answer, merely too old to present as a fresh decision. So it IS
+    // shown, with its own question attached; nothing is withheld.
+    expect(rec.withheld).toBe(0);
     expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(true);
   });
 
@@ -617,7 +626,13 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
     expect(rec.status).toBe("unattributed");
     if (rec.status !== "unattributed") return;
-    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(true);
+    // WITHHELD, not shown: its content belongs to a conversation/tab that is no
+    // longer here, and rendering the chosen option into this conversation's
+    // result is the leak the boundary exists to stop. The COUNT is the
+    // disclosure; the text stays journaled and in the durable log.
+    expect(rec.withheld).toBeGreaterThan(0);
+    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(false);
+    expect(AskAnswers.entriesFor(TAB).some((e) => e.answer === "dpmpp_2m")).toBe(true);
   });
 
   it("an already-journaled answer stops being pushed when its conversation is replaced", () => {
@@ -878,7 +893,13 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
     expect(rec.status).toBe("unattributed");
     if (rec.status !== "unattributed") return;
-    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(true);
+    // WITHHELD, not shown: its content belongs to a conversation/tab that is no
+    // longer here, and rendering the chosen option into this conversation's
+    // result is the leak the boundary exists to stop. The COUNT is the
+    // disclosure; the text stays journaled and in the durable log.
+    expect(rec.withheld).toBeGreaterThan(0);
+    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(false);
+    expect(AskAnswers.entriesFor(TAB).some((e) => e.answer === "dpmpp_2m")).toBe(true);
   });
 
   it("a revoked answer keeps the fingerprint that makes it disclosable", () => {
@@ -1464,7 +1485,13 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(rec.status).toBe("unattributed"); // …and B gets nothing of A's
     if (rec.status !== "unattributed") return;
     // Still reported, quoted with its own question — held, never swallowed.
-    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(true);
+    // WITHHELD, not shown: its content belongs to a conversation/tab that is no
+    // longer here, and rendering the chosen option into this conversation's
+    // result is the leak the boundary exists to stop. The COUNT is the
+    // disclosure; the text stays journaled and in the durable log.
+    expect(rec.withheld).toBeGreaterThan(0);
+    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(false);
+    expect(AskAnswers.entriesFor(TAB).some((e) => e.answer === "dpmpp_2m")).toBe(true);
     // …and never announced into B's conversation either.
     expect(AskAnswers.pending(TAB)).toHaveLength(0);
 
@@ -1494,7 +1521,13 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
     expect(rec.status).toBe("unattributed");
     if (rec.status !== "unattributed") return;
-    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(true);
+    // WITHHELD, not shown: its content belongs to a conversation/tab that is no
+    // longer here, and rendering the chosen option into this conversation's
+    // result is the leak the boundary exists to stop. The COUNT is the
+    // disclosure; the text stays journaled and in the durable log.
+    expect(rec.withheld).toBeGreaterThan(0);
+    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(false);
+    expect(AskAnswers.entriesFor(TAB).some((e) => e.answer === "dpmpp_2m")).toBe(true);
     expect(AskAnswers.pending(TAB)).toHaveLength(0);
     AskAnswers.setIncarnationResolver(() => OCCUPANT);
   });
@@ -1632,11 +1665,14 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(AskAnswers.entriesFor(TAB)[0].delivery).toBe("none");
     expect(AskAnswers.pending(TAB)).toHaveLength(0);
     expect(AskAnswers.hasOutstanding()).toBe(false);
-    // Nothing was swallowed: it is still journaled, still disclosed, still named.
+    // Nothing was swallowed — but nothing is SHOWN to the replacement either.
+    // The count is the disclosure; the text stays journaled and in the log.
     const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
     expect(rec.status).toBe("unattributed");
     if (rec.status !== "unattributed") return;
-    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(true);
+    expect(rec.withheld).toBeGreaterThan(0);
+    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(false);
+    expect(AskAnswers.entriesFor(TAB).some((e) => e.answer === "dpmpp_2m")).toBe(true);
     expect(AskAnswers.allOutstanding().map((e) => e.answer)).toContain("dpmpp_2m");
   });
 
@@ -1705,6 +1741,82 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(carrier!.disclose ?? 0).toBe(0);
     expect(AskAnswers.droppedFor(TAB)).toBe(0);
     expect(AskAnswers.reportDropped(TAB)).toBe(0);
+  });
+
+  // Gate P0-4: the retirement must REPORT before it CLEARS. An earlier draft
+  // cleared each carrier as it totalled them, so a logger that throws took the
+  // only consolidated copy of the debt with it — fixing a misattribution by
+  // creating a silent loss, which is the trade this PR refuses everywhere.
+  it("a retirement whose report THROWS keeps the debt whole", () => {
+    for (let i = 0; i < 60; i += 1) {
+      openAndAnswer(`pa-t-${i}`, { question: `T${i}?`, options: [{ label: "x" }, { label: "y" }] }, `T${i}`);
+    }
+    const owed = AskAnswers.droppedFor(TAB);
+    expect(owed).toBeGreaterThan(0);
+
+    const boom = vi.spyOn(logger, "error").mockImplementation(() => {
+      throw new Error("log sink is down");
+    });
+    expect(() => AskAnswers.closeAsks(TAB)).toThrow(/log sink is down/);
+    boom.mockRestore();
+
+    // NOTHING after the report ran, so the debt is still whole and still owed.
+    expect(AskAnswers.droppedFor(TAB)).toBe(owed);
+
+    // …and a later retirement, with a working sink, surfaces all of it.
+    const errors: string[] = [];
+    const spy = vi.spyOn(logger, "error").mockImplementation((msg: unknown) => {
+      errors.push(String(msg));
+    });
+    AskAnswers.closeAsks(TAB);
+    spy.mockRestore();
+    expect(errors.some((m) => m.includes(`${owed} validated answer(s)`))).toBe(true);
+    expect(AskAnswers.droppedFor(TAB)).toBe(0);
+  });
+
+  // P1: the two flags disagreed. The hand-back permits an AMBIGUOUS answer
+  // (checking only `retired`), while the carrier attach refused one (checking
+  // `recoverable`) — so a delivered answer could never be acked and surfaced
+  // later as an unconfirmed loss that had not happened.
+  it("an AMBIGUOUS answer is still ackable by the turn that carried it", () => {
+    AskAnswers.openAsk("pa-amb", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-amb");
+    const first = AskAnswers.record("pa-amb", "euler", { tabId: TAB });
+    // A second, different answer under the same id makes both ambiguous.
+    const second = AskAnswers.record("pa-amb", "dpmpp_2m", { tabId: TAB });
+    expect(second.recoverable).toBe(false);
+    expect(second.retired).toBeUndefined();
+
+    AskAnswers.markReturned(second.token);
+    // Ambiguity is about WHICH QUESTION, not which conversation — so the turn
+    // that carried it can still prove receipt.
+    expect(second.carrier).toBe(TURN);
+    AskAnswers.ack(second.token, { carrier: TURN });
+    expect(second.acked).toBe(true);
+    // …and it stops being reported as an unconfirmed loss.
+    expect(AskAnswers.allOutstanding().some((e) => e.token === second.token)).toBe(false);
+    void first;
+  });
+
+  // A RETIRED answer, by contrast, gets no carrier at all: no live turn may
+  // receive it, so nothing may certify it either.
+  it("a RETIRED answer gets no carrier and can never be acked", () => {
+    AskAnswers.openAsk("pa-ret", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-ret");
+    const entry = AskAnswers.record("pa-ret", "dpmpp_2m", { tabId: TAB });
+    AskAnswers.closeAsks(TAB);
+    AskAnswers.markReturned(entry.token);
+    expect(entry.carrier).toBeNull();
+    AskAnswers.ack(entry.token, { carrier: TURN });
+    expect(entry.acked).toBeUndefined();
   });
 
   it("never throws when the flusher does", () => {

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -117,8 +117,7 @@ describe("ask-answer journal — an answer survives its tool call (#486)", () =>
       fingerprint: askFingerprint(SAMPLER),
       question: SAMPLER.question,
     });
-    AskAnswers.record("pa-ask-1", "euler", { tabId: TAB });
-    AskAnswers.markReturned("pa-ask-1");
+    AskAnswers.markReturned(AskAnswers.record("pa-ask-1", "euler", { tabId: TAB }).token);
     AskAnswers.closeAsk("pa-ask-1");
     expect(AskAnswers.hasOutstanding()).toBe(false);
     expect(AskAnswers.orphansFor(TAB)).toHaveLength(0);
@@ -360,8 +359,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
         fingerprint: askFingerprint(ask),
         question: ask.question,
       });
-      AskAnswers.record(`pa-ret-${i}`, `A${i}`, { tabId: TAB });
-      AskAnswers.markReturned(`pa-ret-${i}`);
+      AskAnswers.markReturned(AskAnswers.record(`pa-ret-${i}`, `A${i}`, { tabId: TAB }).token);
       AskAnswers.closeAsk(`pa-ret-${i}`);
     }
     expect(AskAnswers.droppedFor(TAB)).toBe(0);
@@ -441,8 +439,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
       fingerprint: askFingerprint(SAMPLER),
       question: SAMPLER.question,
     });
-    AskAnswers.record("pa-ask-1", "dpmpp_2m", { tabId: TAB });
-    AskAnswers.markReturned("pa-ask-1");
+    AskAnswers.markReturned(AskAnswers.record("pa-ask-1", "dpmpp_2m", { tabId: TAB }).token);
     AskAnswers.closeAsk("pa-ask-1");
     const entry = AskAnswers.entriesFor(TAB)[0];
     entry.answeredAt = Date.now() - ASK_RECOVER_MAX_AGE_MS * 10;
@@ -618,8 +615,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
       fingerprint: askFingerprint(SAMPLER),
       question: SAMPLER.question,
     });
-    AskAnswers.record("pa-ask-1", "dpmpp_2m", { tabId: TAB });
-    AskAnswers.markReturned("pa-ask-1");
+    AskAnswers.markReturned(AskAnswers.record("pa-ask-1", "dpmpp_2m", { tabId: TAB }).token);
     AskAnswers.closeAsk("pa-ask-1");
     expect(AskAnswers.hasOutstanding()).toBe(false); // restarts are not stalled
     expect(AskAnswers.allOutstanding().map((e) => e.answer)).toContain("dpmpp_2m");
@@ -843,8 +839,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
         fingerprint: askFingerprint(ask),
         question: ask.question,
       });
-      AskAnswers.record(`pa-done-${i}`, "a", { tabId: TAB });
-      AskAnswers.markReturned(`pa-done-${i}`);
+      AskAnswers.markReturned(AskAnswers.record(`pa-done-${i}`, "a", { tabId: TAB }).token);
       AskAnswers.closeAsk(`pa-done-${i}`);
       expect(AskAnswers.ticketFor(`pa-done-${i}`)).toBeUndefined(); // released
     }

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -1949,16 +1949,21 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     // where closeAsks throws — so restoring afterwards would leave a logger that
     // throws installed for every later test in the file, and the mutation run
     // would report a cascade instead of this one honest failure.
+    let threw = false;
     let escaped: unknown;
     try {
       AskAnswers.closeAsks(TAB);
     } catch (err) {
+      threw = true;
       escaped = err;
     } finally {
       deadWarn.mockRestore();
       surfacer.mockRestore();
     }
-    expect(escaped).toBeUndefined();
+    // `threw` is what DECIDES — a thrown `undefined` is still a throw, and
+    // testing the captured value alone would call that an escape-free run.
+    // `escaped` rides along only so a failure prints what got out.
+    expect({ threw, escaped }).toEqual({ threw: false, escaped: undefined });
 
     // PASS 2 RAN TO THE END: both queued copies were actually offered back, not
     // just the first. A throw out of entry 1's catch would leave entry 2 queued on

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -601,6 +601,10 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     const entry = AskAnswers.record("pa-dup", "dpmpp_2m", { tabId: TAB });
     expect(entry.correlation.status).toBe("foreign");
     expect(entry.fingerprint).toBeNull();
+    // codex round 14, P2: the ticket now holds the LATER card's question, so
+    // carrying it would print that question beside the EARLIER card's answer —
+    // a false association stated inside the honest-fallback disclosure itself.
+    expect(entry.question).toBeNull();
     expect(AskAnswers.recover(TAB, askFingerprint(SCHEDULER)).status).toBe("unattributed");
     expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("unattributed");
     // …but it is still delivered, labelled UNDETERMINED.

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -1844,6 +1844,114 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(AskAnswers.mayDisclose(entry)).toBe(false);
   });
 
+  // Gate P0: the ordering fix in surfaceAndClearDebt (count -> report -> clear)
+  // put a FALLIBLE step ahead of the PROTECTIVE one in its caller. A logger that
+  // throws aborted closeAsks with the fence half-built — and the caller has
+  // ALREADY reset the old agent by then, so it does not stop; the replacement
+  // agent's ready-flush pushes the still-unretired answer.
+  //
+  // The test models the CONTINUATION, not a retry: throw, swallow it exactly as
+  // a caller mid-teardown would, and then do what the caller does next.
+  it("a throwing report cannot leave the boundary half-built", () => {
+    openAndAnswer("pa-halfbuilt", SAMPLER, "dpmpp_2m");
+    // Give the tab an eviction debt too, so the report has something to say and
+    // therefore something to throw on.
+    AskAnswers.noteDroppedForTest(TAB, 2);
+    expect(AskAnswers.pending(TAB)).toHaveLength(1);
+
+    const boom = vi.spyOn(logger, "error").mockImplementation(() => {
+      throw new Error("log sink is down");
+    });
+    // The boundary happens; its report fails.
+    expect(() => AskAnswers.closeAsks(TAB)).toThrow(/log sink is down/);
+    boom.mockRestore();
+
+    // THE CALLER CONTINUES — the old agent is already gone and a replacement
+    // spawns, which flushes on ready. Nothing of the old conversation may go out.
+    const pushed: AskAnswerEvent[] = [];
+    AskAnswers.deliverPending(TAB, (payload) => {
+      pushed.push(payload);
+      return true;
+    });
+    expect(pushed).toEqual([]);
+    expect(AskAnswers.pending(TAB)).toHaveLength(0);
+
+    // …and an identical re-ask cannot recover it either.
+    const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
+    expect(rec.status).toBe("unattributed");
+    if (rec.status !== "unattributed") return;
+    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(false);
+    expect(rec.withheld).toBeGreaterThan(0);
+
+    // The fence is complete; only the DEBT report is still owed, because the step
+    // that destroys it never ran.
+    expect(AskAnswers.entriesFor(TAB)[0].retired).toBe(true);
+    expect(AskAnswers.droppedFor(TAB)).toBe(2);
+  });
+
+  it("a throwing recall cannot leave the boundary half-built either", () => {
+    openAndAnswer("pa-recall", SAMPLER, "dpmpp_2m");
+    openAndAnswer("pa-recall-2", SCHEDULER, "karras");
+    AskAnswers.deliverPending(TAB, () => true); // both queued into a turn
+    AskAnswers.setRevoker(() => {
+      throw new Error("agent is gone");
+    });
+
+    // The revoke is fallible and runs AFTER the fence, so it cannot skip it.
+    AskAnswers.closeAsks(TAB);
+
+    expect(AskAnswers.entriesFor(TAB).every((e) => e.retired === true)).toBe(true);
+    expect(AskAnswers.pending(TAB)).toHaveLength(0);
+    expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("unattributed");
+    AskAnswers.setRevoker(() => false);
+  });
+
+  // Gate P1: `closeAsk` (the ask handler's own unwind) re-armed a RETIRED entry
+  // to `pending`. `pending()` rightly refused to deliver it, but
+  // `hasOutstanding()` counted it as owed — so the self-restart gate stayed shut
+  // forever, cleared only by an unrelated boundary or eviction.
+  it("a retired answer never becomes a permanent blocker on the restart gate", () => {
+    AskAnswers.openAsk("pa-block", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    // The boundary lands while the ask is still waiting…
+    AskAnswers.closeAsks(TAB);
+    // …the old card is then answered…
+    AskAnswers.record("pa-block", "dpmpp_2m", { tabId: TAB });
+    // …and the handler's `finally` unwinds.
+    AskAnswers.closeAsk("pa-block");
+
+    // The unwind must not ARM it in the first place…
+    expect(AskAnswers.entriesFor(TAB)[0].delivery).toBe("none");
+    expect(AskAnswers.pending(TAB)).toHaveLength(0);
+    expect(AskAnswers.hasOutstanding()).toBe(false);
+
+    // …and INDEPENDENTLY, an entry that somehow is armed must still not count as
+    // owed. Two separate guards, because they answer different questions: one
+    // stops the arming, the other stops an undeliverable entry holding the gate.
+    AskAnswers.entriesFor(TAB)[0].delivery = "pending";
+    expect(AskAnswers.pending(TAB)).toHaveLength(0);
+    expect(AskAnswers.hasOutstanding()).toBe(false);
+    // Still journaled and still named on the way out — fenced, not swallowed.
+    expect(AskAnswers.entriesFor(TAB).some((e) => e.answer === "dpmpp_2m")).toBe(true);
+    expect(AskAnswers.allOutstanding().some((e) => e.answer === "dpmpp_2m")).toBe(true);
+  });
+
+  it("a temporarily undeliverable answer DOES still hold the gate", () => {
+    // A different browser tab holding the key is TEMPORARY — the answer becomes
+    // deliverable again when its own tab returns — so tearing down while one is
+    // waiting would be a real loss. Only retirement is permanent.
+    let holder: string | undefined = "browser-tab-A";
+    AskAnswers.setIncarnationResolver(() => holder);
+    openAndAnswer("pa-wait", SAMPLER, "dpmpp_2m");
+    holder = "browser-tab-B";
+    expect(AskAnswers.pending(TAB)).toHaveLength(0); // not deliverable to B…
+    expect(AskAnswers.hasOutstanding()).toBe(true); // …but still owed to A
+    AskAnswers.setIncarnationResolver(() => OCCUPANT);
+  });
+
   it("never throws when the flusher does", () => {
     AskAnswers.setFlusher(() => {
       throw new Error("no agent");

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -90,6 +90,7 @@ beforeEach(() => {
   AskAnswers.setFlusher(() => {});
   AskAnswers.setRevoker(() => false); // nothing queued unless a test says so
   AskAnswers.setTurnAttacher(() => TURN); // a live turn, unless a test says otherwise
+  AskAnswers.setIncarnationResolver(() => undefined); // one occupant, unless a test says otherwise
 });
 
 describe("ask-answer journal — an answer survives its tool call (#486)", () => {
@@ -1385,6 +1386,59 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     AskAnswers.ack(tokens[1], { carrier: TURN });
     expect(AskAnswers.droppedFor(TAB)).toBe(3);
     expect(AskAnswers.hasOutstanding()).toBe(true);
+  });
+
+  // Coordinator gate P0: the CLOCK was incarnation-scoped but the DEBT was not.
+  // After A disconnects owing a disclosure, B opens the same recurring key and
+  // calls panel_ask — and A's debt was reported into B's result and settled by
+  // B's ack, so A's own gone-callback later found nothing to disclose. Cross-tab
+  // delivery AND acknowledgement, one layer below where the keying was fixed.
+  it("a NEW tab on the same key neither reads nor settles the departed tab's debt", () => {
+    let holder: string | undefined = "browser-tab-A";
+    AskAnswers.setIncarnationResolver(() => holder);
+    const tokens: string[] = [];
+    AskAnswers.setTurnAttacher((_key, token) => {
+      tokens.push(token);
+      return TURN;
+    });
+
+    // A strands a debt on the shared key.
+    AskAnswers.noteDroppedForTest(TAB, 3);
+    expect(AskAnswers.reportDropped(TAB)).toBe(3);
+    AskAnswers.ack(tokens[0], { carrier: TURN }); // A was told, and settles it
+    expect(AskAnswers.droppedFor(TAB)).toBe(0);
+
+    // A strands a SECOND debt and then leaves without being told.
+    AskAnswers.noteDroppedForTest(TAB, 2);
+    expect(AskAnswers.droppedFor(TAB)).toBe(2);
+
+    // A different browser tab takes the key over and asks a question.
+    holder = "browser-tab-B";
+    expect(AskAnswers.reportDropped(TAB)).toBe(0); // B is owed nothing
+    // …and even a well-formed ack from B settles nothing of A's.
+    AskAnswers.noteDroppedForTest(TAB, 1); // B's own, later loss
+    expect(AskAnswers.reportDropped(TAB)).toBe(1);
+    AskAnswers.ack(tokens[tokens.length - 1], { carrier: TURN });
+
+    // A's 2 are still owed and still surface when A is finally declared gone.
+    holder = "browser-tab-A";
+    expect(AskAnswers.reportDropped(TAB)).toBe(2);
+    expect(AskAnswers.hasOutstanding()).toBe(true);
+    AskAnswers.setIncarnationResolver(() => undefined);
+  });
+
+  it("retiring one incarnation's debt leaves the other's alone", () => {
+    let holder: string | undefined = "browser-tab-A";
+    AskAnswers.setIncarnationResolver(() => holder);
+    AskAnswers.noteDroppedForTest(TAB, 2);
+    holder = "browser-tab-B";
+    AskAnswers.noteDroppedForTest(TAB, 5);
+    expect(AskAnswers.droppedFor(TAB)).toBe(7); // the tab is owed both
+
+    AskAnswers.retireDebt(TAB, "browser-tab-A"); // A's departure is disclosed
+    expect(AskAnswers.droppedFor(TAB)).toBe(5); // B's survives, untouched
+    expect(AskAnswers.reportDropped(TAB)).toBe(5);
+    AskAnswers.setIncarnationResolver(() => undefined);
   });
 
   it("never throws when the flusher does", () => {

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -994,6 +994,18 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
       expect(unguarded, `${guard}: closeAsks must not run when the provider is unchanged`).toBeNull();
     }
 
+    // The FATAL-EXIT notice is an outlet like any other: it renders answer text
+    // and pushes it to whoever holds the tab, so a retired conversation's pick
+    // must be counted there, not quoted. The durable LOG still gets everything —
+    // two audiences, two buckets.
+    const exitAt2 = src.indexOf("AskAnswers.allOutstanding()");
+    expect(exitAt2, "exit disclosure not found").toBeGreaterThan(-1);
+    const exitBlock = src.slice(exitAt2, exitAt2 + 900);
+    expect(exitBlock, "the notice must gate content on the boundary").toContain(
+      "AskAnswers.mayDisclose(entry)",
+    );
+    expect(exitBlock, "…and count what it withholds").toMatch(/withheld \+= 1/);
+
     // The unsend hook must actually be wired, or closeAsks silently degrades to
     // "leave the stale copy queued"; and the turn attacher must be wired, or the
     // journal has no proof of receipt for the ordinary path and every eviction
@@ -1817,6 +1829,19 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(entry.carrier).toBeNull();
     AskAnswers.ack(entry.token, { carrier: TURN });
     expect(entry.acked).toBeUndefined();
+  });
+
+  it("a retired answer may be counted but never quoted to the tab's current holder", () => {
+    openAndAnswer("pa-exit", SAMPLER, "dpmpp_2m");
+    const entry = AskAnswers.entriesFor(TAB)[0];
+    expect(AskAnswers.mayDisclose(entry)).toBe(true); // its own conversation may see it
+
+    AskAnswers.closeAsks(TAB);
+    // Still named by the exit path (it IS a loss) but no longer showable to
+    // whoever holds the tab now — the count crosses the boundary, the text does
+    // not, and the durable log keeps the text.
+    expect(AskAnswers.allOutstanding().some((e) => e.answer === "dpmpp_2m")).toBe(true);
+    expect(AskAnswers.mayDisclose(entry)).toBe(false);
   });
 
   it("never throws when the flusher does", () => {

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -910,6 +910,40 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(AskAnswers.entriesFor(TAB)).toHaveLength(1);
   });
 
+  // codex round 11, P1: an eviction stamps its undetermined-loss count onto a
+  // surviving entry; a recovery then marks that carrier `returned`, which makes
+  // it the PREFERRED eviction victim — and the returned-victim path dropped it
+  // without re-homing the count. The accepted residual permits losing that
+  // entry's recoverability, not the debt owed for OTHER answers that reached
+  // nobody.
+  it("evicting a RETURNED carrier re-homes the debt it was carrying", () => {
+    for (let i = 0; i < 60; i += 1) {
+      openAndAnswer(`pa-ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
+    }
+    const owed = AskAnswers.droppedFor(TAB);
+    expect(owed).toBeGreaterThan(0);
+    const carrier = AskAnswers.entriesFor(TAB).find((e) => (e.disclose ?? 0) > 0);
+    expect(carrier).toBeDefined();
+    AskAnswers.markSurfaced(carrier!.token); // a recovery handed it over
+    expect(carrier!.returned).toBe(true); // …now the preferred eviction victim
+    // More answers arrive, all of them RETURNED, so every eviction they cause
+    // takes the quiet returned-victim path and creates NO new debt — leaving the
+    // carrier's count as the only debt in play.
+    for (let i = 60; i < 80; i += 1) {
+      const ask = { question: `R${i}?`, options: [{ label: "a" }, { label: "b" }] };
+      AskAnswers.openAsk(`pa-ret-${i}`, {
+        tabId: TAB,
+        fingerprint: askFingerprint(ask),
+        question: ask.question,
+      });
+      AskAnswers.markReturned(AskAnswers.record(`pa-ret-${i}`, `R${i}`, { tabId: TAB }).token);
+      AskAnswers.closeAsk(`pa-ret-${i}`);
+    }
+    expect(AskAnswers.entriesFor(TAB).some((e) => e.token === carrier!.token)).toBe(false);
+    // EXACTLY the same debt — it moved, it did not evaporate with its carrier.
+    expect(AskAnswers.droppedFor(TAB)).toBe(owed);
+  });
+
   it("never throws when the flusher does", () => {
     AskAnswers.setFlusher(() => {
       throw new Error("no agent");

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -66,6 +66,9 @@ function strandEvictionDebt(): void {
  *  from anything else, so tests have to name who is acking. */
 const TURN = "pa-test-turn";
 
+/** The browser tab holding the key in these tests (see AskEntry.incarnation). */
+const OCCUPANT = "browser-tab-default";
+
 /** An ordinary successful ask: answered, handed back in a tool result, and the
  *  turn that carried it produced its own result — the ACK. This is the common
  *  path, and the only one allowed to be forgotten quietly. */
@@ -90,7 +93,7 @@ beforeEach(() => {
   AskAnswers.setFlusher(() => {});
   AskAnswers.setRevoker(() => false); // nothing queued unless a test says so
   AskAnswers.setTurnAttacher(() => TURN); // a live turn, unless a test says otherwise
-  AskAnswers.setIncarnationResolver(() => undefined); // one occupant, unless a test says otherwise
+  AskAnswers.setIncarnationResolver(() => OCCUPANT); // one browser tab, unless a test says otherwise
 });
 
 describe("ask-answer journal — an answer survives its tool call (#486)", () => {
@@ -1269,7 +1272,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     const answersBefore = AskAnswers.entriesFor(TAB).length;
     expect(answersBefore).toBeGreaterThan(0);
 
-    AskAnswers.retireDebt(TAB); // what the bridge's tab-gone listener calls
+    AskAnswers.retireDebt(TAB, OCCUPANT); // what the bridge's tab-gone listener calls
 
     expect(AskAnswers.droppedFor(TAB)).toBe(0);
     expect(AskAnswers.outstandingDebt().some((x) => x.key === TAB)).toBe(false);
@@ -1284,7 +1287,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     for (let t = 0; t < 300; t += 1) {
       const tab = `tab-ephemeral-${t}`;
       AskAnswers.noteDroppedForTest(tab, 1);
-      AskAnswers.retireDebt(tab);
+      AskAnswers.retireDebt(tab, OCCUPANT);
     }
     expect(AskAnswers.outstandingDebt()).toHaveLength(0);
     expect(AskAnswers.droppedFor("tab-ephemeral-0")).toBe(0);
@@ -1429,7 +1432,70 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     holder = "browser-tab-A";
     expect(AskAnswers.reportDropped(TAB)).toBe(2);
     expect(AskAnswers.hasOutstanding()).toBe(true);
-    AskAnswers.setIncarnationResolver(() => undefined);
+    AskAnswers.setIncarnationResolver(() => OCCUPANT);
+  });
+
+  // Gate: the immediate-takeover boundary only fires while the old connection is
+  // still in the map. If A DISCONNECTS FIRST and B arrives afterwards under the
+  // same recurring key, there is no `existing` to compare — so the boundary never
+  // fires and A's entries stayed matched and recoverable under the shared key.
+  // The occupant is therefore carried on the ENTRY and checked at the point of
+  // use, which needs no memory of who left.
+  it("a new occupant cannot recover the previous one's answer, even with no takeover event", () => {
+    let holder: string | undefined = "browser-tab-A";
+    AskAnswers.setIncarnationResolver(() => holder);
+
+    // A asks, times out, and its answer lands with nobody to receive it.
+    AskAnswers.openAsk("pa-a", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-a");
+    const entry = AskAnswers.record("pa-a", "dpmpp_2m", { tabId: TAB });
+    expect(entry.incarnation).toBe("browser-tab-A");
+    expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("recovered");
+
+    // A disconnects; LATER a different browser tab opens the same workflow. No
+    // takeover event fires — there was no live connection to supersede.
+    holder = "browser-tab-B";
+    const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
+    expect(rec.status).toBe("unattributed"); // …and B gets nothing of A's
+    if (rec.status !== "unattributed") return;
+    // Still reported, quoted with its own question — held, never swallowed.
+    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(true);
+    // …and never announced into B's conversation either.
+    expect(AskAnswers.pending(TAB)).toHaveLength(0);
+
+    // A comes back: its own answer is its own again.
+    holder = "browser-tab-A";
+    expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("recovered");
+    expect(AskAnswers.pending(TAB)).toHaveLength(1);
+    AskAnswers.setIncarnationResolver(() => OCCUPANT);
+  });
+
+  it("an answer of UNKNOWN provenance never satisfies a known occupant", () => {
+    // Nothing could say who was holding the tab when this landed. "We could not
+    // tell whose this is" must not resolve to "it is yours" — the honest reading
+    // is unattributed, reported, and never handed over.
+    let holder: string | undefined = undefined;
+    AskAnswers.setIncarnationResolver(() => holder);
+    AskAnswers.openAsk("pa-unknown", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-unknown");
+    const entry = AskAnswers.record("pa-unknown", "dpmpp_2m", { tabId: TAB });
+    expect(entry.incarnation).toBeUndefined();
+
+    holder = "browser-tab-C";
+    const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
+    expect(rec.status).toBe("unattributed");
+    if (rec.status !== "unattributed") return;
+    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(true);
+    expect(AskAnswers.pending(TAB)).toHaveLength(0);
+    AskAnswers.setIncarnationResolver(() => OCCUPANT);
   });
 
   it("retiring one incarnation's debt leaves the other's alone", () => {
@@ -1443,7 +1509,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     AskAnswers.retireDebt(TAB, "browser-tab-A"); // A's departure is disclosed
     expect(AskAnswers.droppedFor(TAB)).toBe(5); // B's survives, untouched
     expect(AskAnswers.reportDropped(TAB)).toBe(5);
-    AskAnswers.setIncarnationResolver(() => undefined);
+    AskAnswers.setIncarnationResolver(() => OCCUPANT);
   });
 
   it("never throws when the flusher does", () => {

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -41,6 +41,26 @@ function openAndAnswer(
   AskAnswers.record(askId, answer, { tabId });
 }
 
+/**
+ * Drive the journal into the state where an eviction's disclosure has NO entry
+ * to ride out on, so the debt is parked in the side map: fill the tab's ceiling
+ * with orphans, hand them all off, then record one more answer whose own handler
+ * is still awaiting (delivery "none") so the eviction it triggers finds nothing
+ * pending to stamp.
+ */
+function strandEvictionDebt(): void {
+  for (let i = 0; i < 48; i += 1) {
+    openAndAnswer(`pa-fill-${i}`, { question: `F${i}?`, options: [{ label: "a" }, { label: "b" }] }, `F${i}`);
+  }
+  AskAnswers.deliverPending(TAB, () => true); // every entry handed off, none pending
+  AskAnswers.openAsk("pa-live", {
+    tabId: TAB,
+    fingerprint: askFingerprint(SAMPLER),
+    question: SAMPLER.question,
+  });
+  AskAnswers.record("pa-live", "dpmpp_2m", { tabId: TAB }); // still awaiting -> "none"
+}
+
 beforeEach(() => {
   AskAnswers.reset();
   AskAnswers.setFlusher(() => {});
@@ -67,13 +87,23 @@ describe("ask-answer journal — an answer survives its tool call (#486)", () =>
     expect(rec.entry.question).toBe(SAMPLER.question);
   });
 
-  it("hands the SAME answer over only once", () => {
+  // A recovery is a HAND-OFF, not a receipt: the ToolResult carrying it can be
+  // abandoned exactly like the one that lost it in the first place. So the
+  // journal keeps its copy and a further re-ask gets it again, FLAGGED.
+  it("a recovered answer is kept and can be surfaced again, flagged", () => {
     openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
     const first = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
     expect(first.status).toBe("recovered");
     if (first.status !== "recovered") return;
-    AskAnswers.consume(first.entry.token);
-    expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("none");
+    expect(first.entry.replayHint).toBeUndefined();
+    AskAnswers.markSurfaced(first.entry.token);
+    const again = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
+    expect(again.status).toBe("recovered");
+    if (again.status !== "recovered") return;
+    expect(again.entry.answer).toBe("dpmpp_2m");
+    expect(again.entry.replayHint).toBe(true);
+    // …and it stops being announced as an unclaimed orphan.
+    expect(AskAnswers.orphansFor(TAB)).toHaveLength(0);
   });
 
   it("an answer handed to a tool result is NOT pushed, but is still recoverable", () => {
@@ -290,7 +320,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
   it("an evicted ORPHAN is counted and disclosed on the next delivery", () => {
     // 16 answers fit per tab; the 17th evicts one. Every one of these reached
     // nobody, so the eviction is a real loss and must be reported.
-    for (let i = 0; i < 20; i += 1) {
+    for (let i = 0; i < 60; i += 1) {
       openAndAnswer(`pa-ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
     }
     expect(AskAnswers.droppedFor(TAB)).toBeGreaterThan(0);
@@ -303,7 +333,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
   });
 
   it("an eviction disclosure is NOT spent by a hand-off that is later given back", () => {
-    for (let i = 0; i < 20; i += 1) {
+    for (let i = 0; i < 60; i += 1) {
       openAndAnswer(`pa-ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
     }
     const carrier = AskAnswers.pending(TAB)[0];
@@ -321,7 +351,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     // Ordinary successful asks must not manufacture "answers were dropped"
     // warnings — they reached a caller. Only the orphan is a loss.
     openAndAnswer("orphan", SAMPLER, "dpmpp_2m");
-    for (let i = 0; i < 30; i += 1) {
+    for (let i = 0; i < 70; i += 1) {
       const ask = { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] };
       AskAnswers.openAsk(`pa-ret-${i}`, {
         tabId: TAB,
@@ -347,7 +377,7 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
       question: SAMPLER.question,
     });
     AskAnswers.closeAsk("pa-ask-old"); // its tool call died; the ticket is evictable
-    for (let i = 0; i < 200; i += 1) {
+    for (let i = 0; i < 1200; i += 1) {
       const ask = { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] };
       AskAnswers.openAsk(`pa-ask-${i}`, {
         tabId: TAB,
@@ -383,20 +413,21 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(AskAnswers.entriesFor(TAB)).toHaveLength(2);
   });
 
-  // codex round 1, P0: an eviction disclosure was stamped onto a surviving entry,
-  // and `consume()` (a recovery) then deleted that carrier outright — so an
-  // eviction the journal had promised to report vanished because an unrelated
-  // answer was recovered. The debt belongs to the TAB, not to its carrier.
-  it("a recovery that consumes the disclosure's carrier re-homes the debt", () => {
-    for (let i = 0; i < 20; i += 1) {
+  // codex rounds 1+3, P0: an eviction disclosure is stamped onto a surviving
+  // entry, and a recovery used to DELETE that carrier — so an eviction the
+  // journal had promised to report vanished because an unrelated answer was
+  // recovered. A recovery no longer deletes anything, so the debt rides on.
+  it("a recovery leaves the disclosure's carrier (and its debt) in place", () => {
+    for (let i = 0; i < 60; i += 1) {
       openAndAnswer(`pa-ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
     }
     const owed = AskAnswers.droppedFor(TAB);
     expect(owed).toBeGreaterThan(0);
     const carrier = AskAnswers.entriesFor(TAB).find((e) => (e.disclose ?? 0) > 0);
     expect(carrier).toBeDefined();
-    AskAnswers.consume(carrier!.token);
+    AskAnswers.markSurfaced(carrier!.token);
     expect(AskAnswers.droppedFor(TAB)).toBe(owed);
+    expect(AskAnswers.entriesFor(TAB).some((e) => e.token === carrier!.token)).toBe(true);
   });
 
   // codex round 1, P0: a RETURNED answer used to be deleted once it aged past the
@@ -470,21 +501,8 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(AskAnswers.hasOutstanding()).toBe(false);
   });
 
-  it("takeDropped reports the un-carried debt once, and leaves entry-carried debt to its push", () => {
-    for (let i = 0; i < 20; i += 1) {
-      openAndAnswer(`pa-ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
-    }
-    // Move all the debt into the side map by consuming every carrier.
-    for (const e of AskAnswers.entriesFor(TAB).filter((x) => (x.disclose ?? 0) > 0)) {
-      AskAnswers.consume(e.token);
-    }
-    // Consuming re-homes onto another PENDING entry when one exists, so drain
-    // them all to force the side map.
-    while (AskAnswers.entriesFor(TAB).some((e) => (e.disclose ?? 0) > 0)) {
-      const carrier = AskAnswers.entriesFor(TAB).find((e) => (e.disclose ?? 0) > 0)!;
-      AskAnswers.consume(carrier.token);
-      if (AskAnswers.pending(TAB).length === 0) break;
-    }
+  it("takeDropped reports the un-carried debt once", () => {
+    strandEvictionDebt();
     const owed = AskAnswers.takeDropped(TAB);
     expect(owed).toBeGreaterThan(0);
     expect(AskAnswers.takeDropped(TAB)).toBe(0); // said once
@@ -536,21 +554,16 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
   // entry is, so a restart while one is owed turns a disclosed loss back into a
   // silent one. It must hold the restart gate and appear in the exit disclosure.
   it("an owed eviction disclosure keeps the journal 'outstanding' and is named on exit", () => {
-    for (let i = 0; i < 20; i += 1) {
-      openAndAnswer(`pa-ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
-    }
+    strandEvictionDebt();
+    // Nothing is left pending or handed off that carries it — only a counter.
     expect(AskAnswers.droppedFor(TAB)).toBeGreaterThan(0);
-    // Every surviving answer is recovered away (each consume re-homes the debt),
-    // so all that is left of the eviction is a COUNTER with no carrier.
-    for (const e of AskAnswers.entriesFor(TAB)) AskAnswers.consume(e.token);
-    expect(AskAnswers.entriesFor(TAB)).toHaveLength(0);
-    expect(AskAnswers.hasOutstanding()).toBe(true); // the debt still holds the gate
+    expect(AskAnswers.hasOutstanding()).toBe(true); // the debt holds the restart gate
     const debt = AskAnswers.outstandingDebt();
-    expect(debt.some((d) => d.key === TAB && d.count > 0)).toBe(true);
+    expect(debt.some((x) => x.key === TAB && x.count > 0)).toBe(true);
   });
 
   it("a debt that a turn actually CARRIED is spent, and stops holding the gate", () => {
-    for (let i = 0; i < 20; i += 1) {
+    for (let i = 0; i < 60; i += 1) {
       openAndAnswer(`pa-ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
     }
     expect(AskAnswers.droppedFor(TAB)).toBeGreaterThan(0);
@@ -578,6 +591,124 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     // claim, so it stops being reported.
     AskAnswers.entriesFor(TAB)[0].answeredAt = Date.now() - ASK_RECOVER_MAX_AGE_MS * 2;
     expect(AskAnswers.allOutstanding()).toHaveLength(0);
+  });
+
+  // codex round 3, P0: the reused-id guard used to live only on the surviving
+  // TICKET, so evicting that ticket restored a "fresh" identity to an id a
+  // still-rendered card can answer — and the old card's click would then be
+  // frozen with the NEW question's fingerprint and could satisfy it.
+  it("reuse is proven by an answer on file, not only by a surviving ticket", () => {
+    AskAnswers.openAsk("pa-dup2", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-dup2");
+    AskAnswers.record("pa-dup2", "dpmpp_2m", { tabId: TAB });
+    // The ticket disappears (an eviction, a purge — anything bounded)…
+    AskAnswers.dropTicketForTest("pa-dup2");
+    expect(AskAnswers.ticketFor("pa-dup2")).toBeUndefined();
+    // …and the id is opened again for a DIFFERENT question.
+    AskAnswers.openAsk("pa-dup2", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SCHEDULER),
+      question: SCHEDULER.question,
+    });
+    expect(AskAnswers.ticketFor("pa-dup2")?.reused).toBe(true);
+    expect(AskAnswers.recover(TAB, askFingerprint(SCHEDULER)).status).toBe("unattributed");
+  });
+
+  // codex round 3, P0: the "this card's conversation is gone" mark used to be a
+  // BOUNDED set of ask ids, so past its ceiling a late click on a retired card
+  // was announced to the replacement conversation. It is now a per-tab
+  // generation, which nothing can overflow.
+  it("the replaced-conversation mark is a per-tab generation, not a bounded set", () => {
+    AskAnswers.openAsk("pa-old", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-old");
+    AskAnswers.closeAsks(TAB);
+    // Hundreds of unrelated asks later, the old card is finally clicked. The old
+    // mark was a FIFO set of ask ids, so this is exactly what used to age it out
+    // and let the answer be announced to the replacement conversation; the epoch
+    // lives on the ticket and is untouched by other cards.
+    for (let i = 0; i < 900; i += 1) {
+      AskAnswers.openAsk(`pa-noise-${i}`, {
+        tabId: OTHER_TAB,
+        fingerprint: askFingerprint({ question: `N${i}?`, options: [{ label: "a" }] }),
+        question: `N${i}?`,
+      });
+      AskAnswers.closeAsk(`pa-noise-${i}`);
+    }
+    const entry = AskAnswers.record("pa-old", "dpmpp_2m", { tabId: TAB });
+    expect(entry.delivery).toBe("none"); // never announced to the new conversation
+    expect(entry.recoverable).toBe(false);
+    // …and still reported, with the question it answers intact.
+    expect(entry.question).toBe(SAMPLER.question);
+  });
+
+  // codex round 3, P0: revoking recoverability by NULLING the fingerprint also
+  // erased the journal's ability to notice "this is about the very question
+  // being re-asked", so the answer stopped being DISCLOSED as well.
+  // The card is still on screen and its question is still on file, so the answer
+  // correlates cleanly — but the conversation that asked is gone, so it may be
+  // REPORTED and never RETURNED. Recoverability is revoked independently of the
+  // fingerprint precisely so this entry can be recognised without being usable.
+  it("a late answer to a retired card can never satisfy the re-ask it matches", () => {
+    AskAnswers.openAsk("pa-retired2", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-retired2");
+    AskAnswers.closeAsks(TAB);
+    const entry = AskAnswers.record("pa-retired2", "dpmpp_2m", { tabId: TAB });
+    expect(entry.fingerprint).toBe(askFingerprint(SAMPLER)); // recognisable…
+    expect(entry.recoverable).toBe(false); // …but not usable
+    const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
+    expect(rec.status).toBe("unattributed");
+    if (rec.status !== "unattributed") return;
+    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(true);
+  });
+
+  it("a revoked answer keeps the fingerprint that makes it disclosable", () => {
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
+    AskAnswers.closeAsks(TAB);
+    const entry = AskAnswers.entriesFor(TAB)[0];
+    expect(entry.recoverable).toBe(false);
+    expect(entry.fingerprint).toBe(askFingerprint(SAMPLER)); // still recognisable
+    expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("unattributed");
+  });
+
+  it("a tab-id migration carries the conversation generation with the tickets", () => {
+    AskAnswers.openAsk("pa-live", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-live");
+    AskAnswers.moveKey(TAB, OTHER_TAB);
+    // The agent moved with the tab id, so its still-live card is still live.
+    const entry = AskAnswers.record("pa-live", "dpmpp_2m", { tabId: OTHER_TAB });
+    expect(entry.key).toBe(OTHER_TAB);
+    expect(entry.delivery).toBe("pending");
+    expect(AskAnswers.recover(OTHER_TAB, askFingerprint(SAMPLER)).status).toBe("recovered");
+  });
+
+  it("a migration does NOT resurrect a card whose conversation was already retired", () => {
+    AskAnswers.openAsk("pa-retired", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-retired");
+    AskAnswers.closeAsks(TAB); // New chat BEFORE the migration
+    AskAnswers.moveKey(TAB, OTHER_TAB);
+    const entry = AskAnswers.record("pa-retired", "dpmpp_2m", { tabId: OTHER_TAB });
+    expect(entry.delivery).toBe("none");
+    expect(entry.recoverable).toBe(false);
   });
 
   it("never throws when the flusher does", () => {

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -1285,6 +1285,34 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(AskAnswers.droppedFor("tab-ephemeral-299")).toBe(0);
   });
 
+  // Coordinator gate P1: the debt's COUNT is tab-keyed and its outstanding
+  // disclosure TOKENS carry that same key, but the ack that settles one is bound
+  // to the agent instance — which deliberately survives a tab-id migration. A
+  // token left pointing at the old key is acked by a perfectly valid result and
+  // clears a debt nobody owes, while the real one sits under the new key forever:
+  // false outstanding debt that blocks the restart gate and later warns for
+  // nothing.
+  it("a tab-id migration moves the debt COUNT and its tokens together", () => {
+    AskAnswers.noteDroppedForTest(TAB, 4);
+    const tokens: string[] = [];
+    AskAnswers.setTurnAttacher((_key, token) => {
+      tokens.push(token);
+      return TURN;
+    });
+    expect(AskAnswers.reportDropped(TAB)).toBe(4); // a warning is riding a turn
+
+    // The tab id migrates while that warning is still in flight.
+    AskAnswers.moveKey(TAB, OTHER_TAB);
+    expect(AskAnswers.droppedFor(OTHER_TAB)).toBe(4);
+    expect(AskAnswers.droppedFor(TAB)).toBe(0);
+
+    // The carrying turn's result lands — the ack must settle the debt where it
+    // actually lives now, not under the id it was minted against.
+    AskAnswers.ack(tokens[0], { carrier: TURN });
+    expect(AskAnswers.droppedFor(OTHER_TAB)).toBe(0);
+    expect(AskAnswers.outstandingDebt()).toHaveLength(0);
+  });
+
   it("never throws when the flusher does", () => {
     AskAnswers.setFlusher(() => {
       throw new Error("no agent");

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -636,17 +636,41 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
   // carried the "N answers were lost" disclosure away with it. It is now spent by
   // a COUNT of reports (the same trade MAX_CARRIED_RELEASES makes for a push):
   // repeated at worst, never swallowed, and it cannot repeat forever.
-  it("an eviction debt survives a hand-off and is retired only after several reports", () => {
+  // Coordinator gate, round 2: the debt was retired after three REPORTS — but a
+  // report is a ToolResult hand-off, so three abandoned calls carried the only
+  // disclosure away with them and the evicted answers' payloads were already
+  // gone. It now rides the same ack as everything else.
+  it("an eviction debt is retired only by the ack of the turn that carried it", () => {
     strandEvictionDebt();
-    const first = AskAnswers.reportDropped(TAB);
-    expect(first).toBeGreaterThan(0);
-    // A second tool result still carries it — the first may never have landed.
-    expect(AskAnswers.reportDropped(TAB)).toBe(first);
+    const owed = AskAnswers.droppedFor(TAB);
+    expect(owed).toBeGreaterThan(0);
+
+    // No live turn to ride: nothing is retired, however many results carry it.
+    AskAnswers.setTurnAttacher(() => false);
+    for (let i = 0; i < 10; i += 1) expect(AskAnswers.reportDropped(TAB)).toBe(owed);
     expect(AskAnswers.hasOutstanding()).toBe(true);
-    // …but it does not repeat for ever.
-    expect(AskAnswers.reportDropped(TAB)).toBe(first);
-    expect(AskAnswers.reportDropped(TAB)).toBe(0);
+
+    // A turn DOES carry it, but ends without proving it was read — still owed.
+    const tokens: string[] = [];
+    AskAnswers.setTurnAttacher((_key, token) => {
+      tokens.push(token);
+      return true;
+    });
+    expect(AskAnswers.reportDropped(TAB)).toBe(owed);
+    AskAnswers.release(tokens[0], { carried: true });
+    // …and a turn that HANDED THE WARNING BACK can never settle it afterwards:
+    // its token is spent, so a late ack for it must be a no-op rather than a
+    // retroactive claim that the tab was told.
+    AskAnswers.ack(tokens[0]);
+    expect(AskAnswers.droppedFor(TAB)).toBe(owed);
+    expect(AskAnswers.reportDropped(TAB)).toBe(owed);
+    expect(AskAnswers.droppedFor(TAB)).toBe(owed);
+
+    // …and only that turn's own result settles it.
+    AskAnswers.ack(tokens[tokens.length - 1]);
     expect(AskAnswers.droppedFor(TAB)).toBe(0);
+    expect(AskAnswers.reportDropped(TAB)).toBe(0);
+    expect(AskAnswers.outstandingDebt().some((x) => x.key === TAB)).toBe(false);
   });
 
   // codex round 4, P0: `record` collapsed onto ANY existing entry for the ask id,

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -114,12 +114,33 @@ describe("ask-answer journal — cross-question misattribution guard (#486)", ()
     expect(askFingerprint({ ...SAMPLER, options: [{ label: "euler" }] })).not.toBe(base);
     expect(askFingerprint({ ...SAMPLER, multi_select: true })).not.toBe(base);
     expect(askFingerprint({ ...SAMPLER, header: "Sampler" })).not.toBe(base);
-    // …but not on cosmetics the user's decision does not depend on.
+    // The option DESCRIPTIONS are part of the question: they are the one-line
+    // explanations the user reads to decide, so the same labels with different
+    // explanations are a different decision and must not recover each other.
+    expect(
+      askFingerprint({
+        ...SAMPLER,
+        options: [{ label: "euler", description: "fast, lower quality" }, { label: "dpmpp_2m" }],
+      }),
+    ).not.toBe(base);
+    expect(
+      askFingerprint({
+        ...SAMPLER,
+        options: [{ label: "euler", description: "now the recommended default" }, { label: "dpmpp_2m" }],
+      }),
+    ).not.toBe(
+      askFingerprint({
+        ...SAMPLER,
+        options: [{ label: "euler", description: "fast, lower quality" }, { label: "dpmpp_2m" }],
+      }),
+    );
+    // …but whitespace/wrapping is not a decision, and a re-ask often re-emits the
+    // same prompt wrapped differently.
     expect(
       askFingerprint({
         ...SAMPLER,
         question: "  Which sampler   should I use?\n",
-        options: [{ label: "euler", description: "fast" }, { label: " dpmpp_2m " }],
+        options: [{ label: " euler " }, { label: "dpmpp_2m\n" }],
       }),
     ).toBe(base);
   });
@@ -359,6 +380,113 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
     openAndAnswer("ask-2", SAMPLER, "dpmpp_2m");
     expect(AskAnswers.entriesFor(TAB)).toHaveLength(2);
+  });
+
+  // codex round 1, P0: an eviction disclosure was stamped onto a surviving entry,
+  // and `consume()` (a recovery) then deleted that carrier outright — so an
+  // eviction the journal had promised to report vanished because an unrelated
+  // answer was recovered. The debt belongs to the TAB, not to its carrier.
+  it("a recovery that consumes the disclosure's carrier re-homes the debt", () => {
+    for (let i = 0; i < 20; i += 1) {
+      openAndAnswer(`ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
+    }
+    const owed = AskAnswers.droppedFor(TAB);
+    expect(owed).toBeGreaterThan(0);
+    const carrier = AskAnswers.entriesFor(TAB).find((e) => (e.disclose ?? 0) > 0);
+    expect(carrier).toBeDefined();
+    AskAnswers.consume(carrier!.token);
+    expect(AskAnswers.droppedFor(TAB)).toBe(owed);
+  });
+
+  // codex round 1, P0: a RETURNED answer used to be deleted once it aged past the
+  // recovery window. "It went into a ToolResult" is exactly the thing that is not
+  // provable here — that IS #486 — so nothing may be dropped on that basis.
+  it("nothing is ever expired by age — only recovery, eviction or a gone tab remove an answer", () => {
+    AskAnswers.openAsk("ask-1", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.record("ask-1", "dpmpp_2m", { tabId: TAB });
+    AskAnswers.markReturned("ask-1");
+    AskAnswers.closeAsk("ask-1");
+    const entry = AskAnswers.entriesFor(TAB)[0];
+    entry.answeredAt = Date.now() - ASK_RECOVER_MAX_AGE_MS * 10;
+    // Any number of later journal operations must not sweep it away.
+    openAndAnswer("ask-2", SCHEDULER, "karras");
+    AskAnswers.recover(TAB, askFingerprint(SCHEDULER));
+    expect(AskAnswers.entriesFor(TAB).some((e) => e.askId === "ask-1")).toBe(true);
+    // Too old to be presented as a fresh decision, but still REPORTABLE.
+    const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
+    expect(rec.status).toBe("unattributed");
+    if (rec.status !== "unattributed") return;
+    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(true);
+  });
+
+  // codex round 1, P0: `closeAsks` dropped the ticket but the card was still on
+  // screen, so a click minutes later was journaled as `foreign`, addressed to the
+  // same tab, and PUSHED into the replacement conversation — an unsolicited turn
+  // about a decision that conversation never asked for.
+  it("an answer to a card whose conversation was replaced is never announced to the new one", () => {
+    AskAnswers.openAsk("ask-1", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("ask-1");
+    AskAnswers.closeAsks(TAB); // New chat / resume of a historical session
+    // The user clicks the still-rendered old card.
+    const entry = AskAnswers.record("ask-1", "dpmpp_2m", { tabId: TAB });
+    expect(entry.delivery).toBe("none");
+    expect(AskAnswers.pending(TAB)).toHaveLength(0);
+    expect(AskAnswers.hasOutstanding()).toBe(false);
+    // …not swallowed either: it is still on file for disclosure, and it can never
+    // satisfy a question.
+    const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
+    expect(rec.status).toBe("unattributed");
+    if (rec.status !== "unattributed") return;
+    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(true);
+  });
+
+  it("an already-journaled answer stops being pushed when its conversation is replaced", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    expect(AskAnswers.pending(TAB)).toHaveLength(1);
+    AskAnswers.closeAsks(TAB);
+    expect(AskAnswers.pending(TAB)).toHaveLength(0);
+    expect(AskAnswers.entriesFor(TAB)).toHaveLength(1); // kept for disclosure
+  });
+
+  it("a late answer for a tab that is GONE is never armed for a doomed push", () => {
+    AskAnswers.openAsk("ask-1", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("ask-1");
+    AskAnswers.forget(TAB); // workflow switched away / tab closed
+    const entry = AskAnswers.record("ask-1", "dpmpp_2m", { tabId: TAB });
+    expect(entry.delivery).toBe("none");
+    expect(AskAnswers.hasOutstanding()).toBe(false);
+  });
+
+  it("takeDropped reports the un-carried debt once, and leaves entry-carried debt to its push", () => {
+    for (let i = 0; i < 20; i += 1) {
+      openAndAnswer(`ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
+    }
+    // Move all the debt into the side map by consuming every carrier.
+    for (const e of AskAnswers.entriesFor(TAB).filter((x) => (x.disclose ?? 0) > 0)) {
+      AskAnswers.consume(e.token);
+    }
+    // Consuming re-homes onto another PENDING entry when one exists, so drain
+    // them all to force the side map.
+    while (AskAnswers.entriesFor(TAB).some((e) => (e.disclose ?? 0) > 0)) {
+      const carrier = AskAnswers.entriesFor(TAB).find((e) => (e.disclose ?? 0) > 0)!;
+      AskAnswers.consume(carrier.token);
+      if (AskAnswers.pending(TAB).length === 0) break;
+    }
+    const owed = AskAnswers.takeDropped(TAB);
+    expect(owed).toBeGreaterThan(0);
+    expect(AskAnswers.takeDropped(TAB)).toBe(0); // said once
   });
 
   it("never throws when the flusher does", () => {

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -857,6 +857,48 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(entry.recoverable).toBe(false);
   });
 
+  // codex round 8, P1: "same id, same text" is only evidence of ONE observation
+  // while the id means one card. Once two cards share it, two picks that happen
+  // to read the same are two validated answers to two questions — merging them
+  // left the second question unanswered with no record at all.
+  it("two reused cards answered IDENTICALLY are both kept", () => {
+    AskAnswers.openAsk("pa-same", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-same");
+    const a = AskAnswers.record("pa-same", "euler", { tabId: TAB });
+    // A second card accidentally reuses the id, for a different question.
+    AskAnswers.openAsk("pa-same", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SCHEDULER),
+      question: SCHEDULER.question,
+    });
+    AskAnswers.closeAsk("pa-same");
+    expect(AskAnswers.ticketFor("pa-same")?.reused).toBe(true);
+    // The user picks the SAME text on the second card.
+    const b = AskAnswers.record("pa-same", "euler", { tabId: TAB });
+    expect(b.token).not.toBe(a.token);
+    expect(AskAnswers.entriesFor(TAB)).toHaveLength(2);
+    expect(b.delivery).toBe("pending"); // still reported, labelled undetermined
+    expect(b.recoverable).toBe(false);
+  });
+
+  it("…but one observation seen twice is still ONE answer", () => {
+    // The grace poll and the bridge sink can both see a single card's reply. The
+    // id is not reused there, so the collapse is identity, not suppression.
+    AskAnswers.openAsk("pa-once", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-once");
+    const a = AskAnswers.record("pa-once", "euler", { tabId: TAB });
+    expect(AskAnswers.record("pa-once", "euler", { tabId: TAB }).token).toBe(a.token);
+    expect(AskAnswers.entriesFor(TAB)).toHaveLength(1);
+  });
+
   it("never throws when the flusher does", () => {
     AskAnswers.setFlusher(() => {
       throw new Error("no agent");

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -1943,9 +1943,22 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     });
 
     // Everything after the fence is fallible, and none of it may escape.
-    expect(() => AskAnswers.closeAsks(TAB)).not.toThrow();
-    deadWarn.mockRestore();
-    surfacer.mockRestore();
+    //
+    // Restored in a `finally`, NOT after the assertion: the mutant this test
+    // exists to catch (unguarding the catch-block warn) is exactly the case
+    // where closeAsks throws — so restoring afterwards would leave a logger that
+    // throws installed for every later test in the file, and the mutation run
+    // would report a cascade instead of this one honest failure.
+    let escaped: unknown;
+    try {
+      AskAnswers.closeAsks(TAB);
+    } catch (err) {
+      escaped = err;
+    } finally {
+      deadWarn.mockRestore();
+      surfacer.mockRestore();
+    }
+    expect(escaped).toBeUndefined();
 
     // PASS 2 RAN TO THE END: both queued copies were actually offered back, not
     // just the first. A throw out of entry 1's catch would leave entry 2 queued on

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { readFileSync } from "node:fs";
 import {
   AskAnswers,
   askFingerprint,
@@ -743,6 +744,30 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     const entry = AskAnswers.record("pa-retired", "dpmpp_2m", { tabId: OTHER_TAB });
     expect(entry.delivery).toBe("none");
     expect(entry.recoverable).toBe(false);
+  });
+
+  // codex round 5, P0: a REWIND discards everything after its anchor, so a
+  // question card the dropped branch put up was never asked by the conversation
+  // that now exists — but the handler only reset the agent, leaving the ask
+  // journal's epoch untouched. A late click on that card was then announced as
+  // "a question card YOU put up", and an identical re-ask in the fork recovered
+  // it. Every conversation boundary must retire this tab's asks.
+  //
+  // Asserted structurally: driving index.ts's panel-event dispatcher needs a
+  // booted orchestrator, and the property at stake is the WIRING — that each
+  // boundary handler calls closeAsks — not behaviour the journal's own tests
+  // don't already cover.
+  it("every conversation-boundary handler retires the tab's asks", () => {
+    const src = readFileSync(
+      new URL("../../orchestrator/index.ts", import.meta.url),
+      "utf8",
+    );
+    for (const kind of ["new_session", "resume_session", "rewind"]) {
+      const start = src.indexOf(`event.type === "${kind}"`);
+      expect(start, `${kind} handler not found`).toBeGreaterThan(-1);
+      const block = src.slice(start, src.indexOf("\n      return;", start));
+      expect(block, `${kind} must retire ask state`).toContain("AskAnswers.closeAsks(");
+    }
   });
 
   it("never throws when the flusher does", () => {

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -762,11 +762,29 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
       new URL("../../orchestrator/index.ts", import.meta.url),
       "utf8",
     );
-    for (const kind of ["new_session", "resume_session", "rewind"]) {
-      const start = src.indexOf(`event.type === "${kind}"`);
-      expect(start, `${kind} handler not found`).toBeGreaterThan(-1);
-      const block = src.slice(start, src.indexOf("\n      return;", start));
-      expect(block, `${kind} must retire ask state`).toContain("AskAnswers.closeAsks(");
+    // A rewind is a boundary with no run-journal counterpart, so it is named.
+    const start = src.indexOf('event.type === "rewind"');
+    expect(start, "rewind handler not found").toBeGreaterThan(-1);
+    const block = src.slice(start, src.indexOf("\n      return;", start));
+    expect(block, "rewind must retire ask state").toContain("AskAnswers.closeAsks(");
+
+    // …and every OTHER boundary is defined by where the run journal draws one.
+    // Pairing the two journals structurally is what stops the next boundary from
+    // being added to one and forgotten in the other — which is exactly how a late
+    // answer reached a conversation that never asked the question, twice.
+    const pairs: Array<[RegExp, string]> = [
+      [/RunCompletions\.closeRuns\((\w+)\)/g, "AskAnswers.closeAsks($1)"],
+      [/RunCompletions\.forget\((\w+)\)/g, "AskAnswers.forget($1)"],
+    ];
+    for (const [re, template] of pairs) {
+      const found = [...src.matchAll(re)];
+      expect(found.length, `no ${re.source} call sites found`).toBeGreaterThan(0);
+      for (const m of found) {
+        const arg = m[1];
+        const want = template.replace("$1", arg);
+        const near = src.slice(m.index!, m.index! + 900);
+        expect(near, `${m[0]} is not paired with ${want}`).toContain(want);
+      }
     }
   });
 

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -217,9 +217,33 @@ describe("ask-answer journal — cross-question misattribution guard (#486)", ()
     expect(entry.correlation.status).toBe("foreign");
     expect(entry.fingerprint).toBeNull();
     expect(entry.question).toBeNull();
-    // It is delivered (labelled), but it can satisfy nothing.
-    expect(entry.delivery).toBe("pending");
+    // NOT announced: with no ticket there is no conversation generation, so we
+    // cannot tell whether the card belongs to the conversation on this tab now or
+    // to a retired one — and announcing it anyway would fold "could not
+    // determine" into "determined not retired". Journaled, logged, and reported
+    // by a later ask instead; it can satisfy nothing either way.
+    expect(entry.delivery).toBe("none");
     expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("unattributed");
+    expect(AskAnswers.orphansFor(TAB).some((e) => e.answer === "dpmpp_2m")).toBe(true);
+  });
+
+  // codex round 13, P1: the journal's ticket bound and the bridge's mapping bound
+  // are separate, so a retired card could lose its ticket (and with it the
+  // conversation generation) while the bridge still recognised its answer — which
+  // was then announced to whatever conversation held the tab.
+  it("a retired card whose ticket was evicted is still never announced", () => {
+    AskAnswers.openAsk("pa-retired3", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-retired3");
+    AskAnswers.closeAsks(TAB); // conversation replaced
+    AskAnswers.dropTicketForTest("pa-retired3"); // …and the ticket bound bites
+    const entry = AskAnswers.record("pa-retired3", "dpmpp_2m", { tabId: TAB });
+    expect(entry.delivery).toBe("none");
+    expect(AskAnswers.hasOutstanding()).toBe(false);
+    expect(AskAnswers.orphansFor(TAB).some((e) => e.answer === "dpmpp_2m")).toBe(true);
   });
 });
 

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -65,6 +65,7 @@ function strandEvictionDebt(): void {
 beforeEach(() => {
   AskAnswers.reset();
   AskAnswers.setFlusher(() => {});
+  AskAnswers.setRevoker(() => false); // nothing queued unless a test says so
 });
 
 describe("ask-answer journal — an answer survives its tool call (#486)", () => {
@@ -768,6 +769,11 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     const block = src.slice(start, src.indexOf("\n      return;", start));
     expect(block, "rewind must retire ask state").toContain("AskAnswers.closeAsks(");
 
+    // The unsend hook must actually be wired, or closeAsks silently degrades to
+    // "leave the stale copy queued".
+    expect(src).toContain("AskAnswers.setRevoker(");
+    expect(src).toContain("AskAnswers.setFlusher(");
+
     // …and every OTHER boundary is defined by where the run journal draws one.
     // Pairing the two journals structurally is what stops the next boundary from
     // being added to one and forgotten in the other — which is exactly how a late
@@ -786,6 +792,69 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
         expect(near, `${m[0]} is not paired with ${want}`).toContain(want);
       }
     }
+  });
+
+  // codex round 7, P1: an answer already QUEUED into an agent carries wording
+  // that claims the reader put the card up. If the conversation is replaced
+  // before that item is read, the sentence is false of the fork — so the queued
+  // copy has to be pulled back, exactly as #468 does for a downgraded completion.
+  it("a replaced conversation unsends an answer that is still queued and unread", () => {
+    const revoked: string[] = [];
+    AskAnswers.setRevoker((_key, token) => {
+      revoked.push(token);
+      return true;
+    });
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
+    AskAnswers.deliverPending(TAB, () => true);
+    const token = AskAnswers.entriesFor(TAB)[0].token;
+    expect(AskAnswers.entriesFor(TAB)[0].delivery).toBe("handed_off");
+    AskAnswers.closeAsks(TAB);
+    expect(revoked).toEqual([token]);
+    expect(AskAnswers.entriesFor(TAB)[0].delivery).toBe("none");
+    AskAnswers.setRevoker(() => false);
+  });
+
+  it("an answer already being READ cannot be recalled, and is not pretended otherwise", () => {
+    AskAnswers.setRevoker(() => false); // the carrying turn already started
+    openAndAnswer("pa-ask-1", SAMPLER, "dpmpp_2m");
+    AskAnswers.deliverPending(TAB, () => true);
+    AskAnswers.closeAsks(TAB);
+    // Still marked handed_off — the text is in the model's context; claiming we
+    // pulled it back would be a lie.
+    expect(AskAnswers.entriesFor(TAB)[0].delivery).toBe("handed_off");
+  });
+
+  // codex round 7, P1: the ticket map used to keep a ticket for every ask ever
+  // made, so a long session's ordinary successful asks filled it and evicted a
+  // genuinely OUTSTANDING card's ticket — taking its retired-conversation marker
+  // with it, after which a late click landed in the replacement conversation.
+  it("an ANSWERED card releases its ticket, so the ceiling only counts cards on screen", () => {
+    AskAnswers.openAsk("pa-outstanding", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("pa-outstanding"); // timed out; card still on screen
+    // …and now 2000 ordinary, ANSWERED asks go by.
+    for (let i = 0; i < 2000; i += 1) {
+      const ask = { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] };
+      AskAnswers.openAsk(`pa-done-${i}`, {
+        tabId: TAB,
+        fingerprint: askFingerprint(ask),
+        question: ask.question,
+      });
+      AskAnswers.record(`pa-done-${i}`, "a", { tabId: TAB });
+      AskAnswers.markReturned(`pa-done-${i}`);
+      AskAnswers.closeAsk(`pa-done-${i}`);
+      expect(AskAnswers.ticketFor(`pa-done-${i}`)).toBeUndefined(); // released
+    }
+    // The outstanding card's ticket — and with it the conversation generation
+    // that protects the replacement conversation — is still there.
+    expect(AskAnswers.ticketFor("pa-outstanding")).toBeDefined();
+    AskAnswers.closeAsks(TAB);
+    const entry = AskAnswers.record("pa-outstanding", "dpmpp_2m", { tabId: TAB });
+    expect(entry.delivery).toBe("none");
+    expect(entry.recoverable).toBe(false);
   });
 
   it("never throws when the flusher does", () => {

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  AskAnswers,
+  askFingerprint,
+  ASK_RECOVER_MAX_AGE_MS,
+  type AskAnswerEvent,
+} from "../../orchestrator/ask-answer-journal.js";
+
+// #486 — a VALIDATED panel_ask answer must survive the tool call that asked for
+// it, and a recovered answer must never satisfy a different question.
+//
+// The journal is the durable half of that: it correlates an answer to its
+// question ONCE, at arrival, replays what could not be delivered, and NEVER
+// suppresses. These tests hold both directions: nothing the user answered is
+// lost, and nothing they answered is presented as the answer to something else.
+
+const TAB = "tab-aaaa1111";
+const OTHER_TAB = "tab-bbbb2222";
+
+const SAMPLER = {
+  question: "Which sampler should I use?",
+  options: [{ label: "euler" }, { label: "dpmpp_2m" }],
+};
+const SCHEDULER = {
+  question: "Which scheduler should I use?",
+  options: [{ label: "karras" }, { label: "normal" }],
+};
+
+function openAndAnswer(
+  askId: string,
+  ask: { question: string; options: unknown; header?: unknown; multi_select?: unknown },
+  answer: string,
+  opts: { tabId?: string; awaiting?: boolean } = {},
+): void {
+  const tabId = opts.tabId ?? TAB;
+  AskAnswers.openAsk(askId, { tabId, fingerprint: askFingerprint(ask), question: ask.question });
+  // The asking handler has already unwound (the tools/call died) unless the test
+  // says otherwise — that is the #486 scenario.
+  if (opts.awaiting !== true) AskAnswers.closeAsk(askId);
+  AskAnswers.record(askId, answer, { tabId });
+}
+
+beforeEach(() => {
+  AskAnswers.reset();
+  AskAnswers.setFlusher(() => {});
+});
+
+describe("ask-answer journal — an answer survives its tool call (#486)", () => {
+  it("journals an answer that arrives with NO handler waiting, and arms it for delivery", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    const entries = AskAnswers.entriesFor(TAB);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].answer).toBe("dpmpp_2m");
+    expect(entries[0].correlation.status).toBe("matched");
+    // Nobody received it, so it is an ORPHAN queued for the durable push.
+    expect(entries[0].delivery).toBe("pending");
+    expect(AskAnswers.hasOutstanding()).toBe(true);
+  });
+
+  it("recovers it for a re-ask of the IDENTICAL question", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
+    expect(rec.status).toBe("recovered");
+    if (rec.status !== "recovered") return;
+    expect(rec.entry.answer).toBe("dpmpp_2m");
+    expect(rec.entry.question).toBe(SAMPLER.question);
+  });
+
+  it("hands the SAME answer over only once", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    const first = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
+    expect(first.status).toBe("recovered");
+    if (first.status !== "recovered") return;
+    AskAnswers.consume(first.entry.token);
+    expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("none");
+  });
+
+  it("an answer handed to a tool result is NOT pushed, but is still recoverable", () => {
+    // The ordinary success path: the handler got the answer and returned it. It
+    // may have gone into a dead request (unobservable), so it stays journaled —
+    // but it must not ALSO be announced to the agent, or every ask would double.
+    AskAnswers.openAsk("ask-1", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.record("ask-1", "euler", { tabId: TAB });
+    AskAnswers.markReturned("ask-1");
+    AskAnswers.closeAsk("ask-1");
+    expect(AskAnswers.hasOutstanding()).toBe(false);
+    expect(AskAnswers.orphansFor(TAB)).toHaveLength(0);
+    expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("recovered");
+  });
+});
+
+describe("ask-answer journal — cross-question misattribution guard (#486)", () => {
+  it("a journaled answer NEVER satisfies a different question", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    const rec = AskAnswers.recover(TAB, askFingerprint(SCHEDULER));
+    // Not "recovered", and not silently "none" either: the answer exists and is
+    // handed back for DISCLOSURE, quoted with its own question.
+    expect(rec.status).toBe("unattributed");
+    if (rec.status !== "unattributed") return;
+    expect(rec.others).toHaveLength(1);
+    expect(rec.others[0].question).toBe(SAMPLER.question);
+  });
+
+  it("matches on the whole question identity — text, option set, order, and mode", () => {
+    const base = askFingerprint(SAMPLER);
+    expect(askFingerprint({ ...SAMPLER, question: "Which sampler should I use ?" })).not.toBe(base);
+    expect(
+      askFingerprint({ ...SAMPLER, options: [{ label: "dpmpp_2m" }, { label: "euler" }] }),
+    ).not.toBe(base); // reordered options are a different card
+    expect(askFingerprint({ ...SAMPLER, options: [{ label: "euler" }] })).not.toBe(base);
+    expect(askFingerprint({ ...SAMPLER, multi_select: true })).not.toBe(base);
+    expect(askFingerprint({ ...SAMPLER, header: "Sampler" })).not.toBe(base);
+    // …but not on cosmetics the user's decision does not depend on.
+    expect(
+      askFingerprint({
+        ...SAMPLER,
+        question: "  Which sampler   should I use?\n",
+        options: [{ label: "euler", description: "fast" }, { label: " dpmpp_2m " }],
+      }),
+    ).toBe(base);
+  });
+
+  it("a label cannot be smuggled to collide with a different question", () => {
+    // The fingerprint escapes its own inputs, so no separator can be forged.
+    const a = askFingerprint({ question: "Pick", options: [{ label: 'x","y' }] });
+    const b = askFingerprint({ question: "Pick", options: [{ label: "x" }, { label: "y" }] });
+    expect(a).not.toBe(b);
+  });
+
+  it("an answer given on ANOTHER tab never satisfies this tab's question", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m", { tabId: OTHER_TAB });
+    expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("none");
+  });
+
+  it("an answer too old to be presented as fresh is disclosed, never returned", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    const entry = AskAnswers.entriesFor(TAB)[0];
+    entry.answeredAt = Date.now() - ASK_RECOVER_MAX_AGE_MS - 1000;
+    const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
+    expect(rec.status).toBe("unattributed");
+    if (rec.status !== "unattributed") return;
+    expect(rec.others[0].answer).toBe("dpmpp_2m");
+  });
+
+  it("a replaced conversation revokes the licence to satisfy a re-ask, but keeps the answer", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    AskAnswers.closeAsks(TAB); // New chat / resume of a historical session
+    const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
+    expect(rec.status).toBe("unattributed");
+    if (rec.status !== "unattributed") return;
+    // Still reported, still quoted with its question — downgraded, not deleted.
+    expect(rec.others[0].answer).toBe("dpmpp_2m");
+    expect(rec.others[0].question).toBe(SAMPLER.question);
+    expect(rec.others[0].correlation.status).toBe("foreign");
+  });
+
+  it("an answer whose ask id this session never opened is UNATTRIBUTED, never matched", () => {
+    AskAnswers.record("never-opened", "dpmpp_2m", { tabId: TAB });
+    const entry = AskAnswers.entriesFor(TAB)[0];
+    expect(entry.correlation.status).toBe("foreign");
+    expect(entry.fingerprint).toBeNull();
+    expect(entry.question).toBeNull();
+    // It is delivered (labelled), but it can satisfy nothing.
+    expect(entry.delivery).toBe("pending");
+    expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("unattributed");
+  });
+});
+
+describe("ask-answer journal — durable delivery (#486, mirroring #468)", () => {
+  function drain(key: string): AskAnswerEvent[] {
+    const seen: AskAnswerEvent[] = [];
+    AskAnswers.deliverPending(key, (payload) => {
+      seen.push(payload);
+      return true;
+    });
+    return seen;
+  }
+
+  it("delivers the answer WITH the question that it answers", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    const [ev] = drain(TAB);
+    expect(ev.ask_answer).toBe("dpmpp_2m");
+    expect(ev.ask_question).toBe(SAMPLER.question);
+    expect(ev.ask_correlation).toBe("matched");
+  });
+
+  it("an answer handed to an agent that then DIES comes back and is replayed", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    const token = AskAnswers.entriesFor(TAB)[0].token;
+    drain(TAB);
+    expect(AskAnswers.pending(TAB)).toHaveLength(0);
+    // The agent was torn down before its turn ran — nobody read it.
+    AskAnswers.release(token, { carried: false });
+    expect(AskAnswers.pending(TAB)).toHaveLength(1);
+    const [again] = drain(TAB);
+    expect(again.ask_answer).toBe("dpmpp_2m");
+    expect(again.replayed).toBe(true);
+  });
+
+  it("teardown handbacks are UNBOUNDED; only turns that carried it are counted", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    const token = AskAnswers.entriesFor(TAB)[0].token;
+    for (let i = 0; i < 10; i += 1) {
+      drain(TAB);
+      AskAnswers.release(token, { carried: false });
+    }
+    expect(AskAnswers.pending(TAB)).toHaveLength(1); // never settled by shuffling
+    for (let i = 0; i < 3; i += 1) {
+      drain(TAB);
+      AskAnswers.release(token, { carried: true });
+    }
+    // Three turns each put the text in front of the agent — settle rather than
+    // loop forever (a duplicate at worst, never an endless replay).
+    expect(AskAnswers.pending(TAB)).toHaveLength(0);
+  });
+
+  it("the turn that carried it ending clears the push but keeps it recoverable", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    const token = AskAnswers.entriesFor(TAB)[0].token;
+    drain(TAB);
+    AskAnswers.ack(token);
+    expect(AskAnswers.hasOutstanding()).toBe(false);
+    // …the user's decision is still on file for a re-ask of the same question.
+    expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("recovered");
+  });
+
+  it("a tab that goes away drops its answers and its tickets", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    AskAnswers.forget(TAB);
+    expect(AskAnswers.entriesFor(TAB)).toHaveLength(0);
+    expect(AskAnswers.hasOutstanding()).toBe(false);
+  });
+
+  it("a tab-id migration re-addresses the answer instead of stranding it", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    AskAnswers.moveKey(TAB, OTHER_TAB);
+    expect(AskAnswers.entriesFor(TAB)).toHaveLength(0);
+    expect(AskAnswers.pending(OTHER_TAB)).toHaveLength(1);
+    expect(AskAnswers.recover(OTHER_TAB, askFingerprint(SAMPLER)).status).toBe("recovered");
+  });
+
+  it("an orphan transition drives the flush itself", () => {
+    const flushed: string[] = [];
+    AskAnswers.setFlusher((k) => flushed.push(k));
+    // Landed with no handler waiting → pushed immediately.
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    expect(flushed).toContain(TAB);
+    flushed.length = 0;
+    // …and an answer that lands WHILE the handler is running is that handler's to
+    // return, so it is not announced until the handler unwinds without it.
+    AskAnswers.openAsk("ask-2", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SCHEDULER),
+      question: SCHEDULER.question,
+    });
+    AskAnswers.record("ask-2", "karras", { tabId: TAB });
+    expect(flushed).toHaveLength(0);
+    AskAnswers.closeAsk("ask-2");
+    expect(flushed).toContain(TAB);
+  });
+});
+
+describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", () => {
+  it("an evicted ORPHAN is counted and disclosed on the next delivery", () => {
+    // 16 answers fit per tab; the 17th evicts one. Every one of these reached
+    // nobody, so the eviction is a real loss and must be reported.
+    for (let i = 0; i < 20; i += 1) {
+      openAndAnswer(`ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
+    }
+    expect(AskAnswers.droppedFor(TAB)).toBeGreaterThan(0);
+    const seen: AskAnswerEvent[] = [];
+    AskAnswers.deliverPending(TAB, (payload) => {
+      seen.push(payload);
+      return true;
+    });
+    expect(seen[0].dropped_answers).toBeGreaterThan(0);
+  });
+
+  it("an eviction disclosure is NOT spent by a hand-off that is later given back", () => {
+    for (let i = 0; i < 20; i += 1) {
+      openAndAnswer(`ask-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
+    }
+    const carrier = AskAnswers.pending(TAB)[0];
+    AskAnswers.deliverPending(TAB, () => true);
+    AskAnswers.release(carrier.token, { carried: false });
+    const seen: AskAnswerEvent[] = [];
+    AskAnswers.deliverPending(TAB, (payload) => {
+      seen.push(payload);
+      return true;
+    });
+    expect(seen[0].dropped_answers).toBeGreaterThan(0);
+  });
+
+  it("an already-RETURNED answer is evicted before an orphan, and silently", () => {
+    // Ordinary successful asks must not manufacture "answers were dropped"
+    // warnings — they reached a caller. Only the orphan is a loss.
+    openAndAnswer("orphan", SAMPLER, "dpmpp_2m");
+    for (let i = 0; i < 30; i += 1) {
+      const ask = { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] };
+      AskAnswers.openAsk(`ret-${i}`, {
+        tabId: TAB,
+        fingerprint: askFingerprint(ask),
+        question: ask.question,
+      });
+      AskAnswers.record(`ret-${i}`, `A${i}`, { tabId: TAB });
+      AskAnswers.markReturned(`ret-${i}`);
+      AskAnswers.closeAsk(`ret-${i}`);
+    }
+    expect(AskAnswers.droppedFor(TAB)).toBe(0);
+    // The orphan is still there — it was never a candidate for a quiet eviction.
+    expect(AskAnswers.orphansFor(TAB).map((e) => e.answer)).toContain("dpmpp_2m");
+  });
+
+  it("a trimmed TICKET can only weaken a correlation, never drop the answer", () => {
+    // `tracks()` is what the bridge sink filters on. If it were answered from the
+    // (bounded) ticket map, an eviction would make a validated answer vanish —
+    // a bounded store protecting against a bounded store.
+    AskAnswers.openAsk("ask-old", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.closeAsk("ask-old"); // its tool call died; the ticket is evictable
+    for (let i = 0; i < 200; i += 1) {
+      const ask = { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] };
+      AskAnswers.openAsk(`ask-${i}`, {
+        tabId: TAB,
+        fingerprint: askFingerprint(ask),
+        question: ask.question,
+      });
+      AskAnswers.closeAsk(`ask-${i}`);
+    }
+    expect(AskAnswers.ticketFor("ask-old")).toBeUndefined(); // ticket trimmed away
+    expect(AskAnswers.tracks("ask-old")).toBe(true); // …but still one of ours
+    AskAnswers.record("ask-old", "dpmpp_2m", { tabId: TAB });
+    const entry = AskAnswers.entriesFor(TAB).find((e) => e.askId === "ask-old");
+    expect(entry?.answer).toBe("dpmpp_2m");
+    expect(entry?.correlation.status).toBe("foreign"); // weakened, not lost
+  });
+
+  it("the same answer observed twice collapses to one entry (identity, not suppression)", () => {
+    // The grace poll and the bridge sink can both see one card's reply.
+    AskAnswers.openAsk("ask-1", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    const a = AskAnswers.record("ask-1", "dpmpp_2m", { tabId: TAB });
+    const b = AskAnswers.record("ask-1", "dpmpp_2m", { tabId: TAB });
+    expect(b.token).toBe(a.token);
+    expect(AskAnswers.entriesFor(TAB)).toHaveLength(1);
+  });
+
+  it("two DIFFERENT answers are never merged, however alike", () => {
+    openAndAnswer("ask-1", SAMPLER, "dpmpp_2m");
+    openAndAnswer("ask-2", SAMPLER, "dpmpp_2m");
+    expect(AskAnswers.entriesFor(TAB)).toHaveLength(2);
+  });
+
+  it("never throws when the flusher does", () => {
+    AskAnswers.setFlusher(() => {
+      throw new Error("no agent");
+    });
+    expect(() => openAndAnswer("ask-1", SAMPLER, "dpmpp_2m")).toThrow();
+    // The entry is journaled regardless — the throw happens after the record.
+    expect(AskAnswers.entriesFor(TAB)).toHaveLength(1);
+    vi.restoreAllMocks();
+  });
+});

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -62,6 +62,25 @@ function strandEvictionDebt(): void {
   AskAnswers.record("pa-live", "dpmpp_2m", { tabId: TAB }); // still awaiting -> "none"
 }
 
+/** An ordinary successful ask: answered, handed back in a tool result, and the
+ *  turn that carried it produced its own result — the ACK. This is the common
+ *  path, and the only one allowed to be forgotten quietly. */
+function ordinaryAckedAsk(
+  askId: string,
+  ask: { question: string; options: unknown },
+  answer: string,
+): void {
+  AskAnswers.openAsk(askId, {
+    tabId: TAB,
+    fingerprint: askFingerprint(ask),
+    question: ask.question,
+  });
+  const token = AskAnswers.record(askId, answer, { tabId: TAB }).token;
+  AskAnswers.markReturned(token);
+  AskAnswers.closeAsk(askId);
+  AskAnswers.ack(token); // the turn's own result landed
+}
+
 beforeEach(() => {
   AskAnswers.reset();
   AskAnswers.setFlusher(() => {});
@@ -372,23 +391,111 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(seen[0].dropped_answers).toBeGreaterThan(0);
   });
 
-  it("an already-RETURNED answer is evicted before an orphan, and silently", () => {
+  it("an ACKED answer is evicted before an orphan, and silently", () => {
     // Ordinary successful asks must not manufacture "answers were dropped"
-    // warnings — they reached a caller. Only the orphan is a loss.
-    openAndAnswer("orphan", SAMPLER, "dpmpp_2m");
+    // warnings — the agent provably read them. Only the orphan is a loss.
+    openAndAnswer("pa-orphan", SAMPLER, "dpmpp_2m");
     for (let i = 0; i < 70; i += 1) {
-      const ask = { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] };
-      AskAnswers.openAsk(`pa-ret-${i}`, {
-        tabId: TAB,
-        fingerprint: askFingerprint(ask),
-        question: ask.question,
-      });
-      AskAnswers.markReturned(AskAnswers.record(`pa-ret-${i}`, `A${i}`, { tabId: TAB }).token);
-      AskAnswers.closeAsk(`pa-ret-${i}`);
+      ordinaryAckedAsk(`pa-ret-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
     }
     expect(AskAnswers.droppedFor(TAB)).toBe(0);
     // The orphan is still there — it was never a candidate for a quiet eviction.
     expect(AskAnswers.orphansFor(TAB).map((e) => e.answer)).toContain("dpmpp_2m");
+  });
+
+  it("acked answers are evicted BEFORE a returned-but-unacked one", () => {
+    // The ORDER is what keeps the common path quiet. If an unacked answer were
+    // picked while acked ones were available, every busy tab would start
+    // reporting undetermined losses for answers that were merely returned.
+    AskAnswers.openAsk("pa-unconfirmed", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    AskAnswers.markReturnedForTest("pa-unconfirmed", "dpmpp_2m", TAB);
+    AskAnswers.closeAsk("pa-unconfirmed");
+    for (let i = 0; i < 70; i += 1) {
+      ordinaryAckedAsk(`pa-ok-${i}`, { question: `Q${i}?`, options: [{ label: "a" }, { label: "b" }] }, `A${i}`);
+    }
+    // Every eviction took an ACKED answer, so nothing was disclosed…
+    expect(AskAnswers.droppedFor(TAB)).toBe(0);
+    // …and the one answer whose receipt was never confirmed is still on file.
+    expect(AskAnswers.entriesFor(TAB).some((e) => e.answer === "dpmpp_2m")).toBe(true);
+  });
+
+  // THE SPLIT (coordinator ruling on Trade A). "returned" says only that the
+  // answer was written to a transport that may already have been abandoned —
+  // which IS #486 — so it can never be the licence to forget. Only a turn that
+  // produced its own result proves the model read it.
+  it("a RETURNED-but-UNACKED answer evicted is counted and disclosed", () => {
+    // 60 answers handed back to tool calls whose turns never completed.
+    for (let i = 0; i < 60; i += 1) {
+      const ask = { question: `U${i}?`, options: [{ label: "a" }, { label: "b" }] };
+      AskAnswers.openAsk(`pa-unacked-${i}`, {
+        tabId: TAB,
+        fingerprint: askFingerprint(ask),
+        question: ask.question,
+      });
+      AskAnswers.markReturned(AskAnswers.record(`pa-unacked-${i}`, `U${i}`, { tabId: TAB }).token);
+      AskAnswers.closeAsk(`pa-unacked-${i}`);
+    }
+    // The ceiling bit, and every eviction was a #486 failure, not an ordinary ask.
+    expect(AskAnswers.droppedFor(TAB)).toBeGreaterThan(0);
+    expect(AskAnswers.hasOutstanding()).toBe(true);
+  });
+
+  it("an ACKED answer never blocks a restart and is not named on the way out", () => {
+    ordinaryAckedAsk("pa-acked", SAMPLER, "dpmpp_2m");
+    const entry = AskAnswers.entriesFor(TAB)[0];
+    expect(entry.acked).toBe(true);
+    expect(AskAnswers.hasOutstanding()).toBe(false);
+    expect(AskAnswers.allOutstanding()).toHaveLength(0);
+  });
+
+  it("a returned answer whose turn never completed IS named on the way out", () => {
+    AskAnswers.openAsk("pa-unconfirmed", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    const token = AskAnswers.markReturnedForTest("pa-unconfirmed", "dpmpp_2m", TAB);
+    AskAnswers.closeAsk("pa-unconfirmed");
+    // The turn ended without proving it was read — #468's release path.
+    AskAnswers.release(token, { carried: true });
+    expect(AskAnswers.entriesFor(TAB)[0].acked).toBeUndefined();
+    expect(AskAnswers.allOutstanding().map((e) => e.answer)).toContain("dpmpp_2m");
+  });
+
+  it("a released tool-result answer is never re-armed for a push, nor settled by a bound", () => {
+    AskAnswers.openAsk("pa-tr", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    const token = AskAnswers.markReturnedForTest("pa-tr", "dpmpp_2m", TAB);
+    AskAnswers.closeAsk("pa-tr");
+    for (let i = 0; i < 10; i += 1) AskAnswers.release(token, { carried: true });
+    // Nothing re-sends a tool-result answer, so there is no loop to bound — and
+    // settling it on one would forge the proof the split exists to withhold.
+    expect(AskAnswers.pending(TAB)).toHaveLength(0);
+    expect(AskAnswers.entriesFor(TAB)[0].acked).toBeUndefined();
+    expect(AskAnswers.entriesFor(TAB)[0].delivery).toBe("none");
+  });
+
+  it("the turn attacher is asked to carry every returned answer", () => {
+    const carried: string[] = [];
+    AskAnswers.setTurnAttacher((_key, token) => {
+      carried.push(token);
+      return true;
+    });
+    AskAnswers.openAsk("pa-attach", {
+      tabId: TAB,
+      fingerprint: askFingerprint(SAMPLER),
+      question: SAMPLER.question,
+    });
+    const token = AskAnswers.markReturnedForTest("pa-attach", "dpmpp_2m", TAB);
+    expect(carried).toEqual([token]);
+    AskAnswers.setTurnAttacher(() => false);
   });
 
   it("a trimmed TICKET can only weaken a correlation, never drop the answer", () => {
@@ -797,22 +904,56 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     // re-addresses renders across it: a finished render is useful to whoever is
     // on the tab now, an answer to a card the new conversation never put up is
     // not. Both switch paths must retire the asks.
+    // …and it must be GATED on an actual change of provider. A routine
+    // same-provider re-hello or a no-op set_backend retiring live cards is the
+    // over-refusal direction of the same fold: a still-live conversation treated
+    // as replaced, so the user's answer to a card it really did put up comes back
+    // "unattributed".
     for (const guard of [
       "if (providerSwitched) flushRunCompletions(panelTab);",
       "if (prev !== reqBackend) flushRunCompletions(panelTab);",
     ]) {
       const at = src.indexOf(guard);
       expect(at, `provider-switch site not found: ${guard}`).toBeGreaterThan(-1);
+      const cond = guard.slice(0, guard.indexOf(")") + 1); // "if (providerSwitched)"
       expect(
         src.slice(at, at + 900),
-        `${guard} must retire ask state`,
-      ).toContain("AskAnswers.closeAsks(panelTab)");
+        `${guard} must retire ask state, under the same guard`,
+      ).toContain(`${cond} AskAnswers.closeAsks(panelTab)`);
+    }
+    // The unconditional form must not appear at either switch site.
+    for (const guard of [
+      "if (providerSwitched) flushRunCompletions(panelTab);",
+      "if (prev !== reqBackend) flushRunCompletions(panelTab);",
+    ]) {
+      const at = src.indexOf(guard);
+      const window = src.slice(at, at + 900);
+      const unguarded = window.match(/\n\s*AskAnswers\.closeAsks\(panelTab\)/);
+      expect(unguarded, `${guard}: closeAsks must not run when the provider is unchanged`).toBeNull();
     }
 
     // The unsend hook must actually be wired, or closeAsks silently degrades to
-    // "leave the stale copy queued".
+    // "leave the stale copy queued"; and the turn attacher must be wired, or the
+    // journal has no proof of receipt for the ordinary path and every eviction
+    // becomes a disclosed loss.
     expect(src).toContain("AskAnswers.setRevoker(");
     expect(src).toContain("AskAnswers.setFlusher(");
+    expect(src).toContain("AskAnswers.setTurnAttacher(");
+    expect(src).toContain("manager.attachTurnToken(");
+
+    // The fatal-exit disclosure must keep RENDERS and ANSWERS apart. A lost
+    // answer is not a ComfyUI run and will NEVER be in history, so pointing the
+    // user at `get_history` for one is a remedy naming a lever that cannot work —
+    // in the one moment they are already dealing with a failure.
+    const exitAt = src.indexOf("The agent backend is being restarted");
+    expect(exitAt, "exit notice not found").toBeGreaterThan(-1);
+    const notice = src.slice(exitAt, exitAt + 1600);
+    expect(notice, "the answer branch must not send the user to get_history").toMatch(
+      /answer\(s\) you gave[\s\S]*there is NO history to look it up in/,
+    );
+    expect(notice, "the answer branch must ask for the answer again").toMatch(
+      /tell it your choice again/,
+    );
 
     // …and every OTHER boundary is defined by where the run journal draws one.
     // Pairing the two journals structurally is what stops the next boundary from
@@ -953,19 +1094,13 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     const carrier = AskAnswers.entriesFor(TAB).find((e) => (e.disclose ?? 0) > 0);
     expect(carrier).toBeDefined();
     AskAnswers.markSurfaced(carrier!.token); // a recovery handed it over
-    expect(carrier!.returned).toBe(true); // …now the preferred eviction victim
-    // More answers arrive, all of them RETURNED, so every eviction they cause
-    // takes the quiet returned-victim path and creates NO new debt — leaving the
-    // carrier's count as the only debt in play.
+    AskAnswers.ack(carrier!.token); // …and that turn completed
+    expect(carrier!.acked).toBe(true); // now the preferred eviction victim
+    // More answers arrive, all of them ACKED, so every eviction they cause takes
+    // the quiet path and creates NO new debt — leaving the carrier's count as the
+    // only debt in play.
     for (let i = 60; i < 80; i += 1) {
-      const ask = { question: `R${i}?`, options: [{ label: "a" }, { label: "b" }] };
-      AskAnswers.openAsk(`pa-ret-${i}`, {
-        tabId: TAB,
-        fingerprint: askFingerprint(ask),
-        question: ask.question,
-      });
-      AskAnswers.markReturned(AskAnswers.record(`pa-ret-${i}`, `R${i}`, { tabId: TAB }).token);
-      AskAnswers.closeAsk(`pa-ret-${i}`);
+      ordinaryAckedAsk(`pa-ret-${i}`, { question: `R${i}?`, options: [{ label: "a" }, { label: "b" }] }, `R${i}`);
     }
     expect(AskAnswers.entriesFor(TAB).some((e) => e.token === carrier!.token)).toBe(false);
     // EXACTLY the same debt — it moved, it did not evaporate with its carrier.
@@ -997,6 +1132,51 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(entry.key).toBe(TAB);
     expect(entry.correlation.status).toBe("foreign");
     expect(AskAnswers.entriesFor(OTHER_TAB)).toHaveLength(0);
+  });
+
+  // Gate P0-2: the disclosure DEBT used to be evictable on the same terms as
+  // payload (64 tabs), so the 65th tab with stranded debt deleted the oldest
+  // tab's only record — after which its later ask, the restart gate and the
+  // fatal-exit report all had nothing, and the log line said outright that the
+  // tab "will not be told". A bounded store must never decide whether a warning
+  // is owed.
+  it("debt for the FIRST tab survives far past any tab ceiling", () => {
+    const FIRST = "tab-first-0001";
+    const strandFor = (tab: string): void => {
+      // Fill the tab's ceiling with orphans, hand them all off, then land one
+      // more answer whose handler is still awaiting — so the eviction it triggers
+      // has no pending entry to stamp and the debt goes to the side map.
+      for (let i = 0; i < 48; i += 1) {
+        const ask = { question: `${tab}-Q${i}?`, options: [{ label: "a" }, { label: "b" }] };
+        AskAnswers.openAsk(`pa-${tab}-${i}`, {
+          tabId: tab,
+          fingerprint: askFingerprint(ask),
+          question: ask.question,
+        });
+        AskAnswers.closeAsk(`pa-${tab}-${i}`);
+        AskAnswers.record(`pa-${tab}-${i}`, `A${i}`, { tabId: tab });
+      }
+      AskAnswers.deliverPending(tab, () => true);
+      AskAnswers.openAsk(`pa-${tab}-live`, {
+        tabId: tab,
+        fingerprint: askFingerprint(SAMPLER),
+        question: SAMPLER.question,
+      });
+      AskAnswers.record(`pa-${tab}-live`, "dpmpp_2m", { tabId: tab });
+    };
+    strandFor(FIRST);
+    const owed = AskAnswers.droppedFor(FIRST);
+    expect(owed).toBeGreaterThan(0);
+    // 200 further tabs each strand their own debt — three times the old ceiling.
+    for (let t = 1; t <= 200; t += 1) strandFor(`tab-other-${String(t).padStart(4, "0")}`);
+    // The FIRST tab is still owed (never less — the global ceiling may have cost
+    // it more answers since), still holds the restart gate, and is still named by
+    // the fatal-exit report.
+    const still = AskAnswers.droppedFor(FIRST);
+    expect(still).toBeGreaterThanOrEqual(owed);
+    expect(AskAnswers.reportDropped(FIRST)).toBe(still);
+    expect(AskAnswers.hasOutstanding()).toBe(true);
+    expect(AskAnswers.outstandingDebt().some((x) => x.key === FIRST && x.count > 0)).toBe(true);
   });
 
   it("never throws when the flusher does", () => {

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -981,6 +981,11 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     // trades a silent loss for unbounded growth.
     expect(src).toContain("bridge.setTabGoneListener(");
     expect(src).toContain("AskAnswers.retireDebt(");
+    // A different browser tab taking over a recurring key is a conversation
+    // boundary too — the ENTRIES are tab-keyed, so the newcomer must be shut out
+    // of them at the hello, not merely kept from the debt.
+    expect(src).toMatch(/setTabTakenOverListener\(\(tabId\) => AskAnswers\.closeAsks\(tabId\)\)/);
+    expect(src).toContain("AskAnswers.setIncarnationResolver(");
     // The ack must carry WHO is acking, or a switched provider can certify the
     // previous conversation's answer.
     expect(src).toMatch(/AskAnswers\.ack\(token, from\)/);

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { readFileSync } from "node:fs";
+import { logger } from "../../utils/logger.js";
 import {
   AskAnswers,
   askFingerprint,
@@ -1604,6 +1605,106 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(AskAnswers.droppedFor(TAB)).toBe(5); // B's survives, untouched
     expect(AskAnswers.reportDropped(TAB)).toBe(5);
     AskAnswers.setIncarnationResolver(() => OCCUPANT);
+  });
+
+  // ── The SECOND boundary: cross-CONVERSATION on the SAME tab ───────────────
+  //
+  // New chat, rewind and a provider switch all keep the same tab id AND the same
+  // browser-tab incarnation, so `(tabId, incarnation)` cannot fence them at all.
+  // Every path that can hand an answer or a disclosure to a live turn has to
+  // consult the boundary mark instead — recovery, replay, push, and the debt
+  // report. Gating them one at a time is how three separate bypasses arrived.
+
+  // P0-1: a turn was already carrying the answer when the boundary happened. Its
+  // release re-armed the entry to `pending`, and the push path never consulted
+  // the mark — so the OLD conversation's answer was pushed into the replacement,
+  // which could then ack it (pushed entries carry no carrier binding).
+  it("a boundary-retired answer is never re-armed for the replacement conversation", () => {
+    openAndAnswer("pa-carry", SAMPLER, "dpmpp_2m");
+    const token = AskAnswers.entriesFor(TAB)[0].token;
+    AskAnswers.deliverPending(TAB, () => true); // a turn is carrying it
+    expect(AskAnswers.entriesFor(TAB)[0].delivery).toBe("handed_off");
+
+    AskAnswers.closeAsks(TAB); // New chat / rewind / provider switch
+    // The carrying turn ends without proving it was read — the ordinary release.
+    AskAnswers.release(token, { carried: false });
+
+    expect(AskAnswers.entriesFor(TAB)[0].delivery).toBe("none");
+    expect(AskAnswers.pending(TAB)).toHaveLength(0);
+    expect(AskAnswers.hasOutstanding()).toBe(false);
+    // Nothing was swallowed: it is still journaled, still disclosed, still named.
+    const rec = AskAnswers.recover(TAB, askFingerprint(SAMPLER));
+    expect(rec.status).toBe("unattributed");
+    if (rec.status !== "unattributed") return;
+    expect(rec.others.some((e) => e.answer === "dpmpp_2m")).toBe(true);
+    expect(AskAnswers.allOutstanding().map((e) => e.answer)).toContain("dpmpp_2m");
+  });
+
+  it("a retired answer cannot be delivered even if something re-arms it directly", () => {
+    openAndAnswer("pa-force", SAMPLER, "dpmpp_2m");
+    AskAnswers.closeAsks(TAB);
+    // Belt and braces: the push path itself refuses, not merely the re-arm.
+    AskAnswers.entriesFor(TAB)[0].delivery = "pending";
+    expect(AskAnswers.pending(TAB)).toHaveLength(0);
+    const seen: AskAnswerEvent[] = [];
+    AskAnswers.deliverPending(TAB, (payload) => {
+      seen.push(payload);
+      return true;
+    });
+    expect(seen).toEqual([]);
+  });
+
+  // P0-2: the eviction DEBT survived a conversation boundary untouched, so the
+  // replacement conversation's next ask reported the old conversation's warning
+  // as its own and settled it with its own ack.
+  it("a conversation boundary retires the debt — reported, then cleared", () => {
+    const tokens: string[] = [];
+    AskAnswers.setTurnAttacher((_key, token) => {
+      tokens.push(token);
+      return TURN;
+    });
+    AskAnswers.noteDroppedForTest(TAB, 5);
+    expect(AskAnswers.droppedFor(TAB)).toBe(5);
+
+    AskAnswers.closeAsks(TAB); // New chat on the SAME tab, SAME incarnation
+
+    // The replacement conversation is owed nothing and can settle nothing.
+    expect(AskAnswers.reportDropped(TAB)).toBe(0);
+    expect(tokens).toHaveLength(0);
+    expect(AskAnswers.droppedFor(TAB)).toBe(0);
+    expect(AskAnswers.outstandingDebt()).toHaveLength(0);
+    expect(AskAnswers.hasOutstanding()).toBe(false);
+  });
+
+  it("a boundary also clears debt riding on an entry, so it is not stranded", () => {
+    // Fill past the ceiling so an eviction stamps its loss onto a surviving entry.
+    for (let i = 0; i < 60; i += 1) {
+      openAndAnswer(`pa-e-${i}`, { question: `E${i}?`, options: [{ label: "x" }, { label: "y" }] }, `E${i}`);
+    }
+    const owed = AskAnswers.droppedFor(TAB);
+    expect(owed).toBeGreaterThan(0);
+    const carrier = AskAnswers.entriesFor(TAB).find((e) => (e.disclose ?? 0) > 0);
+    expect(carrier).toBeDefined();
+    const carried = carrier!.disclose!;
+
+    const errors: string[] = [];
+    const spy = vi.spyOn(logger, "error").mockImplementation((msg: unknown) => {
+      errors.push(String(msg));
+    });
+    AskAnswers.closeAsks(TAB);
+    spy.mockRestore();
+
+    // Those entries are no longer pushed, so a disclosure left riding one would
+    // be stranded on text nobody will read. It is SURFACED with the rest — a
+    // retirement that merely cleared it would trade a misattribution for a
+    // silent loss — and only then cleared.
+    const surfaced = errors.find((m) => m.includes("its conversation was replaced"));
+    expect(surfaced, "the retirement must report what was owed").toBeDefined();
+    expect(surfaced).toContain(`${owed} validated answer(s)`);
+    expect(carried).toBeGreaterThan(0);
+    expect(carrier!.disclose ?? 0).toBe(0);
+    expect(AskAnswers.droppedFor(TAB)).toBe(0);
+    expect(AskAnswers.reportDropped(TAB)).toBe(0);
   });
 
   it("never throws when the flusher does", () => {

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -1313,6 +1313,30 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(AskAnswers.outstandingDebt()).toHaveLength(0);
   });
 
+  // The journal half of the same seam: even if a stranger reaches the debt, its
+  // result must not settle it. The disclosure token is bound to the AGENT
+  // INSTANCE that carried it, so a different conversation on the same tab key
+  // cannot certify a warning it never showed.
+  it("a different agent instance cannot ack the departed tab's disclosure", () => {
+    AskAnswers.noteDroppedForTest(TAB, 3);
+    const tokens: string[] = [];
+    AskAnswers.setTurnAttacher((_key, token) => {
+      tokens.push(token);
+      return "pa-instance-A";
+    });
+    expect(AskAnswers.reportDropped(TAB)).toBe(3);
+
+    // A second browser tab takes over the same key; its agent is a NEW instance.
+    AskAnswers.ack(tokens[0], { carrier: "pa-instance-B" });
+    expect(AskAnswers.droppedFor(TAB)).toBe(3); // still owed
+    AskAnswers.ack(tokens[0]); // …and an unidentified ack proves nothing either
+    expect(AskAnswers.droppedFor(TAB)).toBe(3);
+
+    // Only the instance that actually carried the warning retires it.
+    AskAnswers.ack(tokens[0], { carrier: "pa-instance-A" });
+    expect(AskAnswers.droppedFor(TAB)).toBe(0);
+  });
+
   it("never throws when the flusher does", () => {
     AskAnswers.setFlusher(() => {
       throw new Error("no agent");

--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -28,6 +28,10 @@ const SCHEDULER = {
   question: "Which scheduler should I use?",
   options: [{ label: "karras" }, { label: "normal" }],
 };
+const THIRD_Q = {
+  question: "Should I upscale the result?",
+  options: [{ label: "yes" }, { label: "no" }],
+};
 
 function openAndAnswer(
   askId: string,
@@ -1889,17 +1893,81 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     expect(AskAnswers.droppedFor(TAB)).toBe(2);
   });
 
-  it("a throwing recall cannot leave the boundary half-built either", () => {
+  // Gate P0: A CATCH BLOCK THAT CAN THROW IS NOT A GUARD.
+  //
+  // Pass 2 wraps `revoke()` so a throwing revoker cannot abort the boundary — but
+  // the logger.warn that REPORTS that failure was itself unguarded, so a throwing
+  // revoker plus a throwing warn sink handed the abort straight back: closeAsks
+  // exited inside the first entry's catch, skipping every remaining recall AND
+  // pass 3 (surfaceAndClearDebt). Both halves of the debt then survived on a
+  // retired conversation —
+  //   • the side-map half for a SAME-INCARNATION replacement (New chat does not
+  //     change the incarnation) to read via reportDropped() and settle with its
+  //     own ack, i.e. the departed conversation's warning misattributed and then
+  //     silenced;
+  //   • the entry-carried half stamped on an entry that is now retired and
+  //     therefore permanently undeliverable, which hasOutstanding() still counts
+  //     as owed — a self-restart gate stuck shut forever.
+  //
+  // So this drives BOTH throwing sinks at once and asserts the pass actually ran:
+  // both queued tokens reached the revoker, and the destroy-step after it did too.
+  it("a throwing recall — even with a throwing warn sink — cannot leave the boundary half-built", () => {
     openAndAnswer("pa-recall", SAMPLER, "dpmpp_2m");
     openAndAnswer("pa-recall-2", SCHEDULER, "karras");
+    // Captured BEFORE the hand-off: these two are exactly what pass 2 must pull
+    // back, and naming them is what makes deleting the recall loop fail.
+    const queuedTokens = AskAnswers.entriesFor(TAB).map((e) => e.token);
+    expect(queuedTokens).toHaveLength(2);
     AskAnswers.deliverPending(TAB, () => true); // both queued into a turn
-    AskAnswers.setRevoker(() => {
+
+    // Debt in BOTH places, so pass 3 has both halves to destroy: the side map
+    // (no pending entry to stamp right now) …
+    AskAnswers.noteDroppedForTest(TAB, 2);
+    // … and stamped onto a surviving PENDING entry (the half that jams the gate).
+    openAndAnswer("pa-recall-3", THIRD_Q, "yes");
+    AskAnswers.noteDroppedForTest(TAB, 3);
+    expect(AskAnswers.droppedFor(TAB)).toBe(5);
+
+    const recalls: Array<[string, string]> = [];
+    AskAnswers.setRevoker((key, token) => {
+      recalls.push([key, token]);
       throw new Error("agent is gone");
     });
+    // The failure REPORT is fallible too — that is the whole finding.
+    const deadWarn = vi.spyOn(logger, "warn").mockImplementation(() => {
+      throw new Error("log sink is down");
+    });
+    const surfaced: string[] = [];
+    const surfacer = vi.spyOn(logger, "error").mockImplementation((msg: string) => {
+      surfaced.push(msg);
+    });
 
-    // The revoke is fallible and runs AFTER the fence, so it cannot skip it.
-    AskAnswers.closeAsks(TAB);
+    // Everything after the fence is fallible, and none of it may escape.
+    expect(() => AskAnswers.closeAsks(TAB)).not.toThrow();
+    deadWarn.mockRestore();
+    surfacer.mockRestore();
 
+    // PASS 2 RAN TO THE END: both queued copies were actually offered back, not
+    // just the first. A throw out of entry 1's catch would leave entry 2 queued on
+    // an agent whose conversation is gone.
+    expect(recalls).toEqual([
+      [TAB, queuedTokens[0]],
+      [TAB, queuedTokens[1]],
+    ]);
+
+    // PASS 3 RAN AT ALL, and said WHY and HOW MUCH before destroying it — the
+    // reason, not just the state.
+    expect(surfaced).toHaveLength(1);
+    expect(surfaced[0]).toMatch(/its conversation was replaced/);
+    expect(surfaced[0]).toMatch(/5 validated answer/);
+    expect(AskAnswers.droppedFor(TAB)).toBe(0);
+    // …so the replacement conversation cannot be handed the departed one's
+    // warning as its own…
+    expect(AskAnswers.reportDropped(TAB)).toBe(0);
+    // …and no retired, undeliverable entry is left holding the restart gate.
+    expect(AskAnswers.hasOutstanding()).toBe(false);
+
+    // PASS 1's fence is intact throughout.
     expect(AskAnswers.entriesFor(TAB).every((e) => e.retired === true)).toBe(true);
     expect(AskAnswers.pending(TAB)).toHaveLength(0);
     expect(AskAnswers.recover(TAB, askFingerprint(SAMPLER)).status).toBe("unattributed");

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4409,6 +4409,40 @@ describe("panel_ask keeps a validated answer across a tool timeout (#486)", () =
     expect(AskAnswers.orphansFor(TAB).some((e) => e.answer === "dpmpp_2m")).toBe(true);
   });
 
+  // Gate: a rid proves WHICH CARD replied — it says nothing about whose
+  // conversation is live. An ask retired while its request was still pending (a
+  // different browser tab took the recurring key over, a New chat, a rewind)
+  // must not have its answer handed back through the tool-result channel, which
+  // is the one path a conversation boundary does not otherwise police.
+  it("an answer arriving after its conversation was replaced is reported, not returned", async () => {
+    let askId: string | null = null;
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        askId = String(cmd.ask_id);
+        // The boundary lands while this request is still in flight…
+        AskAnswers.closeAsks(TAB);
+        // …and only then does the user click, resolving THIS send's own rid.
+        return "dpmpp_2m";
+      },
+      canReach: () => true,
+      isHeadless: () => false,
+      resolveActiveTabId: () => TAB,
+      takeLateAskReply: () => undefined,
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx: PanelToolCtx = { bridge, tabId: TAB } as unknown as PanelToolCtx;
+
+    const res = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, ctx);
+    expect(askId).not.toBeNull();
+    expect(res.isError).toBe(true);
+    expect(askText(res)).toMatch(/conversation that asked it has been replaced/i);
+    // Reported, never swallowed — the pick is quoted, attributed to the
+    // conversation it was actually given to.
+    expect(askText(res)).toContain("dpmpp_2m");
+    // …and it was not counted as delivered to anyone.
+    expect(AskAnswers.entriesFor(TAB)[0].returned).toBe(false);
+  });
+
   it("holds the WHOLE handler under one wall-clock ceiling anchored at entry", () => {
     // The card deadline and the grace poll used to be additive on top of
     // everything else, so a bounded ask could still overrun the enclosing

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -28,6 +28,7 @@ import {
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 import { markReplyTimeout } from "../../services/ui-bridge.js";
 import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
+import { AskAnswers } from "../../orchestrator/ask-answer-journal.js";
 
 type Forwarded = Record<string, unknown>;
 
@@ -4121,3 +4122,212 @@ describe("panel_strip_workflow live-canvas fallback (issue #384)", () => {
     expect(err.message).toContain("pass pack, path, or graph");
   });
 });
+
+// -- #486: a VALIDATED panel_ask answer must survive the tool call that asked --
+//
+// The whole failure is that the user's answer has exactly one delivery channel —
+// the return value of an MCP `tools/call` that can be dead by the time it
+// arrives. These tests drive the real handler over a fake bridge and hold both
+// halves of the fix: an answer that was given is never lost, and a recovered
+// answer is never applied to a different question.
+describe("panel_ask keeps a validated answer across a tool timeout (#486)", () => {
+  const REPLY_TIMEOUT_ERR = (cmd: string, ms: number) =>
+    new Error(
+      `Panel tab abcd1234 did not reply to "${cmd}" within ${ms} ms — the ComfyUI tab may be backgrounded or frozen`,
+    );
+  const TAB = "abcd1234";
+  const SAMPLER = {
+    question: "Which sampler should I use?",
+    options: [{ label: "euler" }, { label: "dpmpp_2m" }],
+  };
+  const SCHEDULER = {
+    question: "Which scheduler should I use?",
+    options: [{ label: "karras" }, { label: "normal" }],
+  };
+
+  /** Ask ids of every card the handler actually dispatched, in order. */
+  let dispatchedAskIds: string[] = [];
+
+  function timingOutBridge(): PanelToolCtx["bridge"] {
+    return {
+      send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        if (typeof cmd.ask_id === "string") dispatchedAskIds.push(cmd.ask_id);
+        throw REPLY_TIMEOUT_ERR(String(cmd.cmd), opts?.timeoutMs ?? 0);
+      },
+      canReach: () => true,
+      isHeadless: () => false,
+      resolveActiveTabId: () => TAB,
+      takeLateAskReply: () => undefined,
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+  }
+
+  function askText(res: ToolResult): string {
+    return (res.content[0] as { text: string }).text;
+  }
+
+  beforeEach(() => {
+    AskAnswers.reset();
+    AskAnswers.setFlusher(() => {});
+    dispatchedAskIds = [];
+    __panelAskTestHooks.setAskTiming({ deadlineMs: 5, graceMs: 10, pollMs: 2 });
+  });
+  afterEach(() => {
+    __panelAskTestHooks.setAskTiming(null);
+    AskAnswers.reset();
+  });
+
+  /** Play out the real #486 sequence: the card times out (the tool call is gone),
+   *  and only THEN does the user validate a pick, which the bridge's late-answer
+   *  sink journals with nobody left to hand it to. */
+  async function askThenAnswerLate(
+    ask: { question: string; options: unknown },
+    answer: string,
+  ): Promise<ToolResult> {
+    const ctx: PanelToolCtx = {
+      bridge: timingOutBridge(),
+      tabId: TAB,
+    } as unknown as PanelToolCtx;
+    const res = await defByName("panel_ask").handler(ask as Record<string, unknown>, ctx);
+    const askId = dispatchedAskIds[dispatchedAskIds.length - 1];
+    AskAnswers.record(askId, answer, { tabId: TAB }); // the bridge sink
+    return res;
+  }
+
+  it("journals the answer as an ORPHAN when no tool call is left to receive it", async () => {
+    const first = await askThenAnswerLate(SAMPLER, "dpmpp_2m");
+    expect(first.isError).toBe(true); // the first call genuinely timed out
+    const orphans = AskAnswers.orphansFor(TAB);
+    expect(orphans).toHaveLength(1);
+    expect(orphans[0].answer).toBe("dpmpp_2m");
+    expect(orphans[0].question).toBe(SAMPLER.question);
+    // Armed for the durable push, so the agent learns of it even if panel_ask is
+    // never called again.
+    expect(orphans[0].delivery).toBe("pending");
+  });
+
+  it("a re-ask of the SAME question returns the answer the user already gave", async () => {
+    await askThenAnswerLate(SAMPLER, "dpmpp_2m");
+    const ctx: PanelToolCtx = {
+      bridge: timingOutBridge(),
+      tabId: TAB,
+    } as unknown as PanelToolCtx;
+    // The user does not answer again — they believe they already did.
+    const res = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, ctx);
+    expect(res.isError).toBeFalsy();
+    const text = askText(res);
+    expect(text).toContain("dpmpp_2m");
+    expect(text).toContain("RECOVERED ANSWER");
+    expect(text).toContain(SAMPLER.question);
+  });
+
+  it("a recovered answer is served ONCE — a later ask does not get it again", async () => {
+    await askThenAnswerLate(SAMPLER, "dpmpp_2m");
+    const ctx = () => ({ bridge: timingOutBridge(), tabId: TAB }) as unknown as PanelToolCtx;
+    const first = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, ctx());
+    expect(first.isError).toBeFalsy();
+    const second = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, ctx());
+    expect(second.isError).toBe(true);
+    expect(askText(second)).not.toContain("dpmpp_2m");
+  });
+
+  // THE INVERSE, and the more damaging direction: a replayed answer must never
+  // satisfy a DIFFERENT question. The agent acting on an answer to something else
+  // is worse than the agent losing the answer entirely.
+  it("a journaled answer NEVER satisfies a different question", async () => {
+    await askThenAnswerLate(SAMPLER, "dpmpp_2m");
+    const ctx: PanelToolCtx = {
+      bridge: timingOutBridge(),
+      tabId: TAB,
+    } as unknown as PanelToolCtx;
+    const res = await defByName("panel_ask").handler(SCHEDULER as Record<string, unknown>, ctx);
+    // NOT answered — the scheduler question has no answer on file.
+    expect(res.isError).toBe(true);
+    const text = askText(res);
+    expect(text).toMatch(/not answered in time/i);
+    // ...but the sampler answer is REPORTED rather than swallowed, quoted with
+    // the question it actually answers and an explicit refusal to let it stand in.
+    expect(text).toContain(SAMPLER.question);
+    expect(text).toContain("dpmpp_2m");
+    expect(text).toMatch(/do NOT use any of them as the answer to the question you just asked/i);
+  });
+
+  it("an answer given on a DIFFERENT tab never leaks into this tab's ask", async () => {
+    await askThenAnswerLate(SAMPLER, "dpmpp_2m");
+    const ctx: PanelToolCtx = {
+      bridge: timingOutBridge(),
+      tabId: "zzzz9999",
+    } as unknown as PanelToolCtx;
+    const res = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, ctx);
+    expect(res.isError).toBe(true);
+    expect(askText(res)).not.toContain("dpmpp_2m");
+  });
+
+  it("an answer that merely lost the grace-poll race is returned as THIS ask's own answer", async () => {
+    // The sink journals the pick microseconds after the last poll. It is this
+    // card's answer, so it comes back verbatim — not dressed up as a recovery.
+    let askId: string | null = null;
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        askId = String(cmd.ask_id);
+        throw REPLY_TIMEOUT_ERR(String(cmd.cmd), opts?.timeoutMs ?? 0);
+      },
+      canReach: () => true,
+      isHeadless: () => false,
+      resolveActiveTabId: () => TAB,
+      takeLateAskReply: () => {
+        // Landed in the journal instead of the buffer, just after the last poll.
+        if (askId) AskAnswers.record(askId, "dpmpp_2m", { tabId: TAB });
+        return undefined;
+      },
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx: PanelToolCtx = { bridge, tabId: TAB } as unknown as PanelToolCtx;
+    const res = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(askText(res)).toBe("dpmpp_2m");
+  });
+
+  it("the ordinary answered path is unchanged — the raw pick, and nothing pushed", async () => {
+    const bridge = {
+      send: async () => "euler",
+      canReach: () => true,
+      isHeadless: () => false,
+      resolveActiveTabId: () => TAB,
+      takeLateAskReply: () => undefined,
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx: PanelToolCtx = { bridge, tabId: TAB } as unknown as PanelToolCtx;
+    const res = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(askText(res)).toBe("euler");
+    // A ToolResult is a hand-off, not a proof, so the answer stays on file — but
+    // it must NOT be announced to the agent as an orphan, or every single ask
+    // would be reported twice.
+    expect(AskAnswers.hasOutstanding()).toBe(false);
+    expect(AskAnswers.orphansFor(TAB)).toHaveLength(0);
+  });
+
+  it("a plain unanswered ask (nothing ever given) still fails cleanly and quietly", async () => {
+    const ctx: PanelToolCtx = {
+      bridge: timingOutBridge(),
+      tabId: TAB,
+    } as unknown as PanelToolCtx;
+    const res = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, ctx);
+    expect(res.isError).toBe(true);
+    expect(askText(res)).toMatch(/not answered in time/i);
+    expect(askText(res)).not.toMatch(/HOWEVER/);
+  });
+
+  it("holds the WHOLE handler under one wall-clock ceiling anchored at entry", () => {
+    // The card deadline and the grace poll used to be additive on top of
+    // everything else, so a bounded ask could still overrun the enclosing
+    // tools/call budget and die as a raw transport timeout instead of a result.
+    const t = __panelAskTestHooks.getAskTiming();
+    expect(t.deadlineMs + t.graceMs).toBeLessThanOrEqual(
+      __panelAskTestHooks.ASK_TOTAL_BUDGET_CAP_MS,
+    );
+    expect(__panelAskTestHooks.ASK_TOTAL_BUDGET_CAP_MS).toBeLessThan(300000);
+  });
+});
+

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4221,14 +4221,22 @@ describe("panel_ask keeps a validated answer across a tool timeout (#486)", () =
     expect(text).toContain(SAMPLER.question);
   });
 
-  it("a recovered answer is served ONCE — a later ask does not get it again", async () => {
+  // codex round 3, P0: the recovery used to DELETE the journal's copy the moment
+  // it handed the answer back — but that hand-off is a ToolResult, which is
+  // exactly the thing that can be abandoned (it IS #486). Destroying the copy
+  // there recreates the bug one level up, so a further re-ask gets it AGAIN,
+  // flagged so the agent does not act on it twice.
+  it("a recovered answer survives its own hand-off and is re-surfaced, flagged", async () => {
     await askThenAnswerLate(SAMPLER, "dpmpp_2m");
     const ctx = () => ({ bridge: timingOutBridge(), tabId: TAB }) as unknown as PanelToolCtx;
     const first = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, ctx());
     expect(first.isError).toBeFalsy();
+    expect(askText(first)).toContain("dpmpp_2m");
+    expect(askText(first)).not.toMatch(/handed to you before/i);
     const second = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, ctx());
-    expect(second.isError).toBe(true);
-    expect(askText(second)).not.toContain("dpmpp_2m");
+    expect(second.isError).toBeFalsy();
+    expect(askText(second)).toContain("dpmpp_2m");
+    expect(askText(second)).toMatch(/handed to you before/i);
   });
 
   // THE INVERSE, and the more damaging direction: a replayed answer must never

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4374,6 +4374,41 @@ describe("panel_ask keeps a validated answer across a tool timeout (#486)", () =
     expect(askText(res)).toContain("dpmpp_2m");
   });
 
+  // codex round 9, P0: the LATE answer is claimed from a bridge buffer keyed by
+  // `ask_id` ALONE. If that id ever stood for two cards, the buffer cannot say
+  // which one the reply came from — and the handler used to return it as this
+  // question's answer regardless, handing card B the answer given to card A.
+  // The rid-correlated path is exempt: a reply on THIS send's own request id is
+  // this card's reply by construction.
+  it("a LATE answer whose ask id is ambiguous is reported, never returned as the answer", async () => {
+    let askId: string | null = null;
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        askId = String(cmd.ask_id);
+        // Make the id stand for a SECOND card before the late answer is claimed.
+        AskAnswers.openAsk(askId, {
+          tabId: TAB,
+          fingerprint: "some-other-question",
+          question: "A different question entirely?",
+        });
+        throw REPLY_TIMEOUT_ERR(String(cmd.cmd), opts?.timeoutMs ?? 0);
+      },
+      canReach: () => true,
+      isHeadless: () => false,
+      resolveActiveTabId: () => TAB,
+      takeLateAskReply: () => "dpmpp_2m",
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx: PanelToolCtx = { bridge, tabId: TAB } as unknown as PanelToolCtx;
+    const res = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, ctx);
+    expect(res.isError).toBe(true);
+    expect(askText(res)).toMatch(/CANNOT be attributed/i);
+    // The pick is still surfaced — reported, never swallowed — and it was not
+    // counted as delivered, so the orphan machinery still owns it.
+    expect(askText(res)).toContain("dpmpp_2m");
+    expect(AskAnswers.orphansFor(TAB).some((e) => e.answer === "dpmpp_2m")).toBe(true);
+  });
+
   it("holds the WHOLE handler under one wall-clock ceiling anchored at entry", () => {
     // The card deadline and the grace poll used to be additive on top of
     // everything else, so a bounded ask could still overrun the enclosing

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4319,6 +4319,53 @@ describe("panel_ask keeps a validated answer across a tool timeout (#486)", () =
     expect(askText(res)).not.toMatch(/HOWEVER/);
   });
 
+  // codex round 1, P0: an answer that went into a ToolResult used to be forgotten
+  // once it aged past the recovery window. But "it went into a ToolResult" is
+  // exactly what is NOT provable here (that IS #486), so a re-ask of the same
+  // question past the window must still be TOLD the user answered it — the
+  // difference between a stale answer and silence.
+  it("a re-ask past the recovery window is told the user answered it before", async () => {
+    const bridge = {
+      send: async () => "dpmpp_2m",
+      canReach: () => true,
+      isHeadless: () => false,
+      resolveActiveTabId: () => TAB,
+      takeLateAskReply: () => undefined,
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+    const first = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, {
+      bridge,
+      tabId: TAB,
+    } as unknown as PanelToolCtx);
+    expect(askText(first)).toBe("dpmpp_2m");
+    // Age it out of the recovery window (it must NOT have been deleted).
+    const entry = AskAnswers.entriesFor(TAB)[0];
+    expect(entry).toBeDefined();
+    entry.answeredAt = Date.now() - 60 * 60_000;
+    const res = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, {
+      bridge: timingOutBridge(),
+      tabId: TAB,
+    } as unknown as PanelToolCtx);
+    // Not served as this ask's answer (too old to present as a fresh decision)…
+    expect(res.isError).toBe(true);
+    // …but reported, quoted with the question it answers.
+    expect(askText(res)).toContain("dpmpp_2m");
+    expect(askText(res)).toContain(SAMPLER.question);
+  });
+
+  it("an answer to a card whose CONVERSATION was replaced can never satisfy a re-ask", async () => {
+    await askThenAnswerLate(SAMPLER, "dpmpp_2m");
+    AskAnswers.closeAsks(TAB); // New chat / resume of a historical session
+    const res = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, {
+      bridge: timingOutBridge(),
+      tabId: TAB,
+    } as unknown as PanelToolCtx);
+    expect(res.isError).toBe(true);
+    expect(askText(res)).not.toContain("RECOVERED ANSWER");
+    // Still reported as unattributed rather than swallowed.
+    expect(askText(res)).toContain("dpmpp_2m");
+  });
+
   it("holds the WHOLE handler under one wall-clock ceiling anchored at entry", () => {
     // The card deadline and the grace poll used to be additive on top of
     // everything else, so a bounded ask could still overrun the enclosing

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4370,8 +4370,12 @@ describe("panel_ask keeps a validated answer across a tool timeout (#486)", () =
     } as unknown as PanelToolCtx);
     expect(res.isError).toBe(true);
     expect(askText(res)).not.toContain("RECOVERED ANSWER");
-    // Still reported as unattributed rather than swallowed.
-    expect(askText(res)).toContain("dpmpp_2m");
+    // Reported as a COUNT, never as content: the pick belongs to the replaced
+    // conversation, and showing it here is the leak the boundary exists to stop.
+    expect(askText(res)).not.toContain("dpmpp_2m");
+    expect(askText(res)).toMatch(/belong to a DIFFERENT conversation/i);
+    // …and it is still on file, not swallowed.
+    expect(AskAnswers.entriesFor(TAB).some((e) => e.answer === "dpmpp_2m")).toBe(true);
   });
 
   // codex round 9, P0: the LATE answer is claimed from a bridge buffer keyed by
@@ -4436,11 +4440,72 @@ describe("panel_ask keeps a validated answer across a tool timeout (#486)", () =
     expect(askId).not.toBeNull();
     expect(res.isError).toBe(true);
     expect(askText(res)).toMatch(/conversation that asked it has been replaced/i);
-    // Reported, never swallowed — the pick is quoted, attributed to the
-    // conversation it was actually given to.
-    expect(askText(res)).toContain("dpmpp_2m");
-    // …and it was not counted as delivered to anyone.
+    // The pick is NOT shown. Labelling it "for the replaced conversation" does
+    // not stop the replacement turn from reading it — the tool result is the one
+    // channel a boundary never policed, and a label is not a fence.
+    expect(askText(res)).not.toContain("dpmpp_2m");
+    // …and it was not counted as delivered to anyone, nor swallowed.
     expect(AskAnswers.entriesFor(TAB)[0].returned).toBe(false);
+    expect(AskAnswers.entriesFor(TAB)[0].answer).toBe("dpmpp_2m");
+  });
+
+  // Gate P0-2: the timeout report rendered every same-key entry's question AND
+  // answer verbatim. `others` never went through the boundary gate, because
+  // nothing about a disclosure looked like a hand-off — so tab A's chosen option
+  // was printed into tab B's result.
+  it("a timed-out ask never prints another conversation's chosen option", async () => {
+    await askThenAnswerLate(SAMPLER, "dpmpp_2m");
+    AskAnswers.closeAsks(TAB); // the conversation that asked is replaced
+
+    const res = await defByName("panel_ask").handler(SCHEDULER as Record<string, unknown>, {
+      bridge: timingOutBridge(),
+      tabId: TAB,
+    } as unknown as PanelToolCtx);
+
+    expect(res.isError).toBe(true);
+    // The pick is NOT rendered…
+    expect(askText(res)).not.toContain("dpmpp_2m");
+    // …but the fact that something was answered IS disclosed.
+    expect(askText(res)).toMatch(/belong to a DIFFERENT conversation/i);
+    expect(AskAnswers.entriesFor(TAB).some((e) => e.answer === "dpmpp_2m")).toBe(true);
+  });
+
+  // Gate P0-3: the debt footnote is added by a helper, and the helper reported
+  // the CURRENT occupant's debt and attached its token to the CURRENT turn — so a
+  // result belonging to a conversation replaced mid-ask could carry, and have
+  // settled, a warning that conversation never saw.
+  it("a result from a replaced conversation carries no debt footnote", async () => {
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        void cmd;
+        // The boundary lands while this ask is still in flight (its own debt is
+        // surfaced and retired there)…
+        AskAnswers.closeAsks(TAB);
+        // …and the REPLACEMENT conversation then loses answers of its own. That
+        // debt is owed to it, not to the ask that is about to unwind here.
+        AskAnswers.noteDroppedForTest(TAB, 2);
+        throw REPLY_TIMEOUT_ERR("ask_user", opts?.timeoutMs ?? 0);
+      },
+      canReach: () => true,
+      isHeadless: () => false,
+      resolveActiveTabId: () => TAB,
+      takeLateAskReply: () => undefined,
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+
+    const res = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, {
+      bridge,
+      tabId: TAB,
+    } as unknown as PanelToolCtx);
+
+    expect(res.isError).toBe(true);
+    // No "N further validated answer(s) were dropped" on a result that belongs to
+    // a conversation that no longer exists — the live turn's ack would otherwise
+    // settle a warning nobody was shown.
+    expect(askText(res)).not.toMatch(/were dropped before they/i);
+    // …and the replacement conversation is still owed it, undisturbed.
+    expect(AskAnswers.droppedFor(TAB)).toBe(2);
+    expect(AskAnswers.reportDropped(TAB)).toBe(2);
   });
 
   it("holds the WHOLE handler under one wall-clock ceiling anchored at entry", () => {

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -30,6 +30,7 @@ import {
   describe as describeCorrelation,
   type CompletionPayload,
 } from "../../orchestrator/run-completion-journal.js";
+import { AskAnswerJournalImpl } from "../../orchestrator/ask-answer-journal.js";
 import { destinationHasCollisionState } from "../../orchestrator/session-store.js";
 
 let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
@@ -1638,5 +1639,100 @@ describe("run completion journal correlation (#468)", () => {
     journal.forget("gone");
     expect(journal.outstanding("gone")).toHaveLength(0);
     expect(journal.outstanding("kept")).toHaveLength(1);
+  });
+});
+
+// #486 — a `panel_ask` answer goes back to the model as a TOOL RESULT, so it has
+// no hand-off to ack. It rides the turn its tool call is running inside, and is
+// acked by exactly the same rule a run completion is: that turn produced its own
+// marked result. "Written to the transport" is NOT that rule — a `tools/call` can
+// be abandoned, which is the whole of #486 — so these tests drive a real manager
+// and hold the difference.
+describe("panel_ask answer acks on the turn that returned it (#486)", () => {
+  function askHarness(backend: AgentBackend) {
+    const journal = new AskAnswerJournalImpl();
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      makeBackend: () => backend,
+      onEventDelivered: (_key: string, tokens: string[]) => {
+        for (const t of tokens) journal.ack(t);
+      },
+      onEventUndelivered: (_key: string, tokens: string[], opts?: { carried?: boolean }) => {
+        for (const t of tokens) journal.release(t, { carried: opts?.carried === true });
+      },
+      onAgentReady: () => {},
+    } as never);
+    journal.setTurnAttacher((key, token) => manager.attachTurnToken(key, token));
+    return { journal, manager };
+  }
+
+  /** What the ask handler does from inside a live turn. */
+  function answerDuringTurn(
+    journal: AskAnswerJournalImpl,
+    tab: string,
+    askId: string,
+    answer: string,
+  ): string {
+    journal.openAsk(askId, { tabId: tab, fingerprint: "fp-sampler", question: "Which sampler?" });
+    const token = journal.record(askId, answer, { tabId: tab }).token;
+    journal.markReturned(token); // hands it back AND rides the turn
+    journal.closeAsk(askId);
+    return token;
+  }
+
+  it("acks only when the turn that returned the answer produces its result", async () => {
+    const backend = new ContinuationBackend();
+    const { journal, manager } = askHarness(backend);
+    const tab = "tab-ask-ack";
+
+    manager.send(tab, "ask me which sampler");
+    await waitFor(() => backend.turns.length >= 1);
+
+    const token = answerDuringTurn(journal, tab, "pa-ack-1", "dpmpp_2m");
+    // Handed to the tool result — but the turn has not finished, so there is NO
+    // proof the model read it yet.
+    expect(journal.entriesFor(tab)[0].returned).toBe(true);
+    expect(journal.entriesFor(tab)[0].acked).toBeUndefined();
+
+    backend.finishTurn(); // the turn's own marked result lands
+    await waitFor(() => journal.entriesFor(tab)[0]?.acked === true);
+    expect(journal.entriesFor(tab)[0].token).toBe(token);
+    // An acked answer is not news: it holds no gate and is not named on exit.
+    expect(journal.hasOutstanding()).toBe(false);
+    expect(journal.allOutstanding()).toHaveLength(0);
+  });
+
+  it("a turn that never completes leaves the answer UNACKED and accounted for", async () => {
+    const backend = new ContinuationBackend();
+    backend.strandTurns = true; // the turn never yields a result — the #486 shape
+    const { journal, manager } = askHarness(backend);
+    const tab = "tab-ask-stranded";
+
+    manager.send(tab, "ask me which sampler");
+    await waitFor(() => backend.turns.length >= 1);
+    answerDuringTurn(journal, tab, "pa-ack-2", "dpmpp_2m");
+
+    // Tear the agent down mid-turn: the token comes back unacked.
+    manager.reset(tab);
+    await waitFor(() => journal.entriesFor(tab).length === 1);
+    expect(journal.entriesFor(tab)[0].acked).toBeUndefined();
+    // …and it is still the only copy of the user's decision: named on the way out
+    // and still recoverable by a re-ask of the same question.
+    expect(journal.allOutstanding().map((e) => e.answer)).toContain("dpmpp_2m");
+    expect(journal.recover(tab, "fp-sampler").status).toBe("recovered");
+  });
+
+  it("an answer returned with NO live turn is never treated as read", () => {
+    const backend = new ContinuationBackend();
+    const { journal, manager } = askHarness(backend);
+    const tab = "tab-ask-noturn";
+    // Nothing was ever sent, so there is no turn to ride.
+    expect(manager.attachTurnToken(tab, "aa-nope")).toBe(false);
+    answerDuringTurn(journal, tab, "pa-ack-3", "dpmpp_2m");
+    expect(journal.entriesFor(tab)[0].acked).toBeUndefined();
   });
 });

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -1658,8 +1658,8 @@ describe("panel_ask answer acks on the turn that returned it (#486)", () => {
       onSay: () => {},
       onTurn: () => {},
       makeBackend: () => backend,
-      onEventDelivered: (_key: string, tokens: string[]) => {
-        for (const t of tokens) journal.ack(t);
+      onEventDelivered: (_key: string, tokens: string[], from?: { carrier?: string }) => {
+        for (const t of tokens) journal.ack(t, from);
       },
       onEventUndelivered: (_key: string, tokens: string[], opts?: { carried?: boolean }) => {
         for (const t of tokens) journal.release(t, { carried: opts?.carried === true });
@@ -1731,8 +1731,132 @@ describe("panel_ask answer acks on the turn that returned it (#486)", () => {
     const { journal, manager } = askHarness(backend);
     const tab = "tab-ask-noturn";
     // Nothing was ever sent, so there is no turn to ride.
-    expect(manager.attachTurnToken(tab, "aa-nope")).toBe(false);
+    expect(manager.attachTurnToken(tab, "aa-nope")).toBeNull();
     answerDuringTurn(journal, tab, "pa-ack-3", "dpmpp_2m");
+    const entry = journal.entriesFor(tab)[0];
+    expect(entry.carrier).toBeNull();
+    expect(entry.acked).toBeUndefined();
+    // …and nothing can ever settle it, however the ack is dressed up.
+    journal.ack(entry.token, { carrier: "pa1" });
+    journal.ack(entry.token);
     expect(journal.entriesFor(tab)[0].acked).toBeUndefined();
+  });
+
+  // COORDINATOR GATE P0-2. The tab -> agent mapping MOVES on a provider switch,
+  // so an ack resolved from "whoever owns this tab now" let the NEW provider's
+  // turn certify an answer the new conversation never saw — after which the
+  // entry was acked and therefore silently evictable. The carrier identity is
+  // captured at the instant of return and compared at ack, so it cannot.
+  it("a provider switch cannot ack an answer handed to the previous conversation", async () => {
+    const backend = new ContinuationBackend();
+    const { journal, manager } = askHarness(backend);
+    const tab = "tab-ask-switch";
+
+    // The card is shown and answered inside provider A's turn.
+    manager.send(tab, "ask me which sampler");
+    await waitFor(() => backend.turns.length >= 1);
+    const token = answerDuringTurn(journal, tab, "pa-switch", "dpmpp_2m");
+    const carrierA = journal.entriesFor(tab)[0].carrier;
+    expect(carrierA).not.toBeNull();
+
+    // The user switches provider: the old agent is retired and the SAME tab key
+    // is taken over by a brand-new agent instance.
+    journal.closeAsks(tab); // what the switch path does
+    manager.reset(tab);
+    manager.send(tab, "different provider now");
+    await waitFor(() => backend.turns.length >= 2);
+    const carrierB = manager.attachTurnToken(tab, "aa-probe");
+    expect(carrierB).not.toBe(carrierA);
+
+    // The NEW conversation's turn completes. It must not settle the old
+    // conversation's answer.
+    backend.finishTurn();
+    await new Promise((r) => setTimeout(r, 50));
+    const entry = journal.entriesFor(tab).find((e) => e.token === token);
+    expect(entry?.acked).toBeUndefined();
+    // …so the answer is still accounted for: named on the way out, and never a
+    // candidate for a silent eviction.
+    expect(journal.allOutstanding().map((e) => e.answer)).toContain("dpmpp_2m");
+  });
+
+  // The sharper shape of the same defect: a STALE pre-switch ask handler resumes
+  // AFTER the switch (its card was clicked late) and hands the answer back. It
+  // would otherwise attach to whatever turn is running now — the new
+  // conversation's — whose result then certifies, accurately and uselessly, an
+  // answer that conversation was never shown.
+  it("a stale handler resuming after a switch cannot attach to the new conversation's turn", async () => {
+    const backend = new ContinuationBackend();
+    const { journal, manager } = askHarness(backend);
+    const tab = "tab-ask-stale";
+
+    manager.send(tab, "ask me which sampler");
+    await waitFor(() => backend.turns.length >= 1);
+    journal.openAsk("pa-stale", {
+      tabId: tab,
+      fingerprint: "fp-sampler",
+      question: "Which sampler?",
+    });
+    const token = journal.record("pa-stale", "dpmpp_2m", { tabId: tab }).token;
+
+    // Provider switch happens BEFORE the handler gets to return.
+    journal.closeAsks(tab);
+    manager.reset(tab);
+    manager.send(tab, "different provider now");
+    await waitFor(() => backend.turns.length >= 2);
+
+    // …and only now does the stale handler resume and hand the answer back.
+    journal.markReturned(token);
+    expect(journal.entriesFor(tab)[0].carrier).toBeNull();
+
+    backend.finishTurn();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(journal.entriesFor(tab)[0].acked).toBeUndefined();
+    expect(journal.allOutstanding().map((e) => e.answer)).toContain("dpmpp_2m");
+  });
+
+  it("an ack from a DIFFERENT agent instance is refused", () => {
+    const backend = new ContinuationBackend();
+    const { journal } = askHarness(backend);
+    const tab = "tab-ask-wrongcarrier";
+    journal.setTurnAttacher(() => "pa-agent-A");
+    journal.openAsk("pa-x", { tabId: tab, fingerprint: "fp", question: "Which sampler?" });
+    const token = journal.record("pa-x", "dpmpp_2m", { tabId: tab }).token;
+    journal.markReturned(token);
+    expect(journal.entriesFor(tab)[0].carrier).toBe("pa-agent-A");
+
+    journal.ack(token, { carrier: "pa-agent-B" }); // a different conversation
+    expect(journal.entriesFor(tab)[0].acked).toBeUndefined();
+    journal.ack(token); // …and an ack with no identity at all is unverifiable
+    expect(journal.entriesFor(tab)[0].acked).toBeUndefined();
+
+    journal.ack(token, { carrier: "pa-agent-A" }); // the one that carried it
+    expect(journal.entriesFor(tab)[0].acked).toBe(true);
+  });
+
+  // P1-1: a RECOVERY hands the answer to a live turn exactly as a fresh answer
+  // does, so it must attach by construction. It used to set the flags by hand and
+  // never attach — so a perfect recovery stayed unacked forever, aged into
+  // apparent loss, and eventually raised warnings despite successful receipt.
+  it("a recovered answer attaches to its turn and can be acked", async () => {
+    const backend = new ContinuationBackend();
+    const { journal, manager } = askHarness(backend);
+    const tab = "tab-ask-recover";
+
+    manager.send(tab, "ask me which sampler");
+    await waitFor(() => backend.turns.length >= 1);
+    // An answer arrives with no handler waiting (the #486 orphan).
+    journal.openAsk("pa-rec", { tabId: tab, fingerprint: "fp-sampler", question: "Which sampler?" });
+    journal.closeAsk("pa-rec");
+    const token = journal.record("pa-rec", "dpmpp_2m", { tabId: tab }).token;
+    // A re-ask recovers it and hands it back inside the live turn.
+    const rec = journal.recover(tab, "fp-sampler");
+    expect(rec.status).toBe("recovered");
+    journal.markSurfaced(token);
+    expect(journal.entriesFor(tab)[0].carrier).not.toBeNull();
+
+    backend.finishTurn();
+    await waitFor(() => journal.entriesFor(tab)[0]?.acked === true);
+    // Proven read → not news, and quietly forgettable.
+    expect(journal.allOutstanding()).toHaveLength(0);
   });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -3301,6 +3301,68 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
   // identity precisely when its Web Locks lease could not be acquired — i.e.
   // when a duplicate tab copied the sessionStorage id — so the anonymous path
   // IS the two-tabs-one-key case, not an exotic edge.
+  // The ENTRIES are keyed by tab id, not incarnation — so a takeover has to be a
+  // CONVERSATION BOUNDARY, announced at the hello rather than after a grace: the
+  // newcomer must not be able to reach the departed tab's answers at all.
+  it("a takeover by a different browser tab is announced immediately", async () => {
+    const takenOver: Array<[string, string]> = [];
+    bridge.setTabTakenOverListener((tabId, departed) => takenOver.push([tabId, departed]));
+    const tabA = await connectPanel("wf:boundary", "wf", { tabSessionId: "browser-tab-A" });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:boundary")).toBe(true));
+    expect(takenOver).toEqual([]);
+
+    const tabB = await connectPanel("wf:boundary", "wf", { tabSessionId: "browser-tab-B" });
+    await vi.waitFor(() => expect(takenOver).toHaveLength(1));
+    expect(takenOver[0]).toEqual(["wf:boundary", "browser-tab-A"]);
+    tabA.close();
+    tabB.close();
+    bridge.setTabTakenOverListener(() => {});
+  });
+
+  // The incarnation COMPARISON (rather than merely "was someone here?") is what
+  // this guards: a panel re-hellos on its own live socket — a title change, a
+  // re-registration — with the old connection still in the map. Same occupant,
+  // so its conversation continues and nothing may be retired.
+  it("a re-hello from the SAME tab on a live socket is not a takeover", async () => {
+    const takenOver: string[] = [];
+    bridge.setTabTakenOverListener((tabId) => takenOver.push(tabId));
+    const sock = await connectPanel("wf:rehello", "wf", { tabSessionId: "browser-tab-A" });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:rehello")).toBe(true));
+
+    // Re-register on the SAME socket, without any disconnect in between.
+    sock.send(
+      JSON.stringify({
+        type: "hello",
+        tab_id: "wf:rehello",
+        title: "renamed",
+        enforces_workflow_stamp: true,
+        enforces_workflow_stamp_at_write: true,
+        tab_session_id: "browser-tab-A",
+      }),
+    );
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.title === "renamed")).toBe(true),
+    );
+    expect(takenOver).toEqual([]);
+    sock.close();
+    bridge.setTabTakenOverListener(() => {});
+  });
+
+  it("an ordinary reload is NOT a takeover", async () => {
+    const takenOver: string[] = [];
+    bridge.setTabTakenOverListener((tabId) => takenOver.push(tabId));
+    const sock = await connectPanel("wf:same", "wf", { tabSessionId: "browser-tab-A" });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:same")).toBe(true));
+    sock.close();
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:same")).toBe(false));
+    const back = await connectPanel("wf:same", "wf", { tabSessionId: "browser-tab-A" });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:same")).toBe(true));
+    await new Promise((r) => setTimeout(r, 100));
+    expect(takenOver).toEqual([]); // same occupant — its conversation continues
+    back.close();
+    bridge.setTabTakenOverListener(() => {});
+  });
+
   it("two anonymous departures on one key are both declarable", async () => {
     const gone: string[] = [];
     bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 1200 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -3178,46 +3178,54 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
   // retired live per-tab bookkeeping (the eviction-disclosure debt) during every
   // reload, so the reconnected conversation kept the answer and lost the warning
   // that an answer had been dropped — the worst possible split.
-  it("an ordinary reload does NOT declare the tab gone", () => {
-    return (async () => {
-      const gone: string[] = [];
-      bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 300 });
-      const sock = await connectPanel("tab-reload", "wf", { tabSessionId: "browser-tab-A" });
-      await vi.waitFor(() =>
-        expect(bridge.tabs().some((t) => t.tab_id === "tab-reload")).toBe(true),
-      );
+  // THE GONE-CLOCK TESTS CONTROL TIME RATHER THAN RACING IT.
+  //
+  // These are the one behaviour here defined by elapsed time, and a raced grace
+  // fails both ways: too short and it fails on a CORRECT implementation, too long
+  // and a timer that fires before the successor's hello lands makes a broken
+  // cancel look caught — a false pass, which is worse, because a mutation
+  // "verified" through it was never verified at all. So every test below sets a
+  // grace no run can reach, waits for the state it cares about to be PROVABLY
+  // reached, and only then runs the clocks.
+  const NEVER = 600_000;
+  /** The bridge has finished registering `incarnation` on `tabId`. */
+  const occupied = (tabId: string, incarnation: string) =>
+    vi.waitFor(() => expect(bridge.tabIncarnation(tabId)).toBe(incarnation));
+  const vacant = (tabId: string) =>
+    vi.waitFor(() => expect(bridge.tabIncarnation(tabId)).toBeUndefined());
 
-      // F5: the socket closes and the SAME browser tab re-hellos moments later.
-      // Its `tab_session_id` lives in sessionStorage, so it comes back unchanged.
-      sock.close();
-      await vi.waitFor(() =>
-        expect(bridge.tabs().some((t) => t.tab_id === "tab-reload")).toBe(false),
-      );
-      const back = await connectPanel("tab-reload", "wf", { tabSessionId: "browser-tab-A" });
-      await vi.waitFor(() =>
-        expect(bridge.tabs().some((t) => t.tab_id === "tab-reload")).toBe(true),
-      );
+  it("an ordinary reload does NOT declare the tab gone", async () => {
+    const gone: string[] = [];
+    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: NEVER });
+    const sock = await connectPanel("tab-reload", "wf", { tabSessionId: "browser-tab-A" });
+    await occupied("tab-reload", "browser-tab-A");
 
-      // Well past the grace: the tab came back, so it was never gone.
-      await new Promise((r) => setTimeout(r, 600));
-      expect(gone).toEqual([]);
-      back.close();
-      bridge.setTabGoneListener(() => {});
-    })();
+    // F5: the socket closes and the SAME browser tab re-hellos. Its
+    // `tab_session_id` is sessionStorage-backed, so it comes back unchanged.
+    sock.close();
+    await vacant("tab-reload");
+    const back = await connectPanel("tab-reload", "wf", { tabSessionId: "browser-tab-A" });
+    // The reconnect is COMPLETE before the clock is allowed to run — otherwise a
+    // pass would prove only that the timer won a race.
+    await occupied("tab-reload", "browser-tab-A");
+
+    bridge.__runTabGoneClocksForTest();
+    expect(gone).toEqual([]);
+    back.close();
+    bridge.setTabGoneListener(() => {});
   });
 
-  it("a tab that stays away IS declared gone, once the grace elapses", async () => {
+  it("a tab that stays away IS declared gone", async () => {
     const gone: string[] = [];
-    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 150 });
+    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: NEVER });
     const sock = await connectPanel("tab-really-gone", "wf", { tabSessionId: "browser-tab-Z" });
-    await vi.waitFor(() =>
-      expect(bridge.tabs().some((t) => t.tab_id === "tab-really-gone")).toBe(true),
-    );
+    await occupied("tab-really-gone", "browser-tab-Z");
     sock.close();
-    // Nothing at the moment of the close…
-    expect(gone).toEqual([]);
-    // …and only after the tab has genuinely stayed away.
-    await vi.waitFor(() => expect(gone).toEqual(["tab-really-gone"]), { timeout: 3000 });
+    await vacant("tab-really-gone");
+    expect(gone).toEqual([]); // nothing at the moment of the close
+
+    bridge.__runTabGoneClocksForTest();
+    expect(gone).toEqual(["tab-really-gone"]);
     bridge.setTabGoneListener(() => {});
   });
 
@@ -3229,21 +3237,20 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
   // report and settle the departed tab's lost-answer disclosure as its own.
   it("a DIFFERENT browser tab taking over the same key does not cancel the departed tab's clock", async () => {
     const gone: string[] = [];
-    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 250 });
+    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: NEVER });
     const tabA = await connectPanel("wf:shared", "wf", { tabSessionId: "browser-tab-A" });
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:shared")).toBe(true));
-
-    // A goes away…
+    await occupied("wf:shared", "browser-tab-A");
     tabA.close();
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:shared")).toBe(false));
-    // …and a DIFFERENT browser tab opens the same saved workflow before the grace
-    // elapses, taking over the recurring key.
-    const tabB = await connectPanel("wf:shared", "wf", { tabSessionId: "browser-tab-B" });
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:shared")).toBe(true));
+    await vacant("wf:shared");
 
-    // A is still gone, and must be declarable so — even though something now
-    // holds its key.
-    await vi.waitFor(() => expect(gone).toEqual(["wf:shared"]), { timeout: 3000 });
+    // A DIFFERENT browser tab opens the same saved workflow, taking over the
+    // recurring key. Its hello is PROVABLY complete before the clock runs, so a
+    // pass means the cancel really did decline — not that it lost a race.
+    const tabB = await connectPanel("wf:shared", "wf", { tabSessionId: "browser-tab-B" });
+    await occupied("wf:shared", "browser-tab-B");
+
+    bridge.__runTabGoneClocksForTest();
+    expect(gone).toEqual(["wf:shared"]);
     tabB.close();
     bridge.setTabGoneListener(() => {});
   });
@@ -3253,54 +3260,49 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
   // never declared gone at all — its disclosure stranded for good.
   it("two incarnations of one key get independent clocks", async () => {
     const gone: string[] = [];
-    // Long enough that A's clock is DEMONSTRABLY still pending when B leaves —
-    // otherwise A fires on its own and the test would pass even with one shared
-    // slot per tab id.
-    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 1200 });
+    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: NEVER });
     const tabA = await connectPanel("wf:two", "wf", { tabSessionId: "browser-tab-A" });
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:two")).toBe(true));
+    await occupied("wf:two", "browser-tab-A");
     tabA.close();
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:two")).toBe(false));
+    await vacant("wf:two");
 
-    // B takes the key over, then leaves too — well before A's clock has elapsed.
+    // B takes the key over, then leaves too. A's clock is still armed throughout
+    // — the grace cannot elapse — so this cannot pass by A firing early.
     const tabB = await connectPanel("wf:two", "wf", { tabSessionId: "browser-tab-B" });
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:two")).toBe(true));
+    await occupied("wf:two", "browser-tab-B");
     tabB.close();
-    expect(gone).toEqual([]); // neither clock has elapsed yet
+    await vacant("wf:two");
+    expect(gone).toEqual([]);
 
-    // BOTH departures are declarable: two separate tabs went away.
-    await vi.waitFor(() => expect(gone.filter((t) => t === "wf:two")).toHaveLength(2), {
-      timeout: 6000,
-    });
+    bridge.__runTabGoneClocksForTest();
+    expect(gone.filter((t) => t === "wf:two")).toHaveLength(2);
     bridge.setTabGoneListener(() => {});
   });
 
   // Coordinator gate P1: two tabs open at once on one key. B's hello SUPERSEDES
   // A's socket, so by the time A's close handler runs the map already points at
-  // B — and an "was I the primary?" guard answers no for a tab that very much
-  // did just leave, so A was never armed at all and could never be declared gone.
+  // B — and a "was I the primary?" guard answers no for a tab that very much did
+  // just leave, so A was never armed at all and could never be declared gone.
   it("a tab superseded by a second tab on the same key is still declared gone", async () => {
     const gone: string[] = [];
-    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 250 });
+    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: NEVER });
     const tabA = await connectPanel("wf:takeover", "wf", { tabSessionId: "browser-tab-A" });
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:takeover")).toBe(true));
+    await occupied("wf:takeover", "browser-tab-A");
 
-    // B opens the SAME saved workflow while A is still connected. The bridge
+    // B opens the SAME saved workflow while A is still connected; the bridge
     // supersedes A's socket rather than refusing B.
     const tabB = await connectPanel("wf:takeover", "wf", { tabSessionId: "browser-tab-B" });
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:takeover")).toBe(true));
-
-    // A left, even though it never got to be "the primary that disconnected".
-    await vi.waitFor(() => expect(gone).toEqual(["wf:takeover"]), { timeout: 3000 });
+    await occupied("wf:takeover", "browser-tab-B");
+    // A's close is asynchronous — wait until it has actually armed something.
+    await vi.waitFor(() => {
+      bridge.__runTabGoneClocksForTest();
+      expect(gone).toEqual(["wf:takeover"]);
+    });
     tabB.close();
     void tabA;
     bridge.setTabGoneListener(() => {});
   });
 
-  // …and P1-2: anonymous panels must NOT share one slot. The panel omits its
-  // identity precisely when its Web Locks lease could not be acquired — i.e.
-  // when a duplicate tab copied the sessionStorage id — so the anonymous path
-  // IS the two-tabs-one-key case, not an exotic edge.
   // The ENTRIES are keyed by tab id, not incarnation — so a takeover has to be a
   // CONVERSATION BOUNDARY, announced at the hello rather than after a grace: the
   // newcomer must not be able to reach the departed tab's answers at all.
@@ -3308,7 +3310,7 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
     const takenOver: Array<[string, string]> = [];
     bridge.setTabTakenOverListener((tabId, departed) => takenOver.push([tabId, departed]));
     const tabA = await connectPanel("wf:boundary", "wf", { tabSessionId: "browser-tab-A" });
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:boundary")).toBe(true));
+    await occupied("wf:boundary", "browser-tab-A");
     expect(takenOver).toEqual([]);
 
     const tabB = await connectPanel("wf:boundary", "wf", { tabSessionId: "browser-tab-B" });
@@ -3322,83 +3324,83 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
   // The incarnation COMPARISON (rather than merely "was someone here?") is what
   // this guards: a panel re-hellos on its own live socket — a title change, a
   // re-registration — with the old connection still in the map. Same occupant,
-  // so its conversation continues and nothing may be retired.
+  // so its conversation continues and nothing may be retired. This is also why
+  // the anonymous id must be per CONNECTION: minted per hello, a re-hello would
+  // look like a stranger to itself.
   it("a re-hello from the SAME tab on a live socket is not a takeover", async () => {
     const takenOver: string[] = [];
     bridge.setTabTakenOverListener((tabId) => takenOver.push(tabId));
-    const sock = await connectPanel("wf:rehello", "wf", { tabSessionId: "browser-tab-A" });
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:rehello")).toBe(true));
+    for (const identity of [{ tabSessionId: "browser-tab-A" }, {}]) {
+      const key = identity.tabSessionId ? "wf:rehello" : "wf:rehello-anon";
+      const sock = await connectPanel(key, "wf", identity);
+      await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === key)).toBe(true));
+      const before = bridge.tabIncarnation(key);
 
-    // Re-register on the SAME socket, without any disconnect in between.
-    sock.send(
-      JSON.stringify({
-        type: "hello",
-        tab_id: "wf:rehello",
-        title: "renamed",
-        enforces_workflow_stamp: true,
-        enforces_workflow_stamp_at_write: true,
-        tab_session_id: "browser-tab-A",
-      }),
-    );
-    await vi.waitFor(() =>
-      expect(bridge.tabs().some((t) => t.title === "renamed")).toBe(true),
-    );
-    expect(takenOver).toEqual([]);
-    sock.close();
+      // Re-register on the SAME socket, with no disconnect in between.
+      sock.send(
+        JSON.stringify({
+          type: "hello",
+          tab_id: key,
+          title: "renamed",
+          enforces_workflow_stamp: true,
+          enforces_workflow_stamp_at_write: true,
+          ...(identity.tabSessionId ? { tab_session_id: identity.tabSessionId } : {}),
+        }),
+      );
+      await vi.waitFor(() =>
+        expect(bridge.tabs().some((t) => t.tab_id === key && t.title === "renamed")).toBe(true),
+      );
+      // Same connection, same incarnation — and therefore not a takeover.
+      expect(bridge.tabIncarnation(key)).toBe(before);
+      expect(takenOver).toEqual([]);
+      sock.close();
+      await vacant(key);
+    }
     bridge.setTabTakenOverListener(() => {});
   });
 
-  it("an ordinary reload is NOT a takeover", async () => {
-    const takenOver: string[] = [];
-    bridge.setTabTakenOverListener((tabId) => takenOver.push(tabId));
-    const sock = await connectPanel("wf:same", "wf", { tabSessionId: "browser-tab-A" });
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:same")).toBe(true));
-    sock.close();
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:same")).toBe(false));
-    const back = await connectPanel("wf:same", "wf", { tabSessionId: "browser-tab-A" });
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:same")).toBe(true));
-    await new Promise((r) => setTimeout(r, 100));
-    expect(takenOver).toEqual([]); // same occupant — its conversation continues
-    back.close();
-    bridge.setTabTakenOverListener(() => {});
-  });
-
+  // …and P1-2: anonymous panels must NOT share one slot. The panel omits its
+  // identity precisely when its Web Locks lease could not be acquired — i.e.
+  // when a duplicate tab copied the sessionStorage id — so the anonymous path IS
+  // the two-tabs-one-key case, not an exotic edge.
   it("two anonymous departures on one key are both declarable", async () => {
     const gone: string[] = [];
-    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 1200 });
+    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: NEVER });
     const anonA = await connectPanel("wf:anon", "wf"); // no tab_session_id
     await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:anon")).toBe(true));
     anonA.close();
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:anon")).toBe(false));
+    await vacant("wf:anon");
 
     const anonB = await connectPanel("wf:anon", "wf"); // also anonymous
     await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:anon")).toBe(true));
     anonB.close();
-    expect(gone).toEqual([]); // neither clock has elapsed yet
+    await vacant("wf:anon");
+    expect(gone).toEqual([]);
 
     // Two unproven departures, two owed warnings — the second must not overwrite
     // or clear the first.
-    await vi.waitFor(() => expect(gone.filter((t) => t === "wf:anon")).toHaveLength(2), {
-      timeout: 6000,
-    });
+    bridge.__runTabGoneClocksForTest();
+    expect(gone.filter((t) => t === "wf:anon")).toHaveLength(2);
     bridge.setTabGoneListener(() => {});
   });
 
   it("an unidentified panel cannot prove it came back, so the clock still fires", async () => {
     const gone: string[] = [];
-    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 200 });
-    // No tab_session_id: an old build. Nothing can prove which tab returned, and
-    // unknown-return must let the disclosure surface.
+    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: NEVER });
+    // No tab_session_id: the panel could not take its Web Locks lease. Nothing
+    // can prove which tab returned, and unknown-return must let the disclosure
+    // surface.
     const sock = await connectPanel("tab-anonymous", "wf");
-    await vi.waitFor(() =>
-      expect(bridge.tabs().some((t) => t.tab_id === "tab-anonymous")).toBe(true),
-    );
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-anonymous")).toBe(true));
     sock.close();
+    await vacant("tab-anonymous");
     const back = await connectPanel("tab-anonymous", "wf");
-    await vi.waitFor(() =>
-      expect(bridge.tabs().some((t) => t.tab_id === "tab-anonymous")).toBe(true),
-    );
-    await vi.waitFor(() => expect(gone).toEqual(["tab-anonymous"]), { timeout: 3000 });
+    // The "reconnect" is COMPLETE before the clock runs, so a pass proves the
+    // cancel declined rather than that the timer got there first.
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-anonymous")).toBe(true));
+
+    bridge.__runTabGoneClocksForTest();
+    expect(gone).toEqual(["tab-anonymous"]);
     back.close();
     bridge.setTabGoneListener(() => {});
   });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -3166,6 +3166,45 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
     );
   });
 
+  // Coordinator gate P0: a socket close is NOT evidence a tab is gone — an
+  // ordinary F5 produces exactly that. Firing the tab-gone listener on the close
+  // retired live per-tab bookkeeping (the eviction-disclosure debt) during every
+  // reload, so the reconnected conversation kept the answer and lost the warning
+  // that an answer had been dropped — the worst possible split.
+  it("an ordinary reload does NOT declare the tab gone", async () => {
+    const gone: string[] = [];
+    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 300 });
+    const sock = await connectPanel("tab-reload", "wf");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-reload")).toBe(true));
+
+    // F5: the socket closes and the same tab re-hellos moments later.
+    sock.close();
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-reload")).toBe(false));
+    const back = await connectPanel("tab-reload", "wf");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-reload")).toBe(true));
+
+    // Well past the grace: the tab came back, so it was never gone.
+    await new Promise((r) => setTimeout(r, 600));
+    expect(gone).toEqual([]);
+    back.close();
+    bridge.setTabGoneListener(() => {});
+  });
+
+  it("a tab that stays away IS declared gone, once the grace elapses", async () => {
+    const gone: string[] = [];
+    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 150 });
+    const sock = await connectPanel("tab-really-gone", "wf");
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tab-really-gone")).toBe(true),
+    );
+    sock.close();
+    // Nothing at the moment of the close…
+    expect(gone).toEqual([]);
+    // …and only after the tab has genuinely stayed away.
+    await vi.waitFor(() => expect(gone).toEqual(["tab-really-gone"]), { timeout: 3000 });
+    bridge.setTabGoneListener(() => {});
+  });
+
   it("a throwing sink never breaks the message loop or loses the buffered answer", async () => {
     bridge.setLateAskReplySink(() => {
       throw new Error("journal exploded");

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -129,7 +129,11 @@ async function startBridgeOnFreePort(
   throw new Error(`could not bind a free bridge port after 6 attempts: ${lastErr}`);
 }
 
-function connectPanel(tabId?: string, title = "workflow-a"): Promise<WebSocket> {
+function connectPanel(
+  tabId?: string,
+  title = "workflow-a",
+  opts: { tabSessionId?: string } = {},
+): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
     const sock = new WebSocket(`ws://127.0.0.1:${port}`);
     sock.on("open", () => {
@@ -144,6 +148,9 @@ function connectPanel(tabId?: string, title = "workflow-a"): Promise<WebSocket> 
             title,
             enforces_workflow_stamp: true,
             enforces_workflow_stamp_at_write: true,
+            // The panel's sessionStorage-backed browser-tab identity: unique per
+            // browser tab, stable across a reload (#486/#709).
+            ...(opts.tabSessionId ? { tab_session_id: opts.tabSessionId } : {}),
           }),
         );
       }
@@ -3171,29 +3178,38 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
   // retired live per-tab bookkeeping (the eviction-disclosure debt) during every
   // reload, so the reconnected conversation kept the answer and lost the warning
   // that an answer had been dropped — the worst possible split.
-  it("an ordinary reload does NOT declare the tab gone", async () => {
-    const gone: string[] = [];
-    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 300 });
-    const sock = await connectPanel("tab-reload", "wf");
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-reload")).toBe(true));
+  it("an ordinary reload does NOT declare the tab gone", () => {
+    return (async () => {
+      const gone: string[] = [];
+      bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 300 });
+      const sock = await connectPanel("tab-reload", "wf", { tabSessionId: "browser-tab-A" });
+      await vi.waitFor(() =>
+        expect(bridge.tabs().some((t) => t.tab_id === "tab-reload")).toBe(true),
+      );
 
-    // F5: the socket closes and the same tab re-hellos moments later.
-    sock.close();
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-reload")).toBe(false));
-    const back = await connectPanel("tab-reload", "wf");
-    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-reload")).toBe(true));
+      // F5: the socket closes and the SAME browser tab re-hellos moments later.
+      // Its `tab_session_id` lives in sessionStorage, so it comes back unchanged.
+      sock.close();
+      await vi.waitFor(() =>
+        expect(bridge.tabs().some((t) => t.tab_id === "tab-reload")).toBe(false),
+      );
+      const back = await connectPanel("tab-reload", "wf", { tabSessionId: "browser-tab-A" });
+      await vi.waitFor(() =>
+        expect(bridge.tabs().some((t) => t.tab_id === "tab-reload")).toBe(true),
+      );
 
-    // Well past the grace: the tab came back, so it was never gone.
-    await new Promise((r) => setTimeout(r, 600));
-    expect(gone).toEqual([]);
-    back.close();
-    bridge.setTabGoneListener(() => {});
+      // Well past the grace: the tab came back, so it was never gone.
+      await new Promise((r) => setTimeout(r, 600));
+      expect(gone).toEqual([]);
+      back.close();
+      bridge.setTabGoneListener(() => {});
+    })();
   });
 
   it("a tab that stays away IS declared gone, once the grace elapses", async () => {
     const gone: string[] = [];
     bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 150 });
-    const sock = await connectPanel("tab-really-gone", "wf");
+    const sock = await connectPanel("tab-really-gone", "wf", { tabSessionId: "browser-tab-Z" });
     await vi.waitFor(() =>
       expect(bridge.tabs().some((t) => t.tab_id === "tab-really-gone")).toBe(true),
     );
@@ -3202,6 +3218,79 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
     expect(gone).toEqual([]);
     // …and only after the tab has genuinely stayed away.
     await vi.waitFor(() => expect(gone).toEqual(["tab-really-gone"]), { timeout: 3000 });
+    bridge.setTabGoneListener(() => {});
+  });
+
+  // Coordinator gate: SAME KEY IS NOT THE SAME TAB. A `wf:<hash>` id names a
+  // saved workflow, so a different browser tab opening that workflow takes the
+  // key over. Keyed on the id alone, that stranger's hello cancelled the
+  // departed tab's clock (and satisfied the timer's re-check), so the departed
+  // tab was never declarable gone — and a later result from the stranger could
+  // report and settle the departed tab's lost-answer disclosure as its own.
+  it("a DIFFERENT browser tab taking over the same key does not cancel the departed tab's clock", async () => {
+    const gone: string[] = [];
+    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 250 });
+    const tabA = await connectPanel("wf:shared", "wf", { tabSessionId: "browser-tab-A" });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:shared")).toBe(true));
+
+    // A goes away…
+    tabA.close();
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:shared")).toBe(false));
+    // …and a DIFFERENT browser tab opens the same saved workflow before the grace
+    // elapses, taking over the recurring key.
+    const tabB = await connectPanel("wf:shared", "wf", { tabSessionId: "browser-tab-B" });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:shared")).toBe(true));
+
+    // A is still gone, and must be declarable so — even though something now
+    // holds its key.
+    await vi.waitFor(() => expect(gone).toEqual(["wf:shared"]), { timeout: 3000 });
+    tabB.close();
+    bridge.setTabGoneListener(() => {});
+  });
+
+  // …and the clocks must be independent. Keyed by tab id alone, the SECOND tab's
+  // departure re-arms over the first tab's pending clock and the first tab is
+  // never declared gone at all — its disclosure stranded for good.
+  it("two incarnations of one key get independent clocks", async () => {
+    const gone: string[] = [];
+    // Long enough that A's clock is DEMONSTRABLY still pending when B leaves —
+    // otherwise A fires on its own and the test would pass even with one shared
+    // slot per tab id.
+    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 1200 });
+    const tabA = await connectPanel("wf:two", "wf", { tabSessionId: "browser-tab-A" });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:two")).toBe(true));
+    tabA.close();
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:two")).toBe(false));
+
+    // B takes the key over, then leaves too — well before A's clock has elapsed.
+    const tabB = await connectPanel("wf:two", "wf", { tabSessionId: "browser-tab-B" });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:two")).toBe(true));
+    tabB.close();
+    expect(gone).toEqual([]); // neither clock has elapsed yet
+
+    // BOTH departures are declarable: two separate tabs went away.
+    await vi.waitFor(() => expect(gone.filter((t) => t === "wf:two")).toHaveLength(2), {
+      timeout: 6000,
+    });
+    bridge.setTabGoneListener(() => {});
+  });
+
+  it("an unidentified panel cannot prove it came back, so the clock still fires", async () => {
+    const gone: string[] = [];
+    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 200 });
+    // No tab_session_id: an old build. Nothing can prove which tab returned, and
+    // unknown-return must let the disclosure surface.
+    const sock = await connectPanel("tab-anonymous", "wf");
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tab-anonymous")).toBe(true),
+    );
+    sock.close();
+    const back = await connectPanel("tab-anonymous", "wf");
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tab-anonymous")).toBe(true),
+    );
+    await vi.waitFor(() => expect(gone).toEqual(["tab-anonymous"]), { timeout: 3000 });
+    back.close();
     bridge.setTabGoneListener(() => {});
   });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -3275,6 +3275,53 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
     bridge.setTabGoneListener(() => {});
   });
 
+  // Coordinator gate P1: two tabs open at once on one key. B's hello SUPERSEDES
+  // A's socket, so by the time A's close handler runs the map already points at
+  // B — and an "was I the primary?" guard answers no for a tab that very much
+  // did just leave, so A was never armed at all and could never be declared gone.
+  it("a tab superseded by a second tab on the same key is still declared gone", async () => {
+    const gone: string[] = [];
+    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 250 });
+    const tabA = await connectPanel("wf:takeover", "wf", { tabSessionId: "browser-tab-A" });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:takeover")).toBe(true));
+
+    // B opens the SAME saved workflow while A is still connected. The bridge
+    // supersedes A's socket rather than refusing B.
+    const tabB = await connectPanel("wf:takeover", "wf", { tabSessionId: "browser-tab-B" });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:takeover")).toBe(true));
+
+    // A left, even though it never got to be "the primary that disconnected".
+    await vi.waitFor(() => expect(gone).toEqual(["wf:takeover"]), { timeout: 3000 });
+    tabB.close();
+    void tabA;
+    bridge.setTabGoneListener(() => {});
+  });
+
+  // …and P1-2: anonymous panels must NOT share one slot. The panel omits its
+  // identity precisely when its Web Locks lease could not be acquired — i.e.
+  // when a duplicate tab copied the sessionStorage id — so the anonymous path
+  // IS the two-tabs-one-key case, not an exotic edge.
+  it("two anonymous departures on one key are both declarable", async () => {
+    const gone: string[] = [];
+    bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 1200 });
+    const anonA = await connectPanel("wf:anon", "wf"); // no tab_session_id
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:anon")).toBe(true));
+    anonA.close();
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:anon")).toBe(false));
+
+    const anonB = await connectPanel("wf:anon", "wf"); // also anonymous
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:anon")).toBe(true));
+    anonB.close();
+    expect(gone).toEqual([]); // neither clock has elapsed yet
+
+    // Two unproven departures, two owed warnings — the second must not overwrite
+    // or clear the first.
+    await vi.waitFor(() => expect(gone.filter((t) => t === "wf:anon")).toHaveLength(2), {
+      timeout: 6000,
+    });
+    bridge.setTabGoneListener(() => {});
+  });
+
   it("an unidentified panel cannot prove it came back, so the clock still fires", async () => {
     const gone: string[] = [];
     bridge.setTabGoneListener((tabId) => gone.push(tabId), { graceMs: 200 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -3097,6 +3097,44 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
     bridge.setLateAskReplySink(() => {});
   });
 
+  // codex round 2, P0: the rid→ask_id MAPPING is what makes a late reply
+  // recognisable as a card answer at all, so it gates the durable sink. It used
+  // to share the 5-minute TTL of the reply BUFFER — but a question card sits on
+  // screen until the user deals with it, which can be far longer than any tool
+  // call, so an answer given at T+6min was discarded with no record.
+  it("the ask-id mapping outlives the reply buffer, so a much-later answer is still recognised", async () => {
+    const seen: string[] = [];
+    bridge.setLateAskReplySink((askId) => seen.push(askId));
+    const sock = await connectPanel("tab-longwait", "wf");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-longwait")).toBe(true));
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "ask_user") {
+        // A user who takes their time: the reply comes long after the card's own
+        // reply timer, and after the prune below has run.
+        setTimeout(() => {
+          sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: "Much Later" }));
+        }, 300);
+      }
+    });
+    await expect(
+      bridge.send(
+        { cmd: "ask_user", ask_id: "pa-slow", question: "?", options: [] },
+        { tabId: "tab-longwait", timeoutMs: 30 },
+      ),
+    ).rejects.toThrow(/did not reply/i);
+    // Age the mapping past the BUFFER's TTL (5 min) but well inside the
+    // mapping's own (60 min)…
+    const map = (bridge as unknown as { askRidToId: Map<string, { ts: number }> }).askRidToId;
+    for (const e of map.values()) e.ts = Date.now() - 20 * 60_000;
+    // …and force a prune pass (any take runs one) BEFORE the reply lands, so the
+    // mapping has to survive its own TTL rule rather than merely not be swept.
+    expect(bridge.takeLateAskReply("nothing-here")).toBeUndefined();
+    expect(map.size).toBe(1);
+    await vi.waitFor(() => expect(seen).toEqual(["pa-slow"]), { timeout: 3000 });
+    bridge.setLateAskReplySink(() => {});
+  });
+
   it("a throwing sink never breaks the message loop or loses the buffered answer", async () => {
     bridge.setLateAskReplySink(() => {
       throw new Error("journal exploded");

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -3068,6 +3068,59 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
     expect(bridge.takeLateAskReply("ask-xyz")).toBeUndefined(); // drained once
   });
 
+  // The buffer only helps a caller that is still alive to poll it, and #486 is
+  // exactly the case where there is none — the tools/call that asked has been
+  // abandoned. The SINK is what makes the answer durable: it fires at arrival,
+  // with the tab it was rendered on, whether or not anyone is listening.
+  it("hands a late ask_user answer to the durable sink at arrival, with its tab", async () => {
+    const seen: Array<{ askId: string; result: unknown; tabId: string }> = [];
+    bridge.setLateAskReplySink((askId, result, tabId) => seen.push({ askId, result, tabId }));
+    const sock = await connectPanel("tab-sink", "wf");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-sink")).toBe(true));
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "ask_user") {
+        setTimeout(() => {
+          sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: "Sunk Pick" }));
+        }, 80);
+      }
+    });
+    await expect(
+      bridge.send(
+        { cmd: "ask_user", ask_id: "ask-sink", question: "?", options: [] },
+        { tabId: "tab-sink", timeoutMs: 30 },
+      ),
+    ).rejects.toThrow(/did not reply/i);
+    // NOBODY polls takeLateAskReply here — that is the point.
+    await vi.waitFor(() => expect(seen).toHaveLength(1));
+    expect(seen[0]).toEqual({ askId: "ask-sink", result: "Sunk Pick", tabId: "tab-sink" });
+    bridge.setLateAskReplySink(() => {});
+  });
+
+  it("a throwing sink never breaks the message loop or loses the buffered answer", async () => {
+    bridge.setLateAskReplySink(() => {
+      throw new Error("journal exploded");
+    });
+    const sock = await connectPanel("tab-sink-bad", "wf");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-sink-bad")).toBe(true));
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "ask_user") {
+        setTimeout(() => {
+          sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: "Still Here" }));
+        }, 80);
+      }
+    });
+    await expect(
+      bridge.send(
+        { cmd: "ask_user", ask_id: "ask-bad", question: "?", options: [] },
+        { tabId: "tab-sink-bad", timeoutMs: 30 },
+      ),
+    ).rejects.toThrow(/did not reply/i);
+    await vi.waitFor(() => expect(bridge.takeLateAskReply("ask-bad")).toBe("Still Here"));
+    bridge.setLateAskReplySink(() => {});
+  });
+
   it("does not buffer a non-ask command's late reply (no ask_id → dropped)", async () => {
     const sock = await connectPanel("tab-plain", "wf");
     await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-plain")).toBe(true));

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -3135,6 +3135,37 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
     bridge.setLateAskReplySink(() => {});
   });
 
+  // Preferring loss over misattribution past the open-card ceiling is a sound
+  // call, but a server log is not a disclosure to the person holding the mouse:
+  // without a notice, the next thing that happens is someone clicking a button on
+  // a card that is still on screen and having it do NOTHING. Say it on their
+  // screen, at the moment we know.
+  it("tells the USER when an open card can no longer accept an answer", async () => {
+    const sock = await connectPanel("tab-overflow", "wf");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-overflow")).toBe(true));
+    const said: string[] = [];
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.type === "say" && typeof msg.text === "string") said.push(msg.text);
+    });
+    // Fill the mapping past its ceiling without waiting on 1024 real sends.
+    const map = (bridge as unknown as {
+      askRidToId: Map<string, { askId: string; ts: number; tabId: string }>;
+    }).askRidToId;
+    for (let i = 0; i < 1100; i += 1) {
+      map.set(`rid-${i}`, { askId: `pa-${i}`, ts: Date.now(), tabId: "tab-overflow" });
+    }
+    // Any take runs a prune pass, which is where the ceiling bites.
+    expect(bridge.takeLateAskReply("nothing-here")).toBeUndefined();
+    expect(map.size).toBeLessThanOrEqual(1024);
+    await vi.waitFor(() =>
+      expect(said.some((t) => /can no longer accept an answer/i.test(t))).toBe(true),
+    );
+    expect(said.find((t) => /can no longer accept an answer/i.test(t))).toMatch(
+      /type your choice in the chat/i,
+    );
+  });
+
   it("a throwing sink never breaks the message loop or loses the buffered answer", async () => {
     bridge.setLateAskReplySink(() => {
       throw new Error("journal exploded");

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -396,10 +396,21 @@ export type AskRecovery =
   | { status: "none" }
   /**
    * Answers exist for this tab but NONE of them is provably an answer to THIS
-   * question (a different question, or too old to present as fresh). They are
-   * handed back so the caller can disclose them, quoted with their own question.
+   * question (a different question, or too old to present as fresh).
+   *
+   * `others` are the ones this conversation MAY be shown — same occupant, not
+   * retired — quoted with their own question so they cannot be misread as an
+   * answer to anything else.
+   *
+   * `withheld` counts the ones it may NOT: they belong to a different browser tab
+   * on this recurring key, or to a conversation that has been replaced. Their
+   * CONTENT is deliberately not returned — rendering a departed tab's chosen
+   * option into this conversation's result is the disclosure leaking the very
+   * thing the boundary exists to contain. The count still says something was
+   * answered, which is what keeps this a disclosure rather than a silence; the
+   * text itself is in the durable log.
    */
-  | { status: "unattributed"; others: AskEntry[] };
+  | { status: "unattributed"; others: AskEntry[]; withheld: number };
 
 export class AskAnswerJournalImpl {
   /** ask id → ticket. Ask ids are UUIDs, so exact equality is proof of identity. */
@@ -622,6 +633,21 @@ export class AskAnswerJournalImpl {
     this.trimTickets();
   }
 
+  /**
+   * Is the conversation that opened this ask STILL the one on the tab?
+   *
+   * The debt footnote rides whatever result is going back, and `reportDropped`
+   * attaches its token to the turn that is live NOW. So a result belonging to a
+   * conversation that has since been replaced must not carry it: the live turn's
+   * ack would settle a warning that conversation never saw. Unknown ticket → true,
+   * because a caller with no ticket has nothing to have been replaced.
+   */
+  askBelongsToLiveConversation(askId: string): boolean {
+    const ticket = this.tickets.get(askId);
+    if (!ticket) return true;
+    return ticket.epoch === (this.tabEpoch.get(ticket.tabId) ?? 0);
+  }
+
   /** Does this journal know the ask id — i.e. is a late answer for it one of
    *  OURS? The bridge's late-answer sink is fed by every `ask_user` card
    *  (confirm/consent/secret gates included) and only `panel_ask` answers belong
@@ -840,8 +866,14 @@ export class AskAnswerJournalImpl {
       // uselessly — an answer the current conversation was never shown. The
       // conversation boundary already marked this entry unrecoverable; it makes it
       // unackable too, so the answer stays honestly unproven.
+      // Gated on the BOUNDARY axis only. An AMBIGUOUS answer (an ask id that
+      // stopped identifying one card) is still handed to a caller, so it must
+      // still be ackable by the turn that carried it — refusing the carrier there
+      // left a delivered answer permanently unconfirmed, i.e. surfacing later as
+      // a loss that did not happen. Only a RETIRED answer, which no live turn may
+      // receive at all, gets no carrier.
       entry.carrier =
-        entry.recoverable === false ? null : (this.attachTurn?.(entry.key, token) ?? null);
+        entry.retired === true ? null : (this.attachTurn?.(entry.key, token) ?? null);
       // It reached A caller. Do not ALSO push it as an orphan; a re-ask can
       // still recover it if that caller was already dead.
       //
@@ -889,7 +921,11 @@ export class AskAnswerJournalImpl {
       )
       .sort((a, b) => b.answeredAt - a.answeredAt);
     if (eligible.length > 0) return { status: "recovered", entry: eligible[0] };
-    return { status: "unattributed", others: mine };
+    // SPLIT by what this conversation is allowed to see. `others` goes through
+    // exactly the same gate as every other outlet — nothing about a disclosure
+    // makes it exempt just because it is not a hand-off.
+    const others = mine.filter((e) => this.mayReachLiveTurn(e));
+    return { status: "unattributed", others, withheld: mine.length - others.length };
   }
 
   /**
@@ -1015,18 +1051,24 @@ export class AskAnswerJournalImpl {
     why: "disconnected" | "its conversation was replaced",
   ): void {
     const slot = tabIncarnationSlot(key, incarnation);
-    let owed = this.undisclosedDrop(slot);
-    for (const entry of this.entries.values()) {
-      if (entry.key !== key || entry.incarnation !== incarnation) continue;
-      if (!entry.disclose) continue;
-      owed += entry.disclose;
-      delete entry.disclose;
-    }
+    // COUNT FIRST, WITHOUT MUTATING. An earlier draft cleared each carrier as it
+    // totalled them, so the only consolidated copy of the debt was gone BEFORE
+    // the report — and a logger that throws would take the whole disclosure with
+    // it, leaving nothing for a later ack to re-home. Clear-then-report is not
+    // report-then-clear, and this helper exists precisely so that fixing a
+    // misattribution cannot create a silent loss.
+    const carriers = [...this.entries.values()].filter(
+      (e) => e.key === key && e.incarnation === incarnation && (e.disclose ?? 0) > 0,
+    );
+    const owed = this.undisclosedDrop(slot) + carriers.reduce((n, e) => n + e.disclose!, 0);
     if (owed > 0) {
+      // If this throws, NOTHING below has run: the debt is still whole and still
+      // owed, and the next retirement (or the next report) will surface it.
       logger.error(
         `[ask-answers] tab ${key.slice(0, 8)} ${why} still owed a disclosure for ${owed} validated answer(s) whose content was already dropped — recording it here, as there is no longer anywhere to deliver it; treat those answers as UNDETERMINED`,
       );
     }
+    for (const entry of carriers) delete entry.disclose;
     this.dropped.delete(slot);
     this.disclosedUpTo.delete(slot);
     for (const [t, x] of [...this.debtTokens]) if (x.key === slot) this.debtTokens.delete(t);

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -488,7 +488,11 @@ export class AskAnswerJournalImpl {
     // SCREEN, which is what makes its ceiling unreachable in practice: otherwise
     // a long session's ordinary successful asks fill it and evict a genuinely
     // outstanding card's ticket, taking its retired-conversation marker with it.
-    if (answered) this.tickets.delete(askId);
+    // …EXCEPT under a reused id, where "an entry exists for this ask id" no
+    // longer means "this card was answered" — it may be the OTHER card's answer,
+    // and this one is still on screen. Keeping the ticket keeps its reused flag,
+    // which is what stops either answer satisfying either question.
+    if (answered && ticket?.reused !== true) this.tickets.delete(askId);
     // It is an orphan NOW — deliver it now. Leaving it merely `pending` would
     // make it wait for an unrelated later flush, and this transition happens on
     // the ask handler's unwind, where there may never be one.
@@ -509,6 +513,7 @@ export class AskAnswerJournalImpl {
   record(askId: string, reply: unknown, meta: { tabId: string }): AskEntry {
     const text = answerText(reply);
     const existing = [...this.entries.values()].find((e) => e.askId === askId);
+    const ticket = this.tickets.get(askId);
     // Collapse ONLY an identical observation. The same card's reply can be seen
     // twice (the handler's grace poll takes it out of the bridge buffer while the
     // sink has already forwarded it) and that is one answer, not two — identity,
@@ -519,15 +524,20 @@ export class AskAnswerJournalImpl {
     // discard what the user just chose, so it gets its own entry, and BOTH are
     // demoted to unattributable: nothing on the wire says which card either came
     // from, so neither may satisfy a question.
+    //
+    // …and the collapse is OFF ENTIRELY for a REUSED id. "Same id, same text" is
+    // only evidence of one observation while the id means one card; once two
+    // cards share it, two users' picks that happen to read the same ("euler" on
+    // both) are two validated answers to two questions, and merging them leaves
+    // the second question unanswered with no record at all.
     if (existing) {
-      if (existing.answer === text) return existing;
+      if (existing.answer === text && ticket?.reused !== true) return existing;
       logger.warn(
-        `[ask-answers] a SECOND, different answer arrived under ask id ${askId.slice(0, 12)} ("${text}" vs "${existing.answer}") — both are kept and both are reported as UNDETERMINED; neither can satisfy a question`,
+        `[ask-answers] a SECOND answer arrived under ask id ${askId.slice(0, 12)} ("${text}"${existing.answer === text ? " — same text, but the id is REUSED so this is a different card" : ` vs "${existing.answer}"`}) — both are kept and both are reported as UNDETERMINED; neither can satisfy a question`,
       );
       existing.correlation = { status: "foreign", askId };
       existing.recoverable = false;
     }
-    const ticket = this.tickets.get(askId);
     // A REUSED id proves nothing: the panel sends only the id, so an answer for
     // it could belong to either card. Report it as foreign — real, but
     // UNDETERMINED — rather than claiming it answers the question now open.
@@ -578,9 +588,8 @@ export class AskAnswerJournalImpl {
         `[ask-answers] a validated answer arrived for ask ${askId.slice(0, 8)} with ${ticket ? "a REUSED (ambiguous) ticket" : "no open ticket"} — journaled as UNATTRIBUTED; it can never satisfy a question, only be reported`,
       );
     }
-    // Same release as closeAsk: an answered card whose handler is already gone
-    // has no further use for its ticket, and the entry carries everything.
-    if (ticket && !ticket.awaiting) this.tickets.delete(askId);
+    // Same release as closeAsk (and the same reused-id exception).
+    if (ticket && !ticket.awaiting && ticket.reused !== true) this.tickets.delete(askId);
     this.trimEntries(entry.key);
     // Born orphaned (no handler is waiting on this ask) — push it straight away.
     if (entry.delivery === "pending") this.flush?.(entry.key);

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -178,6 +178,19 @@ export interface AskEntry {
    * a re-ask of the identical question can still recover it.
    */
   returned: boolean;
+  /**
+   * PROVEN read by the agent — the turn that carried this answer produced its
+   * own marked result (#468's ack-on-carry, ridden by a tool-result answer via
+   * PanelAgent.attachTurnToken).
+   *
+   * `returned` and `acked` are deliberately two fields, because they answer two
+   * different questions and conflating them is the bug this whole file exists to
+   * kill. `returned` says only that the answer was written to a transport that
+   * MAY have been abandoned — the premise of #486. `acked` says the model ran to
+   * completion after receiving it. Only the second may license forgetting an
+   * answer quietly.
+   */
+  acked?: boolean;
   delivery: AskDeliveryState;
   attempts: number;
   /** How many turns carried this answer and then ended without a provable ack. */
@@ -245,8 +258,6 @@ const RECOVER_MAX_AGE_MS = 10 * 60_000;
  *  those put the text into a turn the agent read, so settling risks a duplicate,
  *  never a loss. */
 const MAX_CARRIED_RELEASES = 3;
-/** Tabs whose evicted-answer counter is retained. */
-const MAX_DROPPED_KEYS = 64;
 /** How many separate tool results may report an eviction debt before it is
  *  considered said. See reportDropped(). */
 const MAX_DEBT_REPORTS = 3;
@@ -367,6 +378,8 @@ export class AskAnswerJournalImpl {
   private flush: ((key: string) => void) | null = null;
   /** Pull a still-queued answer event back off its agent (see setRevoker). */
   private revoke: ((key: string, token: string) => boolean) | null = null;
+  /** Ride a token on the tab's in-flight turn (see setTurnAttacher). */
+  private attachTurn: ((key: string, token: string) => boolean) | null = null;
 
   /**
    * Wire the push channel (#486).
@@ -392,6 +405,21 @@ export class AskAnswerJournalImpl {
    */
   setRevoker(revoke: (key: string, token: string) => boolean): void {
     this.revoke = revoke;
+  }
+
+  /**
+   * Wire the TOOL-RESULT ack (#486).
+   *
+   * An answer PUSHED as an event is acked when the turn carrying it ends. An
+   * answer handed back as a TOOL RESULT had no such proof — and treating the
+   * hand-off itself as proof is exactly the assumption #486 exists to demolish.
+   * This rides the token on the turn the tool call is running inside, so the
+   * SAME ack-on-carry machinery settles it: either that turn's own marked result
+   * lands (the model ran to completion after receiving the answer), or it never
+   * does and the answer stays accounted for.
+   */
+  setTurnAttacher(attach: (key: string, token: string) => boolean): void {
+    this.attachTurn = attach;
   }
 
   /**
@@ -630,6 +658,10 @@ export class AskAnswerJournalImpl {
     const entry = this.entries.get(token);
     if (entry) {
       entry.returned = true;
+      // Ride the turn this tool call is running inside, so that turn's result —
+      // and nothing less — acks the answer. No live turn to ride means no proof,
+      // so the answer simply stays unacked, which is the conservative reading.
+      this.attachTurn?.(entry.key, token);
       // It reached A caller. Do not ALSO push it as an orphan; a re-ask can
       // still recover it if that caller was already dead.
       //
@@ -820,9 +852,23 @@ export class AskAnswerJournalImpl {
     // the recovery window: a re-ask of the identical question must still be able
     // to return it as its result rather than making the user answer twice. It is
     // flagged so any later surfacing reads as "you have seen this".
-    delete entry.disclose;
+    //
+    // The eviction DISCLOSURE it carries is only SPENT when a real delivery
+    // actually rendered it — `deliverPending` stamps the count onto the entry and
+    // puts `dropped_answers` in that payload, and `attempts > 0` is the record of
+    // it. An entry acked without ever having been pushed (a TOOL-RESULT answer
+    // riding its turn) never showed anyone that count, so deleting it here would
+    // spend a warning nobody was given: re-home it instead.
+    if (entry.disclose) {
+      const owed = entry.disclose;
+      delete entry.disclose;
+      if (entry.attempts === 0) this.noteDropped(entry.key, owed);
+    }
     entry.delivery = "none";
     entry.returned = true;
+    // THE proof. Everything that may forget an answer QUIETLY keys on this and
+    // never on `returned`.
+    entry.acked = true;
     entry.replayHint = true;
   }
 
@@ -840,6 +886,14 @@ export class AskAnswerJournalImpl {
   release(token: string, opts: { carried?: boolean } = {}): void {
     const entry = this.entries.get(token);
     if (!entry) return;
+    // A TOOL-RESULT answer riding a turn (see setTurnAttacher) is not in a
+    // delivery loop: nothing re-sends it, so there is no cycle to bound and
+    // nothing to re-arm. Its turn ended without proving it was read, so the only
+    // correct outcome is that it stays UNACKED — which is what keeps it
+    // recoverable and makes its eviction a disclosed loss rather than a silent
+    // one. Settling it here on a bound would forge the very proof this split
+    // exists to withhold.
+    if (entry.returned && entry.delivery === "none") return;
     if (opts.carried) {
       entry.carriedReleases = (entry.carriedReleases ?? 0) + 1;
       if (entry.carriedReleases >= MAX_CARRIED_RELEASES) {
@@ -886,7 +940,10 @@ export class AskAnswerJournalImpl {
       (e) =>
         e.delivery !== "none" ||
         (e.disclose ?? 0) > 0 ||
-        now - e.answeredAt <= RECOVER_MAX_AGE_MS,
+        // UNACKED only: an answer the agent provably read is not news on the way
+        // out, and naming every ask of the last ten minutes would bury the ones
+        // that actually went missing.
+        (e.acked !== true && now - e.answeredAt <= RECOVER_MAX_AGE_MS),
     );
   }
 
@@ -1033,6 +1090,12 @@ export class AskAnswerJournalImpl {
   dropTicketForTest(askId: string): void {
     this.tickets.delete(askId);
   }
+  /** Record + hand back in one step, returning the token. */
+  markReturnedForTest(askId: string, reply: unknown, tabId: string): string {
+    const token = this.record(askId, reply, { tabId }).token;
+    this.markReturned(token);
+    return token;
+  }
   entriesFor(key: string): AskEntry[] {
     return [...this.entries.values()].filter((e) => e.key === key);
   }
@@ -1088,16 +1151,20 @@ export class AskAnswerJournalImpl {
       return;
     }
     this.dropped.set(key, (this.dropped.get(key) ?? 0) + count);
-    while (this.dropped.size > MAX_DROPPED_KEYS) {
-      const victim = this.dropped.keys().next().value;
-      if (victim === undefined) break;
-      const lost = this.dropped.get(victim) ?? 0;
-      this.dropped.delete(victim);
-      this.droppedReports.delete(victim);
-      logger.error(
-        `[ask-answers] discarding the undelivered-answer count (${lost}) for tab ${victim.slice(0, 8)} — over ${MAX_DROPPED_KEYS} tabs are tracking one; that tab will not be told`,
-      );
-    }
+    // NO CEILING HERE, deliberately.
+    //
+    // This map is not payload — it is the PROMISE that a loss will be reported,
+    // and it is the last record of answers whose text is already gone. Evicting
+    // it on the same terms as data (as an earlier draft did, at 64 tabs) turns a
+    // disclosed loss straight back into a silent one: the tab's next ask, the
+    // restart gate and the fatal-exit report all lose their only trace, and the
+    // log line that announced it said outright that the tab would never be told.
+    // A bounded store must never be what decides whether a warning is owed.
+    //
+    // It cannot grow without limit anyway: one integer per PANEL TAB that has
+    // stranded debt, removed by forget() when the tab goes away (which logs at
+    // ERROR, the one place the promise genuinely cannot be kept) and merged by
+    // moveKey() across a tab-id migration.
   }
 
   /**
@@ -1113,41 +1180,37 @@ export class AskAnswerJournalImpl {
     const evict = (scope: (e: AskEntry) => boolean, limit: number, label: string): void => {
       let mine = [...this.entries.values()].filter(scope);
       while (mine.length > limit) {
-        const victim = mine.find((e) => e.returned) ?? mine[0];
+        // EVICTION ORDER, and the one decision that may forget an answer
+        // QUIETLY. It keys on ACKED — the turn that carried the answer produced
+        // its own marked result — never on `returned`, which says only that the
+        // answer was written to a transport that may already have been
+        // abandoned. That is the premise of #486, so it cannot also be the
+        // licence to forget.
+        //
+        // Ordinary asks ARE acked (the model reads the tool result and finishes
+        // its turn), so the common path stays silent and no warning cries wolf.
+        // An answer whose turn never completed is precisely the #486 failure, so
+        // it is counted and disclosed exactly like one that reached nobody.
+        const victim =
+          mine.find((e) => e.acked === true) ??
+          mine.find((e) => e.returned) ??
+          mine[0];
         this.entries.delete(victim.token);
         mine = mine.filter((e) => e !== victim);
-        if (victim.returned) {
-          // LOGGED, NOT COUNTED as an undetermined loss for the agent — the one
-          // place this file deliberately stops short, so the reasoning is spelled
-          // out rather than assumed.
-          //
-          // A returned answer DID reach a caller; what its eviction costs is the
-          // ability to RECOVER it, not a delivery. Counting each one as "a
-          // validated answer was dropped, treat it as UNDETERMINED" would fire
-          // after ~48 ordinary successful asks on a tab and tell the agent that
-          // answers it almost certainly received are unknown. A warning that is
-          // usually false is its own kind of silence: it trains the reader to
-          // ignore the one that is true.
-          //
-          // The exposure is bounded on both sides — the per-tab ceiling is far
-          // above any plausible burst, orphans are never evicted before these,
-          // and the full answer text is written here — so what survives is a
-          // reconstructable record rather than a misleading alarm.
-          // …but ANY DISCLOSURE IT WAS CARRYING is re-homed, not dropped with it.
-          // The residual above permits losing THIS answer's recoverability; it
-          // says nothing about the debt owed for EARLIER answers that reached
-          // nobody, which merely happened to be stamped on this entry. (Reachable
-          // because a recovery marks its entry `returned` while it is carrying a
-          // count — after which it becomes the preferred eviction victim.)
+        if (victim.acked === true) {
+          // ANY DISCLOSURE IT WAS CARRYING is re-homed, not dropped with it: this
+          // answer's own recoverability is what may be forgotten, never the debt
+          // owed for EARLIER answers that reached nobody and merely happened to
+          // be stamped on this entry.
           if (victim.disclose) this.noteDropped(victim.key, victim.disclose);
-          logger.warn(
-            `[ask-answers] ${label} — forgetting an already-returned answer ("${victim.answer}") to "${preview(victim.question)}"; a re-ask can no longer recover it, and a tool result is not proof it was received`,
+          logger.debug(
+            `[ask-answers] ${label} — forgetting an answer to "${preview(victim.question)}" that the agent provably read`,
           );
           continue;
         }
         this.noteDropped(victim.key, 1 + (victim.disclose ?? 0));
         logger.error(
-          `[ask-answers] ${label} — dropped a VALIDATED answer to "${preview(victim.question)}" that had reached nobody; the next delivery will report it as undetermined`,
+          `[ask-answers] ${label} — dropped a VALIDATED answer to "${preview(victim.question)}"${victim.returned ? " that went into a tool call whose receipt was never confirmed" : " that had reached nobody"}; the next delivery will report it as undetermined`,
         );
       }
     };

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -365,6 +365,8 @@ export class AskAnswerJournalImpl {
   private ticketSeq = 0;
   /** Deliver a tab's newly-orphaned answers (see setFlusher). */
   private flush: ((key: string) => void) | null = null;
+  /** Pull a still-queued answer event back off its agent (see setRevoker). */
+  private revoke: ((key: string, token: string) => boolean) | null = null;
 
   /**
    * Wire the push channel (#486).
@@ -377,6 +379,19 @@ export class AskAnswerJournalImpl {
    */
   setFlusher(flush: (key: string) => void): void {
     this.flush = flush;
+  }
+
+  /**
+   * Wire the "unsend" hook, mirroring #468's.
+   *
+   * An answer's WORDING is materialised when it is queued into an agent, and it
+   * says "a question card YOU put up". If the conversation is replaced before
+   * that item is read, the sentence becomes false — the fork never put that card
+   * up. This pulls the stale copy back while it is still unread. Nothing is
+   * re-delivered afterwards: the addressee is gone, which is the whole point.
+   */
+  setRevoker(revoke: (key: string, token: string) => boolean): void {
+    this.revoke = revoke;
   }
 
   /**
@@ -457,13 +472,23 @@ export class AskAnswerJournalImpl {
     const ticket = this.tickets.get(askId);
     if (ticket) ticket.awaiting = false;
     let armed: AskEntry | null = null;
+    let answered = false;
     for (const entry of this.entries.values()) {
       if (entry.askId !== askId) continue;
+      answered = true;
       if (!entry.returned && entry.delivery === "none") {
         entry.delivery = "pending";
         armed = entry;
       }
     }
+    // The card has been ANSWERED and its handler has finished, so this ticket can
+    // never be needed again — the panel removes an answered card, and everything
+    // the ticket carried (tab, question, fingerprint, conversation generation) is
+    // frozen onto the entry. Releasing it keeps the ticket map to CARDS STILL ON
+    // SCREEN, which is what makes its ceiling unreachable in practice: otherwise
+    // a long session's ordinary successful asks fill it and evict a genuinely
+    // outstanding card's ticket, taking its retired-conversation marker with it.
+    if (answered) this.tickets.delete(askId);
     // It is an orphan NOW — deliver it now. Leaving it merely `pending` would
     // make it wait for an unrelated later flush, and this transition happens on
     // the ask handler's unwind, where there may never be one.
@@ -553,6 +578,9 @@ export class AskAnswerJournalImpl {
         `[ask-answers] a validated answer arrived for ask ${askId.slice(0, 8)} with ${ticket ? "a REUSED (ambiguous) ticket" : "no open ticket"} — journaled as UNATTRIBUTED; it can never satisfy a question, only be reported`,
       );
     }
+    // Same release as closeAsk: an answered card whose handler is already gone
+    // has no further use for its ticket, and the entry carries everything.
+    if (ticket && !ticket.awaiting) this.tickets.delete(askId);
     this.trimEntries(entry.key);
     // Born orphaned (no handler is waiting on this ask) — push it straight away.
     if (entry.delivery === "pending") this.flush?.(entry.key);
@@ -874,6 +902,10 @@ export class AskAnswerJournalImpl {
     for (const [token, entry] of [...this.entries]) {
       if (entry.key !== key) continue;
       this.entries.delete(token);
+      // …and its queued copy goes with it: the journal's record and the agent's
+      // queue must be dropped together, or the text outlives the entry that was
+      // supposed to bound it.
+      if (entry.delivery === "handed_off") this.revoke?.(entry.key, entry.token);
       // EVERY answer is logged, returned ones included: "it went into a
       // ToolResult" is not proof it was received, so a returned answer inside
       // the recovery window is still the only copy of a decision that may never
@@ -938,10 +970,19 @@ export class AskAnswerJournalImpl {
       // NOT a silent discard: the entry stays journaled (so a later ask on this
       // tab that times out still reports it, quoted with its own question) and
       // the loss of the push is logged here.
-      if (entry.delivery === "pending") {
+      // PENDING is easy — it has not been queued anywhere yet. HANDED_OFF has
+      // already been materialised into the agent's queue with wording that claims
+      // the reader put the card up, so it must be pulled back; only once the
+      // carrying turn has STARTED is the text beyond recall.
+      const stale = entry.delivery;
+      if (stale === "pending" || (stale === "handed_off" && this.revoke?.(entry.key, entry.token))) {
         entry.delivery = "none";
         logger.warn(
           `[ask-answers] the conversation that asked "${preview(entry.question)}" on tab ${key.slice(0, 8)} was replaced — the user's answer ("${entry.answer}") will NOT be announced to the replacement conversation; it is kept only for disclosure`,
+        );
+      } else if (stale === "handed_off") {
+        logger.warn(
+          `[ask-answers] tab ${key.slice(0, 8)}: the user's answer to "${preview(entry.question)}" was already being read when the conversation was replaced — it could not be recalled`,
         );
       }
     }

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -77,6 +77,7 @@
 
 import { createHash } from "node:crypto";
 import { logger } from "../utils/logger.js";
+import { tabIncarnationSlot } from "../services/ui-bridge.js";
 
 /** How an answer relates to the asks this session dispatched. Computed ONCE, at
  *  arrival, and frozen onto the journal entry — a replay never re-correlates, so
@@ -407,6 +408,18 @@ export class AskAnswerJournalImpl {
   private disclosedUpTo = new Map<string, number>();
   private seq = 0;
   private ticketSeq = 0;
+  /**
+   * Which browser-tab INCARNATION currently holds a panel tab (#486).
+   *
+   * A `wf:<hash>` tab id names a saved workflow, so it recurs: a second browser
+   * tab opening that workflow takes the key over. Anything that holds or settles
+   * per-tab state must therefore be scoped to (tab, incarnation) — otherwise the
+   * newcomer reads, reports and ACKS the departed tab's bookkeeping, and the
+   * departed tab's own disclosure is silently marked told. Undefined when the tab
+   * is not currently connected.
+   */
+  private incarnationOf: ((key: string) => string | undefined) | null = null;
+
   /** Deliver a tab's newly-orphaned answers (see setFlusher). */
   private flush: ((key: string) => void) | null = null;
   /** Pull a still-queued answer event back off its agent (see setRevoker). */
@@ -454,6 +467,16 @@ export class AskAnswerJournalImpl {
    */
   setTurnAttacher(attach: (key: string, token: string) => string | null): void {
     this.attachTurn = attach;
+  }
+
+  /** Wire the per-tab incarnation lookup — see `incarnationOf`. */
+  setIncarnationResolver(resolve: (key: string) => string | undefined): void {
+    this.incarnationOf = resolve;
+  }
+
+  /** The debt bucket for a tab's CURRENT occupant. */
+  private debtSlot(key: string): string {
+    return tabIncarnationSlot(key, this.incarnationOf?.(key));
   }
 
   /**
@@ -848,8 +871,11 @@ export class AskAnswerJournalImpl {
    * than reporting it once at the first opportunity.
    */
   reportDropped(key: string): number {
-    const total = this.dropped.get(key) ?? 0;
-    const owed = total - (this.disclosedUpTo.get(key) ?? 0);
+    // THIS occupant's bucket only. A different browser tab that inherited the
+    // key has its own, so it can neither read nor settle the departed tab's.
+    const slot = this.debtSlot(key);
+    const total = this.dropped.get(slot) ?? 0;
+    const owed = total - (this.disclosedUpTo.get(slot) ?? 0);
     if (owed <= 0) return 0;
     // The debt is NOT spent by being written into a tool result. A ToolResult is
     // a hand-off, not a receipt — that IS #486 — so counting reports (an earlier
@@ -866,7 +892,7 @@ export class AskAnswerJournalImpl {
     // switched provider must not be able to certify a warning it never showed.
     // The token remembers the TOTAL it is showing, so its ack settles exactly
     // that and nothing that arrives afterwards.
-    if (carrier !== null) this.debtTokens.set(token, { key, carrier, upTo: total });
+    if (carrier !== null) this.debtTokens.set(token, { key: slot, carrier, upTo: total });
     return owed;
   }
 
@@ -885,22 +911,33 @@ export class AskAnswerJournalImpl {
    * answers themselves are still deliverable to the tab when it comes back; only
    * the count of answers whose TEXT is already gone is retired.
    */
-  retireDebt(key: string): void {
-    const owed = this.undisclosedDrop(key);
+  retireDebt(key: string, incarnation: string): void {
+    const slot = tabIncarnationSlot(key, incarnation);
+    const owed = this.undisclosedDrop(slot);
     if (owed > 0) {
       logger.error(
         `[ask-answers] tab ${key.slice(0, 8)} disconnected still owed a disclosure for ${owed} validated answer(s) whose content was already dropped — recording it here, as there is no longer anywhere to deliver it; treat those answers as UNDETERMINED`,
       );
     }
-    this.dropped.delete(key);
-    this.disclosedUpTo.delete(key);
-    for (const [t, d] of [...this.debtTokens]) if (d.key === key) this.debtTokens.delete(t);
+    this.dropped.delete(slot);
+    this.disclosedUpTo.delete(slot);
+    for (const [t, x] of [...this.debtTokens]) if (x.key === slot) this.debtTokens.delete(t);
   }
 
   /** The part of a tab's eviction total that has NOT yet been surfaced and
    *  confirmed. See disclosedUpTo. */
-  private undisclosedDrop(key: string): number {
-    return Math.max(0, (this.dropped.get(key) ?? 0) - (this.disclosedUpTo.get(key) ?? 0));
+  private undisclosedDrop(slot: string): number {
+    return Math.max(0, (this.dropped.get(slot) ?? 0) - (this.disclosedUpTo.get(slot) ?? 0));
+  }
+
+  /** Every debt bucket belonging to a panel tab, across all its incarnations. */
+  private debtSlotsFor(key: string): string[] {
+    // A slot is `["<tabId>",<incarnation>]`, so the tab's slots are exactly those
+    // starting `["<tabId>",` — JSON-escaped, so no tab id can spoof another's.
+    const prefix = `[${JSON.stringify(key)},`;
+    return [...new Set([...this.dropped.keys(), ...this.disclosedUpTo.keys()])].filter((s) =>
+      s.startsWith(prefix),
+    );
   }
 
   /** Answers this tab lost to an eviction and has not yet been told about. */
@@ -908,7 +945,11 @@ export class AskAnswerJournalImpl {
     const carried = [...this.entries.values()]
       .filter((e) => e.key === key)
       .reduce((n, e) => n + (e.disclose ?? 0), 0);
-    return carried + this.undisclosedDrop(key);
+    // Every incarnation's bucket: a diagnostic view of what this TAB is owed,
+    // whoever is holding it now.
+    return (
+      carried + this.debtSlotsFor(key).reduce((n, slot) => n + this.undisclosedDrop(slot), 0)
+    );
   }
 
   /** Entries awaiting a push attempt for this key, in arrival order. */
@@ -939,7 +980,7 @@ export class AskAnswerJournalImpl {
   ): { delivered: number; blockedOn: AskEntry | null } {
     let delivered = 0;
     for (const entry of this.pending(key)) {
-      const lost = (entry.disclose ?? 0) + this.undisclosedDrop(key);
+      const lost = (entry.disclose ?? 0) + this.undisclosedDrop(this.debtSlot(key));
       const payload: AskAnswerEvent = {
         kind: "ask_answer",
         ask_question: entry.question,
@@ -959,8 +1000,9 @@ export class AskAnswerJournalImpl {
         // If this agent dies before its turn runs, the entry is released and
         // replayed, and the warning must go with it. Only ack() clears it.
         entry.disclose = lost;
-        this.dropped.delete(key);
-        this.disclosedUpTo.delete(key);
+        const slot = this.debtSlot(key);
+        this.dropped.delete(slot);
+        this.disclosedUpTo.delete(slot);
       }
       delivered += 1;
     }
@@ -1074,7 +1116,7 @@ export class AskAnswerJournalImpl {
     // answer was lost, and it is destroyed by a teardown exactly as an entry is —
     // tearing down while one is owed turns a disclosed loss back into a silent
     // one, which is the whole thing this journal exists to prevent.
-    for (const key of this.dropped.keys()) if (this.undisclosedDrop(key) > 0) return true;
+    for (const slot of this.dropped.keys()) if (this.undisclosedDrop(slot) > 0) return true;
     return [...this.entries.values()].some(
       (e) => e.delivery !== "none" || (e.disclose ?? 0) > 0,
     );
@@ -1117,9 +1159,13 @@ export class AskAnswerJournalImpl {
    *  name a loss whose carrier is only a counter. */
   outstandingDebt(): Array<{ key: string; count: number }> {
     const byTab = new Map<string, number>();
-    for (const key of this.dropped.keys()) {
-      const owed = this.undisclosedDrop(key);
-      if (owed > 0) byTab.set(key, (byTab.get(key) ?? 0) + owed);
+    for (const slot of this.dropped.keys()) {
+      const owed = this.undisclosedDrop(slot);
+      if (owed <= 0) continue;
+      // The exit disclosure names TABS, not incarnations — every incarnation's
+      // loss belongs to the tab the user is looking at.
+      const key = JSON.parse(slot)[0] as string;
+      byTab.set(key, (byTab.get(key) ?? 0) + owed);
     }
     for (const e of this.entries.values()) {
       if ((e.disclose ?? 0) > 0) byTab.set(e.key, (byTab.get(e.key) ?? 0) + e.disclose!);
@@ -1160,15 +1206,22 @@ export class AskAnswerJournalImpl {
     for (const debt of this.debtTokens.values()) {
       if (debt.key === from) debt.key = to;
     }
-    const lost = this.undisclosedDrop(from);
-    if (this.dropped.has(from)) {
-      this.dropped.delete(from);
-      this.disclosedUpTo.delete(from);
-      // Carry the UNDISCLOSED remainder only — what the source tab was already
-      // told is told, and re-importing it would warn the destination twice.
-      this.dropped.set(to, (this.dropped.get(to) ?? 0) + lost);
-      // The destination inherits the DEBT but not the source's report credit:
-      // those reports went to the source tab's agent, not this one's.
+    // Every incarnation's bucket moves with the tab id, keeping its own
+    // incarnation: the id changed, the browser tabs did not.
+    for (const slot of this.debtSlotsFor(from)) {
+      const [, incarnation] = JSON.parse(slot) as [string, string | null];
+      // Carry the UNDISCLOSED remainder only — what was already told is told,
+      // and re-importing it would warn the destination twice.
+      const lost = this.undisclosedDrop(slot);
+      this.dropped.delete(slot);
+      this.disclosedUpTo.delete(slot);
+      if (lost <= 0) continue;
+      const moved = tabIncarnationSlot(to, incarnation ?? undefined);
+      this.dropped.set(moved, (this.dropped.get(moved) ?? 0) + lost);
+    }
+    for (const debt of this.debtTokens.values()) {
+      const [tab, incarnation] = JSON.parse(debt.key) as [string, string | null];
+      if (tab === from) debt.key = tabIncarnationSlot(to, incarnation ?? undefined);
     }
   }
 
@@ -1196,17 +1249,22 @@ export class AskAnswerJournalImpl {
     // belongs to — while the newer epoch keeps it from being armed for a push at
     // a tab id no agent answers to, exactly as for a replaced conversation.
     this.tabEpoch.set(key, (this.tabEpoch.get(key) ?? 0) + 1);
-    const owed = this.undisclosedDrop(key);
+    const slots = this.debtSlotsFor(key);
+    const owed = slots.reduce((n, slot) => n + this.undisclosedDrop(slot), 0);
     if (owed > 0) {
       logger.error(
         `[ask-answers] tab ${key.slice(0, 8)} is gone still owed a disclosure for ${owed} evicted answer(s) — it will never be told`,
       );
     }
-    this.dropped.delete(key);
-    this.disclosedUpTo.delete(key);
+    for (const slot of slots) {
+      this.dropped.delete(slot);
+      this.disclosedUpTo.delete(slot);
+    }
     // Both halves together — see moveKey. A token left behind here would let a
     // later ack clear a debt for a tab that no longer exists.
-    for (const [t, d] of [...this.debtTokens]) if (d.key === key) this.debtTokens.delete(t);
+    for (const [t, x] of [...this.debtTokens]) {
+      if ((JSON.parse(x.key) as [string, string | null])[0] === key) this.debtTokens.delete(t);
+    }
   }
 
   /**
@@ -1296,7 +1354,7 @@ export class AskAnswerJournalImpl {
   }
   /** Strand an eviction debt on a tab without staging 48 evictions. */
   noteDroppedForTest(key: string, count: number): void {
-    this.dropped.set(key, (this.dropped.get(key) ?? 0) + count);
+    this.dropped.set(this.debtSlot(key), (this.dropped.get(this.debtSlot(key)) ?? 0) + count);
   }
   /** Record + hand back in one step, returning the token. */
   markReturnedForTest(askId: string, reply: unknown, tabId: string): string {
@@ -1359,7 +1417,7 @@ export class AskAnswerJournalImpl {
       carrier.disclose = (carrier.disclose ?? 0) + count;
       return;
     }
-    this.dropped.set(key, (this.dropped.get(key) ?? 0) + count);
+    this.dropped.set(this.debtSlot(key), (this.dropped.get(this.debtSlot(key)) ?? 0) + count);
     // NO CEILING HERE, deliberately.
     //
     // This map is not payload — it is the PROMISE that a loss will be reported,

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -1114,6 +1114,18 @@ export class AskAnswerJournalImpl {
       ticket.epoch = ticket.epoch === fromEpoch ? toEpoch : toEpoch - 1;
     }
     this.tabEpoch.delete(from);
+    // BOTH HALVES OF THE DEBT MOVE TOGETHER. The count is tab-keyed and the
+    // outstanding disclosure TOKENS carry that same key, but the ack that
+    // settles one is bound to the AGENT INSTANCE (see AskEntry.carrier) — which
+    // deliberately survives a tab-id migration. So a token left pointing at the
+    // old key is acked by a perfectly valid result and clears a debt nobody
+    // owes, while the real one sits under the new key forever: false outstanding
+    // debt that blocks the restart gate and later emits a spurious warning. That
+    // is the cry-wolf failure the acked/unacked split exists to prevent,
+    // arriving through migration.
+    for (const debt of this.debtTokens.values()) {
+      if (debt.key === from) debt.key = to;
+    }
     const lost = this.dropped.get(from);
     if (lost !== undefined) {
       this.dropped.delete(from);
@@ -1154,6 +1166,9 @@ export class AskAnswerJournalImpl {
       );
     }
     this.dropped.delete(key);
+    // Both halves together — see moveKey. A token left behind here would let a
+    // later ack clear a debt for a tab that no longer exists.
+    for (const [t, d] of [...this.debtTokens]) if (d.key === key) this.debtTokens.delete(t);
   }
 
   /**

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -598,9 +598,12 @@ export class AskAnswerJournalImpl {
 
   /** The ask handler put this answer into its ToolResult. A hand-off, not proof
    *  of consumption — see AskEntry.returned. */
-  markReturned(askId: string): void {
-    for (const entry of this.entries.values()) {
-      if (entry.askId !== askId) continue;
+  markReturned(token: string): void {
+    // BY TOKEN, not by ask id: under a reused id one ask id can own two entries,
+    // and marking the sibling returned would quietly retire an answer nobody has
+    // been given.
+    const entry = this.entries.get(token);
+    if (entry) {
       entry.returned = true;
       // It reached A caller. Do not ALSO push it as an orphan; a re-ask can
       // still recover it if that caller was already dead.

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -562,9 +562,16 @@ export class AskAnswerJournalImpl {
       key: attributable ? ticket.tabId : meta.tabId,
       // The fingerprint is the LICENCE to satisfy a re-ask, so a reused id gets
       // none — its answer may only ever be reported, never returned as an answer.
-      // The question TEXT is still carried: it is what makes that report honest.
       fingerprint: attributable ? ticket.fingerprint : null,
-      question: ticket?.question ?? null,
+      // …and NOR is the question text, for a REUSED id. The ticket then holds the
+      // LATER card's question, and printing that beside the EARLIER card's answer
+      // states a false association — the very mistake this file exists to
+      // prevent, committed in the disclosure meant to be the honest fallback. A
+      // ticket that is merely RETIRED (its conversation replaced) is different:
+      // its question is still that card's own, and keeping it is what lets the
+      // report name what was actually asked.
+      question:
+        ticket === undefined || ticket.reused === true ? null : ticket.question,
       answer: text,
       answeredAt: Date.now(),
       correlation,

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -53,6 +53,25 @@
 // match exactly is reported as an unattributed answer to ITS OWN question —
 // quoted with that question, so it cannot be read as an answer to anything else.
 //
+// WHAT IS DELIBERATELY NOT GUARANTEED. Three residuals survived four rounds of
+// adversarial review; each is an ACCEPTED trade with its reasoning, not an
+// oversight, and each is stated where it lives as well as here.
+//
+//  1. A RETURNED ANSWER EVICTED BY THE PER-TAB CEILING IS LOGGED, NOT COUNTED as
+//     an undetermined loss (see trimEntries). It reached a caller; what its
+//     eviction costs is the ability to RECOVER it. Counting each one would fire
+//     after ~48 ordinary successful asks and tell the agent that answers it
+//     almost certainly received are unknown — and a warning that is usually
+//     false is its own kind of silence.
+//  2. A RESTART IS NOT DEFERRED FOR A RETURNED ANSWER (see hasOutstanding vs.
+//     allOutstanding). Deferring on one would stall the self-restarter for the
+//     whole recovery window after EVERY ask. The fatal-exit disclosure names it
+//     instead: saying so on the way out costs nothing.
+//  3. A CARD ANSWERED BEYOND THE BRIDGE'S OPEN-CARD CEILING cannot be recognised
+//     at all (UiBridge.MAX_ASK_RID_MAPPINGS). Reaching it needs 1024 unanswered
+//     cards outstanding at once; it is logged at ERROR, and reporting it as a
+//     "dropped answer" would be a lie about questions nobody answered.
+//
 // LOCAL trust domain: this is accidental-loss bookkeeping, not a defence against
 // a hostile panel. Everything is in-memory and process-scoped.
 
@@ -228,6 +247,9 @@ const RECOVER_MAX_AGE_MS = 10 * 60_000;
 const MAX_CARRIED_RELEASES = 3;
 /** Tabs whose evicted-answer counter is retained. */
 const MAX_DROPPED_KEYS = 64;
+/** How many separate tool results may report an eviction debt before it is
+ *  considered said. See reportDropped(). */
+const MAX_DEBT_REPORTS = 3;
 
 /**
  * EXACT identity of a question, and the whole of the cross-question guard.
@@ -335,6 +357,10 @@ export class AskAnswerJournalImpl {
   private entries = new Map<string, AskEntry>();
   /** Answers this tab lost to an eviction and has not yet been told about. */
   private dropped = new Map<string, number>();
+  /** How many tool results have already carried each tab's eviction debt. The
+   *  debt is spent by a COUNT of reports, never by a single hand-off — see
+   *  reportDropped(). */
+  private droppedReports = new Map<string, number>();
   private seq = 0;
   private ticketSeq = 0;
   /** Deliver a tab's newly-orphaned answers (see setFlusher). */
@@ -456,8 +482,26 @@ export class AskAnswerJournalImpl {
    * dropped because it "looks like" something already seen.
    */
   record(askId: string, reply: unknown, meta: { tabId: string }): AskEntry {
+    const text = answerText(reply);
     const existing = [...this.entries.values()].find((e) => e.askId === askId);
-    if (existing) return existing;
+    // Collapse ONLY an identical observation. The same card's reply can be seen
+    // twice (the handler's grace poll takes it out of the bridge buffer while the
+    // sink has already forwarded it) and that is one answer, not two — identity,
+    // not suppression.
+    //
+    // A DIFFERENT answer under the same id is a different validated answer (two
+    // cards, one reused id). Returning the old entry there would silently
+    // discard what the user just chose, so it gets its own entry, and BOTH are
+    // demoted to unattributable: nothing on the wire says which card either came
+    // from, so neither may satisfy a question.
+    if (existing) {
+      if (existing.answer === text) return existing;
+      logger.warn(
+        `[ask-answers] a SECOND, different answer arrived under ask id ${askId.slice(0, 12)} ("${text}" vs "${existing.answer}") — both are kept and both are reported as UNDETERMINED; neither can satisfy a question`,
+      );
+      existing.correlation = { status: "foreign", askId };
+      existing.recoverable = false;
+    }
     const ticket = this.tickets.get(askId);
     // A REUSED id proves nothing: the panel sends only the id, so an answer for
     // it could belong to either card. Report it as foreign — real, but
@@ -466,7 +510,7 @@ export class AskAnswerJournalImpl {
     // resume of a historical session) while its card stayed on screen.
     const conversationGone =
       ticket !== undefined && ticket.epoch !== (this.tabEpoch.get(ticket.tabId) ?? 0);
-    const attributable = ticket !== undefined && ticket.reused !== true;
+    const attributable = ticket !== undefined && ticket.reused !== true && existing === undefined;
     const correlation: AskCorrelation = attributable
       ? { status: "matched", askId }
       : { status: "foreign", askId };
@@ -483,7 +527,7 @@ export class AskAnswerJournalImpl {
       // The question TEXT is still carried: it is what makes that report honest.
       fingerprint: attributable ? ticket.fingerprint : null,
       question: ticket?.question ?? null,
-      answer: answerText(reply),
+      answer: text,
       answeredAt: Date.now(),
       correlation,
       ticketSeq: ticket?.seq ?? 0,
@@ -496,7 +540,7 @@ export class AskAnswerJournalImpl {
       delivery: ticket?.awaiting === true || conversationGone ? "none" : "pending",
       // A question the CURRENT conversation never asked may be reported, never
       // returned as its answer.
-      ...(conversationGone ? { recoverable: false } : {}),
+      ...(conversationGone || existing !== undefined ? { recoverable: false } : {}),
       attempts: 0,
     };
     this.entries.set(entry.token, entry);
@@ -620,9 +664,22 @@ export class AskAnswerJournalImpl {
    * ERROR, and repeating the warning on every subsequent ask forever is worse
    * than reporting it once at the first opportunity.
    */
-  takeDropped(key: string): number {
+  reportDropped(key: string): number {
     const owed = this.dropped.get(key) ?? 0;
-    this.dropped.delete(key);
+    if (owed <= 0) return 0;
+    const said = (this.droppedReports.get(key) ?? 0) + 1;
+    // Bounded by REPORTS, not cleared on the first one. A ToolResult is a
+    // hand-off, not a receipt (that IS #486), so spending the debt on the first
+    // report would let an abandoned call take the disclosure with it — the
+    // suppression rule, one level up. Three independent tool results is the same
+    // trade MAX_CARRIED_RELEASES makes for a pushed answer: a repeated warning at
+    // worst, never a swallowed one, and it cannot repeat forever.
+    if (said >= MAX_DEBT_REPORTS) {
+      this.dropped.delete(key);
+      this.droppedReports.delete(key);
+    } else {
+      this.droppedReports.set(key, said);
+    }
     return owed;
   }
 
@@ -683,6 +740,7 @@ export class AskAnswerJournalImpl {
         // replayed, and the warning must go with it. Only ack() clears it.
         entry.disclose = lost;
         this.dropped.delete(key);
+        this.droppedReports.delete(key);
       }
       delivered += 1;
     }
@@ -803,6 +861,10 @@ export class AskAnswerJournalImpl {
     if (lost !== undefined) {
       this.dropped.delete(from);
       this.dropped.set(to, (this.dropped.get(to) ?? 0) + lost);
+      // The destination inherits the DEBT but not the source's report credit:
+      // those reports went to the source tab's agent, not this one's.
+      this.droppedReports.delete(from);
+      this.droppedReports.delete(to);
     }
   }
 
@@ -903,6 +965,7 @@ export class AskAnswerJournalImpl {
     this.tabEpoch.clear();
     this.entries.clear();
     this.dropped.clear();
+    this.droppedReports.clear();
     this.seq = 0;
     this.ticketSeq = 0;
   }
@@ -952,6 +1015,7 @@ export class AskAnswerJournalImpl {
       if (victim === undefined) break;
       const lost = this.dropped.get(victim) ?? 0;
       this.dropped.delete(victim);
+      this.droppedReports.delete(victim);
       logger.error(
         `[ask-answers] discarding the undelivered-answer count (${lost}) for tab ${victim.slice(0, 8)} — over ${MAX_DROPPED_KEYS} tabs are tracking one; that tab will not be told`,
       );

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -552,11 +552,14 @@ export class AskAnswerJournalImpl {
     const entry: AskEntry = {
       token: `aa${++this.seq}`,
       askId,
-      // The TICKET's tab is authoritative when we have one (that is the tab the
-      // card was rendered on); otherwise the tab the reply physically arrived
-      // from, so an unattributable answer is still addressed somewhere real
-      // instead of being dropped for want of a key.
-      key: ticket?.tabId ?? meta.tabId,
+      // The TICKET's tab is authoritative only while the ticket is ATTRIBUTABLE.
+      // A REUSED id can name a ticket opened by a DIFFERENT tab, and taking its
+      // tab would re-address the answer to a conversation that never rendered the
+      // card — labelled `foreign`, so it could not satisfy anything, but still
+      // delivered to the wrong place. The bridge-supplied tab is the PROVEN
+      // source of this reply (it comes from the routed send, not from the id), so
+      // it wins whenever the ticket cannot be trusted.
+      key: attributable ? ticket.tabId : meta.tabId,
       // The fingerprint is the LICENCE to satisfy a re-ask, so a reused id gets
       // none — its answer may only ever be reported, never returned as an answer.
       // The question TEXT is still carried: it is what makes that report honest.

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -228,6 +228,24 @@ export interface AskEntry {
    */
   recoverable?: boolean;
   /**
+   * The CONVERSATION that asked this question is gone — New chat, a rewind, a
+   * provider switch, an in-place workflow replacement, or another browser tab
+   * taking the key over.
+   *
+   * Deliberately separate from `recoverable`, which also covers AMBIGUITY (an ask
+   * id that stopped identifying one card). The two axes are independent and want
+   * opposite treatment: an ambiguous answer is still PUSHED, labelled
+   * UNDETERMINED, because nobody else can claim it; a retired one must not reach
+   * a live turn at all, because the turn belongs to a conversation that never
+   * asked. Folding them into one flag would either start swallowing ambiguous
+   * answers or keep leaking retired ones.
+   *
+   * There are TWO orthogonal boundaries in this file and this is the second:
+   * `(tabId, incarnation)` fences a different BROWSER TAB, and cannot fence this
+   * one — New chat happens on the same tab, with the same incarnation.
+   */
+  retired?: boolean;
+  /**
    * Which browser-tab INCARNATION this answer belongs to, captured at arrival.
    *
    * Entries are keyed by panel tab id, and that id recurs — `wf:<hash>` names a
@@ -501,6 +519,26 @@ export class AskAnswerJournalImpl {
    * When NOTHING can resolve incarnations at all (no resolver wired) the check is
    * inert and tab-keying alone governs, exactly as before.
    */
+  /**
+   * May this answer be handed to a LIVE TURN — recovered, replayed, or pushed?
+   *
+   * The single gate for the whole set. Both boundaries are checked here, because
+   * they are independent and each alone is insufficient:
+   *  • RETIRED — its conversation is gone (New chat, rewind, provider switch,
+   *    workflow replacement, takeover). Same tab, same incarnation, so no amount
+   *    of incarnation keying can see it.
+   *  • a DIFFERENT OCCUPANT — another browser tab holds this recurring key. Same
+   *    conversation identity as far as the tab is concerned, so no amount of
+   *    epoch bumping can see it.
+   *
+   * Gating the paths one at a time is how the rid bypass, the re-arm bypass and
+   * the debt-reporting bypass each arrived separately; making it a property of
+   * the SET is the fix.
+   */
+  private mayReachLiveTurn(entry: AskEntry): boolean {
+    return entry.retired !== true && this.sameOccupant(entry);
+  }
+
   private sameOccupant(entry: AskEntry): boolean {
     if (this.incarnationOf === null) return true; // nothing to distinguish
     const now = this.incarnationOf(entry.key);
@@ -747,6 +785,9 @@ export class AskAnswerJournalImpl {
       // A question the CURRENT conversation never asked may be reported, never
       // returned as its answer.
       ...(conversationGone || existing !== undefined ? { recoverable: false } : {}),
+      // The BOUNDARY axis only — `existing !== undefined` is ambiguity, which is
+      // still deliverable (labelled), so it must not set this.
+      ...(conversationGone ? { retired: true } : {}),
       // A SECOND answer under one ask id: the id is ambiguous for this entry too,
       // and that must outlive the ticket that proved it.
       ...(existing !== undefined || ticket?.reused === true ? { ambiguousId: true } : {}),
@@ -841,7 +882,7 @@ export class AskAnswerJournalImpl {
         (e) =>
           e.correlation.status === "matched" &&
           e.recoverable !== false &&
-          this.sameOccupant(e) &&
+          this.mayReachLiveTurn(e) &&
           e.fingerprint !== null &&
           e.fingerprint === fingerprint &&
           now - e.answeredAt <= RECOVER_MAX_AGE_MS,
@@ -951,11 +992,39 @@ export class AskAnswerJournalImpl {
    * the count of answers whose TEXT is already gone is retired.
    */
   retireDebt(key: string, incarnation: string): void {
+    this.surfaceAndClearDebt(key, incarnation, "disconnected");
+  }
+
+  /**
+   * SURFACE a debt that can no longer be delivered, then clear it.
+   *
+   * Used for both endings a debt can have: the tab went away, or the
+   * conversation it was owed to was replaced. Both are "there is no longer
+   * anywhere to deliver this", and both must REPORT before clearing — retiring a
+   * warning to stop it being misattributed, without saying it anywhere, would
+   * trade a misattribution for a silent loss, which is the one trade this file
+   * refuses everywhere else.
+   *
+   * Clears the entry-carried disclosures too: those ride out on a push, and a
+   * retired conversation's entries are no longer pushed, so leaving them there
+   * would strand the warning on text nobody will read.
+   */
+  private surfaceAndClearDebt(
+    key: string,
+    incarnation: string | undefined,
+    why: "disconnected" | "its conversation was replaced",
+  ): void {
     const slot = tabIncarnationSlot(key, incarnation);
-    const owed = this.undisclosedDrop(slot);
+    let owed = this.undisclosedDrop(slot);
+    for (const entry of this.entries.values()) {
+      if (entry.key !== key || entry.incarnation !== incarnation) continue;
+      if (!entry.disclose) continue;
+      owed += entry.disclose;
+      delete entry.disclose;
+    }
     if (owed > 0) {
       logger.error(
-        `[ask-answers] tab ${key.slice(0, 8)} disconnected still owed a disclosure for ${owed} validated answer(s) whose content was already dropped — recording it here, as there is no longer anywhere to deliver it; treat those answers as UNDETERMINED`,
+        `[ask-answers] tab ${key.slice(0, 8)} ${why} still owed a disclosure for ${owed} validated answer(s) whose content was already dropped — recording it here, as there is no longer anywhere to deliver it; treat those answers as UNDETERMINED`,
       );
     }
     this.dropped.delete(slot);
@@ -999,7 +1068,7 @@ export class AskAnswerJournalImpl {
       // the card up, so the answer waits (for its own tab to come back) rather
       // than being announced to a stranger. It is still disclosed by a failing
       // ask, and still named on the way out — held, never swallowed.
-      if (entry.key === key && entry.delivery === "pending" && this.sameOccupant(entry)) {
+      if (entry.key === key && entry.delivery === "pending" && this.mayReachLiveTurn(entry)) {
         out.push(entry);
       }
     }
@@ -1140,6 +1209,14 @@ export class AskAnswerJournalImpl {
     // one. Settling it here on a bound would forge the very proof this split
     // exists to withhold.
     if (entry.returned && entry.delivery === "none") return;
+    // A boundary happened while a turn was carrying this. Re-arming it would
+    // hand the OLD conversation's answer to the replacement one — the same bypass
+    // as the rid path, through the release/push door. It stays journaled and
+    // disclosable; it just stops being deliverable.
+    if (entry.retired === true) {
+      entry.delivery = "none";
+      return;
+    }
     if (opts.carried) {
       entry.carriedReleases = (entry.carriedReleases ?? 0) + 1;
       if (entry.carriedReleases >= MAX_CARRIED_RELEASES) {
@@ -1331,6 +1408,13 @@ export class AskAnswerJournalImpl {
     // question attached, i.e. the disclosure would lose the only thing that makes
     // it honest.
     this.tabEpoch.set(key, (this.tabEpoch.get(key) ?? 0) + 1);
+    // The eviction DEBT is owed to the conversation being replaced, and scoping it
+    // by (tab, incarnation) cannot fence this axis — New chat happens on the same
+    // tab, same incarnation. Left alone, the replacement conversation's next ask
+    // would report the old conversation's warning as its own and settle it with
+    // its own ack. Surfaced and retired, exactly as a tab-gone does: reported,
+    // then cleared, never silently dropped.
+    this.surfaceAndClearDebt(key, this.incarnationOf?.(key), "its conversation was replaced");
     for (const entry of this.entries.values()) {
       if (entry.key !== key) continue;
       if (entry.correlation.status === "matched") {
@@ -1340,6 +1424,11 @@ export class AskAnswerJournalImpl {
       // also how a later ask of the SAME question notices this answer exists and
       // reports it. See AskEntry.recoverable.
       entry.recoverable = false;
+      // …and mark it RETIRED, which is what every path that can reach a live turn
+      // consults (see AskEntry.retired). Setting `delivery` alone is not enough:
+      // a turn that was already carrying this answer releases it back to
+      // `pending` afterwards, and the re-arm has no idea a boundary happened.
+      entry.retired = true;
       // …and STOP PUSHING it. Its addressee is gone.
       //
       // This is where an ask answer parts company with a run completion (#468),

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -1,0 +1,848 @@
+// Durable-across-a-tool-timeout delivery of a VALIDATED panel_ask answer
+// (issue #486).
+//
+// THE FAILURE. `panel_ask` renders a choice card and BLOCKS on the user's pick.
+// The user's answer has exactly one delivery channel: the return value of the
+// enclosing MCP `tools/call`. That call has its own budget (~300s) and its own
+// lifetime — a turn that ends, a client that gives up, a session torn down — and
+// when it dies the answer dies with it, in three distinct ways:
+//
+//   1. ANSWERED IN TIME, NOBODY LEFT TO RETURN TO. `bridge.send` resolves with a
+//      validated pick, `askUserWithGrace` returns it, and the ToolResult is
+//      written to a request the client already abandoned. Nothing recorded it.
+//   2. ANSWERED DURING THE GRACE POLL. Same, one layer down: the poll TAKES the
+//      answer out of the bridge's late-reply buffer (destroying it there) and
+//      returns it into the same dead request.
+//   3. ANSWERED AFTER THE GRACE. The handler has already returned "not answered
+//      in time". The answer lands in the bridge's late-reply buffer keyed by
+//      `ask_id` and NOBODY EVER POLLS IT AGAIN — it is TTL-pruned five minutes
+//      later, unread.
+//
+// In every case the user answered, the answer validated, and the agent either
+// asked again or proceeded without it. That is the whole of #486.
+//
+// THE CONTRACT HERE — deliberately the one #468/PR #786 arrived at for run
+// completions (see run-completion-journal.ts), because this is the same problem
+// class and the same traps are waiting:
+//
+//  • Asks are TICKETED by their `ask_id`, opened when the card is dispatched.
+//  • Every answer is CORRELATED ONCE, AT ARRIVAL, by EXACT ask-id equality
+//    against an open ticket — never by recency, never re-derived later. The
+//    ticket's QUESTION FINGERPRINT is frozen onto the entry at that moment.
+//  • An answer that cannot be correlated is still journaled and still delivered,
+//    labelled UNDETERMINED. It is never swallowed, and it can never be presented
+//    as the answer to a question it isn't provably an answer to.
+//  • THE JOURNAL NEVER MERGES AND NEVER SUPPRESSES — IT ONLY EVER LABELS. Every
+//    "already delivered" proof available here (tickets, entries, the bridge's own
+//    5-minute buffer) is BOUNDED, so any rule that SUPPRESSES on one becomes a
+//    silent LOSS the moment it expires at the wrong time. #468 removed
+//    suppression outright after five successive fixes were each defeated one
+//    bound away; nothing here reintroduces it.
+//  • Undelivered answers are REPLAYED at the next delivery opportunity, and an
+//    entry is cleared only when the turn that CARRIED it ended (or when a
+//    matching re-ask provably took it as its result).
+//
+// THE CROSS-QUESTION GUARD is the one rule this file adds over #468's, and it is
+// strictly the more important direction. Losing an answer costs a re-ask;
+// MISATTRIBUTING one makes the agent act on a decision the user never made about
+// the thing at hand. So a recovered answer may only ever satisfy an ask whose
+// QUESTION FINGERPRINT (question text + option labels, in order + multi-select +
+// header) is EXACTLY equal to the fingerprint frozen on the entry at arrival, on
+// the SAME panel tab. There is deliberately no fuzzy match, no "closest
+// question", and no "the only outstanding ask" fallback: an answer that doesn't
+// match exactly is reported as an unattributed answer to ITS OWN question —
+// quoted with that question, so it cannot be read as an answer to anything else.
+//
+// LOCAL trust domain: this is accidental-loss bookkeeping, not a defence against
+// a hostile panel. Everything is in-memory and process-scoped.
+
+import { createHash } from "node:crypto";
+import { logger } from "../utils/logger.js";
+
+/** How an answer relates to the asks this session dispatched. Computed ONCE, at
+ *  arrival, and frozen onto the journal entry — a replay never re-correlates, so
+ *  an answer can never drift onto a question that was asked after it landed. */
+export type AskCorrelation =
+  /** Exact ask-id match with a card THIS session dispatched. The entry also
+   *  carries that ticket's frozen question fingerprint. */
+  | { status: "matched"; askId: string }
+  /** A validated answer whose ask id belongs to no card this session has a
+   *  ticket for (its ticket aged out, or it came from somewhere else). Real, but
+   *  NOT provably an answer to any question we asked — it must never satisfy
+   *  one. */
+  | { status: "foreign"; askId: string };
+
+/** A `panel_ask` card that was dispatched and may still be answered. */
+export interface AskTicket {
+  askId: string;
+  /** Panel tab the card was rendered on. Part of every match: an answer given on
+   *  one tab is not an answer for another tab's agent. */
+  tabId: string;
+  /** Exact identity of the QUESTION — see askFingerprint(). */
+  fingerprint: string;
+  /** The question text, for honest wording when this answer is reported. */
+  question: string;
+  openedAt: number;
+  /**
+   * Generation of THIS ticket. Bumped whenever the same ask id is opened again,
+   * so an answer can only ever settle the exact generation it was correlated
+   * against (ask ids are UUIDs so this is defence in depth, mirroring
+   * RunTicket.seq).
+   */
+  seq: number;
+  /**
+   * The `panel_ask` handler that opened this ticket is STILL RUNNING and will
+   * itself consume the answer if one arrives. False once it has returned — which
+   * is what makes an answer arriving afterwards provably ORPHANED (nobody is
+   * left to hand it to) and therefore worth pushing to the agent on its own.
+   */
+  awaiting: boolean;
+}
+
+/** Where an entry is in the PUSH pipeline (the durable agent-event delivery used
+ *  for answers that were never handed back to any tool result). */
+export type AskDeliveryState =
+  /** Not queued for a push. Either the handler took it as its own tool result,
+   *  or the handler is still running and may yet. */
+  | "none"
+  /** Orphaned: waiting for a delivery attempt to the tab's agent. */
+  | "pending"
+  /** Handed to a live agent's queue; NOT proven read. */
+  | "handed_off";
+
+export interface AskEntry {
+  token: string;
+  askId: string;
+  /** Panel tab this answer belongs to; also the agent-delivery address. */
+  key: string;
+  /** The question identity frozen at ARRIVAL (null when unattributable). The
+   *  ONLY thing a recovery is allowed to match on. */
+  fingerprint: string | null;
+  /** The question text as asked (null when unattributable). */
+  question: string | null;
+  /** The user's answer, verbatim. */
+  answer: string;
+  answeredAt: number;
+  correlation: AskCorrelation;
+  /** Generation of the ticket this entry was matched against (0 = none). */
+  ticketSeq: number;
+  /**
+   * The ask handler put this answer into a ToolResult. A HAND-OFF, NOT A PROOF:
+   * the enclosing `tools/call` may already have been abandoned, which is exactly
+   * the bug. It only means we must not ALSO push it to the agent as an orphan
+   * (that would double-report every ordinary ask); the entry stays journaled so
+   * a re-ask of the identical question can still recover it.
+   */
+  returned: boolean;
+  delivery: AskDeliveryState;
+  attempts: number;
+  /** How many turns carried this answer and then ended without a provable ack. */
+  carriedReleases?: number;
+  /** Evicted-answer count this entry is carrying out on the tab's behalf, so the
+   *  disclosure rides a real delivery instead of a side map that could be
+   *  discarded before it is ever reported. */
+  disclose?: number;
+  /** This answer was already handed to the agent once (as a tool result or a
+   *  push) and is being surfaced again. A LABEL, never a veto. */
+  replayHint?: boolean;
+}
+
+/** Cards tracked at once. Generous: real sessions have one or two. */
+const MAX_TICKETS = 64;
+/** Ask ids remembered as "ours" (see AskAnswerJournalImpl.retired). Deliberately
+ *  far larger than MAX_TICKETS so the memory always outlives the ticket. */
+const MAX_REMEMBERED_ASK_IDS = 1024;
+/**
+ * How long a ticket is kept. The bridge only forwards a LATE answer for a card
+ * whose rid→ask_id mapping is still alive, and that mapping is TTL-pruned at 5
+ * minutes (UiBridge.LATE_ASK_TTL_MS) — so a ticket older than this can no longer
+ * receive one and pruning it is provably lossless rather than a bound we are
+ * hoping never bites.
+ */
+const TICKET_MAX_AGE_MS = 7 * 60_000;
+/** Undelivered/unconsumed answers held per panel tab. */
+const MAX_ENTRIES_PER_KEY = 16;
+/** …and across all tabs. */
+const MAX_ENTRIES_TOTAL = 48;
+/**
+ * How long a journaled answer may still be RECOVERED as the result of a re-ask
+ * of the identical question.
+ *
+ * This bound is a LABEL boundary, not a suppression: past it the answer is not
+ * returned as "the user's answer to the question you just asked" (it is stale
+ * enough that the user plausibly meant it for the earlier moment), but it is
+ * still DISCLOSED, quoted with its own question, so it is never silently
+ * discarded.
+ */
+const RECOVER_MAX_AGE_MS = 10 * 60_000;
+/** Turns that may carry a pushed answer and end without a provable ack before we
+ *  settle it anyway. Same rationale as MAX_CARRIED_RELEASES in #468: each of
+ *  those put the text into a turn the agent read, so settling risks a duplicate,
+ *  never a loss. */
+const MAX_CARRIED_RELEASES = 3;
+/** Tabs whose evicted-answer counter is retained. */
+const MAX_DROPPED_KEYS = 64;
+
+/**
+ * EXACT identity of a question, and the whole of the cross-question guard.
+ *
+ * Everything the user actually reads on the card goes in, in order: the question
+ * text, the option LABELS in the order they are rendered, the multi-select flag,
+ * and the header chip. Two asks are "the same question" only when a user looking
+ * at both cards would see the same thing.
+ *
+ * Deliberately NOT included: the tab id (an entry carries its tab separately, so
+ * a tab-id migration re-keys it without invalidating every fingerprint), option
+ * DESCRIPTIONS (cosmetic sub-text that does not change what is being decided —
+ * including them would be harmless but would turn a reworded tooltip into a
+ * failed recovery), and any timestamp.
+ *
+ * Whitespace is trimmed and internal runs collapsed on the question/labels only,
+ * because a re-ask is often the model re-emitting the same prompt with different
+ * wrapping. Nothing else is normalized: case, punctuation and ordering are all
+ * significant, so "Delete the file?" never matches "delete the file".
+ */
+export function askFingerprint(ask: {
+  question: string;
+  options?: unknown;
+  header?: unknown;
+  multi_select?: unknown;
+}): string {
+  const norm = (s: string): string => s.replace(/\s+/g, " ").trim();
+  const labels = Array.isArray(ask.options)
+    ? ask.options.map((o) => {
+        const label = (o as { label?: unknown } | null)?.label;
+        return typeof label === "string" ? norm(label) : JSON.stringify(o ?? null);
+      })
+    : [];
+  // JSON.stringify is the delimiter: it escapes the payload itself, so no
+  // separator character can ever be smuggled in by a question or an option label
+  // to make two DIFFERENT questions hash the same. (And it keeps this file pure
+  // ASCII — no control bytes, no exotic separators.)
+  const parts = [
+    norm(ask.question ?? ""),
+    typeof ask.header === "string" ? norm(ask.header) : "",
+    ask.multi_select === true ? "multi" : "single",
+    ...labels,
+  ];
+  return createHash("sha256").update(JSON.stringify(parts)).digest("hex").slice(0, 32);
+}
+
+/** Coerce a bridge reply into the answer text the user actually gave. Panel
+ *  ask cards reply with a string; anything else is preserved verbatim as JSON so
+ *  nothing the user chose is ever silently reshaped away. */
+export function answerText(reply: unknown): string {
+  if (typeof reply === "string") return reply;
+  try {
+    return JSON.stringify(reply);
+  } catch {
+    return String(reply);
+  }
+}
+
+/** Why a recovery attempt produced no answer. NEVER collapsed into a single
+ *  falsy value: "this tab has no answer to this question" and "an answer existed
+ *  but could not be attributed / had been evicted" are different facts and the
+ *  caller reports them differently (#796). */
+export type AskRecovery =
+  /** An answer to the IDENTICAL question, on this tab, within the window. */
+  | { status: "recovered"; entry: AskEntry }
+  /** Nothing journaled for this tab at all — a plain unanswered card. */
+  | { status: "none" }
+  /**
+   * Answers exist for this tab but NONE of them is provably an answer to THIS
+   * question (a different question, or too old to present as fresh). They are
+   * handed back so the caller can disclose them, quoted with their own question.
+   */
+  | { status: "unattributed"; others: AskEntry[] };
+
+export class AskAnswerJournalImpl {
+  /** ask id → ticket. Ask ids are UUIDs, so exact equality is proof of identity. */
+  private tickets = new Map<string, AskTicket>();
+  /**
+   * Ask ids this journal has EVER opened, kept long after their ticket is gone.
+   *
+   * This is what `tracks()` answers on, and it exists because the ticket map is
+   * bounded: if "is this one of ours?" were answered from the tickets alone, an
+   * eviction would make the bridge's late-answer sink DROP a validated answer
+   * outright — a bounded store silently protecting against a bounded store,
+   * which is the exact shape of every defect #468 kept re-growing. Losing a
+   * ticket may only ever WEAKEN a correlation (matched → foreign, i.e.
+   * UNDETERMINED); it must never turn an answer into nothing.
+   */
+  private retired = new Set<string>();
+  /** token → entry (insertion-ordered, which is also delivery order). */
+  private entries = new Map<string, AskEntry>();
+  /** Answers this tab lost to an eviction and has not yet been told about. */
+  private dropped = new Map<string, number>();
+  private seq = 0;
+  private ticketSeq = 0;
+  /** Deliver a tab's newly-orphaned answers (see setFlusher). */
+  private flush: ((key: string) => void) | null = null;
+
+  /**
+   * Wire the push channel (#486).
+   *
+   * An answer becomes an ORPHAN at moments the tool layer cannot act on — the
+   * bridge's late-answer sink, or an ask handler unwinding on an error without
+   * having returned one. Whoever owns the agents registers here so those
+   * transitions deliver immediately instead of waiting for some unrelated later
+   * trigger (which is how "journaled" quietly becomes "never delivered").
+   */
+  setFlusher(flush: (key: string) => void): void {
+    this.flush = flush;
+  }
+
+  /**
+   * A `panel_ask` card is being dispatched. Opens the ticket that makes any
+   * answer for `askId` attributable to THIS question.
+   *
+   * Must be called BEFORE the card is sent: the answer can come back on the
+   * bridge's late-reply sink at any moment after that, and an answer that
+   * arrives with no ticket is (correctly, but uselessly) foreign.
+   */
+  openAsk(askId: string, meta: { tabId: string; fingerprint: string; question: string }): void {
+    this.pruneTickets();
+    this.remember(askId);
+    const existing = this.tickets.get(askId);
+    if (existing) {
+      // The same ask id dispatched again (a retry). Reopen rather than stack a
+      // second ticket, so one ask id always means one question.
+      existing.tabId = meta.tabId;
+      existing.fingerprint = meta.fingerprint;
+      existing.question = meta.question;
+      existing.openedAt = Date.now();
+      existing.seq = ++this.ticketSeq;
+      existing.awaiting = true;
+      return;
+    }
+    this.tickets.set(askId, {
+      askId,
+      tabId: meta.tabId,
+      fingerprint: meta.fingerprint,
+      question: meta.question,
+      openedAt: Date.now(),
+      seq: ++this.ticketSeq,
+      awaiting: true,
+    });
+    this.trimTickets();
+  }
+
+  /** Does this journal know the ask id — i.e. is a late answer for it one of
+   *  OURS? The bridge's late-answer sink is fed by every `ask_user` card
+   *  (confirm/consent/secret gates included) and only `panel_ask` answers belong
+   *  here; those other cards have their own, deliberately non-recoverable paths
+   *  (a recovered "Yes, go ahead" must never authorise a different destructive
+   *  operation). */
+  tracks(askId: string): boolean {
+    return this.tickets.has(askId) || this.retired.has(askId);
+  }
+
+  /**
+   * The `panel_ask` handler that opened `askId` has RETURNED. Anything that
+   * arrives from here on has nobody to be handed to, so it is orphaned on
+   * arrival and pushed to the agent on its own.
+   *
+   * If an answer is already journaled and the handler never claimed it
+   * (`markReturned` was not called), arm it for the push now.
+   */
+  closeAsk(askId: string): AskEntry | null {
+    const ticket = this.tickets.get(askId);
+    if (ticket) ticket.awaiting = false;
+    let armed: AskEntry | null = null;
+    for (const entry of this.entries.values()) {
+      if (entry.askId !== askId) continue;
+      if (!entry.returned && entry.delivery === "none") {
+        entry.delivery = "pending";
+        armed = entry;
+      }
+    }
+    // It is an orphan NOW — deliver it now. Leaving it merely `pending` would
+    // make it wait for an unrelated later flush, and this transition happens on
+    // the ask handler's unwind, where there may never be one.
+    if (armed) this.flush?.(armed.key);
+    return armed;
+  }
+
+  /**
+   * Journal a validated answer. Correlation is computed HERE, once, by exact ask
+   * id.
+   *
+   * Idempotent per ask id: the same card can be observed twice (the handler's
+   * grace poll takes it out of the bridge buffer while the bridge's sink has
+   * already forwarded it), and both observations are the SAME answer to the SAME
+   * question. Collapsing them is identity, not suppression — nothing is ever
+   * dropped because it "looks like" something already seen.
+   */
+  record(askId: string, reply: unknown, meta: { tabId: string }): AskEntry {
+    this.pruneTickets();
+    this.expireStaleReturned();
+    const existing = [...this.entries.values()].find((e) => e.askId === askId);
+    if (existing) return existing;
+    const ticket = this.tickets.get(askId);
+    const correlation: AskCorrelation = ticket
+      ? { status: "matched", askId }
+      : { status: "foreign", askId };
+    const entry: AskEntry = {
+      token: `aa${++this.seq}`,
+      askId,
+      // The TICKET's tab is authoritative when we have one (that is the tab the
+      // card was rendered on); otherwise the tab the reply physically arrived
+      // from, so an unattributable answer is still addressed somewhere real
+      // instead of being dropped for want of a key.
+      key: ticket?.tabId ?? meta.tabId,
+      fingerprint: ticket?.fingerprint ?? null,
+      question: ticket?.question ?? null,
+      answer: answerText(reply),
+      answeredAt: Date.now(),
+      correlation,
+      ticketSeq: ticket?.seq ?? 0,
+      returned: false,
+      // An answer that lands while its own handler is still running is that
+      // handler's to return; one that lands afterwards (or with no ticket at
+      // all) has nobody left and is armed for the push immediately.
+      delivery: ticket?.awaiting === true ? "none" : "pending",
+      attempts: 0,
+    };
+    this.entries.set(entry.token, entry);
+    if (!ticket) {
+      logger.warn(
+        `[ask-answers] a validated answer arrived for ask ${askId.slice(0, 8)} with no open ticket — journaled as UNATTRIBUTED; it can never satisfy a question, only be reported`,
+      );
+    }
+    this.trimEntries(entry.key);
+    // Born orphaned (no handler is waiting on this ask) — push it straight away.
+    if (entry.delivery === "pending") this.flush?.(entry.key);
+    return entry;
+  }
+
+  /** The ask handler put this answer into its ToolResult. A hand-off, not proof
+   *  of consumption — see AskEntry.returned. */
+  markReturned(askId: string): void {
+    for (const entry of this.entries.values()) {
+      if (entry.askId !== askId) continue;
+      entry.returned = true;
+      // It reached A caller. Do not ALSO push it as an orphan; a re-ask can
+      // still recover it if that caller was already dead.
+      //
+      // DEFENCE IN DEPTH, not a live path: an ask handler only marks an answer
+      // returned while its own ticket is still `awaiting`, and `record` never
+      // arms one in that state — so nothing reachable enters this branch and no
+      // test can fail on it. It is here because "a caller took this" and
+      // "announce it to the agent as unclaimed" are contradictory states, and a
+      // future caller marking an answer returned from outside the ask handler
+      // would otherwise double-report it.
+      if (entry.delivery === "pending") entry.delivery = "none";
+    }
+  }
+
+  /**
+   * Find the answer the user already gave to THIS EXACT question on THIS tab.
+   *
+   * The match is exact fingerprint equality and nothing else — see the
+   * cross-question guard at the top of this file. When several qualify the
+   * NEWEST wins: it is the user's most recent statement of intent about that
+   * question.
+   *
+   * Returns a discriminated result: "no answer at all" and "answers exist but
+   * none is provably for this question" are DIFFERENT facts and must not be
+   * folded into one falsy value (#796).
+   *
+   * The CURRENT ask's own id is deliberately NOT excluded: an answer that landed
+   * for the very card we just gave up on is the most direct answer there is, and
+   * excluding it would re-open the race the grace poll cannot close (the sink
+   * journals an answer microseconds after the last poll).
+   */
+  recover(key: string, fingerprint: string): AskRecovery {
+    this.expireStaleReturned();
+    const now = Date.now();
+    const mine = [...this.entries.values()].filter((e) => e.key === key);
+    if (mine.length === 0) return { status: "none" };
+    const eligible = mine
+      .filter(
+        (e) =>
+          e.correlation.status === "matched" &&
+          e.fingerprint !== null &&
+          e.fingerprint === fingerprint &&
+          now - e.answeredAt <= RECOVER_MAX_AGE_MS,
+      )
+      .sort((a, b) => b.answeredAt - a.answeredAt);
+    if (eligible.length > 0) return { status: "recovered", entry: eligible[0] };
+    return { status: "unattributed", others: mine };
+  }
+
+  /**
+   * A recovery (or a push the agent provably consumed) took this answer. Drop
+   * it so the same answer can never be handed over twice.
+   *
+   * Deleting an entry that was already pushed and is sitting unread in an
+   * agent's queue is deliberate: the tool result the caller is about to return
+   * carries the SAME answer with the SAME question attached, so the worst case
+   * is the agent reading it twice — never acting on an answer it wasn't given.
+   */
+  consume(token: string): void {
+    this.entries.delete(token);
+  }
+
+  /** Every unconsumed ORPHAN answer for a tab — those that were never handed
+   *  back to any tool result. These are what a failing ask discloses, so a
+   *  validated answer is never silently dropped. */
+  orphansFor(key: string): AskEntry[] {
+    return [...this.entries.values()].filter((e) => e.key === key && !e.returned);
+  }
+
+  /** Answers this tab lost to an eviction and has not yet been told about. */
+  droppedFor(key: string): number {
+    const carried = [...this.entries.values()]
+      .filter((e) => e.key === key)
+      .reduce((n, e) => n + (e.disclose ?? 0), 0);
+    return carried + (this.dropped.get(key) ?? 0);
+  }
+
+  /** Entries awaiting a push attempt for this key, in arrival order. */
+  pending(key: string): AskEntry[] {
+    const out: AskEntry[] = [];
+    for (const entry of this.entries.values()) {
+      if (entry.key === key && entry.delivery === "pending") out.push(entry);
+    }
+    return out;
+  }
+
+  /**
+   * Push every orphaned answer for `key` to the tab's agent, in ARRIVAL order,
+   * stopping at the first refusal so a newer answer never overtakes an older one
+   * that is still stuck.
+   *
+   * `inject` returns whether the agent TOOK the payload onto its queue — not
+   * that it was read. The entry stays journaled either way; only `ack` (the turn
+   * that carried it ended) removes it. That is the durability property: hand it
+   * to an agent that then dies and it comes back here.
+   *
+   * NOTHING is re-correlated. The verdict and the question were frozen at
+   * arrival, so a replay can never be re-attributed to a question asked later.
+   */
+  deliverPending(
+    key: string,
+    inject: (payload: AskAnswerEvent, token: string) => boolean,
+  ): { delivered: number; blockedOn: AskEntry | null } {
+    let delivered = 0;
+    for (const entry of this.pending(key)) {
+      const lost = (entry.disclose ?? 0) + (this.dropped.get(key) ?? 0);
+      const payload: AskAnswerEvent = {
+        kind: "ask_answer",
+        ask_question: entry.question,
+        ask_answer: entry.answer,
+        ask_correlation: entry.correlation.status,
+        ask_answered_at: entry.answeredAt,
+        ...(entry.attempts > 0 ? { replayed: true } : {}),
+        ...(entry.replayHint ? { possible_repeat: true } : {}),
+        ...(lost > 0 ? { dropped_answers: lost } : {}),
+      };
+      const handedOff = inject(payload, entry.token);
+      entry.attempts += 1;
+      entry.delivery = handedOff ? "handed_off" : "pending";
+      if (!handedOff) return { delivered, blockedOn: entry };
+      if (lost > 0) {
+        // CONSOLIDATE onto the entry; the disclosure is NOT spent by a hand-off.
+        // If this agent dies before its turn runs, the entry is released and
+        // replayed, and the warning must go with it. Only ack() clears it.
+        entry.disclose = lost;
+        this.dropped.delete(key);
+      }
+      delivered += 1;
+    }
+    return { delivered, blockedOn: null };
+  }
+
+  /** The turn that CARRIED this answer ended — it genuinely reached the agent. */
+  ack(token: string): void {
+    const entry = this.entries.get(token);
+    if (!entry) return;
+    // The push is done, but the ANSWER stays journaled while it is still within
+    // the recovery window: a re-ask of the identical question must still be able
+    // to return it as its result rather than making the user answer twice. It is
+    // flagged so any later surfacing reads as "you have seen this".
+    delete entry.disclose;
+    entry.delivery = "none";
+    entry.returned = true;
+    entry.replayHint = true;
+  }
+
+  /**
+   * An agent gave a push back undelivered. Re-arm it for replay.
+   *
+   * `carried` distinguishes the two causes, and ONLY the first is bounded:
+   *  • carried: true  — a turn actually DISPATCHED with this answer in it and
+   *    then ended, but its result could not be proven to be that turn's own. The
+   *    agent read the text; after MAX_CARRIED_RELEASES we settle rather than
+   *    loop (a duplicate at worst).
+   *  • carried: false — a teardown handed it back (agent stopped, session died).
+   *    NOBODY read it. These must never count toward the bound.
+   */
+  release(token: string, opts: { carried?: boolean } = {}): void {
+    const entry = this.entries.get(token);
+    if (!entry) return;
+    if (opts.carried) {
+      entry.carriedReleases = (entry.carriedReleases ?? 0) + 1;
+      if (entry.carriedReleases >= MAX_CARRIED_RELEASES) {
+        logger.warn(
+          `[ask-answers] an answer was carried by ${entry.carriedReleases} turns that ended without a provable ack — settling it instead of replaying again`,
+        );
+        this.ack(token);
+        return;
+      }
+    }
+    entry.delivery = "pending";
+  }
+
+  /** Is ANY orphaned answer still awaiting a push? The orchestrator's
+   *  self-restart gate reads this: the journal is in-memory, so restarting while
+   *  one is outstanding silently drops an answer the user actually gave. */
+  hasOutstanding(): boolean {
+    return [...this.entries.values()].some((e) => e.delivery !== "none");
+  }
+
+  /** Every answer still awaiting a push, across all tabs — for the last-ditch
+   *  disclosure the orchestrator makes when a fatal exit destroys them. */
+  allOutstanding(): AskEntry[] {
+    return [...this.entries.values()].filter((e) => e.delivery !== "none");
+  }
+
+  /** Move every entry AND every open ticket from `from` onto `to` — a panel
+   *  tab-id migration re-keys the agent and both must move with it, or an answer
+   *  for a card dispatched under the old id becomes unattributable. */
+  moveKey(from: string, to: string): void {
+    if (from === to) return;
+    for (const entry of this.entries.values()) {
+      if (entry.key === from) entry.key = to;
+    }
+    for (const ticket of this.tickets.values()) {
+      if (ticket.tabId === from) ticket.tabId = to;
+    }
+    const lost = this.dropped.get(from);
+    if (lost !== undefined) {
+      this.dropped.delete(from);
+      this.dropped.set(to, (this.dropped.get(to) ?? 0) + lost);
+    }
+  }
+
+  /** Drop everything belonging to a tab that will never come back. Logs every
+   *  answer that dies unconsumed; a loss must never be silent. */
+  forget(key: string): void {
+    for (const [token, entry] of [...this.entries]) {
+      if (entry.key !== key) continue;
+      this.entries.delete(token);
+      if (!entry.returned) {
+        logger.warn(
+          `[ask-answers] dropping a validated answer to "${preview(entry.question)}" — its tab (${key.slice(0, 8)}) is gone`,
+        );
+      }
+    }
+    for (const [id, ticket] of [...this.tickets]) {
+      if (ticket.tabId === key) this.tickets.delete(id);
+    }
+    const owed = this.dropped.get(key) ?? 0;
+    if (owed > 0) {
+      logger.error(
+        `[ask-answers] tab ${key.slice(0, 8)} is gone still owed a disclosure for ${owed} evicted answer(s) — it will never be told`,
+      );
+    }
+    this.dropped.delete(key);
+  }
+
+  /**
+   * The CONVERSATION that asked this tab's questions is gone — New chat, or a
+   * switch to a historical session.
+   *
+   * Drop the tab's TICKETS and DOWNGRADE its journaled answers to `foreign`, so
+   * an answer given to the old conversation's question can never be returned to
+   * the replacement agent as "the answer to the question YOU just asked". The
+   * answers themselves are kept and still delivered — labelled UNDETERMINED,
+   * quoted with their own question. A correlation may only ever get WEAKER.
+   */
+  closeAsks(key: string): void {
+    for (const [id, ticket] of [...this.tickets]) {
+      if (ticket.tabId === key) this.tickets.delete(id);
+    }
+    for (const entry of this.entries.values()) {
+      if (entry.key !== key || entry.correlation.status !== "matched") continue;
+      entry.correlation = { status: "foreign", askId: entry.correlation.askId };
+      // Its fingerprint was the licence to satisfy a matching re-ask; the
+      // conversation that asked is gone, so revoke it. The QUESTION TEXT stays —
+      // it is what makes the disclosure honest.
+      entry.fingerprint = null;
+    }
+  }
+
+  /** Test/diagnostic helpers. */
+  ticketFor(askId: string): AskTicket | undefined {
+    return this.tickets.get(askId);
+  }
+  entriesFor(key: string): AskEntry[] {
+    return [...this.entries.values()].filter((e) => e.key === key);
+  }
+  reset(): void {
+    // NOTE: the flusher is deliberately NOT cleared — it belongs to the process's
+    // orchestrator, not to any one test's fixture.
+    this.tickets.clear();
+    this.retired.clear();
+    this.entries.clear();
+    this.dropped.clear();
+    this.seq = 0;
+    this.ticketSeq = 0;
+  }
+
+  /** Remember an ask id forever-ish (bounded FIFO) so `tracks()` never denies
+   *  one of ours just because its ticket was trimmed. Far larger than
+   *  MAX_TICKETS so it always outlives the ticket it mirrors. */
+  private remember(askId: string): void {
+    this.retired.add(askId);
+    while (this.retired.size > MAX_REMEMBERED_ASK_IDS) {
+      const oldest = this.retired.values().next().value;
+      if (oldest === undefined) break;
+      this.retired.delete(oldest);
+    }
+  }
+
+  /** Tickets whose card can no longer receive an answer (see TICKET_MAX_AGE_MS)
+   *  and which no handler is still waiting on. */
+  private pruneTickets(): void {
+    const now = Date.now();
+    for (const [id, t] of [...this.tickets]) {
+      if (!t.awaiting && now - t.openedAt > TICKET_MAX_AGE_MS) this.tickets.delete(id);
+    }
+  }
+
+  private trimTickets(): void {
+    while (this.tickets.size > MAX_TICKETS) {
+      // Prefer a ticket no handler is waiting on; otherwise the oldest. Losing a
+      // ticket does not lose an answer — it makes a later answer for it read as
+      // UNATTRIBUTED, which is the honest verdict once we have forgotten the
+      // question — but say so, because it is a real degradation.
+      let victim: string | null = null;
+      for (const [id, t] of this.tickets) {
+        if (!t.awaiting) {
+          victim = id;
+          break;
+        }
+      }
+      if (!victim) victim = this.tickets.keys().next().value ?? null;
+      if (!victim) return;
+      logger.error(
+        `[ask-answers] over ${MAX_TICKETS} question cards are tracked at once — forgetting ask ${victim.slice(0, 8)}; a late answer for it will be reported as UNATTRIBUTED`,
+      );
+      this.tickets.delete(victim);
+    }
+  }
+
+  /**
+   * Forget RETURNED answers past the recovery window.
+   *
+   * These were handed to a tool result and can no longer be recovered by a
+   * re-ask, so dropping them asserts nothing and loses nothing that was still
+   * reachable — it is what keeps ordinary successful asks from filling the
+   * journal and evicting a genuine orphan. ORPHANED answers are never
+   * age-expired: they were handed to nobody, so only a delivery or an
+   * explicitly-disclosed eviction may remove one.
+   */
+  private expireStaleReturned(): void {
+    const now = Date.now();
+    for (const [token, e] of [...this.entries]) {
+      if (!e.returned || e.delivery !== "none") continue;
+      if (now - e.answeredAt > RECOVER_MAX_AGE_MS) this.entries.delete(token);
+    }
+  }
+
+  /**
+   * Record that an answer for `key` was destroyed by an eviction, so the next
+   * delivery to that tab can report it as UNDETERMINED. Stamped onto a surviving
+   * PENDING entry when there is one — it then rides out on a real delivery and
+   * cannot be discarded.
+   */
+  private noteDropped(key: string, count = 1): void {
+    if (count <= 0) return;
+    const carrier = [...this.entries.values()].find(
+      (e) => e.key === key && e.delivery === "pending",
+    );
+    if (carrier) {
+      carrier.disclose = (carrier.disclose ?? 0) + count;
+      return;
+    }
+    this.dropped.set(key, (this.dropped.get(key) ?? 0) + count);
+    while (this.dropped.size > MAX_DROPPED_KEYS) {
+      const victim = this.dropped.keys().next().value;
+      if (victim === undefined) break;
+      const lost = this.dropped.get(victim) ?? 0;
+      this.dropped.delete(victim);
+      logger.error(
+        `[ask-answers] discarding the undelivered-answer count (${lost}) for tab ${victim.slice(0, 8)} — over ${MAX_DROPPED_KEYS} tabs are tracking one; that tab will not be told`,
+      );
+    }
+  }
+
+  /**
+   * Enforce the per-tab and global ceilings.
+   *
+   * EVICTION ORDER matters and is the same judgement #468 makes: an answer that
+   * was already RETURNED to a tool result has reached a caller, so forgetting it
+   * costs at most a re-ask; an ORPHANED one has reached nobody, so evicting it
+   * is a real loss — those go last, are logged at ERROR, and are COUNTED so the
+   * next delivery tells the agent those answers are UNDETERMINED.
+   */
+  private trimEntries(key: string): void {
+    const evict = (scope: (e: AskEntry) => boolean, limit: number, label: string): void => {
+      let mine = [...this.entries.values()].filter(scope);
+      while (mine.length > limit) {
+        const victim = mine.find((e) => e.returned) ?? mine[0];
+        this.entries.delete(victim.token);
+        mine = mine.filter((e) => e !== victim);
+        if (victim.returned) {
+          logger.warn(
+            `[ask-answers] ${label} — forgetting an already-returned answer to "${preview(victim.question)}" (a re-ask can no longer recover it)`,
+          );
+          continue;
+        }
+        this.noteDropped(victim.key, 1 + (victim.disclose ?? 0));
+        logger.error(
+          `[ask-answers] ${label} — dropped a VALIDATED answer to "${preview(victim.question)}" that had reached nobody; the next delivery will report it as undetermined`,
+        );
+      }
+    };
+    if (key) {
+      evict(
+        (e) => e.key === key,
+        MAX_ENTRIES_PER_KEY,
+        `journal for tab ${key.slice(0, 8)} exceeded ${MAX_ENTRIES_PER_KEY} answers`,
+      );
+    }
+    evict(() => true, MAX_ENTRIES_TOTAL, `journal exceeded ${MAX_ENTRIES_TOTAL} answers overall`);
+  }
+}
+
+/** The agent-event payload a pushed (orphaned) answer becomes. */
+export interface AskAnswerEvent {
+  kind: "ask_answer";
+  ask_question: string | null;
+  ask_answer: string;
+  ask_correlation: "matched" | "foreign";
+  ask_answered_at: number;
+  replayed?: boolean;
+  possible_repeat?: boolean;
+  dropped_answers?: number;
+}
+
+/** Short, log-safe rendering of a question. */
+export function preview(question: string | null): string {
+  if (!question) return "(an unattributed question)";
+  const one = question.replace(/\s+/g, " ").trim();
+  return one.length > 60 ? `${one.slice(0, 57)}…` : one;
+}
+
+/** How long a recovered answer may be presented as the result of a re-ask. */
+export const ASK_RECOVER_MAX_AGE_MS = RECOVER_MAX_AGE_MS;
+
+/** Process-wide journal (mirrors the RunCompletions singleton): the panel_ask
+ *  tool opens tickets and consumes recoveries from the tool layer, while the
+ *  orchestrator's bridge sink records late answers and pushes the orphans, with
+ *  no ctx plumbing between them. */
+export const AskAnswers = new AskAnswerJournalImpl();

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -1108,6 +1108,13 @@ export class AskAnswerJournalImpl {
           // above any plausible burst, orphans are never evicted before these,
           // and the full answer text is written here — so what survives is a
           // reconstructable record rather than a misleading alarm.
+          // …but ANY DISCLOSURE IT WAS CARRYING is re-homed, not dropped with it.
+          // The residual above permits losing THIS answer's recoverability; it
+          // says nothing about the debt owed for EARLIER answers that reached
+          // nobody, which merely happened to be stamped on this entry. (Reachable
+          // because a recovery marks its entry `returned` while it is carrying a
+          // count — after which it becomes the preferred eviction victim.)
+          if (victim.disclose) this.noteDropped(victim.key, victim.disclose);
           logger.warn(
             `[ask-answers] ${label} — forgetting an already-returned answer ("${victim.answer}") to "${preview(victim.question)}"; a re-ask can no longer recover it, and a tool result is not proof it was received`,
           );

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -269,9 +269,6 @@ const RECOVER_MAX_AGE_MS = 10 * 60_000;
  *  those put the text into a turn the agent read, so settling risks a duplicate,
  *  never a loss. */
 const MAX_CARRIED_RELEASES = 3;
-/** How many separate tool results may report an eviction debt before it is
- *  considered said. See reportDropped(). */
-const MAX_DEBT_REPORTS = 3;
 
 /**
  * EXACT identity of a question, and the whole of the cross-question guard.
@@ -382,7 +379,9 @@ export class AskAnswerJournalImpl {
   /** How many tool results have already carried each tab's eviction debt. The
    *  debt is spent by a COUNT of reports, never by a single hand-off — see
    *  reportDropped(). */
-  private droppedReports = new Map<string, number>();
+  /** Outstanding eviction-disclosure tokens: token -> panel tab. Retired only
+   *  by the ack of the turn that carried the warning (see reportDropped). */
+  private debtTokens = new Map<string, string>();
   private seq = 0;
   private ticketSeq = 0;
   /** Deliver a tab's newly-orphaned answers (see setFlusher). */
@@ -801,19 +800,17 @@ export class AskAnswerJournalImpl {
   reportDropped(key: string): number {
     const owed = this.dropped.get(key) ?? 0;
     if (owed <= 0) return 0;
-    const said = (this.droppedReports.get(key) ?? 0) + 1;
-    // Bounded by REPORTS, not cleared on the first one. A ToolResult is a
-    // hand-off, not a receipt (that IS #486), so spending the debt on the first
-    // report would let an abandoned call take the disclosure with it — the
-    // suppression rule, one level up. Three independent tool results is the same
-    // trade MAX_CARRIED_RELEASES makes for a pushed answer: a repeated warning at
-    // worst, never a swallowed one, and it cannot repeat forever.
-    if (said >= MAX_DEBT_REPORTS) {
-      this.dropped.delete(key);
-      this.droppedReports.delete(key);
-    } else {
-      this.droppedReports.set(key, said);
-    }
+    // The debt is NOT spent by being written into a tool result. A ToolResult is
+    // a hand-off, not a receipt — that IS #486 — so counting reports (an earlier
+    // draft retired the debt after three) lets three abandoned calls carry the
+    // only disclosure away with them, and the answer's payload is already gone.
+    //
+    // It rides the SAME ack as everything else instead: a token attached to the
+    // turn this tool call is running inside, retired only when that turn produces
+    // its own result. No live turn to ride means no proof and no retirement — the
+    // debt simply stands and the next result reports it again.
+    const token = `aad${++this.seq}`;
+    if (this.attachTurn?.(key, token) === true) this.debtTokens.set(token, key);
     return owed;
   }
 
@@ -874,7 +871,6 @@ export class AskAnswerJournalImpl {
         // replayed, and the warning must go with it. Only ack() clears it.
         entry.disclose = lost;
         this.dropped.delete(key);
-        this.droppedReports.delete(key);
       }
       delivered += 1;
     }
@@ -883,6 +879,16 @@ export class AskAnswerJournalImpl {
 
   /** The turn that CARRIED this answer ended — it genuinely reached the agent. */
   ack(token: string): void {
+    // An eviction-DISCLOSURE token (see reportDropped): the turn that carried the
+    // warning produced its result, so the tab has genuinely been told.
+    const debtKey = this.debtTokens.get(token);
+    if (debtKey !== undefined) {
+      this.debtTokens.delete(token);
+      this.dropped.delete(debtKey);
+      // Any other outstanding token for the same tab is now moot.
+      for (const [t, k] of [...this.debtTokens]) if (k === debtKey) this.debtTokens.delete(t);
+      return;
+    }
     const entry = this.entries.get(token);
     if (!entry) return;
     // The push is done, but the ANSWER stays journaled while it is still within
@@ -921,6 +927,11 @@ export class AskAnswerJournalImpl {
    *    NOBODY read it. These must never count toward the bound.
    */
   release(token: string, opts: { carried?: boolean } = {}): void {
+    // A disclosure token handed back: that turn never proved it was read, so the
+    // debt STANDS and the next result reports it again. Only the token mapping
+    // goes; there is deliberately no bound on how often a warning may be repeated
+    // when nothing has confirmed it.
+    if (this.debtTokens.delete(token)) return;
     const entry = this.entries.get(token);
     if (!entry) return;
     // A TOOL-RESULT answer riding a turn (see setTurnAttacher) is not in a
@@ -1022,8 +1033,6 @@ export class AskAnswerJournalImpl {
       this.dropped.set(to, (this.dropped.get(to) ?? 0) + lost);
       // The destination inherits the DEBT but not the source's report credit:
       // those reports went to the source tab's agent, not this one's.
-      this.droppedReports.delete(from);
-      this.droppedReports.delete(to);
     }
   }
 
@@ -1143,7 +1152,7 @@ export class AskAnswerJournalImpl {
     this.tabEpoch.clear();
     this.entries.clear();
     this.dropped.clear();
-    this.droppedReports.clear();
+    this.debtTokens.clear();
     this.seq = 0;
     this.ticketSeq = 0;
   }

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -393,7 +393,18 @@ export class AskAnswerJournalImpl {
    *  reportDropped(). */
   /** Outstanding eviction-disclosure tokens: token -> panel tab. Retired only
    *  by the ack of the turn that carried the warning (see reportDropped). */
-  private debtTokens = new Map<string, { key: string; carrier: string | null }>();
+  private debtTokens = new Map<string, { key: string; carrier: string | null; upTo: number }>();
+  /**
+   * Per tab: the eviction total that has already been SURFACED and confirmed.
+   *
+   * A warning names a number, and only that number is settled when the turn
+   * carrying it ends. Without this the ack cleared the tab's whole current debt,
+   * so an eviction that happened AFTER the warning was rendered — while its turn
+   * was still running — was wiped by an ack that never mentioned it. A watermark
+   * also makes the ack idempotent: two results reporting the same total settle
+   * the same total, and a later one settles more.
+   */
+  private disclosedUpTo = new Map<string, number>();
   private seq = 0;
   private ticketSeq = 0;
   /** Deliver a tab's newly-orphaned answers (see setFlusher). */
@@ -837,7 +848,8 @@ export class AskAnswerJournalImpl {
    * than reporting it once at the first opportunity.
    */
   reportDropped(key: string): number {
-    const owed = this.dropped.get(key) ?? 0;
+    const total = this.dropped.get(key) ?? 0;
+    const owed = total - (this.disclosedUpTo.get(key) ?? 0);
     if (owed <= 0) return 0;
     // The debt is NOT spent by being written into a tool result. A ToolResult is
     // a hand-off, not a receipt — that IS #486 — so counting reports (an earlier
@@ -852,7 +864,9 @@ export class AskAnswerJournalImpl {
     const carrier = this.attachTurn?.(key, token) ?? null;
     // Bound to the turn that carried it, for the same reason an answer is: a
     // switched provider must not be able to certify a warning it never showed.
-    if (carrier !== null) this.debtTokens.set(token, { key, carrier });
+    // The token remembers the TOTAL it is showing, so its ack settles exactly
+    // that and nothing that arrives afterwards.
+    if (carrier !== null) this.debtTokens.set(token, { key, carrier, upTo: total });
     return owed;
   }
 
@@ -872,14 +886,21 @@ export class AskAnswerJournalImpl {
    * the count of answers whose TEXT is already gone is retired.
    */
   retireDebt(key: string): void {
-    const owed = this.dropped.get(key) ?? 0;
+    const owed = this.undisclosedDrop(key);
     if (owed > 0) {
       logger.error(
         `[ask-answers] tab ${key.slice(0, 8)} disconnected still owed a disclosure for ${owed} validated answer(s) whose content was already dropped — recording it here, as there is no longer anywhere to deliver it; treat those answers as UNDETERMINED`,
       );
     }
     this.dropped.delete(key);
+    this.disclosedUpTo.delete(key);
     for (const [t, d] of [...this.debtTokens]) if (d.key === key) this.debtTokens.delete(t);
+  }
+
+  /** The part of a tab's eviction total that has NOT yet been surfaced and
+   *  confirmed. See disclosedUpTo. */
+  private undisclosedDrop(key: string): number {
+    return Math.max(0, (this.dropped.get(key) ?? 0) - (this.disclosedUpTo.get(key) ?? 0));
   }
 
   /** Answers this tab lost to an eviction and has not yet been told about. */
@@ -887,7 +908,7 @@ export class AskAnswerJournalImpl {
     const carried = [...this.entries.values()]
       .filter((e) => e.key === key)
       .reduce((n, e) => n + (e.disclose ?? 0), 0);
-    return carried + (this.dropped.get(key) ?? 0);
+    return carried + this.undisclosedDrop(key);
   }
 
   /** Entries awaiting a push attempt for this key, in arrival order. */
@@ -918,7 +939,7 @@ export class AskAnswerJournalImpl {
   ): { delivered: number; blockedOn: AskEntry | null } {
     let delivered = 0;
     for (const entry of this.pending(key)) {
-      const lost = (entry.disclose ?? 0) + (this.dropped.get(key) ?? 0);
+      const lost = (entry.disclose ?? 0) + this.undisclosedDrop(key);
       const payload: AskAnswerEvent = {
         kind: "ask_answer",
         ask_question: entry.question,
@@ -939,6 +960,7 @@ export class AskAnswerJournalImpl {
         // replayed, and the warning must go with it. Only ack() clears it.
         entry.disclose = lost;
         this.dropped.delete(key);
+        this.disclosedUpTo.delete(key);
       }
       delivered += 1;
     }
@@ -953,9 +975,18 @@ export class AskAnswerJournalImpl {
     if (debt !== undefined) {
       if (!this.carriedBy(debt.carrier, from)) return;
       this.debtTokens.delete(token);
-      this.dropped.delete(debt.key);
-      // Any other outstanding token for the same tab is now moot.
-      for (const [t, d] of [...this.debtTokens]) if (d.key === debt.key) this.debtTokens.delete(t);
+      // Settle ONLY what this warning actually showed. An eviction that landed
+      // after it was rendered is not covered by it, and must still be reported.
+      const seen = Math.max(this.disclosedUpTo.get(debt.key) ?? 0, debt.upTo);
+      const total = this.dropped.get(debt.key) ?? 0;
+      if (seen >= total) {
+        // Fully told — nothing outstanding, so drop both halves.
+        this.dropped.delete(debt.key);
+        this.disclosedUpTo.delete(debt.key);
+        for (const [t, x] of [...this.debtTokens]) if (x.key === debt.key) this.debtTokens.delete(t);
+      } else {
+        this.disclosedUpTo.set(debt.key, seen);
+      }
       return;
     }
     const entry = this.entries.get(token);
@@ -1043,7 +1074,7 @@ export class AskAnswerJournalImpl {
     // answer was lost, and it is destroyed by a teardown exactly as an entry is —
     // tearing down while one is owed turns a disclosed loss back into a silent
     // one, which is the whole thing this journal exists to prevent.
-    if (this.dropped.size > 0) return true;
+    for (const key of this.dropped.keys()) if (this.undisclosedDrop(key) > 0) return true;
     return [...this.entries.values()].some(
       (e) => e.delivery !== "none" || (e.disclose ?? 0) > 0,
     );
@@ -1086,7 +1117,10 @@ export class AskAnswerJournalImpl {
    *  name a loss whose carrier is only a counter. */
   outstandingDebt(): Array<{ key: string; count: number }> {
     const byTab = new Map<string, number>();
-    for (const [key, n] of this.dropped) byTab.set(key, (byTab.get(key) ?? 0) + n);
+    for (const key of this.dropped.keys()) {
+      const owed = this.undisclosedDrop(key);
+      if (owed > 0) byTab.set(key, (byTab.get(key) ?? 0) + owed);
+    }
     for (const e of this.entries.values()) {
       if ((e.disclose ?? 0) > 0) byTab.set(e.key, (byTab.get(e.key) ?? 0) + e.disclose!);
     }
@@ -1126,9 +1160,12 @@ export class AskAnswerJournalImpl {
     for (const debt of this.debtTokens.values()) {
       if (debt.key === from) debt.key = to;
     }
-    const lost = this.dropped.get(from);
-    if (lost !== undefined) {
+    const lost = this.undisclosedDrop(from);
+    if (this.dropped.has(from)) {
       this.dropped.delete(from);
+      this.disclosedUpTo.delete(from);
+      // Carry the UNDISCLOSED remainder only — what the source tab was already
+      // told is told, and re-importing it would warn the destination twice.
       this.dropped.set(to, (this.dropped.get(to) ?? 0) + lost);
       // The destination inherits the DEBT but not the source's report credit:
       // those reports went to the source tab's agent, not this one's.
@@ -1159,13 +1196,14 @@ export class AskAnswerJournalImpl {
     // belongs to — while the newer epoch keeps it from being armed for a push at
     // a tab id no agent answers to, exactly as for a replaced conversation.
     this.tabEpoch.set(key, (this.tabEpoch.get(key) ?? 0) + 1);
-    const owed = this.dropped.get(key) ?? 0;
+    const owed = this.undisclosedDrop(key);
     if (owed > 0) {
       logger.error(
         `[ask-answers] tab ${key.slice(0, 8)} is gone still owed a disclosure for ${owed} evicted answer(s) — it will never be told`,
       );
     }
     this.dropped.delete(key);
+    this.disclosedUpTo.delete(key);
     // Both halves together — see moveKey. A token left behind here would let a
     // later ack clear a debt for a tab that no longer exists.
     for (const [t, d] of [...this.debtTokens]) if (d.key === key) this.debtTokens.delete(t);
@@ -1276,6 +1314,7 @@ export class AskAnswerJournalImpl {
     this.tabEpoch.clear();
     this.entries.clear();
     this.dropped.clear();
+    this.disclosedUpTo.clear();
     this.debtTokens.clear();
     this.seq = 0;
     this.ticketSeq = 0;

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -186,18 +186,24 @@ const MAX_DROPPED_KEYS = 64;
 /**
  * EXACT identity of a question, and the whole of the cross-question guard.
  *
- * Everything the user actually reads on the card goes in, in order: the question
- * text, the option LABELS in the order they are rendered, the multi-select flag,
- * and the header chip. Two asks are "the same question" only when a user looking
- * at both cards would see the same thing.
+ * EVERYTHING THE USER READS ON THE CARD GOES IN, in order: the question text,
+ * the header chip, the multi-select flag, and every option's LABEL **and
+ * DESCRIPTION**. Two asks are "the same question" only when a user looking at
+ * both cards would see the same thing.
+ *
+ * The descriptions are not decoration: they are the one-line explanations the
+ * user reads to decide, so "euler / fast, lower quality" and "euler / now the
+ * recommended default" are different decisions wearing the same label. Leaving
+ * them out would let a re-worded card recover an answer the user gave to
+ * different information. The guard errs strict in every direction: a stricter
+ * fingerprint costs at most a re-ask, a looser one lets an answer satisfy a
+ * question it was not given for.
  *
  * Deliberately NOT included: the tab id (an entry carries its tab separately, so
- * a tab-id migration re-keys it without invalidating every fingerprint), option
- * DESCRIPTIONS (cosmetic sub-text that does not change what is being decided —
- * including them would be harmless but would turn a reworded tooltip into a
- * failed recovery), and any timestamp.
+ * a tab-id migration re-keys it without invalidating every fingerprint) and any
+ * timestamp.
  *
- * Whitespace is trimmed and internal runs collapsed on the question/labels only,
+ * Whitespace is trimmed and internal runs collapsed on the text fields only,
  * because a re-ask is often the model re-emitting the same prompt with different
  * wrapping. Nothing else is normalized: case, punctuation and ordering are all
  * significant, so "Delete the file?" never matches "delete the file".
@@ -211,8 +217,13 @@ export function askFingerprint(ask: {
   const norm = (s: string): string => s.replace(/\s+/g, " ").trim();
   const labels = Array.isArray(ask.options)
     ? ask.options.map((o) => {
-        const label = (o as { label?: unknown } | null)?.label;
-        return typeof label === "string" ? norm(label) : JSON.stringify(o ?? null);
+        const opt = o as { label?: unknown; description?: unknown } | null;
+        if (typeof opt?.label !== "string") return JSON.stringify(o ?? null);
+        // Label AND description — an option is the whole thing the user reads.
+        return JSON.stringify([
+          norm(opt.label),
+          typeof opt.description === "string" ? norm(opt.description) : "",
+        ]);
       })
     : [];
   // JSON.stringify is the delimiter: it escapes the payload itself, so no
@@ -271,6 +282,16 @@ export class AskAnswerJournalImpl {
    * UNDETERMINED); it must never turn an answer into nothing.
    */
   private retired = new Set<string>();
+  /**
+   * Ask ids whose CONVERSATION was replaced (New chat / resume of a historical
+   * session) while their card was still on screen.
+   *
+   * An answer that arrives for one of these is real and is journaled, but it is
+   * addressed to a conversation that no longer exists, so it is never announced
+   * to the replacement one — see closeAsks() for why this differs from #468's
+   * treatment of run completions.
+   */
+  private conversationGone = new Set<string>();
   /** token → entry (insertion-ordered, which is also delivery order). */
   private entries = new Map<string, AskEntry>();
   /** Answers this tab lost to an eviction and has not yet been told about. */
@@ -376,7 +397,6 @@ export class AskAnswerJournalImpl {
    */
   record(askId: string, reply: unknown, meta: { tabId: string }): AskEntry {
     this.pruneTickets();
-    this.expireStaleReturned();
     const existing = [...this.entries.values()].find((e) => e.askId === askId);
     if (existing) return existing;
     const ticket = this.tickets.get(askId);
@@ -400,12 +420,19 @@ export class AskAnswerJournalImpl {
       returned: false,
       // An answer that lands while its own handler is still running is that
       // handler's to return; one that lands afterwards (or with no ticket at
-      // all) has nobody left and is armed for the push immediately.
-      delivery: ticket?.awaiting === true ? "none" : "pending",
+      // all) has nobody left and is armed for the push immediately. An answer to
+      // a card whose CONVERSATION was replaced is never pushed at all — see
+      // closeAsks(); it is journaled for disclosure only.
+      delivery:
+        ticket?.awaiting === true || this.conversationGone.has(askId) ? "none" : "pending",
       attempts: 0,
     };
     this.entries.set(entry.token, entry);
-    if (!ticket) {
+    if (this.conversationGone.has(askId)) {
+      logger.warn(
+        `[ask-answers] an answer arrived for a card whose conversation was replaced (ask ${askId.slice(0, 8)}, tab ${entry.key.slice(0, 8)}): "${entry.answer}" — journaled for disclosure, NOT announced to the replacement conversation`,
+      );
+    } else if (!ticket) {
       logger.warn(
         `[ask-answers] a validated answer arrived for ask ${askId.slice(0, 8)} with no open ticket — journaled as UNATTRIBUTED; it can never satisfy a question, only be reported`,
       );
@@ -454,7 +481,6 @@ export class AskAnswerJournalImpl {
    * journals an answer microseconds after the last poll).
    */
   recover(key: string, fingerprint: string): AskRecovery {
-    this.expireStaleReturned();
     const now = Date.now();
     const mine = [...this.entries.values()].filter((e) => e.key === key);
     if (mine.length === 0) return { status: "none" };
@@ -479,9 +505,18 @@ export class AskAnswerJournalImpl {
    * agent's queue is deliberate: the tool result the caller is about to return
    * carries the SAME answer with the SAME question attached, so the worst case
    * is the agent reading it twice — never acting on an answer it wasn't given.
+   *
+   * Any eviction disclosure the entry was CARRYING is handed back to the tab
+   * first. The disclosure is a debt owed to the tab, not a property of whichever
+   * entry happens to be carrying it: consuming the carrier without re-homing it
+   * would let an eviction that the journal promised to report disappear because
+   * an unrelated answer was recovered.
    */
   consume(token: string): void {
+    const entry = this.entries.get(token);
+    if (!entry) return;
     this.entries.delete(token);
+    if (entry.disclose) this.noteDropped(entry.key, entry.disclose);
   }
 
   /** Every unconsumed ORPHAN answer for a tab — those that were never handed
@@ -489,6 +524,26 @@ export class AskAnswerJournalImpl {
    *  validated answer is never silently dropped. */
   orphansFor(key: string): AskEntry[] {
     return [...this.entries.values()].filter((e) => e.key === key && !e.returned);
+  }
+
+  /**
+   * Take the eviction debt that has NO other carrier — the count parked in the
+   * side map because this tab had no pending entry to stamp it onto, i.e. no
+   * push is coming to disclose it. The ask path reports it instead.
+   *
+   * Debt riding on an ENTRY is deliberately left alone: that copy goes out with
+   * a real delivery and is cleared only when the turn carrying it ends, so
+   * taking it here could drop a disclosure that push still owes.
+   *
+   * Reporting into a ToolResult is a hand-off, not a proof, so this can still be
+   * lost with an abandoned call — but the eviction itself was already logged at
+   * ERROR, and repeating the warning on every subsequent ask forever is worse
+   * than reporting it once at the first opportunity.
+   */
+  takeDropped(key: string): number {
+    const owed = this.dropped.get(key) ?? 0;
+    this.dropped.delete(key);
+    return owed;
   }
 
   /** Answers this tab lost to an eviction and has not yet been told about. */
@@ -639,7 +694,13 @@ export class AskAnswerJournalImpl {
       }
     }
     for (const [id, ticket] of [...this.tickets]) {
-      if (ticket.tabId === key) this.tickets.delete(id);
+      if (ticket.tabId !== key) continue;
+      this.tickets.delete(id);
+      // Its card may still be on screen. There is no agent left at this tab id,
+      // so a late answer must not be armed for a push that can only fail (and
+      // would sit pending until an eviction) — journal it for disclosure only,
+      // exactly as for a replaced conversation.
+      this.conversationGone.add(id);
     }
     const owed = this.dropped.get(key) ?? 0;
     if (owed > 0) {
@@ -662,15 +723,48 @@ export class AskAnswerJournalImpl {
    */
   closeAsks(key: string): void {
     for (const [id, ticket] of [...this.tickets]) {
-      if (ticket.tabId === key) this.tickets.delete(id);
+      if (ticket.tabId !== key) continue;
+      this.tickets.delete(id);
+      // The CARD IS STILL ON SCREEN. The user can click it minutes from now, and
+      // the bridge will happily deliver that answer — to a conversation that no
+      // longer exists. Remember the id so `record` recognises it as belonging to
+      // the retired conversation instead of treating it as an ordinary
+      // unattributable answer and announcing it to the replacement agent.
+      this.conversationGone.add(id);
+    }
+    while (this.conversationGone.size > MAX_REMEMBERED_ASK_IDS) {
+      const oldest = this.conversationGone.values().next().value;
+      if (oldest === undefined) break;
+      this.conversationGone.delete(oldest);
     }
     for (const entry of this.entries.values()) {
-      if (entry.key !== key || entry.correlation.status !== "matched") continue;
-      entry.correlation = { status: "foreign", askId: entry.correlation.askId };
-      // Its fingerprint was the licence to satisfy a matching re-ask; the
-      // conversation that asked is gone, so revoke it. The QUESTION TEXT stays —
-      // it is what makes the disclosure honest.
-      entry.fingerprint = null;
+      if (entry.key !== key) continue;
+      if (entry.correlation.status === "matched") {
+        entry.correlation = { status: "foreign", askId: entry.correlation.askId };
+        // Its fingerprint was the licence to satisfy a matching re-ask; the
+        // conversation that asked is gone, so revoke it. The QUESTION TEXT stays —
+        // it is what makes the disclosure honest.
+        entry.fingerprint = null;
+      }
+      // …and STOP PUSHING it. Its addressee is gone.
+      //
+      // This is where an ask answer parts company with a run completion (#468),
+      // which is still delivered to the replacement conversation downgraded. A
+      // completion's payload is independently useful — the images are on the
+      // user's canvas either way. An answer to a question the replacement
+      // conversation never asked is useful to nobody: pushing it injects an
+      // unsolicited turn about a decision the new conversation has no context
+      // for, which is a cross-conversation confusion with no upside.
+      //
+      // NOT a silent discard: the entry stays journaled (so a later ask on this
+      // tab that times out still reports it as UNATTRIBUTED, quoted with its own
+      // question) and the loss of the push is logged here.
+      if (entry.delivery === "pending") {
+        entry.delivery = "none";
+        logger.warn(
+          `[ask-answers] the conversation that asked "${preview(entry.question)}" on tab ${key.slice(0, 8)} was replaced — the user's answer ("${entry.answer}") will NOT be announced to the replacement conversation; it is kept only for disclosure`,
+        );
+      }
     }
   }
 
@@ -686,6 +780,7 @@ export class AskAnswerJournalImpl {
     // orchestrator, not to any one test's fixture.
     this.tickets.clear();
     this.retired.clear();
+    this.conversationGone.clear();
     this.entries.clear();
     this.dropped.clear();
     this.seq = 0;
@@ -735,23 +830,6 @@ export class AskAnswerJournalImpl {
     }
   }
 
-  /**
-   * Forget RETURNED answers past the recovery window.
-   *
-   * These were handed to a tool result and can no longer be recovered by a
-   * re-ask, so dropping them asserts nothing and loses nothing that was still
-   * reachable — it is what keeps ordinary successful asks from filling the
-   * journal and evicting a genuine orphan. ORPHANED answers are never
-   * age-expired: they were handed to nobody, so only a delivery or an
-   * explicitly-disclosed eviction may remove one.
-   */
-  private expireStaleReturned(): void {
-    const now = Date.now();
-    for (const [token, e] of [...this.entries]) {
-      if (!e.returned || e.delivery !== "none") continue;
-      if (now - e.answeredAt > RECOVER_MAX_AGE_MS) this.entries.delete(token);
-    }
-  }
 
   /**
    * Record that an answer for `key` was destroyed by an eviction, so the next

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -98,6 +98,17 @@ export interface AskTicket {
    */
   awaiting: boolean;
   /**
+   * Which CONVERSATION on this tab asked the question.
+   *
+   * Bumped on the tab (never on the ticket) by closeAsks(), so a card left on
+   * screen across a New chat / a resume of a historical session is recognisable
+   * as belonging to the conversation that is gone. An epoch per TAB, rather than
+   * a remembered set of ask ids, because the set would be bounded — and a bound
+   * that decides whether an answer may be announced to a different conversation
+   * is a bound deciding a correctness question.
+   */
+  epoch: number;
+  /**
    * This ask id was opened MORE THAN ONCE, so it no longer identifies a single
    * question.
    *
@@ -159,16 +170,30 @@ export interface AskEntry {
   /** This answer was already handed to the agent once (as a tool result or a
    *  push) and is being surfaced again. A LABEL, never a veto. */
   replayHint?: boolean;
+  /**
+   * This answer may be REPORTED but may never be RETURNED as the answer to a
+   * question — the conversation that asked it is gone, or its ask id stopped
+   * identifying one question.
+   *
+   * Separate from the fingerprint on purpose. An earlier draft revoked
+   * recoverability by NULLING the fingerprint, which also erased the journal's
+   * ability to notice "this is about the very question being re-asked" — so the
+   * answer stopped being disclosed as well as stopping being returned, i.e.
+   * revoking a permission silently revoked a promise.
+   */
+  recoverable?: boolean;
 }
 
-/** Cards tracked at once. Generous: real sessions have one or two. */
-const MAX_TICKETS = 64;
-/** Ask ids whose CONVERSATION was replaced, remembered so a late click on the
- *  old card is not announced to the replacement one. Bounded — and safely so:
- *  forgetting one only means the answer is treated as an ordinary unattributable
- *  answer (journaled, labelled), never that it is dropped. */
-const MAX_CONVERSATION_GONE_IDS = 1024;
-
+/**
+ * Cards tracked at once. A ticket is a handful of small fields, and it is what
+ * makes an answer ATTRIBUTABLE, so this is sized for a whole session's asks
+ * rather than for the two that are usually open. There is deliberately no age
+ * limit: a question card sits on screen until the user deals with it, and any
+ * clock here would be a bound quietly deciding that an answer no longer counts.
+ * Overflowing is logged at ERROR and only ever WEAKENS a correlation to
+ * UNDETERMINED — it never drops an answer.
+ */
+const MAX_TICKETS = 1024;
 /**
  * Prefix every `panel_ask` card's ask id carries.
  *
@@ -181,19 +206,10 @@ const MAX_CONVERSATION_GONE_IDS = 1024;
  * cannot expire, evict, or be raced.
  */
 export const PANEL_ASK_ID_PREFIX = "pa-";
-/**
- * How long a ticket is kept. The bridge only forwards a LATE answer for a card
- * whose rid→ask_id mapping is still alive, so this must OUTLIVE that mapping's
- * own TTL (UiBridge.LATE_ASK_MAP_TTL_MS, 60 minutes) or a ticket could be gone
- * while an answer for it can still arrive. Sized above it, so pruning here is
- * provably lossless rather than a bound we are hoping never bites — and losing
- * one anyway only weakens a correlation to UNDETERMINED, never drops an answer.
- */
-const TICKET_MAX_AGE_MS = 65 * 60_000;
 /** Undelivered/unconsumed answers held per panel tab. */
-const MAX_ENTRIES_PER_KEY = 16;
+const MAX_ENTRIES_PER_KEY = 48;
 /** …and across all tabs. */
-const MAX_ENTRIES_TOTAL = 48;
+const MAX_ENTRIES_TOTAL = 192;
 /**
  * How long a journaled answer may still be RECOVERED as the result of a re-ask
  * of the identical question.
@@ -311,16 +327,10 @@ export class AskAnswerJournalImpl {
    * ticket may only ever WEAKEN a correlation (matched → foreign, i.e.
    * UNDETERMINED); it must never turn an answer into nothing.
    */
-  /**
-   * Ask ids whose CONVERSATION was replaced (New chat / resume of a historical
-   * session) while their card was still on screen.
-   *
-   * An answer that arrives for one of these is real and is journaled, but it is
-   * addressed to a conversation that no longer exists, so it is never announced
-   * to the replacement one — see closeAsks() for why this differs from #468's
-   * treatment of run completions.
-   */
-  private conversationGone = new Set<string>();
+  /** Panel tab -> the generation of the conversation currently attached to it.
+   *  Bumped by closeAsks(); a ticket minted under an older generation belongs to
+   *  a conversation that is gone. See AskTicket.epoch. */
+  private tabEpoch = new Map<string, number>();
   /** token → entry (insertion-ordered, which is also delivery order). */
   private entries = new Map<string, AskEntry>();
   /** Answers this tab lost to an eviction and has not yet been told about. */
@@ -352,9 +362,15 @@ export class AskAnswerJournalImpl {
    * arrives with no ticket is (correctly, but uselessly) foreign.
    */
   openAsk(askId: string, meta: { tabId: string; fingerprint: string; question: string }): void {
-    this.pruneTickets();
+    const epoch = this.tabEpoch.get(meta.tabId) ?? 0;
     const existing = this.tickets.get(askId);
-    if (existing) {
+    // REUSE is also proven by an ANSWER already on file for this id, not only by
+    // a surviving ticket. The ticket map is bounded, so keying the guard on it
+    // alone would let an eviction restore a "fresh" identity to an id that a
+    // still-rendered card can answer — the old card's click would then be frozen
+    // with the NEW question's fingerprint and could satisfy it.
+    const answered = [...this.entries.values()].some((e) => e.askId === askId);
+    if (existing || answered) {
       // The same ask id dispatched AGAIN. Reopen rather than stack a second
       // ticket (one ask id always means one ticket) — but the id now stands for
       // MORE THAN ONE question, and the panel's reply carries only the id, so
@@ -362,16 +378,22 @@ export class AskAnswerJournalImpl {
       // reused: every answer for it is reported UNDETERMINED from here on, and
       // in particular the older card's late click can no longer be frozen with
       // the newer question's fingerprint and recovered as its answer.
-      existing.tabId = meta.tabId;
-      existing.fingerprint = meta.fingerprint;
-      existing.question = meta.question;
-      existing.openedAt = Date.now();
-      existing.seq = ++this.ticketSeq;
-      existing.awaiting = true;
-      existing.reused = true;
+      this.tickets.set(askId, {
+        ...(existing ?? {}),
+        askId,
+        tabId: meta.tabId,
+        fingerprint: meta.fingerprint,
+        question: meta.question,
+        openedAt: Date.now(),
+        epoch,
+        seq: ++this.ticketSeq,
+        awaiting: true,
+        reused: true,
+      });
       logger.warn(
         `[ask-answers] ask id ${askId.slice(0, 12)} was opened again — it no longer identifies one question, so every answer for it is reported as UNDETERMINED`,
       );
+      this.trimTickets();
       return;
     }
     this.tickets.set(askId, {
@@ -380,6 +402,7 @@ export class AskAnswerJournalImpl {
       fingerprint: meta.fingerprint,
       question: meta.question,
       openedAt: Date.now(),
+      epoch,
       seq: ++this.ticketSeq,
       awaiting: true,
     });
@@ -433,13 +456,16 @@ export class AskAnswerJournalImpl {
    * dropped because it "looks like" something already seen.
    */
   record(askId: string, reply: unknown, meta: { tabId: string }): AskEntry {
-    this.pruneTickets();
     const existing = [...this.entries.values()].find((e) => e.askId === askId);
     if (existing) return existing;
     const ticket = this.tickets.get(askId);
     // A REUSED id proves nothing: the panel sends only the id, so an answer for
     // it could belong to either card. Report it as foreign — real, but
     // UNDETERMINED — rather than claiming it answers the question now open.
+    // The conversation that opened this ticket has been replaced (New chat, or a
+    // resume of a historical session) while its card stayed on screen.
+    const conversationGone =
+      ticket !== undefined && ticket.epoch !== (this.tabEpoch.get(ticket.tabId) ?? 0);
     const attributable = ticket !== undefined && ticket.reused !== true;
     const correlation: AskCorrelation = attributable
       ? { status: "matched", askId }
@@ -467,12 +493,14 @@ export class AskAnswerJournalImpl {
       // all) has nobody left and is armed for the push immediately. An answer to
       // a card whose CONVERSATION was replaced is never pushed at all — see
       // closeAsks(); it is journaled for disclosure only.
-      delivery:
-        ticket?.awaiting === true || this.conversationGone.has(askId) ? "none" : "pending",
+      delivery: ticket?.awaiting === true || conversationGone ? "none" : "pending",
+      // A question the CURRENT conversation never asked may be reported, never
+      // returned as its answer.
+      ...(conversationGone ? { recoverable: false } : {}),
       attempts: 0,
     };
     this.entries.set(entry.token, entry);
-    if (this.conversationGone.has(askId)) {
+    if (conversationGone) {
       logger.warn(
         `[ask-answers] an answer arrived for a card whose conversation was replaced (ask ${askId.slice(0, 8)}, tab ${entry.key.slice(0, 8)}): "${entry.answer}" — journaled for disclosure, NOT announced to the replacement conversation`,
       );
@@ -532,6 +560,7 @@ export class AskAnswerJournalImpl {
       .filter(
         (e) =>
           e.correlation.status === "matched" &&
+          e.recoverable !== false &&
           e.fingerprint !== null &&
           e.fingerprint === fingerprint &&
           now - e.answeredAt <= RECOVER_MAX_AGE_MS,
@@ -556,11 +585,18 @@ export class AskAnswerJournalImpl {
    * would let an eviction that the journal promised to report disappear because
    * an unrelated answer was recovered.
    */
-  consume(token: string): void {
+  markSurfaced(token: string): void {
     const entry = this.entries.get(token);
     if (!entry) return;
-    this.entries.delete(token);
-    if (entry.disclose) this.noteDropped(entry.key, entry.disclose);
+    // NOT DELETED. An earlier draft consumed a recovered answer outright, on the
+    // reasoning that it had now been handed over — which is the same mistake as
+    // every suppression #468 removed, one level up: the ToolResult carrying it
+    // can itself be abandoned (that IS #486), so deleting the entry destroys the
+    // only durable copy at exactly the moment it is most likely to be needed
+    // again. It is marked handed-over and flagged, so a further re-ask of the
+    // same question gets it again, labelled "you have seen this".
+    entry.returned = true;
+    entry.replayHint = true;
   }
 
   /** Every unconsumed ORPHAN answer for a tab — those that were never handed
@@ -750,9 +786,19 @@ export class AskAnswerJournalImpl {
     for (const entry of this.entries.values()) {
       if (entry.key === from) entry.key = to;
     }
+    // The conversation GENERATION moves with the tickets, or they would all read
+    // as belonging to a replaced conversation at the destination (or, worse, a
+    // retired one would read as live there). A ticket whose conversation was
+    // still current at the source is current at the destination — the agent moved
+    // with it; one already retired stays retired.
+    const fromEpoch = this.tabEpoch.get(from) ?? 0;
+    const toEpoch = this.tabEpoch.get(to) ?? 0;
     for (const ticket of this.tickets.values()) {
-      if (ticket.tabId === from) ticket.tabId = to;
+      if (ticket.tabId !== from) continue;
+      ticket.tabId = to;
+      ticket.epoch = ticket.epoch === fromEpoch ? toEpoch : toEpoch - 1;
     }
+    this.tabEpoch.delete(from);
     const lost = this.dropped.get(from);
     if (lost !== undefined) {
       this.dropped.delete(from);
@@ -774,15 +820,12 @@ export class AskAnswerJournalImpl {
         `[ask-answers] dropping a validated answer ("${entry.answer}") to "${preview(entry.question)}" — its tab (${key.slice(0, 8)}) is gone${entry.returned ? " (it had been handed to a tool result, which is not proof it was received)" : ""}`,
       );
     }
-    for (const [id, ticket] of [...this.tickets]) {
-      if (ticket.tabId !== key) continue;
-      this.tickets.delete(id);
-      // Its card may still be on screen. There is no agent left at this tab id,
-      // so a late answer must not be armed for a push that can only fail (and
-      // would sit pending until an eviction) — journal it for disclosure only,
-      // exactly as for a replaced conversation.
-      this.conversationGone.add(id);
-    }
+    // The TAB is gone, so every conversation it hosted is gone too: bump the
+    // epoch rather than deleting the tickets. A card left on screen can still be
+    // clicked, and the surviving ticket is what names the question that answer
+    // belongs to — while the newer epoch keeps it from being armed for a push at
+    // a tab id no agent answers to, exactly as for a replaced conversation.
+    this.tabEpoch.set(key, (this.tabEpoch.get(key) ?? 0) + 1);
     const owed = this.dropped.get(key) ?? 0;
     if (owed > 0) {
       logger.error(
@@ -803,30 +846,23 @@ export class AskAnswerJournalImpl {
    * quoted with their own question. A correlation may only ever get WEAKER.
    */
   closeAsks(key: string): void {
-    for (const [id, ticket] of [...this.tickets]) {
-      if (ticket.tabId !== key) continue;
-      this.tickets.delete(id);
-      // The CARD IS STILL ON SCREEN. The user can click it minutes from now, and
-      // the bridge will happily deliver that answer — to a conversation that no
-      // longer exists. Remember the id so `record` recognises it as belonging to
-      // the retired conversation instead of treating it as an ordinary
-      // unattributable answer and announcing it to the replacement agent.
-      this.conversationGone.add(id);
-    }
-    while (this.conversationGone.size > MAX_CONVERSATION_GONE_IDS) {
-      const oldest = this.conversationGone.values().next().value;
-      if (oldest === undefined) break;
-      this.conversationGone.delete(oldest);
-    }
+    // BUMP THE TAB'S CONVERSATION GENERATION. Every ticket already minted for
+    // this tab now carries an older epoch, which is what makes a card left on
+    // screen recognisable as the retired conversation's — with no per-id
+    // bookkeeping to overflow. The TICKETS ARE KEPT: they are what still name the
+    // question, and deleting them would turn a late click into an answer with no
+    // question attached, i.e. the disclosure would lose the only thing that makes
+    // it honest.
+    this.tabEpoch.set(key, (this.tabEpoch.get(key) ?? 0) + 1);
     for (const entry of this.entries.values()) {
       if (entry.key !== key) continue;
       if (entry.correlation.status === "matched") {
         entry.correlation = { status: "foreign", askId: entry.correlation.askId };
-        // Its fingerprint was the licence to satisfy a matching re-ask; the
-        // conversation that asked is gone, so revoke it. The QUESTION TEXT stays —
-        // it is what makes the disclosure honest.
-        entry.fingerprint = null;
       }
+      // Revoke the LICENCE to satisfy a re-ask, but keep the fingerprint: it is
+      // also how a later ask of the SAME question notices this answer exists and
+      // reports it. See AskEntry.recoverable.
+      entry.recoverable = false;
       // …and STOP PUSHING it. Its addressee is gone.
       //
       // This is where an ask answer parts company with a run completion (#468),
@@ -838,8 +874,8 @@ export class AskAnswerJournalImpl {
       // for, which is a cross-conversation confusion with no upside.
       //
       // NOT a silent discard: the entry stays journaled (so a later ask on this
-      // tab that times out still reports it as UNATTRIBUTED, quoted with its own
-      // question) and the loss of the push is logged here.
+      // tab that times out still reports it, quoted with its own question) and
+      // the loss of the push is logged here.
       if (entry.delivery === "pending") {
         entry.delivery = "none";
         logger.warn(
@@ -853,6 +889,10 @@ export class AskAnswerJournalImpl {
   ticketFor(askId: string): AskTicket | undefined {
     return this.tickets.get(askId);
   }
+  /** Simulate the ticket map's bound biting, without running 1024 asks. */
+  dropTicketForTest(askId: string): void {
+    this.tickets.delete(askId);
+  }
   entriesFor(key: string): AskEntry[] {
     return [...this.entries.values()].filter((e) => e.key === key);
   }
@@ -860,21 +900,13 @@ export class AskAnswerJournalImpl {
     // NOTE: the flusher is deliberately NOT cleared — it belongs to the process's
     // orchestrator, not to any one test's fixture.
     this.tickets.clear();
-    this.conversationGone.clear();
+    this.tabEpoch.clear();
     this.entries.clear();
     this.dropped.clear();
     this.seq = 0;
     this.ticketSeq = 0;
   }
 
-  /** Tickets whose card can no longer receive an answer (see TICKET_MAX_AGE_MS)
-   *  and which no handler is still waiting on. */
-  private pruneTickets(): void {
-    const now = Date.now();
-    for (const [id, t] of [...this.tickets]) {
-      if (!t.awaiting && now - t.openedAt > TICKET_MAX_AGE_MS) this.tickets.delete(id);
-    }
-  }
 
   private trimTickets(): void {
     while (this.tickets.size > MAX_TICKETS) {
@@ -892,7 +924,7 @@ export class AskAnswerJournalImpl {
       if (!victim) victim = this.tickets.keys().next().value ?? null;
       if (!victim) return;
       logger.error(
-        `[ask-answers] over ${MAX_TICKETS} question cards are tracked at once — forgetting ask ${victim.slice(0, 8)}; a late answer for it will be reported as UNATTRIBUTED`,
+        `[ask-answers] over ${MAX_TICKETS} question cards have been tracked — forgetting ask ${victim.slice(0, 12)}; a late answer for it will be reported as UNATTRIBUTED (its question can no longer be named)`,
       );
       this.tickets.delete(victim);
     }
@@ -943,12 +975,22 @@ export class AskAnswerJournalImpl {
         this.entries.delete(victim.token);
         mine = mine.filter((e) => e !== victim);
         if (victim.returned) {
-          // Logged, not counted as a loss for the agent: it DID reach a caller,
-          // and counting every ordinary successful ask as an undetermined
-          // dropped answer would cry wolf on every tab that asks a lot — the
-          // warning would stop meaning anything, which is its own kind of
-          // silence. The record is here, with the answer text, so a real loss is
-          // still reconstructable.
+          // LOGGED, NOT COUNTED as an undetermined loss for the agent — the one
+          // place this file deliberately stops short, so the reasoning is spelled
+          // out rather than assumed.
+          //
+          // A returned answer DID reach a caller; what its eviction costs is the
+          // ability to RECOVER it, not a delivery. Counting each one as "a
+          // validated answer was dropped, treat it as UNDETERMINED" would fire
+          // after ~48 ordinary successful asks on a tab and tell the agent that
+          // answers it almost certainly received are unknown. A warning that is
+          // usually false is its own kind of silence: it trains the reader to
+          // ignore the one that is true.
+          //
+          // The exposure is bounded on both sides — the per-tab ceiling is far
+          // above any plausible burst, orphans are never evicted before these,
+          // and the full answer text is written here — so what survives is a
+          // reconstructable record rather than a misleading alarm.
           logger.warn(
             `[ask-answers] ${label} — forgetting an already-returned answer ("${victim.answer}") to "${preview(victim.question)}"; a re-ask can no longer recover it, and a tool result is not proof it was received`,
           );

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -191,6 +191,18 @@ export interface AskEntry {
    * answer quietly.
    */
   acked?: boolean;
+  /**
+   * WHICH agent's turn is carrying this answer, captured at the instant it was
+   * handed back and never re-resolved. `null` when there was no live turn to
+   * ride (so nothing can ever ack it).
+   *
+   * The identity has to be frozen because the tab→agent mapping MOVES: a
+   * provider switch retires the old agent and re-points the tab at a new one. An
+   * ack that asked "who owns this tab now?" would let the new provider's turn
+   * settle an answer that belonged to the old conversation — an answer the new
+   * conversation never saw, marked proven-read and therefore silently evictable.
+   */
+  carrier?: string | null;
   delivery: AskDeliveryState;
   attempts: number;
   /** How many turns carried this answer and then ended without a provable ack. */
@@ -381,15 +393,16 @@ export class AskAnswerJournalImpl {
    *  reportDropped(). */
   /** Outstanding eviction-disclosure tokens: token -> panel tab. Retired only
    *  by the ack of the turn that carried the warning (see reportDropped). */
-  private debtTokens = new Map<string, string>();
+  private debtTokens = new Map<string, { key: string; carrier: string | null }>();
   private seq = 0;
   private ticketSeq = 0;
   /** Deliver a tab's newly-orphaned answers (see setFlusher). */
   private flush: ((key: string) => void) | null = null;
   /** Pull a still-queued answer event back off its agent (see setRevoker). */
   private revoke: ((key: string, token: string) => boolean) | null = null;
-  /** Ride a token on the tab's in-flight turn (see setTurnAttacher). */
-  private attachTurn: ((key: string, token: string) => boolean) | null = null;
+  /** Ride a token on the tab's in-flight turn, returning the CARRIER IDENTITY it
+   *  attached to (null when there was no live turn). See setTurnAttacher. */
+  private attachTurn: ((key: string, token: string) => string | null) | null = null;
 
   /**
    * Wire the push channel (#486).
@@ -428,7 +441,7 @@ export class AskAnswerJournalImpl {
    * lands (the model ran to completion after receiving the answer), or it never
    * does and the answer stays accounted for.
    */
-  setTurnAttacher(attach: (key: string, token: string) => boolean): void {
+  setTurnAttacher(attach: (key: string, token: string) => string | null): void {
     this.attachTurn = attach;
   }
 
@@ -687,17 +700,35 @@ export class AskAnswerJournalImpl {
 
   /** The ask handler put this answer into its ToolResult. A hand-off, not proof
    *  of consumption — see AskEntry.returned. */
-  markReturned(token: string): void {
+  markReturned(token: string, opts: { replay?: boolean } = {}): void {
     // BY TOKEN, not by ask id: under a reused id one ask id can own two entries,
     // and marking the sibling returned would quietly retire an answer nobody has
     // been given.
     const entry = this.entries.get(token);
     if (entry) {
       entry.returned = true;
+      if (opts.replay) entry.replayHint = true;
       // Ride the turn this tool call is running inside, so that turn's result —
       // and nothing less — acks the answer. No live turn to ride means no proof,
       // so the answer simply stays unacked, which is the conservative reading.
-      this.attachTurn?.(entry.key, token);
+      //
+      // THE CARRIER IS CAPTURED HERE, at the instant of return, and frozen onto
+      // the entry. Resolving it later from "whoever owns this tab now" is how a
+      // switched provider's turn could ack an answer it never saw: a stale
+      // pre-switch ask handler resumes, attaches to the NEW provider's turn, and
+      // that turn's result settles an answer the new conversation was never
+      // shown. `ack` compares against this, so only the turn that actually
+      // carried the answer can settle it.
+      //
+      // …and an answer whose CONVERSATION is gone never attaches at all. Capturing
+      // the carrier is not enough on its own here: a stale pre-switch ask handler
+      // that resumes when its card is clicked would attach to whatever turn is
+      // running NOW, and that turn's result would then certify — accurately, and
+      // uselessly — an answer the current conversation was never shown. The
+      // conversation boundary already marked this entry unrecoverable; it makes it
+      // unackable too, so the answer stays honestly unproven.
+      entry.carrier =
+        entry.recoverable === false ? null : (this.attachTurn?.(entry.key, token) ?? null);
       // It reached A caller. Do not ALSO push it as an orphan; a re-ask can
       // still recover it if that caller was already dead.
       //
@@ -772,8 +803,16 @@ export class AskAnswerJournalImpl {
     // only durable copy at exactly the moment it is most likely to be needed
     // again. It is marked handed-over and flagged, so a further re-ask of the
     // same question gets it again, labelled "you have seen this".
-    entry.returned = true;
-    entry.replayHint = true;
+    //
+    // IT GOES THROUGH markReturned, and must: a recovery hands the answer to a
+    // live turn exactly as a fresh answer does, so it has to attach a token and
+    // capture its carrier BY CONSTRUCTION. An earlier draft set the flags here
+    // by hand and forgot to attach — so a recovery that completed perfectly
+    // stayed unacked forever, aged into apparent loss, and eventually raised
+    // eviction debt and warnings despite the agent having read it. That is the
+    // routine-false-warning failure the ack split exists to prevent, arriving
+    // through a different door.
+    this.markReturned(token, { replay: true });
   }
 
   /** Every unconsumed ORPHAN answer for a tab — those that were never handed
@@ -810,8 +849,37 @@ export class AskAnswerJournalImpl {
     // its own result. No live turn to ride means no proof and no retirement — the
     // debt simply stands and the next result reports it again.
     const token = `aad${++this.seq}`;
-    if (this.attachTurn?.(key, token) === true) this.debtTokens.set(token, key);
+    const carrier = this.attachTurn?.(key, token) ?? null;
+    // Bound to the turn that carried it, for the same reason an answer is: a
+    // switched provider must not be able to certify a warning it never showed.
+    if (carrier !== null) this.debtTokens.set(token, { key, carrier });
     return owed;
+  }
+
+  /**
+   * The tab's connection is gone. SURFACE any disclosure it is still owed, then
+   * retire it.
+   *
+   * This is the lifecycle wire that keeps the debt map from growing forever now
+   * that it has no ceiling — and the distinction matters: a debt must end because
+   * it was SAID or because its tab genuinely went away, never because a counter
+   * filled up and picked a victim. The durable ERROR log is the disclosure here;
+   * there is no live tab left to tell in-band, which is precisely why keeping the
+   * counter any longer would be bookkeeping for nobody.
+   *
+   * JOURNAL ENTRIES ARE NOT TOUCHED. A disconnect is often a reload, and the
+   * answers themselves are still deliverable to the tab when it comes back; only
+   * the count of answers whose TEXT is already gone is retired.
+   */
+  retireDebt(key: string): void {
+    const owed = this.dropped.get(key) ?? 0;
+    if (owed > 0) {
+      logger.error(
+        `[ask-answers] tab ${key.slice(0, 8)} disconnected still owed a disclosure for ${owed} validated answer(s) whose content was already dropped — recording it here, as there is no longer anywhere to deliver it; treat those answers as UNDETERMINED`,
+      );
+    }
+    this.dropped.delete(key);
+    for (const [t, d] of [...this.debtTokens]) if (d.key === key) this.debtTokens.delete(t);
   }
 
   /** Answers this tab lost to an eviction and has not yet been told about. */
@@ -878,19 +946,31 @@ export class AskAnswerJournalImpl {
   }
 
   /** The turn that CARRIED this answer ended — it genuinely reached the agent. */
-  ack(token: string): void {
+  ack(token: string, from?: { carrier?: string }): void {
     // An eviction-DISCLOSURE token (see reportDropped): the turn that carried the
     // warning produced its result, so the tab has genuinely been told.
-    const debtKey = this.debtTokens.get(token);
-    if (debtKey !== undefined) {
+    const debt = this.debtTokens.get(token);
+    if (debt !== undefined) {
+      if (!this.carriedBy(debt.carrier, from)) return;
       this.debtTokens.delete(token);
-      this.dropped.delete(debtKey);
+      this.dropped.delete(debt.key);
       // Any other outstanding token for the same tab is now moot.
-      for (const [t, k] of [...this.debtTokens]) if (k === debtKey) this.debtTokens.delete(t);
+      for (const [t, d] of [...this.debtTokens]) if (d.key === debt.key) this.debtTokens.delete(t);
       return;
     }
     const entry = this.entries.get(token);
     if (!entry) return;
+    // ONLY THE TURN THAT ACTUALLY CARRIED IT may settle it. The carrier was
+    // frozen at hand-off (see AskEntry.carrier); a result arriving from anything
+    // else — most concretely, the NEW provider's turn after a switch moved the
+    // tab's agent mapping — proves nothing about this answer, so it is refused
+    // and the answer stays honestly unacked.
+    if (!this.carriedBy(entry.carrier, from)) {
+      logger.warn(
+        `[ask-answers] refusing an ack for the user's answer to "${preview(entry.question)}" from ${from?.carrier ?? "an unidentified turn"} — it was handed to ${entry.carrier ?? "no turn at all"}; the answer stays unconfirmed`,
+      );
+      return;
+    }
     // The push is done, but the ANSWER stays journaled while it is still within
     // the recovery window: a re-ask of the identical question must still be able
     // to return it as its result rather than making the user answer twice. It is
@@ -983,15 +1063,22 @@ export class AskAnswerJournalImpl {
    *    nothing and keeps the loss from being silent.
    */
   allOutstanding(): AskEntry[] {
-    const now = Date.now();
     return [...this.entries.values()].filter(
       (e) =>
         e.delivery !== "none" ||
         (e.disclose ?? 0) > 0 ||
-        // UNACKED only: an answer the agent provably read is not news on the way
-        // out, and naming every ask of the last ten minutes would bury the ones
-        // that actually went missing.
-        (e.acked !== true && now - e.answeredAt <= RECOVER_MAX_AGE_MS),
+        // UNACKED, with NO TIME BOUND. An answer the agent provably read is not
+        // news on the way out; one whose receipt was never confirmed is, and it
+        // stays news for as long as it exists.
+        //
+        // An earlier draft also required it to be inside the recovery window,
+        // which quietly undid the whole `returned`/`acked` split: past ten
+        // minutes an unacked answer was neither pending nor debt-bearing, so the
+        // fatal-exit path was handed nothing and a validated choice vanished in
+        // silence. UNACKED MEANS UNPROVEN, and time does not turn unproven into
+        // delivered — the window governs whether an answer may be RECOVERED, and
+        // has no business governing whether a loss is reported.
+        e.acked !== true,
     );
   }
 
@@ -1132,9 +1219,31 @@ export class AskAnswerJournalImpl {
   ticketFor(askId: string): AskTicket | undefined {
     return this.tickets.get(askId);
   }
+  /**
+   * Is an ack from `from` allowed to settle something handed to `carrier`?
+   *
+   * A PUSHED entry has no carrier binding (its token was queued, not attached to
+   * a running turn) and #468's own machinery already gates it — those pass. A
+   * hand-off that never found a live turn (`carrier === null`) can never be
+   * settled by anyone. Everything else must match EXACTLY.
+   *
+   * An ack that arrives with no identity at all is UNVERIFIABLE, and is refused
+   * for a bound answer: "we could not tell who this came from" must never
+   * collapse into "it came from the right place".
+   */
+  private carriedBy(carrier: string | null | undefined, from?: { carrier?: string }): boolean {
+    if (carrier === undefined) return true; // never bound to a turn (a push)
+    if (carrier === null) return false; // handed back with no live turn to ride
+    return from?.carrier === carrier;
+  }
+
   /** Simulate the ticket map's bound biting, without running 1024 asks. */
   dropTicketForTest(askId: string): void {
     this.tickets.delete(askId);
+  }
+  /** Strand an eviction debt on a tab without staging 48 evictions. */
+  noteDroppedForTest(key: string, count: number): void {
+    this.dropped.set(key, (this.dropped.get(key) ?? 0) + count);
   }
   /** Record + hand back in one step, returning the token. */
   markReturnedForTest(askId: string, reply: unknown, tabId: string): string {

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -228,6 +228,22 @@ export interface AskEntry {
    */
   recoverable?: boolean;
   /**
+   * Which browser-tab INCARNATION this answer belongs to, captured at arrival.
+   *
+   * Entries are keyed by panel tab id, and that id recurs — `wf:<hash>` names a
+   * saved workflow, so a second browser tab can hold it. Re-keying every entry by
+   * incarnation would break the thing tab-keying is FOR (a reload keeps its
+   * answers), so the incarnation is carried alongside and checked at the point of
+   * use instead: only the occupant this answer was given by may recover it or be
+   * pushed it. Everyone else may still be TOLD about it — a disclosure quotes its
+   * own question and cannot be misattributed.
+   *
+   * `undefined` when nothing could say who was holding the tab (no resolver
+   * wired, or the tab was not connected). Unknown provenance never satisfies a
+   * known occupant.
+   */
+  incarnation?: string;
+  /**
    * This entry's ask id stands for MORE THAN ONE card.
    *
    * Stamped on the ENTRY, not read from the ticket, because tickets are
@@ -474,6 +490,24 @@ export class AskAnswerJournalImpl {
     this.incarnationOf = resolve;
   }
 
+  /**
+   * May the tab's CURRENT occupant act on this answer — recover it, or be pushed
+   * it?
+   *
+   * Only the occupant it was given by. A different browser tab holding the same
+   * recurring key never asked the question and must not be handed its answer;
+   * unknown provenance on either side is not a match either, because "we could
+   * not tell who this belongs to" must never resolve to "it belongs to you".
+   * When NOTHING can resolve incarnations at all (no resolver wired) the check is
+   * inert and tab-keying alone governs, exactly as before.
+   */
+  private sameOccupant(entry: AskEntry): boolean {
+    if (this.incarnationOf === null) return true; // nothing to distinguish
+    const now = this.incarnationOf(entry.key);
+    if (entry.incarnation === undefined || now === undefined) return false;
+    return entry.incarnation === now;
+  }
+
   /** The debt bucket for a tab's CURRENT occupant. */
   private debtSlot(key: string): string {
     return tabIncarnationSlot(key, this.incarnationOf?.(key));
@@ -684,6 +718,10 @@ export class AskAnswerJournalImpl {
       answeredAt: Date.now(),
       correlation,
       ticketSeq: ticket?.seq ?? 0,
+      // WHO was holding the tab when this answer arrived — see AskEntry.incarnation.
+      ...(this.incarnationOf?.(ticket?.tabId ?? meta.tabId) !== undefined
+        ? { incarnation: this.incarnationOf(ticket?.tabId ?? meta.tabId) }
+        : {}),
       returned: false,
       // An answer that lands while its own handler is still running is that
       // handler's to return; one that lands afterwards has nobody left and is
@@ -803,6 +841,7 @@ export class AskAnswerJournalImpl {
         (e) =>
           e.correlation.status === "matched" &&
           e.recoverable !== false &&
+          this.sameOccupant(e) &&
           e.fingerprint !== null &&
           e.fingerprint === fingerprint &&
           now - e.answeredAt <= RECOVER_MAX_AGE_MS,
@@ -956,7 +995,13 @@ export class AskAnswerJournalImpl {
   pending(key: string): AskEntry[] {
     const out: AskEntry[] = [];
     for (const entry of this.entries.values()) {
-      if (entry.key === key && entry.delivery === "pending") out.push(entry);
+      // A different browser tab now holds this key: its conversation never put
+      // the card up, so the answer waits (for its own tab to come back) rather
+      // than being announced to a stranger. It is still disclosed by a failing
+      // ask, and still named on the way out — held, never swallowed.
+      if (entry.key === key && entry.delivery === "pending" && this.sameOccupant(entry)) {
+        out.push(entry);
+      }
     }
     return out;
   }

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -1525,9 +1525,26 @@ export class AskAnswerJournalImpl {
         // recall.
         recalled = this.revoke?.(entry.key, entry.token) === true;
       } catch (err) {
-        logger.warn(
-          `[ask-answers] could not recall a queued answer on tab ${key.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        // A CATCH BLOCK THAT CAN THROW IS NOT A GUARD. The try above exists so a
+        // throwing revoker cannot abort the pass — but the report of that failure
+        // is itself fallible, and an unguarded one hands the abort straight back:
+        // a throwing revoker AND a throwing warn sink together would exit
+        // closeAsks here, skipping the remaining recalls and, worse, pass 3. The
+        // debt would then stay on the tab for a same-incarnation replacement to
+        // read and settle as its own, and any entry-carried `disclose` would sit
+        // on a retired, undeliverable entry holding hasOutstanding() — and so the
+        // self-restart gate — open forever.
+        //
+        // Every step of this pass therefore has a TERMINAL error path: the report
+        // of a failure must never become a new failure that skips the rest.
+        try {
+          logger.warn(
+            `[ask-answers] could not recall a queued answer on tab ${key.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        } catch {
+          // The fence is already up; a log sink that is down cannot undo it, and
+          // must not stop the debt from being surfaced.
+        }
       }
       if (recalled) entry.delivery = "none";
       try {

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -571,11 +571,26 @@ export class AskAnswerJournalImpl {
       ticketSeq: ticket?.seq ?? 0,
       returned: false,
       // An answer that lands while its own handler is still running is that
-      // handler's to return; one that lands afterwards (or with no ticket at
-      // all) has nobody left and is armed for the push immediately. An answer to
-      // a card whose CONVERSATION was replaced is never pushed at all — see
-      // closeAsks(); it is journaled for disclosure only.
-      delivery: ticket?.awaiting === true || conversationGone ? "none" : "pending",
+      // handler's to return; one that lands afterwards has nobody left and is
+      // armed for the push immediately.
+      //
+      // TWO cases are never pushed, and are journaled for disclosure only:
+      //  • its CONVERSATION was replaced — see closeAsks();
+      //  • THERE IS NO TICKET AT ALL. Without one we cannot tell whether the card
+      //    belongs to the conversation now on this tab or to a retired one (the
+      //    ticket carried that generation), and announcing it anyway would fold
+      //    "could not determine" into "determined not retired". It is also the
+      //    one delivery with nothing to offer: the wording for an unattributable
+      //    answer already says its meaning is UNDETERMINED and that nothing may
+      //    be inferred from it, so pushing it into a conversation that may not be
+      //    the one that asked buys nothing and risks exactly the
+      //    wrong-conversation delivery the epoch guard exists to prevent. The
+      //    answer is still logged with its text and still reported by a later ask
+      //    on this tab — it is not swallowed, it is just not announced.
+      delivery:
+        ticket === undefined || ticket.awaiting === true || conversationGone
+          ? "none"
+          : "pending",
       // A question the CURRENT conversation never asked may be reported, never
       // returned as its answer.
       ...(conversationGone || existing !== undefined ? { recoverable: false } : {}),

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -648,6 +648,18 @@ export class AskAnswerJournalImpl {
     return ticket.epoch === (this.tabEpoch.get(ticket.tabId) ?? 0);
   }
 
+  /**
+   * May this answer's CONTENT be shown to whoever holds its tab right now?
+   *
+   * The public face of the boundary gate, for outlets that live outside this
+   * class. The fatal-exit notice is one: it renders answer text and pushes it to
+   * the tab, so it is a delivery like any other and a retired conversation's pick
+   * must not appear in it. Counts may always cross; content may not.
+   */
+  mayDisclose(entry: AskEntry): boolean {
+    return this.mayReachLiveTurn(entry);
+  }
+
   /** Does this journal know the ask id — i.e. is a late answer for it one of
    *  OURS? The bridge's late-answer sink is fed by every `ask_user` card
    *  (confirm/consent/secret gates included) and only `panel_ask` answers belong

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -1103,7 +1103,7 @@ export class AskAnswerJournalImpl {
     if (entry.disclose) {
       const owed = entry.disclose;
       delete entry.disclose;
-      if (entry.attempts === 0) this.noteDropped(entry.key, owed);
+      if (entry.attempts === 0) this.noteDropped(entry.key, owed, entry.incarnation);
     }
     entry.delivery = "none";
     entry.returned = true;
@@ -1398,8 +1398,8 @@ export class AskAnswerJournalImpl {
     this.tickets.delete(askId);
   }
   /** Strand an eviction debt on a tab without staging 48 evictions. */
-  noteDroppedForTest(key: string, count: number): void {
-    this.dropped.set(this.debtSlot(key), (this.dropped.get(this.debtSlot(key)) ?? 0) + count);
+  noteDroppedForTest(key: string, count: number, incarnation?: string): void {
+    this.noteDropped(key, count, incarnation ?? this.incarnationOf?.(key));
   }
   /** Record + hand back in one step, returning the token. */
   markReturnedForTest(askId: string, reply: unknown, tabId: string): string {
@@ -1453,16 +1453,24 @@ export class AskAnswerJournalImpl {
    * PENDING entry when there is one — it then rides out on a real delivery and
    * cannot be discarded.
    */
-  private noteDropped(key: string, count = 1): void {
+  private noteDropped(key: string, count: number, incarnation: string | undefined): void {
     if (count <= 0) return;
+    // THE LOSS BELONGS TO THE OCCUPANT IT HAPPENED TO, and that is carried in,
+    // never re-derived from the key at write time. The bucket is keyed by
+    // incarnation, so deriving an owner here would file A's loss under whoever
+    // holds the key NOW — B is then pushed A's `dropped_answers`, B's ack clears
+    // it, and A's own lifecycle callback (which retires A's bucket) finds
+    // nothing left to disclose. Keying the bucket and then guessing the key is
+    // the same halfway pattern as scoping the clock but not the debt.
     const carrier = [...this.entries.values()].find(
-      (e) => e.key === key && e.delivery === "pending",
+      (e) => e.key === key && e.delivery === "pending" && e.incarnation === incarnation,
     );
     if (carrier) {
       carrier.disclose = (carrier.disclose ?? 0) + count;
       return;
     }
-    this.dropped.set(this.debtSlot(key), (this.dropped.get(this.debtSlot(key)) ?? 0) + count);
+    const slot = tabIncarnationSlot(key, incarnation);
+    this.dropped.set(slot, (this.dropped.get(slot) ?? 0) + count);
     // NO CEILING HERE, deliberately.
     //
     // This map is not payload — it is the PROMISE that a loss will be reported,
@@ -1514,13 +1522,13 @@ export class AskAnswerJournalImpl {
           // answer's own recoverability is what may be forgotten, never the debt
           // owed for EARLIER answers that reached nobody and merely happened to
           // be stamped on this entry.
-          if (victim.disclose) this.noteDropped(victim.key, victim.disclose);
+          if (victim.disclose) this.noteDropped(victim.key, victim.disclose, victim.incarnation);
           logger.debug(
             `[ask-answers] ${label} — forgetting an answer to "${preview(victim.question)}" that the agent provably read`,
           );
           continue;
         }
-        this.noteDropped(victim.key, 1 + (victim.disclose ?? 0));
+        this.noteDropped(victim.key, 1 + (victim.disclose ?? 0), victim.incarnation);
         logger.error(
           `[ask-answers] ${label} — dropped a VALIDATED answer to "${preview(victim.question)}"${victim.returned ? " that went into a tool call whose receipt was never confirmed" : " that had reached nobody"}; the next delivery will report it as undetermined`,
         );

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -214,6 +214,17 @@ export interface AskEntry {
    * revoking a permission silently revoked a promise.
    */
   recoverable?: boolean;
+  /**
+   * This entry's ask id stands for MORE THAN ONE card.
+   *
+   * Stamped on the ENTRY, not read from the ticket, because tickets are
+   * EVICTABLE: once the reused ticket is trimmed, `ticket?.reused !== true` goes
+   * true again and the identical-answer collapse switches back on — silently
+   * discarding the second card's validated answer before it ever has an entry.
+   * The entry outlives the ticket, so the ambiguity must too. (Exactly the
+   * reasoning behind JournalEntry.ambiguousId in #468's run journal.)
+   */
+  ambiguousId?: boolean;
 }
 
 /**
@@ -462,6 +473,21 @@ export class AskAnswerJournalImpl {
       logger.warn(
         `[ask-answers] ask id ${askId.slice(0, 12)} was opened again — it no longer identifies one question, so every answer for it is reported as UNDETERMINED`,
       );
+      // FREEZE THE AMBIGUITY ONTO THE ENTRIES THAT ALREADY EXIST for this id.
+      // The ticket is evictable and this fact is not: once it is trimmed away,
+      // anything keyed on `ticket.reused` silently reverts to treating the id as
+      // a clean identity. Each such entry keeps its OWN question text — that is
+      // still honest and is what makes its disclosure useful — but loses the
+      // licence to answer anything.
+      for (const entry of this.entries.values()) {
+        if (entry.askId !== askId) continue;
+        entry.ambiguousId = true;
+        entry.recoverable = false;
+        entry.fingerprint = null;
+        if (entry.correlation.status === "matched") {
+          entry.correlation = { status: "foreign", askId };
+        }
+      }
       this.trimTickets();
       return;
     }
@@ -559,12 +585,20 @@ export class AskAnswerJournalImpl {
     // both) are two validated answers to two questions, and merging them leaves
     // the second question unanswered with no record at all.
     if (existing) {
-      if (existing.answer === text && ticket?.reused !== true) return existing;
+      // The ENTRY's own ambiguity flag is the load-bearing half — see
+      // AskEntry.ambiguousId. `ticket?.reused` is kept alongside it as the
+      // earliest signal, but it may have been evicted, and a bound must never be
+      // what decides whether an answer is allowed to disappear.
+      if (existing.answer === text && existing.ambiguousId !== true && ticket?.reused !== true) {
+        return existing;
+      }
       logger.warn(
         `[ask-answers] a SECOND answer arrived under ask id ${askId.slice(0, 12)} ("${text}"${existing.answer === text ? " — same text, but the id is REUSED so this is a different card" : ` vs "${existing.answer}"`}) — both are kept and both are reported as UNDETERMINED; neither can satisfy a question`,
       );
       existing.correlation = { status: "foreign", askId };
       existing.recoverable = false;
+      // …and the ambiguity is frozen here too, so it survives the ticket.
+      existing.ambiguousId = true;
     }
     // A REUSED id proves nothing: the panel sends only the id, so an answer for
     // it could belong to either card. Report it as foreign — real, but
@@ -629,6 +663,9 @@ export class AskAnswerJournalImpl {
       // A question the CURRENT conversation never asked may be reported, never
       // returned as its answer.
       ...(conversationGone || existing !== undefined ? { recoverable: false } : {}),
+      // A SECOND answer under one ask id: the id is ambiguous for this entry too,
+      // and that must outlive the ticket that proved it.
+      ...(existing !== undefined || ticket?.reused === true ? { ambiguousId: true } : {}),
       attempts: 0,
     };
     this.entries.set(entry.token, entry);

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -686,7 +686,11 @@ export class AskAnswerJournalImpl {
     for (const entry of this.entries.values()) {
       if (entry.askId !== askId) continue;
       answered = true;
-      if (!entry.returned && entry.delivery === "none") {
+      // A RETIRED answer is never armed. Arming it produces an entry that
+      // `pending()` correctly refuses to deliver and `hasOutstanding()` counted
+      // as owed — a permanent blocker on the self-restart gate, cleared only by
+      // some unrelated later boundary or eviction.
+      if (!entry.returned && entry.delivery === "none" && entry.retired !== true) {
         entry.delivery = "pending";
         armed = entry;
       }
@@ -1293,8 +1297,18 @@ export class AskAnswerJournalImpl {
     // tearing down while one is owed turns a disclosed loss back into a silent
     // one, which is the whole thing this journal exists to prevent.
     for (const slot of this.dropped.keys()) if (this.undisclosedDrop(slot) > 0) return true;
+    // …but a RETIRED answer is not owed to anyone. It can never be delivered —
+    // the conversation it belongs to is gone — so it is finished, whatever its
+    // `delivery` flag says, and holding the restart gate open for it would wait
+    // forever. Two predicates disagreeing about what `pending` means is what made
+    // this a deadlock: `pending()` reads it as "deliverable", this reads it as
+    // "owed", and only a retirement makes those differ permanently.
+    //
+    // NOT extended to a different-occupant mismatch, which is TEMPORARY: that
+    // answer becomes deliverable again the moment its own browser tab returns, so
+    // tearing down while one is waiting would be a real loss.
     return [...this.entries.values()].some(
-      (e) => e.delivery !== "none" || (e.disclose ?? 0) > 0,
+      (e) => (e.delivery !== "none" && e.retired !== true) || (e.disclose ?? 0) > 0,
     );
   }
 
@@ -1454,21 +1468,23 @@ export class AskAnswerJournalImpl {
    * quoted with their own question. A correlation may only ever get WEAKER.
    */
   closeAsks(key: string): void {
-    // BUMP THE TAB'S CONVERSATION GENERATION. Every ticket already minted for
-    // this tab now carries an older epoch, which is what makes a card left on
-    // screen recognisable as the retired conversation's — with no per-id
-    // bookkeeping to overflow. The TICKETS ARE KEPT: they are what still name the
-    // question, and deleting them would turn a late click into an answer with no
-    // question attached, i.e. the disclosure would lose the only thing that makes
-    // it honest.
+    // ORDER IS THE WHOLE POINT HERE. The rule this and surfaceAndClearDebt share:
+    //
+    //   FENCE BEFORE YOU REPORT. REPORT BEFORE YOU DESTROY.
+    //
+    // Nothing that can throw may stand between a decision and the state change
+    // that makes it safe. In surfaceAndClearDebt the irreversible act is the
+    // clear, so the report goes first. HERE the protective act is the retire, so
+    // it goes first — an earlier draft reported the debt (through a logger, which
+    // can fail) before marking anything retired, and a logger failure left the
+    // fence half-built. The caller has already reset the old agent by then, so
+    // the replacement's ready-flush would push the still-unretired answer and an
+    // identical re-ask could recover it.
+    //
+    // PASS 1 is pure state: no logging, no callbacks, nothing that can throw. By
+    // the end of it every answer on this tab is fenced.
     this.tabEpoch.set(key, (this.tabEpoch.get(key) ?? 0) + 1);
-    // The eviction DEBT is owed to the conversation being replaced, and scoping it
-    // by (tab, incarnation) cannot fence this axis — New chat happens on the same
-    // tab, same incarnation. Left alone, the replacement conversation's next ask
-    // would report the old conversation's warning as its own and settle it with
-    // its own ack. Surfaced and retired, exactly as a tab-gone does: reported,
-    // then cleared, never silently dropped.
-    this.surfaceAndClearDebt(key, this.incarnationOf?.(key), "its conversation was replaced");
+    const queued: AskEntry[] = [];
     for (const entry of this.entries.values()) {
       if (entry.key !== key) continue;
       if (entry.correlation.status === "matched") {
@@ -1489,29 +1505,48 @@ export class AskAnswerJournalImpl {
       // which is still delivered to the replacement conversation downgraded. A
       // completion's payload is independently useful — the images are on the
       // user's canvas either way. An answer to a question the replacement
-      // conversation never asked is useful to nobody: pushing it injects an
-      // unsolicited turn about a decision the new conversation has no context
-      // for, which is a cross-conversation confusion with no upside.
+      // conversation never asked is useful to nobody.
       //
       // NOT a silent discard: the entry stays journaled (so a later ask on this
-      // tab that times out still reports it, quoted with its own question) and
-      // the loss of the push is logged here.
-      // PENDING is easy — it has not been queued anywhere yet. HANDED_OFF has
-      // already been materialised into the agent's queue with wording that claims
-      // the reader put the card up, so it must be pulled back; only once the
-      // carrying turn has STARTED is the text beyond recall.
-      const stale = entry.delivery;
-      if (stale === "pending" || (stale === "handed_off" && this.revoke?.(entry.key, entry.token))) {
-        entry.delivery = "none";
+      // tab that times out still reports its EXISTENCE) and the loss of the push
+      // is logged in pass 2.
+      if (entry.delivery === "pending") entry.delivery = "none";
+      else if (entry.delivery === "handed_off") queued.push(entry);
+    }
+    // PASS 2 is fallible: pulling a queued copy back off an agent, and saying what
+    // happened. Each is isolated, so one failure cannot skip the rest — and none
+    // of it can undo pass 1, which has already made every answer here unusable.
+    for (const entry of queued) {
+      let recalled = false;
+      try {
+        // HANDED_OFF has already been materialised into the agent's queue with
+        // wording that claims the reader put the card up, so it must be pulled
+        // back; only once the carrying turn has STARTED is the text beyond
+        // recall.
+        recalled = this.revoke?.(entry.key, entry.token) === true;
+      } catch (err) {
         logger.warn(
-          `[ask-answers] the conversation that asked "${preview(entry.question)}" on tab ${key.slice(0, 8)} was replaced — the user's answer ("${entry.answer}") will NOT be announced to the replacement conversation; it is kept only for disclosure`,
-        );
-      } else if (stale === "handed_off") {
-        logger.warn(
-          `[ask-answers] tab ${key.slice(0, 8)}: the user's answer to "${preview(entry.question)}" was already being read when the conversation was replaced — it could not be recalled`,
+          `[ask-answers] could not recall a queued answer on tab ${key.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
+      if (recalled) entry.delivery = "none";
+      try {
+        logger.warn(
+          recalled
+            ? `[ask-answers] the conversation that asked "${preview(entry.question)}" on tab ${key.slice(0, 8)} was replaced — the user's answer ("${entry.answer}") will NOT be announced to the replacement conversation; it is kept only for disclosure`
+            : `[ask-answers] tab ${key.slice(0, 8)}: the user's answer to "${preview(entry.question)}" was already being read when the conversation was replaced — it could not be recalled`,
+        );
+      } catch {
+        // The fence is already up; a log sink that is down cannot undo it.
+      }
     }
+    // PASS 3, last because it is the one that DESTROYS. The eviction debt is owed
+    // to the conversation being replaced, and scoping it by (tab, incarnation)
+    // cannot fence this axis — New chat happens on the same tab, same
+    // incarnation. Left alone, the replacement conversation's next ask would
+    // report the old conversation's warning as its own and settle it with its own
+    // ack. Surfaced and retired, exactly as a tab-gone does.
+    this.surfaceAndClearDebt(key, this.incarnationOf?.(key), "its conversation was replaced");
   }
 
   /** Test/diagnostic helpers. */

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -97,6 +97,20 @@ export interface AskTicket {
    * left to hand it to) and therefore worth pushing to the agent on its own.
    */
   awaiting: boolean;
+  /**
+   * This ask id was opened MORE THAN ONCE, so it no longer identifies a single
+   * question.
+   *
+   * Nothing on the wire distinguishes the first card's reply from the second's —
+   * the panel sends only the id — so once an id is reused, ANY answer for it is
+   * genuinely unattributable. It is therefore correlated as `foreign`
+   * (UNDETERMINED) rather than confidently matched: without this, the first
+   * card's late click would be frozen with the SECOND question's fingerprint and
+   * could then be recovered as the answer to a question it was never shown for.
+   * (`panel_ask` mints a fresh UUID per card, so this is defence in depth — but
+   * it is the difference between "unreachable" and "impossible".)
+   */
+  reused?: boolean;
 }
 
 /** Where an entry is in the PUSH pipeline (the durable agent-event delivery used
@@ -149,17 +163,33 @@ export interface AskEntry {
 
 /** Cards tracked at once. Generous: real sessions have one or two. */
 const MAX_TICKETS = 64;
-/** Ask ids remembered as "ours" (see AskAnswerJournalImpl.retired). Deliberately
- *  far larger than MAX_TICKETS so the memory always outlives the ticket. */
-const MAX_REMEMBERED_ASK_IDS = 1024;
+/** Ask ids whose CONVERSATION was replaced, remembered so a late click on the
+ *  old card is not announced to the replacement one. Bounded — and safely so:
+ *  forgetting one only means the answer is treated as an ordinary unattributable
+ *  answer (journaled, labelled), never that it is dropped. */
+const MAX_CONVERSATION_GONE_IDS = 1024;
+
+/**
+ * Prefix every `panel_ask` card's ask id carries.
+ *
+ * The bridge's late-answer sink is fed by EVERY `ask_user` card — the confirm
+ * gate, the 18+ consent card, the secret prompt — and only `panel_ask` answers
+ * belong in this journal. Ownership therefore has to be decidable from the id
+ * ITSELF: an earlier draft answered it from a bounded set of remembered ids,
+ * which meant an eviction turned a validated answer into nothing. A bounded
+ * store must never be what protects against loss, so the test is syntactic and
+ * cannot expire, evict, or be raced.
+ */
+export const PANEL_ASK_ID_PREFIX = "pa-";
 /**
  * How long a ticket is kept. The bridge only forwards a LATE answer for a card
- * whose rid→ask_id mapping is still alive, and that mapping is TTL-pruned at 5
- * minutes (UiBridge.LATE_ASK_TTL_MS) — so a ticket older than this can no longer
- * receive one and pruning it is provably lossless rather than a bound we are
- * hoping never bites.
+ * whose rid→ask_id mapping is still alive, so this must OUTLIVE that mapping's
+ * own TTL (UiBridge.LATE_ASK_MAP_TTL_MS, 60 minutes) or a ticket could be gone
+ * while an answer for it can still arrive. Sized above it, so pruning here is
+ * provably lossless rather than a bound we are hoping never bites — and losing
+ * one anyway only weakens a correlation to UNDETERMINED, never drops an answer.
  */
-const TICKET_MAX_AGE_MS = 7 * 60_000;
+const TICKET_MAX_AGE_MS = 65 * 60_000;
 /** Undelivered/unconsumed answers held per panel tab. */
 const MAX_ENTRIES_PER_KEY = 16;
 /** …and across all tabs. */
@@ -281,7 +311,6 @@ export class AskAnswerJournalImpl {
    * ticket may only ever WEAKEN a correlation (matched → foreign, i.e.
    * UNDETERMINED); it must never turn an answer into nothing.
    */
-  private retired = new Set<string>();
   /**
    * Ask ids whose CONVERSATION was replaced (New chat / resume of a historical
    * session) while their card was still on screen.
@@ -324,17 +353,25 @@ export class AskAnswerJournalImpl {
    */
   openAsk(askId: string, meta: { tabId: string; fingerprint: string; question: string }): void {
     this.pruneTickets();
-    this.remember(askId);
     const existing = this.tickets.get(askId);
     if (existing) {
-      // The same ask id dispatched again (a retry). Reopen rather than stack a
-      // second ticket, so one ask id always means one question.
+      // The same ask id dispatched AGAIN. Reopen rather than stack a second
+      // ticket (one ask id always means one ticket) — but the id now stands for
+      // MORE THAN ONE question, and the panel's reply carries only the id, so
+      // nothing can ever say which card an answer for it came from. Mark it
+      // reused: every answer for it is reported UNDETERMINED from here on, and
+      // in particular the older card's late click can no longer be frozen with
+      // the newer question's fingerprint and recovered as its answer.
       existing.tabId = meta.tabId;
       existing.fingerprint = meta.fingerprint;
       existing.question = meta.question;
       existing.openedAt = Date.now();
       existing.seq = ++this.ticketSeq;
       existing.awaiting = true;
+      existing.reused = true;
+      logger.warn(
+        `[ask-answers] ask id ${askId.slice(0, 12)} was opened again — it no longer identifies one question, so every answer for it is reported as UNDETERMINED`,
+      );
       return;
     }
     this.tickets.set(askId, {
@@ -356,7 +393,7 @@ export class AskAnswerJournalImpl {
    *  (a recovered "Yes, go ahead" must never authorise a different destructive
    *  operation). */
   tracks(askId: string): boolean {
-    return this.tickets.has(askId) || this.retired.has(askId);
+    return askId.startsWith(PANEL_ASK_ID_PREFIX);
   }
 
   /**
@@ -400,7 +437,11 @@ export class AskAnswerJournalImpl {
     const existing = [...this.entries.values()].find((e) => e.askId === askId);
     if (existing) return existing;
     const ticket = this.tickets.get(askId);
-    const correlation: AskCorrelation = ticket
+    // A REUSED id proves nothing: the panel sends only the id, so an answer for
+    // it could belong to either card. Report it as foreign — real, but
+    // UNDETERMINED — rather than claiming it answers the question now open.
+    const attributable = ticket !== undefined && ticket.reused !== true;
+    const correlation: AskCorrelation = attributable
       ? { status: "matched", askId }
       : { status: "foreign", askId };
     const entry: AskEntry = {
@@ -411,7 +452,10 @@ export class AskAnswerJournalImpl {
       // from, so an unattributable answer is still addressed somewhere real
       // instead of being dropped for want of a key.
       key: ticket?.tabId ?? meta.tabId,
-      fingerprint: ticket?.fingerprint ?? null,
+      // The fingerprint is the LICENCE to satisfy a re-ask, so a reused id gets
+      // none — its answer may only ever be reported, never returned as an answer.
+      // The question TEXT is still carried: it is what makes that report honest.
+      fingerprint: attributable ? ticket.fingerprint : null,
       question: ticket?.question ?? null,
       answer: answerText(reply),
       answeredAt: Date.now(),
@@ -432,9 +476,9 @@ export class AskAnswerJournalImpl {
       logger.warn(
         `[ask-answers] an answer arrived for a card whose conversation was replaced (ask ${askId.slice(0, 8)}, tab ${entry.key.slice(0, 8)}): "${entry.answer}" — journaled for disclosure, NOT announced to the replacement conversation`,
       );
-    } else if (!ticket) {
+    } else if (!attributable) {
       logger.warn(
-        `[ask-answers] a validated answer arrived for ask ${askId.slice(0, 8)} with no open ticket — journaled as UNATTRIBUTED; it can never satisfy a question, only be reported`,
+        `[ask-answers] a validated answer arrived for ask ${askId.slice(0, 8)} with ${ticket ? "a REUSED (ambiguous) ticket" : "no open ticket"} — journaled as UNATTRIBUTED; it can never satisfy a question, only be reported`,
       );
     }
     this.trimEntries(entry.key);
@@ -654,13 +698,48 @@ export class AskAnswerJournalImpl {
    *  self-restart gate reads this: the journal is in-memory, so restarting while
    *  one is outstanding silently drops an answer the user actually gave. */
   hasOutstanding(): boolean {
-    return [...this.entries.values()].some((e) => e.delivery !== "none");
+    // The eviction DEBT counts too. It is a promise to tell the agent that an
+    // answer was lost, and it is destroyed by a teardown exactly as an entry is —
+    // tearing down while one is owed turns a disclosed loss back into a silent
+    // one, which is the whole thing this journal exists to prevent.
+    if (this.dropped.size > 0) return true;
+    return [...this.entries.values()].some(
+      (e) => e.delivery !== "none" || (e.disclose ?? 0) > 0,
+    );
   }
 
-  /** Every answer still awaiting a push, across all tabs — for the last-ditch
-   *  disclosure the orchestrator makes when a fatal exit destroys them. */
+  /**
+   * Everything the last-ditch, we-are-about-to-die disclosure must name.
+   *
+   * Broader than `hasOutstanding` on purpose. A restart is a CHOICE we can defer,
+   * so it waits only on what is still deliverable; a fatal exit is not, so it
+   * reports everything a validated answer might still have been needed for:
+   *  • answers awaiting a push (nobody has them);
+   *  • answers that went into a ToolResult RECENTLY — "returned" is a hand-off,
+   *    not a receipt (that IS #486), and inside the recovery window a re-ask was
+   *    still able to produce it. Deferring restarts on these would stall the
+   *    self-restarter after every single ask; SAYING so on the way out costs
+   *    nothing and keeps the loss from being silent.
+   */
   allOutstanding(): AskEntry[] {
-    return [...this.entries.values()].filter((e) => e.delivery !== "none");
+    const now = Date.now();
+    return [...this.entries.values()].filter(
+      (e) =>
+        e.delivery !== "none" ||
+        (e.disclose ?? 0) > 0 ||
+        now - e.answeredAt <= RECOVER_MAX_AGE_MS,
+    );
+  }
+
+  /** Tabs still owed an eviction disclosure, with the count — so a fatal exit can
+   *  name a loss whose carrier is only a counter. */
+  outstandingDebt(): Array<{ key: string; count: number }> {
+    const byTab = new Map<string, number>();
+    for (const [key, n] of this.dropped) byTab.set(key, (byTab.get(key) ?? 0) + n);
+    for (const e of this.entries.values()) {
+      if ((e.disclose ?? 0) > 0) byTab.set(e.key, (byTab.get(e.key) ?? 0) + e.disclose!);
+    }
+    return [...byTab].map(([key, count]) => ({ key, count }));
   }
 
   /** Move every entry AND every open ticket from `from` onto `to` — a panel
@@ -687,11 +766,13 @@ export class AskAnswerJournalImpl {
     for (const [token, entry] of [...this.entries]) {
       if (entry.key !== key) continue;
       this.entries.delete(token);
-      if (!entry.returned) {
-        logger.warn(
-          `[ask-answers] dropping a validated answer to "${preview(entry.question)}" — its tab (${key.slice(0, 8)}) is gone`,
-        );
-      }
+      // EVERY answer is logged, returned ones included: "it went into a
+      // ToolResult" is not proof it was received, so a returned answer inside
+      // the recovery window is still the only copy of a decision that may never
+      // have reached the model.
+      logger.warn(
+        `[ask-answers] dropping a validated answer ("${entry.answer}") to "${preview(entry.question)}" — its tab (${key.slice(0, 8)}) is gone${entry.returned ? " (it had been handed to a tool result, which is not proof it was received)" : ""}`,
+      );
     }
     for (const [id, ticket] of [...this.tickets]) {
       if (ticket.tabId !== key) continue;
@@ -732,7 +813,7 @@ export class AskAnswerJournalImpl {
       // unattributable answer and announcing it to the replacement agent.
       this.conversationGone.add(id);
     }
-    while (this.conversationGone.size > MAX_REMEMBERED_ASK_IDS) {
+    while (this.conversationGone.size > MAX_CONVERSATION_GONE_IDS) {
       const oldest = this.conversationGone.values().next().value;
       if (oldest === undefined) break;
       this.conversationGone.delete(oldest);
@@ -779,24 +860,11 @@ export class AskAnswerJournalImpl {
     // NOTE: the flusher is deliberately NOT cleared — it belongs to the process's
     // orchestrator, not to any one test's fixture.
     this.tickets.clear();
-    this.retired.clear();
     this.conversationGone.clear();
     this.entries.clear();
     this.dropped.clear();
     this.seq = 0;
     this.ticketSeq = 0;
-  }
-
-  /** Remember an ask id forever-ish (bounded FIFO) so `tracks()` never denies
-   *  one of ours just because its ticket was trimmed. Far larger than
-   *  MAX_TICKETS so it always outlives the ticket it mirrors. */
-  private remember(askId: string): void {
-    this.retired.add(askId);
-    while (this.retired.size > MAX_REMEMBERED_ASK_IDS) {
-      const oldest = this.retired.values().next().value;
-      if (oldest === undefined) break;
-      this.retired.delete(oldest);
-    }
   }
 
   /** Tickets whose card can no longer receive an answer (see TICKET_MAX_AGE_MS)
@@ -875,8 +943,14 @@ export class AskAnswerJournalImpl {
         this.entries.delete(victim.token);
         mine = mine.filter((e) => e !== victim);
         if (victim.returned) {
+          // Logged, not counted as a loss for the agent: it DID reach a caller,
+          // and counting every ordinary successful ask as an undetermined
+          // dropped answer would cry wolf on every tab that asks a lot — the
+          // warning would stop meaning anything, which is its own kind of
+          // silence. The record is here, with the answer text, so a real loss is
+          // still reconstructable.
           logger.warn(
-            `[ask-answers] ${label} — forgetting an already-returned answer to "${preview(victim.question)}" (a re-ask can no longer recover it)`,
+            `[ask-answers] ${label} — forgetting an already-returned answer ("${victim.answer}") to "${preview(victim.question)}"; a re-ask can no longer recover it, and a tool result is not proof it was received`,
           );
           continue;
         }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2145,6 +2145,12 @@ export async function runPanelOrchestrator(): Promise<void> {
   // warning is owed), so it needs a LIFECYCLE end instead: a tab leaving the
   // bridge's connection map surfaces whatever it is still owed and retires it.
   // Journal entries survive — a disconnect is usually a reload.
+  // #486 — a DIFFERENT browser tab taking over a recurring `wf:<hash>` key is a
+  // CONVERSATION BOUNDARY, exactly like New chat or a provider switch: the
+  // newcomer never asked the previous occupant's questions, so its answers must
+  // stop being recoverable and stop being pushed. closeAsks downgrades and
+  // unsends; it never deletes, so those answers are still reported.
+  bridge.setTabTakenOverListener((tabId) => AskAnswers.closeAsks(tabId));
   bridge.setTabGoneListener((tabId, incarnation) => AskAnswers.retireDebt(tabId, incarnation));
   bridge.setLateAskReplySink((askId, result, tabId) => {
     if (!AskAnswers.tracks(askId)) return;

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2062,8 +2062,8 @@ export async function runPanelOrchestrator(): Promise<void> {
     // #468 — run-completion journal acks. `key` is the composite agent key; the
     // journal is keyed by the PANEL TAB, so a provider switch (which retires
     // `tab::old` and spawns `tab::new`) can never strand a completion.
-    onEventDelivered: (_key, tokens) => {
-      for (const token of tokens) ackEventToken(token);
+    onEventDelivered: (_key, tokens, from) => {
+      for (const token of tokens) ackEventToken(token, from);
     },
     onEventUndelivered: (key, tokens, opts) => {
       for (const token of tokens) releaseEventToken(token, opts?.carried === true);
@@ -2136,6 +2136,11 @@ export async function runPanelOrchestrator(): Promise<void> {
   AskAnswers.setTurnAttacher((panelTabId, token) =>
     manager.attachTurnToken(agentKeyFor(panelTabId), token),
   );
+  // #486 — the debt map has no ceiling (a bounded store must not decide whether a
+  // warning is owed), so it needs a LIFECYCLE end instead: a tab leaving the
+  // bridge's connection map surfaces whatever it is still owed and retires it.
+  // Journal entries survive — a disconnect is usually a reload.
+  bridge.setTabGoneListener((tabId) => AskAnswers.retireDebt(tabId));
   bridge.setLateAskReplySink((askId, result, tabId) => {
     if (!AskAnswers.tracks(askId)) return;
     const entry = AskAnswers.record(askId, result, { tabId });
@@ -2335,8 +2340,11 @@ export async function runPanelOrchestrator(): Promise<void> {
    * both ignore an unknown token — but routing it correctly is what keeps an ack
    * from leaving the real entry outstanding forever.
    */
-  function ackEventToken(token: string): void {
-    if (token.startsWith("aa")) AskAnswers.ack(token);
+  function ackEventToken(token: string, from?: { carrier?: string }): void {
+    // #486 — the ask journal verifies WHICH agent instance is acking, so a
+    // provider switch cannot let the new conversation certify the old one's
+    // answer. Run completions have their own turn-marker gate and need none.
+    if (token.startsWith("aa")) AskAnswers.ack(token, from);
     else RunCompletions.ack(token);
   }
   function releaseEventToken(token: string, carried: boolean): void {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3239,6 +3239,16 @@ export async function runPanelOrchestrator(): Promise<void> {
       // points at the NEW provider, so the completion reaches the conversation
       // the user actually switched to instead of waiting for their next message.
       if (providerSwitched) flushRunCompletions(panelTab);
+      // #486 — a provider switch IS a conversation boundary for QUESTIONS, even
+      // though it is deliberately NOT one for renders. A finished render is
+      // independently useful to whoever is on the tab now (the images are on the
+      // user's canvas either way), which is why #468 re-addresses it here. An
+      // ANSWER is not: the incoming provider's fresh conversation never put that
+      // card up, so announcing it as "a question card YOU put up" — or letting an
+      // identical re-ask recover it — hands one conversation a decision made in
+      // another. Retire the asks instead; closeAsks downgrades and unsends, it
+      // never deletes, so the answer is still reported.
+      AskAnswers.closeAsks(panelTab);
       // A headless client (mobile/remote pseudo-panel, no browser canvas) advertises
       // itself in the hello frame so its agent gets the in-turn-delivery directive.
       if ((event as { headless?: unknown }).headless === true) headlessTabs.add(panelTab);
@@ -3760,6 +3770,16 @@ export async function runPanelOrchestrator(): Promise<void> {
       // new one, so the completion reaches the conversation the user switched to
       // instead of sitting journaled until their next message.
       if (prev !== reqBackend) flushRunCompletions(panelTab);
+      // #486 — a provider switch IS a conversation boundary for QUESTIONS, even
+      // though it is deliberately NOT one for renders. A finished render is
+      // independently useful to whoever is on the tab now (the images are on the
+      // user's canvas either way), which is why #468 re-addresses it here. An
+      // ANSWER is not: the incoming provider's fresh conversation never put that
+      // card up, so announcing it as "a question card YOU put up" — or letting an
+      // identical re-ask recover it — hands one conversation a decision made in
+      // another. Retire the asks instead; closeAsks downgrades and unsends, it
+      // never deletes, so the answer is still reported.
+      AskAnswers.closeAsks(panelTab);
       // Leaving a LOCAL provider frees its VRAM (no other tab still on it) —
       // the point of switching to Claude/hosted is usually reclaiming the GPU.
       if (prev !== reqBackend) {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -117,6 +117,7 @@ import {
   describe as describeCorrelation,
   type CompletionPayload,
 } from "./run-completion-journal.js";
+import { AskAnswers, preview as previewQuestion } from "./ask-answer-journal.js";
 import { initRunpodWatcher, getRunpodWatcher, type RunpodStatusFrame, type RunpodAlertFrame } from "../services/runpod-watch.js";
 import { getPod } from "../services/runpod-client.js";
 import { listTargetChangeRequests, consumeTargetChange, ackTargetChange, setProgressDir, CONTROL_PREFIX, newestAttemptEpochs, isSupersededAttempt, downloadAttemptKey } from "../services/download-progress.js";
@@ -2062,13 +2063,13 @@ export async function runPanelOrchestrator(): Promise<void> {
     // journal is keyed by the PANEL TAB, so a provider switch (which retires
     // `tab::old` and spawns `tab::new`) can never strand a completion.
     onEventDelivered: (_key, tokens) => {
-      for (const token of tokens) RunCompletions.ack(token);
+      for (const token of tokens) ackEventToken(token);
     },
     onEventUndelivered: (key, tokens, opts) => {
-      for (const token of tokens) RunCompletions.release(token, { carried: opts?.carried === true });
+      for (const token of tokens) releaseEventToken(token, opts?.carried === true);
       const panelTab = panelTabOf(key);
       logger.warn(
-        `[panel-orchestrator] tab ${panelTab.slice(0, 8)} handed back ${tokens.length} undelivered run completion(s) — journaled for replay (#468)`,
+        `[panel-orchestrator] tab ${panelTab.slice(0, 8)} handed back ${tokens.length} undelivered event(s) — journaled for replay (#468/#486)`,
       );
       // Try again immediately. When the agent is still alive (a stall-abandoned
       // turn, a plain Stop) this re-queues the completion into its next turn;
@@ -2076,11 +2077,13 @@ export async function runPanelOrchestrator(): Promise<void> {
       // pending for the next spawn. The refusal path returns false WITHOUT
       // calling back here, so this cannot recurse.
       flushRunCompletions(panelTab);
+      flushAskAnswers(panelTab);
     },
     // A fresh agent for this key can take mail now — replay whatever the
     // previous one never delivered.
     onAgentReady: (key) => {
       flushRunCompletions(panelTabOf(key));
+      flushAskAnswers(panelTabOf(key));
     },
     sessionStore,
     // #570 P0 — bind each persisted exact session to its tab's FULL trusted workflow
@@ -2106,6 +2109,26 @@ export async function runPanelOrchestrator(): Promise<void> {
     (panelTabId, token) => manager.revokeEvent(agentKeyFor(panelTabId), token),
     (panelTabId) => flushRunCompletions(panelTabId),
   );
+
+  // #486 — capture a VALIDATED ask answer the moment it lands, even when no tool
+  // call is left to receive it. This is the whole durability hinge: the bridge's
+  // late-reply buffer is only reachable by a caller still polling it, and the
+  // failure being fixed is precisely the one where there is none. Only answers to
+  // cards THIS journal ticketed are taken — confirm / 18+ consent / secret cards
+  // keep their own, deliberately NON-recoverable paths, because a recovered "Yes,
+  // go ahead" must never be able to authorise a different destructive operation.
+  // The journal itself decides WHEN an answer has become an orphan (the moment it
+  // lands with no handler waiting, or the moment the asking handler unwinds
+  // without having returned it) and drives the push from there, so no caller has
+  // to remember to flush.
+  AskAnswers.setFlusher((panelTabId) => flushAskAnswers(panelTabId));
+  bridge.setLateAskReplySink((askId, result, tabId) => {
+    if (!AskAnswers.tracks(askId)) return;
+    const entry = AskAnswers.record(askId, result, { tabId });
+    logger.info(
+      `[panel-orchestrator] tab ${entry.key.slice(0, 8)} — a validated ask answer landed for "${previewQuestion(entry.question)}"; journaled so it survives the tool call that asked (#486)`,
+    );
+  });
 
   /**
    * Deliver every journaled run completion for a panel tab (#468).
@@ -2140,6 +2163,15 @@ export async function runPanelOrchestrator(): Promise<void> {
         list.push(describeCorrelation(entry.correlation));
         byTab.set(entry.key, list);
       }
+      // #486 — an ask answer the user actually gave that never reached the agent
+      // dies with this process exactly as a completion does, and is at least as
+      // costly to lose. Report it in the same breath, naming the question so the
+      // record is actionable rather than a bare count.
+      for (const entry of AskAnswers.allOutstanding()) {
+        const list = byTab.get(entry.key) ?? [];
+        list.push(`the user's answer to "${previewQuestion(entry.question)}"`);
+        byTab.set(entry.key, list);
+      }
     } catch {
       return; // nothing readable — nothing to report
     }
@@ -2163,7 +2195,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     const record = [...byTab]
       .map(
         ([panelTab, runs]) =>
-          `[panel-orchestrator] tab ${panelTab.slice(0, 8)} — exiting with ${runs.length} undelivered run completion(s), outcome UNDETERMINED: ${runs.join("; ")}`,
+          `[panel-orchestrator] tab ${panelTab.slice(0, 8)} — exiting with ${runs.length} undelivered render result(s)/user answer(s), outcome UNDETERMINED: ${runs.join("; ")}`,
       )
       .join("\n");
     // A FILE is the ONLY synchronous sink. A sync write to a PIPE can block
@@ -2195,8 +2227,8 @@ export async function runPanelOrchestrator(): Promise<void> {
           {
             type: "say",
             text:
-              `⚠️ The agent backend is being restarted, and ${runs.length} finished render result(s) could not be delivered ` +
-              `(${runs.join("; ")}). Their outcome is UNDETERMINED from the agent's point of view — ask it to check ` +
+              `⚠️ The agent backend is being restarted, and ${runs.length} finished render result(s) / answered question card(s) could not be delivered ` +
+              `(${runs.join("; ")}). Their outcome/content is UNDETERMINED from the agent's point of view — ask it to check ` +
               `\`get_history\` for those runs once it reconnects rather than assuming it saw them.`,
           },
           panelTab,
@@ -2219,6 +2251,50 @@ export async function runPanelOrchestrator(): Promise<void> {
         `[panel-orchestrator] tab ${panelTabId.slice(0, 8)} has no live agent for ${describeCorrelation(blockedOn.correlation)} — journaled, replayed when one comes back (#468)`,
       );
     }
+  }
+
+  /**
+   * Deliver every ORPHANED `panel_ask` answer for a panel tab (#486).
+   *
+   * An orphan is an answer the user genuinely gave that NO tool call was alive to
+   * receive — the `tools/call` that asked had already timed out or been
+   * abandoned. Its only remaining channel is the agent's event queue, so it goes
+   * through the same durable path a run completion does: correlated once at
+   * arrival, replayed at every later delivery opportunity, and cleared only when
+   * the turn that carried it ended.
+   *
+   * Answers that DID reach a tool result are never pushed here — that would
+   * double-report every ordinary ask. They stay journaled only so a re-ask of the
+   * identical question can recover one whose caller turned out to be dead.
+   */
+  function flushAskAnswers(panelTabId: string): void {
+    const key = agentKeyFor(panelTabId);
+    const { blockedOn } = AskAnswers.deliverPending(panelTabId, (payload, token) =>
+      manager.injectEvent(key, payload, { eventToken: token }),
+    );
+    if (blockedOn) {
+      logger.warn(
+        `[panel-orchestrator] tab ${panelTabId.slice(0, 8)} has no live agent for the user's answer to "${previewQuestion(blockedOn.question)}" — journaled, replayed when one comes back (#486)`,
+      );
+    }
+  }
+
+  /**
+   * Route an event token back to the journal that minted it.
+   *
+   * Two journals now share the agent's one event-token channel (#468 run
+   * completions, #486 ask answers), so the prefix is the discriminator: `rc…`
+   * and `aa…` respectively. A token from either is safe to hand to the other —
+   * both ignore an unknown token — but routing it correctly is what keeps an ack
+   * from leaving the real entry outstanding forever.
+   */
+  function ackEventToken(token: string): void {
+    if (token.startsWith("aa")) AskAnswers.ack(token);
+    else RunCompletions.ack(token);
+  }
+  function releaseEventToken(token: string, carried: boolean): void {
+    if (token.startsWith("aa")) AskAnswers.release(token, { carried });
+    else RunCompletions.release(token, { carried });
   }
 
   // Flag the mobile mirror picker's "session attached" (green) dot from live agents.
@@ -2881,6 +2957,11 @@ export async function runPanelOrchestrator(): Promise<void> {
           // exactly the misattribution the journal exists to prevent. Drop them
           // (logged per entry) rather than migrate them.
           RunCompletions.forget(migratedFrom);
+          // #486 — same reasoning for the user's ANSWERS: an answer given to a
+          // question the OLD workflow's agent asked must never be recoverable by,
+          // or pushed at, the new workflow's conversation. forget() logs every
+          // undelivered one, so the loss is disclosed rather than silent.
+          AskAnswers.forget(migratedFrom);
           manager.retire(migratedFrom + AGENT_KEY_SEP + prevBackend);
           logger.info(
             `[panel-orchestrator] same-socket re-hello ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} without proven workflow continuity — old agent retired (NOT rebound); each workflow keeps its own conversation`,
@@ -2954,7 +3035,10 @@ export async function runPanelOrchestrator(): Promise<void> {
           // PURGE, never inherit: the destination's completions belong to the tab
           // being superseded, and there is no agent left to deliver them to.
           // forget() logs each one, so the loss is disclosed, not silent.
-          if (destinationHadState) RunCompletions.forget(panelTab);
+          if (destinationHadState) {
+            RunCompletions.forget(panelTab);
+            AskAnswers.forget(panelTab); // #486 — same purge for the superseded tab's answers
+          }
           for (const b of KNOWN_BACKENDS) {
             const srcKey = migratedFrom + AGENT_KEY_SEP + b;
             const newKey = panelTab + AGENT_KEY_SEP + b;
@@ -3008,10 +3092,12 @@ export async function runPanelOrchestrator(): Promise<void> {
           // above (before anything could hand tokens back); now re-address the
           // INCOMING tab's own completions + run tickets onto the new id.
           RunCompletions.moveKey(migratedFrom, panelTab);
+          AskAnswers.moveKey(migratedFrom, panelTab);
           // rebindAgent MOVES the agent rather than spawning one, so onAgentReady
           // never fires for the new id — flush explicitly or the re-addressed
           // entries would sit pending until some unrelated later trigger.
           flushRunCompletions(panelTab);
+          flushAskAnswers(panelTab);
           // #570 — carry the PROVEN source identity forward as the tab's prior identity. The
           // rebound agent belongs to it (prevIdentity === newIdentity by sameWorkflow), but the
           // new tab id has no prior identity and the agent may have no durable record yet
@@ -4251,6 +4337,11 @@ export async function runPanelOrchestrator(): Promise<void> {
       // than as "the run YOU queued". Already-arrived completions keep the
       // verdict frozen at their arrival and are still delivered.
       RunCompletions.closeRuns(tabId);
+      // #486 — and the questions it asked. The user's answers stay journaled and
+      // are still reported, but they lose the fingerprint that let them satisfy a
+      // re-ask: an answer given to the previous conversation must never come back
+      // to the replacement one as "the answer to the question YOU just asked".
+      AskAnswers.closeAsks(tabId);
       // reset() clears the exact-tab store; the stable resume index (#570) is the
       // manager's blind spot, so drop it here too — a deliberate NEW chat must not
       // be resurrected by the unsaved-workflow fallback on the next reload.
@@ -4299,6 +4390,11 @@ export async function runPanelOrchestrator(): Promise<void> {
       // runs, so a completion landing after the switch is UNDETERMINED, not the
       // historical session's own render.
       RunCompletions.closeRuns(tabId);
+      // #486 — and the questions it asked. The user's answers stay journaled and
+      // are still reported, but they lose the fingerprint that let them satisfy a
+      // re-ask: an answer given to the previous conversation must never come back
+      // to the replacement one as "the answer to the question YOU just asked".
+      AskAnswers.closeAsks(tabId);
       if (sid) manager.setResume(key, sid);
       bridge.push({ type: "ack", ok: true, kind: "resume_session" }, tabId);
       bridge.broadcastTabList(); // live agent dropped → refresh mirror pickers
@@ -5360,6 +5456,9 @@ export async function runPanelOrchestrator(): Promise<void> {
       // would silently drop the render result the agent was promised — exactly
       // the failure this whole path exists to prevent. Wait for it to land.
       !RunCompletions.hasOutstanding() &&
+      // …and the same for an ask answer the user actually gave that has not
+      // reached the agent yet (#486). Restarting would destroy it silently.
+      !AskAnswers.hasOutstanding() &&
       !QueueMonitor.isBusy(),
     announce: (text) => void bridge.push({ type: "say", text }),
     teardown: teardownCore,

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3323,6 +3323,14 @@ export async function runPanelOrchestrator(): Promise<void> {
           // kept: a completion that already arrived is still real news and is
           // still delivered — just no longer as this conversation's own.
           RunCompletions.closeRuns(panelTab);
+          // #486 — and the QUESTIONS it asked, for the same reason but with a
+          // sharper failure: a card the replaced workflow's agent put up can
+          // still be clicked, and without this its answer stays `matched` and
+          // gets announced to whoever holds the tab now as "a question card YOU
+          // put up" — or recovered as the answer to a byte-identical question the
+          // new workflow asks. Retiring the epoch keeps the answer (it is still
+          // reported) while revoking its right to answer for anyone else.
+          AskAnswers.closeAsks(panelTab);
         }
       }
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2193,9 +2193,20 @@ export async function runPanelOrchestrator(): Promise<void> {
     // the user can do is give it again. Telling someone to check `get_history`
     // for a lost answer names a lever that cannot work, in the one moment they
     // are already dealing with a failure.
-    const byTab = new Map<string, { runs: string[]; answers: string[] }>();
-    const slot = (key: string): { runs: string[]; answers: string[] } => {
-      const cur = byTab.get(key) ?? { runs: [], answers: [] };
+    // Three buckets per tab, because the DURABLE RECORD and the CHAT NOTICE are
+    // not the same audience. The log is the record of last resort and gets
+    // everything, including answers that belong to a conversation that has since
+    // been replaced. The notice goes to whoever holds the tab NOW, so a retired
+    // conversation's pick may only be COUNTED there — rendering it would make the
+    // exit path the last outlet that carries content across a boundary.
+    const byTab = new Map<
+      string,
+      { runs: string[]; answers: string[]; sealed: string[]; withheld: number }
+    >();
+    const slot = (
+      key: string,
+    ): { runs: string[]; answers: string[]; sealed: string[]; withheld: number } => {
+      const cur = byTab.get(key) ?? { runs: [], answers: [], sealed: [], withheld: 0 };
       byTab.set(key, cur);
       return cur;
     };
@@ -2209,9 +2220,14 @@ export async function runPanelOrchestrator(): Promise<void> {
       // one copy left anywhere, and quoting it back is what lets the user confirm
       // it rather than be asked from scratch.
       for (const entry of AskAnswers.allOutstanding()) {
-        slot(entry.key).answers.push(
-          `“${entry.answer}” (to “${previewQuestion(entry.question)}”)${entry.returned ? " — it went into a tool call whose receipt was never confirmed" : ""}`,
-        );
+        const line = `“${entry.answer}” (to “${previewQuestion(entry.question)}”)${entry.returned ? " — it went into a tool call whose receipt was never confirmed" : ""}`;
+        const bucket = slot(entry.key);
+        // The log always gets the text…
+        bucket.sealed.push(line);
+        // …the notice only when this tab's current holder is the one it was given
+        // to. Otherwise it is counted, and the text survives only in the log.
+        if (AskAnswers.mayDisclose(entry)) bucket.answers.push(line);
+        else bucket.withheld += 1;
       }
       // …and the answers whose only surviving record is a COUNTER, because the
       // journal's bound already destroyed the text. Naming the count is the last
@@ -2241,14 +2257,14 @@ export async function runPanelOrchestrator(): Promise<void> {
     // environment, and losing the disclosure would undercut the whole
     // in-memory-journal tradeoff.)
     const record = [...byTab]
-      .map(([panelTab, { runs, answers }]) =>
+      .map(([panelTab, { runs, sealed }]) =>
         [
           `[panel-orchestrator] tab ${panelTab.slice(0, 8)} — exiting with`,
           runs.length
             ? ` ${runs.length} undelivered render result(s), outcome UNDETERMINED: ${runs.join("; ")}.`
             : "",
-          answers.length
-            ? ` ${answers.length} validated user ANSWER(S) that never reached the agent and cannot be looked up anywhere: ${answers.join("; ")}.`
+          sealed.length
+            ? ` ${sealed.length} validated user ANSWER(S) that never reached the agent and cannot be looked up anywhere: ${sealed.join("; ")}.`
             : "",
         ].join(""),
       )
@@ -2277,7 +2293,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       logger.error("[panel-orchestrator] …and no durable sink accepted that record (it may not survive)");
     }
     try {
-      for (const [panelTab, { runs, answers }] of byTab) {
+      for (const [panelTab, { runs, answers, withheld }] of byTab) {
         // Two different losses, two different remedies — never merged.
         const parts: string[] = ["⚠️ The agent backend is being restarted."];
         if (runs.length) {
@@ -2293,6 +2309,16 @@ export async function runPanelOrchestrator(): Promise<void> {
               `An answer is not a render — there is NO history to look it up in, and the agent has no way to ` +
               `recover it once this restart completes. Please tell it your choice again (or paste the text above) ` +
               `when it comes back.`,
+          );
+        }
+        if (withheld > 0) {
+          // Counted, not quoted: these were given to a conversation that has been
+          // replaced (a new chat, a rewind, a provider switch, another tab taking
+          // this workflow). Their text is in the log, not on this screen.
+          parts.push(
+            `${withheld} further answer(s) on this tab belong to an earlier conversation that has ` +
+              `since been replaced; they were never delivered either, but they are not shown here ` +
+              `because they were not given to the conversation you are in now.`,
           );
         }
         bridge.push({ type: "say", text: parts.join(" ") }, panelTab);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2122,6 +2122,12 @@ export async function runPanelOrchestrator(): Promise<void> {
   // without having returned it) and drives the push from there, so no caller has
   // to remember to flush.
   AskAnswers.setFlusher((panelTabId) => flushAskAnswers(panelTabId));
+  // …and let it UNSEND a queued answer whose conversation was replaced before the
+  // agent read it. The wording ("a question card YOU put up") is baked in at
+  // queue time, so without this the fork reads a sentence that is false of it.
+  AskAnswers.setRevoker((panelTabId, token) =>
+    manager.revokeEvent(agentKeyFor(panelTabId), token),
+  );
   bridge.setLateAskReplySink((askId, result, tabId) => {
     if (!AskAnswers.tracks(askId)) return;
     const entry = AskAnswers.record(askId, result, { tabId });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3041,8 +3041,14 @@ export async function runPanelOrchestrator(): Promise<void> {
           // and the next flush would announce the DESTINATION tab's answer to the
           // SOURCE tab's conversation — an answer delivered to a conversation
           // that never asked the question.
+          // The eviction DEBT counts as state too: a destination holding only
+          // "we dropped N of your answers" is not empty — moveKey would carry
+          // that debt under the destination id and the incoming source's agent
+          // would be told the DESTINATION tab's answers were lost.
           const destinationJournaled =
-            RunCompletions.outstanding(panelTab).length + AskAnswers.entriesFor(panelTab).length;
+            RunCompletions.outstanding(panelTab).length +
+            AskAnswers.entriesFor(panelTab).length +
+            AskAnswers.droppedFor(panelTab);
           const destinationHadState = [...KNOWN_BACKENDS].some((b) =>
             destinationHasCollisionState({
               hasManagerState: manager.hasAnyState(panelTab + AGENT_KEY_SEP + b),

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2128,6 +2128,14 @@ export async function runPanelOrchestrator(): Promise<void> {
   AskAnswers.setRevoker((panelTabId, token) =>
     manager.revokeEvent(agentKeyFor(panelTabId), token),
   );
+  // …and let a TOOL-RESULT answer ride the turn its tool call is running inside,
+  // so #468's ack-on-carry settles it. Without this the journal has no proof of
+  // receipt for the ordinary path and must treat every answer as possibly lost;
+  // with it, "the model read this" is a fact and only the genuinely unconfirmed
+  // ones are held open (#486).
+  AskAnswers.setTurnAttacher((panelTabId, token) =>
+    manager.attachTurnToken(agentKeyFor(panelTabId), token),
+  );
   bridge.setLateAskReplySink((askId, result, tabId) => {
     if (!AskAnswers.tracks(askId)) return;
     const entry = AskAnswers.record(askId, result, { tabId });
@@ -2162,32 +2170,39 @@ export async function runPanelOrchestrator(): Promise<void> {
   function reportLostCompletionsOnExit(): void {
     if (lostCompletionsReported) return; // every exit path calls this; report once
     lostCompletionsReported = true;
-    const byTab = new Map<string, string[]>();
+    // RENDERS and ANSWERS are kept APART, all the way to the wording. They are
+    // lost the same way but they are not the same loss, and their remedies are
+    // not interchangeable: a render can be looked up in ComfyUI's history, an
+    // answer NEVER can — it only ever existed in this journal, so the only thing
+    // the user can do is give it again. Telling someone to check `get_history`
+    // for a lost answer names a lever that cannot work, in the one moment they
+    // are already dealing with a failure.
+    const byTab = new Map<string, { runs: string[]; answers: string[] }>();
+    const slot = (key: string): { runs: string[]; answers: string[] } => {
+      const cur = byTab.get(key) ?? { runs: [], answers: [] };
+      byTab.set(key, cur);
+      return cur;
+    };
     try {
       for (const entry of RunCompletions.allOutstanding()) {
-        const list = byTab.get(entry.key) ?? [];
-        list.push(describeCorrelation(entry.correlation));
-        byTab.set(entry.key, list);
+        slot(entry.key).runs.push(describeCorrelation(entry.correlation));
       }
       // #486 — an ask answer the user actually gave that never reached the agent
       // dies with this process exactly as a completion does, and is at least as
-      // costly to lose. Report it in the same breath, naming the question so the
-      // record is actionable rather than a bare count.
+      // costly to lose. Carry the ANSWER TEXT, not just the question: it is the
+      // one copy left anywhere, and quoting it back is what lets the user confirm
+      // it rather than be asked from scratch.
       for (const entry of AskAnswers.allOutstanding()) {
-        const list = byTab.get(entry.key) ?? [];
-        list.push(
-          `the user's answer to "${previewQuestion(entry.question)}"${entry.returned ? " (handed to a tool call whose receipt was never confirmed)" : ""}`,
+        slot(entry.key).answers.push(
+          `“${entry.answer}” (to “${previewQuestion(entry.question)}”)${entry.returned ? " — it went into a tool call whose receipt was never confirmed" : ""}`,
         );
-        byTab.set(entry.key, list);
       }
       // …and the answers whose only surviving record is a COUNTER, because the
       // journal's bound already destroyed the text. Naming the count is the last
       // thing that keeps that promise; without it the eviction path's "the next
       // delivery will report it" quietly becomes never.
       for (const { key, count } of AskAnswers.outstandingDebt()) {
-        const list = byTab.get(key) ?? [];
-        list.push(`${count} further answer(s) already dropped by the journal (content lost)`);
-        byTab.set(key, list);
+        slot(key).answers.push(`${count} further answer(s) whose text is already lost`);
       }
     } catch {
       return; // nothing readable — nothing to report
@@ -2210,9 +2225,16 @@ export async function runPanelOrchestrator(): Promise<void> {
     // environment, and losing the disclosure would undercut the whole
     // in-memory-journal tradeoff.)
     const record = [...byTab]
-      .map(
-        ([panelTab, runs]) =>
-          `[panel-orchestrator] tab ${panelTab.slice(0, 8)} — exiting with ${runs.length} undelivered render result(s)/user answer(s), outcome UNDETERMINED: ${runs.join("; ")}`,
+      .map(([panelTab, { runs, answers }]) =>
+        [
+          `[panel-orchestrator] tab ${panelTab.slice(0, 8)} — exiting with`,
+          runs.length
+            ? ` ${runs.length} undelivered render result(s), outcome UNDETERMINED: ${runs.join("; ")}.`
+            : "",
+          answers.length
+            ? ` ${answers.length} validated user ANSWER(S) that never reached the agent and cannot be looked up anywhere: ${answers.join("; ")}.`
+            : "",
+        ].join(""),
       )
       .join("\n");
     // A FILE is the ONLY synchronous sink. A sync write to a PIPE can block
@@ -2239,17 +2261,25 @@ export async function runPanelOrchestrator(): Promise<void> {
       logger.error("[panel-orchestrator] …and no durable sink accepted that record (it may not survive)");
     }
     try {
-      for (const [panelTab, runs] of byTab) {
-        bridge.push(
-          {
-            type: "say",
-            text:
-              `⚠️ The agent backend is being restarted, and ${runs.length} finished render result(s) / answered question card(s) could not be delivered ` +
-              `(${runs.join("; ")}). Their outcome/content is UNDETERMINED from the agent's point of view — ask it to check ` +
-              `\`get_history\` for those runs once it reconnects rather than assuming it saw them.`,
-          },
-          panelTab,
-        );
+      for (const [panelTab, { runs, answers }] of byTab) {
+        // Two different losses, two different remedies — never merged.
+        const parts: string[] = ["⚠️ The agent backend is being restarted."];
+        if (runs.length) {
+          parts.push(
+            `${runs.length} finished render result(s) could not be delivered (${runs.join("; ")}). ` +
+              `Their outcome is UNDETERMINED from the agent's point of view — ask it to check \`get_history\` ` +
+              `for those runs once it reconnects rather than assuming it saw them.`,
+          );
+        }
+        if (answers.length) {
+          parts.push(
+            `${answers.length} answer(s) you gave on a question card never reached the agent: ${answers.join("; ")}. ` +
+              `An answer is not a render — there is NO history to look it up in, and the agent has no way to ` +
+              `recover it once this restart completes. Please tell it your choice again (or paste the text above) ` +
+              `when it comes back.`,
+          );
+        }
+        bridge.push({ type: "say", text: parts.join(" ") }, panelTab);
       }
     } catch (err) {
       logger.warn(
@@ -3248,7 +3278,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       // identical re-ask recover it — hands one conversation a decision made in
       // another. Retire the asks instead; closeAsks downgrades and unsends, it
       // never deletes, so the answer is still reported.
-      AskAnswers.closeAsks(panelTab);
+      if (providerSwitched) AskAnswers.closeAsks(panelTab);
       // A headless client (mobile/remote pseudo-panel, no browser canvas) advertises
       // itself in the hello frame so its agent gets the in-turn-delivery directive.
       if ((event as { headless?: unknown }).headless === true) headlessTabs.add(panelTab);
@@ -3779,7 +3809,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       // identical re-ask recover it — hands one conversation a decision made in
       // another. Retire the asks instead; closeAsks downgrades and unsends, it
       // never deletes, so the answer is still reported.
-      AskAnswers.closeAsks(panelTab);
+      if (prev !== reqBackend) AskAnswers.closeAsks(panelTab);
       // Leaving a LOCAL provider frees its VRAM (no other tab still on it) —
       // the point of switching to Claude/hosted is usually reclaiming the GPU.
       if (prev !== reqBackend) {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2169,8 +2169,19 @@ export async function runPanelOrchestrator(): Promise<void> {
       // record is actionable rather than a bare count.
       for (const entry of AskAnswers.allOutstanding()) {
         const list = byTab.get(entry.key) ?? [];
-        list.push(`the user's answer to "${previewQuestion(entry.question)}"`);
+        list.push(
+          `the user's answer to "${previewQuestion(entry.question)}"${entry.returned ? " (handed to a tool call whose receipt was never confirmed)" : ""}`,
+        );
         byTab.set(entry.key, list);
+      }
+      // …and the answers whose only surviving record is a COUNTER, because the
+      // journal's bound already destroyed the text. Naming the count is the last
+      // thing that keeps that promise; without it the eviction path's "the next
+      // delivery will report it" quietly becomes never.
+      for (const { key, count } of AskAnswers.outstandingDebt()) {
+        const list = byTab.get(key) ?? [];
+        list.push(`${count} further answer(s) already dropped by the journal (content lost)`);
+        byTab.set(key, list);
       }
     } catch {
       return; // nothing readable — nothing to report

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -4386,6 +4386,14 @@ export async function runPanelOrchestrator(): Promise<void> {
       const tabId = event.tab_id;
       const anchor = typeof event.anchor === "string" ? event.anchor : null;
       const ok = manager.rewind(agentKeyFor(tabId), anchor);
+      // #486 — a REWIND is a conversation boundary too, not just New chat and
+      // resume: everything after the anchor is discarded, so a question card the
+      // dropped branch put up was never asked by the conversation that now
+      // exists. Retire this tab's asks so a late click on such a card can neither
+      // be announced as "a question card YOU put up" nor recovered as the answer
+      // to an identical question the fork asks afresh. The answers themselves are
+      // kept and still reported — closeAsks downgrades, it does not delete.
+      if (ok) AskAnswers.closeAsks(tabId);
       bridge.push({ type: "ack", ok, kind: "rewind" }, tabId);
       logger.info(`[panel-orchestrator] tab ${tabId.slice(0, 8)} rewind (anchor=${anchor ? anchor.slice(0, 8) : "fresh"}, ok=${ok})`);
       return;

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3023,7 +3023,15 @@ export async function runPanelOrchestrator(): Promise<void> {
           // without counting that the destination reads as unoccupied, the source
           // is rebound onto its id, and the next flush hands the DESTINATION
           // tab's render to the SOURCE tab's conversation.
-          const destinationJournaled = RunCompletions.outstanding(panelTab).length;
+          // #486 — the ask journal counts too, for exactly the same reason and
+          // with a worse failure if it doesn't: a destination whose only state is
+          // the user's ANSWER to a question its (now-gone) conversation asked
+          // would read as unoccupied, the source would be rebound onto its id,
+          // and the next flush would announce the DESTINATION tab's answer to the
+          // SOURCE tab's conversation — an answer delivered to a conversation
+          // that never asked the question.
+          const destinationJournaled =
+            RunCompletions.outstanding(panelTab).length + AskAnswers.entriesFor(panelTab).length;
           const destinationHadState = [...KNOWN_BACKENDS].some((b) =>
             destinationHasCollisionState({
               hasManagerState: manager.hasAnyState(panelTab + AGENT_KEY_SEP + b),

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2133,6 +2133,11 @@ export async function runPanelOrchestrator(): Promise<void> {
   // receipt for the ordinary path and must treat every answer as possibly lost;
   // with it, "the model read this" is a fact and only the genuinely unconfirmed
   // ones are held open (#486).
+  // #486 — a `wf:<hash>` tab id names a WORKFLOW, so a second browser tab can
+  // take it over. The journal scopes every per-tab debt to whoever is actually
+  // holding the key, so the newcomer can neither be told nor settle the
+  // departed tab's owed disclosure.
+  AskAnswers.setIncarnationResolver((panelTabId) => bridge.tabIncarnation(panelTabId));
   AskAnswers.setTurnAttacher((panelTabId, token) =>
     manager.attachTurnToken(agentKeyFor(panelTabId), token),
   );
@@ -2140,7 +2145,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   // warning is owed), so it needs a LIFECYCLE end instead: a tab leaving the
   // bridge's connection map surfaces whatever it is still owed and retires it.
   // Journal entries survive — a disconnect is usually a reload.
-  bridge.setTabGoneListener((tabId) => AskAnswers.retireDebt(tabId));
+  bridge.setTabGoneListener((tabId, incarnation) => AskAnswers.retireDebt(tabId, incarnation));
   bridge.setLateAskReplySink((askId, result, tabId) => {
     if (!AskAnswers.tracks(askId)) return;
     const entry = AskAnswers.record(askId, result, { tabId });

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -235,7 +235,9 @@ export interface PanelAgentDeps {
   onSeen?: (tabId: string, mid: string) => void;
   /** #468 — the turn CARRYING these run-completion journal tokens ended, so the
    *  completions genuinely reached the agent. The journal drops them. */
-  onEventDelivered?: (tabId: string, tokens: string[]) => void;
+  /** #486 — `carrier` identifies the AGENT INSTANCE whose turn carried these
+   *  tokens, so a journal can refuse an ack from anything else. */
+  onEventDelivered?: (tabId: string, tokens: string[], from?: { carrier?: string }) => void;
   /** #468 — these run-completion journal tokens are being handed BACK for replay.
    *  `carried` true means a turn actually DISPATCHED with them and then ended
    *  (the agent read the text; only its ack couldn't be proven) — the journal
@@ -264,6 +266,17 @@ export class PanelAgent {
    *  pushes, sessionStore persistence, the bound panel MCP server) keeps addressing
    *  the DEAD pre-migration tab (#568 Defect 1). */
   tabId: string;
+  /**
+   * Identity of THIS agent object, for the whole of its life (#486).
+   *
+   * Deliberately independent of `tabId`: a tab-id migration re-keys the same
+   * conversation and must NOT invalidate an ack, while a provider switch builds a
+   * NEW agent — which is exactly the case that must not be able to certify the
+   * previous conversation's answer. The instance is the thing that distinguishes
+   * those two, so the carrier identity is the instance and nothing else.
+   */
+  private static instanceSeq = 0;
+  readonly carrierId = `pa${++PanelAgent.instanceSeq}`;
   private deps: PanelAgentDeps;
   /** The injected provider adapter (Claude today). PanelAgent owns the queue,
    *  turn-gate, rewind tracking and self-restart; the backend owns the SDK call,
@@ -1665,7 +1678,7 @@ export class PanelAgent {
             (typeof ev.turn === "number" && ev.turn === this.turnEventTokensMarker);
           if (ackable) {
             try {
-              this.deps.onEventDelivered?.(this.tabId, carried);
+              this.deps.onEventDelivered?.(this.tabId, carried, { carrier: this.carrierId });
             } catch (err) {
               logger.warn(`[panel-agent ${this.short()}] acking completion tokens: ${msgOf(err)}`);
             }
@@ -1812,7 +1825,9 @@ export interface PanelAgentManagerOptions {
   onAgentFatal?: (tabId: string, reason: string) => void;
   /** #468 — a turn carrying these run-completion journal tokens ENDED, so the
    *  completions genuinely reached the agent. Forwarded verbatim from the agent. */
-  onEventDelivered?: (tabId: string, tokens: string[]) => void;
+  /** #486 — `carrier` identifies the AGENT INSTANCE whose turn carried these
+   *  tokens, so a journal can refuse an ack from anything else. */
+  onEventDelivered?: (tabId: string, tokens: string[], from?: { carrier?: string }) => void;
   /** #468 — these run-completion journal tokens came back UNDELIVERED (agent
    *  stopped, turn abandoned, injection refused). Re-arm them for replay.
    *  `carried` true = a turn ran with them and ended (the agent read the text,
@@ -2173,12 +2188,22 @@ export class PanelAgentManager {
     return agent.revokeEvent(token);
   }
 
-  /** Ride a journal token on the tab's IN-FLIGHT turn so that turn's result acks
-   *  it (#486). False when no agent or no turn is running. */
-  attachTurnToken(tabId: string, token: string): boolean {
+  /**
+   * Ride a journal token on the tab's IN-FLIGHT turn so that turn's result acks
+   * it (#486).
+   *
+   * Returns the CARRIER IDENTITY the token was attached to — the agent key plus
+   * that agent's instance identity — or null when there is no agent or no turn
+   * running. The caller freezes it onto the entry and the journal refuses any
+   * ack that does not match, so a provider switch (which re-points the tab at a
+   * different agent) can never let one conversation's turn certify another's
+   * answer.
+   */
+  attachTurnToken(tabId: string, token: string): string | null {
     const agent = this.agents.get(tabId);
-    if (!agent || agent.isStopped) return false;
-    return agent.attachTurnToken(token);
+    if (!agent || agent.isStopped) return null;
+    if (!agent.attachTurnToken(token)) return null;
+    return agent.carrierId;
   }
 
   /** Push a ComfyUI execution error to a tab's agent — interrupt the live turn

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -586,6 +586,13 @@ export class PanelAgent {
       replayed?: boolean;
       dropped_completions?: number;
       possible_repeat?: boolean;
+      /** #486 - a validated `panel_ask` answer that no tool call was alive to
+       *  receive, carried together with the question it (and only it) answers. */
+      ask_question?: string | null;
+      ask_answer?: string;
+      ask_correlation?: "matched" | "foreign";
+      ask_answered_at?: number;
+      dropped_answers?: number;
     },
     opts?: { eventToken?: string },
   ): boolean {
@@ -640,6 +647,48 @@ export class PanelAgent {
       if (this.backend.capabilities.vision) {
         images = imgs.filter((i) => i.filename).map((i) => ({ ...i, type: i.type ?? "output" }));
       }
+    } else if (ev.kind === "ask_answer") {
+      // #486 — the user ANSWERED a question card, but no tool call was alive to
+      // receive it (the `tools/call` that asked had already timed out or been
+      // abandoned). The answer was journaled instead of lost; this is it.
+      //
+      // The QUESTION is always carried with the ANSWER, and the wording pins the
+      // answer to that question explicitly. Losing an answer costs a re-ask;
+      // letting one be read as the answer to a DIFFERENT question makes the
+      // agent act on a decision the user never made — so an answer that could
+      // not be tied to a question this session asked says exactly that and asks
+      // for nothing to be inferred from it.
+      const answer = typeof ev.ask_answer === "string" ? ev.ask_answer : "";
+      if (!answer) return false;
+      const ageS = Math.max(
+        0,
+        Math.round((Date.now() - (ev.ask_answered_at ?? Date.now())) / 1000),
+      );
+      text =
+        `[panel event] ` +
+        (ev.replayed
+          ? `(RE-DELIVERED — this answer could not be handed to you when it arrived.) `
+          : ``) +
+        (ev.possible_repeat
+          ? `⚠️ You may already have been given this answer — do not act on it twice. `
+          : ``) +
+        (typeof ev.dropped_answers === "number" && ev.dropped_answers > 0
+          ? `⚠️ ${ev.dropped_answers} further validated answer(s) on this tab were dropped before delivery — their content is UNDETERMINED. `
+          : ``) +
+        (ev.ask_correlation === "matched" && ev.ask_question
+          ? `The user DID answer a question card you put up ${ageS}s ago, but their answer could not be returned ` +
+            `to the panel_ask call that asked (it had already timed out), so the tool reported no answer. Here it is:\n\n` +
+            `QUESTION YOU ASKED: ${ev.ask_question}\n` +
+            `THE USER'S ANSWER: ${answer}\n\n` +
+            `This is their answer to THAT question and to nothing else — do not apply it to any other decision, ` +
+            `and do not ask it again. If you already proceeded without it, say so and reconcile. `
+          : `A user answered a question card ${ageS}s ago and the answer could NOT be tied to any question this ` +
+            `session asked — its meaning is UNDETERMINED. Reported so it is not silently discarded:\n\n` +
+            `QUESTION: ${ev.ask_question ?? "(unrecorded)"}\n` +
+            `ANSWER: ${answer}\n\n` +
+            `Do NOT treat this as the answer to anything you are currently deciding. If you need that decision, ` +
+            `ask again with panel_ask. `) +
+        `Reply with ONE short sentence and continue — no tool call is required just to acknowledge this.`;
     } else if (ev.kind === "run_error") {
       text =
         `[panel event] The user's workflow run just ERRORED: ${ev.error ?? "unknown error"}. ` +
@@ -2078,6 +2127,13 @@ export class PanelAgentManager {
       replayed?: boolean;
       dropped_completions?: number;
       possible_repeat?: boolean;
+      /** #486 - a validated `panel_ask` answer that no tool call was alive to
+       *  receive, carried together with the question it (and only it) answers. */
+      ask_question?: string | null;
+      ask_answer?: string;
+      ask_correlation?: "matched" | "foreign";
+      ask_answered_at?: number;
+      dropped_answers?: number;
     },
     opts?: { eventToken?: string },
   ): boolean {

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -544,6 +544,28 @@ export class PanelAgent {
     return true;
   }
 
+  /**
+   * Attach a journal token to the turn that is RUNNING RIGHT NOW (#486).
+   *
+   * A `panel_ask` answer goes back to the model as a TOOL RESULT, not as an
+   * injected event — so it has no hand-off to ack. But the tool call happens
+   * INSIDE a live turn, and this class already knows exactly when a turn is
+   * proven to have been read: `turnEventTokens` are acked only when that turn's
+   * own marked `result` lands (#468). Riding the same wires makes "the model
+   * received this answer" a fact rather than an assumption, which is the whole
+   * point — a `tools/call` that was abandoned never produces that result, so its
+   * token is released unacked and the answer stays accounted for.
+   *
+   * Returns false when there is no turn in flight to attach to; the caller then
+   * treats the answer as unacked, which is the conservative reading.
+   */
+  attachTurnToken(token: string): boolean {
+    if (!this.inFlight) return false;
+    if (this.turnEventTokens.includes(token)) return true;
+    this.turnEventTokens.push(token);
+    return true;
+  }
+
   /** Drop a still-queued message (the user cancelled/edited it before the agent
    *  got to it). Returns true if it was found and removed; false if it was
    *  already dequeued (the turn started — too late to cancel). */
@@ -2149,6 +2171,14 @@ export class PanelAgentManager {
     const agent = this.agents.get(tabId);
     if (!agent || agent.isStopped) return false;
     return agent.revokeEvent(token);
+  }
+
+  /** Ride a journal token on the tab's IN-FLIGHT turn so that turn's result acks
+   *  it (#486). False when no agent or no turn is running. */
+  attachTurnToken(tabId: string, token: string): boolean {
+    const agent = this.agents.get(tabId);
+    if (!agent || agent.isStopped) return false;
+    return agent.attachTurnToken(token);
   }
 
   /** Push a ComfyUI execution error to a tab's agent — interrupt the live turn

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4039,6 +4039,28 @@ async function askUserWithGrace(
     // The rid-correlated path is exempt and deliberately so: a reply that came
     // back on THIS send's own request id is this card's reply by construction,
     // whatever the ask id has meant elsewhere.
+    //
+    // A CONVERSATION BOUNDARY is a different exemption, and the rid does NOT
+    // cover it. A rid proves WHICH CARD replied; it says nothing about whose
+    // conversation is live now. If this ask was retired while its request was
+    // still pending — most concretely, a different browser tab took the
+    // recurring key over — then returning the pick here hands it straight into
+    // the conversation the boundary exists to keep it out of, through the one
+    // channel the boundary does not police. So the journal's verdict governs
+    // both paths.
+    if (entry.recoverable === false) {
+      return fail(
+        withDroppedText(
+          tabId,
+          `The user answered this question card, but the conversation that asked it has been ` +
+            `replaced since (a new chat, a rewind, a provider switch, or a different browser tab ` +
+            `taking over this workflow). The answer is NOT being returned as yours, because the ` +
+            `question is no longer one this conversation asked.\n\n` +
+            `WHAT THE USER PICKED (for the REPLACED conversation): ${entry.answer}\n\n` +
+            `Ask again if you still need this decision.`,
+        ),
+      );
+    }
     if (!opts.ridCorrelated && entry.correlation.status !== "matched") {
       // NOT marked returned: nobody has been given this as an answer, so it stays
       // an orphan — pushed and disclosed — rather than quietly counting as

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -58,6 +58,12 @@ import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
 import { QueueMonitor } from "../services/queue-monitor.js";
 import { RunCompletions } from "./run-completion-journal.js";
 import {
+  AskAnswers,
+  askFingerprint,
+  type AskEntry,
+  type AskRecovery,
+} from "./ask-answer-journal.js";
+import {
   getClient,
   getObjectInfo,
   backfillObjectInfo,
@@ -3253,6 +3259,11 @@ export function makePanelToolCtx(
     const deadlineMs = Math.max(1, Math.min(base.deadlineMs, total));
     const graceMs = Math.max(0, total - deadlineMs);
     const timing = { deadlineMs, graceMs, pollMs: base.pollMs };
+    // ONE absolute ceiling for card wait + grace, anchored before any work — see
+    // pollLateAskReply's `hardDeadline`. Without it the two budgets are additive
+    // on top of everything else the handler does, which is how a bounded confirm
+    // still overran the enclosing tools/call budget.
+    const budgetEnd = Date.now() + total;
     const askId = randomUUID();
     try {
       ensureReachable();
@@ -3276,7 +3287,7 @@ export function makePanelToolCtx(
       // panel, transport failure) → "no" so the destructive op is SKIPPED, exactly
       // as the previous catch-all did.
       if (isReplyTimeoutError(err)) {
-        const late = await pollLateAskReply(bridge, askId, timing);
+        const late = await pollLateAskReply(bridge, askId, timing, budgetEnd);
         if (late !== undefined) return isAffirmative(late) ? "yes" : "no";
         return "timeout";
       }
@@ -3827,16 +3838,28 @@ function reResolveDesktopTab(ctx: PanelToolCtx, label: string): string | undefin
 }
 
 /** Poll the bridge's late-reply buffer for a validated ask answer that arrived
- *  after the card-reply timeout, up to the grace budget. undefined if none. */
+ *  after the card-reply timeout, up to the grace budget. undefined if none.
+ *
+ *  `hardDeadline` is an ABSOLUTE wall-clock ceiling (a timestamp), so the total
+ *  ask cannot creep past the enclosing MCP `tools/call` budget by accumulating
+ *  the pre-send work, the send itself and then a fresh full grace on top: the
+ *  grace only ever gets what is LEFT of the budget measured from the moment the
+ *  handler started. Without it the observed worst case is deadline + grace +
+ *  everything else, which is how an ask still ended in a raw transport timeout
+ *  instead of a clean result. */
 async function pollLateAskReply(
   bridge: PanelToolCtx["bridge"],
   askId: string,
   timing: AskTiming,
+  hardDeadline?: number,
 ): Promise<unknown | undefined> {
   const take = (bridge as unknown as { takeLateAskReply?: (id: string) => unknown })
     .takeLateAskReply;
   if (typeof take !== "function") return undefined;
-  const deadline = Date.now() + timing.graceMs;
+  const deadline = Math.min(
+    Date.now() + timing.graceMs,
+    hardDeadline ?? Number.POSITIVE_INFINITY,
+  );
   for (;;) {
     const late = take.call(bridge, askId);
     if (late !== undefined) return late;
@@ -3846,19 +3869,109 @@ async function pollLateAskReply(
   }
 }
 
+/** The tool result for an answer the user gave to THIS EXACT question earlier,
+ *  which no tool call was alive to receive (#486). Always says so, always quotes
+ *  the question it belongs to, and always says how old it is — a recovered
+ *  answer must never be readable as a fresh one, nor as an answer to anything
+ *  else. */
+function recoveredAskResult(entry: AskEntry): ToolResult {
+  const ageS = Math.max(0, Math.round((Date.now() - entry.answeredAt) / 1000));
+  return ok(
+    `[RECOVERED ANSWER] The user already answered this EXACT question ${ageS}s ago, but that ` +
+      `answer could not be handed back — the tool call that asked had already timed out, so ` +
+      `it was journaled instead of being lost (#486).\n\n` +
+      `QUESTION IT ANSWERS: ${entry.question ?? "(unrecorded)"}\n` +
+      `THE USER'S ANSWER: ${entry.answer}\n\n` +
+      `This is their answer to THAT question and to nothing else. It was given ${ageS}s ago, ` +
+      `not just now — do not re-ask it, but if something relevant has changed since, confirm ` +
+      `before acting on it.`,
+  );
+}
+
 /**
- * Run a panel_ask: render the choice card and return the user's pick. Clamps the
- * card deadline under the MCP tools/call budget and, on a reply-timeout, honors a
- * late-but-valid answer from the bridge's late-reply buffer before failing (#486).
+ * The honest failure for an ask nobody answered — plus every validated answer
+ * for this tab that could NOT be attributed to the question just asked.
+ *
+ * Those answers are quoted WITH their own question, never on their own: an
+ * unattributed answer that is merely mentioned invites the agent to use it for
+ * the question at hand, which is the misattribution this whole path exists to
+ * prevent. Reporting them beats swallowing them — the user did answer something.
+ */
+function askTimeoutResult(tabId: string, recovery: AskRecovery): ToolResult {
+  let text =
+    "The question card was not answered in time (or no interactive panel surface " +
+    "rendered it — e.g. an exec/headless run), so nothing was selected. If you " +
+    "still need the decision, ask the user directly in plain chat text, or " +
+    "re-invoke panel_ask from an interactive ComfyUI tab.";
+  // Only answers that were never handed back to ANY tool call are surfaced here;
+  // one that already reached a caller is not news.
+  const orphans = recovery.status === "unattributed" ? recovery.others.filter((e) => !e.returned) : [];
+  if (orphans.length > 0) {
+    text +=
+      `\n\nHOWEVER — the user DID validate ${orphans.length} answer(s) on this tab that could NOT be ` +
+      `attributed to the question you just asked. They are reported here rather than discarded. ` +
+      `Each answers ONLY its own question below; do NOT use any of them as the answer to the ` +
+      `question you just asked:\n` +
+      orphans
+        .map(
+          (e) =>
+            `  • QUESTION: ${e.question ?? "(UNRECORDED — this answer cannot be tied to any question this session asked; its meaning is UNDETERMINED)"}\n` +
+            `    ANSWER: ${e.answer}`,
+        )
+        .join("\n");
+  }
+  const dropped = AskAnswers.droppedFor(tabId);
+  if (dropped > 0) {
+    text +=
+      `\n\n⚠️ ${dropped} further validated answer(s) for this tab were dropped before they could be ` +
+      `delivered — their content is UNDETERMINED and cannot be recovered. Ask the user again for ` +
+      `anything you were waiting on.`;
+  }
+  return fail(text);
+}
+
+/**
+ * Run a panel_ask: render the choice card and return the user's pick.
+ *
  * Sent DIRECTLY over the bridge (like the confirm/consent cards) so a stable
- * `ask_id` can key the late-reply buffer.
+ * `ask_id` keys both the bridge's late-reply buffer and the durable ask journal.
+ *
+ * #486, in three layers:
+ *  1. CLAMP the card deadline under the MCP `tools/call` budget, and hold the
+ *     whole handler (card wait + grace poll) to ONE absolute wall-clock ceiling
+ *     anchored at entry, so the ask always resolves as a clean tool result
+ *     rather than dying as a raw transport timeout.
+ *  2. JOURNAL every validated answer at the moment it validates — including one
+ *     that arrives with no caller left (via the bridge's late-answer sink). An
+ *     answer that reaches a ToolResult is journaled too, because a ToolResult is
+ *     a hand-off and not proof: the request may already have been abandoned.
+ *  3. On a card timeout, RECOVER the answer the user already gave to THIS EXACT
+ *     question — matched on the frozen question fingerprint, never on recency —
+ *     and if there is none, REPORT any unattributed answers instead of letting
+ *     them disappear.
  */
 async function askUserWithGrace(
   ctx: PanelToolCtx,
   ask: { question: string; options: unknown; header?: unknown; multi_select?: unknown },
 ): Promise<ToolResult> {
   const timing = getAskTiming();
+  // ONE ceiling for the whole handler, anchored before any work is done.
+  const budgetEnd = Date.now() + ASK_TOTAL_BUDGET_CAP_MS;
   const askId = randomUUID();
+  // Self-heal FIRST: the tab this resolves to is the tab the card renders on, and
+  // it is the journal key every later match is made against. It throws when no
+  // tab is bindable at all — surfaced as the tool's error exactly as before,
+  // without opening a ticket for a card that was never dispatched.
+  try {
+    ctx.ensureReachable?.();
+  } catch (err) {
+    return fail(err);
+  }
+  const tabId = ctx.tabId;
+  const fingerprint = askFingerprint(ask);
+  // Open the ticket BEFORE dispatching: the answer can validate the instant the
+  // card renders, and an answer that arrives with no ticket is unattributable.
+  AskAnswers.openAsk(askId, { tabId, fingerprint, question: ask.question });
   const cmd = {
     cmd: "ask_user",
     ask_id: askId,
@@ -3867,25 +3980,43 @@ async function askUserWithGrace(
     header: ask.header,
     multi_select: ask.multi_select,
   };
-  try {
-    ctx.ensureReachable?.();
-    const reply = await ctx.bridge.send(cmd as unknown as { cmd: string }, {
-      tabId: ctx.tabId,
-      timeoutMs: timing.deadlineMs,
-    });
+  /** Journal an answer we are about to hand back. `markReturned` records that a
+   *  ToolResult carried it — a hand-off, NOT proof it was received — so it is not
+   *  ALSO pushed to the agent, while a re-ask can still recover it if the caller
+   *  was already gone. */
+  const handBack = (reply: unknown): ToolResult => {
+    AskAnswers.record(askId, reply, { tabId });
+    AskAnswers.markReturned(askId);
     return ok(reply);
+  };
+  try {
+    const reply = await ctx.bridge.send(cmd as unknown as { cmd: string }, {
+      tabId,
+      timeoutMs: Math.max(1, Math.min(timing.deadlineMs, budgetEnd - Date.now())),
+    });
+    return handBack(reply);
   } catch (err) {
-    if (isReplyTimeoutError(err)) {
-      const late = await pollLateAskReply(ctx.bridge, askId, timing);
-      if (late !== undefined) return ok(late);
-      return fail(
-        "The question card was not answered in time (or no interactive panel surface " +
-          "rendered it — e.g. an exec/headless run), so nothing was selected. If you " +
-          "still need the decision, ask the user directly in plain chat text, or " +
-          "re-invoke panel_ask from an interactive ComfyUI tab.",
-      );
+    if (!isReplyTimeoutError(err)) return fail(err);
+    const late = await pollLateAskReply(ctx.bridge, askId, timing, budgetEnd);
+    if (late !== undefined) return handBack(late);
+    // Nothing came back on this card's own wire. An answer the user gave to this
+    // EXACT question may still be journaled — from THIS card (the sink beat the
+    // last poll) or from an earlier ask whose tool call died before it could
+    // return one. Matched on the frozen fingerprint only.
+    const recovery = AskAnswers.recover(tabId, fingerprint);
+    if (recovery.status === "recovered") {
+      const entry = recovery.entry;
+      AskAnswers.consume(entry.token);
+      // Our OWN card's answer that merely lost the poll race is not a "recovered
+      // earlier answer" — it is this ask's answer, and reads as one.
+      return entry.askId === askId ? ok(entry.answer) : recoveredAskResult(entry);
     }
-    return fail(err);
+    return askTimeoutResult(tabId, recovery);
+  } finally {
+    // This handler is gone. Anything already journaled for this ask that we did
+    // NOT hand back is now provably orphaned — arm it for the durable push so
+    // the agent is told even if panel_ask is never called again.
+    AskAnswers.closeAsk(askId);
   }
 }
 
@@ -3899,6 +4030,7 @@ export const __panelAskTestHooks = {
   ASK_TOTAL_BUDGET_CAP_MS,
   askSurfaceError,
   isReplyTimeoutError,
+  askFingerprint,
 };
 
 /** One shared tool definition: name, description, zod raw-shape schema, and a

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4028,9 +4028,33 @@ async function askUserWithGrace(
    *  ToolResult carried it — a hand-off, NOT proof it was received — so it is not
    *  ALSO pushed to the agent, while a re-ask can still recover it if the caller
    *  was already gone. */
-  const handBack = (reply: unknown): ToolResult => {
-    AskAnswers.record(askId, reply, { tabId });
-    AskAnswers.markReturned(askId);
+  const handBack = (reply: unknown, opts: { ridCorrelated: boolean }): ToolResult => {
+    const entry = AskAnswers.record(askId, reply, { tabId });
+    // A LATE answer is claimed from a buffer keyed by `ask_id` ALONE, so if that
+    // id ever stood for two cards the buffer cannot say which one this reply came
+    // from — and returning it here would hand card B the answer the user gave to
+    // card A. The journal already knows (it correlates and demotes a reused id);
+    // consult its verdict instead of trusting the id.
+    //
+    // The rid-correlated path is exempt and deliberately so: a reply that came
+    // back on THIS send's own request id is this card's reply by construction,
+    // whatever the ask id has meant elsewhere.
+    if (!opts.ridCorrelated && entry.correlation.status !== "matched") {
+      // NOT marked returned: nobody has been given this as an answer, so it stays
+      // an orphan — pushed and disclosed — rather than quietly counting as
+      // delivered.
+      return fail(
+        withDroppedText(
+          tabId,
+          `A validated answer came back for this question card, but its ask id no longer identifies ` +
+            `a single card, so it CANNOT be attributed to the question you just asked — it may be the ` +
+            `user's answer to a different card. It is NOT being returned as your answer.\n\n` +
+            `WHAT THE USER PICKED (question UNDETERMINED): ${entry.answer}\n\n` +
+            `Ask again if you still need this decision.`,
+        ),
+      );
+    }
+    AskAnswers.markReturned(entry.token);
     // Even a clean answer carries out any eviction debt this tab is still owed —
     // an answer the journal admits it dropped must not go unmentioned merely
     // because the NEXT ask happened to succeed.
@@ -4041,11 +4065,11 @@ async function askUserWithGrace(
       tabId,
       timeoutMs: Math.max(1, Math.min(timing.deadlineMs, budgetEnd - Date.now())),
     });
-    return handBack(reply);
+    return handBack(reply, { ridCorrelated: true });
   } catch (err) {
     if (!isReplyTimeoutError(err)) return fail(err);
     const late = await pollLateAskReply(ctx.bridge, askId, timing, budgetEnd);
-    if (late !== undefined) return handBack(late);
+    if (late !== undefined) return handBack(late, { ridCorrelated: false });
     // Nothing came back on this card's own wire. An answer the user gave to this
     // EXACT question may still be journaled — from THIS card (the sink beat the
     // last poll) or from an earlier ask whose tool call died before it could

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3953,7 +3953,7 @@ function askTimeoutResult(
  *  succeed. Reading it also SPENDS it (droppedFor is drained by the journal only
  *  when a push carries it), so it is said once. */
 function withDroppedText(tabId: string, text: string): string {
-  const dropped = AskAnswers.takeDropped(tabId);
+  const dropped = AskAnswers.reportDropped(tabId);
   if (dropped <= 0) return text;
   return (
     `${text}\n\n⚠️ ${dropped} further validated answer(s) for this tab were dropped before they ` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4043,12 +4043,16 @@ async function askUserWithGrace(
     // A CONVERSATION BOUNDARY is a different exemption, and the rid does NOT
     // cover it. A rid proves WHICH CARD replied; it says nothing about whose
     // conversation is live now. If this ask was retired while its request was
-    // still pending — most concretely, a different browser tab took the
-    // recurring key over — then returning the pick here hands it straight into
-    // the conversation the boundary exists to keep it out of, through the one
-    // channel the boundary does not police. So the journal's verdict governs
-    // both paths.
-    if (entry.recoverable === false) {
+    // still pending — a New chat, a rewind, a provider switch, or a different
+    // browser tab taking the recurring key over — then returning the pick here
+    // hands it straight into the conversation the boundary exists to keep it out
+    // of, through the one channel the boundary does not police.
+    //
+    // Keyed on `retired` and not `recoverable`: the latter also covers AMBIGUITY,
+    // and an ambiguous answer that arrived on THIS send's own rid is
+    // unambiguously this card's. The rid exemption is right for that axis and
+    // wrong only for this one.
+    if (entry.retired === true) {
       return fail(
         withDroppedText(
           tabId,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3897,15 +3897,29 @@ function recoveredAskResult(entry: AskEntry): ToolResult {
  * the question at hand, which is the misattribution this whole path exists to
  * prevent. Reporting them beats swallowing them — the user did answer something.
  */
-function askTimeoutResult(tabId: string, recovery: AskRecovery): ToolResult {
+function askTimeoutResult(
+  tabId: string,
+  fingerprint: string,
+  recovery: AskRecovery,
+): ToolResult {
   let text =
     "The question card was not answered in time (or no interactive panel surface " +
     "rendered it — e.g. an exec/headless run), so nothing was selected. If you " +
     "still need the decision, ask the user directly in plain chat text, or " +
     "re-invoke panel_ask from an interactive ComfyUI tab.";
-  // Only answers that were never handed back to ANY tool call are surfaced here;
-  // one that already reached a caller is not news.
-  const orphans = recovery.status === "unattributed" ? recovery.others.filter((e) => !e.returned) : [];
+  // What is surfaced, and why each:
+  //  • an answer that reached NO tool call — nobody has it, so it must be told;
+  //  • an answer to THIS EXACT question that DID reach a tool call but is now too
+  //    old to be presented as a fresh decision. "It went into a ToolResult" is
+  //    precisely the thing this file says is not proof of receipt (that IS #486),
+  //    so a stale one is reported rather than quietly forgotten — the agent is
+  //    told the user answered this before, and can decide whether to re-ask.
+  // An answer that reached a caller and belongs to a DIFFERENT question is not
+  // news and stays quiet.
+  const orphans =
+    recovery.status === "unattributed"
+      ? recovery.others.filter((e) => !e.returned || e.fingerprint === fingerprint)
+      : [];
   if (orphans.length > 0) {
     text +=
       `\n\nHOWEVER — the user DID validate ${orphans.length} answer(s) on this tab that could NOT be ` +
@@ -3920,14 +3934,31 @@ function askTimeoutResult(tabId: string, recovery: AskRecovery): ToolResult {
         )
         .join("\n");
   }
-  const dropped = AskAnswers.droppedFor(tabId);
-  if (dropped > 0) {
-    text +=
-      `\n\n⚠️ ${dropped} further validated answer(s) for this tab were dropped before they could be ` +
-      `delivered — their content is UNDETERMINED and cannot be recovered. Ask the user again for ` +
-      `anything you were waiting on.`;
-  }
-  return fail(text);
+  return fail(withDroppedText(tabId, text));
+}
+
+/** The tab's undisclosed eviction debt, appended to whatever is being reported.
+ *  Every exit from the ask path runs through this — an eviction the journal
+ *  promised to report must not go unsaid just because THIS ask happened to
+ *  succeed. Reading it also SPENDS it (droppedFor is drained by the journal only
+ *  when a push carries it), so it is said once. */
+function withDroppedText(tabId: string, text: string): string {
+  const dropped = AskAnswers.takeDropped(tabId);
+  if (dropped <= 0) return text;
+  return (
+    `${text}\n\n⚠️ ${dropped} further validated answer(s) for this tab were dropped before they ` +
+    `could be delivered — their content is UNDETERMINED and cannot be recovered. Ask the user ` +
+    `again for anything you were waiting on.`
+  );
+}
+
+/** Same, for a ToolResult that is already built (the success/recovery paths). */
+function withDroppedAnswerWarning(tabId: string, res: ToolResult): ToolResult {
+  const first = res.content[0];
+  if (!first || first.type !== "text") return res;
+  const text = withDroppedText(tabId, first.text);
+  if (text === first.text) return res;
+  return { ...res, content: [{ type: "text", text }, ...res.content.slice(1)] };
 }
 
 /**
@@ -3987,7 +4018,10 @@ async function askUserWithGrace(
   const handBack = (reply: unknown): ToolResult => {
     AskAnswers.record(askId, reply, { tabId });
     AskAnswers.markReturned(askId);
-    return ok(reply);
+    // Even a clean answer carries out any eviction debt this tab is still owed —
+    // an answer the journal admits it dropped must not go unmentioned merely
+    // because the NEXT ask happened to succeed.
+    return withDroppedAnswerWarning(tabId, ok(reply));
   };
   try {
     const reply = await ctx.bridge.send(cmd as unknown as { cmd: string }, {
@@ -4009,9 +4043,11 @@ async function askUserWithGrace(
       AskAnswers.consume(entry.token);
       // Our OWN card's answer that merely lost the poll race is not a "recovered
       // earlier answer" — it is this ask's answer, and reads as one.
-      return entry.askId === askId ? ok(entry.answer) : recoveredAskResult(entry);
+      const body =
+        entry.askId === askId ? ok(entry.answer) : recoveredAskResult(entry);
+      return withDroppedAnswerWarning(tabId, body);
     }
-    return askTimeoutResult(tabId, recovery);
+    return askTimeoutResult(tabId, fingerprint, recovery);
   } finally {
     // This handler is gone. Anything already journaled for this ask that we did
     // NOT hand back is now provably orphaned — arm it for the durable push so

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3878,7 +3878,11 @@ async function pollLateAskReply(
 function recoveredAskResult(entry: AskEntry): ToolResult {
   const ageS = Math.max(0, Math.round((Date.now() - entry.answeredAt) / 1000));
   return ok(
-    `[RECOVERED ANSWER] The user already answered this EXACT question ${ageS}s ago, but that ` +
+    (entry.replayHint
+      ? `[NOTE] This answer has been handed to you before — it is being surfaced again because ` +
+        `the earlier hand-off could not be confirmed. Do not act on it twice.\n\n`
+      : ``) +
+      `[RECOVERED ANSWER] The user already answered this EXACT question ${ageS}s ago, but that ` +
       `answer could not be handed back — the tool call that asked had already timed out, so ` +
       `it was journaled instead of being lost (#486).\n\n` +
       `QUESTION IT ANSWERS: ${entry.question ?? "(unrecorded)"}\n` +
@@ -3910,11 +3914,16 @@ function askTimeoutResult(
     "re-invoke panel_ask from an interactive ComfyUI tab.";
   // What is surfaced, and why each:
   //  • an answer that reached NO tool call — nobody has it, so it must be told;
-  //  • an answer to THIS EXACT question that DID reach a tool call but is now too
-  //    old to be presented as a fresh decision. "It went into a ToolResult" is
-  //    precisely the thing this file says is not proof of receipt (that IS #486),
-  //    so a stale one is reported rather than quietly forgotten — the agent is
-  //    told the user answered this before, and can decide whether to re-ask.
+  //  • an answer to THIS EXACT question that DID reach a tool call but could not
+  //    be returned now (too old to present as a fresh decision, or its
+  //    conversation was replaced). "It went into a ToolResult" is precisely the
+  //    thing this file says is not proof of receipt (that IS #486), so it is
+  //    reported rather than quietly forgotten — the agent is told the user
+  //    answered this before and can decide whether to re-ask.
+  // The fingerprint match is what makes the second bullet safe AND what makes it
+  // reachable: revoking recoverability must not also revoke the disclosure, so
+  // an entry that is no longer allowed to ANSWER keeps its fingerprint and is
+  // still recognised here as being about the question at hand.
   // An answer that reached a caller and belongs to a DIFFERENT question is not
   // news and stays quiet.
   const orphans =
@@ -4044,11 +4053,17 @@ async function askUserWithGrace(
     const recovery = AskAnswers.recover(tabId, fingerprint);
     if (recovery.status === "recovered") {
       const entry = recovery.entry;
-      AskAnswers.consume(entry.token);
+      // Render BEFORE marking: markSurfaced stamps `replayHint`, and the wording
+      // must describe the entry as it was when we recovered it, not as this very
+      // call has just left it.
+      //
       // Our OWN card's answer that merely lost the poll race is not a "recovered
       // earlier answer" — it is this ask's answer, and reads as one.
       const body =
         entry.askId === askId ? ok(entry.answer) : recoveredAskResult(entry);
+      // Marked handed-over, NOT deleted: this ToolResult can be abandoned too,
+      // and destroying the journal's copy here would recreate #486 one level up.
+      AskAnswers.markSurfaced(entry.token);
       return withDroppedAnswerWarning(tabId, body);
     }
     return askTimeoutResult(tabId, fingerprint, recovery);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -60,6 +60,7 @@ import { RunCompletions } from "./run-completion-journal.js";
 import {
   AskAnswers,
   askFingerprint,
+  PANEL_ASK_ID_PREFIX,
   type AskEntry,
   type AskRecovery,
 } from "./ask-answer-journal.js";
@@ -3988,7 +3989,10 @@ async function askUserWithGrace(
   const timing = getAskTiming();
   // ONE ceiling for the whole handler, anchored before any work is done.
   const budgetEnd = Date.now() + ASK_TOTAL_BUDGET_CAP_MS;
-  const askId = randomUUID();
+  // PREFIXED so the bridge's late-answer sink can tell a panel_ask card from the
+  // other `ask_user` cards (confirm / 18+ consent / secret) purely from the id —
+  // see PANEL_ASK_ID_PREFIX. Ownership must not depend on any bounded store.
+  const askId = `${PANEL_ASK_ID_PREFIX}${randomUUID()}`;
   // Self-heal FIRST: the tab this resolves to is the tab the card renders on, and
   // it is the journal key every later match is made against. It throws when no
   // tab is bindable at all — surfaced as the tool's error exactly as before,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3926,10 +3926,13 @@ function askTimeoutResult(
   // still recognised here as being about the question at hand.
   // An answer that reached a caller and belongs to a DIFFERENT question is not
   // news and stays quiet.
+  // `recovery.others` has ALREADY been gated by the journal to what this
+  // conversation may see; this only narrows it further to what is NEWS.
   const orphans =
     recovery.status === "unattributed"
       ? recovery.others.filter((e) => !e.returned || e.fingerprint === fingerprint)
       : [];
+  const withheld = recovery.status === "unattributed" ? recovery.withheld : 0;
   if (orphans.length > 0) {
     text +=
       `\n\nHOWEVER — the user DID validate ${orphans.length} answer(s) on this tab that could NOT be ` +
@@ -3944,7 +3947,18 @@ function askTimeoutResult(
         )
         .join("\n");
   }
-  return fail(withDroppedText(tabId, text));
+  if (withheld > 0) {
+    // Said, never shown. These belong to a different browser tab on this
+    // recurring key, or to a conversation that has been replaced — rendering
+    // their chosen option here would leak exactly what the boundary contains, so
+    // the count is the disclosure and the text stays in the durable log.
+    text +=
+      `\n\nAlso: ${withheld} validated answer(s) on this tab belong to a DIFFERENT conversation ` +
+      `or browser tab (a new chat, a rewind, a provider switch, or another tab holding this ` +
+      `workflow). They are not shown here and are not yours to act on — if you need this ` +
+      `decision, ask again.`;
+  }
+  return fail(text);
 }
 
 /** The tab's undisclosed eviction debt, appended to whatever is being reported.
@@ -4028,64 +4042,97 @@ async function askUserWithGrace(
    *  ToolResult carried it — a hand-off, NOT proof it was received — so it is not
    *  ALSO pushed to the agent, while a re-ask can still recover it if the caller
    *  was already gone. */
-  const handBack = (reply: unknown, opts: { ridCorrelated: boolean }): ToolResult => {
-    const entry = AskAnswers.record(askId, reply, { tabId });
+  /**
+   * THE ONE EXIT for anything this handler learned from the journal.
+   *
+   * Every outlet that can put journal state in front of a live turn goes through
+   * here — the verbatim answer, the recovered answer, the timeout report, and the
+   * eviction-debt footnote. That is deliberate and structural: the last three
+   * defects on this path were each a NEW outlet (a rid-exempt hand-back, the
+   * `others` list, the debt footnote) that reached a live turn without passing
+   * the boundary check, and auditing outlets one at a time is what let each of
+   * them ship. A single exit means a new outlet cannot be added without either
+   * routing through this gate or deleting it.
+   *
+   * The gate is: an answer belonging to a REPLACED conversation never has its
+   * CONTENT rendered, and a result that is not the live conversation's own never
+   * carries that conversation's debt footnote.
+   */
+  const deliver = (
+    outcome:
+      | { kind: "answer"; entry: AskEntry; raw: unknown; ridCorrelated: boolean }
+      | { kind: "recovered"; entry: AskEntry }
+      | { kind: "timeout"; recovery: AskRecovery },
+  ): ToolResult => {
+    // RETIRED — the conversation that asked is gone. Say so WITHOUT the pick: the
+    // replacement turn reading the old choice is the leak, and a label on it is
+    // not a fence. The text itself stays in the journal and in the durable log,
+    // for the disclosure paths that belong to the conversation it was given to.
+    if (outcome.kind !== "timeout" && outcome.entry.retired === true) {
+      return fail(
+        `The user answered this question card, but the conversation that asked it has been ` +
+          `replaced since (a new chat, a rewind, a provider switch, or a different browser tab ` +
+          `taking over this workflow). Their choice is NOT shown here and is not yours to act ` +
+          `on — it was given to a conversation that no longer exists. Ask again if you still ` +
+          `need this decision.`,
+      );
+    }
+    if (outcome.kind === "timeout") {
+      // The debt footnote rides ONLY a result the LIVE conversation will receive.
+      // `reportDropped` selects the current occupant's debt and attaches its
+      // token to the turn running now, so putting it on a result that belongs to
+      // a conversation replaced mid-ask would let the live turn's ack settle a
+      // warning that conversation never saw — the debt path reaching a live turn
+      // through a helper, which is how it slipped the gate before.
+      const body = askTimeoutResult(tabId, fingerprint, outcome.recovery);
+      return AskAnswers.askBelongsToLiveConversation(askId)
+        ? withDroppedAnswerWarning(tabId, body)
+        : body;
+    }
+    if (outcome.kind === "recovered") {
+      const body =
+        outcome.entry.askId === askId
+          ? ok(outcome.entry.answer)
+          : recoveredAskResult(outcome.entry);
+      AskAnswers.markSurfaced(outcome.entry.token);
+      return withDroppedAnswerWarning(tabId, body);
+    }
     // A LATE answer is claimed from a buffer keyed by `ask_id` ALONE, so if that
     // id ever stood for two cards the buffer cannot say which one this reply came
     // from — and returning it here would hand card B the answer the user gave to
-    // card A. The journal already knows (it correlates and demotes a reused id);
-    // consult its verdict instead of trusting the id.
-    //
-    // The rid-correlated path is exempt and deliberately so: a reply that came
-    // back on THIS send's own request id is this card's reply by construction,
-    // whatever the ask id has meant elsewhere.
-    //
-    // A CONVERSATION BOUNDARY is a different exemption, and the rid does NOT
-    // cover it. A rid proves WHICH CARD replied; it says nothing about whose
-    // conversation is live now. If this ask was retired while its request was
-    // still pending — a New chat, a rewind, a provider switch, or a different
-    // browser tab taking the recurring key over — then returning the pick here
-    // hands it straight into the conversation the boundary exists to keep it out
-    // of, through the one channel the boundary does not police.
-    //
-    // Keyed on `retired` and not `recoverable`: the latter also covers AMBIGUITY,
-    // and an ambiguous answer that arrived on THIS send's own rid is
-    // unambiguously this card's. The rid exemption is right for that axis and
-    // wrong only for this one.
-    if (entry.retired === true) {
-      return fail(
-        withDroppedText(
-          tabId,
-          `The user answered this question card, but the conversation that asked it has been ` +
-            `replaced since (a new chat, a rewind, a provider switch, or a different browser tab ` +
-            `taking over this workflow). The answer is NOT being returned as yours, because the ` +
-            `question is no longer one this conversation asked.\n\n` +
-            `WHAT THE USER PICKED (for the REPLACED conversation): ${entry.answer}\n\n` +
-            `Ask again if you still need this decision.`,
-        ),
-      );
-    }
-    if (!opts.ridCorrelated && entry.correlation.status !== "matched") {
+    // card A. The rid-correlated path is exempt and deliberately so: a reply that
+    // came back on THIS send's own request id is this card's reply by
+    // construction, whatever the ask id has meant elsewhere.
+    if (!outcome.ridCorrelated && outcome.entry.correlation.status !== "matched") {
       // NOT marked returned: nobody has been given this as an answer, so it stays
       // an orphan — pushed and disclosed — rather than quietly counting as
-      // delivered.
+      // delivered. Its own content IS shown: it is not retired, so it belongs to
+      // this conversation; only its QUESTION is undetermined.
       return fail(
         withDroppedText(
           tabId,
           `A validated answer came back for this question card, but its ask id no longer identifies ` +
             `a single card, so it CANNOT be attributed to the question you just asked — it may be the ` +
             `user's answer to a different card. It is NOT being returned as your answer.\n\n` +
-            `WHAT THE USER PICKED (question UNDETERMINED): ${entry.answer}\n\n` +
+            `WHAT THE USER PICKED (question UNDETERMINED): ${outcome.entry.answer}\n\n` +
             `Ask again if you still need this decision.`,
         ),
       );
     }
-    AskAnswers.markReturned(entry.token);
+    AskAnswers.markReturned(outcome.entry.token);
     // Even a clean answer carries out any eviction debt this tab is still owed —
     // an answer the journal admits it dropped must not go unmentioned merely
     // because the NEXT ask happened to succeed.
-    return withDroppedAnswerWarning(tabId, ok(reply));
+    return withDroppedAnswerWarning(tabId, ok(outcome.raw));
   };
+
+  const handBack = (reply: unknown, opts: { ridCorrelated: boolean }): ToolResult =>
+    deliver({
+      kind: "answer",
+      entry: AskAnswers.record(askId, reply, { tabId }),
+      raw: reply,
+      ridCorrelated: opts.ridCorrelated,
+    });
   try {
     const reply = await ctx.bridge.send(cmd as unknown as { cmd: string }, {
       tabId,
@@ -4101,22 +4148,9 @@ async function askUserWithGrace(
     // last poll) or from an earlier ask whose tool call died before it could
     // return one. Matched on the frozen fingerprint only.
     const recovery = AskAnswers.recover(tabId, fingerprint);
-    if (recovery.status === "recovered") {
-      const entry = recovery.entry;
-      // Render BEFORE marking: markSurfaced stamps `replayHint`, and the wording
-      // must describe the entry as it was when we recovered it, not as this very
-      // call has just left it.
-      //
-      // Our OWN card's answer that merely lost the poll race is not a "recovered
-      // earlier answer" — it is this ask's answer, and reads as one.
-      const body =
-        entry.askId === askId ? ok(entry.answer) : recoveredAskResult(entry);
-      // Marked handed-over, NOT deleted: this ToolResult can be abandoned too,
-      // and destroying the journal's copy here would recreate #486 one level up.
-      AskAnswers.markSurfaced(entry.token);
-      return withDroppedAnswerWarning(tabId, body);
-    }
-    return askTimeoutResult(tabId, fingerprint, recovery);
+    return recovery.status === "recovered"
+      ? deliver({ kind: "recovered", entry: recovery.entry })
+      : deliver({ kind: "timeout", recovery });
   } finally {
     // This handler is gone. Anything already journaled for this ask that we did
     // NOT hand back is now provably orphaned — arm it for the durable push so

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2261,7 +2261,7 @@ async function userdataFetch(route: string): Promise<Response> {
  * earlier).
  *
  * Only the literal lowercase FORWARD-slash spelling counts (codex MAJOR). ComfyUI
- * store keys are always "/"-separated and lowercase here, so `workflowsoo.json`
+ * store keys are always "/"-separated and lowercase here, so `workflows\foo.json`
  * and `WORKFLOWS/foo.json` are ordinary names — a real subfolder on a
  * case-sensitive host, or a legal literal filename on POSIX — and stripping either
  * would rewrite a request into one for a different graph.
@@ -2284,7 +2284,7 @@ const stripLibraryPrefix = (key: string): string => key.replace(/^workflows\//, 
  * subfolder matches only that exact path.
  *
  * Path separators are deliberately NOT folded (codex MAJOR): on POSIX a file
- * literally named `diroo.json` is a DIFFERENT file from `dir/foo.json`. Case is
+ * literally named `dir\foo.json` is a DIFFERENT file from `dir/foo.json`. Case is
  * not folded either, for the same reason. Both are reported as near misses instead.
  */
 const matchName = (name: string): string => name.normalize("NFC");

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -890,7 +890,17 @@ export class UiBridge {
    *  caller, instead of being discarded as a "late reply for a timed-out command"
    *  (#486). Timestamped so an abandoned mapping (timeout/disconnect/send-failure
    *  whose late reply never arrives) is TTL-pruned rather than kept forever. */
-  private askRidToId = new Map<string, { askId: string; ts: number }>();
+  private askRidToId = new Map<string, { askId: string; ts: number; tabId: string }>();
+  /**
+   * Notified the instant a LATE (post-reply-timeout) ask answer validates (#486).
+   *
+   * The buffer below only helps a caller that is still alive to poll it. The
+   * whole of #486 is the case where nobody is: the `tools/call` that asked has
+   * been abandoned, so the answer would sit here unread until the TTL pruned it.
+   * This hands it to the orchestrator's ask journal at ARRIVAL, with no live
+   * caller required — after which it is durable and can be replayed or pushed.
+   */
+  private lateAskSink: ((askId: string, result: unknown, tabId: string) => void) | null = null;
   /** Buffered late-but-valid ask_user answers (ask_id → result), drained by the
    *  caller via takeLateAskReply(). Bounded by a short TTL — a stale unclaimed
    *  answer is pruned rather than kept forever. */
@@ -1488,6 +1498,18 @@ export class UiBridge {
             if (msg.ok) {
               this.pruneLateAsk();
               this.lateAskReplies.set(entry.askId, { result: msg.result, ts: Date.now() });
+              // …and hand it to the durable journal RIGHT NOW, whether or not any
+              // caller is still polling (#486). The buffer above is only reachable
+              // by a live poller; this is what makes an answer given after the
+              // tool call died survive at all. Never let a sink fault break the
+              // message loop.
+              try {
+                this.lateAskSink?.(entry.askId, msg.result, entry.tabId);
+              } catch (err) {
+                logger.warn(
+                  `[ui-bridge] late ask-answer sink threw (the answer is still buffered): ${err instanceof Error ? err.message : String(err)}`,
+                );
+              }
             }
           }
           return;
@@ -1880,6 +1902,12 @@ export class UiBridge {
    *  after the card-reply timeout, or undefined if none arrived. The panel_ask
    *  handler polls this for a bounded grace so a slow-but-valid pick is honored
    *  rather than discarded (#486). */
+  /** Wire the durable ask-answer journal to late (post-timeout) card answers
+   *  (#486). Called once at orchestrator start-up. */
+  setLateAskReplySink(sink: (askId: string, result: unknown, tabId: string) => void): void {
+    this.lateAskSink = sink;
+  }
+
   takeLateAskReply(askId: string): unknown | undefined {
     this.pruneLateAsk();
     const e = this.lateAskReplies.get(askId);
@@ -2315,7 +2343,10 @@ export class UiBridge {
     const askId = (cmd as { ask_id?: unknown }).ask_id;
     if (typeof askId === "string" && askId) {
       this.pruneLateAsk();
-      this.askRidToId.set(rid, { askId, ts: Date.now() });
+      // Carry the ROUTED tab id with the mapping: the late-reply branch runs in a
+      // scope that only knows the socket, and the journal needs the tab the card
+      // was rendered on to address the answer.
+      this.askRidToId.set(rid, { askId, ts: Date.now(), tabId: ctx.tabId });
     }
     // Rewrite an old-panel "Unknown command" rejection into an actionable
     // update-your-panel message (see makeUnknownCommandError). Applied to the

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -933,6 +933,8 @@ export class UiBridge {
   private lateAskSink: ((askId: string, result: unknown, tabId: string) => void) | null = null;
   /** See setTabGoneListener. */
   private onTabGone: ((tabId: string, incarnation: string) => void) | null = null;
+  /** See setTabTakenOverListener. */
+  private onTabTakenOver: ((tabId: string, departed: string) => void) | null = null;
   /**
    * How long a tab must stay away before it counts as GONE rather than
    * reconnecting.
@@ -1448,6 +1450,21 @@ export class UiBridge {
         // be distinct rather than shared.
         const incarnationId = incomingTabSessionId ?? `anon:${++this.nextAnonIncarnation}`;
         this.sockIncarnation.set(sock, { tabId, incarnation: incarnationId });
+        // #486 — A DIFFERENT BROWSER TAB has taken this recurring key over. That is
+        // not a reconnect, it is a change of occupant: the previous tab's
+        // conversation is over, and anything of its still addressed to this key must
+        // stop being answerable BEFORE the newcomer can reach it. Fired here, at the
+        // hello, rather than on the departing socket's grace — a takeover is proof,
+        // so there is nothing to wait for.
+        if (existing && existing.incarnationId !== incarnationId) {
+          try {
+            this.onTabTakenOver?.(tabId, existing.incarnationId);
+          } catch (err) {
+            logger.warn(
+              `[ui-bridge] tab-takeover listener threw for ${tabId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
         this.cancelTabGone(tabId, incarnationId);
         this.conns.set(tabId, {
           sock,
@@ -2047,6 +2064,19 @@ export class UiBridge {
    *  connection map (#486). Lets per-tab bookkeeping that can only ever be
    *  delivered to that tab be surfaced and retired, instead of accumulating for
    *  a tab that may never reconnect. */
+  /**
+   * Notified when a DIFFERENT browser tab takes over a recurring tab key (#486).
+   *
+   * Distinct from the gone-listener, and deliberately immediate: a disconnect
+   * might be a reload, but a takeover is PROOF the previous occupant is done —
+   * something else is holding its key right now. Anything keyed by tab id that
+   * belongs to the departed occupant's CONVERSATION must be retired here, before
+   * the newcomer can reach it.
+   */
+  setTabTakenOverListener(listener: (tabId: string, departed: string) => void): void {
+    this.onTabTakenOver = listener;
+  }
+
   setTabGoneListener(
     listener: (tabId: string, incarnation: string) => void,
     opts: { graceMs?: number } = {},

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -110,6 +110,23 @@ interface Conn {
    * tab across a ComfyUI restart. It is used only as an accidental-routing
    * correctness proof for restart readiness; absence fails that proof closed. */
   tabSessionId?: string;
+  /**
+   * ALWAYS-PRESENT incarnation identity for this connection (#486).
+   *
+   * `tabSessionId` when the panel proved one, otherwise a bridge-minted
+   * `anon:<n>` unique to THIS connection. Never absent, and never shared: the
+   * panel returns no identity precisely when its Web Locks lease could not be
+   * acquired — i.e. when a duplicated browser tab copied the sessionStorage id —
+   * which is exactly the two-tabs-one-key case, so collapsing all such
+   * connections into one "anonymous" bucket would lose the very distinction that
+   * matters most. Distinct by construction instead.
+   *
+   * Kept SEPARATE from `tabSessionId` on purpose: that field is a proof used by
+   * the restart-readiness gate (#570/#709) and must stay absent when unproven. A
+   * synthetic id is fine for "which connection is this?" and would be a lie for
+   * "did the same browser tab come back?".
+   */
+  incarnationId: string;
   /** Canvas-less client (mobile/remote pseudo-panel) — advertised in `hello`.
    *  Lets tools resolve media to inline bytes instead of a browser /view ref. */
   headless: boolean;
@@ -733,7 +750,7 @@ export function isCapabilityRefusal(err: unknown): boolean {
  * exactly the distinction the clock has to draw. JSON-encoded so neither part
  * can be forged into the other by a separator.
  */
-function tabGoneSlot(tabId: string, incarnation: string | undefined): string {
+export function tabIncarnationSlot(tabId: string, incarnation: string | undefined): string {
   return JSON.stringify([tabId, incarnation ?? null]);
 }
 
@@ -915,7 +932,7 @@ export class UiBridge {
    */
   private lateAskSink: ((askId: string, result: unknown, tabId: string) => void) | null = null;
   /** See setTabGoneListener. */
-  private onTabGone: ((tabId: string) => void) | null = null;
+  private onTabGone: ((tabId: string, incarnation: string) => void) | null = null;
   /**
    * How long a tab must stay away before it counts as GONE rather than
    * reconnecting.
@@ -929,6 +946,18 @@ export class UiBridge {
   private tabGoneGraceMs = 60_000;
   /** Armed tab-gone clocks, keyed by (tab id, incarnation) — see armTabGone. */
   private tabGoneTimers = new Map<string, { timer: ReturnType<typeof setTimeout> }>();
+  /** Counter behind the synthetic `anon:<n>` incarnations. */
+  private nextAnonIncarnation = 0;
+  /**
+   * Which (tab, incarnation) each live socket registered as.
+   *
+   * The close handler needs this because "was I the primary connection?" is the
+   * WRONG question: when a second tab takes over a recurring `wf:<hash>` key the
+   * bridge closes the first socket, and by the time that close fires the map
+   * already points at the newcomer — so the departing tab was never armed at all
+   * and could never be declared gone. The socket knows who it was; ask it.
+   */
+  private sockIncarnation = new Map<BridgeSocket, { tabId: string; incarnation: string }>();
   /** Buffered late-but-valid ask_user answers (ask_id → result), drained by the
    *  caller via takeLateAskReply(). Bounded by a short TTL — a stale unclaimed
    *  answer is pruned rather than kept forever. */
@@ -1414,7 +1443,12 @@ export class UiBridge {
         // report and settle the departed tab's lost-answer disclosure as its own.
         // Same key is not the same tab; only the same incarnation coming back is
         // a proven return.
-        this.cancelTabGone(tabId, incomingTabSessionId);
+        // ALWAYS an identity for this connection — the panel's proven one, or a
+        // fresh synthetic. See PanelConn.incarnationId for why anonymous ones must
+        // be distinct rather than shared.
+        const incarnationId = incomingTabSessionId ?? `anon:${++this.nextAnonIncarnation}`;
+        this.sockIncarnation.set(sock, { tabId, incarnation: incarnationId });
+        this.cancelTabGone(tabId, incarnationId);
         this.conns.set(tabId, {
           sock,
           tabId,
@@ -1426,6 +1460,7 @@ export class UiBridge {
           // otherwise it cannot prove that the tab receiving the reboot is the
           // tab that came back afterwards.
           tabSessionId: incomingTabSessionId,
+          incarnationId,
           headless: incomingHeadless,
           panelVersion:
             typeof (msg as { panel_version?: unknown }).panel_version === "string"
@@ -1685,12 +1720,16 @@ export class UiBridge {
         if (set.delete(sock) && set.size === 0) this.subscribers.delete(tid);
       }
       this.mirrorViewers.delete(sock);
+      // #486 — WHICH connection just died, from the socket itself. Asked before
+      // any of the map surgery below, and independently of whether this socket
+      // was still the primary: a second tab taking over a recurring key closes
+      // this one AFTER installing itself, so "am I in the map?" answers no for a
+      // tab that very much did just leave.
+      const departing = this.sockIncarnation.get(sock);
+      this.sockIncarnation.delete(sock);
       let wasPrimary = false;
       if (tabId && this.conns.get(tabId)?.sock === sock) {
         wasPrimary = true;
-        // #486 — capture WHICH incarnation is leaving before the record goes;
-        // the gone-clock is armed for that browser tab, not for the key.
-        const departingIncarnation = this.conns.get(tabId)?.tabSessionId;
         this.conns.delete(tabId);
         if (this.lastActiveTabId === tabId) this.setLastActiveTab(null);
         // The mirrored desktop tab is gone — detach its viewers so their input
@@ -1700,16 +1739,20 @@ export class UiBridge {
           if (drivenTab === tabId) this.mirrorViewers.delete(s);
         }
         this.subscribers.delete(tabId);
-        // #486 — a socket close is NOT evidence the tab is gone; it is evidence a
-        // socket closed, and an ordinary F5 produces exactly this. So the
-        // tab-gone listener is ARMED here and only fires if the tab stays away
-        // for the grace: a reload cancels it on the re-hello (see armTabGone).
-        this.armTabGone(tabId, departingIncarnation);
         logger.info(
           `[ui-bridge] panel tab disconnected: ${tabId.slice(0, 8)} — ${this.conns.size} tab(s) remain`,
         );
       }
       if (wasPrimary) this.broadcastTabList(); // a desktop tab left — refresh pickers
+      // #486 — a socket close is NOT evidence the tab is gone; it is evidence a
+      // socket closed, and an ordinary F5 produces exactly this. Arm the clock for
+      // THIS connection's incarnation and let it fire only if that incarnation
+      // stays away. Armed whether or not the socket was still primary: a takeover
+      // by a second tab on the same recurring key leaves the departing tab out of
+      // the map, and it is exactly the one that must still be declarable.
+      if (departing && this.conns.get(departing.tabId)?.incarnationId !== departing.incarnation) {
+        this.armTabGone(departing.tabId, departing.incarnation);
+      }
       // An in-flight command's socket just died. Instead of hard-failing every one
       // with a bare "disconnected" (which reads as a clean failure and invites a
       // blind retry — double render for a run), hand each to the disconnect handler:
@@ -2004,7 +2047,10 @@ export class UiBridge {
    *  connection map (#486). Lets per-tab bookkeeping that can only ever be
    *  delivered to that tab be surfaced and retired, instead of accumulating for
    *  a tab that may never reconnect. */
-  setTabGoneListener(listener: (tabId: string) => void, opts: { graceMs?: number } = {}): void {
+  setTabGoneListener(
+    listener: (tabId: string, incarnation: string) => void,
+    opts: { graceMs?: number } = {},
+  ): void {
     this.onTabGone = listener;
     if (typeof opts.graceMs === "number" && opts.graceMs >= 0) this.tabGoneGraceMs = opts.graceMs;
   }
@@ -2020,13 +2066,13 @@ export class UiBridge {
    * disclosure surface — folding "could not tell" into "it's back" is how a
    * warning goes missing.
    */
-  private armTabGone(tabId: string, incarnation: string | undefined): void {
+  private armTabGone(tabId: string, incarnation: string): void {
     if (!this.onTabGone) return;
     // Keyed per INCARNATION, so two browser tabs that share a recurring
     // `wf:<hash>` key each get their own clock. Keyed by tab id alone, the
     // second tab's departure would silently drop the first tab's pending
     // signal and it would never be declarable gone at all.
-    const slot = tabGoneSlot(tabId, incarnation);
+    const slot = tabIncarnationSlot(tabId, incarnation);
     const prev = this.tabGoneTimers.get(slot);
     if (prev) clearTimeout(prev.timer);
     const timer = setTimeout(() => {
@@ -2034,10 +2080,11 @@ export class UiBridge {
       // Re-check, on the INCARNATION and not just the key: something else may
       // now hold this recurring id, and a stranger holding the key is not this
       // tab coming back.
-      const now = this.conns.get(tabId);
-      if (now && incarnation !== undefined && now.tabSessionId === incarnation) return;
+      // Re-check on the INCARNATION, not the key: something else may now hold
+      // this recurring id, and a stranger holding the key is not this tab back.
+      if (this.conns.get(tabId)?.incarnationId === incarnation) return;
       try {
-        this.onTabGone?.(tabId);
+        this.onTabGone?.(tabId, incarnation);
       } catch (err) {
         logger.warn(
           `[ui-bridge] tab-gone listener threw for ${tabId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
@@ -2059,11 +2106,12 @@ export class UiBridge {
    * unconditionally, for the deliberate teardown path that has no incarnation to
    * name.
    */
-  private cancelTabGone(tabId: string, incarnation: string | undefined): void {
-    // An UNIDENTIFIED hello (an old panel that sends no `tab_session_id`) proves
-    // nothing about which tab came back, so it cancels nothing.
-    if (incarnation === undefined) return;
-    const slot = tabGoneSlot(tabId, incarnation);
+  private cancelTabGone(tabId: string, incarnation: string): void {
+    // Only the SAME incarnation cancels. An anonymous connection gets a fresh
+    // synthetic id, so it can never match a predecessor's slot — an unidentified
+    // panel therefore still cannot suppress anyone's owed warning, which is the
+    // asymmetry this must preserve.
+    const slot = tabIncarnationSlot(tabId, incarnation);
     const armed = this.tabGoneTimers.get(slot);
     if (!armed) return;
     clearTimeout(armed.timer);
@@ -2076,6 +2124,13 @@ export class UiBridge {
     if (!e) return undefined;
     this.lateAskReplies.delete(askId);
     return e.result;
+  }
+
+  /** The incarnation currently holding `tabId` — the identity every structure
+   *  that stores per-tab state must scope to, so a different browser tab taking
+   *  over a recurring `wf:<hash>` key cannot read, settle or inherit it (#486). */
+  tabIncarnation(tabId: string): string | undefined {
+    return this.conns.get(tabId)?.incarnationId;
   }
 
   /** All currently connected tabs, most recent hello last. */

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1908,9 +1908,36 @@ export class UiBridge {
         `[ui-bridge] over ${UiBridge.MAX_ASK_RID_MAPPINGS} question cards are open at once — forgetting the ${excess} oldest; a late answer for those can no longer be delivered`,
       );
       let i = 0;
-      for (const rid of this.askRidToId.keys()) {
+      const orphanedTabs = new Set<string>();
+      for (const [rid, e] of this.askRidToId) {
         if (i++ >= excess) break;
         this.askRidToId.delete(rid);
+        orphanedTabs.add(e.tabId);
+      }
+      // TELL THE USER, on their own screen.
+      //
+      // Preferring loss over misattribution here is a sound call, but a server
+      // log is not a disclosure to the person holding the mouse: without this,
+      // the next thing that happens is someone clicking a button on a card that
+      // is still sitting there and having it do NOTHING — no answer delivered, no
+      // error, no sign anything went wrong. That is the worst possible
+      // presentation of a deliberate trade. Say it once per affected tab, at the
+      // moment we know, and name what to do instead.
+      for (const tabId of orphanedTabs) {
+        try {
+          this.push(
+            {
+              type: "say",
+              text:
+                `⚠️ Too many question cards are open at once in this tab, so the oldest ones can no ` +
+                `longer accept an answer — clicking them will do nothing. Answer the most recent card, ` +
+                `or just type your choice in the chat and the agent will pick it up.`,
+            },
+            tabId,
+          );
+        } catch {
+          // Best-effort: the log above is the durable record.
+        }
       }
     }
   }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -901,6 +901,8 @@ export class UiBridge {
    * caller required — after which it is durable and can be replayed or pushed.
    */
   private lateAskSink: ((askId: string, result: unknown, tabId: string) => void) | null = null;
+  /** See setTabGoneListener. */
+  private onTabGone: ((tabId: string) => void) | null = null;
   /** Buffered late-but-valid ask_user answers (ask_id → result), drained by the
    *  caller via takeLateAskReply(). Bounded by a short TTL — a stale unclaimed
    *  answer is pruned rather than kept forever. */
@@ -1657,6 +1659,17 @@ export class UiBridge {
           if (drivenTab === tabId) this.mirrorViewers.delete(s);
         }
         this.subscribers.delete(tabId);
+        // #486 — the tab is off the map. Anything holding per-tab state it can
+        // only ever hand to THIS tab needs to know now, while the count is still
+        // known, rather than accumulating a record for a tab that may never come
+        // back. Never let a listener's fault break the disconnect path.
+        try {
+          this.onTabGone?.(tabId);
+        } catch (err) {
+          logger.warn(
+            `[ui-bridge] tab-gone listener threw for ${tabId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
         logger.info(
           `[ui-bridge] panel tab disconnected: ${tabId.slice(0, 8)} — ${this.conns.size} tab(s) remain`,
         );
@@ -1950,6 +1963,14 @@ export class UiBridge {
    *  (#486). Called once at orchestrator start-up. */
   setLateAskReplySink(sink: (askId: string, result: unknown, tabId: string) => void): void {
     this.lateAskSink = sink;
+  }
+
+  /** Notified when a tab's PRIMARY connection is dropped and it leaves the
+   *  connection map (#486). Lets per-tab bookkeeping that can only ever be
+   *  delivered to that tab be surfaced and retired, instead of accumulating for
+   *  a tab that may never reconnect. */
+  setTabGoneListener(listener: (tabId: string) => void): void {
+    this.onTabGone = listener;
   }
 
   takeLateAskReply(askId: string): unknown | undefined {

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -947,7 +947,10 @@ export class UiBridge {
    */
   private tabGoneGraceMs = 60_000;
   /** Armed tab-gone clocks, keyed by (tab id, incarnation) — see armTabGone. */
-  private tabGoneTimers = new Map<string, { timer: ReturnType<typeof setTimeout> }>();
+  private tabGoneTimers = new Map<
+    string,
+    { timer: ReturnType<typeof setTimeout>; tabId: string; incarnation: string }
+  >();
   /** Counter behind the synthetic `anon:<n>` incarnations. */
   private nextAnonIncarnation = 0;
   /**
@@ -1448,7 +1451,17 @@ export class UiBridge {
         // ALWAYS an identity for this connection — the panel's proven one, or a
         // fresh synthetic. See PanelConn.incarnationId for why anonymous ones must
         // be distinct rather than shared.
-        const incarnationId = incomingTabSessionId ?? `anon:${++this.nextAnonIncarnation}`;
+        // PER CONNECTION, not per hello. A panel re-hellos on its own live socket
+        // (a title change, a re-registration), and minting a fresh `anon:<n>`
+        // there would make the connection look like a stranger to itself: the
+        // takeover branch below would fire and close its own asks, after which
+        // its real conversation could neither recover nor be pushed its answers.
+        // The identity is a property of the connection; an event that can repeat
+        // on one connection must not mint a new one.
+        const incarnationId =
+          incomingTabSessionId ??
+          this.sockIncarnation.get(sock)?.incarnation ??
+          `anon:${++this.nextAnonIncarnation}`;
         this.sockIncarnation.set(sock, { tabId, incarnation: incarnationId });
         // #486 — A DIFFERENT BROWSER TAB has taken this recurring key over. That is
         // not a reconnect, it is a change of occupant: the previous tab's
@@ -2105,25 +2118,43 @@ export class UiBridge {
     const slot = tabIncarnationSlot(tabId, incarnation);
     const prev = this.tabGoneTimers.get(slot);
     if (prev) clearTimeout(prev.timer);
-    const timer = setTimeout(() => {
-      this.tabGoneTimers.delete(slot);
-      // Re-check, on the INCARNATION and not just the key: something else may
-      // now hold this recurring id, and a stranger holding the key is not this
-      // tab coming back.
-      // Re-check on the INCARNATION, not the key: something else may now hold
-      // this recurring id, and a stranger holding the key is not this tab back.
-      if (this.conns.get(tabId)?.incarnationId === incarnation) return;
-      try {
-        this.onTabGone?.(tabId, incarnation);
-      } catch (err) {
-        logger.warn(
-          `[ui-bridge] tab-gone listener threw for ${tabId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-    }, this.tabGoneGraceMs);
+    const timer = setTimeout(() => this.fireTabGone(slot, tabId, incarnation), this.tabGoneGraceMs);
     // Never hold the process open just to declare a tab gone.
     timer.unref?.();
-    this.tabGoneTimers.set(slot, { timer });
+    this.tabGoneTimers.set(slot, { timer, tabId, incarnation });
+  }
+
+  /** The clock elapsed for one (tab, incarnation). Split out so a test can run
+   *  it at a chosen moment instead of racing a wall-clock grace. */
+  private fireTabGone(slot: string, tabId: string, incarnation: string): void {
+    this.tabGoneTimers.delete(slot);
+    // Re-check on the INCARNATION, not the key: something else may now hold this
+    // recurring id, and a stranger holding the key is not this tab coming back.
+    if (this.conns.get(tabId)?.incarnationId === incarnation) return;
+    try {
+      this.onTabGone?.(tabId, incarnation);
+    } catch (err) {
+      logger.warn(
+        `[ui-bridge] tab-gone listener threw for ${tabId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * TEST ONLY — run every armed gone-clock right now.
+   *
+   * The clocks are the one part of this file whose behaviour is defined by
+   * elapsed time, and a test that races a real grace is worse than no test: too
+   * short and it fails on a correct implementation, too long and a timer that
+   * fires before the successor's hello lands makes a broken cancel look caught.
+   * Widening the window only hides the second direction. So tests wait for the
+   * state they care about to be provably reached, then run the clocks here.
+   */
+  __runTabGoneClocksForTest(): void {
+    for (const [slot, armed] of [...this.tabGoneTimers]) {
+      clearTimeout(armed.timer);
+      this.fireTabGone(slot, armed.tabId, armed.incarnation);
+    }
   }
 
   /**

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -905,10 +905,27 @@ export class UiBridge {
    *  caller via takeLateAskReply(). Bounded by a short TTL — a stale unclaimed
    *  answer is pruned rather than kept forever. */
   private lateAskReplies = new Map<string, { result: unknown; ts: number }>();
-  /** TTL for a buffered late ask answer / an unresolved rid→ask_id mapping. Long
-   *  enough to cover a slow human pick within the MCP tools/call budget, short
-   *  enough that abandoned entries don't accumulate. */
+  /** TTL for a BUFFERED late ask answer. Only an in-flight caller drains this
+   *  (its grace poll lives well under 5 minutes), and the durable copy is the
+   *  journal the sink feeds — so this stays short. */
   private static readonly LATE_ASK_TTL_MS = 5 * 60 * 1000;
+  /**
+   * TTL for the rid→ask_id MAPPING, which is a different thing with a different
+   * job: it is what lets a late reply be RECOGNISED as a card answer at all, and
+   * therefore what gates the durable sink. A question card sits on screen until
+   * the user deals with it — which can be far longer than any tool call — so
+   * pruning this at the buffer's 5 minutes would silently discard a validated
+   * answer that the journal would otherwise have kept (#486). Kept an order of
+   * magnitude longer than the journal's own recovery window, so the JOURNAL's
+   * bound is the binding one and this is never the thing that loses an answer.
+   * Three small fields per open card; the cardinality cap below bounds it.
+   */
+  private static readonly LATE_ASK_MAP_TTL_MS = 60 * 60 * 1000;
+  /** Concurrent ask cards whose rid→ask_id mapping is retained. Far above any
+   *  real session (which has one or two); exceeding it is logged, because
+   *  dropping the oldest mapping means a late answer for that card can no longer
+   *  be recognised. */
+  private static readonly MAX_ASK_RID_MAPPINGS = 1024;
   /** In-flight IDEMPOTENT reads whose socket dropped mid-command, parked per tabId
    *  waiting a bounded grace for that tab to reconnect so we can re-dispatch them
    *  (resume) instead of hard-failing. Never holds mutating commands. */
@@ -1880,16 +1897,21 @@ export class UiBridge {
     for (const [id, e] of this.lateAskReplies) {
       if (now - e.ts > UiBridge.LATE_ASK_TTL_MS) this.lateAskReplies.delete(id);
     }
-    // TTL-prune abandoned rid→ask_id mappings (a card that timed out / dropped and
-    // whose late reply never came), so they don't linger past the window a caller
-    // could still claim them.
+    // TTL-prune abandoned rid→ask_id mappings on their OWN, much longer clock —
+    // this is what makes a late answer recognisable at all (#486), so it must
+    // outlive the buffer above rather than share its window.
     for (const [rid, e] of this.askRidToId) {
-      if (now - e.ts > UiBridge.LATE_ASK_TTL_MS) this.askRidToId.delete(rid);
+      if (now - e.ts > UiBridge.LATE_ASK_MAP_TTL_MS) this.askRidToId.delete(rid);
     }
-    // Belt-and-suspenders cardinality cap in case of a burst of asks within one TTL
-    // window — drop the oldest-inserted mappings so the map can never grow unbounded.
-    if (this.askRidToId.size > 256) {
-      const excess = this.askRidToId.size - 256;
+    // Cardinality cap in case of a burst of asks within one TTL window — drop the
+    // oldest-inserted mappings so the map can never grow unbounded. LOUD: past
+    // this point a late answer for that card can no longer be recognised, so it
+    // is a real (if wildly unlikely) degradation, not routine housekeeping.
+    if (this.askRidToId.size > UiBridge.MAX_ASK_RID_MAPPINGS) {
+      const excess = this.askRidToId.size - UiBridge.MAX_ASK_RID_MAPPINGS;
+      logger.error(
+        `[ui-bridge] over ${UiBridge.MAX_ASK_RID_MAPPINGS} question cards are open at once — forgetting the ${excess} oldest; a late answer for those can no longer be delivered`,
+      );
       let i = 0;
       for (const rid of this.askRidToId.keys()) {
         if (i++ >= excess) break;

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -910,21 +910,18 @@ export class UiBridge {
    *  journal the sink feeds — so this stays short. */
   private static readonly LATE_ASK_TTL_MS = 5 * 60 * 1000;
   /**
-   * TTL for the rid→ask_id MAPPING, which is a different thing with a different
+   * Ask cards whose rid→ask_id mapping is retained.
+   *
+   * This mapping is a different thing from the buffer above, with a different
    * job: it is what lets a late reply be RECOGNISED as a card answer at all, and
-   * therefore what gates the durable sink. A question card sits on screen until
-   * the user deals with it — which can be far longer than any tool call — so
-   * pruning this at the buffer's 5 minutes would silently discard a validated
-   * answer that the journal would otherwise have kept (#486). Kept an order of
-   * magnitude longer than the journal's own recovery window, so the JOURNAL's
-   * bound is the binding one and this is never the thing that loses an answer.
-   * Three small fields per open card; the cardinality cap below bounds it.
+   * therefore what gates the durable ask journal (#486). It deliberately has NO
+   * TTL. A question card sits on screen until the user deals with it, which can
+   * be arbitrarily longer than any tool call, so any clock here would be a
+   * stopwatch quietly deciding that a validated answer no longer counts — and
+   * the answer would be dropped with no record at all. Three small fields per
+   * card, so a whole session's worth costs nothing; overflowing THIS is the only
+   * way a mapping is ever forgotten, and it is logged at ERROR.
    */
-  private static readonly LATE_ASK_MAP_TTL_MS = 60 * 60 * 1000;
-  /** Concurrent ask cards whose rid→ask_id mapping is retained. Far above any
-   *  real session (which has one or two); exceeding it is logged, because
-   *  dropping the oldest mapping means a late answer for that card can no longer
-   *  be recognised. */
   private static readonly MAX_ASK_RID_MAPPINGS = 1024;
   /** In-flight IDEMPOTENT reads whose socket dropped mid-command, parked per tabId
    *  waiting a bounded grace for that tab to reconnect so we can re-dispatch them
@@ -1897,16 +1894,14 @@ export class UiBridge {
     for (const [id, e] of this.lateAskReplies) {
       if (now - e.ts > UiBridge.LATE_ASK_TTL_MS) this.lateAskReplies.delete(id);
     }
-    // TTL-prune abandoned rid→ask_id mappings on their OWN, much longer clock —
-    // this is what makes a late answer recognisable at all (#486), so it must
-    // outlive the buffer above rather than share its window.
-    for (const [rid, e] of this.askRidToId) {
-      if (now - e.ts > UiBridge.LATE_ASK_MAP_TTL_MS) this.askRidToId.delete(rid);
-    }
-    // Cardinality cap in case of a burst of asks within one TTL window — drop the
-    // oldest-inserted mappings so the map can never grow unbounded. LOUD: past
-    // this point a late answer for that card can no longer be recognised, so it
-    // is a real (if wildly unlikely) degradation, not routine housekeeping.
+    // NOTE: rid→ask_id mappings are deliberately NOT TTL-pruned — see
+    // MAX_ASK_RID_MAPPINGS. A card can be answered arbitrarily late, and this
+    // mapping is the only thing that makes such an answer recognisable.
+    //
+    // The cardinality cap is the sole bound: drop the oldest-inserted mappings so
+    // the map can never grow without limit. LOUD, because past this point a late
+    // answer for that card can no longer be recognised — a real (if wildly
+    // unlikely) degradation, not routine housekeeping.
     if (this.askRidToId.size > UiBridge.MAX_ASK_RID_MAPPINGS) {
       const excess = this.askRidToId.size - UiBridge.MAX_ASK_RID_MAPPINGS;
       logger.error(

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -903,6 +903,19 @@ export class UiBridge {
   private lateAskSink: ((askId: string, result: unknown, tabId: string) => void) | null = null;
   /** See setTabGoneListener. */
   private onTabGone: ((tabId: string) => void) | null = null;
+  /**
+   * How long a tab must stay away before it counts as GONE rather than
+   * reconnecting.
+   *
+   * A reload closes the socket and re-hellos moments later, so firing on the
+   * close itself would retire live per-tab state during an ordinary F5. Sized
+   * far above any reload (and above RECONNECT_GRACE_MS, which bounds a much more
+   * urgent decision): waiting costs nothing but a little bookkeeping held
+   * slightly longer, while firing early destroys it.
+   */
+  private tabGoneGraceMs = 60_000;
+  /** Armed tab-gone timers, cancelled by a re-hello. */
+  private tabGoneTimers = new Map<string, ReturnType<typeof setTimeout>>();
   /** Buffered late-but-valid ask_user answers (ask_id → result), drained by the
    *  caller via takeLateAskReply(). Bounded by a short TTL — a stale unclaimed
    *  answer is pruned rather than kept forever. */
@@ -1373,6 +1386,16 @@ export class UiBridge {
             // Already gone.
           }
         }
+        // #486 — the tab is BACK. Cancel any pending "is it gone?" clock so an
+        // ordinary reload never retires state only this tab can be told about.
+        //
+        // DEFENCE IN DEPTH: the timer re-checks `conns` before firing, so a
+        // reconnect is already safe without this and no test can fail on it. It
+        // is here because a live timer for a tab that is demonstrably present is
+        // a lie about the state of the world, and the next person to add a
+        // condition to that callback should not have to discover that the guard
+        // depends on the re-check being reached.
+        this.cancelTabGone(tabId);
         this.conns.set(tabId, {
           sock,
           tabId,
@@ -1659,17 +1682,11 @@ export class UiBridge {
           if (drivenTab === tabId) this.mirrorViewers.delete(s);
         }
         this.subscribers.delete(tabId);
-        // #486 — the tab is off the map. Anything holding per-tab state it can
-        // only ever hand to THIS tab needs to know now, while the count is still
-        // known, rather than accumulating a record for a tab that may never come
-        // back. Never let a listener's fault break the disconnect path.
-        try {
-          this.onTabGone?.(tabId);
-        } catch (err) {
-          logger.warn(
-            `[ui-bridge] tab-gone listener threw for ${tabId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
+        // #486 — a socket close is NOT evidence the tab is gone; it is evidence a
+        // socket closed, and an ordinary F5 produces exactly this. So the
+        // tab-gone listener is ARMED here and only fires if the tab stays away
+        // for the grace: a reload cancels it on the re-hello (see armTabGone).
+        this.armTabGone(tabId);
         logger.info(
           `[ui-bridge] panel tab disconnected: ${tabId.slice(0, 8)} — ${this.conns.size} tab(s) remain`,
         );
@@ -1969,8 +1986,39 @@ export class UiBridge {
    *  connection map (#486). Lets per-tab bookkeeping that can only ever be
    *  delivered to that tab be surfaced and retired, instead of accumulating for
    *  a tab that may never reconnect. */
-  setTabGoneListener(listener: (tabId: string) => void): void {
+  setTabGoneListener(listener: (tabId: string) => void, opts: { graceMs?: number } = {}): void {
     this.onTabGone = listener;
+    if (typeof opts.graceMs === "number" && opts.graceMs >= 0) this.tabGoneGraceMs = opts.graceMs;
+  }
+
+  /** Start the "is this tab actually gone?" clock. A re-hello for the same id
+   *  cancels it (cancelTabGone), so a reload never fires the listener. */
+  private armTabGone(tabId: string): void {
+    if (!this.onTabGone) return;
+    this.cancelTabGone(tabId);
+    const timer = setTimeout(() => {
+      this.tabGoneTimers.delete(tabId);
+      // Re-check: the tab may have come back under this very id.
+      if (this.conns.has(tabId)) return;
+      try {
+        this.onTabGone?.(tabId);
+      } catch (err) {
+        logger.warn(
+          `[ui-bridge] tab-gone listener threw for ${tabId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }, this.tabGoneGraceMs);
+    // Never hold the process open just to declare a tab gone.
+    timer.unref?.();
+    this.tabGoneTimers.set(tabId, timer);
+  }
+
+  /** The tab is back (or is being torn down deliberately) — it is not gone. */
+  private cancelTabGone(tabId: string): void {
+    const timer = this.tabGoneTimers.get(tabId);
+    if (!timer) return;
+    clearTimeout(timer);
+    this.tabGoneTimers.delete(tabId);
   }
 
   takeLateAskReply(askId: string): unknown | undefined {
@@ -2727,6 +2775,8 @@ export class UiBridge {
   }
 
   async stop(): Promise<void> {
+    for (const timer of this.tabGoneTimers.values()) clearTimeout(timer);
+    this.tabGoneTimers.clear();
     if (this.bindRetryTimer) {
       clearTimeout(this.bindRetryTimer);
       this.bindRetryTimer = null;

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -724,6 +724,19 @@ export function isCapabilityRefusal(err: unknown): boolean {
 }
 
 /** Tag an error as a reply-timeout and return it (for throw/reject). */
+/**
+ * Key for a pending "is this tab gone?" clock (#486).
+ *
+ * (tab id, INCARNATION) — a `wf:<hash>` tab id recurs, so it names a workflow,
+ * not a browser tab. The incarnation is the panel's sessionStorage-backed
+ * `tab_session_id`: unique per browser tab and stable across a reload, which is
+ * exactly the distinction the clock has to draw. JSON-encoded so neither part
+ * can be forged into the other by a separator.
+ */
+function tabGoneSlot(tabId: string, incarnation: string | undefined): string {
+  return JSON.stringify([tabId, incarnation ?? null]);
+}
+
 export function markReplyTimeout<E extends Error>(err: E): E {
   Object.defineProperty(err, REPLY_TIMEOUT, {
     value: true,
@@ -914,8 +927,8 @@ export class UiBridge {
    * slightly longer, while firing early destroys it.
    */
   private tabGoneGraceMs = 60_000;
-  /** Armed tab-gone timers, cancelled by a re-hello. */
-  private tabGoneTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Armed tab-gone clocks, keyed by (tab id, incarnation) — see armTabGone. */
+  private tabGoneTimers = new Map<string, { timer: ReturnType<typeof setTimeout> }>();
   /** Buffered late-but-valid ask_user answers (ask_id → result), drained by the
    *  caller via takeLateAskReply(). Bounded by a short TTL — a stale unclaimed
    *  answer is pruned rather than kept forever. */
@@ -1386,16 +1399,22 @@ export class UiBridge {
             // Already gone.
           }
         }
-        // #486 — the tab is BACK. Cancel any pending "is it gone?" clock so an
+        const incomingTabSessionId =
+          typeof (msg as { tab_session_id?: unknown }).tab_session_id === "string" &&
+          (msg as { tab_session_id?: string }).tab_session_id?.trim()
+            ? (msg as { tab_session_id?: string }).tab_session_id!.trim()
+            : undefined;
+        // #486 — THIS tab is back. Cancel its pending "is it gone?" clock, so an
         // ordinary reload never retires state only this tab can be told about.
         //
-        // DEFENCE IN DEPTH: the timer re-checks `conns` before firing, so a
-        // reconnect is already safe without this and no test can fail on it. It
-        // is here because a live timer for a tab that is demonstrably present is
-        // a lie about the state of the world, and the next person to add a
-        // condition to that callback should not have to discover that the guard
-        // depends on the re-check being reached.
-        this.cancelTabGone(tabId);
+        // Matched on the BROWSER-TAB SESSION, not the key: a `wf:<hash>` key
+        // recurs, so a DIFFERENT tab opening the same saved workflow takes it
+        // over. Keyed on the id alone, that stranger's hello would cancel the
+        // departed tab's clock — and a later result from the stranger could then
+        // report and settle the departed tab's lost-answer disclosure as its own.
+        // Same key is not the same tab; only the same incarnation coming back is
+        // a proven return.
+        this.cancelTabGone(tabId, incomingTabSessionId);
         this.conns.set(tabId, {
           sock,
           tabId,
@@ -1406,11 +1425,7 @@ export class UiBridge {
           // tab id. The browser-tab identity must have arrived on THIS hello,
           // otherwise it cannot prove that the tab receiving the reboot is the
           // tab that came back afterwards.
-          tabSessionId:
-            typeof (msg as { tab_session_id?: unknown }).tab_session_id === "string" &&
-            (msg as { tab_session_id?: string }).tab_session_id?.trim()
-              ? (msg as { tab_session_id?: string }).tab_session_id!.trim()
-              : undefined,
+          tabSessionId: incomingTabSessionId,
           headless: incomingHeadless,
           panelVersion:
             typeof (msg as { panel_version?: unknown }).panel_version === "string"
@@ -1673,6 +1688,9 @@ export class UiBridge {
       let wasPrimary = false;
       if (tabId && this.conns.get(tabId)?.sock === sock) {
         wasPrimary = true;
+        // #486 — capture WHICH incarnation is leaving before the record goes;
+        // the gone-clock is armed for that browser tab, not for the key.
+        const departingIncarnation = this.conns.get(tabId)?.tabSessionId;
         this.conns.delete(tabId);
         if (this.lastActiveTabId === tabId) this.setLastActiveTab(null);
         // The mirrored desktop tab is gone — detach its viewers so their input
@@ -1686,7 +1704,7 @@ export class UiBridge {
         // socket closed, and an ordinary F5 produces exactly this. So the
         // tab-gone listener is ARMED here and only fires if the tab stays away
         // for the grace: a reload cancels it on the re-hello (see armTabGone).
-        this.armTabGone(tabId);
+        this.armTabGone(tabId, departingIncarnation);
         logger.info(
           `[ui-bridge] panel tab disconnected: ${tabId.slice(0, 8)} — ${this.conns.size} tab(s) remain`,
         );
@@ -1991,15 +2009,33 @@ export class UiBridge {
     if (typeof opts.graceMs === "number" && opts.graceMs >= 0) this.tabGoneGraceMs = opts.graceMs;
   }
 
-  /** Start the "is this tab actually gone?" clock. A re-hello for the same id
-   *  cancels it (cancelTabGone), so a reload never fires the listener. */
-  private armTabGone(tabId: string): void {
+  /**
+   * Start the "is this tab actually gone?" clock for the INCARNATION that just
+   * left — its browser-tab session id, which is sessionStorage-backed and so
+   * survives a reload while being unique per browser tab.
+   *
+   * `incarnation` undefined means the departing panel never identified itself
+   * (an old build). Nothing can then PROVE it came back, so nothing may suppress
+   * the signal: it fires at the end of the grace. Unknown-return has to let the
+   * disclosure surface — folding "could not tell" into "it's back" is how a
+   * warning goes missing.
+   */
+  private armTabGone(tabId: string, incarnation: string | undefined): void {
     if (!this.onTabGone) return;
-    this.cancelTabGone(tabId);
+    // Keyed per INCARNATION, so two browser tabs that share a recurring
+    // `wf:<hash>` key each get their own clock. Keyed by tab id alone, the
+    // second tab's departure would silently drop the first tab's pending
+    // signal and it would never be declarable gone at all.
+    const slot = tabGoneSlot(tabId, incarnation);
+    const prev = this.tabGoneTimers.get(slot);
+    if (prev) clearTimeout(prev.timer);
     const timer = setTimeout(() => {
-      this.tabGoneTimers.delete(tabId);
-      // Re-check: the tab may have come back under this very id.
-      if (this.conns.has(tabId)) return;
+      this.tabGoneTimers.delete(slot);
+      // Re-check, on the INCARNATION and not just the key: something else may
+      // now hold this recurring id, and a stranger holding the key is not this
+      // tab coming back.
+      const now = this.conns.get(tabId);
+      if (now && incarnation !== undefined && now.tabSessionId === incarnation) return;
       try {
         this.onTabGone?.(tabId);
       } catch (err) {
@@ -2010,15 +2046,28 @@ export class UiBridge {
     }, this.tabGoneGraceMs);
     // Never hold the process open just to declare a tab gone.
     timer.unref?.();
-    this.tabGoneTimers.set(tabId, timer);
+    this.tabGoneTimers.set(slot, { timer });
   }
 
-  /** The tab is back (or is being torn down deliberately) — it is not gone. */
-  private cancelTabGone(tabId: string): void {
-    const timer = this.tabGoneTimers.get(tabId);
-    if (!timer) return;
-    clearTimeout(timer);
-    this.tabGoneTimers.delete(tabId);
+  /**
+   * THIS tab is back (or is being torn down deliberately) — it is not gone.
+   *
+   * Only the SAME incarnation cancels. A different browser tab taking over a
+   * recurring `wf:<hash>` key must leave the departed tab's clock running, or
+   * the departed tab becomes permanently undeclarable and its disclosure can be
+   * settled by a conversation that never owned it. `undefined` cancels
+   * unconditionally, for the deliberate teardown path that has no incarnation to
+   * name.
+   */
+  private cancelTabGone(tabId: string, incarnation: string | undefined): void {
+    // An UNIDENTIFIED hello (an old panel that sends no `tab_session_id`) proves
+    // nothing about which tab came back, so it cancels nothing.
+    if (incarnation === undefined) return;
+    const slot = tabGoneSlot(tabId, incarnation);
+    const armed = this.tabGoneTimers.get(slot);
+    if (!armed) return;
+    clearTimeout(armed.timer);
+    this.tabGoneTimers.delete(slot);
   }
 
   takeLateAskReply(askId: string): unknown | undefined {
@@ -2775,7 +2824,7 @@ export class UiBridge {
   }
 
   async stop(): Promise<void> {
-    for (const timer of this.tabGoneTimers.values()) clearTimeout(timer);
+    for (const armed of this.tabGoneTimers.values()) clearTimeout(armed.timer);
     this.tabGoneTimers.clear();
     if (this.bindRetryTimer) {
       clearTimeout(this.bindRetryTimer);


### PR DESCRIPTION
Closes #486

## Root cause

A `panel_ask` answer had exactly **one** delivery channel: the return value of an MCP `tools/call`. That call has its own ~300s budget and its own lifetime — a turn that ends, a client that gives up, a session torn down — and when it dies the answer dies with it, three different ways:

1. **Answered in time, nobody left to return to.** `bridge.send` resolves with a validated pick, the handler returns it, and the ToolResult is written to a request the client already abandoned. Nothing recorded it.
2. **Answered during the grace poll.** Same, one layer down: the poll *takes* the answer out of the bridge's late-reply buffer (destroying it there) and returns it into the same dead request.
3. **Answered after the grace.** The handler already returned "not answered in time". The answer lands in the bridge's late-reply buffer keyed by `ask_id` and **nobody ever polls it again** — TTL-pruned five minutes later, unread.

In every case the user answered, the answer validated, and the agent either asked again or proceeded without it.

## Fix

New `src/orchestrator/ask-answer-journal.ts`, deliberately modelled on the just-merged #468/PR #786 run-completion journal — same contract, same invariant: **the journal never merges and never suppresses, it only ever labels.**

- **Captured at validation, with no caller required.** `UiBridge` gained a late-answer **sink** that fires the instant a post-timeout reply validates. That is the durability hinge: the old buffer was only reachable by a caller still polling it, and #486 is precisely the case where there is none.
- **Correlated once, at arrival.** Answers are ticketed by `ask_id`; the ticket's **question fingerprint** is frozen onto the entry there and then. A replay never re-correlates.
- **Recovered on the timeout path.** A re-ask of the identical question gets the answer the user already gave, labelled with its age and quoted with the question it answers.
- **Pushed when nobody could receive it.** An answer that reached no tool call is delivered through the agent's event queue on the same durable path a run completion uses (journal → inject → replay → ack only when the carrying turn ended), so the agent finds out even if `panel_ask` is never called again.
- **Reported, never swallowed.** An answer that cannot be attributed is journaled, logged and disclosed on the next failing ask — quoted with its own question — rather than dropped.
- **One wall-clock ceiling.** The card wait and the grace poll are now held to a single budget anchored at handler entry, instead of being additive on top of the handler's own work.

## Cross-question misattribution guard

The inverse is the more damaging direction, and it is the rule this file adds over #468's. A recovered answer may satisfy an ask **only** when:

- the **question fingerprint** is exactly equal — question text + header + multi-select + every option's **label and description** (the descriptions are what the user reads to decide, so the same labels with different explanations are a different decision);
- it is on the **same panel tab**;
- it is inside the recovery window;
- its ask id still means **one** card, and its **conversation** still exists.

There is no fuzzy match, no "closest question", and no "the only outstanding ask" fallback. Anything short of that is reported as an unattributed answer **to its own question** — never as this one's.

Conversation boundaries retire ask state (a per-tab generation, not a bounded id set): New chat, resume, **rewind**, in-place workflow replacement, and **provider switch**. A provider switch is deliberately a boundary for *questions* though #468 re-addresses *renders* across it — a finished render is useful to whoever holds the tab, an answer to a card the new conversation never put up is not. A queued-but-unread answer is **unsent** at a boundary via the same revoker mechanism #468 uses.

## Review

14 rounds of adversarial review with `gpt-5.6-terra`, then a coordinator gate (2 P0 / 1 P1 / 2 P2) and three more rounds to PASS. Findings fixed along the way, each with a mutation-verified regression test: option descriptions missing from the question identity; a recovery deleting the only durable copy; the "conversation gone" marker being a bounded id set; ask-id ownership answered from a bounded store (now syntactic, via a `pa-` prefix); reused-id ambiguity in correlation, collapse, ticket lifetime, tab routing and question text (frozen onto the ENTRY, so a trimmed ticket cannot re-enable it); rewind / workflow-replacement / provider-switch boundaries; and an answer with no ticket being announced into a conversation that may not have asked.

### The ack split, and its timing

`returned` and `acked` are two fields, because they answer two different questions. `returned` says only that the answer was written to a transport that may already have been abandoned — **that is the premise of #486**, so it can never also be the licence to forget. A `panel_ask` answer therefore **rides the turn its tool call is running inside** (`PanelAgent.attachTurnToken`) and is acked by exactly the rule #468 uses for a run completion: that turn produced its own marked result.

Everything that may forget an answer quietly keys on **acked**:
- an **acked** answer is evicted silently, no debt — so the common path stays quiet and no warning cries wolf after ~48 ordinary asks;
- a **returned-but-unacked** answer is precisely the #486 failure: counted and disclosed on eviction, named by the fatal-exit report **with no time bound** (unacked means *unproven*, and time does not turn unproven into delivered), and settleable by no bound.

**The carrier is frozen at the instant of return, not resolved later.** The tab→agent mapping moves on a provider switch, so an ack that asked "who owns this tab now?" let the new provider's turn certify an answer the new conversation never saw. Every hand-off now captures the agent-instance identity onto the entry and `ack` refuses anything else; an ack with no identity is unverifiable and also refused. An answer whose conversation has already been retired never attaches at all, so a stale pre-switch handler resuming late cannot borrow the new conversation's turn. And **recovery goes through the same `markReturned`** — it attaches by construction rather than by remembering to, which is what stopped a perfect recovery from ageing into a false "lost answer" warning.

The eviction **debt** rides that same ack, and it is not evictable: a bounded store must never decide whether a warning is owed. It ends by being **surfaced**, or when its tab is genuinely gone — never because a counter filled up.

"Gone" is not "a socket closed": an ordinary F5 closes the socket and re-hellos moments later, so the tab-gone signal is **armed on the close and only fires if the tab stays away**. A reload therefore keeps both halves of the state — the answer *and* the warning that an answer was lost. (Getting that wrong is the worst possible split: what survives is the part the user cannot see, and what dies is the part that would tell them.)

### Two orthogonal boundaries

There are two, and they need different mechanisms — neither can fence the other:

**Cross-TAB / cross-incarnation.** A different browser tab, or a duplicate, taking a recurring key. Fenced by `(tabId, incarnation)`.

**Cross-CONVERSATION on the same tab.** New chat, rewind, provider switch, in-place workflow replacement. Same tab id, same incarnation, same browser tab — so incarnation keying is blind to it. Fenced by a `retired` mark set at the boundary.

`retired` is deliberately separate from `recoverable`, which also covers *ambiguity* (an ask id that stopped identifying one card). The two axes want opposite treatment: an ambiguous answer is still **pushed**, labelled UNDETERMINED, because nobody else can claim it; a retired one must not reach a live turn at all. One flag for both would either start swallowing ambiguous answers or keep leaking retired ones.

**Counts cross a boundary; content does not.** A retired conversation's answer is never *rendered* to whoever holds the tab now — not in the tool result, not in the timeout report's `others`, not in the fatal-exit notice. What crosses is the fact that something was answered, so the disclosure survives without the leak; the text stays journaled and in the durable log. Labelling content "for the replaced conversation" was tried and is not a fence: the replacement turn reads it either way.

The rule is a property of the **set**, not of individual call sites: every path that can hand an answer or a disclosure to a live turn consults it — recovery, replay/re-arm, push, the tool-result hand-back, the timeout report, the debt footnote, and the fatal-exit notice. Inside `panel_ask` they funnel through a single `deliver()` exit, so a new outlet cannot be added without routing through the gate or deleting it. Gating them one at a time is how three separate bypasses arrived (the rid path, the release/re-arm path, the debt path). **Fence before you report; report before you destroy.** Nothing that can throw may stand between a decision and the state change that makes it safe. `closeAsks` retires every answer on the tab in one unthrowable pass *first*, then does the fallible work (recalling queued copies, logging) — a failing log sink can no longer leave the fence half-built while the caller carries on and resets the agent. And a boundary **surfaces its debt before clearing it** — counted first, reported, then cleared, so a logger that throws leaves the debt whole rather than taking the only consolidated copy with it — exactly as a tab-gone does — retiring a warning to stop it being misattributed, without saying it anywhere, would trade a misattribution for a silent loss.

And **same key is not same tab.** A `wf:<hash>` id names a saved workflow, so a second browser tab opening it takes the key over.

**The incarnation identity is `tab_session_id`, and both properties it needs are guaranteed by construction** — see `comfyui-mcp-panel/web/js/lib/restart-tab-identity.js`, which is worth reading before doubting this:
- sessionStorage supplies a **reload-stable** candidate (so an F5 keeps its identity);
- sessionStorage is persistence, not proof — a duplicated browser tab copies it — so **uniqueness is enforced by an origin-wide Web Locks exclusive lease** held for the page's lifetime;
- if the lease cannot be acquired it returns **`undefined`** and the hello omits the identity, with no timeout-as-proof fallback.

That last point is why **anonymous incarnations must be distinct rather than pooled**: the panel goes anonymous precisely when a duplicate tab copied the id — i.e. exactly the two-tabs-one-key case. The bridge therefore mints a per-connection `anon:<n>`, kept separate from `tabSessionId` so the restart-readiness proof (#570/#709) still fails closed on an unproven identity.

Everything that holds or settles per-tab state is scoped to `(tabId, incarnation)`:
- the **gone clock** is armed per incarnation from the socket's own recorded identity (not from "was I the primary?", which answers *no* for a tab a newcomer just superseded), with independent slots so a second departure cannot swallow the first's pending signal;
- the **debt**, its reporting path and its ack, so a newcomer can neither read nor settle the departed tab's disclosure;
- each **answer** carries the occupant it was given by, checked at the point of use — re-keying entries would break the thing tab-keying is for (a reload keeps its answers), so the check moved instead of the key. Unknown provenance never satisfies a known occupant.

The **writer** of a loss carries the evicted answer's own incarnation rather than re-deriving an owner from the key, so A's eviction after B arrives is filed to A — never stamped onto B's entry or B's bucket.

A **takeover** is announced immediately at the hello (a disconnect might be a reload; a takeover is proof), retiring the departed occupant's asks as a conversation boundary — the same machinery as New chat, rewind and a provider switch.

A **rid proves which card replied, not whose conversation is live**, so an answer arriving after a boundary is reported rather than returned through the tool-result channel — the one path a boundary does not otherwise police.

Both halves of the debt — the count and its outstanding disclosure tokens — **move together** on a tab-id migration, since the ack is bound to the agent instance and deliberately survives that migration. And a warning settles only the **total it actually showed**: the disclosure carries a watermark, so an eviction that lands mid-turn is not wiped by an ack that never mentioned it, and two results naming the same total settle it once.

**An answer that can never be delivered is not outstanding.** `pending()` reads `pending` as *deliverable*, the restart gate reads it as *owed*; only a retirement makes those differ permanently, so a retired answer no longer holds the self-restart gate open forever. A *temporarily* undeliverable one — another browser tab holding the key right now — still does, because it becomes deliverable again when its own tab returns.

### A note on the gone-clock tests

They control time rather than racing it. A raced grace fails both ways — too short and it fails on a correct implementation, too long and a timer firing before the successor's hello makes a broken cancel look caught. The second is the dangerous one, because a mutation "verified" through it was never verified. Each test therefore sets a grace no run can reach, waits for the state it cares about to be **provably** reached (`tabIncarnation` reports the expected occupant), and only then runs the clocks via a test hook. Every clock and identity mutation was re-verified under that regime.

### Residuals

Two remain, both **safety calls the gate affirmed**, with their disclosures fixed:
- a restart is not deferred for a returned answer — the **fatal-exit notice names it**, and keeps renders and answers apart: an answer is not a ComfyUI run and will never be in `get_history`, so its remedy is the answer text quoted back and a request to give it again;
- past the bridge's 1024-simultaneously-open-card ceiling a card can no longer be recognised — the **user is told on their own screen** that those cards cannot be answered and to type the choice in chat, instead of clicking a button that silently does nothing.

### Drive-by

`panel-tools.ts` had two literal form-feed bytes: comments written as `workflows\foo.json` / `dir\foo.json` where `\f` had been consumed as an escape, so a comment explaining that `dir\foo.json` is a *different file* from `dir/foo.json` read `dir^Loo.json` and demonstrated the opposite. Pre-existing on main; two characters.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — **4627 passed / 2 skipped / 0 failed**, on the tree rebased onto `origin/main`
- `npm run check:vocabulary` — OK
- Every new regression test mutation-verified: the fix was broken and the test confirmed to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
