### PR TITLE
0.49.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.49.5] - 2026-08-04
+
+### MCP
+
+#### Fixed
+- `panel_ask`: a validated answer is now durable and is never delivered across a tab or conversation boundary (#486) (#811)
+- `restart_comfyui`: preserve the launcher environment, and never report ownership or a restart that was not observed (#776) (#785)
+- `install_panel`: the panel swap is crash-safe by ordering, and the status report no longer claims what it never observed (#771) (#793)
+- `strip_workflow` / `panel_flatten_workflow`: preserve dynamic widget values and virtual-node links, and disclose anything dropped (#361) (#805)
+- panel agent: rebind the agent tab across id migration and keep the release fallback starvation-free (#568) (#802)
+
 ## [0.49.4] - 2026-08-03
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.49.4",
+  "version": "0.49.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.49.4",
+      "version": "0.49.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.49.4",
+  "version": "0.49.5",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release 0.49.5 — six fixes merged since 0.49.4, all gated through independent adversarial review.

- **#811** `panel_ask` answer durability — a validated answer is captured at arrival with no caller required, and never crosses a tab or conversation boundary. 20 rounds.
- **#785** `restart_comfyui` — preserves the launcher environment, and `ours`/`not-ours` became positive findings only. 21 rounds.
- **#793** `install_panel` — the swap is crash-safe by ordering rather than by a journal, integrity is a manifest, and the status report no longer claims what it never observed. 16 rounds.
- **#805** `strip_workflow` — dynamic widget values and virtual-node links preserved, anything dropped is disclosed. 18 rounds.
- **#802** panel agent tab rebind across id migration.

Note: `npm run changelog` computed its base as v0.49.3 rather than v0.49.4 and duplicated the previous release's entries into this one. Removed by hand here; worth a look separately.