### PR TITLE
download_model: large-file timeouts, no resume, wrong base on Windows portable, non-unique job ids

### DIFF
--- a/docs/tools/models.mdx
+++ b/docs/tools/models.mdx
@@ -272,6 +272,9 @@ Check on model downloads started by download_model. Reports each download's stat
 <ParamField path="id" type="string">
   Download id from download_model. Omit to list every tracked download (incl. in-flight ones from before a reconnect).
 </ParamField>
+<ParamField path="tray_id" type="string">
+  Use this when two rows come back with the SAME `id`, so the id alone cannot say which one you mean. That happens when two different source URLs are downloading to the same destination file. Every row prints its own tray id as `(tray &lt;tray_id&gt;)` — pass that here, together with `id`, to report on exactly one of them.
+</ParamField>
 <ParamField path="url" type="string">
   Adopt an in-flight download by its source URL when you don't have the id (e.g. after a reconnect) — reports the matching job without starting a duplicate.
 </ParamField>
@@ -297,6 +300,9 @@ Cancel ONE in-flight model download started by download_model / download_civitai
 
 <ParamField path="id" type="string" required>
   The download id to cancel (from download_model / download_civitai_model / download_status).
+</ParamField>
+<ParamField path="tray_id" type="string">
+  Use this when a cancel is refused because the `id` names more than one download — two different source URLs writing to the same destination file, so cancelling by id could stop the wrong one. Every download_status row prints its own tray id as `(tray &lt;tray_id&gt;)`; pass the one you want stopped here, together with `id`, and only that download is aborted.
 </ParamField>
 
 ### Example

--- a/src/__tests__/services/download-cache-failclosed.test.ts
+++ b/src/__tests__/services/download-cache-failclosed.test.ts
@@ -63,22 +63,37 @@ describe("assertComplete fail-closed (#467 P1-B)", () => {
   it("does NOT finalize (rename into cache) when the size can't be verified against a known Content-Length", async () => {
     // A full body WITH an authoritative Content-Length. Normally this verifies and
     // finalizes; with stat failing at completion it must fail closed instead.
+    // The stat must fail AT COMPLETION, which is what this test is about. Flipping
+    // the flag before the call would instead trip the staged-file ownership check
+    // (an unreadable staged file now refuses BEFORE writing, rather than being
+    // mistaken for "no partial" and truncated) — a different, also-correct
+    // refusal, but not the one named here. Flip it once the body is consumed.
     fetchMock.mockResolvedValueOnce(
-      new Response("the-model-bytes", {
-        status: 200,
-        statusText: "OK",
-        headers: { "content-length": "15" },
-      }),
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(c) {
+            c.enqueue(new TextEncoder().encode("the-model-bytes"));
+            statCtl.fail = true;
+            c.close();
+          },
+        }),
+        { status: 200, statusText: "OK", headers: { "content-length": "15" } },
+      ),
     );
 
-    statCtl.fail = true;
     await expect(
       downloadWithCache({
         url: "https://example.com/models/failclosed.safetensors",
         headers: {},
         targetPath: join(comfyDir, "out.safetensors"),
       }),
-    ).rejects.toThrow(/could not be verified|not finalizing/i);
+      // Either fail-closed refusal is correct here, and which one fires depends on
+      // WHICH stat the simulated EIO reaches first. The completion check says "I
+      // could not verify the size"; the staged-file ownership check says "I could
+      // not read the staged file, so I will not act on it". Both refuse for the
+      // same reason — an unreadable file is not a known-good one — and the
+      // load-bearing assertion below (nothing was finalized) is unchanged either way.
+    ).rejects.toThrow(/could not be verified|not finalizing|could not be read/i);
 
     // Crucially: nothing was renamed into the cache as a "successful" download.
     statCtl.fail = false;

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -23,6 +23,7 @@ import { config } from "../../config.js";
 import { downloadCacheFs } from "../../services/download-cache.js";
 import { downloadModel } from "../../services/model-resolver.js";
 import type { ResumeDiagnostic } from "../../services/download-resume-diag.js";
+import { setDownloadRetryPolicyForTests } from "../../services/download-retry.js";
 
 /** Capture the resume decision a physical download reports (#467). The decision
  *  is delivered to the CALLER via an onResume callback (no shared map), so a test
@@ -70,6 +71,12 @@ beforeEach(async () => {
   config.civitaiApiToken = undefined;
   vi.stubGlobal("fetch", fetchMock);
   fetchMock.mockReset();
+  // These tests exercise ONE physical attempt's integrity semantics (#343/#467/#473).
+  // #470 added automatic retry on transient failures, which would otherwise re-enter
+  // the stream with a mock that has no further queued response. Pin a single attempt
+  // and disable the stall watchdog so each assertion is about the attempt itself.
+  // Retry behaviour has its own dedicated coverage (download-retry.test.ts).
+  setDownloadRetryPolicyForTests({ maxAttempts: 1, stallTimeoutMs: 0 });
 });
 
 afterEach(async () => {

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -628,29 +628,49 @@ describe("download job registry", () => {
       }
     });
 
-    it("cancel_download with a tray_id aborts EXACTLY that download, leaving its same-id sibling alone", async () => {
-      // Two in-flight jobs in THIS process that share a destination id would
-      // normally coalesce, so drive the distinguishing case directly: two jobs with
-      // different ids, and confirm tray-id selection targets the right one and does
-      // not fall back to "whatever the id row happens to hold".
-      const a = await startDownloadJob(URL_A, "checkpoints");
-      const b = await startDownloadJob(URL_B, "loras");
+    it("cancel_download with a tray_id aborts EXACTLY the named row of a COLLIDING id, and leaves the other alone", async () => {
+      // The real #822 collision: one live local download and one orphaned in-flight
+      // record from before a reconnect, sharing an id because they resolve to the
+      // same destination file. `tray_id` must pick out precisely one of them.
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-822-"));
+      setProgressDir(dir);
+      try {
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        await writeForeignJobRecord(dir, {
+          id: a.job.id,
+          trayId: "orphantrayid0001",
+          progressId: "orphan-prog",
+          url: URL_B,
+          owner: `${PERSIST_OWNER}-reconnected-away`,
+          ageMs: 313_000,
+        });
+        // Precondition: the id really does name two rows.
+        expect(listDownloadJobCandidates(a.job.id)).toHaveLength(2);
 
-      const wrongTray = cancelDownloadJob(a.job.id, b.job.trayId);
-      // a's id + b's tray is not a real download — nothing may be aborted on it.
-      expect(wrongTray.aborted).toBe(false);
-      expect(wrongTray.found).toBe(false);
-      expect(a.job.status).toBe("downloading");
-      expect(b.job.status).toBe("downloading");
+        // Naming the ORPHAN must not touch our live transfer…
+        const orphan = cancelDownloadJob(a.job.id, "orphantrayid0001");
+        expect(orphan.aborted).toBe(false);
+        expect(a.job.status).toBe("downloading");
 
-      const right = cancelDownloadJob(a.job.id, a.job.trayId);
-      expect(right.aborted).toBe(true);
-      await a.settled;
-      expect(a.job.status).toBe("cancelled");
-      // The sibling is untouched.
-      expect(b.job.status).toBe("downloading");
-      hoisted.resolvers.find((r) => r.url === URL_B)!.resolve("/M/loras/other.safetensors");
-      await b.settled;
+        // …and a tray id that names NOTHING must abort nothing at all.
+        const bogus = cancelDownloadJob(a.job.id, "nosuchtrayid0000");
+        expect(bogus.found).toBe(false);
+        expect(bogus.aborted).toBe(false);
+        expect(a.job.status).toBe("downloading");
+        // The refusal still lists what the id DOES name, so the caller can retry.
+        expect(bogus.candidates?.map((c) => c.trayId).sort()).toEqual(
+          [a.job.trayId, "orphantrayid0001"].sort(),
+        );
+
+        // Only the exact tray id aborts the live one.
+        const right = cancelDownloadJob(a.job.id, a.job.trayId);
+        expect(right.aborted).toBe(true);
+        await a.settled;
+        expect(a.job.status).toBe("cancelled");
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
     });
 
     it("an ambiguity refusal NAMES the candidates instead of leaving the caller stuck", async () => {

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -599,6 +599,43 @@ describe("download job registry", () => {
       }
     });
 
+    it("a LIVE foreign download is never hidden behind this session's settled row for the same URL", async () => {
+      // `trayId` is a hash of the URL, so it does NOT separate sessions: this
+      // session's finished record and ANOTHER session's still-running download of
+      // the same URL to the same destination collapse to one (id, trayId) key.
+      // Reporting the settled one would hide a running transfer behind a stale
+      // verdict — worse than the ambiguity this selector exists to surface, and it
+      // would make `tray_id` weaker than the plain by-id lookup in that state.
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-822-"));
+      setProgressDir(dir);
+      try {
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        // Our own download is cancelled and settles…
+        cancelDownloadJob(a.job.id, a.job.trayId);
+        await a.settled;
+        expect(a.job.status).toBe("cancelled");
+
+        // …while another session is still downloading the SAME url to the SAME
+        // destination (same id, and — because trayId hashes the url — same trayId).
+        await writeForeignJobRecord(dir, {
+          id: a.job.id,
+          trayId: a.job.trayId,
+          progressId: "foreign-live-prog",
+          url: URL_A,
+          owner: `${PERSIST_OWNER}-other`,
+        });
+
+        const candidates = listDownloadJobCandidates(a.job.id);
+        expect(candidates).toHaveLength(1);
+        // The LIVE one is reported, not our cancelled one.
+        expect(candidates[0].status).toBe("downloading");
+        expect(getDownloadJob(a.job.id, a.job.trayId)?.status).toBe("downloading");
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
     it("getDownloadJob(id, trayId) resolves the ORPHAN — the row that was unreachable", async () => {
       const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-822-"));
       setProgressDir(dir);

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -109,6 +109,7 @@ import {
   getDownloadJob,
   findDownloadJob,
   listDownloadJobs,
+  listDownloadJobCandidates,
   cancelDownloadJob,
   resetDownloadJobs,
   downloadIdFor,
@@ -557,6 +558,164 @@ describe("download job registry", () => {
     await pub.settled;
     await new Promise((r) => setTimeout(r, 0));
     expect(hoisted.calls).toBe(2);
+  });
+
+  // ── #822: the exposed `id` is not unique, so it cannot select ─────────────
+  //
+  // `id` is a hash of the DESTINATION (+auth), deliberately: two URLs landing on
+  // one file are one writer. The consequence is that `id` is a DESTINATION handle
+  // while download_status renders it as though it were a JOB handle — and when a
+  // reconnect leaves an orphaned in-flight record, two rows carry the same id and
+  // neither can be selected. The composite (id, trayId) is the real identity; this
+  // block is about making it reachable from the public surface.
+  describe("#822 selecting one download when an id names several", () => {
+    it("lists EVERY download an id answers to, keyed by the true (id, trayId) identity", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-822-"));
+      setProgressDir(dir);
+      try {
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        // The #822 shape: an orphan from before a reconnect — same destination
+        // (same id), different SOURCE URL (different trayId), heartbeat stale.
+        await writeForeignJobRecord(dir, {
+          id: a.job.id,
+          trayId: "orphantrayid0001",
+          progressId: "orphan-prog",
+          url: URL_B,
+          owner: `${PERSIST_OWNER}-reconnected-away`,
+          ageMs: 313_000,
+        });
+
+        const candidates = listDownloadJobCandidates(a.job.id);
+        expect(candidates).toHaveLength(2);
+        // Both share the id — which is exactly why the id alone cannot select.
+        expect(new Set(candidates.map((c) => c.id))).toEqual(new Set([a.job.id]));
+        // …and both are distinguishable by trayId.
+        expect(new Set(candidates.map((c) => c.trayId))).toEqual(
+          new Set([a.job.trayId, "orphantrayid0001"]),
+        );
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("getDownloadJob(id, trayId) resolves the ORPHAN — the row that was unreachable", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-822-"));
+      setProgressDir(dir);
+      try {
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        await writeForeignJobRecord(dir, {
+          id: a.job.id,
+          trayId: "orphantrayid0001",
+          progressId: "orphan-prog",
+          url: URL_B,
+          owner: `${PERSIST_OWNER}-reconnected-away`,
+          ageMs: 313_000,
+        });
+
+        // By id alone you get the local live one (which is fine, and is #761's rule).
+        expect(getDownloadJob(a.job.id)?.trayId).toBe(a.job.trayId);
+        // With the tray id you get the specific one you asked for — including the
+        // orphan, which #822 reported as unselectable by any means.
+        const orphan = getDownloadJob(a.job.id, "orphantrayid0001");
+        expect(orphan?.trayId).toBe("orphantrayid0001");
+        expect(orphan?.url).toBe(URL_B);
+        // And a tray id that names nothing resolves to nothing — not to "whichever".
+        expect(getDownloadJob(a.job.id, "nosuchtrayid0000")).toBeUndefined();
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("cancel_download with a tray_id aborts EXACTLY that download, leaving its same-id sibling alone", async () => {
+      // Two in-flight jobs in THIS process that share a destination id would
+      // normally coalesce, so drive the distinguishing case directly: two jobs with
+      // different ids, and confirm tray-id selection targets the right one and does
+      // not fall back to "whatever the id row happens to hold".
+      const a = await startDownloadJob(URL_A, "checkpoints");
+      const b = await startDownloadJob(URL_B, "loras");
+
+      const wrongTray = cancelDownloadJob(a.job.id, b.job.trayId);
+      // a's id + b's tray is not a real download — nothing may be aborted on it.
+      expect(wrongTray.aborted).toBe(false);
+      expect(wrongTray.found).toBe(false);
+      expect(a.job.status).toBe("downloading");
+      expect(b.job.status).toBe("downloading");
+
+      const right = cancelDownloadJob(a.job.id, a.job.trayId);
+      expect(right.aborted).toBe(true);
+      await a.settled;
+      expect(a.job.status).toBe("cancelled");
+      // The sibling is untouched.
+      expect(b.job.status).toBe("downloading");
+      hoisted.resolvers.find((r) => r.url === URL_B)!.resolve("/M/loras/other.safetensors");
+      await b.settled;
+    });
+
+    it("an ambiguity refusal NAMES the candidates instead of leaving the caller stuck", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-822-"));
+      setProgressDir(dir);
+      try {
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        // A FRESH foreign sibling: a genuinely concurrent different-URL download to
+        // the same destination. Cancel-by-id must still decline (#515) — but the
+        // refusal now carries the tray ids that resolve it, which is the difference
+        // between "no move available" and an actionable next step.
+        await writeForeignJobRecord(dir, {
+          id: a.job.id,
+          trayId: "freshtrayid00001",
+          progressId: "fresh-prog",
+          url: URL_B,
+          owner: `${PERSIST_OWNER}-other`,
+        });
+
+        const res = cancelDownloadJob(a.job.id);
+        expect(res.ambiguous).toBe(true);
+        expect(res.aborted).toBe(false);
+        expect(res.candidates?.map((c) => c.trayId).sort()).toEqual(
+          [a.job.trayId, "freshtrayid00001"].sort(),
+        );
+
+        // And naming one resolves it: the local job CAN be cancelled by tray id.
+        const chosen = cancelDownloadJob(a.job.id, a.job.trayId);
+        expect(chosen.aborted).toBe(true);
+        await a.settled;
+        expect(a.job.status).toBe("cancelled");
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("a foreign-session download selected by tray_id is reported as NOT abortable here — never falsely aborted", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-822-"));
+      setProgressDir(dir);
+      try {
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        await writeForeignJobRecord(dir, {
+          id: a.job.id,
+          trayId: "orphantrayid0001",
+          progressId: "orphan-prog",
+          url: URL_B,
+          owner: `${PERSIST_OWNER}-reconnected-away`,
+          ageMs: 313_000,
+        });
+
+        const res = cancelDownloadJob(a.job.id, "orphantrayid0001");
+        expect(res.found).toBe(true);
+        // We hold no AbortController for another session's writer — say so rather
+        // than reporting an abort that did not happen.
+        expect(res.owned).toBe(false);
+        expect(res.aborted).toBe(false);
+        expect(res.job?.url).toBe(URL_B);
+        // Our own live download was NOT collateral damage.
+        expect(a.job.status).toBe("downloading");
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
   });
 
   // ── #515: per-download cancellation ────────────────────────────────────────

--- a/src/__tests__/services/download-retry.test.ts
+++ b/src/__tests__/services/download-retry.test.ts
@@ -52,6 +52,7 @@ vi.mock("../../services/storage/index.js", async () => {
 });
 
 import { config } from "../../config.js";
+import { downloadCacheFs } from "../../services/download-cache.js";
 import { downloadModel } from "../../services/model-resolver.js";
 import {
   abortableDelay,
@@ -653,6 +654,68 @@ describe("download retry + resume, end to end (#470)", () => {
     // The remedy names what the caller can do from here.
     expect(message).toMatch(/download_status/);
     expect(message).toMatch(/re-issue/i);
+  });
+
+  it("emits exactly ONE terminal error row even when the cache path bails out to the direct-download fallback", async () => {
+    // downloadWithCache falls back to a direct stream when the cache layer throws
+    // something that is not a ModelError (an unusable cache dir, say). That
+    // fallback stream is a separate call into streamUrlToFile, so unless it also
+    // defers, the failure is announced twice — once by the fallback and once by
+    // downloadModel — for a single download.
+    const url = "https://example.com/models/cache-unavailable.safetensors";
+    // Break the cache layer with a NON-ModelError so the fallback path is taken.
+    vi.spyOn(downloadCacheFs, "mkdir").mockRejectedValue(new Error("cache dir unusable"));
+    // The body must fail DURING streaming, not at the status line: a non-2xx throws
+    // before any row is emitted, so it would not exercise the emit at all.
+    fetchMock.mockImplementation(async () => shortBody("AB", 100));
+
+    await expect(
+      downloadModel(url, "checkpoints", "cache-unavailable-out.safetensors"),
+    ).rejects.toThrow();
+
+    expect(progressRows.filter((r) => r.status === "error")).toHaveLength(1);
+  });
+
+  it("catches another writer that re-staged a DIFFERENT object at the SAME byte count", async () => {
+    // The splice the size check alone would miss, and the one that actually
+    // corrupts: another writer truncates the shared staged file and re-stages a
+    // DIFFERENT upstream object to exactly the same length. Our resume would then
+    // append v1's suffix onto v2's prefix and every downstream check — size,
+    // Content-Range, total — would still pass.
+    //
+    // It cannot do that without writing the new object's validator to the sidecar,
+    // which is why the snapshot covers the sidecar and not just the size.
+    const url = "https://example.com/models/same-size-swap.safetensors";
+    const { partial, sidecar } = cachePaths(url);
+    setDownloadRetryPolicyForTests({ backoffBaseMs: 2_000, backoffCapMs: 2_000 });
+
+    fetchMock.mockImplementationOnce(async () => {
+      void (async () => {
+        for (let i = 0; i < 400; i += 1) {
+          const size = await stat(partial).then((s) => s.size).catch(() => 0);
+          if (size >= 4) break;
+          await new Promise((r) => setTimeout(r, 5));
+        }
+        await new Promise((r) => setTimeout(r, 250));
+        // SAME length, DIFFERENT object — byte count is unchanged.
+        await writeFile(partial, "ZZZZ");
+        await writeFile(sidecar, '"obj-v2"');
+      })();
+      return shortBody("AAAA", 64, { etag: '"obj-v1"' });
+    });
+    fetchMock.mockImplementation(async () => new Response("MUST-NOT-BE-FETCHED", { status: 200 }));
+
+    const err = await downloadModel(url, "checkpoints", "same-size-swap-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    const message = String((err as Error).message);
+    expect(message).toMatch(/another download is writing the same staged file/i);
+    // It names WHY — the validator, not the size, is what gave it away.
+    expect(message).toMatch(/resume validator changed/i);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Nothing of the other writer's was destroyed.
+    await expect(readFile(partial, "utf-8")).resolves.toBe("ZZZZ");
+    await expect(readFile(sidecar, "utf-8")).resolves.toBe('"obj-v2"');
   });
 
   it("a retry that lands on a POISONED partial (#473 leftover) restarts instead of resuming onto it", async () => {

--- a/src/__tests__/services/download-retry.test.ts
+++ b/src/__tests__/services/download-retry.test.ts
@@ -758,6 +758,113 @@ describe("download retry + resume, end to end (#470)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("a CLOUD retry never truncates a staged file another writer has grown — the most destructive path checks first", async () => {
+    // The cloud (S3/Azure) path cannot range-resume: it TRUNCATES the staged file
+    // and re-downloads in full. Under automatic retry that turns a later attempt
+    // into a destructive writer — before #470 a failed cloud attempt simply ended
+    // and could never come back to clobber anyone. If another process staged real
+    // progress while we were backing off, truncating destroys work that is not ours
+    // and that (unlike an HTTP resume) nothing can cheaply re-fetch.
+    const url = "s3://bucket/models/contended-cloud.safetensors";
+    // A cloud cache path folds in the storage principal, so take it from what the
+    // downloader is actually handed rather than recomputing it here.
+    let stagedPath = "";
+    setDownloadRetryPolicyForTests({ maxAttempts: 3, backoffBaseMs: 1_500, backoffCapMs: 1_500 });
+
+    const cloudDownload = vi.mocked(
+      (await import("../../services/storage/index.js")).downloadCloudUrlToFile,
+    );
+    let call = 0;
+    cloudDownload.mockImplementation(async (_url, targetPath) => {
+      call += 1;
+      stagedPath = targetPath as string;
+      if (call === 1) {
+        await writeFile(stagedPath, "OURS");
+        // The other writer stages substantial progress during our backoff.
+        void (async () => {
+          await new Promise((r) => setTimeout(r, 250));
+          await writeFile(stagedPath, "SOMEONE-ELSES-MANY-GIGABYTES");
+        })();
+        throw Object.assign(new Error("connection reset by peer"), { code: "ECONNRESET" });
+      }
+      // A later attempt must never get here with the other writer's bytes staged.
+      await writeFile(stagedPath, "CLOBBERED");
+      throw new Error("second cloud attempt");
+    });
+
+    const err = await downloadModel(url, "checkpoints", "contended-cloud-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    expect(String((err as Error).message)).toMatch(
+      /another download is writing the same staged file/i,
+    );
+    // THE assertion: the other writer's bytes are untouched. A truncate here would
+    // have been silent, unrecoverable, multi-gigabyte data loss.
+    await expect(readFile(stagedPath, "utf-8")).resolves.toBe("SOMEONE-ELSES-MANY-GIGABYTES");
+  }, 20_000);
+
+  it("an integrity REFUSAL never deletes a partial another writer re-staged — refusing our response is not licence to clean up theirs", async () => {
+    // The refusal paths (#467) remove the staged file and its sidecar, which is
+    // right when the file is OURS. If another writer re-staged it while our request
+    // was in flight it is not — and "we got a bad response" must not become "we
+    // deleted your multi-gigabyte partial". The interference check therefore sits
+    // BEFORE those refusals, not after them.
+    const url = "https://example.com/models/refusal-vs-other-writer.safetensors";
+    const { partial, sidecar } = cachePaths(url);
+    await writeFile(partial, "OURS");
+    await writeFile(sidecar, '"obj-v1"');
+
+    fetchMock.mockImplementationOnce(async () => {
+      // The other writer re-stages while we wait for the response…
+      await writeFile(partial, "SOMEONE-ELSES-CONTENT");
+      await writeFile(sidecar, '"obj-v2"');
+      // …and the response we get is one the integrity guards would REFUSE and then
+      // clean up after (a 206 whose Content-Range starts at the wrong offset).
+      return new Response("XXXX", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 999-1002/1003" },
+      });
+    });
+    fetchMock.mockImplementation(async () => new Response("MUST-NOT-BE-FETCHED", { status: 200 }));
+
+    const err = await downloadModel(url, "checkpoints", "refusal-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    expect(String((err as Error).message)).toMatch(
+      /another download is writing the same staged file/i,
+    );
+    // Neither the partial nor the sidecar was cleaned up on the other writer's behalf.
+    await expect(readFile(partial, "utf-8")).resolves.toBe("SOMEONE-ELSES-CONTENT");
+    await expect(readFile(sidecar, "utf-8")).resolves.toBe('"obj-v2"');
+  });
+
+  it("does NOT promise a resume for bytes with no recorded identity — they exist, but a re-issue re-fetches them", async () => {
+    // A partial with no validator sidecar is deliberately RESTARTED, not resumed
+    // (#343/#467): there is no recorded proof of which object those bytes belong
+    // to. Telling the caller "re-issuing resumes from there" would be a remedy they
+    // cannot act on — the bytes are real, but they will be downloaded again.
+    const url = "https://example.com/models/no-validator-giveup.safetensors";
+    // Short bodies with NO validator header at all, so no sidecar is ever written.
+    fetchMock.mockImplementation(async () => shortBody("ABCD", 100));
+
+    const err = await downloadModel(url, "checkpoints", "no-validator-giveup-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    const message = String((err as Error).message);
+    expect(message).toMatch(/after 3 attempts/i);
+    // It states the bytes exist…
+    expect(message).toMatch(/of partial data is on disk/);
+    // …and is honest that they will NOT be resumed, and why.
+    expect(message).toMatch(/restart from the beginning rather than resume/);
+    expect(message).toMatch(/no recorded proof of WHICH object/);
+    expect(message).not.toMatch(/resumes from there/);
+    // The bytes really are there, and really have no validator — checked on disk.
+    const { partial, sidecar } = cachePaths(url);
+    await expect(stat(partial).then((s) => s.size)).resolves.toBeGreaterThan(0);
+    await expect(stat(sidecar)).rejects.toThrow();
+  });
+
   it("a retry that lands on a POISONED partial (#473 leftover) restarts instead of resuming onto it", async () => {
     const url = "https://example.com/models/poisoned.safetensors";
     const { partial, sidecar } = cachePaths(url);

--- a/src/__tests__/services/download-retry.test.ts
+++ b/src/__tests__/services/download-retry.test.ts
@@ -904,6 +904,36 @@ describe("download retry + resume, end to end (#470)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("REFUSES a retry whose VALIDATOR it cannot read — an unknown validator sends the attempt down the truncating path", async () => {
+    // The sidecar half of the same fail-closed rule, and it is not cosmetic:
+    // readValidatorSidecar() reads "unreadable" as "no validator", which routes the
+    // attempt to the 200-RESTART path — and that path TRUNCATES the staged file. So
+    // an unknown validator plus a same-size replacement by another writer during
+    // the backoff would silently destroy their partial.
+    const url = "https://example.com/models/unreadable-validator.safetensors";
+    const { partial, sidecar } = cachePaths(url);
+    // Staged bytes plus a validator path that CANNOT be read (a blocked directory —
+    // EISDIR, not ENOENT; a MISSING sidecar is knowably "no validator" and is a
+    // legitimate clean restart).
+    await writeFile(partial, "PRECIOUS-BYTES");
+    await mkdir(sidecar, { recursive: true });
+    await writeFile(join(sidecar, "blocker"), "x");
+
+    fetchMock.mockImplementation(async () => new Response("FULL-REPLACEMENT", { status: 200 }));
+
+    const err = await downloadModel(url, "checkpoints", "unreadable-validator-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    // A validator-related refusal — from this guard or from #467's more precise
+    // stale-sidecar one. What must NEVER happen is proceeding to the truncating
+    // restart on a validator nobody could read.
+    expect(String((err as Error).message)).toMatch(
+      /resume validator could not be read|remove or empty the stale resume-validator sidecar|restart failed/i,
+    );
+    // The decisive assertion: the staged bytes were not truncated on the way out.
+    await expect(readFile(partial, "utf-8")).resolves.toBe("PRECIOUS-BYTES");
+  });
+
   it("a cancel that lands DURING the pre-write check still leaves the resumable partial on disk", async () => {
     // The interference check awaits, so a cancel can arrive inside it. Every path
     // after that hook deletes or truncates the staged file, and a cancelled

--- a/src/__tests__/services/download-retry.test.ts
+++ b/src/__tests__/services/download-retry.test.ts
@@ -718,6 +718,46 @@ describe("download retry + resume, end to end (#470)", () => {
     await expect(readFile(sidecar, "utf-8")).resolves.toBe('"obj-v2"');
   });
 
+  it("catches another writer that acts DURING the request — between deciding how to resume and writing", async () => {
+    // The TOCTOU the between-attempts snapshot alone does NOT cover, and the one
+    // that produces a valid-LOOKING corrupt file:
+    //   1. we read the staged file (4 bytes of v1) and its v1 validator;
+    //   2. we issue a ranged request for v1's remainder;
+    //   3. WHILE that request is in flight, another writer truncates and re-stages
+    //      v2, writing 4 bytes and v2's validator;
+    //   4. we append v1's suffix onto v2's prefix — landing on exactly the
+    //      authoritative total, so size, Content-Range and total all still pass.
+    // Re-checking immediately before the write is what stops step 4.
+    const url = "https://example.com/models/toctou.safetensors";
+    const { partial, sidecar } = cachePaths(url);
+    await writeFile(partial, "V1V1");
+    await writeFile(sidecar, '"obj-v1"');
+
+    fetchMock.mockImplementationOnce(async () => {
+      // The other writer lands while our request is being served.
+      await writeFile(partial, "V2V2");
+      await writeFile(sidecar, '"obj-v2"');
+      return new Response("V1SUFFIX", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 4-11/12" },
+      });
+    });
+    fetchMock.mockImplementation(async () => new Response("MUST-NOT-BE-FETCHED", { status: 200 }));
+
+    const err = await downloadModel(url, "checkpoints", "toctou-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    expect(String((err as Error).message)).toMatch(
+      /another download is writing the same staged file/i,
+    );
+    // The spliced file was never written: the staged bytes are still exactly what
+    // the other writer left, with no v1 suffix appended.
+    await expect(readFile(partial, "utf-8")).resolves.toBe("V2V2");
+    // And it is not retried into the same splice on a later attempt.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("a retry that lands on a POISONED partial (#473 leftover) restarts instead of resuming onto it", async () => {
     const url = "https://example.com/models/poisoned.safetensors";
     const { partial, sidecar } = cachePaths(url);

--- a/src/__tests__/services/download-retry.test.ts
+++ b/src/__tests__/services/download-retry.test.ts
@@ -1366,6 +1366,116 @@ describe("download retry + resume, end to end (#470)", () => {
     await expect(readFile(sidecar, "utf-8")).resolves.toBe('"their-object"');
   });
 
+  it("the #473 payload-rejection cleanup proves ownership too — 'we streamed it' is not 'it is still ours'", async () => {
+    // The staged `.partial` sits at a deterministic path in a shared directory, so
+    // a second process running the same download reaches the very same file.
+    // Having streamed the bytes ourselves establishes what we WROTE, not what is
+    // there when we act: `assertModelPayloadOrThrow` reads the head and awaits the
+    // rejection callback, and a foreign writer can take the file over inside that
+    // gap. Destroying THEIR files while reporting OUR rejection is the harm.
+    const url = "https://example.com/models/reject-vs-foreign.safetensors";
+    const { partial, sidecar } = cachePaths(url);
+
+    // A body that will be REJECTED as a non-model (an HTML auth page).
+    fetchMock.mockImplementation(
+      async () =>
+        new Response("<!DOCTYPE html><html><body>login</body></html>", {
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "text/html", etag: '"v"' },
+        }),
+    );
+
+    const realRm = downloadCacheFs.rm;
+    let planted = false;
+    vi.spyOn(downloadCacheFs, "rm").mockImplementation(async (...args) => {
+      const path = String(args[0]);
+      if (!planted && path.endsWith(".partial")) {
+        planted = true;
+        // The foreign writer takes over while we are cleaning up our rejection.
+        await writeFile(partial, "SOMEONE-ELSES-MANY-GIGABYTES");
+        await writeFile(sidecar, '"their-object"');
+      }
+      return realRm(...(args as Parameters<typeof realRm>));
+    });
+
+    await expect(
+      downloadModel(url, "checkpoints", "reject-vs-foreign-out.safetensors"),
+    ).rejects.toThrow();
+
+    // Their validator survives: the sidecar's own check caught the takeover. With
+    // an unconditional "we own this" claim it would have been deleted along with
+    // their partial, leaving them bytes they could no longer resume.
+    await expect(readFile(sidecar, "utf-8")).resolves.toBe('"their-object"');
+  });
+
+  it("an INTEGRITY refusal's cleanup proves ownership too — it does not delete a new writer's validator", async () => {
+    // The integrity refusals (0-byte body, oversized body, bad Content-Range,
+    // unsolicited 206) each issued two raw `safeRm`s with an await between them and
+    // the failure swallowed. Same granularity bug, different spelling: the second
+    // removal acts on whatever is there by then, so a writer that staged a real
+    // transfer in the gap loses the validator that makes its bytes resumable — and
+    // nothing is reported, because safeRm swallows.
+    const url = "https://example.com/models/empty-cleanup-vs-foreign.safetensors";
+    const { partial, sidecar } = cachePaths(url);
+
+    // A 0-byte body: assertComplete removes the empty partial and the cleanup runs.
+    fetchMock.mockImplementation(
+      async () => new Response("", { status: 200, statusText: "OK", headers: { "content-length": "0" } }),
+    );
+
+    const realRm = downloadCacheFs.rm;
+    let planted = false;
+    vi.spyOn(downloadCacheFs, "rm").mockImplementation(async (...args) => {
+      const path = String(args[0]);
+      if (!planted && path.endsWith(".partial")) {
+        planted = true;
+        // A new writer stages a real transfer at the same path.
+        await writeFile(partial, "NEW-WRITERS-BYTES");
+        await writeFile(sidecar, '"new-writers-object"');
+      }
+      return realRm(...(args as Parameters<typeof realRm>));
+    });
+
+    await downloadModel(url, "checkpoints", "empty-cleanup-out.safetensors").catch(
+      () => undefined,
+    );
+
+    // The new writer keeps BOTH its bytes and the validator that makes them resumable.
+    await expect(readFile(sidecar, "utf-8")).resolves.toBe('"new-writers-object"');
+  });
+
+  it("REFUSES when the staged file exists but its size cannot be read — unreadable is not 'no partial'", async () => {
+    // The repo's dominant fold, in its most expensive form. A transient stat error
+    // used to be caught as "No partial — fresh download": the resume offset stayed
+    // 0, the attempt took the non-append path, and a full 200 opened the existing
+    // file in TRUNCATING mode — deleting an active writer's bytes because we could
+    // not read a size.
+    const url = "https://example.com/models/unreadable-is-not-absent.safetensors";
+    const { partial } = cachePaths(url);
+    await writeFile(partial, "ANOTHER-WRITERS-MANY-GIGABYTES");
+
+    const realStat = downloadCacheFs.stat;
+    vi.spyOn(downloadCacheFs, "stat").mockImplementation(async (...args) => {
+      const path = String(args[0]);
+      if (path.endsWith(".partial")) {
+        // EIO, not ENOENT — the file is THERE, we just cannot read its size.
+        throw Object.assign(new Error("EIO: i/o error"), { code: "EIO" });
+      }
+      return realStat(...(args as Parameters<typeof realStat>));
+    });
+    fetchMock.mockImplementation(async () => new Response("FULL-REPLACEMENT", { status: 200 }));
+
+    const err = await downloadModel(url, "checkpoints", "unreadable-absent-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    expect(String((err as Error).message)).toMatch(/size could not be read/i);
+    // The bytes are untouched — not truncated by an attempt that assumed "fresh".
+    await expect(readFile(partial, "utf-8")).resolves.toBe("ANOTHER-WRITERS-MANY-GIGABYTES");
+    // And it refused BEFORE issuing a request.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("a retry that lands on a POISONED partial (#473 leftover) restarts instead of resuming onto it", async () => {
     const url = "https://example.com/models/poisoned.safetensors";
     const { partial, sidecar } = cachePaths(url);

--- a/src/__tests__/services/download-retry.test.ts
+++ b/src/__tests__/services/download-retry.test.ts
@@ -41,6 +41,16 @@ vi.mock("../../services/download-progress.js", async () => {
   };
 });
 
+/** The cloud (S3/Azure) downloader is the vendor SDK; stub it so the watchdog's
+ *  behaviour around it can be exercised without a real bucket. Everything else in
+ *  the storage module (URL detection, principal keying) stays real. */
+vi.mock("../../services/storage/index.js", async () => {
+  const actual = await vi.importActual<typeof import("../../services/storage/index.js")>(
+    "../../services/storage/index.js",
+  );
+  return { ...actual, downloadCloudUrlToFile: vi.fn() };
+});
+
 import { config } from "../../config.js";
 import { downloadModel } from "../../services/model-resolver.js";
 import {
@@ -134,6 +144,23 @@ describe("classifyDownloadFailure (#470)", () => {
       ]) {
         expect(classifyDownloadFailure(new ModelError(message)).retryable).toBe(false);
       }
+    });
+
+    it("does NOT retry on the fetch wrapper's 'network layer' prose alone", () => {
+      // fetchOrThrow wraps EVERY thrown fetch as "…failed at the network layer: …".
+      // If that phrase counted as a transient signature, an expired TLS
+      // certificate, a misconfigured proxy and an aborted request would all look
+      // retryable — inverting this module's fail-safe default for the entire class
+      // of fetch failures. The transport CODE decides instead.
+      const wrapper =
+        "Download request to the model host failed at the network layer: unable to verify the " +
+        "first certificate. This is a connectivity/TLS/proxy failure reaching the file host.";
+      expect(classifyDownloadFailure(new ModelError(wrapper)).retryable).toBe(false);
+      // …and the very same wrapper WITH a transport code is still retried, so this
+      // is about the prose carrying no evidence, not about distrusting the wrapper.
+      expect(
+        classifyDownloadFailure(new ModelError(wrapper, { code: "ECONNRESET" })).retryable,
+      ).toBe(true);
     });
 
     it("defaults to NOT retryable for an error it does not recognise", () => {
@@ -370,22 +397,29 @@ describe("download retry + resume, end to end (#470)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
-  it("never claims preserved bytes it did not observe — an unreadable partial is reported as unknown", async () => {
-    const url = "https://example.com/models/no-partial-left.safetensors";
-    // A 0-byte body: assertComplete removes the empty partial AND its sidecar, so
-    // by the time we report there is genuinely nothing left to resume.
+  it("reports 'no partial survived' — as a FACT, not a shrug — when no bytes were ever staged", async () => {
+    // The mirror of the test above, and the reason `partialSize` separates ABSENT
+    // from UNREADABLE. A 503 is retryable but never streams a body, so no .partial
+    // is ever created. "There is nothing to resume" is KNOWN here, and reporting it
+    // as "could not be read" would be a shrug where a fact was available — the same
+    // failure mode as the reverse, just pointing the other way.
+    const url = "https://example.com/models/never-staged.safetensors";
     fetchMock.mockImplementation(
-      async () => new Response("A", { status: 200, statusText: "OK", headers: { "content-length": "50" } }),
+      async () => new Response("upstream busy", { status: 503, statusText: "Service Unavailable" }),
     );
 
-    const err = await downloadModel(url, "checkpoints", "no-partial-out.safetensors").catch(
+    const err = await downloadModel(url, "checkpoints", "never-staged-out.safetensors").catch(
       (e: unknown) => e,
     );
     const message = String((err as Error).message);
     expect(message).toMatch(/after 3 attempts/i);
-    // It reports what it actually found — a surviving partial here — rather than a
-    // canned "your data is safe". The point is the claim is derived from a stat.
-    expect(message).toMatch(/preserved on disk|No partial data survived|could NOT be read/);
+    expect(message).toMatch(/No partial data survived/);
+    expect(message).not.toMatch(/could NOT be read/);
+    expect(message).not.toMatch(/preserved on disk/);
+    // The claim is TRUE — checked against the filesystem, not against the sentence.
+    const { partial } = cachePaths(url);
+    await expect(stat(partial)).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(3); // a 503 really is retried
   });
 
   it("a CANCEL during backoff stops the download — it is never retried into a completion", async () => {
@@ -424,39 +458,37 @@ describe("download retry + resume, end to end (#470)", () => {
     await expect(stat(partial).then((s) => s.size)).resolves.toBe(4);
   });
 
-  it("a cancel that SURFACES AS A TRANSIENT ERROR is still not retried — cancellation is decided by the signal, not by the message", async () => {
-    // The hazard this pins: aborting a fetch mid-body makes undici raise
-    // `TypeError: terminated` — which is EXACTLY the transient signature #470
-    // asked us to retry. If the loop classified the error instead of consulting
-    // the caller's signal first, a user's cancel would be "recovered from" and the
-    // download would run to completion after they stopped it. The loop must decide
-    // on the SIGNAL, and this test fails if that ordering is ever inverted.
+  it("a cancel whose error IS classified transient is still not retried — cancellation is decided by the signal, not by the message", async () => {
+    // The hazard this pins. Aborting a fetch mid-BODY makes undici raise
+    // `TypeError: terminated` — the exact signature #470 asked us to retry, and
+    // one this suite asserts elsewhere IS retryable. If the loop classified the
+    // error instead of consulting the caller's signal first, a user's cancel would
+    // be "recovered from" and the download would run on after they stopped it.
     const url = "https://example.com/models/cancel-looks-transient.safetensors";
     const ctl = new AbortController();
 
-    // Cancelling while the REQUEST is in flight makes fetch reject with an
-    // AbortError, which fetchOrThrow wraps as "…failed at the network layer: …".
-    // classifyDownloadFailure reads that as TRANSIENT — correctly, because in
-    // every other circumstance it is. Confirm it really does:
-    expect(
-      classifyDownloadFailure(
-        new ModelError(
-          "Download request to the model host failed at the network layer: This operation was aborted.",
-        ),
-      ).retryable,
-    ).toBe(true);
+    // Not a hypothesis — the error this transport raises really is retryable:
+    expect(classifyDownloadFailure(new TypeError("terminated")).retryable).toBe(true);
 
-    fetchMock.mockImplementationOnce(
-      (_u: string, init: { signal?: AbortSignal }) =>
-        new Promise((_resolve, reject) => {
-          setTimeout(() => ctl.abort(), 5);
-          init.signal?.addEventListener(
-            "abort",
-            () => reject(new DOMException("This operation was aborted.", "AbortError")),
-            { once: true },
-          );
-        }),
-    );
+    fetchMock.mockImplementationOnce(async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("AAAA"));
+          setTimeout(() => {
+            // Order matters and is deterministic: both statements run in ONE
+            // synchronous tick, so the caller's signal is already aborted by the
+            // time the pipeline's rejection is handled in a later microtask.
+            c.error(new TypeError("terminated"));
+            ctl.abort();
+          }, 5);
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-length": "64", etag: '"v"' },
+      });
+    });
     fetchMock.mockImplementation(async () => new Response("MUST-NOT-BE-FETCHED", { status: 200 }));
 
     await expect(
@@ -549,6 +581,78 @@ describe("download retry + resume, end to end (#470)", () => {
     const errorRows = progressRows.filter((r) => r.status === "error");
     // Exactly one — not one per attempt, and not zero.
     expect(errorRows).toHaveLength(1);
+  });
+
+  it("does NOT arm the stall watchdog for a cloud (S3/Azure) transfer, which reports no byte progress", async () => {
+    // A cloud transfer is performed by the vendor SDK, which writes the file
+    // itself and never calls back per chunk — so the watchdog's liveness clock
+    // would never be refreshed and a perfectly healthy multi-GB transfer would
+    // look stalled from its first second. That is not merely wasteful: the cloud
+    // path cannot range-resume, so each "retry" TRUNCATES the partial and starts
+    // over, destroying real progress on a loop that could never terminate.
+    setDownloadRetryPolicyForTests({ maxAttempts: 3, stallTimeoutMs: 100 });
+
+    const cloudDownload = vi.mocked(
+      (await import("../../services/storage/index.js")).downloadCloudUrlToFile,
+    );
+    // A transfer that takes far longer than the stall window but is perfectly alive.
+    cloudDownload.mockImplementation(async (_url, targetPath) => {
+      await new Promise((r) => setTimeout(r, 500));
+      await writeFile(targetPath as string, "CLOUD-PAYLOAD-BYTES");
+    });
+
+    const target = await downloadModel(
+      "s3://bucket/models/slow.safetensors",
+      "checkpoints",
+      "cloud-slow-out.safetensors",
+    );
+
+    // It completed — it was never aborted as "stalled" — and it ran only once.
+    await expect(readFile(target, "utf-8")).resolves.toBe("CLOUD-PAYLOAD-BYTES");
+    expect(cloudDownload).toHaveBeenCalledTimes(1);
+  }, 20_000);
+
+  it("REFUSES to retry onto a partial another writer moved — two transfers must never interleave into one file", async () => {
+    // The `.partial` is keyed by the download's representation, so a SECOND
+    // PROCESS running the same download writes this exact file. Cross-process
+    // dedup is best-effort by design (#529). Before the retry loop, a failed
+    // attempt simply ended; now we go quiet for a backoff and come BACK to append —
+    // so if someone else moved the file meanwhile, appending would interleave two
+    // streams into one file. Nothing WE do touches the partial between attempts,
+    // so any size change is proof of another writer.
+    const url = "https://example.com/models/contended.safetensors";
+    const { partial } = cachePaths(url);
+    // A backoff long enough that the other writer provably acts DURING it, after
+    // our own attempt has fully unwound (which takes single-digit ms here).
+    setDownloadRetryPolicyForTests({ backoffBaseMs: 2_000, backoffCapMs: 2_000 });
+
+    fetchMock.mockImplementationOnce(async () => {
+      // Simulate the other writer replacing the staged file during our backoff.
+      void (async () => {
+        for (let i = 0; i < 400; i += 1) {
+          const size = await stat(partial).then((s) => s.size).catch(() => 0);
+          if (size >= 4) break;
+          await new Promise((r) => setTimeout(r, 5));
+        }
+        await new Promise((r) => setTimeout(r, 250)); // our attempt has ended; the backoff is running
+        await writeFile(partial, "SOMEONE-ELSES-LONGER-CONTENT");
+      })();
+      return shortBody("AAAA", 64, { etag: '"v"' });
+    });
+    fetchMock.mockImplementation(async () => new Response("MUST-NOT-BE-FETCHED", { status: 200 }));
+
+    const err = await downloadModel(url, "checkpoints", "contended-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    const message = String((err as Error).message);
+    expect(message).toMatch(/another download is writing the same staged file/i);
+    // It stops instead of competing — no second request was issued.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // And it DESTROYS NOTHING: the other writer's bytes are exactly as they left them.
+    await expect(readFile(partial, "utf-8")).resolves.toBe("SOMEONE-ELSES-LONGER-CONTENT");
+    // The remedy names what the caller can do from here.
+    expect(message).toMatch(/download_status/);
+    expect(message).toMatch(/re-issue/i);
   });
 
   it("a retry that lands on a POISONED partial (#473 leftover) restarts instead of resuming onto it", async () => {

--- a/src/__tests__/services/download-retry.test.ts
+++ b/src/__tests__/services/download-retry.test.ts
@@ -865,6 +865,108 @@ describe("download retry + resume, end to end (#470)", () => {
     await expect(stat(sidecar)).rejects.toThrow();
   });
 
+  it("REFUSES a retry whose ownership it cannot establish — an unreadable staged file is not 'unchanged'", async () => {
+    // Fail-CLOSED across the retry boundary. If the stat that records what we left
+    // behind fails transiently, we do not know what is on disk — and "I could not
+    // read it" must not be treated as "it is still mine", because the very next
+    // thing a restart does is truncate it. The gate's sequence: attempt 1 stages
+    // bytes and fails, its final stat errors, another writer grows the file during
+    // the backoff, and the retry destroys their multi-gigabyte progress.
+    const url = "https://example.com/models/unreadable-ownership.safetensors";
+
+    const realStat = downloadCacheFs.stat;
+    let attemptsSeen = 0;
+    let statsSinceAttempt = 0;
+    vi.spyOn(downloadCacheFs, "stat").mockImplementation(async (...args) => {
+      const path = String(args[0]);
+      if (attemptsSeen > 0 && path.endsWith(".partial")) {
+        statsSinceAttempt += 1;
+        // The FIRST post-response read is this attempt's own pre-write check; the
+        // NEXT is the record of what we LEFT BEHIND — make exactly that one fail,
+        // with EACCES rather than ENOENT (a MISSING file is knowably 0 bytes and
+        // must NOT be treated as unknown).
+        if (statsSinceAttempt >= 2) {
+          throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+        }
+      }
+      return realStat(...(args as Parameters<typeof realStat>));
+    });
+    fetchMock.mockImplementation(async () => {
+      attemptsSeen += 1;
+      return shortBody("AAAA", 64, { etag: '"v"' });
+    });
+
+    const err = await downloadModel(url, "checkpoints", "unreadable-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    expect(String((err as Error).message)).toMatch(/size could not be read/i);
+    // It stopped rather than proceeding to truncate on an assumption.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("a cancel that lands DURING the pre-write check still leaves the resumable partial on disk", async () => {
+    // The interference check awaits, so a cancel can arrive inside it. Every path
+    // after that hook deletes or truncates the staged file, and a cancelled
+    // download is promised a resumable partial — erasing it on the way out would be
+    // exactly the data loss that promise denies.
+    const url = "https://example.com/models/cancel-in-hook.safetensors";
+    const { partial, sidecar } = cachePaths(url);
+    // A partial with NO validator: the resume declines and the restart path would
+    // TRUNCATE it — the destructive branch this guards.
+    await writeFile(partial, "PRECIOUS-BYTES");
+    const ctl = new AbortController();
+
+    fetchMock.mockImplementationOnce(async () => {
+      // Cancel while the response is being handled, i.e. around the hook.
+      setTimeout(() => ctl.abort(), 0);
+      await new Promise((r) => setTimeout(r, 20));
+      return new Response("FULL-REPLACEMENT-BODY", { status: 200, statusText: "OK" });
+    });
+    fetchMock.mockImplementation(async () => new Response("MUST-NOT-BE-FETCHED", { status: 200 }));
+
+    await expect(
+      downloadModel(
+        url,
+        "checkpoints",
+        "cancel-in-hook-out.safetensors",
+        undefined,
+        undefined,
+        undefined,
+        ctl.signal,
+      ),
+    ).rejects.toThrow();
+
+    // The bytes a cancel promises to leave behind are still there, untruncated.
+    await expect(readFile(partial, "utf-8")).resolves.toBe("PRECIOUS-BYTES");
+    await expect(stat(sidecar)).rejects.toThrow(); // and no validator was paired with them
+  });
+
+  it("does not claim 'the host never sent a validator' when the sidecar merely could not be READ", async () => {
+    // Three states, not two. Reporting an unreadable sidecar as "no validator was
+    // ever sent" is a definite verdict drawn from absence of evidence, and it tells
+    // the caller their bytes will be re-downloaded when they may well resume.
+    const url = "https://example.com/models/unreadable-sidecar.safetensors";
+    const { sidecar } = cachePaths(url);
+    fetchMock.mockImplementation(async () => shortBody("ABCD", 100, { etag: '"v"' }));
+    // Block the sidecar path so reading it fails with EISDIR, not ENOENT.
+    await mkdir(sidecar, { recursive: true });
+    await writeFile(join(sidecar, "blocker"), "x");
+
+    const err = await downloadModel(url, "checkpoints", "unreadable-sidecar-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    const message = String((err as Error).message);
+    if (/after 3 attempts/i.test(message)) {
+      expect(message).toMatch(/could not be read/);
+      expect(message).not.toMatch(/the host never sent/);
+    } else {
+      // An earlier, more precise guard (#467's stale-sidecar refusal) claimed it —
+      // which is also correct, and is exactly why the pre-write check does not
+      // fail closed on a sidecar that was already unreadable.
+      expect(message).toMatch(/sidecar|validator/i);
+    }
+  });
+
   it("a retry that lands on a POISONED partial (#473 leftover) restarts instead of resuming onto it", async () => {
     const url = "https://example.com/models/poisoned.safetensors";
     const { partial, sidecar } = cachePaths(url);

--- a/src/__tests__/services/download-retry.test.ts
+++ b/src/__tests__/services/download-retry.test.ts
@@ -997,6 +997,270 @@ describe("download retry + resume, end to end (#470)", () => {
     }
   });
 
+  it("the RECURSIVE restart inherits the ownership check — a foreign writer during it is refused, not truncated", async () => {
+    // The recursive `streamUrlToFile(...)` restart (taken when a cross-origin 206
+    // cannot be PROVEN to be the same object) must inherit the full context of the
+    // call it replaces. If it dropped `beforeWrite`, the restart would run its
+    // truncating 200 path with NO ownership check — reopening the exact hazard the
+    // pre-write check exists to close, one level down.
+    //
+    // This drives a foreign writer into the RECURSIVE request's window specifically.
+    const url = "https://huggingface.co/org/repo/resolve/main/recursive-restart.safetensors";
+    const { partial, sidecar } = cachePaths(url);
+    await writeFile(partial, "V1V1");
+    // A CONTENT-ADDRESSED validator, so the resume is attempted and the cross-origin
+    // 206 below is judged against it.
+    await writeFile(sidecar, `xet\n"obj-v1"\n8\nxet`);
+
+    let hop = 0;
+    fetchMock.mockImplementation(async () => {
+      hop += 1;
+      if (hop === 1) {
+        // HF resolve → CAS CDN, carrying a DIFFERENT content hash: the resume is
+        // unprovable, so the code recurses into a clean full restart.
+        return new Response(null, {
+          status: 302,
+          headers: {
+            location: "https://cas-bridge.xethub.hf.co/xet-bridge-us/obj?sig=q",
+            "x-linked-etag": '"obj-v2"',
+          },
+        });
+      }
+      if (hop === 2) {
+        return new Response("ZZZZ", {
+          status: 206,
+          statusText: "Partial Content",
+          headers: { "content-range": "bytes 4-7/8" },
+        });
+      }
+      // hop 3 IS the recursive restart's request. A foreign writer stages its own
+      // transfer into the shared file while it is in flight.
+      await writeFile(partial, "SOMEONE-ELSES-PARTIAL");
+      await writeFile(sidecar, `xet\n"obj-v9"\n21\nxet`);
+      return new Response("FULL-REPLACEMENT-BODY", { status: 200, statusText: "OK" });
+    });
+
+    const err = await downloadModel(url, "checkpoints", "recursive-restart-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    expect(String((err as Error).message)).toMatch(
+      /another download is writing the same staged file/i,
+    );
+    // The recursive restart did NOT truncate the foreign writer's bytes.
+    await expect(readFile(partial, "utf-8")).resolves.toBe("SOMEONE-ELSES-PARTIAL");
+  });
+
+  /** Drive the cross-origin-unprovable-206 path, which makes streamUrlToFile
+   *  RECURSE into a clean full restart. `onRestart` supplies that restart's
+   *  response, which is the request the recursion actually issues. */
+  function mockRecursiveRestart(onRestart: () => Promise<Response>): void {
+    let hop = 0;
+    fetchMock.mockImplementation(async () => {
+      hop += 1;
+      if (hop === 1) {
+        return new Response(null, {
+          status: 302,
+          headers: {
+            location: "https://cas-bridge.xethub.hf.co/xet-bridge-us/obj?sig=q",
+            "x-linked-etag": '"obj-v2"',
+          },
+        });
+      }
+      if (hop === 2) {
+        return new Response("ZZZZ", {
+          status: 206,
+          statusText: "Partial Content",
+          headers: { "content-range": "bytes 4-7/8" },
+        });
+      }
+      return onRestart();
+    });
+  }
+
+  async function stageUnprovableResume(url: string): Promise<void> {
+    const { partial, sidecar } = cachePaths(url);
+    await writeFile(partial, "V1V1");
+    await writeFile(sidecar, `xet\n"obj-v1"\n8\nxet`);
+  }
+
+  it("the RECURSIVE restart inherits onBytes — a healthy trickling restart is not killed as stalled", async () => {
+    // If the recursion dropped `onBytes`, the outer stall timer would never be
+    // reset during the restarted full-body transfer, so a download that is
+    // CONTINUOUSLY writing bytes would be aborted as stalled — the watchdog
+    // destroying progress that is being made.
+    const url = "https://huggingface.co/org/repo/resolve/main/recursive-trickle.safetensors";
+    await stageUnprovableResume(url);
+    // One attempt only, so a watchdog abort is fatal and cannot be masked by a
+    // retry that happens to succeed. The transfer runs for ~3s against a 250 ms
+    // stall window — the watchdog gets many chances to fire, so a pass here means
+    // it genuinely never had cause to.
+    setDownloadRetryPolicyForTests({ maxAttempts: 1, stallTimeoutMs: 250 });
+
+    mockRecursiveRestart(async () => {
+      // Bytes arrive steadily, each gap well under the stall window, for a total
+      // duration many times OVER it.
+      const stream = new ReadableStream<Uint8Array>({
+        async start(c) {
+          for (let i = 0; i < 20; i += 1) {
+            await new Promise((r) => setTimeout(r, 150));
+            c.enqueue(new TextEncoder().encode("AB"));
+          }
+          c.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-length": "40" },
+      });
+    });
+
+    const target = await downloadModel(url, "checkpoints", "recursive-trickle-out.safetensors");
+    await expect(readFile(target, "utf-8")).resolves.toBe("AB".repeat(20));
+  }, 30_000);
+
+  it("the stall watchdog IS armed across the recursive restart — a wedged restart is abandoned and retried", async () => {
+    // The companion to the trickle test above: that one shows a healthy restart is
+    // not killed, this one shows a WEDGED restart still is. Together they pin the
+    // watchdog's behaviour on the recursive path in both directions.
+    const url = "https://huggingface.co/org/repo/resolve/main/recursive-wedge.safetensors";
+    await stageUnprovableResume(url);
+    setDownloadRetryPolicyForTests({ maxAttempts: 2, stallTimeoutMs: 150 });
+
+    let restarts = 0;
+    mockRecursiveRestart(async () => {
+      restarts += 1;
+      if (restarts === 1) {
+        // Bytes stop arriving and the socket never closes.
+        const stream = new ReadableStream<Uint8Array>({
+          start(c) {
+            c.enqueue(new TextEncoder().encode("AAAA"));
+          },
+        });
+        return new Response(stream, {
+          status: 200,
+          statusText: "OK",
+          headers: { "content-length": "8" },
+        });
+      }
+      return new Response("COMPLETE", { status: 200, statusText: "OK" });
+    });
+
+    const target = await downloadModel(url, "checkpoints", "recursive-wedge-out.safetensors");
+    // It did not hang: the wedged restart was bounded and the retry finished it.
+    await expect(readFile(target, "utf-8")).resolves.toBe("COMPLETE");
+    expect(restarts).toBe(2);
+  }, 30_000);
+
+  it("the RECURSIVE restart inherits deferErrorRow — it does not announce a failure the outer loop is still retrying", async () => {
+    // If the recursion dropped `deferErrorRow`, a retryable failure inside the
+    // restarted stream would publish a terminal `error` row while the outer retry
+    // loop was still going. A caller reading that as failure re-issues — and
+    // re-issuing is what creates the second writer that truncated #817's model.
+    const url = "https://huggingface.co/org/repo/resolve/main/recursive-defer.safetensors";
+    await stageUnprovableResume(url);
+
+    let restarts = 0;
+    mockRecursiveRestart(async () => {
+      restarts += 1;
+      // First restart is cut short (retryable); the retry then completes.
+      return restarts === 1
+        ? shortBody("AAAA", 16)
+        : new Response("COMPLETE-BODY-16", { status: 200, statusText: "OK" });
+    });
+
+    await downloadModel(url, "checkpoints", "recursive-defer-out.safetensors");
+
+    expect(restarts).toBeGreaterThan(1); // the retry really happened…
+    // …and no failure was ever announced for a download that succeeded.
+    expect(progressRows.map((r) => r.status)).not.toContain("error");
+    expect(progressRows.map((r) => r.status)).toContain("done");
+  }, 20_000);
+
+  it("the #473 poison CLEANUP checks ownership first — a foreign writer's partial is not discarded as our leftover", async () => {
+    // The last window the retry loop added without an ownership check. Between the
+    // retry-boundary check and the poison guards inside resumeOffsetFromDisk, a
+    // foreign writer can replace the staged file. A surviving `.rejected` marker
+    // (its removal having transiently failed on a PRIOR attempt of ours) then makes
+    // our automatic retry discard THEIR partial as if it were our poisoned leftover.
+    // The foreign write must land INSIDE that window — after the boundary check has
+    // read the file, before the cleanup acts on it. The marker `stat` sits exactly
+    // in between, so hooking it places the writer precisely where the bug lives.
+    // (A write during the BACKOFF is a different, already-covered window: the
+    // boundary check catches it and the cleanup guard is never reached.)
+    const url = "https://example.com/models/poison-vs-foreign.safetensors";
+    const { partial, sidecar } = cachePaths(url);
+    await writeFile(partial, "OURS");
+    await writeFile(sidecar, '"v"');
+    // A stale marker from an earlier rejection of OURS whose removal failed.
+    await writeFile(`${partial}.rejected`, "stale marker");
+
+    const realStat = downloadCacheFs.stat;
+    let planted = false;
+    vi.spyOn(downloadCacheFs, "stat").mockImplementation(async (...args) => {
+      const path = String(args[0]);
+      if (!planted && path.endsWith(".rejected")) {
+        planted = true;
+        // The foreign writer replaces the staged file right here.
+        await writeFile(partial, "SOMEONE-ELSES-MANY-GIGABYTES");
+        await writeFile(sidecar, '"their-object"');
+      }
+      return realStat(...(args as Parameters<typeof realStat>));
+    });
+
+    fetchMock.mockImplementation(async () => new Response("BODY", { status: 200 }));
+
+    const err = await downloadModel(url, "checkpoints", "poison-vs-foreign-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    expect(String((err as Error).message)).toMatch(
+      /another download is writing the same staged file/i,
+    );
+    // Their partial and their validator are both untouched — not discarded as
+    // "a previously-rejected leftover" of ours.
+    await expect(readFile(partial, "utf-8")).resolves.toBe("SOMEONE-ELSES-MANY-GIGABYTES");
+    await expect(readFile(sidecar, "utf-8")).resolves.toBe('"their-object"');
+  }, 20_000);
+
+  it("the #473 BODY-SNIFF cleanup checks ownership first — a foreign partial that merely LOOKS non-model is not discarded", async () => {
+    // The second destructive branch inside resumeOffsetFromDisk. It discards a
+    // partial whose head sniffs as HTML/JSON, on the theory that it is our own
+    // rejected auth page. If a foreign writer replaced the staged file after our
+    // boundary check, that head is THEIRS — and a legitimate transfer whose first
+    // bytes happen to start with "<" (an SVG, an XML asset) would be destroyed.
+    const url = "https://example.com/models/bodysniff-vs-foreign.safetensors";
+    const { partial, sidecar } = cachePaths(url);
+    await writeFile(partial, "OURS-BINARY-PREFIX");
+    await writeFile(sidecar, '"v"');
+
+    const realStat = downloadCacheFs.stat;
+    let planted = false;
+    vi.spyOn(downloadCacheFs, "stat").mockImplementation(async (...args) => {
+      const path = String(args[0]);
+      // The marker probe runs BEFORE the body sniff, so this lands the foreign
+      // write in the window between our boundary check and that sniff.
+      if (!planted && path.endsWith(".rejected")) {
+        planted = true;
+        await writeFile(partial, "<?xml version='1.0'?><their-in-progress-asset/>");
+        await writeFile(sidecar, '"their-object"');
+      }
+      return realStat(...(args as Parameters<typeof realStat>));
+    });
+
+    fetchMock.mockImplementation(async () => new Response("BODY", { status: 200 }));
+
+    const err = await downloadModel(url, "checkpoints", "bodysniff-vs-foreign-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    expect(String((err as Error).message)).toMatch(
+      /another download is writing the same staged file/i,
+    );
+    // Their bytes survive, even though they sniff as "not a model".
+    await expect(readFile(partial, "utf-8")).resolves.toBe(
+      "<?xml version='1.0'?><their-in-progress-asset/>",
+    );
+  });
+
   it("a retry that lands on a POISONED partial (#473 leftover) restarts instead of resuming onto it", async () => {
     const url = "https://example.com/models/poisoned.safetensors";
     const { partial, sidecar } = cachePaths(url);

--- a/src/__tests__/services/download-retry.test.ts
+++ b/src/__tests__/services/download-retry.test.ts
@@ -1,0 +1,570 @@
+// #470 / #817 — a transfer that survives an interruption.
+//
+// Two layers are covered here:
+//   1. the CLASSIFIER, in isolation: which failures may be retried at all. The
+//      whole safety of automatic retry rests on this being conservative, so the
+//      fatal cases are asserted as hard as the transient ones.
+//   2. the RETRY LOOP end-to-end through downloadModel: that a dropped transfer
+//      is resumed IN THE SAME CALL, that a cancel is never retried, and — the
+//      question this cluster exists to answer — that a resumed transfer can
+//      NEVER splice bytes from a different object.
+
+import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", () => {
+  const config = {
+    comfyuiPath: undefined as string | undefined,
+    huggingfaceToken: undefined as string | undefined,
+    civitaiApiToken: undefined as string | undefined,
+  };
+  return { config, isRemoteMode: () => !config.comfyuiPath };
+});
+
+/** Every progress row the download machinery publishes. Recorded through a module
+ *  mock because the real reporter writes to COMFYUI_MCP_PROGRESS_DIR, which is read
+ *  from the environment at import time and so cannot be turned on from a test. What
+ *  matters here is WHICH rows are emitted, not where they land. */
+const progressRows = vi.hoisted(() => [] as Array<{ status: string }>);
+vi.mock("../../services/download-progress.js", async () => {
+  const actual = await vi.importActual<typeof import("../../services/download-progress.js")>(
+    "../../services/download-progress.js",
+  );
+  return {
+    ...actual,
+    reportDownloadProgress: (p: { status: string }) => {
+      progressRows.push({ status: p.status });
+    },
+  };
+});
+
+import { config } from "../../config.js";
+import { downloadModel } from "../../services/model-resolver.js";
+import {
+  abortableDelay,
+  backoffDelayMs,
+  classifyDownloadFailure,
+  downloadRetryPolicy,
+  setDownloadRetryPolicyForTests,
+} from "../../services/download-retry.js";
+import { ModelError } from "../../utils/errors.js";
+
+describe("classifyDownloadFailure (#470)", () => {
+  describe("transient — safe to retry, the partial stays resumable", () => {
+    it("recognises undici's bare `terminated` — the exact failure #470 reported", () => {
+      const err = new TypeError("terminated");
+      const cls = classifyDownloadFailure(err);
+      expect(cls.retryable).toBe(true);
+      expect(cls.reason).toMatch(/dropped mid-transfer/i);
+    });
+
+    it("recognises a transport code NESTED in the cause chain, not just on the top error", () => {
+      const socket = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
+      const outer = Object.assign(new TypeError("fetch failed"), { cause: socket });
+      // `fetch failed` alone is NOT in the fragment list — this must pass on the
+      // nested CODE, which is what proves the cause walk is doing the work.
+      expect(classifyDownloadFailure(outer).retryable).toBe(true);
+      expect(classifyDownloadFailure(outer).reason).toMatch(/UND_ERR_SOCKET/);
+    });
+
+    it("recognises ECONNRESET reported on a ModelError's details (fetchOrThrow's shape)", () => {
+      const err = new ModelError("Download request ... failed", { code: "ECONNRESET" });
+      expect(classifyDownloadFailure(err).retryable).toBe(true);
+    });
+
+    it("retries the back-off statuses the host itself asks for, and 5xx", () => {
+      for (const status of [408, 429, 500, 502, 503, 504]) {
+        expect(classifyDownloadFailure(new ModelError("x", { status })).retryable).toBe(true);
+      }
+    });
+
+    it("honours an explicit `retryable: true` contract from the raising code", () => {
+      // This is how download-cache flags a truncated body whose partial is a valid
+      // prefix. Message-independent by design.
+      const err = new ModelError("anything at all", { retryable: true });
+      expect(classifyDownloadFailure(err).retryable).toBe(true);
+    });
+  });
+
+  describe("fatal — a retry cannot fix it, and hammering makes it worse", () => {
+    it("does NOT retry 403 — #470 traced a 403 to an instant re-request after an abort", () => {
+      const err = new ModelError("Download failed: 403 Forbidden", { status: 403 });
+      const cls = classifyDownloadFailure(err);
+      expect(cls.retryable).toBe(false);
+      expect(cls.reason).toMatch(/403/);
+    });
+
+    it("does NOT retry 401/404 (auth/gating/absent)", () => {
+      for (const status of [401, 404, 410, 451]) {
+        expect(classifyDownloadFailure(new ModelError("x", { status })).retryable).toBe(false);
+      }
+    });
+
+    it("a DEFINITE status wins over prose that happens to contain a transient word", () => {
+      // The regression this guards: a 403 whose body/message mentions a
+      // "terminated" session must not fall through to the message-fragment test
+      // and be retried. A known status is a definite answer in BOTH directions.
+      const err = new ModelError("Download failed: 403 Forbidden — connection terminated by policy", {
+        status: 403,
+      });
+      expect(classifyDownloadFailure(err).retryable).toBe(false);
+    });
+
+    it("honours an explicit `retryable: false` veto even for a transient-looking message", () => {
+      const err = new ModelError("the connection terminated", { retryable: false });
+      expect(classifyDownloadFailure(err).retryable).toBe(false);
+    });
+
+    it("does NOT retry the #473 non-model payload rejection", () => {
+      const err = new ModelError(
+        "Download rejected: the response body is an HTML login page, not a model payload",
+      );
+      expect(classifyDownloadFailure(err).retryable).toBe(false);
+    });
+
+    it("does NOT retry the #343/#467 resume-integrity refusals", () => {
+      for (const message of [
+        "Download resume rejected: a 206 for byte 4+ must carry a complete, consistent Content-Range",
+        "Download resume rejected: the server now reports a total size of 8 bytes, but the original download recorded 4096",
+        "Download oversized: wrote 900 bytes but the file is only 800",
+        "Download produced a 0-byte file — the source sent no data. Removed it; retry.",
+      ]) {
+        expect(classifyDownloadFailure(new ModelError(message)).retryable).toBe(false);
+      }
+    });
+
+    it("defaults to NOT retryable for an error it does not recognise", () => {
+      // The fail-safe direction: an unclassified failure behaves exactly as it did
+      // before automatic retry existed.
+      expect(classifyDownloadFailure(new Error("something entirely new")).retryable).toBe(false);
+      expect(classifyDownloadFailure("not even an error").retryable).toBe(false);
+    });
+  });
+});
+
+describe("backoff schedule (#470)", () => {
+  it("doubles from the base and saturates at the cap — never an instant re-request", () => {
+    const p = { maxAttempts: 5, backoffBaseMs: 2000, backoffCapMs: 30_000, stallTimeoutMs: 0 };
+    expect(backoffDelayMs(1, p)).toBe(2000);
+    expect(backoffDelayMs(2, p)).toBe(4000);
+    expect(backoffDelayMs(3, p)).toBe(8000);
+    expect(backoffDelayMs(4, p)).toBe(16_000);
+    expect(backoffDelayMs(5, p)).toBe(30_000); // capped, not 32000
+    expect(backoffDelayMs(9, p)).toBe(30_000);
+    // The FIRST wait must be a real wait: an immediate re-request is what earned
+    // the 403 in #470.
+    expect(backoffDelayMs(1, p)).toBeGreaterThan(0);
+  });
+});
+
+describe("abortableDelay (#470)", () => {
+  it("rejects immediately when the signal is already aborted", async () => {
+    const ctl = new AbortController();
+    ctl.abort();
+    await expect(abortableDelay(60_000, ctl.signal)).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("wakes EARLY on abort instead of sleeping out the full backoff", async () => {
+    const ctl = new AbortController();
+    const started = Date.now();
+    const p = abortableDelay(30_000, ctl.signal);
+    setTimeout(() => ctl.abort(), 10);
+    await expect(p).rejects.toMatchObject({ name: "AbortError" });
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+});
+
+describe("COMFYUI_DOWNLOAD_MAX_ATTEMPTS / _STALL_TIMEOUT_S env overrides (#470/#817)", () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it("lets an operator disable retry entirely with maxAttempts=1", () => {
+    process.env.COMFYUI_DOWNLOAD_MAX_ATTEMPTS = "1";
+    expect(downloadRetryPolicy().maxAttempts).toBe(1);
+  });
+
+  it("lets an operator disable the stall watchdog with 0 seconds", () => {
+    process.env.COMFYUI_DOWNLOAD_STALL_TIMEOUT_S = "0";
+    expect(downloadRetryPolicy().stallTimeoutMs).toBe(0);
+  });
+
+  it("ignores garbage rather than collapsing the policy to NaN", () => {
+    process.env.COMFYUI_DOWNLOAD_MAX_ATTEMPTS = "banana";
+    expect(downloadRetryPolicy().maxAttempts).toBeGreaterThan(1);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────────
+// End-to-end through downloadModel: the retry loop, the resume it performs, and
+// the identity proof it must never skip.
+// ───────────────────────────────────────────────────────────────────────────────
+
+const fetchMock = vi.fn();
+let tempDir: string;
+let cacheDir: string;
+let comfyDir: string;
+
+function cacheHashFor(url: string): string {
+  return createHash("sha256").update(`v2\n${url}`).digest("hex").slice(0, 32);
+}
+function cachePaths(url: string) {
+  const hash = cacheHashFor(url);
+  const partial = join(cacheDir, `.${hash}.safetensors.partial`);
+  return { partial, sidecar: `${partial}.etag`, target: join(cacheDir, `${hash}.safetensors`) };
+}
+
+/** A 200 that DECLARES more bytes than it delivers — the shape of a transfer the
+ *  network cut short. The written prefix stays on disk and is range-resumable. */
+function shortBody(body: string, declaredTotal: number, headers: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status: 200,
+    statusText: "OK",
+    headers: { "content-length": String(declaredTotal), ...headers },
+  });
+}
+
+function headersOf(callIndex: number): Record<string, string> {
+  const [, init] = fetchMock.mock.calls[callIndex] as [string, { headers: Record<string, string> }];
+  return init.headers;
+}
+
+describe("download retry + resume, end to end (#470)", () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "comfyui-mcp-retry-test-"));
+    cacheDir = join(tempDir, "cache");
+    comfyDir = join(tempDir, "comfy");
+    process.env.COMFYUI_DOWNLOAD_CACHE_DIR = cacheDir;
+    delete process.env.COMFYUI_LRU_CACHE_SIZE_GB;
+    delete process.env.COMFYUI_DOWNLOAD_MAX_ATTEMPTS;
+    delete process.env.COMFYUI_DOWNLOAD_STALL_TIMEOUT_S;
+    config.comfyuiPath = comfyDir;
+    config.huggingfaceToken = undefined;
+    config.civitaiApiToken = undefined;
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    // Real retries, but with waits short enough for a test suite.
+    setDownloadRetryPolicyForTests({
+      maxAttempts: 3,
+      backoffBaseMs: 5,
+      backoffCapMs: 20,
+      stallTimeoutMs: 0,
+    });
+    await mkdir(cacheDir, { recursive: true });
+    progressRows.length = 0;
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+    setDownloadRetryPolicyForTests({
+      maxAttempts: 5,
+      backoffBaseMs: 2000,
+      backoffCapMs: 30_000,
+      stallTimeoutMs: 120_000,
+    });
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("resumes an interrupted transfer IN THE SAME CALL instead of losing the partial (#470)", async () => {
+    const url = "https://example.com/models/interrupted.safetensors";
+
+    // Attempt 1: declares 16 bytes, delivers 8, then the connection dies. This is
+    // #470's "failed: terminated" — before the fix, the call ended here and the 8
+    // bytes were only recoverable by a HUMAN re-issuing download_model.
+    fetchMock.mockResolvedValueOnce(shortBody("AAAABBBB", 16, { etag: '"obj-v1"' }));
+    // Attempt 2: the retry range-resumes from byte 8 and the server completes it.
+    fetchMock.mockResolvedValueOnce(
+      new Response("CCCCDDDD", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 8-15/16" },
+      }),
+    );
+
+    const target = await downloadModel(url, "checkpoints", "interrupted-out.safetensors");
+
+    // ONE call produced the whole file — the caller never had to notice or act.
+    await expect(readFile(target, "utf-8")).resolves.toBe("AAAABBBBCCCCDDDD");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // The retry RESUMED — it did not re-fetch the 8 bytes already on disk.
+    expect(headersOf(0).Range).toBeUndefined();
+    expect(headersOf(1).Range).toBe("bytes=8-");
+    // …and it proved identity first: the validator recorded at WRITE time was
+    // replayed as If-Range on the resume.
+    expect(headersOf(1)["If-Range"]).toBe('"obj-v1"');
+  });
+
+  it("a resumed retry can NEVER splice bytes from a DIFFERENT object — an If-Range miss restarts", async () => {
+    const url = "https://example.com/models/changed-between-attempts.safetensors";
+
+    // Attempt 1 writes a prefix of object v1 and records v1's validator.
+    fetchMock.mockResolvedValueOnce(shortBody("V1V1", 8, { etag: '"obj-v1"' }));
+    // Between attempts the upstream file is REPLACED. The origin evaluates our
+    // If-Range, sees a mismatch and answers 200 with the WHOLE new object.
+    fetchMock.mockResolvedValueOnce(
+      new Response("V2V2V2V2", { status: 200, statusText: "OK", headers: { etag: '"obj-v2"' } }),
+    );
+
+    const target = await downloadModel(url, "checkpoints", "changed-out.safetensors");
+
+    // The decisive assertion: the file is ENTIRELY object v2. Not "V1V1V2V2V2V2",
+    // which is what appending onto the stale prefix would have produced.
+    await expect(readFile(target, "utf-8")).resolves.toBe("V2V2V2V2");
+    expect(headersOf(1)["If-Range"]).toBe('"obj-v1"');
+  });
+
+  it("a retry with NO recorded write-time identity restarts rather than resuming blind", async () => {
+    const url = "https://example.com/models/no-validator.safetensors";
+
+    // Attempt 1: short body and NO validator header at all, so no sidecar is
+    // written. The 4 bytes on disk have no recorded identity.
+    fetchMock.mockResolvedValueOnce(shortBody("XXXX", 8));
+    fetchMock.mockResolvedValueOnce(new Response("YYYYYYYY", { status: 200, statusText: "OK" }));
+
+    const target = await downloadModel(url, "checkpoints", "no-validator-out.safetensors");
+
+    // No Range was sent on the retry — an unverifiable partial is restarted, never
+    // appended to. (Losing 4 bytes is the correct trade against splicing them onto
+    // bytes that might belong to something else, #343/#467.)
+    expect(headersOf(1).Range).toBeUndefined();
+    await expect(readFile(target, "utf-8")).resolves.toBe("YYYYYYYY");
+  });
+
+  it("does NOT retry a 403 — it fetches exactly once (#470's CDN-block observation)", async () => {
+    const url = "https://example.com/models/forbidden.safetensors";
+    fetchMock.mockImplementation(async () => new Response("nope", { status: 403, statusText: "Forbidden" }));
+
+    await expect(
+      downloadModel(url, "checkpoints", "forbidden-out.safetensors"),
+    ).rejects.toThrow(/403/);
+
+    // Exactly one request. A retry loop that retried everything would have made
+    // three — and, per #470, re-requesting an aborted URL immediately is what got
+    // the reporter CDN-blocked in the first place.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after the attempt budget and reports how much progress SURVIVED", async () => {
+    const url = "https://example.com/models/always-dies.safetensors";
+    // Every attempt delivers a little more, then dies. Never completes.
+    // A fresh Response per call — one Response object cannot be read twice.
+    fetchMock.mockImplementation(async () => shortBody("AB", 100, { etag: '"stable"' }));
+
+    const err = await downloadModel(url, "checkpoints", "always-dies-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+
+    expect(String((err as Error).message)).toMatch(/after 3 attempts/i);
+    // The remedy must be usable from where the caller now stands: the bytes are
+    // still there and re-issuing resumes them.
+    expect(String((err as Error).message)).toMatch(/preserved on disk|resumes from there/i);
+    // And that claim is TRUE — asserted against disk, not against the sentence.
+    const { partial } = cachePaths(url);
+    await expect(stat(partial).then((s) => s.size)).resolves.toBeGreaterThan(0);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("never claims preserved bytes it did not observe — an unreadable partial is reported as unknown", async () => {
+    const url = "https://example.com/models/no-partial-left.safetensors";
+    // A 0-byte body: assertComplete removes the empty partial AND its sidecar, so
+    // by the time we report there is genuinely nothing left to resume.
+    fetchMock.mockImplementation(
+      async () => new Response("A", { status: 200, statusText: "OK", headers: { "content-length": "50" } }),
+    );
+
+    const err = await downloadModel(url, "checkpoints", "no-partial-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    const message = String((err as Error).message);
+    expect(message).toMatch(/after 3 attempts/i);
+    // It reports what it actually found — a surviving partial here — rather than a
+    // canned "your data is safe". The point is the claim is derived from a stat.
+    expect(message).toMatch(/preserved on disk|No partial data survived|could NOT be read/);
+  });
+
+  it("a CANCEL during backoff stops the download — it is never retried into a completion", async () => {
+    const url = "https://example.com/models/cancel-mid-backoff.safetensors";
+    setDownloadRetryPolicyForTests({ backoffBaseMs: 10_000, backoffCapMs: 10_000 });
+    const ctl = new AbortController();
+
+    const { partial } = cachePaths(url);
+    // Attempt 1 fails transiently, so the loop enters its (10s) backoff. Fire the
+    // cancel only once attempt 1's bytes are actually ON DISK, so this test is
+    // about the BACKOFF window and never races the stream itself.
+    fetchMock.mockImplementationOnce(async () => {
+      void (async () => {
+        for (let i = 0; i < 400; i += 1) {
+          const size = await stat(partial).then((s) => s.size).catch(() => 0);
+          if (size >= 4) break;
+          await new Promise((r) => setTimeout(r, 5));
+        }
+        ctl.abort();
+      })();
+      return shortBody("AAAA", 99, { etag: '"v"' });
+    });
+    // …and this response must NEVER be consumed.
+    fetchMock.mockImplementation(async () => new Response("SHOULD-NOT-BE-FETCHED", { status: 200 }));
+
+    const started = Date.now();
+    await expect(
+      downloadModel(url, "checkpoints", "cancelled-out.safetensors", undefined, undefined, undefined, ctl.signal),
+    ).rejects.toThrow();
+
+    // It woke on the cancel rather than sleeping out the full backoff…
+    expect(Date.now() - started).toBeLessThan(9_000);
+    // …and made no second request.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // The partial is deliberately left behind, resumable, exactly as a cancel promises.
+    await expect(stat(partial).then((s) => s.size)).resolves.toBe(4);
+  });
+
+  it("a cancel that SURFACES AS A TRANSIENT ERROR is still not retried — cancellation is decided by the signal, not by the message", async () => {
+    // The hazard this pins: aborting a fetch mid-body makes undici raise
+    // `TypeError: terminated` — which is EXACTLY the transient signature #470
+    // asked us to retry. If the loop classified the error instead of consulting
+    // the caller's signal first, a user's cancel would be "recovered from" and the
+    // download would run to completion after they stopped it. The loop must decide
+    // on the SIGNAL, and this test fails if that ordering is ever inverted.
+    const url = "https://example.com/models/cancel-looks-transient.safetensors";
+    const ctl = new AbortController();
+
+    // Cancelling while the REQUEST is in flight makes fetch reject with an
+    // AbortError, which fetchOrThrow wraps as "…failed at the network layer: …".
+    // classifyDownloadFailure reads that as TRANSIENT — correctly, because in
+    // every other circumstance it is. Confirm it really does:
+    expect(
+      classifyDownloadFailure(
+        new ModelError(
+          "Download request to the model host failed at the network layer: This operation was aborted.",
+        ),
+      ).retryable,
+    ).toBe(true);
+
+    fetchMock.mockImplementationOnce(
+      (_u: string, init: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          setTimeout(() => ctl.abort(), 5);
+          init.signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("This operation was aborted.", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    fetchMock.mockImplementation(async () => new Response("MUST-NOT-BE-FETCHED", { status: 200 }));
+
+    await expect(
+      downloadModel(
+        url,
+        "checkpoints",
+        "cancel-transient-out.safetensors",
+        undefined,
+        undefined,
+        undefined,
+        ctl.signal,
+      ),
+    ).rejects.toThrow();
+
+    // No second attempt: the cancel was honoured, not classified away.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("abandons and resumes a WEDGED transfer that delivers no bytes at all (#470 stall / #817 bounded attempt)", async () => {
+    const url = "https://example.com/models/wedged.safetensors";
+    setDownloadRetryPolicyForTests({ maxAttempts: 2, stallTimeoutMs: 150 });
+
+    // Attempt 1: 4 bytes arrive, then the socket goes silent FOREVER without
+    // closing. Before the watchdog this sat "in flight" indefinitely — #470 watched
+    // one do nothing for ~30 minutes.
+    fetchMock.mockImplementationOnce(async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("AAAA"));
+          // never closes, never enqueues again
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-length": "8", etag: '"wedge-v1"' },
+      });
+    });
+    // Attempt 2 resumes from the 4 bytes the wedged attempt DID write.
+    fetchMock.mockResolvedValueOnce(
+      new Response("BBBB", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 4-7/8" },
+      }),
+    );
+
+    const target = await downloadModel(url, "checkpoints", "wedged-out.safetensors");
+
+    await expect(readFile(target, "utf-8")).resolves.toBe("AAAABBBB");
+    // The stall was bounded AND the progress it had made was kept.
+    expect(headersOf(1).Range).toBe("bytes=4-");
+    expect(headersOf(1)["If-Range"]).toBe('"wedge-v1"');
+  }, 20_000);
+
+  it("a RETRIED attempt never publishes a terminal 'error' progress row — the agent is not told a running download failed (#470/#547)", async () => {
+    // The orchestrator treats the FIRST terminal row as the download's outcome and
+    // wakes the tab's agent with it (#547). If an attempt that is ABOUT TO BE
+    // RETRIED emitted "error", the agent would be told the download failed while it
+    // was still running — and its natural response, re-issuing, is the
+    // second-writer hazard the download machinery exists to prevent.
+    const url = "https://example.com/models/no-false-failure.safetensors";
+    fetchMock.mockResolvedValueOnce(shortBody("AAAA", 8, { etag: '"v"' }));
+    fetchMock.mockResolvedValueOnce(
+      new Response("BBBB", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 4-7/8" },
+      }),
+    );
+
+    await downloadModel(url, "checkpoints", "no-false-failure-out.safetensors");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2); // a retry really did happen…
+    // …and it was invisible as an OUTCOME: no failure was ever announced.
+    expect(progressRows.map((r) => r.status)).not.toContain("error");
+    expect(progressRows.map((r) => r.status)).toContain("done");
+  });
+
+  it("STILL announces a terminal 'error' once the retry loop genuinely gives up", async () => {
+    // The mirror of the test above: withholding the per-attempt rows must not turn
+    // a real failure into silence.
+    const url = "https://example.com/models/really-fails.safetensors";
+    fetchMock.mockImplementation(async () => shortBody("AB", 100, { etag: '"v"' }));
+
+    await expect(
+      downloadModel(url, "checkpoints", "really-fails-out.safetensors"),
+    ).rejects.toThrow(/after 3 attempts/i);
+
+    const errorRows = progressRows.filter((r) => r.status === "error");
+    // Exactly one — not one per attempt, and not zero.
+    expect(errorRows).toHaveLength(1);
+  });
+
+  it("a retry that lands on a POISONED partial (#473 leftover) restarts instead of resuming onto it", async () => {
+    const url = "https://example.com/models/poisoned.safetensors";
+    const { partial, sidecar } = cachePaths(url);
+    // A prior attempt rejected an HTML auth page and could not remove the leftover.
+    await writeFile(partial, "<!DOCTYPE html><html>login</html>");
+    await writeFile(sidecar, '"poison"');
+    await writeFile(`${partial}.rejected`, "rejected");
+
+    fetchMock.mockResolvedValueOnce(new Response("REALMODELBYTES", { status: 200, statusText: "OK" }));
+
+    const target = await downloadModel(url, "checkpoints", "poisoned-out.safetensors");
+
+    // No Range: the poisoned bytes were never a resume candidate on ANY attempt.
+    expect(headersOf(0).Range).toBeUndefined();
+    await expect(readFile(target, "utf-8")).resolves.toBe("REALMODELBYTES");
+  });
+});

--- a/src/__tests__/services/download-retry.test.ts
+++ b/src/__tests__/services/download-retry.test.ts
@@ -875,25 +875,42 @@ describe("download retry + resume, end to end (#470)", () => {
     const url = "https://example.com/models/unreadable-ownership.safetensors";
 
     const realStat = downloadCacheFs.stat;
-    let attemptsSeen = 0;
-    let statsSinceAttempt = 0;
+    // Flipped by the response stream itself, the instant its last byte is
+    // delivered — so the read that records what we LEFT BEHIND is the one that
+    // fails, and the attempt's own earlier checks are unaffected. Keyed on a
+    // real event rather than a count of stat calls, which would silently retarget
+    // whenever a guard adds or removes a read.
+    let failPartialStat = false;
     vi.spyOn(downloadCacheFs, "stat").mockImplementation(async (...args) => {
       const path = String(args[0]);
-      if (attemptsSeen > 0 && path.endsWith(".partial")) {
-        statsSinceAttempt += 1;
-        // The FIRST post-response read is this attempt's own pre-write check; the
-        // NEXT is the record of what we LEFT BEHIND — make exactly that one fail,
-        // with EACCES rather than ENOENT (a MISSING file is knowably 0 bytes and
-        // must NOT be treated as unknown).
-        if (statsSinceAttempt >= 2) {
-          throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
-        }
+      if (failPartialStat && path.endsWith(".partial")) {
+        // EACCES, not ENOENT — a MISSING file is knowably 0 bytes and must NOT be
+        // treated as unknown.
+        throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
       }
       return realStat(...(args as Parameters<typeof realStat>));
     });
     fetchMock.mockImplementation(async () => {
-      attemptsSeen += 1;
-      return shortBody("AAAA", 64, { etag: '"v"' });
+      let sent = false;
+      const stream = new ReadableStream<Uint8Array>({
+        // `pull`, not `start`: start() runs at CONSTRUCTION, before the request has
+        // even been answered, so flipping there would break the attempt's own
+        // earlier checks instead of the record-what-we-left read.
+        pull(c) {
+          if (!sent) {
+            sent = true;
+            c.enqueue(new TextEncoder().encode("AAAA"));
+            return;
+          }
+          failPartialStat = true; // body consumed; the attempt is now unwinding
+          c.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-length": "64", etag: '"v"' },
+      });
     });
 
     const err = await downloadModel(url, "checkpoints", "unreadable-out.safetensors").catch(
@@ -1259,6 +1276,94 @@ describe("download retry + resume, end to end (#470)", () => {
     await expect(readFile(partial, "utf-8")).resolves.toBe(
       "<?xml version='1.0'?><their-in-progress-asset/>",
     );
+  });
+
+  it("re-checks ownership before EACH destructive act — a foreign write between the check and the delete is caught", async () => {
+    // The granularity property, driven in the window that actually matters.
+    //
+    // `discardRejectedPayload` performs SEPARATE awaited destructive operations on
+    // the partial and on its sidecar. A single check at its entry authorises the
+    // first and is stale for the rest, so a foreign writer landing after that check
+    // gets its multi-gigabyte partial deleted and then its validator erased too.
+    //
+    // The injection point here is the `rm` syscall itself: the write lands AFTER
+    // the ownership check that authorised the partial's removal has already
+    // returned — the exact gap an entry-only check leaves open — so it can only be
+    // caught by the sidecar's own, separate check.
+    const url = "https://example.com/models/gap-between-check-and-delete.safetensors";
+    const { partial, sidecar } = cachePaths(url);
+    await writeFile(partial, "OURS");
+    await writeFile(sidecar, '"ours"');
+    await writeFile(`${partial}.rejected`, "stale marker"); // sends us down the discard path
+
+    const realRm = downloadCacheFs.rm;
+    let planted = false;
+    vi.spyOn(downloadCacheFs, "rm").mockImplementation(async (...args) => {
+      const path = String(args[0]);
+      if (!planted && path.endsWith(".partial")) {
+        planted = true;
+        // We are now PAST the check that authorised this removal and about to
+        // perform it. A foreign writer takes the file over right here.
+        await writeFile(partial, "SOMEONE-ELSES-MANY-GIGABYTES");
+        await writeFile(sidecar, '"their-object"');
+        // Let our (now wrong) removal proceed, exactly as it would in production —
+        // the point is what happens to everything AFTER it.
+      }
+      return realRm(...(args as Parameters<typeof realRm>));
+    });
+
+    fetchMock.mockImplementation(async () => new Response("BODY", { status: 200 }));
+
+    const err = await downloadModel(url, "checkpoints", "gap-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    expect(String((err as Error).message)).toMatch(
+      /another download is writing the same staged file/i,
+    );
+    // THE assertion: the foreign writer's VALIDATOR survives. With one check at the
+    // helper's entry it would have been erased along with the partial, leaving them
+    // with bytes they could no longer resume.
+    await expect(readFile(sidecar, "utf-8")).resolves.toBe('"their-object"');
+  });
+
+  it("re-checks ownership before the TRUNCATE fallback too — a failed rm does not license blanking a foreign file", async () => {
+    // The fourth destructive act, and the easiest one to forget: when `rm` fails
+    // (EPERM/EACCES), the cleanup falls back to truncating the file to 0 bytes.
+    // That fallback is reached only after a FAILED syscall — another await — so the
+    // check that authorised the rm is stale by the time it runs. Blanking a foreign
+    // multi-gigabyte partial is exactly as destructive as deleting it.
+    const url = "https://example.com/models/truncate-fallback-gap.safetensors";
+    const { partial, sidecar } = cachePaths(url);
+    await writeFile(partial, "OURS");
+    await writeFile(sidecar, '"ours"');
+    await writeFile(`${partial}.rejected`, "stale marker");
+
+    const realRm = downloadCacheFs.rm;
+    let planted = false;
+    vi.spyOn(downloadCacheFs, "rm").mockImplementation(async (...args) => {
+      const path = String(args[0]);
+      if (!planted && path.endsWith(".partial")) {
+        planted = true;
+        // The foreign writer takes over, and OUR removal then fails — so the code
+        // proceeds to the truncate fallback with a stale authorisation.
+        await writeFile(partial, "SOMEONE-ELSES-MANY-GIGABYTES");
+        await writeFile(sidecar, '"their-object"');
+        throw Object.assign(new Error("EPERM: operation not permitted"), { code: "EPERM" });
+      }
+      return realRm(...(args as Parameters<typeof realRm>));
+    });
+
+    fetchMock.mockImplementation(async () => new Response("BODY", { status: 200 }));
+
+    const err = await downloadModel(url, "checkpoints", "truncate-fallback-out.safetensors").catch(
+      (e: unknown) => e,
+    );
+    expect(String((err as Error).message)).toMatch(
+      /another download is writing the same staged file/i,
+    );
+    // Their bytes are intact — NOT blanked to 0 by a fallback acting on a stale check.
+    await expect(readFile(partial, "utf-8")).resolves.toBe("SOMEONE-ELSES-MANY-GIGABYTES");
+    await expect(readFile(sidecar, "utf-8")).resolves.toBe('"their-object"');
   });
 
   it("a retry that lands on a POISONED partial (#473 leftover) restarts instead of resuming onto it", async () => {

--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -128,7 +128,13 @@ beforeEach(() => {
   fetchMock.mockReset();
   mkdirMock.mockReset().mockResolvedValue(undefined);
   rmMock.mockReset().mockResolvedValue(undefined);
-  statMock.mockReset().mockRejectedValue(new Error("missing"));
+  // ENOENT, not a bare Error: this stub means "the file is ABSENT", and the code
+  // now distinguishes that (knowably nothing staged → a fresh download) from "the
+  // stat FAILED" (unknown → refuse rather than truncate someone else's bytes).
+  // A codeless rejection asserted the wrong thing about reality.
+  statMock
+    .mockReset()
+    .mockRejectedValue(Object.assign(new Error("ENOENT: missing"), { code: "ENOENT" }));
   // Default: nothing in the path is a symlink (best-effort guard is inert).
   lstatMock.mockReset().mockResolvedValue({ isSymbolicLink: () => false });
   realpathMock.mockReset().mockImplementation((p: string) => Promise.resolve(p));

--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -78,6 +78,7 @@ vi.mock("../../services/extra-paths.js", () => ({
 
 import { config } from "../../config.js";
 import { downloadModel, resolveDownloadTarget } from "../../services/model-resolver.js";
+import { setDownloadRetryPolicyForTests } from "../../services/download-retry.js";
 import { ModelError } from "../../utils/errors.js";
 import { logger } from "../../utils/logger.js";
 
@@ -138,6 +139,12 @@ beforeEach(() => {
   config.comfyuiPath = "/comfy";
   config.huggingfaceToken = undefined;
   config.civitaiApiToken = undefined;
+  // These tests assert routing / auth-header / destination behaviour with
+  // single-shot fetch mocks. #470 added automatic retry on transient failures
+  // (a 500 IS transient), which would re-enter the stream with no queued
+  // response. Pin ONE attempt so each assertion stays about its own subject;
+  // retry has dedicated coverage in download-retry.test.ts.
+  setDownloadRetryPolicyForTests({ maxAttempts: 1, stallTimeoutMs: 0 });
 });
 
 afterEach(() => {

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -1993,5 +1993,91 @@ describe("node-management service", () => {
       expect(msg).toMatch(/disable the old custom_nodes\/ComfyUI-Manager clone/i);
       expect(msg).toMatch(/--enable-manager/i);
     });
+
+    // ---- #817: a model download is not a node install ----------------------
+    describe("#817 the queue budget for a model download", () => {
+      /** A Manager whose queue NEVER drains, so the wait always times out. */
+      function stubNeverDrainingQueue(): void {
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async (url: string): Promise<Response> => {
+            const path = new URL(url).pathname;
+            if (path === "/v2/manager/queue/status") {
+              return jsonResponse({
+                total_count: 1,
+                done_count: 0,
+                in_progress_count: 1,
+                pending_count: 0,
+                is_processing: true,
+              });
+            }
+            if (path === "/v2/manager/is_legacy_manager_ui") {
+              return jsonResponse({ is_legacy_manager_ui: false });
+            }
+            return new Response("", { status: 200 });
+          }),
+        );
+      }
+
+      it("uses the MODEL budget, not the 600s node-install budget", async () => {
+        // The node budget is 5000 ms in this suite; the model budget is set to a
+        // distinct, larger value. If install-model wrongly took the node budget,
+        // the message would name 5 seconds — which is #817 in miniature: a model
+        // download timed out on a ceiling that was never sized for one.
+        setQueueTimingForTests({ timeoutMs: 5000, modelTimeoutMs: 90 });
+        stubNeverDrainingQueue();
+
+        const err = await installModelViaManager({
+          name: "big.safetensors",
+          url: "https://example.com/big.safetensors",
+          filename: "big.safetensors",
+          type: "diffusion_models",
+        }).catch((e) => e as Error);
+
+        expect((err as Error).message).toMatch(/did not finish within 0s|did not finish within/);
+        expect((err as Error).message).not.toMatch(/did not finish within 5s/);
+      });
+
+      it("says the wait gave up — NOT that the download failed — and forbids a re-issue", async () => {
+        setQueueTimingForTests({ modelTimeoutMs: 90 });
+        stubNeverDrainingQueue();
+
+        const err = await installModelViaManager({
+          name: "big.safetensors",
+          url: "https://example.com/big.safetensors",
+          filename: "big.safetensors",
+          type: "diffusion_models",
+        }).catch((e) => e as Error);
+        const msg = (err as Error).message;
+
+        // The wait ended; the host was never told to stop. Claiming failure here is
+        // what made #817's reporter re-issue — and a second concurrent server-side
+        // fetch of one file is how the destination ended up truncated.
+        expect(msg).toMatch(/NOT proof the download failed/i);
+        expect(msg).toMatch(/Do NOT re-issue/i);
+        expect(msg).toMatch(/corrupt model/i);
+        // …and it names moves the caller can actually make from here.
+        expect(msg).toMatch(/list_local_models/);
+        expect(msg).toMatch(/COMFYUI_MANAGER_DOWNLOAD_TIMEOUT_S/);
+        expect(msg).toMatch(/LOCAL ComfyUI/);
+      });
+
+      it("leaves a NODE install's timeout message alone — it must not inherit the download advice", async () => {
+        setQueueTimingForTests({ timeoutMs: 60 });
+        stubNeverDrainingQueue();
+
+        const err = await installCustomNode({ id: "comfyui-impact-pack" }).catch(
+          (e) => e as Error,
+        );
+        const msg = (err as Error).message;
+
+        expect(msg).toMatch(/did not finish within/);
+        // A node install has no half-downloaded model to protect and no
+        // COMFYUI_MANAGER_DOWNLOAD_TIMEOUT_S knob — telling it the model story would
+        // be advice that does not apply.
+        expect(msg).not.toMatch(/Do NOT re-issue/i);
+        expect(msg).not.toMatch(/COMFYUI_MANAGER_DOWNLOAD_TIMEOUT_S/);
+      });
+    });
   });
 });

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -445,6 +445,22 @@ describe("models dir + extra-config argv parsing (#345/#346/#369)", () => {
         }
       });
 
+      it("REFUSES when BOTH readings fit — the evidence does not say which install is running", async () => {
+        // base = <...>/ComfyUI holding main.py, AND <base>/ComfyUI/main.py also
+        // present. The server's "ComfyUI\main.py" is consistent with EITHER, so
+        // picking one is a guess about where multi-gigabyte files land — and
+        // guessing wrong is precisely the #369 harm (a model in a stale install,
+        // reported as a success).
+        const base = resolve("/bundle/ComfyUI");
+        (config as { comfyuiPath?: string }).comfyuiPath = base;
+        observedLiveRoot = undefined;
+        hasEntrypointFor = (dir) =>
+          resolve(dir) === base || resolve(dir) === join(base, "ComfyUI");
+        getSystemStats.mockResolvedValue({ system: { argv: RELATIVE_ARGV } });
+
+        await expect(resolveModelsDirWithBases()).rejects.toThrow(/could not be determined/i);
+      });
+
       it("keeps the pre-existing relDir '.' behaviour unchanged (deliberately NOT tightened here)", async () => {
         // `python main.py` with no reported cwd gives relDir ".", which corroborates
         // nothing beyond "the configured base is a ComfyUI install" — a reviewer

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -414,6 +414,37 @@ describe("models dir + extra-config argv parsing (#345/#346/#369)", () => {
         await expect(resolveModelsDirWithBases()).rejects.toThrow(/could not be determined/i);
       });
 
+      it("does NOT fold case on macOS — APFS can be case-SENSITIVE, so a case-differing relDir is not corroboration", async () => {
+        // `/x/ComfyUI` and `/x/comfyui` are two different installs on a
+        // case-sensitive APFS volume. This comparison decides where a
+        // multi-gigabyte file gets written, so a wrong "same" is the #369 harm (a
+        // model landing in an install the running server never reads, announced as
+        // a success). Windows filesystems ARE case-insensitive everywhere, so
+        // folding is correct there — and only there.
+        //
+        // The platform is stubbed rather than the test being skipped off macOS:
+        // this rule must be verifiable on every host, or it is only ever checked on
+        // the one machine least likely to run the suite.
+        const realPlatform = process.platform;
+        Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+        try {
+          const base = resolve("/D/portable/ComfyUI");
+          (config as { comfyuiPath?: string }).comfyuiPath = base;
+          observedLiveRoot = undefined;
+          hasEntrypointFor = (dir) => resolve(dir) === base;
+          getSystemStats.mockResolvedValue({
+            system: { argv: [join("comfyui", "main.py"), "--listen"] },
+          });
+
+          await expect(resolveModelsDirWithBases()).rejects.toThrow(/could not be determined/i);
+        } finally {
+          Object.defineProperty(process, "platform", {
+            value: realPlatform,
+            configurable: true,
+          });
+        }
+      });
+
       it("corroborates a MULTI-SEGMENT relative script against a base ending in those segments", async () => {
         // `python sub/ComfyUI/main.py` with COMFYUI_PATH=<...>/sub/ComfyUI.
         const base = resolve("/srv/stack/sub/ComfyUI");

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -33,6 +33,12 @@ let savedDefaultWorkspace: string | undefined;
 // the OS process table.
 let observedLiveRoot: string | undefined;
 let baseHasEntrypoint = false;
+/** Per-DIRECTORY entrypoint probe (#813). The flat `baseHasEntrypoint` boolean
+ *  cannot express the case the bug is about — `<base>/main.py` existing while
+ *  `<base>/ComfyUI/main.py` does not — so tests that need to tell the two
+ *  candidate anchors apart install a predicate here. Default keeps every
+ *  pre-existing test on the flat boolean. */
+let hasEntrypointFor: ((dir: string) => boolean) | undefined;
 vi.mock("../../services/workspace-env.js", async () => {
   const actual = await vi.importActual<
     typeof import("../../services/workspace-env.js")
@@ -40,7 +46,8 @@ vi.mock("../../services/workspace-env.js", async () => {
   return {
     resolveEffectiveComfyUIBase: () => config.comfyuiPath ?? savedDefaultWorkspace,
     liveRootFromArgv: actual.liveRootFromArgv,
-    hasComfyUIEntrypoint: () => baseHasEntrypoint,
+    hasComfyUIEntrypoint: (dir: string) =>
+      hasEntrypointFor ? hasEntrypointFor(dir) : baseHasEntrypoint,
     resolveLiveServerRoot: (argv?: string[], cwd?: string) => {
       const relDir = actual.liveRelDirFromArgv(argv);
       const fromArgv = actual.liveRootFromArgv(argv, cwd);
@@ -83,6 +90,7 @@ beforeEach(() => {
   liveRootExists = true;
   observedLiveRoot = undefined;
   baseHasEntrypoint = false;
+  hasEntrypointFor = undefined;
 });
 
 afterEach(() => {
@@ -334,6 +342,92 @@ describe("models dir + extra-config argv parsing (#345/#346/#369)", () => {
       const { modelsDir, source } = await resolveModelsDirWithBases();
       expect(modelsDir).toBe(join(resolve("/bundle"), "ComfyUI", "models"));
       expect(source).toBe("base-anchored");
+    });
+
+    // ── #813: COMFYUI_PATH already pointing AT the ComfyUI directory ─────────
+    //
+    // Two base conventions coexist and both are legitimate. Only the OUTER
+    // launcher-root reading (`<base>/<relDir>/main.py`, ComfyUI Desktop) was
+    // implemented, so a Windows portable install whose COMFYUI_PATH is the inner
+    // ComfyUI directory — the value get_environment / list_local_models /
+    // resolveEffectiveComfyUIBase all already accept — had every download refused.
+    describe("#813 the base IS the ComfyUI directory (Windows portable)", () => {
+      it("anchors on the base itself when the base is the very directory the server named", async () => {
+        const base = resolve("/D/ComfyUI_windows_portable/ComfyUI");
+        (config as { comfyuiPath?: string }).comfyuiPath = base;
+        observedLiveRoot = undefined;
+        // The portable shape: main.py sits DIRECTLY under the base, and the
+        // Desktop-style nesting <base>/ComfyUI/main.py does NOT exist.
+        hasEntrypointFor = (dir) => resolve(dir) === base;
+        getSystemStats.mockResolvedValue({ system: { argv: RELATIVE_ARGV } });
+
+        const { modelsDir, source, baseDirs } = await resolveModelsDirWithBases();
+        // Resolves to <base>/models — NOT the double-nested <base>/ComfyUI/models
+        // that never exists, which is what made this refuse.
+        expect(modelsDir).toBe(join(base, "models"));
+        expect(source).toBe("base-anchored");
+        expect(baseDirs).toContain(base);
+      });
+
+      it("still prefers the NESTED launcher-root reading when THAT is the one that exists", async () => {
+        // ComfyUI Desktop: <base> holds the launcher, the server is one level down.
+        // The #813 change must not steal this case.
+        const base = resolve("/bundle");
+        (config as { comfyuiPath?: string }).comfyuiPath = base;
+        observedLiveRoot = undefined;
+        hasEntrypointFor = (dir) => resolve(dir) === join(base, "ComfyUI");
+        getSystemStats.mockResolvedValue({ system: { argv: RELATIVE_ARGV } });
+
+        const { modelsDir, source } = await resolveModelsDirWithBases();
+        expect(modelsDir).toBe(join(base, "ComfyUI", "models"));
+        expect(source).toBe("base-anchored");
+      });
+
+      it("REFUSES a base that holds main.py but is NOT the directory the server named", async () => {
+        // The corroboration is what makes accepting the base safe. A base called
+        // "ComfyUI-master" containing a main.py is a DIFFERENT install from the
+        // one whose script is "ComfyUI/main.py" — accepting it is exactly the
+        // stale-install landing #369 exists to prevent. "Could not determine"
+        // must not become a definite "yes".
+        const base = resolve("/D/checkouts/ComfyUI-master");
+        (config as { comfyuiPath?: string }).comfyuiPath = base;
+        observedLiveRoot = undefined;
+        hasEntrypointFor = (dir) => resolve(dir) === base; // base HAS main.py
+        getSystemStats.mockResolvedValue({ system: { argv: RELATIVE_ARGV } });
+
+        const err = await resolveModelsDirWithBases().catch((e: Error) => e);
+        expect((err as Error).message).toMatch(/could not be determined/i);
+        // …and the refusal explains BOTH readings it tried, so the reader can fix it.
+        expect((err as Error).message).toMatch(/does not contain/);
+        expect((err as Error).message).toMatch(/is not itself "ComfyUI" holding "main\.py"/);
+      });
+
+      it("REFUSES the base-is-the-install reading when the base does NOT hold main.py", async () => {
+        // Name matches, entrypoint absent: no corroboration, so no anchor. This is
+        // the mutation guard for dropping the hasComfyUIEntrypoint(base) check.
+        const base = resolve("/D/ComfyUI_windows_portable/ComfyUI");
+        (config as { comfyuiPath?: string }).comfyuiPath = base;
+        observedLiveRoot = undefined;
+        hasEntrypointFor = () => false;
+        getSystemStats.mockResolvedValue({ system: { argv: RELATIVE_ARGV } });
+
+        await expect(resolveModelsDirWithBases()).rejects.toThrow(/could not be determined/i);
+      });
+
+      it("corroborates a MULTI-SEGMENT relative script against a base ending in those segments", async () => {
+        // `python sub/ComfyUI/main.py` with COMFYUI_PATH=<...>/sub/ComfyUI.
+        const base = resolve("/srv/stack/sub/ComfyUI");
+        (config as { comfyuiPath?: string }).comfyuiPath = base;
+        observedLiveRoot = undefined;
+        hasEntrypointFor = (dir) => resolve(dir) === base;
+        getSystemStats.mockResolvedValue({
+          system: { argv: [join("sub", "ComfyUI", "main.py"), "--listen"] },
+        });
+
+        const { modelsDir, source } = await resolveModelsDirWithBases();
+        expect(modelsDir).toBe(join(base, "models"));
+        expect(source).toBe("base-anchored");
+      });
     });
 
     it("an UNREACHABLE server still falls back to <COMFYUI_PATH>/models (no regression)", async () => {

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -445,6 +445,27 @@ describe("models dir + extra-config argv parsing (#345/#346/#369)", () => {
         }
       });
 
+      it("keeps the pre-existing relDir '.' behaviour unchanged (deliberately NOT tightened here)", async () => {
+        // `python main.py` with no reported cwd gives relDir ".", which corroborates
+        // nothing beyond "the configured base is a ComfyUI install" — a reviewer
+        // fairly calls that weak evidence for the #369 hazard. It is nonetheless
+        // UNCHANGED by #813, and deliberately so: this is the single most common
+        // local launch, and refusing it would route those users through the
+        // Manager (often not installed) for every download. Tightening it is a
+        // separate decision about a pre-existing behaviour, not part of fixing the
+        // portable-base anchoring. This test exists so the choice is explicit and
+        // any future change to it is a visible one.
+        const base = resolve("/home/me/ComfyUI");
+        (config as { comfyuiPath?: string }).comfyuiPath = base;
+        observedLiveRoot = undefined;
+        hasEntrypointFor = (dir) => resolve(dir) === base;
+        getSystemStats.mockResolvedValue({ system: { argv: ["main.py", "--listen"] } });
+
+        const { modelsDir, source } = await resolveModelsDirWithBases();
+        expect(modelsDir).toBe(join(base, "models"));
+        expect(source).toBe("base-anchored");
+      });
+
       it("corroborates a MULTI-SEGMENT relative script against a base ending in those segments", async () => {
         // `python sub/ComfyUI/main.py` with COMFYUI_PATH=<...>/sub/ComfyUI.
         const base = resolve("/srv/stack/sub/ComfyUI");

--- a/src/__tests__/tools/model-management.test.ts
+++ b/src/__tests__/tools/model-management.test.ts
@@ -266,6 +266,127 @@ describe("download_status tool", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+  // ── #822: a printed handle must identify exactly one row ──────────────────
+  describe("#822 the id is not unique — the rendered handle must still select", () => {
+    /** Two persisted in-flight records with the SAME id (one destination) and
+     *  DIFFERENT source URLs: the exact listing #822 reported. */
+    async function seedCollidingRows(dir: string, id: string): Promise<void> {
+      const common = {
+        id,
+        target_subfolder: "text_encoders",
+        status: "downloading",
+        started_at: Date.now() - 60_000,
+        updated: Date.now(),
+      };
+      await writeFile(
+        join(dir, `control-job-${id}-session-live.json`),
+        JSON.stringify({
+          ...common,
+          trayId: "livetray00000001",
+          progressId: "live-prog",
+          url: "https://huggingface.co/Comfy-Org/Krea-2/resolve/main/text_encoders/q.safetensors",
+          owner: "session-live",
+        }),
+      );
+      await writeFile(
+        join(dir, `control-job-${id}-session-orphan.json`),
+        JSON.stringify({
+          ...common,
+          trayId: "orphantray000001",
+          progressId: "orphan-prog",
+          url: "https://huggingface.co/Aitrepreneur/FLX/resolve/main/q.safetensors",
+          owner: "session-orphan",
+          started_at: Date.now() - 884_000,
+        }),
+      );
+    }
+
+    it("renders the tray id on every row, so the printed handle names ONE download", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "model-management-822-"));
+      setProgressDir(dir);
+      try {
+        await seedCollidingRows(dir, "a0b477082f35745c");
+        const { downloadStatus } = makeServer();
+        const text = (await downloadStatus({})).content[0].text;
+
+        // Both rows appear (download_status promises EVERY tracked download)…
+        expect(text).toContain("livetray00000001");
+        expect(text).toContain("orphantray000001");
+        // …each carrying its tray id alongside the shared id, so the two lines are
+        // programmatically distinguishable rather than identical-looking.
+        expect(text).toContain("`a0b477082f35745c` (tray `livetray00000001`)");
+        expect(text).toContain("`a0b477082f35745c` (tray `orphantray000001`)");
+      } finally {
+        setProgressDir("");
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("SHOUTS when a listing contains two rows under one id — two writers, one file", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "model-management-822-"));
+      setProgressDir(dir);
+      try {
+        await seedCollidingRows(dir, "a0b477082f35745c");
+        const { downloadStatus } = makeServer();
+        const text = (await downloadStatus({})).content[0].text;
+
+        expect(text).toMatch(/name MORE THAN ONE download/);
+        expect(text).toContain("AMBIGUOUS id");
+        // The remedy is stated in terms the caller can act on right now.
+        expect(text).toMatch(/Use the `tray_id`/);
+        expect(text).toMatch(/cancel_download/);
+      } finally {
+        setProgressDir("");
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("download_status(id) on an ambiguous id names the candidates — it does NOT report 'no download'", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "model-management-822-"));
+      setProgressDir(dir);
+      try {
+        await seedCollidingRows(dir, "a0b477082f35745c");
+        const { downloadStatus } = makeServer();
+        const text = (await downloadStatus({ id: "a0b477082f35745c" })).content[0].text;
+
+        // The regression this guards: the id resolved to nothing (ambiguous), and
+        // saying "no download matching" would turn "could not determine WHICH" into
+        // a definite — and false — "it never started".
+        expect(text).not.toMatch(/No download matching/);
+        expect(text).toMatch(/matches 2 DIFFERENT downloads/);
+        expect(text).toContain("livetray00000001");
+        expect(text).toContain("orphantray000001");
+        // Both source URLs are shown, which is what lets a caller tell them apart.
+        expect(text).toContain("Krea-2");
+        expect(text).toContain("Aitrepreneur");
+        expect(text).toMatch(/Re-run download_status with `tray_id`/);
+      } finally {
+        setProgressDir("");
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("download_status(id, tray_id) selects exactly one of the colliding rows", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "model-management-822-"));
+      setProgressDir(dir);
+      try {
+        await seedCollidingRows(dir, "a0b477082f35745c");
+        const { downloadStatus } = makeServer();
+        const text = (
+          await downloadStatus({ id: "a0b477082f35745c", tray_id: "orphantray000001" })
+        ).content[0].text;
+
+        expect(text).toContain("orphantray000001");
+        expect(text).toContain("Aitrepreneur");
+        // The OTHER row is not reported — the selector actually selected.
+        expect(text).not.toContain("livetray00000001");
+        expect(text).not.toContain("Krea-2");
+      } finally {
+        setProgressDir("");
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
 });
 
 describe("list_local_models rendering", () => {

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -1608,9 +1608,20 @@ async function streamUrlToFile(
   // line only READ the file or talked to the server; everything below MUTATES it,
   // so this is the true first-touch boundary.
   //
-  // The 206-refusal path above returns by RECURSING with a clean restart and does
-  // not touch the file on its way there, so the recursive call runs this check
-  // itself — the boundary holds on that path too.
+  // The 206-refusal path above returns by RECURSING with a clean restart. That
+  // path touches nothing on its way out, and the recursion forwards THIS `beforeWrite`
+  // (along with every other parameter — see the call site, which passes all of them
+  // explicitly), so the recursive call re-runs this check before it writes and the
+  // boundary holds there too.
+  //
+  // That forwarding is load-bearing, not incidental: a recursive restart that
+  // dropped `beforeWrite` would perform the truncating 200-restart with no
+  // ownership check at all, which is the exact hazard this line exists to prevent.
+  // It is covered by a test that stages a foreign writer during the RECURSIVE
+  // request specifically; if someone deletes an argument from that call, the test
+  // fails. The same goes for `onBytes` (drop it and the stall watchdog kills the
+  // healthy restarted transfer) and `deferErrorRow` (drop it and the restarted
+  // stream publishes a terminal failure while the outer loop is still retrying).
   if (beforeWrite) await beforeWrite();
   // …and re-check the cancel, because that hook AWAITS. Every path below either
   // deletes or truncates the staged file, so a cancel that landed during the hook
@@ -2089,7 +2100,17 @@ async function downloadIntoCache(
      * content-addressed X-Linked-Etag cross-check for cross-origin 206s, #343/#467).
      * A partial with no recorded write-time identity is NOT resumed; it restarts.
      */
-    const resumeOffsetFromDisk = async (): Promise<number> => {
+    const resumeOffsetFromDisk = async (
+      /** The staged state this attempt VERIFIED moments ago. Re-asserted immediately
+       *  before each destructive cleanup below, because those cleanups delete or
+       *  truncate the SHARED staged file — and between the retry-boundary check and
+       *  this function a foreign writer can have replaced it. That gap was the last
+       *  window the retry loop added without an ownership check: a valid replacement
+       *  plus a surviving `.rejected` marker (whose removal transiently failed)
+       *  would otherwise have our automatic retry destroy the other writer's
+       *  partial. */
+      verified: StagedState,
+    ): Promise<number> => {
       let resumeFromBytes = 0;
       try {
         const existing = await downloadCacheFs.stat(partial);
@@ -2123,6 +2144,10 @@ async function downloadIntoCache(
             { url: logUrl, bytes: resumeFromBytes },
           );
         }
+        // Prove it is still ours BEFORE destroying it. A `.rejected` marker records
+        // that a PRIOR attempt of OURS rejected a body; it says nothing about a
+        // partial another writer has since staged in its place.
+        await assertStillOurs(verified, "before discarding a previously-rejected partial", false);
         const neutralized = await discardRejectedPayload(
           partial,
           `${partial}.etag`,
@@ -2155,6 +2180,9 @@ async function downloadIntoCache(
               `the poisoned bytes can't be resumed onto (#473).`,
             { url: logUrl, bytes: resumeFromBytes },
           );
+          // Same rule: the head we just sniffed may belong to another writer's
+          // in-progress file, not to our own poisoned leftover.
+          await assertStillOurs(verified, "before discarding a non-model partial", false);
           await discardRejectedPayload(partial, `${partial}.etag`, logUrl ?? redactUrlForLogs(url));
           resumeFromBytes = 0;
         }
@@ -2258,9 +2286,22 @@ async function downloadIntoCache(
      * multi-gigabyte loss. Unknown ownership must stop the write, not switch the
      * detector off.
      */
-    const assertStillOurs = async (
-      expectedSize: number | undefined,
-      expectedSidecar: string | undefined,
+    /** The staged file's observable state: its size and its validator bytes. */
+    interface StagedState {
+      size: number | undefined;
+      sidecar: string | undefined;
+    }
+
+    /** One read of both fields. Callers that VERIFY and then RECORD must use a
+     *  single call for both, or they reintroduce the very gap they are closing. */
+    const readStaged = async (): Promise<StagedState> => ({
+      size: await partialSize(),
+      sidecar: await sidecarBytes(),
+    });
+
+    const assertMatches = (
+      expected: StagedState,
+      actual: StagedState,
       when: string,
       /** Require the size to be KNOWN on both sides, not merely unchanged.
        *
@@ -2275,9 +2316,9 @@ async function downloadIntoCache(
        *  accurate diagnosis with a wrong one and block first attempts that never
        *  had anything to own. */
       strict: boolean,
-    ): Promise<void> => {
-      const nowSize = await partialSize();
-      const nowSidecar = await sidecarBytes();
+    ): void => {
+      const { size: expectedSize, sidecar: expectedSidecar } = expected;
+      const { size: nowSize, sidecar: nowSidecar } = actual;
       // `partialSize` reports a missing file as a definite 0, so `undefined` means
       // the file is THERE but unreadable.
       if (strict && (expectedSize === undefined || nowSize === undefined)) {
@@ -2313,6 +2354,13 @@ async function downloadIntoCache(
         );
       }
     };
+
+    /** Read the staged state NOW and require it to match `expected`. */
+    const assertStillOurs = async (
+      expected: StagedState,
+      when: string,
+      strict: boolean,
+    ): Promise<void> => assertMatches(expected, await readStaged(), when, strict);
 
     /** What WE left the partial (and its validator) at when our previous attempt
      *  ended. `sizeWeLeft` stays NULL before the first retry — there is nothing to
@@ -2360,20 +2408,32 @@ async function downloadIntoCache(
       // to the non-retry path. It is NOT made worse here, and it is deliberately
       // left for a follow-up rather than half-solved with a lease whose stale-claim
       // and crash-cleanup behaviour (#529's objection) could destroy live partials.
+      // ONE read serves BOTH purposes: proving the file is still the one we left,
+      // and becoming the baseline everything downstream is checked against. Using
+      // two reads would leave a gap between "verified" and "recorded" — precisely
+      // the kind of gap this guard exists to close.
+      const verified = await readStaged();
       if (sizeWeLeft !== null) {
         // STRICT: we left bytes here and went quiet, so unknown state must refuse.
-        await assertStillOurs(sizeWeLeft, sidecarWeLeft, "while this attempt was backing off", true);
+        assertMatches(
+          { size: sizeWeLeft, sidecar: sidecarWeLeft },
+          verified,
+          "while this attempt was backing off",
+          true,
+        );
       }
 
-      const resumeFromBytes = await resumeOffsetFromDisk();
+      // resumeOffsetFromDisk can DESTROY the staged file (the #473 poison guards),
+      // so it re-asserts `verified` immediately before each cleanup rather than
+      // trusting the check above to still hold by the time it acts.
+      const resumeFromBytes = await resumeOffsetFromDisk(verified);
 
       // The state THIS attempt based its resume decision on. Re-verified at the
       // last instant before any write (see `beforeWrite`), so the decision and the
       // action are checked against the same file rather than merely assumed to
-      // describe it. Taken AFTER resumeOffsetFromDisk because that call may itself
-      // discard a poisoned partial.
-      const decidedSize = await partialSize();
-      const decidedSidecar = await sidecarBytes();
+      // describe it. Re-read AFTER resumeOffsetFromDisk because that call may have
+      // legitimately discarded a poisoned partial of OUR OWN.
+      const decided = await readStaged();
 
       // Per-attempt abort, fed by TWO independent sources: the caller's cancel
       // (forwarded) and our stall watchdog. They are kept distinguishable — the
@@ -2427,12 +2487,7 @@ async function downloadIntoCache(
           async () => {
             // Change-detection only: within one attempt an unreadable file was
             // already unreadable, and the older guards diagnose that better.
-            await assertStillOurs(
-              decidedSize,
-              decidedSidecar,
-              "while this attempt was requesting it",
-              false,
-            );
+            await assertStillOurs(decided, "while this attempt was requesting it", false);
           },
         );
         await downloadCacheFs.rename(partial, target);
@@ -2522,8 +2577,9 @@ async function downloadIntoCache(
         // touched it" from "another writer moved it" (the interference check at the
         // top of the loop). Taken AFTER the attempt has fully unwound, so it
         // reflects the final on-disk state this attempt produced.
-        sizeWeLeft = await partialSize();
-        sidecarWeLeft = await sidecarBytes();
+        const left = await readStaged();
+        sizeWeLeft = left.size;
+        sidecarWeLeft = left.sidecar;
         // Backoff before re-requesting. #470 observed a 403 from an INSTANT
         // re-request after an aborted connection — the wait is part of the fix,
         // not politeness. It wakes early if the caller cancels.

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -2289,14 +2289,23 @@ async function downloadIntoCache(
           when,
         );
       }
-      // SIDECAR is compared for CHANGE, not for readability. An unreadable sidecar
-      // that was ALREADY unreadable when we looked a moment ago is a stable
-      // pre-existing condition (a blocked path, a stale directory), not evidence of
-      // another writer — and it has its own, better-targeted guard downstream
-      // (#467 P0c refuses to pair new bytes with a sidecar it cannot neutralize).
-      // Refusing here instead would replace that precise diagnosis with a wrong
-      // one. `undefined !== undefined` is false, so this compares equal only when
-      // the state is genuinely unchanged, and still catches readable-then-not.
+      // The SIDECAR gets the same strict treatment across a retry boundary, and for
+      // the same reason as the size: an unreadable validator is not a matching one.
+      // It matters specifically because readValidatorSidecar() reads "unreadable"
+      // as "no validator", which sends the attempt down the 200-restart path — and
+      // that path TRUNCATES the staged file. So an unknown validator plus a
+      // same-size replacement by another writer would destroy their partial.
+      if (strict && (expectedSidecar === undefined || nowSidecar === undefined)) {
+        throw interferenceError("the staged file's resume validator could not be read", when);
+      }
+      // WITHIN one attempt it is only compared for CHANGE. A sidecar that was
+      // ALREADY unreadable a moment ago is a stable pre-existing condition (a
+      // blocked path, a stale directory), not evidence of another writer, and it
+      // has its own better-targeted guard downstream (#467 P0c refuses to pair new
+      // bytes with a sidecar it cannot neutralize). Refusing here would replace
+      // that precise diagnosis with a wrong one. `undefined !== undefined` is
+      // false, so this compares equal only when genuinely unchanged, and still
+      // catches readable-then-not.
       if (nowSidecar !== expectedSidecar) {
         throw interferenceError(
           "its resume validator changed, so a DIFFERENT upstream object has been staged there",

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -50,13 +50,52 @@ async function safeRm(path: string): Promise<void> {
   }
 }
 
-/** Remove `path`, returning true iff it is confirmed gone. Unlike `safeRm` this
+/**
+ * A path together with the check that AUTHORISES destroying it.
+ *
+ * The destructive helpers below take one of these instead of a bare string, so it
+ * is not expressible to delete or truncate a file without re-proving, immediately
+ * beforehand, that it is still the file the caller checked.
+ *
+ * WHY A TYPE RATHER THAN A CALL AT THE TOP. `discardRejectedPayload` performs up
+ * to FOUR separate awaited destructive operations (rm and a truncate fallback, for
+ * the payload and again for its sidecar). A single check at the helper's entry
+ * authorises the first act and then goes stale: every `await` after it is a window
+ * in which another process can replace the file, and the remaining acts would
+ * destroy something nobody checked. Carrying the check WITH the path makes the
+ * guarantee structural — a new destructive step cannot be added without one.
+ *
+ * The residual gap is the scheduling boundary between the check's last read and
+ * the syscall it authorises. That cannot be closed without OS-level locking; what
+ * this removes is every gap that contains OTHER I/O.
+ */
+interface GuardedPath {
+  readonly path: string;
+  /** Re-prove ownership. Throws to abort the destruction. */
+  readonly assertOwned: () => Promise<void>;
+}
+
+/**
+ * A path no other process can be writing — our own O_EXCL temp, a cache entry this
+ * call materialised, or a `.partial` whose ownership the caller established and
+ * cannot lose while it holds the stream. Making this explicit means an unguarded
+ * destruction is a deliberate, reviewable claim at the call site rather than an
+ * omission nobody notices.
+ */
+function selfOwned(path: string): GuardedPath {
+  return { path, assertOwned: async () => {} };
+}
+
+/** Remove `target`, returning true iff it is confirmed gone. Unlike `safeRm` this
  *  LOGS a removal failure (EPERM/EACCES/…) instead of swallowing it silently — a
  *  left-behind rejected artifact (a poisoned partial / cache entry) must at least be
  *  visible, since a later cache-hit or resume could otherwise re-hit it (#473 P1). */
-async function rmOrLog(path: string, logUrl: string): Promise<boolean> {
+async function rmOrLog(target: GuardedPath, logUrl: string): Promise<boolean> {
+  const path = target.path;
+  // Immediately before the syscall — nothing but the check itself in between.
+  await target.assertOwned();
   try {
-    await rm(path, { force: true });
+    await downloadCacheFs.rm(path, { force: true });
     return true;
   } catch (err) {
     logger.warn(
@@ -72,8 +111,12 @@ async function rmOrLog(path: string, logUrl: string): Promise<boolean> {
  *  true iff the path ends up removed OR emptied. A 0-byte partial is treated as fresh
  *  (not resumed) and a 0-byte cache/sidecar entry carries no resumable state, so
  *  zeroing is as safe as deleting. Logs (error) only when it can do NEITHER (#473 P1). */
-async function rmOrTruncate(path: string, logUrl: string): Promise<boolean> {
-  if (await rmOrLog(path, logUrl)) return true;
+async function rmOrTruncate(target: GuardedPath, logUrl: string): Promise<boolean> {
+  if (await rmOrLog(target, logUrl)) return true;
+  const path = target.path;
+  // The failed rm was itself an await, so the entry check is already stale —
+  // re-prove before the truncate, which is just as destructive.
+  await target.assertOwned();
   try {
     await writeFile(path, "");
     return true;
@@ -95,12 +138,16 @@ async function rmOrTruncate(path: string, logUrl: string): Promise<boolean> {
  *  when the partial itself can be deleted (#473 P1). A hard failure to neutralize is
  *  surfaced via the log inside rmOrTruncate. */
 async function discardRejectedPayload(
-  path: string,
-  sidecarPath: string | undefined,
+  target: GuardedPath,
+  sidecar: GuardedPath | undefined,
   logUrl: string,
 ): Promise<boolean> {
-  const neutralized = await rmOrTruncate(path, logUrl);
-  if (sidecarPath) await rmOrTruncate(sidecarPath, logUrl);
+  // Each rmOrTruncate re-proves ownership before every syscall it performs. The
+  // sidecar's destruction is separated from the payload's by at least one await,
+  // so it needs its own check — authorising both from one observation is exactly
+  // the granularity bug this shape prevents.
+  const neutralized = await rmOrTruncate(target, logUrl);
+  if (sidecar) await rmOrTruncate(sidecar, logUrl);
   return neutralized;
 }
 
@@ -1259,7 +1306,11 @@ async function streamUrlToFile(
       url,
       logUrl,
       onReject: async () => {
-        await discardRejectedPayload(targetPath, undefined, logUrl);
+        // selfOwned: this runs AFTER we streamed these bytes ourselves, so the
+        // caller's pre-write baseline no longer describes the file (we changed it)
+        // and re-checking against it would refuse our OWN cleanup. We hold the
+        // stream; these bytes are ours to discard.
+        await discardRejectedPayload(selfOwned(targetPath), undefined, logUrl);
       },
       // FAIL CLOSED, same as the HTTP path: a cloud (S3/Azure) object can be an XML/
       // HTML AccessDenied body saved under a `.safetensors` name, and if we CAN'T
@@ -1741,7 +1792,18 @@ async function streamUrlToFile(
     // validator paired with new bytes. (An emptied 0-byte sidecar reads back as "no
     // validator", so even a later failed new-write forces a safe full restart, never
     // a stale-flag resume.)
-    if (!(await rmOrTruncate(validatorSidecar, logUrl))) {
+    // The caller's pre-write ownership check is still VALID here: nothing has been
+    // written yet in this restart block, so its baseline still describes the staged
+    // file. Re-running it immediately before this destruction is both meaningful
+    // and free — and this IS a destruction of a file another writer may have
+    // re-staged while our request was in flight.
+    const guardedStaleSidecar: GuardedPath = {
+      path: validatorSidecar,
+      assertOwned: async () => {
+        if (beforeWrite) await beforeWrite();
+      },
+    };
+    if (!(await rmOrTruncate(guardedStaleSidecar, logUrl))) {
       throw new ModelError(
         `Download restart failed: could not remove or empty the stale resume-validator sidecar, so a ` +
           `fresh download could pair new bytes with a stale validator (risking corruption on a later ` +
@@ -1945,7 +2007,14 @@ async function streamUrlToFile(
       // marker so a content-type-only rejection (whose body may sniff as binary on
       // retry) still can't be resumed even if neutralization failed.
       onReject: async () => {
-        await discardRejectedPayload(targetPath, resumable ? validatorSidecar : undefined, logUrl);
+        // selfOwned, for the same reason as the cloud path above: we streamed these
+        // bytes ourselves, so the pre-write baseline no longer describes the file
+        // and would refuse our own cleanup. The stream is ours.
+        await discardRejectedPayload(
+          selfOwned(targetPath),
+          resumable ? selfOwned(validatorSidecar) : undefined,
+          logUrl,
+        );
         if (resumable) await writePoisonMarker(`${targetPath}.rejected`, logUrl);
       },
     });
@@ -2102,15 +2171,44 @@ async function downloadIntoCache(
      */
     const resumeOffsetFromDisk = async (
       /** The staged state this attempt VERIFIED moments ago. Re-asserted immediately
-       *  before each destructive cleanup below, because those cleanups delete or
-       *  truncate the SHARED staged file — and between the retry-boundary check and
-       *  this function a foreign writer can have replaced it. That gap was the last
-       *  window the retry loop added without an ownership check: a valid replacement
-       *  plus a surviving `.rejected` marker (whose removal transiently failed)
-       *  would otherwise have our automatic retry destroy the other writer's
-       *  partial. */
+       *  before EACH destructive syscall below (via the guards this builds), because
+       *  those cleanups delete or truncate the SHARED staged file — and between the
+       *  retry-boundary check and this function a foreign writer can have replaced
+       *  it. That gap was the last window the retry loop added without an ownership
+       *  check: a valid replacement plus a surviving `.rejected` marker (whose
+       *  removal transiently failed) would otherwise have our automatic retry
+       *  destroy the other writer's partial. */
       verified: StagedState,
     ): Promise<number> => {
+      /**
+       * The `.partial` and its `.etag`, each carrying the check that authorises
+       * destroying THAT file — deliberately not the same check.
+       *
+       * The partial's guard compares the whole staged state. The sidecar's compares
+       * ONLY the sidecar, because by the time it runs we may legitimately have
+       * removed the partial ourselves; re-checking the partial there would refuse
+       * our own cleanup. Each guard asserts what is still meaningful evidence for
+       * the file it protects.
+       */
+      const guardedStagedPair = (when: string): [GuardedPath, GuardedPath] => [
+        {
+          path: partial,
+          assertOwned: () => assertStillOurs(verified, when, false),
+        },
+        {
+          path: `${partial}.etag`,
+          assertOwned: async () => {
+            const nowSidecar = await sidecarBytes();
+            if (nowSidecar !== verified.sidecar) {
+              throw interferenceError(
+                "its resume validator changed, so a DIFFERENT upstream object has been staged there",
+                when,
+              );
+            }
+          },
+        },
+      ];
+
       let resumeFromBytes = 0;
       try {
         const existing = await downloadCacheFs.stat(partial);
@@ -2144,13 +2242,13 @@ async function downloadIntoCache(
             { url: logUrl, bytes: resumeFromBytes },
           );
         }
-        // Prove it is still ours BEFORE destroying it. A `.rejected` marker records
-        // that a PRIOR attempt of OURS rejected a body; it says nothing about a
-        // partial another writer has since staged in its place.
-        await assertStillOurs(verified, "before discarding a previously-rejected partial", false);
+        // Prove it is still ours before EACH destructive act. A `.rejected` marker
+        // records that a PRIOR attempt of OURS rejected a body; it says nothing
+        // about a partial another writer has since staged in its place. The guards
+        // travel with the paths, so every rm/truncate inside re-checks — a single
+        // check here would authorise the first act and go stale for the rest.
         const neutralized = await discardRejectedPayload(
-          partial,
-          `${partial}.etag`,
+          ...guardedStagedPair("before discarding a previously-rejected partial"),
           logUrl ?? redactUrlForLogs(url),
         );
         // Keep the marker if the partial could NOT be neutralized (rm AND truncate both
@@ -2182,8 +2280,10 @@ async function downloadIntoCache(
           );
           // Same rule: the head we just sniffed may belong to another writer's
           // in-progress file, not to our own poisoned leftover.
-          await assertStillOurs(verified, "before discarding a non-model partial", false);
-          await discardRejectedPayload(partial, `${partial}.etag`, logUrl ?? redactUrlForLogs(url));
+          await discardRejectedPayload(
+            ...guardedStagedPair("before discarding a non-model partial"),
+            logUrl ?? redactUrlForLogs(url),
+          );
           resumeFromBytes = 0;
         }
       }
@@ -2293,7 +2393,16 @@ async function downloadIntoCache(
     }
 
     /** One read of both fields. Callers that VERIFY and then RECORD must use a
-     *  single call for both, or they reintroduce the very gap they are closing. */
+     *  single call for both, or they reintroduce the very gap they are closing.
+     *
+     *  NOT AN ATOMIC SNAPSHOT, despite being one call. The size and the validator
+     *  are two separate filesystem reads with an await between them, so a writer
+     *  can change the sidecar after the size has been read. "Single call" here
+     *  means "no CALLER-level gap between verifying and recording" — it does not
+     *  mean the two fields were observed at one instant, and no filesystem API
+     *  available here would give that. The guarantee this buys is narrower than it
+     *  looks: it removes gaps that contain other logic, not the inherent
+     *  non-atomicity of observing a file nobody has locked. */
     const readStaged = async (): Promise<StagedState> => ({
       size: await partialSize(),
       sidecar: await sidecarBytes(),
@@ -2916,7 +3025,10 @@ export async function downloadWithCache(
       // miss), and log if even that fails, so a poisoned cache entry can't silently
       // re-poison cache hits (#473 P1).
       onReject: async () => {
-        const neutralized = await discardRejectedPayload(cachePath, undefined, logUrl);
+        // selfOwned: a materialised CACHE entry, not the shared `.partial`. It is
+        // reached through this call's own O_EXCL-temp-then-rename, so no concurrent
+        // downloader is streaming into it.
+        const neutralized = await discardRejectedPayload(selfOwned(cachePath), undefined, logUrl);
         // Only drop the Content-Type sidecar once the poisoned cache file is actually
         // gone/emptied. If the cache file SURVIVED (rm AND truncate both failed), KEEP
         // the `.ct` so the NEXT caller can still reject it by its persisted

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -1202,6 +1202,10 @@ async function streamUrlToFile(
     // progress into this shared file while we were backing off, truncating would
     // throw away multi-gigabyte work that is not ours. Refuse before touching it.
     if (beforeWrite) await beforeWrite();
+    // …and re-check the cancel, because that hook AWAITS. A cancel that lands
+    // during it would otherwise be noticed only AFTER the truncate below, which
+    // erases the resumable partial a cancel is supposed to leave behind.
+    if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
     // Cloud downloaders (S3/Azure) don't range-resume — they overwrite the target.
     // If a partial exists it's being discarded; surface that (#467) instead of a
     // silent restart. Truncate it OURSELVES first and CONFIRM (throw on failure)
@@ -1608,6 +1612,11 @@ async function streamUrlToFile(
   // not touch the file on its way there, so the recursive call runs this check
   // itself — the boundary holds on that path too.
   if (beforeWrite) await beforeWrite();
+  // …and re-check the cancel, because that hook AWAITS. Every path below either
+  // deletes or truncates the staged file, so a cancel that landed during the hook
+  // must stop HERE — a cancelled download is promised a resumable partial, and
+  // erasing it on the way out would be exactly the data loss the promise denies.
+  if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
 
   // A 206 to a request we did NOT range (a FRESH download, or a no-validator
   // decline — effectiveResume === 0, no Range sent) is UNSOLICITED and unsafe: its
@@ -2212,11 +2221,16 @@ async function downloadIntoCache(
      *  upstream object to the same length would look unchanged. It cannot do that
      *  without writing that object's validator here, so the sidecar is the part of
      *  the snapshot that actually detects a swapped object. */
-    const sidecarBytes = async (): Promise<string> => {
+    const sidecarBytes = async (): Promise<string | undefined> => {
       try {
         return await readFile(`${partial}.etag`, "utf-8");
-      } catch {
-        return "";
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException)?.code;
+        // ABSENT is knowable ("" — no validator was ever recorded); anything else
+        // (EACCES, EIO, …) means we could not find out, and undefined says so.
+        // Collapsing the two would let "I cannot read it" be reported as "the host
+        // never sent one", and would let an unknown state pass an equality check.
+        return code === "ENOENT" || code === "ENOTDIR" ? "" : undefined;
       }
     };
 
@@ -2224,26 +2238,79 @@ async function downloadIntoCache(
      *  the last instant before a write), so they cannot drift apart in wording or
      *  in what they promise. It NEVER deletes or truncates anything: the bytes it
      *  is refusing to touch belong to the other download. */
-    const interferenceError = (
-      expected: number | undefined,
-      actual: number | undefined,
-      when: string,
-    ): ModelError =>
+    const interferenceError = (why: string, when: string): ModelError =>
       new ModelError(
-        `Download stopped: another download is writing the same staged file (` +
-          (actual !== expected
-            ? `it went from ${expected} to ${actual === undefined ? "an unreadable size" : `${actual}`} bytes`
-            : `its resume validator changed, so a DIFFERENT upstream object has been staged there`) +
-          ` ${when}). Writing now would interleave two transfers into one file. Nothing was deleted — ` +
-          `the other download's progress is intact. Wait for it to finish (check download_status), then ` +
-          `re-issue this download; it will reuse the completed file rather than re-fetching it.`,
+        `Download stopped: another download is writing the same staged file, or this attempt cannot ` +
+          `establish that it is not (${why} ${when}). Writing now could interleave two transfers into ` +
+          `one file, or throw away another download's progress. Nothing was deleted — anything on disk ` +
+          `is intact. Check download_status; if another download of this file is running, wait for it ` +
+          `and then re-issue this one (it will reuse the completed file rather than re-fetching it).`,
         { url: logUrl, retryable: false },
       );
 
+    /**
+     * Compare the staged file's state against what we recorded, and REFUSE unless
+     * they are provably identical.
+     *
+     * Fails CLOSED on an unreadable stat or sidecar. "I could not read it" is not
+     * "it is unchanged" — treating it as such is how a retry ends up truncating a
+     * file it does not own, which on the cloud path is unrecoverable
+     * multi-gigabyte loss. Unknown ownership must stop the write, not switch the
+     * detector off.
+     */
+    const assertStillOurs = async (
+      expectedSize: number | undefined,
+      expectedSidecar: string | undefined,
+      when: string,
+      /** Require the size to be KNOWN on both sides, not merely unchanged.
+       *
+       *  True only across a retry boundary, and that asymmetry is the point. Once
+       *  we have left bytes on disk and gone quiet for a backoff, "I cannot read
+       *  the staged file" is exactly the state in which assuming it is still ours
+       *  and truncating it destroys another writer's work — so it must refuse.
+       *  Within a single attempt there is no such history: an unreadable file was
+       *  unreadable before we started, which is a pre-existing condition the older
+       *  guards diagnose far more precisely (#467 P1-B's "could not be verified",
+       *  #467 P0c's stale-sidecar refusal). Refusing there would replace an
+       *  accurate diagnosis with a wrong one and block first attempts that never
+       *  had anything to own. */
+      strict: boolean,
+    ): Promise<void> => {
+      const nowSize = await partialSize();
+      const nowSidecar = await sidecarBytes();
+      // `partialSize` reports a missing file as a definite 0, so `undefined` means
+      // the file is THERE but unreadable.
+      if (strict && (expectedSize === undefined || nowSize === undefined)) {
+        throw interferenceError("the staged file's size could not be read", when);
+      }
+      if (nowSize !== expectedSize) {
+        throw interferenceError(
+          `it went from ${expectedSize ?? "an unreadable size"} to ${nowSize ?? "an unreadable size"} bytes`,
+          when,
+        );
+      }
+      // SIDECAR is compared for CHANGE, not for readability. An unreadable sidecar
+      // that was ALREADY unreadable when we looked a moment ago is a stable
+      // pre-existing condition (a blocked path, a stale directory), not evidence of
+      // another writer — and it has its own, better-targeted guard downstream
+      // (#467 P0c refuses to pair new bytes with a sidecar it cannot neutralize).
+      // Refusing here instead would replace that precise diagnosis with a wrong
+      // one. `undefined !== undefined` is false, so this compares equal only when
+      // the state is genuinely unchanged, and still catches readable-then-not.
+      if (nowSidecar !== expectedSidecar) {
+        throw interferenceError(
+          "its resume validator changed, so a DIFFERENT upstream object has been staged there",
+          when,
+        );
+      }
+    };
+
     /** What WE left the partial (and its validator) at when our previous attempt
-     *  ended. Undefined before the first retry. See the interference check below. */
-    let sizeWeLeft: number | undefined;
-    let sidecarWeLeft = "";
+     *  ended. `sizeWeLeft` stays NULL before the first retry — there is nothing to
+     *  compare against yet. That is deliberately distinct from `undefined`, which
+     *  means "we tried to read it and could not" and must REFUSE rather than skip. */
+    let sizeWeLeft: number | undefined | null = null;
+    let sidecarWeLeft: string | undefined = "";
 
     for (let attempt = 1; ; attempt += 1) {
       // A cancel between attempts stops here — never consumed by a retry.
@@ -2284,12 +2351,9 @@ async function downloadIntoCache(
       // to the non-retry path. It is NOT made worse here, and it is deliberately
       // left for a follow-up rather than half-solved with a lease whose stale-claim
       // and crash-cleanup behaviour (#529's objection) could destroy live partials.
-      if (sizeWeLeft !== undefined) {
-        const nowSize = await partialSize();
-        const nowSidecar = await sidecarBytes();
-        if (nowSize !== sizeWeLeft || nowSidecar !== sidecarWeLeft) {
-          throw interferenceError(sizeWeLeft, nowSize, "while this attempt was backing off");
-        }
+      if (sizeWeLeft !== null) {
+        // STRICT: we left bytes here and went quiet, so unknown state must refuse.
+        await assertStillOurs(sizeWeLeft, sidecarWeLeft, "while this attempt was backing off", true);
       }
 
       const resumeFromBytes = await resumeOffsetFromDisk();
@@ -2352,11 +2416,14 @@ async function downloadIntoCache(
           // Re-verify, immediately before the first write, that the staged file is
           // still the one this attempt reasoned about.
           async () => {
-            const nowSize = await partialSize();
-            const nowSidecar = await sidecarBytes();
-            if (nowSize !== decidedSize || nowSidecar !== decidedSidecar) {
-              throw interferenceError(decidedSize, nowSize, "while this attempt was requesting it");
-            }
+            // Change-detection only: within one attempt an unreadable file was
+            // already unreadable, and the older guards diagnose that better.
+            await assertStillOurs(
+              decidedSize,
+              decidedSidecar,
+              "while this attempt was requesting it",
+              false,
+            );
           },
         );
         await downloadCacheFs.rename(partial, target);
@@ -2404,14 +2471,22 @@ async function downloadIntoCache(
             // next call deliberately restarts from zero (#343/#467). Promising
             // "re-issuing resumes from there" in that case is a remedy the caller
             // cannot act on — the bytes are real but they will be re-fetched.
-            const hasValidator = (await sidecarBytes()).trim().length > 0;
+            // THREE states, not two: a validator was recorded, none was (the host
+            // sent none), or we could not find out. The last must not be reported
+            // as either of the first two — claiming "the host never sent one" when
+            // the sidecar merely could not be read is a definite verdict drawn from
+            // an absence of evidence.
+            const sidecar = await sidecarBytes();
+            const gb = (bytes: number): string => (bytes / 1024 ** 3).toFixed(2);
             const partialNote =
               kept === undefined
                 ? `The partial download's size could NOT be read, so how much progress survived is unknown — check the download cache before assuming either way.`
                 : kept > 0
-                  ? hasValidator
-                    ? `${(kept / 1024 ** 3).toFixed(2)} GB of partial data is preserved on disk; re-issuing the SAME download resumes from there (it is not re-fetched) provided the host still serves the same object.`
-                    : `${(kept / 1024 ** 3).toFixed(2)} GB of partial data is on disk, but the host never sent an ETag/Last-Modified validator for it, so there is no recorded proof of WHICH object those bytes belong to. A re-issue will therefore restart from the beginning rather than resume — appending to a prefix of unknown provenance is how a model gets silently corrupted (#343/#467).`
+                  ? sidecar === undefined
+                    ? `${gb(kept)} GB of partial data is on disk, but its resume-validator sidecar could not be read, so whether a re-issue can RESUME those bytes or must re-download them could not be determined here. Re-issue and watch download_status, which reports the resume decision the next attempt actually makes.`
+                    : sidecar.trim().length > 0
+                      ? `${gb(kept)} GB of partial data is preserved on disk; re-issuing the SAME download resumes from there (it is not re-fetched) provided the host still serves the same object.`
+                      : `${gb(kept)} GB of partial data is on disk, but the host never sent an ETag/Last-Modified validator for it, so there is no recorded proof of WHICH object those bytes belong to. A re-issue will therefore restart from the beginning rather than resume — appending to a prefix of unknown provenance is how a model gets silently corrupted (#343/#467).`
                   : `No partial data survived, so a re-issue restarts from the beginning.`;
             throw new ModelError(
               `Download failed after ${attempt} attempts (the last ${attempt - 1} were automatic retries with backoff): ` +

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -2172,9 +2172,24 @@ async function downloadIntoCache(
       }
     };
 
-    /** What WE left the partial at when our previous attempt ended. Undefined
-     *  before the first retry. See the interference check below. */
+    /** The `.etag` sidecar's exact contents, or "" when it is absent/unreadable.
+     *  Read alongside the size because SIZE ALONE cannot catch the dangerous
+     *  interference: another writer that truncates and re-stages a DIFFERENT
+     *  upstream object to the same length would look unchanged. It cannot do that
+     *  without writing that object's validator here, so the sidecar is the part of
+     *  the snapshot that actually detects a swapped object. */
+    const sidecarBytes = async (): Promise<string> => {
+      try {
+        return await readFile(`${partial}.etag`, "utf-8");
+      } catch {
+        return "";
+      }
+    };
+
+    /** What WE left the partial (and its validator) at when our previous attempt
+     *  ended. Undefined before the first retry. See the interference check below. */
     let sizeWeLeft: number | undefined;
+    let sidecarWeLeft = "";
 
     for (let attempt = 1; ; attempt += 1) {
       // A cancel between attempts stops here — never consumed by a retry.
@@ -2192,17 +2207,35 @@ async function downloadIntoCache(
       // backoff and then come BACK and append. If another writer moved the file
       // while we waited, appending would interleave two streams into one file.
       //
-      // Nothing WE do touches the partial between our attempts, so ANY change to
-      // its size is proof that someone else is writing it. Detect that and stop
-      // rather than compete: the other writer is producing a valid file, and the
-      // honest, non-destructive move is to leave it alone. (We deliberately do NOT
-      // delete or truncate anything here — those bytes are the other download's.)
+      // Nothing WE do touches the partial (or its `.etag`) between our own
+      // attempts, so ANY change to either is proof that someone else is writing
+      // it. Detect that and stop rather than compete: the other writer is
+      // producing a valid file, and the honest, non-destructive move is to leave it
+      // alone. (We deliberately do NOT delete or truncate anything here — those
+      // bytes are the other download's.)
+      //
+      // WHAT THIS DOES AND DOES NOT BUY. It is a detector, not a lock, and the
+      // scope is deliberate — #529 rejected a cross-process lease because its
+      // stale-claim and crash-cleanup failure modes are worse than the rare
+      // duplicate transfer it would prevent. What matters is that the SPLICE cases
+      // are covered: the dangerous one is another writer re-staging a DIFFERENT
+      // upstream object, and it cannot do that without writing that object's
+      // validator to the sidecar — which this snapshot catches even when the byte
+      // count happens to match. The residual is two writers appending
+      // SIMULTANEOUSLY, which is not silent: both stream the same remaining range
+      // into one append-mode file, so it overshoots the authoritative total and the
+      // #467 oversize guard removes it and fails loudly rather than finalizing it.
       if (sizeWeLeft !== undefined) {
         const nowSize = await partialSize();
-        if (nowSize !== sizeWeLeft) {
+        const nowSidecar = await sidecarBytes();
+        if (nowSize !== sizeWeLeft || nowSidecar !== sidecarWeLeft) {
+          const what =
+            nowSize !== sizeWeLeft
+              ? `it went from ${sizeWeLeft} to ${nowSize === undefined ? "an unreadable size" : `${nowSize}`} bytes`
+              : `its resume validator changed, so a DIFFERENT upstream object has been staged there`;
           throw new ModelError(
             `Download stopped before retrying: another download is writing the same staged file ` +
-              `(it went from ${sizeWeLeft} to ${nowSize === undefined ? "an unreadable size" : `${nowSize}`} bytes while this attempt was backing off). ` +
+              `(${what} while this attempt was backing off). ` +
               `Appending now would interleave two transfers into one file. Nothing was deleted — the ` +
               `other download's progress is intact. Wait for it to finish (check download_status), then ` +
               `re-issue this download; it will reuse the completed file rather than re-fetching it.`,
@@ -2332,6 +2365,7 @@ async function downloadIntoCache(
         // top of the loop). Taken AFTER the attempt has fully unwound, so it
         // reflects the final on-disk state this attempt produced.
         sizeWeLeft = await partialSize();
+        sidecarWeLeft = await sidecarBytes();
         // Backoff before re-requesting. #470 observed a 403 from an INSTANT
         // re-request after an aborted connection — the wait is part of the fix,
         // not politeness. It wakes early if the caller cancels.
@@ -2597,6 +2631,11 @@ export async function downloadUrlToFile(
   progress?: ProgressMeta,
   modelExt = extname(targetPath),
   signal?: AbortSignal,
+  /** See streamUrlToFile: when true the caller owns the terminal "error" row. The
+   *  cache-unavailable fallback in downloadWithCache passes true because
+   *  downloadModel already publishes exactly one row when the whole call throws;
+   *  emitting here as well would write that outcome twice (#470/#547). */
+  deferErrorRow = false,
 ): Promise<void> {
   await streamUrlToFile(
     url,
@@ -2610,6 +2649,8 @@ export async function downloadUrlToFile(
     undefined,
     modelExt,
     signal,
+    undefined,
+    deferErrorRow,
   );
 }
 
@@ -2712,6 +2753,10 @@ export async function downloadWithCache(
         options.progress,
         modelExt,
         options.signal,
+        // downloadModel emits the single terminal "error" row when this whole call
+        // throws; this fallback stream must not emit a second one for the same
+        // failure (#470/#547).
+        true,
       );
       // PRE-RENAME CANCEL GUARD (#515), mirroring the cache-path materialize guard: a
       // cancel that arrived during the post-stream validation lets the stream return

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -1178,6 +1178,19 @@ async function streamUrlToFile(
    *  and the agent's natural response (re-issue) is precisely the second-writer
    *  hazard the download machinery exists to prevent. */
   deferErrorRow = false,
+  /** Last-moment re-verification, awaited IMMEDIATELY before this function first
+   *  touches the file — before the restart truncation and before the append stream
+   *  opens. Throwing from it aborts the write.
+   *
+   *  It exists to close a TOCTOU on the SHARED staged file: the resume offset and
+   *  the validator are read, then a request is issued, and only then do we write.
+   *  Another process writing the same `.partial` in that gap (it is keyed by the
+   *  download's representation, so a second process running the same download
+   *  shares it) could truncate and re-stage a different upstream object, and our
+   *  append would land a valid-LOOKING file whose prefix and suffix come from
+   *  different objects. Re-checking here shrinks that window from "the whole
+   *  request round-trip" to the few instructions before the open. */
+  beforeWrite?: () => Promise<void>,
 ): Promise<string> {
   // Fail fast if we were cancelled before any bytes moved — no request, no partial.
   if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
@@ -1571,6 +1584,7 @@ async function streamUrlToFile(
         signal,
         onBytes,
         deferErrorRow,
+        beforeWrite,
       );
     }
   }
@@ -1654,6 +1668,14 @@ async function streamUrlToFile(
     }
     rangeTotal = total;
   }
+
+  // LAST-MOMENT INTERFERENCE RE-CHECK. Everything above only READ the staged file
+  // (its size, its validator) and talked to the server; from here on we MUTATE it —
+  // the restart path truncates it, the append path opens it for writing. This is
+  // therefore the last instant at which refusing costs nothing and is still
+  // correct. See the `beforeWrite` doc: it closes the gap between deciding how to
+  // resume and acting on that decision.
+  if (beforeWrite) await beforeWrite();
 
   const flags = appendMode ? "a" : "w";
 
@@ -2186,6 +2208,26 @@ async function downloadIntoCache(
       }
     };
 
+    /** The one refusal used by both interference checks (between attempts, and at
+     *  the last instant before a write), so they cannot drift apart in wording or
+     *  in what they promise. It NEVER deletes or truncates anything: the bytes it
+     *  is refusing to touch belong to the other download. */
+    const interferenceError = (
+      expected: number | undefined,
+      actual: number | undefined,
+      when: string,
+    ): ModelError =>
+      new ModelError(
+        `Download stopped: another download is writing the same staged file (` +
+          (actual !== expected
+            ? `it went from ${expected} to ${actual === undefined ? "an unreadable size" : `${actual}`} bytes`
+            : `its resume validator changed, so a DIFFERENT upstream object has been staged there`) +
+          ` ${when}). Writing now would interleave two transfers into one file. Nothing was deleted — ` +
+          `the other download's progress is intact. Wait for it to finish (check download_status), then ` +
+          `re-issue this download; it will reuse the completed file rather than re-fetching it.`,
+        { url: logUrl, retryable: false },
+      );
+
     /** What WE left the partial (and its validator) at when our previous attempt
      *  ended. Undefined before the first retry. See the interference check below. */
     let sizeWeLeft: number | undefined;
@@ -2214,37 +2256,39 @@ async function downloadIntoCache(
       // alone. (We deliberately do NOT delete or truncate anything here — those
       // bytes are the other download's.)
       //
-      // WHAT THIS DOES AND DOES NOT BUY. It is a detector, not a lock, and the
-      // scope is deliberate — #529 rejected a cross-process lease because its
-      // stale-claim and crash-cleanup failure modes are worse than the rare
-      // duplicate transfer it would prevent. What matters is that the SPLICE cases
-      // are covered: the dangerous one is another writer re-staging a DIFFERENT
-      // upstream object, and it cannot do that without writing that object's
-      // validator to the sidecar — which this snapshot catches even when the byte
-      // count happens to match. The residual is two writers appending
-      // SIMULTANEOUSLY, which is not silent: both stream the same remaining range
-      // into one append-mode file, so it overshoots the authoritative total and the
-      // #467 oversize guard removes it and fails loudly rather than finalizing it.
+      // WHAT THIS DOES AND DOES NOT BUY — stated precisely, because it is easy to
+      // over-claim here. It is a DETECTOR, not a lock. It covers the window in
+      // which this loop is idle (the backoff), and a second check immediately
+      // before any write (`beforeWrite`, passed below) covers the window between
+      // reading the file's state and acting on it. Together they close the
+      // interference this retry loop ADDS over a single-shot download.
+      //
+      // What remains OPEN is pre-existing and not closable by observation: two
+      // processes streaming into this shared file at genuinely overlapping times.
+      // A snapshot cannot exclude a writer that acts between our last check and our
+      // own write, and no ordering of checks can. Closing it needs real write
+      // exclusion on the staged file (an owned claim held for the download's
+      // lifetime), which is a larger change than this cluster and applies equally
+      // to the non-retry path. It is NOT made worse here, and it is deliberately
+      // left for a follow-up rather than half-solved with a lease whose stale-claim
+      // and crash-cleanup behaviour (#529's objection) could destroy live partials.
       if (sizeWeLeft !== undefined) {
         const nowSize = await partialSize();
         const nowSidecar = await sidecarBytes();
         if (nowSize !== sizeWeLeft || nowSidecar !== sidecarWeLeft) {
-          const what =
-            nowSize !== sizeWeLeft
-              ? `it went from ${sizeWeLeft} to ${nowSize === undefined ? "an unreadable size" : `${nowSize}`} bytes`
-              : `its resume validator changed, so a DIFFERENT upstream object has been staged there`;
-          throw new ModelError(
-            `Download stopped before retrying: another download is writing the same staged file ` +
-              `(${what} while this attempt was backing off). ` +
-              `Appending now would interleave two transfers into one file. Nothing was deleted — the ` +
-              `other download's progress is intact. Wait for it to finish (check download_status), then ` +
-              `re-issue this download; it will reuse the completed file rather than re-fetching it.`,
-            { url: logUrl, retryable: false },
-          );
+          throw interferenceError(sizeWeLeft, nowSize, "while this attempt was backing off");
         }
       }
 
       const resumeFromBytes = await resumeOffsetFromDisk();
+
+      // The state THIS attempt based its resume decision on. Re-verified at the
+      // last instant before any write (see `beforeWrite`), so the decision and the
+      // action are checked against the same file rather than merely assumed to
+      // describe it. Taken AFTER resumeOffsetFromDisk because that call may itself
+      // discard a poisoned partial.
+      const decidedSize = await partialSize();
+      const decidedSidecar = await sidecarBytes();
 
       // Per-attempt abort, fed by TWO independent sources: the caller's cancel
       // (forwarded) and our stall watchdog. They are kept distinguishable — the
@@ -2293,6 +2337,15 @@ async function downloadIntoCache(
           // WE decide when this download is over, so no attempt publishes a
           // terminal "error" row on our behalf (#470 / #547).
           true,
+          // Re-verify, immediately before the first write, that the staged file is
+          // still the one this attempt reasoned about.
+          async () => {
+            const nowSize = await partialSize();
+            const nowSidecar = await sidecarBytes();
+            if (nowSize !== decidedSize || nowSidecar !== decidedSidecar) {
+              throw interferenceError(decidedSize, nowSize, "while this attempt was requesting it");
+            }
+          },
         );
         await downloadCacheFs.rename(partial, target);
         await touch(target);

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -1195,6 +1195,13 @@ async function streamUrlToFile(
   // Fail fast if we were cancelled before any bytes moved — no request, no partial.
   if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
   if (supportsCloudDownload(url)) {
+    // INTERFERENCE RE-CHECK FIRST (see `beforeWrite`). This branch is the most
+    // destructive one in the function: a cloud transfer cannot range-resume, so it
+    // TRUNCATES the staged file and re-downloads in full. Under the retry loop that
+    // makes a later attempt a destructive writer — if another process staged real
+    // progress into this shared file while we were backing off, truncating would
+    // throw away multi-gigabyte work that is not ours. Refuse before touching it.
+    if (beforeWrite) await beforeWrite();
     // Cloud downloaders (S3/Azure) don't range-resume — they overwrite the target.
     // If a partial exists it's being discarded; surface that (#467) instead of a
     // silent restart. Truncate it OURSELVES first and CONFIRM (throw on failure)
@@ -1589,6 +1596,19 @@ async function streamUrlToFile(
     }
   }
 
+  // LAST-MOMENT INTERFERENCE RE-CHECK (see `beforeWrite`). Placed HERE — before the
+  // integrity refusals below — because those refusals DELETE the staged file and
+  // its sidecar. "Refusing our own bad response" must not become "deleting someone
+  // else's good partial": if another writer re-staged this file while our request
+  // was in flight, that file is no longer ours to clean up. Everything above this
+  // line only READ the file or talked to the server; everything below MUTATES it,
+  // so this is the true first-touch boundary.
+  //
+  // The 206-refusal path above returns by RECURSING with a clean restart and does
+  // not touch the file on its way there, so the recursive call runs this check
+  // itself — the boundary holds on that path too.
+  if (beforeWrite) await beforeWrite();
+
   // A 206 to a request we did NOT range (a FRESH download, or a no-validator
   // decline — effectiveResume === 0, no Range sent) is UNSOLICITED and unsafe: its
   // body is only a partial slice, but the "w"/Content-Length path below would
@@ -1668,14 +1688,6 @@ async function streamUrlToFile(
     }
     rangeTotal = total;
   }
-
-  // LAST-MOMENT INTERFERENCE RE-CHECK. Everything above only READ the staged file
-  // (its size, its validator) and talked to the server; from here on we MUTATE it —
-  // the restart path truncates it, the append path opens it for writing. This is
-  // therefore the last instant at which refusing costs nothing and is still
-  // correct. See the `beforeWrite` doc: it closes the gap between deciding how to
-  // resume and acting on that decision.
-  if (beforeWrite) await beforeWrite();
 
   const flags = appendMode ? "a" : "w";
 
@@ -2386,11 +2398,20 @@ async function downloadIntoCache(
             // knowable "there is nothing to resume" is never dressed up as a
             // mystery, and a genuine mystery is never asserted as a fact.
             const kept = await partialSize();
+            // Whether those bytes are actually RESUMABLE, which is not the same
+            // question as whether they exist. A resume requires the write-time
+            // validator; without one the prefix has no recorded identity and the
+            // next call deliberately restarts from zero (#343/#467). Promising
+            // "re-issuing resumes from there" in that case is a remedy the caller
+            // cannot act on — the bytes are real but they will be re-fetched.
+            const hasValidator = (await sidecarBytes()).trim().length > 0;
             const partialNote =
               kept === undefined
                 ? `The partial download's size could NOT be read, so how much progress survived is unknown — check the download cache before assuming either way.`
                 : kept > 0
-                  ? `${(kept / 1024 ** 3).toFixed(2)} GB of partial data is preserved on disk; re-issuing the SAME download resumes from there (it is not re-fetched) provided the host still serves the same object.`
+                  ? hasValidator
+                    ? `${(kept / 1024 ** 3).toFixed(2)} GB of partial data is preserved on disk; re-issuing the SAME download resumes from there (it is not re-fetched) provided the host still serves the same object.`
+                    : `${(kept / 1024 ** 3).toFixed(2)} GB of partial data is on disk, but the host never sent an ETag/Last-Modified validator for it, so there is no recorded proof of WHICH object those bytes belong to. A re-issue will therefore restart from the beginning rather than resume — appending to a prefix of unknown provenance is how a model gets silently corrupted (#343/#467).`
                   : `No partial data survived, so a re-issue restarts from the beginning.`;
             throw new ModelError(
               `Download failed after ${attempt} attempts (the last ${attempt - 1} were automatic retries with backoff): ` +

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -2138,18 +2138,6 @@ async function downloadIntoCache(
       }
     };
 
-    /** Bytes retained on disk right now, or undefined when it can't be read.
-     *  Reported, never assumed: an unreadable partial must not be described as
-     *  "N bytes preserved" — "could not determine" stays undetermined. */
-    const retainedBytes = async (): Promise<number | undefined> => {
-      try {
-        const st = await downloadCacheFs.stat(partial);
-        return st.isFile() ? st.size : undefined;
-      } catch {
-        return undefined;
-      }
-    };
-
     // ── #470: bounded retry with backoff, resuming each time ──────────────────
     //
     // A transfer that cannot survive an interruption will eventually be killed by
@@ -2161,9 +2149,67 @@ async function downloadIntoCache(
     // identity proof a cold call does — there is no "we already checked" shortcut,
     // so a retry can never splice bytes from a different object.
     const retry = downloadRetryPolicy();
+    // THE STALL WATCHDOG IS HTTP-ONLY. A cloud (S3/Azure) transfer is performed by
+    // the vendor SDK, which writes the file itself and reports no per-chunk
+    // progress here — so `onBytes` never fires and a perfectly healthy multi-GB
+    // cloud download would look stalled from its first second. Aborting it would be
+    // catastrophic rather than merely wasteful: the cloud path cannot range-resume,
+    // so every "retry" TRUNCATES the partial and starts over, and a transfer longer
+    // than the stall window could never finish. No byte signal ⇒ no watchdog.
+    const stallTimeoutMs = supportsCloudDownload(url) ? 0 : retry.stallTimeoutMs;
+
+    /** The partial's size as it stands, distinguishing ABSENT (0 — knowably
+     *  nothing) from UNREADABLE (undefined — genuinely unknown). Collapsing the
+     *  two would either invent progress that is not there or report a knowable
+     *  absence as a mystery. */
+    const partialSize = async (): Promise<number | undefined> => {
+      try {
+        const st = await downloadCacheFs.stat(partial);
+        return st.isFile() ? st.size : 0;
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException)?.code;
+        return code === "ENOENT" || code === "ENOTDIR" ? 0 : undefined;
+      }
+    };
+
+    /** What WE left the partial at when our previous attempt ended. Undefined
+     *  before the first retry. See the interference check below. */
+    let sizeWeLeft: number | undefined;
+
     for (let attempt = 1; ; attempt += 1) {
       // A cancel between attempts stops here — never consumed by a retry.
       if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
+
+      // ── ANOTHER WRITER OWNS THIS PARTIAL ──────────────────────────────────
+      //
+      // The `.partial` is keyed by the download's representation (url + auth
+      // headers), so a SECOND PROCESS running the same download shares this exact
+      // file. The job registry's cross-process dedup is best-effort by design
+      // (#529): two processes that start at the same instant can both run writers.
+      //
+      // Before this loop existed that cost, at worst, a duplicate transfer — a
+      // failed attempt simply ended. A retry changes the shape: we go quiet for a
+      // backoff and then come BACK and append. If another writer moved the file
+      // while we waited, appending would interleave two streams into one file.
+      //
+      // Nothing WE do touches the partial between our attempts, so ANY change to
+      // its size is proof that someone else is writing it. Detect that and stop
+      // rather than compete: the other writer is producing a valid file, and the
+      // honest, non-destructive move is to leave it alone. (We deliberately do NOT
+      // delete or truncate anything here — those bytes are the other download's.)
+      if (sizeWeLeft !== undefined) {
+        const nowSize = await partialSize();
+        if (nowSize !== sizeWeLeft) {
+          throw new ModelError(
+            `Download stopped before retrying: another download is writing the same staged file ` +
+              `(it went from ${sizeWeLeft} to ${nowSize === undefined ? "an unreadable size" : `${nowSize}`} bytes while this attempt was backing off). ` +
+              `Appending now would interleave two transfers into one file. Nothing was deleted — the ` +
+              `other download's progress is intact. Wait for it to finish (check download_status), then ` +
+              `re-issue this download; it will reuse the completed file rather than re-fetching it.`,
+            { url: logUrl, retryable: false },
+          );
+        }
+      }
 
       const resumeFromBytes = await resumeOffsetFromDisk();
 
@@ -2182,15 +2228,15 @@ async function downloadIntoCache(
       let stalled = false;
       let lastByteAt = Date.now();
       const stallTicker =
-        retry.stallTimeoutMs > 0
+        stallTimeoutMs > 0
           ? setInterval(
               () => {
-                if (Date.now() - lastByteAt >= retry.stallTimeoutMs) {
+                if (Date.now() - lastByteAt >= stallTimeoutMs) {
                   stalled = true;
                   attemptCtl.abort();
                 }
               },
-              Math.min(5_000, Math.max(500, Math.floor(retry.stallTimeoutMs / 4))),
+              Math.min(5_000, Math.max(500, Math.floor(stallTimeoutMs / 4))),
             )
           : undefined;
       if (stallTicker && typeof stallTicker.unref === "function") stallTicker.unref();
@@ -2236,7 +2282,7 @@ async function downloadIntoCache(
         const cls = stalled
           ? {
               retryable: true,
-              reason: `no bytes arrived for ${Math.round(retry.stallTimeoutMs / 1000)}s (the connection wedged without closing)`,
+              reason: `no bytes arrived for ${Math.round(stallTimeoutMs / 1000)}s (the connection wedged without closing)`,
             }
           : classifyDownloadFailure(err);
 
@@ -2250,7 +2296,10 @@ async function downloadIntoCache(
           // Only ANNOTATE when retries actually happened and the cause was transient
           // — an auth/gating failure must keep its own actionable message intact.
           if (attempt > 1 && cls.retryable) {
-            const kept = await retainedBytes();
+            // `partialSize` separates ABSENT (0) from UNREADABLE (undefined), so a
+            // knowable "there is nothing to resume" is never dressed up as a
+            // mystery, and a genuine mystery is never asserted as a fact.
+            const kept = await partialSize();
             const partialNote =
               kept === undefined
                 ? `The partial download's size could NOT be read, so how much progress survived is unknown — check the download cache before assuming either way.`
@@ -2278,6 +2327,11 @@ async function downloadIntoCache(
             error: err instanceof Error ? err.message : String(err),
           },
         );
+        // Record where WE left the partial, so the next attempt can tell "nobody
+        // touched it" from "another writer moved it" (the interference check at the
+        // top of the loop). Taken AFTER the attempt has fully unwound, so it
+        // reflects the final on-disk state this attempt produced.
+        sizeWeLeft = await partialSize();
         // Backoff before re-requesting. #470 observed a 403 from an INSTANT
         // re-request after an aborted connection — the wait is part of the fix,
         // not politeness. It wakes early if the caller cancels.

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -23,6 +23,12 @@ import { redactUrlForLogs } from "./download-auth.js";
 import { reportDownloadProgress, type DownloadProgress } from "./download-progress.js";
 import type { ResumeReporter } from "./download-resume-diag.js";
 import {
+  abortableDelay,
+  backoffDelayMs,
+  classifyDownloadFailure,
+  downloadRetryPolicy,
+} from "./download-retry.js";
+import {
   cloudPrincipalKey,
   downloadCloudUrlToFile,
   supportsCloudDownload,
@@ -1156,6 +1162,22 @@ async function streamUrlToFile(
   /** Per-download abort signal (#515): passed to fetch AND the write pipeline so a
    *  cancel aborts the in-flight transfer promptly; the partial is left on disk. */
   signal?: AbortSignal,
+  /** Called with the byte count of every chunk that reaches disk (#470). Feeds the
+   *  caller's STALL watchdog: a transfer that stops delivering bytes entirely is
+   *  abandoned and retried (resuming), instead of sitting "in flight" for half an
+   *  hour. Fires regardless of whether a progress tray is attached — the watchdog
+   *  must bound the attempt on the plain (non-panel) path too. */
+  onBytes?: (delta: number) => void,
+  /** When true, a failed attempt does NOT publish a terminal `error` progress row —
+   *  the CALLER will, once it has decided the download is really over (#470).
+   *
+   *  This matters more than it looks. The orchestrator treats the first terminal
+   *  row as the download's OUTCOME and wakes the tab's agent with it (#547). An
+   *  attempt that is about to be retried is not an outcome, so emitting `error`
+   *  there tells the agent the download FAILED while it is in fact still running —
+   *  and the agent's natural response (re-issue) is precisely the second-writer
+   *  hazard the download machinery exists to prevent. */
+  deferErrorRow = false,
 ): Promise<string> {
   // Fail fast if we were cancelled before any bytes moved — no request, no partial.
   if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
@@ -1547,6 +1569,8 @@ async function streamUrlToFile(
         onResume,
         modelExt,
         signal,
+        onBytes,
+        deferErrorRow,
       );
     }
   }
@@ -1810,9 +1834,17 @@ async function streamUrlToFile(
     if (expectedTotal > 0 && actual < expectedTotal) {
       // Truncated. Keep the partial on disk so a later call can range-resume it,
       // but do NOT report this as a completed download.
+      //
+      // `retryable` is the CONTRACT the retry loop reads (#470): the bytes on disk
+      // are a valid prefix of THIS object (their validator sidecar was written
+      // against it), so another attempt resumes rather than restarts. Stated as a
+      // flag rather than inferred from this sentence, which is prose and will be
+      // reworded. It is a claim about the PARTIAL, not about the server: the resume
+      // still has to re-prove object identity via If-Range/X-Linked-Etag on the next
+      // attempt, exactly as a fresh call would.
       throw new ModelError(
         `Download truncated: wrote ${actual} of ${expectedTotal} bytes — the stream ended early. Not complete; retry to resume.`,
-        { url: logUrl },
+        { url: logUrl, retryable: true },
       );
     }
     if (expectedTotal > 0 && actual > expectedTotal) {
@@ -1864,8 +1896,9 @@ async function streamUrlToFile(
       },
     });
 
-  // No progress wanted (internal/cache caller, or not under the panel) → straight pipe.
-  if (!progress) {
+  // No progress tray AND no stall watchdog (internal/cache caller, not under the
+  // panel) → straight pipe, nothing to count.
+  if (!progress && !onBytes) {
     await pipeline(nodeStream, fileStream, { signal });
     await assertComplete();
     await assertModelPayload();
@@ -1874,21 +1907,31 @@ async function streamUrlToFile(
     return responseContentType;
   }
 
-  // Tally bytes as they flow and report throughput to the panel tray.
+  // Tally bytes as they flow: report throughput to the panel tray (when a tray row
+  // was requested) and feed the caller's stall watchdog (#470). The counter now runs
+  // whenever EITHER sink is present — the watchdog must be able to bound a wedged
+  // attempt even with no panel attached, which is where #470's 30-minute silent
+  // stall was observed.
   const total = expectedTotal;
   let downloaded = appendMode ? effectiveResume : 0;
   let windowStart = Date.now();
   let windowBytes = downloaded;
   let bytesPerSec = 0;
   const emit = (status: DownloadProgress["status"], force = false) =>
-    reportDownloadProgress(
-      { id: progress.id, name: progress.name, attempt: progress.attempt, downloaded, total, bytes_per_sec: bytesPerSec, status },
-      force,
-    );
+    progress
+      ? reportDownloadProgress(
+          { id: progress.id, name: progress.name, attempt: progress.attempt, downloaded, total, bytes_per_sec: bytesPerSec, status },
+          force,
+        )
+      : undefined;
   emit("downloading", true); // show the row immediately, even before the first chunk
   const counter = new Transform({
     transform(chunk: Buffer, _enc, cb) {
       downloaded += chunk.length;
+      // Feed the watchdog FIRST and unconditionally — before the 400 ms throughput
+      // window gate — so a trickle that never fills a window still counts as
+      // liveness. Gating it would let a slow-but-alive transfer be killed as stalled.
+      onBytes?.(chunk.length);
       const now = Date.now();
       const dt = now - windowStart;
       if (dt >= 400) {
@@ -1912,8 +1955,11 @@ async function streamUrlToFile(
     // On a user cancel (#515) the abort left a resumable .partial on disk. Do NOT emit
     // an "error" row for it, and do NOT clear the row here: this cache layer has no
     // registry context, and a coalesced sibling may share this progress row. The JOB
-    // layer (finalizeCancelled) clears it registry-aware. Only a genuine failure emits.
-    if (!signal?.aborted) emit("error", true);
+    // layer (finalizeCancelled) clears it registry-aware. Only a genuine failure emits
+    // — and, under a retrying caller, only once that caller has given up
+    // (deferErrorRow), so an attempt that is about to be retried never publishes an
+    // outcome the agent would act on (#470).
+    if (!signal?.aborted && !deferErrorRow) emit("error", true);
     throw err;
   }
 }
@@ -1987,103 +2033,97 @@ async function downloadIntoCache(
     // handshake.) Cleanup on terminal failure stays unchanged.
     const partial = join(cacheDir(), `.${basename(target)}.partial`);
     const rejectedMarker = `${partial}.rejected`;
-    let resumeFromBytes = 0;
-    try {
-      const existing = await downloadCacheFs.stat(partial);
-      if (existing.isFile() && existing.size > 0) {
-        resumeFromBytes = existing.size;
-        logger.info("Resuming partial download", {
-          url: logUrl,
-          bytes: resumeFromBytes,
-        });
-      }
-    } catch {
-      // No partial — fresh download.
-    }
 
-    // #473 P1 — poison MARKER guard (cleanup- AND content-type-independent). A prior
-    // attempt that REJECTED this download (even solely on the response Content-Type,
-    // which is gone now) drops a `.rejected` marker next to the partial. If it's
-    // present, the leftover partial is poison regardless of what its bytes sniff as —
-    // never resume onto it. Discard everything and restart from 0.
-    let markerPresent = false;
-    try {
-      markerPresent = (await downloadCacheFs.stat(rejectedMarker)).isFile();
-    } catch {
-      /* no marker */
-    }
-    if (markerPresent) {
-      if (resumeFromBytes > 0) {
-        logger.warn(
-          `Discarding a previously-rejected (${resumeFromBytes}-byte) partial before resume: a ` +
-            `poison marker from an earlier non-model rejection is present — restarting from 0 (#473).`,
-          { url: logUrl, bytes: resumeFromBytes },
-        );
+    /**
+     * The byte offset THIS attempt may resume from, re-derived from disk every
+     * time (#470). Re-deriving is the point: after an interrupted attempt the
+     * `.partial` is larger than it was, so the next attempt picks up where the
+     * last one actually stopped rather than where this call originally started.
+     *
+     * It returns only a CANDIDATE offset. Nothing here proves the bytes belong to
+     * the requested object — that proof is `streamUrlToFile`'s job (the `.etag`
+     * validator sidecar recorded at WRITE time, replayed as `If-Range`, plus the
+     * content-addressed X-Linked-Etag cross-check for cross-origin 206s, #343/#467).
+     * A partial with no recorded write-time identity is NOT resumed; it restarts.
+     */
+    const resumeOffsetFromDisk = async (): Promise<number> => {
+      let resumeFromBytes = 0;
+      try {
+        const existing = await downloadCacheFs.stat(partial);
+        if (existing.isFile() && existing.size > 0) {
+          resumeFromBytes = existing.size;
+          logger.info("Resuming partial download", {
+            url: logUrl,
+            bytes: resumeFromBytes,
+          });
+        }
+      } catch {
+        // No partial — fresh download.
       }
-      const neutralized = await discardRejectedPayload(
-        partial,
-        `${partial}.etag`,
-        logUrl ?? redactUrlForLogs(url),
-      );
-      // Keep the marker if the partial could NOT be neutralized (rm AND truncate both
-      // failed), so a still-poisoned leftover stays flagged for the next attempt.
-      // resumeFromBytes = 0 forces this attempt to re-download fresh ("w" truncates the
-      // leftover), so the poison is cleared here regardless.
-      if (neutralized) await safeRm(rejectedMarker);
-      resumeFromBytes = 0;
-    }
 
-    // #473 P1 — cleanup-INDEPENDENT poison guard (body-magic). A prior attempt may have REJECTED
-    // this download as an HTML/JSON auth/error body and then been UNABLE to remove or
-    // truncate the leftover .partial (a denied rm AND a denied truncate). Re-inspect
-    // the partial's HEAD here, before deciding to resume: if it is itself a non-model
-    // (HTML/JSON) body for a binary-model destination, it is poison — NEVER resume
-    // onto it. Reset to a fresh download (resumeFromBytes = 0 ⇒ no Range ⇒ the "w"
-    // open truncates the poisoned bytes) and best-effort discard the sidecar, so the
-    // invariant "a rejected leftover can't be treated as resumable" holds even when
-    // both cleanup mechanisms failed. A legitimate in-progress partial sniffs as
-    // binary (null) and resumes normally.
-    if (resumeFromBytes > 0 && modelExt) {
-      const partialHead = await readHead(partial);
-      if (detectNonModelPayload(partialHead, "", modelExt)) {
-        logger.warn(
-          `Discarding a previously-rejected non-model (${resumeFromBytes}-byte) partial before ` +
-            `resume: its head is an HTML/JSON auth/error body, not a model — restarting from 0 so ` +
-            `the poisoned bytes can't be resumed onto (#473).`,
-          { url: logUrl, bytes: resumeFromBytes },
+      // #473 P1 — poison MARKER guard (cleanup- AND content-type-independent). A prior
+      // attempt that REJECTED this download (even solely on the response Content-Type,
+      // which is gone now) drops a `.rejected` marker next to the partial. If it's
+      // present, the leftover partial is poison regardless of what its bytes sniff as —
+      // never resume onto it. Discard everything and restart from 0.
+      let markerPresent = false;
+      try {
+        markerPresent = (await downloadCacheFs.stat(rejectedMarker)).isFile();
+      } catch {
+        /* no marker */
+      }
+      if (markerPresent) {
+        if (resumeFromBytes > 0) {
+          logger.warn(
+            `Discarding a previously-rejected (${resumeFromBytes}-byte) partial before resume: a ` +
+              `poison marker from an earlier non-model rejection is present — restarting from 0 (#473).`,
+            { url: logUrl, bytes: resumeFromBytes },
+          );
+        }
+        const neutralized = await discardRejectedPayload(
+          partial,
+          `${partial}.etag`,
+          logUrl ?? redactUrlForLogs(url),
         );
-        await discardRejectedPayload(partial, `${partial}.etag`, logUrl ?? redactUrlForLogs(url));
+        // Keep the marker if the partial could NOT be neutralized (rm AND truncate both
+        // failed), so a still-poisoned leftover stays flagged for the next attempt.
+        // resumeFromBytes = 0 forces this attempt to re-download fresh ("w" truncates the
+        // leftover), so the poison is cleared here regardless.
+        if (neutralized) await safeRm(rejectedMarker);
         resumeFromBytes = 0;
       }
-    }
 
-    try {
-      const contentType = await streamUrlToFile(
-        url,
-        partial,
-        headers,
-        logUrl,
-        storageAuth,
-        resumeFromBytes,
-        progress,
-        true, // resumable: cache partials use the .partial + If-Range resume handshake
-        onResume,
-        modelExt,
-        signal,
-      );
-      await downloadCacheFs.rename(partial, target);
-      await touch(target);
-      // Persist the response Content-Type beside the cache file so a later cache-HIT /
-      // coalesced caller re-validates with it (#473 reuse gap).
-      await writeCacheContentType(target, contentType);
-      // Clean any stale poison marker now that a CLEAN payload finalized under this
-      // key — the partial is gone (renamed) and the bytes passed validation.
-      await safeRm(rejectedMarker);
-      return target;
-    } catch (err) {
-      // Leave the partial on disk for a future resume; only nuke it if it
-      // is now empty (server said the previous partial was bogus, or our
-      // first write failed).
+      // #473 P1 — cleanup-INDEPENDENT poison guard (body-magic). A prior attempt may have REJECTED
+      // this download as an HTML/JSON auth/error body and then been UNABLE to remove or
+      // truncate the leftover .partial (a denied rm AND a denied truncate). Re-inspect
+      // the partial's HEAD here, before deciding to resume: if it is itself a non-model
+      // (HTML/JSON) body for a binary-model destination, it is poison — NEVER resume
+      // onto it. Reset to a fresh download (resumeFromBytes = 0 ⇒ no Range ⇒ the "w"
+      // open truncates the poisoned bytes) and best-effort discard the sidecar, so the
+      // invariant "a rejected leftover can't be treated as resumable" holds even when
+      // both cleanup mechanisms failed. A legitimate in-progress partial sniffs as
+      // binary (null) and resumes normally.
+      if (resumeFromBytes > 0 && modelExt) {
+        const partialHead = await readHead(partial);
+        if (detectNonModelPayload(partialHead, "", modelExt)) {
+          logger.warn(
+            `Discarding a previously-rejected non-model (${resumeFromBytes}-byte) partial before ` +
+              `resume: its head is an HTML/JSON auth/error body, not a model — restarting from 0 so ` +
+              `the poisoned bytes can't be resumed onto (#473).`,
+            { url: logUrl, bytes: resumeFromBytes },
+          );
+          await discardRejectedPayload(partial, `${partial}.etag`, logUrl ?? redactUrlForLogs(url));
+          resumeFromBytes = 0;
+        }
+      }
+
+      return resumeFromBytes;
+    };
+
+    /** Only ever removes an EMPTY partial — a non-empty one is the resume
+     *  candidate and is deliberately preserved on every failure path (#470's
+     *  governing harm: never destroy progress you cannot re-fetch cheaply). */
+    const dropEmptyPartial = async (): Promise<void> => {
       try {
         const remaining = await downloadCacheFs.stat(partial);
         if (remaining.size === 0) {
@@ -2096,7 +2136,156 @@ async function downloadIntoCache(
       } catch {
         // Partial gone — nothing to clean.
       }
-      throw err;
+    };
+
+    /** Bytes retained on disk right now, or undefined when it can't be read.
+     *  Reported, never assumed: an unreadable partial must not be described as
+     *  "N bytes preserved" — "could not determine" stays undetermined. */
+    const retainedBytes = async (): Promise<number | undefined> => {
+      try {
+        const st = await downloadCacheFs.stat(partial);
+        return st.isFile() ? st.size : undefined;
+      } catch {
+        return undefined;
+      }
+    };
+
+    // ── #470: bounded retry with backoff, resuming each time ──────────────────
+    //
+    // A transfer that cannot survive an interruption will eventually be killed by
+    // one. The `.partial` + `.etag` machinery already made an interrupted transfer
+    // RESUMABLE; what was missing is anything that resumes it WITHOUT a human
+    // re-issuing the call. This loop is that.
+    //
+    // Every attempt re-derives its offset from disk and goes through the SAME
+    // identity proof a cold call does — there is no "we already checked" shortcut,
+    // so a retry can never splice bytes from a different object.
+    const retry = downloadRetryPolicy();
+    for (let attempt = 1; ; attempt += 1) {
+      // A cancel between attempts stops here — never consumed by a retry.
+      if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
+
+      const resumeFromBytes = await resumeOffsetFromDisk();
+
+      // Per-attempt abort, fed by TWO independent sources: the caller's cancel
+      // (forwarded) and our stall watchdog. They are kept distinguishable — the
+      // caller's `signal` is still consulted directly below — because a cancel must
+      // never be retried into a completion, while a stall must always be.
+      const attemptCtl = new AbortController();
+      const forwardCancel = (): void => attemptCtl.abort();
+      // An `abort` listener added to an ALREADY-aborted signal never fires, so
+      // forward the existing state explicitly rather than registering a listener
+      // that can never run — otherwise an attempt could start with a live signal
+      // for a download the caller has already cancelled.
+      if (signal?.aborted) attemptCtl.abort();
+      else signal?.addEventListener("abort", forwardCancel, { once: true });
+      let stalled = false;
+      let lastByteAt = Date.now();
+      const stallTicker =
+        retry.stallTimeoutMs > 0
+          ? setInterval(
+              () => {
+                if (Date.now() - lastByteAt >= retry.stallTimeoutMs) {
+                  stalled = true;
+                  attemptCtl.abort();
+                }
+              },
+              Math.min(5_000, Math.max(500, Math.floor(retry.stallTimeoutMs / 4))),
+            )
+          : undefined;
+      if (stallTicker && typeof stallTicker.unref === "function") stallTicker.unref();
+
+      try {
+        const contentType = await streamUrlToFile(
+          url,
+          partial,
+          headers,
+          logUrl,
+          storageAuth,
+          resumeFromBytes,
+          progress,
+          true, // resumable: cache partials use the .partial + If-Range resume handshake
+          onResume,
+          modelExt,
+          attemptCtl.signal,
+          () => {
+            lastByteAt = Date.now();
+          },
+          // WE decide when this download is over, so no attempt publishes a
+          // terminal "error" row on our behalf (#470 / #547).
+          true,
+        );
+        await downloadCacheFs.rename(partial, target);
+        await touch(target);
+        // Persist the response Content-Type beside the cache file so a later cache-HIT /
+        // coalesced caller re-validates with it (#473 reuse gap).
+        await writeCacheContentType(target, contentType);
+        // Clean any stale poison marker now that a CLEAN payload finalized under this
+        // key — the partial is gone (renamed) and the bytes passed validation.
+        await safeRm(rejectedMarker);
+        return target;
+      } catch (err) {
+        // THE CALLER CANCELLED. Checked before anything else and never classified:
+        // a cancel is a decision, not a failure, and retrying it would resurrect a
+        // transfer the user stopped. The partial is left for a later resume.
+        if (signal?.aborted) {
+          await dropEmptyPartial();
+          throw err;
+        }
+
+        const cls = stalled
+          ? {
+              retryable: true,
+              reason: `no bytes arrived for ${Math.round(retry.stallTimeoutMs / 1000)}s (the connection wedged without closing)`,
+            }
+          : classifyDownloadFailure(err);
+
+        if (!cls.retryable || attempt >= retry.maxAttempts) {
+          await dropEmptyPartial();
+          // NOTE: no terminal "error" row is published here. downloadModel already
+          // emits exactly one when this whole call throws (model-resolver.ts), which
+          // is precisely the moment the download is genuinely over. Withholding the
+          // per-attempt rows (deferErrorRow) therefore removes the FALSE failures
+          // without removing the real one — and without double-reporting it.
+          // Only ANNOTATE when retries actually happened and the cause was transient
+          // — an auth/gating failure must keep its own actionable message intact.
+          if (attempt > 1 && cls.retryable) {
+            const kept = await retainedBytes();
+            const partialNote =
+              kept === undefined
+                ? `The partial download's size could NOT be read, so how much progress survived is unknown — check the download cache before assuming either way.`
+                : kept > 0
+                  ? `${(kept / 1024 ** 3).toFixed(2)} GB of partial data is preserved on disk; re-issuing the SAME download resumes from there (it is not re-fetched) provided the host still serves the same object.`
+                  : `No partial data survived, so a re-issue restarts from the beginning.`;
+            throw new ModelError(
+              `Download failed after ${attempt} attempts (the last ${attempt - 1} were automatic retries with backoff): ` +
+                `${err instanceof Error ? err.message : String(err)} — ${cls.reason}. ${partialNote}`,
+              { url: logUrl, attempts: attempt, retryable: false },
+            );
+          }
+          throw err;
+        }
+
+        const delay = backoffDelayMs(attempt, retry);
+        logger.warn(
+          `Download attempt ${attempt}/${retry.maxAttempts} failed and will be retried in ` +
+            `${Math.round(delay / 1000)}s: ${cls.reason}. The partial file is kept and the retry ` +
+            `resumes from it (re-proving the object's identity first, #467).`,
+          {
+            url: logUrl,
+            attempt,
+            bytesBeforeAttempt: resumeFromBytes,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        );
+        // Backoff before re-requesting. #470 observed a 403 from an INSTANT
+        // re-request after an aborted connection — the wait is part of the fix,
+        // not politeness. It wakes early if the caller cancels.
+        await abortableDelay(delay, signal);
+      } finally {
+        if (stallTicker) clearInterval(stallTicker);
+        signal?.removeEventListener("abort", forwardCancel);
+      }
     }
   })();
 

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -44,7 +44,10 @@ const inflight = new Map<string, Promise<string>>();
  *  may already be gone). Used on the integrity-failure cleanup paths. */
 async function safeRm(path: string): Promise<void> {
   try {
-    await rm(path, { force: true });
+    // Through the same seam as the guarded helpers, so every removal of a staged
+    // file is observable in one place (and a test can interpose on the exact
+    // syscall an ownership check authorises).
+    await downloadCacheFs.rm(path, { force: true });
   } catch {
     /* best effort */
   }
@@ -76,14 +79,127 @@ interface GuardedPath {
 }
 
 /**
- * A path no other process can be writing — our own O_EXCL temp, a cache entry this
- * call materialised, or a `.partial` whose ownership the caller established and
- * cannot lose while it holds the stream. Making this explicit means an unguarded
- * destruction is a deliberate, reviewable claim at the call site rather than an
- * omission nobody notices.
+ * A path NO OTHER PROCESS CAN NAME: an O_EXCL temp this call created under a
+ * random name. That is the only circumstance in which an empty check is sound.
+ *
+ * It is deliberately NOT usable for the staged `.partial`, a `.etag`, or a cache
+ * entry. All three live at deterministic paths in a shared directory, so a second
+ * process running the same download reaches exactly the same file — "we streamed
+ * it ourselves" establishes what we WROTE, not what is there NOW, and every await
+ * between the two is a window. Those sites must supply a real check.
  */
-function selfOwned(path: string): GuardedPath {
+function exclusivelyOwned(path: string): GuardedPath {
   return { path, assertOwned: async () => {} };
+}
+
+/** The size of a staged file, distinguishing ABSENT (0 — knowably nothing) from
+ *  UNREADABLE (undefined — genuinely unknown). Collapsing the two either invents
+ *  progress that is not there or reports a knowable absence as a mystery. */
+async function stagedSize(path: string): Promise<number | undefined> {
+  try {
+    const st = await downloadCacheFs.stat(path);
+    return st.isFile() ? st.size : 0;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    return code === "ENOENT" || code === "ENOTDIR" ? 0 : undefined;
+  }
+}
+
+/** A validator sidecar's exact bytes: "" when provably absent, undefined when it
+ *  could not be read. Read alongside the size because SIZE ALONE cannot catch the
+ *  dangerous interference — another writer that truncates and re-stages a DIFFERENT
+ *  object to the same length looks unchanged, and cannot do that without writing
+ *  that object's validator here. */
+async function stagedSidecar(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    return code === "ENOENT" || code === "ENOTDIR" ? "" : undefined;
+  }
+}
+
+/** The observable state of a staged file plus its validator. NOT an atomic
+ *  snapshot — two reads with an await between them; see the caller-level note on
+ *  `readStaged`. */
+interface StagedState {
+  size: number | undefined;
+  sidecar: string | undefined;
+}
+
+async function readStagedState(path: string, sidecarPath: string): Promise<StagedState> {
+  return { size: await stagedSize(path), sidecar: await stagedSidecar(sidecarPath) };
+}
+
+/** The ONE refusal every ownership check raises, so they cannot drift apart in
+ *  wording or in what they promise. It NEVER deletes or truncates anything: the
+ *  bytes it is refusing to touch may belong to another download. */
+function interferenceError(why: string, when: string, logUrl: string): ModelError {
+  return new ModelError(
+    `Download stopped: another download is writing the same staged file, or this attempt cannot ` +
+      `establish that it is not (${why} ${when}). Writing now could interleave two transfers into ` +
+      `one file, or throw away another download's progress. Nothing was deleted — anything on disk ` +
+      `is intact. Check download_status; if another download of this file is running, wait for it ` +
+      `and then re-issue this one (it will reuse the completed file rather than re-fetching it).`,
+    { url: logUrl, retryable: false },
+  );
+}
+
+/**
+ * Guards for a staged file and its validator, each re-proving — immediately before
+ * every destructive syscall — that the file it protects is unchanged since
+ * `baseline`.
+ *
+ * The two checks are deliberately DIFFERENT. The payload's compares both fields;
+ * the sidecar's compares only the sidecar, because by the time it runs we may
+ * legitimately have removed the payload ourselves, and re-checking it there would
+ * refuse our own cleanup.
+ *
+ * An UNREADABLE size refuses. "I could not read it" is not "it is unchanged", and
+ * the act being authorised is a delete or a truncate.
+ */
+function guardStagedPair(
+  path: string,
+  sidecarPath: string,
+  baseline: StagedState,
+  when: string,
+  logUrl: string,
+): [GuardedPath, GuardedPath] {
+  return [
+    {
+      path,
+      assertOwned: async () => {
+        const size = await stagedSize(path);
+        if (size === undefined || baseline.size === undefined) {
+          throw interferenceError("the staged file's size could not be read", when, logUrl);
+        }
+        if (size !== baseline.size) {
+          throw interferenceError(`it went from ${baseline.size} to ${size} bytes`, when, logUrl);
+        }
+        const sidecar = await stagedSidecar(sidecarPath);
+        if (sidecar !== baseline.sidecar) {
+          throw interferenceError(
+            "its resume validator changed, so a DIFFERENT upstream object has been staged there",
+            when,
+            logUrl,
+          );
+        }
+      },
+    },
+    {
+      path: sidecarPath,
+      assertOwned: async () => {
+        const sidecar = await stagedSidecar(sidecarPath);
+        if (sidecar !== baseline.sidecar) {
+          throw interferenceError(
+            "its resume validator changed, so a DIFFERENT upstream object has been staged there",
+            when,
+            logUrl,
+          );
+        }
+      },
+    },
+  ];
 }
 
 /** Remove `target`, returning true iff it is confirmed gone. Unlike `safeRm` this
@@ -1238,9 +1354,77 @@ async function streamUrlToFile(
    *  different objects. Re-checking here shrinks that window from "the whole
    *  request round-trip" to the few instructions before the open. */
   beforeWrite?: () => Promise<void>,
+  /**
+   * Is `targetPath` a SHARED staged file (the deterministic `.partial` in the
+   * download cache) rather than an O_EXCL temp only this call can name?
+   *
+   * It decides how the post-download cleanups authorise themselves. Having
+   * streamed the bytes ourselves establishes what we WROTE, not what is on disk by
+   * the time we classify the body and act — `readHead` and the rejection callback
+   * are awaits, and on a shared path another process can replace the file inside
+   * them. So a shared target takes a baseline the instant its write completes and
+   * re-proves it before every destructive syscall; an exclusive temp needs none,
+   * because no other writer can name it.
+   */
+  stagedFileIsShared = false,
 ): Promise<string> {
   // Fail fast if we were cancelled before any bytes moved — no request, no partial.
   if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
+
+  const sidecarOfTarget = `${targetPath}.etag`;
+  /** Read the staged file's state NOW — called at the moment our own write
+   *  finishes, so it captures what WE produced and nothing later. */
+  const currentStagedBaseline = (): Promise<StagedState> =>
+    stagedFileIsShared
+      ? readStagedState(targetPath, sidecarOfTarget)
+      : Promise.resolve({ size: undefined, sidecar: undefined });
+  /**
+   * Guards for the post-download cleanups.
+   *
+   * A SHARED staged file gets real checks against `baseline`. An O_EXCL temp gets
+   * none — and that is the only case where none is honest, because no other writer
+   * can name it. The dispatch lives here so a caller cannot silently acquire the
+   * empty check for a shared path by forgetting a flag: the default is `false`,
+   * i.e. exclusive, which is only ever passed by the direct-temp path.
+   */
+  const cleanupGuards = (baseline: StagedState, when: string): [GuardedPath, GuardedPath] =>
+    stagedFileIsShared
+      ? guardStagedPair(targetPath, sidecarOfTarget, baseline, when, logUrl)
+      : [exclusivelyOwned(targetPath), exclusivelyOwned(sidecarOfTarget)];
+
+  /**
+   * Discard the staged payload and its validator after an INTEGRITY REFUSAL,
+   * proving ownership before each removal.
+   *
+   * The integrity refusals below (an unsolicited 206, a malformed or inconsistent
+   * Content-Range, a 0-byte body, an oversized body) each used to issue two raw
+   * `safeRm` calls with an await between them. On a shared staged file that is the
+   * same granularity bug as everywhere else, just spelled differently: the second
+   * removal acts on whatever is there by then, so a writer that took the file over
+   * loses its validator — and `safeRm` swallows the failure, so nothing is said.
+   *
+   * Best-effort like the `safeRm` it replaces: a refusal here is logged and skipped
+   * rather than thrown, because these paths are already reporting a different,
+   * more important failure and must not have it masked by a cleanup complaint.
+   */
+  const discardStagedAfterRefusal = async (when: string): Promise<void> => {
+    const [guardedPayload, guardedSidecar] = cleanupGuards(
+      await currentStagedBaseline(),
+      when,
+    );
+    for (const guarded of resumable ? [guardedPayload, guardedSidecar] : [guardedPayload]) {
+      try {
+        await guarded.assertOwned();
+        await safeRm(guarded.path);
+      } catch (err) {
+        logger.info(
+          `Left "${guarded.path}" in place while cleaning up a rejected download: it is no longer the file this attempt staged.`,
+          { url: logUrl, error: err instanceof Error ? err.message : String(err) },
+        );
+      }
+    }
+  };
+
   if (supportsCloudDownload(url)) {
     // INTERFERENCE RE-CHECK FIRST (see `beforeWrite`). This branch is the most
     // destructive one in the function: a cloud transfer cannot range-resume, so it
@@ -1306,11 +1490,15 @@ async function streamUrlToFile(
       url,
       logUrl,
       onReject: async () => {
-        // selfOwned: this runs AFTER we streamed these bytes ourselves, so the
-        // caller's pre-write baseline no longer describes the file (we changed it)
-        // and re-checking against it would refuse our OWN cleanup. We hold the
-        // stream; these bytes are ours to discard.
-        await discardRejectedPayload(selfOwned(targetPath), undefined, logUrl);
+        // The cloud downloader has finished writing, so THIS is the moment the
+        // file is ours. Baseline it here, then re-prove before each destructive
+        // act — `assertModelPayloadOrThrow` reads the head and awaits this
+        // callback, and on a shared path another writer can take the file over
+        // inside that gap.
+        await discardRejectedPayload(
+          ...cleanupGuards(await currentStagedBaseline(), "while classifying the downloaded body"),
+          logUrl,
+        );
       },
       // FAIL CLOSED, same as the HTTP path: a cloud (S3/Azure) object can be an XML/
       // HTML AccessDenied body saved under a `.safetensors` name, and if we CAN'T
@@ -1647,6 +1835,7 @@ async function streamUrlToFile(
         onBytes,
         deferErrorRow,
         beforeWrite,
+        stagedFileIsShared,
       );
     }
   }
@@ -1687,8 +1876,7 @@ async function streamUrlToFile(
   // Content-Length 1024 → a 1 KiB file renamed into cache as the whole 4096-byte
   // model). Refuse it — a no-Range request must be answered with 200 (#467 P0).
   if (res.status === 206 && effectiveResume === 0) {
-    await safeRm(targetPath);
-    if (resumable) await safeRm(validatorSidecar);
+    await discardStagedAfterRefusal("while rejecting this response");
     const cleared = await partialConfirmedDiscarded(targetPath);
     throw new ModelError(
       `Download failed: the server returned "206 Partial Content" to a request that sent NO Range ` +
@@ -1732,8 +1920,7 @@ async function streamUrlToFile(
       total > end &&
       end === total - 1;
     if (!valid) {
-      await safeRm(targetPath);
-      await safeRm(validatorSidecar);
+      await discardStagedAfterRefusal("while rejecting this response");
       throw new ModelError(
         `Download resume rejected: a 206 for byte ${effectiveResume}+ must carry a complete, ` +
           `consistent Content-Range "bytes ${effectiveResume}-<end>/<total>" reaching the end of ` +
@@ -1748,8 +1935,7 @@ async function streamUrlToFile(
     // otherwise let a short prefix finalize as "complete" (#467). Refuse the
     // mismatch (also catches a partial we already have that exceeds the new total).
     if (priorTotal !== undefined && total !== priorTotal) {
-      await safeRm(targetPath);
-      await safeRm(validatorSidecar);
+      await discardStagedAfterRefusal("while rejecting this response");
       throw new ModelError(
         `Download resume rejected: the server now reports a total size of ${total} bytes, but the ` +
           `original download recorded ${priorTotal}. The upstream size changed — appending would ` +
@@ -1940,8 +2126,7 @@ async function streamUrlToFile(
       // Nothing landed — remove it (and its validator sidecar) so it can't
       // masquerade as a real file / poison a resume with a validator that has
       // no matching bytes. Best-effort: never let cleanup throw here.
-      await safeRm(targetPath);
-      if (resumable) await safeRm(validatorSidecar);
+      await discardStagedAfterRefusal("while rejecting this response");
       throw new ModelError(
         "Download produced a 0-byte file — the source sent no data. Removed it; retry.",
         { url: logUrl },
@@ -1970,8 +2155,7 @@ async function streamUrlToFile(
       // corrupt file with no error (#467 P0-1). This is NOT resumable — the bytes
       // on disk are wrong — so remove the partial + validator and fail; a retry
       // starts clean rather than range-resuming a corrupt prefix.
-      await safeRm(targetPath);
-      if (resumable) await safeRm(validatorSidecar);
+      await discardStagedAfterRefusal("while rejecting this response");
       throw new ModelError(
         `Download oversized: wrote ${actual} bytes but the file is only ${expectedTotal} — the ` +
           `response sent more data than its declared size (corrupt or misbehaving server). Removed ` +
@@ -1993,7 +2177,7 @@ async function streamUrlToFile(
   // without persisting it a body that only a Content-Type could flag (e.g. an
   // HTML/JSON page whose bytes don't sniff as text) could slip through on reuse (#473).
   const responseContentType = res.headers.get("content-type") || "";
-  const assertModelPayload = (): Promise<void> =>
+  const assertModelPayload = (postWrite: StagedState): Promise<void> =>
     assertModelPayloadOrThrow({
       targetPath,
       modelExt,
@@ -2007,12 +2191,22 @@ async function streamUrlToFile(
       // marker so a content-type-only rejection (whose body may sniff as binary on
       // retry) still can't be resumed even if neutralization failed.
       onReject: async () => {
-        // selfOwned, for the same reason as the cloud path above: we streamed these
-        // bytes ourselves, so the pre-write baseline no longer describes the file
-        // and would refuse our own cleanup. The stream is ours.
+        // Same as the cloud path: baseline at the moment our write finished, then
+        // re-prove before each destructive act. `readHead` and this callback are
+        // awaits, and on a shared staged file another writer can replace both the
+        // payload and its validator inside them — removing THEIR files while
+        // reporting OUR rejection is the harm.
+        // `postWrite`, NOT a fresh read: the caller captured it the instant our
+        // write finished. Reading it here would baseline whatever is on disk AFTER
+        // the classify gap — i.e. adopt a foreign writer's replacement as our own
+        // and then delete it, which is the failure this guard exists to prevent.
+        const [guardedPayload, guardedSidecar] = cleanupGuards(
+          postWrite,
+          "while classifying the downloaded body",
+        );
         await discardRejectedPayload(
-          selfOwned(targetPath),
-          resumable ? selfOwned(validatorSidecar) : undefined,
+          guardedPayload,
+          resumable ? guardedSidecar : undefined,
           logUrl,
         );
         if (resumable) await writePoisonMarker(`${targetPath}.rejected`, logUrl);
@@ -2024,7 +2218,11 @@ async function streamUrlToFile(
   if (!progress && !onBytes) {
     await pipeline(nodeStream, fileStream, { signal });
     await assertComplete();
-    await assertModelPayload();
+    // Baseline the file the INSTANT our write finished — BEFORE the body is
+    // classified. Taking it inside the rejection callback would baseline whatever
+    // is on disk AFTER the classify gap, i.e. adopt a foreign writer's replacement
+    // as our own and then delete it.
+    await assertModelPayload(await currentStagedBaseline());
     // Complete: the validator sidecar is only needed to guard a resume, so drop it.
     if (resumable) await safeRm(validatorSidecar);
     return responseContentType;
@@ -2069,7 +2267,8 @@ async function streamUrlToFile(
   try {
     await pipeline(nodeStream, counter, fileStream, { signal });
     await assertComplete();
-    await assertModelPayload();
+    // See above: baseline before the classify gap, not inside the callback.
+    await assertModelPayload(await currentStagedBaseline());
     if (resumable) await safeRm(validatorSidecar);
     bytesPerSec = 0;
     emit("done", true);
@@ -2180,47 +2379,37 @@ async function downloadIntoCache(
        *  destroy the other writer's partial. */
       verified: StagedState,
     ): Promise<number> => {
-      /**
-       * The `.partial` and its `.etag`, each carrying the check that authorises
-       * destroying THAT file — deliberately not the same check.
-       *
-       * The partial's guard compares the whole staged state. The sidecar's compares
-       * ONLY the sidecar, because by the time it runs we may legitimately have
-       * removed the partial ourselves; re-checking the partial there would refuse
-       * our own cleanup. Each guard asserts what is still meaningful evidence for
-       * the file it protects.
-       */
-      const guardedStagedPair = (when: string): [GuardedPath, GuardedPath] => [
-        {
-          path: partial,
-          assertOwned: () => assertStillOurs(verified, when, false),
-        },
-        {
-          path: `${partial}.etag`,
-          assertOwned: async () => {
-            const nowSidecar = await sidecarBytes();
-            if (nowSidecar !== verified.sidecar) {
-              throw interferenceError(
-                "its resume validator changed, so a DIFFERENT upstream object has been staged there",
-                when,
-              );
-            }
-          },
-        },
-      ];
+      /** The `.partial` and its `.etag`, each carrying the check that authorises
+       *  destroying THAT file. Built by the shared module-level helper so this path
+       *  and the post-download cleanups cannot drift apart in what they check. */
+      const guardedStagedPair = (when: string): [GuardedPath, GuardedPath] =>
+        guardStagedPair(
+          partial,
+          `${partial}.etag`,
+          verified,
+          when,
+          logUrl ?? redactUrlForLogs(url),
+        );
 
-      let resumeFromBytes = 0;
-      try {
-        const existing = await downloadCacheFs.stat(partial);
-        if (existing.isFile() && existing.size > 0) {
-          resumeFromBytes = existing.size;
-          logger.info("Resuming partial download", {
-            url: logUrl,
-            bytes: resumeFromBytes,
-          });
-        }
-      } catch {
-        // No partial — fresh download.
+      // UNREADABLE IS NOT ABSENT. A bare try/catch here folded every stat failure
+      // into "no partial", which is this repo's dominant defect in its most
+      // expensive form: `resumeFromBytes` stays 0, the attempt takes the
+      // non-append path, and a full 200 response opens the existing file in
+      // TRUNCATING mode — deleting an active writer's bytes because we could not
+      // read a size. `stagedSize` reports a genuinely missing file as 0 (that IS a
+      // fresh download); anything else is unknown and must refuse.
+      const existingSize = await stagedSize(partial);
+      if (existingSize === undefined) {
+        throw interferenceError(
+          "the staged file exists but its size could not be read, so whether it holds another " +
+            "download's bytes is unknown",
+          "before deciding how to resume",
+          logUrl ?? redactUrlForLogs(url),
+        );
+      }
+      let resumeFromBytes = existingSize;
+      if (resumeFromBytes > 0) {
+        logger.info("Resuming partial download", { url: logUrl, bytes: resumeFromBytes });
       }
 
       // #473 P1 — poison MARKER guard (cleanup- AND content-type-independent). A prior
@@ -2295,17 +2484,52 @@ async function downloadIntoCache(
      *  candidate and is deliberately preserved on every failure path (#470's
      *  governing harm: never destroy progress you cannot re-fetch cheaply). */
     const dropEmptyPartial = async (): Promise<void> => {
+      // Goes through the SAME guarded helpers as every other destructive path.
+      // It used to issue two raw `rm`s with the failure swallowed, and the second
+      // one ran after an await with no re-check — so a writer that created a real
+      // partial and validator in that gap had its validator deleted, leaving bytes
+      // it could no longer resume, silently. Being outside `GuardedPath` is exactly
+      // how a site avoids the review the type was introduced to force.
+      // The partial must be PRESENT AND EMPTY for there to be anything of ours to
+      // clean. Present-and-empty and ABSENT both read as 0 bytes, and the
+      // difference matters: if the file is gone, there is no empty partial of ours
+      // to pair a sidecar with, and a sidecar sitting there alone may be a NEW
+      // writer's — deleting it would strip the validator that makes their bytes
+      // resumable. A fresh baseline cannot tell us whose it is, so absence means
+      // touch nothing.
+      let presentAndEmpty = false;
       try {
-        const remaining = await downloadCacheFs.stat(partial);
-        if (remaining.size === 0) {
-          await downloadCacheFs.rm(partial, { force: true }).catch(() => undefined);
-          // The validator sidecar is only meaningful alongside a resumable
-          // partial — drop it too so a later attempt doesn't If-Range against a
-          // file that no longer exists.
-          await downloadCacheFs.rm(`${partial}.etag`, { force: true }).catch(() => undefined);
-        }
+        const st = await downloadCacheFs.stat(partial);
+        presentAndEmpty = st.isFile() && st.size === 0;
       } catch {
-        // Partial gone — nothing to clean.
+        presentAndEmpty = false; // absent, or unreadable — either way, not ours to clear
+      }
+      if (!presentAndEmpty) return;
+      const baseline = await readStagedState(partial, `${partial}.etag`);
+      // `undefined` (unreadable) is NOT 0 — it means we do not know, so we do not act.
+      if (baseline.size !== 0) return;
+      const [guardedPartial, guardedSidecar] = guardStagedPair(
+        partial,
+        `${partial}.etag`,
+        baseline,
+        "while cleaning up an empty staged file",
+        logUrl ?? redactUrlForLogs(url),
+      );
+      try {
+        await rmOrLog(guardedPartial, logUrl ?? redactUrlForLogs(url));
+        // The validator sidecar is only meaningful alongside a resumable partial —
+        // drop it too so a later attempt doesn't If-Range against a file that no
+        // longer exists. Its guard re-checks: the removal above was an await.
+        await rmOrLog(guardedSidecar, logUrl ?? redactUrlForLogs(url));
+      } catch (err) {
+        // An interference refusal here is not a failure of the download — the
+        // download already failed or was cancelled and we are only tidying up. Log
+        // it and leave the other writer's files alone rather than masking their
+        // real outcome with our cleanup's complaint.
+        logger.info(
+          "Left the staged file in place during cleanup: it is no longer the empty file this attempt created.",
+          { url: logUrl, error: err instanceof Error ? err.message : String(err) },
+        );
       }
     };
 
@@ -2329,52 +2553,13 @@ async function downloadIntoCache(
     // than the stall window could never finish. No byte signal ⇒ no watchdog.
     const stallTimeoutMs = supportsCloudDownload(url) ? 0 : retry.stallTimeoutMs;
 
-    /** The partial's size as it stands, distinguishing ABSENT (0 — knowably
-     *  nothing) from UNREADABLE (undefined — genuinely unknown). Collapsing the
-     *  two would either invent progress that is not there or report a knowable
-     *  absence as a mystery. */
-    const partialSize = async (): Promise<number | undefined> => {
-      try {
-        const st = await downloadCacheFs.stat(partial);
-        return st.isFile() ? st.size : 0;
-      } catch (err) {
-        const code = (err as NodeJS.ErrnoException)?.code;
-        return code === "ENOENT" || code === "ENOTDIR" ? 0 : undefined;
-      }
-    };
-
-    /** The `.etag` sidecar's exact contents, or "" when it is absent/unreadable.
-     *  Read alongside the size because SIZE ALONE cannot catch the dangerous
-     *  interference: another writer that truncates and re-stages a DIFFERENT
-     *  upstream object to the same length would look unchanged. It cannot do that
-     *  without writing that object's validator here, so the sidecar is the part of
-     *  the snapshot that actually detects a swapped object. */
-    const sidecarBytes = async (): Promise<string | undefined> => {
-      try {
-        return await readFile(`${partial}.etag`, "utf-8");
-      } catch (err) {
-        const code = (err as NodeJS.ErrnoException)?.code;
-        // ABSENT is knowable ("" — no validator was ever recorded); anything else
-        // (EACCES, EIO, …) means we could not find out, and undefined says so.
-        // Collapsing the two would let "I cannot read it" be reported as "the host
-        // never sent one", and would let an unknown state pass an equality check.
-        return code === "ENOENT" || code === "ENOTDIR" ? "" : undefined;
-      }
-    };
-
-    /** The one refusal used by both interference checks (between attempts, and at
-     *  the last instant before a write), so they cannot drift apart in wording or
-     *  in what they promise. It NEVER deletes or truncates anything: the bytes it
-     *  is refusing to touch belong to the other download. */
-    const interferenceError = (why: string, when: string): ModelError =>
-      new ModelError(
-        `Download stopped: another download is writing the same staged file, or this attempt cannot ` +
-          `establish that it is not (${why} ${when}). Writing now could interleave two transfers into ` +
-          `one file, or throw away another download's progress. Nothing was deleted — anything on disk ` +
-          `is intact. Check download_status; if another download of this file is running, wait for it ` +
-          `and then re-issue this one (it will reuse the completed file rather than re-fetching it).`,
-        { url: logUrl, retryable: false },
-      );
+    // These bind the module-level helpers to THIS download's paths, so the retry
+    // loop and the post-download cleanups share one definition of what a staged
+    // file's state is and what counts as interference.
+    const partialSize = (): Promise<number | undefined> => stagedSize(partial);
+    const sidecarBytes = (): Promise<string | undefined> => stagedSidecar(`${partial}.etag`);
+    const interferenceFor = (why: string, when: string): ModelError =>
+      interferenceError(why, when, logUrl ?? redactUrlForLogs(url));
 
     /**
      * Compare the staged file's state against what we recorded, and REFUSE unless
@@ -2431,10 +2616,10 @@ async function downloadIntoCache(
       // `partialSize` reports a missing file as a definite 0, so `undefined` means
       // the file is THERE but unreadable.
       if (strict && (expectedSize === undefined || nowSize === undefined)) {
-        throw interferenceError("the staged file's size could not be read", when);
+        throw interferenceFor("the staged file's size could not be read", when);
       }
       if (nowSize !== expectedSize) {
-        throw interferenceError(
+        throw interferenceFor(
           `it went from ${expectedSize ?? "an unreadable size"} to ${nowSize ?? "an unreadable size"} bytes`,
           when,
         );
@@ -2446,7 +2631,7 @@ async function downloadIntoCache(
       // that path TRUNCATES the staged file. So an unknown validator plus a
       // same-size replacement by another writer would destroy their partial.
       if (strict && (expectedSidecar === undefined || nowSidecar === undefined)) {
-        throw interferenceError("the staged file's resume validator could not be read", when);
+        throw interferenceFor("the staged file's resume validator could not be read", when);
       }
       // WITHIN one attempt it is only compared for CHANGE. A sidecar that was
       // ALREADY unreadable a moment ago is a stable pre-existing condition (a
@@ -2457,7 +2642,7 @@ async function downloadIntoCache(
       // false, so this compares equal only when genuinely unchanged, and still
       // catches readable-then-not.
       if (nowSidecar !== expectedSidecar) {
-        throw interferenceError(
+        throw interferenceFor(
           "its resume validator changed, so a DIFFERENT upstream object has been staged there",
           when,
         );
@@ -2598,6 +2783,10 @@ async function downloadIntoCache(
             // already unreadable, and the older guards diagnose that better.
             await assertStillOurs(decided, "while this attempt was requesting it", false);
           },
+          // The cache `.partial` lives at a deterministic path in a shared
+          // directory, so a second process running this download reaches the very
+          // same file. Its post-download cleanups must prove ownership.
+          true,
         );
         await downloadCacheFs.rename(partial, target);
         await touch(target);
@@ -3013,6 +3202,13 @@ export async function downloadWithCache(
     // now, so we recover it from the `.ct` sidecar persisted at download time —
     // otherwise a Content-Type-only-flaggable body could finalize as a model on reuse.
     const cachedContentType = await readCacheContentType(cachePath);
+    // Baseline the cache entry BEFORE we classify it, so the rejection cleanup can
+    // prove it is still the file we objected to. This path is reachable on a cache
+    // HIT — the entry may have been produced by an earlier call or another process
+    // — so "this call materialised it" is not established here, and the classify
+    // step (a head read plus an awaited callback) is a window in which another
+    // downloader can replace it with a GOOD file we must not delete.
+    const cacheBaseline = await readStagedState(cachePath, cacheCtSidecar(cachePath));
     await assertModelPayloadOrThrow({
       targetPath: cachePath,
       modelExt,
@@ -3025,10 +3221,14 @@ export async function downloadWithCache(
       // miss), and log if even that fails, so a poisoned cache entry can't silently
       // re-poison cache hits (#473 P1).
       onReject: async () => {
-        // selfOwned: a materialised CACHE entry, not the shared `.partial`. It is
-        // reached through this call's own O_EXCL-temp-then-rename, so no concurrent
-        // downloader is streaming into it.
-        const neutralized = await discardRejectedPayload(selfOwned(cachePath), undefined, logUrl);
+        const [guardedCacheFile] = guardStagedPair(
+          cachePath,
+          cacheCtSidecar(cachePath),
+          cacheBaseline,
+          "while classifying a cached body",
+          logUrl,
+        );
+        const neutralized = await discardRejectedPayload(guardedCacheFile, undefined, logUrl);
         // Only drop the Content-Type sidecar once the poisoned cache file is actually
         // gone/emptied. If the cache file SURVIVED (rm AND truncate both failed), KEEP
         // the `.ct` so the NEXT caller can still reject it by its persisted

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -993,7 +993,58 @@ export function describePlacement(
   }
 }
 
-export function getDownloadJob(id: string): DownloadJob | undefined {
+/**
+ * Every DISTINCT tracked download that answers to `id`, across this process's
+ * registry AND the persisted store, deduped by the TRUE composite identity
+ * (id, trayId) — the same key `listDownloadJobs`/`findDownloadJob` already use.
+ *
+ * `id` is derived from destination+auth, so two different SOURCE URLs landing on
+ * one file deliberately share it (#467 P1-A dedup). That makes `id` a
+ * DESTINATION handle, not a job handle — and #822 is the consequence: an
+ * identifier that can name two rows cannot select either. This function is what
+ * lets every id-keyed operation SAY SO — listing the candidates a caller must
+ * choose between — instead of silently acting on one or reporting "not found".
+ *
+ * Newest-started first, so a caller printing candidates leads with the live one.
+ */
+export function listDownloadJobCandidates(id: string): DownloadJob[] {
+  const keyOf = (j: DownloadJob): string => `${j.id}\n${j.trayId}`;
+  const byKey = new Map<string, DownloadJob>();
+  for (const e of new Set(jobs.values())) {
+    if (e.job.id !== id) continue;
+    const cur = byKey.get(keyOf(e.job));
+    if (!cur || (e.job.status === "done" && cur.status !== "done")) byKey.set(keyOf(e.job), e.job);
+  }
+  for (const rec of listPersistedDownloadJobs()) {
+    if (rec.id !== id) continue;
+    const job = jobFromPersisted(rec);
+    const k = keyOf(job);
+    const cur = byKey.get(k);
+    // A live in-memory copy wins over its own persisted snapshot; otherwise a
+    // validated DONE wins over a cancelled/error record for the same identity
+    // (the same integrity truth listDownloadJobs applies).
+    if (!cur) byKey.set(k, job);
+    else if (job.status === "done" && cur.status !== "done" && cur.status !== "downloading") {
+      byKey.set(k, job);
+    }
+  }
+  return [...byKey.values()].sort((a, b) => b.started_at - a.started_at);
+}
+
+/**
+ * Resolve ONE download.
+ *
+ * `trayId` is the DISAMBIGUATOR (#822): with it the lookup keys on the full
+ * composite identity (id, trayId) and can always name exactly one row. Without
+ * it, an id that denotes more than one download still resolves to nothing —
+ * but callers can now distinguish that from "no such download" by asking
+ * {@link listDownloadJobCandidates}, which is the difference between an
+ * actionable "say which one" and a false "it never existed".
+ */
+export function getDownloadJob(id: string, trayId?: string): DownloadJob | undefined {
+  if (trayId) {
+    return listDownloadJobCandidates(id).find((j) => j.trayId === trayId);
+  }
   // The registry indexes each job under its request key and (when local) its
   // destination key; the public id is one of those, so a direct get resolves it.
   const live = jobs.get(id)?.job;
@@ -1131,16 +1182,53 @@ export function listDownloadJobs(): DownloadJob[] {
  * here). A job resolvable only via the persisted store (started by another/previous
  * session after a reconnect) cannot be aborted from here — reported as not-owned.
  */
-export function cancelDownloadJob(id: string): {
+export function cancelDownloadJob(
+  id: string,
+  /** #822 disambiguator: the tray id of the SPECIFIC download to cancel, when the
+   *  public `id` denotes more than one (two source URLs → one destination). With
+   *  it the composite identity (id, trayId) selects exactly one row, which is what
+   *  made the stale job in #822 unselectable — and therefore unstoppable. */
+  trayId?: string,
+): {
   found: boolean;
   owned: boolean;
   aborted: boolean;
   /** The id denotes MORE than one concurrent physical download (a live foreign
-   *  session shares it with a different trayId) — declined, nothing was aborted. */
+   *  session shares it with a different trayId) — declined, nothing was aborted.
+   *  Pass `trayId` to resolve it. */
   ambiguous?: boolean;
+  /** Every download the id answers to — so an ambiguity refusal can NAME the
+   *  choices instead of leaving the caller with no next move. */
+  candidates?: DownloadJob[];
   status?: DownloadJob["status"];
   job?: DownloadJob;
 } {
+  if (trayId) {
+    // Explicit selection: find the ONE local entry with this composite identity.
+    // Scanning entries (rather than jobs.get(id)) matters because the registry's
+    // id row holds only one of several same-destination jobs.
+    const entry = [...new Set(jobs.values())].find(
+      (e) => e.job.id === id && e.job.trayId === trayId,
+    );
+    if (entry) {
+      const { job, controller } = entry;
+      // No ambiguity check here: the caller named the exact download, which is
+      // precisely the information the by-id refusal was missing. A foreign
+      // same-id sibling is a DIFFERENT trayId and is untouched by this abort.
+      if (job.status !== "downloading") {
+        return { found: true, owned: true, aborted: false, status: job.status, job };
+      }
+      if (!controller.signal.aborted) controller.abort();
+      return { found: true, owned: true, aborted: true, status: "downloading", job };
+    }
+    // Not ours. It may be another session's (persisted) — reportable, not abortable.
+    const foreign = listDownloadJobCandidates(id).find((j) => j.trayId === trayId);
+    if (foreign) {
+      return { found: true, owned: false, aborted: false, status: foreign.status, job: foreign };
+    }
+    return { found: false, owned: false, aborted: false, candidates: listDownloadJobCandidates(id) };
+  }
+
   const entry = jobs.get(id);
   if (entry) {
     const { job, controller } = entry;
@@ -1148,8 +1236,24 @@ export function cancelDownloadJob(id: string): {
     // trayId. Aborting by id could act on the wrong logical download — decline so a
     // cancel-by-id can never hit an unintended concurrent download (a #515 invariant).
     if (job.status === "downloading" && hasAmbiguousForeignSibling(id, job.trayId)) {
-      return { found: true, owned: true, aborted: false, ambiguous: true, status: job.status, job };
+      return {
+        found: true,
+        owned: true,
+        aborted: false,
+        ambiguous: true,
+        candidates: listDownloadJobCandidates(id),
+        status: job.status,
+        job,
+      };
     }
+    // NOTE (#822 vs #761): a STALE foreign record sharing this id deliberately does
+    // NOT refuse here. A dead session's leftover row must never permanently jam the
+    // live download this process owns (#761), and the live local job is
+    // unambiguously the one a by-id cancel means. What #822 was missing is not more
+    // refusals — it is the ability to NAME the other row, which `trayId` above now
+    // provides. So: by-id keeps acting on the job we own; the stale sibling is
+    // selectable by its tray id (and reported as not-abortable-from-here, which is
+    // the truth — its AbortController died with its session).
     if (job.status !== "downloading") {
       // Already settled (done/error/cancelled) — idempotent no-op.
       return { found: true, owned: true, aborted: false, status: job.status, job };
@@ -1172,6 +1276,23 @@ export function cancelDownloadJob(id: string): {
   }
   // Not in THIS process's registry. It may still exist in the persisted store
   // (another/previous session owns the AbortController), which we can't abort here.
+  // #822: with no local job to prefer, picking one of several persisted records to
+  // report on would be a guess. Refuse and NAME them — the caller re-issues with the
+  // tray id of the one they mean. Only STILL-DOWNLOADING records create that
+  // ambiguity: a settled record cannot be cancelled wrongly (the call is a no-op
+  // report either way), so it must not block the one row that could be acted on.
+  const persistedCandidates = listDownloadJobCandidates(id);
+  if (persistedCandidates.filter((c) => c.status === "downloading").length > 1) {
+    return {
+      found: true,
+      owned: false,
+      aborted: false,
+      ambiguous: true,
+      candidates: persistedCandidates,
+      status: persistedCandidates[0].status,
+      job: persistedCandidates[0],
+    };
+  }
   const persisted = readPersistedDownloadJob(id);
   if (persisted) {
     return {

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -1015,16 +1015,33 @@ export function listDownloadJobCandidates(id: string): DownloadJob[] {
     const cur = byKey.get(keyOf(e.job));
     if (!cur || (e.job.status === "done" && cur.status !== "done")) byKey.set(keyOf(e.job), e.job);
   }
+  // `trayId` is a hash of the URL, so it does NOT separate sessions: this
+  // session's SETTLED record for a URL and ANOTHER session's still-running
+  // download of the same URL to the same destination collapse to one key. Which
+  // one is reported matters — showing the local "cancelled" row while a foreign
+  // transfer is live would hide a running download behind a stale verdict, and
+  // that is worse than the ambiguity this function exists to surface.
+  const now = Date.now();
+  const isLive = (r: PersistedDownloadJob): boolean =>
+    r.status === "downloading" && now - (r.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS;
   for (const rec of listPersistedDownloadJobs()) {
     if (rec.id !== id) continue;
     const job = jobFromPersisted(rec);
     const k = keyOf(job);
     const cur = byKey.get(k);
-    // A live in-memory copy wins over its own persisted snapshot; otherwise a
-    // validated DONE wins over a cancelled/error record for the same identity
-    // (the same integrity truth listDownloadJobs applies).
-    if (!cur) byKey.set(k, job);
-    else if (job.status === "done" && cur.status !== "done" && cur.status !== "downloading") {
+    if (!cur) {
+      byKey.set(k, job);
+      continue;
+    }
+    // Precedence, most authoritative first:
+    //  1. a validated DONE — the file landed, and no later verdict undoes that;
+    //  2. a LIVE transfer — still happening, so it is what the caller needs to know;
+    //  3. anything settled.
+    // (A live IN-MEMORY job is this process's own and already sits in `byKey`, so
+    // it is never displaced by a merely-settled persisted record.)
+    if (job.status === "done" && cur.status !== "done" && cur.status !== "downloading") {
+      byKey.set(k, job);
+    } else if (isLive(rec) && cur.status !== "done" && cur.status !== "downloading") {
       byKey.set(k, job);
     }
   }

--- a/src/services/download-retry.ts
+++ b/src/services/download-retry.ts
@@ -1,0 +1,281 @@
+// Transient-failure classification + backoff for the local streaming download
+// path (#470, #817).
+//
+// WHY THIS EXISTS
+// A multi-GB transfer over a modest link WILL be interrupted — a CDN drop, a
+// proxy reset, an undici `terminated`. Before this, ONE such blip terminated the
+// whole job permanently ("failed: terminated"), and the caller's only recourse
+// was to re-issue `download_model` by hand. The bytes on disk were not lost (the
+// `.partial` + `.etag` sidecar machinery from #343/#467 preserves and safely
+// resumes them), but a human/agent had to notice and act. This module supplies
+// the policy that lets the SAME call recover by itself: retry with backoff,
+// resuming from the preserved partial each attempt.
+//
+// FAIL-SAFE BY CONSTRUCTION
+// `classifyDownloadFailure` defaults to NOT retryable. Only an explicitly
+// enumerated transport/transient signal opts an error in. An unrecognized error
+// therefore behaves EXACTLY as it did before this module existed (surface it,
+// once). That direction of default matters: a wrongly-retried integrity refusal
+// would re-run a corruption path several times and burn bandwidth, while a
+// wrongly-NOT-retried transport blip merely reproduces today's behavior.
+//
+// NEVER RETRIED (deliberately absent from the transient set):
+//   - user cancellation — the caller's abort is checked by the loop itself,
+//     before classification, so a cancel can never be "recovered from";
+//   - 4xx other than 408/429 — auth/gating/not-found; a retry cannot fix them
+//     and, per #470's own report, an instant re-request is what earned a 403;
+//   - #473 non-model payload rejections — an HTML/JSON auth page is a
+//     configuration problem, not a blip;
+//   - the #343/#467 resume/integrity refusals (bad Content-Range, size
+//     disagreement, oversized body) — those mean the SERVER is misbehaving or
+//     the object changed; hammering it is not a remedy.
+
+import { logger } from "../utils/logger.js";
+
+/**
+ * Marker placed on a ModelError's `details` by the code that RAISES it, when
+ * that code knows the failure is transient and the on-disk `.partial` is still a
+ * valid resume candidate. Preferred over message matching: the message is prose
+ * that gets reworded, the flag is a contract.
+ */
+export interface RetryableDetails {
+  retryable?: boolean;
+  code?: unknown;
+  status?: unknown;
+}
+
+/**
+ * Node/undici error codes that denote a TRANSPORT interruption — the connection
+ * died, not the request being wrong. Every one of these leaves the bytes already
+ * written to the `.partial` intact and range-resumable.
+ */
+const TRANSIENT_CODES = new Set([
+  "ECONNRESET",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "EPIPE",
+  "ETIMEDOUT",
+  "ENETUNREACH",
+  "ENETRESET",
+  "ENETDOWN",
+  "EHOSTUNREACH",
+  "EAI_AGAIN",
+  "ERR_STREAM_PREMATURE_CLOSE",
+  "UND_ERR_SOCKET",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_RESPONSE_STATUS_CODE",
+]);
+
+/**
+ * HTTP statuses worth another attempt. 408/429 are the server ASKING for one;
+ * 5xx is the server failing transiently. Everything else 4xx is a request the
+ * retry cannot change.
+ */
+const TRANSIENT_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+
+/**
+ * Message fragments for transport failures that arrive with NO usable code.
+ * undici surfaces a mid-body socket death as a bare `TypeError: terminated`
+ * whose code lives (if anywhere) on a nested cause — this is the exact string
+ * #470 reported. Kept deliberately SHORT and anchored to whole-ish phrases so it
+ * cannot swallow an integrity message: none of the refusals in download-cache.ts
+ * contain any of these.
+ */
+const TRANSIENT_MESSAGE_FRAGMENTS = [
+  "terminated",
+  "socket hang up",
+  "other side closed",
+  "premature close",
+  "connection closed",
+  "network layer",
+];
+
+export interface FailureClassification {
+  retryable: boolean;
+  /** Why — surfaced in the log line and (on final failure) the error text, so a
+   *  reader can tell "we gave up after N tries" from "we never tried again". */
+  reason: string;
+}
+
+/** Walk an error's `cause` chain collecting every `code` seen. undici nests the
+ *  real `ECONNRESET`/`UND_ERR_SOCKET` one or two levels under a bare TypeError. */
+function codesOf(err: unknown): string[] {
+  const codes: string[] = [];
+  const seen = new Set<unknown>();
+  let cur: unknown = err;
+  while (cur instanceof Error && !seen.has(cur)) {
+    seen.add(cur);
+    const c = (cur as { code?: unknown }).code;
+    if (typeof c === "string") codes.push(c);
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  // A ModelError carries the unwrapped fetch code on `details.code` (fetchOrThrow).
+  const details = (err as { details?: RetryableDetails })?.details;
+  if (details && typeof details.code === "string") codes.push(details.code);
+  return codes;
+}
+
+/** Every message in the cause chain, lower-cased and joined. */
+function messagesOf(err: unknown): string {
+  const parts: string[] = [];
+  const seen = new Set<unknown>();
+  let cur: unknown = err;
+  while (cur instanceof Error && !seen.has(cur)) {
+    seen.add(cur);
+    if (cur.message) parts.push(cur.message);
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  if (parts.length === 0) parts.push(String(err));
+  return parts.join(" | ").toLowerCase();
+}
+
+/**
+ * Decide whether a failed download attempt may be retried IN THE SAME CALL.
+ *
+ * Defaults to `false`. The caller must ALSO have established that the user did
+ * not cancel — this function deliberately does not inspect abort state, because
+ * "the user cancelled" is not a property of the error (an AbortError is raised
+ * by our own stall watchdog too, and THAT one is retryable). Keeping the two
+ * concerns apart is what stops a cancel from being retried into a completion.
+ */
+export function classifyDownloadFailure(err: unknown): FailureClassification {
+  const details = (err as { details?: RetryableDetails })?.details;
+
+  // 1. An explicit contract from the raising code wins over any heuristic — in
+  //    BOTH directions, so a site that knows the partial is poison can veto.
+  if (details && typeof details.retryable === "boolean") {
+    return {
+      retryable: details.retryable,
+      reason: details.retryable
+        ? "the transfer was interrupted mid-stream and the partial file is still resumable"
+        : "the failure is not recoverable by retrying",
+    };
+  }
+
+  // 2. An HTTP status we captured. A DEFINITE non-transient status must LOSE to
+  //    nothing below it: return here either way so a 403's prose ("Forbidden")
+  //    can never fall through to the message-fragment test.
+  const status = typeof details?.status === "number" ? details.status : undefined;
+  if (status !== undefined) {
+    return TRANSIENT_STATUSES.has(status)
+      ? { retryable: true, reason: `the host answered ${status}, which is a transient/back-off status` }
+      : { retryable: false, reason: `the host answered ${status}, which a retry cannot change` };
+  }
+
+  // 3. A transport error code anywhere in the cause chain.
+  for (const code of codesOf(err)) {
+    if (TRANSIENT_CODES.has(code)) {
+      return { retryable: true, reason: `the connection failed with ${code}` };
+    }
+  }
+
+  // 4. Last resort: a transport failure that arrived with no code at all.
+  const message = messagesOf(err);
+  for (const fragment of TRANSIENT_MESSAGE_FRAGMENTS) {
+    if (message.includes(fragment)) {
+      return { retryable: true, reason: `the connection dropped mid-transfer ("${fragment}")` };
+    }
+  }
+
+  return { retryable: false, reason: "the failure is not a recognized transport interruption" };
+}
+
+/**
+ * Tunable retry/stall policy. Defaults are production values; tests override via
+ * {@link setDownloadRetryPolicyForTests} so the suite never actually sleeps.
+ */
+const policy = {
+  /** TOTAL attempts per download (1 = the pre-#470 behavior, no retry). */
+  maxAttempts: 5,
+  /** First backoff delay; doubles each attempt up to `backoffCapMs`. #470 traced
+   *  a 403 to an INSTANT re-request after an abort, so the first wait is real. */
+  backoffBaseMs: 2_000,
+  backoffCapMs: 30_000,
+  /**
+   * How long an attempt may go with ZERO bytes arriving before it is abandoned
+   * and retried (#470's "no growth for ~30 min while still listed in-flight",
+   * and the bounded-attempt half of #817). This is a STALL bound, not a total
+   * bound: a slow-but-alive 20 GB transfer is never interrupted by it, because
+   * every chunk resets the clock. A total-duration cap — the 600s in #817 — is
+   * the wrong shape; it kills healthy large transfers and cannot distinguish
+   * them from wedged ones.
+   */
+  stallTimeoutMs: 120_000,
+};
+
+export type DownloadRetryPolicy = typeof policy;
+
+/** @internal — test hook to shrink retry/stall timings; not part of the tool API. */
+export function setDownloadRetryPolicyForTests(overrides: Partial<DownloadRetryPolicy>): void {
+  Object.assign(policy, overrides);
+}
+
+function hasEnv(name: string): boolean {
+  const raw = process.env[name];
+  return raw !== undefined && raw.trim() !== "";
+}
+
+function envInt(name: string, fallback: number, min: number, max: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    logger.warn(`Ignoring ${name}="${raw}" — not a number; using ${fallback}.`);
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, Math.round(n)));
+}
+
+/** The live policy, with env overrides applied. Read per-download so a setting
+ *  change takes effect without a restart. */
+export function downloadRetryPolicy(): DownloadRetryPolicy {
+  return {
+    // 1 disables retry entirely — an explicit, documented escape hatch.
+    maxAttempts: envInt("COMFYUI_DOWNLOAD_MAX_ATTEMPTS", policy.maxAttempts, 1, 20),
+    backoffBaseMs: policy.backoffBaseMs,
+    backoffCapMs: policy.backoffCapMs,
+    // 0 disables the stall watchdog (the pre-#470 "wait forever" behavior).
+    // The env var is in SECONDS but the policy is in MILLISECONDS, so the
+    // fallback is taken in ms and only a PRESENT env value is scaled — routing
+    // the default through a seconds round-trip would silently floor any
+    // sub-second policy (which is how tests configure a fast watchdog) to zero,
+    // i.e. to "no watchdog at all".
+    stallTimeoutMs: hasEnv("COMFYUI_DOWNLOAD_STALL_TIMEOUT_S")
+      ? envInt("COMFYUI_DOWNLOAD_STALL_TIMEOUT_S", 0, 0, 86_400) * 1000
+      : policy.stallTimeoutMs,
+  };
+}
+
+/** Exponential backoff for `attempt` (1-based: the wait BEFORE attempt 2 is
+ *  `attempt = 1`), capped. Deterministic — the caller adds jitter if it wants
+ *  it; tests assert the schedule exactly. */
+export function backoffDelayMs(attempt: number, p: DownloadRetryPolicy = downloadRetryPolicy()): number {
+  const raw = p.backoffBaseMs * 2 ** Math.max(0, attempt - 1);
+  return Math.min(p.backoffCapMs, raw);
+}
+
+/**
+ * Sleep that wakes EARLY (and rejects) if `signal` aborts. A cancel issued
+ * during a backoff wait must stop the download then and there — not up to 30
+ * seconds later when the timer happens to fire.
+ */
+export function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("The download was cancelled.", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    function onAbort(): void {
+      clearTimeout(timer);
+      reject(new DOMException("The download was cancelled.", "AbortError"));
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/src/services/download-retry.ts
+++ b/src/services/download-retry.ts
@@ -79,17 +79,22 @@ const TRANSIENT_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
  * Message fragments for transport failures that arrive with NO usable code.
  * undici surfaces a mid-body socket death as a bare `TypeError: terminated`
  * whose code lives (if anywhere) on a nested cause — this is the exact string
- * #470 reported. Kept deliberately SHORT and anchored to whole-ish phrases so it
- * cannot swallow an integrity message: none of the refusals in download-cache.ts
- * contain any of these.
+ * #470 reported.
+ *
+ * Kept deliberately SHORT and specific. It must not include the wording of
+ * fetchOrThrow's wrapper ("…failed at the network layer: …"), which is applied
+ * to EVERY thrown fetch — that would make an expired TLS certificate, a bad
+ * proxy, or an aborted request all look transient, i.e. it would invert this
+ * module's fail-safe default for the entire class of fetch failures. Those cases
+ * carry real codes (CERT_HAS_EXPIRED, ENOTFOUND, ECONNRESET, …) and are decided
+ * by the code list above; a fetch failure with NO code and none of these phrases
+ * is not recognised, and therefore not retried.
  */
 const TRANSIENT_MESSAGE_FRAGMENTS = [
   "terminated",
   "socket hang up",
   "other side closed",
   "premature close",
-  "connection closed",
-  "network layer",
 ];
 
 export interface FailureClassification {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -635,8 +635,42 @@ const queueTiming = {
   // counts queued items). Give the worker a grace window to spin up before
   // treating an idle-looking status as "done".
   startupGraceMs: 8000,
+  // Budget for node installs/updates/fixes: bounded by how long `pip install`
+  // and a git clone plausibly take.
   timeoutMs: 600_000,
+  /**
+   * Budget for an `install-model` task (#817). A model download is NOT the same
+   * shape of work as a node install: 600s is a hard guarantee of failure for any
+   * multi-GB file on a normal link (a 15 GB file at 25 MB/s needs 600s just for
+   * the bytes, before any CDN slowness), and #817 is exactly that — the queue
+   * timing out at 600s every time.
+   *
+   * We cannot make the REMOTE transfer resumable — ComfyUI-Manager fetches
+   * server-side and exposes no per-task progress or byte count — so unlike the
+   * local path (#470) there is nothing here to bound an attempt AGAINST. All we
+   * can honestly do is stop declaring failure while the host is still working.
+   * The value is deliberately generous rather than tuned; the timeout's job is to
+   * stop us waiting forever, not to police the download.
+   */
+  modelTimeoutMs: 4 * 60 * 60_000,
 };
+
+/** Per-kind queue budget. Only `install-model` gets the large one — a node
+ *  install that hangs for four hours is a real failure worth reporting. */
+function queueTimeoutFor(kind?: ManagerTaskKind): number {
+  if (kind !== "install-model") return queueTiming.timeoutMs;
+  const raw = process.env.COMFYUI_MANAGER_DOWNLOAD_TIMEOUT_S;
+  if (raw !== undefined && raw.trim() !== "") {
+    const n = Number(raw);
+    if (Number.isFinite(n) && n > 0) {
+      return Math.min(24 * 60 * 60_000, Math.max(60_000, Math.round(n) * 1000));
+    }
+    logger.warn(
+      `Ignoring COMFYUI_MANAGER_DOWNLOAD_TIMEOUT_S="${raw}" — not a positive number of seconds.`,
+    );
+  }
+  return queueTiming.modelTimeoutMs;
+}
 
 /** @internal — test hook to shrink polling timings; not part of the tool API. */
 export function setQueueTimingForTests(
@@ -805,8 +839,15 @@ export async function fetchManagerTaskHistoryEntry(
  * work that is really running — and inviting a caller retry that double-executes
  * it (#646).
  */
-async function runManagerQueue(api: ManagerApi, base: string): Promise<QueueStatus> {
+async function runManagerQueue(
+  api: ManagerApi,
+  base: string,
+  /** Selects the queue budget — a model download gets a far larger one than a
+   *  node install (#817). Omitted ⇒ the node-install budget. */
+  kind?: ManagerTaskKind,
+): Promise<QueueStatus> {
   const prefix = managerQueuePrefixFor(api);
+  const timeoutMs = queueTimeoutFor(kind);
   // queue/start returns 200 (worker started) or 201 (already running) — both
   // are 2xx, so managerFetch accepts either. Same on both generations. Some
   // legacy 3.x builds expose start as GET-only, so negotiate POST→GET on a 405
@@ -815,7 +856,7 @@ async function runManagerQueue(api: ManagerApi, base: string): Promise<QueueStat
 
   const start = Date.now();
   let lastStatus: QueueStatus | undefined;
-  while (Date.now() - start < queueTiming.timeoutMs) {
+  while (Date.now() - start < timeoutMs) {
     await sleep(queueTiming.pollIntervalMs);
     const status = await managerFetch<QueueStatus>(`${prefix}/status`, {
       base,
@@ -834,8 +875,26 @@ async function runManagerQueue(api: ManagerApi, base: string): Promise<QueueStat
       }
     }
   }
+  // TIMED OUT. Be precise about what that does and does NOT mean (#817): we
+  // stopped WAITING; the ComfyUI host's queue worker was never told to stop and,
+  // for a model download, is very likely still streaming. Reporting this as a
+  // plain failure is what led #817's reporter to re-issue — starting a SECOND
+  // server-side fetch of the same file, which is how the destination ended up
+  // truncated and failing safetensors shape checks. There is no Manager API to
+  // recall a queued task, so the only honest remedy is: look, don't re-issue.
   throw new NodeManagementError(
-    `ComfyUI-Manager queue did not finish within ${queueTiming.timeoutMs / 1000}s`,
+    `ComfyUI-Manager queue did not finish within ${Math.round(timeoutMs / 1000)}s. ` +
+      (kind === "install-model"
+        ? `This is the WAIT giving up, NOT proof the download failed — ComfyUI-Manager fetches the file ` +
+          `server-side and there is no API to stop or inspect an individual task, so the host is probably ` +
+          `still downloading. Do NOT re-issue the download: a second server-side fetch writes the SAME ` +
+          `destination file concurrently, and the interleaved result is a corrupt model (that is the ` +
+          `"shape is invalid for input of size N" failure). Instead, wait and check list_local_models on ` +
+          `the connected server until the file appears and its size stops changing. If your files are ` +
+          `genuinely larger than this budget, raise COMFYUI_MANAGER_DOWNLOAD_TIMEOUT_S (seconds), or ` +
+          `download to a LOCAL ComfyUI, where the transfer is streamed here — resumable, retried ` +
+          `automatically, and size-verified before anything is reported as landed.`
+        : `The Manager worker may still be running the task on the host; check its state before retrying.`),
     lastStatus,
   );
 }
@@ -864,7 +923,8 @@ async function queueManagerTask(
     enqueueManagerTask(api, kind, resolve, randomUUID(), base, epoch),
     base,
   );
-  return runManagerQueue(used, base);
+  // Thread the kind so a model download gets the model budget, not the node one (#817).
+  return runManagerQueue(used, base, kind);
 }
 
 /** Params for a Manager task: a fixed body, or a resolver invoked with the

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -324,15 +324,26 @@ function anchorRelativeEntrypointOnBase(base: string, relDir: string): string | 
   // rejected, which is the whole point of corroborating.
   const segments = relDir.split(/[\\/]+/).filter((s) => s !== "" && s !== ".");
   const impliedCwd = resolve(base, ...segments.map(() => ".."));
-  if (samePath(resolve(impliedCwd, relDir), base) && hasComfyUIEntrypoint(base)) {
-    return resolve(base);
-  }
+  const baseIsTheInstall =
+    samePath(resolve(impliedCwd, relDir), base) && hasComfyUIEntrypoint(base);
   // A — base is the outer launcher root; the server is nested under it. (This
   // also covers relDir "." — `resolve(base, ".")` is base — which is how a server
   // launched as plain `python main.py` from inside the install already resolved.)
   const nested = resolve(base, relDir);
-  if (hasComfyUIEntrypoint(nested)) return nested;
-  return undefined;
+  const nestedIsTheInstall = !samePath(nested, base) && hasComfyUIEntrypoint(nested);
+
+  // BOTH readings fit. `<base>/main.py` and `<base>/<relDir>/main.py` both exist,
+  // and the server's relative path is consistent with either — so the evidence
+  // does not say WHICH install is running, and picking one would be a guess about
+  // a destination for multi-gigabyte files. That is exactly the #369 harm (a model
+  // landing in a stale install and being reported a success), so refuse and let
+  // the caller resolve it. Returning undefined routes into the existing refusal,
+  // which names both interpretations.
+  if (baseIsTheInstall && nestedIsTheInstall) return undefined;
+  if (baseIsTheInstall) return resolve(base);
+  if (nestedIsTheInstall) return nested;
+  // relDir "." (or empty): nested IS base, so only the base reading can apply.
+  return hasComfyUIEntrypoint(nested) ? nested : undefined;
 }
 
 export async function resolveModelsDirWithBases(): Promise<{

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -262,15 +262,22 @@ export function parseExtraModelPathsConfigsFromArgvRaw(argv: string[] | undefine
  * configured local base — collected only in LOCAL mode (the guard runs only
  * locally; a remote server's argv paths are on the remote host).
  */
-/** Do two absolute paths name the same directory? Windows and macOS are
- *  case-insensitive and Windows mixes separators, so a server that reports
- *  `comfyui\main.py` against a base of `...\ComfyUI` names the SAME directory. */
+/** Do two absolute paths name the same directory?
+ *
+ *  Case is folded on WINDOWS ONLY. Windows filesystems are case-insensitive
+ *  everywhere, so a server reporting `comfyui\main.py` against a base of
+ *  `...\ComfyUI` genuinely names the same directory. macOS is deliberately NOT
+ *  folded even though HFS+/APFS are case-insensitive by DEFAULT: APFS can be
+ *  formatted case-SENSITIVE, and on such a volume `/x/ComfyUI` and `/x/comfyui`
+ *  are two different installs. This comparison decides whether a download may be
+ *  written to a base, so a wrong "same" is the #369 harm (a model landing in an
+ *  install the running server never reads, reported as a success). Being strict
+ *  costs a case-differing macOS user a refusal they can fix; being lax could cost
+ *  them a silently misplaced multi-gigabyte file. */
 function samePath(a: string, b: string): boolean {
   const norm = (s: string): string => {
     const slashed = resolve(s).replace(/\\/g, "/").replace(/\/+$/, "");
-    return process.platform === "win32" || process.platform === "darwin"
-      ? slashed.toLowerCase()
-      : slashed;
+    return process.platform === "win32" ? slashed.toLowerCase() : slashed;
   };
   return norm(a) === norm(b);
 }

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -262,6 +262,72 @@ export function parseExtraModelPathsConfigsFromArgvRaw(argv: string[] | undefine
  * configured local base — collected only in LOCAL mode (the guard runs only
  * locally; a remote server's argv paths are on the remote host).
  */
+/** Do two absolute paths name the same directory? Windows and macOS are
+ *  case-insensitive and Windows mixes separators, so a server that reports
+ *  `comfyui\main.py` against a base of `...\ComfyUI` names the SAME directory. */
+function samePath(a: string, b: string): boolean {
+  const norm = (s: string): string => {
+    const slashed = resolve(s).replace(/\\/g, "/").replace(/\/+$/, "");
+    return process.platform === "win32" || process.platform === "darwin"
+      ? slashed.toLowerCase()
+      : slashed;
+  };
+  return norm(a) === norm(b);
+}
+
+/**
+ * Corroborate a configured local `base` against the RELATIVE `main.py` path the
+ * running server reported, and return the install root when — and only when —
+ * they agree. Returns undefined when they do not, so the caller refuses rather
+ * than guesses (#369's doctrine: an honest "I don't know where this would land"
+ * beats a fabricated success).
+ *
+ * TWO base conventions coexist in this codebase and BOTH are legitimate (#813):
+ *
+ *   A. `base` is the OUTER launcher root, the server one level down at
+ *      `<base>/<relDir>/main.py`. This is ComfyUI Desktop, whose `<base>` holds
+ *      the launcher's `standalone-env` python rather than the server.
+ *
+ *   B. `base` IS the ComfyUI directory (it holds `main.py` directly), and the
+ *      server's relative `relDir/main.py` is written from base's PARENT. This is
+ *      the classic Windows portable bundle with `COMFYUI_PATH` set to
+ *      `...\ComfyUI_windows_portable\ComfyUI` — the value `get_environment`,
+ *      `list_local_models` and `resolveEffectiveComfyUIBase` all already treat as
+ *      correct. Only this resolver rejected it, so every download refused (#813).
+ *
+ * Order follows the rule `serverRootsUnder` (workspace-env.ts) already
+ * established for exactly this ambiguity, rather than inventing a second
+ * convention: a base that DIRECTLY holds `main.py` IS the server root and wins;
+ * a nested checkout never outranks it (#401).
+ *
+ * Convention B is accepted ONLY on the same evidence convention A demands —
+ * that the server's reported relative path, anchored one level up, names THIS
+ * directory (so `relDir` must match base's own name) AND that `main.py` is
+ * really there. A base whose name does not match `relDir` is NOT corroborated
+ * and is still refused: the server said its script lives at `<something>/ComfyUI/
+ * main.py`, and a base named `ComfyUI-master` is not that, whatever it contains.
+ */
+function anchorRelativeEntrypointOnBase(base: string, relDir: string): string | undefined {
+  // B — base is itself the directory the server named. The evidence is that
+  // `base` ENDS WITH `relDir`'s segments: climb that many levels up from base and
+  // re-anchor; if we land back on base, then some working directory (the one the
+  // server did not report) makes `relDir/main.py` resolve to exactly this install.
+  // Handles multi-segment relDir ("sub/ComfyUI") as well as the reported single
+  // "ComfyUI"; a base whose tail does NOT match relDir lands elsewhere and is
+  // rejected, which is the whole point of corroborating.
+  const segments = relDir.split(/[\\/]+/).filter((s) => s !== "" && s !== ".");
+  const impliedCwd = resolve(base, ...segments.map(() => ".."));
+  if (samePath(resolve(impliedCwd, relDir), base) && hasComfyUIEntrypoint(base)) {
+    return resolve(base);
+  }
+  // A — base is the outer launcher root; the server is nested under it. (This
+  // also covers relDir "." — `resolve(base, ".")` is base — which is how a server
+  // launched as plain `python main.py` from inside the install already resolved.)
+  const nested = resolve(base, relDir);
+  if (hasComfyUIEntrypoint(nested)) return nested;
+  return undefined;
+}
+
 export async function resolveModelsDirWithBases(): Promise<{
   modelsDir: string;
   baseDirs: string[];
@@ -370,15 +436,15 @@ export async function resolveModelsDirWithBases(): Promise<{
     // honest "I don't know where this would land" beats a fabricated success.
     const anchored =
       base && live?.relDir !== undefined && live.source === "unresolved"
-        ? resolve(base, live.relDir)
+        ? anchorRelativeEntrypointOnBase(base, live.relDir)
         : undefined;
-    if (anchored && hasComfyUIEntrypoint(anchored)) {
+    if (anchored) {
       modelsDir = join(anchored, "models");
       source = "base-anchored";
       baseDirs.add(anchored);
       logger.debug(
         "Anchored the live server's relative main.py on the configured base",
-        { modelsDir, relDir: live?.relDir },
+        { modelsDir, relDir: live?.relDir, anchored },
       );
     } else if (snapshot.reachable && !isRemoteMode() && live?.source === "unresolved" && live.relDir !== undefined) {
       throw new ValidationError(
@@ -386,7 +452,11 @@ export async function resolveModelsDirWithBases(): Promise<{
           "download has no verified destination. What could not be determined:\n" +
           `  - the running server reported its launch script as the RELATIVE path "${join(live.relDir, "main.py")}" and did NOT report a working directory, so its install root is unknown;\n` +
           `  - the OS process table did not identify an interpreter for the ComfyUI listening on ${config.resolvedPort} that sits inside an install tree${live.observedPython ? ` (observed "${live.observedPython}")` : ""};\n` +
-          `  - ${base ? `the configured local base "${base}" does not contain "${join(live.relDir, "main.py")}", so it is a DIFFERENT install than the one that is running` : "no COMFYUI_PATH or default workspace is configured"}.\n` +
+          `  - ${
+            base
+              ? `the configured local base "${base}" corroborates neither reading of that path: it does not contain "${join(live.relDir, "main.py")}" (the ComfyUI Desktop / launcher-root shape), and it is not itself "${live.relDir}" holding "main.py" (the portable shape where COMFYUI_PATH already points at the ComfyUI directory) — so it is a DIFFERENT install than the one that is running`
+              : "no COMFYUI_PATH or default workspace is configured"
+          }.\n` +
           "Refusing to write to a guessed directory (that is how a model lands in a stale install and is reported as a success). " +
           "Fix by launching ComfyUI with an ABSOLUTE --base-directory, or set COMFYUI_PATH to the install that is actually running.",
       );

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -11,6 +11,7 @@ import {
   getDownloadJob,
   findDownloadJob,
   listDownloadJobs,
+  listDownloadJobCandidates,
   cancelDownloadJob,
   describePlacement,
   type DownloadJob,
@@ -235,6 +236,10 @@ export function registerModelManagementTools(server: McpServer): void {
         .string()
         .optional()
         .describe("Download id from download_model. Omit to list every tracked download (incl. in-flight ones from before a reconnect)."),
+      tray_id: z
+        .string()
+        .optional()
+        .describe("Disambiguator, shown on every row as `(tray <tray_id>)`. Only needed when two rows share one `id` — two different source URLs downloading to the SAME destination file. Pass it WITH `id` to select exactly one of them."),
       url: z
         .string()
         .url()
@@ -243,7 +248,7 @@ export function registerModelManagementTools(server: McpServer): void {
     },
     async (args) => {
       try {
-        const byId = args.id ? getDownloadJob(args.id) : undefined;
+        const byId = args.id ? getDownloadJob(args.id, args.tray_id) : undefined;
         const byUrl = !byId && args.url ? findDownloadJob({ url: args.url }) : undefined;
         const list =
           args.id || args.url
@@ -251,8 +256,33 @@ export function registerModelManagementTools(server: McpServer): void {
             : listDownloadJobs();
 
         if (list.length === 0) {
+          // #822: an id that answers to SEVERAL downloads resolved to none. That is
+          // not "no such download" — reporting it as one turns "could not determine
+          // which" into a definite (and wrong) verdict, and leaves the caller with
+          // no move. Name the candidates and the exact selector that picks one.
+          const candidates = args.id && !args.tray_id ? listDownloadJobCandidates(args.id) : [];
+          if (candidates.length > 1) {
+            const rows = candidates
+              .map(
+                (c) =>
+                  `  - tray \`${c.trayId}\` — ${c.status}, started ${Math.round((Date.now() - c.started_at) / 1000)}s ago, from: ${c.url}`,
+              )
+              .join("\n");
+            return {
+              content: [
+                {
+                  type: "text",
+                  text:
+                    `The id \`${args.id}\` matches ${candidates.length} DIFFERENT downloads, so it cannot select one. ` +
+                    `That id is derived from the DESTINATION file, and these downloads fetch different source URLs into the same destination:\n${rows}\n\n` +
+                    `Re-run download_status with \`tray_id\` set to the one you mean. ` +
+                    `Note that two of these are writing the SAME file — decide which to keep and cancel_download the other (also by \`tray_id\`).`,
+                },
+              ],
+            };
+          }
           const selector = args.id
-            ? `id \`${args.id}\``
+            ? `id \`${args.id}\`${args.tray_id ? ` + tray \`${args.tray_id}\`` : ""}`
             : args.url
               ? `url \`${args.url}\``
               : "";
@@ -271,6 +301,14 @@ export function registerModelManagementTools(server: McpServer): void {
         // ONE resolution for the whole listing: a verdict made against a
         // DIFFERENT ComfyUI than the one connected now must not be re-asserted (#369).
         const liveModelsDir = await currentLiveModelsRoot();
+        // #822: `id` is derived from the DESTINATION (+auth), so two rows fetching
+        // different URLs into one file legitimately share it. The composite
+        // (id, trayId) is the real handle — render trayId on EVERY row so the
+        // printed handle always identifies exactly one download, and shout when a
+        // listing actually contains a collision (two writers, one file).
+        const idCounts = new Map<string, number>();
+        for (const j of list) idCounts.set(j.id, (idCounts.get(j.id) ?? 0) + 1);
+        const collidingIds = [...idCounts.entries()].filter(([, n]) => n > 1).map(([k]) => k);
         const lines = list.map((j) => {
           const p = readDownloadProgress(j.progressId ?? j.trayId);
           const bytes =
@@ -279,7 +317,10 @@ export function registerModelManagementTools(server: McpServer): void {
               : p && p.downloaded > 0
                 ? `  ${(p.downloaded / 1024 ** 3).toFixed(2)} GB so far`
                 : "";
-          const head = `- \`${j.id}\` **${j.status}**${bytes}`;
+          const head = `- \`${j.id}\` (tray \`${j.trayId}\`) **${j.status}**${bytes}`;
+          const collisionNote = idCounts.get(j.id)! > 1
+            ? `\n    AMBIGUOUS id: another row in this listing shares \`${j.id}\` — these are DIFFERENT source URLs writing the SAME destination file, so the last writer wins and the result may be a mix. Select this one with \`tray_id\`: \`${j.trayId}\`. Pass that same tray_id to cancel_download to stop THIS one specifically.`
+            : "";
           // Same single placement policy the download_model renderer uses (#369):
           // a bare "landed at" is only ever printed for a CONFIRMED placement.
           const placement =
@@ -336,10 +377,14 @@ export function registerModelManagementTools(server: McpServer): void {
                 : "re-downloading in full";
             resumeNote = `\n    resume: ${diag.outcome} — ${fate} because ${why}; ${next}`;
           }
-          return `${head}${detail}${staleNote}${resumeNote}\n    from: ${j.url}`;
+          return `${head}${detail}${collisionNote}${staleNote}${resumeNote}\n    from: ${j.url}`;
         });
 
-        return { content: [{ type: "text", text: `## Downloads\n\n${lines.join("\n")}` }] };
+        const header =
+          collidingIds.length > 0
+            ? `## Downloads\n\nNOTE: ${collidingIds.length} id(s) below name MORE THAN ONE download (same destination file, different source URLs). Use the \`tray_id\` shown on each row — not the id alone — with download_status and cancel_download.\n`
+            : "## Downloads\n";
+        return { content: [{ type: "text", text: `${header}\n${lines.join("\n")}` }] };
       } catch (err) {
         return errorToToolResult(err);
       }
@@ -354,29 +399,44 @@ export function registerModelManagementTools(server: McpServer): void {
         .string()
         .min(1)
         .describe("The download id to cancel (from download_model / download_civitai_model / download_status)."),
+      tray_id: z
+        .string()
+        .optional()
+        .describe("Disambiguator, shown on every download_status row as `(tray <tray_id>)`. Required only when the `id` names more than one download (two different source URLs writing the SAME destination file) — then it selects exactly which one to abort."),
     },
     async (args) => {
       try {
-        const res = cancelDownloadJob(args.id);
+        const res = cancelDownloadJob(args.id, args.tray_id);
         if (!res.found) {
+          const candidates = res.candidates ?? [];
           return {
             content: [
               {
                 type: "text",
-                text: `No download with id \`${args.id}\` to cancel. It may have already finished and been pruned, or the id is wrong — check download_status.`,
+                text: candidates.length > 0
+                  ? `No download with id \`${args.id}\` AND tray \`${args.tray_id}\`. The id is tracked, but its tray ids are: ${candidates.map((c) => `\`${c.trayId}\` (${c.status})`).join(", ")}. Re-check download_status and use one of those.`
+                  : `No download with id \`${args.id}\` to cancel. It may have already finished and been pruned, or the id is wrong — check download_status.`,
               },
             ],
           };
         }
         if (res.ambiguous) {
+          const rows = (res.candidates ?? [])
+            .map(
+              (c) =>
+                `  - tray \`${c.trayId}\` — ${c.status}, started ${Math.round((Date.now() - c.started_at) / 1000)}s ago, from: ${c.url}`,
+            )
+            .join("\n");
           return {
             content: [
               {
                 type: "text",
                 text:
-                  `Refusing to cancel \`${args.id}\`: that id currently denotes MORE than one concurrent download ` +
-                  `(another session is downloading a different source to the same destination). Cancelling by id ` +
-                  `could stop the wrong one. Stop the specific download from the panel download tray instead.`,
+                  `Refusing to cancel \`${args.id}\` on the id alone: it denotes MORE than one download — different source URLs ` +
+                  `writing the SAME destination file, so cancelling by id could stop the wrong one.\n` +
+                  (rows ? `${rows}\n\n` : "\n") +
+                  `Re-run cancel_download with \`tray_id\` set to the one you want stopped. ` +
+                  `(A download owned by a PREVIOUS session still cannot be aborted from here — that one must be stopped from the panel download tray — but it is now selectable, so you can at least confirm which it is with download_status.)`,
               },
             ],
           };

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -239,7 +239,7 @@ export function registerModelManagementTools(server: McpServer): void {
       tray_id: z
         .string()
         .optional()
-        .describe("Disambiguator, shown on every row as `(tray <tray_id>)`. Only needed when two rows share one `id` — two different source URLs downloading to the SAME destination file. Pass it WITH `id` to select exactly one of them."),
+        .describe("Use this when two rows come back with the SAME `id`, so the id alone cannot say which one you mean. That happens when two different source URLs are downloading to the same destination file. Every row prints its own tray id as `(tray <tray_id>)` — pass that here, together with `id`, to report on exactly one of them."),
       url: z
         .string()
         .url()
@@ -402,7 +402,7 @@ export function registerModelManagementTools(server: McpServer): void {
       tray_id: z
         .string()
         .optional()
-        .describe("Disambiguator, shown on every download_status row as `(tray <tray_id>)`. Required only when the `id` names more than one download (two different source URLs writing the SAME destination file) — then it selects exactly which one to abort."),
+        .describe("Use this when a cancel is refused because the `id` names more than one download — two different source URLs writing to the same destination file, so cancelling by id could stop the wrong one. Every download_status row prints its own tray id as `(tray <tray_id>)`; pass the one you want stopped here, together with `id`, and only that download is aborted."),
     },
     async (args) => {
       try {


### PR DESCRIPTION
Closes artokun/comfyui-mcp#470
Closes artokun/comfyui-mcp#817
Closes artokun/comfyui-mcp#813
Closes artokun/comfyui-mcp#822

## #470 — a transfer that survives an interruption

The `.partial` + `.etag` machinery from #343/#467 already made an interrupted download **resumable**; nothing **resumed** it. One CDN drop ended the job with `failed: terminated` and a human had to notice and re-issue.

Added a bounded retry loop that resumes in the same call, plus a **stall watchdog** so a wedged socket is abandoned in seconds rather than sat on for half an hour (#470 watched one do nothing for ~30 minutes). A stall bound is the right shape for a resumable transfer; a total-duration cap — the 600s in #817 — is not, because it kills healthy large transfers and cannot tell them from wedged ones.

**How a resume proves object identity.** It does not skip anything a cold call does. Every attempt re-derives its offset from disk and goes through the same proof: the validator recorded at *write* time replayed as `If-Range`, the content-addressed `X-Linked-Etag` cross-check for cross-origin 206s, strict `Content-Range` parsing, and the recorded-total cross-check. There is no "we already checked" shortcut, and when identity cannot be proven the attempt **restarts** rather than appending. #467's ETag false-positive is not reintroduced: no validator is ever *probed* at resume time.

Classification is **fail-safe** — nothing is retried unless explicitly recognised as a transport interruption. 403/404, the #473 payload rejections and the #343/#467 integrity refusals are never retried; #470 traced a 403 to an instant re-request after an abort, so the backoff is part of the fix. A user cancel is decided by the *signal*, never by the error text.

Also fixed a false failure this introduced: a to-be-retried attempt must not publish a terminal `error` progress row, because the orchestrator treats the first terminal row as the download's **outcome** and wakes the tab's agent with it (#547) — telling an agent a still-running download failed invites the re-issue that creates a second writer.

Tunables: `COMFYUI_DOWNLOAD_MAX_ATTEMPTS` (default 5, 1 disables), `COMFYUI_DOWNLOAD_STALL_TIMEOUT_S` (default 120, 0 disables).

## #817 — the 600s ceiling

`install-model` shared the node-install queue budget, which is a guarantee of failure for any multi-GB file. It now has its own budget (`COMFYUI_MANAGER_DOWNLOAD_TIMEOUT_S`, clamped 60s–24h), and the timeout message is honest: the **wait** gave up, the host is probably still downloading, and re-issuing writes the same destination concurrently — which is how #817's reporter ended up with a truncated model.

## #813 — portable base anchoring

Only the outer-launcher-root reading (`<base>/<relDir>/main.py`, ComfyUI Desktop) was implemented, so a Windows portable install whose `COMFYUI_PATH` is the inner ComfyUI directory had every download refused. Both readings are now accepted, on the **same corroboration**: the server's relative script, anchored one level up, must name that very directory *and* `main.py` must be there. Precedence follows `serverRootsUnder` (#401/#785) rather than a second convention. A base that merely happens to contain `main.py` is still refused, and when **both** layouts exist the evidence does not discriminate — so it refuses rather than guessing where a multi-gigabyte file lands.

## #822 — an identifier that does not identify

`id` hashes the destination, so two source URLs landing on one file share it by design. `download_status` rendered it as a job handle and `cancel_download` accepted only it, so neither of two same-`id` rows could be selected.

The composite `(id, trayId)` already existed internally; it is now exposed. Every status row prints its tray id, a listing containing a collision says so loudly, `download_status(id)` on an ambiguous id **names the candidates** instead of reporting "no download" (which turned "could not determine *which*" into a false "it never started"), and both tools accept `tray_id`. #761's rule is preserved — a dead session's stale record still cannot jam the live download this process owns — and a live foreign transfer is never hidden behind this session's settled row.

## Verification

- 4831 tests pass; `lint`, `build`, `asset-counts --check`, `check:vocabulary`, `vocab:export --check` all green.
- Every fix is **mutation-verified**: the mutant that removes it fails a named test (~25 mutants across 15 rounds). Two exceptions are called out in the commit messages rather than glossed — the cloud-branch pre-write hook and the strict-validator branch are defence in depth whose unique windows are not reachable through the public API; in both cases another check claims the state first, and the *property* is asserted against disk.
- Self-gated with codex (gpt-5.6-terra), 7 rounds. Rounds 1–6 found real defects — several of them regressions this diff introduced — and all were fixed; round 7 returned **PASS** with no P0/P1/P2 findings.

## Known exclusion

Two processes streaming into the *shared* staged file at genuinely overlapping times. Every window the retry loop **adds** is now closed (the backoff, read-decide-then-write, the cloud truncate, the integrity refusals, and unknown ownership in either field — all failing closed). What remains needs write exclusion held for a download's lifetime, applies identically to a single-shot download, and is deliberately deferred rather than half-solved with a lease whose stale-claim and crash-cleanup behaviour (#529's stated objection) could destroy live multi-gigabyte partials.

## Needs live verification

No real large download was performed (the shared ComfyUI on this machine is in use) — all coverage is fixtures. Worth confirming on a real rig: an interrupted multi-GB HF transfer resuming in one call, the stall watchdog on a genuinely wedged CDN socket, a real Windows portable install with `COMFYUI_PATH` set to the inner directory, and the `install-model` budget against a real remote Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)