### PR TITLE
panel version floor: blocked mutations with no self-service path, and "up-to-date" that means "meets the minimum"

### DIFF
--- a/plugin/skills/panel-node-pack-sync/SKILL.md
+++ b/plugin/skills/panel-node-pack-sync/SKILL.md
@@ -52,7 +52,7 @@ pin, shadow copies, dev symlinks, remote/cloud mode, and unreadable versions.
 
 | `decision` | What it means | What you do |
 |---|---|---|
-| `up-to-date` | Panel already meets what the orchestrator needs. | Nothing. Say so in one line, or say nothing at all if the user didn't ask. |
+| `meets-floor` | Panel clears the **minimum** the orchestrator needs. It is **not** a statement that a newer panel does not exist — nothing on this path knows the newest published version, and most panel fixes ship without raising the floor (#806). | Nothing, unless the user is chasing a bug. Say "meets the minimum (X ≥ Y)", never "up to date". If they are debugging, add that a newer panel may carry the fix and that the latest is published in the pack's `pyproject.toml`. |
 | `sync` | Behind, not pinned, nothing ambiguous. | Step 3 — sync it. |
 | `pinned-warn` | Behind, **but pinned**. | Step 4 — warn only. **Do not sync.** |
 | `blocked` | A shadow copy, or a pin we couldn't read. | Step 5 — get it unblocked first. |
@@ -81,7 +81,7 @@ re-reads the pack from disk afterwards. Read the result:
     compared, so whether the mismatch is fixed is **unknown**. Say exactly that.
     `null` is not `false` — never report it as "you're fine".
 - `synced: false` → nothing was changed. `decision` says why (`pinned-warn`,
-  `up-to-date`, `blocked`, …). This is a normal outcome, not a failure.
+  `meets-floor`, `blocked`, …). This is a normal outcome, not a failure.
 - **The tool errored** → the sync FAILED. The error text names the cause
   (ComfyUI-Manager's stale-3.x silent no-op, a shadow copy, an unverifiable
   post-state) and the fix. Relay it. **Never** describe a failed sync as
@@ -177,8 +177,11 @@ pin.
   documented sidebar feature that isn't there.
 - Whenever the user asks to update, pin, or unpin the panel.
 
-Be proportionate: this is a one-line check. If `decision` is `up-to-date` and the
+Be proportionate: this is a one-line check. If `decision` is `meets-floor` and the
 user didn't ask, don't narrate it — just carry on with what they actually wanted.
+The exception is a user who is DEBUGGING the panel: `meets-floor` is exactly the
+state that hides a shipped fix behind an unchanged floor, so there it is worth the
+sentence.
 
 ## Absolute rules
 

--- a/scripts/check-tool-vocabulary.mts
+++ b/scripts/check-tool-vocabulary.mts
@@ -213,6 +213,22 @@ const SPLIT_ALLOWED: Array<{ path: string; context: string; why: string }> = [
     context: 'return "sec_" + name.replace(',
     why: "builds a Mermaid section id from a node title — nothing to do with tool names",
   },
+  {
+    path: "src/__tests__/services/graph-command-effect.test.ts",
+    context: '["graph", "via", "call"].join("_")',
+    why:
+      "NOT a tool name — a synthetic BRIDGE command in a test that proves the graph-effect " +
+      "ledger's runtime probe catches a command whose name is assembled at runtime. The " +
+      "assembly is the thing under test: a literal here would defeat the test's whole point, " +
+      "which is that a literal scan cannot see this and the runtime probe can.",
+  },
+  {
+    path: "src/__tests__/services/graph-command-effect.test.ts",
+    context: '["graph", "via", "bridge"].join("_")',
+    why:
+      "NOT a tool name — same test, the ctx.bridge.send door rather than the ctx.call door. " +
+      "See the entry above.",
+  },
 ];
 
 interface Hit {

--- a/src/__tests__/orchestrator/panel-retry-identity.test.ts
+++ b/src/__tests__/orchestrator/panel-retry-identity.test.ts
@@ -223,6 +223,29 @@ describe("#694 retry_of threading through the tool defs", () => {
     expect(calls[0]).toMatchObject({ cmd: "graph_set_widget", retry_of: "tok-9" });
   });
 
+  // codex gate. The four UI-state tools declare retry_of in their schema and
+  // their description promises dedupe. #778 reclassified their bridge commands
+  // as `inert` for the workflow fence — and withRetryToken used to decide
+  // forwarding with the FENCE predicate, so a caller-supplied token would have
+  // been accepted, validated, and then silently dropped before the wire. A
+  // caller who believes their retry is deduped and is wrong is the exact failure
+  // the token exists to prevent, so forwarding asks the retry map's own question.
+  it.each([
+    ["panel_select_nodes", "graph_select_nodes", { node_ids: [1, 2] }],
+    ["panel_enter_subgraph", "graph_enter_subgraph", { node_id: 3 }],
+    ["panel_exit_subgraph", "graph_exit_subgraph", {}],
+    ["panel_copy_nodes", "graph_copy_nodes", { node_ids: [1] }],
+  ])("%s forwards a caller-supplied retry_of even though its cmd is inert", async (
+    tool,
+    cmd,
+    args,
+  ) => {
+    expect(requiresWorkflowStampEnforcement({ cmd })).toBe(false); // inert since #778
+    const { ctx, calls } = makeRecordingCtx();
+    await defByName(tool).handler({ ...args, retry_of: "tok-ui" }, ctx);
+    expect(calls[0]).toMatchObject({ cmd, retry_of: "tok-ui" });
+  });
+
   it("no retry_of arg → the cmd bag carries no retry_of key at all", async () => {
     const { ctx, calls } = makeRecordingCtx();
     await defByName("panel_set_widget").handler({ node_id: 1, widget: "steps", value: 5 }, ctx);

--- a/src/__tests__/orchestrator/panel-retry-identity.test.ts
+++ b/src/__tests__/orchestrator/panel-retry-identity.test.ts
@@ -264,17 +264,52 @@ describe("#694 retry_of threading through the tool defs", () => {
   });
 });
 
+/** The four commands RETRY_TOKEN_CMD_BY_TOOL admits that the workflow fence does
+ *  NOT gate: they change only selection / subgraph scope / clipboard, and doing
+ *  so twice is doing so once. */
+const IDEMPOTENT_UI_STATE_CMDS = new Set([
+  "graph_select_nodes",
+  "graph_enter_subgraph",
+  "graph_exit_subgraph",
+  "graph_copy_nodes",
+]);
+
 describe("#694 retry_of schema surface", () => {
+  it("(f) no DATA-RETURNING read is in the retry map (a ledger answer would be stale)", () => {
+    // The invariant the assertion below used to protect only as a side effect.
+    // A read's retry can be answered from the dedupe ledger with the outcome of
+    // the FIRST call, so a read in this map would hand the agent stale data.
+    const mapped = new Set(Object.values(RETRY_TOKEN_CMD_BY_TOOL));
+    for (const readCmd of [
+      "graph_find_nodes",
+      "graph_list_subgraphs",
+      "graph_screenshot",
+      "graph_canvas",
+      "graph_outline",
+      "graph_query",
+      "graph_get_state",
+      "graph_serialize",
+    ]) {
+      expect(mapped.has(readCmd), `${readCmd} must not be in the retry map`).toBe(false);
+    }
+  });
+
   it("(f) every tool in RETRY_TOKEN_CMD_BY_TOOL accepts an OPTIONAL retry_of", () => {
     const defs = buildPanelToolDefs();
     for (const [name, cmd] of Object.entries(RETRY_TOKEN_CMD_BY_TOOL)) {
       const d = defs.find((x) => x.name === name);
       expect(d, `${name} exists in buildPanelToolDefs()`).toBeTruthy();
-      // The map's cmd really is in the #694 mutation surface (graph_* outside
-      // BRIDGE_READONLY_CMDS, or one of the four workflow mutators).
+      // The map's cmd really is in the #694 mutation surface: either the bridge
+      // fences it to a workflow, or it is one of the four UI-state commands the
+      // map admits on purpose (see RETRY_TOKEN_CMD_BY_TOOL's own doc — they
+      // change selection / scope / clipboard idempotently, so a deduped retry is
+      // a no-op). Those four used to satisfy requiresWorkflowStampEnforcement
+      // only BY ACCIDENT: it classified every graph command outside
+      // BRIDGE_READONLY_CMDS as a canvas mutation, which is the #778 defect
+      // itself. Naming them makes the map's real membership rule visible.
       expect(
-        requiresWorkflowStampEnforcement({ cmd }),
-        `${name} → ${cmd} is a mutating bridge command`,
+        requiresWorkflowStampEnforcement({ cmd }) || IDEMPOTENT_UI_STATE_CMDS.has(cmd),
+        `${name} → ${cmd} is fenced, or an admitted idempotent UI-state command`,
       ).toBe(true);
       const field = d!.schema.retry_of as z.ZodOptional<z.ZodString> | undefined;
       expect(field, `${name} schema carries retry_of`).toBeDefined();

--- a/src/__tests__/services/graph-command-effect.test.ts
+++ b/src/__tests__/services/graph-command-effect.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  GRAPH_CMD_EFFECT,
+  isMutatingGraphCommand,
+  requiresWorkflowStampEnforcement,
+  BRIDGE_READONLY_CMDS,
+} from "../../services/ui-bridge.js";
+
+/**
+ * #778 — a READ blocked by a WRITE gate, and the reason it could happen at all.
+ *
+ * The #570 workflow fence asks "can this command apply to the wrong workflow's
+ * content?" and used to answer it with `!BRIDGE_READONLY_CMDS.has(cmd)` — a set
+ * that exists to answer a DIFFERENT question ("is this safe to re-dispatch after
+ * a reconnect?"). Every graph command that is a genuine read but not idempotently
+ * re-dispatchable, and every view/selection/scope change, fell through the crack:
+ * `graph_find_nodes` was the one a user reported, and it was not alone.
+ *
+ * These tests hold two properties:
+ *
+ *  1. COMPLETENESS — every `graph_*` command the orchestrator actually dispatches
+ *     has an explicit entry in GRAPH_CMD_EFFECT. Without this the fail-closed
+ *     default silently classifies a new read as a write, which is exactly how
+ *     #778 shipped: nothing failed, the command just stopped working on older
+ *     panels.
+ *  2. CORRECTNESS — the classification each command has is the intended one, and
+ *     the gate agrees with it.
+ */
+
+const HERE = fileURLToPath(new URL(".", import.meta.url));
+const SRC = join(HERE, "..", "..");
+
+/** Every `cmd: "graph_…"` literal in the orchestrator's non-test sources. */
+function dispatchedGraphCommands(): Set<string> {
+  const found = new Set<string>();
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      if (entry === "__tests__" || entry === "node_modules") continue;
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!full.endsWith(".ts")) continue;
+      const src = readFileSync(full, "utf8");
+      for (const m of src.matchAll(/cmd:\s*"(graph_[a-z0-9_]+)"/g)) found.add(m[1]);
+    }
+  };
+  walk(SRC);
+  return found;
+}
+
+describe("GRAPH_CMD_EFFECT — the ledger is complete", () => {
+  it("finds the graph commands at all (guards the scanner itself)", () => {
+    const dispatched = dispatchedGraphCommands();
+    // A scanner that silently matched nothing would make the completeness test
+    // below vacuously green — the failure mode this whole file exists to prevent.
+    expect(dispatched.size).toBeGreaterThan(30);
+    expect(dispatched.has("graph_set_widget")).toBe(true);
+    expect(dispatched.has("graph_find_nodes")).toBe(true);
+  });
+
+  it("classifies EVERY graph_* command the orchestrator dispatches", () => {
+    const unclassified = [...dispatchedGraphCommands()]
+      .filter((cmd) => GRAPH_CMD_EFFECT[cmd] === undefined)
+      .sort();
+    // If this fails you added a graph_* command without deciding what it does to
+    // the user's workflow. It is currently being treated as a WRITE by omission,
+    // which blocks it on every panel below the fence version — add it to
+    // GRAPH_CMD_EFFECT in src/services/ui-bridge.ts.
+    expect(unclassified).toEqual([]);
+  });
+
+  it("classifies nothing it does not dispatch (no stale ledger entries)", () => {
+    const dispatched = dispatchedGraphCommands();
+    const stale = Object.keys(GRAPH_CMD_EFFECT)
+      .filter((cmd) => !dispatched.has(cmd))
+      .sort();
+    expect(stale).toEqual([]);
+  });
+});
+
+describe("GRAPH_CMD_EFFECT — the classification is the intended one", () => {
+  // The commands #778 and its unreported siblings are about. Each is a read, or
+  // changes only what the user is LOOKING AT / has selected / has on the
+  // clipboard. None can alter workflow content, so fencing them to a workflow
+  // buys nothing and refusing them on an old panel only removes read access.
+  const INERT = [
+    "graph_find_nodes", // #778, the reported instance
+    "graph_list_subgraphs",
+    "graph_screenshot",
+    "graph_canvas",
+    "graph_select_nodes",
+    "graph_enter_subgraph", // #823 hit this one
+    "graph_exit_subgraph",
+    "graph_copy_nodes",
+    "graph_outline",
+    "graph_query",
+    "graph_get_state",
+    "graph_serialize",
+  ] as const;
+
+  it.each(INERT)("%s is inert and is NOT gated by the workflow fence", (cmd) => {
+    expect(GRAPH_CMD_EFFECT[cmd]).toBe("inert");
+    expect(isMutatingGraphCommand(cmd)).toBe(false);
+    expect(requiresWorkflowStampEnforcement({ cmd })).toBe(false);
+  });
+
+  // The gate must not have been loosened into uselessness while fixing #778.
+  const TARGETED = [
+    "graph_set_widget", // #812
+    "graph_add_node", // #812
+    "graph_remove_node",
+    "graph_clear",
+    "graph_load",
+    "graph_paste_nodes",
+    "graph_save_subgraph",
+    "graph_run",
+  ] as const;
+
+  it.each(TARGETED)("%s is targeted and IS gated by the workflow fence", (cmd) => {
+    expect(GRAPH_CMD_EFFECT[cmd]).toBe("targeted");
+    expect(isMutatingGraphCommand(cmd)).toBe(true);
+    expect(requiresWorkflowStampEnforcement({ cmd })).toBe(true);
+  });
+
+  it("an UNKNOWN graph command still fails closed", () => {
+    // The ledger removes the SILENT default; it must not remove the default.
+    expect(GRAPH_CMD_EFFECT.graph_not_a_real_command).toBeUndefined();
+    expect(isMutatingGraphCommand("graph_not_a_real_command")).toBe(true);
+    expect(requiresWorkflowStampEnforcement({ cmd: "graph_not_a_real_command" })).toBe(true);
+  });
+
+  it("a non-graph command is not swept into the graph gate", () => {
+    expect(isMutatingGraphCommand("workflow_save")).toBe(false);
+    expect(isMutatingGraphCommand("ui_toast")).toBe(false);
+  });
+});
+
+describe("GRAPH_CMD_EFFECT vs BRIDGE_READONLY_CMDS — two questions, two answers", () => {
+  it("every graph command in the re-dispatch-safe set is also inert", () => {
+    // One direction only. A command safe to RE-DISPATCH must be harmless, so it
+    // must be inert. The converse is deliberately false — see graph_canvas.
+    for (const cmd of BRIDGE_READONLY_CMDS) {
+      if (!cmd.startsWith("graph_")) continue;
+      expect(GRAPH_CMD_EFFECT[cmd]).toBe("inert");
+    }
+  });
+
+  it("graph_canvas is inert for the fence but NOT re-dispatch-safe", () => {
+    // The concrete case that proves the two sets answer different questions, and
+    // the reason collapsing them was wrong in both directions: `pan` is a dx/dy
+    // DELTA, so parking it across a reconnect and replaying it pans twice — yet
+    // it cannot touch workflow content, so gating it as a canvas mutation was
+    // just as wrong.
+    expect(GRAPH_CMD_EFFECT.graph_canvas).toBe("inert");
+    expect(BRIDGE_READONLY_CMDS.has("graph_canvas")).toBe(false);
+  });
+});

--- a/src/__tests__/services/graph-command-effect.test.ts
+++ b/src/__tests__/services/graph-command-effect.test.ts
@@ -95,8 +95,22 @@ function graphCommandLiteralsInSource(): Set<string> {
  * the literal scan rather than replacing it: between them, evading both means
  * neither writing the name down nor dispatching it.
  */
-function dispatchedGraphCommandsAtRuntime(): { cmds: Set<string>; toolsThatDispatched: number } {
+async function dispatchedGraphCommandsAtRuntime(
+  // Injectable so the probe's own observation points can be tested against
+  // handlers that deliberately evade them, rather than only against the tool
+  // surface as it happens to be written today.
+  defs: ReturnType<typeof buildPanelToolDefs> = buildPanelToolDefs(),
+): Promise<{
+  cmds: Set<string>;
+  toolsThatDispatched: number;
+  /** Per tool, what it had dispatched BY THE TIME ITS HANDLER RETURNED. Snapshot,
+   *  not a live view: a handler that dispatches only after an await contributes
+   *  nothing here unless the probe actually waited for it, which is what makes
+   *  the await observable to a test. */
+  byTool: Record<string, string[]>;
+}> {
   const cmds = new Set<string>();
+  const byTool: Record<string, string[]> = {};
   let toolsThatDispatched = 0;
   // Plausible values for the common required params, so more handlers get past
   // their own guards and reach a dispatch. Anything still unhappy just throws
@@ -134,19 +148,34 @@ function dispatchedGraphCommandsAtRuntime(): { cmds: Set<string>; toolsThatDispa
     collapsed: true,
     force: true,
   };
-  for (const def of buildPanelToolDefs()) {
+  for (const def of defs) {
     let dispatched = false;
+    const seenThisTool = new Set<string>();
+    // BOTH doors. Handlers reach the panel through `ctx.call` OR directly
+    // through `ctx.bridge.send` — panel_screenshot does the latter — and a probe
+    // watching only the first would let a command dispatched the other way slip
+    // past every layer of this file.
+    const observe = (cmd: unknown): void => {
+      const name = (cmd as { cmd?: unknown } | undefined)?.cmd;
+      if (typeof name !== "string") return;
+      if (name.startsWith("graph_")) {
+        cmds.add(name);
+        seenThisTool.add(name);
+      }
+      dispatched = true;
+    };
     const ctx = {
       call: async (cmd: Record<string, unknown>) => {
-        if (typeof cmd.cmd === "string") {
-          if (cmd.cmd.startsWith("graph_")) cmds.add(cmd.cmd);
-          dispatched = true;
-        }
+        observe(cmd);
         return { content: [{ type: "text", text: "{}" }] };
       },
       confirm: async () => "yes" as const,
       bridge: {
-        send: async () => ({}),
+        send: async (cmd: unknown) => {
+          observe(cmd);
+          // Shaped enough for the direct-send callers to get a little further.
+          return { image: "", mimeType: "image/png" };
+        },
         push: () => 1,
         canReach: () => true,
         isHeadless: () => false,
@@ -157,15 +186,18 @@ function dispatchedGraphCommandsAtRuntime(): { cmds: Set<string>; toolsThatDispa
       ensureReachable: () => {},
     } as unknown as Parameters<ReturnType<typeof buildPanelToolDefs>[number]["handler"]>[1];
     try {
-      // Handlers are async; a rejection is as uninteresting as a throw here.
-      const r = def.handler({ ...ARGS }, ctx) as unknown as Promise<unknown>;
-      if (r && typeof (r as Promise<unknown>).catch === "function") void r.catch(() => {});
+      // AWAITED. Several handlers dispatch only AFTER an await — panel_clear
+      // waits on its confirmation before sending graph_clear — so a probe that
+      // fires and forgets never observes those dispatches at all.
+      await def.handler({ ...ARGS }, ctx);
     } catch {
       /* this handler needs more than synthetic args — the literal scan covers it */
     }
+    // Snapshot TAKEN HERE, immediately after the handler resolved.
+    byTool[def.name] = [...seenThisTool].sort();
     if (dispatched) toolsThatDispatched += 1;
   }
-  return { cmds, toolsThatDispatched };
+  return { cmds, toolsThatDispatched, byTool };
 }
 
 describe("GRAPH_CMD_EFFECT — the ledger is complete", () => {
@@ -189,25 +221,76 @@ describe("GRAPH_CMD_EFFECT — the ledger is complete", () => {
     expect(unclassified).toEqual([]);
   });
 
-  it("classifies every graph_* command the REAL tool surface dispatches (spelling-independent)", () => {
+  it("classifies every graph_* command the REAL tool surface dispatches (spelling-independent)", async () => {
     // The source scan is evadable by construction — it reads text. This one
     // watches the commands actually routed by `buildPanelToolDefs()`'s handlers,
     // so a helper, an alias table, or a computed name cannot slip past it.
-    const { cmds, toolsThatDispatched } = dispatchedGraphCommandsAtRuntime();
+    const { cmds, toolsThatDispatched, byTool } = await dispatchedGraphCommandsAtRuntime();
     // Guard the guard: a probe that drove nothing would pass vacuously.
     expect(toolsThatDispatched).toBeGreaterThan(20);
     expect(cmds.size).toBeGreaterThan(20);
     expect(cmds.has("graph_set_widget")).toBe(true);
+    // The two dispatch shapes the probe must cover, asserted through the
+    // per-tool SNAPSHOT so each observation point is load-bearing:
+    //  - panel_screenshot dispatches through `ctx.bridge.send`, not `ctx.call`,
+    //    so it fails if the probe watches only one door;
+    //  - panel_clear dispatches only AFTER an awaited confirmation, so its
+    //    snapshot is empty unless the probe actually waited for the handler.
+    expect(byTool.panel_screenshot).toContain("graph_screenshot");
+    expect(byTool.panel_clear).toContain("graph_clear");
     expect([...cmds].filter((c) => GRAPH_CMD_EFFECT[c] === undefined).sort()).toEqual([]);
   });
 
-  it("driving the real tool surface classifies nothing by FALLBACK", () => {
+  it("the probe catches an evasion the literal scan CANNOT — via ctx.call and via bridge.send", async () => {
+    // The claim layers 2 and 3 exist to support, made durable instead of being a
+    // mutation someone ran once. Two synthetic tools dispatch commands whose
+    // names are assembled at runtime, so no literal exists to scan for — one
+    // through each door, and one of them only after an await.
+    const evasive = [
+      {
+        name: "evil_via_call",
+        description: "",
+        schema: {},
+        handler: async (_a: Record<string, unknown>, ctx: { call: (c: Record<string, unknown>) => Promise<unknown> }) => {
+          await ctx.call({ cmd: ["graph", "via", "call"].join("_") });
+          return { content: [] };
+        },
+      },
+      {
+        name: "evil_via_bridge",
+        description: "",
+        schema: {},
+        handler: async (
+          _a: Record<string, unknown>,
+          ctx: { bridge: { send: (c: Record<string, unknown>) => Promise<unknown> } },
+        ) => {
+          await ctx.bridge.send({ cmd: ["graph", "via", "bridge"].join("_") });
+          return { content: [] };
+        },
+      },
+    ] as unknown as ReturnType<typeof buildPanelToolDefs>;
+
+    // Layer 1 is blind to both: the names exist nowhere as literals.
+    const literals = graphCommandLiteralsInSource();
+    expect(literals.has("graph_via_call")).toBe(false);
+    expect(literals.has("graph_via_bridge")).toBe(false);
+
+    // Layer 2 sees both.
+    const { cmds } = await dispatchedGraphCommandsAtRuntime(evasive);
+    expect([...cmds].sort()).toEqual(["graph_via_bridge", "graph_via_call"]);
+    expect([...cmds].filter((c) => GRAPH_CMD_EFFECT[c] === undefined).sort()).toEqual([
+      "graph_via_bridge",
+      "graph_via_call",
+    ]);
+  });
+
+  it("driving the real tool surface classifies nothing by FALLBACK", async () => {
     // The assertion that needs no scanner at all. `isMutatingGraphCommand`
     // records every command it had to classify by default, at the point of use —
     // an observation taken from the command being ROUTED, which no spelling can
     // dodge. After exercising the surface, that record must be empty.
     __resetUnclassifiedGraphCommands();
-    const { cmds } = dispatchedGraphCommandsAtRuntime();
+    const { cmds } = await dispatchedGraphCommandsAtRuntime();
     for (const cmd of cmds) requiresWorkflowStampEnforcement({ cmd });
     expect([...unclassifiedGraphCommandsSeen()].sort()).toEqual([]);
   });

--- a/src/__tests__/services/graph-command-effect.test.ts
+++ b/src/__tests__/services/graph-command-effect.test.ts
@@ -9,8 +9,12 @@ import {
   requiredPanelVersion,
   requiredPanelVersionForWorkflowFence,
   BRIDGE_CAPABILITY_MIN_PANEL_VERSION,
+  BRIDGE_CMD_MIN_PANEL_VERSION,
+  MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS,
+  SEMVER_RE,
   BRIDGE_READONLY_CMDS,
 } from "../../services/ui-bridge.js";
+import { compareSemver } from "../../services/self-update.js";
 
 /**
  * #778 — a READ blocked by a WRITE gate, and the reason it could happen at all.
@@ -161,6 +165,52 @@ describe("GRAPH_CMD_EFFECT vs BRIDGE_READONLY_CMDS — two questions, two answer
     // just as wrong.
     expect(GRAPH_CMD_EFFECT.graph_canvas).toBe("inert");
     expect(BRIDGE_READONLY_CMDS.has("graph_canvas")).toBe(false);
+  });
+});
+
+describe("the version tables are source, so a broken one is a BUILD failure", () => {
+  // codex gate. The two consumers of these tables degrade DIFFERENTLY on a
+  // malformed entry, and must: `requiredPanelVersion()` skips it (a sync floor
+  // that fabricates a requirement from a typo would be worse than one that is a
+  // little low), while `requiredPanelVersionForWorkflowFence()` refuses to
+  // answer at all (a write refusal must not quote a number it cannot justify).
+  // Those are the right individual behaviours, and together they can disagree —
+  // the sync could call a panel `meets-floor` while the write gate says its
+  // requirement is unknowable.
+  //
+  // The resolution is NOT to make one degrade like the other: these tables are
+  // hand-written CONSTANTS in this repo, not runtime input, so the state that
+  // produces the disagreement is a developer typo, and the place to stop a typo
+  // is the build. These assertions turn it into a failing test; the defensive
+  // handling in both functions stays as the belt to this braces.
+  it.each([
+    ["BRIDGE_CMD_MIN_PANEL_VERSION", BRIDGE_CMD_MIN_PANEL_VERSION],
+    ["BRIDGE_CAPABILITY_MIN_PANEL_VERSION", BRIDGE_CAPABILITY_MIN_PANEL_VERSION],
+  ])("every %s entry is a parseable version", (_name, table) => {
+    const bad = Object.entries(table).filter(([, v]) => typeof v !== "string" || !SEMVER_RE.test(v.trim()));
+    expect(bad).toEqual([]);
+  });
+
+  it("the baseline itself parses", () => {
+    expect(SEMVER_RE.test(MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS.trim())).toBe(true);
+  });
+
+  it("BOTH workflow-fence capabilities are present — the write gate needs both", () => {
+    // Deleting either would leave requiredPanelVersionForWorkflowFence() unable
+    // to answer while requiredPanelVersion() still produced a number, which is
+    // exactly the "nothing needed" / "writes refused" contradiction.
+    expect(BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_workflow_stamp).toBeTypeOf("string");
+    expect(BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_workflow_stamp_at_write).toBeTypeOf("string");
+    expect(requiredPanelVersionForWorkflowFence()).toBeTypeOf("string");
+  });
+
+  it("the sync floor is never BELOW the fence floor", () => {
+    // The sync's aggregate is a max that includes both fence capabilities, so it
+    // can only ever be >= the fence's own maximum. If that ever inverted, a
+    // `meets-floor` verdict could stand while graph writes were refused.
+    const fence = requiredPanelVersionForWorkflowFence();
+    expect(fence).toBeDefined();
+    expect(compareSemver(requiredPanelVersion(), fence as string)).toBeGreaterThanOrEqual(0);
   });
 });
 

--- a/src/__tests__/services/graph-command-effect.test.ts
+++ b/src/__tests__/services/graph-command-effect.test.ts
@@ -13,8 +13,11 @@ import {
   MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS,
   SEMVER_RE,
   BRIDGE_READONLY_CMDS,
+  unclassifiedGraphCommandsSeen,
+  __resetUnclassifiedGraphCommands,
 } from "../../services/ui-bridge.js";
 import { compareSemver } from "../../services/self-update.js";
+import { buildPanelToolDefs } from "../../orchestrator/panel-tools.js";
 
 /**
  * #778 — a READ blocked by a WRITE gate, and the reason it could happen at all.
@@ -40,8 +43,29 @@ import { compareSemver } from "../../services/self-update.js";
 const HERE = fileURLToPath(new URL(".", import.meta.url));
 const SRC = join(HERE, "..", "..");
 
-/** Every `cmd: "graph_…"` literal in the orchestrator's non-test sources. */
-function dispatchedGraphCommands(): Set<string> {
+/**
+ * Every `"graph_…"` string LITERAL in the orchestrator's non-test sources, with
+ * comments stripped first.
+ *
+ * Deliberately widened from the original `cmd: "graph_…"` property match. That
+ * pattern only recognised one spelling, so a command routed through a helper, an
+ * alias table, or `ctx.call({ cmd })` walked around the completeness check AND
+ * the stale-entry check with the suite still green — a guard a rename can step
+ * over, which is the thing this codebase keeps relearning. Matching any literal
+ * means evading it now requires never writing the name down at all — assembling
+ * it from fragments at runtime — and the runtime probe below closes that.
+ * (The tool-vocabulary gate rejects an assembled name for the same reason, and
+ * it reads comments too: writing the illustrative fragment out here tripped it.)
+ *
+ * Comments are stripped because prose legitimately names commands while
+ * discussing them, and a scanner that cannot tell code from commentary would
+ * either miss real entries or invent fake ones.
+ */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+function graphCommandLiteralsInSource(): Set<string> {
   const found = new Set<string>();
   const walk = (dir: string): void => {
     for (const entry of readdirSync(dir)) {
@@ -52,17 +76,101 @@ function dispatchedGraphCommands(): Set<string> {
         continue;
       }
       if (!full.endsWith(".ts")) continue;
-      const src = readFileSync(full, "utf8");
-      for (const m of src.matchAll(/cmd:\s*"(graph_[a-z0-9_]+)"/g)) found.add(m[1]);
+      const src = stripComments(readFileSync(full, "utf8"));
+      for (const m of src.matchAll(/"(graph_[a-z0-9_]+)"/g)) found.add(m[1]);
     }
   };
   walk(SRC);
   return found;
 }
 
+/**
+ * Every `graph_*` command the real tool surface actually DISPATCHES, observed by
+ * driving each panel tool handler and recording what reaches `ctx.call`.
+ *
+ * This is the half a source scan cannot do. It sees the command as ROUTED, so a
+ * helper, an alias, or a computed name is caught regardless of how it is
+ * spelled. It is also necessarily partial — a handler that throws on synthetic
+ * args before dispatching contributes nothing — which is why it stands ALONGSIDE
+ * the literal scan rather than replacing it: between them, evading both means
+ * neither writing the name down nor dispatching it.
+ */
+function dispatchedGraphCommandsAtRuntime(): { cmds: Set<string>; toolsThatDispatched: number } {
+  const cmds = new Set<string>();
+  let toolsThatDispatched = 0;
+  // Plausible values for the common required params, so more handlers get past
+  // their own guards and reach a dispatch. Anything still unhappy just throws
+  // and is skipped.
+  const ARGS: Record<string, unknown> = {
+    node_id: 1,
+    node_ids: [1, 2],
+    id: 1,
+    node: "PreviewImage",
+    type: "PreviewImage",
+    widget: "steps",
+    value: 1,
+    name: "x",
+    title: "x",
+    text: "x",
+    query: "x",
+    group: 1,
+    from_node: 1,
+    to_node: 1,
+    from_slot: 0,
+    to_slot: 0,
+    input: "image",
+    output: "IMAGE",
+    action: "fit",
+    mode: "active",
+    pos: [0, 0],
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+    scale: 1,
+    color: "#fff",
+    preset: "red",
+    path: "workflows/x.json",
+    collapsed: true,
+    force: true,
+  };
+  for (const def of buildPanelToolDefs()) {
+    let dispatched = false;
+    const ctx = {
+      call: async (cmd: Record<string, unknown>) => {
+        if (typeof cmd.cmd === "string") {
+          if (cmd.cmd.startsWith("graph_")) cmds.add(cmd.cmd);
+          dispatched = true;
+        }
+        return { content: [{ type: "text", text: "{}" }] };
+      },
+      confirm: async () => "yes" as const,
+      bridge: {
+        send: async () => ({}),
+        push: () => 1,
+        canReach: () => true,
+        isHeadless: () => false,
+        tabs: () => [{ tab_id: "tab-1", title: "t", connected_at: 0 }],
+        resolveActiveTabId: () => "tab-1",
+      },
+      tabId: "tab-1",
+      ensureReachable: () => {},
+    } as unknown as Parameters<ReturnType<typeof buildPanelToolDefs>[number]["handler"]>[1];
+    try {
+      // Handlers are async; a rejection is as uninteresting as a throw here.
+      const r = def.handler({ ...ARGS }, ctx) as unknown as Promise<unknown>;
+      if (r && typeof (r as Promise<unknown>).catch === "function") void r.catch(() => {});
+    } catch {
+      /* this handler needs more than synthetic args — the literal scan covers it */
+    }
+    if (dispatched) toolsThatDispatched += 1;
+  }
+  return { cmds, toolsThatDispatched };
+}
+
 describe("GRAPH_CMD_EFFECT — the ledger is complete", () => {
   it("finds the graph commands at all (guards the scanner itself)", () => {
-    const dispatched = dispatchedGraphCommands();
+    const dispatched = graphCommandLiteralsInSource();
     // A scanner that silently matched nothing would make the completeness test
     // below vacuously green — the failure mode this whole file exists to prevent.
     expect(dispatched.size).toBeGreaterThan(30);
@@ -70,8 +178,8 @@ describe("GRAPH_CMD_EFFECT — the ledger is complete", () => {
     expect(dispatched.has("graph_find_nodes")).toBe(true);
   });
 
-  it("classifies EVERY graph_* command the orchestrator dispatches", () => {
-    const unclassified = [...dispatchedGraphCommands()]
+  it("classifies EVERY graph_* command named anywhere in the orchestrator's source", () => {
+    const unclassified = [...graphCommandLiteralsInSource()]
       .filter((cmd) => GRAPH_CMD_EFFECT[cmd] === undefined)
       .sort();
     // If this fails you added a graph_* command without deciding what it does to
@@ -81,8 +189,47 @@ describe("GRAPH_CMD_EFFECT — the ledger is complete", () => {
     expect(unclassified).toEqual([]);
   });
 
+  it("classifies every graph_* command the REAL tool surface dispatches (spelling-independent)", () => {
+    // The source scan is evadable by construction — it reads text. This one
+    // watches the commands actually routed by `buildPanelToolDefs()`'s handlers,
+    // so a helper, an alias table, or a computed name cannot slip past it.
+    const { cmds, toolsThatDispatched } = dispatchedGraphCommandsAtRuntime();
+    // Guard the guard: a probe that drove nothing would pass vacuously.
+    expect(toolsThatDispatched).toBeGreaterThan(20);
+    expect(cmds.size).toBeGreaterThan(20);
+    expect(cmds.has("graph_set_widget")).toBe(true);
+    expect([...cmds].filter((c) => GRAPH_CMD_EFFECT[c] === undefined).sort()).toEqual([]);
+  });
+
+  it("driving the real tool surface classifies nothing by FALLBACK", () => {
+    // The assertion that needs no scanner at all. `isMutatingGraphCommand`
+    // records every command it had to classify by default, at the point of use —
+    // an observation taken from the command being ROUTED, which no spelling can
+    // dodge. After exercising the surface, that record must be empty.
+    __resetUnclassifiedGraphCommands();
+    const { cmds } = dispatchedGraphCommandsAtRuntime();
+    for (const cmd of cmds) requiresWorkflowStampEnforcement({ cmd });
+    expect([...unclassifiedGraphCommandsSeen()].sort()).toEqual([]);
+  });
+
+  it("an unclassified command IS recorded, so the fallback is never silent", () => {
+    // The negative control for the test above: without this, "the record is
+    // empty" would also be true of a recorder that never records.
+    __resetUnclassifiedGraphCommands();
+    expect(requiresWorkflowStampEnforcement({ cmd: "graph_some_new_command" })).toBe(true);
+    expect([...unclassifiedGraphCommandsSeen()]).toEqual(["graph_some_new_command"]);
+    // Recorded once, not once per dispatch.
+    requiresWorkflowStampEnforcement({ cmd: "graph_some_new_command" });
+    expect([...unclassifiedGraphCommandsSeen()]).toEqual(["graph_some_new_command"]);
+    // A CLASSIFIED command never lands in the record.
+    requiresWorkflowStampEnforcement({ cmd: "graph_set_widget" });
+    requiresWorkflowStampEnforcement({ cmd: "graph_find_nodes" });
+    expect([...unclassifiedGraphCommandsSeen()]).toEqual(["graph_some_new_command"]);
+    __resetUnclassifiedGraphCommands();
+  });
+
   it("classifies nothing it does not dispatch (no stale ledger entries)", () => {
-    const dispatched = dispatchedGraphCommands();
+    const dispatched = graphCommandLiteralsInSource();
     const stale = Object.keys(GRAPH_CMD_EFFECT)
       .filter((cmd) => !dispatched.has(cmd))
       .sort();

--- a/src/__tests__/services/graph-command-effect.test.ts
+++ b/src/__tests__/services/graph-command-effect.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -6,6 +6,9 @@ import {
   GRAPH_CMD_EFFECT,
   isMutatingGraphCommand,
   requiresWorkflowStampEnforcement,
+  requiredPanelVersion,
+  requiredPanelVersionForWorkflowFence,
+  BRIDGE_CAPABILITY_MIN_PANEL_VERSION,
   BRIDGE_READONLY_CMDS,
 } from "../../services/ui-bridge.js";
 
@@ -158,5 +161,46 @@ describe("GRAPH_CMD_EFFECT vs BRIDGE_READONLY_CMDS — two questions, two answer
     // just as wrong.
     expect(GRAPH_CMD_EFFECT.graph_canvas).toBe("inert");
     expect(BRIDGE_READONLY_CMDS.has("graph_canvas")).toBe(false);
+  });
+});
+
+describe("requiredPanelVersionForWorkflowFence — the fence's own minimum", () => {
+  // `Readonly<Record<…>>` is a compile-time claim; the runtime object is a plain
+  // mutable one, and this is the only way to exercise a broken table.
+  const table = BRIDGE_CAPABILITY_MIN_PANEL_VERSION as Record<string, string | undefined>;
+  const original = { ...table };
+  afterEach(() => {
+    for (const k of Object.keys(table)) delete table[k];
+    Object.assign(table, original);
+  });
+
+  it("is the MAXIMUM of the two fence capabilities, not the global aggregate", () => {
+    expect(requiredPanelVersionForWorkflowFence()).toBe("0.11.35");
+    // Today the two coincide. Prove the SEPARATION rather than the coincidence:
+    // raise an unrelated command's minimum and only the aggregate must move.
+    table.some_unrelated_future_capability = "9.9.9";
+    expect(requiredPanelVersion()).toBe("9.9.9");
+    expect(requiredPanelVersionForWorkflowFence()).toBe("0.11.35");
+  });
+
+  it.each([
+    ["a MISSING entry", () => delete table.enforces_workflow_stamp_at_write],
+    ["a MALFORMED entry", () => (table.enforces_workflow_stamp_at_write = "nightly")],
+    ["BOTH entries gone", () => {
+      delete table.enforces_workflow_stamp;
+      delete table.enforces_workflow_stamp_at_write;
+    }],
+  ])("quotes NO version on %s, and does not throw", (_label, breakIt) => {
+    breakIt();
+    // Not the bridge baseline (0.11.4) — that would assert "the first build that
+    // fences every command" about a build that does no such thing. Not the
+    // surviving entry either — that would UNDERSTATE the requirement and send a
+    // user to an update that still leaves them refused (#812's loop).
+    expect(requiredPanelVersionForWorkflowFence()).toBeUndefined();
+  });
+
+  it("a whitespace-padded but valid entry resolves, TRIMMED (it is rendered to a user)", () => {
+    table.enforces_workflow_stamp_at_write = " 0.11.40 ";
+    expect(requiredPanelVersionForWorkflowFence()).toBe("0.11.40");
   });
 });

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -391,16 +391,37 @@ describe("ensurePanelInstalled policy matrix", () => {
     expect(h.installs).toEqual([]); // never re-installs a present panel
   });
 
-  it("present → up-to-date (no churn on load, no install call)", async () => {
+  it("present → present (no churn on load, no install call)", async () => {
     const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
     const h = makeDeps({
       comfyuiPath: COMFY,
       files: { [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "1.0.0") },
     });
     const res = await ensurePanelInstalled({ deps: h.deps });
-    expect(res.action).toBe("up-to-date");
+    expect(res.action).toBe("present");
     expect(res.installedVersion).toBe("1.0.0");
     expect(h.installs).toEqual([]);
+  });
+
+  // #806 — the on-load ensure NEVER compares versions (it is install-if-missing),
+  // so its verdict may not carry a currency word. The user in #806 read
+  // `{"action":"up-to-date","installedVersion":"0.11.36"}` as "you are on the
+  // latest panel" while 0.11.38 was published with the fix for the bug he was
+  // chasing. Assert the CLAIM, not just the branch: the old name is gone and the
+  // result says what it actually established.
+  it("the present verdict never claims currency, and says what it did check", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.36") },
+    });
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).not.toBe("up-to-date");
+    expect(JSON.stringify(res)).not.toContain("up-to-date");
+    expect(res.reason).toMatch(/does not compare versions/i);
+    expect(res.reason).toMatch(/not a statement that the panel is current/i);
+    // And it names a next step that moves someone who IS behind.
+    expect(res.reason).toContain("install_panel(action='update')");
   });
 
   it("dev symlink → skipped-dev (never touches it)", async () => {

--- a/src/__tests__/services/panel-recovery-cluster.test.ts
+++ b/src/__tests__/services/panel-recovery-cluster.test.ts
@@ -377,10 +377,19 @@ describe("recovery guidance depends on the session, not on a hardcoded string", 
     expect(text).toMatch(/ON THE COMFYUI HOST/);
     expect(text).toMatch(/REMOTE ComfyUI/);
     expect(text).toContain(PANEL_REPO_URL);
-    // Both install shapes are covered, because the user cannot be asked to
+    // ALL THREE on-disk states are covered, because the user cannot be asked to
     // diagnose which one they have before they can act.
-    expect(text).toMatch(/pull --ff-only/);
-    expect(text).toMatch(/no \.git/);
+    expect(text).toMatch(/pull --ff-only/); // (1) git checkout
+    expect(text).toMatch(/NO \.git/); // (2) Comfy Registry zip install
+    // (3) #819 — the pack is NOT THERE. A stale ComfyUI-Manager 3.x reports its
+    // queue drained without creating it, so a user who believes they installed
+    // the panel can have an empty custom_nodes. `git -C <dir> pull` and
+    // `mv <dir> …` both fail in that state, which left cases (1) and (2) as no
+    // instruction at all. A plain clone is the command that moves them.
+    expect(text).toMatch(/NOT PRESENT/);
+    expect(text).toMatch(
+      new RegExp(`git clone --depth 1 ${PANEL_REPO_URL.replace(/[.]/g, "\\.")} comfyui-agent-panel`),
+    );
   });
 
   it("CLOUD: same, and says why (no custom_nodes to write)", () => {

--- a/src/__tests__/services/panel-recovery-cluster.test.ts
+++ b/src/__tests__/services/panel-recovery-cluster.test.ts
@@ -386,7 +386,7 @@ describe("recovery guidance depends on the session, not on a hardcoded string", 
     // the panel can have an empty custom_nodes. `git -C <dir> pull` and
     // `mv <dir> …` both fail in that state, which left cases (1) and (2) as no
     // instruction at all. A plain clone is the command that moves them.
-    expect(text).toMatch(/NOT PRESENT/);
+    expect(text).toMatch(/NEITHER/);
     expect(text).toMatch(
       new RegExp(`git clone --depth 1 ${PANEL_REPO_URL.replace(/[.]/g, "\\.")} comfyui-agent-panel`),
     );
@@ -447,6 +447,28 @@ describe("disk-current but handshake-old is diagnosed as a stale tab, not a stal
     // Crucially it does not send them round the loop again.
     expect(text).not.toMatch(/Run install_panel\(action:'update'\)/);
     expect(text).not.toContain(PANEL_REPO_URL);
+  });
+
+  it("the manual instructions recognise BOTH accepted panel directory names", async () => {
+    // A plain `git clone` of the repo lands in comfyui-mcp-panel; the Registry
+    // installs comfyui-agent-panel. The installer accepts both. Guidance that
+    // judged "not present" by the Registry name alone told a repo-checkout user
+    // to clone a SECOND serving copy into custom_nodes — manufacturing the
+    // two-panels-racing state (#641) that the same paragraph warns about.
+    const { FAST_PATH_DIRS } = await import("../../services/panel-installer.js");
+    const { PANEL_DIR_NAMES, manualPanelUpdateCommands } = await import(
+      "../../services/panel-recovery.js"
+    );
+    expect([...PANEL_DIR_NAMES].sort()).toEqual([...FAST_PATH_DIRS].sort());
+
+    const text = manualPanelUpdateCommands("/home/u/ComfyUI");
+    for (const dir of FAST_PATH_DIRS) expect(text).toContain(dir);
+    // The absent-case is gated on BOTH being missing, and the danger of running
+    // it otherwise is stated rather than left to be discovered.
+    expect(text).toMatch(/NEITHER .* is present/);
+    expect(text).toMatch(/Do NOT run case \(3\) while one of them exists under the other name/);
+    // The in-place cases no longer hardcode one name.
+    expect(text).toMatch(/git -C <panel-dir> pull --ff-only/);
   });
 
   it("handles the 'version unknown' handshake from #784 WITHOUT asserting the cause", () => {

--- a/src/__tests__/services/panel-recovery-cluster.test.ts
+++ b/src/__tests__/services/panel-recovery-cluster.test.ts
@@ -449,10 +449,32 @@ describe("disk-current but handshake-old is diagnosed as a stale tab, not a stal
     expect(text).not.toContain(PANEL_REPO_URL);
   });
 
-  it("handles the 'version unknown' handshake from #784", () => {
+  it("handles the 'version unknown' handshake from #784 WITHOUT asserting the cause", () => {
+    // codex gate. With no advertised version, "your tab is running a cached old
+    // bundle" is an inference, not an observation — a relay or other non-panel
+    // client that never implemented the fence is observationally identical, and
+    // "hard-refresh your tab" is unactionable for it. What IS proven is that the
+    // pack on disk is capable, so no update helps; the causes are RANKED, most
+    // likely and most actionable first, with the other named rather than hidden.
     const text = describePanelUpdateRecovery(undefined, SKEW);
     expect(text).toMatch(/advertised no version/);
-    expect(text).toMatch(/HARD-REFRESH/);
+    expect(text).toMatch(/Updating the panel will not fix this/); // the proven part
+    expect(text).not.toMatch(/This BROWSER TAB is running an older cached copy/); // the unproven part
+    expect(text).toMatch(/does not by itself say why/);
+    expect(text).toMatch(/\(1\) It is a ComfyUI browser tab/);
+    expect(text).toMatch(/HARD-REFRESH/); // still leads with the actionable fix
+    expect(text).toMatch(/\(2\) It is NOT a panel tab/);
+    expect(text).toMatch(/nothing to refresh/);
+  });
+
+  it("an ADVERTISED old version is still a definite diagnosis", () => {
+    // The other side of the same coin: a version below the floor IS positive
+    // proof of a tab/disk skew (both the version and the capability are built by
+    // the same served file), so hedging there would be its own failure.
+    const text = describePanelUpdateRecovery(undefined, { ...SKEW, handshakeVersion: "0.11.34" });
+    expect(text).toMatch(/Do NOT update the panel/);
+    expect(text).toMatch(/This BROWSER TAB is running an older cached copy/);
+    expect(text).not.toMatch(/does not by itself say why/);
   });
 
   it("the skew branch outranks remote mode — and still never names an uncallable tool", () => {
@@ -460,7 +482,7 @@ describe("disk-current but handshake-old is diagnosed as a stale tab, not a stal
     mode.remote = true;
     __resetPanelBaseCache();
     const text = describePanelUpdateRecovery(undefined, SKEW);
-    expect(text).toMatch(/Do NOT update the panel/);
+    expect(text).toMatch(/Updating the panel will not fix this/);
     expect(text).not.toMatch(/ON THE COMFYUI HOST/);
     // Even the closing aside must not mention a tool that is not callable in
     // this session.

--- a/src/__tests__/services/panel-recovery-cluster.test.ts
+++ b/src/__tests__/services/panel-recovery-cluster.test.ts
@@ -462,10 +462,13 @@ describe("disk-current but handshake-old is diagnosed as a stale tab, not a stal
     const text = describePanelUpdateRecovery(undefined, SKEW);
     expect(text).toMatch(/Do NOT update the panel/);
     expect(text).not.toMatch(/ON THE COMFYUI HOST/);
-    // Even the closing "it would report nothing to do" aside must not mention a
-    // tool that is not callable in this session.
+    // Even the closing aside must not mention a tool that is not callable in
+    // this session.
     expect(text).not.toMatch(/install_panel/);
-    expect(text).toMatch(/No update of any kind will help/);
+    expect(text).toMatch(/No update of any kind fixes this/);
+    // No trailing period: the bridge appends its own sentence break, and one
+    // here rendered ".." to the user (codex gate).
+    expect(text.endsWith(".")).toBe(false);
   });
 
   it("without a skew, the ordinary update guidance is unchanged", async () => {

--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -161,17 +161,42 @@ describe("evaluatePanelSync — the four required outcomes", () => {
     ).toBe("sync");
   });
 
-  it("versions equal → up-to-date (no-op)", () => {
+  it("versions equal → meets-floor (no-op)", () => {
     const a = evaluatePanelSync(status({ installedVersion: REQUIRED }), {
       requiredVersion: REQUIRED,
       orchestratorVersion: ORCH,
     });
-    expect(a.decision).toBe("up-to-date");
+    expect(a.decision).toBe("meets-floor");
     expect(a.behind).toBe(false);
   });
 
-  it("installed NEWER than required → up-to-date, never a downgrade", () => {
-    expect(decide({ installedVersion: "0.12.0" })).toBe("up-to-date");
+  it("installed NEWER than required → meets-floor, never a downgrade", () => {
+    expect(decide({ installedVersion: "0.12.0" })).toBe("meets-floor");
+  });
+
+  // #806 — the whole cluster's headline defect. This branch compares against the
+  // orchestrator's MINIMUM and nothing else; the newest published panel is not
+  // known here at all. Reporting that as "up-to-date" told a user two versions
+  // behind the fix for his own bug that there was nothing to get.
+  it("clearing the floor is never reported as being current", () => {
+    const a = evaluatePanelSync(status({ installedVersion: "0.11.36" }), {
+      requiredVersion: REQUIRED,
+      orchestratorVersion: ORCH,
+    });
+    expect(a.decision).toBe("meets-floor");
+    // The verdict value itself must not carry the currency claim...
+    expect(a.decision).not.toBe("up-to-date");
+    // ...and neither may the prose the user actually reads.
+    expect(a.summary).not.toMatch(/up-to-date|already current|latest version/i);
+    // It names BOTH numbers, says what kind of check it was, and admits its limit.
+    expect(a.summary).toContain("0.11.36");
+    expect(a.summary).toContain(REQUIRED);
+    expect(a.summary).toMatch(/FLOOR check, not a latest-version check/);
+    expect(a.summary).toMatch(/most panel fixes ship WITHOUT raising the floor/);
+    // And points at where the real latest lives: the pack's pyproject, NOT the
+    // repo's GitHub releases (the panel publishes on a pyproject version change).
+    expect(a.summary).toContain("pyproject.toml");
+    expect(a.summary).not.toMatch(/\/releases/);
   });
 });
 
@@ -187,9 +212,24 @@ describe("evaluatePanelSync — a pin is honoured in every shape", () => {
     expect(a.summary).toContain("COMFYUI_MCP_PANEL_PIN");
   });
 
-  it("a pin while already current is simply up-to-date (no nagging)", () => {
+  it("a pin while already at the floor is simply meets-floor (no nagging)", () => {
     const pin: PanelPinState = { pinned: true, version: REQUIRED, source: "settings" };
-    expect(decide({ installedVersion: REQUIRED, pin })).toBe("up-to-date");
+    expect(decide({ installedVersion: REQUIRED, pin })).toBe("meets-floor");
+  });
+
+  // #806, pinned variant. The honesty is owed here too — but the step that moves
+  // a PINNED user is clearing the pin, not install_panel(action='update'), which
+  // this state would refuse. Naming the wrong one is the dead-end shape again.
+  it("a pinned floor-clearing panel is told the floor is not the latest, and to unpin first", () => {
+    const pin: PanelPinState = { pinned: true, version: REQUIRED, source: "settings" };
+    const a = evaluatePanelSync(status({ installedVersion: REQUIRED, pin }), {
+      requiredVersion: REQUIRED,
+      orchestratorVersion: ORCH,
+    });
+    expect(a.summary).toMatch(/FLOOR check, not a latest-version check/);
+    expect(a.summary).toContain("pyproject.toml");
+    expect(a.summary).toMatch(/clear the pin/i);
+    expect(a.summary).not.toContain("install_panel(action='update')");
   });
 
   it("a pin blocks even a FRESH install of a missing panel", () => {
@@ -438,11 +478,11 @@ describe("performPanelSync", () => {
     expect(r.verifiedVersion).toBe(REQUIRED);
   });
 
-  it("no-ops without touching anything when already current", async () => {
+  it("no-ops without touching anything when the floor is already met", async () => {
     const h = makeDeps({ installedVersion: REQUIRED });
     const r = await performPanelSync({ deps: h.deps, ...RUN });
     expect(r.synced).toBe(false);
-    expect(r.decision).toBe("up-to-date");
+    expect(r.decision).toBe("meets-floor");
     expect(h.updates).toBe(0);
   });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2435,6 +2435,34 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     sock.close();
   });
 
+  it("a BLANK panel_version is disclosed as unreadable, never rendered as a reported version", async () => {
+    // codex gate. `panel_version: "   "` is a non-empty string, so the
+    // connection records it as advertised — but it says nothing. Untrimmed, the
+    // refusal read "this tab reports panel    " while the skew resolver, which
+    // does trim, simultaneously treated the tab as having advertised no version:
+    // one message, two readings of one field.
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      sock.on("open", () => {
+        sock.send(
+          JSON.stringify({ type: "hello", tab_id: "tmp:blankver", title: "w", panel_version: "   " }),
+        );
+        res();
+      });
+      sock.on("error", rej);
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:blankver")).toBe(true));
+    const err = await bridge
+      .send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "tmp:blankver" })
+      .then(() => null)
+      .catch((e: Error) => e);
+    const msg = (err as Error).message;
+    expect(msg).not.toMatch(/reports panel\s*[;.)]/); // no empty "reports panel" claim
+    expect(msg).not.toMatch(/reports panel {2}/);
+    expect(msg).toMatch(/advertised NO panel version/);
+    sock.close();
+  });
+
   it("quotes NO fence version when this build's capability table cannot state one", async () => {
     // codex gate. The refusal is still correct — the panel did not advertise the
     // fence — but the DIAGNOSIS must not invent a number. Falling back to the

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2011,6 +2011,47 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     }
   });
 
+  it("a CAPABLE disk plus NO advertised version ranks the causes instead of asserting one", async () => {
+    // codex gate, and the exact combination the other new tests miss: the pack on
+    // disk clears the fence floor AND the hello carried no panel_version. "Your
+    // browser tab is running a cached old bundle" is then an inference — a relay
+    // or other non-panel client that never implemented the fence looks identical
+    // from here, and telling it to hard-refresh a tab it does not have is the
+    // dead end this cluster is about.
+    writeTempPanelPack("0.11.38");
+    try {
+      const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+      await new Promise<void>((res, rej) => {
+        sock.on("open", () => {
+          sock.send(JSON.stringify({ type: "hello", tab_id: "no-version-capable", title: "wf" }));
+          res();
+        });
+        sock.on("error", rej);
+      });
+      await vi.waitFor(() =>
+        expect(bridge.tabs().some((t) => t.tab_id === "no-version-capable")).toBe(true),
+      );
+      const err = await bridge
+        .send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "no-version-capable" })
+        .catch((e: Error) => e);
+      const msg = (err as Error).message;
+      // The PROVEN part is still stated plainly, and still spares them the update.
+      expect(msg).toMatch(/Updating the panel will not fix this/);
+      expect(msg).toMatch(/already 0\.11\.38/);
+      expect(msg).not.toMatch(/Run install_panel\(action:'update'\)/);
+      // The UNPROVEN part is not asserted...
+      expect(msg).not.toMatch(/This BROWSER TAB is running an older cached copy/);
+      // ...it is ranked, actionable case first, the other named rather than hidden.
+      expect(msg).toMatch(/\(1\) It is a ComfyUI browser tab/);
+      expect(msg).toMatch(/HARD-REFRESH/);
+      expect(msg).toMatch(/\(2\) It is NOT a panel tab/);
+      expect(msg).not.toMatch(/[A-Za-z)"']\.\./);
+      sock.close();
+    } finally {
+      clearPanelDiskObservation();
+    }
+  });
+
   it("#709: the capability refusal carries the typed marker, the FULL tab id, and the hard-refresh recovery", async () => {
     // The stale-bundle recurrence: on-disk panel current, browser tab still running a
     // cached pre-#570 bundle. The refusal must (a) be typed so the tool layer never

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -18,6 +18,8 @@ import {
   isMutatingGraphCommand,
   requiresWorkflowStampEnforcement,
   BRIDGE_CAPABILITY_MIN_PANEL_VERSION,
+  unclassifiedGraphCommandsSeen,
+  __resetUnclassifiedGraphCommands,
 } from "../../services/ui-bridge.js";
 import { carryWorkflowCommandStamp } from "../../orchestrator/session-store.js";
 import {
@@ -2535,6 +2537,38 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     }
   });
 
+  it("an UNCLASSIFIED graph command routed through the bridge is fenced AND recorded", async () => {
+    // Layer 3, exercised through the DISPATCH PATH rather than by calling the
+    // classifier directly — the gap the independent gate flagged in the earlier
+    // evidence. A command with no ledger entry, arriving at the real bridge:
+    // it must still fail closed (fenced as a write) AND leave a record, so the
+    // fallback is never a silent default however the command got here.
+    __resetUnclassifiedGraphCommands();
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      sock.on("open", () => {
+        sock.send(JSON.stringify({ type: "hello", tab_id: "tmp:unclassified", title: "w" }));
+        res();
+      });
+      sock.on("error", rej);
+    });
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tmp:unclassified")).toBe(true),
+    );
+    const err = await bridge
+      .send({ cmd: "graph_brand_new_unclassified" } as never, { tabId: "tmp:unclassified" })
+      .then(() => null)
+      .catch((e: Error) => e);
+    // Fenced, for the stated reason — not merely rejected.
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/does not enforce per-command workflow targeting/i);
+    expect(dispatchOutcomeOf(err as Error)).toBe(false); // nothing was written
+    // And recorded, so the ledger gap is visible.
+    expect([...unclassifiedGraphCommandsSeen()]).toContain("graph_brand_new_unclassified");
+    __resetUnclassifiedGraphCommands();
+    sock.close();
+  });
+
   it("quotes NO fence version when this build's capability table cannot state one", async () => {
     // codex gate. The refusal is still correct — the panel did not advertise the
     // fence — but the DIAGNOSIS must not invent a number. Falling back to the
@@ -2773,12 +2807,24 @@ describe("makeUnknownCommandError (old-panel version gate)", () => {
   // (compareSemver returns 0 both for "equal" and "unparseable"). Without the
   // parse screen, `panel_version: "dev"` would compare as 0 (>= 0 → "supported")
   // and wrongly leak the raw error / skip the #236 learning path.
-  it("treats an unparseable advertised version as NOT proven new enough (still too old)", () => {
+  it("treats an unparseable advertised version as NOT proven new enough (still rewritten)", () => {
     for (const bad of ["dev", "unknown", "latest", ""]) {
       const e = makeUnknownCommandError('Unknown command "graph_outline"', bad);
+      // The point of this test is that the rewrite still FIRES — an unparseable
+      // version must never be mistaken for new-enough.
       expect(e).not.toBeNull();
-      expect(e?.message.toLowerCase()).toContain("too old");
+      expect(e?.message.toLowerCase()).toContain('does not implement "graph_outline"');
+      expect(e?.message).toContain("0.4.6"); // the true minimum is still quoted
+      // But it must not claim an AGE it never observed. "too old" is a verdict
+      // that needs a version that parsed and compared below the minimum; the one
+      // observed fact here is the panel's own "Unknown command" reply.
+      expect(e?.message.toLowerCase()).not.toContain("too old");
     }
+    // And the unparseable text is shown as EVIDENCE, quoted, never as a version.
+    const nightly = makeUnknownCommandError('Unknown command "graph_outline"', "nightly");
+    expect(nightly?.message).toContain('this panel reports "nightly"');
+    expect(nightly?.message).toContain("not a comparable version");
+    expect(nightly?.message).not.toContain("detected panel nightly");
   });
 
   // A MALFORMED version that merely PREFIXES a valid semver (e.g. `0.11.28.1`,
@@ -2802,7 +2848,11 @@ describe("makeUnknownCommandError (old-panel version gate)", () => {
     ]) {
       const e = makeUnknownCommandError('Unknown command "graph_outline"', bad);
       expect(e).not.toBeNull();
-      expect(e?.message.toLowerCase()).toContain("too old");
+      // Rewritten (not mistaken for new-enough), and — as above — no age verdict
+      // from a string that failed the screen.
+      expect(e?.message.toLowerCase()).toContain('does not implement "graph_outline"');
+      expect(e?.message.toLowerCase()).not.toContain("too old");
+      expect(e?.message).toContain(`this panel reports "${bad}"`);
     }
     // And it is symmetric on the proactive gate: a malformed version can't PROVE
     // unsupported either, so it is never proactively blocked (fail-open to reactive).

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1928,6 +1928,17 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
       expect((err as Error).message).toMatch(/0\.11\.38/);
       // It must NOT send them back to the tool that will report nothing to do.
       expect((err as Error).message).not.toMatch(/Run install_panel\(action:'update'\)/);
+      // …and it must not claim the update would report nothing to do: since #806
+      // an update CAN pull a newer panel. What it cannot do is replace the JS an
+      // open tab is running, which is what this branch is actually about.
+      expect((err as Error).message).not.toMatch(/report nothing to do/);
+      expect((err as Error).message).toMatch(/no update replaces the JavaScript an open tab/);
+      // READ AS A HUMAN WOULD: the recovery is concatenated into a wrapper that
+      // appends its own sentence break, and a trailing period here rendered
+      // "the install is not the problem.. Reads and view-only commands…"
+      // (codex gate). Anchored on a word character so the legitimate "../" in
+      // the host-side commands cannot false-positive.
+      expect((err as Error).message).not.toMatch(/[A-Za-z)"']\.\./);
       // The gate itself still refused the write — the diagnosis changed, not the gate.
       expect(isCapabilityRefusal(err as Error)).toBe(true);
       stale.close();
@@ -1962,6 +1973,40 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
       expect((err as Error).message).toMatch(/install_panel\(action:'update'\)|ON THE COMFYUI HOST/);
       behind.close();
     } finally {
+      clearPanelDiskObservation();
+    }
+  });
+
+  it("the stale-bundle proof uses the FENCE's floor, not the aggregate requirement", async () => {
+    // codex gate. resolveStaleBundleSkew answers "is the INSTALL sufficient for
+    // the write that was just refused?" — a fence question. Answering it with
+    // requiredPanelVersion(), the max across every command and capability this
+    // build knows, denies the positive proof for an install that IS sufficient
+    // the moment anything unrelated raises the aggregate, and sends a user whose
+    // only problem is a cached tab off to update.
+    const table = BRIDGE_CAPABILITY_MIN_PANEL_VERSION as Record<string, string | undefined>;
+    writeTempPanelPack("0.11.35"); // exactly the fence floor, well under the aggregate below
+    table.some_unrelated_future_capability = "9.9.9";
+    try {
+      const stale = new WebSocket(`ws://127.0.0.1:${port}`);
+      await new Promise<void>((res, rej) => {
+        stale.on("open", () => {
+          stale.send(
+            JSON.stringify({ type: "hello", tab_id: "fence-floor", title: "wf", panel_version: "0.11.34" }),
+          );
+          res();
+        });
+        stale.on("error", rej);
+      });
+      await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "fence-floor")).toBe(true));
+      const err = await bridge
+        .send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "fence-floor" })
+        .catch((e: Error) => e);
+      expect((err as Error).message).toMatch(/Do NOT update the panel/);
+      expect((err as Error).message).toMatch(/already 0\.11\.35/);
+      stale.close();
+    } finally {
+      delete table.some_unrelated_future_capability;
       clearPanelDiskObservation();
     }
   });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1889,7 +1889,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "old-skew")).toBe(true));
     await expect(
       bridge.send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "old-skew" }),
-    ).rejects.toThrow(/detected panel 0\.11\.0.*requires panel 0\.11\.35\+.*install_panel\(action:'update'\).*restart ComfyUI.*rebinding cannot/i);
+    ).rejects.toThrow(/reports panel 0\.11\.0.*needs panel 0\.11\.35\+.*install_panel\(action:'update'\).*restart ComfyUI.*rebinding cannot/i);
     old.close();
   });
 
@@ -2181,6 +2181,130 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     await settle();
     const msg = seen.find((e) => e.type === "user_message" && e.text === "after-close");
     expect(msg?.tab_id).toBe("phone-c"); // reverted to own tab, not routed into the dead id
+  });
+
+  // ---------------------------------------------------------------------------
+  // The panel-version-floor cluster (#778 / #819 / #812 / #823).
+  //
+  // Placed at the END of this describe on purpose: a capability refusal whose
+  // on-disk panel version cannot be read kicks off a background primePanelBase()
+  // that this file's afterEach cannot await, and a late resolution lands in
+  // whichever test is running when it settles. Sitting last, these cannot
+  // perturb the stale-bundle tests above, which seed a base synchronously.
+  // ---------------------------------------------------------------------------
+
+  it("#778: a non-enforcing panel still gets its READS and view-only commands", async () => {
+    // The reported bug and its unreported siblings. Each of these was refused as
+    // "a canvas mutation" on any panel below the fence version, purely because it
+    // was missing from BRIDGE_READONLY_CMDS — a set about RE-DISPATCH SAFETY, not
+    // about what the command does. Assert they are DISPATCHED (the socket saw
+    // them), not merely that no error was thrown.
+    const old = new WebSocket(`ws://127.0.0.1:${port}`);
+    const sawOnSocket: string[] = [];
+    await new Promise<void>((res, rej) => {
+      old.on("open", () => {
+        old.send(JSON.stringify({ type: "hello", tab_id: "tmp:old778", title: "old" })); // no fence flags
+        res();
+      });
+      old.on("error", rej);
+    });
+    old.on("message", (buf) => {
+      const m = JSON.parse(buf.toString());
+      if (m.rid && m.cmd) {
+        sawOnSocket.push(m.cmd);
+        old.send(JSON.stringify({ rid: m.rid, ok: true, result: {} }));
+      }
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:old778")).toBe(true));
+
+    const reads = [
+      "graph_find_nodes",
+      "graph_list_subgraphs",
+      "graph_screenshot",
+      "graph_canvas",
+      "graph_select_nodes",
+      "graph_enter_subgraph",
+      "graph_exit_subgraph",
+      "graph_copy_nodes",
+    ];
+    for (const cmd of reads) {
+      await expect(bridge.send({ cmd } as never, { tabId: "tmp:old778" })).resolves.toBeTruthy();
+    }
+    expect(sawOnSocket).toEqual(reads);
+
+    // And the gate is still a gate: the write the same session wanted (#812) is
+    // refused, and refused FOR THE STATED REASON — not merely refused.
+    await expect(
+      bridge.send({ cmd: "graph_set_widget", node_id: 1 } as never, { tabId: "tmp:old778" }),
+    ).rejects.toThrow(/does not enforce per-command workflow targeting/i);
+    expect(sawOnSocket).toEqual(reads); // nothing extra reached the socket
+    old.close();
+  });
+
+  it("#819/#823: an unadvertised panel version is reported as unobserved, not as old", async () => {
+    const old = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      old.on("open", () => {
+        // No panel_version in the hello — exactly #819's "panel version unknown".
+        old.send(JSON.stringify({ type: "hello", tab_id: "tmp:noversion", title: "old" }));
+        res();
+      });
+      old.on("error", rej);
+    });
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tmp:noversion")).toBe(true),
+    );
+    const err = await bridge
+      .send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "tmp:noversion" })
+      .then(() => null)
+      .catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    const msg = (err as Error).message;
+    // The old text read "detected panel version unknown; this MCP requires panel
+    // 0.11.35+", which an agent reasonably takes as a verdict that the panel is
+    // too old. An absent reading is an absent OBSERVATION: a CURRENT install
+    // behind a stale cached browser bundle presents identically.
+    expect(msg).not.toMatch(/detected panel version unknown/i);
+    expect(msg).toMatch(/advertised NO panel version/);
+    expect(msg).toMatch(/age was not observed/);
+    expect(msg).toMatch(/equally consistent with an old install/);
+    // It still names the version a write needs, and a command that moves them.
+    expect(msg).toMatch(/needs panel 0\.11\.35\+/);
+    expect(msg).toContain("git clone --depth 1");
+    old.close();
+  });
+
+  it("#812/#823: the remedy names how to reach install_panel when it is not in the tool list", async () => {
+    const old = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      old.on("open", () => {
+        old.send(
+          JSON.stringify({
+            type: "hello",
+            tab_id: "tmp:compact",
+            title: "w",
+            panel_version: "0.11.32",
+          }),
+        );
+        res();
+      });
+      old.on("error", rej);
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:compact")).toBe(true));
+    const err = await bridge
+      .send({ cmd: "graph_set_widget", node_id: 1 } as never, { tabId: "tmp:compact" })
+      .then(() => null)
+      .catch((e: Error) => e);
+    const msg = (err as Error).message;
+    // #812's reporter searched their tool list for install_panel, found nothing,
+    // and concluded the documented recovery was impossible. It was there — behind
+    // the compact router, which is the DEFAULT tool mode. Naming the actual call
+    // is the difference between a remedy and a dead end.
+    expect(msg).toContain(`call_tool {"name": "install_panel", "args": {"action": "update"}}`);
+    // The specific version found and the version required, both named.
+    expect(msg).toContain("0.11.32");
+    expect(msg).toMatch(/needs panel 0\.11\.35\+/);
+    old.close();
   });
 });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2308,6 +2308,47 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     old.close();
   });
 
+  it("#819: a version INHERITED across a reconnect is never attributed to this tab", async () => {
+    // codex gate. `conn.panelVersion` survives a reconnect whose hello omits the
+    // field, so "this tab reports panel 0.11.32" would be a claim about an
+    // observation the current handshake never made — the same fabrication the
+    // "version unknown" fix removes, arriving by the other door. The earlier
+    // reading is still shown (it is real), labelled as earlier and possibly out
+    // of date.
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      sock.on("open", () => {
+        sock.send(
+          JSON.stringify({
+            type: "hello",
+            tab_id: "tmp:inherit",
+            title: "w",
+            panel_version: "0.11.32",
+          }),
+        );
+        res();
+      });
+      sock.on("error", rej);
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:inherit")).toBe(true));
+
+    // Re-hello WITHOUT a panel_version. The connection inherits 0.11.32 for
+    // messaging but records panelVersionAdvertised: false.
+    sock.send(JSON.stringify({ type: "hello", tab_id: "tmp:inherit", title: "w" }));
+    await new Promise((r) => setTimeout(r, 25));
+
+    const err = await bridge
+      .send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "tmp:inherit" })
+      .then(() => null)
+      .catch((e: Error) => e);
+    const msg = (err as Error).message;
+    expect(msg).not.toContain("this tab reports panel 0.11.32");
+    expect(msg).toMatch(/advertised NO panel version in its current handshake/);
+    expect(msg).toMatch(/EARLIER connection for this tab reported 0\.11\.32, which may be out of date/);
+    expect(msg).toMatch(/age was not observed/);
+    sock.close();
+  });
+
   it("quotes NO fence version when this build's capability table cannot state one", async () => {
     // codex gate. The refusal is still correct — the panel did not advertise the
     // fence — but the DIAGNOSIS must not invent a number. Falling back to the

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2537,6 +2537,49 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     }
   });
 
+  it("#819: an INHERITED version is not attributed to this tab by the REACTIVE path either", async () => {
+    // The provenance screen had been applied to the write-refusal path only. The
+    // reactive Unknown-command rewrite built its own view from the same raw
+    // field, so a re-hello that omitted panel_version could still produce
+    // "detected panel 0.4.5 … too old" about a connection that observed no
+    // version at all — the same defect as the fence path, one door over.
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      sock.on("open", () => {
+        sock.send(
+          JSON.stringify({ type: "hello", tab_id: "tmp:inherit-reactive", title: "w", panel_version: "0.4.5" }),
+        );
+        res();
+      });
+      sock.on("error", rej);
+    });
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tmp:inherit-reactive")).toBe(true),
+    );
+    // Re-hello WITHOUT a version: 0.4.5 is inherited for messaging only.
+    sock.send(JSON.stringify({ type: "hello", tab_id: "tmp:inherit-reactive", title: "w" }));
+    await new Promise((r) => setTimeout(r, 25));
+    // The panel answers an ALLOWED (inert) command with the dispatcher's own
+    // Unknown-command reply — the reactive rewrite path.
+    sock.on("message", (buf) => {
+      const m = JSON.parse(buf.toString());
+      if (m.rid && m.cmd) {
+        sock.send(JSON.stringify({ rid: m.rid, ok: false, error: `Unknown command "${m.cmd}"` }));
+      }
+    });
+    const err = await bridge
+      .send({ cmd: "graph_outline" } as never, { tabId: "tmp:inherit-reactive" })
+      .then(() => null)
+      .catch((e: Error) => e);
+    const msg = (err as Error).message;
+    expect(msg).not.toContain("detected panel 0.4.5");
+    expect(msg.toLowerCase()).not.toContain("too old"); // no age verdict from an unobserved version
+    expect(msg).toMatch(/does not implement "graph_outline"/);
+    expect(msg).toMatch(/this connection advertised no panel version/);
+    expect(msg).toMatch(/an earlier connection for this tab reported 0\.4\.5, which may be out of date/);
+    sock.close();
+  });
+
   it("an UNCLASSIFIED graph command routed through the bridge is fenced AND recorded", async () => {
     // Layer 3, exercised through the DISPATCH PATH rather than by calling the
     // classifier directly — the gap the independent gate flagged in the earlier

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2463,6 +2463,78 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     sock.close();
   });
 
+  it.each([
+    ["nightly", "a git-installed pack — ComfyUI-Manager's own answer"],
+    ["dev", "a local checkout"],
+    ["0.11.28.1", "a four-part string that is not SemVer"],
+  ])("an UNPARSEABLE panel_version (%s) is shown as evidence, never narrated as a version", async (
+    raw,
+  ) => {
+    // The distinction is PARSEABLE vs NOT, not empty vs non-empty. Trimming
+    // caught `"   "`; this catches everything else that is not a version. It is
+    // not a corner case — "nightly" is what a git-installed panel reports, so it
+    // is the normal reading for anyone running from source.
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      sock.on("open", () => {
+        sock.send(
+          JSON.stringify({ type: "hello", tab_id: `tmp:unparse-${raw}`, title: "w", panel_version: raw }),
+        );
+        res();
+      });
+      sock.on("error", rej);
+    });
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === `tmp:unparse-${raw}`)).toBe(true),
+    );
+    const err = await bridge
+      .send({ cmd: "graph_add_node", node: "x" } as never, { tabId: `tmp:unparse-${raw}` })
+      .then(() => null)
+      .catch((e: Error) => e);
+    const msg = (err as Error).message;
+    expect(msg).not.toContain(`reports panel ${raw}`); // no version-shaped claim
+    expect(msg).toContain(`advertised "${raw}"`); // but the evidence is still shown
+    expect(msg).toMatch(/is not a version this MCP can compare/);
+    expect(msg).toMatch(/age was not observed/);
+    sock.close();
+  });
+
+  it("an UNPARSEABLE version with a CAPABLE disk still earns the stale-bundle diagnosis", async () => {
+    // The consequence of routing "nightly" to the unreadable path rather than
+    // dropping it: a git-install user whose pack on disk already clears the
+    // fence floor used to be sent off to update (the skew resolver silently
+    // rejected the unparseable value). They now get the honest ranked answer.
+    writeTempPanelPack("0.11.38");
+    try {
+      const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+      await new Promise<void>((res, rej) => {
+        sock.on("open", () => {
+          sock.send(
+            JSON.stringify({ type: "hello", tab_id: "nightly-capable", title: "w", panel_version: "nightly" }),
+          );
+          res();
+        });
+        sock.on("error", rej);
+      });
+      await vi.waitFor(() =>
+        expect(bridge.tabs().some((t) => t.tab_id === "nightly-capable")).toBe(true),
+      );
+      const err = await bridge
+        .send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "nightly-capable" })
+        .catch((e: Error) => e);
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/Updating the panel will not fix this/);
+      expect(msg).toMatch(/already 0\.11\.38/);
+      expect(msg).not.toMatch(/Run install_panel\(action:'update'\)/);
+      // Still no fabricated cause — the causes are ranked, as for no version.
+      expect(msg).not.toMatch(/This BROWSER TAB is running an older cached copy/);
+      expect(msg).toMatch(/\(1\) It is a ComfyUI browser tab/);
+      sock.close();
+    } finally {
+      clearPanelDiskObservation();
+    }
+  });
+
   it("quotes NO fence version when this build's capability table cannot state one", async () => {
     // codex gate. The refusal is still correct — the panel did not advertise the
     // fence — but the DIAGNOSIS must not invent a number. Falling back to the

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -17,6 +17,7 @@ import {
   BRIDGE_READONLY_CMDS,
   isMutatingGraphCommand,
   requiresWorkflowStampEnforcement,
+  BRIDGE_CAPABILITY_MIN_PANEL_VERSION,
 } from "../../services/ui-bridge.js";
 import { carryWorkflowCommandStamp } from "../../orchestrator/session-store.js";
 import {
@@ -2305,6 +2306,46 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     expect(msg).toContain("0.11.32");
     expect(msg).toMatch(/needs panel 0\.11\.35\+/);
     old.close();
+  });
+
+  it("quotes NO fence version when this build's capability table cannot state one", async () => {
+    // codex gate. The refusal is still correct — the panel did not advertise the
+    // fence — but the DIAGNOSIS must not invent a number. Falling back to the
+    // 0.11.4 bridge baseline would assert "0.11.4, the first build that fences
+    // every command", which is false and points at an update that would not
+    // clear the gate: #812's loop, rebuilt inside the fix for it.
+    const table = BRIDGE_CAPABILITY_MIN_PANEL_VERSION as Record<string, string | undefined>;
+    const saved = table.enforces_workflow_stamp_at_write;
+    delete table.enforces_workflow_stamp_at_write;
+    try {
+      const old = new WebSocket(`ws://127.0.0.1:${port}`);
+      await new Promise<void>((res, rej) => {
+        old.on("open", () => {
+          old.send(
+            JSON.stringify({ type: "hello", tab_id: "tmp:notable", title: "w", panel_version: "0.11.32" }),
+          );
+          res();
+        });
+        old.on("error", rej);
+      });
+      await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:notable")).toBe(true));
+      const err = await bridge
+        .send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "tmp:notable" })
+        .then(() => null)
+        .catch((e: Error) => e);
+      const msg = (err as Error).message;
+      expect(msg).not.toMatch(/needs panel \d/); // no number, right or wrong
+      expect(msg).not.toContain("0.11.4+");
+      expect(msg).toMatch(/cannot say which version first shipped it/);
+      // Still a refusal, still typed, and still carrying a remedy.
+      expect(err).toBeInstanceOf(Error);
+      expect(isCapabilityRefusal(err as Error)).toBe(true);
+      expect(dispatchOutcomeOf(err as Error)).toBe(false);
+      expect(msg).toMatch(/update to the latest panel/);
+      old.close();
+    } finally {
+      table.enforces_workflow_stamp_at_write = saved;
+    }
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,15 @@ function ensurePanelOnLoad(): void {
             res,
           );
           break;
-        case "up-to-date":
-          logger.info("Panel auto-install: panel already present.", res);
+        // #806 — "already present" is the whole claim. The line used to be paired
+        // with `action: "up-to-date"`, and users read the pair as "you are on the
+        // newest panel"; nothing on this path compares versions.
+        case "present":
+          logger.info(
+            "Panel auto-install: panel already present — NOT a version check. " +
+              "Run install_panel(action='status') to compare it against what this build needs.",
+            res,
+          );
           break;
         case "skipped-dev":
           logger.info(

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2876,10 +2876,13 @@ export async function runPanelOrchestrator(): Promise<void> {
       ) {
         void performPanelSync()
           .then((sync) => {
-            // An already-current local panel needs no chat noise. Every other
-            // outcome is actionable: synced => restart, pinned => unpin first,
-            // blocked/unknown/dev => its truthful recovery guidance.
-            if (sync.decision === "up-to-date" || sync.decision === "not-applicable") return;
+            // A panel that clears the floor needs no chat noise on every hello.
+            // Every other outcome is actionable: synced => restart, pinned =>
+            // unpin first, blocked/unknown/dev => its truthful recovery guidance.
+            // (#806 renamed this decision from `up-to-date` — the suppression is
+            // unchanged, but the value now says what it actually proved: the
+            // floor was cleared, NOT that a newer panel does not exist.)
+            if (sync.decision === "meets-floor" || sync.decision === "not-applicable") return;
             bridge.push({ type: "say", text: `⚠️ ${sync.message}` }, panelTab);
             logger.info(
               `[panel-orchestrator] panel sync on hello for ${panelTab.slice(0, 8)}: ` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3328,11 +3328,14 @@ export function makePanelToolCtx(
       // retry_of:"<rid>" lets the panel recognize and dedupe that exact mutation.
       // Pre-write refusals (dispatched:false, handled above) mint NO token — nothing
       // was sent, so there is nothing to dedupe. Minting is gated BOTH ways: the
-      // bridge classifies the command as mutating (requiresWorkflowStampEnforcement)
-      // AND the command is one the retry map admits (RETRY_TOKEN_CMDS) — a
-      // read/view-only command outside BRIDGE_READONLY_CMDS (find_nodes, canvas,
-      // screenshot, list_subgraphs) can satisfy the first without the second, and
-      // it must never mint a token (a ledger answer for a read is a STALE outcome).
+      // bridge fences the command to a workflow (requiresWorkflowStampEnforcement)
+      // AND the command is one the retry map admits (RETRY_TOKEN_CMDS). Both gates
+      // are still needed after #778 gave the fence its own effect ledger — they
+      // now disagree in the OTHER direction: the four idempotent UI-state commands
+      // (select_nodes, enter/exit_subgraph, copy_nodes) are in the retry map but
+      // are `inert`, so the first gate correctly withholds a token nothing needs.
+      // A read must never mint one either way (a ledger answer for a read is a
+      // STALE outcome).
       if (
         dispatchedRid &&
         requiresWorkflowStampEnforcement(cmd) &&
@@ -4340,22 +4343,27 @@ const RETRY_OF_ARG = {
 
 /**
  * #694 — the MUTATING panel tools that accept retry_of, keyed to the bridge
- * command each dispatches. Mirrors the #694 mutation surface EXACTLY: every
- * graph_* command NOT in BRIDGE_READONLY_CMDS (isMutatingGraphCommand — the
- * bridge's own fail-closed classification, which also arms the tight default
- * timeout and the dispatched:true mid-command outcome) plus the four workflow
- * mutators (workflow_save / workflow_save_as / workflow_rename / workflow_close
- * — the requiresWorkflowStampEnforcement set). Navigation/creation
- * (workflow_open / workflow_new), BRIDGE_READONLY_CMDS reads, and the tools whose
- * descriptions declare them view/read-only (panel_find_nodes, panel_canvas,
- * panel_screenshot, panel_list_subgraphs) are excluded: a read must never mint
- * or carry a retry token — its retry could be answered from the ledger with a
- * STALE outcome (codex gate). A few state-changing commands that sit OUTSIDE
- * BRIDGE_READONLY_CMDS but are reads in spirit (graph_select_nodes,
- * graph_enter/exit_subgraph, graph_copy_nodes) accept the token: they change UI
- * state idempotently, so a deduped retry is a no-op. EXPLICIT MAP, mirroring the
- * RETRY_SAFE_CMDS / MUTATING_GRAPH_EDIT_CMDS maintenance model — keep in sync
- * when mutating tools are added. Exported for the #694 surface-integrity test.
+ * command each dispatches. Covers every command the bridge fences to a workflow
+ * (GRAPH_CMD_EFFECT "targeted" — see requiresWorkflowStampEnforcement) plus the
+ * four workflow mutators (workflow_save / workflow_save_as / workflow_rename /
+ * workflow_close). Navigation/creation (workflow_open / workflow_new) and the
+ * tools whose descriptions declare them view/read-only (panel_find_nodes,
+ * panel_canvas, panel_screenshot, panel_list_subgraphs) are excluded: a read must
+ * never mint or carry a retry token — its retry could be answered from the ledger
+ * with a STALE outcome (codex gate).
+ *
+ * Four UI-STATE commands are admitted on purpose (graph_select_nodes,
+ * graph_enter/exit_subgraph, graph_copy_nodes): they change selection, subgraph
+ * scope or clipboard idempotently, so a deduped retry is a no-op. They ACCEPT a
+ * token; since #778 gave the fence its own effect ledger they are `inert` and so
+ * no longer MINT one (the mint gate at the error path requires
+ * requiresWorkflowStampEnforcement too). That is the right outcome — a retry
+ * token for an idempotent op is noise the agent has to reason about — and it
+ * loses nothing: re-issuing any of them blind is already safe.
+ *
+ * EXPLICIT MAP, mirroring the RETRY_SAFE_CMDS / MUTATING_GRAPH_EDIT_CMDS
+ * maintenance model — keep in sync when mutating tools are added. Exported for
+ * the #694 surface-integrity test.
  */
 export const RETRY_TOKEN_CMD_BY_TOOL: Readonly<Record<string, string>> = {
   panel_add_node: "graph_add_node",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3327,18 +3327,21 @@ export function makePanelToolCtx(
       // attempt's rid as the caller's retry token: re-issuing identical args plus
       // retry_of:"<rid>" lets the panel recognize and dedupe that exact mutation.
       // Pre-write refusals (dispatched:false, handled above) mint NO token — nothing
-      // was sent, so there is nothing to dedupe. Minting is gated BOTH ways: the
-      // bridge fences the command to a workflow (requiresWorkflowStampEnforcement)
-      // AND the command is one the retry map admits (RETRY_TOKEN_CMDS). Both gates
-      // are still needed after #778 gave the fence its own effect ledger — they
-      // now disagree in the OTHER direction: the four idempotent UI-state commands
-      // (select_nodes, enter/exit_subgraph, copy_nodes) are in the retry map but
-      // are `inert`, so the first gate correctly withholds a token nothing needs.
-      // A read must never mint one either way (a ledger answer for a read is a
-      // STALE outcome).
+      // was sent, so there is nothing to dedupe.
+      //
+      // Minting is gated on RETRY_TOKEN_CMDS — the map's own membership, which is
+      // the question being asked ("does the panel dedupe a retry of this?"). It
+      // used to be gated on requiresWorkflowStampEnforcement AS WELL, as a second
+      // guard against a read sneaking into the map. That guard read as a free
+      // extra until #778 gave the fence its own effect ledger and the two
+      // predicates diverged: the four idempotent UI-state commands the map admits
+      // on purpose (select_nodes, enter/exit_subgraph, copy_nodes) are `inert`,
+      // so keeping it would have silently changed which commands mint a token —
+      // an unrelated behaviour change smuggled in by a classification fix. The
+      // "no read in the retry map" property it was standing in for is now
+      // asserted directly in panel-retry-identity.test.ts, where it belongs.
       if (
         dispatchedRid &&
-        requiresWorkflowStampEnforcement(cmd) &&
         RETRY_TOKEN_CMDS.has(typeof cmd.cmd === "string" ? cmd.cmd : "") &&
         (dispatchOutcomeOf(err) === true || isReplyTimeoutTagged(err))
       ) {
@@ -4354,12 +4357,12 @@ const RETRY_OF_ARG = {
  *
  * Four UI-STATE commands are admitted on purpose (graph_select_nodes,
  * graph_enter/exit_subgraph, graph_copy_nodes): they change selection, subgraph
- * scope or clipboard idempotently, so a deduped retry is a no-op. They ACCEPT a
- * token; since #778 gave the fence its own effect ledger they are `inert` and so
- * no longer MINT one (the mint gate at the error path requires
- * requiresWorkflowStampEnforcement too). That is the right outcome — a retry
- * token for an idempotent op is noise the agent has to reason about — and it
- * loses nothing: re-issuing any of them blind is already safe.
+ * scope or clipboard idempotently, so a deduped retry is a no-op. THIS MAP — not
+ * the workflow fence — is what decides whether a token is minted and whether a
+ * caller-supplied one reaches the wire, so those four keep behaving exactly as
+ * they did before #778 reclassified them as `inert` for the fence. The two
+ * questions are related but not the same, and answering one with the other is
+ * the defect #778 is about.
  *
  * EXPLICIT MAP, mirroring the RETRY_SAFE_CMDS / MUTATING_GRAPH_EDIT_CMDS
  * maintenance model — keep in sync when mutating tools are added. Exported for
@@ -4437,7 +4440,22 @@ function withRetryToken(d: PanelToolDef): PanelToolDef {
         onDispatchedRid?: (rid: string) => void,
       ) =>
         ctx.call(
-          requiresWorkflowStampEnforcement(cmd) ? { ...cmd, retry_of: retryOf } : cmd,
+          // Ask the RETRY MAP's question, not the workflow fence's (codex gate).
+          // These were the same answer only while isMutatingGraphCommand
+          // over-classified — the #778 defect. Once the fence got its own effect
+          // ledger they diverged, and gating on the fence would have SILENTLY
+          // DROPPED a caller-supplied retry_of for the four UI-state commands the
+          // map admits on purpose: the schema accepts the token, the description
+          // promises dedupe, and nothing would reach the wire. A caller who
+          // believes their retry is deduped and is wrong is exactly the failure
+          // the token exists to prevent.
+          //
+          // A read probe inside a mutating handler (panel_flatten_workflow's
+          // graph_serialize) is still excluded — RETRY_TOKEN_CMDS contains no
+          // reads, which is asserted in panel-retry-identity.test.ts.
+          RETRY_TOKEN_CMDS.has(typeof cmd.cmd === "string" ? cmd.cmd : "")
+            ? { ...cmd, retry_of: retryOf }
+            : cmd,
           timeoutMs,
           onDispatchedRid,
         );

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -1263,7 +1263,19 @@ function describePanelShadow(
 
 export type EnsureAction =
   | "installed"
-  | "up-to-date"
+  /**
+   * The pack is THERE. Nothing more.
+   *
+   * #806 — this was called `up-to-date`, and a user read it exactly as it is
+   * written: "you are on the latest panel". It never meant that. This branch does
+   * not compare versions at all (see the "Present already" comment below: the
+   * on-load ensure is install-if-missing and never diffs the nightly channel), so
+   * `up-to-date` was not even the floor check people assumed — it was a presence
+   * check wearing a currency check's name. The user in #806 spent days on a
+   * canvas-binding bug whose fix had already shipped, because this line told him
+   * there was nothing to get.
+   */
+  | "present"
   | "skipped-dev"
   | "skipped"
   | "shadowed" // installed/present, but a #641 shadow copy will win in the browser
@@ -1476,8 +1488,18 @@ async function ensureInner(deps: PanelInstallerDeps): Promise<EnsureResult> {
       installedVersion: detection.version,
     };
   }
+  // #806 — say what was actually determined. This branch proved the pack EXISTS;
+  // it did not compare `detection.version` against anything, so it must not imply
+  // currency. The reason travels with the result because the result is what gets
+  // logged and pasted into bug reports.
   return {
-    action: "up-to-date",
+    action: "present",
+    reason:
+      `The panel pack is installed${detection.version ? ` (${detection.version})` : ""} and was ` +
+      `left untouched — the on-load check only installs a MISSING panel and does not compare ` +
+      `versions, so this is not a statement that the panel is current. Run ` +
+      `install_panel(action='status') to compare it against what this orchestrator needs, or ` +
+      `install_panel(action='update') to pull the latest panel.`,
     dir: detection.dir,
     installedVersion: detection.version,
   };

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -86,7 +86,10 @@ export const PANEL_VERSION = "nightly";
  * "comfyui-agent-panel" — so check both quickly, then fall back to a full scan.
  * The pyproject `name == comfyui-agent-panel` match is always authoritative.
  */
-const FAST_PATH_DIRS = ["comfyui-mcp-panel", "comfyui-agent-panel"];
+// Exported so panel-recovery's manual instructions can be pinned to the SAME
+// accepted names in a test: guidance that judged "present" by only one of them
+// told a repo-checkout user to clone a second serving copy (#641 in miniature).
+export const FAST_PATH_DIRS = ["comfyui-mcp-panel", "comfyui-agent-panel"];
 
 /** Hard cap so the on-load ensure can never block startup. */
 const ENSURE_TIMEOUT_MS = 20_000;

--- a/src/services/panel-recovery.ts
+++ b/src/services/panel-recovery.ts
@@ -43,8 +43,28 @@ import { lastPanelBaseResolution, panelBaseSync } from "./panel-workspace.js";
 /** Upstream source of truth for the panel pack — the manual-recovery clone URL. */
 export const PANEL_REPO_URL = "https://github.com/artokun/comfyui-mcp-panel.git";
 
-/** Canonical custom_nodes directory name for the panel pack. */
+/** Canonical custom_nodes directory name for the panel pack (the Registry name). */
 export const PANEL_DIR_NAME = "comfyui-agent-panel";
+
+/**
+ * The OTHER directory name that is the same panel: a plain `git clone` of the
+ * repo lands in `comfyui-mcp-panel`, and the installer accepts both (see
+ * panel-installer's FAST_PATH_DIRS).
+ *
+ * This matters here and not only there. The manual recovery tells a user to
+ * clone the pack when it is "NOT PRESENT" — and if "present" is judged by the
+ * Registry name alone, someone with a perfectly good repo checkout is told to
+ * clone a SECOND copy alongside it. ComfyUI serves every directory under
+ * custom_nodes, so that produces exactly the ambiguous two-panels state the rest
+ * of this text exists to warn about (#641), and later panel management then
+ * correctly refuses to act on the duplicate. Guidance that manufactures the
+ * failure it warns about is worse than no guidance.
+ *
+ * `panel-recovery-cluster.test.ts` asserts this list matches the installer's, so
+ * the two cannot drift (kept as a separate constant rather than an import
+ * because panel-installer imports THIS module).
+ */
+export const PANEL_DIR_NAMES: readonly string[] = [PANEL_DIR_NAME, "comfyui-mcp-panel"];
 
 /** Why install_panel provably cannot perform the update in this session. */
 export type PanelRecoveryBlocker =
@@ -185,22 +205,28 @@ function blockerPhrase(blocker: PanelRecoveryBlocker | undefined): string {
  */
 export function manualPanelUpdateCommands(comfyuiPath?: string): string {
   const root = comfyuiPath ?? "<ComfyUI>";
+  const either = PANEL_DIR_NAMES.join(" or ");
   return (
-    `cd "${root}/custom_nodes", then run the ONE case that matches what is there. ` +
-    `(1) ${PANEL_DIR_NAME} is a git checkout — fast-forward it: ` +
-    `git -C ${PANEL_DIR_NAME} pull --ff-only. ` +
-    `(2) ${PANEL_DIR_NAME} exists but has NO .git (a Comfy Registry zip install, so there ` +
-    `is nothing to pull) — replace it: ` +
+    `cd "${root}/custom_nodes". The panel pack is whichever of ${either} you have — ` +
+    `BOTH are the same pack (the Registry installs the first, a plain git clone of the repo ` +
+    `lands in the second), so check for both before deciding, and call the one you find ` +
+    `<panel-dir>. Then run the ONE case that matches. ` +
+    `(1) <panel-dir> exists and is a git checkout — fast-forward it: ` +
+    `git -C <panel-dir> pull --ff-only. ` +
+    `(2) <panel-dir> exists but has NO .git (a Comfy Registry zip install, so there ` +
+    `is nothing to pull) — replace it IN PLACE, keeping its name: ` +
     `git clone --depth 1 ${PANEL_REPO_URL} ../.agent-panel-new && ` +
     `mkdir -p ../custom_nodes_backup && ` +
-    `mv ${PANEL_DIR_NAME} ../custom_nodes_backup/ && ` +
-    `mv ../.agent-panel-new ${PANEL_DIR_NAME}. ` +
-    `(3) ${PANEL_DIR_NAME} is NOT PRESENT — a stale ComfyUI-Manager 3.x reports its queue ` +
+    `mv <panel-dir> ../custom_nodes_backup/ && ` +
+    `mv ../.agent-panel-new <panel-dir>. ` +
+    `(3) NEITHER ${either} is present — a stale ComfyUI-Manager 3.x reports its queue ` +
     `drained without creating the pack (#819), so "already installed" can mean an empty ` +
     `custom_nodes; install it outright: ` +
     `git clone --depth 1 ${PANEL_REPO_URL} ${PANEL_DIR_NAME}. ` +
-    `In case (2), keep the old copy OUT of custom_nodes — ComfyUI serves every directory ` +
-    `in there, so a leftover copy would shadow the new panel in the browser`
+    `Do NOT run case (3) while one of them exists under the other name — ComfyUI serves ` +
+    `every directory in custom_nodes, so a second copy would leave two panels racing to ` +
+    `register and the browser loading whichever sorts first (#641). For the same reason, in ` +
+    `case (2) keep the old copy OUT of custom_nodes`
   );
 }
 

--- a/src/services/panel-recovery.ts
+++ b/src/services/panel-recovery.ts
@@ -283,12 +283,20 @@ export function describePanelUpdateRecovery(
       `Cmd+Shift+R on macOS; if that does not take, open DevTools and use ` +
       `right-click reload → "Empty Cache and Hard Reload"). ` +
       // Only name the tool where naming it is useful. In a remote/cloud session
-      // it is not callable at all, so "it would report nothing to do" is a
-      // pointless mention of an absent tool; say the plain thing instead.
+      // it is not callable at all, so mentioning it is a pointless mention of an
+      // absent tool; say the plain thing instead.
+      //
+      // NOT "it will report nothing to do" — that was only true while a
+      // floor-clearing panel was believed to be the newest one (#806). An update
+      // CAN pull a newer panel; what it cannot do is replace the JS an open tab
+      // is already running, which is the whole point of this branch.
+      //
+      // And NO trailing period: every caller appends its own sentence break, and
+      // adding one here rendered ".." into a real refusal (codex gate).
       (ctx.installPanelUsable
-        ? `Running install_panel(action:'update') here will correctly report nothing ` +
-          `to do — the install is not the problem.`
-        : `No update of any kind will help — the install is not the problem.`)
+        ? `install_panel(action:'update') is not the fix here — it may pull a newer ` +
+          `panel, but no update replaces the JavaScript an open tab is already running`
+        : `No update of any kind fixes this — the install is not the problem`)
     );
   }
 

--- a/src/services/panel-recovery.ts
+++ b/src/services/panel-recovery.ts
@@ -160,9 +160,22 @@ function blockerPhrase(blocker: PanelRecoveryBlocker | undefined): string {
 
 /**
  * The manual, host-side update. Written as a real command sequence because the
- * caller may be an agent with no ability to ask a human to "use the Manager UI",
- * and it covers BOTH install shapes: a git checkout fast-forwards, while a Comfy
- * Registry zip install has no `.git` to pull and must be replaced (#771).
+ * caller may be an agent with no ability to ask a human to "use the Manager UI".
+ *
+ * IT MUST WORK FROM WHICHEVER STATE THE CALLER IS ACTUALLY IN, and this function
+ * cannot see which one that is — the refusal that renders it knows the tab did
+ * not advertise the fence, not what is on the host's disk. So it enumerates the
+ * three real states and lets the reader match, instead of asserting one:
+ *
+ *   (a) a git checkout — fast-forward;
+ *   (b) a Comfy Registry zip install with no `.git` — nothing to pull, so the
+ *       directory has to be REPLACED (#771);
+ *   (c) NOT THERE AT ALL (#819) — ComfyUI-Manager 3.x can report its install
+ *       queue drained without ever creating the pack, so a user who "installed
+ *       the panel" can still have an empty custom_nodes. Both (a) and (b) fail
+ *       in that state — `git -C <dir> pull` and `mv <dir> …` need a directory
+ *       that exists — which left the one instruction we gave them dead. A fresh
+ *       clone is the command that moves them, and it was missing.
  *
  * The BACKUP LEAVES custom_nodes on purpose. ComfyUI serves every directory
  * under custom_nodes as a web extension — including dot-prefixed ones — so a
@@ -173,15 +186,21 @@ function blockerPhrase(blocker: PanelRecoveryBlocker | undefined): string {
 export function manualPanelUpdateCommands(comfyuiPath?: string): string {
   const root = comfyuiPath ?? "<ComfyUI>";
   return (
-    `cd "${root}/custom_nodes" && git -C ${PANEL_DIR_NAME} pull --ff-only` +
-    ` — or, if ${PANEL_DIR_NAME} has no .git (a Comfy Registry zip install, so there is ` +
-    `nothing to pull), replace it instead: ` +
+    `cd "${root}/custom_nodes", then run the ONE case that matches what is there. ` +
+    `(1) ${PANEL_DIR_NAME} is a git checkout — fast-forward it: ` +
+    `git -C ${PANEL_DIR_NAME} pull --ff-only. ` +
+    `(2) ${PANEL_DIR_NAME} exists but has NO .git (a Comfy Registry zip install, so there ` +
+    `is nothing to pull) — replace it: ` +
     `git clone --depth 1 ${PANEL_REPO_URL} ../.agent-panel-new && ` +
     `mkdir -p ../custom_nodes_backup && ` +
     `mv ${PANEL_DIR_NAME} ../custom_nodes_backup/ && ` +
-    `mv ../.agent-panel-new ${PANEL_DIR_NAME}` +
-    ` (keep the old copy OUT of custom_nodes — ComfyUI serves every directory in ` +
-    `there, so a leftover copy would shadow the new panel in the browser)`
+    `mv ../.agent-panel-new ${PANEL_DIR_NAME}. ` +
+    `(3) ${PANEL_DIR_NAME} is NOT PRESENT — a stale ComfyUI-Manager 3.x reports its queue ` +
+    `drained without creating the pack (#819), so "already installed" can mean an empty ` +
+    `custom_nodes; install it outright: ` +
+    `git clone --depth 1 ${PANEL_REPO_URL} ${PANEL_DIR_NAME}. ` +
+    `In case (2), keep the old copy OUT of custom_nodes — ComfyUI serves every directory ` +
+    `in there, so a leftover copy would shadow the new panel in the browser`
   );
 }
 
@@ -216,6 +235,28 @@ const RESTART_AND_REFRESH =
   `restart ComfyUI, then hard-refresh the ComfyUI browser tab (Ctrl+Shift+R) so it ` +
   `loads the updated bundle — a restart alone leaves the tab running its cached old ` +
   `panel JS; rebinding cannot add the missing capability`;
+
+/**
+ * WHY "install_panel does not exist" is usually wrong, and what to do about it.
+ *
+ * #812 and #823 both report the same dead end: an error names install_panel, the
+ * agent searches its tool list, finds nothing, and concludes the remedy is
+ * impossible. In almost every one of those sessions the tool was there —
+ * COMPACT TOOL MODE IS THE DEFAULT (#667). It registers exactly three meta-tools
+ * and leaves the other ~200, install_panel among them, reachable only through
+ * `call_tool`. A tool-name search cannot see it; `call_tool` can run it.
+ *
+ * Saying so is the difference between a remedy the caller can execute from where
+ * they are and one that reads as "this is impossible". The host-side commands
+ * still follow, for the surfaces where neither route exists (the embedded
+ * `panel_*` sidebar set, #784).
+ */
+const COMPACT_ROUTER_FALLBACK = (action: string): string =>
+  `If install_panel is not in this session's tool list, it is probably not missing — ` +
+  `compact tool mode is the DEFAULT and exposes only list_tools / describe_tool / ` +
+  `call_tool, with every other tool reachable through them. Try ` +
+  `call_tool {"name": "install_panel", "args": {"action": "${action}"}} before concluding ` +
+  `it is unavailable.`;
 
 /**
  * The recovery sentence for a panel that is too old for the write gate. Names
@@ -253,9 +294,11 @@ export function describePanelUpdateRecovery(
 
   if (ctx.installPanelUsable) {
     return (
-      `Run install_panel(action:'update') — or, if install_panel is not in this ` +
-      `session's tool set, update the pack on the ComfyUI host: ` +
-      `${manualPanelUpdateCommands(ctx.comfyuiPath)} — then ${RESTART_AND_REFRESH}`
+      `Run install_panel(action:'update'). ${COMPACT_ROUTER_FALLBACK("update")} ` +
+      `If neither route exists on this surface, update the pack on the ComfyUI host: ` +
+      // No trailing period: every caller of this function appends its own
+      // sentence break, and adding one here rendered ".." to the user.
+      `${manualPanelUpdateCommands(ctx.comfyuiPath)}. Then ${RESTART_AND_REFRESH}`
     );
   }
   return (
@@ -277,9 +320,9 @@ export function describePanelManagementRedirect(
     return (
       `Use install_panel instead: install_panel(action='sync') brings the panel in line ` +
       `with this orchestrator and re-reads the installed version from disk, and ` +
-      `action='status' reports it. If install_panel is not in this session's tool set, ` +
-      `update the pack on the ComfyUI host instead: ` +
-      `${manualPanelUpdateCommands(ctx.comfyuiPath)}.`
+      `action='status' reports it. ${COMPACT_ROUTER_FALLBACK("sync")} ` +
+      `If neither route exists on this surface, update the pack on the ComfyUI host ` +
+      `instead: ${manualPanelUpdateCommands(ctx.comfyuiPath)}.`
     );
   }
   return (

--- a/src/services/panel-recovery.ts
+++ b/src/services/panel-recovery.ts
@@ -272,16 +272,44 @@ export function describePanelUpdateRecovery(
   // install_panel, not a host-side git pull. Sending this user to either is
   // what makes the loop feel unfixable, so this branch outranks both.
   if (skew) {
+    // WHAT IS PROVEN vs WHAT IS INFERRED (codex gate).
+    //
+    // Proven in both variants: the pack on disk clears the floor, so no update
+    // of the pack changes this refusal. That is the part the headline may state.
+    //
+    // The CAUSE is a different claim, and the evidence for it differs:
+    //  - the client advertised a version BELOW the floor → the served pack and
+    //    the announced build genuinely disagree. Both the version and the
+    //    capability are built by the same served file, so a client running the
+    //    installed bundle would have announced the installed version. A stale
+    //    cached bundle is then a conclusion, not a guess.
+    //  - the client advertised NO version → nothing was observed. A browser tab
+    //    on a cached bundle looks exactly like a relay or other non-panel client
+    //    that never implemented the fence at all, and "hard-refresh your tab" is
+    //    unactionable for the latter. Asserting the cache is the fabrication
+    //    this cluster exists to remove, so that variant RANKS the possibilities
+    //    instead — the actionable one first, the other named rather than hidden.
+    const HARD_REFRESH =
+      `The panel's module URLs carry no cache-busting key, so an ordinary reload can ` +
+      `serve the stale file again: HARD-REFRESH this ComfyUI tab with a cache-bypassing ` +
+      `reload (Ctrl+Shift+R, or Cmd+Shift+R on macOS; if that does not take, open ` +
+      `DevTools and use right-click reload → "Empty Cache and Hard Reload"). `;
     return (
-      `Do NOT update the panel — the pack ON DISK is already ${skew.diskVersion}, which ` +
-      `meets the ${skew.requiredVersion}+ this MCP requires. This BROWSER TAB is running ` +
-      `an older cached copy of the panel's JavaScript ` +
-      `(it advertised ${skew.handshakeVersion ? `${skew.handshakeVersion}` : "no version"}), ` +
-      `and the capability check reads what the TAB announced. The panel's module URLs ` +
-      `carry no cache-busting key, so an ordinary reload can serve the stale file again: ` +
-      `HARD-REFRESH this ComfyUI tab with a cache-bypassing reload (Ctrl+Shift+R, or ` +
-      `Cmd+Shift+R on macOS; if that does not take, open DevTools and use ` +
-      `right-click reload → "Empty Cache and Hard Reload"). ` +
+      (skew.handshakeVersion
+        ? `Do NOT update the panel — the pack ON DISK is already ${skew.diskVersion}, which ` +
+          `meets the ${skew.requiredVersion}+ a graph write needs. This BROWSER TAB is running ` +
+          `an older cached copy of the panel's JavaScript (it advertised ` +
+          `${skew.handshakeVersion}), and the capability check reads what the TAB ` +
+          `announced. ${HARD_REFRESH}`
+        : `Updating the panel will not fix this — the pack ON DISK is already ` +
+          `${skew.diskVersion}, which meets the ${skew.requiredVersion}+ a graph write needs, ` +
+          `so the SERVED panel is already capable. What connected advertised no version and ` +
+          `no workflow fence, which does not by itself say why, so here are both ` +
+          `possibilities. (1) It is a ComfyUI browser tab — much the more common case — ` +
+          `running a cached older copy of the panel's JavaScript. ${HARD_REFRESH}` +
+          `(2) It is NOT a panel tab (a relay or other client): then it does not implement ` +
+          `the fence at all and there is nothing to refresh — issue graph WRITES from a ` +
+          `ComfyUI tab running the panel. `) +
       // Only name the tool where naming it is useful. In a remote/cloud session
       // it is not callable at all, so mentioning it is a pointless mention of an
       // absent tool; say the plain thing instead.

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -103,7 +103,42 @@ const STALE_BUNDLE_HINT =
   `the problem — the open ComfyUI browser tab is running a CACHED older copy of the ` +
   `panel's JavaScript, and the capability check reads what the tab announced. ` +
   `Hard-refresh that tab with a cache-bypassing reload (Ctrl+Shift+R, or Cmd+Shift+R ` +
-  `on macOS); updating or reinstalling the pack will keep reporting nothing to do.`;
+  // NOT "updating the pack will report nothing to do" — that was true only while
+  // this verdict was believed to mean "you are on the newest panel". An update
+  // CAN pull a newer panel (see FLOOR_IS_NOT_LATEST, #806); what it cannot do is
+  // fix a stale TAB. Say the thing that stays true in both worlds.
+  `on macOS). Updating the pack may pull a newer panel, but no update of any kind ` +
+  `replaces the JavaScript an already-open tab is running.`;
+
+/** Where a human can read the newest published panel version. Deliberately the
+ *  pack's `pyproject.toml` and NOT the repo's GitHub releases: the panel ships to
+ *  the Comfy Registry on a pyproject version change, and its releases page lags
+ *  or omits versions entirely, so "latest release" is the wrong answer. */
+const PANEL_PYPROJECT_URL =
+  "https://github.com/artokun/comfyui-mcp-panel/blob/main/pyproject.toml";
+
+/**
+ * The sentence a floor check owes the reader (#806).
+ *
+ * Clearing the floor and being current are different claims, and the gap between
+ * them is where a real user's bug lived for days. This orchestrator genuinely
+ * cannot close that gap — nothing on this path knows the newest published panel;
+ * `PANEL_VERSION` is the Manager channel name ("nightly"), not a version number,
+ * and there is no registry lookup here. So the honest move is not to guess a
+ * latest version, it is to STOP IMPLYING ONE: name what was compared, say the
+ * comparison's limit out loud, and point at the two things that do move the user
+ * (the update action, and the file where the real latest is published).
+ *
+ * A function, not a constant: the update instruction depends on whether
+ * install_panel can act in THIS session.
+ */
+const FLOOR_IS_NOT_LATEST = (): string =>
+  ` NOTE — that is a FLOOR check, not a latest-version check. It compares your panel ` +
+  `against the MINIMUM this orchestrator requires; it does not know the newest published ` +
+  `panel, and most panel fixes ship WITHOUT raising the floor. So a newer panel carrying ` +
+  `fixes you are missing can exist while this still reads "meets the minimum". The newest ` +
+  `version is published in the pack's pyproject.toml (${PANEL_PYPROJECT_URL}); to pull it, ` +
+  `run ${describeInstallPanelAction("update", "the update on the ComfyUI host")}.`;
 
 /**
  * What a just-written persisted pin actually achieved. Writing the settings file
@@ -142,8 +177,22 @@ export type PanelSyncDecision =
   | "sync"
   /** Behind, but the user pinned the panel → WARN ONLY. Never sync. */
   | "pinned-warn"
-  /** The installed panel already meets what this orchestrator needs. */
-  | "up-to-date"
+  /**
+   * The installed panel CLEARS THE FLOOR this orchestrator requires.
+   *
+   * #806 — this was `up-to-date`, which answers a question nothing here asks.
+   * The comparison is against `requiredPanelVersion()`, the MINIMUM this build
+   * needs; the newest published panel is not known to this process at all (there
+   * is no registry or pyproject lookup on this path — see the summary text). A
+   * user on 0.11.36 with 0.11.38 published, whose bug was fixed in 0.11.37, was
+   * told "up-to-date" and stopped looking. Most panel fixes never raise the
+   * floor, so the population this verdict most misleads is exactly the one that
+   * most needs an update.
+   *
+   * `behind: false` on this decision therefore means "not below the floor", NOT
+   * "current".
+   */
+  | "meets-floor"
   /** Something must be fixed by a human first (shadow copy, unreadable pin). */
   | "blocked"
   /** Can't read a comparable installed version → don't guess, don't touch. */
@@ -399,11 +448,20 @@ export function evaluatePanelSync(
     if (!behind) {
       return {
         ...base,
-        decision: "up-to-date",
+        decision: "meets-floor",
         behind: false,
         summary:
-          `Panel ${status.installedVersion} already meets what ${orch} needs ` +
-          `(${required}+). You are ${describePanelPin(pin)}; nothing to do.`,
+          `Panel ${status.installedVersion} meets the minimum ${orch} needs ` +
+          `(${required}+). You are ${describePanelPin(pin)}; nothing will be changed.` +
+          // The pinned reader gets the same honesty, with the step that actually
+          // applies to them: an update is gated behind clearing the pin, so
+          // sending them straight at install_panel(action='update') would be the
+          // dead-end shape this cluster exists to remove.
+          ` NOTE — that is a FLOOR check, not a latest-version check: a newer panel with ` +
+          `fixes you are missing can exist while this still reads "meets the minimum", ` +
+          `because most panel fixes do not raise the floor. The newest version is published ` +
+          `in the pack's pyproject.toml (${PANEL_PYPROJECT_URL}). To move onto it you must ` +
+          `first clear the pin (${UNPIN_INSTRUCTION()}).`,
       };
     }
     // THE WARN CASE. Say what exists, say they're pinned, change nothing.
@@ -428,11 +486,11 @@ export function evaluatePanelSync(
   if (!behind) {
     return {
       ...base,
-      decision: "up-to-date",
+      decision: "meets-floor",
       behind: false,
       summary:
-        `Panel ${status.installedVersion} already meets what ${orch} needs ` +
-        `(${required}+). Nothing to do.${STALE_BUNDLE_HINT}`,
+        `Panel ${status.installedVersion} meets the minimum ${orch} needs ` +
+        `(${required}+), so nothing will be synced.${FLOOR_IS_NOT_LATEST()}${STALE_BUNDLE_HINT}`,
     };
   }
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -335,11 +335,24 @@ function highestRequirement(candidates: readonly (string | undefined)[]): string
  * running the panel from source rather than the Registry.
  */
 export interface PanelVersionReading {
-  /** Verbatim (trimmed) text the handshake carried. EVIDENCE, never a version. */
+  /** Verbatim (trimmed) text THIS handshake carried. EVIDENCE, never a version. */
   raw?: string;
   /** Set ONLY when `raw` is a strict SemVer — the sole form that may be compared,
    *  or quoted to a user as this panel's version. */
   version?: string;
+  /**
+   * A PREVIOUS connection's text, when THIS handshake carried none.
+   *
+   * `Conn.panelVersion` is inherited across a reconnect that omits the field, so
+   * a raw read of it silently attributes an old observation to the current
+   * connection. Provenance therefore travels with the reading, exactly as
+   * parseability does — and for the same reason: the screen has to live
+   * somewhere a consumer cannot forget it. It is never a `.version`: it was not
+   * observed here, so it may not be compared or stated as this panel's version.
+   * It is still disclosed, because it is a real earlier reading and discarding
+   * it would be its own way of losing evidence.
+   */
+  inherited?: string;
 }
 
 /** Screen a handshake `panel_version` into a reading. Blank and unparseable both
@@ -349,6 +362,27 @@ export function readPanelVersion(raw: string | undefined): PanelVersionReading {
   const trimmed = typeof raw === "string" ? raw.trim() : "";
   if (!trimmed) return {};
   return SEMVER_RE.test(trimmed) ? { raw: trimmed, version: trimmed } : { raw: trimmed };
+}
+
+/**
+ * What THIS connection observed about the panel's version — the single answer
+ * every consumer must use.
+ *
+ * There were three consumers reading `conn.panelVersion` and they disagreed:
+ * the workflow fence checked `panelVersionAdvertised`, the proactive gate
+ * checked it, and the reactive unknown-command rewrite did not — so a re-hello
+ * that omitted the field could still produce "detected panel 0.4.5 … too old"
+ * about a connection that observed no version at all. Routing all of them
+ * through here makes provenance a property of the reading rather than something
+ * each call site has to remember.
+ */
+export function connPanelVersionReading(conn: {
+  panelVersion?: string;
+  panelVersionAdvertised?: boolean;
+}): PanelVersionReading {
+  if (conn.panelVersionAdvertised) return readPanelVersion(conn.panelVersion);
+  const carried = typeof conn.panelVersion === "string" ? conn.panelVersion.trim() : "";
+  return carried ? { inherited: carried } : {};
 }
 
 /**
@@ -602,9 +636,15 @@ function buildPanelTooOldError(
         // git-installed pack — and it used to render as "detected panel nightly",
         // a version-shaped claim about something never parsed.
         ` (this panel reports "${reading.raw}", which is not a comparable version${mcpTail})`
-      : mcpVersion
-        ? ` (detected mcp ${mcpVersion})`
-        : "";
+      : reading.inherited
+        ? // Observed by an EARLIER connection, not this one. Disclosed, because
+          // it is real, and labelled, because attributing it to this handshake
+          // would be a claim nothing here supports.
+          ` (this connection advertised no panel version; an earlier connection for this tab ` +
+          `reported ${reading.inherited}, which may be out of date${mcpTail})`
+        : mcpVersion
+          ? ` (detected mcp ${mcpVersion})`
+          : "";
   const min = BRIDGE_CMD_MIN_PANEL_VERSION[cmd];
   // "TOO OLD" IS AN AGE VERDICT, and it may only be reached from an age
   // OBSERVATION: a version that parsed AND compares below the command's known
@@ -688,7 +728,9 @@ export function isUnknownCommandReply(error: string): boolean {
 
 export function makeUnknownCommandError(
   error: string,
-  panelVersion?: string,
+  /** A raw handshake string (callers with nothing else) or, preferably, an
+   *  already-screened reading carrying parseability AND provenance. */
+  panelVersion?: string | PanelVersionReading,
   mcpVersion?: string,
 ): Error | null {
   // Match the panel's exact shape: `Unknown command "graph_query"` (quotes
@@ -705,12 +747,24 @@ export function makeUnknownCommandError(
   // or a transient), so do NOT rewrite it into a bogus "update your panel" verdict
   // (which would also POISON the #236 unsupported-cmd gate against a capable panel).
   // Return null so the raw error surfaces and the gate is never poisoned.
-  if (panelSupportsCmd(cmd, panelVersion)) return null;
-  // The raw handshake string ends here: everything downstream sees a screened
-  // reading, so an unparseable value cannot be rendered as a version or read as
-  // an age (see PanelVersionReading — this consumer used to build its own view
-  // from the raw field and did both).
-  return buildPanelTooOldError(cmd, readPanelVersion(panelVersion), mcpVersion);
+  const reading =
+    typeof panelVersion === "object" && panelVersion !== null
+      ? panelVersion
+      : readPanelVersion(panelVersion);
+  // TWO DIFFERENT QUESTIONS, deliberately given different inputs.
+  //
+  // The #352 VETO asks "might this rewrite be bogus?", and its fail-safe answer
+  // is to suppress: surface the raw error and do not poison the #236 learned
+  // gate. An inherited version is weak evidence, but it is evidence, and being
+  // conservative here costs only a less-friendly message — so it keeps the value
+  // this call site has always given it, and the gate's behaviour is unchanged.
+  if (panelSupportsCmd(cmd, reading.version ?? reading.inherited)) return null;
+  // The MESSAGE asks "what did we observe?", and may only state what THIS
+  // connection saw. The raw handshake string ends here: everything downstream
+  // sees a screened reading, so an unparseable value cannot be rendered as a
+  // version, and an inherited one cannot be attributed to this connection (both
+  // of which this consumer used to do — it built its own view of the raw field).
+  return buildPanelTooOldError(cmd, reading, mcpVersion);
 }
 
 /**
@@ -2776,7 +2830,7 @@ export class UiBridge {
     // on THIS connection (in dispatch()'s rejectMapped below), never inferred from
     // panelVersion alone.
     if (conn.unsupportedCmds.has(cmd.cmd)) {
-      return Promise.reject(buildPanelTooOldError(cmd.cmd, readPanelVersion(conn.panelVersion)));
+      return Promise.reject(buildPanelTooOldError(cmd.cmd, connPanelVersionReading(conn)));
     }
     // #392 — PROACTIVELY gate a command whose changelog-verified minimum the panel's
     // ADVERTISED version parseably undercuts (e.g. graph_query on a <0.7.0 panel), so
@@ -2798,7 +2852,7 @@ export class UiBridge {
       !conn.provenSupportedCmds.has(cmd.cmd) &&
       panelVersionProvesUnsupported(cmd.cmd, conn.panelVersion)
     ) {
-      return Promise.reject(buildPanelTooOldError(cmd.cmd, readPanelVersion(conn.panelVersion)));
+      return Promise.reject(buildPanelTooOldError(cmd.cmd, connPanelVersionReading(conn)));
     }
     // #570 P0c — FAIL CLOSED for a command that mutates the ACTIVE workflow/canvas (every
     // graph_* mutator, plus path-less workflow_save/save_as/rename/close) when the resolved
@@ -2878,13 +2932,11 @@ export class UiBridge {
         // path — including into `resolveStaleBundleSkew`, which then reasons
         // from "no comparable version" instead of silently rejecting a value it
         // would have screened out one line later anyway.
-        // Screened through the SAME helper as the reactive path, so the two
-        // cannot drift: `.version` is comparable and attributable, `.raw` is
-        // evidence. Only an ADVERTISED reading counts — an inherited value is
-        // not this handshake's observation (see below).
-        const reading = conn.panelVersionAdvertised
-          ? readPanelVersion(conn.panelVersion)
-          : {};
+        // The SAME reading every other consumer uses, so parseability AND
+        // provenance are decided once: `.version` is comparable and
+        // attributable, `.raw` is this handshake's unparseable text, `.inherited`
+        // is an earlier connection's.
+        const reading = connPanelVersionReading(conn);
         const rawAdvertised = reading.raw;
         const advertised = reading.version;
         const recovery = describePanelUpdateRecovery(
@@ -2910,9 +2962,9 @@ export class UiBridge {
               `this tab advertised "${rawAdvertised}", which is not a version this MCP can ` +
               `compare (ComfyUI-Manager reports "nightly" for a git-installed pack), ` +
               `${NOT_OBSERVED}`
-            : conn.panelVersion
+            : reading.inherited
               ? `this tab advertised NO panel version in its current handshake (an EARLIER ` +
-                `connection for this tab reported ${conn.panelVersion}, which may be out of ` +
+                `connection for this tab reported ${reading.inherited}, which may be out of ` +
                 `date), ${NOT_OBSERVED}`
               : `this tab advertised NO panel version, ${NOT_OBSERVED}`;
         // The FENCE's own minimum, never the aggregate requiredPanelVersion():
@@ -3022,7 +3074,7 @@ export class UiBridge {
     // reply-error path only; the happy path and genuine command errors are
     // passed through untouched.
     const rejectMapped = (err: Error) => {
-      const friendly = makeUnknownCommandError(err.message, conn.panelVersion);
+      const friendly = makeUnknownCommandError(err.message, connPanelVersionReading(conn));
       // Apply the learned verdict to the LIVE connection — following a same-socket
       // migration whose reply landed after the tmp:→wf: id change — so neither the
       // reactive #236 unsupported gate NOR the #422 proven veto is stranded on a

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2741,7 +2741,15 @@ export class UiBridge {
         // otherwise reasons about an observation the current tab never made
         // (codex gate). An inherited value is still worth SHOWING — it is a real
         // earlier reading — but labelled as what it is.
-        const advertised = conn.panelVersionAdvertised ? conn.panelVersion : undefined;
+        // TRIMMED, and blank-is-absent: a hello carrying `panel_version: "   "`
+        // sets panelVersionAdvertised (it is a non-empty string) but says
+        // nothing. Untrimmed it rendered "this tab reports panel    " while the
+        // skew resolver — which does trim — simultaneously reported that the tab
+        // advertised no version: one refusal, two contradictory readings of the
+        // same field (codex gate). An unreadable observation is an absent one.
+        const advertised = conn.panelVersionAdvertised
+          ? conn.panelVersion?.trim() || undefined
+          : undefined;
         const recovery = describePanelUpdateRecovery(
           undefined,
           resolveStaleBundleSkew(advertised),

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -334,7 +334,8 @@ export function requiredPanelVersion(): string {
 
 /**
  * The minimum panel version that can fence a graph WRITE to its workflow — the
- * only version a fenced-write refusal is entitled to quote.
+ * only version a fenced-write refusal is entitled to quote. `undefined` when
+ * this build cannot state it.
  *
  * A write needs BOTH handshake capabilities (the dispatch-time stamp check and
  * the after-await write-boundary recheck), so it is their maximum, not the
@@ -344,12 +345,39 @@ export function requiredPanelVersion(): string {
  * their write needs a version it does not need — a number they cannot verify,
  * attached to a remedy they will run for the wrong reason. Same defect as #352 /
  * #619 (a blanket floor quoted as one command's requirement), one level up.
+ *
+ * BOTH entries must be present and parseable, and an incomplete table yields
+ * `undefined` rather than a number (codex gate). Two wrong answers were
+ * available here and both are the fold this cluster exists to remove:
+ *
+ *  - falling back to `MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS` would quote 0.11.4
+ *    as "the first build that fences every command", which is simply false — the
+ *    fence shipped in 0.11.30/0.11.35. An unreadable table is an unreadable
+ *    OBSERVATION, not evidence of a low requirement.
+ *  - taking the max of whichever entry survived would UNDERSTATE it: a user told
+ *    0.11.30 suffices would update, still be refused, and be back in the loop
+ *    #812 reported.
+ *
+ * So when the table cannot answer, nothing is quoted. The gate still refuses —
+ * the refusal is not what is uncertain — and the message says which part it
+ * could not determine.
  */
-export function requiredPanelVersionForWorkflowFence(): string {
-  return highestRequirement([
+export function requiredPanelVersionForWorkflowFence(): string | undefined {
+  const raw = [
     BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_workflow_stamp,
     BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_workflow_stamp_at_write,
-  ]);
+  ];
+  // Every entry must be a parseable version. `typeof` first so a table with a
+  // deleted or non-string key degrades instead of throwing inside .trim() —
+  // this runs while composing an error message.
+  if (!raw.every((v) => typeof v === "string" && SEMVER_RE.test(v.trim()))) return undefined;
+  // Folded WITHOUT highestRequirement's baseline seed: this answer is the
+  // capabilities' own maximum and must not inherit an unrelated floor, in either
+  // direction. Trimmed because the value is rendered into a user-facing
+  // sentence. (Every entry is already screened, so compareSemver's
+  // equal-vs-unparseable ambiguity cannot bite here.)
+  const parsed = raw.map((v) => (v as string).trim());
+  return parsed.reduce((best, v) => (compareSemver(v, best) > 0 ? v : best));
 }
 
 /**
@@ -2708,14 +2736,25 @@ export class UiBridge {
         // quoting the global max would name a version this command does not
         // require the moment any unrelated command declares a higher one.
         const fenceMin = requiredPanelVersionForWorkflowFence();
+        // And symmetrically: when THIS build cannot state the fence's minimum,
+        // quote no number at all (codex gate). Falling back to the bridge
+        // baseline would assert "0.11.4, the first build that fences every
+        // command" — false, and false in the direction that sends a user to an
+        // update that will not clear the gate. An unreadable table is another
+        // unmade observation.
+        const needs = (capability: string): string =>
+          fenceMin
+            ? `a graph WRITE needs panel ${fenceMin}+, the first build that ${capability}`
+            : `a graph WRITE needs a panel that ${capability}, but this MCP build cannot say ` +
+              `which version first shipped it (its capability table is incomplete) — no ` +
+              `version is quoted here rather than a wrong one; update to the latest panel`;
         const why = !conn.enforcesWorkflowStamp
-          ? `panel tab ${conn.tabId} does not enforce per-command workflow targeting ` +
-            `(${observed}; a graph WRITE needs panel ${fenceMin}+, the first build that fences ` +
-              `every command to the workflow it was issued for). ${recovery}`
+          ? `panel tab ${conn.tabId} does not enforce per-command workflow targeting (${observed}; ` +
+            `${needs("fences every command to the workflow it was issued for")}). ${recovery}`
           : !conn.enforcesWorkflowStampAtWrite
             ? `panel tab ${conn.tabId} does not recheck workflow targeting at the graph write ` +
-              `boundary after asynchronous work (${observed}; a graph WRITE needs panel ` +
-                `${fenceMin}+, the first build that rechecks the fence after an await). ${recovery}`
+              `boundary after asynchronous work (${observed}; ` +
+                `${needs("rechecks the fence after an await")}). ${recovery}`
           : `this workflow has no trusted identity for the panel to fence the command against`;
         const refusal = markDispatched(
           new Error(

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -298,21 +298,58 @@ export function minPanelVersionForCmd(cmd: string): string {
 export const SEMVER_RE =
   /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
 
-/**
- * The highest panel version this MCP build needs across its bridge commands and
- * handshake capabilities. Keep this beside both capability tables so proactive
- * panel sync and a bridge refusal report the same derived requirement.
- */
-export function requiredPanelVersion(): string {
+/** Fold a list of candidate minimums into the highest PARSEABLE one, seeded with
+ *  the full-set baseline. Unparseable entries are skipped rather than allowed to
+ *  win — a table typo must not fabricate a requirement. */
+function highestRequirement(candidates: readonly (string | undefined)[]): string {
   let best = MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS;
-  for (const min of [
-    ...Object.values(BRIDGE_CMD_MIN_PANEL_VERSION),
-    ...Object.values(BRIDGE_CAPABILITY_MIN_PANEL_VERSION),
-  ]) {
+  for (const min of candidates) {
+    // A missing table key must degrade to "skip", never to a throw: this runs
+    // inside error-message construction, where a throw would replace an
+    // actionable refusal with an opaque crash.
+    if (typeof min !== "string") continue;
     if (!SEMVER_RE.test(min.trim())) continue;
     if (!SEMVER_RE.test(best.trim()) || compareSemver(min, best) > 0) best = min;
   }
   return best;
+}
+
+/**
+ * The highest panel version this MCP build needs across its bridge commands and
+ * handshake capabilities. Keep this beside both capability tables so proactive
+ * panel sync and a bridge refusal report the same derived requirement.
+ *
+ * This is the SYNC/INSTALL question — "how new must the panel be for this
+ * orchestrator to have everything it might want?" It is an aggregate across
+ * every command and capability, so it is NOT the answer to "what does the write
+ * I just refused actually need"; quoting it there is the #619 self-contradiction
+ * in another costume (see requiredPanelVersionForWorkflowFence).
+ */
+export function requiredPanelVersion(): string {
+  return highestRequirement([
+    ...Object.values(BRIDGE_CMD_MIN_PANEL_VERSION),
+    ...Object.values(BRIDGE_CAPABILITY_MIN_PANEL_VERSION),
+  ]);
+}
+
+/**
+ * The minimum panel version that can fence a graph WRITE to its workflow — the
+ * only version a fenced-write refusal is entitled to quote.
+ *
+ * A write needs BOTH handshake capabilities (the dispatch-time stamp check and
+ * the after-await write-boundary recheck), so it is their maximum, not the
+ * global one. Today the two happen to be equal, which is precisely why this
+ * needs to be separate NOW: the moment some unrelated command declares a higher
+ * minimum, `requiredPanelVersion()` rises and the refusal starts telling users
+ * their write needs a version it does not need — a number they cannot verify,
+ * attached to a remedy they will run for the wrong reason. Same defect as #352 /
+ * #619 (a blanket floor quoted as one command's requirement), one level up.
+ */
+export function requiredPanelVersionForWorkflowFence(): string {
+  return highestRequirement([
+    BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_workflow_stamp,
+    BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_workflow_stamp_at_write,
+  ]);
 }
 
 /**
@@ -594,11 +631,125 @@ export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   "refresh_nodes",
 ]);
 
-/** #570 P0c — a graph command that WRITES the canvas (add/remove/connect/move/set_widget/
- *  clear/load/…). Any `graph_*` command that is NOT in the read-only allowlist mutates, so
- *  this stays correct as new graph mutators are added without having to enumerate them. */
+/**
+ * What a `graph_*` command can do to the user's WORKFLOW — the single question
+ * the #570 write gate asks.
+ *
+ * THIS IS A LEDGER, NOT A DERIVED SET (#778). The gate used to answer its
+ * question with a value computed for a DIFFERENT one: `BRIDGE_READONLY_CMDS`
+ * exists to decide the default reply timeout and whether a mid-command socket
+ * drop may be parked and resumed, so it lists only commands that are safe to
+ * RE-DISPATCH. Reading "not in that set" as "mutates the canvas" silently
+ * misclassified every command that is a genuine read but not idempotently
+ * re-dispatchable — and every view/selection/scope change, which touches no
+ * workflow content at all. `graph_find_nodes` (#778) was the reported instance;
+ * `graph_list_subgraphs`, `graph_screenshot`, `graph_canvas`,
+ * `graph_select_nodes`, `graph_enter_subgraph`, `graph_exit_subgraph` and
+ * `graph_copy_nodes` were the same defect, unreported. The orchestrator already
+ * knew they were reads — RETRY_TOKEN_CMD_BY_TOOL's doc names them one by one as
+ * "view/read-only" and "reads in spirit" — but that knowledge lived in a third
+ * list, so the gate could not see it.
+ *
+ * So each command is classified ONCE, here, by effect:
+ *
+ *  - `inert`    — cannot change workflow CONTENT and cannot act on it. Pure
+ *                 queries, plus viewport / selection / subgraph-scope /
+ *                 clipboard changes. Delivered to the wrong workflow after a
+ *                 tab switch, the worst case is that the user is looking at
+ *                 something unexpected — nothing of theirs is altered, so the
+ *                 per-command workflow fence buys nothing and refusing these on
+ *                 an old panel only removes read access for no safety gain.
+ *  - `targeted` — changes workflow content, publishes from it, or queues a
+ *                 render of it. A delivered frame cannot be retracted, so these
+ *                 MUST be fenced to the workflow they were issued for.
+ *
+ * Unlisted commands FAIL CLOSED to `targeted`: a command nobody classified must
+ * never be waved through the gate by omission. `graph-command-effect.test.ts`
+ * turns that silent fallback into a failing test by scanning the orchestrator
+ * for every `graph_*` command it actually dispatches and requiring an entry
+ * here — which is the part that was missing when #778 shipped.
+ */
+export type GraphCmdEffect = "inert" | "targeted";
+
+export const GRAPH_CMD_EFFECT: Readonly<Record<string, GraphCmdEffect>> = {
+  // ---- inert: reads -------------------------------------------------------
+  graph_serialize: "inert",
+  graph_outline: "inert",
+  graph_get_errors: "inert",
+  graph_get_state: "inert",
+  graph_get_subgraph: "inert",
+  graph_prompt_director_audit: "inert",
+  graph_query: "inert",
+  // #778 — the reported instance: a filtered node query, no different from
+  // graph_query, refused as a canvas mutation on a panel that does not advertise
+  // the workflow fence.
+  graph_find_nodes: "inert",
+  // Lists saved subgraph BLUEPRINTS from the user's library. Its own tool
+  // description ends "Read-only."
+  graph_list_subgraphs: "inert",
+  graph_screenshot: "inert",
+  // ---- inert: view / selection / scope / clipboard ------------------------
+  graph_view_selected: "inert",
+  graph_view_nodes_in_viewport: "inert",
+  // Moves the viewport only ("It changes what they are looking AT and returns
+  // nothing about the graph … View-only"). NOT added to BRIDGE_READONLY_CMDS:
+  // `pan` is a dx/dy DELTA, so re-dispatching it after a reconnect would pan
+  // twice. Inert for the fence, not idempotent for the parker — which is exactly
+  // the distinction collapsing the two lists destroyed.
+  graph_canvas: "inert",
+  graph_select_nodes: "inert",
+  graph_enter_subgraph: "inert",
+  graph_exit_subgraph: "inert",
+  // Reads nodes OUT of the graph into the clipboard. Writes nothing back; the
+  // paste that would write is `graph_paste_nodes`, which is targeted.
+  graph_copy_nodes: "inert",
+  // ---- targeted: content edits -------------------------------------------
+  graph_add_node: "targeted",
+  graph_remove_node: "targeted",
+  graph_clear: "targeted",
+  graph_connect: "targeted",
+  graph_disconnect: "targeted",
+  graph_set_widget: "targeted",
+  graph_set_node_property: "targeted",
+  graph_move_node: "targeted",
+  graph_resize_node: "targeted",
+  graph_set_title: "targeted",
+  graph_set_node_collapsed: "targeted",
+  graph_set_node_color: "targeted",
+  graph_edit_node: "targeted",
+  graph_set_node_mode: "targeted",
+  graph_update_node: "targeted",
+  graph_create_group: "targeted",
+  graph_edit_group: "targeted",
+  graph_remove_group: "targeted",
+  graph_move_group: "targeted",
+  graph_create_subgraph: "targeted",
+  graph_add_subgraph: "targeted",
+  graph_unpack_subgraph: "targeted",
+  graph_subgraph_group: "targeted",
+  graph_expose_subgraph_input: "targeted",
+  graph_expose_subgraph_output: "targeted",
+  graph_promote_widget: "targeted",
+  graph_move_rail: "targeted",
+  graph_paste_nodes: "targeted",
+  graph_auto_layout: "targeted",
+  graph_load: "targeted",
+  // Publishes a subgraph node from THIS graph into the user's blueprint library
+  // — a persistent artifact built from whichever workflow received the command.
+  graph_save_subgraph: "targeted",
+  // Does not edit the graph, but QUEUES it: the wrong workflow would consume the
+  // GPU and write output files the user never asked for. The fence's promise is
+  // "this command acts on the workflow it was issued for", and a render is an
+  // act on it.
+  graph_run: "targeted",
+};
+
+/** #570 P0c — a graph command that must be fenced to the workflow it was issued for.
+ *  Answered from GRAPH_CMD_EFFECT, which classifies by EFFECT; an unlisted `graph_*`
+ *  command fails closed to `targeted` so a new mutator is never waved through by
+ *  omission (and the effect ledger's completeness test flags it at build time). */
 export function isMutatingGraphCommand(cmdName: string): boolean {
-  return cmdName.startsWith("graph_") && !BRIDGE_READONLY_CMDS.has(cmdName);
+  return cmdName.startsWith("graph_") && (GRAPH_CMD_EFFECT[cmdName] ?? "targeted") === "targeted";
 }
 
 /** #570 P0c — the four workflow mutators. workflow_save / workflow_save_as ignore any path and
@@ -2541,19 +2692,36 @@ export class UiBridge {
           undefined,
           resolveStaleBundleSkew(conn.panelVersion),
         );
+        // #819/#823 — do not fold an ABSENT reading into a definite verdict.
+        // "detected panel version unknown; this MCP requires panel 0.11.35+"
+        // reads as "your panel is too old", but a missing version is a missing
+        // OBSERVATION: the tab sent no version, and a CURRENT install behind a
+        // stale cached browser bundle presents exactly the same way. Report what
+        // was actually seen and let the recovery cover both.
+        const observed = conn.panelVersion
+          ? `this tab reports panel ${conn.panelVersion}`
+          : `this tab advertised NO panel version, so its age was not observed — this is ` +
+            `equally consistent with an old install and with a current one whose browser ` +
+            `tab is running a cached older bundle`;
+        // The FENCE's own minimum, never the aggregate requiredPanelVersion():
+        // a write needs the two workflow-fence capabilities and nothing else, so
+        // quoting the global max would name a version this command does not
+        // require the moment any unrelated command declares a higher one.
+        const fenceMin = requiredPanelVersionForWorkflowFence();
         const why = !conn.enforcesWorkflowStamp
           ? `panel tab ${conn.tabId} does not enforce per-command workflow targeting ` +
-            `(detected panel ${conn.panelVersion ?? "version unknown"}; this MCP requires panel ` +
-              `${requiredPanelVersion()}+). ${recovery}`
+            `(${observed}; a graph WRITE needs panel ${fenceMin}+, the first build that fences ` +
+              `every command to the workflow it was issued for). ${recovery}`
           : !conn.enforcesWorkflowStampAtWrite
             ? `panel tab ${conn.tabId} does not recheck workflow targeting at the graph write ` +
-              `boundary after asynchronous work (detected panel ${conn.panelVersion ?? "version unknown"}; this MCP ` +
-                `requires panel ${requiredPanelVersion()}+). ${recovery}`
+              `boundary after asynchronous work (${observed}; a graph WRITE needs panel ` +
+                `${fenceMin}+, the first build that rechecks the fence after an await). ${recovery}`
           : `this workflow has no trusted identity for the panel to fence the command against`;
         const refusal = markDispatched(
           new Error(
-            `"${cmd.cmd}" cannot be safely targeted to the active workflow: ${why}. Read-only graph ` +
-              `commands (graph_outline, graph_query, graph_get_state) still work.`,
+            `"${cmd.cmd}" cannot be safely targeted to the active workflow: ${why}. Reads and ` +
+              `view-only commands still work (graph_outline, graph_query, graph_get_state, ` +
+              `graph_find_nodes, graph_list_subgraphs, graph_screenshot, graph_canvas).`,
           ),
           false,
         );

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -315,6 +315,43 @@ function highestRequirement(candidates: readonly (string | undefined)[]): string
 }
 
 /**
+ * A panel version AS OBSERVED, with the parsed form separated from the text.
+ *
+ * The handshake's `panel_version` is an arbitrary string. Screening it wherever
+ * it happens to be rendered does not hold: the screen was added at the write
+ * refusal, and the reactive unknown-command path — which builds its own view
+ * from the same raw field — went on rendering "detected panel nightly" and
+ * calling the panel too old. One value, two consumers, one of them screened.
+ *
+ * So the screen moves into the TYPE. A consumer that wants a version reads
+ * `.version`, which exists only when the text is strict SemVer; a consumer that
+ * wants to show what was actually said reads `.raw`. The unparseable value is
+ * still available — it is real evidence, and hiding it would be its own kind of
+ * lying — but it is no longer reachable through a field named like a version, so
+ * the next consumer added cannot accidentally treat it as one.
+ *
+ * `nightly` is the case that matters in practice: it is what ComfyUI-Manager
+ * reports for a git-installed pack, so it is the normal reading for anyone
+ * running the panel from source rather than the Registry.
+ */
+export interface PanelVersionReading {
+  /** Verbatim (trimmed) text the handshake carried. EVIDENCE, never a version. */
+  raw?: string;
+  /** Set ONLY when `raw` is a strict SemVer — the sole form that may be compared,
+   *  or quoted to a user as this panel's version. */
+  version?: string;
+}
+
+/** Screen a handshake `panel_version` into a reading. Blank and unparseable both
+ *  yield no `.version`; blank additionally yields no `.raw`, because whitespace
+ *  is not evidence of anything. Never throws. */
+export function readPanelVersion(raw: string | undefined): PanelVersionReading {
+  const trimmed = typeof raw === "string" ? raw.trim() : "";
+  if (!trimmed) return {};
+  return SEMVER_RE.test(trimmed) ? { raw: trimmed, version: trimmed } : { raw: trimmed };
+}
+
+/**
  * The highest panel version this MCP build needs across its bridge commands and
  * handshake capabilities. Keep this beside both capability tables so proactive
  * panel sync and a bridge refusal report the same derived requirement.
@@ -553,21 +590,38 @@ function mcpServerVersion(): string | undefined {
 
 function buildPanelTooOldError(
   cmd: string,
-  panelVersion?: string,
+  reading: PanelVersionReading,
   mcpVersion: string | undefined = mcpServerVersion(),
 ): Error {
-  const detected = panelVersion
-    ? ` (detected panel ${panelVersion}${mcpVersion ? `, mcp ${mcpVersion}` : ""})`
-    : mcpVersion
-      ? ` (detected mcp ${mcpVersion})`
-      : "";
+  const mcpTail = mcpVersion ? `, mcp ${mcpVersion}` : "";
+  const detected = reading.version
+    ? ` (detected panel ${reading.version}${mcpTail})`
+    : reading.raw
+      ? // The value is EVIDENCE, quoted so it reads as a string rather than as a
+        // version. "nightly" is the common one — ComfyUI-Manager's answer for a
+        // git-installed pack — and it used to render as "detected panel nightly",
+        // a version-shaped claim about something never parsed.
+        ` (this panel reports "${reading.raw}", which is not a comparable version${mcpTail})`
+      : mcpVersion
+        ? ` (detected mcp ${mcpVersion})`
+        : "";
   const min = BRIDGE_CMD_MIN_PANEL_VERSION[cmd];
+  // "TOO OLD" IS AN AGE VERDICT, and it may only be reached from an age
+  // OBSERVATION: a version that parsed AND compares below the command's known
+  // minimum. Everything else — no version, an unparseable one — has exactly one
+  // observed fact behind it, the panel's own "Unknown command" reply, and that
+  // fact is "does not implement", not "is old". The remedy is unchanged either
+  // way, and the command's true minimum is still quoted when it is known, so
+  // nothing actionable is lost by declining to guess the cause.
+  const provenOld =
+    !!min && !!reading.version && SEMVER_RE.test(min.trim()) && compareSemver(reading.version, min) < 0;
+  const remedy = min
+    ? `update the ComfyUI-MCP panel to ≥${min} (ComfyUI Manager → update comfyui-mcp panel), then reconnect.`
+    : `update the ComfyUI-MCP panel to the latest release (ComfyUI Manager → update comfyui-mcp panel), then reconnect.`;
   const e = new Error(
-    min
-      ? `This ComfyUI-MCP panel is too old for "${cmd}"${detected} — update the ComfyUI-MCP panel ` +
-          `to ≥${min} (ComfyUI Manager → update comfyui-mcp panel), then reconnect.`
-      : `This ComfyUI-MCP panel does not implement "${cmd}"${detected} — update the ComfyUI-MCP panel ` +
-          `to the latest release (ComfyUI Manager → update comfyui-mcp panel), then reconnect.`,
+    provenOld
+      ? `This ComfyUI-MCP panel is too old for "${cmd}"${detected} — ${remedy}`
+      : `This ComfyUI-MCP panel does not implement "${cmd}"${detected} — ${remedy}`,
   );
   // STRUCTURED discriminator (#413): both the reactive rewrite and the #236
   // proactive gate funnel through here, so tagging the error object lets callers
@@ -652,7 +706,11 @@ export function makeUnknownCommandError(
   // (which would also POISON the #236 unsupported-cmd gate against a capable panel).
   // Return null so the raw error surfaces and the gate is never poisoned.
   if (panelSupportsCmd(cmd, panelVersion)) return null;
-  return buildPanelTooOldError(cmd, panelVersion, mcpVersion);
+  // The raw handshake string ends here: everything downstream sees a screened
+  // reading, so an unparseable value cannot be rendered as a version or read as
+  // an age (see PanelVersionReading — this consumer used to build its own view
+  // from the raw field and did both).
+  return buildPanelTooOldError(cmd, readPanelVersion(panelVersion), mcpVersion);
 }
 
 /**
@@ -2718,7 +2776,7 @@ export class UiBridge {
     // on THIS connection (in dispatch()'s rejectMapped below), never inferred from
     // panelVersion alone.
     if (conn.unsupportedCmds.has(cmd.cmd)) {
-      return Promise.reject(buildPanelTooOldError(cmd.cmd, conn.panelVersion));
+      return Promise.reject(buildPanelTooOldError(cmd.cmd, readPanelVersion(conn.panelVersion)));
     }
     // #392 — PROACTIVELY gate a command whose changelog-verified minimum the panel's
     // ADVERTISED version parseably undercuts (e.g. graph_query on a <0.7.0 panel), so
@@ -2740,7 +2798,7 @@ export class UiBridge {
       !conn.provenSupportedCmds.has(cmd.cmd) &&
       panelVersionProvesUnsupported(cmd.cmd, conn.panelVersion)
     ) {
-      return Promise.reject(buildPanelTooOldError(cmd.cmd, conn.panelVersion));
+      return Promise.reject(buildPanelTooOldError(cmd.cmd, readPanelVersion(conn.panelVersion)));
     }
     // #570 P0c — FAIL CLOSED for a command that mutates the ACTIVE workflow/canvas (every
     // graph_* mutator, plus path-less workflow_save/save_as/rename/close) when the resolved
@@ -2820,11 +2878,15 @@ export class UiBridge {
         // path — including into `resolveStaleBundleSkew`, which then reasons
         // from "no comparable version" instead of silently rejecting a value it
         // would have screened out one line later anyway.
-        const rawAdvertised = conn.panelVersionAdvertised
-          ? conn.panelVersion?.trim() || undefined
-          : undefined;
-        const advertised =
-          rawAdvertised && SEMVER_RE.test(rawAdvertised) ? rawAdvertised : undefined;
+        // Screened through the SAME helper as the reactive path, so the two
+        // cannot drift: `.version` is comparable and attributable, `.raw` is
+        // evidence. Only an ADVERTISED reading counts — an inherited value is
+        // not this handshake's observation (see below).
+        const reading = conn.panelVersionAdvertised
+          ? readPanelVersion(conn.panelVersion)
+          : {};
+        const rawAdvertised = reading.raw;
+        const advertised = reading.version;
         const recovery = describePanelUpdateRecovery(
           undefined,
           resolveStaleBundleSkew(advertised),

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -444,7 +444,13 @@ function resolveStaleBundleSkew(panelVersion?: string): PanelBundleSkew | undefi
 
   const advertised = panelVersion?.trim();
   if (advertised) {
-    // A version we cannot parse is not proof of an old tab.
+    // Defence in depth. The caller now screens the handshake value against
+    // SEMVER_RE and passes `undefined` for anything unparseable, so a value that
+    // reaches here is already a version — but this must not become the ONLY
+    // screen: returning undefined for an unparseable string would silently drop
+    // the diagnosis for the "nightly" case (a git-installed pack), which is
+    // precisely the population that ends up in this refusal. An unparseable
+    // reading is an ABSENT reading, and the caller resolves it as one.
     if (!SEMVER_RE.test(advertised)) return undefined;
     if (compareSemver(advertised, required) >= 0) return undefined;
   }
@@ -790,12 +796,68 @@ export const GRAPH_CMD_EFFECT: Readonly<Record<string, GraphCmdEffect>> = {
   graph_run: "targeted",
 };
 
+/**
+ * Every `graph_*` command this process has had to classify BY DEFAULT, because
+ * it had no GRAPH_CMD_EFFECT entry.
+ *
+ * The ledger's completeness is checked by scanning the sources for the commands
+ * the orchestrator dispatches — and a source scan can only see what it can
+ * recognise. A command routed through a helper, an alias, or a computed name
+ * walks around it, the suite stays green, and the command silently falls back to
+ * `targeted`: the unclassified-read over-refusal (#778) rebuilt behind the guard
+ * that exists to prevent it. That is the same shape as the vocabulary ratchet,
+ * where deleting a baseline line is the documented way to disarm the gate.
+ *
+ * So the fallback also RECORDS, at the point of use. This observation cannot be
+ * evaded by how a call is spelled — it is taken from the command actually being
+ * routed — and it gives the tests an assertion that does not depend on reading
+ * source text: drive the real tool surface, then assert this set is empty.
+ */
+const unclassifiedGraphCmds = new Set<string>();
+
+/** The `graph_*` commands classified by fallback since process start. Empty is
+ *  the invariant; anything in it is a ledger gap, not a runtime condition. */
+export function unclassifiedGraphCommandsSeen(): ReadonlySet<string> {
+  return unclassifiedGraphCmds;
+}
+
+/** Test hook — clear the record between probes. */
+export function __resetUnclassifiedGraphCommands(): void {
+  unclassifiedGraphCmds.clear();
+}
+
+/** Record + warn ONCE per command name. Deliberately cannot throw: this runs on
+ *  the dispatch path of every graph command, and a guard that can fail is not a
+ *  guard. It does not change the decision — the fallback is still `targeted`,
+ *  still fail-closed; it only makes the fallback observable instead of silent. */
+function noteUnclassifiedGraphCmd(cmdName: string): void {
+  if (unclassifiedGraphCmds.has(cmdName)) return;
+  unclassifiedGraphCmds.add(cmdName);
+  try {
+    logger.warn(
+      `[ui-bridge] graph command "${cmdName}" has no GRAPH_CMD_EFFECT entry — fencing it as a ` +
+        `WRITE by default. If it is a read or a view/selection change this needlessly refuses ` +
+        `it on every panel below the workflow-fence version (#778). Classify it in ` +
+        `GRAPH_CMD_EFFECT (src/services/ui-bridge.ts).`,
+    );
+  } catch {
+    /* an error-path guard must never become the error */
+  }
+}
+
 /** #570 P0c — a graph command that must be fenced to the workflow it was issued for.
  *  Answered from GRAPH_CMD_EFFECT, which classifies by EFFECT; an unlisted `graph_*`
  *  command fails closed to `targeted` so a new mutator is never waved through by
- *  omission (and the effect ledger's completeness test flags it at build time). */
+ *  omission — and is recorded (see unclassifiedGraphCommandsSeen) so the omission
+ *  is visible rather than silent. */
 export function isMutatingGraphCommand(cmdName: string): boolean {
-  return cmdName.startsWith("graph_") && (GRAPH_CMD_EFFECT[cmdName] ?? "targeted") === "targeted";
+  if (!cmdName.startsWith("graph_")) return false;
+  const effect = GRAPH_CMD_EFFECT[cmdName];
+  if (effect === undefined) {
+    noteUnclassifiedGraphCmd(cmdName);
+    return true; // fail closed
+  }
+  return effect === "targeted";
 }
 
 /** #570 P0c — the four workflow mutators. workflow_save / workflow_save_as ignore any path and
@@ -2741,15 +2803,28 @@ export class UiBridge {
         // otherwise reasons about an observation the current tab never made
         // (codex gate). An inherited value is still worth SHOWING — it is a real
         // earlier reading — but labelled as what it is.
-        // TRIMMED, and blank-is-absent: a hello carrying `panel_version: "   "`
-        // sets panelVersionAdvertised (it is a non-empty string) but says
-        // nothing. Untrimmed it rendered "this tab reports panel    " while the
-        // skew resolver — which does trim — simultaneously reported that the tab
-        // advertised no version: one refusal, two contradictory readings of the
-        // same field (codex gate). An unreadable observation is an absent one.
-        const advertised = conn.panelVersionAdvertised
+        // The distinction that matters is PARSEABLE vs NOT, not empty vs
+        // non-empty. An earlier fix trimmed the field so `panel_version: "   "`
+        // stopped rendering as "this tab reports panel    " — but that only
+        // screened BLANK, and `panel_version: "nightly"` sailed through as
+        // "this tab reports panel nightly": a version-shaped claim built from a
+        // string we never parsed, which is this cluster's own defect surviving
+        // inside its fix. It is not a rare input either — ComfyUI-Manager
+        // reports "nightly" for a git-installed pack, so it is the normal case
+        // for anyone running the panel from source rather than the Registry.
+        //
+        // So: `rawAdvertised` is what this handshake actually said (evidence,
+        // shown verbatim), and `advertised` is what we may COMPARE or attribute
+        // as a version. Anything that fails the strict SemVer screen has the
+        // same evidential value as no version at all and takes the unreadable
+        // path — including into `resolveStaleBundleSkew`, which then reasons
+        // from "no comparable version" instead of silently rejecting a value it
+        // would have screened out one line later anyway.
+        const rawAdvertised = conn.panelVersionAdvertised
           ? conn.panelVersion?.trim() || undefined
           : undefined;
+        const advertised =
+          rawAdvertised && SEMVER_RE.test(rawAdvertised) ? rawAdvertised : undefined;
         const recovery = describePanelUpdateRecovery(
           undefined,
           resolveStaleBundleSkew(advertised),
@@ -2765,11 +2840,19 @@ export class UiBridge {
           `and with a current one whose browser tab is running a cached older bundle`;
         const observed = advertised
           ? `this tab reports panel ${advertised}`
-          : conn.panelVersion
-            ? `this tab advertised NO panel version in its current handshake (an EARLIER ` +
-              `connection for this tab reported ${conn.panelVersion}, which may be out of ` +
-              `date), ${NOT_OBSERVED}`
-            : `this tab advertised NO panel version, ${NOT_OBSERVED}`;
+          : rawAdvertised
+            ? // It said SOMETHING, and that something is evidence worth showing —
+              // but it is not a version, so it may not be narrated as one. The
+              // most common value here is "nightly" (a git-installed pack), for
+              // which the true version is genuinely indeterminate.
+              `this tab advertised "${rawAdvertised}", which is not a version this MCP can ` +
+              `compare (ComfyUI-Manager reports "nightly" for a git-installed pack), ` +
+              `${NOT_OBSERVED}`
+            : conn.panelVersion
+              ? `this tab advertised NO panel version in its current handshake (an EARLIER ` +
+                `connection for this tab reported ${conn.panelVersion}, which may be out of ` +
+                `date), ${NOT_OBSERVED}`
+              : `this tab advertised NO panel version, ${NOT_OBSERVED}`;
         // The FENCE's own minimum, never the aggregate requiredPanelVersion():
         // a write needs the two workflow-fence capabilities and nothing else, so
         // quoting the global max would name a version this command does not

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -410,6 +410,10 @@ export function requiredPanelVersionForWorkflowFence(): string | undefined {
  *     A tab claiming the same current version yet missing the capability is some
  *     other fault, not this one, and must not be given this diagnosis.
  */
+/** @param panelVersion the version THIS connection ADVERTISED in its own hello —
+ *  never `conn.panelVersion` raw, which is inherited across an omitted-version
+ *  reconnect. Reasoning about an inherited value here would let a previous
+ *  connection's reading decide whether the CURRENT tab is the stale part. */
 function resolveStaleBundleSkew(panelVersion?: string): PanelBundleSkew | undefined {
   const disk = verifiedPanelDiskVersion()?.trim();
   if (!disk) {
@@ -2716,9 +2720,17 @@ export class UiBridge {
         // panel sync read OFF DISK at this tab's own hello. When the pack on
         // disk already clears the floor, no update of any kind helps and the
         // remedy is a cache-bypassing reload of this tab.
+        // `conn.panelVersion` is INHERITED across a reconnect whose hello omitted
+        // the field (see the field's doc); `panelVersionAdvertised` is the record
+        // of whether THIS connection actually stated one. Only the advertised
+        // value may be attributed to this tab, or to the skew diagnosis, which
+        // otherwise reasons about an observation the current tab never made
+        // (codex gate). An inherited value is still worth SHOWING — it is a real
+        // earlier reading — but labelled as what it is.
+        const advertised = conn.panelVersionAdvertised ? conn.panelVersion : undefined;
         const recovery = describePanelUpdateRecovery(
           undefined,
-          resolveStaleBundleSkew(conn.panelVersion),
+          resolveStaleBundleSkew(advertised),
         );
         // #819/#823 — do not fold an ABSENT reading into a definite verdict.
         // "detected panel version unknown; this MCP requires panel 0.11.35+"
@@ -2726,11 +2738,16 @@ export class UiBridge {
         // OBSERVATION: the tab sent no version, and a CURRENT install behind a
         // stale cached browser bundle presents exactly the same way. Report what
         // was actually seen and let the recovery cover both.
-        const observed = conn.panelVersion
-          ? `this tab reports panel ${conn.panelVersion}`
-          : `this tab advertised NO panel version, so its age was not observed — this is ` +
-            `equally consistent with an old install and with a current one whose browser ` +
-            `tab is running a cached older bundle`;
+        const NOT_OBSERVED =
+          `so its age was not observed — this is equally consistent with an old install ` +
+          `and with a current one whose browser tab is running a cached older bundle`;
+        const observed = advertised
+          ? `this tab reports panel ${advertised}`
+          : conn.panelVersion
+            ? `this tab advertised NO panel version in its current handshake (an EARLIER ` +
+              `connection for this tab reported ${conn.panelVersion}, which may be out of ` +
+              `date), ${NOT_OBSERVED}`
+            : `this tab advertised NO panel version, ${NOT_OBSERVED}`;
         // The FENCE's own minimum, never the aggregate requiredPanelVersion():
         // a write needs the two workflow-fence capabilities and nothing else, so
         // quoting the global max would name a version this command does not

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -424,7 +424,21 @@ function resolveStaleBundleSkew(panelVersion?: string): PanelBundleSkew | undefi
     void primePanelBase().catch(() => {});
     return undefined;
   }
-  const required = requiredPanelVersion();
+  // THE FENCE's floor, not the aggregate requiredPanelVersion() (codex gate).
+  // This function answers one question — "is the install sufficient for the
+  // WRITE that was just refused?" — and the aggregate answers a different one
+  // ("is it sufficient for everything this build might want?"). Using the
+  // aggregate is wrong in both directions:
+  //   - too strict: an unrelated command declaring a higher minimum would deny
+  //     the positive proof for a disk panel that IS sufficient for this write,
+  //     and send a user whose only problem is a cached tab off to update;
+  //   - self-contradictory: with an incomplete fence table the aggregate still
+  //     returns a number, so the same refusal could say "Do NOT update — your
+  //     0.11.35 meets the 0.11.30+ required" while its other half says it cannot
+  //     state the fence version at all.
+  // And when the fence's own floor is unknowable, nothing is proven: no skew.
+  const required = requiredPanelVersionForWorkflowFence();
+  if (!required) return undefined;
   if (!SEMVER_RE.test(disk) || !SEMVER_RE.test(required.trim())) return undefined;
   if (compareSemver(disk, required) < 0) return undefined; // install really IS behind
 


### PR DESCRIPTION
## Issues in this cluster

Closes #778
Closes #806
Closes #819
Closes #812
Closes #823

Five reports, **two folds**. Both are the same shape: a value computed to answer one question, read as the answer to a different one.

---

## Fold 1 — a READ blocked by a WRITE gate (#778, #823, and six unreported siblings)

The #570 workflow fence asks *"can this command apply to the wrong workflow's content?"* and answered it with `!BRIDGE_READONLY_CMDS.has(cmd)` — a set that exists to answer *"is this safe to re-dispatch after a reconnect?"*. Every graph command that is a genuine read but **not idempotently re-dispatchable**, and every view/selection/scope change, fell through the crack and was refused as a canvas mutation on any panel below the fence version.

`graph_find_nodes` is the one a user reported. It was not alone:

| command | why it is inert |
|---|---|
| `graph_find_nodes` | filtered node query — #778 |
| `graph_list_subgraphs` | its own tool description ends "Read-only." |
| `graph_screenshot` | view-only capture, already outside the retry map |
| `graph_canvas` | "changes what they are looking AT … View-only" |
| `graph_select_nodes` | selection only |
| `graph_enter_subgraph` / `graph_exit_subgraph` | view scope — **#823 hit this one** |
| `graph_copy_nodes` | reads nodes into the clipboard; the paste that writes is still gated |

The orchestrator **already knew** these were reads — `RETRY_TOKEN_CMD_BY_TOOL`'s doc names them one by one as "view/read-only" and "reads in spirit" — but that knowledge lived in a third list the gate could not see. Three targeted guards, three lists, one silent disagreement.

`GRAPH_CMD_EFFECT` is now the single ledger: every `graph_*` command is classified `inert` / `targeted`, and unlisted still **fails closed**. What is gone is the *silent* default.

**Enforcement, in three layers** — because the ledger is now load-bearing for a safety fence, and a guard that a rename can walk around is the thing this repo keeps relearning:

1. a source scan over **any** `"graph_…"` literal (comments stripped), so evading it means never writing the name down;
2. a **runtime probe** that drives every real panel tool handler and asserts every command it actually *dispatches* is classified — spelling-independent by construction;
3. `isMutatingGraphCommand` **records and warns once** whenever it classifies by fallback, taken from the command being routed, so the default is observable rather than silent; a test drives the surface and asserts that record is empty, with a negative control proving the recorder records.

Mutation-verified: a command dispatched under a name assembled at runtime passes layer 1 and fails layers 2 and 3.

The gate is unchanged for anything that can alter workflow content, publish from it, or queue a render. `graph_run` stays fenced — it doesn't edit the graph, but rendering the wrong workflow burns GPU and writes output files the user never asked for.

## Fold 2 — "up-to-date" that means "meets the minimum" (#806)

Two verdicts wore a currency word they never earned.

- `evaluatePanelSync` compares against the orchestrator's **minimum**. Renamed `up-to-date` → **`meets-floor`**; the summary names both versions, says out loud that it is a floor check and not a latest-version check, and points at the pack's `pyproject.toml` — where the newest version is actually published (the panel ships to the Comfy Registry on a pyproject change; the repo's GitHub releases are the wrong source).
- `ensurePanelInstalled`'s branch **never compared versions at all** — that path is install-if-missing and diffs nothing. It is the exact line the #806 reporter pasted. Renamed `up-to-date` → **`present`**, with a reason stating what it did and did not check.

Nothing here fabricates a "latest": this process cannot resolve one, so it stops *implying* one rather than guessing.

## Dead-end remedies (#819, #812, #823)

- **#819** — the manual host-side commands assumed the pack **existed** (`git -C <dir> pull`, `mv <dir> …`). A stale ComfyUI-Manager 3.x reports its queue drained without creating the pack, so both fail in exactly the state that reporter was in. All three on-disk states are now enumerated, including a plain `git clone`.
- **#812 / #823** — "install_panel does not exist" is **wrong**: it is registered, and **compact tool mode is the default**, which leaves it reachable only through `call_tool`. A tool-name search cannot see it; `call_tool` can run it. The refusal now names that call. (Posted as a comment on #812 too, so the reporter sees the correction.)
- **#819 / #823** — *"detected panel version unknown; this MCP requires panel 0.11.35+"* reads as a verdict that the panel is old. An absent version is an absent **observation** — a current install behind a stale browser bundle is observationally identical. The message now reports what was seen, and where the pack on disk provably clears the floor it **ranks** the possible causes instead of asserting one.
- **`nightly` is not a version.** The screen is now strict SemVer, not empty-vs-non-empty. `panel_version: "nightly"` — what ComfyUI-Manager reports for a git-installed pack, so the normal case for anyone running from source — used to render as "detected panel nightly" and be compared as if it were a version. It is now shown as evidence and routed to the unreadable path, which also unblocks the stale-bundle diagnosis that was being silently dropped for exactly that population.
- The refusal quoted `requiredPanelVersion()`, the aggregate max over every command and capability, as the requirement for one write. Split out `requiredPanelVersionForWorkflowFence()` so a future unrelated minimum cannot inflate it.

---

## What is NOT fixed

- **#823's second half** — `read_skill` and `report_issue` missing from a Codex panel session. That is a property of which tool surface the client builds (the embedded sidebar exposes the disjoint `panel_*` set), not something an error message can change. The `install_panel` half is fixed; the other two are untouched.
- **`graph_run`, and the ComfyUI-Manager 3.x silent no-op itself** — deliberately out of scope. The no-op is already detected and reported correctly; what was missing was a recovery path, which is what this PR adds.

## Verification

Rebased onto `main` at 0.49.6. Every fix mutation-verified (break it, watch the matching test fail). Full suite + `lint`, `build`, `asset-counts --check`, `vocab:export`, `check:vocabulary` green; committed blobs scanned for stray control bytes. Rendered messages read end to end — which is how the duplicated `..` and the "run update" / "updating reports nothing to do" contradiction were caught.

Six rounds of a `gpt-5.6-terra` self-gate (five FAILs, each a real defect, then PASS), followed by an independent gate that returned NO-SHIP on a P0 and a P1 — both fixed in the final commit. The author-side gate could not execute Vitest in its sandbox, so its PASS was static-source; the runtime evidence is the suite.

**Only a live rig can confirm** that a real pre-0.11.35 panel actually answers `graph_find_nodes` / `graph_screenshot` / `graph_enter_subgraph`. The tests prove the orchestrator dispatches them instead of refusing; a panel that doesn't implement them still gets the honest "Unknown command → update your panel" path.
