### PR TITLE
fix(#809): truncated results name their own remedy — and one that works from where the caller is

### DIFF
--- a/docs/tools/custom-nodes.mdx
+++ b/docs/tools/custom-nodes.mdx
@@ -535,7 +535,7 @@ List the files in one installed custom-node pack under &lt;COMFYUI_PATH&gt;/cust
   Optional glob to filter entries (supports *, **, ?), matched against pack-relative paths.
 </ParamField>
 <ParamField path="max_entries" type="integer">
-  Maximum entries to return (default 500, max 2000).
+  Maximum entries to return (default 500, max 2000 — a hard clamp). The walk STOPS at this many, so a capped result is not the pack's full file list.
 </ParamField>
 
 ### Example
@@ -569,7 +569,7 @@ Read a slice of one file inside a custom-node pack (read-only), with bounded out
   Number of lines to return (default 240, max 800).
 </ParamField>
 <ParamField path="max_chars" type="integer">
-  Maximum characters to return (default 12000, max 24000).
+  Maximum characters to return (default 12000, min 500, max 24000 — hard clamps; values outside are silently pulled into range).
 </ParamField>
 
 ### Example
@@ -603,7 +603,7 @@ Regex-search custom-node source under custom_nodes/ (read-only). Uses ripgrep wh
   Optional glob to restrict which files are searched (e.g. '**/*.py').
 </ParamField>
 <ParamField path="max_results" type="integer">
-  Maximum matches to return (default 50, max 100).
+  Maximum matches to return (default 50, max 100). The scan STOPS at this many, so a capped result is not a complete match set.
 </ParamField>
 <ParamField path="case_sensitive" type="boolean">
   Match case-sensitively (default false).
@@ -703,7 +703,7 @@ Run a git operation inside one custom-node pack (status/diff/log/commit/push). R
   Pack-relative paths to stage/scope (jail-checked). Defaults to all pack changes.
 </ParamField>
 <ParamField path="max_chars" type="integer">
-  Maximum characters of git output to return (default 12000).
+  Maximum characters of git output to return (default 12000, min 500, max 24000 — hard clamps the runtime applies; values outside are silently pulled into range).
 </ParamField>
 
 ### Example

--- a/docs/tools/workflow-authoring.mdx
+++ b/docs/tools/workflow-authoring.mdx
@@ -315,7 +315,7 @@ Read Prompt Director's latest sanitized RUNTIME state after its nodes execute. R
 
 ## query_workflow
 
-QUERY a SAVED workflow FILE (or JSON you pass in) — NOT the live canvas, which is panel_query_graph / panel_graph_outline. Filter, traverse, project, and aggregate over its nodes WITHOUT dumping the whole JSON (the missing middle between analyze_workflow's fixed summary and get_workflow's full dump; on 100+-node graphs this is the ONLY context-safe way to answer questions like 'which KSamplers run cfg&gt;7', 'what feeds node 42', 'count nodes by type'). Provide exactly one of path/filename/graph, then combine: `types` (class_type contains any), `title` (contains), `where` widget predicates ANDed ('cfg&gt;7', 'steps&lt;=20', 'sampler_name=euler', 'text~sunset' — ops = != &gt;= &lt;= &gt; &lt; ~contains), `ids` (exact nodes — the way to read ONE node's detail), `upstream_of`/`downstream_of` + `depth` (dependency traversal: upstream = what FEEDS that node, downstream = what CONSUMES it; seed included at depth 0), `fields` ('compact' one line per node [default], 'ids', or 'detail' JSON rows with widgets + wiring), `group_by:'type'` (counts only), `limit` (default 40). Output is TOKEN-BOUNDED with an explicit truncation marker. Read-only.
+QUERY a SAVED workflow FILE (or JSON you pass in) — NOT the live canvas, which is panel_query_graph / panel_graph_outline. Filter, traverse, project, and aggregate over its nodes WITHOUT dumping the whole JSON (the missing middle between analyze_workflow's fixed summary and get_workflow's full dump; on 100+-node graphs this is the ONLY context-safe way to answer questions like 'which KSamplers run cfg&gt;7', 'what feeds node 42', 'count nodes by type'). Provide exactly one of path/filename/graph, then combine: `types` (class_type contains any), `title` (contains), `where` widget predicates ANDed ('cfg&gt;7', 'steps&lt;=20', 'sampler_name=euler', 'text~sunset' — ops = != &gt;= &lt;= &gt; &lt; ~contains), `ids` (exact nodes — the way to read ONE node's detail), `upstream_of`/`downstream_of` + `depth` (dependency traversal: upstream = what FEEDS that node, downstream = what CONSUMES it; seed included at depth 0), `fields` ('compact' one line per node [default], 'ids', or 'detail' JSON rows with widgets + wiring), `group_by:'type'` (counts only), `limit` (default 40, max 200), `max_chars` (default 12000, max 60000). Output is TOKEN-BOUNDED and, when it truncates, the tail names WHICH of the two caps fired and the exact parameter to raise — read it and retry rather than concluding the graph can't be read. Read-only.
 
 ### Parameters
 
@@ -356,10 +356,10 @@ QUERY a SAVED workflow FILE (or JSON you pass in) — NOT the live canvas, which
   Aggregate: counts per class_type instead of listing. Options: `type`.
 </ParamField>
 <ParamField path="limit" type="integer">
-  Max nodes listed (default 40).
+  Max nodes listed (default 40, max 200).
 </ParamField>
 <ParamField path="max_chars" type="integer">
-  Output character bound (default 12000). Raise only for deliberate full reads.
+  Output character bound (default 12000, max 60000). Raise this — not `limit` — when the truncation tail says the char budget cut the result.
 </ParamField>
 
 ### Example

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -941,15 +941,24 @@ describe("panel-tools: panel_find_nodes (live-graph search)", () => {
 });
 
 describe("panel-tools: panel_graph_outline (compact text map)", () => {
-  it("is registered and takes no args", () => {
+  // #809: the outline gained ONE optional argument — `max_chars`, deliberately the same
+  // name and clamp as panel_query_graph's, so there is one budget concept to learn. It
+  // stays argument-free for the "just show me the canvas" call.
+  it("is registered and takes only the optional max_chars budget", () => {
     expect(buildPanelToolDefs().map((d) => d.name)).toContain("panel_graph_outline");
-    expect(Object.keys(defByName("panel_graph_outline").schema)).toEqual([]);
+    expect(Object.keys(defByName("panel_graph_outline").schema)).toEqual(["max_chars"]);
   });
 
   it("forwards graph_outline", async () => {
     const { ctx, calls } = makeFakeCtx();
     await defByName("panel_graph_outline").handler({}, ctx);
     expect(calls[0]).toMatchObject({ cmd: "graph_outline" });
+  });
+
+  it("forwards max_chars when the caller sets one", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_graph_outline").handler({ max_chars: 4000 }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "graph_outline", max_chars: 4000 });
   });
 });
 

--- a/src/__tests__/services/graph-query.test.ts
+++ b/src/__tests__/services/graph-query.test.ts
@@ -148,7 +148,7 @@ describe("queryApiGraph", () => {
 
     it("the oversized widget value is capped, not dropped silently", () => {
       const r = queryApiGraph(Gblob, { ids: [164], fields: "detail" });
-      expect(r.text).toContain("truncated)"); // the per-value cap marker
+      expect(r.text).toContain("per-widget cap"); // #809: the per-value cap marker, naming the cap
       expect(r.text.length).toBeLessThan(BLOB.length); // blob no longer flooding
       expect(r.text).toContain('"width":1024'); // the small sibling value survives intact
     });
@@ -174,8 +174,11 @@ describe("queryApiGraph", () => {
       expect(r.matched).toBe(3);
       expect(r.shown).toBe(1); // first renders, rest budget-truncated (bounded output)
       expect(r.truncated).toBe(true);
-      expect(r.text).toContain("raise max_chars");
+      expect(r.text).toContain("raise `max_chars`");
       expect(r.text).not.toContain("narrow with"); // no dead-end advice for explicit ids
+      // #809: the char budget did the cutting, so `limit` must NOT be offered as the fix.
+      expect(r.truncated_by).toBe("max_chars");
+      expect(r.text).not.toContain("raise `limit`");
     });
 
     it("even the protected first node's detail stays token-bounded (many oversized widgets)", () => {
@@ -190,7 +193,7 @@ describe("queryApiGraph", () => {
       expect(r.shown).toBe(1); // still renders the requested node
       // Bounded: the single line must not be an order of magnitude over the budget.
       expect(r.text.length).toBeLessThan(maxChars * 2);
-      expect(r.text).toContain("omitted (exceeded budget)"); // honest elision marker
+      expect(r.text).toContain("cut by the `max_chars` budget"); // #809: elision marker names its lever
     });
 
     it("detail bound holds for a SMALL budget, even with ESCAPE-HEAVY content", () => {
@@ -218,7 +221,7 @@ describe("queryApiGraph", () => {
       const parsed = JSON.parse(r.text.split("\n")[1]);
       expect(Array.isArray(parsed.widgets.presets)).toBe(true); // FAIL-BEFORE: was a string
       expect(parsed.widgets.presets).toHaveLength(300);
-      expect(r.text).not.toContain("truncated)");
+      expect(r.text).not.toContain("per-widget cap");
     });
 
     it("a genuinely oversize OBJECT still truncates with the per-value cap marker", () => {
@@ -228,7 +231,7 @@ describe("queryApiGraph", () => {
       const Gover = { "1": { class_type: "Presets", inputs: { presets: arr } } };
       const r = queryApiGraph(Gover, { ids: [1], fields: "detail", max_chars: 6000 });
       expect(r.shown).toBe(1);
-      expect(r.text).toContain("chars, truncated)");
+      expect(r.text).toContain("per-widget cap"); // #809
       expect(r.text.length).toBeLessThan(JSON.stringify(arr).length); // capped, not flooding
     });
 
@@ -326,7 +329,7 @@ describe("queryApiGraph", () => {
       const r = queryApiGraph(G7, { group_by: "type", max_chars: maxChars });
       expect(r.text.length).toBeLessThan(maxChars * 2);
       expect(r.truncated).toBe(true);
-      expect(r.text).toContain("more type(s) omitted");
+      expect(r.text).toContain("more type(s) cut by `max_chars`");
     });
 
     it("fields:'ids' also bounds a pathologically long node id (#609)", () => {
@@ -344,7 +347,7 @@ describe("queryApiGraph", () => {
       for (let i = 0; i < 30; i++) many[String(i)] = { class_type: "KSampler", inputs: { note: "y".repeat(400) } };
       const r = queryApiGraph(many, { fields: "detail", max_chars: 800 });
       expect(r.truncated).toBe(true);
-      expect(r.text).toContain("narrow with types/where/ids/depth");
+      expect(r.text).toContain("narrow with `types`/`where`/`ids`/`depth`");
     });
   });
 });

--- a/src/__tests__/services/node-dev.test.ts
+++ b/src/__tests__/services/node-dev.test.ts
@@ -50,6 +50,11 @@ import {
   NodeDevError,
   LONG_LINE_CHUNK,
   READ_MAX_CHARS,
+  // #809
+  MIN_OUTPUT_CHARS,
+  SEARCH_LINE_MAX,
+  SEARCH_MAX_RESULTS,
+  LIST_MAX_ENTRIES,
   defaultDeps,
   type NodeDevDeps,
   type RunResult,
@@ -196,12 +201,39 @@ describe("bounding helpers", () => {
   });
 
   it("boundText clips and flags truncation", () => {
-    const r = boundText("abcdef", 3);
+    // #809: the notice is REQUIRED — boundText is shared by tools with different levers,
+    // so a default naming `max_chars` would ship a dead remedy to callers without one.
+    const notice = (dropped: number) => `[cut ${dropped}]`;
+    // The notice is reserved OUT of the budget (#809), so the budget must leave room for
+    // both: 20 chars fits "abcdef"'s head plus the ~8-char marker.
+    const r = boundText("abcdef".repeat(10), 20, notice);
     expect(r.truncated).toBe(true);
-    expect(r.text.startsWith("abc")).toBe(true);
-    const ok = boundText("abc", 10);
+    expect(r.text.startsWith("a")).toBe(true);
+    expect(r.text.length).toBeLessThanOrEqual(20);
+    const ok = boundText("abc", 10, notice);
     expect(ok.truncated).toBe(false);
     expect(ok.text).toBe("abc");
+  });
+
+  // #809 (codex gate): the marker is spent from the very budget it describes, so a longer
+  // marker must not be able to push the result past maxChars — the bound is the promise
+  // the parameter makes, and breaking it to explain the break would be absurd.
+  it("boundText keeps the RESULT within maxChars even with a long notice", () => {
+    const notice = (dropped: number) =>
+      `\n\n[... ${dropped} more char(s) cut by \`max_chars\`; raise \`max_chars\` up to ${READ_MAX_CHARS} ...]`;
+    const noticeLen = notice(50_000).length;
+    for (const budget of [200, 1000, 5000, 12_000]) {
+      const r = boundText("z".repeat(50_000), budget, notice);
+      expect(r.truncated).toBe(true);
+      expect(r.text.length, `budget ${budget} breached`).toBeLessThanOrEqual(budget);
+      // And the marker itself survives — reserving space must not clip the instruction.
+      expect(r.text).toContain("raise `max_chars`");
+    }
+    // A budget smaller than the marker cannot honour both; the MARKER wins, because an
+    // empty unexplained field reads as "the file is empty".
+    const tiny = boundText("z".repeat(50_000), 5, notice);
+    expect(tiny.text).toContain("raise `max_chars`");
+    expect(tiny.text.length).toBeLessThanOrEqual(noticeLen);
   });
 
   it("readNodeFile reports total_lines on a CRLF file and clips char budget", () => {
@@ -278,6 +310,171 @@ describe("searchNodePacks", () => {
     expect(rgCallsSpy[0].args).toContain("hit");
     // no option-injection: query passed after --regexp, not as a bare arg
     expect(rgCallsSpy[0].args[rgCallsSpy[0].args.indexOf("--regexp") + 1]).toBe("hit");
+  });
+
+  // #809 (codex gate) — BOTH directions of the truncation lie, run for real rather than
+  // asserted against the source text.
+  //
+  // `--max-count` is PER FILE, so asking rg for exactly `cap` meant a file holding more
+  // had its extras dropped by rg before we saw a line (silent loss), while a search with
+  // exactly `cap` real matches was labelled truncated (false alarm — the agent is told to
+  // retry wider for nothing, which is how it learns to distrust the tool). Asking for
+  // `cap + 1` closes both: the extra line is the proof, its absence the proof of
+  // completeness.
+  it("asks ripgrep for ONE past the cap so truncation can be PROVEN either way", () => {
+    const seen: string[][] = [];
+    const { deps } = makeDeps({
+      hasRipgrep: () => true,
+      runRipgrep: (args) => {
+        seen.push(args);
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    searchNodePacks({ query: "x", maxResults: 5 }, deps);
+    expect(seen[0][seen[0].indexOf("--max-count") + 1]).toBe("6");
+  });
+
+  it("does NOT claim truncation when the match count is exactly max_results", () => {
+    const lines = Array.from({ length: 3 }, (_, i) => `a.py:${i + 1}:hit`).join("\n");
+    const { deps } = makeDeps({
+      hasRipgrep: () => true,
+      runRipgrep: () => ({ status: 0, stdout: `${lines}\n`, stderr: "" }),
+    });
+    const res = searchNodePacks({ query: "hit", maxResults: 3 }, deps);
+    expect(res.matches).toHaveLength(3);
+    expect(res.truncated).toBe(false);
+    expect(res.truncation_hint).toBeUndefined();
+  });
+
+  it("DOES claim truncation — with the lever and ceiling — on the (cap+1)-th match", () => {
+    const lines = Array.from({ length: 4 }, (_, i) => `a.py:${i + 1}:hit`).join("\n");
+    const { deps } = makeDeps({
+      hasRipgrep: () => true,
+      runRipgrep: () => ({ status: 0, stdout: `${lines}\n`, stderr: "" }),
+    });
+    const res = searchNodePacks({ query: "hit", maxResults: 3 }, deps);
+    expect(res.matches).toHaveLength(3);
+    expect(res.truncated).toBe(true);
+    expect(res.truncated_by).toBe("max_results");
+    expect(res.truncation_hint).toContain("`max_results`");
+    expect(res.truncation_hint).toContain(`up to ${SEARCH_MAX_RESULTS}`);
+  });
+
+  // codex gate: the FIRST cut is the one the caller must act on. If a later write could
+  // flip an actionable "raise `max_results`" into "no parameter raises it", the remedy
+  // would name the wrong lever — the defect this whole issue is about.
+  it("keeps the FIRST truncation cause, so the remedy names the lever that applies", () => {
+    const files = Array.from({ length: 50 }, (_, i) => ({ name: `f${i}.py`, isDir: false }));
+    const { deps } = makeDeps({
+      hasRipgrep: () => false,
+      isDirectory: () => true,
+      listDir: () => files,
+      fileSize: () => 10,
+      readFileBuffer: () => Buffer.from("hit\nhit\nhit\n"),
+    });
+    const res = searchNodePacks({ query: "hit", maxResults: 2 }, deps);
+    expect(res.truncated).toBe(true);
+    expect(res.truncated_by).toBe("max_results");
+    expect(res.truncation_hint).toContain("`max_results`");
+    expect(res.truncation_hint).not.toContain("no parameter raises it");
+  });
+
+  it("marks the 600-char per-line clip and stays inside it", () => {
+    const { deps } = makeDeps({
+      hasRipgrep: () => true,
+      runRipgrep: () => ({ status: 0, stdout: `a.py:1:${"z".repeat(5000)}\n`, stderr: "" }),
+    });
+    const res = searchNodePacks({ query: "z" }, deps);
+    expect(res.matches[0].text.length).toBeLessThanOrEqual(SEARCH_LINE_MAX);
+    expect(res.matches[0].text).toContain("fixed 600-char per-line cap");
+  });
+});
+
+// #809 (codex gate): the file walk had the same exact-cap false alarm, and reported a
+// bare boolean with no total and no lever.
+describe("listNodePackFiles truncation honesty (#809)", () => {
+  const seed = (n: number) => {
+    const pack = join(customNodes, "Pack");
+    mkdirSync(pack, { recursive: true });
+    for (let i = 0; i < n; i++) writeFileSync(join(pack, `f${i}.py`), "x");
+  };
+
+  it("does NOT claim truncation when the entry count is exactly max_entries", () => {
+    seed(3);
+    const res = listNodePackFiles({ pack: "Pack", maxEntries: 3 });
+    expect(res.entries).toHaveLength(3);
+    expect(res.truncated).toBe(false);
+    expect(res.truncation_hint).toBeUndefined();
+  });
+
+  it("names max_entries, its ceiling, and glob when the walk really stopped early", () => {
+    seed(5);
+    const res = listNodePackFiles({ pack: "Pack", maxEntries: 3 });
+    expect(res.entries).toHaveLength(3);
+    expect(res.truncated).toBe(true);
+    expect(res.truncation_hint).toContain("`max_entries`");
+    expect(res.truncation_hint).toContain(`up to ${LIST_MAX_ENTRIES}`);
+    expect(res.truncation_hint).toContain("`glob`");
+  });
+});
+
+// #809 (codex gate): the clamps must be exercised, not asserted about. A remedy that
+// quotes a ceiling the runtime does not enforce is the same defect as a wrong param.
+describe("max_chars clamps are real (#809)", () => {
+  it("read_node_file honours the ceiling AND the floor it advertises", () => {
+    const pack = join(customNodes, "Pack");
+    mkdirSync(pack, { recursive: true });
+    // MANY lines, so paging by start_line/line_count is a live remedy here.
+    writeFileSync(join(pack, "big.py"), Array.from({ length: 5000 }, (_, i) => `line ${i} ${"z".repeat(60)}`).join("\n"));
+
+    // line_count high enough that the CHAR budget is what cuts, not the line window.
+    const over = readNodeFile({ path: "Pack/big.py", maxChars: 1_000_000, lineCount: 800 });
+    expect(over.content.length).toBeLessThanOrEqual(READ_MAX_CHARS);
+    expect(over.truncated).toBe(true);
+    // Clamped to the ceiling, so the remedy must NOT say "raise max_chars to 24000" —
+    // the caller is already there, and that retry would change nothing (#809 codex gate).
+    expect(over.content).toContain(`already at its ceiling of ${READ_MAX_CHARS}`);
+    expect(over.content).not.toContain("raise `max_chars` (up to");
+    // What IS left must still be named.
+    expect(over.content).toContain("`start_line`");
+
+    // A budget of 1 used to yield either an unexplained empty field or a marker that
+    // breached its own bound. The FLOOR (not the ceiling) fixes that.
+    const under = readNodeFile({ path: "Pack/big.py", maxChars: 1 });
+    expect(under.content.length).toBeLessThanOrEqual(MIN_OUTPUT_CHARS);
+    expect(under.content).toContain("raise `max_chars`");
+  });
+
+  // codex gate: `start_line`/`line_count` index SOURCE lines. On a slice that is ONE
+  // physical line there is nothing to page to, so offering it names a real lever that
+  // cannot move — the same wasted round trip as naming a nonexistent one.
+  it("does NOT offer line paging when the slice is a single overlong line", () => {
+    const pack = join(customNodes, "Pack");
+    mkdirSync(pack, { recursive: true });
+    writeFileSync(join(pack, "min.js"), "z".repeat(200_000));
+
+    const r = readNodeFile({ path: "Pack/min.js", maxChars: 1_000_000 });
+    expect(r.truncated).toBe(true);
+    expect(r.content).toMatch(/SINGLE physical line/);
+    expect(r.content).toMatch(/`start_line`\/`line_count` cannot reach the rest/);
+    // At the ceiling it must not pretend another parameter would help either.
+    expect(r.content).toContain(`at the ${READ_MAX_CHARS} ceiling this tool cannot return more of it`);
+    expect(r.content).toContain("search_node_packs");
+  });
+
+  it("node_pack_git honours the same ceiling and floor", () => {
+    mkdirSync(join(customNodes, "Pack"), { recursive: true });
+    const { deps } = makeDeps({
+      runGit: () => ({ status: 0, stdout: "d".repeat(200_000), stderr: "" }),
+    });
+    const over = nodePackGit({ pack: "Pack", action: "diff", maxChars: 1_000_000 }, deps);
+    expect(over.stdout.length).toBeLessThanOrEqual(READ_MAX_CHARS);
+    expect(over.stdout).toContain(`already at its ceiling of ${READ_MAX_CHARS}`);
+    expect(over.stdout).toContain("`paths`");
+
+    const under = nodePackGit({ pack: "Pack", action: "diff", maxChars: 1 }, deps);
+    expect(under.stdout.length).toBeLessThanOrEqual(MIN_OUTPUT_CHARS);
+    expect(under.stdout).toContain("raise `max_chars`");
   });
 });
 

--- a/src/__tests__/services/queue-manager.test.ts
+++ b/src/__tests__/services/queue-manager.test.ts
@@ -85,7 +85,13 @@ describe("getJobStatus history enrichment", () => {
         },
       },
     });
-    expect(status.error?.traceback).toHaveLength(TRACEBACK_MAX_CHARS);
+    // #809: the cut is now MARKED inline — a traceback that simply stopped at 2000 chars
+    // was indistinguishable, to a reader, from one that ended. The retained payload is
+    // still exactly TRACEBACK_MAX_CHARS; the marker rides after it.
+    const tb = status.error?.traceback ?? "";
+    expect(tb.slice(0, TRACEBACK_MAX_CHARS)).toHaveLength(TRACEBACK_MAX_CHARS);
+    expect(tb.slice(TRACEBACK_MAX_CHARS)).toMatch(/more char\(s\) cut at the fixed 2000-char/);
+    expect(tb.slice(TRACEBACK_MAX_CHARS)).toContain("get_logs");
   });
 
   it("adds optional timing stats for successful completed prompts", async () => {

--- a/src/__tests__/tools/get-workflow-warnings.test.ts
+++ b/src/__tests__/tools/get-workflow-warnings.test.ts
@@ -24,7 +24,14 @@ vi.mock("../../services/workflow-converter.js", () => ({
 
 // Unused-by-this-test services still imported by the module under test.
 vi.mock("../../services/workflow-slicer.js", () => ({ sliceWorkflow: vi.fn() }));
-vi.mock("../../services/graph-query.js", () => ({ queryApiGraph: vi.fn() }));
+// #809: query_workflow's schema + description now quote the engine's own clamps, so
+// the mock has to carry them — a stub that omits them fails registration outright.
+vi.mock("../../services/graph-query.js", () => ({
+  queryApiGraph: vi.fn(),
+  LIMIT_CEILING: 200,
+  MAX_CHARS_CEILING: 60000,
+  MAX_CHARS_FLOOR: 500,
+}));
 vi.mock("../../services/workflow-sections.js", () => ({ detectSections: vi.fn() }));
 vi.mock("../../services/hierarchical-mermaid.js", () => ({
   generateOverview: vi.fn(),

--- a/src/__tests__/tools/truncation-remedies.test.ts
+++ b/src/__tests__/tools/truncation-remedies.test.ts
@@ -1,0 +1,897 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listRegisteredTools } from "../../tools/introspect.js";
+import { buildPanelToolDefs } from "../../orchestrator/panel-tools.js";
+import { extractExecutionError, TRACEBACK_MAX_CHARS } from "../../services/job-history.js";
+import { parseCrashBlock } from "../../services/crash-log.js";
+import {
+  readBoundNotice,
+  gitBoundNotice,
+  patchBoundNotice,
+  clipMatchLine,
+  searchTruncationHint,
+  READ_MAX_CHARS,
+  SEARCH_LINE_MAX,
+  SEARCH_MAX_RESULTS,
+} from "../../services/node-dev.js";
+import {
+  queryApiGraph,
+  LIMIT_CEILING,
+  MAX_CHARS_CEILING,
+  MAX_CHARS_FLOOR,
+} from "../../services/graph-query.js";
+
+/**
+ * #809 — a truncation marker is an INSTRUCTION TO A MACHINE.
+ *
+ * The defect this file exists to prevent is not "the hint is missing", it is "the hint
+ * names the WRONG lever". `query_workflow`'s truncation tail told callers to raise
+ * `limit` even when the CHAR BUDGET had cut the result — where raising `limit` does
+ * nothing and makes the overflow worse. The agent tries it, it fails, and the failure
+ * confirms the wrong conclusion: "this tool cannot read this graph."
+ *
+ * So the assertions below are driven off the REAL registered surface — the JSON Schema
+ * the SDK derives from each tool's zod shape, fetched through a real MCP client by
+ * listRegisteredTools(). A hand-written table of "params that exist" would rot in
+ * exactly the way the hint itself rotted, and would have passed the whole time.
+ *
+ * The conventions the extraction relies on, which every remedy string must follow:
+ *
+ *   • A parameter OF THE EMITTING TOOL is written in `backticks`. Everything backticked
+ *     that looks like an identifier is checked against that tool's schema.
+ *   • A parameter OF A DIFFERENT tool is written bare, inside that tool's own call
+ *     syntax (`panel_query_graph {ids:[…]}`) — it is not this tool's lever and must not
+ *     be dressed as one.
+ *   • A SIBLING TOOL is named bare and must be a registered tool.
+ *   • A stated ceiling is written "`param` up to N", and N must equal the schema's real
+ *     maximum — not the prose's idea of it. (`node_pack_git`'s true 24000 ceiling was a
+ *     code clamp its description never mentioned, so callers raised past it and saw
+ *     nothing change.)
+ */
+
+/** Identifier-shaped backticked tokens: `max_chars`, `limit`, `group_by`. */
+const BACKTICKED = /`([A-Za-z_][A-Za-z0-9_]*)`/g;
+/**
+ * A sentence is a REMEDY when it tells the caller what to do about dropped content.
+ * Descriptions legitimately backtick things that are not parameters (a binary name, a
+ * response field), so the strict "backticked ⇒ parameter" rule is applied to remedy
+ * sentences only — which is exactly the surface this issue is about, and which no
+ * hand-maintained allowlist has to be kept in step with.
+ */
+const REMEDY_SENTENCE = /\braise\b|truncat|\bcut by\b|\bcapped\b|\bcap\b|\bSTOPS\b|\bbudget\b|\bomitted\b/i;
+const splitSentences = (text: string): string[] =>
+  text.split(/(?<=[.!?;])\s+|\n+/).filter((s) => s.trim().length > 0);
+/** Bare panel tool references — response fields never carry this prefix. */
+const PANEL_TOOL_REF = /\b(panel_[a-z0-9_]+)\b/g;
+/** A stated ceiling: "`max_chars` up to 60000" or "raise `max_chars` (up to 60000)". */
+const CEILING = /`([A-Za-z_][A-Za-z0-9_]*)`\s+\(?up to\s+(\d+)/g;
+/** An instruction to raise a parameter — which is only actionable WITH a ceiling. */
+const RAISE = /\braise\s+`([A-Za-z_][A-Za-z0-9_]*)`/gi;
+
+function matchAll(re: RegExp, text: string, group = 1): string[] {
+  const out: string[] = [];
+  for (const m of text.matchAll(new RegExp(re.source, re.flags))) out.push(m[group]);
+  return out;
+}
+
+describe("#809 truncation remedies name a lever that actually exists", () => {
+  let schemaOf: Map<string, Record<string, unknown>>;
+  let toolNames: Set<string>;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    // Same isolation as the surface gate: autoloaded saved-workflow tools and the
+    // compact tool mode both change what "registered" means.
+    for (const key of ["COMFYUI_WORKFLOWS_DIR", "COMFYUI_MCP_TOOL_MODE"]) {
+      saved[key] = process.env[key];
+    }
+    process.env.COMFYUI_WORKFLOWS_DIR = await mkdtemp(join(tmpdir(), "comfyui-mcp-remedy-"));
+    delete process.env.COMFYUI_MCP_TOOL_MODE;
+
+    const registered = await listRegisteredTools();
+    schemaOf = new Map();
+    toolNames = new Set(registered.map((t) => t.name));
+    for (const t of registered) {
+      const props = (t.inputSchema as { properties?: Record<string, unknown> })?.properties ?? {};
+      schemaOf.set(t.name, props);
+    }
+    // The panel_* surface is registered against a LIVE panel session, so it is not in
+    // the headless registration pass. Take its schemas from the single source of truth
+    // both transports register from — still the real zod shape, never a hand list.
+    for (const d of buildPanelToolDefs()) {
+      toolNames.add(d.name);
+      if (!schemaOf.has(d.name)) schemaOf.set(d.name, { ...d.schema });
+    }
+  });
+
+  afterAll(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  /** The one assertion the issue asks for, applied to one emitted string. */
+  function assertRemedyIsActionable(tool: string, where: string, text: string): void {
+    const props = schemaOf.get(tool);
+    expect(props, `${tool} is not a registered tool — the scenario table is stale`).toBeTruthy();
+
+    for (const name of matchAll(BACKTICKED, text)) {
+      expect(
+        Object.prototype.hasOwnProperty.call(props!, name),
+        `${where}: remedy names \`${name}\`, which is NOT a parameter of ${tool}. ` +
+          `Backticks mean "a lever on THIS tool" — a parameter of another tool must be ` +
+          `written bare inside that tool's call syntax. Remedy: ${JSON.stringify(text)}`,
+      ).toBe(true);
+    }
+
+    for (const referenced of matchAll(PANEL_TOOL_REF, text)) {
+      expect(
+        toolNames.has(referenced),
+        `${where}: remedy points the caller at "${referenced}", which is not a ` +
+          `registered tool. Remedy: ${JSON.stringify(text)}`,
+      ).toBe(true);
+    }
+
+    // THE STRONGER BAR. "names a parameter that exists" is necessary and NOT sufficient:
+    // a parameter already at its ceiling names a real lever that cannot move, and costs
+    // the caller exactly the wasted round trip this issue exists to prevent. So any
+    // remedy that says "raise `X`" must also say HOW FAR — otherwise the caller cannot
+    // tell whether the retry is even possible.
+    for (const m of text.matchAll(RAISE)) {
+      const name = m[1];
+      const stated = new RegExp(
+        `\`${name}\`[^.]{0,40}?(up to \\d+)|\`${name}\` is already at its ceiling`,
+      );
+      expect(
+        stated.test(text),
+        `${where}: remedy says "raise \`${name}\`" without a ceiling. A caller already at ` +
+          `the maximum is being sent on a retry that cannot change anything — the same ` +
+          `wasted round trip as naming a parameter that does not exist. Say "up to N", ` +
+          `or say it is already at its ceiling. Remedy: ${JSON.stringify(text)}`,
+      ).toBe(true);
+    }
+
+    for (const m of text.matchAll(CEILING)) {
+      const [, name, stated] = m;
+      const spec = props![name] as { maximum?: number } | undefined;
+      // Only enforce where the schema publishes a REAL maximum. `z.number().int()` with
+      // no `.max()` still emits `maximum: Number.MAX_SAFE_INTEGER` — the int-range
+      // sentinel, not a ceiling — and treating it as one would demand that every remedy
+      // quote 9007199254740991. Those tools clamp in code instead (node_pack_git's
+      // hidden 24000 is the case the issue names), and their remedies are pinned against
+      // the exported clamp constant by their own cases below.
+      const published =
+        spec && typeof spec.maximum === "number" && spec.maximum !== Number.MAX_SAFE_INTEGER;
+      if (published) {
+        expect(
+          Number(stated),
+          `${where}: remedy says "\`${name}\` up to ${stated}" but the schema's real ` +
+            `maximum is ${spec.maximum}. A ceiling the runtime does not honour sends the ` +
+            `caller at a value that is silently clamped.`,
+        ).toBe(spec.maximum);
+      }
+    }
+  }
+
+  // ---- query_workflow (src/services/graph-query.ts) --------------------------------
+  //
+  // Scenarios are real engine runs, not fixtures: the string under test is the one the
+  // tool would actually emit.
+
+  const bigGraph = (n: number, widget = "x") =>
+    Object.fromEntries(
+      Array.from({ length: n }, (_, i) => [
+        String(i + 1),
+        { class_type: "KSampler", inputs: { [widget]: `v${i}`, cfg: 8 }, _meta: { title: `n${i}` } },
+      ]),
+    );
+
+  const scenarios: Array<{ name: string; text: () => string }> = [
+    {
+      name: "limit cut, no ids",
+      text: () => queryApiGraph(bigGraph(120), { limit: 5, max_chars: 60000 }).text,
+    },
+    {
+      name: "char-budget cut, no ids",
+      text: () => queryApiGraph(bigGraph(120), { limit: 200, max_chars: 600 }).text,
+    },
+    {
+      name: "limit cut with explicit ids",
+      text: () =>
+        queryApiGraph(bigGraph(120), {
+          ids: Array.from({ length: 60 }, (_, i) => String(i + 1)),
+          limit: 3,
+          max_chars: 60000,
+        }).text,
+    },
+    {
+      name: "char-budget cut with explicit ids",
+      text: () =>
+        queryApiGraph(bigGraph(120), {
+          ids: Array.from({ length: 60 }, (_, i) => String(i + 1)),
+          max_chars: 600,
+        }).text,
+    },
+    {
+      name: "aggregate cut by the char budget",
+      text: () => {
+        const g: Record<string, { class_type: string; inputs: Record<string, unknown> }> = {};
+        for (let i = 0; i < 400; i++) g[String(i)] = { class_type: `Type${i}`, inputs: {} };
+        return queryApiGraph(g, { group_by: "type", max_chars: MAX_CHARS_FLOOR }).text;
+      },
+    },
+    {
+      name: "detail row whose widget value hits the fixed per-widget cap",
+      text: () =>
+        queryApiGraph(
+          { "1": { class_type: "T", inputs: { blob: "z".repeat(9000) } } },
+          { fields: "detail", max_chars: 60000 },
+        ).text,
+    },
+    {
+      // The per-widget cap TIGHTENS to the budget when the budget is the smaller of the
+      // two. That path's remedy is the opposite of the fixed-cap one — raising max_chars
+      // genuinely lifts it — so it needs its own coverage.
+      name: "detail widget value cut by the BUDGET-tightened per-value cap",
+      text: () =>
+        queryApiGraph(
+          { "1": { class_type: "T", inputs: { blob: "b".repeat(3000) } } },
+          { fields: "detail", max_chars: 2000 },
+        ).text,
+    },
+    {
+      name: "detail row whose widgets are dropped by the char budget",
+      text: () => {
+        const inputs: Record<string, unknown> = {};
+        for (let i = 0; i < 200; i++) inputs[`w${i}`] = "y".repeat(60);
+        return queryApiGraph({ "1": { class_type: "T", inputs } }, { fields: "detail", max_chars: 900 })
+          .text;
+      },
+    },
+    {
+      name: "detail row past the fixed ref / consumer caps",
+      text: () => {
+        const g: Record<string, { class_type: string; inputs: Record<string, unknown> }> = {
+          "1": { class_type: "Hub", inputs: {} },
+        };
+        const inputs: Record<string, unknown> = {};
+        for (let i = 0; i < 90; i++) {
+          g[String(i + 2)] = { class_type: "Src", inputs: {} };
+          inputs[`in${i}`] = [String(i + 2), 0];
+        }
+        g["1"].inputs = inputs;
+        return queryApiGraph(g, { ids: ["1"], fields: "detail", max_chars: MAX_CHARS_CEILING }).text;
+      },
+    },
+    {
+      name: "compact row whose widget values hit the fixed 60-char clip",
+      text: () => queryApiGraph({ "1": { class_type: "T", inputs: { p: "q".repeat(400) } } }, {}).text,
+    },
+    {
+      name: "compact line longer than the whole budget",
+      text: () => {
+        const inputs: Record<string, unknown> = {};
+        for (let i = 0; i < 400; i++) inputs[`w${i}`] = "k".repeat(30);
+        return queryApiGraph({ "1": { class_type: "T", inputs } }, { max_chars: MAX_CHARS_FLOOR }).text;
+      },
+    },
+  ];
+
+  for (const s of scenarios) {
+    it(`query_workflow — ${s.name}`, () => {
+      const text = s.text();
+      // Every scenario must actually have dropped something, or it is asserting nothing.
+      expect(text, `scenario "${s.name}" produced no truncation marker`).toMatch(
+        /…|truncated|cut|omitted/,
+      );
+      assertRemedyIsActionable("query_workflow", `query_workflow (${s.name})`, text);
+    });
+  }
+
+  // ---- defect 1: the tail must name the lever that ACTUALLY fired -------------------
+
+  it("names max_chars — and NOT limit — when the char budget did the cutting", () => {
+    const r = queryApiGraph(bigGraph(120), { limit: LIMIT_CEILING, max_chars: 600 });
+    expect(r.truncated).toBe(true);
+    expect(r.truncated_by).toBe("max_chars");
+    expect(r.text).toContain("`max_chars`");
+    expect(r.text).toContain(`up to ${MAX_CHARS_CEILING}`);
+    // The pre-#809 tail ended "…or raise limit." on this exact path. Raising `limit`
+    // here cannot help, so the tail must not read as an instruction to raise it.
+    expect(r.text).not.toMatch(/raise `limit`/);
+    expect(r.text).toMatch(/Raising `limit` will not help/);
+  });
+
+  it("names limit — and says max_chars is not the constraint — when the limit did the cutting", () => {
+    const r = queryApiGraph(bigGraph(120), { limit: 5, max_chars: MAX_CHARS_CEILING });
+    expect(r.truncated).toBe(true);
+    expect(r.truncated_by).toBe("limit");
+    expect(r.text).toContain("raise `limit`");
+    expect(r.text).toContain(`up to ${LIMIT_CEILING}`);
+    expect(r.text).toMatch(/`max_chars` is not the constraint here/);
+  });
+
+  it("applies the same cause split on the explicit-ids path", () => {
+    const ids = Array.from({ length: 60 }, (_, i) => String(i + 1));
+    const byLimit = queryApiGraph(bigGraph(120), { ids, limit: 3, max_chars: MAX_CHARS_CEILING });
+    expect(byLimit.truncated_by).toBe("limit");
+    expect(byLimit.text).toContain("raise `limit`");
+    expect(byLimit.text).not.toMatch(/raise `max_chars`/);
+
+    const byChars = queryApiGraph(bigGraph(120), { ids, max_chars: 600 });
+    expect(byChars.truncated_by).toBe("max_chars");
+    expect(byChars.text).toContain("raise `max_chars`");
+    expect(byChars.text).not.toMatch(/raise `limit`/);
+  });
+
+  // codex gate: "raise `X` up to N" is ITSELF a dead retry at N. The whole point of this
+  // issue is that a wasted retry teaches the agent the tool cannot do the job — so a
+  // caller already at the ceiling must be pointed somewhere that can still work.
+  it("stops telling the caller to raise a parameter that is already at its ceiling", () => {
+    const byLimit = queryApiGraph(bigGraph(500), {
+      limit: LIMIT_CEILING,
+      max_chars: MAX_CHARS_CEILING,
+    });
+    expect(byLimit.truncated_by).toBe("limit");
+    expect(byLimit.text).toMatch(new RegExp(`\`limit\` is already at its ceiling of ${LIMIT_CEILING}`));
+    expect(byLimit.text).not.toMatch(/raise `limit` up to/);
+    // …and it still names what IS left.
+    expect(byLimit.text).toMatch(/narrow with `types`/);
+
+    // Fat rows so the CHAR budget fires before the row cap, with both at their ceilings.
+    const fat: Record<string, { class_type: string; inputs: Record<string, unknown> }> = {};
+    for (let i = 0; i < 100; i++) {
+      const inputs: Record<string, unknown> = {};
+      for (let w = 0; w < 30; w++) inputs[`w${w}`] = "v".repeat(80);
+      fat[String(i)] = { class_type: "KSampler", inputs };
+    }
+    const byChars = queryApiGraph(fat, {
+      limit: LIMIT_CEILING,
+      max_chars: MAX_CHARS_CEILING,
+    });
+    expect(byChars.truncated_by).toBe("max_chars");
+    expect(byChars.text).toMatch(
+      new RegExp(`\`max_chars\` is already at its ceiling of ${MAX_CHARS_CEILING}`),
+    );
+    expect(byChars.text).not.toMatch(/raise `max_chars` up to/);
+  });
+
+  it("still offers the raise when the caller is below the ceiling", () => {
+    const r = queryApiGraph(bigGraph(500), { limit: 10, max_chars: MAX_CHARS_CEILING });
+    expect(r.text).toContain(`raise \`limit\` up to ${LIMIT_CEILING}`);
+    expect(r.text).not.toMatch(/already at its ceiling/);
+  });
+
+  // The INVERSE defect, and just as costly: claiming a cut that did not happen. The
+  // caller retries wider for nothing, or distrusts a complete result. Reserving the
+  // footer's worst case up front caused exactly this at the 500 floor (codex gate), so
+  // the fit is done afterwards by dropping only as many rows as actually needed.
+  it("never claims truncation for a result that fits, even at the max_chars floor", () => {
+    const small = {
+      "1": { class_type: "A", inputs: { s: 1 } },
+      "2": { class_type: "B", inputs: { s: 2 } },
+    };
+    const r = queryApiGraph(small, { max_chars: MAX_CHARS_FLOOR });
+    expect(r.shown).toBe(2);
+    expect(r.truncated).toBe(false);
+    expect(r.truncated_by).toBeNull();
+    expect(r.text).not.toMatch(/truncated at/);
+    expect(r.text.length).toBeLessThanOrEqual(MAX_CHARS_FLOOR);
+  });
+
+  it("keeps the WHOLE result — tail and footer included — inside max_chars", () => {
+    // The tail and the clip footer are part of the result. Appending them past the bound
+    // would break the promise the parameter makes; the first row stays exempt (#609).
+    for (const budget of [MAX_CHARS_FLOOR, 900, 4000]) {
+      const g: Record<string, { class_type: string; inputs: Record<string, unknown> }> = {};
+      for (let i = 0; i < 60; i++) {
+        g[String(i)] = { class_type: `Type${i}`, inputs: { note: "n".repeat(300) } };
+      }
+      const r = queryApiGraph(g, { max_chars: budget });
+      const firstRowLen = r.text.split("\n")[1]?.length ?? 0;
+      expect(
+        r.text.length,
+        `budget ${budget} breached (first row ${firstRowLen})`,
+      ).toBeLessThanOrEqual(Math.max(budget, firstRowLen * 2));
+      if (r.shown > 1) expect(r.text.length).toBeLessThanOrEqual(budget);
+    }
+  });
+
+  it("keeps the AGGREGATE inside max_chars too, tail included", () => {
+    // The aggregate path filled the budget with rows and then appended its tail — the
+    // same tail-after-budget defect the row path had, on a branch the row-path fix does
+    // not touch (codex gate).
+    for (const budget of [MAX_CHARS_FLOOR, 800, 3000]) {
+      const g: Record<string, { class_type: string; inputs: Record<string, unknown> }> = {};
+      for (let i = 0; i < 400; i++) g[String(i)] = { class_type: `VeryLongTypeName_${i}`, inputs: {} };
+      const r = queryApiGraph(g, { group_by: "type", max_chars: budget });
+      expect(r.text.length, `aggregate breached budget ${budget}`).toBeLessThanOrEqual(budget);
+      expect(r.truncated).toBe(true);
+      expect(r.truncated_by).toBe("max_chars");
+    }
+  });
+
+  it("counts only the clips in rows it actually returned", () => {
+    // The footer used a running total, so rows the budget rejected — and rows the
+    // post-fit loop popped — still counted. A note claiming clips the reader cannot see
+    // is a false truncation claim inside the one string that has to be trustworthy.
+    const g: Record<string, { class_type: string; inputs: Record<string, unknown> }> = {};
+    for (let i = 0; i < 40; i++) {
+      g[String(i)] = { class_type: "T", inputs: { long: "v".repeat(400) } };
+    }
+    const r = queryApiGraph(g, { max_chars: 900 });
+    const m = /\((\d+) widget value\(s\) clipped/.exec(r.text);
+    expect(m, "the clip footer must be present").toBeTruthy();
+    // Exactly one clipped value per rendered row, so the count must equal `shown`.
+    expect(Number(m![1])).toBe(r.shown);
+    expect(r.text.split("\n").filter((l) => l.startsWith("#")).length).toBe(r.shown);
+  });
+
+  it("says when it clipped the id it is echoing back", () => {
+    // A shortened id echoed with a bare "…" reads as "that is the id I looked for", so a
+    // caller cannot tell a typo from a clip and re-sends the same value (codex gate).
+    const r = queryApiGraph({ "1": { class_type: "T", inputs: {} } }, { upstream_of: "n".repeat(400) });
+    expect(r.text).toMatch(/id shown clipped to 120 of 400 chars/);
+    expect(r.text).toMatch(/not found in the graph/);
+  });
+
+  it("reports truncated_by: null when nothing was dropped", () => {
+    const r = queryApiGraph(bigGraph(3), { max_chars: MAX_CHARS_CEILING });
+    expect(r.truncated).toBe(false);
+    expect(r.truncated_by).toBeNull();
+  });
+
+  // ---- the fixed caps must not advertise a lever that cannot move them --------------
+
+  it("names max_chars when the per-value cap was TIGHTENED by the budget", () => {
+    // Same code path, opposite remedy: here raising `max_chars` really does lift the cut,
+    // so it must be named — and it must not repeat the "does not raise" wording.
+    const r = queryApiGraph(
+      { "1": { class_type: "T", inputs: { blob: "b".repeat(3000) } } },
+      { fields: "detail", max_chars: 2000 },
+    );
+    expect(r.text).toMatch(/chars cut over the `max_chars` budget; raise `max_chars`/);
+    expect(r.text).not.toMatch(/does not raise/);
+  });
+
+  it("says plainly that the per-widget cap is NOT raised by max_chars", () => {
+    const r = queryApiGraph(
+      { "1": { class_type: "T", inputs: { blob: "z".repeat(9000) } } },
+      { fields: "detail", max_chars: MAX_CHARS_CEILING },
+    );
+    expect(r.text).toMatch(/per-widget cap, which `max_chars` does not raise/);
+  });
+
+  it("points the fixed ref/consumer caps at the traversal that returns them all", () => {
+    const g: Record<string, { class_type: string; inputs: Record<string, unknown> }> = {
+      "1": { class_type: "Hub", inputs: {} },
+    };
+    const inputs: Record<string, unknown> = {};
+    for (let i = 0; i < 90; i++) {
+      g[String(i + 2)] = { class_type: "Src", inputs: {} };
+      inputs[`in${i}`] = [String(i + 2), 0];
+    }
+    g["1"].inputs = inputs;
+    const r = queryApiGraph(g, { ids: ["1"], fields: "detail", max_chars: MAX_CHARS_CEILING });
+    expect(r.text).toContain("`upstream_of`");
+    expect(r.text).toContain("`depth`");
+  });
+
+  it("stops saying 'list all' once the follow-up would exceed limit's own ceiling", () => {
+    // codex gate: at more than LIMIT_CEILING-1 neighbours the suggested traversal cannot
+    // return them in one call. Promising "list all" there would be a SECOND false hint
+    // inside the remedy for the first one.
+    const g: Record<string, { class_type: string; inputs: Record<string, unknown> }> = {
+      "1": { class_type: "Hub", inputs: {} },
+    };
+    const inputs: Record<string, unknown> = {};
+    for (let i = 0; i < 250; i++) {
+      g[String(i + 2)] = { class_type: "Src", inputs: {} };
+      inputs[`in${i}`] = [String(i + 2), 0];
+    }
+    g["1"].inputs = inputs;
+    const r = queryApiGraph(g, { ids: ["1"], fields: "detail", max_chars: MAX_CHARS_CEILING });
+    expect(r.text).not.toMatch(/list all/);
+    expect(r.text).toContain(`list the first ${LIMIT_CEILING}`);
+    // query_workflow has NO cursor/offset, so "page through them" would be a second
+    // false promise inside the remedy for the first one.
+    expect(r.text).toMatch(/there is no cursor\/offset/);
+    // And it still never quotes a limit above the ceiling.
+    expect(r.text).not.toMatch(/`limit`:2[0-9][1-9]/);
+    assertRemedyIsActionable("query_workflow", "query_workflow 250-ref follow-up", r.text);
+  });
+
+  it("points the fixed compact-value clip at fields:'detail', not at a dead lever", () => {
+    const r = queryApiGraph({ "1": { class_type: "T", inputs: { p: "q".repeat(400) } } }, {});
+    expect(r.text).toContain('`fields`:"detail"');
+    expect(r.text).not.toMatch(/raise `max_chars`/);
+  });
+
+  // ---- panel_* descriptions and riders ---------------------------------------------
+
+  it("panel_find_nodes no longer claims it does not truncate", () => {
+    const d = buildPanelToolDefs().find((t) => t.name === "panel_find_nodes");
+    expect(d).toBeTruthy();
+    expect(d!.description).not.toMatch(/no truncation/i);
+    // It must state the cap AND that a capped result is not a complete match set —
+    // "returns 40" without that reads as "there are 40".
+    expect(d!.description).toMatch(/`limit`/);
+    expect(d!.description).toMatch(/STOPS/);
+  });
+
+  /** Apply the rule to a DESCRIPTION, sentence by sentence, remedy sentences only. */
+  function assertDescriptionRemediesAreActionable(tool: string, description: string): void {
+    for (const sentence of splitSentences(description)) {
+      if (!REMEDY_SENTENCE.test(sentence)) continue;
+      assertRemedyIsActionable(tool, `${tool} description`, sentence);
+    }
+  }
+
+  it("every panel_* description's truncation prose names real parameters of that tool", () => {
+    for (const d of buildPanelToolDefs()) {
+      assertDescriptionRemediesAreActionable(d.name, d.description);
+    }
+  });
+
+  it("every registered tool's truncation prose names real parameters of that tool", async () => {
+    // Through the real registry, so a renamed parameter still quoted in prose fails here
+    // rather than misleading a caller in production.
+    for (const t of await listRegisteredTools()) {
+      assertDescriptionRemediesAreActionable(t.name, t.description);
+    }
+  });
+
+  // ---- the panel riders (#809): a boolean is replaced by a usable instruction --------
+  //
+  // Driven through the REAL tool definitions with a stubbed panel reply, so the string
+  // asserted here is the one a caller would receive.
+
+  async function runPanelTool(
+    name: string,
+    args: Record<string, unknown>,
+    reply: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const d = buildPanelToolDefs().find((t) => t.name === name);
+    expect(d, `${name} is not a panel tool`).toBeTruthy();
+    const res = await d!.handler(args, {
+      call: async () => ({
+        content: [{ type: "text" as const, text: JSON.stringify(reply, null, 2) }],
+      }),
+      // The riders only use ctx.call; the rest of the ctx surface is unused here.
+    } as unknown as Parameters<typeof d.handler>[1]);
+    const text = res.content.find((c) => c.type === "text");
+    expect(text, `${name} returned no text block`).toBeTruthy();
+    return JSON.parse((text as { text: string }).text) as Record<string, unknown>;
+  }
+
+  const riderCases: Array<{
+    tool: string;
+    args?: Record<string, unknown>;
+    reply: Record<string, unknown>;
+    key: string;
+    /** Substrings the remedy must contain to be actionable at all. */
+    mustSay: RegExp[];
+  }> = [
+    {
+      tool: "panel_find_nodes",
+      args: { query: "load", limit: 40 },
+      reply: { total: 690, count: 40, truncated: true, matches: new Array(40).fill({ id: 1 }) },
+      key: "truncation_hint",
+      // "MAY be incomplete", never "there ARE more": this orchestrator ships ahead of the
+      // panel, and an older panel sets `truncated` on an exact-cap result that dropped
+      // nothing. Asserting more exist would manufacture the false alarm (codex gate).
+      mustSay: [/`limit`/, /up to 200/, /MAY be incomplete/, /not proof a node is absent/],
+    },
+    {
+      tool: "panel_view_selected",
+      reply: { selected_count: 690, nodes: new Array(100).fill({ id: 1 }), truncated: true },
+      key: "truncation_hint",
+      mustSay: [/100 of 690/, /FIXED cap/, /no parameter raises it/, /panel_query_graph/],
+    },
+    {
+      tool: "panel_view_nodes_in_viewport",
+      reply: { in_view_count: 300, nodes: new Array(100).fill({ id: 1 }), truncated: true },
+      key: "truncation_hint",
+      mustSay: [/100 of 300/, /no parameter raises it/, /panel_query_graph/],
+    },
+    {
+      tool: "panel_get_subgraph",
+      args: { node_id: 7 },
+      reply: { node_count: 240, nodes: new Array(100).fill({ id: 1 }), truncated: true },
+      key: "truncation_hint",
+      mustSay: [/100 of 240/, /no parameter raises it/, /panel_enter_subgraph/],
+    },
+    {
+      tool: "panel_get_errors",
+      reply: { errored_count: 150, nodes: new Array(100).fill({ id: 1 }), truncated: true },
+      key: "truncation_hint",
+      mustSay: [/100 of 150/, /no parameter raises it/],
+    },
+    {
+      tool: "panel_graph_outline",
+      args: { max_chars: 4000 },
+      reply: { node_count: 690, group_count: 12, degraded: true, detail_level: "groups", outline: "…" },
+      key: "truncation_hint",
+      mustSay: [/covers ALL 690 node/, /`max_chars`/, /up to 60000/],
+    },
+  ];
+
+  for (const c of riderCases) {
+    it(`${c.tool} replaces its bare truncation boolean with an instruction`, async () => {
+      const payload = await runPanelTool(c.tool, c.args ?? {}, c.reply);
+      const hint = payload[c.key];
+      expect(typeof hint, `${c.tool} emitted no ${c.key}`).toBe("string");
+      for (const re of c.mustSay) expect(hint as string).toMatch(re);
+      assertRemedyIsActionable(c.tool, `${c.tool} ${c.key}`, hint as string);
+    });
+
+    it(`${c.tool} attaches nothing when the result was not cut`, async () => {
+      const clean = { ...c.reply, truncated: false, degraded: false };
+      const payload = await runPanelTool(c.tool, c.args ?? {}, clean);
+      expect(payload[c.key]).toBeUndefined();
+    });
+  }
+
+  it("the stale-red-flags rider does not imply the shown count is the whole list", async () => {
+    const payload = await runPanelTool(
+      "panel_get_errors",
+      {},
+      {
+        errored_count: 3,
+        nodes: [],
+        stale_flags: new Array(100).fill({ id: 1 }),
+        stale_flags_truncated: true,
+      },
+    );
+    const hint = payload.stale_flags_truncation_hint as string;
+    expect(typeof hint).toBe("string");
+    // Older panels send no total for this list. Saying "Showing 100" alone would read as
+    // "there are 100" — the rider must say the remainder is unknown instead.
+    expect(hint).toMatch(/unknown number more were cut/);
+    assertRemedyIsActionable("panel_get_errors", "panel_get_errors stale flags", hint);
+  });
+
+  // ---- node-dev: the same schema check, on the builders those tools emit -------------
+  //
+  // These are exported precisely so the check needs no filesystem. `boundText` is shared
+  // by tools with DIFFERENT levers (read_node_file has `max_chars`, apply_node_patch has
+  // none), which is how a shared default would have shipped a dead remedy.
+
+  const nodeDevRemedies: Array<{ tool: string; where: string; text: string }> = [
+    {
+      tool: "read_node_file",
+      where: "read_node_file bound notice",
+      text: readBoundNotice(12_000, 1, 240)(5_000),
+    },
+    {
+      tool: "node_pack_git",
+      where: "node_pack_git bound notice",
+      text: gitBoundNotice(12_000)(5_000),
+    },
+    {
+      tool: "search_node_packs",
+      where: "search_node_packs result cap",
+      text: searchTruncationHint("max_results", 50, 50),
+    },
+    {
+      tool: "search_node_packs",
+      where: "search_node_packs scanned-file bound",
+      text: searchTruncationHint("scanned_files", 12, 50),
+    },
+  ];
+
+  for (const r of nodeDevRemedies) {
+    it(`${r.where} names only real parameters of ${r.tool}`, () => {
+      assertRemedyIsActionable(r.tool, r.where, r.text);
+    });
+  }
+
+  // Where the schema publishes no maximum, the remedy and the runtime clamp are the SAME
+  // exported constant by construction. That the CLAMP really honours it is exercised for
+  // real in src/__tests__/services/node-dev.test.ts ("max_chars clamps are real"), which
+  // calls readNodeFile / nodePackGit with an over-ceiling budget — asserting
+  // `Math.min(x, CONST) === CONST` here would only restate arithmetic.
+  it("code-clamp remedies quote the exported constant, not a hand-typed number", () => {
+    expect(readBoundNotice(1, 1, 2)(1)).toContain(`up to ${READ_MAX_CHARS}`);
+    expect(searchTruncationHint("max_results", 1, 1)).toContain(`up to ${SEARCH_MAX_RESULTS}`);
+  });
+
+  it("node_pack_git's remedy quotes the CODE clamp its description used to hide", () => {
+    // The issue records this specifically: the real ceiling (24000) is a runtime clamp,
+    // and the schema publishes no `maximum`, so the schema-driven ceiling check cannot
+    // see it. Pin it against the constant the clamp itself uses.
+    const text = gitBoundNotice(12_000)(1);
+    expect(text).toContain(`up to ${READ_MAX_CHARS}`);
+    expect(text).toContain("a hard clamp");
+  });
+
+  it("apply_node_patch's remedy names NO lever, because it has none", () => {
+    const text = patchBoundNotice(500);
+    // Its only parameter is `patch`. A remedy naming `max_chars` here would be defect 1
+    // pointing the other way: a lever the caller cannot pull.
+    assertRemedyIsActionable("apply_node_patch", "apply_node_patch bound notice", text);
+    expect(text).toMatch(/has no parameter to raise it/);
+    // Nor may it hand off to a tool that cannot run the same command: node_pack_git's
+    // actions are status/diff/log/commit/push — it cannot `git apply` (codex gate). The
+    // only real remedy is a smaller patch.
+    expect(text).not.toContain("node_pack_git");
+    expect(text).toMatch(/Split the patch into smaller per-file hunks/);
+  });
+
+  it("the per-line search clip stays INSIDE the cap it describes", () => {
+    const clipped = clipMatchLine("q".repeat(5_000));
+    expect(clipped.length).toBeLessThanOrEqual(SEARCH_LINE_MAX);
+    expect(clipped).toMatch(/fixed 600-char per-line cap/);
+    expect(clipped).toContain("read_node_file");
+  });
+
+  // ---- sites with NO lever: they must say so, and must not promise one ---------------
+  //
+  // These fell outside the schema-driven sweep because their text is not emitted by a
+  // parameterised tool at all. That is exactly why they need checking: a fixed cap with
+  // an invented remedy is the same defect as defect 1, pointing the other way.
+
+  it("the traceback cap states it is fixed, and only says get_logs MAY have the rest", () => {
+    const err = extractExecutionError({
+      status: {
+        messages: [
+          [
+            "execution_error",
+            {
+              node_id: "3",
+              node_type: "KSampler",
+              exception_message: "boom",
+              traceback: ["Traceback\n", "x".repeat(TRACEBACK_MAX_CHARS + 500)],
+            },
+          ],
+        ],
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    const tb = err?.traceback ?? "";
+    expect(err?.traceback_truncated).toBe(true);
+    expect(tb).toContain(`fixed ${TRACEBACK_MAX_CHARS}-char traceback cap`);
+    expect(tb).toContain("no parameter raises it");
+    // A Python traceback prints the exception LAST, so the cut end is the useful end —
+    // the marker has to say that or the reader trusts a head that names nothing.
+    expect(tb).toMatch(/final exception line is likely among the cut frames/);
+    // "may still hold" — never a promise. Nothing re-serves the /history traceback.
+    expect(tb).toMatch(/get_logs may still hold/);
+    expect(tb).not.toMatch(/read the full traceback with/);
+  });
+
+  it("the crash-block cap states it is fixed and does not promise get_logs has the rest", () => {
+    const head = "Windows fatal exception: access violation\n";
+    const r = parseCrashBlock(head + "F".repeat(9000));
+    expect(r.fatal).toBe(true);
+    expect(r.block).toContain("crash-block cap");
+    expect(r.block).toContain("no parameter raises it");
+    expect(r.block).toMatch(/get_logs may still hold/);
+  });
+
+  it("does not claim full coverage when the outline REFUSED to render", async () => {
+    // `degraded` covers two opposite outcomes. On "refused" the panel returned NO
+    // outline, so "still covers ALL 690 nodes" would describe content the reader cannot
+    // see — the same lie as a silent cut, wearing the opposite hat (codex gate).
+    const payload = await runPanelTool(
+      "panel_graph_outline",
+      { max_chars: 500 },
+      { node_count: 690, group_count: 12, degraded: true, detail_level: "refused", outline: "⚠" },
+    );
+    const hint = payload.truncation_hint as string;
+    expect(hint).toMatch(/NO outline was returned/);
+    expect(hint).not.toMatch(/still covers ALL/);
+    expect(hint).toMatch(/690 node\(s\)/);
+    expect(hint).toMatch(/withheld because it would read as complete/);
+    assertRemedyIsActionable("panel_graph_outline", "panel_graph_outline refusal", hint);
+  });
+
+  it("says so when the panel is too old to honour the max_chars it was sent", async () => {
+    // The orchestrator ships ahead of the panel. An older build ignores the budget and
+    // returns the full outline, so the bound this tool ADVERTISES silently did not apply
+    // — and an unbounded reply would otherwise read as "this fitted" (codex gate).
+    const legacy = await runPanelTool(
+      "panel_graph_outline",
+      { max_chars: 4000 },
+      { node_count: 690, group_count: 12, outline: "…" }, // no max_chars echoed back
+    );
+    const hint = legacy.max_chars_hint as string;
+    expect(typeof hint).toBe("string");
+    expect(hint).toMatch(/does not support `max_chars`/);
+    expect(hint).toMatch(/was NOT applied/);
+    expect(hint).toMatch(/690 node\(s\)/);
+    // The synthetic flag is plumbing and must never reach the caller.
+    expect(legacy.__budget_ignored).toBeUndefined();
+    assertRemedyIsActionable("panel_graph_outline", "panel_graph_outline legacy", hint);
+
+    // A current panel echoes the budget back, so the rider stays silent.
+    const current = await runPanelTool(
+      "panel_graph_outline",
+      { max_chars: 4000 },
+      { node_count: 690, group_count: 12, outline: "…", max_chars: 4000 },
+    );
+    expect(current.max_chars_hint).toBeUndefined();
+
+    // And it stays silent when the caller never asked for a budget.
+    const noArg = await runPanelTool("panel_graph_outline", {}, { node_count: 3, outline: "…" });
+    expect(noArg.max_chars_hint).toBeUndefined();
+  });
+
+  it("does not tell the caller to raise a budget that could never hold the outline", async () => {
+    // A graph whose group-level floor exceeds the CEILING cannot be outlined at any
+    // accepted budget. "Raise max_chars to 60000" there is a guaranteed second refusal.
+    const payload = await runPanelTool(
+      "panel_graph_outline",
+      { max_chars: 500 },
+      {
+        node_count: 20000,
+        group_count: 300,
+        degraded: true,
+        detail_level: "refused",
+        floor_chars: 100_000,
+        max_chars: 500,
+        outline: "⚠",
+      },
+    );
+    const hint = payload.truncation_hint as string;
+    expect(hint).toMatch(/raising it will NOT produce an outline/);
+    expect(hint).not.toMatch(/Raise `max_chars` \(up to/);
+    expect(hint).toMatch(/panel_query_graph/);
+  });
+
+  it("does not promise a raise will work when the panel cannot say whether it would", async () => {
+    // The panel revision between "accepts max_chars" and "reports floor_chars" refuses
+    // without saying how big the floor is. Treating UNKNOWN as reachable is what produced
+    // the dead retry: on a graph whose floor exceeds the ceiling, "raise to 60000" must
+    // refuse again (codex gate).
+    const payload = await runPanelTool(
+      "panel_graph_outline",
+      { max_chars: 500 },
+      {
+        node_count: 20000,
+        group_count: 300,
+        degraded: true,
+        detail_level: "refused",
+        max_chars: 500, // budget-aware…
+        outline: "⚠", // …but no floor_chars
+      },
+    );
+    const hint = payload.truncation_hint as string;
+    expect(hint).toMatch(/does not report how large the smallest form would be/);
+    expect(hint).toMatch(/MAY still refuse/);
+    expect(hint).toMatch(/panel_query_graph/);
+    // It must NOT read as an assurance that the retry succeeds.
+    expect(hint).not.toMatch(/Raise `max_chars` \(up to \d+\) for more detail/);
+    assertRemedyIsActionable("panel_graph_outline", "panel_graph_outline unknown floor", hint);
+  });
+
+  it("does not offer a follow-up as if it could return everything", () => {
+    // panel_query_graph clamps `limit` at 200 and has no cursor, so on a >200-node
+    // subgraph it reads MORE, not all. Saying "to read the rest" overpromised.
+    const d = buildPanelToolDefs().find((t) => t.name === "panel_get_subgraph");
+    const handlerSrc = String(d!.handler);
+    expect(handlerSrc).toContain("max 200");
+    expect(handlerSrc).toContain("no cursor");
+    expect(handlerSrc).not.toContain("To read the rest");
+  });
+
+  it("discloses that groups/rails ride outside the max_chars accounting", () => {
+    // Fixing that accounting is #807. This issue's job is that the CURRENT behaviour is
+    // stated: a caller lowering max_chars and still overflowing must know why.
+    const d = buildPanelToolDefs().find((t) => t.name === "panel_query_graph");
+    expect(d!.description).toMatch(/bounds the `text` field ONLY/);
+    expect(d!.description).toMatch(/#807/);
+  });
+
+  it("never clobbers a hint the panel itself supplied", async () => {
+    const payload = await runPanelTool(
+      "panel_find_nodes",
+      { query: "x" },
+      { truncated: true, count: 40, matches: [], truncation_hint: "panel-supplied" },
+    );
+    expect(payload.truncation_hint).toBe("panel-supplied");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1183,6 +1183,124 @@ function toolResultText(res: ToolResult): string {
   return res?.content?.find((c) => c.type === "text")?.text ?? "workflow_open failed";
 }
 
+// ---- #809: turn the panel's silent `truncated: true` booleans into a remedy --------
+//
+// A bare boolean is the WORST truncation signal there is: it is a field, not prose, so
+// a model reading the result gets no instruction from it at all. The observed failure
+// (a Kimi session on a 690-node graph) is an agent concluding the TOOL cannot do the
+// thing and escalating to the human, when a different argument would have answered it.
+//
+// These riders are applied ORCHESTRATOR-side on purpose. The panel ships as a separate
+// package on its own release cadence, so attaching the remedy here means every user
+// gets it the moment they update the MCP server, regardless of their panel build. When
+// a newer panel supplies its own hint under the same key, the rider defers to it.
+// The REAL panel-side clamp for graph_find_nodes (`Math.min(Math.max(limit ?? 40, 1), 200)`
+// in comfyui-mcp-panel.js). Kept as named constants so the zod `.max()`, the parameter
+// description and the truncation remedy below cannot drift apart — the drift is exactly
+// what made `panel_find_nodes` claim "no truncation" while capping at 40 (#809).
+const FIND_NODES_DEFAULT_LIMIT = 40;
+const FIND_NODES_LIMIT_CEILING = 200;
+
+// #809: panel_graph_outline's budget. Deliberately the SAME name and the SAME
+// 500–60000 clamp as panel_query_graph's max_chars — one budget concept, one spelling,
+// so an agent that has learned the lever on one graph read already knows it on the
+// other. The outline degrades by RESOLUTION, never by coverage: half a map is not a
+// smaller map, and an agent handed the first 200 of 690 nodes cannot tell what it is
+// missing. See the panel-side ladder in comfyui-mcp-panel.js (graph_outline).
+const OUTLINE_MAX_CHARS_FLOOR = 500;
+const OUTLINE_MAX_CHARS_DEFAULT = 24000;
+const OUTLINE_MAX_CHARS_CEILING = 60000;
+
+interface TruncationRule {
+  /** Attach only when the panel reply carries this field as boolean `true`. */
+  flag: string;
+  /** Field to attach the remedy under. Must not collide with a panel-supplied field. */
+  key: string;
+  /** Build the remedy from the reply. Keep it one sentence — it is spent from context. */
+  text: (payload: Record<string, unknown>) => string;
+}
+
+/** Count of an array-valued reply field, or null when it isn't an array. */
+function replyCount(payload: Record<string, unknown>, key: string): number | null {
+  const v = payload[key];
+  return Array.isArray(v) ? v.length : null;
+}
+
+/** "N of M" when both are known, else "N" — never invent a total we weren't given. */
+function shownOf(shown: number | null, total: unknown): string {
+  const t = typeof total === "number" && Number.isFinite(total) ? total : null;
+  if (shown == null) return t == null ? "some" : `some of ${t}`;
+  return t == null ? `${shown}` : `${shown} of ${t}`;
+}
+
+function withTruncationHints(res: ToolResult, rules: TruncationRule[]): ToolResult {
+  const payload = parseToolResultJson(res);
+  if (!payload) return res;
+  let changed = false;
+  for (const rule of rules) {
+    if (payload[rule.flag] !== true) continue;
+    // Never clobber a hint the panel itself supplied — a newer panel knows its own caps
+    // better than this rider does.
+    if (payload[rule.key] != null) continue;
+    payload[rule.key] = rule.text(payload);
+    changed = true;
+  }
+  // Synthetic flags (markBudgetIgnored) are plumbing, not part of the tool's result —
+  // strip them so a caller never sees a field the panel did not send.
+  if (payload.__budget_ignored !== undefined) {
+    delete payload.__budget_ignored;
+    changed = true;
+  }
+  if (!changed) return res;
+  // Rewrite ONLY the JSON text block, so an image-carrying reply keeps its other parts.
+  const idx = res.content.findIndex((c) => c.type === "text");
+  if (idx < 0) return res;
+  return {
+    ...res,
+    content: res.content.map((c, i) =>
+      i === idx && c.type === "text" ? { ...c, text: JSON.stringify(payload, null, 2) } : c,
+    ),
+  };
+}
+
+/**
+ * #809 (codex gate): set a synthetic `__budget_ignored` flag when the caller asked for a
+ * `max_chars` on the outline and the reply shows no sign of it. A panel that supports the
+ * budget echoes `max_chars` back; an older build silently returns the full outline, so
+ * the bound this tool advertises did not apply. The flag is stripped again before the
+ * result is returned — it exists only to drive the rider.
+ */
+function markBudgetIgnored(res: ToolResult, requested: unknown): ToolResult {
+  if (typeof requested !== "number") return res;
+  const payload = parseToolResultJson(res);
+  if (!payload || typeof payload.max_chars === "number") return res;
+  const idx = res.content.findIndex((c) => c.type === "text");
+  if (idx < 0) return res;
+  payload.__budget_ignored = true;
+  return {
+    ...res,
+    content: res.content.map((c, i) =>
+      i === idx && c.type === "text" ? { ...c, text: JSON.stringify(payload, null, 2) } : c,
+    ),
+  };
+}
+
+/** The MAX_STATE_NODES views (#809): a FIXED panel-side cap with no parameter to
+ *  raise. Saying so plainly — and naming the tool that CAN target the rest — is the
+ *  honest remedy; inventing a lever these tools do not have would be the same defect
+ *  in the other direction. */
+function fixedCapHint(
+  what: string,
+  shown: number | null,
+  total: unknown,
+  targeted: string,
+): string {
+  return (
+    `Showing ${shownOf(shown, total)} ${what} — this view has a FIXED cap and no parameter raises it. ` +
+    targeted
+  );
+}
+
 // ---- panel_civitai_results inline sample thumbnails (#623) -------------------
 // The agent recommends CivitAI models/LoRAs for a VISUAL medium, so it must be
 // able to SEE the sample images — not just read titles + download counts. The
@@ -4070,7 +4188,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
   const defs: PanelToolDef[] = [
     def(
       "panel_query_graph",
-      "FILTER or TRAVERSE a SUBSET of the live canvas, for when you ALREADY KNOW what you're looking for. NOT for 'show me the canvas' or any whole-graph overview — call panel_graph_outline FIRST for that. NOT query_workflow (that queries a saved file or JSON you provide, not the live canvas). Filters, traverses, projects and aggregates over the workflow the user is CURRENTLY VIEWING without dumping the whole graph (replaces the old panel_get_graph full-JSON dump; output is TOKEN-BOUNDED with an explicit truncation marker, so a big graph can never flood your context). Combine: `types` (node type contains any), `title` (contains), `where` widget predicates ANDed ('cfg>7', 'steps<=20', 'sampler_name=euler', 'text~sunset' — ops = != >= <= > < ~contains), `ids` (exact nodes — THE way to read ONE node's exact slot/widget detail: {ids:[42], fields:'detail'}), `upstream_of`/`downstream_of` + `depth` (dependency traversal: upstream = what FEEDS that node, downstream = what CONSUMES it; seed at depth 0), `fields` ('compact' one line per node [default], 'ids', 'detail' = the full node summary with slots + connections + mode), `group_by:'type'` (counts only), `limit` (default 40). detail rows include each node's MODE — a 'bypass' node is skipped and a 'mute' node kills everything downstream, so check modes on the path you care about before running (fix with panel_set_node_mode). Every result also carries `groups` (id, title, member node_ids — groups are geometric, trust this list) and, when viewing a SUBGRAPH (after panel_enter_subgraph), `rails` (boundary rail ids/slots). Typical flow: panel_graph_outline to orient → panel_query_graph to pinpoint/inspect → edit. Read-only.",
+      "FILTER or TRAVERSE a SUBSET of the live canvas, for when you ALREADY KNOW what you're looking for. NOT for 'show me the canvas' or any whole-graph overview — call panel_graph_outline FIRST for that. NOT query_workflow (that queries a saved file or JSON you provide, not the live canvas). Filters, traverses, projects and aggregates over the workflow the user is CURRENTLY VIEWING without dumping the whole graph (replaces the old panel_get_graph full-JSON dump; output is TOKEN-BOUNDED with an explicit truncation marker, so a big graph can never flood your context). Combine: `types` (node type contains any), `title` (contains), `where` widget predicates ANDed ('cfg>7', 'steps<=20', 'sampler_name=euler', 'text~sunset' — ops = != >= <= > < ~contains), `ids` (exact nodes — THE way to read ONE node's exact slot/widget detail: {ids:[42], fields:'detail'}), `upstream_of`/`downstream_of` + `depth` (dependency traversal: upstream = what FEEDS that node, downstream = what CONSUMES it; seed at depth 0), `fields` ('compact' one line per node [default], 'ids', 'detail' = the full node summary with slots + connections + mode), `group_by:'type'` (counts only), `limit` (default 40). detail rows include each node's MODE — a 'bypass' node is skipped and a 'mute' node kills everything downstream, so check modes on the path you care about before running (fix with panel_set_node_mode). Every result also carries `groups` (id, title, member node_ids — groups are geometric, trust this list) and, when viewing a SUBGRAPH (after panel_enter_subgraph), `rails` (boundary rail ids/slots). NOTE: `max_chars` bounds the `text` field ONLY; those two riders are bounded by their own fixed caps and say so in-band when they cut, so lowering `max_chars` shrinks the rows and not the groups list (folding them into one budget is artokun/comfyui-mcp#807). Typical flow: panel_graph_outline to orient → panel_query_graph to pinpoint/inspect → edit. Read-only.",
       {
         types: z.array(z.string()).optional().describe("Node type contains ANY of these (case-insensitive)."),
         title: z.string().optional().describe("Node title contains this."),
@@ -4108,7 +4226,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .min(500)
           .max(60000)
           .optional()
-          .describe("Output character bound (default 12000). Raise only for deliberate full reads, e.g. layout passes needing every node's geometry."),
+          .describe(
+            "Output character bound for the `text` field (default 12000, max 60000). Raise only for deliberate full reads, e.g. layout passes needing every node's geometry. " +
+              "It bounds `text` ONLY: the `groups` and `rails` riders are bounded separately by their own fixed caps (each marked in-band when it cuts), so lowering this shrinks the rows and not those (artokun/comfyui-mcp#807 tracks folding them into one budget).",
+          ),
       },
       async (args: A, ctx) =>
         ctx.call({
@@ -4128,21 +4249,127 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_graph_outline",
-      "READ THE LIVE CANVAS the user is looking at, as text. 'Show me what's on the canvas' / 'what's on the graph right now' / 'read the current workflow' / 'describe the open graph' -> THIS TOOL, with no arguments. NOT visualize_workflow or visualize_workflow_hierarchical (those DRAW A DIAGRAM of a workflow you PASS IN — a saved file or JSON — and never see the live canvas). NOT panel_query_graph (that FILTERS a SUBSET, for when you already know what you're looking for). Returns one `outline` string covering the WHOLE open graph, topologically sorted (sources first, sinks last): each node as `id Type \"title\" [bypass/mute] [OUTPUT] · group:X  widget=value …` with `← inputs` (source_node.output_name) and `→ outputs` (target_node.input_name), after a GROUPS index (title → member node ids). It gives you the WIRING you would otherwise reconstruct by hand — read it FIRST to get oriented, then panel_query_graph to inspect one node ({ids:[42], fields:'detail'}) or panel_find_nodes for free-text search. Read-only.",
-      {},
-      async (_args, ctx) => ctx.call({ cmd: "graph_outline" }),
+      "READ THE LIVE CANVAS the user is looking at, as text. 'Show me what's on the canvas' / 'what's on the graph right now' / 'read the current workflow' / 'describe the open graph' -> THIS TOOL, with no arguments. NOT visualize_workflow or visualize_workflow_hierarchical (those DRAW A DIAGRAM of a workflow you PASS IN — a saved file or JSON — and never see the live canvas). NOT panel_query_graph (that FILTERS a SUBSET, for when you already know what you're looking for). Returns one `outline` string covering the WHOLE open graph, topologically sorted (sources first, sinks last): each node as `id Type \"title\" [bypass/mute] [OUTPUT] · group:X  widget=value …` with `← inputs` (source_node.output_name) and `→ outputs` (target_node.input_name), after a GROUPS index (title → member node ids). It gives you the WIRING you would otherwise reconstruct by hand — read it FIRST to get oriented, then panel_query_graph to inspect one node ({ids:[42], fields:'detail'}) or panel_find_nodes for free-text search. Over `max_chars` it never cuts the graph short: it sheds per-node detail, or refuses with a reason — never a partial outline. Read-only.",
+      {
+        max_chars: z
+          .number()
+          .int()
+          .min(OUTLINE_MAX_CHARS_FLOOR)
+          .max(OUTLINE_MAX_CHARS_CEILING)
+          .optional()
+          .describe(
+            `Output character bound for the outline (default ${OUTLINE_MAX_CHARS_DEFAULT}, max ${OUTLINE_MAX_CHARS_CEILING}) — the SAME budget concept as panel_query_graph's max_chars. ` +
+              `COVERAGE IS NEVER TRADED AWAY: over budget the outline sheds RESOLUTION, not nodes — first per-node widget values, then titles, and at the floor a per-group summary — so any outline it DOES return describes the whole graph, with real node/group counts. ` +
+              `If even the group-level floor will not fit, it returns NO outline and says so (detail_level:"refused") rather than a partial one that would read as complete. ` +
+              `detail_level names the rung used and degraded_reason says why. Panel builds older than this budget ignore it and return the full outline; the result carries a max_chars field when the budget was actually applied.`,
+          ),
+      },
+      async (args: A, ctx) =>
+        withTruncationHints(
+          // The synthetic `__budget_ignored` flag below is derived from the reply, not
+          // sent by the panel: a build that supports the budget echoes `max_chars` back.
+          markBudgetIgnored(
+            await ctx.call({ cmd: "graph_outline", max_chars: args.max_chars }),
+            args.max_chars,
+          ),
+          [
+            {
+              // #809 (codex gate): a panel older than this budget IGNORES `max_chars` and
+              // returns the full outline, so the bound this tool advertises silently did
+              // not apply. A current panel echoes `max_chars` back; its absence is the
+              // tell. Saying so is the whole point — the caller must not read an
+              // unbounded reply as "this fitted".
+              flag: "__budget_ignored",
+              key: "max_chars_hint",
+              text: (p) =>
+                `This panel build does not support \`max_chars\` on the outline, so the budget you set (${typeof args.max_chars === "number" ? args.max_chars : OUTLINE_MAX_CHARS_DEFAULT}) was NOT applied and the outline below is the full, unbounded one (${typeof p.node_count === "number" ? p.node_count : "all"} node(s)). ` +
+                `Update the ComfyUI Agent Panel to bound it, or scope the read with panel_query_graph in the meantime.`,
+            },
+            {
+              // On an older panel this is never set either, so the rider is inert there.
+              flag: "degraded",
+              key: "truncation_hint",
+              text: (p) => {
+                const inForce =
+                  typeof args.max_chars === "number" ? args.max_chars : OUTLINE_MAX_CHARS_DEFAULT;
+                // At the ceiling "raise max_chars" is a dead retry (codex gate).
+                const more =
+                  inForce >= OUTLINE_MAX_CHARS_CEILING
+                    ? `\`max_chars\` is already at its ceiling of ${OUTLINE_MAX_CHARS_CEILING}, so this is the most one outline can carry — read specific nodes with panel_query_graph {ids:[…], fields:'detail'}.`
+                    : `Raise \`max_chars\` (up to ${OUTLINE_MAX_CHARS_CEILING}) for more detail, or read specific nodes with panel_query_graph {ids:[…], fields:'detail'}.`;
+                const nodes = typeof p.node_count === "number" ? p.node_count : "the";
+                const groups = typeof p.group_count === "number" ? p.group_count : "all";
+                // `degraded` covers TWO different outcomes and they say opposite things
+                // (codex gate). "refused" means NO outline was produced at all — claiming
+                // it "still covers ALL nodes" would describe content the reader cannot
+                // see, which is the same lie as a silent cut.
+                if (p.detail_level === "refused") {
+                  // And if the floor exceeds the CEILING, raising is a guaranteed second
+                  // refusal — a dead retry inside the message explaining the first.
+                  //
+                  // A panel that refuses WITHOUT reporting `floor_chars` (the revision
+                  // just before that field existed) leaves this unknowable, and treating
+                  // unknown as reachable is what produced the dead retry (codex gate). So
+                  // hedge: offer the raise as something to TRY, and name the fallback in
+                  // the same breath, instead of asserting it will work.
+                  const floor = typeof p.floor_chars === "number" ? p.floor_chars : null;
+                  const next =
+                    floor != null && floor > OUTLINE_MAX_CHARS_CEILING
+                      ? `Its smallest whole-graph form needs ~${floor} chars, past \`max_chars\`'s ceiling of ${OUTLINE_MAX_CHARS_CEILING}, so raising it will NOT produce an outline for this graph — read it in parts with panel_query_graph.`
+                      : floor != null || inForce >= OUTLINE_MAX_CHARS_CEILING
+                        ? more
+                        : `This panel build does not report how large the smallest form would be, so raising \`max_chars\` (up to ${OUTLINE_MAX_CHARS_CEILING}) MAY still refuse — if it does, the graph cannot be outlined in one call; read it in parts with panel_query_graph.`;
+                  return (
+                    `NO outline was returned: even the smallest whole-graph form did not fit \`max_chars\`=${inForce}, and a PARTIAL outline is deliberately withheld because it would read as complete. ` +
+                    `The graph has ${nodes} node(s) and ${groups} group(s). ${next}`
+                  );
+                }
+                return (
+                  `The outline still covers ALL ${nodes} node(s) and ${groups} group(s), but at reduced detail (detail_level ${JSON.stringify(p.detail_level ?? "reduced")}) to fit \`max_chars\`=${inForce}. ` +
+                  more
+                );
+              },
+            },
+          ],
+        ),
     ),
     def(
       "panel_view_selected",
       "What the user has SELECTED on the canvas right now. Call this FIRST whenever they say \"this node\", \"the selected one\", \"the highlighted node\", \"where did I get this from\", or otherwise point at something without giving an id — the selection IS the answer, and reading it costs one call instead of scanning the graph. Returns the full detail summary (id, type, title, widgets, inputs with sources, outputs, mode) for each selected node, plus `selected_count` and any selected groups/reroutes. If `selected_count` is 0, nothing is selected — ask the user to click the node rather than guessing. NEVER dump the whole graph to work out which node they mean. Read-only.",
       {},
-      async (_args, ctx) => ctx.call({ cmd: "graph_view_selected" }),
+      async (_args, ctx) =>
+        withTruncationHints(await ctx.call({ cmd: "graph_view_selected" }), [
+          {
+            flag: "truncated",
+            key: "truncation_hint",
+            text: (p) =>
+              fixedCapHint(
+                "selected node(s)",
+                replyCount(p, "nodes"),
+                p.selected_count,
+                "Ask the user to select fewer nodes, or read the ones you need by id with panel_query_graph {ids:[…], fields:'detail'}, which DOES take limit and max_chars.",
+              ),
+          },
+        ]),
     ),
     def(
       "panel_view_nodes_in_viewport",
       "ONLY the nodes inside the current VIEWPORT (pan+zoom) — a screen-region subset, NOT the whole open graph (that is panel_graph_outline, which is what 'show me what's on the canvas' means). Use this to SCOPE your work to what's on their screen: when they say \"these nodes\", \"the ones here\", \"what am I looking at right now\", or when a graph is large and you only need the region in front of them. Returns the viewport rect in graph coordinates (x, y, width, height, zoom), `node_count` (whole graph) vs `in_view_count`, and the detail summary of each visible node. A node counts as visible if any part of it overlaps the viewport. On a big canvas this is dramatically cheaper than reading everything. Read-only.",
       {},
-      async (_args, ctx) => ctx.call({ cmd: "graph_view_nodes_in_viewport" }),
+      async (_args, ctx) =>
+        withTruncationHints(await ctx.call({ cmd: "graph_view_nodes_in_viewport" }), [
+          {
+            flag: "truncated",
+            key: "truncation_hint",
+            text: (p) =>
+              fixedCapHint(
+                "visible node(s)",
+                replyCount(p, "nodes"),
+                p.in_view_count,
+                "Ask the user to zoom in so fewer nodes are on screen, or read the region with panel_query_graph (which DOES take limit and max_chars) / panel_graph_outline for the whole graph.",
+              ),
+          },
+        ]),
     ),
     def(
       "panel_audit_prompt_director",
@@ -4154,11 +4381,27 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "panel_get_subgraph",
       "Read INSIDE a subgraph node on the user's open graph: ids, types, widget values, and connections of its inner nodes. Use after panel_graph_outline / panel_query_graph shows a node with is_subgraph=true. Read-only.",
       { node_id: z.number().int().describe("Subgraph node id (is_subgraph=true).") },
-      async (args: A, ctx) => ctx.call({ cmd: "graph_get_subgraph", node_id: args.node_id }),
+      async (args: A, ctx) =>
+        withTruncationHints(await ctx.call({ cmd: "graph_get_subgraph", node_id: args.node_id }), [
+          {
+            flag: "truncated",
+            key: "truncation_hint",
+            text: (p) =>
+              fixedCapHint(
+                "inner node(s)",
+                replyCount(p, "nodes"),
+                p.node_count,
+                // Honest about the follow-up's OWN ceiling (codex gate): panel_query_graph
+                // clamps limit at 200 and has no cursor, so on a >200-node subgraph it is
+                // a way to read MORE, not a way to read all.
+                "panel_enter_subgraph into it, then panel_query_graph — which takes limit (max 200) and max_chars. It has no cursor, so beyond 200 inner nodes use its types/where filters to work through them.",
+              ),
+          },
+        ]),
     ),
     def(
       "panel_find_nodes",
-      "SEARCH the live canvas for nodes matching a term you supply — the right way to PINPOINT a node (a specific loader, sampler, save, switch) in a LARGE graph. Supply a free-text `query` and/or targeted filters; with nothing specific in mind, read the whole graph with panel_graph_outline instead. This searches the LIVE graph ON THE CANVAS — NOT the installable node registry (that's panel_search_nodes). It scans EVERY node (no truncation). Give a free-text `query` (matched case-insensitively across node type, title, description, widget NAMES, widget VALUES, and input/output port names+types — a node hits if ANY of those contain it) and/or targeted filters: type, title, input, output, widget (name), widget_value (contents), is_output, is_subgraph, mode. Targeted filters are ANDed together; the free `query` ORs across fields. Each match is the SAME rich summary as panel_query_graph's detail rows (id, type, title, widgets, inputs WITH their connected_from sources, outputs, mode, is_output, …) PLUS the node's description and a `matched_on` list saying WHY it matched. Read-only. Examples — the video loader: {query:'tiktok'} or {type:'LoadVideo'} or {input:'video'}; every output node: {is_output:true}; the node whose widget holds a file: {widget_value:'.png'}; a bypassed switch: {type:'Switch', mode:'bypass'}.",
+      "SEARCH the live canvas for nodes matching a term you supply — the right way to PINPOINT a node (a specific loader, sampler, save, switch) in a LARGE graph. Supply a free-text `query` and/or targeted filters; with nothing specific in mind, read the whole graph with panel_graph_outline instead. This searches the LIVE graph ON THE CANVAS — NOT the installable node registry (that's panel_search_nodes). It scans the graph in the canvas's own node order and STOPS once it has `limit` matches (default 40, max 200) — so a capped result is neither exhaustive nor a count of all matches: the result's count field is what was returned, total is the graph's node count, and truncated:true means the scan REACHED the cap — on current panels that proves more matches exist, on older panel builds it can also fire on an exactly-`limit` result that dropped nothing, so read it as 'may be incomplete'. Either way the result carries a truncation_hint naming the fix (raise `limit`, up to 200, or add a filter) — retry, do not conclude the node isn't there. Give a free-text `query` (matched case-insensitively across node type, title, description, widget NAMES, widget VALUES, and input/output port names+types — a node hits if ANY of those contain it) and/or targeted filters: type, title, input, output, widget (name), widget_value (contents), is_output, is_subgraph, mode. Targeted filters are ANDed together; the free `query` ORs across fields. Each match is the SAME rich summary as panel_query_graph's detail rows (id, type, title, widgets, inputs WITH their connected_from sources, outputs, mode, is_output, …) PLUS the node's description and a `matched_on` list saying WHY it matched. Read-only. Examples — the video loader: {query:'tiktok'} or {type:'LoadVideo'} or {input:'video'}; every output node: {is_output:true}; the node whose widget holds a file: {widget_value:'.png'}; a bypassed switch: {type:'Switch', mode:'bypass'}.",
       {
         query: z
           .string()
@@ -4200,25 +4443,56 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .number()
           .int()
           .min(1)
-          .max(200)
+          .max(FIND_NODES_LIMIT_CEILING)
           .optional()
-          .describe("Max matches to return (default 40)."),
+          .describe(
+            `Max matches to return (default ${FIND_NODES_DEFAULT_LIMIT}, max ${FIND_NODES_LIMIT_CEILING}). The scan STOPS once this many match, so a capped result is not a complete match set.`,
+          ),
       },
       async (args: A, ctx) =>
-        ctx.call({
-          cmd: "graph_find_nodes",
-          query: args.query,
-          type: args.type,
-          title: args.title,
-          input: args.input,
-          output: args.output,
-          widget: args.widget,
-          widget_value: args.widget_value,
-          is_output: args.is_output,
-          is_subgraph: args.is_subgraph,
-          mode: args.mode,
-          limit: args.limit,
-        }),
+        withTruncationHints(
+          await ctx.call({
+            cmd: "graph_find_nodes",
+            query: args.query,
+            type: args.type,
+            title: args.title,
+            input: args.input,
+            output: args.output,
+            widget: args.widget,
+            widget_value: args.widget_value,
+            is_output: args.is_output,
+            is_subgraph: args.is_subgraph,
+            mode: args.mode,
+            limit: args.limit,
+          }),
+          [
+            {
+              flag: "truncated",
+              key: "truncation_hint",
+              // #809 (defect 2): the scan STOPS at the cap, so `count` is not a match
+              // total and the absent matches are not "no more matches".
+              //
+              // The wording is deliberately "may be incomplete", not "there ARE more"
+              // (codex gate): this orchestrator ships ahead of the panel, and a panel
+              // build older than the matching panel PR sets `truncated` on an EXACT-cap
+              // result that dropped nothing. Asserting more exist would manufacture the
+              // very false alarm this issue is removing. A current panel supplies its own
+              // precise hint and the rider defers to it.
+              text: (p) => {
+                const inForce =
+                  typeof args.limit === "number" ? args.limit : FIND_NODES_DEFAULT_LIMIT;
+                const raise =
+                  inForce >= FIND_NODES_LIMIT_CEILING
+                    ? `\`limit\` is already at its ceiling of ${FIND_NODES_LIMIT_CEILING}, so narrow with \`type\`/\`title\`/\`widget_value\` instead`
+                    : `Raise \`limit\` up to ${FIND_NODES_LIMIT_CEILING}, or narrow with \`type\`/\`title\`/\`widget_value\``;
+                return (
+                  `The scan reached \`limit\`=${inForce} at ${replyCount(p, "matches") ?? "the cap"} match(es), so this result MAY be incomplete — ` +
+                  `treat it as "not proof a node is absent" rather than as the full match set. ${raise}.`
+                );
+              },
+            },
+          ],
+        ),
     ),
     def(
       "panel_add_node",
@@ -4770,7 +5044,34 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "panel_get_errors",
       "WHY IS THAT NODE RED / WHY DID THE RUN FAIL? The single error surface for the user's open tab: every errored node JOINED TO ITS CAUSE, which ComfyUI itself does not show — LiteGraph only paints a red outline and stores no reason, which is why users report \"red node, no error message\". Call this whenever the user mentions a red/highlighted/erroring node, a failed run, or \"required models are missing\" — instead of guessing from widget values. Each entry in `nodes[]` is the node's full detail summary plus `red_outline` and `reasons[]`, drawn from every source: `missing_model` (exact file, its models directory, the widget holding it, and a download URL when known), `missing_media` (a referenced input image/video that isn't on disk — the usual cause of a red LoadImage), `validation` (per-input errors from the last queue attempt: message, details, offending input), and `execution` (runtime failure with `exception_type`, e.g. PIL.UnidentifiedImageError). TWO THINGS THAT MAKE THIS ESSENTIAL: (1) missing model/media assets paint nodes red AS SOON AS THE WORKFLOW LOADS, long before any queue attempt — so the raw validation map is still EMPTY while the user is staring at red nodes; (2) a node that throws AT RUNTIME is never painted red at all, so it can't be spotted on the canvas — it appears here with red_outline:false. Also returns graph-level `missing_models`, `missing_media`, `missing_node_types` (or `missing_node_count`), plus the raw `node_errors` map and `last_execution_error` for reference. A ⚠️ GRAPH VALIDATION block is auto-injected at your turn start when this state changes; call this to re-check on demand (e.g. after you edit widgets/links). Read-only.",
       {},
-      async (_args, ctx) => ctx.call({ cmd: "graph_get_errors" }),
+      async (_args, ctx) =>
+        withTruncationHints(await ctx.call({ cmd: "graph_get_errors" }), [
+          {
+            flag: "truncated",
+            key: "truncation_hint",
+            text: (p) =>
+              fixedCapHint(
+                "errored node(s)",
+                replyCount(p, "nodes"),
+                p.errored_count,
+                "Fix these first and re-check, or inspect specific ids with panel_query_graph {ids:[…], fields:'detail'}.",
+              ),
+          },
+          {
+            flag: "stale_flags_truncated",
+            key: "stale_flags_truncation_hint",
+            // Older panels send no total for this list, so the rider says so rather than
+            // implying the shown count is the whole of it (codex gate). A current panel
+            // supplies its own hint WITH the total, and the rider defers to it.
+            text: (p) =>
+              fixedCapHint(
+                "stale red-outline node(s)",
+                replyCount(p, "stale_flags"),
+                undefined,
+                "An unknown number more were cut (this panel build reports no total). They are cosmetic leftovers, not errors; the cap is fixed and there is no parameter to page it.",
+              ),
+          },
+        ]),
     ),
     def(
       "panel_refresh_nodes",

--- a/src/services/crash-log.ts
+++ b/src/services/crash-log.ts
@@ -137,7 +137,13 @@ export function parseCrashBlock(text: string): CrashParseResult {
   let block = text.slice(lineStart).trim();
   if (block.length > MAX_BLOCK_CHARS) {
     // Keep the HEAD of the block (the signature + the top frames matter most).
-    block = block.slice(0, MAX_BLOCK_CHARS) + "\n…(truncated)";
+    // #809: "…(truncated)" said nothing actionable. Name the amount, the fixed cap, and
+    // the tool that holds the rest — this block is INJECTED, so it has no parameters of
+    // its own and inventing a lever here would send the caller nowhere.
+    const dropped = block.length - MAX_BLOCK_CHARS;
+    block =
+      block.slice(0, MAX_BLOCK_CHARS) +
+      `\n…(+${dropped} more char(s) cut at the fixed ${MAX_BLOCK_CHARS}-char crash-block cap — no parameter raises it; get_logs may still hold the full crash while it is within the log tail)`;
   }
 
   // Culprit: the DEEPEST (innermost / actually-crashing) frame in the fatal

--- a/src/services/graph-query.ts
+++ b/src/services/graph-query.ts
@@ -13,6 +13,35 @@
 /** A widget predicate: "name op value". Ops: = != >= <= > < ~ (contains). */
 const PREDICATE_RE = /^\s*([A-Za-z0-9_.]+)\s*(>=|<=|!=|=|>|<|~)\s*(.*?)\s*$/;
 
+// #809: the REAL clamps, exported so the remedy strings below and the zod schema on
+// query_workflow (src/tools/workflow-library.ts) are derived from ONE number. A hint
+// that names a ceiling the runtime does not actually enforce is the same class of
+// defect as a hint that names the wrong parameter — it sends the caller at a value
+// that gets silently clamped, which reads to the caller as "the tool can't do this".
+export const LIMIT_CEILING = 200;
+export const MAX_CHARS_CEILING = 60000;
+export const MAX_CHARS_FLOOR = 500;
+/** Per-widget-value cap in the `detail` projection — a FIXED cap, NOT raised by max_chars. */
+export const WIDGET_VALUE_CAP = 2048;
+/** Widget values are clipped to this in the `compact` projection (fixed). */
+export const COMPACT_VALUE_CLIP = 60;
+/** Ref-inputs / downstream-consumer list caps in the `detail` projection (fixed). */
+export const REF_CAP = 64;
+export const DOWN_CAP = 64;
+
+/**
+ * #809 (codex gate): "raise `X` up to N" is ITSELF a dead retry when the caller is
+ * already at N, and "raise `X`" with no ceiling leaves them guessing how far. Both waste
+ * the round trip this issue exists to prevent. One helper so every marker — inline or
+ * tail — states the same true thing.
+ */
+export function raiseOrCeiling(param: string, inForce: number, ceiling: number): string {
+  return inForce >= ceiling
+    ? `\`${param}\` is already at its ceiling of ${ceiling}`
+    : `raise \`${param}\` (up to ${ceiling})`;
+}
+
+
 export interface GraphQueryOptions {
   /** Keep nodes whose class_type contains ANY of these (case-insensitive). */
   types?: string[];
@@ -48,7 +77,16 @@ export interface GraphQueryResult {
   matched: number;
   /** Nodes actually rendered (≤ limit, ≤ char bound). */
   shown: number;
+  /** Whether ROWS were dropped. Field-level caps inside a rendered row (per-widget,
+   *  per-ref, compact value clip) do NOT set this — they are reported inline, next to
+   *  the thing they cut, and are visible in `text`. Stated explicitly because "truncated
+   *  is false" would otherwise read as "you have everything" (codex gate). */
   truncated: boolean;
+  /** #809: WHICH ROW-LEVEL cap fired, so the remedy can name the lever that actually
+   *  applies. `null` when no rows were dropped — which, per `truncated` above, does NOT
+   *  mean no content was cut. "limit" ⇒ raising max_chars does nothing; "max_chars" ⇒
+   *  raising limit does nothing (and makes the overflow worse). */
+  truncated_by: "limit" | "max_chars" | null;
   text: string;
 }
 
@@ -71,10 +109,19 @@ function clip(v: unknown, n = 60): string {
   return one.length > n ? `${one.slice(0, n - 1)}…` : one;
 }
 
+/** clip(), but reporting whether it actually cut — so the COMPACT projection can
+ *  raise ONE footer note naming the lever (`fields`:"detail") instead of leaving a
+ *  bare `…` per value (#809). */
+function clipFlag(v: unknown, n = COMPACT_VALUE_CLIP): { text: string; clipped: boolean } {
+  const s = typeof v === "string" ? v : JSON.stringify(v);
+  const one = (s ?? "").replace(/\s+/g, " ");
+  return one.length > n ? { text: `${one.slice(0, n - 1)}…`, clipped: true } : { text: one, clipped: false };
+}
+
 // #609: per-widget-value cap for the `detail` projection. One oversized value
 // (a ResolutionMaster presets JSON, LTXDirector.timeline_data, a VHS videopreview)
 // must not consume the whole max_chars budget and starve the rest of the query.
-const WIDGET_VALUE_CAP = 2048;
+// WIDGET_VALUE_CAP is exported above (#809) so the remedy can state it honestly.
 
 /** Bound one widget value by its ESCAPED (JSON-serialized) size (#609), so the bound
  *  holds regardless of content — control chars and lone surrogates escape to 6 chars
@@ -83,7 +130,12 @@ const WIDGET_VALUE_CAP = 2048;
  *  and type-change a fitting object/array into a truncated string (review nit).
  *  Small values pass through; else the longest head prefix whose encoding fits `cap`,
  *  with an honest marker naming how many raw chars were dropped. */
-function capWidgetValue(value: unknown, cap = WIDGET_VALUE_CAP): unknown {
+function capWidgetValue(
+  value: unknown,
+  cap = WIDGET_VALUE_CAP,
+  /** The `max_chars` in force, so a caller already at the ceiling isn't sent back. */
+  maxChars = Number.POSITIVE_INFINITY,
+): unknown {
   if (value == null) return value;
   const isString = typeof value === "string";
   const s = isString ? value : (() => { try { return JSON.stringify(value); } catch { return String(value); } })();
@@ -91,7 +143,19 @@ function capWidgetValue(value: unknown, cap = WIDGET_VALUE_CAP): unknown {
   // A string is emitted escaped (JSON.stringify(s)); a non-string's emission IS s.
   const serializedSize = isString ? JSON.stringify(s).length : s.length;
   if (serializedSize <= cap) return value;
-  const target = Math.max(2, cap - 40);
+  // #809: name the lever that ACTUALLY applies. capWidgets() tightens the per-value
+  // cap to the char budget only when the budget is the smaller of the two, so
+  // `cap < WIDGET_VALUE_CAP` ⟺ max_chars is what cut this value and raising it helps.
+  // At the FIXED 2048 cap raising max_chars does nothing, and saying so stops the
+  // caller burning a retry on a parameter that cannot move this.
+  const remedy =
+    cap < WIDGET_VALUE_CAP
+      ? `over the \`max_chars\` budget; ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)}`
+      : `at the ${WIDGET_VALUE_CAP}-char per-widget cap, which \`max_chars\` does not raise`;
+  const marker = (dropped: number) => `…(+${dropped} chars cut ${remedy})`;
+  // Reserve EXACTLY the marker's own size (its digit count is bounded by s.length),
+  // not a fixed 40 — a longer, more useful marker must not be able to breach `cap`.
+  const target = Math.max(2, cap - marker(s.length).length);
   let lo = 0;
   let hi = s.length;
   let best = 0;
@@ -100,7 +164,7 @@ function capWidgetValue(value: unknown, cap = WIDGET_VALUE_CAP): unknown {
     if (JSON.stringify(s.slice(0, mid)).length <= target) { best = mid; lo = mid + 1; }
     else hi = mid - 1;
   }
-  return `${s.slice(0, best)}…(+${s.length - best} chars, truncated)`;
+  return `${s.slice(0, best)}${marker(s.length - best)}`;
 }
 
 /** Clip a KEY/name to a small bound (#609) so a pathological long key can't blow the line. */
@@ -132,7 +196,7 @@ function capWidgets(widgets: Record<string, unknown>, totalCap = Number.POSITIVE
   let omitted = 0;
   for (let i = 0; i < entries.length; i++) {
     const k = capKey(entries[i][0]);
-    const capped = capWidgetValue(entries[i][1], perValueCap);
+    const capped = capWidgetValue(entries[i][1], perValueCap, totalCap);
     const size = entrySize(k, capped);
     if (Number.isFinite(totalCap) && Object.keys(out).length > 0 && used + size > totalCap) {
       omitted = entries.length - i;
@@ -141,7 +205,12 @@ function capWidgets(widgets: Record<string, unknown>, totalCap = Number.POSITIVE
     out[k] = capped;
     used += size;
   }
-  if (omitted > 0) out["…"] = `${omitted} widget(s) omitted (exceeded budget); raise max_chars`;
+  // #809: `max_chars` backticked so the schema-driven remedy test can see it, and the
+  // remaining count stated — the caller needs "how much is left", not just "some".
+  if (omitted > 0)
+    out["…"] =
+      `${omitted} more widget(s) cut by the \`max_chars\` budget; ` +
+      raiseOrCeiling("max_chars", totalCap, MAX_CHARS_CEILING);
   return out;
 }
 
@@ -150,7 +219,13 @@ function capWidgets(widgets: Record<string, unknown>, totalCap = Number.POSITIVE
  *  would else emit an unbounded first line. */
 function clipLine(line: string, maxChars: number): string {
   if (!Number.isFinite(maxChars) || line.length <= maxChars) return line;
-  return line.slice(0, Math.max(0, maxChars - 1)) + "…";
+  // #809: a bare "…" told the caller nothing. Say how much was cut and name the lever
+  // (raising max_chars genuinely lifts THIS cut). The reserve is the marker's own
+  // worst-case size, so the clipped line still respects maxChars.
+  const marker = (dropped: number) =>
+    `…(+${dropped} chars over \`max_chars\`; ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)})`;
+  const keep = Math.max(0, maxChars - marker(line.length).length);
+  return line.slice(0, keep) + marker(line.length - keep);
 }
 
 /** Final guard for a DETAIL (JSON) line (#609): if a node's fully-capped detail STILL
@@ -167,10 +242,10 @@ function fitDetailLine(line: string, stub: Record<string, unknown>, maxChars: nu
   if (stub.title != null) safe.title = clipF(stub.title);
   const s = JSON.stringify({
     ...safe,
-    detail_omitted: `full detail is ${line.length} chars > max_chars ${maxChars}; raise max_chars to read this node`,
+    detail_omitted: `full detail is ${line.length} chars > \`max_chars\` ${maxChars}; ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)} to read this node`,
   });
   if (s.length <= maxChars) return s;
-  return JSON.stringify({ id: typeof safe.id === "string" ? safe.id.slice(0, 40) : safe.id, detail_omitted: "raise max_chars" });
+  return JSON.stringify({ id: typeof safe.id === "string" ? safe.id.slice(0, 40) : safe.id, detail_omitted: "raise `max_chars`" });
 }
 
 function matchPredicate(value: unknown, op: string, rhs: string): boolean {
@@ -230,8 +305,8 @@ function closure(adj: Map<string, Set<string>>, seed: string, depth: number): Se
 export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): GraphQueryResult {
   const nodeIds = Object.keys(graph);
   const total = nodeIds.length;
-  const limit = Math.min(Math.max(opts.limit ?? 40, 1), 200);
-  const maxChars = Math.min(Math.max(opts.max_chars ?? 12000, 500), 60000);
+  const limit = Math.min(Math.max(opts.limit ?? 40, 1), LIMIT_CEILING);
+  const maxChars = Math.min(Math.max(opts.max_chars ?? 12000, MAX_CHARS_FLOOR), MAX_CHARS_CEILING);
 
   // Adjacency (upstream = the nodes my ref-inputs point at; downstream = inverse).
   const up = new Map<string, Set<string>>();
@@ -252,9 +327,13 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
   let scope: Set<string> | null = null;
   const depth = opts.depth != null && opts.depth >= 0 ? opts.depth : Number.POSITIVE_INFINITY;
   const seedErr = (which: string, id: string): GraphQueryResult => ({
-    total, candidates: 0, matched: 0, shown: 0, truncated: false,
+    total, candidates: 0, matched: 0, shown: 0, truncated: false, truncated_by: null,
     // #609: clip the caller-supplied id so an oversized seed can't flood the diagnostic.
-    text: `${which} node ${clip(id, 120)} not found in the graph (${total} nodes).`,
+    // #809: SAY when it was clipped — echoing back a shortened id with a bare "…" reads
+    // as "that is the id I looked for", so the caller cannot tell a typo from a clip.
+    text:
+      `${which} node ${clip(id, 120)}${id.length > 120 ? ` (id shown clipped to 120 of ${id.length} chars)` : ""}` +
+      ` not found in the graph (${total} nodes).`,
   });
   if (opts.upstream_of != null) {
     const seed = String(opts.upstream_of);
@@ -325,11 +404,32 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
       kept.push(l);
       used += l.length + 1;
     }
-    const aggTail = aggTruncated ? `\n…(${allLines.length - kept.length} more type(s) omitted; raise max_chars)` : "";
+    // #809: the aggregate can ONLY be cut by the char budget (limit is ignored here),
+    // so name that one lever and its real ceiling.
+    const aggAssemble = (): string => {
+      const tail = aggTruncated
+        ? `\n…(${allLines.length - kept.length} more type(s) cut by \`max_chars\`=${maxChars}; ${
+            maxChars >= MAX_CHARS_CEILING
+              ? `\`max_chars\` is already at its ceiling of ${MAX_CHARS_CEILING} — narrow the matched set with \`types\`/\`where\`/\`upstream_of\` instead`
+              : `raise \`max_chars\` up to ${MAX_CHARS_CEILING}`
+          })`
+        : "";
+      return `${head}\n${kept.join("\n")}${tail}`;
+    };
+    // The tail is part of the result here too (codex gate) — the loop above filled the
+    // budget with rows and then appended it, breaching the bound on exactly the path the
+    // row projection had already been fixed for. Fit afterwards, same as there.
+    let aggText = aggAssemble();
+    while (aggText.length > maxChars && kept.length > 0) {
+      kept.pop();
+      aggTruncated = true;
+      aggText = aggAssemble();
+    }
     return {
       total, candidates: candidates.length, matched: matched.length,
       shown: matched.length, truncated: aggTruncated,
-      text: `${head}\n${kept.join("\n")}${aggTail}`,
+      truncated_by: aggTruncated ? "max_chars" : null,
+      text: aggText,
     };
   }
 
@@ -349,10 +449,25 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
   const lines: string[] = [];
   let shown = 0;
   let truncated = false;
+  // #809: WHICH cap fired. `limit` and `max_chars` are different levers with opposite
+  // remedies — the pre-#809 tail named `limit` for both, so a caller cut by the char
+  // budget was told to raise the one parameter that makes the overflow worse.
+  let truncatedBy: "limit" | "max_chars" | null = null;
+  /** #809: compact rows clip widget values at a FIXED 60 chars, which no parameter
+   *  raises — so the footer points at `fields`:"detail" (the projection that carries
+   *  fuller values) rather than at a lever that would do nothing.
+   *
+   *  Counted PER ROW and summed over the rows actually RETURNED (codex gate). A running
+   *  total would include rows the budget rejected and rows the post-fit loop popped, so
+   *  the footer would claim clips the reader cannot see — a false claim inside the very
+   *  note that has to be trustworthy. */
+  const lineClips: number[] = [];
+  let rowClips = 0;
   let chars = header.length;
   for (const id of matched) {
-    if (shown >= limit) { truncated = true; break; }
+    if (shown >= limit) { truncated = true; truncatedBy = "limit"; break; }
     const n = graph[id] ?? {};
+    rowClips = 0;
     let line: string;
     if (fields === "ids") {
       line = clipLine(String(id), maxChars); // #609: bound even a pathological long id
@@ -361,17 +476,41 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
       // the title/type, clip ref-input names + source ids and cap their count, and cap
       // the downstream consumer list (a fan-out hub can have hundreds) — each with a
       // "+N more" / "…" tail. widgets is total-capped by capWidgets.
-      const REF_CAP = 64;
       const upRefs: Record<string, string> = {};
       const refEntries = Object.entries(n.inputs ?? {}).filter(([, v]) => isRef(v));
       for (const [k, v] of refEntries.slice(0, REF_CAP)) {
         upRefs[capKey(k)] = clip(`${(v as [unknown, unknown])[0]}.${(v as [unknown, unknown])[1]}`, 128);
       }
-      if (refEntries.length > REF_CAP) upRefs["…"] = `+${refEntries.length - REF_CAP} more`;
+      // #809: these two are FIXED caps that no parameter raises — so the marker names
+      // the traversal that DOES return the full set instead of a lever that cannot.
+      // The suggested follow-up carries its OWN `limit` (codex gate): a bare
+      // `upstream_of`+`depth`:1 would re-truncate at the default limit of 40 and land the
+      // caller in a second silent cut, which is the failure this issue exists to stop.
+      // `fields`:"ids" keeps that follow-up cheap. The seed counts as one row, hence +1.
+      // The traversal returns the seed PLUS every direct neighbour, so it needs
+      // count+1 rows. Past LIMIT_CEILING that is unreachable in one call, and claiming
+      // "list all" there would be a second false promise (codex gate) — so the verb
+      // changes with the fact.
+      const followUpText = (param: string, count: number) => {
+        const need = count + 1; // the traversal returns the seed PLUS its neighbours
+        const call = `\`${param}\`:${id}, \`depth\`:1, \`limit\`:${Math.min(LIMIT_CEILING, need)}, \`fields\`:"ids"`;
+        // Above the ceiling a single call CANNOT return them all, and query_workflow has
+        // no cursor/offset — so "page through them" would be a second false promise
+        // inside the remedy for the first one (codex gate). Say what is actually true.
+        return need <= LIMIT_CEILING
+          ? `list all with ${call}`
+          : `list the first ${LIMIT_CEILING} with ${call}; there is no cursor/offset, so enumerate the rest by re-running that query with \`types\`/\`where\` narrowed`;
+      };
+      if (refEntries.length > REF_CAP)
+        upRefs["…"] = `+${refEntries.length - REF_CAP} more (fixed ${REF_CAP}-ref cap) — ${followUpText("upstream_of", refEntries.length)}`;
       const allDown = [...(down.get(String(id)) ?? [])];
-      const DOWN_CAP = 64;
       const downstream: Array<string | number> =
-        allDown.length > DOWN_CAP ? [...allDown.slice(0, DOWN_CAP), `…+${allDown.length - DOWN_CAP} more`] : allDown;
+        allDown.length > DOWN_CAP
+          ? [
+              ...allDown.slice(0, DOWN_CAP),
+              `…+${allDown.length - DOWN_CAP} more (fixed ${DOWN_CAP}-consumer cap) — ${followUpText("downstream_of", allDown.length)}`,
+            ]
+          : allDown;
       const title = n._meta?.title != null ? clip(n._meta.title, 200) : n._meta?.title;
       line = JSON.stringify({
         id, type: clip(n.class_type ?? "?", 200), title,
@@ -382,7 +521,13 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
       // is never dropped yet can't flood — every rendered detail line ends up ≤ max_chars.
       line = fitDetailLine(line, { id, type: clip(n.class_type ?? "?", 200) }, maxChars);
     } else {
-      const w = Object.entries(widgetsOf(n)).map(([k, v]) => `${k}=${clip(v)}`).join(" ");
+      const w = Object.entries(widgetsOf(n))
+        .map(([k, v]) => {
+          const c = clipFlag(v);
+          if (c.clipped) rowClips++;
+          return `${k}=${c.text}`;
+        })
+        .join(" ");
       const ins = Object.entries(n.inputs ?? {})
         .filter(([, v]) => isRef(v))
         .map(([k, v]) => `${k}:${(v as [unknown, unknown])[0]}`)
@@ -397,19 +542,75 @@ export function queryApiGraph(graph: ApiGraph, opts: GraphQueryOptions = {}): Gr
       line = clipLine(line, maxChars);
     }
     const protectedLine = shown === 0; // first match always renders → shown≥1
-    if (!protectedLine && chars + line.length + 1 > maxChars) { truncated = true; break; }
+    if (!protectedLine && chars + line.length + 1 > maxChars) {
+      truncated = true;
+      truncatedBy = "max_chars";
+      break;
+    }
     chars += line.length + 1;
     lines.push(line);
+    lineClips.push(rowClips);
     shown++;
   }
-  const tail = truncated
-    ? (wantIds?.length
-        ? `\n… truncated at ${shown} of ${matched.length} — requested nodes exceed max_chars (per-field values are already capped); raise max_chars or request fewer ids at once.`
-        : `\n… truncated at ${shown} of ${matched.length} — narrow with types/where/ids/depth, use group_by:"type", or raise limit.`)
-    : "";
-  const body = fields === "ids" ? lines.join(",") : lines.join("\n");
+  // #809 (defect 1): BOTH cuts above land here, and they have OPPOSITE remedies —
+  // raising `limit` on a char-budget cut only makes the overflow worse. Name the lever
+  // that actually fired, with its REAL ceiling, and say plainly that the other one
+  // will not help, so a caller cannot burn a retry proving the tool "can't do this".
+  //
+  // AND (codex gate): "raise X up to N" is itself a dead retry when the caller is ALREADY
+  // at N. Telling someone at limit=200 to raise limit to 200 is the same wasted round
+  // trip as naming the wrong lever — so at the ceiling the remedy switches to what is
+  // actually left: narrowing, or the aggregate.
+  const buildTail = (by: "limit" | "max_chars" | null, shownNow: number): string => {
+    if (!by) return "";
+    const atCeiling = by === "limit" ? limit >= LIMIT_CEILING : maxChars >= MAX_CHARS_CEILING;
+    const param = by === "limit" ? "limit" : "max_chars";
+    const ceiling = by === "limit" ? LIMIT_CEILING : MAX_CHARS_CEILING;
+    const raise = atCeiling
+      ? `\`${param}\` is already at its ceiling of ${ceiling}, so raising it is not an option`
+      : `raise \`${param}\` up to ${ceiling}`;
+    const other =
+      by === "limit" ? "`max_chars` is not the constraint here." : "Raising `limit` will not help.";
+    const narrow = wantIds?.length
+      ? "request fewer `ids` at once"
+      : 'narrow with `types`/`where`/`ids`/`depth`, or count with `group_by`:"type"';
+    const cutBy =
+      by === "limit"
+        ? `\`limit\`=${limit}`
+        : `\`max_chars\`=${maxChars}${wantIds?.length ? " (per-field values are already capped)" : ""}`;
+    const subject = wantIds?.length ? " requested node(s)" : "";
+    return `\n… truncated at ${shownNow} of ${matched.length}${subject} by ${cutBy} — ${raise}, or ${narrow}. ${other}`;
+  };
+  // #809: the compact projection's 60-char value clip is FIXED — no parameter lifts it,
+  // so point at the projection that carries fuller values instead of at a dead lever.
+  const buildClipNote = (n: number): string =>
+    n > 0
+      ? `\n(${n} widget value(s) clipped to ${COMPACT_VALUE_CLIP} chars by \`fields\`:"compact" — read fuller values with \`fields\`:"detail", which caps values at ${WIDGET_VALUE_CAP} chars.)`
+      : "";
+  const assemble = (): string => {
+    const body = fields === "ids" ? lines.join(",") : lines.join("\n");
+    return `${header}\n${body}${buildTail(truncatedBy, shown)}${buildClipNote(lineClips.reduce((x, y) => x + y, 0))}`;
+  };
+
+  // #809 (codex gate): the tail and the footer are part of the RESULT and must fit inside
+  // `max_chars`, not be appended past it. Reserving their worst case UP FRONT was wrong —
+  // at the 500 floor it pre-spent the whole budget and manufactured a truncation on a
+  // result that fitted, which is the false-truncation defect this issue also exists to
+  // remove. So fit AFTERWARDS instead: drop rows from the end, exactly as many as needed.
+  // The first row is never dropped (the documented #609 protection), so a single
+  // pathological row can still exceed the budget — that exception is unchanged.
+  let text = assemble();
+  while (text.length > maxChars && lines.length > 1) {
+    lines.pop();
+    lineClips.pop();
+    shown--;
+    truncated = true;
+    truncatedBy = "max_chars";
+    text = assemble();
+  }
   return {
     total, candidates: candidates.length, matched: matched.length, shown, truncated,
-    text: `${header}\n${body}${tail}`,
+    truncated_by: truncatedBy,
+    text,
   };
 }

--- a/src/services/job-history.ts
+++ b/src/services/job-history.ts
@@ -151,9 +151,27 @@ function tracebackText(value: unknown): string | undefined {
   return undefined;
 }
 
+/**
+ * #809: a `traceback_truncated: true` boolean next to a traceback that just STOPS is
+ * indistinguishable, to a reader, from a traceback that ended. Mark the cut inline and
+ * say what to do — this cap is FIXED (no parameter raises it), so the remedy is the
+ * tool that holds the untruncated text, not a lever that does not exist.
+ */
 function truncateTraceback(text: string): { text: string; truncated: boolean } {
   if (text.length <= TRACEBACK_MAX_CHARS) return { text, truncated: false };
-  return { text: text.slice(0, TRACEBACK_MAX_CHARS), truncated: true };
+  const dropped = text.length - TRACEBACK_MAX_CHARS;
+  return {
+    // The remedy is deliberately a MAY, not a promise (codex gate): the full text came
+    // from ComfyUI's /history and no tool re-serves it, so claiming get_logs "has" it
+    // would be the same lie as naming a parameter that does not exist. What IS certain:
+    // this is the HEAD, and a Python traceback prints the exception LAST — so the line
+    // that names the failure may be among the cut frames. Say that; it changes what the
+    // reader does next.
+    text:
+      text.slice(0, TRACEBACK_MAX_CHARS) +
+      `\n[... ${dropped} more char(s) cut at the fixed ${TRACEBACK_MAX_CHARS}-char traceback cap — no parameter raises it, and the rest is not retained in this result. This is the HEAD, so the final exception line is likely among the cut frames; get_logs may still hold the full traceback if the run is recent ...]`,
+    truncated: true,
+  };
 }
 
 function isOomError(error: ExecutionErrorDetails): boolean {

--- a/src/services/node-dev.ts
+++ b/src/services/node-dev.ts
@@ -86,6 +86,27 @@ export const LONG_LINE_CHUNK = 1_000;
 export const SEARCH_LINE_MAX = 600;
 /** Bound on any subprocess (git / patch) stdout+stderr surfaced to the caller. */
 export const CMD_OUTPUT_MAX = 12_000;
+/**
+ * #809 (codex gate): the FLOOR for any `max_chars`, mirroring query_workflow's own 500.
+ * A budget of 1 cannot hold the sentence that explains why the output was cut, so it
+ * used to produce either an unexplained empty field or a marker that breached the very
+ * bound it described. Neither is honest. This raises a FLOOR, not a cap — the ceiling is
+ * untouched — and it is the smallest value at which the tool can still answer "why is
+ * this empty?".
+ */
+export const MIN_OUTPUT_CHARS = 500;
+
+/**
+ * #809 (codex gate): "raise `X` up to N" is ITSELF a dead retry when the caller is
+ * already at N. Telling someone at max_results=100 to raise it to 100 wastes exactly the
+ * round trip this issue exists to prevent, and teaches the same wrong lesson ("the tool
+ * can't do this"). At the ceiling the remedy must switch to what is actually left.
+ */
+export function raiseOrCeiling(param: string, inForce: number, ceiling: number): string {
+  return inForce >= ceiling
+    ? `\`${param}\` is already at its ceiling of ${ceiling}, so raising it is not an option`
+    : `raise \`${param}\` up to ${ceiling}`;
+}
 export const LIST_DEFAULT_ENTRIES = 500;
 export const LIST_MAX_ENTRIES = 2_000;
 export const SEARCH_DEFAULT_RESULTS = 50;
@@ -397,14 +418,38 @@ export function chunkLongLines(lines: string[], width = LONG_LINE_CHUNK): string
   return out;
 }
 
-/** Clip text to maxChars, appending a truncation notice when clipped. */
+/**
+ * Clip text to maxChars, appending a truncation notice when clipped.
+ *
+ * #809: the default notice ("request a narrower range") named no parameter at all, so
+ * a caller could not tell WHICH argument to change or how far it could go. Callers now
+ * pass a notice built by `boundedNotice`, which states how much was dropped, the exact
+ * parameter to raise, and that parameter's REAL clamp — not the one in the prose.
+ */
 export function boundText(
   text: string,
   maxChars: number,
-  notice = "\n\n[... output truncated — request a narrower range ...]",
+  /**
+   * REQUIRED (codex gate): there is no safe default. `boundText` is shared by tools with
+   * DIFFERENT levers — read_node_file has `max_chars`, apply_node_patch has none — so a
+   * default naming `max_chars` would ship a dead remedy to whichever caller lacks it.
+   * Every call site states its own.
+   */
+  notice: (dropped: number) => string,
 ): { text: string; truncated: boolean } {
   if (text.length <= maxChars) return { text, truncated: false };
-  return { text: text.slice(0, maxChars) + notice, truncated: true };
+  // The marker is spent from the SAME budget it describes (codex gate): reserve its
+  // worst-case size up front so the returned text still honours `maxChars`. The digit
+  // count is bounded by text.length, so the reserve can never be too small.
+  //
+  // The one case that cannot honour it: a budget SMALLER than the marker itself. There
+  // the marker still wins and content is dropped entirely — an empty field with no
+  // explanation reads as "the file is empty", which is a worse lie than an over-budget
+  // sentence. Every real caller clamps well above the marker, so this is a corner, not
+  // the contract.
+  const reserve = notice(text.length).length;
+  const keep = Math.max(0, maxChars - reserve);
+  return { text: text.slice(0, keep) + notice(text.length - keep), truncated: true };
 }
 
 // ---------------------------------------------------------------------------
@@ -457,6 +502,9 @@ export interface ListFilesResult {
   root: string;
   entries: ListedEntry[];
   truncated: boolean;
+  /** #809: the remedy in prose. A bare `truncated` boolean is not text the model reads,
+   *  so an agent that hits it concludes the pack simply has these files. */
+  truncation_hint?: string;
   is_git_repo: boolean;
   has_pyproject: boolean;
 }
@@ -489,23 +537,28 @@ export function listNodePackFiles(
       if (truncated) return;
       const full = join(dir, item.name);
       const rel = relative(packDir, full).split(/[\\/]/).join("/");
+      // #809 (codex gate): stopping AT the cap cannot tell "exactly cap entries" from
+      // "capped", so a pack with exactly `max_entries` files was reported as truncated.
+      // Take ONE past the cap, then drop it: the extra entry is the proof, and its
+      // presence is the only honest truncation signal.
+      const take = (entry: ListedEntry): boolean => {
+        entries.push(entry);
+        if (entries.length > cap) {
+          entries.pop();
+          truncated = true;
+          return true;
+        }
+        return false;
+      };
       if (item.isDir) {
         if (SKIP_DIRS.has(item.name)) continue;
         if (!matcher || matcher.test(rel)) {
-          entries.push({ path: rel, size: 0, dir: true });
-          if (entries.length >= cap) {
-            truncated = true;
-            return;
-          }
+          if (take({ path: rel, size: 0, dir: true })) return;
         }
         walk(full);
       } else {
         if (matcher && !matcher.test(rel)) continue;
-        entries.push({ path: rel, size: deps.fileSize(full), dir: false });
-        if (entries.length >= cap) {
-          truncated = true;
-          return;
-        }
+        if (take({ path: rel, size: deps.fileSize(full), dir: false })) return;
       }
     }
   };
@@ -516,6 +569,14 @@ export function listNodePackFiles(
     root: packDir,
     entries,
     truncated,
+    ...(truncated
+      ? {
+          truncation_hint:
+            `Stopped at \`max_entries\`=${cap} after ${entries.length} entr(ies); the walk did NOT ` +
+            `finish, so this is not the pack's full file list. ` +
+            `${raiseOrCeiling("max_entries", cap, LIST_MAX_ENTRIES)}, or narrow with \`glob\` (e.g. '**/*.py').`,
+        }
+      : {}),
     is_git_repo: deps.isDirectory(join(packDir, ".git")),
     has_pyproject: deps.isFile(join(packDir, "pyproject.toml")),
   };
@@ -532,6 +593,35 @@ export interface ReadFileOptions {
   maxChars?: number;
 }
 
+/**
+ * #809: read_node_file's truncation notice. Exported (with the other notice builders
+ * below) so the schema-driven remedy test can check the parameters they name against
+ * read_node_file's REAL zod shape without standing up a filesystem — an untested hint
+ * string is precisely how this issue's defect 1 happened.
+ *
+ * Two DIFFERENT levers, both named: the char budget and the line window. A caller cut by
+ * one and told to raise the other burns a retry and concludes the file is unreadable.
+ */
+export const readBoundNotice =
+  (maxChars: number, startLine: number, endLine: number, sliceLineCount = 2) =>
+  (dropped: number) => {
+    // Paging by `start_line`/`line_count` indexes SOURCE lines. On a slice that is ONE
+    // physical line (a minified bundle, an embedded blob) there is nothing to page to —
+    // offering it would be a lever that exists and cannot move (codex gate). Say what is
+    // actually true: past the ceiling this tool cannot return the rest of that line.
+    const onePhysicalLine = sliceLineCount <= 1;
+    // Deliberately NOT quoting a length for that line (codex gate): what was measured is
+    // the CHUNKED text, which carries inserted newlines, so any number here would be a
+    // small lie inside a marker whose whole job is to be trusted.
+    const rest = onePhysicalLine
+      ? `this slice is a SINGLE physical line, so \`start_line\`/\`line_count\` cannot reach the rest — ` +
+        (maxChars >= READ_MAX_CHARS
+          ? `at the ${READ_MAX_CHARS} ceiling this tool cannot return more of it; search within it with search_node_packs instead`
+          : `${raiseOrCeiling("max_chars", maxChars, READ_MAX_CHARS)}, and past that use search_node_packs to locate what you need inside it`)
+      : `${raiseOrCeiling("max_chars", maxChars, READ_MAX_CHARS)}, or page with \`start_line\`/\`line_count\` (max ${READ_MAX_LINES} lines)`;
+    return `\n\n[... ${dropped} more char(s) in lines ${startLine}-${endLine} cut by \`max_chars\`=${maxChars}; ${rest} ...]`;
+  };
+
 export interface ReadFileResult {
   path: string;
   content: string;
@@ -540,6 +630,9 @@ export interface ReadFileResult {
   total_lines: number;
   size: number;
   truncated: boolean;
+  /** #809: present when content was dropped WITHOUT an inline marker (the line window
+   *  ended short of the file) — names the parameter to page with. */
+  truncation_hint?: string;
 }
 
 export function readNodeFile(
@@ -564,7 +657,9 @@ export function readNodeFile(
     READ_MAX_LINES,
   );
   const maxChars = Math.min(
-    Math.max(1, Math.floor(options.maxChars ?? READ_DEFAULT_CHARS)),
+    // #809: floor at MIN_OUTPUT_CHARS so the truncation notice always fits inside the
+    // budget it describes. The CEILING is unchanged.
+    Math.max(MIN_OUTPUT_CHARS, Math.floor(options.maxChars ?? READ_DEFAULT_CHARS)),
     READ_MAX_CHARS,
   );
 
@@ -573,7 +668,26 @@ export function readNodeFile(
   const endLine = Math.min(totalLines, startIdx + slice.length);
 
   const chunked = chunkLongLines(slice);
-  const bounded = boundText(chunked.join("\n"), maxChars);
+  // #809: name BOTH levers this tool actually has — the char budget and the line window
+  // — with their real clamps, so a caller who hit the wrong one doesn't retry the wrong
+  // parameter and conclude the file is unreadable.
+  const bounded = boundText(
+    chunked.join("\n"),
+    maxChars,
+    // slice.length is the count of SOURCE lines — the unit `start_line`/`line_count`
+    // address. `chunked` is longer when a line was split, and paging cannot reach those
+    // chunks, so the notice must be told the real number (codex gate).
+    readBoundNotice(maxChars, startLine, endLine, slice.length),
+  );
+  // The line window can end short of the file INDEPENDENTLY of the char budget — two
+  // different cuts with two different remedies. Suppressing this note whenever the char
+  // budget also fired lost the continuation point exactly when the caller needed it most
+  // (codex gate): the inline marker only describes the chars cut WITHIN the shown range,
+  // and says nothing about the lines beyond it.
+  const linesCut = endLine < totalLines;
+  const truncationHint = linesCut
+    ? `Shown lines ${startLine}-${endLine} of ${totalLines} (${totalLines - endLine} line(s) remain); continue with \`start_line\`:${endLine + 1} (\`line_count\` max ${READ_MAX_LINES}).`
+    : undefined;
 
   return {
     path: rel.split(/[\\/]/).join("/"),
@@ -582,7 +696,8 @@ export function readNodeFile(
     end_line: endLine,
     total_lines: totalLines,
     size,
-    truncated: bounded.truncated || endLine < totalLines,
+    truncated: bounded.truncated || linesCut,
+    ...(truncationHint ? { truncation_hint: truncationHint } : {}),
   };
 }
 
@@ -608,6 +723,37 @@ export interface SearchResult {
   engine: "ripgrep" | "builtin";
   matches: SearchMatch[];
   truncated: boolean;
+  /** #809: WHICH cap fired — "max_results" has a lever (`max_results`), "scanned_files"
+   *  does NOT (it is a fixed walker bound) and must be narrowed with `path`/`glob`
+   *  instead. Naming the wrong one of these sends the caller at a dead parameter. */
+  truncated_by?: "max_results" | "scanned_files";
+  /** The remedy in prose — a boolean alone never reaches the model's reading of the result. */
+  truncation_hint?: string;
+}
+
+/** #809: a hard 600-char slice with no marker read as if the line simply ended there.
+ *  Mark it, and say the cap is fixed so nobody retries a parameter that can't move it. */
+export function clipMatchLine(text: string): string {
+  if (text.length <= SEARCH_LINE_MAX) return text;
+  // The marker is spent from the SAME cap it describes (codex gate), so reserve its
+  // worst-case size — the emitted field still honours SEARCH_LINE_MAX.
+  const marker = (dropped: number) =>
+    // "read the FULL line" would over-promise (codex gate): read_node_file has its own
+    // 24000-char budget, so it returns MORE of the line, not necessarily all of it.
+    `…(+${dropped} chars; fixed ${SEARCH_LINE_MAX}-char per-line cap — read more of it with read_node_file, itself bounded by its own max_chars, max ${READ_MAX_CHARS})`;
+  const keep = Math.max(0, SEARCH_LINE_MAX - marker(text.length).length);
+  return text.slice(0, keep) + marker(text.length - keep);
+}
+
+/** #809: the whole-result remedy, naming the lever that matches the cause. */
+export function searchTruncationHint(
+  reason: "max_results" | "scanned_files",
+  shown: number,
+  cap: number,
+): string {
+  return reason === "max_results"
+    ? `Stopped at \`max_results\`=${cap} after ${shown} match(es); there may be more. ${raiseOrCeiling("max_results", cap, SEARCH_MAX_RESULTS)}, or narrow with \`path\`/\`glob\`.`
+    : `Stopped after scanning ${SEARCH_MAX_SCANNED_FILES} files (a FIXED walker bound — no parameter raises it) with ${shown} match(es) found. Narrow with \`path\`/\`glob\`, or install ripgrep on PATH to remove this bound.`;
 }
 
 /** Resolve the directory a search runs over (default "." = the whole jail root). */
@@ -653,8 +799,15 @@ function searchWithRipgrep(
     "never",
     "--path-separator",
     "/",
+    // #809 (codex gate): ask for ONE past the cap. `--max-count` is PER FILE, so with
+    // `cap` exactly, a file holding more matches had them dropped BY RIPGREP before we
+    // saw a line — and the loop below reported truncated:false. With `cap + 1`, any
+    // truncation anywhere necessarily produces a (cap+1)-th line, which the loop sees;
+    // and a search with exactly `cap` real matches produces no extra line, so it is no
+    // longer mislabelled as truncated. Both directions of the lie are closed by the
+    // same +1.
     "--max-count",
-    String(cap),
+    String(cap + 1),
   ];
   if (!options.caseSensitive) args.push("-i");
   if (options.glob) args.push("-g", options.glob);
@@ -671,21 +824,35 @@ function searchWithRipgrep(
 
   const matches: SearchMatch[] = [];
   let truncated = false;
+  // Paired with the `cap + 1` above: seeing a (cap+1)-th line is the PROOF that content
+  // was dropped, and its absence is proof that nothing was. No per-file bookkeeping is
+  // needed — rg cannot hide a match without also pushing the global count past `cap`.
   for (const raw of res.stdout.split(/\r?\n/)) {
     if (!raw) continue;
+    const m = /^(.*?):(\d+):(.*)$/.exec(raw);
+    if (!m) continue;
     if (matches.length >= cap) {
       truncated = true;
       break;
     }
-    const m = /^(.*?):(\d+):(.*)$/.exec(raw);
-    if (!m) continue;
     matches.push({
       file: m[1],
       line: Number(m[2]),
-      text: m[3].slice(0, SEARCH_LINE_MAX),
+      text: clipMatchLine(m[3]),
     });
   }
-  return { engine: "ripgrep", matches, truncated };
+  return {
+    engine: "ripgrep",
+    matches,
+    truncated,
+    // ripgrep walks everything, so the only cut here is the result cap.
+    ...(truncated
+      ? {
+          truncated_by: "max_results" as const,
+          truncation_hint: searchTruncationHint("max_results", matches.length, cap),
+        }
+      : {}),
+  };
 }
 
 function searchBuiltin(
@@ -699,6 +866,19 @@ function searchBuiltin(
   const globMatcher = options.glob ? globToRegExp(options.glob) : null;
   const matches: SearchMatch[] = [];
   let truncated = false;
+  // #809: the builtin walker has TWO independent cuts with OPPOSITE remedies — the
+  // result cap (raise `max_results`) and the fixed scanned-file bound (no lever;
+  // narrow the search). Remember which one fired.
+  //
+  // WRITE-ONCE (codex gate): the FIRST cut is the one the caller has to act on. A later
+  // write would flip an actionable "raise `max_results`" into "no parameter raises it",
+  // which is the exact wrong-lever defect this issue exists to remove. The recursive walk
+  // already unwinds on `truncated`, so no overwrite path is known today — this makes the
+  // invariant explicit rather than depending on every future early-return staying correct.
+  let reason: "max_results" | "scanned_files" | null = null;
+  const setReason = (r: "max_results" | "scanned_files") => {
+    if (reason === null) reason = r;
+  };
   let scanned = 0;
 
   const walk = (dir: string) => {
@@ -722,6 +902,7 @@ function searchBuiltin(
       if (deps.fileSize(full) > SEARCH_MAX_FILE_BYTES) continue;
       if (++scanned > SEARCH_MAX_SCANNED_FILES) {
         truncated = true;
+        setReason("scanned_files");
         return;
       }
       let buf: Buffer;
@@ -734,21 +915,34 @@ function searchBuiltin(
       const lines = buf.toString("utf-8").split(/\r\n|\n/);
       for (let i = 0; i < lines.length; i++) {
         if (re.test(lines[i])) {
+          // #809 (codex gate): stopping AT the cap cannot distinguish "exactly cap
+          // matches" from "capped". Reaching a (cap+1)-th match is the proof.
           if (matches.length >= cap) {
             truncated = true;
+            setReason("max_results");
             return;
           }
           matches.push({
             file: rel,
             line: i + 1,
-            text: lines[i].slice(0, SEARCH_LINE_MAX),
+            text: clipMatchLine(lines[i]),
           });
         }
       }
     }
   };
   walk(searchDir);
-  return { engine: "builtin", matches, truncated };
+  return {
+    engine: "builtin",
+    matches,
+    truncated,
+    ...(truncated && reason
+      ? {
+          truncated_by: reason,
+          truncation_hint: searchTruncationHint(reason, matches.length, cap),
+        }
+      : {}),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -835,6 +1029,15 @@ export function parsePatchPaths(patch: string): string[] {
   return [...paths];
 }
 
+/**
+ * #809 (codex gate): apply_node_patch's ONLY parameter is `patch` — it has no
+ * `max_chars`. Its git output cap is therefore fixed, and a remedy naming a lever this
+ * tool does not have would be the very defect this issue is about, pointing the other
+ * way. Say the cap is fixed, and name the tool that CAN page the same text.
+ */
+export const patchBoundNotice = (dropped: number) =>
+  `\n\n[... ${dropped} more char(s) cut at the fixed ${CMD_OUTPUT_MAX}-char git-output cap — apply_node_patch has no parameter to raise it. Split the patch into smaller per-file hunks and re-apply: the output shrinks with the patch ...]`;
+
 export function applyNodePatch(
   patch: string,
   deps: NodeDevDeps = defaultDeps,
@@ -871,8 +1074,8 @@ export function applyNodePatch(
       success: false,
       stage: "check",
       touched,
-      stdout: boundText(check.stdout, CMD_OUTPUT_MAX).text,
-      stderr: boundText(check.stderr, CMD_OUTPUT_MAX).text,
+      stdout: boundText(check.stdout, CMD_OUTPUT_MAX, patchBoundNotice).text,
+      stderr: boundText(check.stderr, CMD_OUTPUT_MAX, patchBoundNotice).text,
     };
   }
 
@@ -886,8 +1089,8 @@ export function applyNodePatch(
     success: apply.status === 0,
     stage: "apply",
     touched,
-    stdout: boundText(apply.stdout, CMD_OUTPUT_MAX).text,
-    stderr: boundText(apply.stderr, CMD_OUTPUT_MAX).text,
+    stdout: boundText(apply.stdout, CMD_OUTPUT_MAX, patchBoundNotice).text,
+    stderr: boundText(apply.stderr, CMD_OUTPUT_MAX, patchBoundNotice).text,
   };
 }
 
@@ -931,6 +1134,13 @@ function packRelativePath(packDir: string, p: string, deps: NodeDevDeps): string
   return rel.split(/[\\/]/).join("/") || ".";
 }
 
+/** #809: node_pack_git's real ceiling is READ_MAX_CHARS (24000) — a CODE clamp the
+ *  parameter description never mentioned. State it here so a caller who raises
+ *  `max_chars` past it learns why the extra was silently dropped, and narrow-the-scope
+ *  is offered because a whole-pack `diff` is often better answered by `paths`. */
+export const gitBoundNotice = (maxChars: number) => (dropped: number) =>
+  `\n\n[... ${dropped} more char(s) cut by \`max_chars\`=${maxChars}; ${raiseOrCeiling("max_chars", maxChars, READ_MAX_CHARS)} (a hard clamp), or scope the command with \`paths\` ...]`;
+
 export function nodePackGit(
   options: GitOptions,
   deps: NodeDevDeps = defaultDeps,
@@ -941,7 +1151,9 @@ export function nodePackGit(
   }
   const action = options.action;
   const maxChars = Math.min(
-    Math.max(1, options.maxChars ?? CMD_OUTPUT_MAX),
+    // #809: same floor as read_node_file — a budget too small to explain itself is not a
+    // usable budget. Ceiling untouched.
+    Math.max(MIN_OUTPUT_CHARS, options.maxChars ?? CMD_OUTPUT_MAX),
     READ_MAX_CHARS,
   );
 
@@ -979,8 +1191,8 @@ export function nodePackGit(
           action,
           argv: addArgs,
           status: add.status,
-          stdout: boundText(add.stdout, maxChars).text,
-          stderr: boundText(add.stderr, maxChars).text,
+          stdout: boundText(add.stdout, maxChars, gitBoundNotice(maxChars)).text,
+          stderr: boundText(add.stderr, maxChars, gitBoundNotice(maxChars)).text,
           success: false,
         };
       }
@@ -1002,8 +1214,8 @@ export function nodePackGit(
     action,
     argv,
     status: res.status,
-    stdout: boundText(res.stdout, maxChars).text,
-    stderr: boundText(res.stderr, maxChars).text,
+    stdout: boundText(res.stdout, maxChars, gitBoundNotice(maxChars)).text,
+    stderr: boundText(res.stderr, maxChars, gitBoundNotice(maxChars)).text,
     success: res.status === 0,
   };
 }

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -105,7 +105,10 @@ export function registerModelManagementTools(server: McpServer): void {
                 (m, i) =>
                   `${i + 1}. **${m.modelId}** by ${m.author || "unknown"}\n` +
                   `   Downloads: ${m.downloads.toLocaleString()} | Likes: ${m.likes}\n` +
-                  `   Tags: ${m.tags.slice(0, 5).join(", ") || "none"}`,
+                  // #809: a silently-clipped tag list reads as the model's COMPLETE tag
+                  // set, so a caller filtering on tags draws a false conclusion. Say how
+                  // many more there are; the 5-tag cap itself is fixed.
+                  `   Tags: ${m.tags.slice(0, 5).join(", ") || "none"}${m.tags.length > 5 ? ` (+${m.tags.length - 5} more; fixed 5-tag preview that no parameter raises — the rest are only on the model's Hub page)` : ""}`,
               )
               .join("\n\n");
 

--- a/src/tools/node-dev.ts
+++ b/src/tools/node-dev.ts
@@ -7,6 +7,19 @@ import {
   writeNodeFile,
   applyNodePatch,
   nodePackGit,
+  // #809: quote the REAL clamps, never a hand-typed number. node_pack_git's 24000
+  // ceiling was a code clamp its description never mentioned, which is exactly how a
+  // caller ends up raising a parameter and seeing nothing change.
+  READ_DEFAULT_LINES,
+  READ_MAX_LINES,
+  READ_DEFAULT_CHARS,
+  READ_MAX_CHARS,
+  SEARCH_DEFAULT_RESULTS,
+  SEARCH_MAX_RESULTS,
+  CMD_OUTPUT_MAX,
+  LIST_DEFAULT_ENTRIES,
+  LIST_MAX_ENTRIES,
+  MIN_OUTPUT_CHARS,
 } from "../services/node-dev.js";
 import { errorToToolResult } from "../utils/errors.js";
 
@@ -42,7 +55,9 @@ export function registerNodeDevTools(server: McpServer): void {
         .number()
         .int()
         .optional()
-        .describe("Maximum entries to return (default 500, max 2000)."),
+        .describe(
+          `Maximum entries to return (default ${LIST_DEFAULT_ENTRIES}, max ${LIST_MAX_ENTRIES} — a hard clamp). The walk STOPS at this many, so a capped result is not the pack's full file list.`,
+        ),
     },
     async (args) => {
       try {
@@ -80,12 +95,12 @@ export function registerNodeDevTools(server: McpServer): void {
         .number()
         .int()
         .optional()
-        .describe("Number of lines to return (default 240, max 800)."),
+        .describe(`Number of lines to return (default ${READ_DEFAULT_LINES}, max ${READ_MAX_LINES}).`),
       max_chars: z
         .number()
         .int()
         .optional()
-        .describe("Maximum characters to return (default 12000, max 24000)."),
+        .describe(`Maximum characters to return (default ${READ_DEFAULT_CHARS}, min ${MIN_OUTPUT_CHARS}, max ${READ_MAX_CHARS} — hard clamps; values outside are silently pulled into range).`),
     },
     async (args) => {
       try {
@@ -126,7 +141,7 @@ export function registerNodeDevTools(server: McpServer): void {
         .number()
         .int()
         .optional()
-        .describe("Maximum matches to return (default 50, max 100)."),
+        .describe(`Maximum matches to return (default ${SEARCH_DEFAULT_RESULTS}, max ${SEARCH_MAX_RESULTS}). The scan STOPS at this many, so a capped result is not a complete match set.`),
       case_sensitive: z
         .boolean()
         .optional()
@@ -244,7 +259,7 @@ export function registerNodeDevTools(server: McpServer): void {
         .number()
         .int()
         .optional()
-        .describe("Maximum characters of git output to return (default 12000)."),
+        .describe(`Maximum characters of git output to return (default ${CMD_OUTPUT_MAX}, min ${MIN_OUTPUT_CHARS}, max ${READ_MAX_CHARS} — hard clamps the runtime applies; values outside are silently pulled into range).`),
     },
     async (args) => {
       try {

--- a/src/tools/registry-search.ts
+++ b/src/tools/registry-search.ts
@@ -83,6 +83,13 @@ export function registerRegistrySearchTools(server: McpServer): void {
             ...details.versions.slice(0, 5).map(
               (v) => `- **${v.version}**${v.changelog ? `: ${v.changelog}` : ""}`,
             ),
+            // #809: say how many were dropped. This preview has no parameter to raise,
+            // so the honest remedy is the upstream index, not an invented lever.
+            ...(details.versions.length > 5
+              ? [
+                  `- …and ${details.versions.length - 5} older version(s) not shown (fixed 5-version preview — full history at https://registry.comfy.org/)`,
+                ]
+              : []),
           );
         }
 

--- a/src/tools/run-template.ts
+++ b/src/tools/run-template.ts
@@ -61,9 +61,17 @@ function overridesToOps(
     const widget = key.slice(dot + 1);
     const node = workflow[nodeId];
     if (!node) {
-      const ids = Object.keys(workflow).slice(0, 40).join(", ");
+      // #809: an id list clipped at 40 with no marker looks exhaustive, so a caller
+      // whose node sits past the cut concludes the id does not exist at all. Say it was
+      // cut, and name the tool that reports every override key.
+      const allIds = Object.keys(workflow);
+      const ids = allIds.slice(0, 40).join(", ");
+      const more =
+        allIds.length > 40
+          ? ` (+${allIds.length - 40} more not listed — get_template_schema reports every override key)`
+          : "";
       throw new ValidationError(
-        `Override "${key}": no node "${nodeId}" in the template's graph. Node ids: ${ids}`,
+        `Override "${key}": no node "${nodeId}" in the template's graph. Node ids: ${ids}${more}`,
       );
     }
     const widgetInputs = Object.entries(node.inputs ?? {})

--- a/src/tools/template-schema.ts
+++ b/src/tools/template-schema.ts
@@ -375,7 +375,12 @@ export function resolveTemplateFromIndex(
 /** Fetch an official workflow template's graph from the live ComfyUI. */
 async function loadServerTemplate(
   name: string,
-): Promise<{ graph: unknown; source: string } | { error: string; available: string[] }> {
+): Promise<
+  | { graph: unknown; source: string }
+  // #809: `available` is a bounded PREVIEW, so the shape carries the true total and an
+  // explicit "this was cut" line — a caller must never read the preview as the index.
+  | { error: string; available: string[]; available_count?: number; available_truncated?: string }
+> {
   // Use the SAME canonical base URL + auth headers as the connected ComfyUI
   // client (getObjectInfo/getClient). A bare protocol://host:port fetch drops
   // the reverse-proxy base path and any gateway auth headers, so a proxied or
@@ -410,6 +415,15 @@ async function loadServerTemplate(
     return {
       error: `No custom-node-contributed workflow template named "${name}" (core templates from the comfyui-workflow-templates package are not in this /api/workflow_templates index — check the ComfyUI frontend's Templates browser for those).`,
       available: near.length ? near : resolved.all.slice(0, 20),
+      // #809: `available` is a PREVIEW, and a caller who reads it as the full index
+      // concludes their template does not exist. State the real total and the tool that
+      // lists all of them.
+      available_count: resolved.all.length,
+      ...((near.length ? near.length : Math.min(resolved.all.length, 20)) < resolved.all.length
+        ? {
+            available_truncated: `Showing ${near.length ? near.length : Math.min(resolved.all.length, 20)} of ${resolved.all.length} templates (fixed preview cap — no parameter raises it); list_workflow_templates returns every one.`,
+          }
+        : {}),
     };
   }
   const { module, name: tmpl } = resolved.match;
@@ -519,7 +533,15 @@ export function registerTemplateSchemaTools(server: McpServer): void {
                   slots,
                   other_slot_count: other_slots.length,
                   other_slots,
+                  // #809: a warnings array silently clipped at 20 reads as "these are
+                  // all the warnings". Report the true count alongside the preview.
+                  warning_count: normalized.warnings.length,
                   warnings: normalized.warnings.slice(0, 20),
+                  ...(normalized.warnings.length > 20
+                    ? {
+                        warnings_truncated: `Showing 20 of ${normalized.warnings.length} warnings (fixed preview cap — no parameter raises it); fix these and re-run to surface the rest.`,
+                      }
+                    : {}),
                 },
                 null,
                 2,

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -13,7 +13,12 @@ import {
   collectNodeTypes,
 } from "../services/workflow-converter.js";
 import { sliceWorkflow } from "../services/workflow-slicer.js";
-import { queryApiGraph } from "../services/graph-query.js";
+import {
+  queryApiGraph,
+  LIMIT_CEILING,
+  MAX_CHARS_CEILING,
+  MAX_CHARS_FLOOR,
+} from "../services/graph-query.js";
 import { detectSections } from "../services/workflow-sections.js";
 import {
   generateOverview,
@@ -253,7 +258,9 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
       "detail), `upstream_of`/`downstream_of` + `depth` (dependency traversal: upstream = what FEEDS " +
       "that node, downstream = what CONSUMES it; seed included at depth 0), `fields` ('compact' one " +
       "line per node [default], 'ids', or 'detail' JSON rows with widgets + wiring), `group_by:'type'` " +
-      "(counts only), `limit` (default 40). Output is TOKEN-BOUNDED with an explicit truncation marker. Read-only.",
+      `(counts only), \`limit\` (default 40, max ${LIMIT_CEILING}), \`max_chars\` (default 12000, max ${MAX_CHARS_CEILING}). ` +
+      "Output is TOKEN-BOUNDED and, when it truncates, the tail names WHICH of the two caps fired and the exact " +
+      "parameter to raise — read it and retry rather than concluding the graph can't be read. Read-only.",
     {
       path: z.string().optional().describe("Absolute server-side path to a workflow .json on disk."),
       filename: z
@@ -296,14 +303,24 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
         .optional()
         .describe("Projection: compact one-liners (default), bare ids, or detail JSON rows."),
       group_by: z.enum(["type"]).optional().describe("Aggregate: counts per class_type instead of listing."),
-      limit: z.number().int().min(1).max(200).optional().describe("Max nodes listed (default 40)."),
+      // #809: the ceilings come from the engine's own clamps, so a hint that quotes a
+      // ceiling can never disagree with what the schema accepts or the runtime enforces.
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(LIMIT_CEILING)
+        .optional()
+        .describe(`Max nodes listed (default 40, max ${LIMIT_CEILING}).`),
       max_chars: z
         .number()
         .int()
-        .min(500)
-        .max(60000)
+        .min(MAX_CHARS_FLOOR)
+        .max(MAX_CHARS_CEILING)
         .optional()
-        .describe("Output character bound (default 12000). Raise only for deliberate full reads."),
+        .describe(
+          `Output character bound (default 12000, max ${MAX_CHARS_CEILING}). Raise this — not \`limit\` — when the truncation tail says the char budget cut the result.`,
+        ),
     },
     async ({ path, filename, graph, ...query }) => {
       try {


### PR DESCRIPTION
Closes artokun/comfyui-mcp#809

## Why

A truncation marker is an instruction to a machine. An agent that hits a **silent** cap concludes the *tool* cannot do the thing and escalates to the human, instead of retrying with a bigger budget. Observed live, not hypothetical: a Kimi session on a 690-node graph reported *"the output keeps getting truncated"* and asked for a workaround — raising `max_chars` would have answered it outright, but nothing told it `max_chars` existed.

## The two defects the issue named

**1. `query_workflow` named the wrong lever.** The no-`ids` tail read *"narrow with types/where/ids/depth, use `group_by:"type"`, or raise **limit**"* — but truncation reaches that tail from **two** causes, the `limit` cut and the char-budget cut. On the budget path raising `limit` does nothing and makes the overflow worse. The agent tries it, it fails, and the failure confirms the wrong conclusion.

The tail now names the cap that **actually fired**, with its real ceiling, and says plainly that the other lever will not help. `truncated_by: "limit" | "max_chars" | null` exposes the cause structurally too.

**2. `panel_find_nodes` claimed it doesn't truncate.** *"It scans EVERY node (no truncation)"*, while stopping at `limit` (default 40) and reporting a bare boolean. Fixed without touching the cap.

## The bar, sharpened by the review gate

Eleven codex rounds, each finding real defects. The most useful thing they produced was a sharper bar than the issue started with:

> Naming a real parameter or tool is **necessary and not sufficient**. The remedy must be **actionable from the caller's current state.**

A parameter already at its ceiling, a narrower tool that re-truncates at *its* default, a paging remedy on a slice that is one physical line, a tool that cannot re-serve the data — all name real things, and all cost exactly the wasted round trip this issue exists to prevent. Concrete instances caught and fixed:

- `apply_node_patch` telling the caller to raise a `max_chars` it does not have
- the ref-cap remedy suggesting a traversal that would re-truncate at the default limit of 40
- "read the full traceback with `get_logs`" when nothing re-serves the `/history` traceback
- "raise `max_chars` up to 60000" emitted to a caller already at 60000
- a refusal telling the caller to raise to a ceiling that could not hold the graph either

## The inverse defect, and please don't skim past it

**This PR also removes a lie, not just adds disclosure.** A **false** truncation claim costs the same wasted round trip and is worse in one way: it teaches an agent to distrust a *complete* result.

ripgrep's `--max-count` is **per file**. Asking for exactly `max_results` did two wrong things at once: a file with more matches had its extras dropped *by rg* before we ever saw a line (silent loss reported as `truncated: false`), and a search with exactly `max_results` real matches was **labelled truncated** when nothing had been dropped. Asking for `cap + 1` closes both directions with one change — the extra line is the proof of loss, and its absence is the proof of completeness. The same one-past-then-drop fix landed on `list_node_pack_files` and `panel_find_nodes`.

## Also in scope

- Every result now fits the `max_chars` it advertises — rows, tail and footers, on the row **and** aggregate paths. Fitted *afterwards* rather than reserved up front, because reserving pre-spent the 500-char floor and manufactured a truncation on a result that fitted.
- The `MAX_STATE_NODES` views say they capped, at what number, that the cap is **fixed**, and name the tool that can target the rest — **no new parameter**, per the maintainer's ruling.
- `panel_graph_outline` gains `max_chars` (same name and 500–60000 clamp as `panel_query_graph`) and degrades by **resolution, never coverage**: half a map is not a smaller map. At the floor it **refuses** with the true shape rather than returning a partial outline that reads as complete. Panel-side implementation is in the companion PR; this repo carries the surface, and detects and reports an older panel that ignores the budget.
- `node_pack_git`'s real 24000 ceiling — a code clamp its description never mentioned — is now stated, plus a 500 floor so a budget can always afford the sentence explaining itself.
- Fixed caps with no lever (per-widget 2048, per-line 600, traceback 2000, crash block 4000, tag/version/template previews) say exactly that, rather than suggesting a parameter that cannot move them.

## The test

`src/__tests__/tools/truncation-remedies.test.ts` asserts every remedy string names a parameter that **actually exists on the tool emitting it**, driven off the **real registered schema** — `listRegisteredTools()` through a real MCP client — rather than a hand-written list, which would have rotted in exactly the way the hint itself rotted. It also checks stated ceilings against the schema's real maximum, that suggested `panel_*` tools are registered, and that no "raise X" is emitted without a ceiling.

Mutation-verified: reverting the fix to its pre-#809 wording fails it; so does renaming a parameter in a remedy, dropping a ceiling, or restoring the "no truncation" claim.

## Verification

- `npm test` 4441 passed, `tsc --noEmit` clean, `npm run docs:gen` re-run so the published parameter reference matches.
- 11 codex review rounds (`gpt-5.6-terra`), iterated to a clean bill on the caller-facing contract.
- No NUL bytes; no binary diffs.

## Ordering

The panel half is a **separate PR** in `artokun/comfyui-mcp-panel` (same branch name). **Land this one first** — it is the surface that advertises the new behaviour, and it degrades honestly against a panel that predates the change.

## Left for follow-up

- **#807** owns folding `panel_query_graph`'s `groups`/`rails` riders into the `max_chars` accounting. This PR bounds them and states in-band and in the description that `max_chars` bounds `text` only.
- The mermaid diagram label truncations (`hierarchical-mermaid.ts`, `mermaid-converter.ts`) are deliberately untouched — a remedy string inside a rendered diagram node label is noise, not an instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
