### PR TITLE
graph binding after reconnect/retarget: a documented recovery that could not recover (#803, #770, #772)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4706,6 +4706,29 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
   // uncorroborated top-level `active` "is never a safe source for replacing a
   // command fence". These cases hold the rebind to it.
 
+  it("ADOPTS when the identities differ only in path SYNTAX — a contradiction check must not refuse a real match", async () => {
+    // The contradiction check compares through the same canonicalizer the rest of
+    // this file uses. Comparing raw strings would call "./workflows/a.json" and
+    // "workflows/a.json" a contradiction and refuse a legitimate recovery — this
+    // defect class pointed the other way, which is precisely what the check was
+    // added to avoid committing (codex gate).
+    const { bridge, refresh, tab } = fenceBridge({
+      fence: STALE,
+      active: {
+        path: "./workflows/a.json",
+        routing_key: "wf:workflows/a.json",
+        workflow_uuid: LIVE,
+      },
+      workflows: [
+        { path: "workflows/a.json", routing_key: "wf:workflows/a.json", active: true },
+      ],
+    });
+    const { res } = await setCurrent(bridge, tab);
+
+    expect(refresh).toHaveBeenCalledExactlyOnceWith(tab, LIVE);
+    expect(res.isError).toBeFalsy();
+  });
+
   it("REFUSES a PARTIAL contradiction — one matching field never outvotes a conflicting one", async () => {
     const OTHER = "33333333-3333-4333-8333-333333333333";
     const { bridge, refresh, tab, currentStamp } = fenceBridge({
@@ -5101,6 +5124,52 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     // And it must not leave "reads work" standing, which is false for a tab that
     // cannot be routed to at all.
     expect(text).toMatch(/reads are not working either/);
+  });
+
+  it("does NOT blame the panel version when the socket is merely CLOSING", async () => {
+    // Transport, not version. Folding this into "capability" told the user to
+    // update a pack that was already correct (codex gate).
+    const { bridge, tab } = fenceBridge({
+      fence: STALE,
+      active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+    });
+    const ctx = makePanelToolCtx(bridge, tab, new WorkflowTargetStore());
+    ctx.tabGraphMutationCapability = () => ({
+      known: true,
+      canMutate: false,
+      because: "disconnected" as const,
+    });
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    const text = (res.content[0] as { text: string }).text;
+
+    expect(text).toMatch(/socket is CLOSING/);
+    expect(text).not.toMatch(/update the comfyui-mcp-panel pack/);
+    expect(text).toMatch(/wait for the panel to reconnect/);
+  });
+
+  it("does NOT blame the panel version when only the workflow IDENTITY is missing", async () => {
+    // A modern panel advertising both fences, with no trusted stamp. Reads work
+    // and a rebind is the fix — so "no rebind can add it" and "update the pack"
+    // are both false here (codex gate).
+    const { bridge, tab } = fenceBridge({
+      fence: STALE,
+      active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+    });
+    const ctx = makePanelToolCtx(bridge, tab, new WorkflowTargetStore());
+    ctx.tabGraphMutationCapability = () => ({
+      known: true,
+      canMutate: false,
+      because: "no_identity" as const,
+    });
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    const text = (res.content[0] as { text: string }).text;
+
+    expect(text).toMatch(/no trusted workflow identity/);
+    expect(text).toMatch(/panel build is FINE/);
+    expect(text).not.toMatch(/update the comfyui-mcp-panel pack/);
+    // The old wording actively told the caller a retry could not help. It can.
+    expect(text).not.toMatch(/including calling this tool again — can add it/);
+    expect(text).toMatch(/call this tool again to bind an identity/);
   });
 
   it("reports `unverified` — not `bound` — when the write capability cannot be determined", async () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4619,6 +4619,7 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
       // is standing in for the map that holds the stamp.
       workflowUuidFor: () => ({ known: true, uuid: stamp }),
       tabCanMutateGraph: () => true,
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
     } as unknown as PanelToolCtx["bridge"];
     return { bridge, sent, refresh, tab, currentStamp: () => stamp };
   }
@@ -4681,9 +4682,15 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     // Nothing to change — so nothing is claimed to have changed.
     expect(refresh).not.toHaveBeenCalled();
     expect(JSON.parse(text).graph_binding_status).toBe("already_current");
-    expect(text).toMatch(/already named the live canvas/);
-    // A DIFFERENT remedy from every failure branch: the disagreement is not here.
-    expect(text).toMatch(/the mismatch is coming from the panel/);
+    expect(text).toMatch(/already named the canvas the panel reported as active a moment ago/);
+    // The SAME post-probe switch window `refreshed` discloses — a switch in that
+    // instant leaves this stamp stale too, and the fix for that is this very call.
+    expect(text).toMatch(/cleared by calling this\s+again/);
+    // …so the reload is reserved for a mismatch that SURVIVES a repeat, which is
+    // the only thing that actually implicates the panel.
+    expect(text).toMatch(/call this once more/);
+    expect(text).toMatch(/If the\s+mismatch SURVIVES that repeat/);
+    expect(text.indexOf("call this once more")).toBeLessThan(text.indexOf("manually refresh"));
   });
 
   it("FAILS — and discloses what did apply — when the live identity is UNREADABLE and a stale fence remains", async () => {
@@ -4872,7 +4879,7 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
       active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
     });
     const ctx = makePanelToolCtx(bridge, tab, new WorkflowTargetStore());
-    ctx.tabCanMutateGraph = () => false; // stamp adopted, capability absent
+    ctx.tabGraphMutationCapability = () => ({ known: true, canMutate: false }); // observed absent
     const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
     const text = (res.content[0] as { text: string }).text;
 
@@ -4897,9 +4904,8 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
       active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
     });
     const ctx = makePanelToolCtx(bridge, tab, new WorkflowTargetStore());
-    ctx.tabCanMutateGraph = () => {
-      throw new Error("cannot tell");
-    };
+    // The PRODUCTION shape of "cannot tell": the bridge probe answers known:false.
+    ctx.tabGraphMutationCapability = () => ({ known: false, reason: "could not inspect the tab" });
     const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
     const text = (res.content[0] as { text: string }).text;
 
@@ -5064,7 +5070,7 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
       active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
     });
     const ctx = makePanelToolCtx(bridge, tab, new WorkflowTargetStore());
-    ctx.tabCanMutateGraph = () => true;
+    ctx.tabGraphMutationCapability = () => ({ known: true, canMutate: true });
     const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
     const text = (res.content[0] as { text: string }).text;
 

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4556,3 +4556,439 @@ describe("panel_ask keeps a validated answer across a tool timeout (#486)", () =
     expect(__panelAskTestHooks.ASK_TOTAL_BUDGET_CAP_MS).toBeLessThan(300000);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #770 / #803 / #716 — panel_set_workflow_target({mode:"current"}) as a recovery
+// that actually recovers.
+//
+// The reported wedge: after a reconnect, a soft reload, or a same-tab workflow
+// replacement, the active canvas gets a NEW workflow-instance uuid while the
+// session keeps the OLD one as its command stamp. Every stamped command is then
+// (correctly) refused by the panel's fence with `workflow instance mismatch`.
+// The error text names mode:"current" as the remedy — but that call only ever
+// re-pointed ROUTING, and routing is a no-op while the bound tab is still
+// reachable, so it returned "Following the user's current workflow tab." and
+// changed nothing. A documented recovery that could not recover.
+//
+// Every assertion below checks the REASON, not just the state: a refusal for the
+// wrong cause and a refusal for the right cause are different results, and one
+// bucket verdict covering four causes is what this cluster is about.
+// ---------------------------------------------------------------------------
+describe("panel-tools: mode:'current' re-derives the workflow command fence (#770/#803)", () => {
+  const STALE = "11111111-1111-4111-8111-111111111111";
+  const LIVE = "22222222-2222-4222-8222-222222222222";
+
+  /** A bridge modelling the ONE thing that matters here: the tab is REACHABLE,
+   *  the session holds `fence`, and the panel's live active record reports
+   *  `active`. `workflow_list` answers from `active`; everything else acks. */
+  function fenceBridge(opts: {
+    fence?: string;
+    active?: Record<string, unknown> | null;
+    listThrows?: string;
+    refreshReturns?: boolean;
+    tabId?: string;
+  }) {
+    const tab = opts.tabId ?? "wf:workflows/a.json";
+    let stamp = opts.fence;
+    const sent: Array<Record<string, unknown>> = [];
+    const refresh = vi.fn((_tabId: string, uuid: string) => {
+      if (opts.refreshReturns === false) return false;
+      stamp = uuid;
+      return true;
+    });
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        sent.push(cmd);
+        if (cmd.cmd === "workflow_list") {
+          if (opts.listThrows) throw new Error(opts.listThrows);
+          return opts.active == null ? { workflows: [] } : { active: opts.active };
+        }
+        return { ok: true };
+      },
+      push: () => 1,
+      canReach: (id: string) => id === tab,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: tab, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => tab,
+      refreshWorkflowUuid: refresh,
+      workflowUuidFor: () => stamp,
+    } as unknown as PanelToolCtx["bridge"];
+    return { bridge, sent, refresh, tab, currentStamp: () => stamp };
+  }
+
+  async function setCurrent(bridge: PanelToolCtx["bridge"], tab: string) {
+    const ctx = makePanelToolCtx(bridge, tab, new WorkflowTargetStore());
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    return { res, ctx, text: (res.content[0] as { text: string }).text };
+  }
+
+  it("REBINDS a stale fence onto the live canvas — the wedge these reports describe", async () => {
+    // The tab never went away (canReach true), so the pre-existing routing rebind
+    // is a no-op; only the FENCE is wrong. This is the reported dominant case.
+    const { bridge, refresh, tab, currentStamp } = fenceBridge({
+      fence: STALE,
+      active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+    });
+    const { res, ctx, text } = await setCurrent(bridge, tab);
+
+    expect(res.isError).toBeFalsy();
+    expect(ctx.tabId).toBe(tab); // routing untouched — it was never the problem
+    expect(refresh).toHaveBeenCalledExactlyOnceWith(tab, LIVE);
+    expect(currentStamp()).toBe(LIVE); // the fence a later graph command will carry
+    expect(JSON.parse(text)).toMatchObject({
+      graph_binding: "bound",
+      graph_binding_status: "refreshed",
+    });
+    // The REASON, rendered: both uuids named, so a reader can verify the swap.
+    expect(text).toContain(LIVE);
+    expect(text).toContain(STALE);
+    expect(text).toMatch(/Rebound the graph command fence onto the live canvas/);
+  });
+
+  it("rebinds for an UNSAVED (tmp:) canvas, which the saved-path #716 refresh can never reach", async () => {
+    // No `path`/`routing_key` to corroborate — canonicalRequestedSavedIdentity()
+    // returns null for every unsaved token, which is why open/pin cannot refresh
+    // here. mode:"current" has no caller-supplied target to corroborate: the live
+    // active canvas IS the target.
+    const { bridge, refresh, tab, currentStamp } = fenceBridge({
+      fence: STALE,
+      active: { workflow_uuid: LIVE, filename: "Unsaved Workflow" },
+      tabId: "tmp:abc123",
+    });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    expect(res.isError).toBeFalsy();
+    expect(refresh).toHaveBeenCalledExactlyOnceWith("tmp:abc123", LIVE);
+    expect(currentStamp()).toBe(LIVE);
+    expect(JSON.parse(text).graph_binding_status).toBe("refreshed");
+  });
+
+  it("reports ALREADY_CURRENT (and points at the panel) rather than a hollow rebind", async () => {
+    const { bridge, refresh, tab } = fenceBridge({
+      fence: LIVE,
+      active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+    });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    expect(res.isError).toBeFalsy();
+    // Nothing to change — so nothing is claimed to have changed.
+    expect(refresh).not.toHaveBeenCalled();
+    expect(JSON.parse(text).graph_binding_status).toBe("already_current");
+    expect(text).toMatch(/already named the live canvas/);
+    // A DIFFERENT remedy from every failure branch: the disagreement is not here.
+    expect(text).toMatch(/the mismatch is coming from the panel/);
+  });
+
+  it("FAILS — and discloses what did apply — when the live identity is UNREADABLE and a stale fence remains", async () => {
+    const { bridge, refresh, tab, currentStamp } = fenceBridge({
+      fence: STALE,
+      listThrows: "no connected tab",
+    });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    // Never "your recovery worked" when it did not.
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/did NOT restore this session's graph binding/);
+    // DISCLOSE, don't retract: the target write already happened.
+    expect(text).toMatch(/APPLIED \(do not repeat this part\)[\s\S]*mode:"current"/);
+    // The REASON — an unknown, explicitly not a rebind — and the stale uuid still in force.
+    expect(text).toMatch(/Could NOT read the live canvas identity/);
+    expect(text).toMatch(/This is not a rebind — it is an unknown/);
+    expect(text).toContain(STALE);
+    expect(refresh).not.toHaveBeenCalled();
+    expect(currentStamp()).toBe(STALE); // the fence was left intact, not cleared
+
+    // The remedy must be reachable AND must not contradict itself. The quoted
+    // transport cause can itself say "rebind with panel_set_workflow_target
+    // ({mode:'current'})" — the call that just failed — so the quote is labelled
+    // and explicitly disarmed, and our own remedy is stated BEFORE it.
+    expect(text).toMatch(/disregard any rebind advice inside it/);
+    expect(text.indexOf("WHAT TO DO")).toBeLessThan(text.indexOf("UNDERLYING CAUSE"));
+    expect(text).toMatch(/Repeating this call WITHOUT that refresh will fail the same way/);
+    // …and the remedy never sends the caller to panel_reload, which #803 observed
+    // leaving the tab permanently unresponsive from exactly this state.
+    expect(text).toMatch(/Do NOT use panel_reload/);
+  });
+
+  it("distinguishes NO_IDENTITY from UNREADABLE — same wedge, different remedy", async () => {
+    const { bridge, refresh, tab } = fenceBridge({
+      fence: STALE,
+      active: { path: "workflows/a.json" }, // panel answered; no workflow_uuid in it
+    });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/reported NO workflow identity for the active canvas/);
+    // NOT the unreadable wording — the panel DID answer, which is a different fact.
+    expect(text).not.toMatch(/Could NOT read the live canvas identity/);
+    expect(text).toMatch(/cached[\s\S]{0,30}older panel bundle/);
+    // …and the remedy is the one that actually replaces a cached bundle.
+    expect(text).toMatch(/HARD refresh here specifically/);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes a REJECTED adoption — read the identity, could not take it", async () => {
+    const { bridge, refresh, tab, currentStamp } = fenceBridge({
+      fence: STALE,
+      active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+      refreshReturns: false, // the orchestrator's validator declined it
+    });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    expect(res.isError).toBe(true);
+    expect(refresh).toHaveBeenCalledExactlyOnceWith(tab, LIVE);
+    expect(currentStamp()).toBe(STALE); // fail closed — old fence untouched
+    expect(text).toMatch(/could NOT adopt it as this session's graph command fence/);
+    // Distinct from both "unreadable" and "no identity": we DID read it.
+    expect(text).not.toMatch(/Could NOT read the live canvas identity/);
+    expect(text).not.toMatch(/reported NO workflow identity/);
+    expect(text).toContain(LIVE);
+  });
+
+  it("does NOT fail a session that never had a fence (an old panel stays usable)", async () => {
+    // Nothing was stale, so nothing failed to be repaired. Reporting this as a
+    // failed recovery would be the same fold in the opposite direction.
+    const { bridge, tab } = fenceBridge({ fence: undefined, active: { path: "workflows/a.json" } });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    expect(res.isError).toBeFalsy();
+    // …but it is NOT reported as a usable graph binding either: reads work,
+    // mutations do not. "bound" here would overstate in the other direction.
+    expect(JSON.parse(text)).toMatchObject({
+      graph_binding: "reads_only",
+      graph_binding_status: "no_identity",
+    });
+    expect(text).toMatch(/graph MUTATIONS stay refused/);
+  });
+
+  it("does NOT read the live canvas at all when the rebind DEFERRED (zero tabs connected)", async () => {
+    // There is nothing to read from yet, and the deferred note already says so.
+    // Probing anyway would turn a truthful deferral into a spurious failure.
+    // Collapse the real ~20s reconnect wait — this asserts a branch, not a clock.
+    __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 1, intervalMs: 1 });
+    const sent: Array<Record<string, unknown>> = [];
+    const refresh = vi.fn(() => true);
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        sent.push(cmd);
+        throw new Error(`no connected tab with id "x". Connected: none`);
+      },
+      push: () => 1,
+      canReach: () => false,
+      isHeadless: () => false,
+      tabs: () => [],
+      resolveActiveTabId: () => {
+        throw new Error("Panel not reachable: no panel connected");
+      },
+      refreshWorkflowUuid: refresh,
+      workflowUuidFor: () => STALE,
+    } as unknown as PanelToolCtx["bridge"];
+    const { res, text } = await setCurrent(bridge, "wf:gone");
+
+    expect(res.isError).toBeFalsy();
+    expect(JSON.parse(text)).toMatchObject({ deferred: true });
+    expect(sent.filter((c) => c.cmd === "workflow_list")).toHaveLength(0);
+    expect(text).not.toMatch(/graph command fence/);
+    __panelToolsTestHooks.setReconnectWaitTiming(null);
+  });
+
+  it("leaves mode:'pinned' on its own #716 path — no extra live-canvas adoption", async () => {
+    // The pinned path adopts only a uuid corroborated against the CALLER's exact
+    // saved path. It must not inherit the target-free adoption above.
+    const store = new WorkflowTargetStore();
+    const refresh = vi.fn(() => true);
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) =>
+        cmd.cmd === "workflow_list"
+          ? {
+              active: {
+                path: "workflows/other.json",
+                routing_key: "wf:workflows/other.json",
+                workflow_uuid: LIVE,
+              },
+              workflows: [
+                {
+                  path: "workflows/other.json",
+                  key: "k",
+                  routing_key: "wf:workflows/other.json",
+                  active: true,
+                },
+              ],
+            }
+          : { ok: true },
+      push: () => 1,
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: "t", title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => "t",
+      refreshWorkflowUuid: refresh,
+      workflowUuidFor: () => STALE,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "t", store);
+    const res = await defByName("panel_set_workflow_target").handler(
+      { mode: "pinned", path: "workflows/notthisone.json" },
+      ctx,
+    );
+    // Not open under that caller path → the #259 fail-closed refusal still wins,
+    // and no fence adoption happened on the way.
+    expect(res.isError).toBe(true);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #772 — the run-to-node graph-stamp race is the ONE rejection safe to re-issue,
+// because the panel CERTIFIES that nothing entered the queue. Everything else
+// stays terminal: a wrong "retryable" here queues a second render.
+// ---------------------------------------------------------------------------
+describe("panel-tools: panel_run scoped-run stamp-race retry (#772)", () => {
+  const RACE =
+    "run-to-node scope for node 650 was NOT applied: the workflow graph CHANGED after the run " +
+    "was queued - the deferred dispatch would render a modified workflow, not the one that was " +
+    "scoped. Nothing was queued - refusing to fall through to a full-graph execution (#556).";
+
+  /** A ctx whose graph_run replies are scripted per attempt. */
+  function runCtx(replies: Array<Record<string, unknown>>) {
+    const runs: Record<string, unknown>[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        if (cmd.cmd !== "graph_run") return { content: [{ type: "text", text: "{}" }] };
+        const reply = replies[runs.length] ?? { queued: true };
+        runs.push(cmd);
+        if (typeof reply.__error === "string") {
+          return { content: [{ type: "text", text: `Error: ${reply.__error}` }], isError: true };
+        }
+        return { content: [{ type: "text", text: JSON.stringify(reply) }] };
+      },
+      confirm: async () => "yes" as const,
+      bridge: { push: () => 1 } as unknown as PanelToolCtx["bridge"],
+      tabId: "t",
+    };
+    return { ctx, runs };
+  }
+
+  const runText = (r: ToolResult) => (r.content[0] as { text: string }).text;
+
+  it("re-issues the scoped run EXACTLY ONCE and discloses that only one render was queued", async () => {
+    const { ctx, runs } = runCtx([{ error: RACE }, { queued: true, prompt_id: "p1" }]);
+    const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(runs).toHaveLength(2);
+    expect(runs[1]).toMatchObject({ cmd: "graph_run", to_node_id: 650 }); // same scope
+    expect(runText(res)).toMatch(/Exactly one render was queued/);
+    expect(runText(res)).toMatch(/re-issued once/);
+  });
+
+  it("does NOT retry a rejection that is not the certified race (validation failure)", async () => {
+    const { ctx, runs } = runCtx([
+      { node_errors: { 5: { class_type: "KSampler", errors: [{ message: "bad seed" }] } } },
+    ]);
+    const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(1);
+    expect(runText(res)).toMatch(/bad seed/);
+    expect(runText(res)).not.toMatch(/re-issued/);
+  });
+
+  it("does NOT retry when the panel omits the 'Nothing was queued' certification", async () => {
+    // Same race verdict, no proof the queue is clean → a retry could double-queue.
+    const uncertified = RACE.replace("Nothing was queued - refusing", "Refusing");
+    const { ctx, runs } = runCtx([{ error: uncertified }, { queued: true }]);
+    const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("does NOT retry an isError reply even when it quotes both phrases (outcome unknown)", async () => {
+    // A post-write timeout / transport drop may ALREADY have queued the run.
+    const { ctx, runs } = runCtx([{ __error: RACE }, { queued: true }]);
+    const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("does NOT retry a FULL-graph run — the gate reads our own args, not panel prose", async () => {
+    const { ctx, runs } = runCtx([{ error: RACE }, { queued: true }]);
+    const res = await defByName("panel_run").handler({}, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("re-races once and then STOPS, disclosing the second dispatch without claiming its outcome", async () => {
+    const { ctx, runs } = runCtx([{ error: RACE }, { error: RACE }]);
+    const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(2); // never a third
+    expect(runText(res)).toMatch(/re-issued exactly once/);
+    expect(runText(res)).toMatch(/the first dispatch definitely queued nothing/);
+    // It does NOT assert the second dispatch's queue state — only the first is certified.
+    expect(runText(res)).not.toMatch(/Exactly one render was queued/);
+  });
+
+  it("the retryable-race classifier itself refuses an unknown outcome", () => {
+    const race: ToolResult = { content: [{ type: "text", text: RACE }] };
+    const answered: ToolResult = { content: [{ type: "text", text: "{}" }] };
+    const errored: ToolResult = { content: [{ type: "text", text: "boom" }], isError: true };
+    expect(__panelRunTestHooks.isRetryableRunToNodeStampRace(answered, race)).toBe(true);
+    expect(__panelRunTestHooks.isRetryableRunToNodeStampRace(errored, race)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #803 — the bridge now names the FULL routing tab id in its no-reply timeout.
+// The ack-timeout classifier must keep matching it, INCLUDING ids with spaces
+// (ComfyUI's own default workflow name has two), or the whole verify-after-
+// timeout recovery silently stops firing for exactly the workflows in these
+// reports: a guard answering "no" because it could not parse.
+// ---------------------------------------------------------------------------
+describe("panel-tools: ack-timeout classification survives a full, spaced tab id (#803)", () => {
+  const timeout = (tabId: string): ToolResult => ({
+    content: [
+      {
+        type: "text",
+        text:
+          `Panel tab ${tabId} did not reply to "workflow_open" within 15000 ms — ` +
+          `the ComfyUI tab may be backgrounded or frozen`,
+      },
+    ],
+    isError: true,
+  });
+
+  it("classifies a SPACED full routing id as an ack timeout", () => {
+    expect(
+      __openWorkflowTestHooks.isAckTimeout(
+        timeout("wf:workflows/Untitled 2026-08-04 06-15-58.json"),
+      ),
+    ).toBe(true);
+  });
+
+  it("still classifies the unspaced and legacy sliced forms", () => {
+    expect(__openWorkflowTestHooks.isAckTimeout(timeout("wf:workflows/a.json"))).toBe(true);
+    expect(__openWorkflowTestHooks.isAckTimeout(timeout("wf:workf"))).toBe(true);
+  });
+
+  it("still refuses a timeout for a DIFFERENT command, and any non-error result", () => {
+    const other: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: `Panel tab wf:workflows/My Graph.json did not reply to "graph_run" within 20000 ms — the ComfyUI tab may be backgrounded or frozen`,
+        },
+      ],
+      isError: true,
+    };
+    expect(__openWorkflowTestHooks.isAckTimeout(other)).toBe(false);
+    expect(
+      __openWorkflowTestHooks.isAckTimeout({
+        ...timeout("wf:workflows/a.json"),
+        isError: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4614,7 +4614,10 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
       tabs: () => [{ tab_id: tab, title: "wf", connected_at: 0 }],
       resolveActiveTabId: () => tab,
       refreshWorkflowUuid: refresh,
-      workflowUuidFor: () => stamp,
+      // The REAL bridge contract: tri-state. `{known:true}` with no uuid means
+      // "definitively unfenced" — a claim the stub is entitled to make because it
+      // is standing in for the map that holds the stamp.
+      workflowUuidFor: () => ({ known: true, uuid: stamp }),
       tabCanMutateGraph: () => true,
     } as unknown as PanelToolCtx["bridge"];
     return { bridge, sent, refresh, tab, currentStamp: () => stamp };
@@ -4906,6 +4909,97 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     expect(text).toMatch(/treat mutation readiness as unconfirmed/);
   });
 
+  it("a THROWING adoption is not narrated as a refusal — whether the fence changed is UNKNOWN", async () => {
+    // A refusal (`false`) proves the old fence survived. A THROW can land on
+    // either side of the write, so "the previous fence is unchanged" would be a
+    // state nobody observed. It also must not escape the handler: the target
+    // write and push already happened, and their disclosure would be lost.
+    const tab = "wf:workflows/a.json";
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) =>
+        cmd.cmd === "workflow_list"
+          ? { active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE } }
+          : { ok: true },
+      push: () => 1,
+      canReach: (id: string) => id === tab,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: tab, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => tab,
+      refreshWorkflowUuid: () => {
+        throw new Error("validator exploded");
+      },
+      workflowUuidFor: () => ({ known: true, uuid: STALE }),
+      tabCanMutateGraph: () => true,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, tab, new WorkflowTargetStore());
+
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    const text = (res.content[0] as { text: string }).text;
+
+    expect(res.isError).toBe(true);
+    // The disclosure that survived the throw.
+    expect(text).toMatch(/APPLIED \(do not repeat this part\)/);
+    expect(text).toMatch(/adopting it as this session's graph command fence THREW/);
+    expect(text).toMatch(/whether the\s+fence changed is UNKNOWN/);
+    expect(text).toMatch(/validator exploded/);
+    // Explicitly NOT the refusal wording, which would claim the old fence survived.
+    expect(text).not.toMatch(/The adoption was REFUSED/);
+    // …and the remedy is safe to follow.
+    expect(text).toMatch(/call this again — a second attempt is safe and settles it/);
+  });
+
+  it("RE-READS the fence when the probe moved the session, instead of comparing against the old tab", async () => {
+    // ctx.call's retry can rebind ctx.tabId. Comparing the NEW tab's live canvas
+    // against the OLD tab's fence can yield a bogus `already_current` — skipping a
+    // refresh the new tab genuinely needed and reporting a binding that is still
+    // wedged. Here the OLD tab's fence happens to equal the new canvas's uuid,
+    // while the NEW tab is stale: the naive comparison says "nothing to do".
+    const OLD = "wf:workflows/old.json";
+    const NEW = "wf:workflows/new.json";
+    const stamps = new Map<string, string>([
+      [OLD, LIVE], // old tab already names the live canvas…
+      [NEW, STALE], // …but the tab we end up on does NOT
+    ]);
+    let live = OLD;
+    let dropped = false;
+    const refresh = vi.fn((tabId: string, uuid: string) => {
+      stamps.set(tabId, uuid);
+      return true;
+    });
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+        if (cmd.cmd === "workflow_list" && !dropped) {
+          dropped = true;
+          live = NEW;
+          throw new Error(`no connected tab with id "${opts?.tabId}". Connected: none`);
+        }
+        if (cmd.cmd === "workflow_list") {
+          return { active: { path: "workflows/new.json", workflow_uuid: LIVE } };
+        }
+        return { ok: true };
+      },
+      push: () => 1,
+      canReach: (id: string) => id === live,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: live, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => live,
+      refreshWorkflowUuid: refresh,
+      workflowUuidFor: (id: string) => ({ known: true, uuid: stamps.get(id) }),
+      tabCanMutateGraph: () => true,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, OLD, new WorkflowTargetStore());
+
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    const text = (res.content[0] as { text: string }).text;
+
+    expect(ctx.tabId).toBe(NEW);
+    // The NEW tab's stale stamp was actually replaced — not skipped as "already current".
+    expect(refresh).toHaveBeenCalledWith(NEW, LIVE);
+    expect(stamps.get(NEW)).toBe(LIVE);
+    expect(JSON.parse(text).graph_binding_status).toBe("refreshed");
+    expect(JSON.parse(text).graph_binding_status).not.toBe("already_current");
+  });
+
   it("does not narrate an UNREADABLE prior fence as an ABSENT one", async () => {
     // `workflowUuidFor` swallows a throwing resolver, so "could not read the
     // fence" and "there is no fence" arrive as the same value unless the read is
@@ -5030,6 +5124,48 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     expect(text).toMatch(/ask the user which workflow they want this session on/);
     // …and disclose that the fence WAS refreshed, since that did happen.
     expect(text).toMatch(/graph command fence WAS refreshed onto this tab's live canvas/);
+  });
+
+  it("does NOT claim the fence was refreshed on the moved-to pinned tab when it was not", async () => {
+    // The moved-to-pinned disclosure used to say "the fence WAS refreshed"
+    // unconditionally — false whenever the probe came back unreadable, identity-
+    // less, refused, or already matching. Here the panel answers with NO workflow
+    // identity, so nothing was adopted, and the text must say so.
+    const store = new WorkflowTargetStore();
+    const OLD = "wf:workflows/old.json";
+    const NEW = "wf:workflows/new.json";
+    store.set(NEW, { mode: "pinned", path: "workflows/other.json", filename: "other.json" });
+    let live = OLD;
+    let dropped = false;
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+        if (cmd.cmd === "workflow_list" && !dropped) {
+          dropped = true;
+          live = NEW;
+          throw new Error(`no connected tab with id "${opts?.tabId}". Connected: none`);
+        }
+        // Answers, but exposes no workflow identity → nothing to adopt.
+        if (cmd.cmd === "workflow_list") return { active: { path: "workflows/new.json" } };
+        return { ok: true };
+      },
+      push: () => 1,
+      canReach: (id: string) => id === live,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: live, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => live,
+      refreshWorkflowUuid: () => true,
+      workflowUuidFor: () => ({ known: true, uuid: STALE }),
+      tabCanMutateGraph: () => true,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, OLD, store);
+
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    const text = (res.content[0] as { text: string }).text;
+
+    expect(res.isError).toBe(true);
+    expect(text).not.toMatch(/fence WAS refreshed/);
+    expect(text).toMatch(/fence was NOT established on this tab \(no_identity\)/);
+    expect(text).toMatch(/may also fail here with a workflow-instance mismatch/);
   });
 
   it("re-applies mode:'current' onto the moved-to tab when that takes nothing away", async () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4694,6 +4694,7 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     // The REASON — an unknown, explicitly not a rebind — and the stale uuid still in force.
     expect(text).toMatch(/Could NOT read the live canvas identity/);
     expect(text).toMatch(/This is not a rebind — it is an unknown/);
+    expect(text).toMatch(/NOTHING about this session's graph binding was observed/);
     expect(text).toContain(STALE);
     expect(refresh).not.toHaveBeenCalled();
     expect(currentStamp()).toBe(STALE); // the fence was left intact, not cleared
@@ -4704,10 +4705,23 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     // and explicitly disarmed, and our own remedy is stated BEFORE it.
     expect(text).toMatch(/disregard any rebind advice inside it/);
     expect(text.indexOf("WHAT TO DO")).toBeLessThan(text.indexOf("UNDERLYING CAUSE"));
-    expect(text).toMatch(/Repeating this call WITHOUT that refresh will fail the same way/);
     // …and the remedy never sends the caller to panel_reload, which #803 observed
     // leaving the tab permanently unresponsive from exactly this state.
     expect(text).toMatch(/Do NOT use panel_reload/);
+  });
+
+  it("an UNREADABLE read is an unknown even with NO prior fence — it never claims reads work", async () => {
+    // The read that would have told us whether this session is usable is the one
+    // that failed. Reporting "graph READS work" from a failed observation is the
+    // same could-not-determine/therefore-not fold, pointed at a positive.
+    const { bridge, tab } = fenceBridge({ fence: undefined, listThrows: "no connected tab" });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/whether graph reads work is unknown/i);
+    expect(text).not.toMatch(/graph READS work/);
+    // …and the FIRST remedy offered is the one reachable right now.
+    expect(text).toMatch(/WHAT TO DO: retry in a moment/);
   });
 
   it("distinguishes NO_IDENTITY from UNREADABLE — same wedge, different remedy", async () => {
@@ -4759,6 +4773,11 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
       graph_binding_status: "no_identity",
     });
     expect(text).toMatch(/graph MUTATIONS stay refused/);
+    // The remedy must be reachable: a panel build with no workflow identity will
+    // NEVER acquire one by reconnecting, so "wait for a reconnect" would be an
+    // aspirational instruction. Name the thing that does work.
+    expect(text).toMatch(/reconnecting alone will NOT restore mutations/);
+    expect(text).toMatch(/pack UPDATED/);
   });
 
   it("does NOT read the live canvas at all when the rebind DEFERRED (zero tabs connected)", async () => {
@@ -4834,6 +4853,52 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     expect(res.isError).toBe(true);
     expect(refresh).not.toHaveBeenCalled();
   });
+
+  it("COMMITS the target store BEFORE the live-canvas round trip, so a concurrent pin isn't clobbered", async () => {
+    // The store is shared by every session bound to this tab. An await placed
+    // between the decision and the write widens the window in which THIS call's
+    // staler `current` overwrites a concurrent agent's later, successful pin —
+    // and that agent was told its edits were pinned. It also makes the failure
+    // text's "APPLIED (do not repeat this part)" literally true.
+    const store = new WorkflowTargetStore();
+    const order: string[] = [];
+    const tab = "wf:workflows/a.json";
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        if (cmd.cmd === "workflow_list") {
+          order.push("workflow_list");
+          // The target must ALREADY be committed by the time we are asked to read.
+          expect(store.get(tab)).toMatchObject({ mode: "current" });
+          throw new Error("no connected tab");
+        }
+        return { ok: true };
+      },
+      push: () => {
+        order.push("push");
+        return 1;
+      },
+      canReach: (id: string) => id === tab,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: tab, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => tab,
+      refreshWorkflowUuid: () => true,
+      workflowUuidFor: () => STALE,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, tab, store);
+
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    // The fence read failed, so the call reports failure…
+    expect(res.isError).toBe(true);
+    // …but the target write it already performed is NOT retracted, and it landed
+    // before the round trip (the push precedes the read).
+    expect(store.get(tab)).toMatchObject({ mode: "current" });
+    // The push (which follows the store write) precedes EVERY workflow_list probe —
+    // ctx.call retries a retry-safe read once, so there may be more than one.
+    expect(order[0]).toBe("push");
+    expect(order.filter((o) => o === "workflow_list").length).toBeGreaterThan(0);
+    expect(order.indexOf("push")).toBeLessThan(order.indexOf("workflow_list"));
+    expect((res.content[0] as { text: string }).text).toMatch(/APPLIED \(do not repeat this part\)/);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -4847,7 +4912,8 @@ describe("panel-tools: panel_run scoped-run stamp-race retry (#772)", () => {
     "was queued - the deferred dispatch would render a modified workflow, not the one that was " +
     "scoped. Nothing was queued - refusing to fall through to a full-graph execution (#556).";
 
-  /** A ctx whose graph_run replies are scripted per attempt. */
+  /** A ctx whose graph_run replies are scripted per attempt. A reply of
+   *  `{__error}` is an isError ToolResult; `{__throw}` makes ctx.call THROW. */
   function runCtx(replies: Array<Record<string, unknown>>) {
     const runs: Record<string, unknown>[] = [];
     const ctx: PanelToolCtx = {
@@ -4855,6 +4921,7 @@ describe("panel-tools: panel_run scoped-run stamp-race retry (#772)", () => {
         if (cmd.cmd !== "graph_run") return { content: [{ type: "text", text: "{}" }] };
         const reply = replies[runs.length] ?? { queued: true };
         runs.push(cmd);
+        if (typeof reply.__throw === "string") throw new Error(reply.__throw);
         if (typeof reply.__error === "string") {
           return { content: [{ type: "text", text: `Error: ${reply.__error}` }], isError: true };
         }
@@ -4931,12 +4998,72 @@ describe("panel-tools: panel_run scoped-run stamp-race retry (#772)", () => {
     expect(runText(res)).not.toMatch(/Exactly one render was queued/);
   });
 
+  it("STRUCTURED queue evidence vetoes the prose — `queued:true` alongside the race never retries", async () => {
+    // detectRunRejection deliberately calls any non-empty `error` a rejection even
+    // with a stale `queued:true` (#213). For the RETRY decision that same reply is
+    // the opposite case: an OBSERVED positive queue signal. "Nothing was queued" is
+    // prose the panel wrote; `queued:true` is a fact it reported. Retrying here
+    // would put a SECOND render in the queue.
+    const { ctx, runs } = runCtx([{ queued: true, error: RACE }, { queued: true }]);
+    const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("a reported prompt_id also vetoes the retry", async () => {
+    const { ctx, runs } = runCtx([{ error: RACE, prompt_id: "p-already-queued" }, { queued: true }]);
+    const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("does NOT retry an unparseable reply — unreadable is an unknown, not a clean queue", async () => {
+    const runs: Record<string, unknown>[] = [];
+    const ctx = {
+      call: async (cmd: Record<string, unknown>) => {
+        if (cmd.cmd !== "graph_run") return { content: [{ type: "text", text: "{}" }] };
+        runs.push(cmd);
+        // Non-JSON body that still carries both phrases.
+        return { content: [{ type: "text", text: RACE }] };
+      },
+      confirm: async () => "yes" as const,
+      bridge: { push: () => 1 } as unknown as PanelToolCtx["bridge"],
+      tabId: "t",
+    } as unknown as PanelToolCtx;
+    await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("a THROWING second dispatch reports both facts instead of destroying them", async () => {
+    // The one point where a throw would lose evidence we already hold: that the
+    // first dispatch was certified not-queued, and that a second went out whose
+    // outcome is now unknown. Never claim the queue is clean; never invite a third.
+    const { ctx, runs } = runCtx([{ error: RACE }, { __throw: "socket exploded" }]);
+    const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(runs).toHaveLength(2);
+    const t = runText(res);
+    expect(t).toMatch(/outcome is UNKNOWN and it may have queued a render/);
+    expect(t).toMatch(/FIRST dispatch was certified by the panel to have queued nothing/);
+    expect(t).toMatch(/Do NOT re-run blindly/);
+    expect(t).toMatch(/socket exploded/); // the cause is preserved, not swallowed
+  });
+
   it("the retryable-race classifier itself refuses an unknown outcome", () => {
     const race: ToolResult = { content: [{ type: "text", text: RACE }] };
     const answered: ToolResult = { content: [{ type: "text", text: "{}" }] };
     const errored: ToolResult = { content: [{ type: "text", text: "boom" }], isError: true };
+    const queued: ToolResult = {
+      content: [{ type: "text", text: JSON.stringify({ queued: true, error: RACE }) }],
+    };
+    const unparseable: ToolResult = { content: [{ type: "text", text: "not json" }] };
     expect(__panelRunTestHooks.isRetryableRunToNodeStampRace(answered, race)).toBe(true);
     expect(__panelRunTestHooks.isRetryableRunToNodeStampRace(errored, race)).toBe(false);
+    expect(__panelRunTestHooks.isRetryableRunToNodeStampRace(queued, race)).toBe(false);
+    expect(__panelRunTestHooks.isRetryableRunToNodeStampRace(unparseable, race)).toBe(false);
   });
 });
 
@@ -4971,6 +5098,42 @@ describe("panel-tools: ack-timeout classification survives a full, spaced tab id
   it("still classifies the unspaced and legacy sliced forms", () => {
     expect(__openWorkflowTestHooks.isAckTimeout(timeout("wf:workflows/a.json"))).toBe(true);
     expect(__openWorkflowTestHooks.isAckTimeout(timeout("wf:workf"))).toBe(true);
+  });
+
+  it("accepts the wrapper's `Error: ` prefix and an APPENDED retry token", () => {
+    // ctx.call surfaces a reply timeout as exactly `Error: ` + the bridge message,
+    // and #694 may append a retry-token sentence. Both must still classify, or the
+    // recovery silently switches off.
+    const wrapped: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text:
+            `Error: Panel tab wf:workflows/My Graph.json did not reply to "workflow_open" within ` +
+            `15000 ms — the ComfyUI tab may be backgrounded or frozen\n\nTo retry this exact ` +
+            `mutation, re-issue identical args plus retry_of:"abc"; otherwise call normally.`,
+        },
+      ],
+      isError: true,
+    };
+    expect(__openWorkflowTestHooks.isAckTimeout(wrapped)).toBe(true);
+  });
+
+  it("REFUSES an acked executor error that merely EMBEDS the timeout phrase", () => {
+    // Only the bridge's own no-reply message STARTS with the preamble. A relayed
+    // executor failure that quotes it is a real, acked error — treating it as a
+    // no-reply sends it down the receipt-recovery path, where it can be reported
+    // as a "recovered" success for something that genuinely failed.
+    const embedded: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: `relay failed: Panel tab wf:workflows/a.json did not reply to "workflow_open" within 15000 ms — reconnecting`,
+        },
+      ],
+      isError: true,
+    };
+    expect(__openWorkflowTestHooks.isAckTimeout(embedded)).toBe(false);
   });
 
   it("still refuses a timeout for a DIFFERENT command, and any non-error result", () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4854,6 +4854,133 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     expect(refresh).not.toHaveBeenCalled();
   });
 
+  it("does NOT report `bound` when the panel cannot fence a WRITE — a stamp is not a capability", async () => {
+    // tabCanMutateGraph requires the panel to advertise BOTH write-boundary fences
+    // ON TOP of a valid stamp. An older bundle can report a perfectly good workflow
+    // uuid and still have every mutation refused at dispatch, so reporting "graph
+    // tools will now target the workflow in view" off the stamp alone answers a
+    // question nobody asked.
+    const { bridge, refresh, tab } = fenceBridge({
+      fence: STALE,
+      active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+    });
+    const ctx = makePanelToolCtx(bridge, tab, new WorkflowTargetStore());
+    ctx.tabCanMutateGraph = () => false; // stamp adopted, capability absent
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    const text = (res.content[0] as { text: string }).text;
+
+    // The fence WAS repaired — that part really happened and is reported.
+    expect(res.isError).toBeFalsy();
+    expect(refresh).toHaveBeenCalledExactlyOnceWith(tab, LIVE);
+    expect(JSON.parse(text).graph_binding_status).toBe("refreshed");
+    // …but the session is read-only, and the remedy is the one that exists.
+    expect(JSON.parse(text).graph_binding).toBe("reads_only");
+    expect(text).toMatch(/graph MUTATIONS are still refused for this tab/);
+    expect(text).toMatch(/UPDATE the comfyui-mcp-panel pack/);
+    expect(text).toMatch(/which no rebind can add/);
+  });
+
+  it("reports `bound` when the panel DOES advertise the write fence", async () => {
+    const { bridge, tab } = fenceBridge({
+      fence: STALE,
+      active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+    });
+    const ctx = makePanelToolCtx(bridge, tab, new WorkflowTargetStore());
+    ctx.tabCanMutateGraph = () => true;
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    const text = (res.content[0] as { text: string }).text;
+
+    expect(JSON.parse(text).graph_binding).toBe("bound");
+    expect(text).not.toMatch(/graph MUTATIONS are still refused/);
+  });
+
+  it("REFUSES to claim mode:'current' when the probe moved this session onto a PINNED tab", async () => {
+    // workflow_list is retry-safe: a transient drop makes ctx.call rebind onto
+    // another tab and retry there. The fence then belongs to the NEW tab while the
+    // mode:"current" record belongs to the OLD one — and if the new tab carries
+    // someone else's pin, the next graph command routes through that pin. Claiming
+    // "following the user's current workflow tab" would name a state that is not
+    // the case, and overwriting the pin would clobber another session's binding.
+    const store = new WorkflowTargetStore();
+    const OLD = "wf:workflows/old.json";
+    const NEW = "wf:workflows/new.json";
+    store.set(NEW, { mode: "pinned", path: "workflows/other.json", filename: "other.json" });
+    let live = OLD;
+    let dropped = false;
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+        if (cmd.cmd === "workflow_list" && !dropped) {
+          dropped = true;
+          live = NEW; // the old tab is gone; a different one is live now
+          throw new Error(`no connected tab with id "${opts?.tabId}". Connected: none`);
+        }
+        if (cmd.cmd === "workflow_list") {
+          return { active: { path: "workflows/new.json", workflow_uuid: LIVE } };
+        }
+        return { ok: true };
+      },
+      push: () => 1,
+      canReach: (id: string) => id === live,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: live, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => live,
+      refreshWorkflowUuid: () => true,
+      workflowUuidFor: () => STALE,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, OLD, store);
+
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    const text = (res.content[0] as { text: string }).text;
+
+    expect(res.isError).toBe(true);
+    expect(ctx.tabId).toBe(NEW);
+    // The other session's pin is LEFT ALONE.
+    expect(store.get(NEW)).toMatchObject({ mode: "pinned", path: "workflows/other.json" });
+    expect(text).toMatch(/did NOT take effect on the tab this session is now bound to/);
+    expect(text).toMatch(/rebound from tab wf:workflows\/old\.json onto tab wf:workflows\/new\.json/);
+    expect(text).toMatch(/left untouched, because another session may own that pin/);
+    // …and the remedy is a call the caller can make right now.
+    expect(text).toMatch(/call panel_set_workflow_target\(\{mode:"current"\}\) again/);
+  });
+
+  it("re-applies mode:'current' onto the moved-to tab when that takes nothing away", async () => {
+    const store = new WorkflowTargetStore();
+    const OLD = "wf:workflows/old.json";
+    const NEW = "wf:workflows/new.json";
+    let live = OLD;
+    let dropped = false;
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+        if (cmd.cmd === "workflow_list" && !dropped) {
+          dropped = true;
+          live = NEW;
+          throw new Error(`no connected tab with id "${opts?.tabId}". Connected: none`);
+        }
+        if (cmd.cmd === "workflow_list") {
+          return { active: { path: "workflows/new.json", workflow_uuid: LIVE } };
+        }
+        return { ok: true };
+      },
+      push: () => 1,
+      canReach: (id: string) => id === live,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: live, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => live,
+      refreshWorkflowUuid: () => true,
+      workflowUuidFor: () => STALE,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, OLD, store);
+
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    const text = (res.content[0] as { text: string }).text;
+
+    expect(res.isError).toBeFalsy();
+    // The record now governs the tab the session is actually on…
+    expect(store.get(NEW)).toMatchObject({ mode: "current" });
+    // …and the move is DISCLOSED, not silently absorbed.
+    expect(text).toMatch(/moved from tab wf:workflows\/old\.json onto tab wf:workflows\/new\.json/);
+  });
+
   it("COMMITS the target store BEFORE the live-canvas round trip, so a concurrent pin isn't clobbered", async () => {
     // The store is shared by every session bound to this tab. An await placed
     // between the decision and the write widens the window in which THIS call's
@@ -4936,15 +5063,29 @@ describe("panel-tools: panel_run scoped-run stamp-race retry (#772)", () => {
 
   const runText = (r: ToolResult) => (r.content[0] as { text: string }).text;
 
-  it("re-issues the scoped run EXACTLY ONCE and discloses that only one render was queued", async () => {
+  it("re-issues the scoped run EXACTLY ONCE and discloses the extra dispatch", async () => {
     const { ctx, runs } = runCtx([{ error: RACE }, { queued: true, prompt_id: "p1" }]);
     const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
 
     expect(res.isError).toBeFalsy();
     expect(runs).toHaveLength(2);
     expect(runs[1]).toMatchObject({ cmd: "graph_run", to_node_id: 650 }); // same scope
-    expect(runText(res)).toMatch(/Exactly one render was queued/);
     expect(runText(res)).toMatch(/re-issued once/);
+    expect(runText(res)).toMatch(/first dispatch contributed NOTHING to the queue/);
+  });
+
+  it("does NOT claim a render COUNT — batch_count means the second dispatch can queue several", async () => {
+    // `batch_count` is "times to queue", and the panel reports one prompt id, not a
+    // count. The certified fact is about DISPATCHES ("the first queued nothing"),
+    // not renders. Naming a number would be an unobserved state.
+    const { ctx, runs } = runCtx([{ error: RACE }, { queued: true, prompt_id: "p1" }]);
+    const res = await defByName("panel_run").handler({ to_node_id: 650, batch_count: 3 }, ctx);
+
+    expect(res.isError).toBeFalsy();
+    expect(runs).toHaveLength(2);
+    expect(runs[1]).toMatchObject({ batch_count: 3 }); // the batch is preserved, not dropped
+    expect(runText(res)).not.toMatch(/Exactly one render/i);
+    expect(runText(res)).toMatch(/queued once, not twice/);
   });
 
   it("does NOT retry a rejection that is not the certified race (validation failure)", async () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4876,8 +4876,9 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     // …but the session is read-only, and the remedy is the one that exists.
     expect(JSON.parse(text).graph_binding).toBe("reads_only");
     expect(text).toMatch(/graph MUTATIONS are still refused for this tab/);
-    expect(text).toMatch(/UPDATE the comfyui-mcp-panel pack/);
-    expect(text).toMatch(/which no rebind can add/);
+    expect(text).toMatch(/update the comfyui-mcp-panel pack/);
+    // The remedy must not tell the caller to re-run a tool that cannot help.
+    expect(text).toMatch(/including calling this tool again — can add it/);
   });
 
   it("reports `bound` when the panel DOES advertise the write fence", async () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4587,6 +4587,14 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
   function fenceBridge(opts: {
     fence?: string;
     active?: Record<string, unknown> | null;
+    /** Override the `workflows` list. By DEFAULT the stub mirrors `active` into a
+     *  single `active:true` entry — the shape a healthy panel returns, and the
+     *  CORROBORATION a fence adoption requires. Pass this explicitly to model a
+     *  stale/mixed/absent list. Supplying only a top-level `active` object is NOT
+     *  a safe fixture: it is the exact reply shape that let another canvas's uuid
+     *  overwrite this tab's stamp, so the default must not encode it. */
+    workflows?: Array<Record<string, unknown>>;
+    activeConfirmed?: boolean;
     listThrows?: string;
     refreshReturns?: boolean;
     tabId?: string;
@@ -4604,7 +4612,15 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
         sent.push(cmd);
         if (cmd.cmd === "workflow_list") {
           if (opts.listThrows) throw new Error(opts.listThrows);
-          return opts.active == null ? { workflows: [] } : { active: opts.active };
+          if (opts.active == null) return { workflows: opts.workflows ?? [] };
+          // Mirror `active` into a corroborating `active:true` entry unless the
+          // test is deliberately modelling a stale/mixed/absent list.
+          const workflows = opts.workflows ?? [{ ...opts.active, active: true }];
+          return {
+            active: opts.active,
+            workflows,
+            ...(opts.activeConfirmed === undefined ? {} : { active_confirmed: opts.activeConfirmed }),
+          };
         }
         return { ok: true };
       },
@@ -4660,7 +4676,14 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     // active canvas IS the target.
     const { bridge, refresh, tab, currentStamp } = fenceBridge({
       fence: STALE,
-      active: { workflow_uuid: LIVE, filename: "Unsaved Workflow" },
+      // A real unsaved workflow has no saved path, but it DOES have a stable
+      // routing key — which is what corroborates it against the open list.
+      active: {
+        key: "tmp:abc123",
+        routing_key: "tmp:abc123",
+        workflow_uuid: LIVE,
+        filename: "Unsaved Workflow",
+      },
       tabId: "tmp:abc123",
     });
     const { res, text } = await setCurrent(bridge, tab);
@@ -4669,6 +4692,126 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     expect(refresh).toHaveBeenCalledExactlyOnceWith("tmp:abc123", LIVE);
     expect(currentStamp()).toBe(LIVE);
     expect(JSON.parse(text).graph_binding_status).toBe("refreshed");
+  });
+
+  // ---- The corroboration the fence adoption requires -----------------------
+  //
+  // A stale or MIXED workflow_list can carry a top-level `active` naming ANOTHER
+  // canvas, whose uuid is perfectly valid in shape and origin. Adopting it
+  // overwrites this tab's stamp, wedges the next graph command, and — because the
+  // adoption "succeeded" — gets reported as `bound`. A fresh wedge announced as a
+  // recovery is strictly worse than the wedge this whole PR exists to fix.
+  //
+  // `resolveOpenWorkflow` had already arrived at this rule for pins: an
+  // uncorroborated top-level `active` "is never a safe source for replacing a
+  // command fence". These cases hold the rebind to it.
+
+  it("REFUSES to adopt when the active record CONTRADICTS the open-workflow list (stale/mixed reply)", async () => {
+    const OTHER = "33333333-3333-4333-8333-333333333333";
+    const { bridge, refresh, tab, currentStamp } = fenceBridge({
+      fence: STALE,
+      // Top-level active names canvas B, carrying a VALID uuid…
+      active: { path: "workflows/b.json", routing_key: "wf:workflows/b.json", workflow_uuid: OTHER },
+      // …while the panel's own list says canvas A is the active one.
+      workflows: [{ path: "workflows/a.json", routing_key: "wf:workflows/a.json", active: true }],
+    });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    // Nothing adopted — the other canvas's uuid never reaches the fence.
+    expect(refresh).not.toHaveBeenCalled();
+    expect(currentStamp()).toBe(STALE);
+    // …and it is NOT reported as a recovery.
+    expect(res.isError).toBe(true);
+    expect(text).not.toMatch(/"graph_binding": "bound"/);
+    expect(text).toMatch(/could not be corroborated, so nothing was adopted/);
+    expect(text).toMatch(/name DIFFERENT workflows \(a stale or mixed reply\)/);
+    // The reason it matters, stated: this is what protects the tab.
+    expect(text).toMatch(/could have stamped ANOTHER canvas's identity onto this tab/);
+    // The remedy fits the cause — transient, so retry; not "update your panel".
+    expect(text).toMatch(/call this again in a moment/);
+    expect(text).not.toMatch(/must be UPDATED/);
+  });
+
+  it("REFUSES to adopt from a reply with no open-workflow list to corroborate against", async () => {
+    const { bridge, refresh, tab, currentStamp } = fenceBridge({
+      fence: STALE,
+      active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+      workflows: [], // the exact shape the first version of this fix accepted
+    });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    expect(refresh).not.toHaveBeenCalled();
+    expect(currentStamp()).toBe(STALE);
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/no open-workflow list to corroborate the active record against/);
+  });
+
+  it("REFUSES a MIXED list with two entries marked active, rather than arbitrating", async () => {
+    const { bridge, refresh, tab } = fenceBridge({
+      fence: STALE,
+      active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+      workflows: [
+        { path: "workflows/a.json", routing_key: "wf:workflows/a.json", active: true },
+        { path: "workflows/b.json", routing_key: "wf:workflows/b.json", active: true },
+      ],
+    });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    expect(refresh).not.toHaveBeenCalled();
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/2 entries in the open-workflow list are marked active \(a mixed reply\)/);
+  });
+
+  it("REFUSES when the panel itself says its active record is UNCONFIRMED", async () => {
+    const { bridge, refresh, tab } = fenceBridge({
+      fence: STALE,
+      active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+      activeConfirmed: false,
+    });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    expect(refresh).not.toHaveBeenCalled();
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/reported its active workflow as UNCONFIRMED/);
+  });
+
+  it("an UNCORROBORATED reply with NO prior fence is `unverified`, not a wedge and not a repair", async () => {
+    // Nothing was stale, so nothing failed to be repaired — but nothing was
+    // established either. Calling it `reads_only` would describe a permanent
+    // limitation this is not (the panel DOES report identities); calling it
+    // `not_recovered` would report a wedge that does not exist.
+    const { bridge, refresh, tab } = fenceBridge({
+      fence: undefined,
+      active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+      workflows: [], // uncorroborated
+    });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    expect(res.isError).toBeFalsy();
+    expect(refresh).not.toHaveBeenCalled();
+    expect(JSON.parse(text)).toMatchObject({
+      graph_binding: "unverified",
+      graph_binding_status: "no_identity",
+    });
+    expect(text).toMatch(/had no fence to damage, so it is no worse off/);
+    expect(text).toMatch(/call this again in a moment/);
+    // NOT the update-your-panel remedy: this panel reports identities fine.
+    expect(text).not.toMatch(/must be UPDATED/);
+  });
+
+  it("REFUSES when the active record and the list share no comparable identity field", async () => {
+    // Agreement was never established — which is not agreement. Filename is
+    // deliberately not comparable: it collides across tabs.
+    const { bridge, refresh, tab } = fenceBridge({
+      fence: STALE,
+      active: { filename: "a.json", workflow_uuid: LIVE },
+      workflows: [{ filename: "a.json", active: true }],
+    });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    expect(refresh).not.toHaveBeenCalled();
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/share no comparable identity field/);
   });
 
   it("reports ALREADY_CURRENT (and points at the panel) rather than a hollow rebind", async () => {
@@ -4749,9 +4892,13 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     expect(text).toMatch(/reported NO workflow identity for the active canvas/);
     // NOT the unreadable wording — the panel DID answer, which is a different fact.
     expect(text).not.toMatch(/Could NOT read the live canvas identity/);
-    expect(text).toMatch(/cached[\s\S]{0,30}older panel bundle/);
+    // …and NOT the uncorroborated wording either: this reply hung together fine,
+    // the panel simply has no identity to give. Different fact, different remedy.
+    expect(text).not.toMatch(/could not be corroborated/);
+    expect(text).toMatch(/cached bundle/);
     // …and the remedy is the one that actually replaces a cached bundle.
     expect(text).toMatch(/HARD refresh here specifically/);
+    expect(text).toMatch(/must be UPDATED — no rebind can add it/);
     expect(refresh).not.toHaveBeenCalled();
   });
 
@@ -4924,7 +5071,10 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     const bridge = {
       send: async (cmd: Record<string, unknown>) =>
         cmd.cmd === "workflow_list"
-          ? { active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE } }
+          ? {
+              active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+              workflows: [{ path: "workflows/a.json", routing_key: "wf:workflows/a.json", active: true }],
+            }
           : { ok: true },
       push: () => 1,
       canReach: (id: string) => id === tab,
@@ -4980,7 +5130,10 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
           throw new Error(`no connected tab with id "${opts?.tabId}". Connected: none`);
         }
         if (cmd.cmd === "workflow_list") {
-          return { active: { path: "workflows/new.json", workflow_uuid: LIVE } };
+          return {
+            active: { path: "workflows/new.json", routing_key: "wf:workflows/new.json", workflow_uuid: LIVE },
+            workflows: [{ path: "workflows/new.json", routing_key: "wf:workflows/new.json", active: true }],
+          };
         }
         return { ok: true };
       },
@@ -5099,7 +5252,10 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
           throw new Error(`no connected tab with id "${opts?.tabId}". Connected: none`);
         }
         if (cmd.cmd === "workflow_list") {
-          return { active: { path: "workflows/new.json", workflow_uuid: LIVE } };
+          return {
+            active: { path: "workflows/new.json", routing_key: "wf:workflows/new.json", workflow_uuid: LIVE },
+            workflows: [{ path: "workflows/new.json", routing_key: "wf:workflows/new.json", active: true }],
+          };
         }
         return { ok: true };
       },
@@ -5188,7 +5344,10 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
           throw new Error(`no connected tab with id "${opts?.tabId}". Connected: none`);
         }
         if (cmd.cmd === "workflow_list") {
-          return { active: { path: "workflows/new.json", workflow_uuid: LIVE } };
+          return {
+            active: { path: "workflows/new.json", routing_key: "wf:workflows/new.json", workflow_uuid: LIVE },
+            workflows: [{ path: "workflows/new.json", routing_key: "wf:workflows/new.json", active: true }],
+          };
         }
         return { ok: true };
       },

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4706,6 +4706,32 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
   // uncorroborated top-level `active` "is never a safe source for replacing a
   // command fence". These cases hold the rebind to it.
 
+  it("REFUSES a PARTIAL contradiction — one matching field never outvotes a conflicting one", async () => {
+    const OTHER = "33333333-3333-4333-8333-333333333333";
+    const { bridge, refresh, tab, currentStamp } = fenceBridge({
+      fence: STALE,
+      // The pathological middle case the total-disagreement test above cannot
+      // reach: `routing_key` AGREES while `path` flatly contradicts. The verdict
+      // returned on the FIRST equal pair without ever reading the rest, so a
+      // reply that disagreed with itself was adopted as a positive identity
+      // (codex gate P0). A contradicted positive is worse than an unverified one.
+      active: {
+        path: "workflows/b.json",
+        routing_key: "wf:workflows/a.json",
+        workflow_uuid: OTHER,
+      },
+      workflows: [
+        { path: "workflows/a.json", routing_key: "wf:workflows/a.json", active: true },
+      ],
+    });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    expect(refresh).not.toHaveBeenCalled();
+    expect(currentStamp()).toBe(STALE);
+    expect(res.isError).toBe(true);
+    expect(text).not.toMatch(/"graph_binding": "bound"/);
+  });
+
   it("REFUSES to adopt when the active record CONTRADICTS the open-workflow list (stale/mixed reply)", async () => {
     const OTHER = "33333333-3333-4333-8333-333333333333";
     const { bridge, refresh, tab, currentStamp } = fenceBridge({
@@ -5026,7 +5052,14 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
       active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
     });
     const ctx = makePanelToolCtx(bridge, tab, new WorkflowTargetStore());
-    ctx.tabGraphMutationCapability = () => ({ known: true, canMutate: false }); // observed absent
+    // Observed absent, and the WHY is an old panel build — which is what makes
+    // the pack-update remedy below the right one. The sibling test covers the
+    // other why.
+    ctx.tabGraphMutationCapability = () => ({
+      known: true,
+      canMutate: false,
+      because: "capability" as const,
+    });
     const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
     const text = (res.content[0] as { text: string }).text;
 
@@ -5040,6 +5073,34 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     expect(text).toMatch(/update the comfyui-mcp-panel pack/);
     // The remedy must not tell the caller to re-run a tool that cannot help.
     expect(text).toMatch(/including calling this tool again — can add it/);
+  });
+
+  it("does NOT blame the panel version when the tab is simply UNREACHABLE", async () => {
+    // Both whys yield canMutate:false, and they used to share one value — so this
+    // path told the user to update their panel pack and hard-refresh a tab that
+    // was gone, while their READS were failing too and the note said reads work
+    // (codex gate P1). A bucket narrated as a cause, with a remedy for a problem
+    // they did not have.
+    const { bridge, tab } = fenceBridge({
+      fence: STALE,
+      active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+    });
+    const ctx = makePanelToolCtx(bridge, tab, new WorkflowTargetStore());
+    ctx.tabGraphMutationCapability = () => ({
+      known: true,
+      canMutate: false,
+      because: "unroutable" as const,
+    });
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    const text = (res.content[0] as { text: string }).text;
+
+    expect(text).toMatch(/NOT REACHABLE/);
+    // The wrong remedy must be absent, not merely accompanied by the right one.
+    expect(text).not.toMatch(/update the comfyui-mcp-panel pack/);
+    expect(text).toMatch(/NOT a panel-version problem/);
+    // And it must not leave "reads work" standing, which is false for a tab that
+    // cannot be routed to at all.
+    expect(text).toMatch(/reads are not working either/);
   });
 
   it("reports `unverified` — not `bound` — when the write capability cannot be determined", async () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4580,7 +4580,10 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
 
   /** A bridge modelling the ONE thing that matters here: the tab is REACHABLE,
    *  the session holds `fence`, and the panel's live active record reports
-   *  `active`. `workflow_list` answers from `active`; everything else acks. */
+   *  `active`. `workflow_list` answers from `active`; everything else acks.
+   *  `tabCanMutateGraph` defaults to TRUE — a current panel — so the common tests
+   *  exercise the realistic path rather than the can't-tell one. The false and
+   *  unanswerable cases get their own tests. */
   function fenceBridge(opts: {
     fence?: string;
     active?: Record<string, unknown> | null;
@@ -4612,6 +4615,7 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
       resolveActiveTabId: () => tab,
       refreshWorkflowUuid: refresh,
       workflowUuidFor: () => stamp,
+      tabCanMutateGraph: () => true,
     } as unknown as PanelToolCtx["bridge"];
     return { bridge, sent, refresh, tab, currentStamp: () => stamp };
   }
@@ -4881,6 +4885,85 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     expect(text).toMatch(/including calling this tool again — can add it/);
   });
 
+  it("reports `unverified` — not `bound` — when the write capability cannot be determined", async () => {
+    // An unanswerable capability probe is an UNKNOWN. Rounding it up to `bound`
+    // (which the tool description defines as "graph tools are usable again") is
+    // the same could-not-determine/therefore-yes fold, one step further out.
+    const { bridge, tab } = fenceBridge({
+      fence: STALE,
+      active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+    });
+    const ctx = makePanelToolCtx(bridge, tab, new WorkflowTargetStore());
+    ctx.tabCanMutateGraph = () => {
+      throw new Error("cannot tell");
+    };
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    const text = (res.content[0] as { text: string }).text;
+
+    expect(res.isError).toBeFalsy(); // the fence WAS repaired — that is not a failure
+    expect(JSON.parse(text).graph_binding).toBe("unverified");
+    expect(text).toMatch(/could not be determined from this context/);
+    expect(text).toMatch(/treat mutation readiness as unconfirmed/);
+  });
+
+  it("does not narrate an UNREADABLE prior fence as an ABSENT one", async () => {
+    // `workflowUuidFor` swallows a throwing resolver, so "could not read the
+    // fence" and "there is no fence" arrive as the same value unless the read is
+    // tri-state. Rendering the first as the second asserts an absence nobody saw.
+    const tab = "wf:workflows/a.json";
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        if (cmd.cmd === "workflow_list") throw new Error("no connected tab");
+        return { ok: true };
+      },
+      push: () => 1,
+      canReach: (id: string) => id === tab,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: tab, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => tab,
+      refreshWorkflowUuid: () => true,
+      workflowUuidFor: () => {
+        throw new Error("resolver exploded");
+      },
+      tabCanMutateGraph: () => true,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, tab, new WorkflowTargetStore());
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    const text = (res.content[0] as { text: string }).text;
+
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/could not be read either, so its binding is\s+entirely unknown/);
+    expect(text).toMatch(/not known-good and not known-absent/);
+    // NOT the absent-fence wording.
+    expect(text).not.toMatch(/It has no graph command fence/);
+  });
+
+  it("reports `unverified` when the panel has no identity AND the prior fence is unreadable", async () => {
+    // Failing would report a wedge nobody observed; succeeding would report a
+    // repair nobody observed. Neither is available, so it says so.
+    const tab = "wf:workflows/a.json";
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) =>
+        cmd.cmd === "workflow_list" ? { active: { path: "workflows/a.json" } } : { ok: true },
+      push: () => 1,
+      canReach: (id: string) => id === tab,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: tab, title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => tab,
+      refreshWorkflowUuid: () => true,
+      tabCanMutateGraph: () => true,
+      // no workflowUuidFor at all — this bridge cannot answer
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, tab, new WorkflowTargetStore());
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    const text = (res.content[0] as { text: string }).text;
+
+    expect(res.isError).toBeFalsy();
+    expect(JSON.parse(text).graph_binding).toBe("unverified");
+    expect(text).toMatch(/could NOT be determined/);
+    expect(text).toMatch(/Treat graph tools as unconfirmed/);
+  });
+
   it("reports `bound` when the panel DOES advertise the write fence", async () => {
     const { bridge, tab } = fenceBridge({
       fence: STALE,
@@ -4939,9 +5022,14 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     expect(store.get(NEW)).toMatchObject({ mode: "pinned", path: "workflows/other.json" });
     expect(text).toMatch(/did NOT take effect on the tab this session is now bound to/);
     expect(text).toMatch(/rebound from tab wf:workflows\/old\.json onto tab wf:workflows\/new\.json/);
-    expect(text).toMatch(/left untouched, because another session may own that pin/);
-    // …and the remedy is a call the caller can make right now.
-    expect(text).toMatch(/call panel_set_workflow_target\(\{mode:"current"\}\) again/);
+    expect(text).toMatch(/that pin was left untouched/);
+    // The remedy must not be SELF-DEFEATING: re-issuing mode:"current" on this tab
+    // would delete the very pin we just declined to clobber. Say that plainly
+    // instead of prescribing it, and name what to do when ownership is unclear.
+    expect(text).toMatch(/WILL REPLACE that pin — do that only if the pin is yours/);
+    expect(text).toMatch(/ask the user which workflow they want this session on/);
+    // …and disclose that the fence WAS refreshed, since that did happen.
+    expect(text).toMatch(/graph command fence WAS refreshed onto this tab's live canvas/);
   });
 
   it("re-applies mode:'current' onto the moved-to tab when that takes nothing away", async () => {
@@ -5276,6 +5364,24 @@ describe("panel-tools: ack-timeout classification survives a full, spaced tab id
       isError: true,
     };
     expect(__openWorkflowTestHooks.isAckTimeout(embedded)).toBe(false);
+  });
+
+  it("REFUSES a whitespace- or newline-prefixed message (the anchor is not trimmed away)", () => {
+    // The bridge message never carries leading whitespace, so trimming before the
+    // anchor buys nothing and only lets a prefixed acked error through.
+    for (const prefix of [" ", "\n", "\t", "  \n"]) {
+      expect(
+        __openWorkflowTestHooks.isAckTimeout({
+          content: [
+            {
+              type: "text",
+              text: `${prefix}Panel tab wf:a.json did not reply to "workflow_open" within 15000 ms — the ComfyUI tab may be backgrounded or frozen`,
+            },
+          ],
+          isError: true,
+        }),
+      ).toBe(false);
+    }
   });
 
   it("still refuses a timeout for a DIFFERENT command, and any non-error result", () => {

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2867,28 +2867,34 @@ describe("defaultBridgeTimeoutMs — tolerant read timeout (#357)", () => {
 });
 
 // #770/#803 — the fence READ the rebind needs to tell "repaired a stale fence"
-// apart from "there was never a fence". Both are answers; only one is a repair.
+// apart from "there was never a fence" apart from "I could not look". Three
+// answers, three remedies; this is the only window onto the stamp, so a
+// distinction lost here is lost for good.
 describe("UiBridge.workflowUuidFor (#770 fence read)", () => {
-  it("returns the resolver's value, and undefined for empty/missing/throwing resolvers", () => {
+  it("distinguishes a present fence, a definitively absent one, and an unreadable one", () => {
     const b = new UiBridge(0);
-    // No resolver injected at all → undefined (never a fabricated identity).
-    expect(b.workflowUuidFor("t")).toBeUndefined();
+    // No resolver at all → NOT KNOWN. Reporting this as "no fence" would assert
+    // an absence from a mechanism that was never wired up.
+    expect(b.workflowUuidFor("t")).toMatchObject({ known: false });
 
     b.setTabWorkflowUuidResolver((tabId) => (tabId === "t" ? "u-1" : undefined));
-    expect(b.workflowUuidFor("t")).toBe("u-1");
-    expect(b.workflowUuidFor("other")).toBeUndefined();
+    expect(b.workflowUuidFor("t")).toEqual({ known: true, uuid: "u-1" });
+    // A resolver that ANSWERS with nothing is a real, observed absence.
+    expect(b.workflowUuidFor("other")).toEqual({ known: true, uuid: undefined });
 
-    // An empty string is not an identity.
+    // An empty string is not an identity — but it is still an answer.
     b.setTabWorkflowUuidResolver(() => "");
-    expect(b.workflowUuidFor("t")).toBeUndefined();
+    expect(b.workflowUuidFor("t")).toEqual({ known: true, uuid: undefined });
 
-    // A guard that can throw is not a guard: a faulting resolver must not take
-    // down the recovery that reads it.
+    // A guard that can throw is not a guard: a faulting resolver must neither take
+    // down the recovery that reads it NOR be reported as "there is no fence".
     b.setTabWorkflowUuidResolver(() => {
       throw new Error("resolver exploded");
     });
     expect(() => b.workflowUuidFor("t")).not.toThrow();
-    expect(b.workflowUuidFor("t")).toBeUndefined();
+    const read = b.workflowUuidFor("t");
+    expect(read.known).toBe(false);
+    expect(read).toMatchObject({ reason: expect.stringContaining("resolver exploded") });
   });
 });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2864,6 +2864,48 @@ describe("defaultBridgeTimeoutMs — tolerant read timeout (#357)", () => {
     );
     a.close();
   });
+
+  // #770/#803 — the same fold as workflowUuidFor, one method over.
+  // tabCanMutateGraph fails CLOSED, which is right for gating and wrong for prose:
+  // rendered, it told users their panel "does not advertise" a capability when we
+  // had merely failed to look. Driven against a LIVE tab so resolveTarget succeeds
+  // and the stamp resolver is actually reached — probing a nonexistent tab exits
+  // before that and would pass with the collapse still in place.
+  it("tabGraphMutationCapability separates an UNREADABLE probe from an observed 'cannot' (#770)", async () => {
+    const tabId = "wf:workflows/cap.json";
+    const a = await connectPanel(tabId); // advertises both write fences
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+
+    // A stamp is present and both fences are advertised → observed CAN.
+    bridge.setTabWorkflowUuidResolver(() => "11111111-1111-4111-8111-111111111111");
+    expect(bridge.tabGraphMutationCapability(tabId)).toEqual({ known: true, canMutate: true });
+    expect(bridge.tabCanMutateGraph(tabId)).toBe(true);
+
+    // The resolver ANSWERS with no stamp → an observed CANNOT (nothing to fence).
+    bridge.setTabWorkflowUuidResolver(() => undefined);
+    expect(bridge.tabGraphMutationCapability(tabId)).toEqual({ known: true, canMutate: false });
+    expect(bridge.tabCanMutateGraph(tabId)).toBe(false);
+
+    // The resolver THROWS → the inputs could not be READ. That is UNKNOWN, and
+    // must never be rendered as "this panel lacks the write fence".
+    bridge.setTabWorkflowUuidResolver(() => {
+      throw new Error("resolver exploded");
+    });
+    const unknown = bridge.tabGraphMutationCapability(tabId);
+    expect(unknown.known).toBe(false);
+    expect(unknown).toMatchObject({ reason: expect.stringContaining("resolver exploded") });
+    // …while the fail-closed convenience keeps its contract for the readiness
+    // callers that GATE on it rather than describe it.
+    expect(bridge.tabCanMutateGraph(tabId)).toBe(false);
+
+    // An unroutable tab is `known`: routing nowhere IS an observation about
+    // mutability, not a failure to look.
+    expect(bridge.tabGraphMutationCapability("no-such-tab")).toEqual({
+      known: true,
+      canMutate: false,
+    });
+    a.close();
+  });
 });
 
 // #770/#803 — the fence READ the rebind needs to tell "repaired a stale fence"
@@ -2897,26 +2939,6 @@ describe("UiBridge.workflowUuidFor (#770 fence read)", () => {
     expect(read).toMatchObject({ reason: expect.stringContaining("resolver exploded") });
   });
 
-  // #770/#803 — same fold, one method over. tabCanMutateGraph fails CLOSED, which
-  // is right for gating and wrong for prose: rendered, it told users their panel
-  // "does not advertise" a capability when we had merely failed to look.
-  it("tabGraphMutationCapability separates an unreadable probe from an observed 'cannot'", () => {
-    const b = new UiBridge(0);
-    // No tab at all → routable-nowhere is an OBSERVATION about mutability.
-    expect(b.tabGraphMutationCapability("nope")).toEqual({ known: true, canMutate: false });
-    expect(b.tabCanMutateGraph("nope")).toBe(false);
-
-    // A resolver that THROWS means the inputs could not be read → UNKNOWN…
-    b.setTabWorkflowUuidResolver(() => {
-      throw new Error("resolver exploded");
-    });
-    // …but only once there is a tab to resolve; with none, the routing answer wins.
-    const noTab = b.tabGraphMutationCapability("nope");
-    expect(noTab).toEqual({ known: true, canMutate: false });
-
-    // The fail-closed convenience keeps its contract for the readiness callers.
-    expect(b.tabCanMutateGraph("nope")).toBe(false);
-  });
 });
 
 describe("makeUnknownCommandError (old-panel version gate)", () => {

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2883,10 +2883,16 @@ describe("defaultBridgeTimeoutMs — tolerant read timeout (#357)", () => {
 
     // The resolver ANSWERS with no stamp → an observed CANNOT (nothing to fence).
     bridge.setTabWorkflowUuidResolver(() => undefined);
+    // A modern panel that advertises both fences but has NO trusted stamp is a
+    // BINDING problem, not an old-pack one: reads work and a rebind fixes it.
+    // Labelling it "capability" sent it to the one remedy that cannot help —
+    // update the pack, hard-refresh — for a pack that was already correct
+    // (codex gate). `canMutate` is a conjunction of four unrelated conditions and
+    // each has to answer for itself.
     expect(bridge.tabGraphMutationCapability(tabId)).toEqual({
       known: true,
       canMutate: false,
-      because: "capability",
+      because: "no_identity",
     });
     expect(bridge.tabCanMutateGraph(tabId)).toBe(false);
 
@@ -2908,6 +2914,27 @@ describe("defaultBridgeTimeoutMs — tolerant read timeout (#357)", () => {
     // so the recovery told users to update their panel pack and hard-refresh
     // when the tab was simply gone and their READS were failing too (codex gate
     // P1). Same boolean, opposite remedy: the cause is what separates them.
+    // A socket that is CLOSING is reachable but cannot carry a write. That is a
+    // transport state, not an old panel — folding it into "capability" told the
+    // user to update a pack that was already correct (codex gate).
+    bridge.setTabWorkflowUuidResolver(() => "11111111-1111-4111-8111-111111111111");
+    const sock = (bridge as unknown as { conns: Map<string, { sock: { readyState: number } }> });
+    const conn = sock.conns?.get(tabId);
+    if (conn) {
+      Object.defineProperty(conn.sock, "readyState", {
+        value: 2 /* CLOSING */,
+        configurable: true,
+      });
+      expect(bridge.tabGraphMutationCapability(tabId)).toEqual({
+        known: true,
+        canMutate: false,
+        because: "disconnected",
+      });
+      Object.defineProperty(conn.sock, "readyState", { value: 1, configurable: true });
+    } else {
+      throw new Error("test setup: expected a live connection for " + tabId);
+    }
+
     const unroutable = bridge.tabGraphMutationCapability("no-such-tab");
     expect(unroutable).toEqual({ known: true, canMutate: false, because: "unroutable" });
     // The load-bearing assertion is that these two do NOT compare equal.

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2845,6 +2845,51 @@ describe("defaultBridgeTimeoutMs — tolerant read timeout (#357)", () => {
     );
     a.close();
   });
+
+  // #803 — the no-reply timeout named `conn.tabId.slice(0, 8)`. Routing ids are
+  // `wf:<path>`, so EVERY workflow tab rendered as the identical, alarming
+  // `wf:workf`: two tabs timing out were indistinguishable in a transcript and
+  // the id read like a corrupted routing key (it sent one diagnosis down a wrong
+  // path outright). Evidence must not be destroyed before it can be reported.
+  it("names the FULL routing tab id in a no-reply timeout, not an 8-char slice (#803)", async () => {
+    const tabId = "wf:workflows/Untitled 2026-08-04 06-15-58.json";
+    const a = await connectPanel(tabId); // never replies
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    await expect(bridge.send({ cmd: "graph_query" }, { timeoutMs: 120 })).rejects.toThrow(
+      `Panel tab ${tabId} did not reply to "graph_query" within 120 ms`,
+    );
+    // And specifically NOT the old collapsed form that made every workflow tab look alike.
+    await expect(bridge.send({ cmd: "graph_query" }, { timeoutMs: 120 })).rejects.not.toThrow(
+      /Panel tab wf:workf did not reply/,
+    );
+    a.close();
+  });
+});
+
+// #770/#803 — the fence READ the rebind needs to tell "repaired a stale fence"
+// apart from "there was never a fence". Both are answers; only one is a repair.
+describe("UiBridge.workflowUuidFor (#770 fence read)", () => {
+  it("returns the resolver's value, and undefined for empty/missing/throwing resolvers", () => {
+    const b = new UiBridge(0);
+    // No resolver injected at all → undefined (never a fabricated identity).
+    expect(b.workflowUuidFor("t")).toBeUndefined();
+
+    b.setTabWorkflowUuidResolver((tabId) => (tabId === "t" ? "u-1" : undefined));
+    expect(b.workflowUuidFor("t")).toBe("u-1");
+    expect(b.workflowUuidFor("other")).toBeUndefined();
+
+    // An empty string is not an identity.
+    b.setTabWorkflowUuidResolver(() => "");
+    expect(b.workflowUuidFor("t")).toBeUndefined();
+
+    // A guard that can throw is not a guard: a faulting resolver must not take
+    // down the recovery that reads it.
+    b.setTabWorkflowUuidResolver(() => {
+      throw new Error("resolver exploded");
+    });
+    expect(() => b.workflowUuidFor("t")).not.toThrow();
+    expect(b.workflowUuidFor("t")).toBeUndefined();
+  });
 });
 
 describe("makeUnknownCommandError (old-panel version gate)", () => {

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2896,6 +2896,27 @@ describe("UiBridge.workflowUuidFor (#770 fence read)", () => {
     expect(read.known).toBe(false);
     expect(read).toMatchObject({ reason: expect.stringContaining("resolver exploded") });
   });
+
+  // #770/#803 — same fold, one method over. tabCanMutateGraph fails CLOSED, which
+  // is right for gating and wrong for prose: rendered, it told users their panel
+  // "does not advertise" a capability when we had merely failed to look.
+  it("tabGraphMutationCapability separates an unreadable probe from an observed 'cannot'", () => {
+    const b = new UiBridge(0);
+    // No tab at all → routable-nowhere is an OBSERVATION about mutability.
+    expect(b.tabGraphMutationCapability("nope")).toEqual({ known: true, canMutate: false });
+    expect(b.tabCanMutateGraph("nope")).toBe(false);
+
+    // A resolver that THROWS means the inputs could not be read → UNKNOWN…
+    b.setTabWorkflowUuidResolver(() => {
+      throw new Error("resolver exploded");
+    });
+    // …but only once there is a tab to resolve; with none, the routing answer wins.
+    const noTab = b.tabGraphMutationCapability("nope");
+    expect(noTab).toEqual({ known: true, canMutate: false });
+
+    // The fail-closed convenience keeps its contract for the readiness callers.
+    expect(b.tabCanMutateGraph("nope")).toBe(false);
+  });
 });
 
 describe("makeUnknownCommandError (old-panel version gate)", () => {

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2883,7 +2883,11 @@ describe("defaultBridgeTimeoutMs — tolerant read timeout (#357)", () => {
 
     // The resolver ANSWERS with no stamp → an observed CANNOT (nothing to fence).
     bridge.setTabWorkflowUuidResolver(() => undefined);
-    expect(bridge.tabGraphMutationCapability(tabId)).toEqual({ known: true, canMutate: false });
+    expect(bridge.tabGraphMutationCapability(tabId)).toEqual({
+      known: true,
+      canMutate: false,
+      because: "capability",
+    });
     expect(bridge.tabCanMutateGraph(tabId)).toBe(false);
 
     // The resolver THROWS → the inputs could not be READ. That is UNKNOWN, and
@@ -2899,11 +2903,15 @@ describe("defaultBridgeTimeoutMs — tolerant read timeout (#357)", () => {
     expect(bridge.tabCanMutateGraph(tabId)).toBe(false);
 
     // An unroutable tab is `known`: routing nowhere IS an observation about
-    // mutability, not a failure to look.
-    expect(bridge.tabGraphMutationCapability("no-such-tab")).toEqual({
-      known: true,
-      canMutate: false,
-    });
+    // mutability, not a failure to look. But it is a DIFFERENT observation from
+    // a panel that lacks the write fence, and the two used to share one value —
+    // so the recovery told users to update their panel pack and hard-refresh
+    // when the tab was simply gone and their READS were failing too (codex gate
+    // P1). Same boolean, opposite remedy: the cause is what separates them.
+    const unroutable = bridge.tabGraphMutationCapability("no-such-tab");
+    expect(unroutable).toEqual({ known: true, canMutate: false, because: "unroutable" });
+    // The load-bearing assertion is that these two do NOT compare equal.
+    expect(unroutable).not.toEqual({ known: true, canMutate: false, because: "capability" });
     a.close();
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2252,11 +2252,18 @@ function describeFenceRebind(
 } {
   // A panel that cannot fence a WRITE gives reads only, however good the stamp is.
   const mutationsRefused = canMutate === false;
+  // Its own remedy, NOT the reload sentence: re-calling this tool cannot add a
+  // missing panel capability, so telling the caller to "call this again" here
+  // would be another instruction that provably cannot work.
   const mutationCaveat = mutationsRefused
     ? `\n\nBUT graph MUTATIONS are still refused for this tab: its panel build does not ` +
-      `advertise the write-boundary workflow fence a graph edit requires, which no rebind can ` +
-      `add. Reads work now. To make edits work, UPDATE the comfyui-mcp-panel pack, then ` +
-      `${RELOAD_TAB_REMEDY}`
+      `advertise the write-boundary workflow fence a graph edit requires, and no rebind — ` +
+      `including calling this tool again — can add it. Reads work now (this call just read the ` +
+      `live canvas).\n\nWHAT TO DO FOR EDITS: update the comfyui-mcp-panel pack, then have the ` +
+      `user HARD-refresh (Ctrl+Shift+R) the ComfyUI browser tab — an open tab keeps running its ` +
+      `cached bundle, so the capability lags the version on disk until it does. Do NOT use ` +
+      `panel_reload for this: it has been observed to leave the tab permanently unresponsive ` +
+      `(#803).`
     : "";
   switch (r.status) {
     case "refreshed":

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2431,7 +2431,7 @@ function describeFenceRebind(
    * both yield `canMutate:false` but need opposite advice, and narrating the
    * first as the second is a bucket standing in for a cause (codex gate P1).
    */
-  refusalCause?: "unroutable" | "capability",
+  refusalCause?: "unroutable" | "disconnected" | "no_identity" | "capability",
 ): {
   binding: "bound" | "reads_only" | "unverified" | "not_recovered";
   note: string;
@@ -2452,7 +2452,21 @@ function describeFenceRebind(
   // Its own remedy, NOT the reload sentence: re-calling this tool cannot add a
   // missing panel capability, so telling the caller to "call this again" here
   // would be another instruction that provably cannot work.
-  const mutationCaveat = mutationsRefused && refusalCause === "unroutable"
+  const mutationCaveat = mutationsRefused && refusalCause === "disconnected"
+    ? `\n\nBUT this tab's panel socket is CLOSING or already closed, so graph mutations are ` +
+      `refused. That is a transport state, not a panel-version problem: the pack is fine and ` +
+      `hard-refreshing is not the fix. Reads through this session are unreliable until it ` +
+      `reconnects.` +
+      `\n\nWHAT TO DO: wait for the panel to reconnect — it does so on its own — then call ` +
+      `this again.`
+    : mutationsRefused && refusalCause === "no_identity"
+    ? `\n\nBUT graph MUTATIONS are refused because this session has no trusted workflow ` +
+      `identity for the tab to fence a write against. The panel build is FINE — it advertises ` +
+      `the write fence — so updating the pack and hard-refreshing will not help. Reads work.` +
+      `\n\nWHAT TO DO: call this tool again to bind an identity. If it keeps coming back ` +
+      `without one, have the user click into the workflow tab so the panel reports an active ` +
+      `canvas, then call this again.`
+    : mutationsRefused && refusalCause === "unroutable"
     ? `\n\nBUT this tab is NOT REACHABLE from the orchestrator right now, so graph mutations ` +
       `are refused — and reads are not working either, whatever this note says about them. ` +
       `This is NOT a panel-version problem: updating the pack and hard-refreshing cannot help, ` +
@@ -3033,18 +3047,37 @@ function identityVerdict(rec: OpenWorkflowRecord, activeObj: unknown): boolean |
   // contradicted one, and it could mint the very instance-mismatch wedge this
   // recovery exists to clear.
   //
-  // Only SAME-FIELD pairs can contradict. The cross pairs below (key↔routing_key)
-  // are alias attempts: their agreement is evidence, but their disagreement means
-  // only "these two namespaces differ", which is ordinary. Treating that as a
-  // contradiction would be this same fold pointed the other way — a false refusal
-  // of a real match.
-  const sameField: Array<[unknown, unknown]> = [
-    [r.key, a.key],
-    [r.path, a.path],
-    [r.routing_key, a.routing_key],
+  // Only SAME-FIELD pairs can contradict DECISIVELY here. The cross pairs below
+  // (key↔routing_key) are alias attempts: their agreement is evidence, but their
+  // disagreement means only "these two namespaces differ", which is ordinary.
+  //
+  // Note what the tail of this function still does: when the ONLY comparable
+  // pairs were cross ones and none agreed, it returns `false` rather than
+  // `undefined`. That is deliberately conservative — `false` refuses the
+  // adoption, and refusing to replace a command fence on an uncorroborated
+  // reading is the safe direction. It is not a claim that the two identities
+  // were proven different, and nothing downstream may read it as one.
+  // Compared through the SAME canonicalizer the rest of this file uses, not as
+  // raw strings (codex gate). `./workflows/a.json` and `workflows/a.json` are one
+  // saved identity; declaring them a contradiction would refuse a legitimate
+  // recovery — this defect class pointed the other way, which is exactly what the
+  // contradiction check was added to avoid committing.
+  //
+  // `key` is compared raw because it is an opaque panel handle with no path
+  // syntax to normalize; the other two are paths and are normalized as such.
+  const sameField: Array<[unknown, unknown, (v: unknown) => string | null]> = [
+    [r.key, a.key, (v) => (nonEmpty(v) ? v : null)],
+    [r.path, a.path, canonicalSavedWorkflowPath],
+    [r.routing_key, a.routing_key, canonicalSavedWorkflowRoutingIdentity],
   ];
-  for (const [x, y] of sameField) {
-    if (nonEmpty(x) && nonEmpty(y) && x !== y) return false;
+  for (const [x, y, canon] of sameField) {
+    if (!nonEmpty(x) || !nonEmpty(y)) continue;
+    const cx = canon(x);
+    const cy = canon(y);
+    // If either side does not canonicalize, we could not compare them — which is
+    // not the same as finding them different. Leave it to the pair loop below.
+    if (cx === null || cy === null) continue;
+    if (cx !== cy) return false;
   }
 
   let comparable = false;
@@ -4026,7 +4059,11 @@ export interface PanelToolCtx {
    */
   tabGraphMutationCapability?: () =>
     | { known: true; canMutate: true }
-    | { known: true; canMutate: false; because: "unroutable" | "capability" }
+    | {
+        known: true;
+        canMutate: false;
+        because: "unroutable" | "disconnected" | "no_identity" | "capability";
+      }
     | { known: false; reason: string };
 }
 
@@ -7355,7 +7392,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // fence" — a claim about the panel built from our own failure to look
         // (codex gate). Only an OBSERVED negative may say that.
         let canMutateNow: boolean | undefined;
-        let refusalCause: "unroutable" | "capability" | undefined;
+        let refusalCause: "unroutable" | "disconnected" | "no_identity" | "capability" | undefined;
         try {
           if (ctx.tabGraphMutationCapability) {
             const cap = ctx.tabGraphMutationCapability();

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2426,6 +2426,12 @@ const RELOAD_TAB_REMEDY =
 function describeFenceRebind(
   r: WorkflowFenceRebind,
   canMutate: boolean | undefined,
+  /**
+   * WHY mutations are refused, when they are. An unroutable tab and an old panel
+   * both yield `canMutate:false` but need opposite advice, and narrating the
+   * first as the second is a bucket standing in for a cause (codex gate P1).
+   */
+  refusalCause?: "unroutable" | "capability",
 ): {
   binding: "bound" | "reads_only" | "unverified" | "not_recovered";
   note: string;
@@ -2446,7 +2452,14 @@ function describeFenceRebind(
   // Its own remedy, NOT the reload sentence: re-calling this tool cannot add a
   // missing panel capability, so telling the caller to "call this again" here
   // would be another instruction that provably cannot work.
-  const mutationCaveat = mutationsRefused
+  const mutationCaveat = mutationsRefused && refusalCause === "unroutable"
+    ? `\n\nBUT this tab is NOT REACHABLE from the orchestrator right now, so graph mutations ` +
+      `are refused — and reads are not working either, whatever this note says about them. ` +
+      `This is NOT a panel-version problem: updating the pack and hard-refreshing cannot help, ` +
+      `because there is nothing to refresh until the tab is connected again.` +
+      `\n\nWHAT TO DO: check that the ComfyUI browser tab is still open and its panel is ` +
+      `connected, then call this again.`
+    : mutationsRefused
     ? `\n\nBUT graph MUTATIONS are still refused for this tab: its panel build does not ` +
       `advertise the write-boundary workflow fence a graph edit requires, and no rebind — ` +
       `including calling this tool again — can add it. Reads work now (this call just read the ` +
@@ -3013,6 +3026,27 @@ function identityVerdict(rec: OpenWorkflowRecord, activeObj: unknown): boolean |
     [r.key, a.routing_key],
     [r.routing_key, a.key],
   ];
+  // A CONTRADICTION OUTRANKS AN AGREEMENT (codex gate P0). Returning `true` on
+  // the first equal pair meant a mixed reply — matching `key`, conflicting
+  // `path` — was adopted as a positive identity without the disagreeing field
+  // ever being read. That is not merely an unverified positive; it is a
+  // contradicted one, and it could mint the very instance-mismatch wedge this
+  // recovery exists to clear.
+  //
+  // Only SAME-FIELD pairs can contradict. The cross pairs below (key↔routing_key)
+  // are alias attempts: their agreement is evidence, but their disagreement means
+  // only "these two namespaces differ", which is ordinary. Treating that as a
+  // contradiction would be this same fold pointed the other way — a false refusal
+  // of a real match.
+  const sameField: Array<[unknown, unknown]> = [
+    [r.key, a.key],
+    [r.path, a.path],
+    [r.routing_key, a.routing_key],
+  ];
+  for (const [x, y] of sameField) {
+    if (nonEmpty(x) && nonEmpty(y) && x !== y) return false;
+  }
+
   let comparable = false;
   for (const [x, y] of pairs) {
     if (nonEmpty(x) && nonEmpty(y)) {
@@ -3991,7 +4025,8 @@ export interface PanelToolCtx {
    * Optional so lightweight test contexts can omit it.
    */
   tabGraphMutationCapability?: () =>
-    | { known: true; canMutate: boolean }
+    | { known: true; canMutate: true }
+    | { known: true; canMutate: false; because: "unroutable" | "capability" }
     | { known: false; reason: string };
 }
 
@@ -7320,17 +7355,25 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // fence" — a claim about the panel built from our own failure to look
         // (codex gate). Only an OBSERVED negative may say that.
         let canMutateNow: boolean | undefined;
+        let refusalCause: "unroutable" | "capability" | undefined;
         try {
           if (ctx.tabGraphMutationCapability) {
             const cap = ctx.tabGraphMutationCapability();
             canMutateNow = cap.known ? cap.canMutate : undefined;
+            if (cap.known && !cap.canMutate) refusalCause = cap.because;
           } else {
+            // The legacy boolean probe cannot say WHY, and guessing would put us
+            // back where the tri-state started. Leave the cause undefined so the
+            // narration falls back to the generic wording rather than inventing one.
             canMutateNow = ctx.tabCanMutateGraph?.();
           }
         } catch {
           canMutateNow = undefined; // a guard that can throw is not a guard
+          refusalCause = undefined;
         }
-        const fence = fenceRebind ? describeFenceRebind(fenceRebind, canMutateNow) : undefined;
+        const fence = fenceRebind
+          ? describeFenceRebind(fenceRebind, canMutateNow, refusalCause)
+          : undefined;
         if (fence && fence.binding === "not_recovered") {
           return fail(
             `panel_set_workflow_target({mode:"current"}) did NOT restore this session's graph ` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2160,9 +2160,16 @@ function currentWorkflowFence(ctx: PanelToolCtx): FenceRead {
 //
 // This is the one place that answers the question `mode:"current"` actually asks
 // — "bind me to whatever workflow is live NOW" — by reading the panel's own
-// authoritative active record. It needs no path corroboration precisely because
+// authoritative active record. It needs no CALLER-PATH corroboration, because
 // there is no caller-supplied target to corroborate: the live active canvas IS
 // the target. That is also why it works for an unsaved canvas.
+//
+// But it DOES need RECORD corroboration, which is a different axis and was the
+// gate's P0 (see corroborateActiveForFence). "The caller named no target" does
+// not imply "any active record the reply happens to carry describes this tab".
+// A stale or mixed workflow_list can hand back another canvas's perfectly valid
+// uuid; adopting it would overwrite this tab's stamp, wedge the next command,
+// and report `bound` while doing so.
 //
 // It does NOT weaken #570. The fence still fails closed for every command issued
 // AFTER this point: if the user switches again, the next command carries what
@@ -2184,8 +2191,20 @@ export type WorkflowFenceRebind =
   | { status: "already_current"; uuid: string; before: FenceRead }
   /** The panel did not answer, or its reply was not readable. Unknown, not "fine". */
   | { status: "unreadable"; before: FenceRead; detail: string }
-  /** The panel answered, but its active canvas exposes no usable workflow uuid. */
-  | { status: "no_identity"; before: FenceRead }
+  /** The panel answered, but no usable identity could be adopted from it. TWO
+   *  different facts with different remedies, so they are discriminated rather
+   *  than bucketed: `no_uuid` = this panel build exposes no workflow identity at
+   *  all (a cached/older bundle — updating it is the fix); `uncorroborated` = it
+   *  DOES report one, but the reply did not hang together well enough to prove
+   *  the record describes the live canvas (a stale/mixed snapshot — retrying is
+   *  the fix). Telling a user to update a current panel would be as unactionable
+   *  as telling them to retry a build that will never answer. */
+  | {
+      status: "no_identity";
+      before: FenceRead;
+      kind: "no_uuid" | "uncorroborated";
+      why: string;
+    }
   /** A live identity was read, but the bridge declined to adopt it (the tab stopped
    *  being reachable, or the uuid failed the orchestrator's shape/origin check).
    *  A clean `false` — nothing was written. */
@@ -2195,6 +2214,85 @@ export type WorkflowFenceRebind =
    *  of the write, so whether the fence changed is UNKNOWN and must not be
    *  described either way. */
   | { status: "adopt_error"; uuid: string; before: FenceRead; detail: string };
+
+/**
+ * Is this `workflow_list` reply's top-level `active` record CORROBORATED — i.e.
+ * does the panel's own open-workflow list agree that this record describes the
+ * canvas that is live right now?
+ *
+ * THE RULE THIS RESTORES (independent gate, P0). `resolveOpenWorkflow` already
+ * decided that an uncorroborated top-level `active` object "may remain a
+ * compatibility-valid pin selector, but is never a safe source for replacing a
+ * command fence". The first version of the rebind bypassed that rule, reasoning
+ * that `mode:"current"` has no caller-supplied target to corroborate against.
+ * That was right about the CALLER and wrong about the axis. The question a fence
+ * adoption asks is not "did the caller name a target we must check", it is
+ * "does this record describe the canvas we are about to stamp" — and a MIXED or
+ * STALE reply answers that wrongly no matter what the caller asked for. Adopting
+ * another canvas's valid uuid passes the shape/origin validator, overwrites this
+ * tab's stamp, and gets reported as `bound`: a fresh wedge, announced as a
+ * recovery. That is strictly worse than the wedge this PR exists to fix.
+ *
+ * FAILS CLOSED. Anything that cannot be positively corroborated returns a reason
+ * and the caller lands in `no_identity`, which already says honestly that the
+ * fence was not replaced and names what to do. A recovery that declines is fine.
+ */
+function corroborateActiveForFence(
+  parsed: Record<string, unknown>,
+): { ok: true; active: Record<string, unknown> } | { ok: false; why: string } {
+  const active = parsed.active;
+  if (!active || typeof active !== "object") {
+    return { ok: false, why: "the reply carried no active-workflow record" };
+  }
+  // #514: the panel says so itself when its active record is not confirmed. An
+  // explicit `false` is the panel telling us the value is untrustworthy — never
+  // adopt through that. (Absent = an older panel that cannot say; the list
+  // corroboration below then has to carry the whole weight.)
+  if (parsed.active_confirmed === false) {
+    return { ok: false, why: "the panel reported its active workflow as UNCONFIRMED" };
+  }
+  const list = parsed.workflows;
+  if (!Array.isArray(list) || list.length === 0) {
+    return {
+      ok: false,
+      why: "the reply carried no open-workflow list to corroborate the active record against",
+    };
+  }
+  // Only an AFFIRMATIVE per-record flag can nominate the corroborating entry;
+  // inferring it from the active object would be circular.
+  const flaggedActive = list.filter(
+    (w): w is OpenWorkflowRecord =>
+      !!w && typeof w === "object" && (w as { active?: unknown }).active === true,
+  );
+  if (flaggedActive.length === 0) {
+    return { ok: false, why: "no entry in the open-workflow list is marked active" };
+  }
+  if (flaggedActive.length > 1) {
+    // A mixed/partial snapshot. Exactly the shape that would let another canvas's
+    // uuid through, so it is refused rather than arbitrated.
+    return {
+      ok: false,
+      why: `${flaggedActive.length} entries in the open-workflow list are marked active (a mixed reply)`,
+    };
+  }
+  // Same tri-state primitive the pin path uses. `false` = they name DIFFERENT
+  // canvases (the stale/mixed case). `undefined` = they share no comparable
+  // identity field, so agreement was never established — which is not agreement.
+  const verdict = identityVerdict(flaggedActive[0], active);
+  if (verdict === false) {
+    return {
+      ok: false,
+      why: "the active record and the entry marked active in the open-workflow list name DIFFERENT workflows (a stale or mixed reply)",
+    };
+  }
+  if (verdict !== true) {
+    return {
+      ok: false,
+      why: "the active record and the open-workflow list share no comparable identity field, so nothing corroborates it",
+    };
+  }
+  return { ok: true, active: active as Record<string, unknown> };
+}
 
 /**
  * Re-derive this session's command fence from the panel's live active canvas.
@@ -2236,9 +2334,24 @@ async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebi
       detail: "the panel's workflow_list reply was not readable as JSON",
     };
   }
-  const active = (parsed as { active?: unknown }).active;
+  // CORROBORATE before adopting. The uuid must come from a record the panel's own
+  // open-workflow list agrees is the live canvas — otherwise a stale or mixed
+  // reply's uuid (valid in shape, belonging to ANOTHER canvas) would overwrite
+  // this tab's stamp and be reported as a successful rebind.
+  const corroborated = corroborateActiveForFence(parsed);
+  if (!corroborated.ok) {
+    return { status: "no_identity", before, kind: "uncorroborated", why: corroborated.why };
+  }
+  const active = corroborated.active;
   const uuid = responseWorkflowUuid(active);
-  if (!uuid) return { status: "no_identity", before };
+  if (!uuid) {
+    return {
+      status: "no_identity",
+      before,
+      kind: "no_uuid",
+      why: "the active workflow record carries no usable workflow_uuid",
+    };
+  }
   // "already current" requires a KNOWN prior fence equal to the live uuid. An
   // UNKNOWN prior fence must not short-circuit the adoption: we would be claiming
   // the stamp already matched without ever having read it.
@@ -2444,45 +2557,76 @@ function describeFenceRebind(
       //  - an UNREADABLE prior fence → we cannot say either way → unverified.
       //    Failing here would report a wedge nobody observed; succeeding would
       //    report a repair nobody observed. Neither is available, so say so.
+    {
+      // WHY nothing was adopted decides the remedy. A panel that exposes no
+      // identity needs UPDATING (retrying forever will not help); a reply that
+      // did not hang together needs RETRYING (the pack is fine). Bucketing them
+      // would hand half the callers an instruction they cannot act on.
+      const lead =
+        r.kind === "no_uuid"
+          ? ` The panel answered but reported NO workflow identity for the active canvas`
+          : ` The panel answered, but its reply could not be corroborated, so nothing was ` +
+            `adopted — ${r.why}. NOTHING was written to this session's fence: adopting an ` +
+            `uncorroborated record could have stamped ANOTHER canvas's identity onto this tab`;
+      const remedy =
+        r.kind === "no_uuid"
+          ? `\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY} Make it a HARD refresh here specifically: a ` +
+            `plain reload can serve the same cached bundle again; only a hard refresh replaces ` +
+            `it. If a hard refresh does not help, the installed pack itself predates the ` +
+            `per-workflow identity and must be UPDATED — no rebind can add it.`
+          : `\n\nWHAT TO DO: call this again in a moment. A stale or mixed workflow list is ` +
+            `usually transient — it settles once the panel finishes reconciling its tabs. If ` +
+            `it persists across a few attempts: ${RELOAD_TAB_REMEDY}`;
       if (!r.before.known) {
         return {
           binding: "unverified",
           note:
-            ` The panel answered but reported NO workflow identity for the active canvas, and ` +
-            `this session's existing fence could not be read either — so whether its graph ` +
-            `binding is healthy could NOT be determined. Routing is set. Treat graph tools as ` +
-            `unconfirmed: if the next one fails with a workflow-instance mismatch, that is the ` +
-            `answer, and a cached older panel bundle is the usual cause.` +
-            `\n\nWHAT TO DO if it does fail: ${RELOAD_TAB_REMEDY}`,
+            `${lead}, and this session's existing fence could not be read either — so whether ` +
+            `its graph binding is healthy could NOT be determined. Routing is set. Treat graph ` +
+            `tools as unconfirmed: if the next one fails with a workflow-instance mismatch, ` +
+            `that is the answer.${remedy}`,
         };
       }
       return r.before.uuid
         ? {
             binding: "not_recovered",
             note:
-              ` The panel answered but reported NO workflow identity for the active canvas, so ` +
-              `this session is STILL fenced to the previous workflow instance ` +
-              `(${r.before.uuid}) and graph tools will keep failing. A cached older panel ` +
-              `bundle is the usual cause.` +
-              `\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY} Make it a HARD refresh here specifically: a ` +
-              `plain reload can serve the same cached bundle again; only a hard refresh replaces ` +
-              `it. If a hard refresh does not help, the installed pack itself predates the ` +
-              `per-workflow identity and must be UPDATED — no rebind can add it.`,
+              `${lead}, so this session is STILL fenced to the previous workflow instance ` +
+              `(${r.before.uuid}) and graph tools will keep failing.${remedy}`,
           }
-        : {
-            binding: "reads_only",
-            // Honest limit (codex gate): "until it reconnects with one" was not
-            // actionable — a panel build that has no workflow identity will never
-            // acquire one merely by reconnecting. Name the remedy that exists.
-            note:
-              ` The panel answered but reports NO workflow identity for the active canvas. Graph ` +
-              `READS work; graph MUTATIONS stay refused, because there is no instance for the ` +
-              `panel to fence a write against. Routing is set.` +
-              `\n\nNOTE: reconnecting alone will NOT restore mutations — a panel build that ` +
-              `reports no workflow identity needs the comfyui-mcp-panel pack UPDATED (then a ` +
-              `hard refresh of the ComfyUI browser tab, since the open tab can keep running a ` +
-              `cached older bundle). Until then this session is read-only for graph tools.`,
-          };
+        : r.kind === "no_uuid"
+          ? {
+              binding: "reads_only",
+              // Honest limit (codex gate): "until it reconnects with one" was not
+              // actionable — a panel build that has no workflow identity will never
+              // acquire one merely by reconnecting. Name the remedy that exists.
+              note:
+                ` The panel answered but reports NO workflow identity for the active canvas. ` +
+                `Graph READS work; graph MUTATIONS stay refused, because there is no instance ` +
+                `for the panel to fence a write against. Routing is set.` +
+                `\n\nNOTE: reconnecting alone will NOT restore mutations — a panel build that ` +
+                `reports no workflow identity needs the comfyui-mcp-panel pack UPDATED (then a ` +
+                `hard refresh of the ComfyUI browser tab, since the open tab can keep running a ` +
+                `cached older bundle). Until then this session is read-only for graph tools.`,
+            }
+          : {
+              // A panel that DOES report identities, whose reply merely did not hang
+              // together this time. Nothing was stale (no prior fence) and nothing was
+              // adopted, so the session is no worse than before — but we did not
+              // establish a fence either, and saying "reads work, mutations don't"
+              // would describe a permanent limitation this is not.
+              binding: "unverified",
+              note:
+                ` The panel's reply could not be corroborated, so nothing was adopted — ` +
+                `${r.why}. NOTHING was written to this session's fence: adopting an ` +
+                `uncorroborated record could have stamped ANOTHER canvas's identity onto this ` +
+                `tab. This session had no fence to damage, so it is no worse off — but no ` +
+                `fence was established either, so graph mutations remain unconfirmed.` +
+                `\n\nWHAT TO DO: call this again in a moment. A stale or mixed workflow list ` +
+                `is usually transient — it settles once the panel finishes reconciling its ` +
+                `tabs. If it persists across a few attempts: ${RELOAD_TAB_REMEDY}`,
+            };
+    }
   }
 }
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2125,8 +2125,19 @@ function currentWorkflowFence(ctx: PanelToolCtx): FenceRead {
   const read = (ctx.bridge as unknown as { workflowUuidFor?: unknown }).workflowUuidFor;
   if (typeof read !== "function") return { known: false };
   try {
-    const uuid = read.call(ctx.bridge, ctx.tabId) as unknown;
-    return { known: true, uuid: typeof uuid === "string" && uuid.length > 0 ? uuid : undefined };
+    const out = read.call(ctx.bridge, ctx.tabId) as unknown;
+    // The bridge answers TRI-STATE (TabWorkflowUuidRead). Preserve it: swallowing
+    // its `known:false` back into an absent fence here would undo the whole point,
+    // since the bridge is the only thing that can see the stamp.
+    if (out && typeof out === "object" && "known" in out) {
+      const r = out as { known: unknown; uuid?: unknown };
+      if (r.known !== true) return { known: false };
+      return { known: true, uuid: typeof r.uuid === "string" && r.uuid.length > 0 ? r.uuid : undefined };
+    }
+    // A lightweight/legacy stub that still returns a bare string|undefined: a
+    // string is a fence; anything else is NOT evidence of absence, only of a
+    // shape we cannot interpret.
+    return typeof out === "string" && out.length > 0 ? { known: true, uuid: out } : { known: false };
   } catch {
     return { known: false };
   }
@@ -2176,8 +2187,14 @@ export type WorkflowFenceRebind =
   /** The panel answered, but its active canvas exposes no usable workflow uuid. */
   | { status: "no_identity"; before: FenceRead }
   /** A live identity was read, but the bridge declined to adopt it (the tab stopped
-   *  being reachable, or the uuid failed the orchestrator's shape/origin check). */
-  | { status: "rejected"; uuid: string; before: FenceRead };
+   *  being reachable, or the uuid failed the orchestrator's shape/origin check).
+   *  A clean `false` — nothing was written. */
+  | { status: "rejected"; uuid: string; before: FenceRead }
+  /** The adoption itself THREW. Distinct from `rejected` (codex gate): a refusal
+   *  proves the old fence is untouched, whereas a throw can land on either side
+   *  of the write, so whether the fence changed is UNKNOWN and must not be
+   *  described either way. */
+  | { status: "adopt_error"; uuid: string; before: FenceRead; detail: string };
 
 /**
  * Re-derive this session's command fence from the panel's live active canvas.
@@ -2185,15 +2202,27 @@ export type WorkflowFenceRebind =
  * the caller — not this function — decides what that means for its own report.
  */
 async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebind> {
-  const before = currentWorkflowFence(ctx);
+  const tabAtStart = ctx.tabId;
+  let before = currentWorkflowFence(ctx);
+  // `before` describes the tab we are ABOUT to compare against — but ctx.call can
+  // MOVE us (workflow_list is retry-safe; its retry runs ensureReachable, which
+  // rebinds an orphaned current-mode session). Re-read after any move, or we would
+  // compare the NEW tab's live canvas against the OLD tab's fence: an accidental
+  // `already_current` would then skip a refresh the new tab genuinely needed, and
+  // report a recovered binding that is still wedged (codex gate).
+  const syncFenceToCurrentTab = (): void => {
+    if (ctx.tabId !== tabAtStart) before = currentWorkflowFence(ctx);
+  };
   let parsed: Record<string, unknown> | null = null;
   try {
     const res = await ctx.call({ cmd: "workflow_list" }, 6000);
+    syncFenceToCurrentTab();
     if (res?.isError) {
       return { status: "unreadable", before, detail: toolResultText(res) };
     }
     parsed = parseToolResultJson(res);
   } catch (err) {
+    syncFenceToCurrentTab();
     return {
       status: "unreadable",
       before,
@@ -2218,9 +2247,26 @@ async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebi
   // re-checks reachability and the uuid's shape/origin binding. A `false` here is
   // a REFUSAL, not a no-op, so it gets its own status rather than being reported
   // as a successful rebind.
-  return refreshWorkflowUuid(ctx, active)
-    ? { status: "refreshed", uuid, before }
-    : { status: "rejected", uuid, before };
+  // The adoption is itself an operation that can fail — the bridge hands the value
+  // to an orchestrator-supplied validator that reads live connection state. A
+  // throw here would escape this whole handler AFTER the target store write and
+  // push, taking the "APPLIED (do not repeat this part)" disclosure with it and
+  // leaving the caller unable to tell what happened (rules 3 and 4). Catch it, and
+  // do NOT claim the fence is unchanged: a throw can land on either side of the
+  // write, so `rejected`'s "the previous fence is unchanged" would be a state
+  // nobody observed.
+  try {
+    return refreshWorkflowUuid(ctx, active)
+      ? { status: "refreshed", uuid, before }
+      : { status: "rejected", uuid, before };
+  } catch (err) {
+    return {
+      status: "adopt_error",
+      uuid,
+      before,
+      detail: err instanceof Error ? err.message : String(err ?? "unknown error"),
+    };
+  }
 }
 
 /**
@@ -2325,8 +2371,23 @@ function describeFenceRebind(
         note:
           ` Read the live canvas identity (${r.uuid}) but could NOT adopt it as this session's ` +
           `graph command fence — the bound tab stopped being reachable, or the panel reported an ` +
-          `identity this orchestrator does not trust. The previous fence is unchanged, so graph ` +
-          `tools will keep failing.\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY}`,
+          `identity this orchestrator does not trust. The adoption was REFUSED, so the previous ` +
+          `fence is unchanged and graph tools will keep failing.` +
+          `\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY}`,
+      };
+    case "adopt_error":
+      return {
+        binding: "not_recovered",
+        note:
+          ` Read the live canvas identity (${r.uuid}), but adopting it as this session's graph ` +
+          `command fence THREW. Unlike a refusal, this does not tell us the previous fence ` +
+          `survived: the failure can have landed on either side of the write, so whether the ` +
+          `fence changed is UNKNOWN. Do not assume either way — the next graph command's ` +
+          `outcome is the reliable answer, and it is safe to find out (a mismatched fence is ` +
+          `refused, never misapplied).` +
+          `\n\nWHAT TO DO: call this again — a second attempt is safe and settles it. If it ` +
+          `keeps throwing: ${RELOAD_TAB_REMEDY}` +
+          `\n\nUNDERLYING CAUSE: ${r.detail}`,
       };
     case "unreadable":
       // ALWAYS not_recovered, with or without a prior fence (codex gate). The read
@@ -7037,6 +7098,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             const onNewTab = ctx.workflowTarget.get(ctx.tabId);
             if (onNewTab?.mode === "pinned") {
               const pinLabel = onNewTab.filename ?? onNewTab.path;
+              // Report the fence outcome from the actual status, never as a flat
+              // "it was refreshed" (codex gate): the probe that moved us may also
+              // have come back unreadable, identity-less, refused, or already
+              // matching, and only one of those is a refresh.
+              const fenceLine =
+                fenceRebind.status === "refreshed"
+                  ? `The graph command fence WAS refreshed onto this tab's live canvas (workflow instance ${fenceRebind.uuid}), which is correct for it either way.`
+                  : fenceRebind.status === "already_current"
+                    ? `The graph command fence already named this tab's live canvas, so it needed no change.`
+                    : `The graph command fence was NOT established on this tab (${fenceRebind.status}) — so graph tools may also fail here with a workflow-instance mismatch, independently of the pin below.`;
               return fail(
                 `panel_set_workflow_target({mode:"current"}) did NOT take effect on the tab this ` +
                   `session is now bound to.\n\nWHAT HAPPENED: the panel dropped mid-call, so this ` +
@@ -7044,14 +7115,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   `request was in flight. Your mode:"current" was recorded against the PREVIOUS ` +
                   `tab. The tab you are on now is PINNED to "${pinLabel}", and that pin was left ` +
                   `untouched — the workflow-target store is shared, so another session may own ` +
-                  `it. The graph command fence WAS refreshed onto this tab's live canvas, which ` +
-                  `is correct for it either way.\n\nWHAT TO DO — read this before retrying: graph ` +
-                  `tools will currently target "${pinLabel}". If that is what you want, proceed ` +
-                  `normally; nothing else is needed. If you need to follow the tab the user is ` +
-                  `viewing instead, calling panel_set_workflow_target({mode:"current"}) again ` +
-                  `WILL REPLACE that pin — do that only if the pin is yours. If it is not, or ` +
-                  `you cannot tell, ask the user which workflow they want this session on rather ` +
-                  `than overwriting another session's binding.`,
+                  `it. ${fenceLine}\n\nWHAT TO DO — read this before retrying: graph tools will ` +
+                  `currently target "${pinLabel}". If that is what you want, try one graph call ` +
+                  `and let its outcome tell you whether the binding is usable. If you need to ` +
+                  `follow the tab the user is viewing instead, calling ` +
+                  `panel_set_workflow_target({mode:"current"}) again WILL REPLACE that pin — do ` +
+                  `that only if the pin is yours. If it is not, or you cannot tell, ask the user ` +
+                  `which workflow they want this session on rather than overwriting another ` +
+                  `session's binding.`,
               );
             }
             // Nothing to take away — re-apply the caller's request where it now counts.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2233,28 +2233,50 @@ const RELOAD_TAB_REMEDY =
  *                      in the opposite direction.
  *  - `not_recovered` — the session is STILL fenced by a stamp that does not name
  *                      the live canvas. The caller must not report success.
+ *
+ * `canMutate` is `bridge.tabCanMutateGraph(tabId)` — the SEPARATE question of
+ * whether this panel build advertises the two write-boundary fences a graph
+ * MUTATION requires (codex gate). A stamp is necessary but NOT sufficient: an
+ * older bundle can report a perfectly good workflow uuid and still have every
+ * mutation refused at dispatch. Reporting `bound` off the stamp alone answered
+ * a question nobody asked. `undefined` means the capability is not determinable
+ * from this context (a lightweight test ctx) — that is an unknown, so it does
+ * NOT downgrade, and it does not claim either.
  */
-function describeFenceRebind(r: WorkflowFenceRebind): {
+function describeFenceRebind(
+  r: WorkflowFenceRebind,
+  canMutate: boolean | undefined,
+): {
   binding: "bound" | "reads_only" | "not_recovered";
   note: string;
 } {
+  // A panel that cannot fence a WRITE gives reads only, however good the stamp is.
+  const mutationsRefused = canMutate === false;
+  const mutationCaveat = mutationsRefused
+    ? `\n\nBUT graph MUTATIONS are still refused for this tab: its panel build does not ` +
+      `advertise the write-boundary workflow fence a graph edit requires, which no rebind can ` +
+      `add. Reads work now. To make edits work, UPDATE the comfyui-mcp-panel pack, then ` +
+      `${RELOAD_TAB_REMEDY}`
+    : "";
   switch (r.status) {
     case "refreshed":
       return {
-        binding: "bound",
+        binding: mutationsRefused ? "reads_only" : "bound",
         note:
           ` Rebound the graph command fence onto the live canvas (workflow instance ${r.uuid})` +
-          `${r.previous ? `, replacing the stale ${r.previous}` : ""} — graph tools will now ` +
-          `target the workflow that is in view.`,
+          `${r.previous ? `, replacing the stale ${r.previous}` : ""} — graph ` +
+          `${mutationsRefused ? "READS" : "tools"} will now target the workflow that is in ` +
+          `view.${mutationCaveat}`,
       };
     case "already_current":
       return {
-        binding: "bound",
+        binding: mutationsRefused ? "reads_only" : "bound",
         note:
           ` The graph command fence already named the live canvas (workflow instance ${r.uuid}), ` +
           `so nothing needed rebinding. If graph tools are still failing with a workflow-instance ` +
           `mismatch, this session and the panel AGREE on the target and the mismatch is coming ` +
-          `from the panel, not from this binding.\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY}`,
+          `from the panel, not from this binding.${mutationCaveat}` +
+          (mutationsRefused ? "" : `\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY}`),
       };
     case "rejected":
       return {
@@ -5998,14 +6020,20 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // genuinely stalled render is caught by the turn-start stall notice, which
         // does the staleness gating and keeps the interrupt guidance.
         // #772 — never report a dispatch history the caller did not see. When the scoped
-        // run only queued on the SECOND dispatch, say so: exactly one render is in the
-        // queue, and the agent must not read the earlier refusal (if it surfaces in a
-        // log) as a separate queued job.
+        // run only queued on the SECOND dispatch, say so, so the agent does not read the
+        // earlier refusal (if it surfaces in a log) as a separate queued job.
+        //
+        // It says only what was OBSERVED (codex gate). An earlier draft said "exactly one
+        // render was queued" — but `batch_count` is "times to queue", so a successful
+        // dispatch can enqueue several, and the panel reports one prompt id, not a count.
+        // The certified fact is about DISPATCHES, not renders: the first queued nothing,
+        // so everything in the queue came from the second. State that and stop.
         const retryNote = scopeRebuilt
           ? "\n\n[NOTE] The first dispatch of this scoped run was refused by the panel's run-to-node " +
             "graph-stamp race (the graph changed between dispatch and apply); the panel certified that " +
             "nothing was queued, so the scope was rebuilt and re-issued once, and THAT is the run above. " +
-            "Exactly one render was queued."
+            "The first dispatch contributed NOTHING to the queue, so whatever this run queued was " +
+            "queued once, not twice."
           : "";
         let warn = "";
         if (pre.connected && pre.running) {
@@ -6922,7 +6950,42 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // the failure text's "APPLIED (do not repeat this part)" literally true: the
         // target write is already committed and pushed by the time we can fail.
         if (mode === "current" && ctx.rebindToActiveTab && !deferredBind) {
+          const tabBeforeProbe = ctx.tabId;
           fenceRebind = await rebindWorkflowFence(ctx);
+          // The probe itself can MOVE this session (codex gate). `workflow_list` is
+          // retry-safe, so a transient reconnect inside ctx.call sleeps, calls
+          // ensureReachable — which may rebind ctx.tabId onto a different tab — and
+          // retries there. The fence we just adopted then belongs to the NEW tab,
+          // while the `mode:"current"` record we wrote belongs to the OLD one. If the
+          // new tab already carries a PIN (ordinary with two agents on one machine),
+          // the next graph command routes through that pin, and reporting "following
+          // the user's current workflow tab" would name a state that is not the case.
+          //
+          // Do NOT silently overwrite the new tab's pin — that is someone else's
+          // binding, and clobbering it is the very failure the ordering fix above
+          // exists to prevent. Adopt the target onto the new tab only when doing so
+          // takes nothing away (no entry, or already current); otherwise say plainly
+          // what happened and hand back a call the caller can actually make.
+          if (ctx.tabId !== tabBeforeProbe) {
+            const onNewTab = ctx.workflowTarget.get(ctx.tabId);
+            if (onNewTab?.mode === "pinned") {
+              return fail(
+                `panel_set_workflow_target({mode:"current"}) did NOT take effect on the tab this ` +
+                  `session is now bound to.\n\nWHAT HAPPENED: the panel dropped mid-call, so this ` +
+                  `session was rebound from tab ${tabBeforeProbe} onto tab ${ctx.tabId} while the ` +
+                  `request was in flight. Your mode:"current" was recorded against the PREVIOUS ` +
+                  `tab. The tab you are on now is PINNED to "${onNewTab.filename ?? onNewTab.path}" ` +
+                  `— left untouched, because another session may own that pin.\n\nWHAT TO DO: ` +
+                  `call panel_set_workflow_target({mode:"current"}) again now that the binding ` +
+                  `has settled; it will apply to this tab. If the pin is yours and you want it, ` +
+                  `do nothing — graph tools will target "${onNewTab.filename ?? onNewTab.path}".`,
+              );
+            }
+            // Nothing to take away — re-apply the caller's request where it now counts.
+            const moved = ctx.workflowTarget.set(ctx.tabId, { mode: "current" });
+            ctx.bridge.push({ type: "workflow_target", target: moved }, ctx.tabId);
+            rebindNote += ` The panel dropped mid-call: this session moved from tab ${tabBeforeProbe} onto tab ${ctx.tabId}, and mode:"current" was applied there too.`;
+          }
         }
         const hint =
           target.mode === "pinned"
@@ -6937,7 +7000,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // thing it must never say when it did not. `graph_binding` carries the same
         // verdict machine-readably, and `graph_binding_status` the specific cause, so a
         // caller never has to infer four different remedies from one sentence.
-        const fence = fenceRebind ? describeFenceRebind(fenceRebind) : undefined;
+        // A stamp is necessary but not sufficient for a graph EDIT — the panel build
+        // must also advertise the write-boundary fence. Ask that question separately
+        // (codex gate) so `bound` never overstates a read-only panel. A ctx that
+        // cannot answer leaves it undefined: an unknown, which downgrades nothing.
+        let canMutateNow: boolean | undefined;
+        try {
+          canMutateNow = ctx.tabCanMutateGraph?.();
+        } catch {
+          canMutateNow = undefined; // a guard that can throw is not a guard
+        }
+        const fence = fenceRebind ? describeFenceRebind(fenceRebind, canMutateNow) : undefined;
         if (fence && fence.binding === "not_recovered") {
           return fail(
             `panel_set_workflow_target({mode:"current"}) did NOT restore this session's graph ` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2359,11 +2359,23 @@ function describeFenceRebind(
       return {
         binding: okBinding,
         note:
-          ` The graph command fence already named the live canvas (workflow instance ${r.uuid}), ` +
-          `so nothing needed rebinding. If graph tools are still failing with a workflow-instance ` +
-          `mismatch, this session and the panel AGREE on the target and the mismatch is coming ` +
-          `from the panel, not from this binding.${mutationCaveat}${unknownCaveat}` +
-          (mutationsRefused ? "" : `\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY}`),
+          ` The graph command fence already named the canvas the panel reported as active a ` +
+          `moment ago (workflow instance ${r.uuid}), so nothing needed rebinding.` +
+          // The SAME post-probe window as `refreshed` (codex gate). This branch used
+          // to jump straight to "the mismatch is coming from the panel" and send the
+          // caller to a browser reload — but a switch after workflow_list replied
+          // leaves the stamp stale here too, and the immediate remedy for that is
+          // this very call, not a reload. Reserve the reload for a mismatch that
+          // PERSISTS across a repeat, which is the only thing that actually
+          // implicates the panel.
+          ` (If the user switched tabs again in that instant, the next graph command ` +
+          `fails closed with a fresh instance mismatch — safe, and cleared by calling this ` +
+          `again.)${mutationCaveat}${unknownCaveat}` +
+          (mutationsRefused
+            ? ""
+            : `\n\nWHAT TO DO if graph tools are still failing: call this once more. If the ` +
+              `mismatch SURVIVES that repeat, this session and the panel agree on the target ` +
+              `and the disagreement is inside the panel — ${RELOAD_TAB_REMEDY}`),
       };
     case "rejected":
       return {
@@ -3827,6 +3839,16 @@ export interface PanelToolCtx {
    * Optional only for lightweight legacy test contexts.
    */
   tabCanMutateGraph?: () => boolean;
+  /**
+   * The same question TRI-STATE, for code that must REPORT the answer rather than
+   * gate on it. `tabCanMutateGraph` fails closed (an unreadable probe becomes
+   * `false`), which is right for gating and wrong for prose: it made the recovery
+   * tell users their panel lacked a capability when we had merely failed to look.
+   * Optional so lightweight test contexts can omit it.
+   */
+  tabGraphMutationCapability?: () =>
+    | { known: true; canMutate: boolean }
+    | { known: false; reason: string };
 }
 
 /** Build a tab-bound execution context shared by both transports. */
@@ -4252,6 +4274,7 @@ export function makePanelToolCtx(
   ctx.panelConnectionIdentity = panelConnectionIdentity;
   ctx.awaitPostRestartReachable = awaitPostRestartReachable;
   ctx.tabCanMutateGraph = () => bridge.tabCanMutateGraph(ctx.tabId);
+  ctx.tabGraphMutationCapability = () => bridge.tabGraphMutationCapability(ctx.tabId);
   return ctx;
 }
 
@@ -7148,9 +7171,18 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // must also advertise the write-boundary fence. Ask that question separately
         // (codex gate) so `bound` never overstates a read-only panel. A ctx that
         // cannot answer leaves it undefined: an unknown, which downgrades nothing.
+        // Prefer the TRI-STATE probe: the boolean one fails closed, so an
+        // unreadable capability would be RENDERED as "your panel lacks the write
+        // fence" — a claim about the panel built from our own failure to look
+        // (codex gate). Only an OBSERVED negative may say that.
         let canMutateNow: boolean | undefined;
         try {
-          canMutateNow = ctx.tabCanMutateGraph?.();
+          if (ctx.tabGraphMutationCapability) {
+            const cap = ctx.tabGraphMutationCapability();
+            canMutateNow = cap.known ? cap.canMutate : undefined;
+          } else {
+            canMutateNow = ctx.tabCanMutateGraph?.();
+          }
         } catch {
           canMutateNow = undefined; // a guard that can throw is not a guard
         }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1213,9 +1213,12 @@ function isAckTimeout(res: ToolResult): boolean {
   // that still admits every real ack timeout. The tail stays open on purpose —
   // anchoring the end would reject the appended-token variant and silently switch
   // the recovery off, which is the same failure in the opposite direction.
-  return /^(?:Error: )?Panel tab .+? did not reply to "workflow_open" within \d+\s*ms/i.test(
-    text.trimStart(),
-  );
+  //
+  // Matched against the RAW text — no `.trim()` (codex gate, and the same call
+  // isReplyTimeoutError documents). The bridge message never carries leading
+  // whitespace, so trimming buys nothing and only lets a whitespace/newline-
+  // prefixed acked error reach the receipt-recovery path.
+  return /^(?:Error: )?Panel tab .+? did not reply to "workflow_open" within \d+\s*ms/i.test(text);
 }
 
 /** Parse a ctx.call ToolResult's text payload as JSON, or null if not parseable. */
@@ -2103,18 +2106,29 @@ function refreshWorkflowUuid(ctx: PanelToolCtx, value: unknown): boolean {
   return uuid && typeof refresh === "function" ? refresh.call(ctx.bridge, ctx.tabId, uuid) : false;
 }
 
-/** The stamp currently fencing this session's tab, or undefined when it has none.
- *  Reading it is what lets the rebind below tell "repaired a stale fence" apart
- *  from "there was never a fence" — two states with different remedies. Never
- *  throws: a guard that can throw is not a guard. */
-function currentWorkflowFence(ctx: PanelToolCtx): string | undefined {
+/**
+ * The stamp currently fencing this session's tab — TRI-STATE, because reading it
+ * is itself an operation that can fail (codex gate).
+ *
+ *  - `{ known: true, uuid }` — there IS a fence, and this is it.
+ *  - `{ known: true }`       — there is definitively NO fence.
+ *  - `{ known: false }`      — we could not find out: this bridge has no accessor,
+ *                              or the resolver threw and the guard swallowed it.
+ *
+ * Collapsing the third into the second is exactly the fold this cluster is about.
+ * It made a failed read render as "it has no graph command fence" — an absence
+ * nobody observed. Never throws.
+ */
+type FenceRead = { known: true; uuid?: string } | { known: false };
+
+function currentWorkflowFence(ctx: PanelToolCtx): FenceRead {
   const read = (ctx.bridge as unknown as { workflowUuidFor?: unknown }).workflowUuidFor;
-  if (typeof read !== "function") return undefined;
+  if (typeof read !== "function") return { known: false };
   try {
     const uuid = read.call(ctx.bridge, ctx.tabId) as unknown;
-    return typeof uuid === "string" && uuid.length > 0 ? uuid : undefined;
+    return { known: true, uuid: typeof uuid === "string" && uuid.length > 0 ? uuid : undefined };
   } catch {
-    return undefined;
+    return { known: false };
   }
 }
 
@@ -2154,16 +2168,16 @@ function currentWorkflowFence(ctx: PanelToolCtx): string | undefined {
  */
 export type WorkflowFenceRebind =
   /** Read the live identity; it differed from the stamp and has REPLACED it. */
-  | { status: "refreshed"; uuid: string; previous?: string }
+  | { status: "refreshed"; uuid: string; before: FenceRead }
   /** Read the live identity; the stamp already named it. Nothing to repair. */
-  | { status: "already_current"; uuid: string; previous: string }
+  | { status: "already_current"; uuid: string; before: FenceRead }
   /** The panel did not answer, or its reply was not readable. Unknown, not "fine". */
-  | { status: "unreadable"; previous?: string; detail: string }
+  | { status: "unreadable"; before: FenceRead; detail: string }
   /** The panel answered, but its active canvas exposes no usable workflow uuid. */
-  | { status: "no_identity"; previous?: string }
+  | { status: "no_identity"; before: FenceRead }
   /** A live identity was read, but the bridge declined to adopt it (the tab stopped
    *  being reachable, or the uuid failed the orchestrator's shape/origin check). */
-  | { status: "rejected"; uuid: string; previous?: string };
+  | { status: "rejected"; uuid: string; before: FenceRead };
 
 /**
  * Re-derive this session's command fence from the panel's live active canvas.
@@ -2171,39 +2185,42 @@ export type WorkflowFenceRebind =
  * the caller — not this function — decides what that means for its own report.
  */
 async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebind> {
-  const previous = currentWorkflowFence(ctx);
+  const before = currentWorkflowFence(ctx);
   let parsed: Record<string, unknown> | null = null;
   try {
     const res = await ctx.call({ cmd: "workflow_list" }, 6000);
     if (res?.isError) {
-      return { status: "unreadable", previous, detail: toolResultText(res) };
+      return { status: "unreadable", before, detail: toolResultText(res) };
     }
     parsed = parseToolResultJson(res);
   } catch (err) {
     return {
       status: "unreadable",
-      previous,
+      before,
       detail: err instanceof Error ? err.message : String(err ?? "unknown error"),
     };
   }
   if (!parsed) {
     return {
       status: "unreadable",
-      previous,
+      before,
       detail: "the panel's workflow_list reply was not readable as JSON",
     };
   }
   const active = (parsed as { active?: unknown }).active;
   const uuid = responseWorkflowUuid(active);
-  if (!uuid) return { status: "no_identity", previous };
-  if (uuid === previous) return { status: "already_current", uuid, previous };
+  if (!uuid) return { status: "no_identity", before };
+  // "already current" requires a KNOWN prior fence equal to the live uuid. An
+  // UNKNOWN prior fence must not short-circuit the adoption: we would be claiming
+  // the stamp already matched without ever having read it.
+  if (before.known && before.uuid === uuid) return { status: "already_current", uuid, before };
   // refreshWorkflowUuid routes through the orchestrator's validator, which
   // re-checks reachability and the uuid's shape/origin binding. A `false` here is
   // a REFUSAL, not a no-op, so it gets its own status rather than being reported
   // as a successful rebind.
   return refreshWorkflowUuid(ctx, active)
-    ? { status: "refreshed", uuid, previous }
-    : { status: "rejected", uuid, previous };
+    ? { status: "refreshed", uuid, before }
+    : { status: "rejected", uuid, before };
 }
 
 /**
@@ -2234,24 +2251,39 @@ const RELOAD_TAB_REMEDY =
  *  - `not_recovered` — the session is STILL fenced by a stamp that does not name
  *                      the live canvas. The caller must not report success.
  *
+ *  - `unverified`    — the fence is repaired, but whether this panel build also
+ *                      permits graph EDITS could not be determined from this
+ *                      context. An unknown is not a yes; it is also not a no.
+ *
  * `canMutate` is `bridge.tabCanMutateGraph(tabId)` — the SEPARATE question of
  * whether this panel build advertises the two write-boundary fences a graph
  * MUTATION requires (codex gate). A stamp is necessary but NOT sufficient: an
  * older bundle can report a perfectly good workflow uuid and still have every
- * mutation refused at dispatch. Reporting `bound` off the stamp alone answered
- * a question nobody asked. `undefined` means the capability is not determinable
- * from this context (a lightweight test ctx) — that is an unknown, so it does
- * NOT downgrade, and it does not claim either.
+ * mutation refused at dispatch. Reporting `bound` off the stamp alone answered a
+ * question nobody asked — and reporting `bound` off an UNANSWERABLE capability
+ * probe is the same mistake one step further out, so that gets its own value
+ * rather than being rounded to the good news.
  */
 function describeFenceRebind(
   r: WorkflowFenceRebind,
   canMutate: boolean | undefined,
 ): {
-  binding: "bound" | "reads_only" | "not_recovered";
+  binding: "bound" | "reads_only" | "unverified" | "not_recovered";
   note: string;
 } {
   // A panel that cannot fence a WRITE gives reads only, however good the stamp is.
   const mutationsRefused = canMutate === false;
+  const mutationsUnknown = canMutate === undefined;
+  const okBinding: "bound" | "reads_only" | "unverified" = mutationsRefused
+    ? "reads_only"
+    : mutationsUnknown
+      ? "unverified"
+      : "bound";
+  const unknownCaveat = mutationsUnknown
+    ? `\n\nNOT VERIFIED: whether this panel build also permits graph EDITS could not be ` +
+      `determined from this context — the fence is repaired, but treat mutation readiness as ` +
+      `unconfirmed until a graph command succeeds.`
+    : "";
   // Its own remedy, NOT the reload sentence: re-calling this tool cannot add a
   // missing panel capability, so telling the caller to "call this again" here
   // would be another instruction that provably cannot work.
@@ -2268,21 +2300,23 @@ function describeFenceRebind(
   switch (r.status) {
     case "refreshed":
       return {
-        binding: mutationsRefused ? "reads_only" : "bound",
+        binding: okBinding,
         note:
           ` Rebound the graph command fence onto the live canvas (workflow instance ${r.uuid})` +
-          `${r.previous ? `, replacing the stale ${r.previous}` : ""} — graph ` +
-          `${mutationsRefused ? "READS" : "tools"} will now target the workflow that is in ` +
-          `view.${mutationCaveat}`,
+          `${r.before.known && r.before.uuid ? `, replacing the stale ${r.before.uuid}` : ""} — ` +
+          `graph ${mutationsRefused ? "READS" : "tools"} will now target the workflow the panel ` +
+          `reported as active a moment ago. (If the user switched tabs again in that instant, the ` +
+          `next graph command fails closed with a fresh instance mismatch — safe, and cleared by ` +
+          `calling this again.)${mutationCaveat}${unknownCaveat}`,
       };
     case "already_current":
       return {
-        binding: mutationsRefused ? "reads_only" : "bound",
+        binding: okBinding,
         note:
           ` The graph command fence already named the live canvas (workflow instance ${r.uuid}), ` +
           `so nothing needed rebinding. If graph tools are still failing with a workflow-instance ` +
           `mismatch, this session and the panel AGREE on the target and the mismatch is coming ` +
-          `from the panel, not from this binding.${mutationCaveat}` +
+          `from the panel, not from this binding.${mutationCaveat}${unknownCaveat}` +
           (mutationsRefused ? "" : `\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY}`),
       };
     case "rejected":
@@ -2291,8 +2325,8 @@ function describeFenceRebind(
         note:
           ` Read the live canvas identity (${r.uuid}) but could NOT adopt it as this session's ` +
           `graph command fence — the bound tab stopped being reachable, or the panel reported an ` +
-          `identity this orchestrator does not trust. The previous fence is still in place, so ` +
-          `graph tools will keep failing.\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY}`,
+          `identity this orchestrator does not trust. The previous fence is unchanged, so graph ` +
+          `tools will keep failing.\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY}`,
       };
     case "unreadable":
       // ALWAYS not_recovered, with or without a prior fence (codex gate). The read
@@ -2312,11 +2346,17 @@ function describeFenceRebind(
         note:
           ` Could NOT read the live canvas identity — the panel did not answer, so NOTHING ` +
           `about this session's graph binding was observed.` +
-          (r.previous
-            ? ` It is still fenced to the previous workflow instance (${r.previous}), which the ` +
-              `panel will keep refusing.`
-            : ` It has no graph command fence; whether graph reads work is unknown, because the ` +
-              `read that would have told us is the one that failed.`) +
+          // THREE states, not two (codex gate). "We could not read the existing
+          // fence either" must not render as "it has no fence" — that absence was
+          // never observed, and it is the same fold one level down.
+          (!r.before.known
+            ? ` What fence it currently carries could not be read either, so its binding is ` +
+              `entirely unknown — not known-good and not known-absent.`
+            : r.before.uuid
+              ? ` It is still fenced to the previous workflow instance (${r.before.uuid}), which ` +
+                `the panel will keep refusing.`
+              : ` It has no graph command fence; whether graph reads work is unknown, because the ` +
+                `read that would have told us is the one that failed.`) +
           ` This is not a rebind — it is an unknown.` +
           `\n\nWHAT TO DO: retry in a moment — a busy or mid-reconnect panel often answers on ` +
           `the next attempt. If it keeps failing: ${RELOAD_TAB_REMEDY}` +
@@ -2324,13 +2364,33 @@ function describeFenceRebind(
           `rebinding is what just failed): ${r.detail}`,
       };
     case "no_identity":
-      return r.previous
+      // THREE answers, because there are three states (codex gate):
+      //  - a KNOWN stale fence  → the session really is wedged  → not_recovered;
+      //  - a KNOWN absent fence → nothing was stale, the panel is simply
+      //    identity-less                                        → reads_only;
+      //  - an UNREADABLE prior fence → we cannot say either way → unverified.
+      //    Failing here would report a wedge nobody observed; succeeding would
+      //    report a repair nobody observed. Neither is available, so say so.
+      if (!r.before.known) {
+        return {
+          binding: "unverified",
+          note:
+            ` The panel answered but reported NO workflow identity for the active canvas, and ` +
+            `this session's existing fence could not be read either — so whether its graph ` +
+            `binding is healthy could NOT be determined. Routing is set. Treat graph tools as ` +
+            `unconfirmed: if the next one fails with a workflow-instance mismatch, that is the ` +
+            `answer, and a cached older panel bundle is the usual cause.` +
+            `\n\nWHAT TO DO if it does fail: ${RELOAD_TAB_REMEDY}`,
+        };
+      }
+      return r.before.uuid
         ? {
             binding: "not_recovered",
             note:
               ` The panel answered but reported NO workflow identity for the active canvas, so ` +
-              `this session is STILL fenced to the previous workflow instance (${r.previous}) ` +
-              `and graph tools will keep failing. A cached older panel bundle is the usual cause.` +
+              `this session is STILL fenced to the previous workflow instance ` +
+              `(${r.before.uuid}) and graph tools will keep failing. A cached older panel ` +
+              `bundle is the usual cause.` +
               `\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY} Make it a HARD refresh here specifically: a ` +
               `plain reload can serve the same cached bundle again; only a hard refresh replaces ` +
               `it. If a hard refresh does not help, the installed pack itself predates the ` +
@@ -6829,7 +6889,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_set_workflow_target",
-      "Pin the agent to a specific open workflow tab (it must be the ACTIVE/in-view workflow at pin time), or release the pin to follow the user's current tab. The panel can only read or edit the workflow currently in view, so pinning to a background tab is REJECTED at pin time — to work on a different open workflow, switch to it first with panel_open_workflow (that makes it active), then pin. Pinning does NOT change the user's view; it binds your panel_* graph edits to that workflow and makes a later mismatch (e.g. the user switches away) fail loudly instead of silently editing the wrong graph. Set mode:'pinned' with path from panel_list_workflows; set mode:'current' (or omit path) to follow the active tab again. mode:'current' is ALSO the explicit RECOVERY signal: if your panel_* calls started failing with `no connected tab`, or with a `workflow instance mismatch` / out-of-sync-graph error, after ComfyUI reconnected, the panel reloaded, or the workflow on the canvas was switched or replaced, call this with mode:'current'. It rebinds this session onto the tab that's live now AND re-derives the workflow-instance fence your graph commands are stamped with from the panel's live active canvas — that second half is what clears an instance mismatch. It reports whether that actually worked: `graph_binding:\"bound\"` means graph tools are usable again, `\"reads_only\"` means reads work but mutations stay refused, and it FAILS (rather than reporting a hollow success) when the binding could not be restored, naming what to do instead.",
+      "Pin the agent to a specific open workflow tab (it must be the ACTIVE/in-view workflow at pin time), or release the pin to follow the user's current tab. The panel can only read or edit the workflow currently in view, so pinning to a background tab is REJECTED at pin time — to work on a different open workflow, switch to it first with panel_open_workflow (that makes it active), then pin. Pinning does NOT change the user's view; it binds your panel_* graph edits to that workflow and makes a later mismatch (e.g. the user switches away) fail loudly instead of silently editing the wrong graph. Set mode:'pinned' with path from panel_list_workflows; set mode:'current' (or omit path) to follow the active tab again. mode:'current' is ALSO the explicit RECOVERY signal: if your panel_* calls started failing with `no connected tab`, or with a `workflow instance mismatch` / out-of-sync-graph error, after ComfyUI reconnected, the panel reloaded, or the workflow on the canvas was switched or replaced, call this with mode:'current'. It rebinds this session onto the tab that's live now AND re-derives the workflow-instance fence your graph commands are stamped with from the panel's live active canvas — that second half is what clears an instance mismatch. It reports whether that actually worked: `graph_binding:\"bound\"` means graph tools are usable again, `\"reads_only\"` means reads work but mutations stay refused, `\"unverified\"` means the fence is set but readiness could not be confirmed (treat the next graph call as the test), and it FAILS (rather than reporting a hollow success) when the binding could not be restored, naming what to do instead.",
       {
         mode: z
           .enum(["current", "pinned"])
@@ -6976,16 +7036,22 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           if (ctx.tabId !== tabBeforeProbe) {
             const onNewTab = ctx.workflowTarget.get(ctx.tabId);
             if (onNewTab?.mode === "pinned") {
+              const pinLabel = onNewTab.filename ?? onNewTab.path;
               return fail(
                 `panel_set_workflow_target({mode:"current"}) did NOT take effect on the tab this ` +
                   `session is now bound to.\n\nWHAT HAPPENED: the panel dropped mid-call, so this ` +
                   `session was rebound from tab ${tabBeforeProbe} onto tab ${ctx.tabId} while the ` +
                   `request was in flight. Your mode:"current" was recorded against the PREVIOUS ` +
-                  `tab. The tab you are on now is PINNED to "${onNewTab.filename ?? onNewTab.path}" ` +
-                  `— left untouched, because another session may own that pin.\n\nWHAT TO DO: ` +
-                  `call panel_set_workflow_target({mode:"current"}) again now that the binding ` +
-                  `has settled; it will apply to this tab. If the pin is yours and you want it, ` +
-                  `do nothing — graph tools will target "${onNewTab.filename ?? onNewTab.path}".`,
+                  `tab. The tab you are on now is PINNED to "${pinLabel}", and that pin was left ` +
+                  `untouched — the workflow-target store is shared, so another session may own ` +
+                  `it. The graph command fence WAS refreshed onto this tab's live canvas, which ` +
+                  `is correct for it either way.\n\nWHAT TO DO — read this before retrying: graph ` +
+                  `tools will currently target "${pinLabel}". If that is what you want, proceed ` +
+                  `normally; nothing else is needed. If you need to follow the tab the user is ` +
+                  `viewing instead, calling panel_set_workflow_target({mode:"current"}) again ` +
+                  `WILL REPLACE that pin — do that only if the pin is yours. If it is not, or ` +
+                  `you cannot tell, ask the user which workflow they want this session on rather ` +
+                  `than overwriting another session's binding.`,
               );
             }
             // Nothing to take away — re-apply the caller's request where it now counts.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1202,7 +1202,20 @@ function isAckTimeout(res: ToolResult): boolean {
   // workflows these reports were filed against: a guard quietly answering "no"
   // because it could not parse, which is the very fold this cluster is about.
   // Mirrors isReplyTimeoutError's identical `.+?` segmentation.
-  return /Panel tab .+? did not reply to "workflow_open" within \d+\s*ms/i.test(text);
+  //
+  // START-ANCHORED (codex gate). The old form matched the phrase ANYWHERE, so an
+  // ACKED executor error that merely EMBEDS or WRAPS it — `relay failed: Panel tab
+  // … did not reply to "workflow_open" …` — was treated as a no-reply and sent
+  // down the receipt-recovery path, where it could be reported as a "recovered"
+  // success. Only the bridge's own message starts with the preamble; ctx.call
+  // surfaces a reply timeout as exactly `Error: ` + that message (and may APPEND a
+  // retry token), so the optional prefix plus a start anchor is the tight form
+  // that still admits every real ack timeout. The tail stays open on purpose —
+  // anchoring the end would reject the appended-token variant and silently switch
+  // the recovery off, which is the same failure in the opposite direction.
+  return /^(?:Error: )?Panel tab .+? did not reply to "workflow_open" within \d+\s*ms/i.test(
+    text.trimStart(),
+  );
 }
 
 /** Parse a ctx.call ToolResult's text payload as JSON, or null if not parseable. */
@@ -1958,7 +1971,16 @@ function detectRunRejection(res: ToolResult): ToolResult | null {
  *  - the reply must be a panel ANSWER (`!isError`). A transport error, a reply
  *    timeout, or a mid-command drop leaves the outcome UNKNOWN — the command may
  *    already be queued — and an unknown must never be retried;
- *  - the text must carry BOTH the race verdict and the explicit
+ *  - the reply must PARSE. An unreadable reply is an unknown, not a clean queue;
+ *  - STRUCTURED queue evidence VETOES the retry, and beats prose (codex gate).
+ *    `detectRunRejection` classifies any non-empty `error` as a rejection even
+ *    when the same reply carries `queued:true` (#213) — deliberately, because a
+ *    stale success flag must not mask a validation failure. But for the RETRY
+ *    decision that reply is the opposite case: an OBSERVED positive queue signal.
+ *    "Nothing was queued" is prose the panel wrote; `queued:true` / a `prompt_id`
+ *    is a fact it reported. A wrong "yes" here queues a second render, so any
+ *    positive queue evidence wins and the run is never re-issued;
+ *  - the text must then carry BOTH the race verdict and the explicit
  *    "Nothing was queued" certification. Either alone is not proof, so a future
  *    panel that drops the certification simply stops qualifying;
  *  - the caller must actually have sent a scoped run — checked at the call site
@@ -1966,6 +1988,10 @@ function detectRunRejection(res: ToolResult): ToolResult | null {
  */
 function isRetryableRunToNodeStampRace(res: ToolResult, rejection: ToolResult): boolean {
   if (res?.isError) return false; // outcome unknown — never retry
+  const parsed = parseToolResultJson(res);
+  if (!parsed) return false; // unreadable reply — an unknown, not a clean queue
+  if (parsed.queued === true) return false; // observed queue evidence vetoes prose
+  if (typeof parsed.prompt_id === "string" && parsed.prompt_id.trim() !== "") return false;
   const text = toolResultText(rejection);
   return (
     /workflow graph CHANGED after the run was queued/i.test(text) &&
@@ -2240,29 +2266,34 @@ function describeFenceRebind(r: WorkflowFenceRebind): {
           `graph tools will keep failing.\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY}`,
       };
     case "unreadable":
-      return r.previous
-        ? {
-            binding: "not_recovered",
-            // The quoted cause is a WRAPPED transport error whose own text may
-            // suggest rebinding with mode:"current" — the call that just failed.
-            // Quote it last, label it as a quote, and disarm it explicitly rather
-            // than letting the reader end on advice that provably cannot work.
-            note:
-              ` Could NOT read the live canvas identity, so this session is STILL fenced to the ` +
-              `previous workflow instance (${r.previous}) and graph tools will keep failing with ` +
-              `a workflow-instance mismatch. This is not a rebind — it is an unknown.` +
-              `\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY} Repeating this call WITHOUT that refresh ` +
-              `will fail the same way.` +
-              `\n\nUNDERLYING CAUSE (quoted verbatim — disregard any rebind advice inside it; ` +
-              `rebinding is what just failed): ${r.detail}`,
-          }
-        : {
-            binding: "reads_only",
-            note:
-              ` Could not read the live canvas identity, so this session has no graph command ` +
-              `fence: routing is set and graph READS work, but graph MUTATIONS stay refused. ` +
-              `(Cause, quoted verbatim: ${r.detail})`,
-          };
+      // ALWAYS not_recovered, with or without a prior fence (codex gate). The read
+      // we just attempted FAILED, so nothing about this session was observed —
+      // including whether graph READS work. The earlier draft reported the
+      // no-prior-fence case as a usable `reads_only`, which asserted a capability
+      // straight out of a failed observation: the exact "could not determine X,
+      // therefore X" fold this cluster exists to remove. Say UNKNOWN and say what
+      // is possible.
+      //
+      // The quoted cause is a WRAPPED transport error whose own text may suggest
+      // rebinding with mode:"current" — the call that just failed. Quote it last,
+      // label it as a quote, and disarm it explicitly rather than letting the
+      // reader end on advice that provably cannot work.
+      return {
+        binding: "not_recovered",
+        note:
+          ` Could NOT read the live canvas identity — the panel did not answer, so NOTHING ` +
+          `about this session's graph binding was observed.` +
+          (r.previous
+            ? ` It is still fenced to the previous workflow instance (${r.previous}), which the ` +
+              `panel will keep refusing.`
+            : ` It has no graph command fence; whether graph reads work is unknown, because the ` +
+              `read that would have told us is the one that failed.`) +
+          ` This is not a rebind — it is an unknown.` +
+          `\n\nWHAT TO DO: retry in a moment — a busy or mid-reconnect panel often answers on ` +
+          `the next attempt. If it keeps failing: ${RELOAD_TAB_REMEDY}` +
+          `\n\nUNDERLYING CAUSE (quoted verbatim — disregard any rebind advice inside it; ` +
+          `rebinding is what just failed): ${r.detail}`,
+      };
     case "no_identity":
       return r.previous
         ? {
@@ -2272,14 +2303,23 @@ function describeFenceRebind(r: WorkflowFenceRebind): {
               `this session is STILL fenced to the previous workflow instance (${r.previous}) ` +
               `and graph tools will keep failing. A cached older panel bundle is the usual cause.` +
               `\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY} Make it a HARD refresh here specifically: a ` +
-              `plain reload can serve the same cached bundle again; only a hard refresh replaces it.`,
+              `plain reload can serve the same cached bundle again; only a hard refresh replaces ` +
+              `it. If a hard refresh does not help, the installed pack itself predates the ` +
+              `per-workflow identity and must be UPDATED — no rebind can add it.`,
           }
         : {
             binding: "reads_only",
+            // Honest limit (codex gate): "until it reconnects with one" was not
+            // actionable — a panel build that has no workflow identity will never
+            // acquire one merely by reconnecting. Name the remedy that exists.
             note:
-              ` The panel reported no workflow identity for the active canvas, so graph READS ` +
-              `work but graph MUTATIONS stay refused for this tab until it reconnects with one. ` +
-              `Routing is set.`,
+              ` The panel answered but reports NO workflow identity for the active canvas. Graph ` +
+              `READS work; graph MUTATIONS stay refused, because there is no instance for the ` +
+              `panel to fence a write against. Routing is set.` +
+              `\n\nNOTE: reconnecting alone will NOT restore mutations — a panel build that ` +
+              `reports no workflow identity needs the comfyui-mcp-panel pack UPDATED (then a ` +
+              `hard refresh of the ComfyUI browser tab, since the open tab can keep running a ` +
+              `cached older bundle). Until then this session is read-only for graph tools.`,
           };
   }
 }
@@ -5886,8 +5926,24 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           isRetryableRunToNodeStampRace(res, rejection)
         ) {
           scopeRebuilt = true;
-          res = await ctx.call(runCmd, 20000);
-          rejection = detectRunRejection(res);
+          try {
+            res = await ctx.call(runCmd, 20000);
+            rejection = detectRunRejection(res);
+          } catch (err) {
+            // ctx.call settles every panel/transport failure into a ToolResult and does
+            // not throw today — but this await is the one point where a throw would
+            // DESTROY evidence we already hold: that the first dispatch was certified
+            // not-queued, and that a second dispatch went out whose outcome is now
+            // unknown. Propagating the raw throw would lose both and invite a third
+            // dispatch. Report what we observed, claim nothing we did not.
+            return fail(
+              `panel_run re-issued the scoped run after the panel's certified run-to-node ` +
+                `stamp race, and that SECOND dispatch failed before any reply could be read — ` +
+                `its outcome is UNKNOWN and it may have queued a render. The FIRST dispatch was ` +
+                `certified by the panel to have queued nothing. Do NOT re-run blindly: check the ` +
+                `queue (action:"list") or get_history before deciding. (${err instanceof Error ? err.message : String(err)})`,
+            );
+          }
         }
         if (rejection) {
           // Disclose the re-issue on the failure path too: the caller must know a SECOND
@@ -6817,15 +6873,6 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           if (!deferredBind && ctx.tabId !== before) {
             rebindNote = ` Rebound this session from tab ${before.slice(0, 8)} onto the active tab ${ctx.tabId.slice(0, 8)}.`;
           }
-          // #770/#803/#716 — ROUTING is only half of "follow the tab that's live now".
-          // rebindToActiveTab is a NO-OP whenever the bound tab is still REACHABLE, which
-          // is the dominant wedge: the socket is fine, the canvas was replaced (or
-          // re-registered) under it, and the command fence still names the workflow
-          // instance that is gone. Re-derive the fence from the panel's live active
-          // record so this call delivers the recovery its own documentation promises.
-          // Deferred (zero-tab) sessions are skipped: there is nothing to read from yet,
-          // and their note already says exactly that.
-          if (!deferredBind) fenceRebind = await rebindWorkflowFence(ctx);
         }
         // PIN: bind to the EXACT open-workflow identity from the authoritative
         // workflow_list, canonicalizing to its stable `key`, FAILING CLOSED when the
@@ -6855,6 +6902,28 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           refreshWorkflowUuid(ctx, { workflow_uuid: pinnedWorkflowUuid });
         }
         ctx.bridge.push({ type: "workflow_target", target }, ctx.tabId);
+        // #770/#803/#716 — ROUTING is only half of "follow the tab that's live now".
+        // rebindToActiveTab is a NO-OP whenever the bound tab is still REACHABLE, which
+        // is the dominant wedge: the socket is fine, the canvas was replaced (or
+        // re-registered) under it, and the command fence still names the workflow
+        // instance that is gone. Re-derive the fence from the panel's live active record
+        // so this call delivers the recovery its own documentation promises. Deferred
+        // (zero-tab) sessions are skipped: there is nothing to read from yet, and their
+        // note already says exactly that.
+        //
+        // ORDER MATTERS (codex gate): this round trip runs AFTER the target store write
+        // and the panel push, never between the decision and the write. The store is
+        // shared by every session bound to this tab (panel-mcp-http mounts one per
+        // connection), so an await placed BEFORE the write would widen the window in
+        // which a concurrent agent's later, successful pin can be clobbered by this
+        // call's staler `current` — and that agent would have been told its edits were
+        // pinned. The pre-existing awaitReachable/resolvePinTarget awaits already sit
+        // ahead of the write; this change must not add another. It is also what makes
+        // the failure text's "APPLIED (do not repeat this part)" literally true: the
+        // target write is already committed and pushed by the time we can fail.
+        if (mode === "current" && ctx.rebindToActiveTab && !deferredBind) {
+          fenceRebind = await rebindWorkflowFence(ctx);
+        }
         const hint =
           target.mode === "pinned"
             ? `Pinned to "${target.filename ?? target.path}". Graph tools will target that workflow without switching the user's view.`

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1192,7 +1192,17 @@ function isAckTimeout(res: ToolResult): boolean {
   // on the bridge preamble AND the exact command name so a merely timeout-WORDED
   // acked executor error (which the panel relays verbatim) is NOT mistaken for a
   // no-reply and thus never masked as a false "recovered" success (codex gate).
-  return /Panel tab \S+ did not reply to "workflow_open" within \d+\s*ms/i.test(text);
+  //
+  // #803 — the tab-id segment is `.+?` (LAZY, bounded by the fixed 19-char
+  // ` did not reply to "` that follows), NOT `\S+`. The bridge now emits the FULL
+  // routing tab id instead of an 8-char slice, and a routing id is `wf:<path>` — a
+  // saved workflow whose filename contains a SPACE ("Untitled 2026-08-04 06-15-58.json",
+  // ComfyUI's own default name) would make `\S+` fail to match. The whole
+  // verify-after-timeout recovery would then silently stop firing for exactly the
+  // workflows these reports were filed against: a guard quietly answering "no"
+  // because it could not parse, which is the very fold this cluster is about.
+  // Mirrors isReplyTimeoutError's identical `.+?` segmentation.
+  return /Panel tab .+? did not reply to "workflow_open" within \d+\s*ms/i.test(text);
 }
 
 /** Parse a ctx.call ToolResult's text payload as JSON, or null if not parseable. */
@@ -1210,6 +1220,19 @@ function parseToolResultJson(res: ToolResult): Record<string, unknown> | null {
 
 function toolResultText(res: ToolResult): string {
   return res?.content?.find((c) => c.type === "text")?.text ?? "workflow_open failed";
+}
+
+/** Append a disclosure to a ToolResult's FIRST text block, preserving everything
+ *  else about it — including `isError` and any non-text content. Used where the
+ *  original message must reach the caller VERBATIM and we are only adding what we
+ *  additionally know, never restating (or re-classifying) what it already said. */
+function appendToolResultText(res: ToolResult, extra: string): ToolResult {
+  const idx = res?.content?.findIndex((c) => c.type === "text") ?? -1;
+  const block = idx >= 0 ? res.content[idx] : undefined;
+  if (!block || block.type !== "text") return res;
+  const content = [...res.content];
+  content[idx] = { type: "text", text: `${block.text}${extra}` };
+  return { ...res, content };
 }
 
 // ---- #809: turn the panel's silent `truncated: true` booleans into a remedy --------
@@ -1918,9 +1941,42 @@ function detectRunRejection(res: ToolResult): ToolResult | null {
   return fail(formatRunRejection({ error: topError, node_errors: nodeErrors }));
 }
 
+/**
+ * #772 — the ONE graph_run rejection that is explicitly safe to re-issue: the
+ * run-to-node stamp race.
+ *
+ * A scoped (`to_node_id`) run is dispatched, then applied on a deferred tick. If
+ * the graph changed in between, the panel refuses to run the modified graph under
+ * a scope built for the old one AND refuses to fall through to a full-graph
+ * execution (#556) — so it CERTIFIES that nothing entered the queue. That
+ * certification is the whole basis for retrying: rebuilding the scope against the
+ * graph as it is now is exactly what the caller would do by hand, and the caller
+ * is currently made to do it by hand for a race they cannot see.
+ *
+ * FAILS CLOSED in every other direction, because a wrong "yes" here queues a
+ * second render:
+ *  - the reply must be a panel ANSWER (`!isError`). A transport error, a reply
+ *    timeout, or a mid-command drop leaves the outcome UNKNOWN — the command may
+ *    already be queued — and an unknown must never be retried;
+ *  - the text must carry BOTH the race verdict and the explicit
+ *    "Nothing was queued" certification. Either alone is not proof, so a future
+ *    panel that drops the certification simply stops qualifying;
+ *  - the caller must actually have sent a scoped run — checked at the call site
+ *    from OUR OWN args, never inferred from panel prose.
+ */
+function isRetryableRunToNodeStampRace(res: ToolResult, rejection: ToolResult): boolean {
+  if (res?.isError) return false; // outcome unknown — never retry
+  const text = toolResultText(rejection);
+  return (
+    /workflow graph CHANGED after the run was queued/i.test(text) &&
+    /Nothing was queued/i.test(text)
+  );
+}
+
 export const __panelRunTestHooks = {
   detectRunRejection,
   formatRunRejection,
+  isRetryableRunToNodeStampRace,
 };
 
 /** Drop a trailing .json (case-insensitive) so filename/path forms compare equal. */
@@ -2019,6 +2075,213 @@ function refreshWorkflowUuid(ctx: PanelToolCtx, value: unknown): boolean {
   const uuid = responseWorkflowUuid(value);
   const refresh = (ctx.bridge as unknown as { refreshWorkflowUuid?: unknown }).refreshWorkflowUuid;
   return uuid && typeof refresh === "function" ? refresh.call(ctx.bridge, ctx.tabId, uuid) : false;
+}
+
+/** The stamp currently fencing this session's tab, or undefined when it has none.
+ *  Reading it is what lets the rebind below tell "repaired a stale fence" apart
+ *  from "there was never a fence" — two states with different remedies. Never
+ *  throws: a guard that can throw is not a guard. */
+function currentWorkflowFence(ctx: PanelToolCtx): string | undefined {
+  const read = (ctx.bridge as unknown as { workflowUuidFor?: unknown }).workflowUuidFor;
+  if (typeof read !== "function") return undefined;
+  try {
+    const uuid = read.call(ctx.bridge, ctx.tabId) as unknown;
+    return typeof uuid === "string" && uuid.length > 0 ? uuid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// ---- #770/#803/#716 — re-deriving the command fence from the LIVE canvas ------
+//
+// The per-command workflow stamp (#570) is set from a tab's HELLO. For a
+// `mode:"current"` session that hello is the ONLY moment it is ever refreshed —
+// and a hello is not the only way the active canvas can change identity. A
+// workflow replaced in place on a still-open socket, a frontend soft reload, or a
+// reconnect that re-registers under a DIFFERENT routing key all give the canvas a
+// new workflow uuid with no new hello for the key this session holds. The stamp
+// then names a workflow instance that no longer exists, the panel's fence
+// correctly refuses every stamped command, and NOTHING in the orchestrator could
+// replace it: the open/pin refresh paths (#716) require a caller-supplied SAVED
+// path to corroborate, so they cannot fire for `mode:"current"` at all, and
+// cannot fire for an UNSAVED (`tmp:`) canvas under any mode. That is the wedge —
+// and it is why the recovery the error text prescribed could not recover.
+//
+// This is the one place that answers the question `mode:"current"` actually asks
+// — "bind me to whatever workflow is live NOW" — by reading the panel's own
+// authoritative active record. It needs no path corroboration precisely because
+// there is no caller-supplied target to corroborate: the live active canvas IS
+// the target. That is also why it works for an unsaved canvas.
+//
+// It does NOT weaken #570. The fence still fails closed for every command issued
+// AFTER this point: if the user switches again, the next command carries what
+// this call adopted and the panel refuses it, exactly as before. All that changes
+// is that an explicit, user-initiated "follow what's live" can now actually
+// re-point the fence.
+
+/**
+ * The DISTINCT answers to the distinct questions a fence rebind asks.
+ * Deliberately not one boolean: "could not read the identity" is not "the
+ * identity is unchanged", and neither is "there was no fence to begin with".
+ * Folding them is what produced a tool reporting success while the session
+ * stayed wedged (#803 step 7).
+ */
+export type WorkflowFenceRebind =
+  /** Read the live identity; it differed from the stamp and has REPLACED it. */
+  | { status: "refreshed"; uuid: string; previous?: string }
+  /** Read the live identity; the stamp already named it. Nothing to repair. */
+  | { status: "already_current"; uuid: string; previous: string }
+  /** The panel did not answer, or its reply was not readable. Unknown, not "fine". */
+  | { status: "unreadable"; previous?: string; detail: string }
+  /** The panel answered, but its active canvas exposes no usable workflow uuid. */
+  | { status: "no_identity"; previous?: string }
+  /** A live identity was read, but the bridge declined to adopt it (the tab stopped
+   *  being reachable, or the uuid failed the orchestrator's shape/origin check). */
+  | { status: "rejected"; uuid: string; previous?: string };
+
+/**
+ * Re-derive this session's command fence from the panel's live active canvas.
+ * NEVER throws and NEVER fabricates: every failure mode gets its own status, and
+ * the caller — not this function — decides what that means for its own report.
+ */
+async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebind> {
+  const previous = currentWorkflowFence(ctx);
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    const res = await ctx.call({ cmd: "workflow_list" }, 6000);
+    if (res?.isError) {
+      return { status: "unreadable", previous, detail: toolResultText(res) };
+    }
+    parsed = parseToolResultJson(res);
+  } catch (err) {
+    return {
+      status: "unreadable",
+      previous,
+      detail: err instanceof Error ? err.message : String(err ?? "unknown error"),
+    };
+  }
+  if (!parsed) {
+    return {
+      status: "unreadable",
+      previous,
+      detail: "the panel's workflow_list reply was not readable as JSON",
+    };
+  }
+  const active = (parsed as { active?: unknown }).active;
+  const uuid = responseWorkflowUuid(active);
+  if (!uuid) return { status: "no_identity", previous };
+  if (uuid === previous) return { status: "already_current", uuid, previous };
+  // refreshWorkflowUuid routes through the orchestrator's validator, which
+  // re-checks reachability and the uuid's shape/origin binding. A `false` here is
+  // a REFUSAL, not a no-op, so it gets its own status rather than being reported
+  // as a successful rebind.
+  return refreshWorkflowUuid(ctx, active)
+    ? { status: "refreshed", uuid, previous }
+    : { status: "rejected", uuid, previous };
+}
+
+/**
+ * The ONE remedy that is actually reachable from every wedged state below, and
+ * the one the reporters found to be the only thing that worked.
+ *
+ * Deliberately says MANUAL browser refresh and deliberately steers OFF
+ * `panel_reload`: in #803 the agent followed a `panel_reload({scope:"frontend"})`
+ * instruction and the tab never answered again — the prescribed recovery made a
+ * partially-working session fully unresponsive. Naming a remedy that has been
+ * observed to make things worse is not better than naming none.
+ */
+const RELOAD_TAB_REMEDY =
+  "Ask the user to manually refresh (F5, or Ctrl+Shift+R for a hard refresh) the ComfyUI " +
+  "browser tab, then call this again. Do NOT use panel_reload for this: it has been observed " +
+  "to leave the tab permanently unresponsive from exactly this state (#803).";
+
+/**
+ * The one TRUE account of what a fence rebind achieved, and how usable the
+ * session actually is afterwards.
+ *
+ *  - `bound`         — graph reads AND mutations will work.
+ *  - `reads_only`    — nothing was STALE (so nothing failed to be repaired), but
+ *                      no workflow identity exists, so mutations stay refused.
+ *                      This is a pre-existing condition, not a wedged binding —
+ *                      reporting it as a failed recovery would be the same fold
+ *                      in the opposite direction.
+ *  - `not_recovered` — the session is STILL fenced by a stamp that does not name
+ *                      the live canvas. The caller must not report success.
+ */
+function describeFenceRebind(r: WorkflowFenceRebind): {
+  binding: "bound" | "reads_only" | "not_recovered";
+  note: string;
+} {
+  switch (r.status) {
+    case "refreshed":
+      return {
+        binding: "bound",
+        note:
+          ` Rebound the graph command fence onto the live canvas (workflow instance ${r.uuid})` +
+          `${r.previous ? `, replacing the stale ${r.previous}` : ""} — graph tools will now ` +
+          `target the workflow that is in view.`,
+      };
+    case "already_current":
+      return {
+        binding: "bound",
+        note:
+          ` The graph command fence already named the live canvas (workflow instance ${r.uuid}), ` +
+          `so nothing needed rebinding. If graph tools are still failing with a workflow-instance ` +
+          `mismatch, this session and the panel AGREE on the target and the mismatch is coming ` +
+          `from the panel, not from this binding.\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY}`,
+      };
+    case "rejected":
+      return {
+        binding: "not_recovered",
+        note:
+          ` Read the live canvas identity (${r.uuid}) but could NOT adopt it as this session's ` +
+          `graph command fence — the bound tab stopped being reachable, or the panel reported an ` +
+          `identity this orchestrator does not trust. The previous fence is still in place, so ` +
+          `graph tools will keep failing.\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY}`,
+      };
+    case "unreadable":
+      return r.previous
+        ? {
+            binding: "not_recovered",
+            // The quoted cause is a WRAPPED transport error whose own text may
+            // suggest rebinding with mode:"current" — the call that just failed.
+            // Quote it last, label it as a quote, and disarm it explicitly rather
+            // than letting the reader end on advice that provably cannot work.
+            note:
+              ` Could NOT read the live canvas identity, so this session is STILL fenced to the ` +
+              `previous workflow instance (${r.previous}) and graph tools will keep failing with ` +
+              `a workflow-instance mismatch. This is not a rebind — it is an unknown.` +
+              `\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY} Repeating this call WITHOUT that refresh ` +
+              `will fail the same way.` +
+              `\n\nUNDERLYING CAUSE (quoted verbatim — disregard any rebind advice inside it; ` +
+              `rebinding is what just failed): ${r.detail}`,
+          }
+        : {
+            binding: "reads_only",
+            note:
+              ` Could not read the live canvas identity, so this session has no graph command ` +
+              `fence: routing is set and graph READS work, but graph MUTATIONS stay refused. ` +
+              `(Cause, quoted verbatim: ${r.detail})`,
+          };
+    case "no_identity":
+      return r.previous
+        ? {
+            binding: "not_recovered",
+            note:
+              ` The panel answered but reported NO workflow identity for the active canvas, so ` +
+              `this session is STILL fenced to the previous workflow instance (${r.previous}) ` +
+              `and graph tools will keep failing. A cached older panel bundle is the usual cause.` +
+              `\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY} Make it a HARD refresh here specifically: a ` +
+              `plain reload can serve the same cached bundle again; only a hard refresh replaces it.`,
+          }
+        : {
+            binding: "reads_only",
+            note:
+              ` The panel reported no workflow identity for the active canvas, so graph READS ` +
+              `work but graph MUTATIONS stay refused for this tab until it reconnects with one. ` +
+              `Routing is set.`,
+          };
+  }
 }
 
 /**
@@ -5602,10 +5865,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // render is already running silently stacks behind it (this is how a stuck
         // job once let three more pile up). Snapshot the watchdog BEFORE we queue.
         const pre = QueueMonitor.snapshot();
-        const res = await ctx.call(
-          { cmd: "graph_run", batch_count: args.batch_count, to_node_id: args.to_node_id },
-          20000,
-        );
+        const runCmd = { cmd: "graph_run", batch_count: args.batch_count, to_node_id: args.to_node_id };
+        let res = await ctx.call(runCmd, 20000);
         // Derive the verdict from the AUTHORITATIVE reply, not a bare `queued`
         // flag. A rejection — a no-connected-tab / thrown-queuePrompt error
         // (#331/#248), or a ComfyUI /prompt refusal on EITHER channel
@@ -5613,8 +5874,37 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // node_errors) — is surfaced as a failure WITHOUT the success-only
         // "you'll be notified automatically" guidance. Only a genuine queue
         // gets the anti-poll note below.
-        const rejection = detectRunRejection(res);
-        if (rejection) return rejection;
+        let rejection = detectRunRejection(res);
+        // #772 — ONE re-issue, and only for the scoped-run stamp race the panel
+        // explicitly certifies as not-queued. Gated on OUR OWN args (this really was a
+        // scoped run) and on the panel having ANSWERED, so an unknown outcome is never
+        // retried. Exactly once: a second race is surfaced, never re-raced.
+        let scopeRebuilt = false;
+        if (
+          rejection &&
+          typeof args.to_node_id === "number" &&
+          isRetryableRunToNodeStampRace(res, rejection)
+        ) {
+          scopeRebuilt = true;
+          res = await ctx.call(runCmd, 20000);
+          rejection = detectRunRejection(res);
+        }
+        if (rejection) {
+          // Disclose the re-issue on the failure path too: the caller must know a SECOND
+          // dispatch went out. The disclosure states only what is CERTIFIED — that the
+          // FIRST dispatch queued nothing — and leaves the second attempt's outcome to be
+          // read from the rejection itself, which may be a post-write timeout whose
+          // outcome nobody can honestly claim to know.
+          if (!scopeRebuilt) return rejection;
+          return appendToolResultText(
+            rejection,
+            `\n\n(Dispatch history: the first graph_run was refused by the panel's run-to-node ` +
+              `graph-stamp race, which CERTIFIED that nothing was queued, so the scoped run was ` +
+              `re-issued exactly once. The failure above is that SECOND dispatch; it was not ` +
+              `retried again. Judge whether anything was queued from that message alone — the ` +
+              `first dispatch definitely queued nothing.)`,
+          );
+        }
         // Attribute this genuine queue to ourselves so a later panel_run in the
         // same batch recognizes the in-flight job as our own and doesn't false-warn
         // (#559). The panel forwards ComfyUI's /prompt reply, which carries the
@@ -5651,6 +5941,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // clear_pending remedy that would wipe the user's whole batch (#559). A
         // genuinely stalled render is caught by the turn-start stall notice, which
         // does the staleness gating and keeps the interrupt guidance.
+        // #772 — never report a dispatch history the caller did not see. When the scoped
+        // run only queued on the SECOND dispatch, say so: exactly one render is in the
+        // queue, and the agent must not read the earlier refusal (if it surfaces in a
+        // log) as a separate queued job.
+        const retryNote = scopeRebuilt
+          ? "\n\n[NOTE] The first dispatch of this scoped run was refused by the panel's run-to-node " +
+            "graph-stamp race (the graph changed between dispatch and apply); the panel certified that " +
+            "nothing was queued, so the scope was rebuilt and re-issued once, and THAT is the run above. " +
+            "Exactly one render was queued."
+          : "";
         let warn = "";
         if (pre.connected && pre.running) {
           const pending = Math.max(0, pre.queueDepth - 1);
@@ -5671,7 +5971,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         if (res.content?.[0]?.type === "text") {
           return {
             ...res,
-            content: [{ type: "text", text: res.content[0].text + warn + note }, ...res.content.slice(1)],
+            content: [
+              { type: "text", text: res.content[0].text + retryNote + warn + note },
+              ...res.content.slice(1),
+            ],
           };
         }
         return res;
@@ -6435,7 +6738,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_set_workflow_target",
-      "Pin the agent to a specific open workflow tab (it must be the ACTIVE/in-view workflow at pin time), or release the pin to follow the user's current tab. The panel can only read or edit the workflow currently in view, so pinning to a background tab is REJECTED at pin time — to work on a different open workflow, switch to it first with panel_open_workflow (that makes it active), then pin. Pinning does NOT change the user's view; it binds your panel_* graph edits to that workflow and makes a later mismatch (e.g. the user switches away) fail loudly instead of silently editing the wrong graph. Set mode:'pinned' with path from panel_list_workflows; set mode:'current' (or omit path) to follow the active tab again. mode:'current' is ALSO the explicit RECOVERY signal: if your panel_* calls started failing with `no connected tab` after ComfyUI reconnected, the panel reloaded, or the user switched to a different workflow FILE, call this with mode:'current' to rebind this session onto the tab that's live now.",
+      "Pin the agent to a specific open workflow tab (it must be the ACTIVE/in-view workflow at pin time), or release the pin to follow the user's current tab. The panel can only read or edit the workflow currently in view, so pinning to a background tab is REJECTED at pin time — to work on a different open workflow, switch to it first with panel_open_workflow (that makes it active), then pin. Pinning does NOT change the user's view; it binds your panel_* graph edits to that workflow and makes a later mismatch (e.g. the user switches away) fail loudly instead of silently editing the wrong graph. Set mode:'pinned' with path from panel_list_workflows; set mode:'current' (or omit path) to follow the active tab again. mode:'current' is ALSO the explicit RECOVERY signal: if your panel_* calls started failing with `no connected tab`, or with a `workflow instance mismatch` / out-of-sync-graph error, after ComfyUI reconnected, the panel reloaded, or the workflow on the canvas was switched or replaced, call this with mode:'current'. It rebinds this session onto the tab that's live now AND re-derives the workflow-instance fence your graph commands are stamped with from the panel's live active canvas — that second half is what clears an instance mismatch. It reports whether that actually worked: `graph_binding:\"bound\"` means graph tools are usable again, `\"reads_only\"` means reads work but mutations stay refused, and it FAILS (rather than reporting a hollow success) when the binding could not be restored, naming what to do instead.",
       {
         mode: z
           .enum(["current", "pinned"])
@@ -6463,6 +6766,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // clear error if a single active tab can't be determined.
         let rebindNote = "";
         let deferredBind = false;
+        let fenceRebind: WorkflowFenceRebind | undefined;
         if (mode === "current" && ctx.rebindToActiveTab) {
           const before = ctx.tabId;
           // Give an in-flight reconnect (a ComfyUI restart / panel reload still
@@ -6513,6 +6817,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           if (!deferredBind && ctx.tabId !== before) {
             rebindNote = ` Rebound this session from tab ${before.slice(0, 8)} onto the active tab ${ctx.tabId.slice(0, 8)}.`;
           }
+          // #770/#803/#716 — ROUTING is only half of "follow the tab that's live now".
+          // rebindToActiveTab is a NO-OP whenever the bound tab is still REACHABLE, which
+          // is the dominant wedge: the socket is fine, the canvas was replaced (or
+          // re-registered) under it, and the command fence still names the workflow
+          // instance that is gone. Re-derive the fence from the panel's live active
+          // record so this call delivers the recovery its own documentation promises.
+          // Deferred (zero-tab) sessions are skipped: there is nothing to read from yet,
+          // and their note already says exactly that.
+          if (!deferredBind) fenceRebind = await rebindWorkflowFence(ctx);
         }
         // PIN: bind to the EXACT open-workflow identity from the authoritative
         // workflow_list, canonicalizing to its stable `key`, FAILING CLOSED when the
@@ -6546,7 +6859,30 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           target.mode === "pinned"
             ? `Pinned to "${target.filename ?? target.path}". Graph tools will target that workflow without switching the user's view.`
             : "Following the user's current workflow tab.";
-        return ok({ ...target, ...(deferredBind ? { deferred: true } : {}), note: hint + rebindNote });
+        // #803 — this used to END here for every mode:"current" call, with the
+        // unconditional "Following the user's current workflow tab." Reporters followed
+        // that as the documented recovery, read it as success, and stayed wedged. The
+        // target write DID happen, so the outcome is DISCLOSED either way — never
+        // retracted as if nothing had been applied — but when the graph binding was NOT
+        // restored the result is an ERROR, because "your recovery worked" is the one
+        // thing it must never say when it did not. `graph_binding` carries the same
+        // verdict machine-readably, and `graph_binding_status` the specific cause, so a
+        // caller never has to infer four different remedies from one sentence.
+        const fence = fenceRebind ? describeFenceRebind(fenceRebind) : undefined;
+        if (fence && fence.binding === "not_recovered") {
+          return fail(
+            `panel_set_workflow_target({mode:"current"}) did NOT restore this session's graph ` +
+              `binding.\n\nAPPLIED (do not repeat this part): the workflow target is now ` +
+              `mode:"current"${rebindNote ? `.${rebindNote}` : "."}\n\nNOT APPLIED:${fence.note}`,
+          );
+        }
+        return ok({
+          ...target,
+          ...(deferredBind ? { deferred: true } : {}),
+          ...(fence ? { graph_binding: fence.binding } : {}),
+          ...(fenceRebind ? { graph_binding_status: fenceRebind.status } : {}),
+          note: hint + rebindNote + (fence?.note ?? ""),
+        });
       },
     ),
     def(

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -773,6 +773,16 @@ export function makeUnknownCommandError(
  * the mutating-vs-read classification and the default-timeout policy share one
  * authoritative list. Everything not listed is treated as mutating.
  */
+/**
+ * #770/#803 — the result of reading a tab's trusted workflow command stamp.
+ * Three states, because "could not read it" is not "there is none": collapsing
+ * them is what let a recovery report an absence it never observed. See
+ * {@link UiBridge.workflowUuidFor}.
+ */
+export type TabWorkflowUuidRead =
+  | { known: true; uuid?: string }
+  | { known: false; reason: string };
+
 export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   "graph_serialize",
   "graph_outline",
@@ -3344,25 +3354,38 @@ export class UiBridge {
   }
 
   /**
-   * #770/#803 — READ the trusted command stamp currently fencing `tabId`, or
-   * `undefined` when this tab has none (no resolver injected, old panel, or an
-   * identity regression cleared it).
+   * #770/#803 — READ the trusted command stamp currently fencing `tabId`.
    *
-   * Exists so a rebind can tell the three DIFFERENT answers apart instead of
-   * folding them into one verdict: "the fence was stale and has been replaced",
-   * "the fence already named the live canvas", and "there was never a fence to
-   * repair". Those have three different remedies, and reporting any of them as
-   * the others is how a recovery came to claim success it had not achieved.
+   * TRI-STATE on purpose (codex gate). An earlier version returned
+   * `string | undefined` and swallowed a throwing resolver into `undefined`,
+   * which made "I could not read the fence" indistinguishable from "there is no
+   * fence" — so a failed read rendered to the user as a definite absence, and the
+   * recovery narrated a state nobody had observed. Since this is the ONLY window
+   * onto the stamp, the distinction has to survive here or it is lost for good.
+   *
+   *  - `{ known: true, uuid }` — this tab IS fenced, by this uuid.
+   *  - `{ known: true }`       — this tab is definitively NOT fenced (no resolver
+   *                              value: an old panel, or an identity regression
+   *                              cleared it).
+   *  - `{ known: false }`      — the read itself failed; nothing is known.
    *
    * Never throws: the resolver is orchestrator-supplied, and a guard that can
    * throw is not a guard.
    */
-  workflowUuidFor(tabId: string): string | undefined {
+  workflowUuidFor(tabId: string): TabWorkflowUuidRead {
+    if (!this.resolveTabWorkflowUuid) {
+      // No resolver injected at all — the stamp mechanism is not wired in this
+      // process. That is a genuine "cannot know", not proof of an absent fence.
+      return { known: false, reason: "no workflow-uuid resolver is installed on this bridge" };
+    }
     try {
-      const uuid = this.resolveTabWorkflowUuid?.(tabId);
-      return typeof uuid === "string" && uuid.length > 0 ? uuid : undefined;
-    } catch {
-      return undefined;
+      const uuid = this.resolveTabWorkflowUuid(tabId);
+      return { known: true, uuid: typeof uuid === "string" && uuid.length > 0 ? uuid : undefined };
+    } catch (err) {
+      return {
+        known: false,
+        reason: err instanceof Error ? err.message : String(err ?? "unknown error"),
+      };
     }
   }
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2240,31 +2240,43 @@ export class UiBridge {
    * `workflowUuidFor` had, one method over, and it defeated the `unverified`
    * distinction in exactly the production contexts it was added for.
    *
-   *  - `{ known: true, canMutate }` — observed: this tab can (or cannot) mutate.
+   *  - `{ known: true, canMutate: true }` — observed: this tab can mutate.
+   *  - `{ known: true, canMutate: false, because }` — observed that it cannot, and
+   *    WHY. The two whys have different remedies, so they must not share a value
+   *    (codex gate P1): an old panel needs a pack update and a hard refresh, an
+   *    unroutable tab needs neither and cannot do READS either.
    *  - `{ known: false, reason }`   — the probe itself failed; nothing is known.
    */
   tabGraphMutationCapability(
     tabId: string,
-  ): { known: true; canMutate: boolean } | { known: false; reason: string } {
+  ):
+    | { known: true; canMutate: true }
+    | { known: true; canMutate: false; because: "unroutable" | "capability" }
+    | { known: false; reason: string } {
     let conn: Conn;
     try {
       conn = this.resolveTarget(tabId);
     } catch {
       // Cannot route to the tab at all. That IS an observation about mutability —
       // an unroutable tab mutates nothing — so it is `known`, not unknown.
-      return { known: true, canMutate: false };
+      //
+      // It is NOT the same observation as "this panel build lacks the write
+      // fence", and sharing one value with that case sent users to a remedy for a
+      // problem they did not have — update the pack, hard-refresh — while the tab
+      // was simply gone and their reads were failing too.
+      return { known: true, canMutate: false, because: "unroutable" };
     }
     try {
       const stamp = this.resolveTabWorkflowUuid?.(tabId);
-      return {
-        known: true,
-        canMutate:
-          conn.sock.readyState === WebSocket.OPEN &&
-          conn.enforcesWorkflowStamp &&
-          conn.enforcesWorkflowStampAtWrite &&
-          typeof stamp === "string" &&
-          stamp.length > 0,
-      };
+      const canMutate =
+        conn.sock.readyState === WebSocket.OPEN &&
+        conn.enforcesWorkflowStamp &&
+        conn.enforcesWorkflowStampAtWrite &&
+        typeof stamp === "string" &&
+        stamp.length > 0;
+      return canMutate
+        ? { known: true, canMutate: true }
+        : { known: true, canMutate: false, because: "capability" };
     } catch (err) {
       // The stamp resolver threw: the capability inputs could not be read, so the
       // answer is unknown — NOT "the panel lacks the capability".

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2221,18 +2221,57 @@ export class UiBridge {
    * needed to avoid an unfenced wrong-workflow write.
    */
   tabCanMutateGraph(tabId: string): boolean {
+    // FAIL-CLOSED convenience for the readiness callers: an unreadable probe is
+    // treated as "not ready", which is the right default when the question is
+    // "may I promise the user graph tools work?". Callers that must DESCRIBE the
+    // state to a human should use tabGraphMutationCapability instead — see below.
+    const r = this.tabGraphMutationCapability(tabId);
+    return r.known ? r.canMutate : false;
+  }
+
+  /**
+   * #770/#803 — the same question, TRI-STATE, for anyone who has to REPORT the
+   * answer rather than act on it.
+   *
+   * `tabCanMutateGraph` collapses an unreadable probe into `false`, which is a
+   * safe default for gating but a false statement when rendered: it made the
+   * recovery tell users their panel "does not advertise the write-boundary
+   * fence" when in truth we had merely failed to look. That is the same fold
+   * `workflowUuidFor` had, one method over, and it defeated the `unverified`
+   * distinction in exactly the production contexts it was added for.
+   *
+   *  - `{ known: true, canMutate }` — observed: this tab can (or cannot) mutate.
+   *  - `{ known: false, reason }`   — the probe itself failed; nothing is known.
+   */
+  tabGraphMutationCapability(
+    tabId: string,
+  ): { known: true; canMutate: boolean } | { known: false; reason: string } {
+    let conn: Conn;
     try {
-      const conn = this.resolveTarget(tabId);
-      const stamp = this.resolveTabWorkflowUuid?.(tabId);
-      return (
-        conn.sock.readyState === WebSocket.OPEN &&
-        conn.enforcesWorkflowStamp &&
-        conn.enforcesWorkflowStampAtWrite &&
-        typeof stamp === "string" &&
-        stamp.length > 0
-      );
+      conn = this.resolveTarget(tabId);
     } catch {
-      return false;
+      // Cannot route to the tab at all. That IS an observation about mutability —
+      // an unroutable tab mutates nothing — so it is `known`, not unknown.
+      return { known: true, canMutate: false };
+    }
+    try {
+      const stamp = this.resolveTabWorkflowUuid?.(tabId);
+      return {
+        known: true,
+        canMutate:
+          conn.sock.readyState === WebSocket.OPEN &&
+          conn.enforcesWorkflowStamp &&
+          conn.enforcesWorkflowStampAtWrite &&
+          typeof stamp === "string" &&
+          stamp.length > 0,
+      };
+    } catch (err) {
+      // The stamp resolver threw: the capability inputs could not be read, so the
+      // answer is unknown — NOT "the panel lacks the capability".
+      return {
+        known: false,
+        reason: err instanceof Error ? err.message : String(err ?? "unknown error"),
+      };
     }
   }
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2251,7 +2251,11 @@ export class UiBridge {
     tabId: string,
   ):
     | { known: true; canMutate: true }
-    | { known: true; canMutate: false; because: "unroutable" | "capability" }
+    | {
+        known: true;
+        canMutate: false;
+        because: "unroutable" | "disconnected" | "no_identity" | "capability";
+      }
     | { known: false; reason: string } {
     let conn: Conn;
     try {
@@ -2268,15 +2272,23 @@ export class UiBridge {
     }
     try {
       const stamp = this.resolveTabWorkflowUuid?.(tabId);
-      const canMutate =
-        conn.sock.readyState === WebSocket.OPEN &&
-        conn.enforcesWorkflowStamp &&
-        conn.enforcesWorkflowStampAtWrite &&
-        typeof stamp === "string" &&
-        stamp.length > 0;
-      return canMutate
-        ? { known: true, canMutate: true }
-        : { known: true, canMutate: false, because: "capability" };
+      // `canMutate` is a conjunction of four unrelated conditions, and folding
+      // all four into "capability" sent three of them to the one remedy that
+      // cannot help (codex gate). Each is reported as itself, most transient
+      // first — a closing socket is not an old panel, and a modern panel with no
+      // trusted stamp is a BINDING problem that reads survive and a rebind fixes.
+      if (conn.sock.readyState !== WebSocket.OPEN) {
+        return { known: true, canMutate: false, because: "disconnected" };
+      }
+      if (!conn.enforcesWorkflowStamp || !conn.enforcesWorkflowStampAtWrite) {
+        // The only genuinely version-shaped cause: this build does not advertise
+        // the write-boundary fence, and no retry can add it.
+        return { known: true, canMutate: false, because: "capability" };
+      }
+      if (typeof stamp !== "string" || stamp.length === 0) {
+        return { known: true, canMutate: false, because: "no_identity" };
+      }
+      return { known: true, canMutate: true };
     } catch (err) {
       // The stamp resolver threw: the capability inputs could not be read, so the
       // answer is unknown — NOT "the panel lacks the capability".

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -3093,7 +3093,7 @@ export class UiBridge {
       ctx.reject(
         markReplyTimeout(
           new Error(
-            `Panel tab ${conn.tabId.slice(0, 8)} did not reply to "${cmd.cmd}" within ${ctx.timeoutMs} ms — the ComfyUI tab may be backgrounded or frozen`,
+            `Panel tab ${conn.tabId} did not reply to "${cmd.cmd}" within ${ctx.timeoutMs} ms — the ComfyUI tab may be backgrounded or frozen`,
           ),
         ),
       );
@@ -3149,11 +3149,20 @@ export class UiBridge {
       // dispatched:true so a mutating caller (e.g. comfy_reboot readiness) treats it as an
       // accepted-but-unacked dispatch and verifies by observation, rather than mistaking a
       // genuinely-sent command for one that never went out (#509).
+      //
+      // #803 — name the FULL tab id, never the log-style 8-char slice. Routing tab
+      // ids are `wf:<path>` / `tmp:<key>`, so an 8-char slice renders EVERY workflow
+      // tab as the identical, alarming-looking `wf:workf`: two tabs timing out are
+      // indistinguishable in the transcript and the id reads like a corrupted key
+      // (it sent one diagnosis down a wrong path outright). Same call as the #709
+      // refusal above. `isAckTimeout`/`isReplyTimeoutError` both segment the id with
+      // a lazy `.+?` bounded by the fixed ` did not reply to "` delimiter, so a full
+      // id CONTAINING SPACES (`wf:workflows/Untitled 2026-08-04.json`) still matches.
       ctx.reject(
         markReplyTimeout(
           markDispatched(
             new Error(
-              `Panel tab ${conn.tabId.slice(0, 8)} did not reply to "${cmd.cmd}" within ${ctx.timeoutMs} ms — the ComfyUI tab may be backgrounded or frozen`,
+              `Panel tab ${conn.tabId} did not reply to "${cmd.cmd}" within ${ctx.timeoutMs} ms — the ComfyUI tab may be backgrounded or frozen`,
             ),
             true,
           ),
@@ -3332,6 +3341,29 @@ export class UiBridge {
    */
   refreshWorkflowUuid(tabId: string, workflowUuid: string): boolean {
     return this.refreshTabWorkflowUuid?.(tabId, workflowUuid) ?? false;
+  }
+
+  /**
+   * #770/#803 — READ the trusted command stamp currently fencing `tabId`, or
+   * `undefined` when this tab has none (no resolver injected, old panel, or an
+   * identity regression cleared it).
+   *
+   * Exists so a rebind can tell the three DIFFERENT answers apart instead of
+   * folding them into one verdict: "the fence was stale and has been replaced",
+   * "the fence already named the live canvas", and "there was never a fence to
+   * repair". Those have three different remedies, and reporting any of them as
+   * the others is how a recovery came to claim success it had not achieved.
+   *
+   * Never throws: the resolver is orchestrator-supplied, and a guard that can
+   * throw is not a guard.
+   */
+  workflowUuidFor(tabId: string): string | undefined {
+    try {
+      const uuid = this.resolveTabWorkflowUuid?.(tabId);
+      return typeof uuid === "string" && uuid.length > 0 ? uuid : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   /** The open DESKTOP tabs (non-headless primaries) for the mobile mirror picker. */


### PR DESCRIPTION
## Issues in this cluster

- #803 — graph binding desyncs after reconnect; **all three documented recoveries fail**
- #770 — panel graph reads stay wedged after a workflow retarget
- #772 — `panel_run` run-to-node stamp race returned as terminal
- #716 — stale workflow UUID after reconnect/open/re-pin (closed by #722; **recurring**)

## The defect

`panel_set_workflow_target({mode:"current"})` is documented — by the panel's own error text, by three other orchestrator messages, and by its own tool description — as the way out of a wedged graph binding. It could not do it.

The per-command workflow-instance fence (#570) is written **only from a panel hello**. A hello is not the only way the active canvas changes identity: a workflow replaced in place on a still-open socket, a frontend soft reload, or a reconnect that re-registers under a different routing key all give the canvas a new workflow uuid with no new hello for the key the session holds. The stamp then names an instance that no longer exists, the panel's fence correctly refuses every stamped command, and **nothing in the orchestrator could replace it** — the #716 open/pin refresh paths require a caller-supplied *saved* path to corroborate, so they cannot fire for `mode:"current"` at all, and cannot fire for an unsaved (`tmp:`) canvas under any mode.

Meanwhile `rebindToActiveTab()` is a no-op whenever the bound tab is still reachable — the dominant reported case. So the call re-pointed nothing, and returned `"Following the user's current workflow tab."` A documented recovery that could not recover, reporting success.

## What this fixes

**#770 — fixed.** `rebindWorkflowFence()` re-derives the fence from the panel's own live `workflow_list.active`. No path corroboration, because `mode:"current"` has no caller-supplied target to corroborate — the live active canvas *is* the target. That is also why it works for an unsaved canvas, which every `tmp:` report hit. #570 is not weakened: every command issued after this point still fails closed if the user switches again.

**#803 — fixed on the orchestrator side.** The recovery now recovers, and what we tell the user matches what the code does. One verdict became five statuses (`refreshed` / `already_current` / `unreadable` / `no_identity` / `rejected`, plus `adopt_error`), surfaced as `graph_binding` (`bound` / `reads_only` / `unverified` / `not_recovered`) and `graph_binding_status`. When the binding is **not** restored the tool now fails — after first disclosing that the target write *did* apply, so nothing that succeeded is retracted. Every remedy was read end to end and checked against the caller's actual state; the ones that could not be followed were replaced, not softened.

**#772 — fixed.** `panel_run` re-issues a scoped run **exactly once**, only when the panel both reports the run-to-node stamp race *and* certifies nothing was queued. Structured queue evidence (`queued:true`, a `prompt_id`) vetoes the prose; an unparseable or `isError` reply is an unknown and is never retried; the gate reads our own `to_node_id`, never panel prose. Both the success and failure paths disclose the second dispatch, and claim only what is certified.

**#716 — not re-fixed, and not claimed.** #722's saved-path open/pin refresh is untouched. The recurrence reports are the `mode:"current"` and unsaved-canvas gaps above, which this closes. Left closed.

Also, from #803's own notes: the bridge's no-reply timeout named `tabId.slice(0, 8)`, rendering **every** workflow tab as the identical `wf:workf` — two tabs timing out were indistinguishable in a transcript and the id read like a corrupted routing key. It now names the full id. That change alone would have silently disabled the whole `workflow_open` verify-after-timeout recovery for any workflow whose filename contains a space (ComfyUI's default name has two), because `isAckTimeout` segmented the id with `\S+`; that regex is fixed and start-anchored in the same commit.

## The property, not the instances

Every fix here is the same fold: **"could not determine X" reported or treated as "determined X is not the case"** — in both directions. It was found in eight places, several only after the earlier fix had been applied one level up:

- a fence rebind that reported success without looking;
- a **read** of the existing fence that collapsed "the resolver threw" into "there is no fence" — fixed in the orchestrator, then found *still collapsed in the bridge*, which is the only thing that can see the stamp;
- a **capability** probe that collapsed "could not inspect" into "your panel lacks the write fence" — a claim about the user's install built from our own failed probe;
- `already_current` claiming agreement it had verified against the *previous* tab, after the probe's own retry moved the session;
- an adoption **throw** narrated as a refusal, when a refusal proves the old fence survived and a throw does not.

## Self-gate

Six rounds of adversarial codex review (`gpt-5.6-terra`). Rounds 1–5 produced 19 findings — 2 P0, the rest P1 — all fixed or answered on the record; round 6 returned **PASS** with one P2 (a test that probed a nonexistent tab and so never reached the code it named), now rewritten against a live tab.

Every fix is mutation-verified: the code was broken and the matching test confirmed failing, 31 times. Tests assert the **reason**, not just the state.

Full suite green at `--maxWorkers=2` (255 files, 5169 tests) — this machine is loaded and full-speed runs flake in a rotating cast of unrelated files, so that is the honest number. Plus `build`, `lint`, `check:vocabulary`, `vocab:export` (no diff). Committed blobs scanned for control bytes: clean, all four files git-TEXT.

## Deliberately not fixed

- **`panel_open_workflow` on the already-active workflow cannot satisfy its own proof requirement** (#803 step 3). The `"could not prove that the active canvas was rebound"` text is produced by **comfyui-mcp-panel**'s `workflow_open` handler, not this repo. Panel-side.
- **`panel_reload({scope:"frontend"})` leaving the tab permanently unresponsive** (#803 steps 5–6). Panel-side. Every remedy this PR writes now explicitly steers *off* `panel_reload` and names a manual browser refresh, which is the only thing reporters found effective.
- **`panel_search_nodes` rejected by the workflow-instance fence** (reported on #770). Manager registry search is not graph-scoped; the orchestrator stamps the frame but the decision to fence it is the panel's `activeWorkflowFenceApplies`. Panel-side — but worth checking whether the orchestrator should stop stamping non-canvas commands at all.
- **A compare-and-set on the active canvas.** Between the `workflow_list` reply and the stamp write the user can switch the same tab, so an adopted fence can already be stale. The failure direction is safe — the panel refuses the next command; it never writes the wrong workflow — so the defect was the *claim*, which is now qualified ("the canvas the panel reported active a moment ago", and a switch in that instant fails closed and is cleared by calling again). A real fix needs a panel-supplied active-canvas generation token: a **comfyui-mcp-panel protocol change**. The same window already exists in the pre-existing #716 pinned path.
- **Per-tab operation tokens on target changes.** Two sessions bound to one tab share the `WorkflowTargetStore`, and a slow call can clobber a later pin. That race is **pre-existing** and is wider through the pre-existing `awaitReachable` await (~20s) already ahead of the store write than through anything here. This PR does not widen it — the live-canvas probe was deliberately moved to *after* the store write and push — but it does not close it either.
- **`resolveEffectiveComfyUIBase()` / `comfy-cli.ts` (#490)** — reopened and owned elsewhere. Not touched.

## Only a live rig can confirm

The wedge itself is a reconnect/replace race against a real ComfyUI. The unit tests drive the exact reply shapes, but nothing here proves the panel's `workflow_list.active.workflow_uuid` is populated for every real wedge — particularly on an unsaved `tmp:` canvas after a soft reload, which is where several reports originate. If it is ever absent there, this lands in `no_identity` and reports that honestly rather than pretending, but the recovery would not complete. The shared ComfyUI on this rig has unrelated unsaved tabs open, so it was not restarted for destructive validation.
