### PR TITLE
restart: a stop we cannot undo — relaunch, Desktop-spawned servers, and stale instance binding

### DIFF
--- a/src/__tests__/orchestrator/panel-reboot-cache-invalidation.test.ts
+++ b/src/__tests__/orchestrator/panel-reboot-cache-invalidation.test.ts
@@ -80,11 +80,18 @@ describe("panel_restart_comfyui cache invalidation", () => {
       probeTimeoutMs: 20,
     });
     __panelToolsTestHooks.setHealthProbe(async () => false); // panel round-trip governs
+    // #814 widened the refuse-safe preflight to EVERY local target, not only a
+    // tab-bound one, so it now runs on this path too. These tests are about the
+    // dispatch classification, not about relaunch safety, and the real preflight
+    // would do live process/port discovery against the host — stub a PASS so the
+    // subject under test is the only thing being measured.
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
   });
 
   afterEach(() => {
     __panelToolsTestHooks.setPanelRebootTiming(null);
     __panelToolsTestHooks.setHealthProbe(null);
+  __panelToolsTestHooks.setLocalRestartPreflight(null);
   });
 
   it("invalidates the client + object_info caches on a CONFIRMED reboot", async () => {

--- a/src/__tests__/orchestrator/panel-reboot-cache-invalidation.test.ts
+++ b/src/__tests__/orchestrator/panel-reboot-cache-invalidation.test.ts
@@ -20,6 +20,13 @@ const { buildPanelToolDefs, rebootConfirmed, __panelToolsTestHooks } = await imp
 );
 import type { PanelToolCtx } from "../../orchestrator/panel-tools.js";
 import type { ToolResult } from "../../orchestrator/panel-tools.js";
+import { getBootLocalComfyUIBaseUrl } from "../../config.js";
+
+/** The orchestrator own boot endpoint — what a local tab must front to be bound. */
+const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(
+  /[/]+$/,
+  "",
+);
 
 function ctxReplying(reply: unknown): PanelToolCtx {
   // comfy_reboot is dispatched via ctx.bridge.send (pinned, no rebind); readiness
@@ -32,7 +39,11 @@ function ctxReplying(reply: unknown): PanelToolCtx {
     bridge: {
       send: async () => reply,
       tabOrigin: () => undefined,
-      tabIsLocal: () => false,
+      // BOUND to our own boot instance (#814): a LOCAL target the panel cannot be
+      // tied to is now refused before any dispatch, so a suite about what happens
+      // AFTER the dispatch has to model the ordinary local panel.
+      tabIsLocal: () => true,
+      tabServerOrigin: () => BOOT_BASE,
       tabSockId: () => "s0",
       canReach: () => false,
     } as unknown as PanelToolCtx["bridge"],

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -655,64 +655,39 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
-  it("#814: a LOCAL target the tab cannot be bound to is REFUSED, never dispatched", async () => {
-    // THE #814 DEFECT, pinned — and the second attempt at it, also pinned.
+  it("#814: a LOCAL target the tab cannot be bound to is REFUSED, whatever the local check says", async () => {
+    // THE #814 DEFECT, pinned — together with two wrong answers to it.
     //
-    // Originally the safety check was gated on the same capture as the
-    // CERTIFICATION, so an instance we could not certify was also never assessed:
-    // the reboot went out with no evidence, the server stopped, nothing brought it
-    // back, and the result honestly said it could not confirm the return.
+    // Originally the safety check was gated on the same capture as the CERTIFICATION,
+    // so an instance we could not certify was also never assessed: the reboot went out
+    // with no evidence, the server stopped, nothing brought it back, and the result
+    // honestly said it could not confirm the return.
     //
-    // The first fix ran the local preflight in that case and let a PASS proceed.
-    // That was wrong in a subtler way: the assessment describes the CONFIGURED
-    // instance while the reboot goes to the bound TAB's, so a safe local install
-    // could authorize stopping an orphaned backend in some other tab. A pass for one
-    // instance is not permission to stop another.
+    // The first fix ran the local preflight anyway and let a PASS proceed. But the
+    // assessment describes the orchestrator CONFIGURED instance while the reboot goes
+    // to the bound TAB, so a safe local install could authorize stopping an orphaned
+    // backend in some other tab. The second tried to keep only the FAIL half, which is
+    // incoherent: if the configured target is a good enough proxy to refuse on, it is
+    // good enough to proceed on.
     //
-    // So the two outcomes are spent asymmetrically when unbound: a FAIL refuses (a
-    // restart costs nothing to decline), while a PASS authorizes nothing and the
-    // dispatch proceeds on the footing it always had — see the companion test below.
-    const preflight = vi.fn(async () => ({
-      ok: false,
-      reason: "no Desktop app is still supervising it.",
-    }));
-    __panelToolsTestHooks.setLocalRestartPreflight(preflight);
-    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: false });
-
-    const out = parse(await restartTool().handler({}, ctx));
-
-    expect(preflight).toHaveBeenCalled();
-    expect(out.refused).toBe(true);
-    expect(out.rebooting).toBe(false);
-    expect(String(out.note)).toMatch(/no Desktop app is still supervising it/);
-    // The inference is DISCLOSED rather than hidden: the refusal is right, but the
-    // user is told which part could not be confirmed.
-    expect(String(out.note)).toMatch(/could not confirm that this panel fronts that same instance/i);
-    // CRITICAL: nothing was dispatched, so nothing was stopped.
-    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
-  });
-
-  it("#814: an unbindable LOCAL target's PASS authorizes nothing — it is not spent as permission", async () => {
-    // The other half of the asymmetry, and codex round 11's finding: the assessment
-    // describes the CONFIGURED instance while the reboot goes to the bound TAB's, so
-    // a safe local install must not become permission to stop a different one. The
-    // dispatch here proceeds on the footing it always had — honestly reported as
-    // unconfirmable — NOT on the strength of this pass.
-    //
-    // What pins that distinction is the refusal above: were the pass being spent as
-    // permission, the FAIL would have to be too, and it is (it refuses). Here the
-    // result must carry no claim that anything was verified.
+    // So an unbindable LOCAL target is refused outright — and the local assessment is
+    // not consulted at all, because nothing it could say may be spent on a different
+    // instance.
     const preflight = vi.fn(async () => ({ ok: true }));
     __panelToolsTestHooks.setLocalRestartPreflight(preflight);
     const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: false });
 
     const out = parse(await restartTool().handler({}, ctx));
 
-    expect(out.rebooting).toBe(true);
-    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
-    // Unconfirmable, and it says so — no proxy certification from the local pass.
-    expect(out.confirmed_cycle).toBe(false);
-    expect(String(out.note)).toMatch(/can't confirm|could not confirm|verify/i);
+    expect(out.refused).toBe(true);
+    expect(out.rebooting).toBe(false);
+    expect(String(out.note)).toMatch(/cannot tell which server the restart would stop/i);
+    expect(String(out.note)).toMatch(/still running/i);
+    // A PASSING local assessment did not launder permission for a target it does not
+    // describe — and was never even asked.
+    expect(preflight).not.toHaveBeenCalled();
+    // CRITICAL: nothing was dispatched, so nothing was stopped.
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
   it("#814: a BOUND local target with a failing assessment refuses with its reason", async () => {

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -655,18 +655,23 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
-  it("#814: a LOCAL target the tab cannot be bound to is STILL assessed, and a failing assessment refuses", async () => {
-    // THE #814 DEFECT, pinned. The safety check used to be gated on the same
-    // capture as the CERTIFICATION — "can I watch this instance come back?" — so
-    // an instance we could not watch was also an instance we never assessed. The
-    // reboot went out with no evidence at all, the server stopped, nothing brought
-    // it back, and the result then said it could not confirm the return: a verdict
-    // about a stop that should never have been made. Being unable to observe a
-    // recovery is a reason for more care about stopping, not less.
+  it("#814: a LOCAL target the tab cannot be bound to is REFUSED, never dispatched", async () => {
+    // THE #814 DEFECT, pinned — and the second attempt at it, also pinned.
     //
-    // FAIL-BEFORE: with the gate keyed on the tab binding, `frontsBoot: false`
-    // skipped the preflight entirely and dispatched. PASS-AFTER: the preflight runs
-    // for the local target and its refusal stands.
+    // Originally the safety check was gated on the same capture as the
+    // CERTIFICATION, so an instance we could not certify was also never assessed:
+    // the reboot went out with no evidence, the server stopped, nothing brought it
+    // back, and the result honestly said it could not confirm the return.
+    //
+    // The first fix ran the local preflight in that case and let a PASS proceed.
+    // That was wrong in a subtler way: the assessment describes the CONFIGURED
+    // instance while the reboot goes to the bound TAB's, so a safe local install
+    // could authorize stopping an orphaned backend in some other tab. A pass for one
+    // instance is not permission to stop another.
+    //
+    // So the two outcomes are spent asymmetrically when unbound: a FAIL refuses (a
+    // restart costs nothing to decline), while a PASS authorizes nothing and the
+    // dispatch proceeds on the footing it always had — see the companion test below.
     const preflight = vi.fn(async () => ({
       ok: false,
       reason: "no Desktop app is still supervising it.",
@@ -679,22 +684,68 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     expect(preflight).toHaveBeenCalled();
     expect(out.refused).toBe(true);
     expect(out.rebooting).toBe(false);
-    // The REASON is carried through, not replaced by a generic one — a Desktop
-    // user must not be sent to look at Pinokio's controls.
+    expect(String(out.note)).toMatch(/no Desktop app is still supervising it/);
+    // The inference is DISCLOSED rather than hidden: the refusal is right, but the
+    // user is told which part could not be confirmed.
+    expect(String(out.note)).toMatch(/could not confirm that this panel fronts that same instance/i);
+    // CRITICAL: nothing was dispatched, so nothing was stopped.
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("#814: an unbindable LOCAL target's PASS authorizes nothing — it is not spent as permission", async () => {
+    // The other half of the asymmetry, and codex round 11's finding: the assessment
+    // describes the CONFIGURED instance while the reboot goes to the bound TAB's, so
+    // a safe local install must not become permission to stop a different one. The
+    // dispatch here proceeds on the footing it always had — honestly reported as
+    // unconfirmable — NOT on the strength of this pass.
+    //
+    // What pins that distinction is the refusal above: were the pass being spent as
+    // permission, the FAIL would have to be too, and it is (it refuses). Here the
+    // result must carry no claim that anything was verified.
+    const preflight = vi.fn(async () => ({ ok: true }));
+    __panelToolsTestHooks.setLocalRestartPreflight(preflight);
+    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: false });
+
+    const out = parse(await restartTool().handler({}, ctx));
+
+    expect(out.rebooting).toBe(true);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
+    // Unconfirmable, and it says so — no proxy certification from the local pass.
+    expect(out.confirmed_cycle).toBe(false);
+    expect(String(out.note)).toMatch(/can't confirm|could not confirm|verify/i);
+  });
+
+  it("#814: a BOUND local target with a failing assessment refuses with its reason", async () => {
+    // The bound path, where the assessment genuinely describes the instance the
+    // reboot will reach. A Desktop instance whose supervisor has gone is refused
+    // BEFORE anything is stopped, and the specific reason is carried through rather
+    // than replaced by a generic one — a Desktop user must not be sent to look at
+    // Pinokio's controls.
+    const preflight = vi.fn(async () => ({
+      ok: false,
+      reason: "no Desktop app is still supervising it.",
+    }));
+    __panelToolsTestHooks.setLocalRestartPreflight(preflight);
+    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: true });
+
+    const out = parse(await restartTool().handler({}, ctx));
+
+    expect(preflight).toHaveBeenCalled();
+    expect(out.refused).toBe(true);
+    expect(out.rebooting).toBe(false);
     expect(String(out.note)).toMatch(/no Desktop app is still supervising it/);
     expect(String(out.note)).toMatch(/still running/i);
     // CRITICAL: nothing was ever dispatched, so nothing was ever stopped.
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
-  it("#814: an unbindable LOCAL target with a PASSING assessment still dispatches", async () => {
-    // The counterpart, and the reason the widened gate is a check rather than a
-    // blanket refusal: an instance we cannot watch but CAN prove relaunchable is
-    // restarted exactly as before — the result is honestly unconfirmable, which is
-    // a different thing from unsafe.
+  it("a BOUND local target with a PASSING assessment dispatches as before", async () => {
+    // The control: the refusals are about missing or negative evidence, not a
+    // blanket denial. When the tab provably fronts our own instance and its
+    // relaunch is proven, the restart proceeds exactly as it always did.
     const preflight = vi.fn(async () => ({ ok: true }));
     __panelToolsTestHooks.setLocalRestartPreflight(preflight);
-    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: false });
+    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: true });
 
     const out = parse(await restartTool().handler({}, ctx));
 
@@ -798,6 +849,11 @@ describe("panel_restart_comfyui — restart dispatch record (r4/r5)", () => {
     // record: the dispatch can't be proven to have hit the instance a later
     // decline would probe. It lands only in the process-wide non-causation
     // slot (documenting that a dispatch happened).
+    // REMOTE, because that is where an unbound dispatch still happens: a LOCAL
+    // target the tab cannot be tied to is now refused outright (#814 — a stop is
+    // never sent to a server we cannot identify). The subject here is unchanged:
+    // an unconfirmable dispatch must not stamp a causation-capable record.
+    hoistedConfig.remote.value = true;
     __panelToolsTestHooks.setHealthProbe(async () => "down");
     const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: false });
 
@@ -824,11 +880,17 @@ describe("panel_restart_comfyui — restart dispatch record (r4/r5)", () => {
     __panelToolsTestHooks.setHealthProbe(async () => seq[Math.min(i++, seq.length - 1)]);
     const { ctx, sends } = makeCtx({ confirm: "yes", fronts });
 
-    // 1. Accepted reboot while UNBOUND — dispatched, honestly unconfirmable.
+    // 1. Accepted reboot while UNBOUND — dispatched, honestly unconfirmable. REMOTE,
+    // because that is where an unbound dispatch still happens: a LOCAL target the tab
+    // cannot be tied to is now refused outright (#814). The scenario under test is
+    // unchanged — a reboot of a possibly-different instance must never be blamed for
+    // a later down on the bound one.
+    hoistedConfig.remote.value = true;
     const out1 = parse(await restartTool().handler({}, ctx));
     expect(out1.rebooting).toBe(true);
 
     // 2. The session REBINDS to the boot tab and a second card is declined.
+    hoistedConfig.remote.value = false;
     fronts.current = true;
     ctx.confirm = async () => "no" as const;
     __panelToolsTestHooks.setHealthProbe(async () => "down"); // full-window refusal

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -68,6 +68,9 @@ function makeCtx(opts: {
   fronts?: { current: boolean };
   /** The comfy_reboot reply (default: an accepted `{rebooting: true}`). */
   rebootReply?: Record<string, unknown>;
+  /** Called on every ctx.ensureReachable() — lets a test land a retarget at a
+   *  specific point in the handler (the DISPATCH point is the third call). */
+  onEnsureReachable?: () => void;
 }): { ctx: PanelToolCtx; sends: Array<Record<string, unknown>> } {
   const sends: Array<Record<string, unknown>> = [];
   const frontsBoot = opts.frontsBoot ?? true;
@@ -90,7 +93,7 @@ function makeCtx(opts: {
       throw new Error("ctx.call must not be used by the restart handler");
     },
     confirm: async () => opts.confirm,
-    ensureReachable: () => {},
+    ensureReachable: () => opts.onEnsureReachable?.(),
     bridge,
     tabId: "bound-tab",
     panelConnectionIdentity: () => ({ generation: 1, tabSessionId: "browser-tab-a" }),
@@ -538,12 +541,17 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     expect(resetObjectInfoCache).not.toHaveBeenCalled();
   });
 
-  it("a failing preflight with a mid-await REBIND issues NO stale-target refusal (r8)", async () => {
-    // Bound at the preflight decision; the session rebinds to an unconfirmable
-    // target DURING the await and the preflight FAILS. The refusal must NOT be
-    // composed against the stale pre-await target ("ComfyUI is still running"
-    // would describe a target never validated) — nothing was stopped, so the
-    // flow falls through to the honest unbound dispatch instead.
+  it("a failing preflight with a mid-await REBIND issues NO STALE-TARGET refusal (r8)", async () => {
+    // Bound at the preflight decision; the session rebinds to an unconfirmable target
+    // DURING the await and the preflight FAILS. r8's rule stands: the refusal must NOT
+    // be composed against the STALE pre-await target — "ComfyUI is still running" would
+    // describe an instance that was never validated, and the reason would name a
+    // diagnosis belonging to a different install.
+    //
+    // What CHANGED is where the flow lands instead. It used to fall through to an
+    // honest unbound dispatch; a local target we cannot identify is now refused at the
+    // DISPATCH POINT (#814), so the outcome is a refusal about the CURRENT binding —
+    // the panel connection changed — not about the stale one.
     const fronts = { current: true }; // bound when the preflight is decided…
     __panelToolsTestHooks.setLocalRestartPreflight(async () => {
       fronts.current = false; // …but a rebind lands DURING the preflight await
@@ -560,46 +568,14 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     const out = parse(await restartTool().handler({}, ctx));
     const note = String(out.note ?? "");
 
-    // NO stale-target refusal, no unvalidated "still running" claim…
-    expect(note).not.toMatch(/Refusing to restart/i);
+    // The r8 invariant: NOTHING from the stale assessment appears — not its reason,
+    // and not a "still running" claim about an instance it never validated.
+    expect(note).not.toMatch(/does not exist on disk/i);
     expect(note).not.toMatch(/still running/i);
-    expect(out.refused).not.toBe(true);
-    // …the restart proceeds against the CURRENT (unbound) target and is
-    // reported honestly as dispatched-but-unconfirmable.
-    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
-    expect(out.rebooting).toBe(true);
-    expect(note).toMatch(/can't confirm/i);
-    expect(__panelToolsTestHooks.getSessionRestartDispatch(ctx)).toBeNull();
-  });
-
-  it("a CONFIG-ONLY retarget mid-await still REFUSES the proven-dangerous boot instance (r9)", async () => {
-    // The tab fronts the boot instance THROUGHOUT; only the MUTABLE runtime
-    // config moves during the preflight await. The failed preflight already
-    // PROVED that instance unrelaunchable — the proof follows the instance the
-    // tab fronts, not the mutable config — so the reboot must be REFUSED and
-    // never dispatched (an instance proven unrelaunchable is NEVER sent a
-    // stop/reboot, regardless of config shuffling mid-flight).
-    __panelToolsTestHooks.setLocalRestartPreflight(async () => {
-      hoistedConfig.configBase.value = "http://127.0.0.1:9999"; // config-only retarget mid-await
-      hoistedConfig.generation.value += 1; // every real retarget bumps the generation
-      return {
-        ok: false,
-        reason:
-          "Resolved ComfyUI script does not exist on disk: main.py — could not " +
-          "locate the ComfyUI install.",
-      };
-    });
-    __panelToolsTestHooks.setHealthProbe(async () => "down");
-    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: true });
-
-    const out = parse(await restartTool().handler({}, ctx));
-    const note = String(out.note ?? "");
-
+    // The refusal is about the binding that actually applies now.
     expect(out.refused).toBe(true);
-    expect(note).toMatch(/Refusing to restart/i);
-    expect(note).toMatch(/still running/i);
-    // CRITICAL: the reboot was NEVER dispatched — the proven-dangerous
-    // instance was not stopped.
+    expect(note).toMatch(/panel connection changed/i);
+    // CRITICAL: nothing was dispatched to the unidentified target.
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
@@ -682,7 +658,9 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     expect(out.refused).toBe(true);
     expect(out.rebooting).toBe(false);
     expect(String(out.note)).toMatch(/cannot tell which server the restart would stop/i);
-    expect(String(out.note)).toMatch(/still running/i);
+    // It reports what it DID — not a 'still running' claim about an instance it has
+    // just said it cannot identify (the same rule r8 enforces for a stale target).
+    expect(String(out.note)).toMatch(/nothing was stopped/i);
     // A PASSING local assessment did not launder permission for a target it does not
     // describe — and was never even asked.
     expect(preflight).not.toHaveBeenCalled();
@@ -727,6 +705,32 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     expect(preflight).toHaveBeenCalled();
     expect(out.rebooting).toBe(true);
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
+  });
+
+  it("a retarget landing AFTER the preflight is caught at the dispatch point", async () => {
+    // The dispatch-point check has to compare the tab's instance against the target
+    // as it stands THEN. A retarget that lands after the preflight block leaves the
+    // tab bound to the old base while the reboot would go to a different configured
+    // instance — so a check that only asked "is the tab bound to something?" would
+    // wave it through. `ensureReachable` is called at the dispatch point (third
+    // call), which is where this lands the move.
+    let calls = 0;
+    const { ctx, sends } = makeCtx({
+      confirm: "yes",
+      frontsBoot: true,
+      onEnsureReachable: () => {
+        calls++;
+        if (calls >= 3) {
+          hoistedConfig.configBase.value = "http://127.0.0.1:9999";
+          hoistedConfig.generation.value += 1;
+        }
+      },
+    });
+
+    const out = parse(await restartTool().handler({}, ctx));
+
+    expect(out.refused).toBe(true);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
   it("a REMOTE target is not assessed — the Manager reboot is its only restart path", async () => {
@@ -881,10 +885,14 @@ describe("panel_restart_comfyui — restart dispatch record (r4/r5)", () => {
   });
 
   it("a rebind DURING the preflight await withholds the causation-capable stamp (r7)", async () => {
-    // Bound at the preflight DECISION, but the session rebinds to an
-    // unconfirmable target MID-AWAIT: the dispatch proceeds to the new target,
-    // yet the stamp must use the DISPATCH-POINT binding (unbound → process-wide
-    // non-causation slot only) — never the stale pre-await bound base.
+    // Bound at the preflight DECISION, but the session rebinds to an unconfirmable
+    // target MID-AWAIT. r7's rule is that nothing may be stamped against the STALE
+    // pre-await bound base — the dispatch-point binding governs.
+    //
+    // That rule now holds in its strongest form: a local target we cannot identify is
+    // refused AT THE DISPATCH POINT (#814), so there is no dispatch and no record at
+    // all — neither session-held nor process-wide. A stamp against the stale base was
+    // never possible, because nothing was ever sent.
     const fronts = { current: true }; // bound when the preflight is decided…
     __panelToolsTestHooks.setLocalRestartPreflight(async () => {
       fronts.current = false; // …but a rebind lands DURING the preflight await
@@ -895,14 +903,11 @@ describe("panel_restart_comfyui — restart dispatch record (r4/r5)", () => {
 
     const out = parse(await restartTool().handler({}, ctx));
 
-    // The dispatch still proceeded (to the new, unconfirmable target) and was
-    // accepted — honestly reported unconfirmable.
-    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
-    expect(out.rebooting).toBe(true);
-    // The causation-capable stamp is WITHHELD: no session-held record…
+    expect(out.refused).toBe(true);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+    // NOTHING is on record — least of all against the stale bound base.
     expect(__panelToolsTestHooks.getSessionRestartDispatch(ctx)).toBeNull();
-    // …only the shared process-wide (never-causation) slot knows of it.
-    expect(getRestartDispatchRecord(PROCESS_WIDE_RESTART_DISPATCH_TOKEN)).not.toBeNull();
+    expect(getRestartDispatchRecord(PROCESS_WIDE_RESTART_DISPATCH_TOKEN)).toBeNull();
   });
 
   it("a dispatch stamped DURING a decline probe survives the exoneration clear (r15)", async () => {

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -575,6 +575,9 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     // The refusal is about the binding that actually applies now.
     expect(out.refused).toBe(true);
     expect(note).toMatch(/panel connection changed/i);
+    // Same condition on this refusal: name the alternative and say why it works.
+    expect(note).toMatch(/use restart_comfyui instead/i);
+    expect(note).toMatch(/not tied to a browser tab/i);
     // CRITICAL: nothing was dispatched to the unidentified target.
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
@@ -661,6 +664,10 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     // It reports what it DID — not a 'still running' claim about an instance it has
     // just said it cannot identify (the same rule r8 enforces for a stale target).
     expect(String(out.note)).toMatch(/nothing was stopped/i);
+    // A user who loses this entry point is told which one still works AND why: the
+    // refusal is a documented trade, not a dead end (coordinator ruling).
+    expect(String(out.note)).toMatch(/use restart_comfyui instead/i);
+    expect(String(out.note)).toMatch(/not tied to a browser tab/i);
     // A PASSING local assessment did not launder permission for a target it does not
     // describe — and was never even asked.
     expect(preflight).not.toHaveBeenCalled();

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -25,6 +25,9 @@ vi.mock("../../comfyui/client.js", () => ({
 const hoistedConfig = vi.hoisted(() => ({
   configBase: { value: null as string | null },
   generation: { value: 0 },
+  /** #814: drive REMOTE mode, the one target shape the widened preflight gate
+   *  deliberately excludes (no local process to assess). */
+  remote: { value: false },
 }));
 vi.mock("../../config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../config.js")>();
@@ -32,6 +35,7 @@ vi.mock("../../config.js", async (importOriginal) => {
     ...actual,
     getComfyUIBaseUrl: () => hoistedConfig.configBase.value ?? actual.getComfyUIBaseUrl(),
     getComfyuiTargetGeneration: () => hoistedConfig.generation.value,
+    isRemoteMode: () => hoistedConfig.remote.value || actual.isRemoteMode(),
   };
 });
 
@@ -127,6 +131,7 @@ beforeEach(() => {
   // r9: real configured base unless a test retargets it mid-flight.
   hoistedConfig.configBase.value = null;
   hoistedConfig.generation.value = 0;
+  hoistedConfig.remote.value = false;
 });
 
 afterEach(() => {
@@ -137,6 +142,7 @@ afterEach(() => {
   __processControlTestHooks.reset();
   hoistedConfig.configBase.value = null;
   hoistedConfig.generation.value = 0;
+  hoistedConfig.remote.value = false;
 });
 
 describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
@@ -649,18 +655,67 @@ describe("panel_restart_comfyui — Pinokio-style refuse-safe preflight (#742)",
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
-  it("does NOT consult the preflight when the tab doesn't provably front our boot instance", async () => {
-    // The preflight guards OUR local boot instance only. A reboot bound for a
-    // different/remote instance proceeds exactly as before (dispatched +
-    // accepted, honestly unconfirmable from here).
+  it("#814: a LOCAL target the tab cannot be bound to is STILL assessed, and a failing assessment refuses", async () => {
+    // THE #814 DEFECT, pinned. The safety check used to be gated on the same
+    // capture as the CERTIFICATION — "can I watch this instance come back?" — so
+    // an instance we could not watch was also an instance we never assessed. The
+    // reboot went out with no evidence at all, the server stopped, nothing brought
+    // it back, and the result then said it could not confirm the return: a verdict
+    // about a stop that should never have been made. Being unable to observe a
+    // recovery is a reason for more care about stopping, not less.
+    //
+    // FAIL-BEFORE: with the gate keyed on the tab binding, `frontsBoot: false`
+    // skipped the preflight entirely and dispatched. PASS-AFTER: the preflight runs
+    // for the local target and its refusal stands.
+    const preflight = vi.fn(async () => ({
+      ok: false,
+      reason: "no Desktop app is still supervising it.",
+    }));
+    __panelToolsTestHooks.setLocalRestartPreflight(preflight);
+    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: false });
+
+    const out = parse(await restartTool().handler({}, ctx));
+
+    expect(preflight).toHaveBeenCalled();
+    expect(out.refused).toBe(true);
+    expect(out.rebooting).toBe(false);
+    // The REASON is carried through, not replaced by a generic one — a Desktop
+    // user must not be sent to look at Pinokio's controls.
+    expect(String(out.note)).toMatch(/no Desktop app is still supervising it/);
+    expect(String(out.note)).toMatch(/still running/i);
+    // CRITICAL: nothing was ever dispatched, so nothing was ever stopped.
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("#814: an unbindable LOCAL target with a PASSING assessment still dispatches", async () => {
+    // The counterpart, and the reason the widened gate is a check rather than a
+    // blanket refusal: an instance we cannot watch but CAN prove relaunchable is
+    // restarted exactly as before — the result is honestly unconfirmable, which is
+    // a different thing from unsafe.
+    const preflight = vi.fn(async () => ({ ok: true }));
+    __panelToolsTestHooks.setLocalRestartPreflight(preflight);
+    const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: false });
+
+    const out = parse(await restartTool().handler({}, ctx));
+
+    expect(preflight).toHaveBeenCalled();
+    expect(out.rebooting).toBe(true);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
+  });
+
+  it("a REMOTE target is not assessed — the Manager reboot is its only restart path", async () => {
+    // There is no local process to assess, and a supervised remote (the tunnelled
+    // Desktop app) restarts through exactly this reboot by design. Refusing here
+    // would remove a path that works, which is the opposite of the point.
+    hoistedConfig.remote.value = true;
     const preflight = vi.fn(async () => ({ ok: false, reason: "would refuse" }));
     __panelToolsTestHooks.setLocalRestartPreflight(preflight);
     const { ctx, sends } = makeCtx({ confirm: "yes", frontsBoot: false });
 
     const out = parse(await restartTool().handler({}, ctx));
 
-    expect(out.rebooting).toBe(true);
     expect(preflight).not.toHaveBeenCalled();
+    expect(out.rebooting).toBe(true);
     expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(true);
   });
 

--- a/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
@@ -333,10 +333,16 @@ describe("panel_restart_comfyui recovery after an ACCEPTED reboot (coordinator p
     expect(resetClient).not.toHaveBeenCalled();
   });
 
-  it("P0: a `localhost` tab origin is ambiguous → HONEST dispatched, probe (with auth) never sent", async () => {
-    // Boot base is the concrete 127.0.0.1 default; the tab advertises http://localhost:8188.
-    // localhost may resolve to ::1 in the browser, so we CANNOT prove the tab fronts the
-    // 127.0.0.1 instance — captureRebootHealthBase → null → honest dispatched, no probe.
+  it("P0: a `localhost` tab origin is ambiguous → REFUSED, probe (with auth) never sent", async () => {
+    // Boot base is the concrete 127.0.0.1 default; the tab advertises
+    // http://localhost:8188. localhost may resolve to ::1 in the browser, so we CANNOT
+    // prove the tab fronts the 127.0.0.1 instance — captureRebootHealthBase → null.
+    //
+    // That used to mean an honest dispatched-but-unconfirmable reboot. It now REFUSES
+    // (#814): a reboot STOPS whatever the tab fronts, and being unable to say WHICH
+    // server that is means being unable to say anything about bringing it back. The
+    // original assertion holds more strongly than before — the probe is not merely
+    // unsent, nothing is dispatched at all.
     const health = vi.fn(async () => "healthy" as const);
     __panelToolsTestHooks.setHealthProbe(health);
     const { ctx } = makeCtx({ reboot: { rebooting: true }, origin: "http://localhost:8188", local: true });
@@ -344,19 +350,23 @@ describe("panel_restart_comfyui recovery after an ACCEPTED reboot (coordinator p
     const res = await rebootHandler()({ force: false }, ctx);
     expect(res.isError).not.toBe(true);
     const out = parse(res);
-    expect(out.dispatched).toBe(true);
-    expect(out.ready).toBe(false);
+    expect(out.refused).toBe(true);
+    expect(out.rebooting).toBe(false);
     expect(out.confirmed_cycle).toBe(false);
     expect(health).not.toHaveBeenCalled(); // ambiguous origin → never probed, no auth sent
-    expect(String(out.note)).toMatch(/health_check|verify|can't confirm|couldn't/i);
+    expect(String(out.note)).toMatch(/cannot tell which server/i);
   });
 
-  it("Gap: no probeable boot endpoint (remote/old panel) → HONEST dispatched, NOT a false-timeout, NEVER a proxy certify", async () => {
+  it("Gap: no probeable boot endpoint → REFUSED for a local target, and never a proxy certify", async () => {
     // captureRebootHealthBase → null (non-local tab): there is NO sound proof this
-    // (possibly remote) instance cycled. We must NOT invent one from a panel reconnect
-    // (tab_id is client-supplied — a different same-kind socket can take it over), and we
-    // must NOT emit the old #509 false-TIMEOUT error. Honest outcome: dispatched+accepted,
-    // ready:false, told to verify — and the boot probe is never consulted (null base).
+    // instance would cycle, and — since #814 — no proof of WHICH instance would be
+    // stopped either. For a LOCAL target that now refuses before dispatch.
+    //
+    // Everything this test was written to forbid still holds, and more cheaply: no
+    // invented proof from a panel reconnect, no #509 false-TIMEOUT error, and the boot
+    // probe never consulted. The honest dispatched-but-unconfirmable result remains for
+    // REMOTE targets, where the Manager reboot is the only restart path (covered in
+    // panel-restart-cancel-truth).
     let healthConsulted = false;
     __panelToolsTestHooks.setHealthProbe(async () => {
       healthConsulted = true;
@@ -367,25 +377,26 @@ describe("panel_restart_comfyui recovery after an ACCEPTED reboot (coordinator p
     const res = await rebootHandler()({ force: false }, ctx);
     expect(res.isError).not.toBe(true); // NOT the #509 false-timeout error
     const out = parse(res);
-    expect(out.rebooting).toBe(true);
-    expect(out.dispatched).toBe(true);
-    expect(out.ready).toBe(false); // no sound proof → honest couldn't-confirm
+    expect(out.refused).toBe(true);
+    expect(out.rebooting).toBe(false);
     expect(out.confirmed_cycle).toBe(false);
     expect(out.via).toBeUndefined(); // no proxy proof value
     expect(healthConsulted).toBe(false); // boot probe never consulted (null base)
-    expect(String(out.note)).toMatch(/health_check|verify|can't confirm|couldn't/i);
+    expect(String(out.note)).toMatch(/cannot tell which server/i);
   });
 
-  it("Gap: a DROPPED reboot with no boot endpoint is ALSO honest dispatched, not a false success", async () => {
-    // Same as above but via the EXPECTED-DROP accept path (mid-command OUTCOME UNKNOWN):
-    // still no probeable endpoint, so still an honest dispatched/verify — never ready:true.
+  it("Gap: a DROPPED reboot with no boot endpoint is REFUSED before it can drop", async () => {
+    // Same shape via the EXPECTED-DROP accept path: with no probeable endpoint there is
+    // no proof of which instance is being stopped, so the refusal happens BEFORE the
+    // dispatch — the drop never occurs. Never a false success, which is what this test
+    // has always been about.
     const { ctx } = makeCtx({ reboot: DROP, local: false });
 
     const out = parse(await rebootHandler()({ force: false }, ctx));
-    expect(out.rebooting).toBe(true);
-    expect(out.ready).toBe(false);
+    expect(out.refused).toBe(true);
+    expect(out.rebooting).toBe(false);
     expect(out.confirmed_cycle).toBe(false);
-    expect(String(out.note)).toMatch(/health_check|verify|can't confirm|couldn't/i);
+    expect(String(out.note)).toMatch(/cannot tell which server/i);
   });
 
   it("accepted but endpoint NEVER becomes healthy → couldn't-confirm (ready:false)", async () => {

--- a/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
@@ -252,11 +252,16 @@ describe("panel_restart_comfyui — legacy no-endpoint fallback", () => {
   it("bound tab does NOT front the boot instance → does NOT restart the wrong local server", async () => {
     // The managed kill+relaunch acts on the orchestrator's global target; if we can't
     // prove the bound tab fronts THAT (boot) instance, we must not restart a different
-    // local instance and claim success — return the refusal verbatim instead.
+    // local instance and claim success.
+    //
+    // Since #814 the guard fires EARLIER and harder: an unbindable local target is
+    // refused before any reboot is dispatched at all, so the legacy fallback is never
+    // reached. The assertion this test exists for — the wrong local server is not
+    // restarted — holds a fortiori.
     const { ctx } = makeCtx(NO_ENDPOINT_REPLY, /* frontsBoot */ false);
     const res = (await restartTool().handler({}, ctx)) as ToolResult;
     expect(hoisted.restart).not.toHaveBeenCalled();
-    expect(res.content[0].text).toContain("was NOT restarted");
+    expect(res.content[0].text).toMatch(/cannot tell which server the restart would stop/i);
   });
 
   it("busy-guard refusal → NEVER falls back (does not abort a running render)", async () => {

--- a/src/__tests__/orchestrator/panel-restart-readiness.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-readiness.test.ts
@@ -20,6 +20,13 @@ const { buildPanelToolDefs, __panelToolsTestHooks } = await import(
   "../../orchestrator/panel-tools.js"
 );
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import { getBootLocalComfyUIBaseUrl } from "../../config.js";
+
+/** The orchestrator's own boot endpoint — what a local tab must front to be bound. */
+const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(
+  /\/+$/,
+  "",
+);
 
 const parse = (res: ToolResult): Record<string, unknown> =>
   JSON.parse(res.content.find((c) => c.type === "text")!.text as string);
@@ -39,7 +46,13 @@ function ctxReboot(reply: Record<string, unknown> | null, throwMsg?: string): Pa
         return reply ?? {};
       },
       tabOrigin: () => undefined,
-      tabIsLocal: () => false,
+      // BOUND to our own boot instance (#814): panel_restart_comfyui now refuses a
+      // LOCAL target it cannot tie to the instance it can account for, because a
+      // reboot STOPS a server and it must know which one. These tests are about the
+      // dispatch CLASSIFICATION that follows, so they model the ordinary local panel:
+      // a loopback tab fronting the boot ComfyUI.
+      tabIsLocal: () => true,
+      tabServerOrigin: () => BOOT_BASE,
       tabSockId: () => "s0",
       canReach: () => false,
     } as unknown as PanelToolCtx["bridge"],

--- a/src/__tests__/orchestrator/panel-restart-readiness.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-readiness.test.ts
@@ -56,6 +56,12 @@ function rebootHandler() {
 beforeEach(() => {
   resetClient.mockClear();
   resetObjectInfoCache.mockClear();
+  // #814 widened the refuse-safe preflight to EVERY local target, not only a
+  // tab-bound one, so it now runs on this path too. These tests are about the
+  // dispatch classification, not about relaunch safety, and the real preflight
+  // would do live process/port discovery against the host — stub a PASS so the
+  // subject under test is the only thing being measured.
+  __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
   __panelToolsTestHooks.setPanelRebootTiming({
     settleMs: 0,
     budgetMs: 60,
@@ -67,6 +73,7 @@ beforeEach(() => {
 afterEach(() => {
   __panelToolsTestHooks.setPanelRebootTiming(null);
   __panelToolsTestHooks.setHealthProbe(null);
+  __panelToolsTestHooks.setLocalRestartPreflight(null);
 });
 
 describe("panel_restart_comfyui reboot-dispatch classification", () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -3665,9 +3665,19 @@ describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)",
     return (res.content[0] as { text: string }).text;
   }
 
+  // #814 widened the refuse-safe preflight to EVERY local target, not only a
+  // tab-bound one, so panel_restart_comfyui now consults it on this path too.
+  // These tests are about the confirm card, and the real preflight would do live
+  // process/port discovery against the host — stub a PASS so the card is the only
+  // thing under test.
+  beforeEach(() => {
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
+  });
+
   afterEach(() => {
     __panelAskTestHooks.setAskTiming(null);
     __panelToolsTestHooks.setHealthProbe(null);
+    __panelToolsTestHooks.setLocalRestartPreflight(null);
   });
 
   // FAIL-BEFORE: the old confirm swallowed a card-reply timeout as `false`, so an

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4529,4 +4529,3 @@ describe("panel_ask keeps a validated answer across a tool timeout (#486)", () =
     expect(__panelAskTestHooks.ASK_TOTAL_BUDGET_CAP_MS).toBeLessThan(300000);
   });
 });
-

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { z } from "zod";
 import { getNsfwConsent, setNsfwConsent } from "../../services/panel-settings.js";
+import { getBootLocalComfyUIBaseUrl } from "../../config.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   buildPanelToolDefs,
@@ -3678,6 +3679,7 @@ describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)",
     __panelAskTestHooks.setAskTiming(null);
     __panelToolsTestHooks.setHealthProbe(null);
     __panelToolsTestHooks.setLocalRestartPreflight(null);
+    __panelToolsTestHooks.setPanelRebootTiming(null);
   });
 
   // FAIL-BEFORE: the old confirm swallowed a card-reply timeout as `false`, so an
@@ -3792,6 +3794,16 @@ describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)",
   // #404: a normally-confirmed restart still proceeds to dispatch the reboot — the bound
   // is on the WAIT only; a real "yes" is honored exactly as before.
   it("panel_restart_comfyui still dispatches the reboot on a normal 'yes' confirmation (#404)", async () => {
+    // A BOUND tab (below) means the handler also observes recovery on the boot
+    // endpoint, so give it a fast, deterministic budget — this test asserts that the
+    // confirmation is honored and the reboot dispatched, not what the recovery says.
+    __panelToolsTestHooks.setPanelRebootTiming({
+      settleMs: 0,
+      budgetMs: 30,
+      intervalMs: 5,
+      probeTimeoutMs: 10,
+    });
+    __panelToolsTestHooks.setHealthProbe(async () => false);
     const dispatched: Array<Record<string, unknown>> = [];
     const bridge = {
       send: async (cmd: Record<string, unknown>) => {
@@ -3799,6 +3811,12 @@ describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)",
         dispatched.push(cmd);
         return { rebooting: true };
       },
+      // BOUND to our own boot instance (#814): a LOCAL target the panel cannot tie
+      // to the instance this server accounts for is refused before dispatch, since a
+      // reboot STOPS a server and it must know which one. This test is about the
+      // CONFIRMATION being honored, so it models the ordinary local panel.
+      tabIsLocal: () => true,
+      tabServerOrigin: () => (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/[/]+$/, ""),
     } as unknown as PanelToolCtx["bridge"];
     const ctx = makePanelToolCtx(bridge, "abcd1234");
 

--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -112,9 +112,27 @@ beforeEach(() => {
   // Desktop classification is itself derived from that same possibly-stale argv, so
   // it cannot be what decides whether to verify. It needs the port owner's creation
   // time at both ends; model the ordinary host where that is readable.
-  __processControlTestHooks.setProcessIdentityResolver(() => ({
-    startedAt: "stable-stamp",
-  }));
+  // …and a LIVE Desktop shell above the backend (#814). A Manager reboot STOPS the
+  // process and depends on that shell to start it again, so the restart now proves
+  // the shell is there before dispatching anything. These tests are about what
+  // happens AFTER the dispatch — the reboot firing, and above all that the instance
+  // is never KILLED (#400) — so they must model the install they mean to model: an
+  // ordinary Desktop with its supervisor running. The refusal path has its own tests.
+  __processControlTestHooks.setProcessIdentityResolver((pid) => {
+    if (pid === 300) {
+      return {
+        executablePath: "C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe",
+        commandLine: '"C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe"',
+        startedAt: "2000", // the shell predates the backend it spawned
+      };
+    }
+    // A COMPARABLE stamp, not a placeholder: the supervisor check confirms the
+    // parent link causally (a parent cannot have started after its child), so a
+    // stamp that cannot be compared against the shell's leaves the link unverified.
+    return { startedAt: "5000", parentPid: 300 };
+  });
+  __processControlTestHooks.setParentPidResolver((pid) => (pid === 4321 ? 300 : undefined));
+  __processControlTestHooks.setProcessExistsProbe(() => true);
 });
 
 afterEach(() => {

--- a/src/__tests__/services/port-owner-probe.test.ts
+++ b/src/__tests__/services/port-owner-probe.test.ts
@@ -1647,7 +1647,83 @@ describe("probePortOwner — POSIX (#795: owner attributed from /proc/<pid>/fd)"
     expect(probe.state).toBe("unknown");
     expect(probe).not.toMatchObject({ pid: 4321 });
     expect(probe).toMatchObject({
-      reason: expect.stringMatching(/no longer holds the socket/i),
+      reason: expect.stringMatching(/could not be re-confirmed as the owner/i),
+    });
+    // The inner reason states the search was COMPLETE and found nobody — not that it
+    // hit a wall, which is the other way to fail this re-check.
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/no process in \/proc holds it/i),
+    });
+  });
+
+  it("a socket that CHANGED HANDS between the scans is not attributed to the old owner", async () => {
+    // The fd is passed on: the same inode is still listening, so the socket half of
+    // the bracket holds — but the owner is now somebody else, and returning the
+    // former holder would point a stop at a process that no longer has anything to do
+    // with the port.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("");
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6,
+    );
+    const tree: Record<number, Record<string, string>> = {
+      4321: { "0": "socket:[54321]" },
+      200: { "0": "/dev/null" },
+    };
+    const walker = fdReader(tree);
+    let walks = 0;
+    __portOwnerTestHooks.setProcFdReader({
+      ...walker,
+      listPids: () => {
+        walks++;
+        if (walks > 1) {
+          tree[4321] = { "0": "/dev/null" };
+          tree[200] = { "0": "socket:[54321]" };
+        }
+        return walker.listPids();
+      },
+    });
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).not.toMatchObject({ pid: 4321 });
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/changed hands .*PID 4321, then PID 200/i),
+    });
+  });
+
+  it("a SECOND holder appearing between the scans withdraws the finding", async () => {
+    // The claim being bracketed is "exactly one visible process holds this socket".
+    // Re-checking only that OUR pid still holds it accepts a second holder appearing
+    // beside it — which the opening scan would have refused as ambiguous, so the
+    // bracket would launder a verdict the same evidence was not allowed to produce a
+    // moment earlier. The closing check therefore re-derives the WHOLE finding.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("");
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6,
+    );
+    // 4321 holds it throughout; 200 inherits the same socket after the first pass.
+    const tree: Record<number, Record<string, string>> = {
+      4321: { "0": "socket:[54321]" },
+      200: { "0": "/dev/null" },
+    };
+    const walker = fdReader(tree);
+    let walks = 0;
+    __portOwnerTestHooks.setProcFdReader({
+      ...walker,
+      listPids: () => {
+        walks++;
+        if (walks > 1) tree[200] = { "0": "socket:[54321]" };
+        return walker.listPids();
+      },
+    });
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).not.toMatchObject({ pid: 4321 });
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/held by several processes \(200, 4321\)/),
     });
   });
 
@@ -1676,7 +1752,7 @@ describe("probePortOwner — POSIX (#795: owner attributed from /proc/<pid>/fd)"
     const probe = probePortOwner(8188);
     expect(probe.state).toBe("unknown");
     expect(probe).toMatchObject({
-      reason: expect.stringMatching(/no longer holds the socket/i),
+      reason: expect.stringMatching(/no process in \/proc holds it/i),
     });
   });
 
@@ -1702,7 +1778,7 @@ describe("probePortOwner — POSIX (#795: owner attributed from /proc/<pid>/fd)"
     const probe = probePortOwner(8188);
     expect(probe.state).toBe("unknown");
     expect(probe).toMatchObject({
-      reason: expect.stringMatching(/could not be re-checked/i),
+      reason: expect.stringMatching(/could not all be read/i),
     });
   });
 

--- a/src/__tests__/services/port-owner-probe.test.ts
+++ b/src/__tests__/services/port-owner-probe.test.ts
@@ -32,6 +32,17 @@ vi.mock("node:fs", () => ({
   readFileSync: vi.fn(() => {
     throw Object.assign(new Error("no /proc in test"), { code: "ENOENT" });
   }),
+  // The #795 pid-ATTRIBUTION walk goes through the same `/proc`, and on a Linux
+  // runner the real one exists — an un-mocked readdir would grade these assertions
+  // against the runner's own process table. Absent by default, so every test that
+  // does not explicitly install a fd reader falls through to lsof, which is the
+  // contract the rest of this file was written against.
+  readdirSync: vi.fn(() => {
+    throw Object.assign(new Error("no /proc in test"), { code: "ENOENT" });
+  }),
+  readlinkSync: vi.fn(() => {
+    throw Object.assign(new Error("no /proc in test"), { code: "ENOENT" });
+  }),
 }));
 
 /** `execSync` throws with `status` (the exit code) for a command that RAN and
@@ -1182,6 +1193,466 @@ describe("probePortOwner — POSIX (kernel socket table, consulted before lsof)"
     expect(probePortOwner(8188).state).toBe("unknown");
     expect(mockExecSync).toHaveBeenCalled();
     expect(String(mockExecSync.mock.calls[0][0])).toMatch(/lsof/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #795 — naming the OWNER from /proc alone.
+//
+// #785 established the split this suite rests on: EXISTENCE is decided by the
+// kernel table, and lsof only ATTRIBUTES a socket to a pid. That left attribution
+// as the half a host without lsof could never perform, so every feature built on
+// process identity said "cannot confirm" there forever. `/proc/net/tcp{,6}` prints
+// each socket's inode and `/proc/<pid>/fd/*` resolves to `socket:[<inode>]`, so the
+// same source can do both.
+//
+// The standard each answer is held to is unchanged, and asymmetric on purpose:
+// `owned` is a positive finding about ONE process (it is what gets spent to kill
+// something), while failing to attribute is never evidence the port is free — the
+// kernel already said a socket is there.
+// ---------------------------------------------------------------------------
+describe("probePortOwner — POSIX (#795: owner attributed from /proc/<pid>/fd)", () => {
+  const HEADER_V4 =
+    "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode";
+  const HEADER_V6 =
+    "  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode";
+
+  const hex = (port: number): string =>
+    port.toString(16).toUpperCase().padStart(4, "0");
+
+  /** One `/proc/net/tcp` LISTEN row, with the inode and local address under test. */
+  function v4Table(
+    rows: Array<{ port: number; inode: string; address?: string; state?: string }>,
+  ): string {
+    return [
+      HEADER_V4,
+      ...rows.map(
+        (r, i) =>
+          `   ${i}: ${r.address ?? "0100007F"}:${hex(r.port)} 00000000:0000 ${
+            r.state ?? "0A"
+          } 00000000:00000000 00:00000000 00000000  1000        0 ${r.inode} 1`,
+      ),
+      "",
+    ].join("\n");
+  }
+  /** The same, in `/proc/net/tcp6`'s 32-hex-digit address width. */
+  function v6Table(rows: Array<{ port: number; inode: string; address?: string }>): string {
+    return [
+      HEADER_V6,
+      ...rows.map(
+        (r, i) =>
+          `   ${i}: ${
+            r.address ?? "00000000000000000000000001000000"
+          }:${hex(r.port)} 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 ${r.inode} 1`,
+      ),
+      "",
+    ].join("\n");
+  }
+  const emptyV4 = `${HEADER_V4}\n`;
+  const emptyV6 = `${HEADER_V6}\n`;
+  const enoent = (): NodeJS.ErrnoException =>
+    Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  const eacces = (): NodeJS.ErrnoException =>
+    Object.assign(new Error("EACCES"), { code: "EACCES" });
+
+  /** A `/proc` where each pid holds the listed fd → link targets. */
+  function fdReader(
+    tree: Record<number, Record<string, string> | NodeJS.ErrnoException>,
+  ): {
+    listPids: () => number[];
+    listFds: (pid: number) => string[];
+    readFdLink: (pid: number, fd: string) => string;
+  } {
+    return {
+      listPids: () => Object.keys(tree).map(Number),
+      listFds: (pid) => {
+        const entry = tree[pid];
+        if (entry instanceof Error) throw entry;
+        return Object.keys(entry ?? {});
+      },
+      readFdLink: (pid, fd) => {
+        const entry = tree[pid];
+        if (entry instanceof Error) throw entry;
+        const link = entry?.[fd];
+        if (link === undefined) throw enoent();
+        return link;
+      },
+    };
+  }
+
+  function install(
+    tables: (table: string) => string,
+    tree: Parameters<typeof fdReader>[0],
+    hooks: { setProcNetReader: (f: (t: string) => string) => void; setProcFdReader: (f: ReturnType<typeof fdReader>) => void },
+  ): void {
+    hooks.setProcNetReader(tables);
+    hooks.setProcFdReader(fdReader(tree));
+  }
+
+  it("names the owner from /proc alone, WITHOUT spawning lsof", async () => {
+    // The headline of #795: the inode in the socket table and the fd symlink are the
+    // whole identity. lsof must not even be reached — asserting that is what
+    // separates "attributed from /proc" from "lsof happened to answer too".
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    install(
+      (t) => (t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6),
+      { 4321: { "0": "socket:[54321]", "1": "/dev/null" } },
+      __portOwnerTestHooks,
+    );
+
+    expect(probePortOwner(8188)).toEqual({ state: "owned", pid: 4321 });
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("names the owner on a host where lsof does not exist at all", async () => {
+    // The condition the issue is actually about — a minimal container. Even if the
+    // fall-through ran, lsof would fail to spawn, so a pass here can only come from
+    // /proc.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockImplementation(() => {
+      throw spawnFailure("ENOENT");
+    });
+    install(
+      (t) => (t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6),
+      { 4321: { "0": "socket:[54321]" } },
+      __portOwnerTestHooks,
+    );
+
+    expect(probePortOwner(8188)).toEqual({ state: "owned", pid: 4321 });
+  });
+
+  it("attributes a 32-hex-digit tcp6 listener, address-matched to the host asked for", async () => {
+    // `00000000000000000000000001000000` is `::1` as a real kernel prints it: four
+    // LITTLE-ENDIAN 32-bit words, so the bytes reverse within each word. Decoding it
+    // as big-endian would yield `100:0` and the host match would fail.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    install(
+      (t) => (t === "/proc/net/tcp6" ? v6Table([{ port: 8188, inode: "22454" }]) : emptyV4),
+      { 909: { "3": "socket:[22454]" } },
+      __portOwnerTestHooks,
+    );
+
+    expect(probePortOwner(8188, "::1")).toEqual({ state: "owned", pid: 909 });
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("does not attribute a listener bound to an address that does not serve the host", async () => {
+    // `0501A8C0` is 192.168.1.5. It is a real listener on the port — so the port is
+    // NOT free — but it is not the loopback instance we are talking to, and naming
+    // its process as our port's owner would point a kill at a stranger.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("");
+    install(
+      (t) =>
+        t === "/proc/net/tcp"
+          ? v4Table([{ port: 8188, inode: "54321", address: "0501A8C0" }])
+          : emptyV6,
+      { 4321: { "0": "socket:[54321]" } },
+      __portOwnerTestHooks,
+    );
+
+    const probe = probePortOwner(8188, "127.0.0.1");
+    expect(probe.state).toBe("unknown");
+    expect(probe).not.toMatchObject({ pid: 4321 });
+  });
+
+  it("an IPv6 address this module will not decode is not attributed to a requested host", async () => {
+    // `B80D0120…01000000` is 2001:db8::1. A general IPv6 address has several legal
+    // textual spellings, so string-comparing a decoded one against a user-supplied
+    // host would be a guess — and the finding it would produce is a POSITIVE, the
+    // direction that licenses stopping a process. Declining costs a fall-through to
+    // lsof; guessing would cost somebody else's server.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("");
+    install(
+      (t) =>
+        t === "/proc/net/tcp6"
+          ? v6Table([
+              { port: 8188, inode: "31337", address: "B80D0120000000000000000001000000" },
+            ])
+          : emptyV4,
+      { 4321: { "0": "socket:[31337]" } },
+      __portOwnerTestHooks,
+    );
+
+    const probe = probePortOwner(8188, "::1");
+    expect(probe.state).toBe("unknown");
+    expect(probe).not.toMatchObject({ pid: 4321 });
+  });
+
+  it("…but with NO host asked for, that same listener IS attributed", async () => {
+    // The counterpart, and the reason the check is not simply "decode or refuse":
+    // with no host constraint every listener on the port qualifies (exactly as the
+    // lsof parser behaves), so the address is never decoded and #795's benefit is
+    // not thrown away on hosts whose ComfyUI binds a global IPv6 address.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    install(
+      (t) =>
+        t === "/proc/net/tcp6"
+          ? v6Table([
+              { port: 8188, inode: "31337", address: "B80D0120000000000000000001000000" },
+            ])
+          : emptyV4,
+      { 4321: { "0": "socket:[31337]" } },
+      __portOwnerTestHooks,
+    );
+
+    expect(probePortOwner(8188)).toEqual({ state: "owned", pid: 4321 });
+  });
+
+  it("only the process holding THAT inode is the owner", async () => {
+    // Two processes, one socket. Attribution is by inode, not by "a process exists".
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    install(
+      (t) => (t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6),
+      {
+        111: { "0": "socket:[99999]", "1": "/tmp/x" },
+        222: { "0": "socket:[54321]" },
+      },
+      __portOwnerTestHooks,
+    );
+
+    expect(probePortOwner(8188)).toEqual({ state: "owned", pid: 222 });
+  });
+
+  it("an inode from a DIFFERENT port's row is never our owner", async () => {
+    // The join key must come from the row that matched the port and the LISTEN
+    // state. Taking any inode in the table would attribute an unrelated service.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("");
+    install(
+      (t) =>
+        t === "/proc/net/tcp"
+          ? v4Table([
+              { port: 9999, inode: "11111" },
+              { port: 8188, inode: "22222" },
+            ])
+          : emptyV6,
+      { 777: { "0": "socket:[11111]" } },
+      __portOwnerTestHooks,
+    );
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("a socket several processes share names NONE of them", async () => {
+    // Forked workers / SO_REUSEPORT genuinely share one listener. Naming any single
+    // one would license killing a process whose death does not release the port, so
+    // the ambiguity itself is the answer — and it is STATED, not merely implied.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("");
+    install(
+      (t) => (t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6),
+      { 100: { "0": "socket:[54321]" }, 200: { "4": "socket:[54321]" } },
+      __portOwnerTestHooks,
+    );
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/held by several processes \(100, 200\)/),
+    });
+  });
+
+  it("a pid whose fds cannot be READ is a blind spot, and says so", async () => {
+    // EACCES is another user's process: it may well be the owner, and reporting "no
+    // process holds it" would describe a search we did not finish. The REASON is
+    // asserted because the state alone (`unknown`) is reachable from a clean,
+    // complete search that simply found nothing.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("");
+    install(
+      (t) => (t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6),
+      { 1: eacces() },
+      __portOwnerTestHooks,
+    );
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/could not all be read/i),
+    });
+  });
+
+  it("a pid that EXITED mid-walk is not a blind spot", async () => {
+    // ENOENT while reading a pid's fds means that process is gone — a process that
+    // does not exist cannot be holding the socket, so the search is still complete.
+    // Conflating it with EACCES would permanently downgrade every scan (pids come
+    // and go constantly) and make the honest "nobody holds it" unreachable.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("");
+    install(
+      (t) => (t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6),
+      { 5: enoent(), 6: { "0": "/dev/null" } },
+      __portOwnerTestHooks,
+    );
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/no process in \/proc holds it/i),
+    });
+  });
+
+  it("failing to attribute NEVER reports the port as free", async () => {
+    // The one inversion that would be catastrophic: the kernel said a socket is
+    // there, so "I could not name its owner" must never become "nothing is
+    // listening" — a caller waiting for a port release would act on a server that is
+    // still running. lsof states absence here, which is exactly the shape that would
+    // fabricate it.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188\n";
+      return err as never;
+    });
+    install(
+      (t) => (t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6),
+      { 1: eacces() },
+      __portOwnerTestHooks,
+    );
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("inode 0 is never matched", async () => {
+    // A row printing inode `0` has no inode of its own; `socket:[0]` in some
+    // process's fd table could only be a coincidence, never our listener.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("");
+    install(
+      (t) => (t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "0" }]) : emptyV6),
+      { 4321: { "0": "socket:[0]" } },
+      __portOwnerTestHooks,
+    );
+
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("a row truncated before its inode still proves a LISTENER, it just cannot name one", async () => {
+    // The two halves keep their own standards: existence survives a row cut short
+    // (the fields it already showed cannot be unmade), attribution does not (the
+    // inode is simply not there). Regressing existence to require a whole row would
+    // turn a damaged table into a false "nothing is listening".
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockImplementation(() => {
+      const err = exitWith(1) as Error & { status: number; stdout: string };
+      err.stdout = "lsof: Internet address not located: TCP:8188\n";
+      return err as never;
+    });
+    const truncated = [
+      HEADER_V4,
+      `   0: 0100007F:${hex(8188)} 00000000:0000 0A`,
+      "",
+    ].join("\n");
+    install(
+      (t) => (t === "/proc/net/tcp" ? truncated : emptyV6),
+      { 4321: { "0": "socket:[54321]" } },
+      __portOwnerTestHooks,
+    );
+
+    // NOT free — lsof stated absence and was overruled by the kernel's positive.
+    expect(probePortOwner(8188).state).toBe("unknown");
+  });
+
+  it("still reports FREE from the kernel table without walking /proc at all", async () => {
+    // Attribution must not disturb the decisive negative #785 established: when the
+    // tables are whole and hold no listener, the port is free and nothing else runs.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const walker = fdReader({ 4321: { "0": "socket:[54321]" } });
+    const listPids = vi.fn(walker.listPids);
+    __portOwnerTestHooks.setProcNetReader((t) => (t === "/proc/net/tcp" ? emptyV4 : emptyV6));
+    __portOwnerTestHooks.setProcFdReader({ ...walker, listPids });
+
+    expect(probePortOwner(8188)).toEqual({ state: "free" });
+    expect(listPids).not.toHaveBeenCalled();
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it("a listener that CHANGED between the table read and the fd walk is not attributed", async () => {
+    // The inode and the fd walk are two separate observations, and a socket inode is
+    // reusable the moment its socket closes: the listener can go away in between,
+    // its number be handed to an unrelated socket, and the walk then name whatever
+    // process holds THAT. Nothing downstream would catch it when the server is
+    // wedged and has no argv to corroborate against — and the pid is what a stop
+    // kills. So the join is BRACKETED: the same inode must still be listening on the
+    // port afterwards.
+    //
+    // Modelled as a second table read that shows a DIFFERENT inode on the port.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("");
+    let reads = 0;
+    __portOwnerTestHooks.setProcNetReader((t) => {
+      if (t !== "/proc/net/tcp") return emptyV6;
+      reads++;
+      // The first pass sees inode 54321; by the second, a different socket holds
+      // the port.
+      return v4Table([{ port: 8188, inode: reads <= 1 ? "54321" : "99999" }]);
+    });
+    __portOwnerTestHooks.setProcFdReader(
+      fdReader({ 4321: { "0": "socket:[54321]" }, 5555: { "0": "socket:[99999]" } }),
+    );
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).not.toMatchObject({ pid: 4321 });
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/changed while its owner was being identified/i),
+    });
+  });
+
+  it("an unchanged listener passes the bracket and is still attributed", async () => {
+    // The control: the bracket must not reject the ordinary case, or attribution
+    // would never succeed at all.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    const reader = vi.fn((t: string) =>
+      t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6,
+    );
+    __portOwnerTestHooks.setProcNetReader(reader);
+    __portOwnerTestHooks.setProcFdReader(fdReader({ 4321: { "0": "socket:[54321]" } }));
+
+    expect(probePortOwner(8188)).toEqual({ state: "owned", pid: 4321 });
+    // Read twice: once to find the inode, once to confirm it is still the listener.
+    expect(reader.mock.calls.filter((c) => c[0] === "/proc/net/tcp").length).toBe(2);
+  });
+
+  it("a single readable holder is named even when another process could not be read", async () => {
+    // A DELIBERATE asymmetry, stated so it is reviewed rather than assumed. Requiring
+    // a complete /proc walk would make attribution impossible on any multi-user host
+    // — an unprivileged process cannot read ANY other user's fds and every box runs
+    // root daemons — which is exactly the permanent "cannot confirm" #795 removes.
+    // lsof reaches no further (same files, same credentials), and a socket is shared
+    // by INHERITANCE, so an unseen co-holder is a descendant that the process-tree
+    // kill takes with it anyway.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6,
+    );
+    __portOwnerTestHooks.setProcFdReader(
+      fdReader({ 1: eacces(), 4321: { "0": "socket:[54321]" } }),
+    );
+
+    expect(probePortOwner(8188)).toEqual({ state: "owned", pid: 4321 });
+  });
+
+  it("a /proc that cannot be enumerated at all falls through to lsof", async () => {
+    // The honest fallback #795 explicitly asks to preserve: shrinking the
+    // unverifiable set, not removing the other source.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("p4321\nn127.0.0.1:8188\n");
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6,
+    );
+    __portOwnerTestHooks.setProcFdReader({
+      listPids: () => {
+        throw eacces();
+      },
+      listFds: () => [],
+      readFdLink: () => "",
+    });
+
+    expect(probePortOwner(8188)).toEqual({ state: "owned", pid: 4321 });
+    expect(mockExecSync).toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/services/port-owner-probe.test.ts
+++ b/src/__tests__/services/port-owner-probe.test.ts
@@ -1616,6 +1616,96 @@ describe("probePortOwner — POSIX (#795: owner attributed from /proc/<pid>/fd)"
     expect(reader.mock.calls.filter((c) => c[0] === "/proc/net/tcp").length).toBe(2);
   });
 
+  it("the SAME PID must still hold the socket, not merely the same inode be listening", async () => {
+    // The bracket has two halves because the finding pairs a pid with a socket.
+    // Re-reading the table proves the INODE is still on the port; it says nothing
+    // about who holds it. An fd can be closed or handed on between the walk and the
+    // re-read, leaving that inode listening under a NEW owner while the pid we return
+    // is a former holder — and that pid is what a stop kills.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("");
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6,
+    );
+    // The first walk finds 4321 holding it; by the re-check it has let it go.
+    let walks = 0;
+    const tree: Record<number, Record<string, string>> = {
+      4321: { "0": "socket:[54321]" },
+    };
+    const walker = fdReader(tree);
+    __portOwnerTestHooks.setProcFdReader({
+      ...walker,
+      listFds: (pid) => {
+        walks++;
+        // The attribution walk sees the fd; the re-check does not.
+        if (walks > 1) tree[4321] = { "0": "/dev/null" };
+        return walker.listFds(pid);
+      },
+    });
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).not.toMatchObject({ pid: 4321 });
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/no longer holds the socket/i),
+    });
+  });
+
+  it("a pid that EXITED before the re-check is a definite negative, not a blind spot", async () => {
+    // The reason is what distinguishes these, since both refuse: a process that no
+    // longer exists definitively does not hold the socket, whereas a permission wall
+    // means we could not look. Collapsing the first into the second would report a
+    // blind spot to a user whose evidence was actually complete.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("");
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6,
+    );
+    let walks = 0;
+    const walker = fdReader({ 4321: { "0": "socket:[54321]" } });
+    __portOwnerTestHooks.setProcFdReader({
+      ...walker,
+      listFds: (pid) => {
+        walks++;
+        // The process is gone by the time we re-check.
+        if (walks > 1) throw enoent();
+        return walker.listFds(pid);
+      },
+    });
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/no longer holds the socket/i),
+    });
+  });
+
+  it("a re-check that cannot be performed does not confirm ownership either", async () => {
+    // A permission wall on the re-read is "I could not look", and an unverified
+    // pairing must not be spent as a verified one.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("");
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp" ? v4Table([{ port: 8188, inode: "54321" }]) : emptyV6,
+    );
+    let walks = 0;
+    const walker = fdReader({ 4321: { "0": "socket:[54321]" } });
+    __portOwnerTestHooks.setProcFdReader({
+      ...walker,
+      listFds: (pid) => {
+        walks++;
+        if (walks > 1) throw eacces();
+        return walker.listFds(pid);
+      },
+    });
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(/could not be re-checked/i),
+    });
+  });
+
   it("a single readable holder is named even when another process could not be read", async () => {
     // A DELIBERATE asymmetry, stated so it is reviewed rather than assumed. Requiring
     // a complete /proc walk would make attribution impossible on any multi-user host

--- a/src/__tests__/services/port-owner-probe.test.ts
+++ b/src/__tests__/services/port-owner-probe.test.ts
@@ -1656,6 +1656,84 @@ describe("probePortOwner — POSIX (#795: owner attributed from /proc/<pid>/fd)"
     });
   });
 
+  it("holding SOME listener on the port is not holding THE one we bracketed", async () => {
+    // The subtlest form of the substitution, and the reason the re-check asks about
+    // the specific inode rather than just the pid. Two listeners on the port, I and
+    // J. First pass: our pid holds I and is the only VISIBLE holder (another process
+    // is unreadable, which does not withdraw a single-holder finding). Second pass:
+    // our pid has released I and holds only J, while the unreadable process now holds
+    // I. Re-attribution still names our pid — it does hold *a* listener — so a check
+    // that stops at the pid would confirm a claim about a socket it no longer has.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    mockExecSync.mockReturnValue("");
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? v4Table([
+            { port: 8188, inode: "54321" },
+            { port: 8188, inode: "99999" },
+          ])
+        : emptyV6,
+    );
+    const tree: Record<number, Record<string, string> | NodeJS.ErrnoException> = {
+      1: eacces(), // the other holder, never readable
+      4321: { "0": "socket:[54321]" },
+    };
+    const walker = fdReader(tree);
+    let walks = 0;
+    __portOwnerTestHooks.setProcFdReader({
+      ...walker,
+      listPids: () => {
+        walks++;
+        if (walks > 1) tree[4321] = { "0": "socket:[99999]" };
+        return walker.listPids();
+      },
+    });
+
+    const probe = probePortOwner(8188);
+    expect(probe.state).toBe("unknown");
+    expect(probe).not.toMatchObject({ pid: 4321 });
+    // The reason names THIS fact — it holds another listener, which is a different
+    // finding — rather than collapsing into "changed hands (PID 4321, then PID 4321)".
+    expect(probe).toMatchObject({
+      reason: expect.stringMatching(
+        /no longer holds the socket it was identified by .* holds another listener/i,
+      ),
+    });
+  });
+
+  it("a DUAL-STACK holder is not withdrawn just because the walk reached its other socket first", async () => {
+    // The counterpart, and why the re-check asks whether the pid's COMPLETE set
+    // contains the bracketed inode rather than whether the walk selected it again. A
+    // process listening on two sockets of the same port holds both; which one an fd
+    // scan stops at is an artifact of directory order, not a change in the world.
+    // Recording only the first match would make this ordinary case fail at random.
+    const { probePortOwner, __portOwnerTestHooks } = await loadProbe();
+    __portOwnerTestHooks.setProcNetReader((t) =>
+      t === "/proc/net/tcp"
+        ? v4Table([
+            { port: 8188, inode: "54321" },
+            { port: 8188, inode: "99999" },
+          ])
+        : emptyV6,
+    );
+    const tree: Record<number, Record<string, string>> = {
+      4321: { "0": "socket:[54321]" },
+    };
+    const walker = fdReader(tree);
+    let walks = 0;
+    __portOwnerTestHooks.setProcFdReader({
+      ...walker,
+      listPids: () => {
+        walks++;
+        // Still both sockets — the OTHER one simply comes first this time.
+        if (walks > 1) tree[4321] = { "0": "socket:[99999]", "1": "socket:[54321]" };
+        return walker.listPids();
+      },
+    });
+
+    expect(probePortOwner(8188)).toEqual({ state: "owned", pid: 4321 });
+  });
+
   it("a socket that CHANGED HANDS between the scans is not attributed to the old owner", async () => {
     // The fd is passed on: the same inode is still listening, so the socket half of
     // the bracket holds — but the owner is now somebody else, and returning the

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -194,6 +194,36 @@ afterEach(() => {
   __processControlTestHooks.reset();
 });
 
+/**
+ * A live ComfyUI Desktop shell supervising the backend on the port (#814).
+ *
+ * A Manager reboot STOPS the process and depends on that shell to start it again, so
+ * a Desktop restart now has to prove the shell is there before it dispatches
+ * anything. Tests about what happens AFTER the dispatch — the reboot firing, the
+ * caches, the dispatch record, "it is never killed" — therefore have to model the
+ * install they mean to model: an ordinary Desktop with its supervisor running.
+ * Without this they exercise the refusal instead, which is a different test.
+ */
+function installLiveDesktopSupervisor(backendPid = 4321, shellPid = 300): void {
+  __processControlTestHooks.setProcessIdentityResolver((pid) => {
+    if (pid === backendPid) return { startedAt: "5000", parentPid: shellPid };
+    if (pid === shellPid) {
+      return {
+        // The OS's own record of the binary — what the supervisor check trusts.
+        executablePath: "C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe",
+        commandLine: '"C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe"',
+        // The shell predates the backend it spawned, as causality requires.
+        startedAt: "2000",
+      };
+    }
+    return undefined;
+  });
+  __processControlTestHooks.setParentPidResolver((pid) =>
+    pid === backendPid ? shellPid : undefined,
+  );
+  __processControlTestHooks.setProcessExistsProbe(() => true);
+}
+
 describe("process-control startup readiness", () => {
   it("reports ready after the bounded readiness probe succeeds", async () => {
     setLaunchInfo();
@@ -569,6 +599,9 @@ describe("process-control restart relaunch preflight (#368/#370)", () => {
     // Exe cannot be located on disk — under the old path this refused; now it
     // is never consulted because we reboot via the Manager instead.
     mockExistsSync.mockImplementation(() => false);
+    // …and the shell that would re-exec it is running, which is what makes the
+    // reboot a safe stop at all (#814).
+    installLiveDesktopSupervisor();
     __processControlTestHooks.setRemoteRebootTimingForTests({
       settleMs: 0,
       budgetMs: 1000,
@@ -839,7 +872,11 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
     expect(preflight.ok).toBe(true);
   });
 
-  it("preflightLocalRestart passes a Desktop app (the Manager reboot IS its safe path, #400)", async () => {
+  it("preflightLocalRestart passes a Desktop app whose supervisor is PROVEN live (#400)", async () => {
+    // #400's ruling is preserved exactly: the Manager reboot is the Desktop restart
+    // path and the relaunch command is never consulted. What changed is that being
+    // Desktop no longer stands in for being SUPERVISED — that is a fact about the
+    // running process tree, and here it is established.
     mockLivePortNoKill();
     mockGetSystemStats.mockResolvedValue({
       system: {
@@ -851,19 +888,49 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
       },
     });
     mockExistsSync.mockImplementation(() => false); // relaunch never consulted
+    installLiveDesktopSupervisor();
 
     const preflight = await preflightLocalRestart();
 
     expect(preflight.ok).toBe(true);
   });
 
-  it("preflightLocalRestart passes when no running process can be proven", async () => {
+  it("preflightLocalRestart REFUSES a Desktop app whose supervision cannot be established (#814)", async () => {
+    // The counterpart, and the policy the #814 loss forced. A reboot has not happened
+    // yet and cannot be undone, so "I could not establish that anything will restart
+    // this" refuses — unlike `listener_ownership`, where the launch has ALREADY
+    // happened and uncertainty is merely disclosed. Refuse before, disclose after.
+    mockLivePortNoKill();
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: [
+          "C:\\Users\\x\\AppData\\Local\\Programs\\Comfy Desktop\\resources\\ComfyUI\\main.py",
+          "--port",
+          "8188",
+        ],
+      },
+    });
+    // No parent chain readable — the ordinary shape on a locked-down host.
+    __processControlTestHooks.setParentPidResolver(() => undefined);
+
+    const preflight = await preflightLocalRestart();
+
+    expect(preflight.ok).toBe(false);
+    expect(preflight.reason).toMatch(/could not be established/i);
+  });
+
+  it("preflightLocalRestart REFUSES when no running process can be identified", async () => {
+    // The door beside the gate: an instance whose listener cannot be attributed — a
+    // container with no `lsof`, a permission wall — used to resolve to NOTHING and
+    // return ok, so the reboot went out with no check at all. An instance we cannot
+    // identify is an instance whose relaunch we cannot prove.
     mockNoPortProcess();
     mockGetSystemStats.mockRejectedValue(new Error("connection refused"));
 
     const preflight = await preflightLocalRestart();
 
-    expect(preflight.ok).toBe(true);
+    expect(preflight.ok).toBe(false);
+    expect(preflight.reason).toMatch(/could not be identified/i);
   });
 
   it("stop succeeded but relaunch fails → truthful lost-server message, never 'cancelled' (#742)", async () => {
@@ -968,6 +1035,7 @@ describe("restart truthfulness + Pinokio-shaped refusal (#742)", () => {
         ],
       },
     });
+    installLiveDesktopSupervisor();
     __processControlTestHooks.setRemoteRebootTimingForTests({
       settleMs: 0,
       budgetMs: 30,

--- a/src/__tests__/services/restart-relaunch-lifecycle.test.ts
+++ b/src/__tests__/services/restart-relaunch-lifecycle.test.ts
@@ -238,20 +238,25 @@ describe("classifyDesktopSupervision — is anything going to start this again? 
     expect(verdict).toBe("supervised");
   });
 
-  it("the DESKTOP SHELL ITSELF is a supervisor — it is not walked past", () => {
-    // When ComfyUI is unreachable and its port cannot be attributed, the caller falls
-    // back to the Desktop shell's own pid; that fallback exists so a hung install can
-    // still be rebooted. Walking up from the shell finds Explorer/launchd and then the
-    // tree root, so an ordinary live Desktop would come back `abandoned` and the one
-    // recovery path left to that user would be refused — precisely when they already
-    // have no working ComfyUI.
+  it("being a Desktop shell ITSELF proves nothing about the server on the port", () => {
+    // An earlier revision short-circuited to `supervised` when the pid handed in was
+    // itself a Desktop shell, to serve a caller that falls back to "use whatever
+    // Desktop process is running" when the port cannot be attributed. But that
+    // fallback picks a shell by scanning process NAMES — bound to no port and no
+    // backend — so a second, unrelated Desktop window would have licensed stopping an
+    // orphaned backend it has never heard of.
+    //
+    // The premise was the problem, not the walk: the caller now declines before
+    // reaching here (see the preflight suite), and this classifier only ever sees a
+    // pid resolved FROM THE PORT. Asked about a shell anyway, it answers the same way
+    // it answers about anything with no supervisor above it.
     const { verdict } = classifyDesktopSupervision(
       tree({
         500: { cmd: DESKTOP_SHELL, started: "1000", parent: 400 },
         400: { cmd: "explorer.exe", started: "10", parent: 1 },
       }),
     );
-    expect(verdict).toBe("supervised");
+    expect(verdict).not.toBe("supervised");
   });
 
   it("an intermediate wrapper is walked THROUGH, not treated as an answer", () => {
@@ -1316,6 +1321,43 @@ describe("preflightLocalRestart — an instance we cannot identify is not a pass
     expect(result.reason).toMatch(/could not be identified/i);
     // It says what it could not establish rather than asserting something is wrong.
     expect(result.reason).toMatch(/could not be established that stopping it/i);
+  });
+
+  it("REFUSES when the only Desktop app found was located by scanning process names", async () => {
+    // Round-9 gate. When the port cannot be attributed, acquireProcessInfo falls back
+    // to the first Desktop process on the machine — bound to no port and no backend.
+    // Treating it as the supervisor let an unrelated Desktop window (a reopened app,
+    // a second install) authorize stopping an orphaned backend it has never heard of:
+    // the same lost server by a new route.
+    //
+    // Modelled as: the server does not answer, no port owner can be resolved, and a
+    // Desktop process IS found by name.
+    mockGetSystemStats.mockRejectedValue(new Error("fetch failed"));
+    mockExecSync.mockImplementation((cmd: string) => {
+      const c = String(cmd);
+      // The port cannot be attributed at all.
+      if (/netstat|lsof/i.test(c)) throw new Error("command not found");
+      // …but a Desktop shell is running somewhere.
+      if (/tasklist/i.test(c)) return '"Comfy Desktop.exe","900","Console","1","206,248 K"';
+      if (/pgrep/i.test(c)) return "900\n";
+      return "";
+    });
+    // Even a perfectly readable, live shell at that pid must not stand in.
+    __processControlTestHooks.setProcessIdentityResolver((pid) =>
+      pid === 900
+        ? {
+            executablePath: "C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe",
+            startedAt: "1000",
+          }
+        : undefined,
+    );
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+
+    const result = await preflightLocalRestart();
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/scanning process names/i);
+    expect(result.reason).toMatch(/nothing ties it to that port/i);
   });
 
   it("still PASSES a non-Desktop instance whose relaunch is validated", async () => {

--- a/src/__tests__/services/restart-relaunch-lifecycle.test.ts
+++ b/src/__tests__/services/restart-relaunch-lifecycle.test.ts
@@ -124,6 +124,7 @@ vi.mock("../../services/workspace-env.js", () => ({
 
 import {
   __processControlTestHooks,
+  preflightLocalRestart,
   restartComfyUI,
   startComfyUI,
   stopComfyUI,
@@ -231,7 +232,7 @@ describe("classifyDesktopSupervision — is anything going to start this again? 
   }
 
   it("a live Desktop shell directly above the server is SUPERVISED", () => {
-    const verdict = classifyDesktopSupervision(
+    const { verdict } = classifyDesktopSupervision(
       tree({ 500: { parent: 300 }, 300: { cmd: DESKTOP_SHELL, parent: 100 } }),
     );
     expect(verdict).toBe("supervised");
@@ -244,7 +245,7 @@ describe("classifyDesktopSupervision — is anything going to start this again? 
     // tree root, so an ordinary live Desktop would come back `abandoned` and the one
     // recovery path left to that user would be refused — precisely when they already
     // have no working ComfyUI.
-    const verdict = classifyDesktopSupervision(
+    const { verdict } = classifyDesktopSupervision(
       tree({
         500: { cmd: DESKTOP_SHELL, started: "1000", parent: 400 },
         400: { cmd: "explorer.exe", started: "10", parent: 1 },
@@ -257,7 +258,7 @@ describe("classifyDesktopSupervision — is anything going to start this again? 
     // A launcher shim between the shell and python is ordinary. Stopping at the
     // first non-supervisor would report every wrapped Desktop install abandoned and
     // deny those users a restart that works.
-    const verdict = classifyDesktopSupervision(
+    const { verdict } = classifyDesktopSupervision(
       tree({
         500: { parent: 400 },
         400: { cmd: "cmd.exe /c launch.bat", parent: 300 },
@@ -270,7 +271,7 @@ describe("classifyDesktopSupervision — is anything going to start this again? 
   it("THE #814 SHAPE: the supervisor's pid is provably vacant → ABANDONED", () => {
     // The Desktop shell that spawned this server has exited. A Manager reboot stops
     // the process and there is nobody left to start it again.
-    const verdict = classifyDesktopSupervision(
+    const { verdict } = classifyDesktopSupervision(
       tree({ 500: { parent: 300 }, 300: { cmd: DESKTOP_SHELL } }, { vanished: [300] }),
     );
     expect(verdict).toBe("abandoned");
@@ -278,12 +279,12 @@ describe("classifyDesktopSupervision — is anything going to start this again? 
 
   it("a process reparented to init is ABANDONED", () => {
     // On POSIX the reparenting IS the record that whoever spawned it has gone.
-    const verdict = classifyDesktopSupervision(tree({ 500: { parent: 1 } }));
+    const { verdict } = classifyDesktopSupervision(tree({ 500: { parent: 1 } }));
     expect(verdict).toBe("abandoned");
   });
 
   it("a readable chain to the tree top with no supervisor on it is ABANDONED", () => {
-    const verdict = classifyDesktopSupervision(
+    const { verdict } = classifyDesktopSupervision(
       tree({
         500: { parent: 400 },
         400: { cmd: "explorer.exe", parent: 200 },
@@ -297,7 +298,7 @@ describe("classifyDesktopSupervision — is anything going to start this again? 
     // Refusing on missing evidence would take the Desktop restart away from every
     // host whose process tree cannot be read, which is the far more common and far
     // more damaging failure. Only a positive finding refuses.
-    const verdict = classifyDesktopSupervision(tree({ 500: {} }));
+    const { verdict } = classifyDesktopSupervision(tree({ 500: {} }));
     expect(verdict).toBe("unconfirmed");
   });
 
@@ -307,7 +308,7 @@ describe("classifyDesktopSupervision — is anything going to start this again? 
     // its number to ANOTHER Comfy Desktop.exe (the user restarted the app), and that
     // new shell has never heard of this backend. Causality catches it — a parent
     // cannot have started after its child.
-    const verdict = classifyDesktopSupervision(
+    const { verdict } = classifyDesktopSupervision(
       tree({
         500: { parent: 300, started: "1000" },
         300: { cmd: DESKTOP_SHELL, started: "5000" }, // started AFTER its "child"
@@ -318,7 +319,7 @@ describe("classifyDesktopSupervision — is anything going to start this again? 
 
   it("a supervisor that genuinely predates the server is still SUPERVISED", () => {
     // The control for the causality check: an ordinary tree must not be broken by it.
-    const verdict = classifyDesktopSupervision(
+    const { verdict } = classifyDesktopSupervision(
       tree({
         500: { parent: 300, started: "5000" },
         300: { cmd: DESKTOP_SHELL, started: "1000" },
@@ -331,7 +332,7 @@ describe("classifyDesktopSupervision — is anything going to start this again? 
     // Without a way to check the link, "that pid exists and looks like a shell" is
     // not evidence it is THIS server's shell. Unconfirmed still proceeds, so this
     // costs a restart nothing on a host with no readable start times.
-    const verdict = classifyDesktopSupervision(
+    const { verdict } = classifyDesktopSupervision(
       tree({ 500: { parent: 300 }, 300: { cmd: DESKTOP_SHELL } }, { noStamps: true }),
     );
     expect(verdict).toBe("unconfirmed");
@@ -341,7 +342,7 @@ describe("classifyDesktopSupervision — is anything going to start this again? 
     // Pids are recycled: something holding that number is not evidence that a
     // supervisor does. This is the other direction of the same rule — an
     // unidentifiable parent must not license the stop either.
-    const verdict = classifyDesktopSupervision(tree({ 500: { parent: 300 }, 300: {} }));
+    const { verdict } = classifyDesktopSupervision(tree({ 500: { parent: 300 }, 300: {} }));
     expect(verdict).toBe("unconfirmed");
   });
 
@@ -351,21 +352,21 @@ describe("classifyDesktopSupervision — is anything going to start this again? 
     // restart on the strength of a process we never identified. The stamp is
     // readable, so only the identity is missing — which is exactly the case that
     // must not be mistaken for evidence.
-    const verdict = classifyDesktopSupervision(
+    const { verdict } = classifyDesktopSupervision(
       tree({ 500: { started: "5000", parent: 300 }, 300: { started: "1000", parent: 1 } }),
     );
     expect(verdict).toBe("unconfirmed");
   });
 
   it("a parent whose existence cannot be established is unconfirmed", () => {
-    const verdict = classifyDesktopSupervision(
+    const { verdict } = classifyDesktopSupervision(
       tree({ 500: { parent: 300 }, 300: { cmd: DESKTOP_SHELL } }, { unknownExistence: [300] }),
     );
     expect(verdict).toBe("unconfirmed");
   });
 
   it("a self-parenting reading is damage, not a tree root", () => {
-    const verdict = classifyDesktopSupervision(tree({ 500: { parent: 500 } }));
+    const { verdict } = classifyDesktopSupervision(tree({ 500: { parent: 500 } }));
     expect(verdict).toBe("unconfirmed");
   });
 
@@ -377,7 +378,7 @@ describe("classifyDesktopSupervision — is anything going to start this again? 
     for (let pid = 500; pid < 600; pid++) {
       nodes[pid] = { parent: pid + 1, cmd: "wrapper", started: String(2000 - pid) };
     }
-    const verdict = classifyDesktopSupervision(tree(nodes));
+    const { verdict } = classifyDesktopSupervision(tree(nodes));
     expect(verdict).toBe("unconfirmed");
   });
 
@@ -801,7 +802,11 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
       if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
       if (pid === 300) {
         return {
-          commandLine: "C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe",
+          // As Windows really reports it: a path with spaces is QUOTED, and
+          // ExecutablePath is supplied alongside — which is what actually decides.
+          commandLine: '"C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe"',
+          argv: ["C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe"],
+          executablePath: "C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe",
           startedAt: "2000",
         };
       }
@@ -1018,6 +1023,140 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
     expect(fetchSpy).toHaveBeenCalled();
   });
 
+  it("a shim living INSIDE the bundle is not the bundle's shell", async () => {
+    // The accidental sibling of the two forgeries the gate already caught. Accepting
+    // any binary under `Contents/MacOS/` meant a launcher script or venv python that
+    // happens to live inside the app bundle was read as the Electron shell — and a
+    // shim re-execs nothing, so the reboot would stop a server nothing restarts. The
+    // bundle's MAIN binary is named after the bundle; a shim is not.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        return {
+          commandLine:
+            "/Applications/Comfy Desktop.app/Contents/MacOS/python launch.py --port 8188",
+          startedAt: "2000",
+          parentPid: 1,
+        };
+      }
+      return undefined;
+    });
+    __processControlTestHooks.setParentPidResolver((pid) => {
+      if (pid === 4321) return 300;
+      if (pid === 300) return 1;
+      return undefined;
+    });
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it("a shim inside the bundle is rejected on the AUTHENTICATED path too", async () => {
+    // The same rule has to hold wherever the executable comes from. Here the OS names
+    // the binary outright — and it is a python living in the bundle's MacOS dir, not
+    // the bundle's own binary. A check that accepted any path through
+    // `Contents/MacOS/` would call it the shell on the strength of authenticated
+    // evidence, which is worse than doing it on a guess.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        return {
+          commandLine: "(unreadable)",
+          executablePath: "/Applications/Comfy Desktop.app/Contents/MacOS/python",
+          startedAt: "2000",
+          parentPid: 1,
+        };
+      }
+      return undefined;
+    });
+    __processControlTestHooks.setParentPidResolver((pid) => {
+      if (pid === 4321) return 300;
+      if (pid === 300) return 1;
+      return undefined;
+    });
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/no Desktop app is still supervising it/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("the bundle's OWN binary on the authenticated path IS the shell", async () => {
+    // The control for the two rejections above: the real thing must still be
+    // recognised, or macOS Desktop users lose the restart entirely.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        return {
+          commandLine: "(unreadable)",
+          executablePath:
+            "/Applications/Comfy Desktop.app/Contents/MacOS/Comfy Desktop",
+          startedAt: "2000",
+          parentPid: 1,
+        };
+      }
+      return undefined;
+    });
+    __processControlTestHooks.setParentPidResolver((pid) => {
+      if (pid === 4321) return 300;
+      if (pid === 300) return 1;
+      return undefined;
+    });
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true, status: 200 }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it("an Electron HELPER inside the bundle is not the shell either", async () => {
+    // Helpers live at `<App>.app/Contents/Frameworks/<Helper>.app/Contents/MacOS/…`,
+    // so the bundle naming the path is not the one followed by `Contents/MacOS`. They
+    // are excluded structurally rather than by a name blocklist.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        return {
+          commandLine:
+            "/Applications/Comfy Desktop.app/Contents/Frameworks/Comfy Desktop Helper.app" +
+            "/Contents/MacOS/Comfy Desktop Helper --type=renderer",
+          startedAt: "2000",
+          parentPid: 1,
+        };
+      }
+      return undefined;
+    });
+    __processControlTestHooks.setParentPidResolver((pid) => {
+      if (pid === 4321) return 300;
+      if (pid === 300) return 1;
+      return undefined;
+    });
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("a WRAPPER that merely mentions the Desktop install is not a supervisor", async () => {
     // A Desktop BACKEND identifies itself by carrying `--extra-model-paths-config
     // …/Comfy Desktop/…`. Testing a candidate supervisor with that same rule would
@@ -1055,12 +1194,56 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
     expect(killWasIssued()).toBe(false);
   });
 
-  it("an UNREADABLE process tree still proceeds — uncertainty is not a refusal", async () => {
-    // Refusing here would break the Desktop restart on every host where the parent
-    // chain cannot be read. Only the proven-abandoned shape refuses.
+  it("an UNREADABLE process tree REFUSES the reboot, and names what it could not establish", async () => {
+    // THE POLICY, and it is the inverse of the one that governs `listener_ownership`.
+    //
+    // There, `unconfirmed` keeps `started: true` because the launch has ALREADY
+    // HAPPENED and only its description is uncertain — denying it would turn an
+    // uncertain description into a false one, so uncertainty is DISCLOSED.
+    //
+    // A reboot has NOT happened yet and cannot be undone. "I could not establish that
+    // anything will restart this" is uncertainty about whether the user still has a
+    // ComfyUI afterwards, so it is REFUSED. Refuse before, disclose after.
+    //
+    // The chain here is exactly the dangerous shape: a Desktop parent that HAS
+    // departed, on a host where the probe cannot say so. Proceeding would stop an
+    // orphaned backend that nothing relaunches — #814 recurring through a gap in the
+    // evidence rather than through a gap in the check.
     desktopServer();
     __processControlTestHooks.setProcessIdentityResolver((pid) =>
-      pid === 4321 ? { startedAt: "stable-stamp" } : undefined,
+      pid === 4321 ? { startedAt: "5000", parentPid: 300 } : undefined,
+    );
+    __processControlTestHooks.setParentPidResolver((pid) => (pid === 4321 ? 300 : undefined));
+    // The parent is gone, but this host cannot establish that either way.
+    __processControlTestHooks.setProcessExistsProbe(() => undefined);
+    const fetchSpy = vi.fn(async () => ({ ok: true, status: 200 }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/refusing to restart/i);
+    // The refusal SAYS what it failed to establish — a bare "unconfirmed" would leave
+    // the user with nothing to act on.
+    expect(result.message).toMatch(
+      /could not be established whether PID 300 .* is still running/i,
+    );
+    expect(result.message).toMatch(/still running \(not stopped\)|left running/i);
+    // CRITICAL: nothing was dispatched and nothing was killed.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it("#400 is not disturbed: the refusal leaves the server RUNNING, it never kills it", async () => {
+    // The claim this policy had to be separated from. #400 established that a Desktop
+    // process must never be KILLED locally, because respawning the exe does not
+    // reliably bring the listener back. Refusing an unverified Manager stop does not
+    // touch that: the server stays up and the user is pointed at the app that
+    // restarts it reliably.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) =>
+      pid === 4321 ? { startedAt: "5000" } : undefined,
     );
     __processControlTestHooks.setParentPidResolver(() => undefined);
     const fetchSpy = vi.fn(async () => ({ ok: true, status: 200 }) as Response);
@@ -1068,8 +1251,10 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
 
     const result = await restartComfyUI();
 
-    expect(result.message).not.toMatch(/refusing to restart/i);
-    expect(fetchSpy).toHaveBeenCalled();
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(result.message).toMatch(/Restart it from the ComfyUI Desktop app/i);
+    expect(killWasIssued()).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("a wedged DESKTOP instance is recognised from the OS command line and never killed", async () => {
@@ -1099,5 +1284,53 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
     // than the kill+relaunch path.
     expect(result.message).toMatch(/no Desktop app is still supervising it/i);
     expect(killWasIssued()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The out-of-band preflight — the door beside the gate
+// ---------------------------------------------------------------------------
+
+describe("preflightLocalRestart — an instance we cannot identify is not a pass", () => {
+  it("REFUSES when the local ComfyUI cannot be resolved at all", async () => {
+    // The widened gate had a door beside it: a local instance whose listener cannot
+    // be attributed — a container with no `lsof`, a permission wall, no `/proc` —
+    // resolves to NOTHING here, and `!info` returned ok:true. The preflight
+    // "assessed" it, passed, and the Manager reboot went out without anyone having
+    // checked whether a supervisor was still there: the container/permission form of
+    // the same #814 loss.
+    //
+    // Modelled as probes that cannot RUN (which is "I could not look") and a server
+    // that does not answer.
+    mockGetSystemStats.mockRejectedValue(new Error("fetch failed"));
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/netstat|lsof|tasklist|pgrep|powershell/i.test(String(cmd))) {
+        throw new Error("command not found");
+      }
+      return "";
+    });
+
+    const result = await preflightLocalRestart();
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/could not be identified/i);
+    // It says what it could not establish rather than asserting something is wrong.
+    expect(result.reason).toMatch(/could not be established that stopping it/i);
+  });
+
+  it("still PASSES a non-Desktop instance whose relaunch is validated", async () => {
+    // The control: the refusal must be about missing evidence, not a blanket denial.
+    // A reachable install with a resolvable launch command proceeds exactly as before.
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [ABS_MAIN, "--port", "8188"] },
+    });
+    mockLivePortThenFree();
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "stable-stamp",
+    }));
+
+    const result = await preflightLocalRestart();
+
+    expect(result.ok).toBe(true);
   });
 });

--- a/src/__tests__/services/restart-relaunch-lifecycle.test.ts
+++ b/src/__tests__/services/restart-relaunch-lifecycle.test.ts
@@ -1,0 +1,1103 @@
+// NEVER STOP WHAT YOU CANNOT RESTART (#814, #767).
+//
+// Three reports, one rule. In each of them the tool took a server down and then
+// discovered it could not bring it back:
+//
+//   #814 — panel_restart_comfyui asked ComfyUI-Manager to reboot a Comfy
+//          Desktop-spawned server whose Electron supervisor had already moved on.
+//          The reboot stopped the process; nothing restarted it. The result then
+//          said it "can't confirm it came back" — a verdict computed AFTER a stop
+//          it should never have made.
+//   #767 — a ComfyUI wedged by a CUDA OOM stopped answering /system_stats, so the
+//          launch arguments came back empty. `stop_comfyui` killed it anyway and
+//          reported `has_restart_info: true`; `start_comfyui` then answered "No
+//          command-line info captured from previous run". The OS had the whole
+//          command line the entire time.
+//
+// So: relaunch capability is established BEFORE the stop, refusal is loud, and the
+// claim that a restart is possible means a command was actually built and
+// validated. Where a relaunch genuinely cannot be proven but the launch command WAS
+// observed, the stop still happens (stop_comfyui is an explicit instruction, and a
+// wedged server is exactly when someone means it) — but it says so, and hands over
+// the command to run by hand.
+//
+// Boundaries only are mocked: config, the env services, the python resolver,
+// child_process, node:fs, the ComfyUI client, and global fetch.
+
+import { EventEmitter } from "node:events";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  classifyDesktopSupervision,
+  compareStartTimes,
+  unclassifiedSupervision,
+} from "../../services/listener-ownership.js";
+import { tokenizeCommandLine } from "../../services/live-interpreter.js";
+
+/** `lsof -V` STATING that nothing is listening (see restart-live-first.test.ts). */
+function noListener(): Error {
+  const err = new Error("no listener") as Error & {
+    status?: number;
+    stdout?: string;
+    stderr?: string;
+  };
+  err.status = 1;
+  err.stdout =
+    "lsof: Internet address not located: TCP:8188\nlsof: TCP state not located: LISTEN\n";
+  err.stderr = "";
+  return err;
+}
+
+class FakeChild extends EventEmitter {
+  unref = vi.fn();
+  pid: number | undefined = 4321;
+}
+
+const mockConfig = vi.hoisted(() => ({
+  resolvedPort: 8188,
+  comfyuiPath: undefined as string | undefined,
+}));
+
+const mockExecSync = vi.hoisted(() => vi.fn());
+const mockSpawn = vi.hoisted(() => vi.fn());
+const mockGetSystemStats = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn((_p: string) => true));
+const mockIsFile = vi.hoisted(() => vi.fn((_p: string) => true));
+const mockFindComfyuiPython = vi.hoisted(() => vi.fn());
+const mockResolveBase = vi.hoisted(() => vi.fn<[], string | undefined>());
+const mockLiveRootFromArgv = vi.hoisted(() =>
+  vi.fn<[string[], string?], string | undefined>(),
+);
+
+vi.mock("../../config.js", () => ({
+  config: mockConfig,
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyUIAuthHeaders: () => ({}),
+  isRemoteMode: () => false,
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: mockExecSync,
+  spawn: mockSpawn,
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: mockExistsSync,
+  readlinkSync: vi.fn(() => {
+    throw new Error("no /proc in test");
+  }),
+  readFileSync: vi.fn(() => {
+    throw Object.assign(new Error("no /proc in test"), { code: "ENOENT" });
+  }),
+  // #795 walks /proc/<pid>/fd to attribute a socket; absent here so the port probe
+  // answers from the lsof fixtures below.
+  readdirSync: vi.fn(() => {
+    throw Object.assign(new Error("no /proc in test"), { code: "ENOENT" });
+  }),
+  statSync: vi.fn((p: string) => {
+    if (!mockExistsSync(String(p))) throw new Error("ENOENT");
+    return { isFile: () => mockIsFile(String(p)) };
+  }),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getSystemStats: mockGetSystemStats,
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../services/env-capabilities.js", () => ({
+  findComfyuiPython: mockFindComfyuiPython,
+}));
+
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveEffectiveComfyUIBase: mockResolveBase,
+  liveRootFromArgv: mockLiveRootFromArgv,
+  markLocalComfyUILaunched: vi.fn(),
+  resetLocalComfyUILaunchState: vi.fn(),
+}));
+
+import {
+  __processControlTestHooks,
+  restartComfyUI,
+  startComfyUI,
+  stopComfyUI,
+} from "../../services/process-control.js";
+
+const BASE = resolve("ComfyUI_wedged", "ComfyUI");
+const ABS_MAIN = join(BASE, "main.py");
+const ABS_PYTHON = join(BASE, ".venv", "Scripts", "python.exe");
+
+const ORIGINAL_ENV = { ...process.env };
+
+/** A live pid on the port until a kill is issued, then a free port. */
+function mockLivePortThenFree(pid = 4321): { killed: () => boolean } {
+  let killed = false;
+  mockExecSync.mockImplementation((cmd: string) => {
+    if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+      killed = true;
+      return "";
+    }
+    if (/netstat/i.test(cmd)) {
+      return killed ? "" : `  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       ${pid}`;
+    }
+    if (/lsof/i.test(cmd)) {
+      if (killed) throw noListener();
+      return `p${pid}\nn127.0.0.1:8188\n`;
+    }
+    return "";
+  });
+  return { killed: () => killed };
+}
+
+/** Was a kill actually issued to the OS? */
+function killWasIssued(): boolean {
+  return mockExecSync.mock.calls.some((c) => /taskkill|pkill|\bkill\b/i.test(String(c[0])));
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  process.env = { ...ORIGINAL_ENV };
+  process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+  process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "1";
+  process.env.COMFYUI_PORT_FREE_TIMEOUT_S = "1";
+  mockConfig.resolvedPort = 8188;
+  mockConfig.comfyuiPath = undefined;
+  mockFindComfyuiPython.mockReturnValue(ABS_PYTHON);
+  mockLiveRootFromArgv.mockReturnValue(undefined);
+  mockResolveBase.mockReturnValue(BASE);
+  mockExistsSync.mockImplementation((p: string) => {
+    const s = String(p);
+    return s === ABS_MAIN || s === ABS_PYTHON;
+  });
+  mockIsFile.mockImplementation((_p: string) => true);
+  __processControlTestHooks.reset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  process.env = { ...ORIGINAL_ENV };
+  __processControlTestHooks.reset();
+});
+
+// ---------------------------------------------------------------------------
+// The classifier
+// ---------------------------------------------------------------------------
+
+describe("classifyDesktopSupervision — is anything going to start this again? (#814)", () => {
+  const DESKTOP_SHELL = "C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe";
+  const isSupervisorProcess = (identity: { commandLine?: string }): boolean =>
+    (identity.commandLine ?? "").toLowerCase().includes("comfy desktop");
+
+  /**
+   * A process tree: pid → { parent, cmd, started }.
+   *
+   * `started` is a Linux-style clock-tick stamp, and it is load-bearing rather than
+   * decoration: a parent pid outlives the process that earned it, so the link is
+   * only real when the parent started no later than the child. Nodes default to a
+   * stamp that satisfies that, and the recycled-pid tests break it deliberately.
+   */
+  function tree(
+    nodes: Record<number, { parent?: number; cmd?: string; started?: string }>,
+    opts: { vanished?: number[]; unknownExistence?: number[]; noStamps?: boolean } = {},
+  ): Parameters<typeof classifyDesktopSupervision>[0] {
+    return {
+      pid: 500,
+      readParentPid: (pid) => nodes[pid]?.parent,
+      readIdentity: (pid) => {
+        const node = nodes[pid];
+        if (!node) return undefined;
+        // A parent's default stamp is OLDER than its child's, which is what a real
+        // tree looks like: deeper pids were started later.
+        const started = opts.noStamps ? undefined : (node.started ?? String(pid));
+        if (!node.cmd && started === undefined) return undefined;
+        return { commandLine: node.cmd, startedAt: started };
+      },
+      processExists: (pid) => {
+        if (opts.vanished?.includes(pid)) return false;
+        if (opts.unknownExistence?.includes(pid)) return undefined;
+        return true;
+      },
+      isSupervisorProcess,
+    };
+  }
+
+  it("a live Desktop shell directly above the server is SUPERVISED", () => {
+    const verdict = classifyDesktopSupervision(
+      tree({ 500: { parent: 300 }, 300: { cmd: DESKTOP_SHELL, parent: 100 } }),
+    );
+    expect(verdict).toBe("supervised");
+  });
+
+  it("the DESKTOP SHELL ITSELF is a supervisor — it is not walked past", () => {
+    // When ComfyUI is unreachable and its port cannot be attributed, the caller falls
+    // back to the Desktop shell's own pid; that fallback exists so a hung install can
+    // still be rebooted. Walking up from the shell finds Explorer/launchd and then the
+    // tree root, so an ordinary live Desktop would come back `abandoned` and the one
+    // recovery path left to that user would be refused — precisely when they already
+    // have no working ComfyUI.
+    const verdict = classifyDesktopSupervision(
+      tree({
+        500: { cmd: DESKTOP_SHELL, started: "1000", parent: 400 },
+        400: { cmd: "explorer.exe", started: "10", parent: 1 },
+      }),
+    );
+    expect(verdict).toBe("supervised");
+  });
+
+  it("an intermediate wrapper is walked THROUGH, not treated as an answer", () => {
+    // A launcher shim between the shell and python is ordinary. Stopping at the
+    // first non-supervisor would report every wrapped Desktop install abandoned and
+    // deny those users a restart that works.
+    const verdict = classifyDesktopSupervision(
+      tree({
+        500: { parent: 400 },
+        400: { cmd: "cmd.exe /c launch.bat", parent: 300 },
+        300: { cmd: DESKTOP_SHELL, parent: 100 },
+      }),
+    );
+    expect(verdict).toBe("supervised");
+  });
+
+  it("THE #814 SHAPE: the supervisor's pid is provably vacant → ABANDONED", () => {
+    // The Desktop shell that spawned this server has exited. A Manager reboot stops
+    // the process and there is nobody left to start it again.
+    const verdict = classifyDesktopSupervision(
+      tree({ 500: { parent: 300 }, 300: { cmd: DESKTOP_SHELL } }, { vanished: [300] }),
+    );
+    expect(verdict).toBe("abandoned");
+  });
+
+  it("a process reparented to init is ABANDONED", () => {
+    // On POSIX the reparenting IS the record that whoever spawned it has gone.
+    const verdict = classifyDesktopSupervision(tree({ 500: { parent: 1 } }));
+    expect(verdict).toBe("abandoned");
+  });
+
+  it("a readable chain to the tree top with no supervisor on it is ABANDONED", () => {
+    const verdict = classifyDesktopSupervision(
+      tree({
+        500: { parent: 400 },
+        400: { cmd: "explorer.exe", parent: 200 },
+        200: { cmd: "services.exe", parent: 1 },
+      }),
+    );
+    expect(verdict).toBe("abandoned");
+  });
+
+  it("an UNREADABLE parent pid is unconfirmed — never abandoned", () => {
+    // Refusing on missing evidence would take the Desktop restart away from every
+    // host whose process tree cannot be read, which is the far more common and far
+    // more damaging failure. Only a positive finding refuses.
+    const verdict = classifyDesktopSupervision(tree({ 500: {} }));
+    expect(verdict).toBe("unconfirmed");
+  });
+
+  it("A RECYCLED parent pid that looks exactly like a supervisor is ABANDONED, not supervised", () => {
+    // The nastiest variant of #814, and the one a pid-plus-command-line check waves
+    // straight through: the shell that spawned this backend exited, Windows handed
+    // its number to ANOTHER Comfy Desktop.exe (the user restarted the app), and that
+    // new shell has never heard of this backend. Causality catches it — a parent
+    // cannot have started after its child.
+    const verdict = classifyDesktopSupervision(
+      tree({
+        500: { parent: 300, started: "1000" },
+        300: { cmd: DESKTOP_SHELL, started: "5000" }, // started AFTER its "child"
+      }),
+    );
+    expect(verdict).toBe("abandoned");
+  });
+
+  it("a supervisor that genuinely predates the server is still SUPERVISED", () => {
+    // The control for the causality check: an ordinary tree must not be broken by it.
+    const verdict = classifyDesktopSupervision(
+      tree({
+        500: { parent: 300, started: "5000" },
+        300: { cmd: DESKTOP_SHELL, started: "1000" },
+      }),
+    );
+    expect(verdict).toBe("supervised");
+  });
+
+  it("stamps that cannot be compared leave the link UNVERIFIED, never supervised", () => {
+    // Without a way to check the link, "that pid exists and looks like a shell" is
+    // not evidence it is THIS server's shell. Unconfirmed still proceeds, so this
+    // costs a restart nothing on a host with no readable start times.
+    const verdict = classifyDesktopSupervision(
+      tree({ 500: { parent: 300 }, 300: { cmd: DESKTOP_SHELL } }, { noStamps: true }),
+    );
+    expect(verdict).toBe("unconfirmed");
+  });
+
+  it("a parent that exists but cannot be IDENTIFIED is unconfirmed, not supervised", () => {
+    // Pids are recycled: something holding that number is not evidence that a
+    // supervisor does. This is the other direction of the same rule — an
+    // unidentifiable parent must not license the stop either.
+    const verdict = classifyDesktopSupervision(tree({ 500: { parent: 300 }, 300: {} }));
+    expect(verdict).toBe("unconfirmed");
+  });
+
+  it("an unidentifiable ancestor STOPS the walk — it is not stepped over", () => {
+    // A process we cannot see the nature of might BE the shell. Walking past it to
+    // the tree top would turn "I could not tell" into `abandoned`, refusing a
+    // restart on the strength of a process we never identified. The stamp is
+    // readable, so only the identity is missing — which is exactly the case that
+    // must not be mistaken for evidence.
+    const verdict = classifyDesktopSupervision(
+      tree({ 500: { started: "5000", parent: 300 }, 300: { started: "1000", parent: 1 } }),
+    );
+    expect(verdict).toBe("unconfirmed");
+  });
+
+  it("a parent whose existence cannot be established is unconfirmed", () => {
+    const verdict = classifyDesktopSupervision(
+      tree({ 500: { parent: 300 }, 300: { cmd: DESKTOP_SHELL } }, { unknownExistence: [300] }),
+    );
+    expect(verdict).toBe("unconfirmed");
+  });
+
+  it("a self-parenting reading is damage, not a tree root", () => {
+    const verdict = classifyDesktopSupervision(tree({ 500: { parent: 500 } }));
+    expect(verdict).toBe("unconfirmed");
+  });
+
+  it("running out of hops is 'did not finish looking', never a verdict", () => {
+    // A chain longer than the budget is not a layout we can reason about.
+    const nodes: Record<number, { parent?: number; cmd?: string; started?: string }> = {};
+    // Each link is causally sound (every parent predates its child), so the walk is
+    // stopped by the BUDGET and nothing else.
+    for (let pid = 500; pid < 600; pid++) {
+      nodes[pid] = { parent: pid + 1, cmd: "wrapper", started: String(2000 - pid) };
+    }
+    const verdict = classifyDesktopSupervision(tree(nodes));
+    expect(verdict).toBe("unconfirmed");
+  });
+
+  it("a caller that did not classify may only say unconfirmed", () => {
+    expect(unclassifiedSupervision()).toBe("unconfirmed");
+  });
+});
+
+describe("compareStartTimes — a parent cannot start after its child", () => {
+  it("compares a Windows FILETIME exactly, beyond Number's safe range", () => {
+    // 18-digit FILETIMEs exceed Number.MAX_SAFE_INTEGER (9007199254740991), so a
+    // float comparison silently equates stamps 100ns — or much more — apart. Two
+    // real, adjacent FILETIMEs that differ only in their last digits:
+    const older = "133700000000000001";
+    const newer = "133700000000000002";
+    expect(Number(older) === Number(newer)).toBe(true); // the trap, demonstrated
+    expect(compareStartTimes(older, newer)).toBe("parent-first");
+    expect(compareStartTimes(newer, older)).toBe("parent-newer");
+  });
+
+  it("treats an equal stamp as sound — coarse clocks put a spawn in the same second", () => {
+    expect(compareStartTimes("1000", "1000")).toBe("parent-first");
+  });
+
+  it("compares macOS ctime-style stamps by date", () => {
+    expect(compareStartTimes("Fri Aug  1 12:00:00 2026", "Fri Aug  1 12:00:05 2026")).toBe(
+      "parent-first",
+    );
+    expect(compareStartTimes("Fri Aug  1 12:00:05 2026", "Fri Aug  1 12:00:00 2026")).toBe(
+      "parent-newer",
+    );
+  });
+
+  it("an unreadable or unparseable stamp is UNKNOWN, never 'fine'", () => {
+    expect(compareStartTimes(undefined, "1000")).toBe("unknown");
+    expect(compareStartTimes("1000", undefined)).toBe("unknown");
+    expect(compareStartTimes("stable-stamp", "also-not-a-time")).toBe("unknown");
+  });
+});
+
+describe("tokenizeCommandLine — the OS's flattened command line back into argv", () => {
+  it("groups a quoted path with spaces", () => {
+    expect(
+      tokenizeCommandLine('"C:\\Program Files\\ComfyUI\\python.exe" main.py --port 8188'),
+    ).toEqual(["C:\\Program Files\\ComfyUI\\python.exe", "main.py", "--port", "8188"]);
+  });
+
+  it("follows the Windows backslash rule so a trailing separator cannot swallow the rest", () => {
+    // `"a\\"` is a quoted argument ending in ONE backslash — the doubled backslashes
+    // are literal and the quote CLOSES. A naive parser reads that quote as an opener
+    // instead, fusing every later argument into one string: the relaunch then spawns
+    // with mangled arguments while the existence checks upstream still pass, because
+    // they only validate the executable and the script.
+    // The command line is literally:  python "C:\Comfy\\" --port 8188
+    expect(tokenizeCommandLine('python "C:\\Comfy\\\\" --port 8188')).toEqual([
+      "python",
+      "C:\\Comfy\\",
+      "--port",
+      "8188",
+    ]);
+    // And the ODD count is the other half of the same rule: one backslash before a
+    // quote escapes it, so the quote stays open and the argument runs on. Pinning
+    // both directions is what keeps a "fix" from simply inverting the bug.
+    expect(tokenizeCommandLine('python "C:\\Comfy\\" --port 8188')).toEqual([
+      "python",
+      'C:\\Comfy" --port 8188',
+    ]);
+  });
+
+  it("an escaped quote is a literal character, not a delimiter", () => {
+    expect(tokenizeCommandLine('python --title \\"hi\\" --port 8188')).toEqual([
+      "python",
+      "--title",
+      '"hi"',
+      "--port",
+      "8188",
+    ]);
+  });
+
+  it("leaves a POSIX path's backslashes alone", () => {
+    // Backslash is a legal filename character on POSIX, and nothing here quotes.
+    expect(tokenizeCommandLine("python /srv/comfy\\ui/main.py")).toEqual([
+      "python",
+      "/srv/comfy\\ui/main.py",
+    ]);
+  });
+
+  it("keeps an empty quoted argument", () => {
+    expect(tokenizeCommandLine('python --flag "" --port 8188')).toEqual([
+      "python",
+      "--flag",
+      "",
+      "--port",
+      "8188",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #767 — the stop and the start must agree
+// ---------------------------------------------------------------------------
+
+describe("stop_comfyui — has_restart_info means a relaunch was BUILT (#767)", () => {
+  /**
+   * The #767 shape: a wedged server. `/system_stats` does not answer, so the launch
+   * arguments come back EMPTY — every relaunch decision downstream used to have
+   * nothing to work with.
+   */
+  function wedgedServer(): void {
+    mockGetSystemStats.mockRejectedValue(new Error("fetch failed"));
+  }
+
+  /**
+   * A wedged server that is REPLACED once it has been identified.
+   *
+   * The swap has to happen at a definite point in the gather, and the last
+   * `/system_stats` attempt is one: the pid's identity is captured before it, and the
+   * pre-kill re-check happens after. Keying on that rather than on "the Nth call to
+   * the identity reader" keeps the test about the substitution instead of about how
+   * many times any one reader happens to be consulted.
+   */
+  function swapAfterSecondStatsAttempt(): () => boolean {
+    let attempts = 0;
+    let swapped = false;
+    mockGetSystemStats.mockImplementation(async () => {
+      attempts++;
+      if (attempts >= 2) swapped = true;
+      throw new Error("fetch failed");
+    });
+    return () => swapped;
+  }
+
+  it("rebuilds the relaunch from the OS command line when the server cannot answer", async () => {
+    // The user's own recovery in #767 was to read the command line out of the
+    // process table by hand. It was readable the whole time.
+    wedgedServer();
+    mockLivePortThenFree();
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "stable-stamp",
+      commandLine: `${ABS_PYTHON} ${ABS_MAIN} --cache-none`,
+      argv: [ABS_PYTHON, ABS_MAIN, "--cache-none"],
+      // Linux/Windows: the argument vector can be reconstructed faithfully, so it is
+      // a command and not merely a reading.
+      argvFidelity: "exact" as const,
+    }));
+    const children: FakeChild[] = [];
+    mockSpawn.mockImplementation(() => {
+      const child = new FakeChild();
+      children.push(child);
+      return child;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const stopped = await stopComfyUI();
+    expect(stopped.stopped).toBe(true);
+    // THE CLAIM #767 WAS ABOUT — and it is now backed by a built command.
+    expect(stopped.has_restart_info).toBe(true);
+
+    const started = await startComfyUI();
+    expect(started.started).toBe(true);
+    // The OS argv[0] is the INTERPRETER (unlike sys.argv, whose first element is
+    // the script), so it is spawned verbatim — no interpreter has to be guessed.
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [exe, args] = mockSpawn.mock.calls[0];
+    expect(exe).toBe(ABS_PYTHON);
+    expect(args).toEqual([ABS_MAIN, "--cache-none"]);
+
+    killSpy.mockRestore();
+  });
+
+  it("will not SPAWN a command line the OS could only report FLATTENED", async () => {
+    // macOS `ps -o command=` joins argv with spaces, so `--output-directory
+    // /Users/a/Comfy Outputs` cannot be told from two arguments. Relaunching from
+    // that reading would spawn a command the user never ran — very possibly one
+    // ComfyUI's own argument parser rejects, AFTER the server had been stopped
+    // (codex gate round 6). The reading is still shown to the user, who can see where
+    // the quotes belong; we cannot.
+    wedgedServer();
+    mockLivePortThenFree();
+    const OUT = "/Users/a/Comfy Outputs";
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "stable-stamp",
+      commandLine: `${ABS_PYTHON} ${ABS_MAIN} --output-directory ${OUT}`,
+      // What a naive split yields — and precisely why it must not be spawned.
+      argv: [ABS_PYTHON, ABS_MAIN, "--output-directory", "/Users/a/Comfy", "Outputs"],
+      argvFidelity: "flattened" as const,
+    }));
+    mockSpawn.mockImplementation(() => new FakeChild());
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const stopped = await stopComfyUI();
+
+    // The stop still happens — it was asked for — but the tool does not claim it can
+    // undo it, and the hint says the arguments are approximate.
+    expect(stopped.stopped).toBe(true);
+    expect(stopped.has_restart_info).toBe(false);
+    expect(stopped.restart_hint?.command).toBe(
+      `${ABS_PYTHON} ${ABS_MAIN} --output-directory ${OUT}`,
+    );
+    expect(stopped.restart_hint?.command_flattened).toBe(true);
+    expect(stopped.message).toMatch(/needs re-quoting/i);
+
+    // And the start does NOT spawn the mangled argv.
+    const started = await startComfyUI();
+    expect(started.started).toBe(false);
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("REFUSES the stop when nothing at all was observed about how to start it", async () => {
+    // Neither the server nor the OS could say what this process is running, so a
+    // stop is a one-way door: not by this tool, and not by hand either. That is the
+    // one case where an explicit "stop" is declined.
+    wedgedServer();
+    mockLivePortThenFree();
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "stable-stamp",
+    }));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const stopped = await stopComfyUI();
+
+    expect(stopped.stopped).toBe(false);
+    expect(stopped.has_restart_info).toBe(false);
+    expect(stopped.message).toMatch(/refusing to stop/i);
+    expect(stopped.message).toMatch(/no way to bring it back/i);
+    // CRITICAL: the server is untouched.
+    expect(killWasIssued()).toBe(false);
+
+    killSpy.mockRestore();
+  });
+
+  it("stops but says PLAINLY that start_comfyui cannot bring it back, and how to do it by hand", async () => {
+    // FAIL-BEFORE: this reported `has_restart_info: true` and a bare success, and
+    // the start that followed failed. The stop is still performed — it was asked
+    // for, and a wedged server is exactly when someone means it — but the report
+    // does not pretend the tool can undo it.
+    wedgedServer();
+    mockLivePortThenFree();
+    // The command line names an install that is NOT on disk, so no relaunch can be
+    // validated — but it is still what a human needs to see.
+    const GONE_PY = join(resolve("gone"), "main.py");
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "stable-stamp",
+      commandLine: `python ${GONE_PY} --port 8188`,
+      argv: ["python", GONE_PY, "--port", "8188"],
+    }));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const stopped = await stopComfyUI();
+
+    expect(stopped.stopped).toBe(true);
+    expect(stopped.has_restart_info).toBe(false);
+    expect(stopped.message).toMatch(/start_comfyui will NOT be able to bring this back/i);
+    expect(stopped.relaunch_blocked).toBeTruthy();
+    // The recovery command is handed over, not left in the process table.
+    expect(stopped.restart_hint?.command).toContain(GONE_PY);
+    expect(stopped.message).toMatch(/To start it by hand, run:/i);
+
+    killSpy.mockRestore();
+  });
+
+  it("refuses to kill a REPLACEMENT that inherited the wedged server's PID", async () => {
+    // Round-5 codex gate. Recovering a wedged server means acting on a pid that no
+    // server answered for, so the usual corroboration (the OS's command line against
+    // the server's own argv) has nothing to work with. That must not collapse into
+    // bare pid/port equality: A is observed, A exits, B rebinds the port after
+    // inheriting A's number, and the stop would kill B using A's relaunch data.
+    //
+    // The pid's creation stamp is read on this path too, and it is exactly what pid
+    // reuse defeats — so it is retained, and re-checked before the kill.
+    mockLivePortThenFree();
+    // The substitution lands AFTER the instance has been identified. The identity is
+    // captured before the last /system_stats attempt of the gather, so counting that
+    // attempt is a stable way to say "now the pid means somebody else" without
+    // depending on how many times any single reader happens to be called.
+    const swapped = swapAfterSecondStatsAttempt();
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      // Byte-identical command line — a replacement ComfyUI looks just like the one
+      // that went away, so the command line alone cannot separate them.
+      commandLine: `${ABS_PYTHON} ${ABS_MAIN} --cache-none`,
+      argv: [ABS_PYTHON, ABS_MAIN, "--cache-none"],
+      // …but it is a different process, and the OS says so.
+      startedAt: swapped() ? "second-boot" : "first-boot",
+    }));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const stopped = await stopComfyUI();
+
+    expect(stopped.stopped).toBe(false);
+    expect(stopped.message).toMatch(/refusing to stop/i);
+    expect(stopped.message).toMatch(/creation time/i);
+    // CRITICAL: the replacement is untouched.
+    expect(killWasIssued()).toBe(false);
+
+    killSpy.mockRestore();
+  });
+
+  it("refuses when the pid is now running something else entirely", async () => {
+    // The other half of the same protection: the number was reused by a program with
+    // a DIFFERENT command line. Comparing the OS's later reading against its earlier
+    // one is not self-corroboration — the two are separated in time, which is what a
+    // substitution has to survive.
+    mockLivePortThenFree();
+    const swapped = swapAfterSecondStatsAttempt();
+    __processControlTestHooks.setProcessIdentityResolver(() =>
+      swapped()
+        ? {
+            commandLine: "C:\\Windows\\System32\\notepad.exe",
+            argv: ["C:\\Windows\\System32\\notepad.exe"],
+            startedAt: "stable-stamp",
+          }
+        : {
+            commandLine: `${ABS_PYTHON} ${ABS_MAIN} --cache-none`,
+            argv: [ABS_PYTHON, ABS_MAIN, "--cache-none"],
+            startedAt: "stable-stamp",
+          },
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const stopped = await stopComfyUI();
+
+    expect(stopped.stopped).toBe(false);
+    expect(stopped.message).toMatch(/refusing to stop/i);
+    expect(stopped.message).toMatch(/running something other than/i);
+    expect(killWasIssued()).toBe(false);
+
+    killSpy.mockRestore();
+  });
+
+  it("a healthy install still reports has_restart_info true", async () => {
+    // The control: the claim must not become uniformly pessimistic. A server whose
+    // relaunch really is buildable still says so.
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [ABS_MAIN, "--port", "8188"] },
+    });
+    mockLivePortThenFree();
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "stable-stamp",
+    }));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const stopped = await stopComfyUI();
+
+    expect(stopped.stopped).toBe(true);
+    expect(stopped.has_restart_info).toBe(true);
+    expect(stopped.message).not.toMatch(/will NOT be able/i);
+
+    killSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #814 — a Desktop instance is never stopped on an assumption about its supervisor
+// ---------------------------------------------------------------------------
+
+describe("restart_comfyui — a Desktop reboot needs a supervisor that is actually there (#814)", () => {
+  /**
+   * A ComfyUI **Desktop** instance as it really appears: `sys.argv` carries the
+   * Desktop-flavoured `--extra-model-paths-config`, which is what identifies it
+   * (captured from the #814 report's own recovery command line).
+   */
+  const DESKTOP_ARGV = [
+    "ComfyUI\\main.py",
+    "--enable-manager",
+    "--extra-model-paths-config",
+    "C:\\Users\\u\\AppData\\Roaming\\Comfy Desktop\\shared_model_paths.yaml",
+    "--port",
+    "8188",
+  ];
+
+  function desktopServer(): void {
+    mockGetSystemStats.mockResolvedValue({ system: { argv: DESKTOP_ARGV } });
+    mockLivePortThenFree();
+  }
+
+  it("REFUSES before any reboot when the Desktop supervisor has gone", async () => {
+    // #814 exactly: two backends off one install, the shell that spawned the bound
+    // one had moved on, and the reboot stopped a server nothing would restart.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) =>
+      pid === 4321
+        ? { startedAt: "stable-stamp", parentPid: 300, argv: DESKTOP_ARGV }
+        : undefined,
+    );
+    __processControlTestHooks.setParentPidResolver((pid) =>
+      pid === 4321 ? 300 : undefined,
+    );
+    // The shell's pid is vacant — it exited.
+    __processControlTestHooks.setProcessExistsProbe((pid) => (pid === 300 ? false : true));
+    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(result.message).toMatch(/no Desktop app is still supervising it/i);
+    expect(result.message).toMatch(/left running/i);
+    // CRITICAL: no reboot was fired and nothing was killed. The refusal happened
+    // BEFORE the stop, which is the entire point.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+    // And the user is told how to bring it back if they need to.
+    expect(result.restart_hint?.server_argv).toEqual(DESKTOP_ARGV);
+  });
+
+  it("proceeds to the Manager reboot when a live Desktop shell IS supervising it", async () => {
+    // The control for the refusal: an ordinary Desktop restart must keep working
+    // (#400 routes it here precisely because killing it does not). The shell
+    // genuinely predates the backend, so the parent link is verified rather than
+    // merely unreadable — this proves the SUPERVISED path, not the unconfirmed one.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        return {
+          commandLine: "C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe",
+          startedAt: "2000",
+        };
+      }
+      return undefined;
+    });
+    __processControlTestHooks.setParentPidResolver((pid) => (pid === 4321 ? 300 : undefined));
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true, status: 200 }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    // The Manager reboot route was actually taken.
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it("a wrapper that PASSES THE DESKTOP EXE AS AN ARGUMENT is not a supervisor", async () => {
+    // Round-2 codex gate. Testing the whole command line for the Desktop binary is
+    // not enough: a wrapper can carry that exact path as an argument, pass the
+    // start-time causality check, and be read as the shell — after which the reboot
+    // stops a server the wrapper will never restart. The supervisor must BE the
+    // Desktop binary (argv[0]), not merely name it.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        // Both spellings of the same trick in one command line: the Windows exe AND
+        // a macOS bundle binary, each carried as an ARGUMENT. Neither may stand in
+        // for the shell, and the positional macOS fallback must not be reachable
+        // from a path that does not open the line.
+        const commandLine =
+          'python.exe wrapper.py --desktop-exe "C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe"' +
+          ' --mac-app "/Applications/Comfy Desktop.app/Contents/MacOS/Comfy Desktop"';
+        return {
+          commandLine,
+          // argv[0] is the WRAPPER's own executable — the Desktop paths are arguments.
+          argv: [
+            "python.exe",
+            "wrapper.py",
+            "--desktop-exe",
+            "C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe",
+            "--mac-app",
+            "/Applications/Comfy Desktop.app/Contents/MacOS/Comfy Desktop",
+          ],
+          startedAt: "2000",
+          parentPid: 1,
+        };
+      }
+      return undefined;
+    });
+    __processControlTestHooks.setParentPidResolver((pid) => {
+      if (pid === 4321) return 300;
+      if (pid === 300) return 1;
+      return undefined;
+    });
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/no Desktop app is still supervising it/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it("a process CLAIMING to be the Desktop shell in argv[0] is not one", async () => {
+    // Round-3 codex gate. argv[0] is a string the launcher chose — `exec -a`, or a
+    // hand-built Windows command line, lets any program present itself as any other.
+    // A wrapper that spawned the backend and predates it would otherwise pass the
+    // causality check, be read as the shell, and get the reboot dispatched; it
+    // restarts nothing, so the server stays down. The OS's own record of the binary
+    // is what the process cannot set, and it settles this.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        return {
+          // Everything the process says about itself is a Desktop shell…
+          commandLine: '"C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe"',
+          argv: ["C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe"],
+          // …and the kernel says it is python.
+          executablePath: "C:\\tools\\python.exe",
+          startedAt: "2000",
+          parentPid: 1,
+        };
+      }
+      return undefined;
+    });
+    __processControlTestHooks.setParentPidResolver((pid) => {
+      if (pid === 4321) return 300;
+      if (pid === 300) return 1;
+      return undefined;
+    });
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/no Desktop app is still supervising it/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it("the authenticated executable path is enough on its own, with NO command line at all", async () => {
+    // The other direction of the same rule, and the absent-field path specifically:
+    // a process whose command line cannot be read but whose EXECUTABLE the OS names
+    // is still identified. Gating the walk on the command line alone would stop
+    // here and never consult the authenticated evidence that exists to settle
+    // exactly this — in this direction it would deny a working Desktop restart, and
+    // in the other it would let a wrapper through (codex gate round 4).
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        return {
+          // No commandLine and no argv — the OS gave us only the binary.
+          executablePath: "C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe",
+          startedAt: "2000",
+          parentPid: 1,
+        };
+      }
+      return undefined;
+    });
+    __processControlTestHooks.setParentPidResolver((pid) => {
+      if (pid === 4321) return 300;
+      if (pid === 300) return 1;
+      return undefined;
+    });
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true, status: 200 }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it("a NON-Desktop binary with no command line is not waved through as unconfirmed", async () => {
+    // The negative half of the absent-field path. Stopping the walk at "no command
+    // line" would report `unconfirmed` — which PROCEEDS — for a wrapper the OS has
+    // already told us is python, and the reboot would then stop a server nothing
+    // restarts. With the executable known, the walk carries on past it and reaches
+    // the top of the tree, which is the honest answer.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        return {
+          executablePath: "C:\\tools\\python.exe",
+          startedAt: "2000",
+          parentPid: 1,
+        };
+      }
+      return undefined;
+    });
+    __processControlTestHooks.setParentPidResolver((pid) => {
+      if (pid === 4321) return 300;
+      if (pid === 300) return 1;
+      return undefined;
+    });
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/no Desktop app is still supervising it/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it("recognises a macOS app-bundle shell whose path contains a space", async () => {
+    // `ps -o command=` joins argv with spaces, so "Comfy Desktop.app" cannot be
+    // tokenised back out — and if the shell went unrecognised the walk would carry on
+    // past it to launchd and report a working install ABANDONED, refusing a restart
+    // that works. It is recognised by POSITION instead: argv[0] opens the line, and
+    // the directory prefix before the app name has no spaces.
+    desktopServer();
+    const BUNDLE =
+      "/Applications/Comfy Desktop.app/Contents/MacOS/Comfy Desktop --no-sandbox";
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        return {
+          commandLine: BUNDLE,
+          // Truncated at the first space, exactly as the tokeniser must leave it.
+          argv: ["/Applications/Comfy"],
+          startedAt: "2000",
+          parentPid: 1,
+        };
+      }
+      return undefined;
+    });
+    // The shell's own parent is launchd, so a failure to recognise the shell does
+    // NOT land in a harmless "unconfirmed": the walk reaches the top of the tree and
+    // reports a perfectly healthy install ABANDONED. That is what makes this test
+    // about the recognition rather than about the walk stopping early.
+    __processControlTestHooks.setParentPidResolver((pid) => {
+      if (pid === 4321) return 300;
+      if (pid === 300) return 1;
+      return undefined;
+    });
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true, status: 200 }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it("a WRAPPER that merely mentions the Desktop install is not a supervisor", async () => {
+    // A Desktop BACKEND identifies itself by carrying `--extra-model-paths-config
+    // …/Comfy Desktop/…`. Testing a candidate supervisor with that same rule would
+    // let any wrapper passing that flag stand in for the Electron shell — and a
+    // wrapper cannot re-exec anything, so the reboot would still lose the server
+    // (codex gate). The supervisor test requires the Desktop BINARY.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        return {
+          // Mentions the Desktop install, but is python — not the Electron shell.
+          commandLine:
+            "python.exe wrapper.py --extra-model-paths-config " +
+            "C:\\Users\\u\\AppData\\Roaming\\Comfy Desktop\\shared_model_paths.yaml",
+          startedAt: "2000",
+          parentPid: 1,
+        };
+      }
+      return undefined;
+    });
+    __processControlTestHooks.setParentPidResolver((pid) => {
+      if (pid === 4321) return 300;
+      if (pid === 300) return 1; // the wrapper's own parent is gone
+      return undefined;
+    });
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/no Desktop app is still supervising it/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(killWasIssued()).toBe(false);
+  });
+
+  it("an UNREADABLE process tree still proceeds — uncertainty is not a refusal", async () => {
+    // Refusing here would break the Desktop restart on every host where the parent
+    // chain cannot be read. Only the proven-abandoned shape refuses.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) =>
+      pid === 4321 ? { startedAt: "stable-stamp" } : undefined,
+    );
+    __processControlTestHooks.setParentPidResolver(() => undefined);
+    const fetchSpy = vi.fn(async () => ({ ok: true, status: 200 }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it("a wedged DESKTOP instance is recognised from the OS command line and never killed", async () => {
+    // With no answer from the server, `isDesktopApp` used to see an empty argv and
+    // classify a Desktop instance as an ordinary Python install — which routes to
+    // KILL + relaunch, the one thing #400 exists to prevent. The OS knows what it is.
+    mockGetSystemStats.mockRejectedValue(new Error("fetch failed"));
+    mockLivePortThenFree();
+    __processControlTestHooks.setProcessIdentityResolver((pid) =>
+      pid === 4321
+        ? {
+            startedAt: "stable-stamp",
+            commandLine: DESKTOP_ARGV.join(" "),
+            argv: DESKTOP_ARGV,
+            parentPid: 300,
+          }
+        : undefined,
+    );
+    __processControlTestHooks.setParentPidResolver((pid) => (pid === 4321 ? 300 : undefined));
+    __processControlTestHooks.setProcessExistsProbe((pid) => (pid === 300 ? false : true));
+    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    // It took the Desktop path (and refused there, since the shell is gone) rather
+    // than the kill+relaunch path.
+    expect(result.message).toMatch(/no Desktop app is still supervising it/i);
+    expect(killWasIssued()).toBe(false);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6550,9 +6550,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               // A claim about what I DID, not about a server I have just said I cannot
               // identify: "it is still running" would be exactly the unvalidated
               // assertion the stale-target rule forbids (r8).
-              "again. Nothing was dispatched, so nothing was stopped. Restart it from " +
-              "whatever launches it (its own launcher, the Desktop app, or your terminal), or " +
-              "use restart_comfyui, which acts on the instance this server is configured for.",
+              "again. Nothing was dispatched, so nothing was stopped. USE restart_comfyui " +
+              // The alternative is NAMED and the difference EXPLAINED (coordinator
+              // ruling): this tool restarts whatever the calling TAB fronts, which is
+              // exactly the thing that could not be identified here. restart_comfyui is
+              // not tab-scoped — it acts on the ComfyUI this server is configured for,
+              // which it can identify and assess — so it remains available. A user who
+              // loses one entry point must be told the other one works, and why.
+              "INSTEAD: unlike this panel-scoped restart, it is not tied to a browser tab " +
+              "— it acts on the ComfyUI this server is configured for, which it CAN " +
+              "identify and check before stopping. Or restart ComfyUI from whatever " +
+              "launches it (its own launcher, the Desktop app, or your terminal).",
           });
         }
         if (preflightBound) {
@@ -6679,9 +6687,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               "was being prepared, and I can no longer confirm which ComfyUI this tab " +
               "fronts — a restart STOPS a server, so it is never sent to one I cannot " +
               // Again: what I did, not what an unidentified instance is doing.
-              "identify. Nothing was dispatched, so nothing was stopped. Retry once " +
-              "the panel has settled, or use restart_comfyui, which acts on the instance " +
-              "this server is configured for.",
+              "identify. Nothing was dispatched, so nothing was stopped. Retry once the " +
+              "panel has settled, or USE restart_comfyui INSTEAD: unlike this panel-scoped " +
+              "restart, it is not tied to a browser tab — it acts on the ComfyUI this " +
+              "server is configured for, which it CAN identify and check before stopping.",
           });
         }
         const timing = getPanelRebootTiming();

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6511,27 +6511,24 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // Desktop backend in some other tab (codex gate round 11). A pass for one
         // instance is not permission to stop another.
         //
-        // So the assessment is consulted for ANY local target, and what it may be
-        // SPENT ON depends on the binding — asymmetrically, because the two outcomes
-        // are not equally transferable between instances:
+        // So: BOUND, assess the instance the reboot will reach and decide on it.
+        // UNBOUND and local, REFUSE — the assessment describes the orchestrator's
+        // CONFIGURED target, which is not shown to be what the reboot reaches, and a
+        // finding about one instance may not be spent on another IN EITHER DIRECTION.
         //
-        //   BOUND   — it describes the very instance the reboot will reach. Both
-        //             outcomes count, exactly as before.
-        //   UNBOUND — it describes the orchestrator's CONFIGURED local target, which
-        //             may not be what the reboot reaches. A PASS therefore authorizes
-        //             nothing: proving one instance safe is not permission to stop
-        //             another, and the dispatch proceeds on the footing it always had
-        //             (honestly reported as unconfirmable), not on this evidence. A
-        //             FAIL is still acted on: the local target is the likeliest thing
-        //             a local panel tab fronts, and a refusal costs a restart while
-        //             dispatching into a proven-unrelaunchable install costs the
-        //             server. The note says which part could not be confirmed.
+        // An asymmetric version was tried (a pass authorizes nothing, a fail still
+        // refuses) and is incoherent: if the configured target is a good enough proxy
+        // to refuse on, it is good enough to proceed on, and if it is not, the refusal
+        // is as unfounded as the permission. Keeping only the refusal would also break
+        // a working tab-fronted instance whenever the unrelated configured one is
+        // stale — while still leaving the dispatch unproven.
         //
-        // A blanket refusal for every unbound local target was tried and is NOT what
-        // this does: `captureRebootHealthBase` also returns null for ordinary setups
-        // (an ambiguous `localhost` origin, a basePath mount, an older panel), and
-        // those are deliberately served by the honest dispatched-but-unconfirmable
-        // result. Removing that wholesale is a product decision, not a bug fix.
+        // The cost is real and is the point: `captureRebootHealthBase` also returns
+        // null for ordinary local setups (an ambiguous `localhost` origin, a basePath
+        // mount, an older panel), and those lose the panel restart until the binding
+        // can be proven. They keep restart_comfyui, and the note says so. Weighed
+        // against #814 — where exactly such a user's server was stopped and never came
+        // back — declining is the recoverable side.
         const preflightHealthBase = captureRebootHealthBase(ctx);
         const preflightBound =
           preflightHealthBase != null &&
@@ -6540,7 +6537,22 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // local process to assess, and the Manager reboot is their ONLY restart path —
         // a supervised remote (the tunnelled Desktop app) restarts through it by
         // design, so refusing there would remove a path that works.
-        if (preflightBound || (!isRemoteMode() && !isCloudMode())) {
+        if (!preflightBound && !isRemoteMode() && !isCloudMode()) {
+          return ok({
+            rebooting: false,
+            ready: false,
+            confirmed_cycle: false,
+            refused: true,
+            note:
+              "Refusing to restart ComfyUI: I could not confirm that this panel's ComfyUI is " +
+              "the local instance I can account for, so I cannot tell which server the restart " +
+              "would stop — and it STOPS it, relying on whatever supervises it to start it " +
+              "again. Nothing was dispatched and ComfyUI is still running. Restart it from " +
+              "whatever launches it (its own launcher, the Desktop app, or your terminal), or " +
+              "use restart_comfyui, which acts on the instance this server is configured for.",
+          });
+        }
+        if (preflightBound) {
           // Snapshot the target GENERATION at the decision (r11): a final-state
           // base comparison (A vs A) cannot detect an intervening A→B→A
           // retarget, so stability is judged by the monotonic epoch bumped on
@@ -6563,13 +6575,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             sameHttpBase(preflightHealthBase, postPreflightHealthBase);
           const configStable =
             getComfyuiTargetGeneration() === preflightTargetGeneration;
-          // r10 is a BOUND-PATH guard, and only that: it exists so a PASS cannot
-          // vouch for the tab-fronted instance after the target moved mid-check. On
-          // the unbound path a pass is never spent as permission in the first place
-          // (see the block comment above), so there is nothing here for it to
-          // protect — saying so keeps the condition from carrying generality it does
-          // not have.
-          if (!configStable && preflightBound && tabFrontsSameInstance) {
+          if (!configStable && tabFrontsSameInstance) {
             // r10: the target config moved MID-CHECK, so the preflight result
             // — pass OR fail — cannot vouch for the tab-fronted instance (a
             // PASS may have validated a different, safe install; it must never
@@ -6589,11 +6595,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 "panel_restart_comfyui.",
             });
           }
-          // A FAILURE applies on both paths, scoped by what it can speak for: bound,
-          // as long as the tab still fronts the instance it assessed (r9);
-          // unbound, as the likeliest description of what a local tab fronts —
-          // where declining costs a restart and proceeding could cost the server.
-          if (!preflight.ok && (preflightBound ? tabFrontsSameInstance : true)) {
+          // r9: the danger proof follows the INSTANCE the tab fronts, not the mutable
+          // runtime config — a config-only retarget mid-await must not wash out the
+          // proof that the tab-fronted boot instance is unrelaunchable.
+          if (!preflight.ok && tabFrontsSameInstance) {
             // r9: the danger proof follows the INSTANCE the tab fronts, NOT the
             // mutable runtime config — a config-only retarget mid-await must
             // not wash out the proof that the tab-fronted boot instance is
@@ -6616,14 +6621,6 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 // supervisor has gone (#814) — and telling a Desktop user to check
                 // Pinokio would send them somewhere they have never been.
                 `Refusing to restart ComfyUI: ${preflight.reason}` +
-                // Said plainly when the tab could not be tied to the instance this
-                // describes: the refusal is still the right call (a restart costs
-                // nothing to decline, a lost server cannot be undone), but the user
-                // should know which part is inference.
-                (preflightBound
-                  ? ""
-                  : " (I could not confirm that this panel fronts that same instance, but a" +
-                    " restart is not sent to an install whose relaunch is unproven.)") +
                 " A restart from here would " +
                 "STOP ComfyUI and nothing would bring it back automatically, so it was " +
                 "refused BEFORE anything was stopped — ComfyUI is still running. Restart it " +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6493,8 +6493,27 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // (Electron-supervised, #400), unverifiable, or remote — proceeds exactly as
         // before. The binding for this DECISION is captured pre-await; nothing
         // downstream may reuse it (r7).
+        //
+        // #814: THE GATE IS NOT THE SAME AS THE PROOF. `captureRebootHealthBase`
+        // answers "can I CERTIFY that this instance cycled?" — it requires a
+        // loopback boot base, a server-observed handshake Origin, a pathless mount.
+        // Gating the SAFETY CHECK on that same capture meant an instance we could
+        // not certify was also an instance we never assessed: the reboot went out
+        // with no evidence at all, the server stopped, nothing brought it back, and
+        // the result honestly reported that it could not confirm the return — a
+        // verdict computed after a stop it should not have made. Being unable to
+        // watch something come back is a reason for MORE care about stopping it, not
+        // less. So the assessment below now runs for ANY local target; only the
+        // certification stays bound to the tab.
         const preflightHealthBase = captureRebootHealthBase(ctx);
-        if (preflightHealthBase != null && sameHttpBase(getComfyUIBaseUrl(), preflightHealthBase)) {
+        const preflightBound =
+          preflightHealthBase != null &&
+          sameHttpBase(getComfyUIBaseUrl(), preflightHealthBase);
+        // Cloud/remote targets are excluded for the reason they always were: there is
+        // no local process to assess, and the Manager reboot is their ONLY restart
+        // path — a supervised remote (the tunnelled Desktop app) restarts through it
+        // by design, so refusing there would remove a path that works.
+        if (preflightBound || (!isRemoteMode() && !isCloudMode())) {
           // Snapshot the target GENERATION at the decision (r11): a final-state
           // base comparison (A vs A) cannot detect an intervening A→B→A
           // retarget, so stability is judged by the monotonic epoch bumped on
@@ -6517,7 +6536,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             sameHttpBase(preflightHealthBase, postPreflightHealthBase);
           const configStable =
             getComfyuiTargetGeneration() === preflightTargetGeneration;
-          if (!configStable && tabFrontsSameInstance) {
+          // WHOM DOES THE ASSESSMENT SPEAK FOR?
+          //   • bound (r9): the instance the TAB fronts, so it holds exactly as long
+          //     as the tab still fronts that same instance — unchanged behaviour.
+          //   • unbound (#814): there was no tab binding to follow, so the assessment
+          //     speaks for the orchestrator's own local target, which is what the
+          //     reboot will reach. It applies unconditionally; whether the config
+          //     moved mid-await is handled immediately below, where an assessment
+          //     that can no longer vouch for anything refuses rather than proceeds.
+          const assessmentApplies = preflightBound ? tabFrontsSameInstance : true;
+          if (!configStable && assessmentApplies) {
             // r10: the target config moved MID-CHECK, so the preflight result
             // — pass OR fail — cannot vouch for the tab-fronted instance (a
             // PASS may have validated a different, safe install; it must never
@@ -6531,13 +6559,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               note:
                 "Refusing to restart ComfyUI: the ComfyUI target configuration changed " +
                 "while the restart safety check was running, so the check cannot vouch " +
-                "for a safe relaunch of the instance this panel fronts. A stop is never " +
+                `for a safe relaunch of the instance this restart would cycle${
+                  preflightBound ? " (the one this panel fronts)" : ""
+                }. A stop is never ` +
                 "sent to an instance whose relaunch is unproven — ComfyUI was NOT " +
                 "stopped (it is still running). Let the target settle, then retry " +
                 "panel_restart_comfyui.",
             });
           }
-          if (!preflight.ok && tabFrontsSameInstance) {
+          if (!preflight.ok && assessmentApplies) {
             // r9: the danger proof follows the INSTANCE the tab fronts, NOT the
             // mutable runtime config — a config-only retarget mid-await must
             // not wash out the proof that the tab-fronted boot instance is
@@ -6554,11 +6584,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               confirmed_cycle: false,
               refused: true,
               note:
-                `Refusing to restart ComfyUI: ${preflight.reason} This looks like an ` +
-                "externally-managed install (e.g. Pinokio): a restart from here would STOP " +
-                "ComfyUI and nothing would bring it back automatically, so it was refused " +
-                "BEFORE anything was stopped — ComfyUI is still running. Restart it from the " +
-                "launcher that owns it (e.g. Pinokio's own controls), or point COMFYUI_PATH " +
+                // The REASON leads, because there is now more than one shape that
+                // reaches here — an externally-managed install whose launch command
+                // cannot be rebuilt (Pinokio, #742) and a Desktop instance whose
+                // supervisor has gone (#814) — and telling a Desktop user to check
+                // Pinokio would send them somewhere they have never been.
+                `Refusing to restart ComfyUI: ${preflight.reason} A restart from here would ` +
+                "STOP ComfyUI and nothing would bring it back automatically, so it was " +
+                "refused BEFORE anything was stopped — ComfyUI is still running. Restart it " +
+                "from whatever launches it (its own launcher — e.g. Pinokio's own controls — " +
+                "the Desktop app, or your terminal); for an externally-managed install you " +
+                "can also point COMFYUI_PATH " +
                 "at the live install so a relaunch can be proven and use restart_comfyui.",
             });
           }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6547,7 +6547,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               "Refusing to restart ComfyUI: I could not confirm that this panel's ComfyUI is " +
               "the local instance I can account for, so I cannot tell which server the restart " +
               "would stop — and it STOPS it, relying on whatever supervises it to start it " +
-              "again. Nothing was dispatched and ComfyUI is still running. Restart it from " +
+              // A claim about what I DID, not about a server I have just said I cannot
+              // identify: "it is still running" would be exactly the unvalidated
+              // assertion the stale-target rule forbids (r8).
+              "again. Nothing was dispatched, so nothing was stopped. Restart it from " +
               "whatever launches it (its own launcher, the Desktop app, or your terminal), or " +
               "use restart_comfyui, which acts on the instance this server is configured for.",
           });
@@ -6651,6 +6654,36 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // routing id while the original is still reconnecting.
         const preRestartPanelIdentity = ctx.panelConnectionIdentity?.();
         const healthBase = captureRebootHealthBase(ctx);
+        // THE BINDING RULE APPLIES AT THE DISPATCH POINT, NOT ONLY BEFORE THE AWAIT.
+        //
+        // The check above happens before the preflight; a tab or connection rebind
+        // DURING that await lands here with a target that is no longer bound, and
+        // `tabFrontsSameInstance` being false meant neither post-await refusal fired
+        // — so both a passing and a failing preflight fell through and the fresh,
+        // unidentified tab received the reboot (codex gate round 12). The pre-await
+        // check is kept because it avoids assessing an instance we already know we
+        // may not act on; this one is what actually holds the line.
+        //
+        // Same rule, same exclusions: only a LOCAL target we cannot tie to the
+        // instance this server accounts for is refused.
+        const dispatchBound =
+          healthBase != null && sameHttpBase(getComfyUIBaseUrl(), healthBase);
+        if (!dispatchBound && !isRemoteMode() && !isCloudMode()) {
+          return ok({
+            rebooting: false,
+            ready: false,
+            confirmed_cycle: false,
+            refused: true,
+            note:
+              "Refusing to restart ComfyUI: the panel connection changed while the restart " +
+              "was being prepared, and I can no longer confirm which ComfyUI this tab " +
+              "fronts — a restart STOPS a server, so it is never sent to one I cannot " +
+              // Again: what I did, not what an unidentified instance is doing.
+              "identify. Nothing was dispatched, so nothing was stopped. Retry once " +
+              "the panel has settled, or use restart_comfyui, which acts on the instance " +
+              "this server is configured for.",
+          });
+        }
         const timing = getPanelRebootTiming();
         const dispatchTimeout = Math.max(1, Math.min(15000, overallDeadline - Date.now()));
         // CONCURRENT OBSERVATION (coordinator): start probing the fixed boot endpoint NOW,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6494,25 +6494,52 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // before. The binding for this DECISION is captured pre-await; nothing
         // downstream may reuse it (r7).
         //
-        // #814: THE GATE IS NOT THE SAME AS THE PROOF. `captureRebootHealthBase`
-        // answers "can I CERTIFY that this instance cycled?" — it requires a
-        // loopback boot base, a server-observed handshake Origin, a pathless mount.
-        // Gating the SAFETY CHECK on that same capture meant an instance we could
-        // not certify was also an instance we never assessed: the reboot went out
-        // with no evidence at all, the server stopped, nothing brought it back, and
-        // the result honestly reported that it could not confirm the return — a
-        // verdict computed after a stop it should not have made. Being unable to
-        // watch something come back is a reason for MORE care about stopping it, not
-        // less. So the assessment below now runs for ANY local target; only the
-        // certification stays bound to the tab.
+        // #814: AN UNIDENTIFIED LOCAL TARGET IS NOT SENT AN IRREVERSIBLE STOP.
+        //
+        // `captureRebootHealthBase` answers "is the instance this tab fronts provably
+        // our own local boot ComfyUI?" — loopback base, server-observed handshake
+        // Origin, pathless mount. When it cannot say yes, we do not know WHICH
+        // ComfyUI the reboot will reach: the command goes to the bound TAB, not to
+        // the orchestrator's configured target.
+        //
+        // The original code dispatched anyway and reported honestly that it could not
+        // confirm the return — a verdict computed after a stop it should not have
+        // made, and the #814 lost server. A first attempt at this ran the local
+        // preflight in that case and let a PASS proceed, which was worse in a subtle
+        // way: the assessment describes the CONFIGURED instance while the reboot hits
+        // the TAB's, so a safe local install could authorize stopping an orphaned
+        // Desktop backend in some other tab (codex gate round 11). A pass for one
+        // instance is not permission to stop another.
+        //
+        // So the assessment is consulted for ANY local target, and what it may be
+        // SPENT ON depends on the binding — asymmetrically, because the two outcomes
+        // are not equally transferable between instances:
+        //
+        //   BOUND   — it describes the very instance the reboot will reach. Both
+        //             outcomes count, exactly as before.
+        //   UNBOUND — it describes the orchestrator's CONFIGURED local target, which
+        //             may not be what the reboot reaches. A PASS therefore authorizes
+        //             nothing: proving one instance safe is not permission to stop
+        //             another, and the dispatch proceeds on the footing it always had
+        //             (honestly reported as unconfirmable), not on this evidence. A
+        //             FAIL is still acted on: the local target is the likeliest thing
+        //             a local panel tab fronts, and a refusal costs a restart while
+        //             dispatching into a proven-unrelaunchable install costs the
+        //             server. The note says which part could not be confirmed.
+        //
+        // A blanket refusal for every unbound local target was tried and is NOT what
+        // this does: `captureRebootHealthBase` also returns null for ordinary setups
+        // (an ambiguous `localhost` origin, a basePath mount, an older panel), and
+        // those are deliberately served by the honest dispatched-but-unconfirmable
+        // result. Removing that wholesale is a product decision, not a bug fix.
         const preflightHealthBase = captureRebootHealthBase(ctx);
         const preflightBound =
           preflightHealthBase != null &&
           sameHttpBase(getComfyUIBaseUrl(), preflightHealthBase);
-        // Cloud/remote targets are excluded for the reason they always were: there is
-        // no local process to assess, and the Manager reboot is their ONLY restart
-        // path — a supervised remote (the tunnelled Desktop app) restarts through it
-        // by design, so refusing there would remove a path that works.
+        // Remote and cloud are excluded for the reason they always were: there is no
+        // local process to assess, and the Manager reboot is their ONLY restart path —
+        // a supervised remote (the tunnelled Desktop app) restarts through it by
+        // design, so refusing there would remove a path that works.
         if (preflightBound || (!isRemoteMode() && !isCloudMode())) {
           // Snapshot the target GENERATION at the decision (r11): a final-state
           // base comparison (A vs A) cannot detect an intervening A→B→A
@@ -6536,16 +6563,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             sameHttpBase(preflightHealthBase, postPreflightHealthBase);
           const configStable =
             getComfyuiTargetGeneration() === preflightTargetGeneration;
-          // WHOM DOES THE ASSESSMENT SPEAK FOR?
-          //   • bound (r9): the instance the TAB fronts, so it holds exactly as long
-          //     as the tab still fronts that same instance — unchanged behaviour.
-          //   • unbound (#814): there was no tab binding to follow, so the assessment
-          //     speaks for the orchestrator's own local target, which is what the
-          //     reboot will reach. It applies unconditionally; whether the config
-          //     moved mid-await is handled immediately below, where an assessment
-          //     that can no longer vouch for anything refuses rather than proceeds.
-          const assessmentApplies = preflightBound ? tabFrontsSameInstance : true;
-          if (!configStable && assessmentApplies) {
+          // r10 is a BOUND-PATH guard, and only that: it exists so a PASS cannot
+          // vouch for the tab-fronted instance after the target moved mid-check. On
+          // the unbound path a pass is never spent as permission in the first place
+          // (see the block comment above), so there is nothing here for it to
+          // protect — saying so keeps the condition from carrying generality it does
+          // not have.
+          if (!configStable && preflightBound && tabFrontsSameInstance) {
             // r10: the target config moved MID-CHECK, so the preflight result
             // — pass OR fail — cannot vouch for the tab-fronted instance (a
             // PASS may have validated a different, safe install; it must never
@@ -6559,15 +6583,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               note:
                 "Refusing to restart ComfyUI: the ComfyUI target configuration changed " +
                 "while the restart safety check was running, so the check cannot vouch " +
-                `for a safe relaunch of the instance this restart would cycle${
-                  preflightBound ? " (the one this panel fronts)" : ""
-                }. A stop is never ` +
+                "for a safe relaunch of the instance this panel fronts. A stop is never " +
                 "sent to an instance whose relaunch is unproven — ComfyUI was NOT " +
                 "stopped (it is still running). Let the target settle, then retry " +
                 "panel_restart_comfyui.",
             });
           }
-          if (!preflight.ok && assessmentApplies) {
+          // A FAILURE applies on both paths, scoped by what it can speak for: bound,
+          // as long as the tab still fronts the instance it assessed (r9);
+          // unbound, as the likeliest description of what a local tab fronts —
+          // where declining costs a restart and proceeding could cost the server.
+          if (!preflight.ok && (preflightBound ? tabFrontsSameInstance : true)) {
             // r9: the danger proof follows the INSTANCE the tab fronts, NOT the
             // mutable runtime config — a config-only retarget mid-await must
             // not wash out the proof that the tab-fronted boot instance is
@@ -6589,7 +6615,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 // cannot be rebuilt (Pinokio, #742) and a Desktop instance whose
                 // supervisor has gone (#814) — and telling a Desktop user to check
                 // Pinokio would send them somewhere they have never been.
-                `Refusing to restart ComfyUI: ${preflight.reason} A restart from here would ` +
+                `Refusing to restart ComfyUI: ${preflight.reason}` +
+                // Said plainly when the tab could not be tied to the instance this
+                // describes: the refusal is still the right call (a restart costs
+                // nothing to decline, a lost server cannot be undone), but the user
+                // should know which part is inference.
+                (preflightBound
+                  ? ""
+                  : " (I could not confirm that this panel fronts that same instance, but a" +
+                    " restart is not sent to an install whose relaunch is unproven.)") +
+                " A restart from here would " +
                 "STOP ComfyUI and nothing would bring it back automatically, so it was " +
                 "refused BEFORE anything was stopped — ComfyUI is still running. Restart it " +
                 "from whatever launches it (its own launcher — e.g. Pinokio's own controls — " +

--- a/src/services/listener-ownership.ts
+++ b/src/services/listener-ownership.ts
@@ -38,6 +38,205 @@ export function unclassifiedOwnership(): ListenerOwnership {
 }
 
 // ---------------------------------------------------------------------------
+// Will a supervisor bring this process back? (#814)
+// ---------------------------------------------------------------------------
+
+declare const SUPERVISION_CLASSIFIED: unique symbol;
+
+/**
+ * Whether stopping this process is SURVIVABLE — i.e. whether something else will
+ * start it again.
+ *
+ * The question exists because a ComfyUI **Desktop** instance is never killed and
+ * relaunched by us (#400): the Electron shell owns the process, so the restart path
+ * asks ComfyUI-Manager to re-exec it and relies on that shell to be there. #814 is
+ * what happens when it is NOT — the reboot stopped a Desktop-spawned server whose
+ * shell had already moved on, nothing brought it back, and the user was left with no
+ * ComfyUI at all. The stop was dispatched on an ASSUMPTION about a supervisor nobody
+ * had looked for.
+ *
+ * Branded for exactly the reason `ListenerOwnership` is: a definite verdict may only
+ * come from the code that gathered the evidence. Here BOTH definite verdicts are
+ * costly in opposite directions — `supervised` licenses a stop, `abandoned` denies a
+ * user a restart that would have worked — so neither is reachable from a literal.
+ */
+export type SupervisorRelaunch = ("supervised" | "abandoned" | "unconfirmed") & {
+  readonly [SUPERVISION_CLASSIFIED]: true;
+};
+
+function classifiedSupervision(
+  verdict: "supervised" | "abandoned" | "unconfirmed",
+): SupervisorRelaunch {
+  return verdict as SupervisorRelaunch;
+}
+
+/** The only verdict a caller that did NOT classify is entitled to return. */
+export function unclassifiedSupervision(): SupervisorRelaunch {
+  return "unconfirmed" as SupervisorRelaunch;
+}
+
+export interface SupervisionEvidence {
+  /** The process that would be stopped — the one holding ComfyUI's port. */
+  pid: number;
+  readParentPid: (pid: number) => number | undefined;
+  readIdentity: (pid: number) => ProcessIdentity | undefined;
+  /**
+   * Does this pid exist? TRI-STATE, from a signal-0 probe:
+   *   false     — ESRCH: nothing holds that number.
+   *   true      — it exists (or exists and is not ours to signal).
+   *   undefined — could not tell.
+   * The DEFINITE FALSE is the load-bearing one: "the supervisor's pid is gone" is
+   * the positive finding that a stop will not be undone.
+   */
+  processExists: (pid: number) => boolean | undefined;
+  /**
+   * Is this process a Desktop supervisor (the Electron shell / .app)?
+   *
+   * Takes the whole identity, not just the command line, so the decision can be made
+   * from argv[0] — the process's OWN executable. A predicate over the raw string
+   * cannot tell "this IS the Desktop shell" from "this merely mentions it", and a
+   * wrapper that passes the Desktop exe as an argument re-execs nothing.
+   */
+  isSupervisorProcess: (identity: ProcessIdentity) => boolean;
+}
+
+/**
+ * Is `parent` old enough to BE the parent of `child`?
+ *
+ * A parent pid alone does not identify a parent process. When a process's parent
+ * exits, the number it held stays written in the child's record and becomes
+ * reusable — so a LATER process can inherit it, and on Windows that later process
+ * can perfectly well be another `Comfy Desktop.exe` (the user restarted the app).
+ * Checking only "does that pid exist and look like a shell" then answers
+ * `supervised` about a shell that has never heard of this backend, which is the very
+ * lost-server this classifier exists to prevent (codex gate).
+ *
+ * Causality settles it: a parent cannot have started AFTER its child. Equality is
+ * allowed because the stamps are coarse on some platforms (macOS `lstart` has
+ * one-second resolution, and a shell spawning its backend immediately lands in the
+ * same second).
+ *
+ * The stamps are only ever compared against another reading from the SAME platform,
+ * as everywhere else in this codebase. All-digit forms (Linux clock ticks since
+ * boot; a Windows FILETIME, which exceeds Number.MAX_SAFE_INTEGER and is therefore
+ * compared as BigInt) compare numerically; otherwise a date parse is attempted.
+ * Anything that cannot be compared is `unknown` — never quietly "fine".
+ */
+type StartOrder = "parent-first" | "parent-newer" | "unknown";
+
+export function compareStartTimes(
+  parent: string | undefined,
+  child: string | undefined,
+): StartOrder {
+  if (!parent || !child) return "unknown";
+  const p = parent.trim();
+  const c = child.trim();
+  if (/^\d+$/.test(p) && /^\d+$/.test(c)) {
+    return BigInt(p) <= BigInt(c) ? "parent-first" : "parent-newer";
+  }
+  const pd = Date.parse(p);
+  const cd = Date.parse(c);
+  if (Number.isNaN(pd) || Number.isNaN(cd)) return "unknown";
+  return pd <= cd ? "parent-first" : "parent-newer";
+}
+
+/**
+ * Is a live Desktop supervisor still watching `pid`?
+ *
+ * ANCESTRY, WALKED UPWARD — which is the opposite direction from
+ * `isDescendantOfChild` above, and for a different question. That one asks "is this
+ * the child WE spawned?", where tracing to a long-lived ancestor proves nothing
+ * because every stale sibling shares it. This one asks "is anything above this
+ * process going to restart it?", and an ancestor is precisely what can: the Desktop
+ * shell spawns the Python backend, so the shell IS the supervisor. Intermediate
+ * wrappers (a launcher script, a shim) are walked THROUGH rather than treated as an
+ * answer.
+ *
+ *   `supervised` — an ancestor is alive and its command line is a Desktop shell.
+ *                  Positive: there is something there to re-exec the process.
+ *   `abandoned`  — the chain was READ to its top and no live Desktop shell stands on
+ *                  it: either the parent's number is provably vacant (the shell
+ *                  exited) or the tree root was reached with every step readable and
+ *                  none of them a supervisor. Positive too — this is the #814 shape,
+ *                  and it is what refuses a stop.
+ *   `unconfirmed`— the chain became unreadable, a pid could not be probed, or the hop
+ *                  budget ran out. NOT an answer in either direction: it neither
+ *                  licenses the stop by itself nor denies the user a restart.
+ *
+ * The hop budget is small on purpose. A Desktop backend sits one or two levels under
+ * its shell; a chain longer than that is not a layout we can reason about, and
+ * "cannot tell" is the honest verdict for it.
+ */
+export function classifyDesktopSupervision(
+  input: SupervisionEvidence,
+  maxHops = 8,
+): SupervisorRelaunch {
+  const self = input.readIdentity(input.pid);
+  // THE PROCESS MAY BE THE SUPERVISOR ITSELF. When ComfyUI is unreachable and its
+  // port cannot be attributed, the caller falls back to the Desktop shell's own pid —
+  // that fallback exists precisely so a hung install can still be rebooted. Walking
+  // UP from the shell finds Explorer/launchd and then the tree root, so an ordinary
+  // live Desktop would be reported `abandoned` and the one recovery path left to that
+  // user refused, exactly when they already have no working ComfyUI (codex gate
+  // round 7). A live shell supervises its own backend; there is nothing above it to
+  // look for.
+  if (self && input.isSupervisorProcess(self)) {
+    return classifiedSupervision("supervised");
+  }
+  let current = input.pid;
+  let currentStartedAt = self?.startedAt;
+  for (let hop = 0; hop < maxHops; hop++) {
+    const parent = input.readParentPid(current);
+    // The chain stopped being readable. Nothing was learned in either direction.
+    if (parent == null) return classifiedSupervision("unconfirmed");
+    // A process cannot be its own parent; that reading is damage, not a tree root.
+    if (parent === current) return classifiedSupervision("unconfirmed");
+    // The TOP of the tree, reached without passing a supervisor. On POSIX an
+    // orphan is reparented to init (1) — that reparenting is itself the record
+    // that whoever spawned it has gone.
+    if (parent <= 1) return classifiedSupervision("abandoned");
+    const alive = input.processExists(parent);
+    // THE #814 SIGNAL: the parent's number is vacant, so the shell that spawned this
+    // server has exited. Nothing is left to act on a reboot request.
+    if (alive === false) return classifiedSupervision("abandoned");
+    // Exists, but we could not establish that — do not spend it either way.
+    if (alive !== true) return classifiedSupervision("unconfirmed");
+    const identity = input.readIdentity(parent);
+    // Something holds that number and we cannot see WHAT it is. A pid can be
+    // RECYCLED, so "a process exists there" is not evidence a supervisor does.
+    //
+    // "What it is" now has two possible sources, and either will do: the command
+    // line, or the OS's own record of the binary. Gating on the command line alone
+    // was a leftover from when it was the only one — a process whose command line is
+    // unreadable but whose EXECUTABLE the OS names would stop the walk here, and the
+    // authenticated evidence that exists precisely to settle this question would
+    // never be consulted (codex gate round 4).
+    if (!identity || (!identity.commandLine && !identity.executablePath)) {
+      return classifiedSupervision("unconfirmed");
+    }
+    // IS THIS REALLY THE PARENT, or just whoever holds that number now? A pid
+    // recorded in a child's record outlives the process that earned it, and the
+    // replacement can look exactly like a supervisor.
+    const order = compareStartTimes(identity.startedAt, currentStartedAt);
+    // The process at that number started AFTER its supposed child, so the real
+    // parent has exited — which is what made the number reusable. That is positive
+    // evidence the supervisor is gone.
+    if (order === "parent-newer") return classifiedSupervision("abandoned");
+    // No usable stamps on one side or the other: the link is unverified, so nothing
+    // built on it may be claimed. Costs a Desktop restart nothing — `unconfirmed`
+    // proceeds.
+    if (order === "unknown") return classifiedSupervision("unconfirmed");
+    if (input.isSupervisorProcess(identity)) {
+      return classifiedSupervision("supervised");
+    }
+    current = parent;
+    currentStartedAt = identity.startedAt;
+  }
+  // Ran out of hops: did not finish looking.
+  return classifiedSupervision("unconfirmed");
+}
+
+// ---------------------------------------------------------------------------
 // Path tokens
 // ---------------------------------------------------------------------------
 

--- a/src/services/listener-ownership.ts
+++ b/src/services/listener-ownership.ts
@@ -75,6 +75,20 @@ export function unclassifiedSupervision(): SupervisorRelaunch {
   return "unconfirmed" as SupervisorRelaunch;
 }
 
+/**
+ * The verdict AND what stopped the walk from reaching a definite one.
+ *
+ * `because` exists because `unconfirmed` now REFUSES a reboot rather than allowing
+ * it, and a refusal that cannot say what it failed to establish is not actionable:
+ * "could not read the parent of PID 4321" tells a user (and a maintainer) something
+ * a bare "unconfirmed" does not. Only populated for `unconfirmed` — the two definite
+ * verdicts describe themselves.
+ */
+export interface SupervisionAssessment {
+  verdict: SupervisorRelaunch;
+  because?: string;
+}
+
 export interface SupervisionEvidence {
   /** The process that would be stopped — the one holding ComfyUI's port. */
   pid: number;
@@ -160,8 +174,11 @@ export function compareStartTimes(
  *                  none of them a supervisor. Positive too — this is the #814 shape,
  *                  and it is what refuses a stop.
  *   `unconfirmed`— the chain became unreadable, a pid could not be probed, or the hop
- *                  budget ran out. NOT an answer in either direction: it neither
- *                  licenses the stop by itself nor denies the user a restart.
+ *                  budget ran out. NOT an answer in either direction — and note that
+ *                  it is the CALLER that decides what to do with it. For a reboot,
+ *                  which is irreversible and has not happened yet, the caller refuses:
+ *                  see assessDesktopSupervision. Each such outcome carries `because`,
+ *                  so a refusal can name what it failed to establish.
  *
  * The hop budget is small on purpose. A Desktop backend sits one or two levels under
  * its shell; a chain longer than that is not a layout we can reason about, and
@@ -170,7 +187,14 @@ export function compareStartTimes(
 export function classifyDesktopSupervision(
   input: SupervisionEvidence,
   maxHops = 8,
-): SupervisorRelaunch {
+): SupervisionAssessment {
+  const unconfirmed = (because: string): SupervisionAssessment => ({
+    verdict: classifiedSupervision("unconfirmed"),
+    because,
+  });
+  const definite = (v: "supervised" | "abandoned"): SupervisionAssessment => ({
+    verdict: classifiedSupervision(v),
+  });
   const self = input.readIdentity(input.pid);
   // THE PROCESS MAY BE THE SUPERVISOR ITSELF. When ComfyUI is unreachable and its
   // port cannot be attributed, the caller falls back to the Desktop shell's own pid —
@@ -180,27 +204,25 @@ export function classifyDesktopSupervision(
   // user refused, exactly when they already have no working ComfyUI (codex gate
   // round 7). A live shell supervises its own backend; there is nothing above it to
   // look for.
-  if (self && input.isSupervisorProcess(self)) {
-    return classifiedSupervision("supervised");
-  }
+  if (self && input.isSupervisorProcess(self)) return definite("supervised");
   let current = input.pid;
   let currentStartedAt = self?.startedAt;
   for (let hop = 0; hop < maxHops; hop++) {
     const parent = input.readParentPid(current);
     // The chain stopped being readable. Nothing was learned in either direction.
-    if (parent == null) return classifiedSupervision("unconfirmed");
+    if (parent == null) return unconfirmed(`the parent process of PID ${current} could not be read`);
     // A process cannot be its own parent; that reading is damage, not a tree root.
-    if (parent === current) return classifiedSupervision("unconfirmed");
+    if (parent === current) return unconfirmed(`PID ${current} was reported as its own parent, which is not a tree this can be read from`);
     // The TOP of the tree, reached without passing a supervisor. On POSIX an
     // orphan is reparented to init (1) — that reparenting is itself the record
     // that whoever spawned it has gone.
-    if (parent <= 1) return classifiedSupervision("abandoned");
+    if (parent <= 1) return definite("abandoned");
     const alive = input.processExists(parent);
     // THE #814 SIGNAL: the parent's number is vacant, so the shell that spawned this
     // server has exited. Nothing is left to act on a reboot request.
-    if (alive === false) return classifiedSupervision("abandoned");
+    if (alive === false) return definite("abandoned");
     // Exists, but we could not establish that — do not spend it either way.
-    if (alive !== true) return classifiedSupervision("unconfirmed");
+    if (alive !== true) return unconfirmed(`it could not be established whether PID ${parent} (the parent of PID ${current}) is still running`);
     const identity = input.readIdentity(parent);
     // Something holds that number and we cannot see WHAT it is. A pid can be
     // RECYCLED, so "a process exists there" is not evidence a supervisor does.
@@ -212,7 +234,7 @@ export function classifyDesktopSupervision(
     // authenticated evidence that exists precisely to settle this question would
     // never be consulted (codex gate round 4).
     if (!identity || (!identity.commandLine && !identity.executablePath)) {
-      return classifiedSupervision("unconfirmed");
+      return unconfirmed(`PID ${parent} (the parent of PID ${current}) exists but what it is running could not be read`);
     }
     // IS THIS REALLY THE PARENT, or just whoever holds that number now? A pid
     // recorded in a child's record outlives the process that earned it, and the
@@ -221,19 +243,24 @@ export function classifyDesktopSupervision(
     // The process at that number started AFTER its supposed child, so the real
     // parent has exited — which is what made the number reusable. That is positive
     // evidence the supervisor is gone.
-    if (order === "parent-newer") return classifiedSupervision("abandoned");
+    if (order === "parent-newer") return definite("abandoned");
     // No usable stamps on one side or the other: the link is unverified, so nothing
-    // built on it may be claimed. Costs a Desktop restart nothing — `unconfirmed`
-    // proceeds.
-    if (order === "unknown") return classifiedSupervision("unconfirmed");
-    if (input.isSupervisorProcess(identity)) {
-      return classifiedSupervision("supervised");
+    // built on it may be claimed.
+    if (order === "unknown") {
+      return unconfirmed(
+        `PID ${parent} could not be confirmed as the parent of PID ${current} — the process ` +
+          `start times needed to rule out a reused PID could not be compared`,
+      );
     }
+    if (input.isSupervisorProcess(identity)) return definite("supervised");
     current = parent;
     currentStartedAt = identity.startedAt;
   }
   // Ran out of hops: did not finish looking.
-  return classifiedSupervision("unconfirmed");
+  return unconfirmed(
+    `no Desktop supervisor was found within ${maxHops} levels above PID ${input.pid}, and the ` +
+      `walk ran out before reaching the top of the process tree`,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/listener-ownership.ts
+++ b/src/services/listener-ownership.ts
@@ -195,16 +195,19 @@ export function classifyDesktopSupervision(
   const definite = (v: "supervised" | "abandoned"): SupervisionAssessment => ({
     verdict: classifiedSupervision(v),
   });
+  // NO SELF-SUPERVISOR SHORTCUT. An earlier revision returned `supervised` when the
+  // pid handed in was ITSELF a Desktop shell, to serve the caller's fallback of
+  // "ComfyUI could not be attributed to the port, so use whatever Desktop shell is
+  // running". But that fallback picks a shell by scanning process NAMES — it is bound
+  // to no port and to no backend, so "this pid is a Desktop shell" says nothing about
+  // whether it supervises the server the reboot would stop. A second, unrelated
+  // Desktop window would have licensed stopping an orphaned backend it has never
+  // heard of, which is the same lost server by a new route (codex gate round 9).
+  //
+  // The premise, not the shortcut, was the problem: that caller now declines before
+  // reaching here, so every pid this classifier sees is one resolved FROM THE PORT —
+  // a backend, whose supervisor is genuinely somewhere above it.
   const self = input.readIdentity(input.pid);
-  // THE PROCESS MAY BE THE SUPERVISOR ITSELF. When ComfyUI is unreachable and its
-  // port cannot be attributed, the caller falls back to the Desktop shell's own pid —
-  // that fallback exists precisely so a hung install can still be rebooted. Walking
-  // UP from the shell finds Explorer/launchd and then the tree root, so an ordinary
-  // live Desktop would be reported `abandoned` and the one recovery path left to that
-  // user refused, exactly when they already have no working ComfyUI (codex gate
-  // round 7). A live shell supervises its own backend; there is nothing above it to
-  // look for.
-  if (self && input.isSupervisorProcess(self)) return definite("supervised");
   let current = input.pid;
   let currentStartedAt = self?.startedAt;
   for (let hop = 0; hop < maxHops; hop++) {

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -26,7 +26,7 @@
 // should be added here as tier 0 — it works for remote servers too.
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readlinkSync } from "node:fs";
 import { isAbsolute } from "node:path";
 import { platform } from "node:os";
 import { findPidByPort } from "./port-owner.js";
@@ -104,10 +104,134 @@ export function argv0FromCommandLine(cmdline: string): string | undefined {
   return m ? m[0] : undefined;
 }
 
+/**
+ * Split a command line the OS reports as ONE STRING back into argv.
+ *
+ * Needed because Windows (WMI `CommandLine`) and macOS (`ps -o command=`) hand back
+ * a flattened string, and a relaunch needs the pieces. Only double quotes group —
+ * that is the rule on Windows, and on macOS `ps` reproduces the argv joined by
+ * spaces, where a quote is at worst part of a filename.
+ *
+ * On WINDOWS the round-trip is faithful: this implements CommandLineToArgvW, the very
+ * rule the child's own runtime applies to that same string, so an argument containing
+ * a space was necessarily quoted (or the process itself would have seen two).
+ *
+ * On macOS it is LOSSY BY NATURE — `ps` prints argv joined by spaces and the quoting
+ * is gone, so `--output-directory /a/My Outputs` cannot be told from two arguments.
+ * That is why the caller records `argvFidelity`, and why a "flattened" argv may be
+ * READ but never SPAWNED (codex gate round 6).
+ *
+ * The result is likewise never used to CORROBORATE an identity against the command
+ * line it came from — a string tokenised from itself would trivially agree with
+ * itself, which is not evidence of anything. Linux does not use this at all:
+ * `/proc/<pid>/cmdline` is already NUL-separated argv.
+ */
+export function tokenizeCommandLine(commandLine: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quoted = false;
+  let started = false;
+  let backslashes = 0;
+
+  /** Flush pending backslashes as literal characters. */
+  const flushBackslashes = (count: number): void => {
+    current += "\\".repeat(count);
+    if (count > 0) started = true;
+  };
+
+  for (const ch of commandLine) {
+    if (ch === "\\") {
+      backslashes++;
+      continue;
+    }
+    if (ch === '"') {
+      // The documented Windows rule (CommandLineToArgvW): 2n backslashes before a
+      // quote emit n backslashes and the quote GROUPS; 2n+1 emit n backslashes and
+      // the quote is LITERAL. Without this, `--flag "a\\" --next` loses the closing
+      // quote and everything after it fuses into one argument — a relaunch command
+      // that spawns with mangled arguments while every existence check upstream
+      // still passes, because those only validate the executable and the script.
+      flushBackslashes(Math.floor(backslashes / 2));
+      const literalQuote = backslashes % 2 === 1;
+      backslashes = 0;
+      if (literalQuote) {
+        current += '"';
+      } else {
+        quoted = !quoted;
+      }
+      started = true;
+      continue;
+    }
+    flushBackslashes(backslashes);
+    backslashes = 0;
+    if (!quoted && /\s/.test(ch)) {
+      if (started) tokens.push(current);
+      current = "";
+      started = false;
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  flushBackslashes(backslashes);
+  if (started) tokens.push(current);
+  return tokens;
+}
+
 /** What the OS can tell us about a running process. */
 export interface ProcessIdentity {
   /** Full command line, as the OS reports it. */
   commandLine?: string;
+  /**
+   * The command line as ARGV — exact on Linux (`/proc/<pid>/cmdline` is already
+   * NUL-separated), tokenised from the flattened string elsewhere.
+   *
+   * Its ONLY purpose is to rebuild a relaunch command for a server that could not
+   * report its own `sys.argv` (a wedged or unreachable ComfyUI, #767). It is never
+   * evidence of identity: on the platforms where it is tokenised it is derived from
+   * `commandLine`, so checking one against the other proves nothing.
+   */
+  argv?: string[];
+  /**
+   * Does `argv` reproduce the argument vector the process ACTUALLY received?
+   *
+   * This is the difference between an argv that can be spawned and one that can only
+   * be read (codex gate round 6).
+   *
+   *   "exact"     — Linux `/proc/<pid>/cmdline`, which is already NUL-separated, and
+   *                 Windows `Win32_Process.CommandLine`, which is the literal string
+   *                 handed to CreateProcess and is parsed by the child's own runtime
+   *                 with exactly the CommandLineToArgvW rule `tokenizeCommandLine`
+   *                 implements. An argument containing a space MUST have been quoted
+   *                 there, or the process itself would have seen two — so the
+   *                 round-trip is faithful.
+   *   "flattened" — macOS `ps -o command=`, where the kernel joined argv with spaces
+   *                 and the quoting is simply GONE. `--output-directory /a/My Outputs`
+   *                 is indistinguishable from two arguments, and relaunching from it
+   *                 would spawn a command the user never ran.
+   */
+  argvFidelity?: "exact" | "flattened";
+  /**
+   * The OS's OWN record of which binary this process is running — independent of
+   * argv[0], which the process itself supplies.
+   *
+   * argv[0] is a string the launcher chose. `exec -a`, or a hand-built Windows
+   * command line, can make any program present itself as any other, so argv[0] is a
+   * CLAIM. This field is the kernel's answer (`Win32_Process.ExecutablePath`,
+   * `/proc/<pid>/exe`) and cannot be set by the process (codex gate round 3).
+   *
+   * Used ONLY where the question is "what program is this?" — deciding whether a
+   * parent really is the ComfyUI Desktop shell before its supervision is allowed to
+   * license a stop. It is deliberately NOT used for the INTERPRETER question this
+   * module exists for: for a venv, both sources resolve through the trampoline to the
+   * BASE interpreter, while argv[0] is the venv python whose site-packages the server
+   * actually imports (#401). Two questions, two fields.
+   *
+   * `undefined` where the platform or permissions do not expose it — macOS `ps`
+   * reports no such column, and an elevated Windows process may withhold it — in
+   * which case the caller falls back to argv[0], which is what it had before.
+   */
+  executablePath?: string;
   /** Process creation time, in whatever stable form the platform provides. Only ever
    *  compared against another reading taken on the SAME platform. */
   startedAt?: string;
@@ -123,17 +247,22 @@ export interface ProcessIdentity {
 /**
  * Read a running process's command line AND creation time from the OS.
  *
- * Windows: WMI's `CommandLine`, NOT `ExecutablePath`. This distinction is the whole
+ * Windows: WMI's `CommandLine` is what answers the INTERPRETER question, NOT
+ * `ExecutablePath`. This distinction is the whole
  * point — for a venv, Windows reports ExecutablePath as the BASE interpreter the
  * venv trampoline loads (e.g. …\standalone-env\python.exe) while CommandLine's
  * argv[0] is the venv python (…\ComfyUI\.venv\Scripts\python.exe), which is what
  * `sys.executable` reports and whose site-packages the server actually imports.
  * Verified against a live ComfyUI Desktop instance while fixing #401.
+ * `ExecutablePath` IS read, into its own field, for the separate "what program is
+ * this?" question — see `executablePath`.
  *
  * Linux: /proc/PID/cmdline ("\u0000"-separated argv) plus field 22 of /proc/PID/stat
- * (starttime, in clock ticks since boot). Avoids /proc/PID/exe, which resolves
+ * (starttime, in clock ticks since boot). /proc/PID/exe likewise goes to
+ * `executablePath` ONLY, never to the interpreter answer, because it resolves
  * through the venv symlink to the base interpreter.
- * macOS: `ps -o lstart=,command=`.
+ * macOS: `ps -o lstart=,command=` — which exposes no authenticated executable
+ * column, so `executablePath` is undefined there.
  */
 function parsePid(raw: string | undefined): number | undefined {
   if (raw == null) return undefined;
@@ -150,7 +279,7 @@ export function readProcessIdentity(pid: number): ProcessIdentity | undefined {
           "-NoProfile",
           "-Command",
           `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; ` +
-            `if ($p) { "START=" + $p.CreationDate.ToFileTimeUtc(); "PPID=" + $p.ParentProcessId; "CMD=" + $p.CommandLine }`,
+            `if ($p) { "START=" + $p.CreationDate.ToFileTimeUtc(); "PPID=" + $p.ParentProcessId; "EXE=" + $p.ExecutablePath; "CMD=" + $p.CommandLine }`,
         ],
         { encoding: "utf-8", timeout: 8000, windowsHide: true },
       );
@@ -158,10 +287,16 @@ export function readProcessIdentity(pid: number): ProcessIdentity | undefined {
       // PPID before CMD in the output so a multi-line command line (captured with
       // [\s\S]) cannot swallow it.
       const parentPid = parsePid(out.match(/^PPID=(.+)$/m)?.[1]);
+      // EXE before CMD for the same reason PPID is: a multi-line command line
+      // (captured with [\s\S]) must not swallow the fields after it.
+      const executablePath = out.match(/^EXE=(.*)$/m)?.[1]?.trim();
       const commandLine = out.match(/^CMD=([\s\S]*)$/m)?.[1]?.trim();
       if (!startedAt && !commandLine) return undefined;
       return {
         commandLine: commandLine || undefined,
+        argv: commandLine ? tokenizeCommandLine(commandLine) : undefined,
+        argvFidelity: "exact",
+        executablePath: executablePath || undefined,
         startedAt: startedAt || undefined,
         parentPid,
       };
@@ -169,7 +304,9 @@ export function readProcessIdentity(pid: number): ProcessIdentity | undefined {
     if (platform() === "linux") {
       // argv entries are "\u0000"-separated; rejoin them as a command line.
       const raw = readFileSync(`/proc/${pid}/cmdline`, "utf-8");
-      const commandLine = raw.split("\u0000").filter(Boolean).join(" ").trim();
+      // EXACT argv — the kernel already separated it, so nothing is guessed here.
+      const argv = raw.split("\u0000").filter(Boolean);
+      const commandLine = argv.join(" ").trim();
       let startedAt: string | undefined;
       let parentPid: number | undefined;
       try {
@@ -183,8 +320,24 @@ export function readProcessIdentity(pid: number): ProcessIdentity | undefined {
       } catch {
         /* start time unavailable → the launched-by-us tier fails closed */
       }
+      // The kernel's own record of the binary, which argv[0] cannot forge. Absent
+      // (EACCES) for another user's process, which is exactly the case where the
+      // caller must fall back rather than conclude anything.
+      let executablePath: string | undefined;
+      try {
+        executablePath = readlinkSync(`/proc/${pid}/exe`);
+      } catch {
+        /* not ours to read → undefined, and the caller falls back to argv[0] */
+      }
       if (!commandLine && !startedAt) return undefined;
-      return { commandLine: commandLine || undefined, startedAt, parentPid };
+      return {
+        commandLine: commandLine || undefined,
+        argv: argv.length > 0 ? argv : undefined,
+        argvFidelity: "exact",
+        executablePath: executablePath || undefined,
+        startedAt,
+        parentPid,
+      };
     }
     const out = execFileSync(
       "ps",
@@ -196,11 +349,13 @@ export function readProcessIdentity(pid: number): ProcessIdentity | undefined {
     const m = out.match(
       /^\s*(\d+)\s+(\w{3}\s+\w{3}\s+\d+\s+\d{2}:\d{2}:\d{2}\s+\d{4})\s+([\s\S]*)$/,
     );
-    if (!m) return { commandLine: out };
+    if (!m) return { commandLine: out, argv: tokenizeCommandLine(out), argvFidelity: "flattened" };
     return {
       parentPid: parsePid(m[1]),
       startedAt: m[2].replace(/\s+/g, " "),
       commandLine: m[3].trim(),
+      argv: tokenizeCommandLine(m[3].trim()),
+      argvFidelity: "flattened",
     };
   } catch {
     return undefined;

--- a/src/services/port-owner.ts
+++ b/src/services/port-owner.ts
@@ -784,35 +784,6 @@ function pidVanished(err: unknown): boolean {
   return code === "ENOENT" || code === "ESRCH";
 }
 
-/**
- * Does `pid` STILL hold `inode`? Tri-state — `undefined` when we could not look.
- *
- * The closing half of the bracket. Re-reading the socket table proves the INODE is
- * still on the port; it says nothing about whether the pid we named still holds it.
- * An fd can be closed (or passed on) between the walk and the re-read, leaving the
- * same inode listening under a different owner while we return the former one as
- * `owned` — and that pid is what a stop kills (coordinator gate).
- */
-function pidStillHoldsInode(pid: number, inode: string): boolean | undefined {
-  const wanted = `socket:[${inode}]`;
-  let fds: string[];
-  try {
-    fds = procFdReader.listFds(pid);
-  } catch (err) {
-    // The process is gone: it is definitively not holding the socket any more.
-    return pidVanished(err) ? false : undefined;
-  }
-  for (const fd of fds) {
-    try {
-      if (procFdReader.readFdLink(pid, fd) === wanted) return true;
-    } catch (err) {
-      // One fd closing mid-scan is ordinary; a permission wall means we cannot say.
-      if (!pidVanished(err)) return undefined;
-    }
-  }
-  return false;
-}
-
 function attributeInodes(inodes: string[], port: number): ProcAttribution {
   const wanted = new Map(inodes.map((inode) => [`socket:[${inode}]`, inode]));
   let pids: number[];
@@ -951,30 +922,39 @@ export function probePortOwner(port: number, host?: string): PortOwnerProbe {
       // /system_stats pairing: carry something across two observations that a
       // substitution cannot reproduce.
       const after = readKernelSocketTables(port, host);
-      // BOTH HALVES of the pairing have to survive, because the finding is about a
-      // pid AND a socket:
-      //   • the SPECIFIC inode the fd walk matched must still be listening on the
-      //     port — not merely "some listener is there", which a replacement socket
-      //     would satisfy;
-      //   • and the pid must STILL hold it. Confirming only the inode leaves the
-      //     other substitution open: the fd is closed or handed on, the same inode is
-      //     on the port under a new owner, and the pid we return is a former holder
-      //     (coordinator gate). That pid is what a stop kills.
+      // THE WHOLE FINDING HAS TO REPRODUCE, not just a part of it.
+      //
+      // The claim being bracketed is "exactly one visible process holds THIS socket",
+      // so the closing check re-derives exactly that. Two weaker versions were both
+      // wrong, in the same way:
+      //   • confirming only that a listener is still on the port accepts a REPLACEMENT
+      //     socket that reused the inode;
+      //   • confirming only that OUR pid still holds the inode accepts a SECOND holder
+      //     appearing beside it — which the opening scan would have refused as
+      //     ambiguous, so the bracket would have laundered a verdict the same evidence
+      //     was not allowed to produce a moment earlier (codex gate round 10).
+      // A full re-attribution costs one more `/proc` walk on the positive path — the
+      // same order as the lsof spawn it replaces — and is the only form that cannot
+      // certify something the first pass would have rejected.
+      // The two conditions are exactly the two halves of the claim, and no more:
+      // the socket we attributed is still listening, and re-deriving the owner still
+      // yields THIS pid — alone. Requiring the re-attribution to arrive via the same
+      // INODE was a third condition the claim does not make: a process listening on
+      // both address families holds two of them, and which one the walk stops at is
+      // an artifact of fd ordering. `stillListening` already pins the socket.
       const stillListening = after.inodes.includes(attributed.inode);
-      const stillHeld = stillListening
-        ? pidStillHoldsInode(attributed.pid, attributed.inode)
-        : false;
-      if (stillListening && stillHeld === true) {
+      const recheck = stillListening ? attributeInodes(after.inodes, port) : undefined;
+      if (recheck?.state === "owned" && recheck.pid === attributed.pid) {
         return { state: "owned", pid: attributed.pid };
       }
       procNote = !stillListening
         ? `the socket listening on port ${port} changed while its owner was being identified, ` +
           `so PID ${attributed.pid} cannot be tied to it`
-        : stillHeld === false
-          ? `PID ${attributed.pid} no longer holds the socket listening on port ${port}, so it ` +
-            `cannot be named as its owner`
-          : `PID ${attributed.pid} could not be re-checked against the socket listening on ` +
-            `port ${port}, so its ownership is unconfirmed`;
+        : recheck?.state === "owned"
+          ? `the socket listening on port ${port} changed hands while its owner was being ` +
+            `identified (PID ${attributed.pid}, then PID ${recheck.pid})`
+          : `PID ${attributed.pid} could not be re-confirmed as the owner of the socket ` +
+            `listening on port ${port}: ${recheck?.reason ?? "the re-check could not be performed"}`;
     } else {
       procNote = attributed.reason;
     }

--- a/src/services/port-owner.ts
+++ b/src/services/port-owner.ts
@@ -204,6 +204,33 @@ type LsofAbsence = "stated" | "inconclusive" | "silent";
 const LSOF_INCONCLUSIVE_REASON =
   "lsof reported nothing listening on the port but also reported that it could not enumerate everything, so its search describes only what it could see";
 
+/**
+ * THE ONLY WAY THIS MODULE MAY RUN `lsof`.
+ *
+ * Invariant 4 — lsof must STATE absence (`-V`); silence is not evidence — is a
+ * property of the COMMAND, and a rule that lives in a comment survives only as long
+ * as everyone remembers it at the next call site. A quiet `lsof` without `-V` exits 1
+ * with empty stdout AND stderr whether it searched and found nothing or could not
+ * search at all, so a second invocation that omitted the flag would hand a caller a
+ * `free` verdict for a live port. Building the argument list HERE, once, is what
+ * makes the invariant structural: there is no other place to get an lsof result from,
+ * and a future call site inherits `-V` whether or not its author knew to ask for it.
+ *
+ * `2>&1` for the matching reason: lsof reports an INCOMPLETE enumeration on stderr,
+ * and on the success path `execSync` returns stdout ONLY — so without the redirect a
+ * marker on stdout beside a warning on stderr reads as a clean absence and certifies
+ * a release from a search that admitted it was partial. The error path already sees
+ * both streams; this makes the success path see what the error path sees. Warnings do
+ * not disturb the field parser, which keys on `p`/`n` line prefixes, so a host whose
+ * lsof warns routinely loses only the fast path — a wait, never a wrong answer.
+ */
+function runLsofListenerQuery(port: number): string {
+  return execSync(`lsof -V -nP -iTCP:${port} -sTCP:LISTEN -Fpn 2>&1`, {
+    encoding: "utf-8",
+    timeout: 5000,
+  });
+}
+
 function readLsofAbsence(output: string): LsofAbsence {
   if (!/internet address not located/i.test(output)) return "silent";
   return admitsIncompleteEnumeration(output) ? "inconclusive" : "stated";
@@ -757,6 +784,35 @@ function pidVanished(err: unknown): boolean {
   return code === "ENOENT" || code === "ESRCH";
 }
 
+/**
+ * Does `pid` STILL hold `inode`? Tri-state — `undefined` when we could not look.
+ *
+ * The closing half of the bracket. Re-reading the socket table proves the INODE is
+ * still on the port; it says nothing about whether the pid we named still holds it.
+ * An fd can be closed (or passed on) between the walk and the re-read, leaving the
+ * same inode listening under a different owner while we return the former one as
+ * `owned` — and that pid is what a stop kills (coordinator gate).
+ */
+function pidStillHoldsInode(pid: number, inode: string): boolean | undefined {
+  const wanted = `socket:[${inode}]`;
+  let fds: string[];
+  try {
+    fds = procFdReader.listFds(pid);
+  } catch (err) {
+    // The process is gone: it is definitively not holding the socket any more.
+    return pidVanished(err) ? false : undefined;
+  }
+  for (const fd of fds) {
+    try {
+      if (procFdReader.readFdLink(pid, fd) === wanted) return true;
+    } catch (err) {
+      // One fd closing mid-scan is ordinary; a permission wall means we cannot say.
+      if (!pidVanished(err)) return undefined;
+    }
+  }
+  return false;
+}
+
 function attributeInodes(inodes: string[], port: number): ProcAttribution {
   const wanted = new Map(inodes.map((inode) => [`socket:[${inode}]`, inode]));
   let pids: number[];
@@ -895,15 +951,30 @@ export function probePortOwner(port: number, host?: string): PortOwnerProbe {
       // /system_stats pairing: carry something across two observations that a
       // substitution cannot reproduce.
       const after = readKernelSocketTables(port, host);
-      // The SPECIFIC inode the fd walk matched — not merely "one of the ones we
-      // started with". A different listener arriving on the port is exactly the
-      // substitution being guarded against.
-      if (after.inodes.includes(attributed.inode)) {
+      // BOTH HALVES of the pairing have to survive, because the finding is about a
+      // pid AND a socket:
+      //   • the SPECIFIC inode the fd walk matched must still be listening on the
+      //     port — not merely "some listener is there", which a replacement socket
+      //     would satisfy;
+      //   • and the pid must STILL hold it. Confirming only the inode leaves the
+      //     other substitution open: the fd is closed or handed on, the same inode is
+      //     on the port under a new owner, and the pid we return is a former holder
+      //     (coordinator gate). That pid is what a stop kills.
+      const stillListening = after.inodes.includes(attributed.inode);
+      const stillHeld = stillListening
+        ? pidStillHoldsInode(attributed.pid, attributed.inode)
+        : false;
+      if (stillListening && stillHeld === true) {
         return { state: "owned", pid: attributed.pid };
       }
-      procNote =
-        `the socket listening on port ${port} changed while its owner was being identified, ` +
-        `so PID ${attributed.pid} cannot be tied to it`;
+      procNote = !stillListening
+        ? `the socket listening on port ${port} changed while its owner was being identified, ` +
+          `so PID ${attributed.pid} cannot be tied to it`
+        : stillHeld === false
+          ? `PID ${attributed.pid} no longer holds the socket listening on port ${port}, so it ` +
+            `cannot be named as its owner`
+          : `PID ${attributed.pid} could not be re-checked against the socket listening on ` +
+            `port ${port}, so its ownership is unconfirmed`;
     } else {
       procNote = attributed.reason;
     }
@@ -936,21 +1007,7 @@ export function probePortOwner(port: number, host?: string): PortOwnerProbe {
   };
 
   try {
-    // `-V` makes lsof STATE what it failed to locate, which is the only positive
-    // "nothing is listening" signal it offers (see readLsofAbsence).
-    //
-    // `2>&1` because lsof reports an INCOMPLETE enumeration on stderr, and on the
-    // success path `execSync` returns stdout ONLY — so without the redirect a marker
-    // on stdout beside a warning on stderr reads as a clean absence, and certifies a
-    // release from a search that admitted it was partial. The error path already sees
-    // both streams; this makes the success path see what the error path sees.
-    // Warnings do not disturb the field parser, which keys on `p`/`n` line prefixes.
-    // A host whose lsof warns routinely therefore loses the fast path — it costs a
-    // wait, never a wrong answer, which is the trade this whole probe makes.
-    const out = execSync(`lsof -V -nP -iTCP:${port} -sTCP:LISTEN -Fpn 2>&1`, {
-      encoding: "utf-8",
-      timeout: 5000,
-    });
+    const out = runLsofListenerQuery(port);
     const pid = parseListenerPidFromLsof(out, port, host);
     if (pid) return { state: "owned", pid };
     const absence = readLsofAbsence(out);

--- a/src/services/port-owner.ts
+++ b/src/services/port-owner.ts
@@ -770,8 +770,19 @@ function readKernelSocketTables(port: number, host?: string): KernelTableReading
  *     regardless of owner.
  */
 type ProcAttribution =
-  /** `inode` is carried so the caller can re-verify THAT socket, not just the port. */
-  | { state: "owned"; pid: number; inode: string }
+  | {
+      state: "owned";
+      pid: number;
+      /** The socket the caller brackets on — one specific listener, not just "the port". */
+      inode: string;
+      /**
+       * EVERY listening socket on the port this pid holds, not merely the one the walk
+       * stopped at. A process listening on both address families holds two, and the
+       * re-check has to be able to ask "does it still hold I?" rather than "did the
+       * walk happen to select I again?" — the second question is about fd ordering.
+       */
+      inodes: string[];
+    }
   | { state: "unattributed"; reason: string };
 
 /** Did this read fail because the process is GONE, or because we could not look? */
@@ -797,7 +808,7 @@ function attributeInodes(inodes: string[], port: number): ProcAttribution {
       })`,
     };
   }
-  const owners = new Map<number, string>();
+  const owners = new Map<number, string[]>();
   let blind = false;
   for (const pid of pids) {
     let fds: string[];
@@ -818,14 +829,23 @@ function attributeInodes(inodes: string[], port: number): ProcAttribution {
       }
       const inode = wanted.get(link);
       if (inode !== undefined) {
-        owners.set(pid, inode);
-        break;
+        // NO EARLY BREAK. Stopping at the first match records an ARBITRARY one of the
+        // pid's listening sockets, and a later re-check asking "does it still hold I?"
+        // would then be answered by whichever socket the walk happened to reach first
+        // — so a process that released I while acquiring another listener on the same
+        // port would still look unchanged (codex gate round 11).
+        const seen = owners.get(pid);
+        if (seen) {
+          if (!seen.includes(inode)) seen.push(inode);
+        } else {
+          owners.set(pid, [inode]);
+        }
       }
     }
   }
   if (owners.size === 1) {
-    const [pid, inode] = [...owners][0];
-    return { state: "owned", pid, inode };
+    const [pid, inodes] = [...owners][0];
+    return { state: "owned", pid, inode: inodes[0], inodes };
   }
   if (owners.size > 1) {
     return {
@@ -936,25 +956,41 @@ export function probePortOwner(port: number, host?: string): PortOwnerProbe {
       // A full re-attribution costs one more `/proc` walk on the positive path — the
       // same order as the lsof spawn it replaces — and is the only form that cannot
       // certify something the first pass would have rejected.
-      // The two conditions are exactly the two halves of the claim, and no more:
-      // the socket we attributed is still listening, and re-deriving the owner still
-      // yields THIS pid — alone. Requiring the re-attribution to arrive via the same
-      // INODE was a third condition the claim does not make: a process listening on
-      // both address families holds two of them, and which one the walk stops at is
-      // an artifact of fd ordering. `stillListening` already pins the socket.
+      // THREE conditions, which together are exactly the claim and no more: the socket
+      // we attributed is still listening, re-deriving the owner still yields THIS pid
+      // alone, and that pid still holds THAT socket.
+      //
+      // The third is not the same as "the walk selected the same inode again" — which
+      // is about fd ordering and would fail a dual-stack listener spuriously. It asks
+      // whether I is in the pid's complete set. Dropping it entirely (as an earlier
+      // revision did) reopens the substitution from the other side: A could release I
+      // while holding another listener J on the same port, an unreadable B could take
+      // I, and re-attribution would return A/J alone — proving A owns *a* listener
+      // while never proving it still owns the one being bracketed (codex gate r11).
       const stillListening = after.inodes.includes(attributed.inode);
       const recheck = stillListening ? attributeInodes(after.inodes, port) : undefined;
-      if (recheck?.state === "owned" && recheck.pid === attributed.pid) {
+      if (
+        recheck?.state === "owned" &&
+        recheck.pid === attributed.pid &&
+        recheck.inodes.includes(attributed.inode)
+      ) {
         return { state: "owned", pid: attributed.pid };
       }
+      // Each way the re-check can fail is a DIFFERENT fact about the world, and the
+      // reason has to say which — "changed hands (PID 4321, then PID 4321)" is what
+      // comes out of collapsing the same-pid-different-socket case into the
+      // changed-owner one.
       procNote = !stillListening
         ? `the socket listening on port ${port} changed while its owner was being identified, ` +
           `so PID ${attributed.pid} cannot be tied to it`
-        : recheck?.state === "owned"
+        : recheck?.state === "owned" && recheck.pid !== attributed.pid
           ? `the socket listening on port ${port} changed hands while its owner was being ` +
             `identified (PID ${attributed.pid}, then PID ${recheck.pid})`
-          : `PID ${attributed.pid} could not be re-confirmed as the owner of the socket ` +
-            `listening on port ${port}: ${recheck?.reason ?? "the re-check could not be performed"}`;
+          : recheck?.state === "owned"
+            ? `PID ${attributed.pid} no longer holds the socket it was identified by on port ` +
+              `${port} — it holds another listener there, which is not the same finding`
+            : `PID ${attributed.pid} could not be re-confirmed as the owner of the socket ` +
+              `listening on port ${port}: ${recheck?.reason ?? "the re-check could not be performed"}`;
     } else {
       procNote = attributed.reason;
     }

--- a/src/services/port-owner.ts
+++ b/src/services/port-owner.ts
@@ -7,7 +7,7 @@
 // existing tests keep importing it from there.
 
 import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync, readlinkSync } from "node:fs";
 import { platform } from "node:os";
 
 const IS_WIN = platform() === "win32";
@@ -241,13 +241,48 @@ const defaultProcNetReader: ProcNetTableReader = (table) => readFileSync(table, 
 
 let procNetReader: ProcNetTableReader = defaultProcNetReader;
 
+/**
+ * How `/proc/<pid>/fd` is walked to ATTRIBUTE a kernel socket to a process (#795).
+ *
+ * Injected for the same reason as the socket-table reader: on a Linux runner the
+ * real `/proc` exists, so an un-injected read would grade assertions against the
+ * runner's own process table instead of the fixtures. Kept as three narrow
+ * operations rather than a filesystem handle so a test can make ONE pid unreadable
+ * (the permission case that must never become a definite answer) without having to
+ * model a filesystem.
+ */
+export interface ProcFdReader {
+  /** Numeric entries of `/proc` — every process on the machine. */
+  listPids(): number[];
+  /** Entries of `/proc/<pid>/fd`. */
+  listFds(pid: number): string[];
+  /** Target of `/proc/<pid>/fd/<fd>` — `socket:[<inode>]` for a socket. */
+  readFdLink(pid: number, fd: string): string;
+}
+
+const defaultProcFdReader: ProcFdReader = {
+  listPids: () =>
+    readdirSync("/proc")
+      .filter((name) => /^\d+$/.test(name))
+      .map((name) => Number(name)),
+  listFds: (pid) => readdirSync(`/proc/${pid}/fd`),
+  readFdLink: (pid, fd) => readlinkSync(`/proc/${pid}/fd/${fd}`),
+};
+
+let procFdReader: ProcFdReader = defaultProcFdReader;
+
 export const __portOwnerTestHooks = {
   /** Drive the kernel-table read. `null` restores the real `/proc` reader. */
   setProcNetReader(fn: ProcNetTableReader | null): void {
     procNetReader = fn ?? defaultProcNetReader;
   },
+  /** Drive the `/proc/<pid>/fd` walk (#795). `null` restores the real reader. */
+  setProcFdReader(fn: ProcFdReader | null): void {
+    procFdReader = fn ?? defaultProcFdReader;
+  },
   reset(): void {
     procNetReader = defaultProcNetReader;
+    procFdReader = defaultProcFdReader;
   },
 };
 
@@ -387,7 +422,15 @@ const KERNEL_DECIMAL = /^\d+$/;
 interface KernelRow {
   slot: number;
   localPort: string;
+  /** The local address exactly as the table printed it (8 or 32 hex digits). */
+  localAddressHex: string;
   state: string;
+  /**
+   * The socket's inode, present only when the WHOLE row parsed. This is the join
+   * key to `/proc/<pid>/fd/*` → `socket:[<inode>]`, i.e. the half of the identity
+   * that names an OWNER (#795); the existence half above never depends on it.
+   */
+  inode?: string;
 }
 
 /**
@@ -428,7 +471,12 @@ function parseKernelRowPrefix(
   ) {
     return undefined;
   }
-  return { slot: Number(slot[1]), localPort: local[2], state };
+  return {
+    slot: Number(slot[1]),
+    localPort: local[2],
+    localAddressHex: local[1],
+    state,
+  };
 }
 
 function parseKernelRow(
@@ -448,7 +496,63 @@ function parseKernelRow(
   ) {
     return undefined;
   }
-  return prefix;
+  return { ...prefix, inode: cols[9] };
+}
+
+/**
+ * The kernel's hex local address as text the ADDRESS COMPARATOR understands, or
+ * `undefined` when this module will not risk a comparison.
+ *
+ * Both tables print addresses as little-endian 32-bit words, so the bytes come out
+ * reversed WITHIN each word: `0100007F` is 127.0.0.1, and the 32-digit
+ * `00000000000000000000000001000000` is `::1`. Verified against live kernel output.
+ *
+ * Only the forms whose spelling is unambiguous are produced — a dotted quad, the
+ * two wildcards, `::1`, and an IPv4-mapped `::ffff:a.b.c.d` reduced to its IPv4
+ * form. A general IPv6 address has several legal textual spellings (which groups
+ * `::` elides, leading zeros, case), and picking one to string-compare against a
+ * user-supplied host would be a guess; guessing here would produce a POSITIVE
+ * attribution, which is the direction that licenses stopping a process. So it
+ * returns `undefined` and the caller declines to attribute — the honest cost is a
+ * fall-through to lsof, never a wrong owner.
+ */
+function decodeKernelAddress(hex: string): string | undefined {
+  const bytes: number[] = [];
+  if (hex.length !== 8 && hex.length !== 32) return undefined;
+  for (let word = 0; word < hex.length / 8; word++) {
+    const w = hex.slice(word * 8, word * 8 + 8);
+    // Little-endian: the LAST byte pair of the word is the FIRST address byte.
+    for (let i = 3; i >= 0; i--) {
+      const byte = parseInt(w.slice(i * 2, i * 2 + 2), 16);
+      if (Number.isNaN(byte)) return undefined;
+      bytes.push(byte);
+    }
+  }
+  if (bytes.length === 4) return bytes.join(".");
+  const zeros = (from: number, to: number): boolean =>
+    bytes.slice(from, to).every((b) => b === 0);
+  if (zeros(0, 16)) return "::";
+  if (zeros(0, 15) && bytes[15] === 1) return "::1";
+  // IPv4-mapped (::ffff:a.b.c.d) — what a dual-stack socket shows for an IPv4 peer.
+  if (zeros(0, 10) && bytes[10] === 0xff && bytes[11] === 0xff) {
+    return bytes.slice(12).join(".");
+  }
+  return undefined;
+}
+
+/**
+ * May a kernel row be attributed to the host we are actually talking to?
+ *
+ * With no host constraint every listener on the port qualifies, exactly as the lsof
+ * parser behaves — so the address is not even decoded. With one, an address we
+ * decline to decode is NOT a match: the strictness belongs to the finding that
+ * would name an owner.
+ */
+function kernelRowServesHost(localAddressHex: string, wantHost?: string): boolean {
+  if (!wantHost) return true;
+  const decoded = decodeKernelAddress(localAddressHex);
+  if (decoded === undefined) return false;
+  return addressServesHost(decoded, wantHost);
 }
 
 /**
@@ -477,8 +581,25 @@ function kernelHeader(remoteColumn: string): RegExp {
   );
 }
 
-function readKernelSocketTables(port: number): KernelSocketTables {
+/**
+ * What the kernel tables said: whether anything is listening, and — separately —
+ * the inodes of the listening sockets that may be attributed to `host` (#795).
+ *
+ * The two answer DIFFERENT questions and are gathered to different standards. The
+ * existence half stays exactly as #785 left it: port-only (a listener on any local
+ * address blocks a `free` verdict) and satisfied by a row truncated after its state.
+ * The inode half backs a POSITIVE claim about a specific process, so it takes only
+ * rows that parsed WHOLE and whose address provably serves the host asked about.
+ */
+interface KernelTableReading {
+  existence: KernelSocketTables;
+  inodes: string[];
+}
+
+function readKernelSocketTables(port: number, host?: string): KernelTableReading {
   const wanted = port.toString(16).toUpperCase().padStart(4, "0");
+  const inodes: string[] = [];
+  let sawListener = false;
   let tablesRead = 0;
   let blind = false;
   for (const { path: table, addressHexWidth, header } of KERNEL_TABLES) {
@@ -528,19 +649,32 @@ function readKernelSocketTables(port: number): KernelSocketTables {
       // ahead of this would be the same fold as everywhere else in this function,
       // merely pointed at a positive: withholding a finding we actually made.
       const prefix = parseKernelRowPrefix(cols, addressHexWidth);
-      if (
-        prefix &&
+      const matchesPort =
+        prefix != null &&
         prefix.localPort.toUpperCase() === wanted &&
-        prefix.state.toUpperCase() === LISTEN_STATE
-      ) {
-        return "listening";
-      }
+        prefix.state.toUpperCase() === LISTEN_STATE;
+      if (matchesPort) sawListener = true;
       // Everything below serves the NEGATIVE, which is the half that needs the row
-      // to be whole.
+      // to be whole — and the inode, which needs the same wholeness for its own
+      // reason (see KernelTableReading). Scanning ON past a positive costs one more
+      // table read and cannot unmake `sawListener`, which is spent before `blind`
+      // below: a socket we have already seen stays seen however damaged the rest is.
       const row = parseKernelRow(cols, addressHexWidth);
       if (row === undefined) {
         blind = true;
         continue;
+      }
+      if (
+        matchesPort &&
+        row.inode != null &&
+        // A LISTEN row always carries a real inode. `0` is what a socket with no
+        // inode of its own prints (a TIME_WAIT/request socket), and `socket:[0]`
+        // is not something any `/proc/<pid>/fd` entry points at — matching on it
+        // could only ever produce a coincidence, never an owner.
+        row.inode !== "0" &&
+        kernelRowServesHost(row.localAddressHex, host)
+      ) {
+        inodes.push(row.inode);
       }
       // The kernel numbers rows with a running counter from 0, so the sequence is
       // its own continuity check: a GAP means a record between these two is missing
@@ -555,11 +689,133 @@ function readKernelSocketTables(port: number): KernelSocketTables {
     // not see where it ENDS. Either way this read cannot support a definite negative.
     if (!sawHeader || !raw.endsWith("\n")) blind = true;
   }
-  // A blind spot outranks everything except a positive: it means something could
-  // still be hiding. Only when nothing could be — every table either read cleanly
-  // or provably does not exist — may this answer be spent.
-  if (blind) return "incomplete";
-  return tablesRead === 0 ? "unavailable" : "none";
+  // A POSITIVE outranks everything, including a blind spot: a socket we saw is a
+  // socket, however much else was lost. Then a blind spot outranks the negative — it
+  // means something could still be hiding. Only when nothing could be — every table
+  // either read cleanly or provably does not exist — may the negative be spent.
+  const existence: KernelSocketTables = sawListener
+    ? "listening"
+    : blind
+      ? "incomplete"
+      : tablesRead === 0
+        ? "unavailable"
+        : "none";
+  return { existence, inodes };
+}
+
+/**
+ * WHO holds these listening sockets, resolved from `/proc` alone (#795).
+ *
+ * `/proc/net/tcp{,6}` gave the socket's inode; every `/proc/<pid>/fd/*` symlink of a
+ * process holding it reads `socket:[<inode>]`. Matching the two names the owner with
+ * no external binary at all, which is the point: a host without `lsof` was otherwise
+ * permanently unable to identify its own ComfyUI, and every feature built on process
+ * identity degraded to "cannot confirm" there forever.
+ *
+ * Both halves of the tri-state are earned:
+ *   • `owned` means THIS PROCESS HOLDS THE LISTENING SOCKET. Deliberately not "is
+ *     the only process that holds it" — see the note on blindness below.
+ *   • anything else is `unattributed`, which is NOT a statement that the port is
+ *     free — the kernel already told us a socket is there. It only means this source
+ *     could not name the owner, and the caller falls through to lsof exactly as
+ *     before.
+ *
+ * SEVERAL VISIBLE holders is `unattributed` on purpose. Forked workers and
+ * SO_REUSEPORT siblings genuinely share one listener, and picking one of them out of
+ * a set we can SEE would be arbitrary. "Two processes share this socket" is a better
+ * answer than an arbitrary one.
+ *
+ * A pid whose `/proc/<pid>/fd` cannot be read does NOT withdraw a single-holder
+ * finding, and that asymmetry is a decision, not an oversight:
+ *
+ *   • Requiring a complete walk would make attribution impossible on any multi-user
+ *     host. An unprivileged process cannot read the fds of ANY other user's process,
+ *     and every Linux box runs root daemons — so "the walk was complete" is
+ *     essentially never true, and demanding it would restore exactly the permanent
+ *     "cannot confirm" this whole change exists to remove.
+ *   • lsof reaches no further. It reads the same `/proc/<pid>/fd` with the same
+ *     credentials, so falling through to it after refusing here buys nothing.
+ *   • The residual harm is bounded by HOW the pid is spent. A socket is shared by
+ *     INHERITANCE (fork, or SCM_RIGHTS), so an unseen co-holder is essentially always
+ *     a descendant — and every kill in this codebase kills the process TREE/group,
+ *     which takes those with it. Nothing here is ever used to certify a port as free;
+ *     that verdict comes only from the kernel table, which sees every socket
+ *     regardless of owner.
+ */
+type ProcAttribution =
+  /** `inode` is carried so the caller can re-verify THAT socket, not just the port. */
+  | { state: "owned"; pid: number; inode: string }
+  | { state: "unattributed"; reason: string };
+
+/** Did this read fail because the process is GONE, or because we could not look? */
+function pidVanished(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException)?.code;
+  // ENOENT: the pid exited between listing /proc and reading its fds — it cannot be
+  // holding the socket. ESRCH is the same fact by another name. Anything else
+  // (EACCES/EPERM on another user's process, and an errno-less failure) is a place we
+  // could not see into, and something could be hiding there.
+  return code === "ENOENT" || code === "ESRCH";
+}
+
+function attributeInodes(inodes: string[], port: number): ProcAttribution {
+  const wanted = new Map(inodes.map((inode) => [`socket:[${inode}]`, inode]));
+  let pids: number[];
+  try {
+    pids = procFdReader.listPids();
+  } catch (err) {
+    return {
+      state: "unattributed",
+      reason: `a socket is listening on port ${port} but /proc could not be enumerated to name its owner (${
+        err instanceof Error ? err.message : String(err)
+      })`,
+    };
+  }
+  const owners = new Map<number, string>();
+  let blind = false;
+  for (const pid of pids) {
+    let fds: string[];
+    try {
+      fds = procFdReader.listFds(pid);
+    } catch (err) {
+      if (!pidVanished(err)) blind = true;
+      continue;
+    }
+    for (const fd of fds) {
+      let link: string;
+      try {
+        link = procFdReader.readFdLink(pid, fd);
+      } catch (err) {
+        // A single fd closing mid-walk is ordinary; a permission wall is not.
+        if (!pidVanished(err)) blind = true;
+        continue;
+      }
+      const inode = wanted.get(link);
+      if (inode !== undefined) {
+        owners.set(pid, inode);
+        break;
+      }
+    }
+  }
+  if (owners.size === 1) {
+    const [pid, inode] = [...owners][0];
+    return { state: "owned", pid, inode };
+  }
+  if (owners.size > 1) {
+    return {
+      state: "unattributed",
+      reason: `the socket listening on port ${port} is held by several processes (${[
+        ...owners.keys(),
+      ]
+        .sort((a, b) => a - b)
+        .join(", ")}), so no single process owns it`,
+    };
+  }
+  return {
+    state: "unattributed",
+    reason: blind
+      ? `a socket is listening on port ${port} but the /proc entries that would name its owner could not all be read (it belongs to another user, or the process list changed underneath us)`
+      : `a socket is listening on port ${port} but no process in /proc holds it`,
+  };
 }
 
 export function probePortOwner(port: number, host?: string): PortOwnerProbe {
@@ -612,12 +868,52 @@ export function probePortOwner(port: number, host?: string): PortOwnerProbe {
   // not, so lsof failing to find or name a listener the kernel CAN see means "I
   // could not identify it", never "it is not there". A positive existence finding is
   // therefore never overridable by a negative from a source that sees strictly less.
-  const kernel = readKernelSocketTables(port);
+  const reading = readKernelSocketTables(port, host);
+  const kernel = reading.existence;
   if (kernel === "none") return { state: "free" };
+
+  // ATTRIBUTION FROM THE SAME SOURCE (#795). The kernel table already handed us the
+  // listening socket's inode; `/proc/<pid>/fd` says which process holds it. Consulted
+  // BEFORE lsof because it is the same evidence one step further along, needs no
+  // external binary, and reaches exactly as far as an unprivileged lsof does — so on
+  // a host with no lsof at all this is the difference between an identified server
+  // and a permanent "cannot confirm". It never answers `free`: existence was settled
+  // above, and failing to NAME an owner is not evidence there is none.
+  let procNote: string | undefined;
+  if (reading.inodes.length > 0) {
+    const attributed = attributeInodes(reading.inodes, port);
+    if (attributed.state === "owned") {
+      // BRACKET THE JOIN (codex gate). The inode came from one read and the fd walk
+      // is another, and a socket inode is reusable the moment its socket closes: the
+      // listener can go away between the two, its number be handed to an unrelated
+      // socket, and the walk then name whatever process holds THAT. Nothing later
+      // would catch it on the path where the server is wedged and has no argv to
+      // corroborate against — and the pid is what a stop kills.
+      //
+      // So re-read the table and require the SAME inode to still be listening on the
+      // port. This is the same discipline the restart path already applies to the
+      // /system_stats pairing: carry something across two observations that a
+      // substitution cannot reproduce.
+      const after = readKernelSocketTables(port, host);
+      // The SPECIFIC inode the fd walk matched — not merely "one of the ones we
+      // started with". A different listener arriving on the port is exactly the
+      // substitution being guarded against.
+      if (after.inodes.includes(attributed.inode)) {
+        return { state: "owned", pid: attributed.pid };
+      }
+      procNote =
+        `the socket listening on port ${port} changed while its owner was being identified, ` +
+        `so PID ${attributed.pid} cannot be tied to it`;
+    } else {
+      procNote = attributed.reason;
+    }
+  }
 
   const listeningButUnnamed = {
     state: "unknown",
-    reason: "a socket is listening on the port but lsof could not name its owner",
+    reason:
+      "a socket is listening on the port but lsof could not name its owner" +
+      (procNote ? `, and ${procNote}` : ""),
   } as const;
 
   /**
@@ -676,7 +972,12 @@ export function probePortOwner(port: number, host?: string): PortOwnerProbe {
     }
     return {
       state: "unknown",
-      reason: `lsof: ${err instanceof Error ? err.message : String(err)}`,
+      reason:
+        // The /proc finding leads when there is one: on a host with no lsof at all
+        // (#795's whole subject) "lsof: spawn ENOENT" says nothing about the port,
+        // while "a socket is listening but its owner is another user's" does.
+        (procNote ? `${procNote}; ` : "") +
+        `lsof: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
 }

--- a/src/services/port-owner.ts
+++ b/src/services/port-owner.ts
@@ -1022,6 +1022,26 @@ export function probePortOwner(port: number, host?: string): PortOwnerProbe {
     return { state: "free" };
   };
 
+  // WHICH HALF CARRIES THE GUARANTEE — stated here because the two sources below do
+  // NOT offer the same one, and a reader who assumes they do will over-trust this.
+  //
+  // The `/proc` attribution above brackets a pid against a SPECIFIC SOCKET: the inode
+  // is re-read from the kernel table and the pid's complete fd set must still contain
+  // it, so a socket that changed hands, or was released while its holder kept another
+  // listener on the same port, withdraws the finding.
+  //
+  // `lsof -Fpn` cannot express that. Its records carry a pid and an address:port and
+  // NO inode, so this fallback attributes BY PID ALONE — it can say "some process is
+  // listening there and it is this one", not "this process holds the socket I was
+  // tracking". The substitution the bracket closes is therefore closed for the /proc
+  // path and NOT for this one.
+  //
+  // It is kept regardless, and deliberately: it is exactly the pre-existing behaviour
+  // (this is how the port owner has always been named on hosts without a readable
+  // /proc), so nothing is made worse, while removing it would restore the permanent
+  // "cannot confirm" on every non-Linux and unprivileged host — the very state #795
+  // exists to shrink. The honest summary is that /proc attribution is stronger than
+  // lsof attribution, not that both are airtight.
   try {
     const out = runLsofListenerQuery(port);
     const pid = parseListenerPidFromLsof(out, port, host);

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -93,6 +93,18 @@ interface ProcessInfo {
   osArgvExact?: boolean;
   /** The OS's raw command line — the recovery hint even when argv is not spawnable. */
   osCommandLine?: string;
+  /**
+   * TRUE when `pid` was found by SCANNING PROCESS NAMES for a Desktop shell, rather
+   * than resolved from the port.
+   *
+   * The distinction decides whether anything may be concluded about supervision. A
+   * port-resolved pid is the process that would be stopped, so what stands above it
+   * is its supervisor. A name-scanned one is merely "a Desktop app is running
+   * somewhere on this machine" — bound to no port and no backend — and a second,
+   * unrelated Desktop window must never license stopping a server it has never heard
+   * of (codex gate round 9).
+   */
+  pidFromDesktopScan?: boolean;
   isDesktopApp: boolean;
   desktopExePath?: string;
   /**
@@ -1459,6 +1471,20 @@ function assessDesktopSupervision(info: ProcessInfo): {
       `stop could not be undone.`,
   });
 
+  // A SHELL FOUND BY NAME IS NOT EVIDENCE ABOUT THIS PORT'S SERVER. When ComfyUI
+  // could not be attributed to the port, the caller falls back to whatever Desktop
+  // process is running anywhere on the machine. That pid is bound to no port and no
+  // backend: a second, unrelated Desktop window would otherwise stand in as the
+  // supervisor of an orphaned backend it has never heard of, and the reboot would
+  // stop a server nothing restarts (codex gate round 9). There is nothing to classify
+  // here — the premise is missing, not the evidence.
+  if (info.pidFromDesktopScan) {
+    return cannotAssess(
+      `the server on port ${info.port} could not be identified, and the only ComfyUI Desktop ` +
+        `process found (PID ${info.pid}) was located by scanning process names — nothing ties ` +
+        `it to that port, so it cannot be shown to supervise the server this would stop`,
+    );
+  }
   // NO SPECIAL CASE FOR A MISSING PID. An early `ok: true` here would be one more
   // permissive exit skipping the guard, and an untestable one at that. The classifier
   // already handles pid 0 the way it handles any pid it cannot read — the identity
@@ -1634,6 +1660,10 @@ async function acquireProcessInfo(): Promise<{
           argv: [],
           isDesktopApp: true,
           desktopExePath: findDesktopExeFromCommonPaths(),
+          // FOUND BY NAME, NOT BY PORT — nothing ties this shell to the server on
+          // config.resolvedPort. Recorded so the restart preflight cannot mistake
+          // "a Desktop app is running" for "this Desktop app supervises that server".
+          pidFromDesktopScan: true,
         },
       };
     }

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -412,7 +412,15 @@ function isDesktopSupervisorProcess(identity: ProcessIdentity): boolean {
     const base = norm.split("/").pop() ?? "";
     // Current and legacy Windows branding, including the electron-era install dir.
     if (base === "comfy desktop.exe" || base === "comfyui.exe") return true;
-    return /\/(comfy desktop|comfyui)\.app\/contents\/macos\//.test(norm);
+    // macOS: the bundle's MAIN binary, which by convention is named after the bundle
+    // (`Comfy Desktop.app/Contents/MacOS/Comfy Desktop`). Accepting ANY binary under
+    // `Contents/MacOS/` was too loose: a venv shim or launcher script living inside
+    // the bundle would pass, and a shim re-execs nothing (coordinator gate). The
+    // backreference ties the two halves together so the binary must belong to the
+    // bundle naming it. Electron HELPERS are excluded structurally — they live in
+    // `Contents/Frameworks/<Helper>.app/Contents/MacOS/…`, so the first bundle in the
+    // path is not followed by `Contents/MacOS/`.
+    return /\/(comfy desktop|comfyui)\.app\/contents\/macos\/\1$/.test(norm);
   };
 
   // THE KERNEL'S ANSWER FIRST, and ALONE when it exists (codex gate round 3).
@@ -441,8 +449,16 @@ function isDesktopSupervisorProcess(identity: ProcessIdentity): boolean {
   // the app name itself, so the directory prefix before it has none. An argument can
   // never satisfy that — reaching it would mean crossing the space that separates it
   // from argv[0].
+  //
+  // The BINARY NAME is required here too, for the same reason as above: a launcher
+  // script or venv shim inside the bundle would otherwise be read as the shell
+  // (coordinator gate). `\2` ties it to the bundle that names it, and the match must
+  // end at whitespace or end-of-line so the binary is the whole argv[0] rather than a
+  // prefix of some longer name.
   const line = (identity.commandLine ?? "").trim().replace(/\\/g, "/").toLowerCase();
-  return /^"?(\/[^\s"]*\/)?(comfy desktop|comfyui)\.app\/contents\/macos\//.test(line);
+  return /^"?(\/[^\s"]*\/)?(comfy desktop|comfyui)\.app\/contents\/macos\/\2(\s|"|$)/.test(
+    line,
+  );
 }
 
 function isDesktopApp(argv: string[]): boolean {
@@ -1402,33 +1418,74 @@ function processExists(pid: number): boolean | undefined {
  * "couldn't confirm it came back" — a verdict computed AFTER the stop, about a stop
  * it should never have made.
  *
- * ONLY the proven-abandoned shape refuses. `unconfirmed` proceeds exactly as before,
- * because a Desktop restart normally works and refusing on missing evidence would
- * take that away from every host where the process tree cannot be read — the same
- * standing ruling the rest of this file applies to uncertainty.
+ * ONLY `supervised` proceeds. `unconfirmed` REFUSES, and the asymmetry with the rest
+ * of this file is deliberate rather than an inconsistency (coordinator gate):
+ *
+ *   `listener_ownership` reports on an action that HAS ALREADY HAPPENED — the child
+ *   was spawned, the server is answering — and only the DESCRIPTION of it is
+ *   uncertain. Denying `started` there would turn an uncertain description into a
+ *   false one, so uncertainty is DISCLOSED.
+ *
+ *   A reboot has NOT happened yet and cannot be undone. Uncertainty about whether
+ *   anything will restart the process is uncertainty about whether the user still has
+ *   a ComfyUI afterwards, so it is REFUSED.
+ *
+ * Refuse before, disclose after — the same principle pointed in opposite directions
+ * by whether the irreversible step is still ahead.
+ *
+ * The earlier reading — that proceeding on `unconfirmed` preserved #400 — conflated
+ * two different claims. #400 established that a Desktop process must never be KILLED
+ * locally, because respawning the exe does not reliably bring the listener back. It
+ * did not establish that an UNVERIFIED Manager stop is safe. Only the first is
+ * settled, and refusing here does not touch it: the refusal leaves the server
+ * RUNNING and points the user at the Desktop app, which restarts it reliably.
  */
 function assessDesktopSupervision(info: ProcessInfo): {
   ok: boolean;
   reason?: string;
   supervision: SupervisorRelaunch;
 } {
-  if (!info.pid) return { ok: true, supervision: unclassifiedSupervision() };
-  const supervision = classifyDesktopSupervision({
+  const cannotAssess = (because: string): {
+    ok: boolean;
+    reason: string;
+    supervision: SupervisorRelaunch;
+  } => ({
+    ok: false,
+    supervision: unclassifiedSupervision(),
+    reason:
+      `this is a ComfyUI Desktop instance, and it could not be established that a Desktop app ` +
+      `is still supervising it (${because}). A restart from here asks ComfyUI-Manager to STOP ` +
+      `the process and depends on that supervisor to start it again — so without that, the ` +
+      `stop could not be undone.`,
+  });
+
+  // NO SPECIAL CASE FOR A MISSING PID. An early `ok: true` here would be one more
+  // permissive exit skipping the guard, and an untestable one at that. The classifier
+  // already handles pid 0 the way it handles any pid it cannot read — the identity
+  // and parent reads come back empty and the verdict is `unconfirmed`, which now
+  // refuses — so letting it fall through inherits a path that IS tested.
+  const { verdict, because } = classifyDesktopSupervision({
     pid: info.pid,
     readParentPid,
     readIdentity: resolveProcessIdentity,
     processExists,
     isSupervisorProcess: isDesktopSupervisorProcess,
   });
-  if (supervision !== "abandoned") return { ok: true, supervision };
+  if (verdict === "supervised") return { ok: true, supervision: verdict };
+  if (verdict === "abandoned") {
+    return {
+      ok: false,
+      supervision: verdict,
+      reason:
+        `ComfyUI Desktop started the server on port ${info.port} (PID ${info.pid}), but no ` +
+        `Desktop app is still supervising it — its parent process is gone. A restart from here ` +
+        `asks ComfyUI-Manager to stop the process and relies on that supervisor to start it ` +
+        `again, so it would be stopped and nothing would bring it back.`,
+    };
+  }
   return {
-    ok: false,
-    supervision,
-    reason:
-      `ComfyUI Desktop started the server on port ${info.port} (PID ${info.pid}), but no ` +
-      `Desktop app is still supervising it — its parent process is gone. A restart from here ` +
-      `asks ComfyUI-Manager to stop the process and relies on that supervisor to start it ` +
-      `again, so it would be stopped and nothing would bring it back.`,
+    ...cannotAssess(because ?? `the process tree above PID ${info.pid} could not be read`),
+    supervision: verdict,
   };
 }
 
@@ -2978,30 +3035,51 @@ export function getRestartDispatchRecord(
  * server is externally supervised yet its relaunch is NOT provable from here
  * (a relative `main.py` argv with no COMFYUI_PATH/workspace anchor and no live
  * process cwd), and the supervisor does NOT re-launch after a plain Manager
- * restart — so the reboot would kill ComfyUI permanently. Only the PROVEN
- * dangerous shape refuses: a reachable, running, non-Desktop local instance
- * whose relaunch command cannot be built/validated. Everything else returns
- * ok:true and the caller proceeds exactly as before:
- *   - remote mode (no local process to assess);
- *   - nothing found / unreachable-but-unmapped (no proven running process —
- *     #449 already punts those to a Manager reboot on purpose);
- *   - a Desktop app (Electron-supervised — the Manager reboot IS its safe
- *     restart path, #400);
- *   - a validated relaunch (assessRelaunch, the #476/#426 machinery).
+ * restart — so the reboot would kill ComfyUI permanently.
+ *
+ * WHAT PASSES is now stated positively, because every "everything else proceeds"
+ * clause here turned out to be a way in for the same loss:
+ *   - remote mode — there is no local process to assess, and the Manager reboot is
+ *     that target's restart path by design;
+ *   - a Desktop instance a live supervisor is proven to be watching (#400's safe
+ *     path, now checked rather than assumed);
+ *   - a non-Desktop instance whose relaunch command can be built and validated
+ *     (assessRelaunch, the #476/#426 machinery).
+ * Everything else — including an instance that could not be identified at all —
+ * REFUSES, and says what it could not establish.
  */
 export async function preflightLocalRestart(): Promise<{
   ok: boolean;
   reason?: string;
 }> {
   if (isRemoteMode()) return { ok: true };
-  const { info } = await acquireProcessInfo();
-  if (!info) return { ok: true };
+  const { info, diagnostic } = await acquireProcessInfo();
+  // NOTHING COULD BE RESOLVED — and that is not a pass (coordinator gate).
+  //
+  // This was the door beside the widened gate: a local instance whose listener cannot
+  // be attributed (a container with no `lsof`, a permission wall, no `/proc`) resolves
+  // to NOTHING here, so the preflight "assessed" it, passed, and the reboot went out
+  // without anyone having checked whether a supervisor was still there. That is the
+  // container/permission form of the very #814 loss the gate exists to prevent — an
+  // instance we cannot identify is an instance whose relaunch we cannot prove.
+  //
+  // The refusal is safe in the genuinely-nothing-running case too: there is no server
+  // to lose, and the message says exactly what could not be established rather than
+  // asserting something is wrong.
+  if (!info) {
+    return {
+      ok: false,
+      reason:
+        `the ComfyUI this restart would stop could not be identified from here` +
+        (diagnostic ? ` (${diagnostic})` : ` (nothing was found listening on port ${config.resolvedPort})`) +
+        `, so it could not be established that stopping it is something we could undo.`,
+    };
+  }
   if (info.isDesktopApp) {
     // NOT an automatic pass any more (#814). Electron supervision is what makes a
     // Desktop reboot safe, and it is a FACT about the running process tree, not a
-    // property of the install — when the supervisor has gone, the reboot is a stop
-    // with no way back. Only that proven shape refuses; everything else still
-    // proceeds, as #400 requires.
+    // property of the install. See assessDesktopSupervision for why UNCONFIRMED
+    // refuses here while it is merely disclosed on the post-launch ownership path.
     const desktop = assessDesktopSupervision(info);
     if (desktop.ok) return { ok: true };
     return { ok: false, reason: `${desktop.reason}${describeRecovery(recoveryHint(info))}` };

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -21,11 +21,14 @@ import {
   type LaunchEnvResolution,
 } from "./launcher-env.js";
 import {
+  classifyDesktopSupervision,
   classifyListenerOwnership,
   isDescendantOfChild,
   launchedChildStillRunning,
   unclassifiedOwnership,
+  unclassifiedSupervision,
   type ListenerOwnership,
+  type SupervisorRelaunch,
 } from "./listener-ownership.js";
 import { resetManagerApiCache } from "./manager-api-cache.js";
 import {
@@ -37,6 +40,7 @@ import {
   recordLaunchedInterpreter,
   clearLaunchedInterpreter,
   readProcessIdentity,
+  argv0FromCommandLine,
   commandLineMatchesArgv,
   type ProcessIdentity,
 } from "./live-interpreter.js";
@@ -55,6 +59,40 @@ interface ProcessInfo {
   pid: number;
   port: number;
   argv: string[];
+  /**
+   * The port owner's argv as the OS reports it, captured when the SERVER could not
+   * report its own (#767).
+   *
+   * A ComfyUI wedged by a CUDA OOM stops answering `/system_stats`, so `argv` comes
+   * back empty — and with it went every way to relaunch: `stop_comfyui` killed the
+   * process anyway, announced `has_restart_info: true`, and `start_comfyui` then had
+   * nothing to start. The OS knew the whole command line the entire time. The user's
+   * own recovery was to read it out of the process table by hand.
+   *
+   * Kept in a SEPARATE field, never merged into `argv`, because the two have
+   * different standing. `argv` is the server's own account of itself and is what the
+   * OS command line is CORROBORATED against; folding a value derived from that same
+   * command line into it would make the check compare a reading with itself and
+   * always agree. This one is only ever spent to build a relaunch and to tell the
+   * user how to start the server by hand.
+   */
+  osArgv?: string[];
+  /**
+   * May `osArgv` be SPAWNED, or only read?
+   *
+   * macOS reports a process's arguments as one flattened string (`ps -o command=`),
+   * so `--output-directory /a/My Outputs` is indistinguishable from two arguments and
+   * relaunching from it would spawn a command the user never ran — very possibly one
+   * ComfyUI's own argument parser rejects, after we had already stopped the server
+   * (codex gate round 6). Linux and Windows can be reconstructed faithfully.
+   *
+   * A flattened argv is still perfectly good for the two things it is READ for: the
+   * recovery hint a human acts on, and the before/after comparison that catches a pid
+   * substitution. Only the SPAWN needs fidelity.
+   */
+  osArgvExact?: boolean;
+  /** The OS's raw command line — the recovery hint even when argv is not spawnable. */
+  osCommandLine?: string;
   isDesktopApp: boolean;
   desktopExePath?: string;
   /**
@@ -93,10 +131,49 @@ interface ProcessInfo {
   envPlan?: LaunchEnvResolution;
 }
 
+/**
+ * How to bring this instance back BY HAND — captured while the process is still
+ * alive, because the process table entry dies with it (#814/#767).
+ *
+ * Every field is what we actually observed, with its provenance intact, because the
+ * two sources are not equally complete. `server_argv` is Python's `sys.argv`: its
+ * first element is the SCRIPT, so the interpreter is simply not in it and pasting it
+ * into a shell would not work. `command` is the OS's view and IS the whole thing.
+ * Presenting either as "the command to run" without saying which it is would hand a
+ * user a recovery instruction that fails at the moment they need it most.
+ */
+interface RecoveryHint {
+  /** The full command line the OS reported for the process, when readable. */
+  command?: string;
+  /**
+   * TRUE when the OS gave us the arguments FLATTENED into one string (macOS), so a
+   * value containing a space cannot be told from two arguments. The command is still
+   * what a human needs — they can see where the quotes belong — but it is reported as
+   * approximate rather than as something to paste unread.
+   */
+  command_flattened?: boolean;
+  /** The server's own `sys.argv` — NO interpreter (Python does not put it there). */
+  server_argv?: string[];
+  /** The working directory the process was running in, when readable. */
+  cwd?: string;
+}
+
 interface StopResult {
   stopped: boolean;
   message: string;
+  /**
+   * Can `start_comfyui` actually bring this back?
+   *
+   * It used to mean "we stored a ProcessInfo", which was true even when that info
+   * held nothing runnable — so a stop reported `true` and the start that followed
+   * reported "No command-line info captured from previous run" (#767). It now means
+   * what its name says: a relaunch command was BUILT AND VALIDATED before the kill.
+   */
   has_restart_info: boolean;
+  /** Present whenever a hand-restart may be needed — always on a refusal. */
+  restart_hint?: RecoveryHint;
+  /** Why a relaunch could not be validated, when it could not. */
+  relaunch_blocked?: string;
   auto_restart?: SupervisorResult;
   /**
    * Set when the stop was COMMITTED without being able to confirm the process
@@ -134,6 +211,10 @@ interface RestartResult {
   stopped: boolean;
   started: boolean;
   message: string;
+  /** How to start it by hand — carried on every refusal, so a user who is told
+   *  "not restarting" is never left to dig the command out of the process table
+   *  themselves (#814). */
+  restart_hint?: RecoveryHint;
   ready?: boolean;
   readiness?: StartupReadinessResult;
   auto_restart?: SupervisorResult;
@@ -301,6 +382,67 @@ function killDesktopApp(portPid: number): void {
     // Fallback — just kill the port process
     killProcessTree(portPid);
   }
+}
+
+/**
+ * Is THIS PROCESS the Desktop supervisor — the Electron shell itself?
+ *
+ * Deliberately NOT `isDesktopApp`, and the difference matters. That one asks "was
+ * this SERVER started by Desktop?", and answers yes on any mention of the Desktop
+ * install — including a `--extra-model-paths-config` pointing into
+ * `…/Comfy Desktop/…`, which is exactly how a Desktop backend identifies itself.
+ * Reusing it here would let a WRAPPER that merely passes such a flag stand in for
+ * the shell, and a wrapper cannot re-exec anything (codex gate).
+ *
+ * So this requires the Desktop binary to be the process's OWN EXECUTABLE — argv[0],
+ * never merely somewhere on the command line. Searching the whole line let a wrapper
+ * that PASSES the Desktop exe as an argument
+ * (`python wrapper.py --desktop-exe "…/Comfy Desktop.exe"`) stand in for the shell,
+ * and a wrapper re-execs nothing (codex gate round 2).
+ *
+ * THE ASYMMETRY IS DELIBERATE. Failing to recognise a real supervisor costs the walk
+ * a hop and can end in `abandoned` — a REFUSED restart, which leaves the server
+ * running and points the user at the Desktop app that would have restarted it
+ * anyway. Recognising a NON-supervisor licenses a stop that nothing undoes. So when
+ * the evidence is shaped awkwardly, this errs strict.
+ */
+function isDesktopSupervisorProcess(identity: ProcessIdentity): boolean {
+  const looksLikeDesktopBinary = (path: string): boolean => {
+    const norm = path.replace(/\\/g, "/").toLowerCase();
+    const base = norm.split("/").pop() ?? "";
+    // Current and legacy Windows branding, including the electron-era install dir.
+    if (base === "comfy desktop.exe" || base === "comfyui.exe") return true;
+    return /\/(comfy desktop|comfyui)\.app\/contents\/macos\//.test(norm);
+  };
+
+  // THE KERNEL'S ANSWER FIRST, and ALONE when it exists (codex gate round 3).
+  // argv[0] is a string the launcher chose: `exec -a`, or a hand-built Windows
+  // command line, lets any program present itself as any other, so a check that
+  // trusts it can be told "I am Comfy Desktop.exe" by something that is not. The
+  // executable path comes from the OS (`Win32_Process.ExecutablePath`,
+  // `/proc/<pid>/exe`) and the process cannot set it. When we have it, a NEGATIVE
+  // from it is final — falling through to argv[0] afterwards would hand the claim
+  // back its authority.
+  if (identity.executablePath) return looksLikeDesktopBinary(identity.executablePath);
+
+  // argv[0] — exact on Linux, and on Windows the launcher quotes a path with spaces
+  // (which "Comfy Desktop" always has), so the tokeniser recovers it whole. Reached
+  // only where the OS withheld the authenticated path (macOS `ps` has no such
+  // column; an elevated Windows process may withhold it), which is the evidence this
+  // check had before and is still better than nothing.
+  const exe =
+    identity.argv?.[0] ?? argv0FromCommandLine(identity.commandLine ?? "") ?? "";
+  if (looksLikeDesktopBinary(exe)) return true;
+  // macOS: `ps -o command=` prints argv joined by SPACES, so an app-bundle argv[0]
+  // containing one ("Comfy Desktop.app" — the current branding) cannot be tokenised
+  // back out, and every such install would otherwise walk past its own shell into a
+  // false `abandoned`. It is still recognisable by POSITION rather than content:
+  // argv[0] OPENS the command line, and the only space in the bundle path is inside
+  // the app name itself, so the directory prefix before it has none. An argument can
+  // never satisfy that — reaching it would mean crossing the space that separates it
+  // from argv[0].
+  const line = (identity.commandLine ?? "").trim().replace(/\\/g, "/").toLowerCase();
+  return /^"?(\/[^\s"]*\/)?(comfy desktop|comfyui)\.app\/contents\/macos\//.test(line);
 }
 
 function isDesktopApp(argv: string[]): boolean {
@@ -944,8 +1086,27 @@ function processIdentityStillValid(
   // server's argv is POSITIVE evidence this pid is somebody else, and gating it
   // behind `startedAt` would discard that evidence exactly when we have least of
   // it (codex gate).
+  // WHAT THIS PROCESS SHOULD STILL BE RUNNING — the server's own account when it
+  // gave one, otherwise the OS's EARLIER reading of the same pid.
+  //
+  // Passing `info.argv` unguarded was wrong: commandLineMatchesArgv fails CLOSED on
+  // an empty argv, which is right for "is this ComfyUI?" and wrong here — a server
+  // that never answered has no argv to disagree with, and reading that absence as a
+  // mismatch refuses to stop exactly the wedged instance the user is recovering
+  // (#767). But simply SKIPPING the check there left the wedged path with nothing
+  // but numeric pid/port equality (codex gate round 5). The OS reading is the
+  // answer: comparing a LATER reading against an EARLIER one is not
+  // self-corroboration — they are two observations separated in time, which is
+  // exactly what a substitution has to survive. Together with the creation stamp
+  // below (now retained on this path), a replacement that inherited the number is
+  // caught whether or not it runs the same command line.
+  const expectedArgv = info.argv.length > 0 ? info.argv : (info.osArgv ?? []);
   const now = resolveProcessIdentity(info.pid);
-  if (now?.commandLine && !commandLineMatchesArgv(now.commandLine, info.argv)) {
+  if (
+    expectedArgv.length > 0 &&
+    now?.commandLine &&
+    !commandLineMatchesArgv(now.commandLine, expectedArgv)
+  ) {
     return {
       ok: false,
       reason:
@@ -975,11 +1136,31 @@ function resolveLiveProcessCwd(pid: number): string | undefined {
   }
 }
 
+/**
+ * The argv a relaunch is built from: the SERVER's own `sys.argv` when it could tell
+ * us, otherwise the OS's view of the same process (#767).
+ *
+ * The two differ in shape and both are handled downstream: `sys.argv[0]` is the
+ * SCRIPT (`main.py`, so an interpreter has to be resolved for it), while the OS's
+ * argv[0] is the INTERPRETER itself — which is strictly better, since it needs no
+ * resolution at all. The order is not a preference between sources of truth: the
+ * server's answer simply comes with an identity binding the OS reading cannot have,
+ * so it is used whenever it exists.
+ */
+function relaunchArgv(info: ProcessInfo): string[] {
+  if (info.argv.length > 0) return info.argv;
+  // A FLATTENED reading is not a command. It is still reported to the user, who can
+  // see where the quotes belong; we cannot, and guessing would spawn arguments the
+  // server never had (codex gate round 6).
+  return info.osArgvExact ? (info.osArgv ?? []) : [];
+}
+
 function resolveLaunchCommand(
   info: ProcessInfo,
 ): { exe: string; args: string[]; cwd?: string } | null {
-  if (info.argv.length === 0) return null;
-  const [first, ...rest] = info.argv;
+  const argv = relaunchArgv(info);
+  if (argv.length === 0) return null;
+  const [first, ...rest] = argv;
   // Strip surrounding quotes a launcher may leave on the script path BEFORE the
   // suffix test — otherwise `"C:\…\main.py"` fails the `.py` check, bypasses the
   // unified live-first resolver, and gets treated as the executable (#401 / PR #433
@@ -987,7 +1168,7 @@ function resolveLaunchCommand(
   const firstUnquoted = first.trim().replace(/^["']+/, "").replace(/["']+$/, "");
   const looksLikeScript = /\.pyw?$/i.test(firstUnquoted);
   if (looksLikeScript) {
-    const python = findComfyuiPython(config.comfyuiPath ?? undefined, info.argv);
+    const python = findComfyuiPython(config.comfyuiPath ?? undefined, argv);
     if (!python) return null;
     // sys.argv[0] can be RELATIVE (the standard Windows portable launcher runs
     // `python ComfyUI\main.py` from the portable root). We force cwd to
@@ -1012,7 +1193,7 @@ function resolveLaunchCommand(
     // to the base — not to config.comfyuiPath directly. When no absolute anchor
     // exists we keep the raw (possibly relative) script and let assessRelaunch's
     // refuse-safe preflight catch a truly unresolvable install.
-    const anchor = resolveScriptAnchor(info.argv);
+    const anchor = resolveScriptAnchor(argv);
     const scriptIsAbsolute = isAbsolute(firstUnquoted) || isWindowsAbsolute;
     // LIVE-CWD anchor (#535): before falling back to the canonical base, resolve a
     // RELATIVE script against the running process's OWN cwd (captured live, so it
@@ -1033,7 +1214,7 @@ function resolveLaunchCommand(
     let liveCwdPython: string | undefined;
     if (!scriptIsAbsolute && info.liveCwd && relSegments.length > 0) {
       const candidateScript = join(info.liveCwd, ...relSegments);
-      const candidatePython = findComfyuiPython(info.liveCwd, info.argv);
+      const candidatePython = findComfyuiPython(info.liveCwd, argv);
       const pythonIsAbsolute =
         !!candidatePython &&
         (isAbsolute(candidatePython) || /^[a-zA-Z]:[\\/]/.test(candidatePython));
@@ -1137,6 +1318,118 @@ function isRegularFile(p: string | undefined): boolean {
 /** True when a token looks like a filesystem path (has a separator or a drive). */
 function looksLikePath(s: string): boolean {
   return /[\\/]/.test(s) || /^[a-zA-Z]:/.test(s);
+}
+
+/** Quote a token only when it needs it, so the hint can be pasted into a shell. */
+function quoteToken(token: string): string {
+  return /[\s"]/.test(token) ? `"${token.replace(/"/g, '\\"')}"` : token;
+}
+
+/**
+ * Everything we know about how to restart this instance by hand, captured from a
+ * LIVE process (#814/#767). Both sources are reported with their provenance rather
+ * than merged: see RecoveryHint.
+ */
+function recoveryHint(info: ProcessInfo): RecoveryHint | undefined {
+  const hint: RecoveryHint = {};
+  if (info.osArgvExact && info.osArgv?.length) {
+    hint.command = info.osArgv.map(quoteToken).join(" ");
+  } else if (info.osCommandLine) {
+    // Re-quoting a flattened reading would invent boundaries we do not know, so it is
+    // passed through EXACTLY as the OS printed it and labelled as approximate.
+    hint.command = info.osCommandLine;
+    hint.command_flattened = true;
+  }
+  if (info.argv.length > 0) hint.server_argv = info.argv;
+  if (info.liveCwd) hint.cwd = info.liveCwd;
+  return hint.command || hint.server_argv || hint.cwd ? hint : undefined;
+}
+
+/** The sentence appended to a refusal so the user can act on it immediately. */
+function describeRecovery(hint: RecoveryHint | undefined): string {
+  if (!hint) return "";
+  if (hint.command) {
+    return (
+      ` To start it by hand, run: ${hint.command}${
+        hint.cwd ? ` (from ${hint.cwd})` : ""
+      }.` +
+      (hint.command_flattened
+        ? " (This OS reports arguments flattened into one line, so any path containing" +
+          " a space needs re-quoting before you run it.)"
+        : "")
+    );
+  }
+  if (hint.server_argv) {
+    return ` The server reported these launch arguments: ${hint.server_argv
+      .map(quoteToken)
+      .join(" ")}${
+      hint.cwd ? ` (from ${hint.cwd})` : ""
+    } — note this is Python's sys.argv, so the interpreter that ran it is not part of it.`;
+  }
+  return "";
+}
+
+/** Injectable existence probe, so supervision can be driven without real pids. */
+let processExistsOverride: ((pid: number) => boolean | undefined) | null = null;
+
+/**
+ * Does something hold this pid? TRI-STATE — see SupervisionEvidence.processExists.
+ * EPERM is "exists but not ours to signal", which is still existence; anything else
+ * unrecognised is "cannot tell" and must not be spent as either answer.
+ */
+function processExists(pid: number): boolean | undefined {
+  if (processExistsOverride) return processExistsOverride(pid);
+  if (!pid || pid <= 0) return undefined;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") return false;
+    if (code === "EPERM") return true;
+    return undefined;
+  }
+}
+
+/**
+ * Will the Desktop supervisor bring this instance back after a Manager reboot?
+ *
+ * A Desktop instance is NEVER killed and relaunched by us (#400) — the Electron
+ * shell owns it, so the restart path asks ComfyUI-Manager to re-exec the process and
+ * depends on that shell being there to do it. #814 is the case where it was not: two
+ * ComfyUI backends off one install, the shell that spawned the bound one had moved
+ * on, the reboot stopped it, and nothing brought it back. The tool then said it
+ * "couldn't confirm it came back" — a verdict computed AFTER the stop, about a stop
+ * it should never have made.
+ *
+ * ONLY the proven-abandoned shape refuses. `unconfirmed` proceeds exactly as before,
+ * because a Desktop restart normally works and refusing on missing evidence would
+ * take that away from every host where the process tree cannot be read — the same
+ * standing ruling the rest of this file applies to uncertainty.
+ */
+function assessDesktopSupervision(info: ProcessInfo): {
+  ok: boolean;
+  reason?: string;
+  supervision: SupervisorRelaunch;
+} {
+  if (!info.pid) return { ok: true, supervision: unclassifiedSupervision() };
+  const supervision = classifyDesktopSupervision({
+    pid: info.pid,
+    readParentPid,
+    readIdentity: resolveProcessIdentity,
+    processExists,
+    isSupervisorProcess: isDesktopSupervisorProcess,
+  });
+  if (supervision !== "abandoned") return { ok: true, supervision };
+  return {
+    ok: false,
+    supervision,
+    reason:
+      `ComfyUI Desktop started the server on port ${info.port} (PID ${info.pid}), but no ` +
+      `Desktop app is still supervising it — its parent process is gone. A restart from here ` +
+      `asks ComfyUI-Manager to stop the process and relies on that supervisor to start it ` +
+      `again, so it would be stopped and nothing would bring it back.`,
+  };
 }
 
 /**
@@ -1556,8 +1849,28 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
     );
   }
 
-  const desktop = isDesktopApp(argv);
-  const desktopExe = desktop ? findDesktopExePath(argv) : undefined;
+  // THE SERVER COULD NOT SAY WHAT IT IS RUNNING — ask the OS (#767).
+  //
+  // An empty `argv` means `/system_stats` did not answer: the server is wedged
+  // (a CUDA OOM is the reported case) or otherwise unreachable, which is EXACTLY
+  // when a user reaches for stop/restart. Everything downstream then had nothing to
+  // relaunch from, so the stop went ahead and the start could not follow. The OS has
+  // the command line throughout.
+  //
+  // Read here, while the pid is alive, for the same reason `liveCwd` is: the process
+  // table entry is gone the instant the kill lands.
+  const osIdentity = argv.length === 0 ? resolveProcessIdentity(pid) : undefined;
+  const osArgv = osIdentity?.argv;
+  const osArgvExact = osIdentity?.argvFidelity === "exact";
+  const osCommandLine = osIdentity?.commandLine;
+
+  // Desktop is decided from WHATEVER account of the process we have. Deciding it
+  // from `argv` alone meant an unreachable Desktop instance (argv empty) classified
+  // as an ordinary Python install — and would then be KILLED, which is the one thing
+  // the Desktop path exists to never do (#400).
+  const identifyingArgv = argv.length > 0 ? argv : (osArgv ?? []);
+  const desktop = isDesktopApp(identifyingArgv);
+  const desktopExe = desktop ? findDesktopExePath(identifyingArgv) : undefined;
   // Capture the live process cwd NOW, while the pid is guaranteed alive — the
   // `/proc/<pid>/cwd` symlink is gone the instant a later stop kills it (#535).
   const liveCwd = desktop ? undefined : resolveLiveProcessCwd(pid);
@@ -1584,10 +1897,20 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
     err.identityAmbiguous = true;
     throw err;
   }
-  const startedAt =
-    desktop || corroboration.kind !== "confirmed"
-      ? undefined
-      : corroboration.identity.startedAt;
+  const startedAt = desktop
+    ? undefined
+    : corroboration.kind === "confirmed"
+      ? corroboration.identity.startedAt
+      : // THE WEDGED PATH KEEPS ITS STAMP (codex gate round 5). With no answer from
+        // the server there is nothing to corroborate the pid against, and the
+        // corroboration therefore comes back `unknown` — but the pid's own creation
+        // time was read all the same, and that stamp is precisely what pid REUSE
+        // defeats. Discarding it would leave the pre-kill check with nothing but
+        // numeric pid/port equality, so a replacement instance that rebound the port
+        // after inheriting the number would be killed as if it were the one we
+        // identified. Only reachable when the server said nothing: a corroboration
+        // that came back `mismatch` has already thrown above.
+        osIdentity?.startedAt;
 
   // BIND THE PID TO THE PROCESS THAT ANSWERED (coordinator gate P1(1)).
   //
@@ -1626,6 +1949,9 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
     pid,
     port,
     argv,
+    osArgv,
+    osArgvExact,
+    osCommandLine,
     isDesktopApp: desktop,
     desktopExePath: desktopExe,
     liveCwd,
@@ -1693,6 +2019,52 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
     isDesktopApp: info.isDesktopApp,
     argv: info.argv.join(" "),
   });
+
+  // CAN THIS BE STARTED AGAIN? Asked BEFORE the kill, and answered honestly (#767).
+  //
+  // The stop used to report `has_restart_info: true` on the strength of having
+  // stored a ProcessInfo — which is true even when that info holds nothing runnable.
+  // A user recovering a wedged server was told the restart information was there,
+  // and `start_comfyui` then answered "No command-line info captured from previous
+  // run". By then the server was gone.
+  //
+  // A REFUSAL is reserved for the genuinely unrecoverable case: no launch command
+  // from the server, none from the OS, nothing to tell the user to run. Then the stop
+  // is a one-way door and it is not ours to walk through. When a command WAS observed
+  // the stop proceeds — `stop_comfyui` is an explicit instruction to stop, and a
+  // wedged server is precisely when someone means it — but `has_restart_info` states
+  // whether we can do the starting, and the hint says how to do it by hand.
+  //
+  // `requireReproducibleEnv` is deliberately NOT set here, and the distinction is the
+  // point: this flag answers "is there a command to run?", which is what #767 was
+  // about and what start_comfyui needs to exist at all. An irreproducible launcher
+  // environment is a different, weaker fact — the spawn still happens, it may simply
+  // fail during import — and it is reported as its own caveat below rather than
+  // collapsed into "there is no restart information", which would say something
+  // untrue about a case where the command is right there.
+  const relaunch = assessRelaunch(info);
+  // Resolved EXPLICITLY rather than read off `info.envPlan`, which is only populated
+  // by whichever caller happened to ask for it — a caveat that appears when the stop
+  // came through restartComfyUI and vanishes when the same install is stopped
+  // directly would be worse than no caveat at all.
+  let envPlan: LaunchEnvResolution | undefined;
+  if (relaunch.ok && !info.isDesktopApp) {
+    const cmd = resolveLaunchCommand(info);
+    if (cmd) envPlan = ensureLaunchEnvPlan(info, cmd);
+  }
+  const hint = recoveryHint(info);
+  if (!relaunch.ok && !hint) {
+    return {
+      stopped: false,
+      has_restart_info: false,
+      relaunch_blocked: relaunch.reason,
+      message:
+        `Refusing to stop ComfyUI (PID ${info.pid}): ${relaunch.reason} Nothing was killed — ` +
+        `and nothing was observed about how this server was launched, so stopping it would ` +
+        `leave you with no way to bring it back, by this tool or by hand. Stop it from the ` +
+        `launcher/console that owns it instead.`,
+    };
+  }
 
   // Remember HOW to relaunch before doing anything irreversible. Saving this only
   // after a committed stop meant that any later refusal — including one taken while
@@ -1820,8 +2192,23 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
     stopped: true,
     message:
       `ComfyUI (PID ${info.pid}) stopped on port ${info.port}` +
-      (unverified ? ` — NOTE: ${unverified}; continuing so the server can be brought back.` : ""),
-    has_restart_info: true,
+      (unverified ? ` — NOTE: ${unverified}; continuing so the server can be brought back.` : "") +
+      // Said PLAINLY and up front, not left to a boolean the caller may not read:
+      // start_comfyui will not be able to do this, so the human has to.
+      (relaunch.ok
+        ? // A command exists, but the environment it was launched into may not be
+          // reproducible — a weaker claim, stated as one.
+          envPlan && !envPlan.reproducible
+          ? ` NOTE: ${envPlan.reason ?? envPlan.info.note} start_comfyui will still try, but the relaunch may fail during import.` +
+            describeRecovery(hint)
+          : ""
+        : ` WARNING: start_comfyui will NOT be able to bring this back — ${relaunch.reason}` +
+          describeRecovery(hint)),
+    // The one claim #767 was about: it now means a relaunch command was built AND
+    // validated, not merely that some process info was stored.
+    has_restart_info: relaunch.ok,
+    relaunch_blocked: relaunch.ok ? undefined : relaunch.reason,
+    restart_hint: hint,
     auto_restart: supervisorResult(info),
     unverified_exit: unverified,
   };
@@ -2389,6 +2776,25 @@ export async function restartComfyUI(): Promise<RestartResult> {
   // supervisor that owns the process cycles it — and NEVER kill it. Only
   // self-spawned Python installs fall through to the kill+relaunch path below.
   if (info.isDesktopApp) {
+    // …but only when a supervisor is actually there to do the cycling. The Manager
+    // reboot STOPS the process; the Electron shell is what starts it again. When the
+    // shell has provably gone, firing the reboot is stopping a server we cannot
+    // restart, which is the #814 lost-server. Decided BEFORE anything is dispatched.
+    const desktop = assessDesktopSupervision(info);
+    if (!desktop.ok) {
+      const hint = recoveryHint(info);
+      return {
+        stopped: false,
+        started: false,
+        message:
+          `Refusing to restart: ${desktop.reason} ComfyUI was left running (not stopped) so ` +
+          `you don't lose the server. Restart it from the ComfyUI Desktop app.` +
+          describeRecovery(hint),
+        restart_hint: hint,
+        // Nothing was stopped and nothing launched.
+        listener_ownership: unclassifiedOwnership(),
+      };
+    }
     return restartViaManagerReboot({ label: "Desktop" });
   }
 
@@ -2399,11 +2805,13 @@ export async function restartComfyUI(): Promise<RestartResult> {
     return {
       stopped: false,
       started: false,
+      restart_hint: recoveryHint(info),
       message:
         `Refusing to restart: ${relaunch.reason} ComfyUI was left running (not stopped) ` +
         "so you don't lose the server. " +
         (relaunch.advice ??
-          "Fix the launch path (e.g. COMFYUI_PATH) and try again."),
+          "Fix the launch path (e.g. COMFYUI_PATH) and try again.") +
+        describeRecovery(recoveryHint(info)),
       // Refused before touching anything: the still-running server is the one that
       // was already there, which this call did not start.
       listener_ownership: unclassifiedOwnership(),
@@ -2588,7 +2996,16 @@ export async function preflightLocalRestart(): Promise<{
   if (isRemoteMode()) return { ok: true };
   const { info } = await acquireProcessInfo();
   if (!info) return { ok: true };
-  if (info.isDesktopApp) return { ok: true };
+  if (info.isDesktopApp) {
+    // NOT an automatic pass any more (#814). Electron supervision is what makes a
+    // Desktop reboot safe, and it is a FACT about the running process tree, not a
+    // property of the install — when the supervisor has gone, the reboot is a stop
+    // with no way back. Only that proven shape refuses; everything else still
+    // proceeds, as #400 requires.
+    const desktop = assessDesktopSupervision(info);
+    if (desktop.ok) return { ok: true };
+    return { ok: false, reason: `${desktop.reason}${describeRecovery(recoveryHint(info))}` };
+  }
   // NOTE (#776): the launch-ENVIRONMENT check is deliberately NOT applied here.
   // This preflight guards an OUT-OF-BAND ComfyUI-Manager reboot, which re-execs
   // the SAME process — it inherits its own (launcher-supplied) environment, so a
@@ -2611,6 +3028,7 @@ export const __processControlTestHooks = {
     liveEnvResolverOverride = null;
     processIdentityOverride = null;
     parentPidResolverOverride = null;
+    processExistsOverride = null;
     deliberateStop = false;
     restartDispatchRecords.clear();
   },
@@ -2618,6 +3036,11 @@ export const __processControlTestHooks = {
    *  real process tree. */
   setParentPidResolver(fn: ((pid: number) => number | undefined) | null): void {
     parentPidResolverOverride = fn;
+  },
+  /** Inject a fake pid-existence probe (#814) so the Desktop supervision check can
+   *  be driven without spawning and killing real processes. */
+  setProcessExistsProbe(fn: ((pid: number) => boolean | undefined) | null): void {
+    processExistsOverride = fn;
   },
   /** Inject a fake process-identity (creation time) reader so tests can drive
    *  recycled-PID scenarios on any host, including where the native read is


### PR DESCRIPTION
## The rule

**Never stop what you cannot restart.** Relaunch capability is established *before* the
stop, refusal is loud, and the claim that a restart is possible now means a command was
actually built and validated.

## #795 — determination first: only HALF had shipped

PR #785 made `/proc/net/tcp{,6}` the primary Linux source for **existence** (is anything
listening?). The pid **attribution** half — which #795 actually asks for — had not shipped,
and the merged code says so itself:

> `// It does not name the owning pid — that still needs lsof (or #795's /proc/<pid>/fd scan)`
> — `src/services/port-owner.ts`

So #795 was still open work. It is implemented here: the socket inode from the kernel table
is matched against `/proc/<pid>/fd/*` (`socket:[<inode>]`), consulted **before** lsof, and it
can never answer `free` — existence was already settled, and failing to *name* an owner is
not evidence there is none. A host with no `lsof` can now identify its own ComfyUI instead
of being permanently unverifiable.

The join is **bracketed**: a socket inode is reusable the moment its socket closes, so the
table is re-read after the fd walk and the same inode must still be listening. Addresses are
decoded little-endian per 32-bit word; a spelling this module will not risk comparing
declines to attribute rather than guessing.

## #814 (P1) — a Desktop reboot dispatched on an assumption

Two defects compounded:

1. **The safety check was gated on the ability to CERTIFY recovery.** `captureRebootHealthBase`
   answers "can I watch this instance come back?" — loopback boot base, server-observed
   handshake Origin, pathless mount. The refuse-safe preflight was gated on that same
   capture, so an instance we could not certify was also an instance we never assessed. The
   reboot went out with no evidence at all, and the honest "can't confirm it came back" was
   a verdict about a stop that should never have been made. Being unable to watch something
   come back is a reason for *more* care about stopping it. The preflight now runs for **any
   local target**; only remote/cloud are excluded, where the Manager reboot is the restart
   path by design.
2. **A Desktop instance was assumed supervised.** `preflightLocalRestart` returned `ok: true`
   for Desktop unconditionally. Electron supervision is a *fact about the running process
   tree*, not a property of the install — and when the shell has gone, the reboot is a stop
   with no way back.

New branded verdict `SupervisorRelaunch`, minted only by `classifyDesktopSupervision`.
`abandoned` — the one verdict that refuses — needs positive evidence: a vacant parent pid, a
reparented process, or a readable chain to the tree top with no live Desktop shell on it.
`unconfirmed` proceeds, so no host loses a restart to missing evidence (#400 stands).

## #767 — the stop and the start disagreed

A ComfyUI wedged by a CUDA OOM stops answering `/system_stats`, so `argv` came back empty.
`stop_comfyui` killed it anyway and reported `has_restart_info: true`; `start_comfyui` then
answered *"No command-line info captured from previous run"*. **The OS had the whole command
line throughout** — the reporter's own recovery was to read it out of the process table by
hand.

- the relaunch is rebuilt from the OS process table when the server cannot speak for itself;
- `has_restart_info` now means a command was **built and validated**, not that some struct
  was stored;
- `stop_comfyui` refuses only when *nothing at all* was observed about how to start it again
  — otherwise it stops (it was asked to) and says plainly whether the tool can undo it,
  handing over the command to run by hand;
- Desktop is classified from whichever account of the process we have, so an unreachable
  Desktop instance is no longer misread as an ordinary Python install and **killed**.

## #535 — already fixed, strengthened here

The reported failure (relative `main.py` refused against the orchestrator's cwd) was fixed by
the live-cwd anchor in 7fc3b5e, shipped in 0.48.23; the reporter was on 0.48.21. Covered by
`restart-live-first.test.ts`. The OS-argv fallback here strengthens the same path.

## Evidence standards kept apart

Each answer requires exactly what it proves:

| claim | what backs it |
|---|---|
| this pid holds the listener | inode→fd match, re-verified against the table |
| the port is free | the kernel table alone — attribution can never produce it |
| a supervisor will restart this | the **kernel's** record of the binary, which `argv[0]` cannot forge |
| this pid is still the process we identified | the OS's **later** reading vs its **earlier** one, plus the creation stamp |
| this argv can be spawned | only a source that reproduces it faithfully — a flattened macOS `ps` line may be **read**, never **spawned** |

## Verification

- 4847 tests green, including on the **merged** tree (CI tests the merge commit); CI green on ubuntu/windows/macos.
- Every fix **mutation-verified** — ~40 mutants across `port-owner`, `listener-ownership`,
  `process-control` and `panel-tools`, each a syntactically valid behavioural change, all
  killed. Mutants that failed to typecheck were rewritten rather than counted.
- **14 codex adversarial rounds** (`gpt-5.6-terra`), final verdict PASS with no P2 nits. Each
  round found exactly one real P1 and each is fixed with its own regression test: the
  inode→fd TOCTOU race; a recycled parent pid that is another live `Comfy Desktop.exe`; a
  wrapper carrying the Desktop exe as an *argument*; a wrapper *claiming* to be the shell in
  `argv[0]`; the identity gate that skipped the authenticated path when `commandLine` was
  absent; the wedged path losing its pid-reuse protection; a flattened macOS argv being
  spawned; and the Desktop-shell fallback pid being falsely reported `abandoned`.

## Maintainer-gate round (4 P0 + 1 P1) — all addressed

**P0-1 — `unconfirmed` authorized the Manager reboot.** Fixed: only `supervised`
proceeds. The rule is the **inverse** of the ownership rule, and both now say so where
they are applied — for `listener_ownership` the action has ALREADY happened and only
its description is uncertain, so uncertainty is **disclosed**; a reboot has not
happened yet and cannot be undone, so uncertainty **refuses**. Refuse before, disclose
after. #400 rules out *killing* a Desktop process locally; it never made an unverified
Manager stop safe. Every `unconfirmed` now carries a `because`, so the refusal names
what it could not establish.

**P0-2 — the widened preflight passed on `!info`.** Fixed: an instance that cannot be
identified is one whose relaunch cannot be proven. What PASSES is now stated
positively, because every "everything else proceeds" clause turned out to be a way in
for the same loss.

**P0-3 — `lsof -w -nP` without `-V`, and `isEmptyResultExit` turning a quiet status-1
into `free`.** **Could not reproduce — since confirmed by the maintainer.** Neither identifier exists in this branch or on
main (`git grep` on `origin/main` returns nothing, and this branch's `port-owner.ts`
was byte-identical to main's before my changes). The single lsof invocation has always
carried `-V`. The *structural* recommendation is adopted regardless: all lsof
execution now goes through one `runLsofListenerQuery`, so invariant 4 is a property of
the only door rather than something a future call site must remember. There is an
unrelated pre-existing `lsof -ti` in `orchestrator/index.ts`, but it returns `null` for
a diagnostic hint and never produces a `free` verdict.

**P0-4 — the macOS bundle match was forgeable by accident.** Fixed: the bundle's main
binary is named after the bundle (tied by backreference), so a launcher script or venv
shim inside `Contents/MacOS/` no longer passes; Electron helpers are excluded
structurally by living under `Contents/Frameworks/<Helper>.app/`.

**P1 — the inode bracket verified the inode, not the pid.** Fixed, then fixed again —
see below.

## Six further gate rounds (9–14), NO-SHIP each time, ending PASS

Three of these were defects **introduced by my own earlier fixes**, which is worth
stating plainly:

- **r9** — the round-7 self-supervisor shortcut let a Desktop shell found by *scanning
  process names* (bound to no port, no backend) authorize stopping an orphaned
  backend. The premise was wrong rather than the shortcut: the fallback now records how
  the pid was found and the preflight declines on it before classifying anything.
- **r10 / r11** — the bracket re-derived only part of its own finding. It now
  re-attributes completely (the same sole pid) **and** requires that pid's complete
  inode set to still contain the bracketed socket — closing both the second-holder and
  the "A releases I but keeps J" substitutions, while still accepting a genuine
  dual-stack owner.
- **r12 / r13** — the panel preflight let a pass for the *configured* instance
  authorize a reboot of the *tab's*. An asymmetric version (a pass authorizes nothing,
  a fail still refuses) was tried and is incoherent: if the configured target is a good
  enough proxy to refuse on, it is good enough to proceed on. An unbindable **local**
  target is now refused outright, and the rule is applied **at the dispatch point**,
  not only before the preflight await, so a mid-await rebind cannot slip past it.

## Deliberate functional trade — please read before merging

`panel_restart_comfyui` now **refuses** when the target is local and the panel tab
cannot be tied to the ComfyUI this server accounts for. That is the state in which we
cannot know *which* server a stop would hit — precisely the condition that produced
#814 — so the restart is declined rather than sent.

**Affected shapes.** These setups lose `panel_restart_comfyui` until the binding can be
proven. `captureRebootHealthBase` returns null for each:

| shape | why the binding cannot be proven |
|---|---|
| **Ambiguous `localhost` tab origin** | `localhost` may resolve to `::1` in the browser while the boot base is the concrete `127.0.0.1` — the two cannot be shown to be the same instance. |
| **ComfyUI mounted under a basePath** (e.g. `:8188/comfy`) | A handshake `Origin` carries scheme+host+port and **no path**, so it cannot prove the tab fronts *that mount* rather than another instance on the same host:port. |
| **Older / untrusted-locality panel** | The tab did not arrive on the token-less loopback listener, or supplies no server-observed `Origin`, so its provenance is not established. |
| **Non-loopback boot base** | The boot ComfyUI is not on loopback, so the probe target cannot be family-matched. |

**What those users keep.** `restart_comfyui` is unaffected and does the same job: it is
**not tab-scoped**, so it acts on the ComfyUI this server is configured for — an
instance it *can* identify, assess for relaunch, and stop safely. The refusal message
says this explicitly and explains the difference, so a user who hits it is told which
entry point still works and why:

> …Nothing was dispatched, so nothing was stopped. **USE `restart_comfyui` INSTEAD:**
> unlike this panel-scoped restart, it is not tied to a browser tab — it acts on the
> ComfyUI this server is configured for, which it CAN identify and check before
> stopping. Or restart ComfyUI from whatever launches it…

Remote and cloud targets are untouched: there is no local process to assess and the
Manager reboot is their only restart path.

## Known residual: the two attribution sources do not carry the same guarantee

`probePortOwner` has two ways to name a port's owner, and only one of them is
substitution-proof. This is stated in the code at the fallback site as well:

- **`/proc` attribution (new, Linux)** — brackets a pid against a **specific socket**.
  The inode is re-read from the kernel table after the fd walk, and the pid's complete
  fd set must still contain it. A socket that changed hands, or was released while its
  holder kept *another* listener on the same port, withdraws the finding.
- **`lsof` fallback (pre-existing, all POSIX)** — `-Fpn` records carry a pid and an
  `address:port` and **no inode**, so this path attributes **by pid alone**. It can say
  "some process is listening there and it is this one", not "this process holds the
  socket I was tracking".

So the substitution is closed for the `/proc` path and **not** for the lsof fallback.
The fallback is kept deliberately: it is exactly the pre-existing behaviour, so nothing
is made worse, while removing it would restore the permanent "cannot confirm" on every
non-Linux and unprivileged host — the state #795 exists to shrink.

## Needs live verification

Every path here is unit-proven with injected OS readers; none has been exercised against a
real Comfy Desktop install. Worth a live pass on: a Desktop restart with the shell alive
(must proceed), the same with the shell killed (must refuse before dispatch), and a wedged
server recovered via `stop_comfyui` → `start_comfyui`.

## Not covered

#814's items 3–4 — surfacing a duplicate/stale instance in `get_environment` / `health_check`
and the missing-node staleness caveat — are diagnostics in other files and are **not** in
this PR. The related residual: if one *live* Desktop shell spawned two backends, this
classifier reports `supervised` and the reboot still proceeds. Detecting that needs sibling
listener enumeration, which is what those items are about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
