### PR TITLE
truncated results fit the budget they report, and a library listing that looks in the folders (#807, #810)

### DIFF
--- a/docs/tools/workflow-authoring.mdx
+++ b/docs/tools/workflow-authoring.mdx
@@ -323,7 +323,7 @@ QUERY a SAVED workflow FILE (or JSON you pass in) — NOT the live canvas, which
   Absolute server-side path to a workflow .json on disk.
 </ParamField>
 <ParamField path="filename" type="string">
-  Workflow filename in the ComfyUI userdata library, as an alternative to path.
+  Workflow library name as list_workflows reports it (subfolders included, e.g. 'IMAGE/portrait.json'), as an alternative to path.
 </ParamField>
 <ParamField path="graph" type="object">
   Inline workflow JSON (UI or API format), as an alternative to path/filename.

--- a/docs/tools/workflow-library.mdx
+++ b/docs/tools/workflow-library.mdx
@@ -10,9 +10,9 @@ icon: "folder-open"
 
 ## list_workflows
 
-List the filenames of workflows saved in the connected ComfyUI server's user library (the same workflows visible in the ComfyUI web UI). Requires a running ComfyUI server. Takes no parameters. Returns a numbered list of .json filenames; pass a filename to get_workflow or analyze_workflow to load one. Returns "No saved workflows found." when the library is empty.
+List the workflows saved in the connected ComfyUI server's user library (the same workflows visible in the ComfyUI web UI), INCLUDING the ones filed in subfolders. Requires a running ComfyUI server. Takes no parameters. Returns a numbered list of library names, each relative to the library root — a workflow in a folder appears as 'VIDEO/MiniMaxH3/clip.json', and that whole string is what get_workflow / analyze_workflow / query_workflow take as `filename`. Says the library is empty ONLY when the server actually reported an empty library; a listing it could not read is reported as unread, never as empty.
 
-<Tip>**In plain terms:** The saved workflow FILES in your ComfyUI — the same list you see in the ComfyUI sidebar. Usually the first call in any "open my…" request.</Tip>
+<Tip>**In plain terms:** The saved workflow FILES in your ComfyUI — the same list you see in the ComfyUI sidebar, folders and all. Usually the first call in any "open my…" request.</Tip>
 
 <Note>This tool takes no parameters.</Note>
 
@@ -27,7 +27,7 @@ List the filenames of workflows saved in the connected ComfyUI server's user lib
 }
 ```
 
-**You get back:** A numbered list of .json filenames. Pick one and hand it to analyze_workflow or get_workflow.
+**You get back:** A numbered list of names, each relative to the library root — one filed in a folder shows as VIDEO/MiniMaxH3/clip.json. Pick one and hand the whole name to analyze_workflow or get_workflow.
 
 ---
 
@@ -40,7 +40,7 @@ Return the full JSON of a SAVED workflow FILE, named from the library — a file
 ### Parameters
 
 <ParamField path="filename" type="string" required>
-  Workflow filename (e.g. 'my_workflow.json'). Use list_workflows to see available files.
+  Workflow library name, exactly as list_workflows reports it. A workflow filed in a folder keeps its folder in the name ('VIDEO/MiniMaxH3/clip.json') and that whole string goes here.
 </ParamField>
 <ParamField path="format" type="enum" default="api">
   Output format: 'api' (default, recommended) converts to compact API format with named inputs, connection references, and _meta.mode flags for muted/bypassed nodes. 'ui' returns the raw UI format with layout positions and links arrays. Options: `ui`, `api`.
@@ -118,7 +118,7 @@ Strip a workflow to a clean, flat API graph — resolving Get/Set buses, Reroute
   Absolute server-side path to a workflow .json on disk (e.g. C:\\Users\\you\\ComfyUI\\user\\default\\workflows\\pusa_extend.json). Read directly from disk — no library lookup.
 </ParamField>
 <ParamField path="filename" type="string">
-  Workflow filename in the ComfyUI userdata library, as an alternative to path.
+  Workflow library name as list_workflows reports it (subfolders included, e.g. 'IMAGE/portrait.json'), as an alternative to path.
 </ParamField>
 <ParamField path="graph" type="object">
   Inline UI-format workflow JSON, as an alternative to path/filename.
@@ -150,7 +150,7 @@ Slice ONE pipeline out of a toggle-template workflow — the kind built with rgt
   Absolute server-side path to the workflow .json on disk.
 </ParamField>
 <ParamField path="filename" type="string">
-  Workflow filename in the ComfyUI userdata library.
+  Workflow library name as list_workflows reports it, subfolders included (e.g. 'IMAGE/portrait.json').
 </ParamField>
 <ParamField path="graph" type="object">
   Inline UI-format workflow JSON.
@@ -235,7 +235,7 @@ SUMMARIZE a SAVED workflow FILE named from the library — sections, node settin
 ### Parameters
 
 <ParamField path="filename" type="string" required>
-  Workflow filename (e.g. 'Scene Builder v3.json'). Use list_workflows to see available files.
+  Workflow library name, exactly as list_workflows reports it (e.g. 'Scene Builder v3.json', or 'VIDEO/MiniMaxH3/clip.json' for one filed in a folder — the folder is part of the name).
 </ParamField>
 <ParamField path="view" type="enum" default="summary">
   summary (default): structured text with sections, node IDs, key settings, virtual wires, and full connection graph — best for AI understanding. overview: mermaid diagram showing sections as summary nodes with cross-section data flow. detail: mermaid diagram for one section (requires section parameter). list: text listing of all sections with data flow summary. flat: single mermaid flowchart of the entire workflow (best for small workflows). health: graph-health heuristics (disconnected nodes, duplicate model loads, orphaned branches, muted/bypassed). Options: `summary`, `overview`, `detail`, `list`, `flat`, `health`.

--- a/docs/tools/workflow-library.mdx
+++ b/docs/tools/workflow-library.mdx
@@ -10,7 +10,7 @@ icon: "folder-open"
 
 ## list_workflows
 
-List the workflows saved in the connected ComfyUI server's user library (the same workflows visible in the ComfyUI web UI), INCLUDING the ones filed in subfolders. Requires a running ComfyUI server. Takes no parameters. Returns a numbered list of library names, each relative to the library root — a workflow in a folder appears as 'VIDEO/MiniMaxH3/clip.json', and that whole string is what get_workflow / analyze_workflow / query_workflow take as `filename`. Says the library is empty ONLY when the server actually reported an empty library; a listing it could not read is reported as unread, never as empty.
+List the workflows saved in the connected ComfyUI server's user library (the same workflows visible in the ComfyUI web UI), INCLUDING the ones filed in subfolders. Requires a running ComfyUI server. Takes no parameters. Returns a numbered list of library names, each relative to the library root — a workflow in a folder appears as 'VIDEO/MiniMaxH3/clip.json', and that whole string is what get_workflow / analyze_workflow / query_workflow take as `filename`. It never reports an absence it did not establish: a listing it could not read says so, and an EMPTY listing says the library could not be CONFIRMED empty (an answer with no names in it cannot show whether it covered subfolders) and tells you to check the ComfyUI sidebar rather than recreate anything.
 
 <Tip>**In plain terms:** The saved workflow FILES in your ComfyUI — the same list you see in the ComfyUI sidebar, folders and all. Usually the first call in any "open my…" request.</Tip>
 

--- a/scripts/tool-doc-examples.ts
+++ b/scripts/tool-doc-examples.ts
@@ -292,14 +292,16 @@ export const TOOL_DOC_EXAMPLES: Readonly<Record<string, ToolDocEntry>> = {
   list_workflows: {
     gloss:
       "The saved workflow FILES in your ComfyUI — the same list you see in the " +
-      "ComfyUI sidebar. Usually the first call in any \"open my…\" request.",
+      "ComfyUI sidebar, folders and all. Usually the first call in any " +
+      "\"open my…\" request.",
     examples: [
       {
         ask: "What workflows have I got saved?",
         args: {},
         returns:
-          "A numbered list of .json filenames. Pick one and hand it to " +
-          "analyze_workflow or get_workflow.",
+          "A numbered list of names, each relative to the library root — one filed " +
+          "in a folder shows as VIDEO/MiniMaxH3/clip.json. Pick one and hand the " +
+          "whole name to analyze_workflow or get_workflow.",
       },
     ],
   },

--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -48,6 +48,9 @@ vi.mock("../../comfyui/client.js", async (importOriginal) => {
 });
 
 const { buildPanelToolDefs } = await import("../../orchestrator/panel-tools.js");
+// #810: the listing route is now shared with list_workflows, so pinning the literal
+// here would let the two drift apart again — which is how one recursed and one did not.
+const { WORKFLOW_LIBRARY_LISTING_ROUTE } = await import("../../services/userdata-library.js");
 import type { PanelToolCtx } from "../../orchestrator/panel-tools.js";
 
 type Forwarded = Record<string, unknown>;
@@ -745,7 +748,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
 
     expect(res.isError).toBeUndefined();
     expect(calls[0].graph).toMatchObject(graph);
-    expect(fetchApi).toHaveBeenCalledWith("/api/userdata?dir=workflows&recurse=true");
+    expect(fetchApi).toHaveBeenCalledWith(WORKFLOW_LIBRARY_LISTING_ROUTE);
     expect(fetchApi).toHaveBeenCalledWith(
       `/api/userdata/${encodeURIComponent(`workflows/recipes/${nfc}`)}`,
     );
@@ -989,7 +992,7 @@ describe("readWorkflowFromPath: near-miss names resolve via the server's OWN lis
     expect(calls).toHaveLength(0);
     // The listing WAS consulted (and its 500 swallowed) — otherwise this test would
     // pass even if the near-miss lookup had been dropped entirely.
-    expect(fetchApi).toHaveBeenCalledWith("/api/userdata?dir=workflows&recurse=true");
+    expect(fetchApi).toHaveBeenCalledWith(WORKFLOW_LIBRARY_LISTING_ROUTE);
     expect(JSON.stringify(res)).toMatch(/list_workflows/);
     // And the refusal admits the listing was unreadable rather than implying the
     // library was fully checked.

--- a/src/__tests__/orchestrator/query-graph-budget.test.ts
+++ b/src/__tests__/orchestrator/query-graph-budget.test.ts
@@ -390,6 +390,26 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       expect(note).not.toMatch(/for a smaller reply lower `max_chars`/);
     });
 
+    it("keeps an EMPTY groups list — a stated zero is an observation, not a rider", async () => {
+      // `groups: []` costs about fifteen characters and says "this graph has no
+      // groups". Deleting it saved nothing and turned that stated zero into an absent
+      // field, and then let the overrun note claim nothing had been discarded when a
+      // field had (codex gate r7).
+      const { payload, text } = await runQueryGraph(
+        { max_chars: 900 },
+        {
+          viewing: { scope: "subgraph", owner_node_id: 1, title: "T".repeat(3000) },
+          groups: [],
+          total: 1,
+          shown: 0,
+          text: "0 match(es)",
+        },
+      );
+      expect(payload.groups).toEqual([]);
+      assertBoundHonoured(payload, text, 900);
+      expect(String(payload.budget_overrun)).toMatch(/Nothing was discarded to meet the budget/);
+    });
+
     it("discloses an over-budget aggregate (group_by) reply", async () => {
       const { payload, text } = await runQueryGraph(
         { max_chars: 700, group_by: "type" },

--- a/src/__tests__/orchestrator/query-graph-budget.test.ts
+++ b/src/__tests__/orchestrator/query-graph-budget.test.ts
@@ -209,7 +209,9 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       panelReply({ groups: 5, rails: false, extra: { rails }, text: "0 match(es)" }),
     );
     expect(payload.rails).toBeUndefined();
-    expect(payload.rails_omitted).toMatch(/panel_query_graph/);
+    // The way back is judged the same way the groups' is: measured, not asserted.
+    expect(payload.rails_omitted).toMatch(/did not fit `max_chars`=500 without them/);
+    expect(payload.rails_omitted).toMatch(/`max_chars`|narrow/);
     // At the 500 FLOOR the sentences explaining what was dropped are themselves larger
     // than the budget. They are not cut — a silently missing rider is the defect — so
     // the reply must say plainly that it overran, and why.
@@ -237,12 +239,13 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
     expect(typeof overrun).toBe("string");
     expect(overrun).toMatch(/over `max_chars`=1000/);
     expect(overrun).toMatch(/never discarded to meet a budget/);
-    // The stated size must be the size of the thing the caller is holding, within the
-    // handful of characters the note's own digits move it by. A round number pulled out
-    // of the air would pass a "mentions a number" assertion and fail this one.
-    const claimed = Number(/This reply is ~(\d+) chars/.exec(overrun)?.[1]);
+    // EXACTLY the size of the thing the caller is holding, this note included. A size
+    // measured before the note was added would understate the reply by the length of
+    // the sentence claiming to have counted everything (codex gate MAJOR), and a round
+    // number pulled out of the air would pass a "mentions a number" assertion.
+    const claimed = Number(/This reply is (\d+) chars/.exec(overrun)?.[1]);
     expect(Number.isFinite(claimed)).toBe(true);
-    expect(Math.abs(text.length - claimed)).toBeLessThan(600);
+    expect(claimed).toBe(text.length);
   });
 
   it("leaves a reply that already fits completely alone — no shedding, no notes", async () => {
@@ -260,23 +263,103 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
     expect(payload.budget_overrun).toBeUndefined();
   });
 
-  it("passes a rider-free reply straight through, untouched", async () => {
-    // Nothing rides alongside the answer, so there is no accounting to apply and no
-    // reason to rewrite the panel's reply at all.
+  it("keeps a rider-free reply intact, adding only the budget it was fitted to", async () => {
     const reply = { total: 3, matched: 0, shown: 0, truncated: false, text: "0 match(es)" };
-    const { payload } = await runQueryGraph({ max_chars: 500 }, reply);
-    expect(payload).toEqual(reply);
-    expect(payload.max_chars).toBeUndefined();
+    const { payload, text } = await runQueryGraph({ max_chars: 500 }, reply);
+    expect(payload).toEqual({ ...reply, max_chars: 500 });
+    assertBoundHonoured(payload, text, 500);
   });
 
-  it("never overwrites a max_chars the panel reported itself", async () => {
-    // A newer panel that does its own whole-reply accounting knows better than this
-    // rider what budget it actually worked to.
-    const { payload } = await runQueryGraph(
+  describe("every reply is measured, including the ones with nothing to shed", () => {
+    // The shortcut this replaces — "no groups and no rails, so skip the accounting" —
+    // let a reply exceed the budget it reports with nothing said, which is the exact
+    // defect #807 is about wearing a different hat (codex gate SEVERE).
+
+    it("discloses an over-budget reply that has NO riders at all", async () => {
+      const reply = {
+        total: 3,
+        matched: 1,
+        shown: 1,
+        truncated: false,
+        text: "x".repeat(2000),
+      };
+      const { payload, text } = await runQueryGraph({ max_chars: 900 }, reply);
+      expect(payload.text).toBe(reply.text);
+      assertBoundHonoured(payload, text, 900);
+      expect(String(payload.budget_overrun)).toMatch(/render to \d+ chars on their own/);
+    });
+
+    it("counts a field it has never seen before", async () => {
+      // A future panel field is not a rider this code knows how to shed, but it is
+      // still part of what the caller receives — so it must at least be COUNTED, and
+      // the shortfall admitted, rather than sailing past the bound unremarked.
+      const { payload, text } = await runQueryGraph(
+        { max_chars: 900 },
+        { total: 1, shown: 0, text: "0 match(es)", some_future_index: "z".repeat(2000) },
+      );
+      expect(payload.some_future_index).toBe("z".repeat(2000));
+      assertBoundHonoured(payload, text, 900);
+    });
+
+    it("counts an oversized `viewing`, which identifies the graph and is never shed", async () => {
+      // Subgraph titles are user-controlled and unbounded. `viewing` says WHICH graph
+      // the answer describes, so dropping it would make the whole reply ambiguous — it
+      // is kept, counted, and the overrun stated.
+      const { payload, text } = await runQueryGraph(
+        { max_chars: 900 },
+        {
+          viewing: { scope: "subgraph", owner_node_id: 12, title: "T".repeat(3000) },
+          total: 1,
+          shown: 0,
+          text: "0 match(es)",
+        },
+      );
+      expect((payload.viewing as { title: string }).title).toHaveLength(3000);
+      assertBoundHonoured(payload, text, 900);
+    });
+
+    it("discloses an over-budget aggregate (group_by) reply", async () => {
+      const { payload, text } = await runQueryGraph(
+        { max_chars: 700, group_by: "type" },
+        {
+          viewing: { scope: "root" },
+          total: 900,
+          matched: 900,
+          shown: 900,
+          truncated: true,
+          truncated_by: "max_chars",
+          text: "900 node(s) across 300 type(s):\n" + "12× SomeNodeType\n".repeat(80),
+        },
+      );
+      assertBoundHonoured(payload, text, 700);
+    });
+
+    it("discloses an over-budget seed-not-found reply", async () => {
+      // The early returns carry no riders at all, and used to bypass the fitter.
+      const { payload, text } = await runQueryGraph(
+        { max_chars: 500, upstream_of: 999 },
+        {
+          total: 690,
+          candidates: 0,
+          matched: 0,
+          shown: 0,
+          truncated: false,
+          text: `upstream_of node ${"9".repeat(1200)} not found (690 nodes in view).`,
+        },
+      );
+      assertBoundHonoured(payload, text, 500);
+    });
+  });
+
+  it("reports the budget it ENFORCED, not one the panel happened to mention", async () => {
+    // Deferring to a panel-supplied `max_chars` reports a bound nothing checked: a
+    // reply fitted to 4000 announcing 3777 looks compliant at 3900 (codex gate SEVERE).
+    const { payload, text } = await runQueryGraph(
       { max_chars: 4000 },
       panelReply({ groups: 2, membersPerGroup: 2, extra: { max_chars: 3777 } }),
     );
-    expect(payload.max_chars).toBe(3777);
+    expect(payload.max_chars).toBe(4000);
+    assertBoundHonoured(payload, text, 4000);
   });
 
   it("leaves an error reply alone", async () => {
@@ -307,8 +390,19 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       const { payload } = await runQueryGraph({ max_chars: 4000 }, reply);
       const note = String(payload.groups_omitted ?? payload.groups_membership_omitted);
       expect(note).toMatch(/past `max_chars`'s ceiling of 60000/);
-      expect(note).toMatch(/will NOT bring them back/);
+      expect(note).toMatch(/no combination of raising it and narrowing/);
       expect(note).not.toMatch(/raise `max_chars` \(up to/);
+    });
+
+    it("offers raise-AND-narrow only when narrowing would actually bring it under the ceiling", async () => {
+      // The full reply is past the ceiling, but the riders alone are not: with the rows
+      // gone they fit, so BOTH levers together are a real remedy and either alone is not.
+      const reply = panelReply({ groups: 45, membersPerGroup: 40, text: "r".repeat(30000) });
+      expect(JSON.stringify(reply, null, 2).length).toBeGreaterThan(CEILING);
+      expect(JSON.stringify({ ...reply, text: "" }, null, 2).length).toBeLessThan(CEILING);
+      const { payload } = await runQueryGraph({ max_chars: 4000 }, reply);
+      const note = String(payload.groups_omitted ?? payload.groups_membership_omitted);
+      expect(note).toMatch(/raise `max_chars` \(up to 60000\) AND narrow the query/);
     });
 
     it("says the budget is maxed instead of telling a caller at the ceiling to raise it", async () => {

--- a/src/__tests__/orchestrator/query-graph-budget.test.ts
+++ b/src/__tests__/orchestrator/query-graph-budget.test.ts
@@ -58,6 +58,8 @@ function panelReply(opts: {
   membersPerGroup?: number;
   rails?: boolean;
   text?: string;
+  /** What the PANEL says cut its own rows, if anything. */
+  truncatedBy?: "limit" | "max_chars";
   extra?: Record<string, unknown>;
 }): Record<string, unknown> {
   const { groups = 0, membersPerGroup = 200, rails = false, text = "1 match(es)\n#42 KSampler" } = opts;
@@ -72,8 +74,8 @@ function panelReply(opts: {
     candidates: 690,
     matched: 1,
     shown: 1,
-    truncated: false,
-    truncated_by: null,
+    truncated: opts.truncatedBy != null,
+    truncated_by: opts.truncatedBy ?? null,
     text,
   };
 }
@@ -484,6 +486,31 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       expect(note).toMatch(/past `max_chars`'s ceiling of 60000/);
       expect(note).toMatch(/no combination of raising it and narrowing/);
       expect(note).not.toMatch(/raise `max_chars` \(up to/);
+    });
+
+    it("does not size a raise against rows the panel had ALREADY cut at this budget", async () => {
+      // The panel stops adding rows at this same `max_chars` and says so in
+      // `truncated_by`. Sizing "raise to ~N to keep them" against the rows in hand then
+      // describes a reply nobody has seen: raising the budget returns MORE ROWS as well,
+      // and the riders can be shed all over again (codex gate r9).
+      const cut = await runQueryGraph(
+        { max_chars: 4000 },
+        panelReply({ groups: 20, membersPerGroup: 60, truncatedBy: "max_chars" }),
+      );
+      const note = String(cut.payload.groups_membership_omitted ?? cut.payload.groups_omitted);
+      expect(note).toMatch(/THESE rows/);
+      expect(note).toMatch(/cut the ROWS at this same budget too/);
+      expect(note).toMatch(/may still not leave room/);
+
+      // A reply the panel did NOT cut carries no such caveat — the size really is what a
+      // raise would need, so hedging it would be its own false claim.
+      const whole = await runQueryGraph(
+        { max_chars: 4000 },
+        panelReply({ groups: 20, membersPerGroup: 60 }),
+      );
+      const plain = String(whole.payload.groups_membership_omitted ?? whole.payload.groups_omitted);
+      expect(plain).toMatch(/raise `max_chars` \(up to 60000\)/);
+      expect(plain).not.toMatch(/cut the ROWS at this same budget/);
     });
 
     it("offers raise-AND-narrow only when narrowing would actually bring it under the ceiling", async () => {

--- a/src/__tests__/orchestrator/query-graph-budget.test.ts
+++ b/src/__tests__/orchestrator/query-graph-budget.test.ts
@@ -180,6 +180,30 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
     expect(text.length).toBeLessThanOrEqual(1500);
   });
 
+  it("does not call a pre-capped group list complete when only membership was shed", async () => {
+    // The panel caps `groups` at 200 before this code sees it. Saying "every group is
+    // still listed" on that reply contradicts the panel's own "showing 200 of 640"
+    // sitting two fields away, and claims whole-graph coverage nobody observed
+    // (codex gate MAJOR). This is the MEMBERSHIP rung — the index survives, so the
+    // temptation to claim completeness is at its strongest here.
+    const reply = panelReply({
+      groups: 30,
+      membersPerGroup: 120,
+      extra: { groups_truncated: true, groups_truncation_hint: "Showing 200 of 640 group(s)…" },
+    });
+    const { payload, text } = await runQueryGraph({ max_chars: 8000 }, reply);
+    expect(payload.groups).toHaveLength(30); // the membership rung, not the index rung
+    const note = String(payload.groups_membership_omitted);
+    expect(note).toMatch(/CARRIED/);
+    expect(note).toMatch(/not the graph's total/);
+    expect(note).not.toMatch(/Every group is still listed/);
+    assertBoundHonoured(payload, text, 8000);
+
+    // …and the unclipped case still says the plain thing, so this is not just prose.
+    const plain = await runQueryGraph({ max_chars: 8000 }, panelReply({ groups: 30, membersPerGroup: 120 }));
+    expect(String(plain.payload.groups_membership_omitted)).toMatch(/Every group is still listed/);
+  });
+
   it("does not pass off the panel's own capped group list as the graph's total", async () => {
     // The panel caps `groups` at 200 before the orchestrator ever sees it. Saying "all
     // 200 groups" there would report a number nobody observed.

--- a/src/__tests__/orchestrator/query-graph-budget.test.ts
+++ b/src/__tests__/orchestrator/query-graph-budget.test.ts
@@ -215,6 +215,31 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
     const { payload } = await runQueryGraph({ max_chars: 1500 }, reply);
     expect(payload.groups_omitted).toMatch(/not the graph's total/);
     expect(payload.groups_omitted).not.toMatch(/all 200 group\(s\)/);
+    // …and the panel's own marker is the ONLY place the real figure (640) survives, so
+    // dropping it along with the list would destroy the one coverage fact still
+    // available (codex gate r6). It rides on every rung below the index.
+    expect(payload.groups_truncation_hint).toBe(reply.groups_truncation_hint);
+    expect(payload.groups_truncated).toBe(true);
+  });
+
+  it("keeps the panel's cap evidence even when the rails go too", async () => {
+    const rails: Record<string, unknown> = {};
+    for (let i = 0; i < 60; i++) rails[`slot_${i}`] = { id: -10 - i, name: "x".repeat(60) };
+    const { payload } = await runQueryGraph(
+      { max_chars: 500 },
+      panelReply({
+        groups: 200,
+        membersPerGroup: 200,
+        extra: {
+          rails,
+          groups_truncated: true,
+          groups_truncation_hint: "Showing 200 of 640 group(s)…",
+        },
+      }),
+    );
+    expect(payload.groups).toBeUndefined();
+    expect(payload.rails).toBeUndefined();
+    expect(payload.groups_truncation_hint).toBe("Showing 200 of 640 group(s)…");
   });
 
   it("keeps the subgraph rails until last — groups go before boundary wiring", async () => {

--- a/src/__tests__/orchestrator/query-graph-budget.test.ts
+++ b/src/__tests__/orchestrator/query-graph-budget.test.ts
@@ -17,26 +17,40 @@ import { describe, expect, it } from "vitest";
 import { buildPanelToolDefs } from "../../orchestrator/panel-tools.js";
 import type { PanelToolCtx } from "../../orchestrator/panel-tools.js";
 
+type ToolResult = { isError?: boolean; content: Array<{ type: string; text?: string }> };
+
 const DEFAULT_MAX_CHARS = 12000;
 const CEILING = 60000;
 
 /** Run the REAL panel_query_graph def against a stubbed panel reply, and hand back both
- *  the parsed payload and the exact text a caller would receive. */
+ *  the parsed payload and the exact text a caller would receive.
+ *
+ *  `extraBlocks` models a reply whose content list carries MORE than the JSON block —
+ *  the shape the ToolResult type allows and the fitter must still account for. */
 async function runQueryGraph(
   args: Record<string, unknown>,
   reply: Record<string, unknown>,
-): Promise<{ payload: Record<string, unknown>; text: string }> {
+  extraBlocks: Array<{ type: "text"; text: string } | { type: "image"; data: string }> = [],
+): Promise<{ payload: Record<string, unknown>; text: string; res: ToolResult }> {
   const d = buildPanelToolDefs().find((t) => t.name === "panel_query_graph");
   expect(d, "panel_query_graph is not a panel tool").toBeTruthy();
   const res = await d!.handler(args, {
     call: async () => ({
       // The same shape the bridge produces: pretty-printed JSON, riders first.
-      content: [{ type: "text" as const, text: JSON.stringify(reply, null, 2) }],
+      content: [
+        { type: "text" as const, text: JSON.stringify(reply, null, 2) },
+        ...extraBlocks,
+      ],
     }),
   } as unknown as PanelToolCtx);
   const block = res.content.find((c) => c.type === "text") as { text: string } | undefined;
   expect(block, "panel_query_graph returned no text block").toBeTruthy();
-  return { payload: JSON.parse(block!.text) as Record<string, unknown>, text: block!.text };
+  return { payload: JSON.parse(block!.text) as Record<string, unknown>, text: block!.text, res };
+}
+
+/** Every character the CALLER receives, across every text block of the result. */
+function replyChars(res: ToolResult): number {
+  return res.content.reduce((n, c) => (c.type === "text" ? n + (c.text?.length ?? 0) : n), 0);
 }
 
 /** A group as the panel actually summarizes one (summarizeGroup in comfyui-mcp-panel.js):
@@ -90,15 +104,18 @@ const keyOrder = (payload: Record<string, unknown>): string[] => Object.keys(pay
  */
 function assertBoundHonoured(
   payload: Record<string, unknown>,
-  text: string,
+  res: ToolResult,
   budget: number,
 ): void {
   expect(payload.max_chars, "the reply must report the budget it was fitted to").toBe(budget);
+  // Measured over EVERY text block, not just the JSON one: a bound that describes part
+  // of a reply is the defect this file exists to catch (independent gate P0).
+  const chars = replyChars(res);
   if (payload.budget_overrun === undefined) {
-    expect(text.length, "no overrun was declared, so the reply must fit").toBeLessThanOrEqual(budget);
+    expect(chars, "no overrun was declared, so the whole reply must fit").toBeLessThanOrEqual(budget);
   } else {
     expect(String(payload.budget_overrun)).toContain(`\`max_chars\`=${budget}`);
-    expect(text.length, "an overrun was declared on a reply that actually fits").toBeGreaterThan(budget);
+    expect(chars, "an overrun was declared on a reply that actually fits").toBeGreaterThan(budget);
   }
 }
 
@@ -112,7 +129,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       DEFAULT_MAX_CHARS * 5,
     );
 
-    const { payload, text } = await runQueryGraph({}, reply);
+    const { payload, text, res } = await runQueryGraph({}, reply);
 
     // The two halves of the claim, asserted together — either alone passes via the
     // wrong path. `max_chars` is what the reply SAYS its bound is; text.length is what
@@ -128,8 +145,8 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       [1, 500], // below the floor
       [999999, CEILING], // above the ceiling
     ] as const) {
-      const { payload, text } = await runQueryGraph({ max_chars: asked }, reply);
-      assertBoundHonoured(payload, text, expected);
+      const { payload, text, res } = await runQueryGraph({ max_chars: asked }, reply);
+      assertBoundHonoured(payload, res, expected);
     }
   });
 
@@ -137,7 +154,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
     // The rows are the answer to the question that was asked. A budget that trades them
     // for contextual extras answers a different question than the caller put.
     const rows = "1 match(es) of 690 in scope\n" + JSON.stringify({ id: 42, type: "KSampler" });
-    const { payload } = await runQueryGraph({ max_chars: 2000 }, panelReply({ groups: 40, text: rows }));
+    const { payload, res } = await runQueryGraph({ max_chars: 2000 }, panelReply({ groups: 40, text: rows }));
     expect(payload.text).toBe(rows);
     expect(payload.shown).toBe(1);
     expect(payload.matched).toBe(1);
@@ -146,7 +163,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
   it("serializes the riders AFTER the answer, never before it", async () => {
     // "…truncated by groups before reaching node details" was literal: the panel emits
     // the riders first, so an agent reading top-down met the rosters before its answer.
-    const { payload } = await runQueryGraph({ max_chars: CEILING }, panelReply({ groups: 2, membersPerGroup: 3, rails: true }));
+    const { payload, res } = await runQueryGraph({ max_chars: CEILING }, panelReply({ groups: 2, membersPerGroup: 3, rails: true }));
     const order = keyOrder(payload);
     expect(order.indexOf("text")).toBeLessThan(order.indexOf("groups"));
     expect(order.indexOf("text")).toBeLessThan(order.indexOf("rails"));
@@ -157,7 +174,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
     // Half a group list reads as "this graph has that many groups". A complete index
     // without member ids does not, and it still answers "which groups exist".
     const reply = panelReply({ groups: 30, membersPerGroup: 120 });
-    const { payload, text } = await runQueryGraph({ max_chars: 8000 }, reply);
+    const { payload, text, res } = await runQueryGraph({ max_chars: 8000 }, reply);
 
     const groups = payload.groups as Array<Record<string, unknown>>;
     expect(Array.isArray(groups)).toBe(true);
@@ -175,7 +192,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
 
   it("drops the group index only when the index itself will not fit, and says how many", async () => {
     const reply = panelReply({ groups: 200, membersPerGroup: 200 });
-    const { payload, text } = await runQueryGraph({ max_chars: 1500 }, reply);
+    const { payload, text, res } = await runQueryGraph({ max_chars: 1500 }, reply);
 
     expect(payload.groups).toBeUndefined();
     expect(payload.groups_omitted).toMatch(/all 200 group\(s\)/);
@@ -193,13 +210,13 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       membersPerGroup: 120,
       extra: { groups_truncated: true, groups_truncation_hint: "Showing 200 of 640 group(s)…" },
     });
-    const { payload, text } = await runQueryGraph({ max_chars: 8000 }, reply);
+    const { payload, text, res } = await runQueryGraph({ max_chars: 8000 }, reply);
     expect(payload.groups).toHaveLength(30); // the membership rung, not the index rung
     const note = String(payload.groups_membership_omitted);
     expect(note).toMatch(/CARRIED/);
     expect(note).toMatch(/not the graph's total/);
     expect(note).not.toMatch(/Every group is still listed/);
-    assertBoundHonoured(payload, text, 8000);
+    assertBoundHonoured(payload, res, 8000);
 
     // …and the unclipped case still says the plain thing, so this is not just prose.
     const plain = await runQueryGraph({ max_chars: 8000 }, panelReply({ groups: 30, membersPerGroup: 120 }));
@@ -214,7 +231,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       membersPerGroup: 200,
       extra: { groups_truncated: true, groups_truncation_hint: "Showing 200 of 640 group(s)…" },
     });
-    const { payload } = await runQueryGraph({ max_chars: 1500 }, reply);
+    const { payload, res } = await runQueryGraph({ max_chars: 1500 }, reply);
     expect(payload.groups_omitted).toMatch(/not the graph's total/);
     expect(payload.groups_omitted).not.toMatch(/all 200 group\(s\)/);
     // …and the panel's own marker is the ONLY place the real figure (640) survives, so
@@ -227,7 +244,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
   it("keeps the panel's cap evidence even when the rails go too", async () => {
     const rails: Record<string, unknown> = {};
     for (let i = 0; i < 60; i++) rails[`slot_${i}`] = { id: -10 - i, name: "x".repeat(60) };
-    const { payload } = await runQueryGraph(
+    const { payload, res } = await runQueryGraph(
       { max_chars: 500 },
       panelReply({
         groups: 200,
@@ -246,7 +263,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
 
   it("keeps the subgraph rails until last — groups go before boundary wiring", async () => {
     const reply = panelReply({ groups: 30, membersPerGroup: 200, rails: true });
-    const { payload } = await runQueryGraph({ max_chars: 2000 }, reply);
+    const { payload, res } = await runQueryGraph({ max_chars: 2000 }, reply);
     expect(payload.groups).toBeUndefined();
     expect(payload.rails).toBeDefined();
     expect(payload.rails_omitted).toBeUndefined();
@@ -255,7 +272,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
   it("drops the rails too rather than break the bound, and says how to get them back", async () => {
     const rails: Record<string, unknown> = {};
     for (let i = 0; i < 60; i++) rails[`slot_${i}`] = { id: -10 - i, name: "x".repeat(60) };
-    const { payload, text } = await runQueryGraph(
+    const { payload, text, res } = await runQueryGraph(
       { max_chars: 500 },
       panelReply({ groups: 5, rails: false, extra: { rails }, text: "0 match(es)" }),
     );
@@ -266,7 +283,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
     // At the 500 FLOOR the sentences explaining what was dropped are themselves larger
     // than the budget. They are not cut — a silently missing rider is the defect — so
     // the reply must say plainly that it overran, and why.
-    assertBoundHonoured(payload, text, 500);
+    assertBoundHonoured(payload, res, 500);
     // The notes, not the rows, are the overflow here — so the note must NOT send the
     // caller off to narrow a query or lower a budget that cannot shrink them.
     expect(String(payload.budget_overrun)).toMatch(/note\(s\) above saying which context was dropped/);
@@ -280,7 +297,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
     // discarding that would be answering a different question — so the overrun is
     // DISCLOSED with the real number rather than papered over.
     const rows = "row\n".repeat(400); // ~1600 chars against a 1000-char budget
-    const { payload, text } = await runQueryGraph(
+    const { payload, text, res } = await runQueryGraph(
       { max_chars: 1000 },
       panelReply({ groups: 4, text: rows }),
     );
@@ -313,7 +330,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
     // A FALSE truncation costs the same round trip as a silent one and teaches distrust
     // of a complete result (#809). Nothing here is over budget, so nothing may be cut.
     const reply = panelReply({ groups: 2, membersPerGroup: 3, rails: true });
-    const { payload, text } = await runQueryGraph({ max_chars: CEILING }, reply);
+    const { payload, text, res } = await runQueryGraph({ max_chars: CEILING }, reply);
     expect(text.length).toBeLessThanOrEqual(CEILING);
     expect((payload.groups as unknown[]).length).toBe(2);
     expect((payload.groups as Array<Record<string, unknown>>)[0].node_ids).toEqual([1000, 1001, 1002]);
@@ -326,9 +343,9 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
 
   it("keeps a rider-free reply intact, adding only the budget it was fitted to", async () => {
     const reply = { total: 3, matched: 0, shown: 0, truncated: false, text: "0 match(es)" };
-    const { payload, text } = await runQueryGraph({ max_chars: 500 }, reply);
+    const { payload, text, res } = await runQueryGraph({ max_chars: 500 }, reply);
     expect(payload).toEqual({ ...reply, max_chars: 500 });
-    assertBoundHonoured(payload, text, 500);
+    assertBoundHonoured(payload, res, 500);
   });
 
   describe("every reply is measured, including the ones with nothing to shed", () => {
@@ -344,9 +361,9 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
         truncated: false,
         text: "x".repeat(2000),
       };
-      const { payload, text } = await runQueryGraph({ max_chars: 900 }, reply);
+      const { payload, text, res } = await runQueryGraph({ max_chars: 900 }, reply);
       expect(payload.text).toBe(reply.text);
-      assertBoundHonoured(payload, text, 900);
+      assertBoundHonoured(payload, res, 900);
       expect(String(payload.budget_overrun)).toMatch(/rows answering your query are \d+ chars/);
       // With no riders there really was nothing to drop, so the plain claim is true —
       // which is what keeps the guarded wording above from being blanket hedging.
@@ -357,19 +374,19 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       // A future panel field is not a rider this code knows how to shed, but it is
       // still part of what the caller receives — so it must at least be COUNTED, and
       // the shortfall admitted, rather than sailing past the bound unremarked.
-      const { payload, text } = await runQueryGraph(
+      const { payload, text, res } = await runQueryGraph(
         { max_chars: 900 },
         { total: 1, shown: 0, text: "0 match(es)", some_future_index: "z".repeat(2000) },
       );
       expect(payload.some_future_index).toBe("z".repeat(2000));
-      assertBoundHonoured(payload, text, 900);
+      assertBoundHonoured(payload, res, 900);
     });
 
     it("counts an oversized `viewing`, which identifies the graph and is never shed", async () => {
       // Subgraph titles are user-controlled and unbounded. `viewing` says WHICH graph
       // the answer describes, so dropping it would make the whole reply ambiguous — it
       // is kept, counted, and the overrun stated.
-      const { payload, text } = await runQueryGraph(
+      const { payload, text, res } = await runQueryGraph(
         { max_chars: 900 },
         {
           viewing: { scope: "subgraph", owner_node_id: 12, title: "T".repeat(3000) },
@@ -379,7 +396,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
         },
       );
       expect((payload.viewing as { title: string }).title).toHaveLength(3000);
-      assertBoundHonoured(payload, text, 900);
+      assertBoundHonoured(payload, res, 900);
 
       // And the overrun note must not BLAME the rows for it (codex gate r3). The rows
       // here are 11 characters; calling 3000 of subgraph title "the rows that answer
@@ -397,7 +414,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       // groups". Deleting it saved nothing and turned that stated zero into an absent
       // field, and then let the overrun note claim nothing had been discarded when a
       // field had (codex gate r7).
-      const { payload, text } = await runQueryGraph(
+      const { payload, text, res } = await runQueryGraph(
         { max_chars: 900 },
         {
           viewing: { scope: "subgraph", owner_node_id: 1, title: "T".repeat(3000) },
@@ -408,12 +425,66 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
         },
       );
       expect(payload.groups).toEqual([]);
-      assertBoundHonoured(payload, text, 900);
+      assertBoundHonoured(payload, res, 900);
       expect(String(payload.budget_overrun)).toMatch(/Nothing was discarded to meet the budget/);
     });
 
+    it("counts EVERY text block, not just the one carrying the JSON", async () => {
+      // Measuring the first block and leaving the rest untouched is this issue's own
+      // defect relocated to the block list: a small fitted payload reporting
+      // `max_chars` with an unmeasured 100k block riding beside it (independent gate
+      // P0). "The last place the reply is touched" has to mean the whole reply.
+      const reply = { total: 1, shown: 1, truncated: false, text: "#42 KSampler" };
+      // Alone, this payload fits 500 easily and is passed through with no complaint.
+      const alone = await runQueryGraph({ max_chars: 500 }, reply);
+      expect(alone.text.length).toBeLessThanOrEqual(500);
+      expect(alone.payload.budget_overrun).toBeUndefined();
+
+      const { payload, res } = await runQueryGraph({ max_chars: 500 }, reply, [
+        { type: "text", text: "S".repeat(100_000) },
+      ]);
+      expect(replyChars(res)).toBeGreaterThan(100_000);
+      const overrun = String(payload.budget_overrun);
+      expect(overrun, "an unmeasured sibling block escaped the budget").toMatch(
+        /over `max_chars`=500/,
+      );
+      // The figure is the WHOLE reply, and the siblings are named rather than folded
+      // silently into "everything else".
+      expect(Number(/This reply is (\d+) chars/.exec(overrun)?.[1])).toBe(replyChars(res));
+      expect(overrun).toMatch(/1 further text block\(s\) carrying 100000 chars/);
+    });
+
+    it("counts sibling blocks on the FITTING path too, rather than only when it overruns", async () => {
+      // A reply whose JSON fits alone but not once the sibling is counted must shed its
+      // riders exactly as if those bytes had been in the JSON — the sibling is the ONLY
+      // difference between these two runs.
+      const reply = panelReply({ groups: 3, membersPerGroup: 60 });
+      const alone = await runQueryGraph({ max_chars: 4000 }, reply);
+      expect(alone.payload.groups).toHaveLength(3);
+      expect((alone.payload.groups as Array<Record<string, unknown>>)[0].node_ids).toBeDefined();
+      expect(alone.payload.groups_membership_omitted).toBeUndefined();
+      assertBoundHonoured(alone.payload, alone.res, 4000);
+
+      const { payload, res } = await runQueryGraph({ max_chars: 4000 }, reply, [
+        { type: "text", text: "S".repeat(2000) },
+      ]);
+      expect(payload.groups_membership_omitted ?? payload.groups_omitted).toBeDefined();
+      assertBoundHonoured(payload, res, 4000);
+    });
+
+    it("discloses non-text blocks rather than silently leaving them out of the figure", async () => {
+      const { payload, res } = await runQueryGraph(
+        { max_chars: 500 },
+        { total: 1, shown: 1, truncated: false, text: "x".repeat(2000) },
+        [{ type: "image", data: "AAAA" }],
+      );
+      expect(String(payload.budget_overrun)).toMatch(
+        /1 non-text block\(s\), whose bytes `max_chars` does not bound/,
+      );
+    });
+
     it("discloses an over-budget aggregate (group_by) reply", async () => {
-      const { payload, text } = await runQueryGraph(
+      const { payload, text, res } = await runQueryGraph(
         { max_chars: 700, group_by: "type" },
         {
           viewing: { scope: "root" },
@@ -425,12 +496,12 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
           text: "900 node(s) across 300 type(s):\n" + "12× SomeNodeType\n".repeat(80),
         },
       );
-      assertBoundHonoured(payload, text, 700);
+      assertBoundHonoured(payload, res, 700);
     });
 
     it("discloses an over-budget seed-not-found reply", async () => {
       // The early returns carry no riders at all, and used to bypass the fitter.
-      const { payload, text } = await runQueryGraph(
+      const { payload, text, res } = await runQueryGraph(
         { max_chars: 500, upstream_of: 999 },
         {
           total: 690,
@@ -441,19 +512,44 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
           text: `upstream_of node ${"9".repeat(1200)} not found (690 nodes in view).`,
         },
       );
-      assertBoundHonoured(payload, text, 500);
+      assertBoundHonoured(payload, res, 500);
     });
+  });
+
+  it("re-derives its own markers instead of carrying an inbound one through", async () => {
+    // `budget_overrun` and the omission notes are fields THIS accounting authors. An
+    // arriving copy is a claim from a different measurement: carried through, a reply
+    // that FITS would still announce that it does not — a false positive on the one
+    // marker that has to be trustworthy, and a caller who learns to distrust it will
+    // ignore the real ones (independent gate P0).
+    const { payload, text, res } = await runQueryGraph(
+      { max_chars: 4000 },
+      {
+        total: 1,
+        shown: 1,
+        truncated: false,
+        text: "#42 KSampler",
+        budget_overrun: "This reply is 99999 chars, over `max_chars`=500",
+        groups_omitted: "stale claim from somewhere else",
+        rails_omitted: "likewise",
+      },
+    );
+    expect(text.length).toBeLessThanOrEqual(4000);
+    expect(payload.budget_overrun).toBeUndefined();
+    expect(payload.groups_omitted).toBeUndefined();
+    expect(payload.rails_omitted).toBeUndefined();
+    assertBoundHonoured(payload, res, 4000);
   });
 
   it("reports the budget it ENFORCED, not one the panel happened to mention", async () => {
     // Deferring to a panel-supplied `max_chars` reports a bound nothing checked: a
     // reply fitted to 4000 announcing 3777 looks compliant at 3900 (codex gate SEVERE).
-    const { payload, text } = await runQueryGraph(
+    const { payload, text, res } = await runQueryGraph(
       { max_chars: 4000 },
       panelReply({ groups: 2, membersPerGroup: 2, extra: { max_chars: 3777 } }),
     );
     expect(payload.max_chars).toBe(4000);
-    assertBoundHonoured(payload, text, 4000);
+    assertBoundHonoured(payload, res, 4000);
   });
 
   it("leaves an error reply alone", async () => {
@@ -470,7 +566,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       const reply = panelReply({ groups: 20, membersPerGroup: 60 });
       const needed = JSON.stringify(reply, null, 2).length;
       expect(needed).toBeLessThan(CEILING); // a raise CAN hold it
-      const { payload } = await runQueryGraph({ max_chars: 4000 }, reply);
+      const { payload, res } = await runQueryGraph({ max_chars: 4000 }, reply);
       const note = String(payload.groups_membership_omitted ?? payload.groups_omitted);
       expect(note).toMatch(/raise `max_chars` \(up to 60000\)/);
     });
@@ -481,7 +577,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       // explaining the first one.
       const reply = panelReply({ groups: 200, membersPerGroup: 200 });
       expect(JSON.stringify(reply, null, 2).length).toBeGreaterThan(CEILING);
-      const { payload } = await runQueryGraph({ max_chars: 4000 }, reply);
+      const { payload, res } = await runQueryGraph({ max_chars: 4000 }, reply);
       const note = String(payload.groups_omitted ?? payload.groups_membership_omitted);
       expect(note).toMatch(/past `max_chars`'s ceiling of 60000/);
       expect(note).toMatch(/no combination of raising it and narrowing/);
@@ -519,13 +615,13 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       const reply = panelReply({ groups: 45, membersPerGroup: 40, text: "r".repeat(30000) });
       expect(JSON.stringify(reply, null, 2).length).toBeGreaterThan(CEILING);
       expect(JSON.stringify({ ...reply, text: "" }, null, 2).length).toBeLessThan(CEILING);
-      const { payload } = await runQueryGraph({ max_chars: 4000 }, reply);
+      const { payload, res } = await runQueryGraph({ max_chars: 4000 }, reply);
       const note = String(payload.groups_omitted ?? payload.groups_membership_omitted);
       expect(note).toMatch(/raise `max_chars` \(up to 60000\) AND narrow the query/);
     });
 
     it("says the budget is maxed instead of telling a caller at the ceiling to raise it", async () => {
-      const { payload } = await runQueryGraph(
+      const { payload, res } = await runQueryGraph(
         { max_chars: CEILING },
         panelReply({ groups: 200, membersPerGroup: 200 }),
       );

--- a/src/__tests__/orchestrator/query-graph-budget.test.ts
+++ b/src/__tests__/orchestrator/query-graph-budget.test.ts
@@ -262,7 +262,12 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
     const overrun = payload.budget_overrun as string;
     expect(typeof overrun).toBe("string");
     expect(overrun).toMatch(/over `max_chars`=1000/);
-    expect(overrun).toMatch(/Nothing was discarded to meet the budget/);
+    // …and it must NOT say "nothing was discarded" while `groups_omitted` two fields up
+    // says the groups were (codex gate r4). A contradiction that plain gets resolved by
+    // distrusting both notes.
+    expect(payload.groups_omitted).toBeDefined();
+    expect(overrun).not.toMatch(/Nothing was discarded/);
+    expect(overrun).toMatch(/already has been, and the note\(s\) above record it/);
     // The rows really ARE the bulk here, so the note may say so and may offer the two
     // levers that shrink them.
     const rows_ = Number(/rows answering your query are (\d+) chars/.exec(overrun)?.[1]);
@@ -316,6 +321,9 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       expect(payload.text).toBe(reply.text);
       assertBoundHonoured(payload, text, 900);
       expect(String(payload.budget_overrun)).toMatch(/rows answering your query are \d+ chars/);
+      // With no riders there really was nothing to drop, so the plain claim is true —
+      // which is what keeps the guarded wording above from being blanket hedging.
+      expect(String(payload.budget_overrun)).toMatch(/Nothing was discarded to meet the budget/);
     });
 
     it("counts a field it has never seen before", async () => {

--- a/src/__tests__/orchestrator/query-graph-budget.test.ts
+++ b/src/__tests__/orchestrator/query-graph-budget.test.ts
@@ -1,0 +1,343 @@
+// #807 — panel_query_graph's `groups[]` membership lists were UNBUDGETED riders.
+//
+// Reported live by eicosaproton on a 690-node workflow: "the output keeps getting
+// truncated by groups before reaching node details." The panel bounded the `text` field
+// to `max_chars` and nothing else; `groups` (id, title, box geometry and every member
+// node id) and the subgraph `rails` rode alongside it under separate FIXED caps, and
+// were serialized BEFORE the rows the caller had asked for. So a reply that announced
+// "truncated at 12 of 690 by max_chars=12000" could hand back an order of magnitude
+// more than that, and the model reading it concluded the tool could not show it node
+// detail rather than retrying with a bigger budget.
+//
+// The property under test is NOT "something got truncated" — a size assertion alone
+// passes via the wrong path. It is that the budget the reply REPORTS describes the reply
+// it is attached to, and that what gets shed to achieve that is the CONTEXT, never the
+// rows that answer the query.
+import { describe, expect, it } from "vitest";
+import { buildPanelToolDefs } from "../../orchestrator/panel-tools.js";
+import type { PanelToolCtx } from "../../orchestrator/panel-tools.js";
+
+const DEFAULT_MAX_CHARS = 12000;
+const CEILING = 60000;
+
+/** Run the REAL panel_query_graph def against a stubbed panel reply, and hand back both
+ *  the parsed payload and the exact text a caller would receive. */
+async function runQueryGraph(
+  args: Record<string, unknown>,
+  reply: Record<string, unknown>,
+): Promise<{ payload: Record<string, unknown>; text: string }> {
+  const d = buildPanelToolDefs().find((t) => t.name === "panel_query_graph");
+  expect(d, "panel_query_graph is not a panel tool").toBeTruthy();
+  const res = await d!.handler(args, {
+    call: async () => ({
+      // The same shape the bridge produces: pretty-printed JSON, riders first.
+      content: [{ type: "text" as const, text: JSON.stringify(reply, null, 2) }],
+    }),
+  } as unknown as PanelToolCtx);
+  const block = res.content.find((c) => c.type === "text") as { text: string } | undefined;
+  expect(block, "panel_query_graph returned no text block").toBeTruthy();
+  return { payload: JSON.parse(block!.text) as Record<string, unknown>, text: block!.text };
+}
+
+/** A group as the panel actually summarizes one (summarizeGroup in comfyui-mcp-panel.js):
+ *  id, title, color, box geometry, the true node_count and the member id list. */
+function group(id: number, members: number): Record<string, unknown> {
+  return {
+    id,
+    title: `REGION ${id} — sampling and refinement`,
+    color: "#3f789e",
+    bounding: [id * 100, id * 40, 1280, 720],
+    node_count: members,
+    node_ids: Array.from({ length: members }, (_, i) => id * 1000 + i),
+  };
+}
+
+/** The panel's own reply shape for a graph query: riders FIRST, answer last. */
+function panelReply(opts: {
+  groups?: number;
+  membersPerGroup?: number;
+  rails?: boolean;
+  text?: string;
+  extra?: Record<string, unknown>;
+}): Record<string, unknown> {
+  const { groups = 0, membersPerGroup = 200, rails = false, text = "1 match(es)\n#42 KSampler" } = opts;
+  return {
+    viewing: { kind: "root", workflow: "big.json" },
+    ...(groups ? { groups: Array.from({ length: groups }, (_, i) => group(i + 1, membersPerGroup)) } : {}),
+    ...(rails
+      ? { rails: { input: { id: -10, slots: ["model", "positive"] }, output: { id: -20, slots: ["IMAGE"] } } }
+      : {}),
+    ...opts.extra,
+    total: 690,
+    candidates: 690,
+    matched: 1,
+    shown: 1,
+    truncated: false,
+    truncated_by: null,
+    text,
+  };
+}
+
+/** Every key the payload carries, in serialization order. */
+const keyOrder = (payload: Record<string, unknown>): string[] => Object.keys(payload);
+
+/**
+ * THE invariant, in one place: the reply either FITS the budget it reports, or SAYS it
+ * does not, naming that same budget. A silent overrun is the fabricated observation this
+ * issue is about; a silent under-report of the budget would be the same defect inverted.
+ */
+function assertBoundHonoured(
+  payload: Record<string, unknown>,
+  text: string,
+  budget: number,
+): void {
+  expect(payload.max_chars, "the reply must report the budget it was fitted to").toBe(budget);
+  if (payload.budget_overrun === undefined) {
+    expect(text.length, "no overrun was declared, so the reply must fit").toBeLessThanOrEqual(budget);
+  } else {
+    expect(String(payload.budget_overrun)).toContain(`\`max_chars\`=${budget}`);
+    expect(text.length, "an overrun was declared on a reply that actually fits").toBeGreaterThan(budget);
+  }
+}
+
+describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
+  it("the reported budget describes the actual payload, not just the rows", async () => {
+    // The exact reported failure: a 690-node graph with many groups. Before the fix the
+    // riders alone rendered to ~100k characters next to a `max_chars` of 12000.
+    const reply = panelReply({ groups: 40, membersPerGroup: 200 });
+    const unbudgeted = JSON.stringify(reply, null, 2).length;
+    expect(unbudgeted, "fixture is too small to exercise the defect").toBeGreaterThan(
+      DEFAULT_MAX_CHARS * 5,
+    );
+
+    const { payload, text } = await runQueryGraph({}, reply);
+
+    // The two halves of the claim, asserted together — either alone passes via the
+    // wrong path. `max_chars` is what the reply SAYS its bound is; text.length is what
+    // the caller actually receives.
+    expect(payload.max_chars).toBe(DEFAULT_MAX_CHARS);
+    expect(text.length).toBeLessThanOrEqual(DEFAULT_MAX_CHARS);
+  });
+
+  it("honours an explicit max_chars, clamped exactly as the panel clamps it", async () => {
+    const reply = panelReply({ groups: 40 });
+    for (const [asked, expected] of [
+      [20000, 20000],
+      [1, 500], // below the floor
+      [999999, CEILING], // above the ceiling
+    ] as const) {
+      const { payload, text } = await runQueryGraph({ max_chars: asked }, reply);
+      assertBoundHonoured(payload, text, expected);
+    }
+  });
+
+  it("spends the budget on the ROWS first — the answer is never cut to fit the riders", async () => {
+    // The rows are the answer to the question that was asked. A budget that trades them
+    // for contextual extras answers a different question than the caller put.
+    const rows = "1 match(es) of 690 in scope\n" + JSON.stringify({ id: 42, type: "KSampler" });
+    const { payload } = await runQueryGraph({ max_chars: 2000 }, panelReply({ groups: 40, text: rows }));
+    expect(payload.text).toBe(rows);
+    expect(payload.shown).toBe(1);
+    expect(payload.matched).toBe(1);
+  });
+
+  it("serializes the riders AFTER the answer, never before it", async () => {
+    // "…truncated by groups before reaching node details" was literal: the panel emits
+    // the riders first, so an agent reading top-down met the rosters before its answer.
+    const { payload } = await runQueryGraph({ max_chars: CEILING }, panelReply({ groups: 2, membersPerGroup: 3, rails: true }));
+    const order = keyOrder(payload);
+    expect(order.indexOf("text")).toBeLessThan(order.indexOf("groups"));
+    expect(order.indexOf("text")).toBeLessThan(order.indexOf("rails"));
+    expect(order.indexOf("shown")).toBeLessThan(order.indexOf("groups"));
+  });
+
+  it("sheds RESOLUTION before COVERAGE: every group stays listed, membership goes first", async () => {
+    // Half a group list reads as "this graph has that many groups". A complete index
+    // without member ids does not, and it still answers "which groups exist".
+    const reply = panelReply({ groups: 30, membersPerGroup: 120 });
+    const { payload, text } = await runQueryGraph({ max_chars: 8000 }, reply);
+
+    const groups = payload.groups as Array<Record<string, unknown>>;
+    expect(Array.isArray(groups)).toBe(true);
+    expect(groups).toHaveLength(30); // coverage intact
+    for (const g of groups) {
+      expect(g.node_ids).toBeUndefined(); // resolution shed
+      expect(g.bounding).toBeUndefined();
+      expect(g.node_count).toBe(120); // …and the true size still stated
+      expect(typeof g.id).toBe("number");
+    }
+    expect(payload.groups_membership_omitted).toMatch(/all 30 group\(s\)/);
+    expect(payload.groups_membership_omitted).toMatch(/never dropped to make room/);
+    expect(text.length).toBeLessThanOrEqual(8000);
+  });
+
+  it("drops the group index only when the index itself will not fit, and says how many", async () => {
+    const reply = panelReply({ groups: 200, membersPerGroup: 200 });
+    const { payload, text } = await runQueryGraph({ max_chars: 1500 }, reply);
+
+    expect(payload.groups).toBeUndefined();
+    expect(payload.groups_omitted).toMatch(/all 200 group\(s\)/);
+    expect(text.length).toBeLessThanOrEqual(1500);
+  });
+
+  it("does not pass off the panel's own capped group list as the graph's total", async () => {
+    // The panel caps `groups` at 200 before the orchestrator ever sees it. Saying "all
+    // 200 groups" there would report a number nobody observed.
+    const reply = panelReply({
+      groups: 200,
+      membersPerGroup: 200,
+      extra: { groups_truncated: true, groups_truncation_hint: "Showing 200 of 640 group(s)…" },
+    });
+    const { payload } = await runQueryGraph({ max_chars: 1500 }, reply);
+    expect(payload.groups_omitted).toMatch(/not the graph's total/);
+    expect(payload.groups_omitted).not.toMatch(/all 200 group\(s\)/);
+  });
+
+  it("keeps the subgraph rails until last — groups go before boundary wiring", async () => {
+    const reply = panelReply({ groups: 30, membersPerGroup: 200, rails: true });
+    const { payload } = await runQueryGraph({ max_chars: 2000 }, reply);
+    expect(payload.groups).toBeUndefined();
+    expect(payload.rails).toBeDefined();
+    expect(payload.rails_omitted).toBeUndefined();
+  });
+
+  it("drops the rails too rather than break the bound, and says how to get them back", async () => {
+    const rails: Record<string, unknown> = {};
+    for (let i = 0; i < 60; i++) rails[`slot_${i}`] = { id: -10 - i, name: "x".repeat(60) };
+    const { payload, text } = await runQueryGraph(
+      { max_chars: 500 },
+      panelReply({ groups: 5, rails: false, extra: { rails }, text: "0 match(es)" }),
+    );
+    expect(payload.rails).toBeUndefined();
+    expect(payload.rails_omitted).toMatch(/panel_query_graph/);
+    // At the 500 FLOOR the sentences explaining what was dropped are themselves larger
+    // than the budget. They are not cut — a silently missing rider is the defect — so
+    // the reply must say plainly that it overran, and why.
+    assertBoundHonoured(payload, text, 500);
+    // The notes, not the rows, are the overflow here — so the note must NOT send the
+    // caller off to narrow a query or lower a budget that cannot shrink them.
+    expect(String(payload.budget_overrun)).toMatch(/the rest is the note\(s\) above/);
+    expect(String(payload.budget_overrun)).toMatch(/no parameter shrinks them/);
+    expect(String(payload.budget_overrun)).not.toMatch(/narrow the query/);
+  });
+
+  it("reports the TRUE size when the rows alone overrun, instead of standing on a bound that did not hold", async () => {
+    // The panel fits `text` to `max_chars`; JSON framing and escaping sit on top of it.
+    // With every rider already gone there is nothing left to shed but the answer, and
+    // discarding that would be answering a different question — so the overrun is
+    // DISCLOSED with the real number rather than papered over.
+    const rows = "row\n".repeat(400); // ~1600 chars against a 1000-char budget
+    const { payload, text } = await runQueryGraph(
+      { max_chars: 1000 },
+      panelReply({ groups: 4, text: rows }),
+    );
+    expect(payload.text).toBe(rows); // the answer survives intact
+    expect(payload.groups).toBeUndefined();
+    const overrun = payload.budget_overrun as string;
+    expect(typeof overrun).toBe("string");
+    expect(overrun).toMatch(/over `max_chars`=1000/);
+    expect(overrun).toMatch(/never discarded to meet a budget/);
+    // The stated size must be the size of the thing the caller is holding, within the
+    // handful of characters the note's own digits move it by. A round number pulled out
+    // of the air would pass a "mentions a number" assertion and fail this one.
+    const claimed = Number(/This reply is ~(\d+) chars/.exec(overrun)?.[1]);
+    expect(Number.isFinite(claimed)).toBe(true);
+    expect(Math.abs(text.length - claimed)).toBeLessThan(600);
+  });
+
+  it("leaves a reply that already fits completely alone — no shedding, no notes", async () => {
+    // A FALSE truncation costs the same round trip as a silent one and teaches distrust
+    // of a complete result (#809). Nothing here is over budget, so nothing may be cut.
+    const reply = panelReply({ groups: 2, membersPerGroup: 3, rails: true });
+    const { payload, text } = await runQueryGraph({ max_chars: CEILING }, reply);
+    expect(text.length).toBeLessThanOrEqual(CEILING);
+    expect((payload.groups as unknown[]).length).toBe(2);
+    expect((payload.groups as Array<Record<string, unknown>>)[0].node_ids).toEqual([1000, 1001, 1002]);
+    expect(payload.rails).toEqual(reply.rails);
+    expect(payload.groups_membership_omitted).toBeUndefined();
+    expect(payload.groups_omitted).toBeUndefined();
+    expect(payload.rails_omitted).toBeUndefined();
+    expect(payload.budget_overrun).toBeUndefined();
+  });
+
+  it("passes a rider-free reply straight through, untouched", async () => {
+    // Nothing rides alongside the answer, so there is no accounting to apply and no
+    // reason to rewrite the panel's reply at all.
+    const reply = { total: 3, matched: 0, shown: 0, truncated: false, text: "0 match(es)" };
+    const { payload } = await runQueryGraph({ max_chars: 500 }, reply);
+    expect(payload).toEqual(reply);
+    expect(payload.max_chars).toBeUndefined();
+  });
+
+  it("never overwrites a max_chars the panel reported itself", async () => {
+    // A newer panel that does its own whole-reply accounting knows better than this
+    // rider what budget it actually worked to.
+    const { payload } = await runQueryGraph(
+      { max_chars: 4000 },
+      panelReply({ groups: 2, membersPerGroup: 2, extra: { max_chars: 3777 } }),
+    );
+    expect(payload.max_chars).toBe(3777);
+  });
+
+  it("leaves an error reply alone", async () => {
+    const d = buildPanelToolDefs().find((t) => t.name === "panel_query_graph")!;
+    const res = await d.handler({ max_chars: 500 }, {
+      call: async () => ({ content: [{ type: "text" as const, text: "Error: no connected tab" }], isError: true }),
+    } as unknown as PanelToolCtx);
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toBe("Error: no connected tab");
+  });
+
+  describe("the remedy is actionable from where the caller actually is", () => {
+    it("names a raise with its real ceiling when a raise would in fact help", async () => {
+      const reply = panelReply({ groups: 20, membersPerGroup: 60 });
+      const needed = JSON.stringify(reply, null, 2).length;
+      expect(needed).toBeLessThan(CEILING); // a raise CAN hold it
+      const { payload } = await runQueryGraph({ max_chars: 4000 }, reply);
+      const note = String(payload.groups_membership_omitted ?? payload.groups_omitted);
+      expect(note).toMatch(/raise `max_chars` \(up to 60000\)/);
+    });
+
+    it("does NOT offer a raise the ceiling could never satisfy", async () => {
+      // 200 groups × 200 member ids renders to far past 60000. "Raise max_chars up to
+      // 60000" there is a guaranteed second failure — a dead retry inside the message
+      // explaining the first one.
+      const reply = panelReply({ groups: 200, membersPerGroup: 200 });
+      expect(JSON.stringify(reply, null, 2).length).toBeGreaterThan(CEILING);
+      const { payload } = await runQueryGraph({ max_chars: 4000 }, reply);
+      const note = String(payload.groups_omitted ?? payload.groups_membership_omitted);
+      expect(note).toMatch(/past `max_chars`'s ceiling of 60000/);
+      expect(note).toMatch(/will NOT bring them back/);
+      expect(note).not.toMatch(/raise `max_chars` \(up to/);
+    });
+
+    it("says the budget is maxed instead of telling a caller at the ceiling to raise it", async () => {
+      const { payload } = await runQueryGraph(
+        { max_chars: CEILING },
+        panelReply({ groups: 200, membersPerGroup: 200 }),
+      );
+      const note = String(payload.groups_omitted ?? payload.groups_membership_omitted);
+      expect(note).toMatch(/already at its ceiling of 60000/);
+      expect(note).not.toMatch(/raise `max_chars`/);
+    });
+
+    it("only suggests narrowing the query when narrowing could actually free the room", async () => {
+      // Rows of 4000 chars against a deficit of ~2000: cutting rows can close it.
+      const canHelp = await runQueryGraph(
+        { max_chars: 8000 },
+        panelReply({ groups: 8, membersPerGroup: 40, text: "r".repeat(4000) }),
+      );
+      expect(String(canHelp.payload.groups_membership_omitted ?? canHelp.payload.groups_omitted)).toMatch(
+        /Narrowing this query/,
+      );
+
+      // Groups alone dwarf the budget: with two rows to give back, "ask for less" is a
+      // dead retry however aggressively the caller narrows.
+      const cannotHelp = await runQueryGraph(
+        { max_chars: 1000 },
+        panelReply({ groups: 200, membersPerGroup: 200, text: "#42 KSampler" }),
+      );
+      expect(String(cannotHelp.payload.groups_omitted)).not.toMatch(/Narrowing this query/);
+    });
+  });
+});

--- a/src/__tests__/orchestrator/query-graph-budget.test.ts
+++ b/src/__tests__/orchestrator/query-graph-budget.test.ts
@@ -242,9 +242,9 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
     assertBoundHonoured(payload, text, 500);
     // The notes, not the rows, are the overflow here — so the note must NOT send the
     // caller off to narrow a query or lower a budget that cannot shrink them.
-    expect(String(payload.budget_overrun)).toMatch(/the rest is the note\(s\) above/);
-    expect(String(payload.budget_overrun)).toMatch(/no parameter shrinks them/);
-    expect(String(payload.budget_overrun)).not.toMatch(/narrow the query/);
+    expect(String(payload.budget_overrun)).toMatch(/note\(s\) above saying which context was dropped/);
+    expect(String(payload.budget_overrun)).toMatch(/act on the ROWS ONLY/);
+    expect(String(payload.budget_overrun)).toMatch(/no parameter shrinks the rest/);
   });
 
   it("reports the TRUE size when the rows alone overrun, instead of standing on a bound that did not hold", async () => {
@@ -262,7 +262,12 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
     const overrun = payload.budget_overrun as string;
     expect(typeof overrun).toBe("string");
     expect(overrun).toMatch(/over `max_chars`=1000/);
-    expect(overrun).toMatch(/never discarded to meet a budget/);
+    expect(overrun).toMatch(/Nothing was discarded to meet the budget/);
+    // The rows really ARE the bulk here, so the note may say so and may offer the two
+    // levers that shrink them.
+    const rows_ = Number(/rows answering your query are (\d+) chars/.exec(overrun)?.[1]);
+    expect(rows_).toBeGreaterThan(1000);
+    expect(overrun).toMatch(/lower `max_chars` \(floor 500\)/);
     // EXACTLY the size of the thing the caller is holding, this note included. A size
     // measured before the note was added would understate the reply by the length of
     // the sentence claiming to have counted everything (codex gate MAJOR), and a round
@@ -310,7 +315,7 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       const { payload, text } = await runQueryGraph({ max_chars: 900 }, reply);
       expect(payload.text).toBe(reply.text);
       assertBoundHonoured(payload, text, 900);
-      expect(String(payload.budget_overrun)).toMatch(/render to \d+ chars on their own/);
+      expect(String(payload.budget_overrun)).toMatch(/rows answering your query are \d+ chars/);
     });
 
     it("counts a field it has never seen before", async () => {
@@ -340,6 +345,16 @@ describe("#807 — panel_query_graph's budget covers the WHOLE reply", () => {
       );
       expect((payload.viewing as { title: string }).title).toHaveLength(3000);
       assertBoundHonoured(payload, text, 900);
+
+      // And the overrun note must not BLAME the rows for it (codex gate r3). The rows
+      // here are 11 characters; calling 3000 of subgraph title "the rows that answer
+      // your query" and then offering to shrink them names two levers that cannot
+      // touch the field responsible — the dead retry this accounting exists to remove.
+      const note = String(payload.budget_overrun);
+      expect(note).toMatch(/rows answering your query are 1[0-9] chars/);
+      expect(note).toMatch(/act on the ROWS ONLY/);
+      expect(note).toMatch(/no parameter shrinks the rest/);
+      expect(note).not.toMatch(/for a smaller reply lower `max_chars`/);
     });
 
     it("discloses an over-budget aggregate (group_by) reply", async () => {

--- a/src/__tests__/tools/list-workflows-recursive.test.ts
+++ b/src/__tests__/tools/list-workflows-recursive.test.ts
@@ -158,6 +158,24 @@ describe("#810 — list_workflows sees the whole library, subfolders included", 
     expect(text).toMatch(/Found 3 workflow\(s\)/);
   });
 
+  it("claims subfolder coverage only where the listing itself proves it", async () => {
+    // Asking for `recurse=true` proves what was REQUESTED, not what answered (codex
+    // gate r10). A name carrying a folder is the listing proving it recursed, so there
+    // the claim is observed; with every name at the root there is no such proof, and
+    // an accidental wrong URL/port returning a shallow list is the nonempty form of
+    // this very issue — so that reply says which reading to trust and how to tell.
+    const nested = await listWorkflows();
+    expect(nested).toMatch(/Subfolders ARE included/);
+    expect(nested).toMatch(/proving it recursed/);
+
+    forcedEntries = ["a.json", "b.json"];
+    const flat = await listWorkflows();
+    expect(flat).toMatch(/Found 2 workflow\(s\)/);
+    expect(flat).not.toMatch(/Subfolders ARE included/);
+    expect(flat).toMatch(/Every name here sits at the library root/);
+    expect(flat).toMatch(/not reaching that ComfyUI/);
+  });
+
   it("an EMPTY subfolder contributes nothing and breaks nothing", async () => {
     const text = await listWorkflows();
     expect(text).not.toContain("Empty Folder");

--- a/src/__tests__/tools/list-workflows-recursive.test.ts
+++ b/src/__tests__/tools/list-workflows-recursive.test.ts
@@ -204,8 +204,16 @@ describe("#810 — an unread library is never reported as an empty one", () => {
     mkdirSync(join(userRoot, "workflows"));
     const text = await listWorkflows();
     expect(text).toMatch(/No saved workflows found/);
-    expect(text).toMatch(/reported an empty workflow library/);
-    expect(text).toMatch(/subfolders included/);
+    expect(text).toMatch(/empty list/);
+    // The subfolder coverage is stated as the CONDITION it rests on, not asserted flat
+    // (codex gate r5): "(subfolders included)" would be an unverifiable claim printed
+    // next to the exact wrong answer this issue is about. It holds because ComfyUI's
+    // `recurse` shipped in the same commit as the library — a build without it 404s
+    // instead — and the one way that ground fails is something else answering the API,
+    // which the message names.
+    expect(text).toMatch(/every ComfyUI build that has this library supports recursion/);
+    expect(text).toMatch(/not reaching that ComfyUI/);
+    expect(text).toMatch(/before recreating anything/);
   });
 
   it("distinguishes a library directory that does not exist yet", async () => {

--- a/src/__tests__/tools/list-workflows-recursive.test.ts
+++ b/src/__tests__/tools/list-workflows-recursive.test.ts
@@ -22,6 +22,8 @@ let userRoot = "";
 let forcedStatus: number | null = null;
 /** Force the transport to fail before any Response exists. */
 let forcedThrow: string | null = null;
+/** Force the listing body to be exactly this array, bypassing the tree walk. */
+let forcedEntries: unknown[] | null = null;
 /** Every route the tool actually requested, so the shallow spelling cannot creep back. */
 const requested: string[] = [];
 
@@ -62,6 +64,7 @@ function handle(rawUrl: string): Response {
     }
     const recurse = (url.searchParams.get("recurse") ?? "").toLowerCase() === "true";
     const split = (url.searchParams.get("split") ?? "").toLowerCase() === "true";
+    if (forcedEntries) return Response.json(forcedEntries);
     const files = listFiles(path, recurse);
     return Response.json(split ? files.map((f) => [f, ...f.split("/")]) : files);
   }
@@ -126,6 +129,7 @@ beforeEach(() => {
   userRoot = mkdtempSync(join(tmpdir(), "comfyui-userdata-"));
   forcedStatus = null;
   forcedThrow = null;
+  forcedEntries = null;
   requested.length = 0;
   const wf = join(userRoot, "workflows");
   mkdirSync(join(wf, "IMAGE"), { recursive: true });
@@ -210,9 +214,34 @@ describe("#810 — an unread library is never reported as an empty one", () => {
     // with the reason attached rather than left as a bare "none".
     rmSync(join(userRoot, "workflows"), { recursive: true, force: true });
     const text = await listWorkflows();
-    expect(text).toMatch(/No saved workflows found/);
+    expect(text).toMatch(/No workflows to list/);
     expect(text).toMatch(/HTTP 404/);
-    expect(text).toMatch(/nothing has been saved/);
+    expect(text).toMatch(/not there right now/);
+    // …but a 404 proves the directory is missing NOW, not that nothing was ever saved,
+    // and not that this call even reached the userdata API. Reporting it as a verdict
+    // on the library is what would send someone to recreate a workflow they still have.
+    expect(text).toMatch(/do NOT recreate/);
+    expect(text).toMatch(/different --user-directory/);
+  });
+
+  it("does not call a listing of UNRECOGNISED entries an empty library", async () => {
+    // `[{}]` decodes to zero names but is not zero workflows: each undecodable entry is
+    // a file that EXISTS and cannot be named here.
+    forcedEntries = [{}, { size: 12 }];
+    const text = await listWorkflows();
+    expect(text).toMatch(/Could NOT read the workflow library/);
+    expect(text).toMatch(/2 entry\(ies\)/);
+    expect(text).not.toMatch(/No saved workflows found/);
+    expect(text).toMatch(/do not create or overwrite/);
+  });
+
+  it("says the list may be short when SOME entries could not be named", async () => {
+    forcedEntries = ["IMAGE/portrait.json", {}, 42];
+    const text = await listWorkflows();
+    expect(text).toMatch(/Found 1 workflow\(s\)/);
+    expect(text).toContain("IMAGE/portrait.json");
+    expect(text).toMatch(/2 further entry\(ies\)/);
+    expect(text).toMatch(/this list may be short/);
   });
 
   it("refuses to call a REFUSED listing empty", async () => {

--- a/src/__tests__/tools/list-workflows-recursive.test.ts
+++ b/src/__tests__/tools/list-workflows-recursive.test.ts
@@ -173,7 +173,13 @@ describe("#810 — list_workflows sees the whole library, subfolders included", 
     expect(flat).toMatch(/Found 2 workflow\(s\)/);
     expect(flat).not.toMatch(/Subfolders ARE included/);
     expect(flat).toMatch(/Every name here sits at the library root/);
-    expect(flat).toMatch(/not reaching that ComfyUI/);
+    // Root-only names are NOT proof that no subfolders exist — they are also what a
+    // read that never recursed looks like. Both readings are offered; neither is
+    // asserted (codex gate r11).
+    expect(flat).toMatch(/cannot tell apart from a subfolder read that did not happen/);
+    expect(flat).toMatch(/the usual reading is/);
+    expect(flat).toMatch(/check the URL\/port/);
+    expect(flat).not.toMatch(/that means it has no workflow subfolders/);
   });
 
   it("an EMPTY subfolder contributes nothing and breaks nothing", async () => {

--- a/src/__tests__/tools/list-workflows-recursive.test.ts
+++ b/src/__tests__/tools/list-workflows-recursive.test.ts
@@ -224,7 +224,11 @@ describe("#810 — an unread library is never reported as an empty one", () => {
     const text = await listWorkflows();
     expect(text).toMatch(/No workflows to list/);
     expect(text).toMatch(/HTTP 404/);
-    expect(text).toMatch(/not there right now/);
+    // The STATUS is the observation; "the directory is not there" is an inference from
+    // it, and a proxy 404 or a mismatched base path makes that inference false. The two
+    // must stay apart (codex gate r8).
+    expect(text).toMatch(/the answer it gives for a directory it does not have/);
+    expect(text).toMatch(/all this call observed, not a verdict on your library/);
     // …but a 404 proves the directory is missing NOW, not that nothing was ever saved,
     // and not that this call even reached the userdata API. Reporting it as a verdict
     // on the library is what would send someone to recreate a workflow they still have.
@@ -273,7 +277,11 @@ describe("#810 — an unread library is never reported as an empty one", () => {
     forcedThrow = "socket hang up";
     const text = await listWorkflows();
     expect(text).toMatch(/Could NOT read the workflow library/);
-    expect(text).toMatch(/never reached the server/);
+    // Not "the request never arrived" — a reply lost after ComfyUI had already listed
+    // the directory looks identical from here. What was observed is the absence of a
+    // response (codex gate r8).
+    expect(text).toMatch(/no response came back/);
+    expect(text).toMatch(/learned nothing about the library either way/);
     expect(text).not.toMatch(/No saved workflows found/);
   });
 });

--- a/src/__tests__/tools/list-workflows-recursive.test.ts
+++ b/src/__tests__/tools/list-workflows-recursive.test.ts
@@ -223,21 +223,23 @@ describe("#810 — list_workflows sees the whole library, subfolders included", 
 });
 
 describe("#810 — an unread library is never reported as an empty one", () => {
-  it("says the library is EMPTY only when the server actually said so", async () => {
+  it("does not call an empty listing an empty library — an empty answer proves nothing about its own coverage", async () => {
     rmSync(join(userRoot, "workflows"), { recursive: true, force: true });
     mkdirSync(join(userRoot, "workflows"));
     const text = await listWorkflows();
-    expect(text).toMatch(/No saved workflows found/);
+    // An EMPTY list is the one answer with no evidence about its own coverage: asking
+    // for `recurse=true` says what was REQUESTED, and a responder that ignored it
+    // returns exactly this for a library whose workflows are all in folders — #810
+    // itself, moved one layer out (independent gate P0). So the verdict headline is
+    // withheld and the open question is stated, with the check that settles it.
+    expect(text).toMatch(/Could NOT confirm the workflow library is empty/);
+    expect(text).not.toMatch(/No saved workflows found/);
     expect(text).toMatch(/empty list/);
-    // The subfolder coverage is stated as the CONDITION it rests on, not asserted flat
-    // (codex gate r5): "(subfolders included)" would be an unverifiable claim printed
-    // next to the exact wrong answer this issue is about. It holds because ComfyUI's
-    // `recurse` shipped in the same commit as the library — a build without it 404s
-    // instead — and the one way that ground fails is something else answering the API,
-    // which the message names.
-    expect(text).toMatch(/every ComfyUI build that has this library supports recursion/);
-    expect(text).toMatch(/not reaching that ComfyUI/);
-    expect(text).toMatch(/before recreating anything/);
+    expect(text).toMatch(/carries no name to tell those apart/);
+    expect(text).toMatch(/CHECK THE COMFYUI SIDEBAR/);
+    expect(text).toMatch(/do not\s+recreate them/);
+    // …and it still tells a user with a genuinely empty library what to do next.
+    expect(text).toMatch(/save one from the/);
   });
 
   it("distinguishes a library directory that does not exist yet", async () => {

--- a/src/__tests__/tools/list-workflows-recursive.test.ts
+++ b/src/__tests__/tools/list-workflows-recursive.test.ts
@@ -1,0 +1,242 @@
+// #810 — list_workflows read the library SHALLOWLY and reported the result as empty.
+//
+// The reporter had six workflows saved, all of them filed under `IMAGE/` and
+// `VIDEO/MiniMaxH3/` — the folder tree the ComfyUI web UI sidebar shows — and
+// list_workflows answered "No saved workflows found." That is the repo's dominant
+// defect class wearing its most expensive hat: "could not determine X" rendered as
+// "determined X is not the case", where acting on the wrong answer means recreating a
+// workflow that already exists.
+//
+// The listing is exercised against a REAL directory tree through a stand-in for
+// ComfyUI's own `listuserdata` endpoint (app/user_manager.py), reimplemented here with
+// its documented semantics: `recurse=true` globs `<dir>/**\/*`, non-files are skipped,
+// and each entry is the path relative to `dir` with "/" separators. A fixture list of
+// strings would pass whether or not the request ever asked to recurse.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync, statSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
+
+let userRoot = "";
+/** Force the listing endpoint to answer with this status instead of reading the tree. */
+let forcedStatus: number | null = null;
+/** Force the transport to fail before any Response exists. */
+let forcedThrow: string | null = null;
+/** Every route the tool actually requested, so the shallow spelling cannot creep back. */
+const requested: string[] = [];
+
+/** Files under `dir`, mirroring ComfyUI's glob: `**\/*` when recursing, `*` otherwise,
+ *  keeping only regular files. Directories — including empty ones — never appear. */
+function listFiles(dir: string, recurse: boolean): string[] {
+  const out: string[] = [];
+  const walk = (d: string, depth: number): void => {
+    for (const name of readdirSync(d)) {
+      const full = join(d, name);
+      if (statSync(full).isDirectory()) {
+        if (recurse) walk(full, depth + 1);
+        continue;
+      }
+      out.push(relative(dir, full).split(sep).join("/"));
+    }
+  };
+  walk(dir, 0);
+  return out;
+}
+
+/** ComfyUI's userdata endpoints, over a real directory tree. */
+function handle(rawUrl: string): Response {
+  if (forcedThrow) throw new Error(forcedThrow);
+  const url = new URL(rawUrl, "http://comfy.local");
+  requested.push(url.pathname + url.search);
+
+  if (url.pathname === "/api/userdata") {
+    if (forcedStatus != null) {
+      return new Response("nope", { status: forcedStatus, headers: { "content-type": "text/plain" } });
+    }
+    const dir = url.searchParams.get("dir") ?? "";
+    if (!dir) return new Response("Directory not provided", { status: 400 });
+    const path = join(userRoot, dir);
+    // The endpoint 404s a directory that does not exist — it does not invent an empty list.
+    if (!existsSync(path)) {
+      return new Response("Directory not found", { status: 404, headers: { "content-type": "text/plain" } });
+    }
+    const recurse = (url.searchParams.get("recurse") ?? "").toLowerCase() === "true";
+    const split = (url.searchParams.get("split") ?? "").toLowerCase() === "true";
+    const files = listFiles(path, recurse);
+    return Response.json(split ? files.map((f) => [f, ...f.split("/")]) : files);
+  }
+
+  const file = url.pathname.startsWith("/api/userdata/")
+    ? decodeURIComponent(url.pathname.slice("/api/userdata/".length))
+    : null;
+  if (file != null) {
+    const path = join(userRoot, file);
+    if (!existsSync(path) || statSync(path).isDirectory()) {
+      return new Response("Not found", { status: 404, headers: { "content-type": "text/plain" } });
+    }
+    return new Response(readFileSync(path, "utf8"), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+  return new Response("unhandled", { status: 500 });
+}
+
+vi.mock("../../comfyui/client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../comfyui/client.js")>();
+  return {
+    ...actual,
+    getClient: () => ({
+      apiURL: (route: string) => `http://comfy.local${route}`,
+      apiHeaders: () => ({ "Comfy-User": "default" }),
+      fetch: async (url: string) => handle(url),
+      // The library client's real contract: throw for any non-2xx, decoding the body as
+      // JSON while building the error — which is why the listing does NOT use it.
+      fetchApi: async (route: string) => {
+        const res = handle(`http://comfy.local${route}`);
+        if (!res.ok) throw new Error(`Endpoint Bad Request (${res.status}): ${route}`);
+        return res;
+      },
+    }),
+  };
+});
+
+const { registerWorkflowLibraryTools } = await import("../../tools/workflow-library.js");
+
+type ToolResult = { isError?: boolean; content: Array<{ type: string; text: string }> };
+type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+
+function tools(): Map<string, ToolHandler> {
+  const handlers = new Map<string, ToolHandler>();
+  registerWorkflowLibraryTools({
+    tool: (name: string, _d: string, _s: unknown, handler: ToolHandler) => handlers.set(name, handler),
+  } as never);
+  return handlers;
+}
+
+const listWorkflows = async (): Promise<string> =>
+  (await tools().get("list_workflows")!({})).content[0].text;
+
+// A name with characters that must survive URL encoding on the way back to the server:
+// spaces, an ampersand, a hash, a plus and non-ASCII.
+const AWKWARD_DIR = "Weird & Nested #1/ünïcode + space";
+const AWKWARD_FILE = `${AWKWARD_DIR}/my workflow (v2).json`;
+
+beforeEach(() => {
+  userRoot = mkdtempSync(join(tmpdir(), "comfyui-userdata-"));
+  forcedStatus = null;
+  forcedThrow = null;
+  requested.length = 0;
+  const wf = join(userRoot, "workflows");
+  mkdirSync(join(wf, "IMAGE"), { recursive: true });
+  mkdirSync(join(wf, "VIDEO", "MiniMaxH3"), { recursive: true });
+  // An EMPTY subfolder: a directory entry the walk must skip, not report or trip on.
+  mkdirSync(join(wf, "Empty Folder"), { recursive: true });
+  mkdirSync(join(wf, AWKWARD_DIR), { recursive: true });
+  const graph = JSON.stringify({ nodes: [], links: [] });
+  writeFileSync(join(wf, "IMAGE", "portrait.json"), graph);
+  writeFileSync(join(wf, "VIDEO", "MiniMaxH3", "video_minimax_h3_t2v.json"), graph);
+  writeFileSync(join(wf, AWKWARD_FILE), JSON.stringify({ nodes: [{ id: 7 }], links: [] }));
+});
+
+afterEach(() => {
+  rmSync(userRoot, { recursive: true, force: true });
+});
+
+describe("#810 — list_workflows sees the whole library, subfolders included", () => {
+  it("lists workflows that exist only in subfolders instead of reporting none", async () => {
+    // The reported repro exactly: nothing at the top level, everything in folders.
+    const text = await listWorkflows();
+    expect(text).not.toMatch(/No saved workflows found/);
+    expect(text).toContain("IMAGE/portrait.json");
+    expect(text).toContain("VIDEO/MiniMaxH3/video_minimax_h3_t2v.json");
+    expect(text).toContain(AWKWARD_FILE);
+    expect(text).toMatch(/Found 3 workflow\(s\)/);
+  });
+
+  it("an EMPTY subfolder contributes nothing and breaks nothing", async () => {
+    const text = await listWorkflows();
+    expect(text).not.toContain("Empty Folder");
+    expect(text).toMatch(/Found 3 workflow\(s\)/);
+  });
+
+  it("still lists root-level workflows — the recursive listing is a superset", async () => {
+    // A fix that traded root entries for nested ones would swap one wrong "not found"
+    // for another.
+    writeFileSync(join(userRoot, "workflows", "top_level.json"), "{}");
+    const text = await listWorkflows();
+    expect(text).toContain("top_level.json");
+    expect(text).toContain("IMAGE/portrait.json");
+    expect(text).toMatch(/Found 4 workflow\(s\)/);
+  });
+
+  it("reports names that get_workflow can load back verbatim, escaping and all", async () => {
+    // The listing is only useful if its output is accepted where it is meant to be used.
+    // A name with spaces, `&`, `#`, `+` and non-ASCII has to survive the round trip
+    // through encodeURIComponent to reach the same file on disk.
+    const text = await listWorkflows();
+    const name = text
+      .split("\n")
+      .map((l) => l.replace(/^\d+\.\s*/, ""))
+      .find((l) => l.endsWith("my workflow (v2).json"));
+    expect(name).toBe(AWKWARD_FILE);
+
+    const loaded = await tools().get("get_workflow")!({ filename: name!, format: "ui" });
+    expect(loaded.isError).toBeFalsy();
+    expect(JSON.parse(loaded.content[0].text)).toEqual({ nodes: [{ id: 7 }], links: [] });
+  });
+
+  it("asks the server to recurse — and only ever asks once", async () => {
+    await listWorkflows();
+    expect(requested).toHaveLength(1);
+    expect(requested[0]).toContain("recurse=true");
+    expect(requested[0]).toContain("dir=workflows");
+  });
+});
+
+describe("#810 — an unread library is never reported as an empty one", () => {
+  it("says the library is EMPTY only when the server actually said so", async () => {
+    rmSync(join(userRoot, "workflows"), { recursive: true, force: true });
+    mkdirSync(join(userRoot, "workflows"));
+    const text = await listWorkflows();
+    expect(text).toMatch(/No saved workflows found/);
+    expect(text).toMatch(/reported an empty workflow library/);
+    expect(text).toMatch(/subfolders included/);
+  });
+
+  it("distinguishes a library directory that does not exist yet", async () => {
+    // ComfyUI 404s a directory it does not have. For the workflow library that IS a
+    // determined negative — nothing has ever been saved — and it is worded as one,
+    // with the reason attached rather than left as a bare "none".
+    rmSync(join(userRoot, "workflows"), { recursive: true, force: true });
+    const text = await listWorkflows();
+    expect(text).toMatch(/No saved workflows found/);
+    expect(text).toMatch(/HTTP 404/);
+    expect(text).toMatch(/nothing has been saved/);
+  });
+
+  it("refuses to call a REFUSED listing empty", async () => {
+    // A proxy 403, an auth failure, a 500: none of them are evidence about what is
+    // saved. Reporting them as "no workflows" is what sends a user to recreate a
+    // workflow they already have — and, worse, to overwrite it.
+    for (const status of [401, 403, 500, 502]) {
+      forcedStatus = status;
+      const text = await listWorkflows();
+      expect(text, `HTTP ${status}`).toMatch(/Could NOT read the workflow library/);
+      expect(text, `HTTP ${status}`).toContain(`HTTP ${status}`);
+      expect(text, `HTTP ${status}`).not.toMatch(/No saved workflows found/);
+      expect(text, `HTTP ${status}`).toMatch(/do not create or overwrite one/);
+    }
+  });
+
+  it("refuses to call an UNREACHABLE server empty", async () => {
+    // No Response object ever exists — the server was never reached. That is the one
+    // outcome that says nothing at all about the library, so it must not be dressed as
+    // an answer about it.
+    forcedThrow = "socket hang up";
+    const text = await listWorkflows();
+    expect(text).toMatch(/Could NOT read the workflow library/);
+    expect(text).toMatch(/never reached the server/);
+    expect(text).not.toMatch(/No saved workflows found/);
+  });
+});

--- a/src/__tests__/tools/truncation-remedies.test.ts
+++ b/src/__tests__/tools/truncation-remedies.test.ts
@@ -878,12 +878,53 @@ describe("#809 truncation remedies name a lever that actually exists", () => {
     expect(handlerSrc).not.toContain("To read the rest");
   });
 
-  it("discloses that groups/rails ride outside the max_chars accounting", () => {
-    // Fixing that accounting is #807. This issue's job is that the CURRENT behaviour is
-    // stated: a caller lowering max_chars and still overflowing must know why.
+  it("no longer advertises groups/rails as riding outside the max_chars accounting", () => {
+    // #807 folded them in, so the #809-era disclosure would now be false. A budget the
+    // description says covers only `text` sends a caller lowering max_chars looking for
+    // a second knob that no longer exists.
     const d = buildPanelToolDefs().find((t) => t.name === "panel_query_graph");
-    expect(d!.description).toMatch(/bounds the `text` field ONLY/);
-    expect(d!.description).toMatch(/#807/);
+    expect(d!.description).not.toMatch(/bounds the `text` field ONLY/);
+    expect(d!.description).toMatch(/`max_chars` bounds the WHOLE result/);
+  });
+
+  it("#807 — every note the whole-reply budget emits names a real lever of this tool", async () => {
+    // The budget accounting added for #807 emits four new strings, and each of them is a
+    // remedy in exactly the sense this file polices. They go through the SAME schema-driven
+    // check as everything else, so a note that backticks a RESPONSE FIELD (`node_ids`,
+    // `groups`) as though it were a parameter, or points at a tool that is not registered,
+    // fails here rather than costing a caller a round trip.
+    const groups = Array.from({ length: 40 }, (_, i) => ({
+      id: i,
+      title: `REGION ${i}`,
+      color: "#333",
+      bounding: [0, 0, 100, 100],
+      node_count: 200,
+      node_ids: Array.from({ length: 200 }, (_, n) => i * 1000 + n),
+    }));
+    const base = { total: 690, matched: 1, shown: 1, truncated: false, text: "#42 KSampler" };
+
+    for (const [where, args, reply] of [
+      // Membership shed, with a raise that WOULD fit.
+      ["membership", { max_chars: 4000 }, { ...base, groups: groups.slice(0, 6) }],
+      // Group index shed, with a raise that could never fit.
+      ["index", { max_chars: 1500 }, { ...base, groups }],
+      // Caller already at the ceiling.
+      ["ceiling", { max_chars: 60000 }, { ...base, groups }],
+      // Rails shed and the reply still over the bound.
+      ["rails", { max_chars: 500 }, { ...base, groups, rails: { input: { id: -10 } } }],
+    ] as Array<[string, Record<string, unknown>, Record<string, unknown>]>) {
+      const payload = await runPanelTool("panel_query_graph", args, reply);
+      const notes = [
+        payload.groups_membership_omitted,
+        payload.groups_omitted,
+        payload.rails_omitted,
+        payload.budget_overrun,
+      ].filter((n): n is string => typeof n === "string");
+      expect(notes.length, `${where}: the budget shed content without saying so`).toBeGreaterThan(0);
+      for (const note of notes) {
+        assertRemedyIsActionable("panel_query_graph", `panel_query_graph #807 (${where})`, note);
+      }
+    }
   });
 
   it("never clobbers a hint the panel itself supplied", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1552,10 +1552,17 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
         ? `Both levers act on the rows, so for a smaller reply lower \`max_chars\` (floor ${QUERY_GRAPH_MAX_CHARS_FLOOR}) or narrow the query with \`ids\`/\`types\`/\`where\`/\`limit\`.`
         : `\`max_chars\` is already at its floor of ${QUERY_GRAPH_MAX_CHARS_FLOOR}, so narrow the query with \`ids\`/\`types\`/\`where\`/\`limit\` for a smaller reply.`
       : `Lowering \`max_chars\` and narrowing the query both act on the ROWS ONLY, and everything else here is already ${floorWithNotes} chars on its own — so neither would bring this reply under the budget, and no parameter shrinks the rest.`;
+  // "Nothing was discarded" is FALSE next to a groups_omitted note saying exactly what
+  // was (codex gate r4). Two fields down, that contradiction is the kind a reader
+  // resolves by distrusting both. Say which of the two situations this is.
+  const shedSomething = hasGroups || hasRails;
   const overrun = (size: number): string =>
     `This reply is ${size} chars, over \`max_chars\`=${budget} — that figure counts the JSON framing and escaping, and this note itself. ` +
     `Of it, the rows answering your query are ${rowsChars} chars; the remaining ${size - rowsChars} is the fields identifying the graph this came from, anything else the panel sent, and the note(s) above saying which context was dropped. ` +
-    `Nothing was discarded to meet the budget: the rows are your answer, and a silently missing rider — or a silently missing explanation of one — is the defect this accounting exists to prevent. ` +
+    (shedSomething
+      ? `The context that COULD be dropped for the budget already has been, and the note(s) above record it; what remains was not cut down any further. `
+      : `Nothing was discarded to meet the budget — there was no context to drop. `) +
+    `The rows are your answer, and a silently short answer — or a silently missing rider, or a silently missing explanation of one — is the defect this accounting exists to prevent. ` +
     shrink;
   // The stated size must include the statement (codex gate MAJOR), so solve for it: the
   // note only grows the payload, and only its own digit count feeds back, so this

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1530,22 +1530,33 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
       recovery(render(noGroups).length, floorOf(withoutGroups));
   }
 
-  // Every rider is gone and it STILL does not fit. What is left is the rows plus the
-  // sentences saying what was dropped, and neither may be silently cut — so the overrun
-  // is DISCLOSED with the real number rather than left standing behind a `max_chars`
-  // that did not hold. Which of the two is responsible decides the remedy: telling a
-  // caller to narrow a query when the notes are the overflow is the same dead retry
-  // this whole accounting exists to prevent.
-  const answerChars = render(answer).length;
+  // Every rider is gone and it STILL does not fit. What is left is the rows, the fields
+  // that say which graph they came from, and the sentences saying what was dropped —
+  // none of which may be silently cut, so the overrun is DISCLOSED with the real number
+  // rather than left standing behind a `max_chars` that did not hold.
+  //
+  // WHICH part is responsible has to be measured, not assumed (codex gate MAJOR). The
+  // earlier wording called every non-rider byte "the rows that answer your query" and
+  // then offered to shrink them, which on a reply carrying a 3000-character subgraph
+  // title blamed the wrong field AND named two levers that cannot touch it — the dead
+  // retry this whole accounting exists to prevent. `lower max_chars` and `narrow the
+  // query` both act on the ROWS ONLY, so they are offered only while the rest of the
+  // reply would fit without them.
+  const withoutRows = (p: Record<string, unknown>): Record<string, unknown> =>
+    answer.text !== undefined ? { ...p, text: "" } : p;
+  const rowsChars = render(answer).length - render(withoutRows(answer)).length;
+  const floorWithNotes = render(withoutRows(bare)).length;
   const shrink =
-    budget > QUERY_GRAPH_MAX_CHARS_FLOOR
-      ? `For a smaller reply, lower \`max_chars\` (floor ${QUERY_GRAPH_MAX_CHARS_FLOOR}) or narrow the query with \`ids\`/\`types\`/\`where\`/\`limit\`.`
-      : `\`max_chars\` is already at its floor of ${QUERY_GRAPH_MAX_CHARS_FLOOR}, so narrow the query with \`ids\`/\`types\`/\`where\`/\`limit\` for a smaller reply.`;
+    floorWithNotes <= budget
+      ? budget > QUERY_GRAPH_MAX_CHARS_FLOOR
+        ? `Both levers act on the rows, so for a smaller reply lower \`max_chars\` (floor ${QUERY_GRAPH_MAX_CHARS_FLOOR}) or narrow the query with \`ids\`/\`types\`/\`where\`/\`limit\`.`
+        : `\`max_chars\` is already at its floor of ${QUERY_GRAPH_MAX_CHARS_FLOOR}, so narrow the query with \`ids\`/\`types\`/\`where\`/\`limit\` for a smaller reply.`
+      : `Lowering \`max_chars\` and narrowing the query both act on the ROWS ONLY, and everything else here is already ${floorWithNotes} chars on its own — so neither would bring this reply under the budget, and no parameter shrinks the rest.`;
   const overrun = (size: number): string =>
-    `This reply is ${size} chars, over \`max_chars\`=${budget} (that figure counts the JSON framing and escaping, and this note itself). ` +
-    (answerChars > budget
-      ? `The rows that answer your query render to ${answerChars} chars on their own and are never discarded to meet a budget. ${shrink}`
-      : `The rows render to ${answerChars} chars; the rest is the note(s) above saying which context was dropped, kept deliberately because a silently missing rider is the defect this budget exists to prevent, and no parameter shrinks them.`);
+    `This reply is ${size} chars, over \`max_chars\`=${budget} — that figure counts the JSON framing and escaping, and this note itself. ` +
+    `Of it, the rows answering your query are ${rowsChars} chars; the remaining ${size - rowsChars} is the fields identifying the graph this came from, anything else the panel sent, and the note(s) above saying which context was dropped. ` +
+    `Nothing was discarded to meet the budget: the rows are your answer, and a silently missing rider — or a silently missing explanation of one — is the defect this accounting exists to prevent. ` +
+    shrink;
   // The stated size must include the statement (codex gate MAJOR), so solve for it: the
   // note only grows the payload, and only its own digit count feeds back, so this
   // settles in one or two passes. The loop is bounded and the last pass is emitted

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1451,20 +1451,30 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
    * Response FIELDS are named bare on purpose: backticks here mean "a lever on this
    * tool", and dressing a field as a parameter is that same wasted retry.
    */
+  //
+  // And the ROWS IN HAND may already be a cut set. The panel stops adding rows at this
+  // same `max_chars` and reports `truncated_by:"max_chars"` when it did, so on that path
+  // raising the budget returns MORE ROWS as well — a budget sized to "these rows plus
+  // the riders" is then not enough to keep both, and calling that size "the untruncated
+  // reply" describes a reply nobody has seen (codex gate MAJOR).
+  const rowsCutByBudget = answer.truncated_by === "max_chars";
   const recovery = (needed: number, floor: number): string => {
     const narrow =
       floor <= budget
         ? " Narrowing this query (`ids`/`types`/`where`/`limit`) frees budget for them too."
         : "";
+    const alsoMoreRows = rowsCutByBudget
+      ? " But the panel cut the ROWS at this same budget too, so raising it returns more rows as well and may still not leave room for them — narrow the query (`ids`/`types`/`where`/`limit`) in the same call to be sure."
+      : narrow;
     if (budget >= QUERY_GRAPH_MAX_CHARS_CEILING) {
       return floor <= budget
         ? `\`max_chars\` is already at its ceiling of ${QUERY_GRAPH_MAX_CHARS_CEILING}.${narrow}`
         : `\`max_chars\` is already at its ceiling of ${QUERY_GRAPH_MAX_CHARS_CEILING}, and they need ~${floor} chars even with no matching rows at all, so one reply cannot carry them.`;
     }
     if (needed <= QUERY_GRAPH_MAX_CHARS_CEILING)
-      return `The untruncated reply is ~${needed} chars: raise \`max_chars\` (up to ${QUERY_GRAPH_MAX_CHARS_CEILING}) to about that to keep them.${narrow}`;
+      return `Keeping them alongside THESE rows takes ~${needed} chars: raise \`max_chars\` (up to ${QUERY_GRAPH_MAX_CHARS_CEILING}) to about that.${alsoMoreRows}`;
     if (floor <= QUERY_GRAPH_MAX_CHARS_CEILING)
-      return `The untruncated reply is ~${needed} chars, past this tool's ceiling — but only ~${floor} chars without the matching rows, so raise \`max_chars\` (up to ${QUERY_GRAPH_MAX_CHARS_CEILING}) AND narrow the query (\`ids\`/\`types\`/\`where\`/\`limit\`) together.`;
+      return `Keeping them alongside THESE rows takes ~${needed} chars, past this tool's ceiling — but only ~${floor} chars without the rows, so raise \`max_chars\` (up to ${QUERY_GRAPH_MAX_CHARS_CEILING}) AND narrow the query (\`ids\`/\`types\`/\`where\`/\`limit\`) together.`;
     return `They need ~${floor} chars even with no matching rows at all, past \`max_chars\`'s ceiling of ${QUERY_GRAPH_MAX_CHARS_CEILING}, so no combination of raising it and narrowing this query returns them here.`;
   };
   /** The same reply with the answer rows removed — the floor `recovery` reasons about. */

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1500,17 +1500,25 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
     if (render(p).length <= budget) return replaceWith(p);
   }
 
+  // The panel's OWN cap markers are evidence about the GRAPH, not payload this code is
+  // free to spend: `groups_truncation_hint` is the only place the real group count
+  // ("Showing 200 of 640") survives, so dropping it while dropping the list destroys the
+  // one coverage fact the caller could still have had (codex gate MAJOR). They are two
+  // short fields and they are kept on every rung below the index.
+  const capEvidence: Record<string, unknown> = {};
+  if (riders.groups_truncated !== undefined) capEvidence.groups_truncated = riders.groups_truncated;
+  if (riders.groups_truncation_hint !== undefined)
+    capEvidence.groups_truncation_hint = riders.groups_truncation_hint;
+
   // Rung 2 — the group index itself goes. Its true size is stated in its place.
   const withoutGroups: Record<string, unknown> = { ...riders };
   delete withoutGroups.groups;
-  delete withoutGroups.groups_truncated;
-  delete withoutGroups.groups_truncation_hint;
   const noGroups = assemble(withoutGroups);
   if (hasGroups) {
     // The count we can vouch for is "what this reply carried", not "what the graph has".
     const carried =
       groupsPreCapped
-        ? `the ${groups!.length} group(s) this reply carried (the panel had already capped that list, so that is not the graph's total)`
+        ? `the ${groups!.length} group(s) this reply carried (the panel had already capped that list, so that is not the graph's total — its own groups_truncated / groups_truncation_hint are kept here and record the real figure)`
         : `all ${groups!.length} group(s)`;
     noGroups.groups_omitted =
       `The groups rider was dropped entirely — ${carried} — because the whole reply did not fit \`max_chars\`=${budget} even with their membership already omitted, ` +
@@ -1520,8 +1528,8 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
   }
   if (render(noGroups).length <= budget) return replaceWith(noGroups);
 
-  // Rung 3 — the subgraph rails go too.
-  const bare = assemble({});
+  // Rung 3 — the subgraph rails go too. The cap evidence still rides.
+  const bare = assemble(capEvidence);
   if (hasGroups && noGroups.groups_omitted !== undefined)
     bare.groups_omitted = noGroups.groups_omitted;
   if (hasRails) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -54,6 +54,7 @@ import {
 } from "../services/user-mcp-config.js";
 import { setComfyuiSecret, setAgentSecret, isAllowedAgentSecretKey } from "../services/panel-secrets.js";
 import { flattenUiWorkflow } from "../services/flatten-workflow.js";
+import { listWorkflowLibraryKeys, userdataFetch } from "../services/userdata-library.js";
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
 import { QueueMonitor } from "../services/queue-monitor.js";
 import { RunCompletions } from "./run-completion-journal.js";
@@ -1308,6 +1309,205 @@ function fixedCapHint(
   );
 }
 
+// ---- #807: ONE budget, for the WHOLE panel_query_graph reply ----------------------
+//
+// `max_chars` used to bound the `text` field and nothing else. Everything else in the
+// reply — the `groups` array with each group's full member `node_ids`, and the subgraph
+// `rails` — rode ALONGSIDE it under separate fixed caps, and was serialized BEFORE the
+// rows the caller had asked for. On a 690-node graph that is not a rounding error: at
+// the panel's own caps those riders alone can render to well over 100k characters, so a
+// reply announcing "truncated at 12 of 690 by max_chars=12000" could hand back ten times
+// that. A budget figure that does not describe the actual payload is a fabricated
+// observation, and the agent that reads it concludes the TOOL cannot show it node
+// detail — which is exactly what the reporter's session concluded.
+//
+// The accounting is applied HERE, once, over the finished payload, for the same reason
+// the #809 riders are: this is the last place the reply is touched before the caller
+// sees it, it measures the EXACT string that will be returned (pretty-printed JSON,
+// escaping and all), and it holds against every panel build rather than only the ones
+// that ship after it.
+//
+// Two rules govern what gets shed:
+//   1. The rows that ANSWER THE QUERY are never dropped to make room for context. The
+//      riders are spent from what is left over, and are moved to the END of the object
+//      so the answer is also what a reader meets first.
+//   2. Coverage before resolution, mirroring panel_graph_outline's ladder: dropping
+//      every group's membership still leaves a complete group index, whereas listing
+//      half the groups reads as "this graph has that many groups".
+const QUERY_GRAPH_MAX_CHARS_FLOOR = 500;
+const QUERY_GRAPH_MAX_CHARS_DEFAULT = 12000;
+const QUERY_GRAPH_MAX_CHARS_CEILING = 60000;
+
+/** The panel's own clamp for graph_query's budget, mirrored so the figure this module
+ *  reports and enforces is the one the panel was actually working to. */
+function clampQueryGraphMaxChars(v: unknown): number {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return QUERY_GRAPH_MAX_CHARS_DEFAULT;
+  return Math.min(
+    Math.max(Math.floor(n), QUERY_GRAPH_MAX_CHARS_FLOOR),
+    QUERY_GRAPH_MAX_CHARS_CEILING,
+  );
+}
+
+/** The reply fields that are CONTEXT rather than answer. `viewing` is deliberately not
+ *  one of them: it identifies which graph the answer describes, it is a couple of small
+ *  fields, and a reply that cannot say what it is about is worse than a bigger one. */
+const QUERY_GRAPH_RIDER_KEYS = [
+  "groups_truncated",
+  "groups_truncation_hint",
+  "groups",
+  "rails",
+] as const;
+
+/** A group reduced to its INDEX form: which groups exist, what they are called, and how
+ *  many nodes each holds. Membership and geometry are what grow with the graph. */
+function groupIndexEntry(g: unknown): unknown {
+  if (!g || typeof g !== "object" || Array.isArray(g)) return g;
+  const r = g as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  if ("id" in r) out.id = r.id;
+  if ("title" in r) out.title = r.title;
+  // `node_count` is the group's TRUE size on every panel that reports it. Falling back
+  // to the length of `node_ids` is only sound when that list was not itself clipped —
+  // otherwise the count would understate the group, which is the same lie one rung down.
+  if (typeof r.node_count === "number") out.node_count = r.node_count;
+  else if (Array.isArray(r.node_ids) && r.node_ids_truncated === undefined)
+    out.node_count = r.node_ids.length;
+  return out;
+}
+
+/**
+ * Fit the WHOLE panel_query_graph reply inside the `max_chars` it advertises, by
+ * shedding CONTEXT — never the rows that answer the query.
+ *
+ * Returns the reply untouched when there is no context to spend a budget on, so a
+ * result that fitted is never dressed up as a truncated one (the false-truncation
+ * defect #809 also exists to remove).
+ */
+function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
+  const payload = parseToolResultJson(res);
+  if (!payload) return res;
+  const idx = res.content.findIndex((c) => c.type === "text");
+  if (idx < 0) return res;
+
+  const budget = clampQueryGraphMaxChars(requested);
+  const render = (p: Record<string, unknown>): string => JSON.stringify(p, null, 2);
+  const replaceWith = (p: Record<string, unknown>): ToolResult => ({
+    ...res,
+    content: res.content.map((c, i) =>
+      i === idx && c.type === "text" ? { ...c, text: render(p) } : c,
+    ),
+  });
+
+  const riderKeys = new Set<string>(QUERY_GRAPH_RIDER_KEYS);
+  const answer: Record<string, unknown> = {};
+  const riders: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(payload)) {
+    if (riderKeys.has(k)) riders[k] = v;
+    else answer[k] = v;
+  }
+  // Echo the budget that governs the WHOLE reply, so the bound is checkable against the
+  // reply itself rather than taken on trust. Never over a value the panel supplied.
+  if (answer.max_chars === undefined) answer.max_chars = budget;
+
+  const groups = Array.isArray(riders.groups) ? (riders.groups as unknown[]) : null;
+  const hasGroups = !!groups && groups.length > 0;
+  const hasRails = riders.rails !== undefined;
+  // Nothing to spend the budget on but the answer: leave the panel's reply alone.
+  if (!hasGroups && !hasRails) return res;
+
+  const full: Record<string, unknown> = { ...answer };
+  for (const k of QUERY_GRAPH_RIDER_KEYS) if (riders[k] !== undefined) full[k] = riders[k];
+  const fullChars = render(full).length;
+  if (fullChars <= budget) return replaceWith(full);
+
+  // How the caller gets the shed context, checked against where they actually are.
+  // "Raise `max_chars`" is a dead retry at the ceiling, and equally dead when even the
+  // ceiling could not hold the full reply — both cost the round trip this exists to save.
+  // Response FIELDS are named bare on purpose: backticks in these strings mean "a lever
+  // on this tool", and dressing a field as a parameter is the same wasted retry.
+  const raise =
+    budget >= QUERY_GRAPH_MAX_CHARS_CEILING
+      ? `\`max_chars\` is already at its ceiling of ${QUERY_GRAPH_MAX_CHARS_CEILING}, so it cannot carry them in one reply.`
+      : fullChars <= QUERY_GRAPH_MAX_CHARS_CEILING
+        ? `The untruncated reply is ~${fullChars} chars: raise \`max_chars\` (up to ${QUERY_GRAPH_MAX_CHARS_CEILING}) to about that to keep them.`
+        : `The untruncated reply is ~${fullChars} chars, past \`max_chars\`'s ceiling of ${QUERY_GRAPH_MAX_CHARS_CEILING}, so raising it will NOT bring them back.`;
+  // Narrowing only frees room when the ROWS are big enough to account for the overflow;
+  // on a graph whose groups alone dwarf the budget, "ask for less" changes nothing.
+  const textChars = typeof answer.text === "string" ? (answer.text as string).length : 0;
+  const narrow =
+    fullChars - budget < textChars
+      ? " Narrowing this query (`ids`/`types`/`where`/`limit`) frees budget for them too."
+      : "";
+  const outline =
+    ` panel_graph_outline's GROUPS index lists every member id — but only while its own max_chars affords a node-level rung; if it reports detail_level:"groups" it gives counts, not ids.`;
+
+  // Rung 1 — every group still listed, membership and geometry gone.
+  if (hasGroups) {
+    const reduced: Record<string, unknown> = { ...answer };
+    if (riders.groups_truncated !== undefined) reduced.groups_truncated = riders.groups_truncated;
+    if (riders.groups_truncation_hint !== undefined)
+      reduced.groups_truncation_hint = riders.groups_truncation_hint;
+    reduced.groups = groups!.map(groupIndexEntry);
+    reduced.groups_membership_omitted =
+      `Member node_ids and box geometry were omitted from all ${groups!.length} group(s) so the WHOLE reply fits \`max_chars\`=${budget} — ` +
+      `the rows answering your query are never dropped to make room for them. Every group is still listed and each node_count is exact. ` +
+      raise +
+      narrow +
+      outline;
+    if (hasRails) reduced.rails = riders.rails;
+    if (render(reduced).length <= budget) return replaceWith(reduced);
+  }
+
+  // Rung 2 — the group index itself goes. Its true size is stated in its place.
+  const noGroups: Record<string, unknown> = { ...answer };
+  if (hasGroups) {
+    // The panel caps its own groups list before we ever see it, so the count we can
+    // vouch for is "what this reply carried", not "what the graph has".
+    const carried =
+      riders.groups_truncated === true
+        ? `the ${groups!.length} group(s) this reply carried (the panel had already capped that list, so that is not the graph's total)`
+        : `all ${groups!.length} group(s)`;
+    noGroups.groups_omitted =
+      `The groups rider was dropped entirely — ${carried} — so the WHOLE reply fits \`max_chars\`=${budget}, ` +
+      `and the rows answering your query are never dropped to make room for it. ` +
+      raise +
+      narrow +
+      outline;
+  }
+  if (hasRails) noGroups.rails = riders.rails;
+  if (render(noGroups).length <= budget) return replaceWith(noGroups);
+
+  // Rung 3 — the subgraph rails go too.
+  const bare: Record<string, unknown> = { ...noGroups };
+  if (hasRails) {
+    delete bare.rails;
+    bare.rails_omitted =
+      `The subgraph boundary rails were dropped so the WHOLE reply fits \`max_chars\`=${budget}. ` +
+      `Re-read them with a narrower query — panel_query_graph {ids:[…], fields:"ids"} on this same subgraph carries them again as soon as the rows leave room.`;
+  }
+  const bareChars = render(bare).length;
+  if (bareChars <= budget) return replaceWith(bare);
+
+  // Every rider is gone and it STILL does not fit. What is left is the rows plus the
+  // sentences saying what was dropped, and neither may be silently cut — so the overrun
+  // is DISCLOSED with the real number rather than left standing behind a `max_chars`
+  // that did not hold. Which of the two is responsible decides the remedy: telling a
+  // caller to narrow a query when the notes are the overflow is the same dead retry
+  // this whole accounting exists to prevent.
+  const answerChars = render(answer).length;
+  const shrink =
+    budget > QUERY_GRAPH_MAX_CHARS_FLOOR
+      ? `For a smaller reply, lower \`max_chars\` (floor ${QUERY_GRAPH_MAX_CHARS_FLOOR}) or narrow the query with \`ids\`/\`types\`/\`where\`/\`limit\`.`
+      : `\`max_chars\` is already at its floor of ${QUERY_GRAPH_MAX_CHARS_FLOOR}, so narrow the query with \`ids\`/\`types\`/\`where\`/\`limit\` for a smaller reply.`;
+  bare.budget_overrun =
+    `This reply is ~${bareChars} chars, over \`max_chars\`=${budget} (the figure counts the JSON framing and escaping). ` +
+    (answerChars > budget
+      ? `The rows that answer your query render to ~${answerChars} chars on their own and are never discarded to meet a budget. ${shrink}`
+      : `The rows render to ~${answerChars} chars; the rest is the note(s) above saying which context was dropped, kept deliberately because a silently missing rider is the defect this budget exists to prevent, and no parameter shrinks them.`);
+  return replaceWith(bare);
+}
+
 // ---- panel_civitai_results inline sample thumbnails (#623) -------------------
 // The agent recommends CivitAI models/LoRAs for a VISUAL medium, so it must be
 // able to SEE the sample images — not just read titles + download counts. The
@@ -2337,29 +2537,10 @@ function comfyWorkflowsDirs(): string[] {
   ];
 }
 
-/**
- * Issue ONE userdata GET and hand back the raw Response.
- *
- * This deliberately bypasses the client's own `fetchApi` (codex/gate MAJOR).
- * `fetchApi` throws for every non-2xx AND calls `response.json()` while building
- * that error — so a refusal with a non-JSON body (a `403 text/plain` from a proxy,
- * an HTML 502) rejects with a STATUSLESS SyntaxError. There is then no way to tell
- * "the server refused" from "the server was never reached", and the resolver's
- * local fallback would re-open for a server that had explicitly refused, loading a
- * different graph (#202).
- *
- * Building the request from the client's own `apiURL` + `apiHeaders` keeps every
- * transport concern identical (host, ssl, base path, clientId, Comfy-User, the
- * injected COMFYUI_AUTH_* fetch) while making the outcome unambiguous:
- *   - a returned Response  = the server ANSWERED; classify by status, decode later
- *   - a thrown error       = no Response exists, so the request never got one
- * Nothing here reads a body, so a body that cannot be decoded can never be
- * mistaken for a transport failure.
- */
-async function userdataFetch(route: string): Promise<Response> {
-  const client = getClient();
-  return await client.fetch(client.apiURL(route), { headers: client.apiHeaders() });
-}
+// The raw-Response userdata GET (why it bypasses `fetchApi`, and what a thrown error
+// vs a returned Response each prove) now lives in services/userdata-library.ts, shared
+// with list_workflows — see #810: the two callers had drifted, one recursing into
+// subfolders and one not.
 
 /**
  * Drop the one leading "workflows/" segment from CALLER input, leaving a key that
@@ -2433,26 +2614,12 @@ const looseName = (name: string): string =>
  * so this needs no version gate.
  */
 async function listUserdataWorkflowKeys(): Promise<string[] | null> {
-  try {
-    const res = await userdataFetch("/api/userdata?dir=workflows&recurse=true");
-    if (!res.ok) return null;
-    const body: unknown = await res.json();
-    if (!Array.isArray(body)) return null;
-    // Tolerate both shapes ComfyUI builds return: bare strings (the default on
-    // 0.29.2), and {path} objects (what full_info=true emits, in case a build
-    // returns that shape by default).
-    return body
-      .map((entry) => {
-        if (typeof entry === "string") return entry;
-        const rec = entry as { path?: unknown; name?: unknown } | null;
-        if (rec && typeof rec.path === "string") return rec.path;
-        if (rec && typeof rec.name === "string") return rec.name;
-        return null;
-      })
-      .filter((k): k is string => typeof k === "string" && k.length > 0);
-  } catch {
-    return null;
-  }
+  // ONE listing read for the whole server (#810): the recursive route, the entry-shape
+  // tolerance and the status classification all live in services/userdata-library.ts.
+  // This resolver only needs "keys, or nothing", so every unreadable flavour collapses
+  // to null here — which is exactly what its refusal path already means.
+  const listing = await listWorkflowLibraryKeys();
+  return listing.ok ? listing.keys : null;
 }
 
 /** Validate a parsed value is a UI/litegraph workflow (a top-level `nodes`
@@ -4485,7 +4652,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
   const defs: PanelToolDef[] = [
     def(
       "panel_query_graph",
-      "FILTER or TRAVERSE a SUBSET of the live canvas, for when you ALREADY KNOW what you're looking for. NOT for 'show me the canvas' or any whole-graph overview — call panel_graph_outline FIRST for that. NOT query_workflow (that queries a saved file or JSON you provide, not the live canvas). Filters, traverses, projects and aggregates over the workflow the user is CURRENTLY VIEWING without dumping the whole graph (replaces the old panel_get_graph full-JSON dump; output is TOKEN-BOUNDED with an explicit truncation marker, so a big graph can never flood your context). Combine: `types` (node type contains any), `title` (contains), `where` widget predicates ANDed ('cfg>7', 'steps<=20', 'sampler_name=euler', 'text~sunset' — ops = != >= <= > < ~contains), `ids` (exact nodes — THE way to read ONE node's exact slot/widget detail: {ids:[42], fields:'detail'}), `upstream_of`/`downstream_of` + `depth` (dependency traversal: upstream = what FEEDS that node, downstream = what CONSUMES it; seed at depth 0), `fields` ('compact' one line per node [default], 'ids', 'detail' = the full node summary with slots + connections + mode), `group_by:'type'` (counts only), `limit` (default 40). detail rows include each node's MODE — a 'bypass' node is skipped and a 'mute' node kills everything downstream, so check modes on the path you care about before running (fix with panel_set_node_mode). Every result also carries `groups` (id, title, member node_ids — groups are geometric, trust this list) and, when viewing a SUBGRAPH (after panel_enter_subgraph), `rails` (boundary rail ids/slots). NOTE: `max_chars` bounds the `text` field ONLY; those two riders are bounded by their own fixed caps and say so in-band when they cut, so lowering `max_chars` shrinks the rows and not the groups list (folding them into one budget is artokun/comfyui-mcp#807). Typical flow: panel_graph_outline to orient → panel_query_graph to pinpoint/inspect → edit. Read-only.",
+      "FILTER or TRAVERSE a SUBSET of the live canvas, for when you ALREADY KNOW what you're looking for. NOT for 'show me the canvas' or any whole-graph overview — call panel_graph_outline FIRST for that. NOT query_workflow (that queries a saved file or JSON you provide, not the live canvas). Filters, traverses, projects and aggregates over the workflow the user is CURRENTLY VIEWING without dumping the whole graph (replaces the old panel_get_graph full-JSON dump; output is TOKEN-BOUNDED with an explicit truncation marker, so a big graph can never flood your context). Combine: `types` (node type contains any), `title` (contains), `where` widget predicates ANDed ('cfg>7', 'steps<=20', 'sampler_name=euler', 'text~sunset' — ops = != >= <= > < ~contains), `ids` (exact nodes — THE way to read ONE node's exact slot/widget detail: {ids:[42], fields:'detail'}), `upstream_of`/`downstream_of` + `depth` (dependency traversal: upstream = what FEEDS that node, downstream = what CONSUMES it; seed at depth 0), `fields` ('compact' one line per node [default], 'ids', 'detail' = the full node summary with slots + connections + mode), `group_by:'type'` (counts only), `limit` (default 40). detail rows include each node's MODE — a 'bypass' node is skipped and a 'mute' node kills everything downstream, so check modes on the path you care about before running (fix with panel_set_node_mode). Every result also carries `groups` (id, title, member node_ids — groups are geometric, trust this list) and, when viewing a SUBGRAPH (after panel_enter_subgraph), `rails` (boundary rail ids/slots). `max_chars` bounds the WHOLE result, those riders included, and the rows you asked for are spent first: on a big graph the riders lose their member ids, then drop out entirely, rather than starving your query — and each says in-band that it did, with the true counts. Typical flow: panel_graph_outline to orient → panel_query_graph to pinpoint/inspect → edit. Read-only.",
       {
         types: z.array(z.string()).optional().describe("Node type contains ANY of these (case-insensitive)."),
         title: z.string().optional().describe("Node title contains this."),
@@ -4520,29 +4687,36 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         max_chars: z
           .number()
           .int()
-          .min(500)
-          .max(60000)
+          .min(QUERY_GRAPH_MAX_CHARS_FLOOR)
+          .max(QUERY_GRAPH_MAX_CHARS_CEILING)
           .optional()
           .describe(
-            "Output character bound for the `text` field (default 12000, max 60000). Raise only for deliberate full reads, e.g. layout passes needing every node's geometry. " +
-              "It bounds `text` ONLY: the `groups` and `rails` riders are bounded separately by their own fixed caps (each marked in-band when it cuts), so lowering this shrinks the rows and not those (artokun/comfyui-mcp#807 tracks folding them into one budget).",
+            `Character bound for the WHOLE result, not just its rows (default ${QUERY_GRAPH_MAX_CHARS_DEFAULT}, max ${QUERY_GRAPH_MAX_CHARS_CEILING}). Raise only for deliberate full reads, e.g. layout passes needing every node's geometry. ` +
+              "The rows answering your query are spent FIRST and are never dropped to fit the contextual groups/rails riders; those are spent from what is left and say in-band when they were reduced or omitted (#807).",
           ),
       },
+      // #807: the reply is fitted to `max_chars` as a WHOLE here — see fitQueryGraphReply.
+      // The panel bounds `text`; the `groups`/`rails` riders were never in that
+      // accounting, so on a large graph the reply could be many times the budget it
+      // announced. Nothing is shed while the whole reply fits.
       async (args: A, ctx) =>
-        ctx.call({
-          cmd: "graph_query",
-          types: args.types,
-          title: args.title,
-          where: args.where,
-          ids: args.ids,
-          upstream_of: args.upstream_of,
-          downstream_of: args.downstream_of,
-          depth: args.depth,
-          fields: args.fields,
-          group_by: args.group_by,
-          limit: args.limit,
-          max_chars: args.max_chars,
-        }),
+        fitQueryGraphReply(
+          await ctx.call({
+            cmd: "graph_query",
+            types: args.types,
+            title: args.title,
+            where: args.where,
+            ids: args.ids,
+            upstream_of: args.upstream_of,
+            downstream_of: args.downstream_of,
+            depth: args.depth,
+            fields: args.fields,
+            group_by: args.group_by,
+            limit: args.limit,
+            max_chars: args.max_chars,
+          }),
+          args.max_chars,
+        ),
     ),
     def(
       "panel_graph_outline",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1359,6 +1359,17 @@ const QUERY_GRAPH_RIDER_KEYS = [
   "rails",
 ] as const;
 
+/** The fields THIS accounting authors. Any inbound copy is dropped before measuring, so
+ *  a stale claim from a different measurement can never ride out as if this one made it
+ *  (independent gate P0). `max_chars` is re-set unconditionally just below. */
+const QUERY_GRAPH_OWNED_KEYS: ReadonlySet<string> = new Set([
+  "max_chars",
+  "groups_membership_omitted",
+  "groups_omitted",
+  "rails_omitted",
+  "budget_overrun",
+]);
+
 /** A group reduced to its INDEX form: which groups exist, what they are called, and how
  *  many nodes each holds. Membership and geometry are what grow with the graph. */
 function groupIndexEntry(g: unknown): unknown {
@@ -1390,9 +1401,12 @@ function groupIndexEntry(g: unknown): unknown {
  *
  * An error or non-JSON reply is passed through untouched. It makes no budget CLAIM —
  * there is no `max_chars` on it to be wrong — and rewriting a failure message to
- * mention a character budget would bury the failure. Non-text content blocks (this tool
- * emits none, but the shape allows them) are preserved and not counted: `max_chars`
- * bounds characters, and calling image bytes characters would be its own false figure.
+ * mention a character budget would bury the failure.
+ *
+ * EVERY text block is counted, not only the one carrying the JSON, and a non-text block
+ * (this tool emits none, but the shape allows them) has its PRESENCE disclosed rather
+ * than silently ignored — `max_chars` bounds characters, and calling image bytes
+ * characters would be its own false figure.
  */
 function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
   const payload = parseToolResultJson(res);
@@ -1401,7 +1415,23 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
   if (idx < 0) return res;
 
   const budget = clampQueryGraphMaxChars(requested);
+  // EVERY text block counts, not just the one carrying the JSON (independent gate P0).
+  // Measuring the first block and leaving the rest untouched is the SAME defect this
+  // function exists to remove — a budget describing one part of a reply while something
+  // rides beside it — relocated from `groups`/`rails` to the block list. A small fitted
+  // payload next to an unmeasured 100k second block would report `max_chars` and no
+  // overrun. "The last place the reply is touched" has to mean the whole reply.
+  const siblingText = res.content.reduce(
+    (n, c, i) => (i !== idx && c.type === "text" ? n + (c.text?.length ?? 0) : n),
+    0,
+  );
+  // Blocks that are not text (this tool emits none, but the shape allows them) are not
+  // counted — `max_chars` bounds characters, and calling image bytes characters would be
+  // its own false figure — so their PRESENCE is disclosed instead of silently ignored.
+  const nonTextBlocks = res.content.filter((c) => c.type !== "text").length;
   const render = (p: Record<string, unknown>): string => JSON.stringify(p, null, 2);
+  /** The whole reply's character count: the fitted JSON plus every sibling text block. */
+  const sizeOf = (p: Record<string, unknown>): number => render(p).length + siblingText;
   const replaceWith = (p: Record<string, unknown>): ToolResult => ({
     ...res,
     content: res.content.map((c, i) =>
@@ -1414,12 +1444,19 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
   const riders: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(payload)) {
     if (riderKeys.has(k)) riders[k] = v;
-    else answer[k] = v;
+    else if (!QUERY_GRAPH_OWNED_KEYS.has(k)) answer[k] = v;
   }
   // The budget this call ENFORCED, always — it is the number the fitting below works
   // to, and it is measured with this field already present. Deferring to a panel-supplied
   // `max_chars` would report a bound nothing checked (codex gate SEVERE): a reply fitted
   // to 4000 could announce 3777 and look compliant at 3900.
+  //
+  // The loop above drops any INBOUND copy of the fields this function authors, for the
+  // same reason (independent gate P0). An arriving `budget_overrun` is a claim from a
+  // different measurement: carried through, a reply that fits after fitting would still
+  // announce that it does not — a false positive on the one marker that has to be
+  // trustworthy, and a caller who learns to distrust it will ignore the real ones. This
+  // accounting is the sole author of these fields, so it is also their sole source.
   answer.max_chars = budget;
 
   const groups = Array.isArray(riders.groups) ? (riders.groups as unknown[]) : null;
@@ -1434,7 +1471,7 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
   };
 
   const full = assemble(riders);
-  const fullChars = render(full).length;
+  const fullChars = sizeOf(full);
   if (fullChars <= budget) return replaceWith(full);
 
   /**
@@ -1479,7 +1516,7 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
   };
   /** The same reply with the answer rows removed — the floor `recovery` reasons about. */
   const floorOf = (r: Record<string, unknown>): number =>
-    render({ ...assemble(r), ...(answer.text !== undefined ? { text: "" } : {}) }).length;
+    sizeOf({ ...assemble(r), ...(answer.text !== undefined ? { text: "" } : {}) });
 
   const outline =
     ` panel_graph_outline's GROUPS index lists every member id — but only while its own max_chars affords a node-level rung; if it reports detail_level:"groups" it gives counts, not ids.`;
@@ -1507,7 +1544,7 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
         : `Every group is still listed and each node_count is exact. `) +
       recovery(fullChars, floorOf(riders)) +
       outline;
-    if (render(p).length <= budget) return replaceWith(p);
+    if (sizeOf(p) <= budget) return replaceWith(p);
   }
 
   // The panel's OWN cap markers are evidence about the GRAPH, not payload this code is
@@ -1541,7 +1578,7 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
       recovery(fullChars, floorOf(riders)) +
       outline;
   }
-  if (render(noGroups).length <= budget) return replaceWith(noGroups);
+  if (sizeOf(noGroups) <= budget) return replaceWith(noGroups);
 
   // Rung 3 — the subgraph rails go too. The cap evidence, and an empty groups
   // observation, still ride.
@@ -1553,7 +1590,7 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
   if (hasRails) {
     bare.rails_omitted =
       `The subgraph boundary rails were dropped because the reply did not fit \`max_chars\`=${budget} without them. ` +
-      recovery(render(noGroups).length, floorOf(withoutGroups));
+      recovery(sizeOf(noGroups), floorOf(withoutGroups));
   }
 
   // Every rider is gone and it STILL does not fit. What is left is the rows, the fields
@@ -1571,7 +1608,7 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
   const withoutRows = (p: Record<string, unknown>): Record<string, unknown> =>
     answer.text !== undefined ? { ...p, text: "" } : p;
   const rowsChars = render(answer).length - render(withoutRows(answer)).length;
-  const floorWithNotes = render(withoutRows(bare)).length;
+  const floorWithNotes = sizeOf(withoutRows(bare));
   const shrink =
     floorWithNotes <= budget
       ? budget > QUERY_GRAPH_MAX_CHARS_FLOOR
@@ -1582,23 +1619,34 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
   // was (codex gate r4). Two fields down, that contradiction is the kind a reader
   // resolves by distrusting both. Say which of the two situations this is.
   const shedSomething = hasGroups || hasRails;
+  // Sibling text blocks are part of the reply and part of the figure, so they are named
+  // rather than folded silently into "everything else" (independent gate P0).
+  const siblings =
+    siblingText > 0
+      ? `${res.content.filter((c, i) => i !== idx && c.type === "text").length} further text block(s) carrying ${siblingText} chars, `
+      : "";
+  const nonText =
+    nonTextBlocks > 0
+      ? ` This reply also carries ${nonTextBlocks} non-text block(s), whose bytes \`max_chars\` does not bound and this figure does not count.`
+      : "";
   const overrun = (size: number): string =>
-    `This reply is ${size} chars, over \`max_chars\`=${budget} — that figure counts the JSON framing and escaping, and this note itself. ` +
-    `Of it, the rows answering your query are ${rowsChars} chars; the remaining ${size - rowsChars} is the fields identifying the graph this came from, anything else the panel sent, and the note(s) above saying which context was dropped. ` +
+    `This reply is ${size} chars, over \`max_chars\`=${budget} — that figure counts the JSON framing and escaping, every text block, and this note itself. ` +
+    `Of it, the rows answering your query are ${rowsChars} chars; the remaining ${size - rowsChars} is ${siblings}the fields identifying the graph this came from, anything else the panel sent, and the note(s) above saying which context was dropped. ` +
     (shedSomething
       ? `The context that COULD be dropped for the budget already has been, and the note(s) above record it; what remains was not cut down any further. `
       : `Nothing was discarded to meet the budget — there was no context to drop. `) +
     `The rows are your answer, and a silently short answer — or a silently missing rider, or a silently missing explanation of one — is the defect this accounting exists to prevent. ` +
-    shrink;
+    shrink +
+    nonText;
   // The stated size must include the statement (codex gate MAJOR), so solve for it: the
   // note only grows the payload, and only its own digit count feeds back, so this
   // settles in one or two passes. The loop is bounded and the last pass is emitted
   // regardless — a size that is a character or two low is still the honest order of
   // magnitude, and the `budget_overrun` field itself is what carries the finding.
-  let claimed = render({ ...bare, budget_overrun: overrun(render(bare).length) }).length;
+  let claimed = sizeOf({ ...bare, budget_overrun: overrun(sizeOf(bare)) });
   for (let i = 0; i < 4; i++) {
     const attempt = { ...bare, budget_overrun: overrun(claimed) };
-    const size = render(attempt).length;
+    const size = sizeOf(attempt);
     if (size === claimed) return replaceWith(attempt);
     claimed = size;
   }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1380,9 +1380,19 @@ function groupIndexEntry(g: unknown): unknown {
  * Fit the WHOLE panel_query_graph reply inside the `max_chars` it advertises, by
  * shedding CONTEXT — never the rows that answer the query.
  *
- * Returns the reply untouched when there is no context to spend a budget on, so a
- * result that fitted is never dressed up as a truncated one (the false-truncation
- * defect #809 also exists to remove).
+ * EVERY reply is measured, including the ones with no riders to shed (codex gate
+ * SEVERE): the early "there is nothing to cut, so skip the accounting" shortcut let a
+ * reply with a large `viewing`, a field this build has never seen, or simply very long
+ * rows exceed the budget it reports with nothing said. There is no third outcome here —
+ * a reply either fits the budget it names or carries `budget_overrun` saying it does
+ * not. Nothing is invented on the way: a result that fits is never dressed up as a
+ * truncated one (the false-truncation defect #809 also exists to remove).
+ *
+ * An error or non-JSON reply is passed through untouched. It makes no budget CLAIM —
+ * there is no `max_chars` on it to be wrong — and rewriting a failure message to
+ * mention a character budget would bury the failure. Non-text content blocks (this tool
+ * emits none, but the shape allows them) are preserved and not counted: `max_chars`
+ * bounds characters, and calling image bytes characters would be its own false figure.
  */
 function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
   const payload = parseToolResultJson(res);
@@ -1406,61 +1416,87 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
     if (riderKeys.has(k)) riders[k] = v;
     else answer[k] = v;
   }
-  // Echo the budget that governs the WHOLE reply, so the bound is checkable against the
-  // reply itself rather than taken on trust. Never over a value the panel supplied.
-  if (answer.max_chars === undefined) answer.max_chars = budget;
+  // The budget this call ENFORCED, always — it is the number the fitting below works
+  // to, and it is measured with this field already present. Deferring to a panel-supplied
+  // `max_chars` would report a bound nothing checked (codex gate SEVERE): a reply fitted
+  // to 4000 could announce 3777 and look compliant at 3900.
+  answer.max_chars = budget;
 
   const groups = Array.isArray(riders.groups) ? (riders.groups as unknown[]) : null;
   const hasGroups = !!groups && groups.length > 0;
   const hasRails = riders.rails !== undefined;
-  // Nothing to spend the budget on but the answer: leave the panel's reply alone.
-  if (!hasGroups && !hasRails) return res;
 
-  const full: Record<string, unknown> = { ...answer };
-  for (const k of QUERY_GRAPH_RIDER_KEYS) if (riders[k] !== undefined) full[k] = riders[k];
+  /** The answer plus whichever riders `r` still carries, riders last. */
+  const assemble = (r: Record<string, unknown>): Record<string, unknown> => {
+    const p: Record<string, unknown> = { ...answer };
+    for (const k of QUERY_GRAPH_RIDER_KEYS) if (r[k] !== undefined) p[k] = r[k];
+    return p;
+  };
+
+  const full = assemble(riders);
   const fullChars = render(full).length;
   if (fullChars <= budget) return replaceWith(full);
 
-  // How the caller gets the shed context, checked against where they actually are.
-  // "Raise `max_chars`" is a dead retry at the ceiling, and equally dead when even the
-  // ceiling could not hold the full reply — both cost the round trip this exists to save.
-  // Response FIELDS are named bare on purpose: backticks in these strings mean "a lever
-  // on this tool", and dressing a field as a parameter is the same wasted retry.
-  const raise =
-    budget >= QUERY_GRAPH_MAX_CHARS_CEILING
-      ? `\`max_chars\` is already at its ceiling of ${QUERY_GRAPH_MAX_CHARS_CEILING}, so it cannot carry them in one reply.`
-      : fullChars <= QUERY_GRAPH_MAX_CHARS_CEILING
-        ? `The untruncated reply is ~${fullChars} chars: raise \`max_chars\` (up to ${QUERY_GRAPH_MAX_CHARS_CEILING}) to about that to keep them.`
-        : `The untruncated reply is ~${fullChars} chars, past \`max_chars\`'s ceiling of ${QUERY_GRAPH_MAX_CHARS_CEILING}, so raising it will NOT bring them back.`;
-  // Narrowing only frees room when the ROWS are big enough to account for the overflow;
-  // on a graph whose groups alone dwarf the budget, "ask for less" changes nothing.
-  const textChars = typeof answer.text === "string" ? (answer.text as string).length : 0;
-  const narrow =
-    fullChars - budget < textChars
-      ? " Narrowing this query (`ids`/`types`/`where`/`limit`) frees budget for them too."
-      : "";
+  /**
+   * How the caller gets shed context back, judged against where they actually are.
+   *
+   * `needed` is the size of the reply that still carries it; `floor` is that same reply
+   * with NO matching rows at all — the smallest this call could ever be while keeping
+   * it. Both are MEASURED, not estimated, which is what lets each branch below be true:
+   * narrowing the query can only help while `floor` fits, and raising `max_chars` can
+   * only help while `needed` (or, combined with narrowing, `floor`) is under the
+   * ceiling. Every other phrasing is a dead retry — a real lever that cannot move,
+   * which costs the same round trip as naming one that does not exist.
+   *
+   * Response FIELDS are named bare on purpose: backticks here mean "a lever on this
+   * tool", and dressing a field as a parameter is that same wasted retry.
+   */
+  const recovery = (needed: number, floor: number): string => {
+    const narrow =
+      floor <= budget
+        ? " Narrowing this query (`ids`/`types`/`where`/`limit`) frees budget for them too."
+        : "";
+    if (budget >= QUERY_GRAPH_MAX_CHARS_CEILING) {
+      return floor <= budget
+        ? `\`max_chars\` is already at its ceiling of ${QUERY_GRAPH_MAX_CHARS_CEILING}.${narrow}`
+        : `\`max_chars\` is already at its ceiling of ${QUERY_GRAPH_MAX_CHARS_CEILING}, and they need ~${floor} chars even with no matching rows at all, so one reply cannot carry them.`;
+    }
+    if (needed <= QUERY_GRAPH_MAX_CHARS_CEILING)
+      return `The untruncated reply is ~${needed} chars: raise \`max_chars\` (up to ${QUERY_GRAPH_MAX_CHARS_CEILING}) to about that to keep them.${narrow}`;
+    if (floor <= QUERY_GRAPH_MAX_CHARS_CEILING)
+      return `The untruncated reply is ~${needed} chars, past this tool's ceiling — but only ~${floor} chars without the matching rows, so raise \`max_chars\` (up to ${QUERY_GRAPH_MAX_CHARS_CEILING}) AND narrow the query (\`ids\`/\`types\`/\`where\`/\`limit\`) together.`;
+    return `They need ~${floor} chars even with no matching rows at all, past \`max_chars\`'s ceiling of ${QUERY_GRAPH_MAX_CHARS_CEILING}, so no combination of raising it and narrowing this query returns them here.`;
+  };
+  /** The same reply with the answer rows removed — the floor `recovery` reasons about. */
+  const floorOf = (r: Record<string, unknown>): number =>
+    render({ ...assemble(r), ...(answer.text !== undefined ? { text: "" } : {}) }).length;
+
   const outline =
     ` panel_graph_outline's GROUPS index lists every member id — but only while its own max_chars affords a node-level rung; if it reports detail_level:"groups" it gives counts, not ids.`;
 
+  // Every note below states what was OBSERVED — that the reply did not fit — and never
+  // that dropping this made it fit (codex gate MAJOR). Whether it ultimately did is
+  // answered by the presence or absence of `budget_overrun`, which is checked, not
+  // predicted.
+
   // Rung 1 — every group still listed, membership and geometry gone.
   if (hasGroups) {
-    const reduced: Record<string, unknown> = { ...answer };
-    if (riders.groups_truncated !== undefined) reduced.groups_truncated = riders.groups_truncated;
-    if (riders.groups_truncation_hint !== undefined)
-      reduced.groups_truncation_hint = riders.groups_truncation_hint;
-    reduced.groups = groups!.map(groupIndexEntry);
-    reduced.groups_membership_omitted =
-      `Member node_ids and box geometry were omitted from all ${groups!.length} group(s) so the WHOLE reply fits \`max_chars\`=${budget} — ` +
-      `the rows answering your query are never dropped to make room for them. Every group is still listed and each node_count is exact. ` +
-      raise +
-      narrow +
+    const reduced: Record<string, unknown> = { ...riders, groups: groups!.map(groupIndexEntry) };
+    const p = assemble(reduced);
+    p.groups_membership_omitted =
+      `Member node_ids and box geometry were omitted from all ${groups!.length} group(s): the whole reply did not fit \`max_chars\`=${budget}, ` +
+      `and the rows answering your query are never dropped to make room for context. Every group is still listed and each node_count is exact. ` +
+      recovery(fullChars, floorOf(riders)) +
       outline;
-    if (hasRails) reduced.rails = riders.rails;
-    if (render(reduced).length <= budget) return replaceWith(reduced);
+    if (render(p).length <= budget) return replaceWith(p);
   }
 
   // Rung 2 — the group index itself goes. Its true size is stated in its place.
-  const noGroups: Record<string, unknown> = { ...answer };
+  const withoutGroups: Record<string, unknown> = { ...riders };
+  delete withoutGroups.groups;
+  delete withoutGroups.groups_truncated;
+  delete withoutGroups.groups_truncation_hint;
+  const noGroups = assemble(withoutGroups);
   if (hasGroups) {
     // The panel caps its own groups list before we ever see it, so the count we can
     // vouch for is "what this reply carried", not "what the graph has".
@@ -1469,25 +1505,22 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
         ? `the ${groups!.length} group(s) this reply carried (the panel had already capped that list, so that is not the graph's total)`
         : `all ${groups!.length} group(s)`;
     noGroups.groups_omitted =
-      `The groups rider was dropped entirely — ${carried} — so the WHOLE reply fits \`max_chars\`=${budget}, ` +
+      `The groups rider was dropped entirely — ${carried} — because the whole reply did not fit \`max_chars\`=${budget} even with their membership already omitted, ` +
       `and the rows answering your query are never dropped to make room for it. ` +
-      raise +
-      narrow +
+      recovery(fullChars, floorOf(riders)) +
       outline;
   }
-  if (hasRails) noGroups.rails = riders.rails;
   if (render(noGroups).length <= budget) return replaceWith(noGroups);
 
   // Rung 3 — the subgraph rails go too.
-  const bare: Record<string, unknown> = { ...noGroups };
+  const bare = assemble({});
+  if (hasGroups && noGroups.groups_omitted !== undefined)
+    bare.groups_omitted = noGroups.groups_omitted;
   if (hasRails) {
-    delete bare.rails;
     bare.rails_omitted =
-      `The subgraph boundary rails were dropped so the WHOLE reply fits \`max_chars\`=${budget}. ` +
-      `Re-read them with a narrower query — panel_query_graph {ids:[…], fields:"ids"} on this same subgraph carries them again as soon as the rows leave room.`;
+      `The subgraph boundary rails were dropped because the reply did not fit \`max_chars\`=${budget} without them. ` +
+      recovery(render(noGroups).length, floorOf(withoutGroups));
   }
-  const bareChars = render(bare).length;
-  if (bareChars <= budget) return replaceWith(bare);
 
   // Every rider is gone and it STILL does not fit. What is left is the rows plus the
   // sentences saying what was dropped, and neither may be silently cut — so the overrun
@@ -1500,12 +1533,24 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
     budget > QUERY_GRAPH_MAX_CHARS_FLOOR
       ? `For a smaller reply, lower \`max_chars\` (floor ${QUERY_GRAPH_MAX_CHARS_FLOOR}) or narrow the query with \`ids\`/\`types\`/\`where\`/\`limit\`.`
       : `\`max_chars\` is already at its floor of ${QUERY_GRAPH_MAX_CHARS_FLOOR}, so narrow the query with \`ids\`/\`types\`/\`where\`/\`limit\` for a smaller reply.`;
-  bare.budget_overrun =
-    `This reply is ~${bareChars} chars, over \`max_chars\`=${budget} (the figure counts the JSON framing and escaping). ` +
+  const overrun = (size: number): string =>
+    `This reply is ${size} chars, over \`max_chars\`=${budget} (that figure counts the JSON framing and escaping, and this note itself). ` +
     (answerChars > budget
-      ? `The rows that answer your query render to ~${answerChars} chars on their own and are never discarded to meet a budget. ${shrink}`
-      : `The rows render to ~${answerChars} chars; the rest is the note(s) above saying which context was dropped, kept deliberately because a silently missing rider is the defect this budget exists to prevent, and no parameter shrinks them.`);
-  return replaceWith(bare);
+      ? `The rows that answer your query render to ${answerChars} chars on their own and are never discarded to meet a budget. ${shrink}`
+      : `The rows render to ${answerChars} chars; the rest is the note(s) above saying which context was dropped, kept deliberately because a silently missing rider is the defect this budget exists to prevent, and no parameter shrinks them.`);
+  // The stated size must include the statement (codex gate MAJOR), so solve for it: the
+  // note only grows the payload, and only its own digit count feeds back, so this
+  // settles in one or two passes. The loop is bounded and the last pass is emitted
+  // regardless — a size that is a character or two low is still the honest order of
+  // magnitude, and the `budget_overrun` field itself is what carries the finding.
+  let claimed = render({ ...bare, budget_overrun: overrun(render(bare).length) }).length;
+  for (let i = 0; i < 4; i++) {
+    const attempt = { ...bare, budget_overrun: overrun(claimed) };
+    const size = render(attempt).length;
+    if (size === claimed) return replaceWith(attempt);
+    claimed = size;
+  }
+  return replaceWith({ ...bare, budget_overrun: overrun(claimed) });
 }
 
 // ---- panel_civitai_results inline sample thumbnails (#623) -------------------

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1511,8 +1511,13 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
     capEvidence.groups_truncation_hint = riders.groups_truncation_hint;
 
   // Rung 2 — the group index itself goes. Its true size is stated in its place.
+  //
+  // An EMPTY `groups: []` is not a rider to shed, it is an OBSERVATION — "this graph has
+  // no groups" — costing about fifteen characters. Deleting it saved nothing and quietly
+  // turned a stated zero into an absent field, which is the same coverage loss one rung
+  // up (codex gate MAJOR). Only a non-empty list is dropped here.
   const withoutGroups: Record<string, unknown> = { ...riders };
-  delete withoutGroups.groups;
+  if (hasGroups) delete withoutGroups.groups;
   const noGroups = assemble(withoutGroups);
   if (hasGroups) {
     // The count we can vouch for is "what this reply carried", not "what the graph has".
@@ -1528,8 +1533,11 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
   }
   if (render(noGroups).length <= budget) return replaceWith(noGroups);
 
-  // Rung 3 — the subgraph rails go too. The cap evidence still rides.
-  const bare = assemble(capEvidence);
+  // Rung 3 — the subgraph rails go too. The cap evidence, and an empty groups
+  // observation, still ride.
+  const bareRiders: Record<string, unknown> = { ...capEvidence };
+  if (!hasGroups && riders.groups !== undefined) bareRiders.groups = riders.groups;
+  const bare = assemble(bareRiders);
   if (hasGroups && noGroups.groups_omitted !== undefined)
     bare.groups_omitted = noGroups.groups_omitted;
   if (hasRails) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1479,13 +1479,22 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
   // answered by the presence or absence of `budget_overrun`, which is checked, not
   // predicted.
 
-  // Rung 1 — every group still listed, membership and geometry gone.
+  // The panel caps its own groups list at 200 BEFORE this code sees it, so the coverage
+  // claim any note here can make is about what the reply CARRIED, never about the graph
+  // (codex gate MAJOR — "every group is still listed" sat next to the panel's own
+  // "showing 200 of 640" and contradicted it).
+  const groupsPreCapped = riders.groups_truncated === true;
+
+  // Rung 1 — every group the reply carried still listed, membership and geometry gone.
   if (hasGroups) {
     const reduced: Record<string, unknown> = { ...riders, groups: groups!.map(groupIndexEntry) };
     const p = assemble(reduced);
     p.groups_membership_omitted =
       `Member node_ids and box geometry were omitted from all ${groups!.length} group(s): the whole reply did not fit \`max_chars\`=${budget}, ` +
-      `and the rows answering your query are never dropped to make room for context. Every group is still listed and each node_count is exact. ` +
+      `and the rows answering your query are never dropped to make room for context. ` +
+      (groupsPreCapped
+        ? `Every group this reply CARRIED is still listed with an exact node_count — but the panel had already capped that list before this call saw it (see groups_truncation_hint), so ${groups!.length} is not the graph's total. `
+        : `Every group is still listed and each node_count is exact. `) +
       recovery(fullChars, floorOf(riders)) +
       outline;
     if (render(p).length <= budget) return replaceWith(p);
@@ -1498,10 +1507,9 @@ function fitQueryGraphReply(res: ToolResult, requested: unknown): ToolResult {
   delete withoutGroups.groups_truncation_hint;
   const noGroups = assemble(withoutGroups);
   if (hasGroups) {
-    // The panel caps its own groups list before we ever see it, so the count we can
-    // vouch for is "what this reply carried", not "what the graph has".
+    // The count we can vouch for is "what this reply carried", not "what the graph has".
     const carried =
-      riders.groups_truncated === true
+      groupsPreCapped
         ? `the ${groups!.length} group(s) this reply carried (the panel had already capped that list, so that is not the graph's total)`
         : `all ${groups!.length} group(s)`;
     noGroups.groups_omitted =

--- a/src/services/userdata-library.ts
+++ b/src/services/userdata-library.ts
@@ -80,7 +80,24 @@ export type WorkflowLibraryListing =
    *  `unreadable` is 0, because an entry this build could not decode is a workflow that
    *  EXISTS and is missing from `keys`. Reporting `[{}]` as an empty library would be
    *  the same false negative in miniature (codex gate MAJOR). */
-  | { ok: true; keys: string[]; unreadable: number }
+  | {
+      ok: true;
+      keys: string[];
+      unreadable: number;
+      /**
+       * Whether the RESPONSE shows it covered subfolders — true only when a returned
+       * name carries a path separator, which is the listing itself proving it recursed.
+       *
+       * The REQUEST is not evidence about the response (independent gate P0). Asking for
+       * `recurse=true` says what we wanted; a proxy, a shim, or a handler that ignores
+       * the parameter answers with the top-level list and looks identical. On a
+       * non-empty result the tell exists in the data; on an EMPTY one it cannot, which
+       * is exactly why an empty listing is UNDETERMINED with respect to subfolders and
+       * must not be reported as "you have none" — the original #810 failure, moved one
+       * layer out.
+       */
+      recursionProven: boolean;
+    }
   | { ok: false; kind: "absent" | "refused" | "unreachable" | "undecodable"; detail: string };
 
 /** Normalize one listing entry to a store-relative key, or null when it is not one. */
@@ -154,5 +171,12 @@ export async function listWorkflowLibraryKeys(): Promise<WorkflowLibraryListing>
   // this call cannot name. Silently dropping it is how a listing becomes a lie by
   // omission — and a listing of ONLY such entries would otherwise read as an empty
   // library. Count them so the caller can say the list may be short.
-  return { ok: true, keys, unreadable: decoded.length - keys.length };
+  return {
+    ok: true,
+    keys,
+    unreadable: decoded.length - keys.length,
+    // Positive evidence only: a name carrying a separator is the response demonstrating
+    // it recursed. Anything else — including an empty list — leaves it unproven.
+    recursionProven: keys.some((k) => k.includes("/")),
+  };
 }

--- a/src/services/userdata-library.ts
+++ b/src/services/userdata-library.ts
@@ -62,14 +62,17 @@ export async function userdataFetch(route: string): Promise<Response> {
  * The outcome of one library listing, with "the library is empty" kept DISTINCT from
  * "the library could not be read".
  *
- *  - `ok: true`   — the server answered with a list. `keys` may legitimately be empty.
- *  - `ok: false`  — no usable list. `kind` says which flavour, so a caller can word an
- *                   empty directory ("nothing saved yet") differently from a refusal
- *                   ("could not be determined") instead of collapsing both into
- *                   "no workflows found".
+ *  - `ok: true`   — the server answered with a list.
+ *  - `ok: false`  — no usable list. `kind` says which flavour, so a caller can word a
+ *                   missing directory differently from a refusal, instead of collapsing
+ *                   both into "no workflows found".
  */
 export type WorkflowLibraryListing =
-  | { ok: true; keys: string[] }
+  /** The server answered with a list. `keys` may legitimately be empty — but only when
+   *  `unreadable` is 0, because an entry this build could not decode is a workflow that
+   *  EXISTS and is missing from `keys`. Reporting `[{}]` as an empty library would be
+   *  the same false negative in miniature (codex gate MAJOR). */
+  | { ok: true; keys: string[]; unreadable: number }
   | { ok: false; kind: "absent" | "refused" | "unreachable" | "undecodable"; detail: string };
 
 /** Normalize one listing entry to a store-relative key, or null when it is not one. */
@@ -110,12 +113,14 @@ export async function listWorkflowLibraryKeys(): Promise<WorkflowLibraryListing>
     };
   }
   if (!res.ok) {
-    // 404 is ComfyUI's answer for "that directory does not exist", which for the
-    // workflow library means nothing has ever been saved into it. That is a
-    // DETERMINED negative and is worded as one; every other status is a refusal we
-    // must not dress up as an empty library.
+    // 404 is ComfyUI's answer for "that directory does not exist". What it PROVES is
+    // that the directory is not there NOW — not the historical claim that nothing was
+    // ever saved (codex gate MAJOR), and not that this request even reached the
+    // listing handler rather than a proxy or a mismatched base path. So it is kept
+    // separate from a refusal, and the caller words it as an observation with its
+    // caveat rather than as a verdict on the user's library.
     return res.status === 404
-      ? { ok: false, kind: "absent", detail: "the server has no `workflows` directory (HTTP 404)" }
+      ? { ok: false, kind: "absent", detail: "the server answered HTTP 404 for its `workflows` directory" }
       : { ok: false, kind: "refused", detail: `the server answered HTTP ${res.status}` };
   }
   let body: unknown;
@@ -131,5 +136,11 @@ export async function listWorkflowLibraryKeys(): Promise<WorkflowLibraryListing>
   if (!Array.isArray(body)) {
     return { ok: false, kind: "undecodable", detail: "the listing was not a JSON array" };
   }
-  return { ok: true, keys: body.map(entryKey).filter((k): k is string => k != null) };
+  const decoded = body.map(entryKey);
+  const keys = decoded.filter((k): k is string => k != null);
+  // An entry in a shape none of the known ComfyUI response forms produce is a workflow
+  // this call cannot name. Silently dropping it is how a listing becomes a lie by
+  // omission — and a listing of ONLY such entries would otherwise read as an empty
+  // library. Count them so the caller can say the list may be short.
+  return { ok: true, keys, unreadable: decoded.length - keys.length };
 }

--- a/src/services/userdata-library.ts
+++ b/src/services/userdata-library.ts
@@ -117,7 +117,11 @@ export async function listWorkflowLibraryKeys(): Promise<WorkflowLibraryListing>
     return {
       ok: false,
       kind: "unreachable",
-      detail: `the request never reached the server (${err instanceof Error ? err.message : String(err)})`,
+      // What was observed is that NO Response came back — not that the request failed to
+      // arrive (codex gate MAJOR). A reply lost after ComfyUI had already listed the
+      // directory looks identical from here, and for a read that distinction changes
+      // nothing except whether the sentence is true.
+      detail: `no response came back (${err instanceof Error ? err.message : String(err)}), so this call learned nothing about the library either way`,
     };
   }
   if (!res.ok) {

--- a/src/services/userdata-library.ts
+++ b/src/services/userdata-library.ts
@@ -1,0 +1,135 @@
+// The connected ComfyUI's SAVED workflow library, read through its userdata API.
+//
+// #810: `list_workflows` asked for `/api/userdata?dir=workflows` — a SHALLOW read —
+// and reported the resulting empty array as "No saved workflows found." A user whose
+// six workflows all live in `IMAGE/` and `VIDEO/MiniMaxH3/` (the folder tree the
+// ComfyUI web UI sidebar shows) was told their library was empty. That is the repo's
+// dominant defect class: "could not determine X" rendered as "determined X is not the
+// case", and here it is worse than slow — it sends the user to recreate a workflow
+// they already have.
+//
+// One listing read, in one place, so a second caller cannot re-introduce the shallow
+// spelling: panel_load_workflow's resolver already used `recurse=true` (it was fixed
+// for #202) while list_workflows did not, which is exactly the drift a shared helper
+// removes.
+import { getClient } from "../comfyui/client.js";
+
+/**
+ * The listing route for the workflow library.
+ *
+ * `recurse=true` is VERIFIED against the installed ComfyUI (app/user_manager.py
+ * `listuserdata`): with it the glob is `<dir>/**\/*` and a workflow in a SUBFOLDER
+ * comes back as its store-relative path ("VIDEO/MiniMaxH3/x.json"); without it the
+ * glob is `<dir>/*` and that file is simply absent. Root entries stay bare either way,
+ * so the recursive listing is a strict superset — nothing that used to be listed stops
+ * being listed.
+ *
+ * `split=false` is explicit rather than implied. The endpoint switches shape on
+ * `split=true` (each entry becomes `[rel_path, ...segments]`), and its default is
+ * "absent means false"; naming it means a build that ever flipped that default cannot
+ * silently turn every entry into an array. Unknown/false-valued query args are ignored
+ * by builds that do not implement them, so this needs no version gate: the worst case
+ * on an ancient build is the flat list it already returned.
+ */
+export const WORKFLOW_LIBRARY_LISTING_ROUTE =
+  "/api/userdata?dir=workflows&recurse=true&split=false";
+
+/**
+ * Issue ONE userdata GET and hand back the raw Response.
+ *
+ * This deliberately bypasses the client's own `fetchApi` (panel #202, codex/gate
+ * MAJOR). `fetchApi` throws for every non-2xx AND calls `response.json()` while
+ * building that error — so a refusal with a non-JSON body (ComfyUI's own `403 Invalid
+ * directory` / `404 Directory not found` are text/plain, as is a proxy's 403 or an
+ * HTML 502) rejects with a STATUSLESS SyntaxError. There is then no way to tell "the
+ * server refused" from "the server was never reached", and both get reported as
+ * whatever the caller's catch-all says.
+ *
+ * Building the request from the client's own `apiURL` + `apiHeaders` keeps every
+ * transport concern identical (host, ssl, base path, clientId, Comfy-User, the
+ * injected COMFYUI_AUTH_* fetch) while making the outcome unambiguous:
+ *   - a returned Response  = the server ANSWERED; classify by status, decode later
+ *   - a thrown error       = no Response exists, so the request never got one
+ * Nothing here reads a body, so a body that cannot be decoded can never be mistaken
+ * for a transport failure.
+ */
+export async function userdataFetch(route: string): Promise<Response> {
+  const client = getClient();
+  return await client.fetch(client.apiURL(route), { headers: client.apiHeaders() });
+}
+
+/**
+ * The outcome of one library listing, with "the library is empty" kept DISTINCT from
+ * "the library could not be read".
+ *
+ *  - `ok: true`   — the server answered with a list. `keys` may legitimately be empty.
+ *  - `ok: false`  — no usable list. `kind` says which flavour, so a caller can word an
+ *                   empty directory ("nothing saved yet") differently from a refusal
+ *                   ("could not be determined") instead of collapsing both into
+ *                   "no workflows found".
+ */
+export type WorkflowLibraryListing =
+  | { ok: true; keys: string[] }
+  | { ok: false; kind: "absent" | "refused" | "unreachable" | "undecodable"; detail: string };
+
+/** Normalize one listing entry to a store-relative key, or null when it is not one. */
+function entryKey(entry: unknown): string | null {
+  // The default shape on every build we have seen: a bare relative path.
+  if (typeof entry === "string") return entry || null;
+  // `split=true` shape, in case a build ever returns it despite `split=false`:
+  // [rel_path, ...segments] — element 0 is the same key the default shape returns.
+  if (Array.isArray(entry)) return typeof entry[0] === "string" && entry[0] ? entry[0] : null;
+  // `full_info=true` shape: { path, size, modified }.
+  const rec = entry as { path?: unknown; name?: unknown } | null;
+  if (rec && typeof rec.path === "string" && rec.path) return rec.path;
+  if (rec && typeof rec.name === "string" && rec.name) return rec.name;
+  return null;
+}
+
+/**
+ * The connected ComfyUI's OWN list of saved workflow store keys — asked, never
+ * reconstructed, so it reflects the server's runtime `--user-directory`.
+ *
+ * Keys are store-relative and INCLUDE any subfolder ("VIDEO/MiniMaxH3/x.json"). They
+ * are used verbatim: nothing is stripped, case-folded or separator-folded here,
+ * because a depth-0 request must only ever match a depth-0 entry (panel #202 gate
+ * MAJOR) and because those keys are what `get_workflow`/`analyze_workflow`/
+ * `query_workflow` take as `filename`.
+ *
+ * Never throws.
+ */
+export async function listWorkflowLibraryKeys(): Promise<WorkflowLibraryListing> {
+  let res: Response;
+  try {
+    res = await userdataFetch(WORKFLOW_LIBRARY_LISTING_ROUTE);
+  } catch (err) {
+    return {
+      ok: false,
+      kind: "unreachable",
+      detail: `the request never reached the server (${err instanceof Error ? err.message : String(err)})`,
+    };
+  }
+  if (!res.ok) {
+    // 404 is ComfyUI's answer for "that directory does not exist", which for the
+    // workflow library means nothing has ever been saved into it. That is a
+    // DETERMINED negative and is worded as one; every other status is a refusal we
+    // must not dress up as an empty library.
+    return res.status === 404
+      ? { ok: false, kind: "absent", detail: "the server has no `workflows` directory (HTTP 404)" }
+      : { ok: false, kind: "refused", detail: `the server answered HTTP ${res.status}` };
+  }
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (err) {
+    return {
+      ok: false,
+      kind: "undecodable",
+      detail: `the listing body did not parse as JSON (${err instanceof Error ? err.message : String(err)})`,
+    };
+  }
+  if (!Array.isArray(body)) {
+    return { ok: false, kind: "undecodable", detail: "the listing was not a JSON array" };
+  }
+  return { ok: true, keys: body.map(entryKey).filter((k): k is string => k != null) };
+}

--- a/src/services/userdata-library.ts
+++ b/src/services/userdata-library.ts
@@ -27,9 +27,17 @@ import { getClient } from "../comfyui/client.js";
  * `split=false` is explicit rather than implied. The endpoint switches shape on
  * `split=true` (each entry becomes `[rel_path, ...segments]`), and its default is
  * "absent means false"; naming it means a build that ever flipped that default cannot
- * silently turn every entry into an array. Unknown/false-valued query args are ignored
- * by builds that do not implement them, so this needs no version gate: the worst case
- * on an ancient build is the flat list it already returned.
+ * silently turn every entry into an array.
+ *
+ * There is no "the server ignored `recurse`" case to version-gate against, and that is
+ * a checked fact rather than an assumption (codex gate MAJOR asked for the proof): the
+ * `/userdata` listing route and its `recurse` parameter arrived in the SAME ComfyUI
+ * commit as the workflow library itself — 90aebb6c, "New Menu & Workflow Management"
+ * (#3112, 2024-06-25), present from tag v0.0.1 onward. A build old enough to ignore
+ * `recurse` has no `workflows` userdata library to list, so it answers 404 and takes
+ * the `absent` path, never the empty-list one. The empty-list message still states that
+ * dependency rather than asserting subfolder coverage outright, because something OTHER
+ * than that ComfyUI answering this route is the one way the ground could be false.
  */
 export const WORKFLOW_LIBRARY_LISTING_ROUTE =
   "/api/userdata?dir=workflows&recurse=true&split=false";

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -55,12 +55,17 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
                 {
                   type: "text",
                   text:
-                    `No workflows to list: ${listing.detail}, so that directory is not there right now — ` +
-                    `usually because nothing has been saved into it yet, in which case save one from the ` +
-                    `ComfyUI web UI or with save_workflow. If you expected workflows here, do NOT recreate ` +
-                    `them on this result: the same answer comes back when the server is running with a ` +
-                    `different --user-directory, or when this call did not reach its userdata API at all. ` +
-                    `Check the ComfyUI sidebar first.`,
+                    // The status is the observation; "the directory is not there" is an
+                    // INFERENCE from it, and a 404 from a proxy or a mismatched base path
+                    // makes the same inference false (codex gate). State the one, offer
+                    // the other as what it usually means, and keep them apart.
+                    `No workflows to list: ${listing.detail} — the answer it gives for a directory it does ` +
+                    `not have, usually because nothing has been saved into that library yet, in which case ` +
+                    `save one from the ComfyUI web UI or with save_workflow. That status is all this call ` +
+                    `observed, not a verdict on your library: the same 404 comes back when the server is ` +
+                    `running with a different --user-directory, and when this call reached something other ` +
+                    `than that ComfyUI's userdata API. If you expected workflows here, check the ComfyUI ` +
+                    `sidebar first — do NOT recreate them on this result.`,
                 },
               ],
             };

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -43,17 +43,24 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
 
         if (!listing.ok) {
           // "Could not determine" must never be rendered as "determined there are
-          // none" (#810). `absent` is the one flavour that IS a determined negative —
-          // ComfyUI 404s the listing when the directory does not exist, which for the
-          // workflow library means nothing has ever been saved into it.
+          // none" (#810). `absent` is the closest thing to a determined negative —
+          // ComfyUI 404s the listing when the directory is not there — but it proves
+          // the directory is missing NOW, not that nothing was ever saved, and not
+          // that the request reached that handler at all. So it is reported as the
+          // observation it is, with the one alternative explanation that would send
+          // someone to recreate a workflow they still have.
           if (listing.kind === "absent") {
             return {
               content: [
                 {
                   type: "text",
                   text:
-                    `No saved workflows found: ${listing.detail}, so nothing has been saved to this ` +
-                    `server's library yet. Save one from the ComfyUI web UI, or with save_workflow.`,
+                    `No workflows to list: ${listing.detail}, so that directory is not there right now — ` +
+                    `usually because nothing has been saved into it yet, in which case save one from the ` +
+                    `ComfyUI web UI or with save_workflow. If you expected workflows here, do NOT recreate ` +
+                    `them on this result: the same answer comes back when the server is running with a ` +
+                    `different --user-directory, or when this call did not reach its userdata API at all. ` +
+                    `Check the ComfyUI sidebar first.`,
                 },
               ],
             };
@@ -73,6 +80,14 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
         }
 
         const files = [...listing.keys].sort((a, b) => a.localeCompare(b));
+        // Entries the listing carried that this build could not turn into a name. Each
+        // one is a workflow that EXISTS and is missing below, so it is stated rather
+        // than dropped — and a listing of nothing BUT those is not an empty library.
+        const unreadable =
+          listing.unreadable > 0
+            ? ` ${listing.unreadable} further entry(ies) came back in a shape this build does not recognise ` +
+              `and could not be named, so this list may be short — read the ComfyUI sidebar for those.`
+            : "";
 
         if (files.length === 0) {
           return {
@@ -80,8 +95,12 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
               {
                 type: "text",
                 text:
-                  "No saved workflows found: the connected ComfyUI reported an empty workflow library " +
-                  "(subfolders included).",
+                  listing.unreadable > 0
+                    ? `Could NOT read the workflow library: the connected ComfyUI answered with ${listing.unreadable} ` +
+                      `entry(ies) in a shape this build does not recognise, and none it could name. This is NOT ` +
+                      `"the library is empty" — do not create or overwrite a workflow on the strength of it.`
+                    : "No saved workflows found: the connected ComfyUI reported an empty workflow library " +
+                      "(subfolders included).",
               },
             ],
           };
@@ -101,7 +120,7 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
               type: "text",
               text:
                 `Found ${files.length} workflow(s) (subfolders included; each name below is what ` +
-                `get_workflow / analyze_workflow / query_workflow take as \`filename\`):\n\n${text}`,
+                `get_workflow / analyze_workflow / query_workflow take as \`filename\`).${unreadable}\n\n${text}`,
             },
           ],
         };

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -129,13 +129,25 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
           .map((f, i) => `${i + 1}. ${f}`)
           .join("\n");
 
+        // "Subfolders included" is a claim about the ANSWER, and asking for
+        // `recurse=true` only proves what was requested (codex gate). A name carrying a
+        // folder is the listing PROVING it recursed, so on that reply the claim is
+        // observed rather than assumed. With every name at the root there is no such
+        // proof — the usual reason is a flat library, and the message says which reading
+        // to trust and how to tell, instead of asserting coverage it cannot see.
+        const coverage = files.some((f) => f.includes("/"))
+          ? " Subfolders ARE included: the names carrying one are this listing proving it recursed."
+          : " Every name here sits at the library root — the listing was requested recursively, so on the" +
+            " connected ComfyUI that means it has no workflow subfolders. If its sidebar DOES show folders," +
+            " this call is not reaching that ComfyUI; check the URL/port.";
+
         return {
           content: [
             {
               type: "text",
               text:
-                `Found ${files.length} workflow(s) (subfolders included; each name below is what ` +
-                `get_workflow / analyze_workflow / query_workflow take as \`filename\`).${unreadable}\n\n${text}`,
+                `Found ${files.length} workflow(s) — each name below is what get_workflow / ` +
+                `analyze_workflow / query_workflow take as \`filename\`.${coverage}${unreadable}\n\n${text}`,
             },
           ],
         };

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -99,8 +99,18 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
                     ? `Could NOT read the workflow library: the connected ComfyUI answered with ${listing.unreadable} ` +
                       `entry(ies) in a shape this build does not recognise, and none it could name. This is NOT ` +
                       `"the library is empty" — do not create or overwrite a workflow on the strength of it.`
-                    : "No saved workflows found: the connected ComfyUI reported an empty workflow library " +
-                      "(subfolders included).",
+                    : // The subfolder coverage is a CONDITION, not a bare assertion: it holds
+                      // because ComfyUI's `recurse` parameter shipped in the same commit as
+                      // the workflow library, so a build without it 404s instead of answering
+                      // with an empty list. Say the condition, and say what a contradiction
+                      // between this answer and the sidebar would mean — the alternative is
+                      // an unverifiable "(subfolders included)" next to the exact wrong
+                      // answer #810 is about.
+                      "No saved workflows found: the connected ComfyUI answered the library listing with an " +
+                      "empty list. That listing was recursive, and every ComfyUI build that has this library " +
+                      "supports recursion, so it covers subfolders too. If the ComfyUI sidebar DOES show " +
+                      "workflows, then this call is not reaching that ComfyUI — check the URL/port before " +
+                      "recreating anything.",
               },
             ],
           };

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -33,7 +33,7 @@ import { analyzeGraphHealth } from "../services/workflow-health.js";
 export function registerWorkflowLibraryTools(server: McpServer): void {
   server.tool(
     "list_workflows",
-    "List the workflows saved in the connected ComfyUI server's user library (the same workflows visible in the ComfyUI web UI), INCLUDING the ones filed in subfolders. Requires a running ComfyUI server. Takes no parameters. Returns a numbered list of library names, each relative to the library root — a workflow in a folder appears as 'VIDEO/MiniMaxH3/clip.json', and that whole string is what get_workflow / analyze_workflow / query_workflow take as `filename`. Says the library is empty ONLY when the server actually reported an empty library; a listing it could not read is reported as unread, never as empty.",
+    "List the workflows saved in the connected ComfyUI server's user library (the same workflows visible in the ComfyUI web UI), INCLUDING the ones filed in subfolders. Requires a running ComfyUI server. Takes no parameters. Returns a numbered list of library names, each relative to the library root — a workflow in a folder appears as 'VIDEO/MiniMaxH3/clip.json', and that whole string is what get_workflow / analyze_workflow / query_workflow take as `filename`. It never reports an absence it did not establish: a listing it could not read says so, and an EMPTY listing says the library could not be CONFIRMED empty (an answer with no names in it cannot show whether it covered subfolders) and tells you to check the ComfyUI sidebar rather than recreate anything.",
     {},
     async () => {
       try {
@@ -104,18 +104,21 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
                     ? `Could NOT read the workflow library: the connected ComfyUI answered with ${listing.unreadable} ` +
                       `entry(ies) in a shape this build does not recognise, and none it could name. This is NOT ` +
                       `"the library is empty" — do not create or overwrite a workflow on the strength of it.`
-                    : // The subfolder coverage is a CONDITION, not a bare assertion: it holds
-                      // because ComfyUI's `recurse` parameter shipped in the same commit as
-                      // the workflow library, so a build without it 404s instead of answering
-                      // with an empty list. Say the condition, and say what a contradiction
-                      // between this answer and the sidebar would mean — the alternative is
-                      // an unverifiable "(subfolders included)" next to the exact wrong
-                      // answer #810 is about.
-                      "No saved workflows found: the connected ComfyUI answered the library listing with an " +
-                      "empty list. That listing was recursive, and every ComfyUI build that has this library " +
-                      "supports recursion, so it covers subfolders too. If the ComfyUI sidebar DOES show " +
-                      "workflows, then this call is not reaching that ComfyUI — check the URL/port before " +
-                      "recreating anything.",
+                    : // An EMPTY list is the one answer that carries no evidence about its own
+                      // coverage (independent gate P0). `recurse=true` says what was REQUESTED;
+                      // a proxy, a shim or a handler that ignores it returns the top-level list,
+                      // and with no names there is no separator to prove otherwise. So this is
+                      // UNDETERMINED, not "none" — which is #810 itself, moved one layer out —
+                      // and it is worded as the open question it is, with the check that
+                      // settles it. Verdict headline deliberately withheld.
+                      "Could NOT confirm the workflow library is empty: the connected ComfyUI answered the " +
+                      "recursive listing with an empty list. That is what an empty library returns — and " +
+                      "also what a responder that ignored `recurse` returns for a library whose workflows " +
+                      "all live in folders. An empty answer carries no name to tell those apart, so this " +
+                      "call cannot. CHECK THE COMFYUI SIDEBAR: if it lists workflows, this call is not " +
+                      "reaching that ComfyUI (check the URL/port) and they are still there — do not " +
+                      "recreate them. If it lists none, the library is genuinely empty; save one from the " +
+                      "web UI or with save_workflow.",
               },
             ],
           };
@@ -134,8 +137,10 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
         // folder is the listing PROVING it recursed, so on that reply the claim is
         // observed rather than assumed. With every name at the root there is no such
         // proof — the usual reason is a flat library, and the message says which reading
-        // to trust and how to tell, instead of asserting coverage it cannot see.
-        const coverage = files.some((f) => f.includes("/"))
+        // to trust and how to tell, instead of asserting coverage it cannot see. The
+        // predicate is the listing's own `recursionProven`, so this branch and the empty
+        // one above cannot come to different conclusions from the same evidence.
+        const coverage = listing.recursionProven
           ? " Subfolders ARE included: the names carrying one are this listing proving it recursed."
           : " Every name here sits at the library root, which this listing cannot tell apart from a" +
             " subfolder read that did not happen: the usual reading is that the library has no workflow" +

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -19,6 +19,7 @@ import {
   MAX_CHARS_CEILING,
   MAX_CHARS_FLOOR,
 } from "../services/graph-query.js";
+import { listWorkflowLibraryKeys } from "../services/userdata-library.js";
 import { detectSections } from "../services/workflow-sections.js";
 import {
   generateOverview,
@@ -32,20 +33,64 @@ import { analyzeGraphHealth } from "../services/workflow-health.js";
 export function registerWorkflowLibraryTools(server: McpServer): void {
   server.tool(
     "list_workflows",
-    "List the filenames of workflows saved in the connected ComfyUI server's user library (the same workflows visible in the ComfyUI web UI). Requires a running ComfyUI server. Takes no parameters. Returns a numbered list of .json filenames; pass a filename to get_workflow or analyze_workflow to load one. Returns \"No saved workflows found.\" when the library is empty.",
+    "List the workflows saved in the connected ComfyUI server's user library (the same workflows visible in the ComfyUI web UI), INCLUDING the ones filed in subfolders. Requires a running ComfyUI server. Takes no parameters. Returns a numbered list of library names, each relative to the library root — a workflow in a folder appears as 'VIDEO/MiniMaxH3/clip.json', and that whole string is what get_workflow / analyze_workflow / query_workflow take as `filename`. Says the library is empty ONLY when the server actually reported an empty library; a listing it could not read is reported as unread, never as empty.",
     {},
     async () => {
       try {
-        const client = getClient();
-        const res = await client.fetchApi("/api/userdata?dir=workflows");
-        const files = (await res.json()) as string[];
+        // #810: the listing is RECURSIVE. Users organize the library into folders in
+        // the web UI, and a shallow read reported six visible workflows as none.
+        const listing = await listWorkflowLibraryKeys();
 
-        if (files.length === 0) {
+        if (!listing.ok) {
+          // "Could not determine" must never be rendered as "determined there are
+          // none" (#810). `absent` is the one flavour that IS a determined negative —
+          // ComfyUI 404s the listing when the directory does not exist, which for the
+          // workflow library means nothing has ever been saved into it.
+          if (listing.kind === "absent") {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text:
+                    `No saved workflows found: ${listing.detail}, so nothing has been saved to this ` +
+                    `server's library yet. Save one from the ComfyUI web UI, or with save_workflow.`,
+                },
+              ],
+            };
+          }
           return {
-            content: [{ type: "text", text: "No saved workflows found." }],
+            content: [
+              {
+                type: "text",
+                text:
+                  `Could NOT read the workflow library — ${listing.detail}. This is NOT "the library is ` +
+                  `empty": workflows may well be saved on this server and this call cannot see them, so ` +
+                  `do not create or overwrite one on the strength of this result. Check that the ComfyUI ` +
+                  `server is up and reachable, then retry.`,
+              },
+            ],
           };
         }
 
+        const files = [...listing.keys].sort((a, b) => a.localeCompare(b));
+
+        if (files.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  "No saved workflows found: the connected ComfyUI reported an empty workflow library " +
+                  "(subfolders included).",
+              },
+            ],
+          };
+        }
+
+        // Deliberately UNCAPPED. For a listing, coverage IS the content: a name cut
+        // off the end reads to the caller as "that workflow does not exist", which is
+        // the very defect #810 is about, and one short line per file is a far cheaper
+        // failure than sending someone to recreate a workflow they already have.
         const text = files
           .map((f, i) => `${i + 1}. ${f}`)
           .join("\n");
@@ -54,7 +99,9 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
           content: [
             {
               type: "text",
-              text: `Found ${files.length} workflows:\n\n${text}`,
+              text:
+                `Found ${files.length} workflow(s) (subfolders included; each name below is what ` +
+                `get_workflow / analyze_workflow / query_workflow take as \`filename\`):\n\n${text}`,
             },
           ],
         };
@@ -74,7 +121,8 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
       filename: z
         .string()
         .describe(
-          "Workflow filename (e.g. 'my_workflow.json'). Use list_workflows to see available files.",
+          "Workflow library name, exactly as list_workflows reports it. A workflow filed in a folder " +
+            "keeps its folder in the name ('VIDEO/MiniMaxH3/clip.json') and that whole string goes here.",
         ),
       format: z
         .enum(["ui", "api"])
@@ -167,7 +215,10 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
       filename: z
         .string()
         .optional()
-        .describe("Workflow filename in the ComfyUI userdata library, as an alternative to path."),
+        .describe(
+          "Workflow library name as list_workflows reports it (subfolders included, e.g. " +
+            "'IMAGE/portrait.json'), as an alternative to path.",
+        ),
       graph: z
         .record(z.string(), z.any())
         .optional()
@@ -266,7 +317,10 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
       filename: z
         .string()
         .optional()
-        .describe("Workflow filename in the ComfyUI userdata library, as an alternative to path."),
+        .describe(
+          "Workflow library name as list_workflows reports it (subfolders included, e.g. " +
+            "'IMAGE/portrait.json'), as an alternative to path.",
+        ),
       graph: z
         .record(z.string(), z.any())
         .optional()
@@ -378,7 +432,9 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
       "strip_workflow afterward to flatten the Set/Get buses into real connections.",
     {
       path: z.string().optional().describe("Absolute server-side path to the workflow .json on disk."),
-      filename: z.string().optional().describe("Workflow filename in the ComfyUI userdata library."),
+      filename: z.string().optional().describe(
+        "Workflow library name as list_workflows reports it, subfolders included (e.g. 'IMAGE/portrait.json').",
+      ),
       graph: z.record(z.string(), z.any()).optional().describe("Inline UI-format workflow JSON."),
       groups: z
         .union([z.string(), z.array(z.string())])
@@ -557,7 +613,8 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
       filename: z
         .string()
         .describe(
-          "Workflow filename (e.g. 'Scene Builder v3.json'). Use list_workflows to see available files.",
+          "Workflow library name, exactly as list_workflows reports it (e.g. 'Scene Builder v3.json', or " +
+            "'VIDEO/MiniMaxH3/clip.json' for one filed in a folder — the folder is part of the name).",
         ),
       view: z
         .enum(["summary", "overview", "detail", "list", "flat", "health"])

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -137,9 +137,10 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
         // to trust and how to tell, instead of asserting coverage it cannot see.
         const coverage = files.some((f) => f.includes("/"))
           ? " Subfolders ARE included: the names carrying one are this listing proving it recursed."
-          : " Every name here sits at the library root — the listing was requested recursively, so on the" +
-            " connected ComfyUI that means it has no workflow subfolders. If its sidebar DOES show folders," +
-            " this call is not reaching that ComfyUI; check the URL/port.";
+          : " Every name here sits at the library root, which this listing cannot tell apart from a" +
+            " subfolder read that did not happen: the usual reading is that the library has no workflow" +
+            " subfolders, and the other one is that something besides that ComfyUI's userdata API answered." +
+            " If its sidebar DOES show folders, it is the second — check the URL/port.";
 
         return {
           content: [


### PR DESCRIPTION
Two results that described themselves wrongly.

Closes #807
Closes #810

## #807 — a budget that did not describe the payload

`panel_query_graph`'s `max_chars` bounded the `text` field and nothing else. The reply
also carried `groups` — each group's id, title, colour, box geometry and **full member
`node_ids` list** — and, inside a subgraph, `rails`. Those rode alongside the budget
under their own fixed panel-side caps (200 groups × 200 member ids), and were
serialized **before** the rows the caller had asked for. At those caps the riders alone
render past 100k characters, so a reply announcing *"truncated at 12 of 690 by
max_chars=12000"* could hand back an order of magnitude more than that.

A budget figure that does not describe the actual payload is a fabricated observation,
and the agent reading it draws the conclusion the reporter's Kimi session drew: **the
tool cannot show me node detail.**

### The accounting is applied once, over the finished payload

Orchestrator-side, at the last place the reply is touched before the caller sees it —
the same reasoning the #809 riders already use. It measures the exact pretty-printed
string that will be returned, escaping and framing included, and it holds against every
panel build rather than only the ones that ship after it.

**There is no third outcome.** Every JSON reply is measured — across **every text block**
of the result, not just the one carrying the JSON — and it either fits the budget it
reports or carries `budget_overrun` saying it does not. This accounting is also the sole
author of `max_chars` and the omission markers: an inbound copy of any of them is dropped
before measuring and re-derived, so a stale claim from a different measurement can never
ride out as if this one had made it. Two rules decide what gives way:

1. **The rows that answer the query are never dropped to make room for context.** The
   riders are spent from what is left, and now serialize *after* the answer.
2. **Coverage before resolution**, mirroring `panel_graph_outline`'s ladder: groups
   first lose their member ids and geometry (every group still listed, every
   `node_count` exact), then the index itself goes, then the rails. Listing half the
   groups would read as "this graph has that many".

Every rung says in-band that it fired, with counts actually observed — a panel that had
already capped its own list is reported as "the N this reply carried", and the panel's
own `groups_truncation_hint` (the only surviving record of the real total) rides along
instead of being deleted with the list it describes.

Every remedy is derived from two **measured** numbers — the size of the reply that keeps
the content, and that same reply with no matching rows at all — so "narrow the query" is
offered only while the floor fits, and "raise `max_chars`" only while the ceiling could
hold it. When the panel reports it cut the rows at this same budget, the note says
raising it returns more rows too, so narrowing must accompany the raise.

### What cannot be shed, and says so

`text` is the answer and `viewing` identifies the graph it describes; dropping either
would answer a different question, or none. Both are **counted**, so when they alone
exceed the budget the reply states its true size (including the note stating it) and the
measured split between the rows, the identifying fields and the notes — rather than
letting `max_chars` stand as a bound that did not hold. At the 500 floor the sentences
explaining a cut are themselves larger than the budget; they are still not cut.

## #810 — a shallow read reported as "you have none"

`list_workflows` asked `/api/userdata?dir=workflows` and reported the empty array as
*"No saved workflows found."* for a user whose six workflows all lived in `IMAGE/` and
`VIDEO/MiniMaxH3/`. "Could not determine X" rendered as "determined X is not the case",
in the shape that costs the most: it sends someone to recreate a workflow they already
have, over the top of it.

The listing recurses, through **one shared helper** — `panel_load_workflow`'s resolver
already recursed (fixed for panel #202) while this did not, and that drift is the
defect. The listing also stopped going through the client's `fetchApi`, which decodes a
non-2xx body as JSON while building its error, so ComfyUI's own text/plain "Directory
not found" surfaced as a statusless `SyntaxError`.

Every flavour of unread listing is now distinct from an empty one, and each says only
what was observed:

| outcome | what it says |
|---|---|
| non-empty | the names, verbatim, subfolder and all — and it claims subfolder coverage only where a returned name carries a folder, which *is* the listing proving it recursed |
| root-only | both readings (a flat library, or something else answering the API) with the tell that separates them |
| empty | **no verdict**: an answer with no names cannot show whether it covered subfolders, so it says the library could not be *confirmed* empty and names the check that settles it |
| 404 | the status as the observation, the missing directory as what it usually means, and "do NOT recreate on this result" |
| 403/500/unreachable/undecodable | not "the library is empty" — explicitly |
| partially decodable | the names it could read, plus how many it could not, so the list is not read as complete |

## Verification

`query-graph-budget.test.ts` asserts the **joined** claim, never either half: the budget
the reply *reports* is the budget it was fitted to, **and** the reply either fits it or
says it does not. A size assertion alone passes via the wrong path.

`list-workflows-recursive.test.ts` runs against a **real nested tree** — including an
empty subfolder and a folder whose name needs escaping (spaces, `&`, `#`, `+`,
non-ASCII) — through a stand-in for ComfyUI's own `listuserdata` semantics. A fixture
list of strings would pass whether or not the request ever asked to recurse.

`assertBoundHonoured` — the invariant every budget test runs through — measures across
**all** text blocks, so the whole file enforces the wider bound, not only the cases
written for it.

Every fix was mutation-verified. Disabling the fitter fails 21 tests; reverting the
route to the shallow spelling fails 5; zeroing the sibling-block count fails 2; carrying
the owned marker fields through fails 1; restoring the "No saved workflows found"
headline fails 1. Each gate fix has its own mutation recorded in the commit that made it.

Full suite green at full concurrency: 254 files, 5107 tests, 37s — plus `lint`, `build`,
`asset-counts` and `vocab:export`.

## Gates

**Self-gate:** 11 rounds of `gpt-5.6-terra`, ending in PASS. It found real defects in the
fix itself — the same defect class the issues are about — including two SEVERE (deferring
to a `max_chars` the panel had put on the reply rather than the one enforced; a "nothing
to shed, so skip the accounting" shortcut that let whole classes of reply go unmeasured)
and eight MAJOR, each fixed with its own regression test.

**Independent gate: 3 P0**, all accepted, all the same shape — the defect one layer out
from where I had fixed it:

1. The fitter measured only the **first text block**, so a small fitted payload could sit
   beside an unmeasured 100k second block reporting `max_chars` and no overrun. #807
   relocated from `groups`/`rails` to the block list.
2. An **inbound `budget_overrun`** was carried through, so a reply that *fits* could
   announce that it does not — a false positive on the one marker that must be trusted.
3. **#810 survived its own fix**: any successful array, `[]` included, was treated as a
   complete recursive listing. The request URL is not evidence about the response, and an
   empty answer carries no name to prove otherwise — so that case is *undetermined*, not
   *empty*.

Re-gated after the fixes: PASS.

## Not fixed, deliberately

- **The panel still computes and sends the riders.** The orchestrator is where the
  caller-visible defect is fixed, and it works against every panel build; the panel
  sending fewer bytes over a loopback socket is a local efficiency matter, and a
  separate PR in the panel repo.
- **`list_workflows` output is uncapped.** For a listing, coverage *is* the content: a
  name cut off the end reads as "that workflow does not exist", which is the defect #810
  is about.
- **An error or non-JSON reply passes through untouched.** It carries no `max_chars`, so
  it makes no budget claim to be wrong, and rewriting a failure message to talk about a
  character budget would bury the failure.

## One correction to the issues

#807 suggested making `groups` opt-out, or omitting membership when `ids` is present.
Neither is done, and both would have been wrong: an unconditional rule cuts context on
the small graphs where it costs nothing, and a caller reading a node's group membership
by id is a real use. The budget decides instead, from measured sizes, so the same query
keeps its groups on a 20-node graph and loses them on a 690-node one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
