### PR TITLE
sweep the "could not determine" fold across the remaining surface, plus the auto-install tree gate

### DIFF
--- a/src/__tests__/services/install-comfyui.test.ts
+++ b/src/__tests__/services/install-comfyui.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+// Imported so the mocked fs/child_process functions can be scripted per-test;
+// these resolve to the vi.mock factories below.
+import { statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 
 // Mock node:child_process and node:fs so NO real git/pip/clone/disk access runs,
 // even if the default deps path is exercised.
@@ -285,5 +289,28 @@ describe("installComfyUI — failure surfacing", () => {
     // Clone was attempted; pip never reached.
     expect(calls.some((c) => c.args.includes("clone"))).toBe(true);
     expect(calls.some((c) => c.args.includes("install"))).toBe(false);
+  });
+});
+
+describe("installComfyUI — the default never-clobber probe (#796)", () => {
+  // These exercise defaultIsNonEmptyDir itself (no injected isNonEmptyDir):
+  // "could not look" must never be read as "empty".
+  it("an UNREADABLE target is refused, not folded into 'empty'", () => {
+    vi.mocked(statSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+    });
+    expect(() => installComfyUI({ targetPath: "/ws/comfy" })).toThrow(
+      /Refusing to install into a directory whose contents cannot be checked/,
+    );
+  });
+
+  it("a proven-ABSENT target (ENOENT) proceeds past the guard (control)", () => {
+    vi.mocked(statSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" });
+    });
+    vi.mocked(spawnSync).mockReturnValueOnce({ status: 1, stdout: "", stderr: "" } as never);
+    // The guard passes and the clone is what fails — a different error
+    // entirely, which is what proves we got past the guard.
+    expect(() => installComfyUI({ targetPath: "/ws/comfy" })).toThrow(/Command failed/);
   });
 });

--- a/src/__tests__/services/lora-catalog.test.ts
+++ b/src/__tests__/services/lora-catalog.test.ts
@@ -1,0 +1,572 @@
+// #796 — the LoRA catalog folded "could not parse" into "is empty", and the
+// next write (an unattended training handoff, an explicit upsert) then
+// DESTROYED the original file: the rescue path deleting the thing it rescues.
+// A corrupt catalog is evidence, and writes must preserve it — or refuse.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Passthrough by default; some tests script readFileSync/existsSync to
+// simulate another writer landing mid-persist. The real implementations are
+// stashed in a hoisted object so tests never pay an importActual mid-test.
+const realFs = vi.hoisted(() => ({
+  readFileSync: undefined as unknown as typeof import("node:fs").readFileSync,
+  existsSync: undefined as unknown as typeof import("node:fs").existsSync,
+  writeFileSync: undefined as unknown as typeof import("node:fs").writeFileSync,
+}));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  realFs.readFileSync = actual.readFileSync;
+  realFs.existsSync = actual.existsSync;
+  realFs.writeFileSync = actual.writeFileSync;
+  return {
+    ...actual,
+    readFileSync: vi.fn(actual.readFileSync),
+    existsSync: vi.fn(actual.existsSync),
+  };
+});
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { LoraCatalog } from "../../services/lora-catalog.js";
+
+let dir: string;
+let catalogPath: string;
+let previewsDir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cmcp-loracat-"));
+  catalogPath = join(dir, "lora-catalog.json");
+  previewsDir = join(dir, "previews");
+  process.env.COMFYUI_MCP_LORA_CATALOG = catalogPath;
+  process.env.COMFYUI_MCP_LORA_PREVIEWS = previewsDir;
+});
+
+afterEach(() => {
+  delete process.env.COMFYUI_MCP_LORA_CATALOG;
+  delete process.env.COMFYUI_MCP_LORA_PREVIEWS;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const backups = () =>
+  readdirSync(dir).filter((f) => f.startsWith("lora-catalog.json.corrupt-"));
+
+const TS = "2026-01-01T00:00:00Z";
+/** A full, write-path-shaped catalog entry (the bar the reader validates). */
+function validEntry(id: string, extra: Record<string, unknown> = {}) {
+  return {
+    id,
+    relPath: `loras/${id}.safetensors`,
+    displayName: id,
+    description: "",
+    setupInstructions: "",
+    keywords: [],
+    baseModels: [],
+    createdAt: TS,
+    updatedAt: TS,
+    ...extra,
+  };
+}
+
+describe("a corrupt catalog is never silently overwritten", () => {
+  it("a write over an unparseable file PRESERVES the original first", () => {
+    const corrupt = `{"version": 1, "entries": {"half-written": `;
+    writeFileSync(catalogPath, corrupt);
+
+    const catalog = new LoraCatalog();
+    // The corrupt content is not readable, so the in-memory view is empty…
+    expect(catalog.list()).toEqual([]);
+    // …but the write must not destroy the evidence of what was there.
+    catalog.upsert({ relPath: "loras/new.safetensors", description: "fresh" });
+
+    expect(backups()).toHaveLength(1);
+    expect(readFileSync(join(dir, backups()[0]!), "utf-8")).toBe(corrupt);
+    const now = JSON.parse(readFileSync(catalogPath, "utf-8"));
+    expect(Object.keys(now.entries)).toHaveLength(1);
+  });
+
+  it("a wrong-shape file (valid JSON, not a catalog) is corrupt, not empty", () => {
+    writeFileSync(catalogPath, JSON.stringify({ hello: "world" }));
+    const catalog = new LoraCatalog();
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(backups()).toHaveLength(1);
+  });
+
+  it("an entries ARRAY passes no shape check — it is corrupt, not a catalog", () => {
+    // `typeof [] === "object"`, and a string-keyed upsert on an array does not
+    // survive JSON.stringify: accepted-as-valid would mean a reported-success
+    // write that persists nothing.
+    const original = JSON.stringify({ version: 1, entries: [] });
+    writeFileSync(catalogPath, original);
+    const catalog = new LoraCatalog();
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(backups()).toHaveLength(1);
+    const now = JSON.parse(readFileSync(catalogPath, "utf-8"));
+    expect(Object.keys(now.entries)).toHaveLength(1);
+  });
+
+  it("entries: null is corrupt too (typeof null === 'object')", () => {
+    writeFileSync(catalogPath, JSON.stringify({ version: 1, entries: null }));
+    const catalog = new LoraCatalog();
+    // Accepted-as-valid would throw at Object.values(null) here instead.
+    expect(catalog.list()).toEqual([]);
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(backups()).toHaveLength(1);
+  });
+
+  it("malformed VALUES are set aside, and the write still preserves the original", () => {
+    // A partial write / hand-edit can leave "some-lora": null inside an
+    // otherwise valid catalog. The valid entries stay usable, the null one
+    // does not crash list(), and the original is backed up before any write.
+    const original = JSON.stringify({
+      version: 1,
+      entries: {
+        good: validEntry("good"),
+        bad: null,
+      },
+    });
+    writeFileSync(catalogPath, original);
+    const catalog = new LoraCatalog();
+    expect(catalog.list().map((e) => e.id)).toEqual(["good"]);
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(backups()).toHaveLength(1);
+    expect(readFileSync(join(dir, backups()[0]!), "utf-8")).toBe(original);
+  });
+
+  it("an entry object missing displayName is malformed too (the sort would crash)", () => {
+    const original = JSON.stringify({
+      version: 1,
+      entries: {
+        good: validEntry("good"),
+        bad: {},
+      },
+    });
+    writeFileSync(catalogPath, original);
+    const catalog = new LoraCatalog();
+    expect(catalog.list().map((e) => e.id)).toEqual(["good"]);
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(backups()).toHaveLength(1);
+    expect(readFileSync(join(dir, backups()[0]!), "utf-8")).toBe(original);
+  });
+
+  it("a string where an array field belongs is malformed (list would crash on .some)", () => {
+    const original = JSON.stringify({
+      version: 1,
+      entries: {
+        good: validEntry("good", { baseModels: ["FLUX.1-dev"] }),
+        bad: validEntry("bad", { baseModels: "FLUX" }),
+      },
+    });
+    writeFileSync(catalogPath, original);
+    const catalog = new LoraCatalog();
+    // The malformed entry is set aside; filtering must not throw on it.
+    expect(catalog.list({ baseModel: "flux" }).map((e) => e.id)).toEqual(["good"]);
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(backups()).toHaveLength(1);
+    expect(readFileSync(join(dir, backups()[0]!), "utf-8")).toBe(original);
+  });
+
+  it("a null INSIDE an array field (or a null timestamp) is malformed too", () => {
+    const original = JSON.stringify({
+      version: 1,
+      entries: {
+        good: validEntry("good", { tags: ["a"] }),
+        bad: validEntry("bad", { tags: [null] }),
+        worse: validEntry("worse", { createdAt: null }),
+      },
+    });
+    writeFileSync(catalogPath, original);
+    const catalog = new LoraCatalog();
+    // tags:[null] would crash the tag filter on null.toLowerCase(); both
+    // malformed entries are set aside (each by its own check).
+    expect(catalog.list({ tag: "a" }).map((e) => e.id)).toEqual(["good"]);
+    expect(catalog.get("bad")).toBeNull();
+    expect(catalog.get("worse")).toBeNull();
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(backups()).toHaveLength(1);
+    expect(readFileSync(join(dir, backups()[0]!), "utf-8")).toBe(original);
+  });
+
+  it("two backups in the same millisecond never collide (pid+seq names)", () => {
+    // The clock is frozen so the names can ONLY differ by design, never by a
+    // lucky tick: a shared name would let the second backup overwrite the
+    // first, erasing a preserved original after all.
+    vi.setSystemTime(new Date("2026-08-04T12:00:00Z"));
+    try {
+      const corrupt1 = `{"version": 1, "entries": {"half-written": `;
+      writeFileSync(catalogPath, corrupt1);
+      const catalog = new LoraCatalog();
+      catalog.upsert({ relPath: "loras/one.safetensors" }); // backup 1
+      const corrupt2 = `{"version": 1, "entries": {"also-truncated": `;
+      writeFileSync(catalogPath, corrupt2); // corrupt AGAIN (another writer crashed)
+      catalog.upsert({ relPath: "loras/two.safetensors" }); // backup 2, re-observed
+      const names = backups();
+      expect(names).toHaveLength(2);
+      const bodies = names.map((n) => readFileSync(join(dir, n), "utf-8"));
+      expect(bodies).toContain(corrupt1);
+      expect(bodies).toContain(corrupt2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a file REPAIRED since our read is refused, not overwritten — retry reconciles", () => {
+    // Our in-memory state derives from the CORRUPT read; writing it over the
+    // repair would silently destroy another writer's completed update.
+    writeFileSync(catalogPath, `{"version": 1, "entries": {"half-written": `);
+    const catalog = new LoraCatalog();
+    const fresh = validEntry("fresh");
+    writeFileSync(catalogPath, JSON.stringify({ version: 1, entries: { fresh } }));
+    expect(() => catalog.upsert({ relPath: "loras/new.safetensors" })).toThrow(/changed on disk/);
+    expect(backups()).toHaveLength(0);
+    // The refusal re-synced us onto the repaired state, dropping our mutation…
+    expect(catalog.get("fresh")?.id).toBe("fresh");
+    expect(catalog.get("loras/new.safetensors")).toBeNull();
+    // …so the retry applies cleanly, on top of the repair.
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(catalog.get("fresh")?.id).toBe("fresh");
+    expect(catalog.get("loras/new.safetensors")?.id).toBe("loras-new");
+    expect(backups()).toHaveLength(0);
+  });
+
+  it("an entry without an id cannot be 'removed' — remove reports the truth", () => {
+    // {"bad": {"displayName": "Bad"}} is not an entry. Accepted as one,
+    // remove("bad") would delete entries[undefined], persist, and return true
+    // — a removal that never happened, reported as done. Set aside at read,
+    // the honest answer is false.
+    writeFileSync(
+      catalogPath,
+      JSON.stringify({ version: 1, entries: { bad: { displayName: "Bad" } } }),
+    );
+    const catalog = new LoraCatalog();
+    expect(catalog.remove("bad")).toBe(false);
+    // And the malformed value is preserved when a write happens.
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(backups()).toHaveLength(1);
+  });
+
+  it("an entry filed under a KEY that is not its id cannot fabricate a removal", () => {
+    // remove("real") matches the value by relPath, then deletes
+    // entries[entry.id] — "real" — which is not where the entry lives.
+    // Deleting nothing and returning true is a fabricated removal, so a
+    // key/id mismatch marks the file corrupt at read.
+    writeFileSync(
+      catalogPath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          "stale-key": validEntry("real"),
+        },
+      }),
+    );
+    const catalog = new LoraCatalog();
+    expect(catalog.list()).toEqual([]);
+    expect(catalog.remove("real")).toBe(false);
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(backups()).toHaveLength(1);
+  });
+
+  it("a non-string previewFile is malformed (remove would throw AFTER deleting)", () => {
+    // remove() deletes and persists the entry, then join(dir, previewFile)
+    // throws on a number — a failure reported for a removal that already
+    // happened. The entry is set aside at read instead.
+    writeFileSync(
+      catalogPath,
+      JSON.stringify({ version: 1, entries: { x: validEntry("x", { previewFile: 1 }) } }),
+    );
+    const catalog = new LoraCatalog();
+    expect(catalog.get("x")).toBeNull();
+    expect(catalog.remove("x")).toBe(false);
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(backups()).toHaveLength(1);
+  });
+
+  it('a string "missing" flag is malformed (a present LoRA would list as missing)', () => {
+    // "false" is TRUTHY — list() filters on !!entry.missing, so this entry
+    // would silently vanish from every default listing.
+    writeFileSync(
+      catalogPath,
+      JSON.stringify({ version: 1, entries: { x: validEntry("x", { missing: "false" }) } }),
+    );
+    const catalog = new LoraCatalog();
+    expect(catalog.get("x")).toBeNull();
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(backups()).toHaveLength(1);
+  });
+
+  it(
+    "a write that finds the file CHANGED mid-persist refuses instead of overwriting it",
+    { timeout: 20000 },
+    async () => {
+    // Another process recovers/updates the catalog between our probe and our
+    // write: overwriting would destroy their update with no recoverable copy.
+    // The second read inside persist is scripted to simulate exactly that.
+    const v1 = JSON.stringify({ version: 1, entries: {} });
+    const v2 = JSON.stringify({
+      version: 1,
+      entries: { other: validEntry("other") },
+    });
+    writeFileSync(catalogPath, v1);
+    const catalog = new LoraCatalog();
+    let catalogReads = 0;
+    vi.mocked(readFileSync).mockImplementation(((p: unknown, ...rest: unknown[]) => {
+      if (p === catalogPath) {
+        catalogReads++;
+        if (catalogReads === 2) {
+          // The other writer lands their recovery right here.
+          realFs.writeFileSync(catalogPath, v2);
+        }
+      }
+      return (realFs.readFileSync as (...a: unknown[]) => unknown)(p, ...rest);
+    }) as never);
+    try {
+      expect(() => catalog.upsert({ relPath: "loras/new.safetensors" })).toThrow(
+        /changed on disk/,
+      );
+      // Their update survived, and nothing was backed up (nothing was corrupt).
+      expect(realFs.readFileSync(catalogPath, "utf-8")).toBe(v2);
+      expect(backups()).toHaveLength(0);
+      // The failed mutation did not linger either — we re-synced onto their state.
+      expect(catalog.list().map((e) => e.id)).toEqual(["other"]);
+    } finally {
+      vi.mocked(readFileSync).mockImplementation(realFs.readFileSync as never);
+    }
+  });
+
+  it("a file corrupted AFTER our read is still preserved at write time", () => {
+    // The corruption check re-observes the file at write time: a healthy read
+    // followed by another writer's crash-truncated file must not make our
+    // upsert the thing that destroys the evidence.
+    writeFileSync(catalogPath, JSON.stringify({ version: 1, entries: {} }));
+    const catalog = new LoraCatalog(); // reads the healthy file
+    const corrupt = `{"version": 1, "entries": {"half-written": `;
+    writeFileSync(catalogPath, corrupt); // another writer crashes mid-write
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(backups()).toHaveLength(1);
+    expect(readFileSync(join(dir, backups()[0]!), "utf-8")).toBe(corrupt);
+  });
+
+  it("a failed persist leaves NO uncommitted mutation in memory", () => {
+    // The write is refused (a directory at the catalog path can be neither
+    // read nor backed up). The upsert that was just reported as FAILED must
+    // not linger in memory to be committed by a later, successful write.
+    mkdirSync(catalogPath);
+    const catalog = new LoraCatalog();
+    expect(() => catalog.upsert({ relPath: "loras/ghost.safetensors" })).toThrow(
+      /Refusing to overwrite/,
+    );
+    expect(catalog.list()).toEqual([]); // the failed mutation is gone
+  });
+
+  it("a corrupt original that cannot even be COPIED refuses the write outright", () => {
+    // A directory at the catalog path: the read fails, and so does the
+    // preserving copy — the only honest outcome left is a loud refusal, and
+    // the original must be exactly where it was.
+    mkdirSync(catalogPath);
+    const catalog = new LoraCatalog();
+    expect(() => catalog.upsert({ relPath: "loras/new.safetensors" })).toThrow(
+      /Refusing to overwrite/,
+    );
+    // The cause is a READ failure — nothing was ever parsed, and the message
+    // must not claim otherwise.
+    expect(() => catalog.upsert({ relPath: "loras/new.safetensors" })).toThrow(
+      /could not be read/,
+    );
+    expect(statSync(catalogPath).isDirectory()).toBe(true);
+  });
+
+  it("a healthy catalog writes WITHOUT a backup (control)", () => {
+    writeFileSync(
+      catalogPath,
+      JSON.stringify({ version: 1, entries: {} }),
+    );
+    const catalog = new LoraCatalog();
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(backups()).toHaveLength(0);
+    expect(Object.keys(catalog.list())).toHaveLength(1);
+  });
+
+  it("no catalog at all writes fresh WITHOUT a backup (control)", () => {
+    const catalog = new LoraCatalog();
+    catalog.upsert({ relPath: "loras/new.safetensors" });
+    expect(backups()).toHaveLength(0);
+    expect(JSON.parse(readFileSync(catalogPath, "utf-8")).entries).toBeTypeOf("object");
+  });
+});
+
+describe("a failed persist never orphans a preview reference", () => {
+  const ENTRY = validEntry("x", { previewFile: "old.png" });
+
+  /** Script persist's identity re-read to carry another writer's update. */
+  function anotherWriterLandsMidPersist(v2: string): () => void {
+    let catalogReads = 0;
+    vi.mocked(readFileSync).mockImplementation(((p: unknown, ...rest: unknown[]) => {
+      if (p === catalogPath && ++catalogReads === 2) {
+        realFs.writeFileSync(catalogPath, v2);
+      }
+      return (realFs.readFileSync as (...a: unknown[]) => unknown)(p, ...rest);
+    }) as never);
+    return () => vi.mocked(readFileSync).mockImplementation(realFs.readFileSync as never);
+  }
+
+  it(
+    "remove() deletes the preview only AFTER the catalog write succeeds",
+    { timeout: 20000 },
+    async () => {
+    writeFileSync(catalogPath, JSON.stringify({ version: 1, entries: { x: ENTRY } }));
+    mkdirSync(previewsDir, { recursive: true });
+    writeFileSync(join(previewsDir, "old.png"), "png");
+    const catalog = new LoraCatalog();
+    const restore = anotherWriterLandsMidPersist(
+      JSON.stringify({
+        version: 1,
+        entries: {
+          x: ENTRY,
+          other: validEntry("other"),
+        },
+      }),
+    );
+    try {
+      expect(() => catalog.remove("x")).toThrow(/changed on disk/);
+      // The refusal restored the entry — and its preview must still exist.
+      expect(catalog.get("x")?.id).toBe("x");
+      expect(existsSync(join(previewsDir, "old.png"))).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it(
+    "setPreview() deletes the replaced preview only AFTER the catalog write succeeds",
+    { timeout: 20000 },
+    async () => {
+    writeFileSync(catalogPath, JSON.stringify({ version: 1, entries: { x: ENTRY } }));
+    mkdirSync(previewsDir, { recursive: true });
+    writeFileSync(join(previewsDir, "old.png"), "old");
+    const src = join(dir, "new.png");
+    writeFileSync(src, "new");
+    const catalog = new LoraCatalog();
+    const restore = anotherWriterLandsMidPersist(
+      JSON.stringify({
+        version: 1,
+        entries: {
+          x: ENTRY,
+          other: validEntry("other"),
+        },
+      }),
+    );
+    try {
+      // The catalog write is refused AND the already-written preview file is
+      // disclosed — never a bare refusal that hides the applied half.
+      const err = (() => {
+        try {
+          catalog.setPreview("x", src);
+          return undefined;
+        } catch (e) {
+          return e as Error;
+        }
+      })();
+      expect(err?.message).toMatch(/changed on disk/);
+      expect(err?.message).toMatch(/already written to/);
+      expect(existsSync(join(previewsDir, "old.png"))).toBe(true);
+      expect(catalog.get("x")?.previewFile).toBe("old.png");
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("a preview file is deleted only when nothing references it", () => {
+  it("remove() keeps a preview another entry still references", () => {
+    writeFileSync(
+      catalogPath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          x: validEntry("x", { previewFile: "shared.png" }),
+          y: validEntry("y", { previewFile: "shared.png" }),
+        },
+      }),
+    );
+    mkdirSync(previewsDir, { recursive: true });
+    writeFileSync(join(previewsDir, "shared.png"), "png");
+    const catalog = new LoraCatalog();
+    expect(catalog.remove("x")).toBe(true);
+    expect(existsSync(join(previewsDir, "shared.png"))).toBe(true);
+    expect(catalog.remove("y")).toBe(true);
+    expect(existsSync(join(previewsDir, "shared.png"))).toBe(false);
+  });
+});
+
+describe("cleanup never deletes on a corrupt read", () => {
+  it(
+    "a corrupt catalog at preview-cleanup time answers 'referenced'",
+    { timeout: 20000 },
+    () => {
+    writeFileSync(
+      catalogPath,
+      JSON.stringify({ version: 1, entries: { x: validEntry("x", { previewFile: "shared.png" }) } }),
+    );
+    mkdirSync(previewsDir, { recursive: true });
+    writeFileSync(join(previewsDir, "shared.png"), "png");
+    const catalog = new LoraCatalog();
+    let catalogReads = 0;
+    vi.mocked(readFileSync).mockImplementation(((p: unknown, ...rest: unknown[]) => {
+      if (p === catalogPath && ++catalogReads === 3) {
+        // persist's two reads passed; the preview-cleanup read finds the file
+        // crash-truncated — nothing is known about what references the preview.
+        return `{"version": 1, "entries": {"truncated": `;
+      }
+      return (realFs.readFileSync as (...a: unknown[]) => unknown)(p, ...rest);
+    }) as never);
+    try {
+      // The removal itself succeeds (the catalog write went through)…
+      expect(catalog.remove("x")).toBe(true);
+      // …but the preview is NOT deleted on a corrupt read.
+      expect(existsSync(join(previewsDir, "shared.png"))).toBe(true);
+    } finally {
+      vi.mocked(readFileSync).mockImplementation(realFs.readFileSync as never);
+    }
+  });
+});
+
+describe("inaccessible is not absent", () => {
+  it(
+    "an unsearchable path is not 'absent': the write preserves what it could not see",
+    { timeout: 20000 },
+    () => {
+    // existsSync answers false for an unsearchable ancestor exactly as for a
+    // missing file. Reading "absent" from that and then writing would destroy
+    // the catalog that was merely out of reach.
+    const original = JSON.stringify({ version: 1, entries: { y: validEntry("y") } });
+    writeFileSync(catalogPath, original);
+    vi.mocked(existsSync).mockImplementation(((p: unknown) =>
+      p === catalogPath
+        ? false
+        : (realFs.existsSync as (a: unknown) => boolean)(p)) as never);
+    vi.mocked(readFileSync).mockImplementation(((p: unknown, ...rest: unknown[]) => {
+      if (p === catalogPath) {
+        throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      }
+      return (realFs.readFileSync as (...a: unknown[]) => unknown)(p, ...rest);
+    }) as never);
+    try {
+      const catalog = new LoraCatalog();
+      expect(catalog.list()).toEqual([]); // unreachable — but that is NOT "empty"
+      catalog.upsert({ relPath: "loras/new.safetensors" });
+      expect(backups()).toHaveLength(1);
+      expect(readFileSync(join(dir, backups()[0]!), "utf-8")).toBe(original);
+    } finally {
+      vi.mocked(existsSync).mockImplementation(realFs.existsSync as never);
+      vi.mocked(readFileSync).mockImplementation(realFs.readFileSync as never);
+    }
+  });
+});

--- a/src/__tests__/services/missing-models.test.ts
+++ b/src/__tests__/services/missing-models.test.ts
@@ -8,6 +8,7 @@ import {
   matchQuality,
   rankCandidates,
   resolveCandidates,
+  resolveCandidatesDetailed,
   type ObjectInfoLike,
 } from "../../services/missing-models.js";
 
@@ -264,6 +265,36 @@ describe("resolveCandidates", () => {
     }));
     // a checkpoint hunt must not return LoRAs
     expect(seenTypes).toEqual(["Checkpoint"]);
+  });
+
+  it("a FAILED lookup is reported as failed, never folded into an empty list (#796)", async () => {
+    const out = await resolveCandidatesDetailed(
+      MISSING,
+      deps({
+        searchCivitai: async () => { throw new Error("civitai 503"); },
+        searchHf: async () => { throw new Error("hf timeout"); },
+      }),
+    );
+    expect(out.candidates).toEqual([]);
+    expect(out.failedProviders).toEqual(["CivitAI", "HuggingFace"]);
+  });
+
+  it("a one-provider failure degrades AND is disclosed", async () => {
+    const out = await resolveCandidatesDetailed(
+      MISSING,
+      deps({ searchCivitai: async () => { throw new Error("civitai 503"); } }),
+    );
+    expect(out.candidates.length).toBeGreaterThan(0);
+    expect(out.failedProviders).toEqual(["CivitAI"]);
+  });
+
+  it("a genuinely empty answer carries NO failures — 'nothing found' is then honest", async () => {
+    const out = await resolveCandidatesDetailed(
+      MISSING,
+      deps({ searchCivitai: async () => [], searchHf: async () => [] }),
+    );
+    expect(out.candidates).toEqual([]);
+    expect(out.failedProviders).toEqual([]);
   });
 });
 

--- a/src/__tests__/services/panel-autoinstall-tree-gate.test.ts
+++ b/src/__tests__/services/panel-autoinstall-tree-gate.test.ts
@@ -1,0 +1,187 @@
+// #820 — the on-load auto-install gate asked only "is the CURRENT base
+// resolution live-derived?", never whether that resolution names the tree the
+// install is about to land in. The tree is frozen at pin time; the resolution
+// is re-read at the gate; and the two can diverge WITHOUT any retarget — the
+// pin-time probe fails (configured fallback frozen), then a re-resolution of
+// the SAME target recovers and names the server's real --base-directory. The
+// pinned-generation check cannot see that (no retarget, no bump), so a
+// live-derived resolution naming tree B used to license an unattended install
+// into frozen tree A — an observation of one tree licensing a mutation of
+// another, landing in a custom_nodes nothing loads (no panel, no error).
+//
+// These tests drive `ensurePanelInstalled` with the PRODUCTION dep set — the
+// gate applies to it alone — over a real filesystem, with only the network
+// edge mocked.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.COMFYUI_MCP_PANEL_LOCK = join(
+  tmpdir(),
+  `cmcp-lock-autoinstall-${process.pid}.lock`,
+);
+
+const generation = vi.hoisted(() => ({ value: 0 }));
+vi.mock("../../config.js", () => ({
+  config: { comfyuiPath: undefined as string | undefined },
+  isLocalMode: () => true,
+  isRemoteMode: () => false,
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyuiTargetGeneration: () => generation.value,
+}));
+
+const workspace = vi.hoisted(() => ({
+  base: undefined as string | undefined,
+  liveArgv: undefined as string[] | undefined,
+  reachable: false,
+}));
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveEffectiveComfyUIBase: () => workspace.base,
+  liveRootFromArgv: (argv: string[] | undefined) => {
+    const main = argv?.find((a) => a.endsWith("main.py"));
+    return main ? main.slice(0, main.length - "/main.py".length) : undefined;
+  },
+  getLiveServerSnapshot: async () => ({
+    reachable: workspace.reachable,
+    argv: workspace.liveArgv,
+    cwd: undefined,
+  }),
+}));
+
+// The reachability probe is the seam where the mid-operation cache flip lands:
+// it runs AFTER the base was frozen and BEFORE the gate reads the resolution.
+const probeHook = vi.hoisted(() => ({ fn: undefined as undefined | (() => void) }));
+vi.mock("../../comfyui/client.js", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getSystemStats: async () => {
+    probeHook.fn?.();
+    return {};
+  },
+}));
+
+// The install itself is a spy with a sentinel failure: reaching it at all is
+// the signal that the gate PASSED, and the sentinel travels into the ensure
+// result's reason (ensurePanelInstalled converts errors to `unavailable`).
+const installSpy = vi.hoisted(() => ({
+  calls: [] as Array<{ id?: string }>,
+  sentinel: "INSTALL-REACHED-PAST-THE-GATE",
+}));
+vi.mock("../../services/node-management.js", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  installCustomNode: async (opts: { id?: string }) => {
+    installSpy.calls.push(opts);
+    throw new Error(installSpy.sentinel);
+  },
+}));
+
+import {
+  defaultDeps,
+  ensurePanelInstalled,
+  PANEL_REGISTRY_ID,
+} from "../../services/panel-installer.js";
+import { __resetPanelBaseCache } from "../../services/panel-workspace.js";
+
+let rootA: string;
+let savedPin: string | undefined;
+let savedAutoinstall: string | undefined;
+
+beforeEach(() => {
+  rootA = mkdtempSync(join(tmpdir(), "cmcp-autoinstall-"));
+  mkdirSync(join(rootA, "custom_nodes"), { recursive: true });
+  workspace.base = rootA;
+  workspace.liveArgv = undefined;
+  workspace.reachable = false;
+  probeHook.fn = undefined;
+  installSpy.calls.length = 0;
+  generation.value = 0;
+  __resetPanelBaseCache();
+  // Deterministic pin state regardless of the host's settings file.
+  savedPin = process.env.COMFYUI_MCP_PANEL_PIN;
+  process.env.COMFYUI_MCP_PANEL_PIN = "off";
+  savedAutoinstall = process.env.COMFYUI_MCP_PANEL_AUTOINSTALL;
+  delete process.env.COMFYUI_MCP_PANEL_AUTOINSTALL;
+});
+
+afterEach(() => {
+  rmSync(rootA, { recursive: true, force: true });
+  __resetPanelBaseCache();
+  if (savedPin === undefined) delete process.env.COMFYUI_MCP_PANEL_PIN;
+  else process.env.COMFYUI_MCP_PANEL_PIN = savedPin;
+  if (savedAutoinstall === undefined) delete process.env.COMFYUI_MCP_PANEL_AUTOINSTALL;
+  else process.env.COMFYUI_MCP_PANEL_AUTOINSTALL = savedAutoinstall;
+});
+
+describe("the auto-install gate requires the live resolution to name THIS tree (#820)", () => {
+  it("a live-derived resolution naming a DIFFERENT tree does not license the install", async () => {
+    // Pin-time probe fails → the configured fallback (rootA) is frozen. By the
+    // time the gate runs, the server answers and names its real root (rootB):
+    // no retarget, no generation bump — the window the generation check
+    // cannot see.
+    const rootB = mkdtempSync(join(tmpdir(), "cmcp-autoinstall-live-"));
+    mkdirSync(join(rootB, "custom_nodes"), { recursive: true });
+    probeHook.fn = () => {
+      workspace.reachable = true;
+      workspace.liveArgv = [`${rootB}/main.py`];
+    };
+    try {
+      const res = await ensurePanelInstalled({ deps: defaultDeps });
+      expect(res.action).toBe("unavailable");
+      // The reason must state the ACTUAL cause — a different tree named — not
+      // fold it into the configured-fallback wording.
+      expect(res.reason).toMatch(/DIFFERENT tree/);
+      expect(res.reason).toContain(rootB);
+      expect(res.reason).not.toMatch(/came from configuration/);
+      // And nothing may have been installed into the frozen tree.
+      expect(installSpy.calls).toEqual([]);
+    } finally {
+      rmSync(rootB, { recursive: true, force: true });
+    }
+  });
+
+  it("a same-URL restart onto a NEW tree inside the cache TTL does not license the install", async () => {
+    // The pin primes a live-derived rootA. ComfyUI then restarts at the SAME
+    // URL onto rootB — no retarget, no generation bump, and the 60s
+    // resolution cache would still vouch for A. The gate must re-resolve
+    // rather than trust the cache.
+    const rootB = mkdtempSync(join(tmpdir(), "cmcp-autoinstall-restart-"));
+    mkdirSync(join(rootB, "custom_nodes"), { recursive: true });
+    workspace.reachable = true;
+    workspace.liveArgv = [`${rootA}/main.py`];
+    probeHook.fn = () => {
+      workspace.liveArgv = [`${rootB}/main.py`]; // the restart lands mid-operation
+    };
+    try {
+      const res = await ensurePanelInstalled({ deps: defaultDeps });
+      expect(res.action).toBe("unavailable");
+      expect(res.reason).toMatch(/DIFFERENT tree/);
+      expect(res.reason).toContain(rootB);
+      expect(installSpy.calls).toEqual([]);
+    } finally {
+      rmSync(rootB, { recursive: true, force: true });
+    }
+  });
+
+  it("a live-derived resolution naming the SAME tree lets the install proceed", async () => {
+    // The reverse fold — an over-strict gate refusing a corroborated install —
+    // is the same defect pointed at a positive. The pin primes live-derived
+    // rootA; the gate must pass and reach the Manager install.
+    workspace.reachable = true;
+    workspace.liveArgv = [`${rootA}/main.py`];
+    const res = await ensurePanelInstalled({ deps: defaultDeps });
+    expect(installSpy.calls).toEqual([{ id: PANEL_REGISTRY_ID, version: "nightly" }]);
+    // The sentinel proves the install was attempted; ensure converts the
+    // thrown sentinel into an unavailable carrying it.
+    expect(res.action).toBe("unavailable");
+    expect(res.reason).toContain(installSpy.sentinel);
+  });
+
+  it("a merely configured resolution is still refused (the original #766 case)", async () => {
+    const res = await ensurePanelInstalled({ deps: defaultDeps });
+    expect(res.action).toBe("unavailable");
+    expect(res.reason).toMatch(/came from configuration/);
+    expect(res.reason).not.toMatch(/DIFFERENT tree/);
+    expect(installSpy.calls).toEqual([]);
+  });
+});

--- a/src/__tests__/services/panel-recovery-cluster.test.ts
+++ b/src/__tests__/services/panel-recovery-cluster.test.ts
@@ -2703,6 +2703,57 @@ describe("a wholesale replacement needs the RUNNING server to have chosen the tr
   });
 });
 
+describe("status does not let a live reading of ANOTHER tree certify the frozen one (#820)", () => {
+  it("a live-derived resolution naming a DIFFERENT tree does not prove the frozen tree's absence", async () => {
+    // The pin froze the CONFIGURED fallback (the probe failed at pin time); a
+    // re-resolution of the same target then named the server's real root — no
+    // retarget, no generation bump. The absence was observed in the frozen
+    // tree; a live reading about ANOTHER tree must not "prove" it and unblock
+    // an install there.
+    workspace.base = root;
+    workspace.reachable = false;
+    __resetPanelBaseCache();
+    const pinned = await pinPanelBase(defaultDeps);
+    expect(pinned.comfyuiPath()).toBe(root);
+    const otherRoot = mkdtempSync(join(tmpdir(), "cmcp-other-"));
+    mkdirSync(join(otherRoot, "custom_nodes"), { recursive: true });
+    try {
+      __setPanelBaseForTests(otherRoot, "live-argv-root");
+      const { panelStatus } = await import("../../services/panel-installer.js");
+      const { evaluatePanelSync } = await import("../../services/panel-sync.js");
+      const status = await panelStatus(pinned);
+      expect(status.installed).toBe(false);
+      expect(status.absenceProven).toBe(false);
+      expect(evaluatePanelSync(status).decision).toBe("blocked");
+      // The note must name the actual cause — not assert the plain
+      // "Not installed" the flipped resolution used to certify.
+      expect(status.note).toMatch(/DIFFERENT tree/);
+      expect(status.note).toContain(otherRoot);
+      expect(status.note).not.toMatch(/Not installed\. Run install_panel/);
+      // Nor may it attribute this scan to the live root it did not scan.
+      expect(status.note).not.toMatch(/Resolved (against|from) the RUNNING/);
+    } finally {
+      rmSync(otherRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("a live-derived resolution naming the SAME tree still proves the absence", async () => {
+    // The reverse fold — an over-strict check refusing a real finding — is the
+    // same defect pointed at a positive: a corroborated absence must still be
+    // reported as proven.
+    workspace.base = undefined;
+    workspace.reachable = true;
+    workspace.liveArgv = [`${root}/main.py`];
+    __resetPanelBaseCache();
+    const { panelStatus } = await import("../../services/panel-installer.js");
+    const status = await panelStatus();
+    expect(status.installed).toBe(false);
+    expect(status.absenceProven).toBe(true);
+    expect(status.note).toMatch(/Not installed\. Run install_panel/);
+    expect(status.note).toMatch(/Resolved from the RUNNING/);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // 4. Target resolution (#766, #769)
 // ---------------------------------------------------------------------------

--- a/src/__tests__/services/queue-manager-escalation.test.ts
+++ b/src/__tests__/services/queue-manager-escalation.test.ts
@@ -1,0 +1,415 @@
+// #796 — `waitForRunningCleared` folded a FAILED /queue poll into "still
+// running", and after the timeout the caller declared the job "wedged inside
+// a single step — restart ComfyUI, do NOT queue another run". A crashed
+// ComfyUI also stops answering /queue — and takes the job with it — so the
+// fold produced a confident wedge verdict (and a blocking instruction) about
+// a job that no longer existed. The verdict is now three-state.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  isCloudMode: () => queueBehavior.cloud,
+}));
+
+const queueBehavior = vi.hoisted(() => ({
+  mode: "down" as
+    | "down"
+    | "running"
+    | "dies"
+    | "recovers"
+    | "clears-after-free"
+    | "unobserved-start"
+    | "recovers-unobserved"
+    | "someone-running"
+    | "someone-wedged"
+    | "dies-late"
+    | "named-late"
+    | "unwatched-then-wedged"
+    | "stops-on-interrupt",
+  calls: 0,
+  freeFails: false,
+  clearFails: false,
+  cloud: false,
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getClient: vi.fn(),
+  getHistory: vi.fn(),
+  getQueue: async () => {
+    queueBehavior.calls++;
+    if (queueBehavior.mode === "down") throw new Error("ECONNREFUSED");
+    if (queueBehavior.mode === "dies" && queueBehavior.calls > 2) {
+      throw new Error("ECONNRESET");
+    }
+    // Unreachable through the honor window, then answers with an EMPTY queue:
+    // the job is gone, but what removed it was never observed.
+    if (queueBehavior.mode === "recovers") {
+      if (queueBehavior.calls === 1) {
+        return { queue_running: [[1, "prompt-xyz"]], queue_pending: [] };
+      }
+      if (queueBehavior.calls <= 3) throw new Error("ECONNRESET");
+      return { queue_running: [], queue_pending: [] };
+    }
+    // The pre-interrupt read fails; every later poll answers EMPTY.
+    if (queueBehavior.mode === "unobserved-start") {
+      if (queueBehavior.calls === 1) throw new Error("ECONNREFUSED");
+      return { queue_running: [], queue_pending: [] };
+    }
+    // NOTHING answers until the final verification poll, which is EMPTY.
+    if (queueBehavior.mode === "recovers-unobserved") {
+      if (queueBehavior.calls <= 3) throw new Error("ECONNRESET");
+      return { queue_running: [], queue_pending: [] };
+    }
+    // Pre-check and first window fail; the named prompt appears in the FINAL window.
+    if (queueBehavior.mode === "named-late") {
+      if (queueBehavior.calls <= 3) throw new Error("ECONNRESET");
+      return { queue_running: [[1, "prompt-xyz"]], queue_pending: [] };
+    }
+    // Observed running at pre-check, honor window fails, final window: running.
+    if (queueBehavior.mode === "unwatched-then-wedged") {
+      if (queueBehavior.calls === 1) return { queue_running: [[1, "prompt-xyz"]], queue_pending: [] };
+      if (queueBehavior.calls <= 3) throw new Error("ECONNRESET");
+      return { queue_running: [[1, "prompt-xyz"]], queue_pending: [] };
+    }
+    // The FINAL window answers once (still running), then dies.
+    if (queueBehavior.mode === "dies-late") {
+      if (queueBehavior.calls <= 3) throw new Error("ECONNRESET");
+      if (queueBehavior.calls === 4) return { queue_running: [[1, "prompt-xyz"]], queue_pending: [] };
+      throw new Error("ECONNRESET");
+    }
+    // The pre-check fails; SOME job is running at every poll, forever.
+    if (queueBehavior.mode === "someone-wedged") {
+      if (queueBehavior.calls === 1) throw new Error("ECONNREFUSED");
+      return { queue_running: [[1, "prompt-xyz"]], queue_pending: [] };
+    }
+    // The pre-check fails; the honor window shows SOME job running; empty after /free.
+    if (queueBehavior.mode === "someone-running") {
+      if (queueBehavior.calls === 1) throw new Error("ECONNREFUSED");
+      if (queueBehavior.calls <= 3) return { queue_running: [[1, "prompt-xyz"]], queue_pending: [] };
+      return { queue_running: [], queue_pending: [] };
+    }
+    // Running at the pre-check, empty from the first poll on.
+    if (queueBehavior.mode === "stops-on-interrupt" && queueBehavior.calls >= 2) {
+      return { queue_running: [], queue_pending: [] };
+    }
+    // Answering and running through the honor window, empty afterwards: the
+    // /free escalation went out between the two.
+    if (queueBehavior.mode === "clears-after-free" && queueBehavior.calls >= 4) {
+      return { queue_running: [], queue_pending: [] };
+    }
+    return { queue_running: [[1, "prompt-xyz"]], queue_pending: [] };
+  },
+  interrupt: async () => {},
+  deleteQueueItem: vi.fn(),
+  clearQueue: async () => {
+    if (queueBehavior.clearFails) throw new Error("clear refused");
+  },
+  enqueuePrompt: vi.fn(),
+  freeMemory: async () => {
+    if (queueBehavior.freeFails) throw new Error("free refused");
+  },
+}));
+
+import { cancelRunningJobEscalating } from "../../services/queue-manager.js";
+
+let savedInterruptS: string | undefined;
+
+beforeEach(() => {
+  queueBehavior.calls = 0;
+  queueBehavior.freeFails = false;
+  queueBehavior.clearFails = false;
+  queueBehavior.cloud = false;
+  savedInterruptS = process.env.COMFYUI_MCP_INTERRUPT_S;
+  process.env.COMFYUI_MCP_INTERRUPT_S = "2"; // keep the honor window short
+});
+
+afterEach(() => {
+  if (savedInterruptS === undefined) delete process.env.COMFYUI_MCP_INTERRUPT_S;
+  else process.env.COMFYUI_MCP_INTERRUPT_S = savedInterruptS;
+});
+
+describe("cancel escalation never folds a dead queue into a wedge verdict", () => {
+  it(
+    "a queue that NEVER answers reports UNKNOWN, not wedged",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "down";
+      const res = await cancelRunningJobEscalating({});
+      expect(res.wedged).toBe(false);
+      expect(res.unverified).toBe(true);
+      expect(res.honored).toBe(false);
+      expect(res.message).toMatch(/UNKNOWN/);
+      // It never answered — the message must not claim a transition.
+      expect(res.message).toMatch(/did not answer during verification/);
+      // The confident wedge diagnosis and its blocking instruction must be gone.
+      expect(res.message).not.toMatch(/wedged inside a single step/);
+      expect(res.message).not.toMatch(/Do NOT queue another run/);
+    },
+  );
+
+  it(
+    "a queue that dies MID-verification is unknown, not wedged",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "dies";
+      const res = await cancelRunningJobEscalating({});
+      expect(res.wedged).toBe(false);
+      expect(res.unverified).toBe(true);
+      expect(res.message).toMatch(/UNKNOWN/);
+      // The final verification window never answered.
+      expect(res.message).toMatch(/did not answer during verification/);
+    },
+  );
+
+  it(
+    "cloud mode never narrates a VRAM free (the call is a no-op there)",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "running";
+      queueBehavior.cloud = true;
+      const res = await cancelRunningJobEscalating({});
+      expect(res.wedged).toBe(true);
+      expect(res.freed_vram).toBe(false);
+      expect(res.message).not.toMatch(/VRAM free/);
+    },
+  );
+
+  it(
+    "a wedge after an UNWATCHED first window does not claim continuous polling",
+    { timeout: 20000 },
+      async () => {
+      queueBehavior.mode = "unwatched-then-wedged";
+      const res = await cancelRunningJobEscalating({});
+      expect(res.wedged).toBe(true);
+      expect(res.message).toMatch(/wedged inside a single step/);
+      expect(res.message).toMatch(/at a verified check/);
+      expect(res.message).not.toMatch(/across ~\d+s of verified polling/);
+    },
+  );
+
+  it(
+    "a wedged verdict with a failed /free does not claim freed VRAM",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "running";
+      queueBehavior.freeFails = true;
+      const res = await cancelRunningJobEscalating({});
+      expect(res.wedged).toBe(true);
+      expect(res.freed_vram).toBe(false);
+      expect(res.message).toMatch(/VRAM-free escalation did not complete/);
+    },
+  );
+
+  it(
+    "a job still running on a LIVE queue is still declared wedged (control)",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "running";
+      const res = await cancelRunningJobEscalating({});
+      expect(res.wedged).toBe(true);
+      expect(res.unverified).toBeUndefined();
+      expect(res.message).toMatch(/wedged inside a single step/);
+      // The stated duration must be BOTH windows (2s honor + 2s re-check here),
+      // not just the first.
+      expect(res.message).toMatch(/across ~4s of verified polling/);
+    },
+  );
+
+  it(
+    "a FAILED /free escalation is not narrated as a performed one",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "down";
+      queueBehavior.freeFails = true;
+      const res = await cancelRunningJobEscalating({});
+      expect(res.unverified).toBe(true);
+      expect(res.freed_vram).toBe(false);
+      expect(res.message).toMatch(/VRAM-free escalation did not complete/);
+      // A throw means no completion was OBSERVED — never "never reached the server".
+      expect(res.message).not.toMatch(/never reached the server/);
+      expect(res.message).not.toMatch(/\(and a VRAM free\)/);
+    },
+  );
+
+  it(
+    "a FAILED clear_pending is not reported as cleared",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "down";
+      queueBehavior.clearFails = true;
+      const res = await cancelRunningJobEscalating({ clear_pending: true });
+      expect(res.unverified).toBe(true);
+      expect(res.pending_cleared).toBeUndefined();
+      expect(res.message).toMatch(/Clearing pending jobs FAILED/);
+      expect(res.message).not.toMatch(/Pending jobs were cleared/);
+    },
+  );
+
+  it(
+    "cleared after /free states the SEQUENCE, never the cause",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "clears-after-free";
+      const res = await cancelRunningJobEscalating({});
+      expect(res.honored).toBe(true);
+      expect(res.wedged).toBe(false);
+      expect(res.message).toMatch(/has now STOPPED \(verified via \/queue\)/);
+      expect(res.message).not.toMatch(/freeing VRAM cleared it/);
+    },
+  );
+
+  it(
+    "an unclear stop after a FAILED /free does not suggest the free may have worked",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "recovers";
+      queueBehavior.freeFails = true;
+      const res = await cancelRunningJobEscalating({});
+      expect(res.honored).toBe(true);
+      expect(res.freed_vram).toBe(false);
+      expect(res.message).toMatch(/VRAM-free escalation did not complete/);
+      expect(res.message).not.toMatch(/VRAM free may have done it/);
+    },
+  );
+
+  it(
+    "gone-after-an-unobservable window does NOT credit the VRAM free with the stop",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "recovers";
+      const res = await cancelRunningJobEscalating({});
+      expect(res.honored).toBe(true);
+      expect(res.wedged).toBe(false);
+      // The stop is verified; its cause is not.
+      expect(res.message).toMatch(/what stopped it is unknown/);
+      expect(res.message).not.toMatch(/freeing VRAM cleared it/);
+    },
+  );
+
+  it(
+    "an UNOBSERVED start is not reported as 'Interrupted the running job'",
+    { timeout: 20000 },
+    async () => {
+      // The pre-interrupt read failed, then the queue answered EMPTY. All that
+      // is established is "nothing is running now" — never that the interrupt
+      // stopped something.
+      queueBehavior.mode = "unobserved-start";
+      const res = await cancelRunningJobEscalating({});
+      expect(res.honored).toBe(false);
+      expect(res.unverified).toBe(true);
+      expect(res.wedged).toBe(false);
+      expect(res.message).toMatch(/nothing is running now/);
+      expect(res.message).toMatch(/UNKNOWN/);
+      expect(res.message).not.toMatch(/Interrupted the running job/);
+    },
+  );
+
+  it(
+    "an observed stop is still reported as interrupted (control)",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "stops-on-interrupt";
+      const res = await cancelRunningJobEscalating({});
+      expect(res.honored).toBe(true);
+      expect(res.unverified).toBeUndefined();
+      expect(res.message).toMatch(/Interrupted the running job/);
+    },
+  );
+
+  it(
+    "empty-after-total-outage asserts neither a running job nor a stop cause",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "recovers-unobserved";
+      const res = await cancelRunningJobEscalating({});
+      expect(res.honored).toBe(false);
+      expect(res.unverified).toBe(true);
+      expect(res.wedged).toBe(false);
+      expect(res.message).toMatch(/Nothing is running now \(verified via \/queue\)/);
+      expect(res.message).toMatch(/UNKNOWN/);
+      expect(res.message).not.toMatch(/The running job/);
+    },
+  );
+
+  it(
+    "the UNKNOWN verdict never invents an observed running job",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "down";
+      const res = await cancelRunningJobEscalating({});
+      expect(res.unverified).toBe(true);
+      expect(res.message).toMatch(/An interrupt was sent/);
+      expect(res.message).not.toMatch(/The running job/);
+    },
+  );
+
+  it(
+    "a named prompt first sighted INSIDE the window is not a verified stop either",
+    { timeout: 20000 },
+    async () => {
+      // Pre-check fails; the prompt appears during the honor window (it may
+      // have STARTED after the interrupt — a no-op for it), then clears.
+      queueBehavior.mode = "someone-running";
+      const res = await cancelRunningJobEscalating({ prompt_id: "prompt-xyz" });
+      expect(res.honored).toBe(false);
+      expect(res.unverified).toBe(true);
+      expect(res.message).toMatch(/whether the job that stopped is the one that was interrupted is UNKNOWN/);
+      expect(res.message).not.toMatch(/has now STOPPED/);
+    },
+  );
+
+  it(
+    "a NAMED prompt never observed before the interrupt keeps the identity caveat",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "named-late";
+      const res = await cancelRunningJobEscalating({ prompt_id: "prompt-xyz" });
+      expect(res.wedged).toBe(true);
+      expect(res.unverified).toBe(true);
+      expect(res.message).toMatch(/Whether this IS the job the interrupt addressed is UNKNOWN/);
+      expect(res.message).toMatch(/may have started after/);
+      expect(res.message).not.toMatch(/did NOT stop after interrupt/);
+    },
+  );
+
+  it(
+    "a queue that answers once in the final window and then dies says so",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "dies-late";
+      const res = await cancelRunningJobEscalating({});
+      expect(res.unverified).toBe(true);
+      expect(res.message).toMatch(/stopped answering partway through verification/);
+      expect(res.message).not.toMatch(/did not answer during verification/);
+    },
+  );
+
+  it(
+    "a wedged job whose start was never observed keeps the caveat",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "someone-wedged";
+      const res = await cancelRunningJobEscalating({});
+      // A job IS verifiably wedged — but its identity was never established.
+      expect(res.wedged).toBe(true);
+      expect(res.unverified).toBe(true);
+      expect(res.message).toMatch(/wedged inside a single step/);
+      expect(res.message).toMatch(/Whether this IS the job the interrupt addressed is UNKNOWN/);
+      expect(res.message).not.toMatch(/The running job/);
+    },
+  );
+
+  it(
+    "a job seen only DURING the window is not tied to the interrupt",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "someone-running";
+      const res = await cancelRunningJobEscalating({});
+      expect(res.honored).toBe(false);
+      expect(res.unverified).toBe(true);
+      expect(res.message).toMatch(/whether the job that stopped is the one that was interrupted is UNKNOWN/);
+      expect(res.message).not.toMatch(/The job didn't stop/);
+    },
+  );
+});

--- a/src/__tests__/services/training-jobs.test.ts
+++ b/src/__tests__/services/training-jobs.test.ts
@@ -244,6 +244,67 @@ describe("startTrainingJob", () => {
     expect(done.result!.previewFile).toBe("loras-test-job.png");
   });
 
+  it("a failed CATALOG upsert does not fail a job whose LoRA was published (#796)", async () => {
+    // The LoRA copy lands BEFORE the catalog write, so a catalog that throws
+    // (a corrupt on-disk catalog it refuses to overwrite) is a disclosure on
+    // a completed job — never "output handoff failed" for a published model.
+    const d = deferred<{ code: number; tail: string }>();
+    const catalog = fakeCatalog();
+    catalog.upsert = () => {
+      throw new Error("Refusing to overwrite it — inspect or repair the file manually.");
+    };
+    const lorasDir = join(root, "loras");
+    const job = await startWith({
+      startTraining: (opts) => {
+        const outDir = join(opts.outputDir, "test_job");
+        mkdirSync(outDir, { recursive: true });
+        writeFileSync(join(outDir, "test_job.safetensors"), "weights");
+        setTimeout(() => d.resolve({ code: 0, tail: "" }), 5);
+        return fakeHandle(d);
+      },
+      lorasDir: () => lorasDir,
+      catalog,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    const done = (await mod.getJob(job.id))!;
+    expect(done.status).toBe("completed");
+    expect(done.result!.loraPath).toBe(join(lorasDir, "test_job.safetensors"));
+    expect(existsSync(done.result!.loraPath)).toBe(true);
+    expect(done.result!.catalogId).toBeUndefined();
+    expect(done.result!.catalogError).toMatch(/Refusing to overwrite/);
+    expect(done.error).toBeUndefined();
+  });
+
+  it("a failed PREVIEW handoff is disclosed on the completed job, not dropped (#796)", async () => {
+    // setPreview can fail AFTER writing the preview file (it discloses exactly
+    // that). Silently logging it would report a completed job with neither
+    // previewFile nor error while the preview sits unreconciled.
+    const d = deferred<{ code: number; tail: string }>();
+    const catalog = fakeCatalog();
+    catalog.setPreview = () => {
+      throw new Error("The preview image was already written to /x.png, but recording it in the catalog FAILED");
+    };
+    const lorasDir = join(root, "loras");
+    const job = await startWith({
+      startTraining: (opts) => {
+        const outDir = join(opts.outputDir, "test_job");
+        mkdirSync(join(outDir, "samples"), { recursive: true });
+        writeFileSync(join(outDir, "test_job.safetensors"), "weights");
+        writeFileSync(join(outDir, "samples", "0001.png"), "sample");
+        setTimeout(() => d.resolve({ code: 0, tail: "" }), 5);
+        return fakeHandle(d);
+      },
+      lorasDir: () => lorasDir,
+      catalog,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    const done = (await mod.getJob(job.id))!;
+    expect(done.status).toBe("completed");
+    expect(done.result!.catalogId).toBe("loras-test-job");
+    expect(done.result!.previewFile).toBeUndefined();
+    expect(done.result!.catalogError).toMatch(/preview:.*already written/);
+  });
+
   it("marks the job failed when the container exits non-zero", async () => {
     const d = deferred<{ code: number; tail: string }>();
     const job = await startWith({

--- a/src/__tests__/tools/missing-models.test.ts
+++ b/src/__tests__/tools/missing-models.test.ts
@@ -1,0 +1,84 @@
+// #796 — resolve_missing_models folded a FAILED provider lookup into an empty
+// result and then asserted "No candidates found on CivitAI or HuggingFace —
+// try a different query": "could not look" narrated as "nothing exists",
+// with advice that blames the query. The message must state the failure.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: async () => ({
+    CheckpointLoaderSimple: {
+      input: { required: { ckpt_name: [["already-have.safetensors"], {}] } },
+    },
+  }),
+  getSystemStats: async () => ({ devices: [{ vram_total: 16 * 1024 ** 3 }] }),
+}));
+
+const providers = vi.hoisted(() => ({ civitaiDown: true, hfDown: true }));
+vi.mock("../../services/civitai-resolver.js", () => ({
+  searchCivitaiModels: async () => {
+    if (providers.civitaiDown) throw new Error("civitai 503");
+    return { hits: [] };
+  },
+}));
+vi.mock("../../services/model-resolver.js", () => ({
+  searchHuggingFaceModels: async () => {
+    if (providers.hfDown) throw new Error("hf timeout");
+    return [];
+  },
+}));
+
+import { registerMissingModelTools } from "../../tools/missing-models.js";
+
+type Handler = (args: unknown) => Promise<{ content: Array<{ text: string }> }>;
+
+function captureHandler(): Handler {
+  let handler: Handler | undefined;
+  const fakeServer = {
+    tool: (_name: string, _desc: string, _schema: unknown, h: Handler) => {
+      handler = h;
+    },
+  };
+  registerMissingModelTools(fakeServer as never);
+  if (!handler) throw new Error("tool was not registered");
+  return handler;
+}
+
+const WORKFLOW = {
+  "1": {
+    class_type: "CheckpointLoaderSimple",
+    inputs: { ckpt_name: "flux1-dev.safetensors" },
+  },
+};
+
+beforeEach(() => {
+  providers.civitaiDown = true;
+  providers.hfDown = true;
+});
+
+describe("resolve_missing_models never calls a failed lookup an empty one", () => {
+  it("both providers down → 'could not look', NOT 'nothing exists'", async () => {
+    const res = await captureHandler()({ workflow: WORKFLOW });
+    const text = res.content[0]!.text;
+    expect(text).toMatch(/the lookup FAILED/);
+    expect(text).toMatch(/could not look/);
+    expect(text).not.toMatch(/No candidates found on CivitAI or HuggingFace/);
+  });
+
+  it("one provider down with zero hits from the other → still not 'nothing exists'", async () => {
+    providers.hfDown = false; // answers, but with nothing
+    const res = await captureHandler()({ workflow: WORKFLOW });
+    const text = res.content[0]!.text;
+    expect(text).toMatch(/the lookup FAILED \(CivitAI\)/);
+    expect(text).not.toMatch(/No candidates found on CivitAI or HuggingFace/);
+  });
+
+  it("both providers answering empty → the plain 'no candidates' message (control)", async () => {
+    providers.civitaiDown = false;
+    providers.hfDown = false;
+    const res = await captureHandler()({ workflow: WORKFLOW });
+    const text = res.content[0]!.text;
+    expect(text).toMatch(/No candidates found on CivitAI or HuggingFace/);
+    expect(text).not.toMatch(/lookup FAILED/);
+  });
+});

--- a/src/services/install-comfyui.ts
+++ b/src/services/install-comfyui.ts
@@ -121,16 +121,24 @@ function defaultHasCommand(cmd: string): boolean {
 }
 
 function defaultIsNonEmptyDir(p: string): boolean {
+  // Three answers, because the caller's never-clobber guard reads `false` as
+  // "safe to install here". There is NO existsSync pre-screen: it cannot tell
+  // "absent" from "cannot look", and folding an unreadable target into
+  // "empty/absent" would wave the installer into a directory it may be about
+  // to clobber. Only a proven-absent (ENOENT) target is empty.
   try {
-    if (!existsSync(p)) return false;
     const st = statSync(p);
     if (!st.isDirectory()) {
       // A file occupying the target path is also a conflict.
       return true;
     }
     return readdirSync(p).length > 0;
-  } catch {
-    return false;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return false;
+    throw new ValidationError(
+      `Could not inspect the target path ${p}: ${err instanceof Error ? err.message : String(err)}. ` +
+        `Refusing to install into a directory whose contents cannot be checked — it may not be empty.`,
+    );
   }
 }
 

--- a/src/services/lora-catalog.ts
+++ b/src/services/lora-catalog.ts
@@ -116,27 +116,116 @@ function defaultDisplayName(relPath: string): string {
   return file.replace(/\.(safetensors|ckpt|pt|bin)$/i, "").replace(/_/g, " ");
 }
 
-function readCatalogFile(): LoraCatalogFile {
-  const path = loraCatalogPath();
-  if (!existsSync(path)) {
-    return { version: CATALOG_VERSION, entries: {} };
-  }
+/**
+ * The on-disk catalog read THREE ways: absent (start fresh), parsed (use it),
+ * or CORRUPT (present but unparseable — crash-truncated, hand-edited wrong).
+ * The third must never be folded into the first: an empty in-memory catalog
+ * written back over a corrupt file destroys whatever curation the file still
+ * holds — "could not determine" becoming "determined empty" with data loss.
+ */
+interface CatalogRead {
+  data: LoraCatalogFile;
+  /** Why the existing file could not be used — set only when it EXISTS. */
+  corrupt?: string;
+}
+
+/** The catalog file's raw text, three ways: absent, unreadable, or the bytes. */
+function readCatalogRaw(path: string): { raw?: string; unreadable?: string } {
+  // NO existsSync pre-screen: it cannot tell "absent" from "cannot look" (an
+  // unsearchable ancestor answers false either way), and a false "absent"
+  // would let a later write overwrite a catalog we merely failed to SEE.
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    return { raw: readFileSync(path, "utf-8") };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return {};
+    return { unreadable: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/** Parse raw catalog text, setting aside malformed entry VALUES. */
+function parseCatalogRaw(raw: string): CatalogRead {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    const entries = (parsed as LoraCatalogFile | null)?.entries;
     if (
       parsed &&
       typeof parsed === "object" &&
       (parsed as LoraCatalogFile).version === CATALOG_VERSION &&
-      typeof (parsed as LoraCatalogFile).entries === "object"
+      // null passes typeof "object"; an ARRAY passes it too but string-keyed
+      // upserts on it do not survive JSON.stringify — the write would report
+      // success and persist nothing. Only a plain record is a catalog.
+      entries !== null &&
+      entries !== undefined &&
+      typeof entries === "object" &&
+      !Array.isArray(entries)
     ) {
-      return parsed as LoraCatalogFile;
+      // The record itself is shaped right, but individual VALUES may not be
+      // (a hand-edit or a partial write leaves "some-lora": null or {} behind
+      // — a null crashes list(), a missing displayName crashes the sort, a
+      // missing id makes remove() "delete" a key of `undefined`, a key that
+      // is not the entry's id makes remove() delete nothing while reporting
+      // the removal done, a string in an array field (or a non-string member)
+      // crashes .some(x => x.toLowerCase()), a non-string previewFile makes
+      // remove() throw AFTER the entry was durably deleted, and a null
+      // createdAt is silently coalesced on the next write). The bar is the
+      // shape every write path in this file produces. Keep the valid
+      // entries, and mark the file corrupt so the next write PRESERVES the
+      // original before replacing it.
+      const clean: Record<string, LoraCatalogEntry> = {};
+      const dropped: string[] = [];
+      for (const [key, value] of Object.entries(entries)) {
+        const v = value as LoraCatalogEntry | null;
+        const rec = v as unknown as Record<string, unknown> | null;
+        const stringArray = (f: string, required: boolean) => {
+          const arr = rec?.[f];
+          if (arr === undefined) return !required;
+          return Array.isArray(arr) && arr.every((x) => typeof x === "string");
+        };
+        const optString = (f: string) =>
+          rec?.[f] === undefined || typeof rec?.[f] === "string";
+        const optNumber = (f: string) =>
+          rec?.[f] === undefined || typeof rec?.[f] === "number";
+        if (
+          v &&
+          typeof v === "object" &&
+          !Array.isArray(v) &&
+          v.id === key &&
+          typeof v.relPath === "string" &&
+          typeof v.displayName === "string" &&
+          typeof rec!.createdAt === "string" &&
+          typeof rec!.updatedAt === "string" &&
+          typeof rec!.description === "string" &&
+          typeof rec!.setupInstructions === "string" &&
+          stringArray("keywords", true) &&
+          stringArray("baseModels", true) &&
+          stringArray("negativeKeywords", false) &&
+          stringArray("tags", false) &&
+          ["previewFile", "sourceUrl", "notes", "modifiedAt"].every(optString) &&
+          ["strengthMin", "strengthMax", "strengthDefault", "civitaiModelId", "civitaiVersionId", "fileSize"].every(optNumber) &&
+          // "missing": "false" is truthy — a present LoRA would list as missing.
+          (rec!.missing === undefined || typeof rec!.missing === "boolean")
+        ) {
+          clean[key] = value;
+        } else {
+          dropped.push(key);
+        }
+      }
+      if (dropped.length === 0) return { data: parsed as LoraCatalogFile };
+      const detail =
+        `${dropped.length} malformed ${dropped.length === 1 ? "entry" : "entries"} ` +
+        `(${dropped.slice(0, 3).join(", ")}${dropped.length > 3 ? ", …" : ""})`;
+      return {
+        data: { ...(parsed as LoraCatalogFile), entries: clean },
+        corrupt: detail,
+      };
     }
+    return { data: { version: CATALOG_VERSION, entries: {} }, corrupt: "not a v1 catalog" };
   } catch (err) {
-    logger.warn(
-      `[lora-catalog] could not parse ${path}: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    return {
+      data: { version: CATALOG_VERSION, entries: {} },
+      corrupt: err instanceof Error ? err.message : String(err),
+    };
   }
-  return { version: CATALOG_VERSION, entries: {} };
 }
 
 function writeCatalogFile(data: LoraCatalogFile): void {
@@ -144,6 +233,9 @@ function writeCatalogFile(data: LoraCatalogFile): void {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(data, null, 2));
 }
+
+/** Monotonic suffix so two backups in the same millisecond never collide. */
+let backupSeq = 0;
 
 function normalizeRelPath(path: string): string {
   const p = path.replace(/\\/g, "/").replace(/^\/+/, "");
@@ -226,15 +318,144 @@ export function toLoraSummary(entry: LoraCatalogEntry): Record<string, unknown> 
   };
 }
 
+/**
+ * Is this preview file still referenced by the catalog AS IT NOW IS ON DISK?
+ * Checked before deleting: another writer may have persisted a reference to
+ * the file after our own write, and deleting it would orphan THEIR entry.
+ * A failed re-read answers "referenced" — the safe side for a delete.
+ */
+function previewReferencedOnDisk(previewFile: string): boolean {
+  const probe = readCatalogRaw(loraCatalogPath());
+  if (!probe.raw) return true; // unreadable/absent → do not delete
+  const read = parseCatalogRaw(probe.raw);
+  // A corrupt catalog says NOTHING about what references the file — the safe
+  // answer for a delete is "referenced".
+  if (read.corrupt) return true;
+  return Object.values(read.data.entries).some((e) => e.previewFile === previewFile);
+}
+
+/** Delete a preview file only once nothing on disk references it. */
+function deletePreviewIfUnreferenced(previewsDirPath: string, previewFile: string): void {
+  if (previewReferencedOnDisk(previewFile)) return;
+  const p = join(previewsDirPath, previewFile);
+  if (existsSync(p)) {
+    try {
+      unlinkSync(p);
+    } catch {
+      /* best effort */
+    }
+  }
+}
+
 export class LoraCatalog {
-  private data: LoraCatalogFile;
+  // Immediately overwritten by reload() from the constructor.
+  private data: LoraCatalogFile = { version: CATALOG_VERSION, entries: {} };
+  /**
+   * The on-disk state `this.data` was built from — the baseline every write
+   * is checked against. `{}` (neither field) means the file was absent.
+   */
+  private baseline: { raw?: string; unreadable?: string } = {};
 
   constructor() {
-    this.data = readCatalogFile();
+    this.reload();
   }
 
   reload(): void {
-    this.data = readCatalogFile();
+    const path = loraCatalogPath();
+    const probe = readCatalogRaw(path);
+    this.baseline = probe;
+    if (probe.unreadable) {
+      logger.warn(`[lora-catalog] could not read ${path}: ${probe.unreadable}`);
+      this.data = { version: CATALOG_VERSION, entries: {} };
+      return;
+    }
+    if (probe.raw === undefined) {
+      this.data = { version: CATALOG_VERSION, entries: {} };
+      return;
+    }
+    const read = parseCatalogRaw(probe.raw);
+    if (read.corrupt) {
+      logger.warn(
+        `[lora-catalog] ${path}: ${read.corrupt}; the original will be preserved before any write replaces it.`,
+      );
+    }
+    this.data = read.data;
+  }
+
+  /**
+   * Persist — but NEVER over a corrupt original without preserving it first.
+   * The corrupt file is the only copy of whatever curation it still holds;
+   * overwriting it unread is the rescue path deleting the thing it rescues.
+   * If it cannot even be copied, refuse the write outright: a loud failure
+   * beats silent data loss.
+   *
+   * TWO checks before anything is replaced:
+   *  - STALE-INSTANCE: the file must still be the state this.data was built
+   *    from. Another writer's COMPLETED, healthy update is refused (re-read
+   *    and retry) rather than silently overwritten; a file that became
+   *    CORRUPT since our read is preserved and then replaced (nothing
+   *    readable is lost — our in-memory state is the newer good copy of it).
+   *  - MID-PERSIST RACE: the bytes probed must still be the bytes on disk
+   *    when the write begins. The window cannot be zero without a lock (none
+   *    exists for this file); the check covers the realistic interleaving — a
+   *    whole recovery landing between the two reads.
+   *
+   * And on ANY failure, re-sync from disk before rethrowing: the caller is
+   * about to see this mutation as FAILED, so it must not linger in memory —
+   * a later persist would silently commit what was reported as not applied.
+   */
+  private persist(): void {
+    try {
+      const path = loraCatalogPath();
+      const probe = readCatalogRaw(path);
+      const now = readCatalogRaw(path);
+      if (now.raw !== probe.raw || now.unreadable !== probe.unreadable) {
+        throw new Error(
+          `The LoRA catalog at ${path} changed on disk while this write was being ` +
+            `prepared — NOT overwriting another writer's update. This change was not ` +
+            `saved; re-read and retry.`,
+        );
+      }
+      const unchanged =
+        probe.raw === this.baseline.raw && probe.unreadable === this.baseline.unreadable;
+      const probeParsed = probe.raw !== undefined ? parseCatalogRaw(probe.raw) : undefined;
+      const corrupt = probe.unreadable ?? probeParsed?.corrupt;
+      if (!unchanged && !corrupt) {
+        throw new Error(
+          `The LoRA catalog at ${path} changed on disk since it was read — NOT ` +
+            `overwriting another writer's update. This change was not saved; re-read ` +
+            `and retry.`,
+        );
+      }
+      if (corrupt) {
+        const action = probe.unreadable ? "read" : "parsed";
+        // Unique per process AND per backup within it: two stale instances
+        // sharing a Date.now() tick must not have the second backup overwrite
+        // the first — that would erase the corrupt original after all.
+        const backup = `${path}.corrupt-${Date.now()}-${process.pid}-${backupSeq++}`;
+        try {
+          copyFileSync(path, backup);
+          logger.warn(
+            `[lora-catalog] the catalog at ${path} could not be ${action} (${corrupt}); ` +
+              `the original was preserved at ${backup} before being replaced.`,
+          );
+        } catch (err) {
+          throw new Error(
+            `The LoRA catalog at ${path} could not be ${action} (${corrupt}) and ` +
+              `could not be preserved either (${err instanceof Error ? err.message : String(err)}). ` +
+              `Refusing to overwrite it — inspect or repair the file manually.`,
+          );
+        }
+      }
+      writeCatalogFile(this.data);
+      // The file on disk is now exactly what we wrote — that is the baseline
+      // the NEXT persist compares against.
+      this.baseline = { raw: JSON.stringify(this.data, null, 2) };
+    } catch (err) {
+      // reload() never throws (a failed read degrades to empty + corrupt).
+      this.reload();
+      throw err;
+    }
   }
 
   list(opts: LoraCatalogListOptions = {}): LoraCatalogEntry[] {
@@ -300,7 +521,7 @@ export class LoraCatalog {
       }
     }
 
-    writeCatalogFile(this.data);
+    this.persist();
     return {
       scanned: models.length,
       added,
@@ -348,7 +569,7 @@ export class LoraCatalog {
     };
 
     this.data.entries[id] = entry;
-    writeCatalogFile(this.data);
+    this.persist();
     return entry;
   }
 
@@ -368,36 +589,43 @@ export class LoraCatalog {
     const destName = `${entry.id}${ext}`;
     const dest = join(dir, destName);
 
-    if (entry.previewFile && entry.previewFile !== destName) {
-      const old = join(dir, entry.previewFile);
-      if (existsSync(old)) {
-        try {
-          unlinkSync(old);
-        } catch {
-          /* best effort */
-        }
-      }
+    // Write the new preview and PERSIST the reference before deleting the old
+    // one: persist can refuse (a concurrently-changed catalog, an
+    // unpreservable corrupt original), and an old preview deleted ahead of a
+    // failed persist leaves the surviving entry pointing at a file that is
+    // gone. An orphaned NEW preview after a failed persist is the harmless
+    // direction.
+    copyFileSync(src, dest);
+    let updated: LoraCatalogEntry;
+    try {
+      updated = this.upsert({ id: entry.id, previewFile: destName });
+    } catch (err) {
+      // The file swap already happened; only its description failed. Disclose
+      // BOTH — refusing as though nothing changed would misreport applied
+      // work, and the retry reconciles the catalog with the file.
+      throw new Error(
+        `The preview image was already written to ${dest}, but recording it in the ` +
+          `catalog FAILED: ${err instanceof Error ? err.message : String(err)}. ` +
+          `The file on disk is the NEW preview; the catalog may still describe the old one — retry to reconcile.`,
+      );
     }
 
-    copyFileSync(src, dest);
-    return this.upsert({ id: entry.id, previewFile: destName });
+    if (entry.previewFile && entry.previewFile !== destName) {
+      deletePreviewIfUnreferenced(dir, entry.previewFile);
+    }
+    return updated;
   }
 
   remove(idOrPath: string): boolean {
     const entry = this.get(idOrPath);
     if (!entry) return false;
-    if (entry.previewFile) {
-      const p = join(loraPreviewsDir(), entry.previewFile);
-      if (existsSync(p)) {
-        try {
-          unlinkSync(p);
-        } catch {
-          /* best effort */
-        }
-      }
-    }
     delete this.data.entries[entry.id];
-    writeCatalogFile(this.data);
+    // Persist BEFORE deleting the preview: a refused persist reloads the
+    // entry (still referencing its preview), so the preview must still exist.
+    this.persist();
+    if (entry.previewFile) {
+      deletePreviewIfUnreferenced(loraPreviewsDir(), entry.previewFile);
+    }
     return true;
   }
 }

--- a/src/services/missing-models.ts
+++ b/src/services/missing-models.ts
@@ -285,27 +285,44 @@ const CIVITAI_TYPE_BY_DIR: Record<string, string[]> = {
 
 const MB = 1024 * 1024;
 
+export interface CandidateLookup {
+  candidates: ModelCandidate[];
+  /**
+   * Providers whose LOOKUP FAILED — distinct from "answered with nothing".
+   * An empty `candidates` with failures here is "could not look", and saying
+   * "no candidates found" for it is the confident-wrong-negative fold.
+   */
+  failedProviders: string[];
+}
+
 /**
  * Find installable candidates for ONE missing model, annotated with precision,
- * size and whether it fits this GPU, best first.
+ * size and whether it fits this GPU, best first — AND which providers failed
+ * to answer at all.
  *
  * Deliberately does NOT auto-pick: the same filename ships across quants and
  * base models, so we return a ranked, annotated list and let the caller decide.
  * Network failures degrade to fewer candidates rather than failing the lookup —
- * a partial answer beats none when one provider is down.
+ * a partial answer beats none when one provider is down — but the failures are
+ * REPORTED, so an empty list is never read as "nothing exists" when the search
+ * itself failed.
  */
-export async function resolveCandidates(
+export async function resolveCandidatesDetailed(
   missing: MissingModel,
   deps: ResolveDeps,
   opts: { limit?: number } = {},
-): Promise<ModelCandidate[]> {
+): Promise<CandidateLookup> {
   const limit = opts.limit ?? 8;
   const query = fileStem(missing.name);
   const vram = await deps.vramBytes().catch(() => undefined);
   const out: ModelCandidate[] = [];
+  const failedProviders: string[] = [];
 
   const civitaiTypes = missing.directory ? CIVITAI_TYPE_BY_DIR[missing.directory] : undefined;
-  const hits = await deps.searchCivitai(query, civitaiTypes).catch(() => []);
+  const hits = await deps.searchCivitai(query, civitaiTypes).catch(() => {
+    failedProviders.push("CivitAI");
+    return [];
+  });
   for (const h of hits) {
     const size = typeof h.size_mb === "number" ? Math.round(h.size_mb * MB) : undefined;
     const p = classifyPrecision(h.name);
@@ -327,9 +344,15 @@ export async function resolveCandidates(
   // routinely ranked below the official one, and on a constrained GPU it is the
   // only candidate that actually helps — slicing too tightly drops exactly the
   // answer the user needs.
-  const repos = await deps.searchHf(query).catch(() => []);
+  const repos = await deps.searchHf(query).catch(() => {
+    failedProviders.push("HuggingFace");
+    return [];
+  });
   for (const repo of repos.slice(0, 6)) {
-    const files = await deps.hfRepoFiles(repo.id).catch(() => []);
+    const files = await deps.hfRepoFiles(repo.id).catch(() => {
+      failedProviders.push(`HuggingFace repo ${repo.id}`);
+      return [];
+    });
     for (const f of files) {
       const p = classifyPrecision(f.filename);
       out.push({
@@ -345,7 +368,19 @@ export async function resolveCandidates(
     }
   }
 
-  return rankCandidates(missing.name, dedupeCandidates(out)).slice(0, limit);
+  return {
+    candidates: rankCandidates(missing.name, dedupeCandidates(out)).slice(0, limit),
+    failedProviders,
+  };
+}
+
+/** The candidate list alone — see `resolveCandidatesDetailed` for the contract. */
+export async function resolveCandidates(
+  missing: MissingModel,
+  deps: ResolveDeps,
+  opts: { limit?: number } = {},
+): Promise<ModelCandidate[]> {
+  return (await resolveCandidatesDetailed(missing, deps, opts)).candidates;
 }
 
 /**

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -71,6 +71,7 @@ import {
   panelTargetGeneration,
   primePanelBase,
   recordPanelDiskObservation,
+  type PanelBaseResolution,
   type PanelBaseSource,
 } from "./panel-workspace.js";
 
@@ -1398,21 +1399,45 @@ async function ensureInner(deps: PanelInstallerDeps): Promise<EnsureResult> {
           "skipping auto-install to avoid a duplicate/unverified install.",
       };
     }
-    // #766 — and the same caution about WHICH TREE we looked in. An unattended
-    // install into a root the running server never named would land in a
-    // custom_nodes nothing loads, and the user would see no panel and no error.
-    // On a split install (Comfy Desktop's --base-directory) the configured path
-    // is exactly that root. Nobody is watching this path, so it only acts on a
-    // tree the live server itself chose.
-    if (isRealDeps(deps) && !isLiveDerivedBase(lastPanelBaseResolution())) {
-      return {
-        action: "unavailable",
-        reason:
-          "The panel appears absent, but the ComfyUI root scanned came from " +
-          "configuration rather than the running server, so it is not proven to be " +
-          "the tree ComfyUI serves from (#766). Skipping auto-install rather than " +
-          "installing into a custom_nodes that may never be loaded.",
-      };
+    // #766/#820 — and the same caution about WHICH TREE we looked in. An
+    // unattended install into a root the running server never named would land
+    // in a custom_nodes nothing loads, and the user would see no panel and no
+    // error. On a split install (Comfy Desktop's --base-directory) the
+    // configured path is exactly that root. Live-derived is not sufficient on
+    // its own (#820): the resolution is re-read HERE while the tree was frozen
+    // at pin time, and the two can diverge with NO retarget — the pin-time
+    // probe failed (configured fallback frozen), then a re-resolution of the
+    // SAME target recovered and named the server's real --base-directory. The
+    // pinned-generation check cannot see that (no retarget, no bump), so a
+    // live-derived resolution naming tree B would license an install into
+    // frozen tree A — an observation of one tree licensing a mutation of
+    // another. The resolution must name the tree we are about to install into.
+    //
+    // And it must be FRESH: the resolution cache lives for 60s, and a ComfyUI
+    // restart at the same URL (new --base-directory, no retarget, no bump)
+    // leaves the cache naming the OLD tree. The pin froze from that cache, so
+    // a cached A-to-A match can certify a tree the server no longer serves.
+    // The reachability probe above succeeded, so re-resolve FORCED — a live
+    // answer is available right now.
+    if (isRealDeps(deps)) {
+      const installTree = pinnedBaseOf(deps) ?? deps.comfyuiPath();
+      const resolution = await primePanelBase({ force: true });
+      const liveBase = isLiveDerivedBase(resolution) ? resolution?.base : undefined;
+      if (!liveBase || !samePathCI(installTree, liveBase, deps)) {
+        return {
+          action: "unavailable",
+          reason: liveBase
+            ? `The panel appears absent in ${installTree ?? "the resolved tree"}, ` +
+              `but the running ComfyUI's own launch arguments name a DIFFERENT tree ` +
+              `(${liveBase}), so the tree that would be installed into is not proven ` +
+              `to be the one ComfyUI serves from (#766/#820). Skipping auto-install ` +
+              `rather than installing into a custom_nodes that may never be loaded.`
+            : "The panel appears absent, but the ComfyUI root scanned came from " +
+              "configuration rather than the running server, so it is not proven to be " +
+              "the tree ComfyUI serves from (#766). Skipping auto-install rather than " +
+              "installing into a custom_nodes that may never be loaded.",
+        };
+      }
     }
     // Final pin check adjacent to the mutation (see runPanelActionInner): the
     // reachability probe and detection above are not instantaneous.
@@ -1748,8 +1773,21 @@ export async function panelStatus(
   const baseResolution = isRealDeps(deps) ? lastPanelBaseResolution() : undefined;
   const comfyuiPath = deps.comfyuiPath();
   const baseSource: PanelBaseSource | undefined = baseResolution?.source;
+  // A live-derived resolution taken NOW only certifies the tree FROZEN for this
+  // read when it names that same tree (#820). The two can diverge without any
+  // retarget (a pin-time probe failure froze the configured fallback, a later
+  // re-resolution naming the server's real root), and attributing this scan to
+  // the resolution's tree anyway would certify the wrong root.
+  const resolutionNamesScannedTree =
+    !!baseResolution?.base && samePathCI(comfyuiPath, baseResolution.base, deps);
+  // The corroboration verdict for THIS read, computed ONCE here: the recording
+  // step below (clearPanelDiskObservation) drops the resolution cache, so any
+  // re-read afterwards answers "nothing resolved" — a cache wipe is not
+  // evidence the tree was uncorroborated.
+  const scannedTreeCorroborated =
+    isLiveDerivedBase(baseResolution) && resolutionNamesScannedTree;
   const baseNote = (() => {
-    if (!baseResolution?.base) return "";
+    if (!baseResolution?.base || !resolutionNamesScannedTree) return "";
     if (baseResolution.source === "live-base-directory") {
       return (
         ` Resolved against the RUNNING ComfyUI's --base-directory (${baseResolution.base})` +
@@ -1802,8 +1840,18 @@ export async function panelStatus(
     // `installed: false` from a failed enumeration is "we could not look", and
     // inviting an install on that basis could clobber a panel the scan simply
     // missed — the loss `scanReliable` was introduced to prevent.
-    const uncorroborated =
-      isRealDeps(deps) && !isLiveDerivedBase(baseResolution);
+    // uncorroborated means the resolution does not certify THIS tree — either
+    // it is not live-derived at all, or it is live-derived but names a
+    // DIFFERENT tree (#820). The two causes are stated separately below:
+    // folding them into one message would assert whichever cause it happened
+    // to name.
+    const liveMismatchBase =
+      isRealDeps(deps) &&
+      isLiveDerivedBase(baseResolution) &&
+      !resolutionNamesScannedTree
+        ? baseResolution?.base
+        : undefined;
+    const uncorroborated = isRealDeps(deps) && !scannedTreeCorroborated;
     note = swapNote
       ? // An unresolved interrupted swap OWNS this message. Leading with "Not
         // installed — run install" would tell the user to start fresh in the
@@ -1820,7 +1868,14 @@ export async function panelStatus(
         `recommended — one could clobber a panel the scan missed. Make custom_nodes ` +
         `readable, then re-check.`
       : uncorroborated
-      ? `No panel found in ${comfyuiPath ?? "custom_nodes"} — but this is the ` +
+      ? liveMismatchBase
+      ? `No panel found in ${comfyuiPath ?? "custom_nodes"} — and the only live ` +
+        `reading available names a DIFFERENT tree (${liveMismatchBase}), so whether ` +
+        `the running ComfyUI serves from this one is UNCORROBORATED: "not installed" ` +
+        `here may simply be the wrong tree (#766/#820). Check that tree, or ` +
+        `get_environment's local.workspace_path, before installing — a blind install ` +
+        `here would land in a custom_nodes nothing loads.`
+      : `No panel found in ${comfyuiPath ?? "custom_nodes"} — but this is the ` +
         `CONFIGURED path, and the running ComfyUI did not confirm it is the tree it ` +
         `serves from, so "not installed" is UNCORROBORATED. On a split install ` +
         `(Comfy Desktop's --base-directory, #766) the panel lives elsewhere and ` +
@@ -1884,7 +1939,7 @@ export async function panelStatus(
       ? undefined
       : detection.applicable &&
         detection.scanReliable !== false &&
-        (!isRealDeps(deps) || isLiveDerivedBase(baseResolution)),
+        (!isRealDeps(deps) || scannedTreeCorroborated),
     pin,
     note: note + baseNote + swapNote + shadowNote + pinNote,
   };
@@ -2283,7 +2338,32 @@ function assertSwapTreeCorroborated(
   what: string,
   managerReason: string,
 ): void {
-  if (swapTreeIsCorroborated(deps)) return;
+  // An injected dep set declared its own base; nothing to corroborate against.
+  if (!isRealDeps(deps)) return;
+  // ONE read for the verdict AND the message: a cache expiry between two
+  // reads would narrate a different-tree refusal as "the CONFIGURED path".
+  const resolution = lastPanelBaseResolution();
+  if (liveResolutionNamesTree(deps, pinnedBaseOf(deps) ?? deps.comfyuiPath(), resolution)) {
+    return;
+  }
+  // "Not corroborated" covers two different situations — no live-derived
+  // reading at all, or a live reading that names ANOTHER tree (#820) — and
+  // only the second tells the user where their served panel actually lives.
+  // Asserting "this is the CONFIGURED path" for both would mislabel the
+  // mismatch case, so name it when it is the cause.
+  const liveBase = isLiveDerivedBase(resolution) ? resolution?.base : undefined;
+  const mismatch =
+    liveBase && !samePathCI(comfyuiPath, liveBase, deps) ? liveBase : undefined;
+  if (mismatch) {
+    throw new PanelInstallError(
+      `Panel update did NOT apply (${managerReason}), and ${what} is REFUSED: the ` +
+        `running ComfyUI's own launch arguments name a DIFFERENT tree (${mismatch}) ` +
+        `than ${comfyuiPath}, so updating here could move a copy nobody serves while ` +
+        `the browser keeps loading the real one — reported as a verified success. ` +
+        `Check which install this orchestrator is targeting (COMFYUI_PATH / saved ` +
+        `workspace), then retry. ${describePanelUpdateRecovery()}`,
+    );
+  }
   throw new PanelInstallError(
     `Panel update did NOT apply (${managerReason}), and ${what} is REFUSED: the ` +
       `running ComfyUI did not confirm that ${comfyuiPath} is the tree it serves from, ` +
@@ -2766,7 +2846,7 @@ interface SwapReconcileResult {
  * copy", "your panel at <dir>"), so the appended sentence has an antecedent.
  *
  * AND IT MUST BE THIS TREE THAT WAS CORROBORATED — the same rule, and the same
- * reasoning, as `swapTreeIsCorroborated`. Asking only "is the CURRENT
+ * reasoning, as the swap's corroboration gate (`liveResolutionNamesTree`). Asking only "is the CURRENT
  * resolution live-derived?" answers a question about NOW, while the path this
  * sentence names was pinned earlier. A retarget in between (status pins A, the
  * target moves to B, a live probe caches B) would let an observation
@@ -2780,6 +2860,9 @@ function servingQualifier(
   comfyuiPath: string,
   subject: string,
 ): string {
+  // ONE read, for the verdict AND the message: the cache can expire between
+  // two reads, and a mismatch claim derived from a second, empty read would
+  // assert "a DIFFERENT tree" on nothing more than a lost cache entry.
   const resolution = isRealDeps(deps) ? lastPanelBaseResolution() : undefined;
   const liveBase = isLiveDerivedBase(resolution) ? resolution?.base : undefined;
   const confirmed =
@@ -4067,41 +4150,42 @@ function resolveSwapOps(deps: PanelInstallerDeps): PanelSwapOps | undefined {
 }
 
 /**
- * May we perform a WHOLESALE REPLACEMENT against this tree?
+ * Does the CURRENT base resolution corroborate THIS tree — i.e. the running
+ * server itself named a root, and the root it named IS this one?
  *
- * The base resolution falls back to the configured path whenever
- * `/system_stats` cannot be reached — and on a Comfy Desktop split install the
- * configured path is exactly the tree the running server does NOT read (#766).
- * A transient probe failure is indistinguishable from "there is no split", so
- * the fallback can hand us a directory that holds a panel nobody is serving.
+ * Both halves are load-bearing and neither implies the other:
  *
- * For a READ that is acceptable (it is the best answer available, and it is
- * labelled). For deleting a directory and moving another over it, it is not: we
- * would replace a dormant copy, verify it happily, and report a verified update
- * while the panel in the user's browser stayed exactly where it was. So this
- * path requires the running server to have had a SAY in choosing the tree.
+ *  - LIVE-DERIVED: the base resolution falls back to the configured path
+ *    whenever `/system_stats` cannot be reached — and on a Comfy Desktop split
+ *    install the configured path is exactly the tree the running server does
+ *    NOT read (#766). A transient probe failure is indistinguishable from
+ *    "there is no split", so the fallback can hand us a directory that holds a
+ *    panel nobody is serving. REACHABLE IS NOT ENOUGH either: a /system_stats
+ *    response with absent or unparseable argv proves only that something
+ *    answered on the URL; it does not prove COMFYUI_PATH is the tree that
+ *    server reads. Only a root the running server actually named qualifies.
  *
- * `liveProbeFailed === false` with `source: "configured"` is fine — the server
- * answered and its argv simply offered nothing better.
+ *  - SAME TREE: asking only "is the CURRENT resolution live-derived?" answers
+ *    a question about NOW, while the tree we are about to mutate or describe
+ *    was frozen earlier. The two can diverge WITHOUT any retarget — a probe
+ *    that failed at pin time (configured fallback frozen) recovering when the
+ *    same target is re-resolved — so the pinned-generation check cannot see it
+ *    (#820). A live-derived resolution naming root B is not evidence about
+ *    root A: an observation of one tree must never license a mutation of, or
+ *    a claim about, another.
+ *
+ * This asks only the resolution question. What an INJECTED dep set means
+ * (there is no live server to corroborate against) is each caller's decision.
  */
-function swapTreeIsCorroborated(deps: PanelInstallerDeps): boolean {
-  // An injected dep set declared its own base explicitly; there is no live
-  // server to corroborate it against and none is implied.
-  if (!isRealDeps(deps)) return true;
-  // REACHABLE IS NOT ENOUGH. A /system_stats response with absent or
-  // unparseable argv proves only that something answered on the URL; it does
-  // not prove COMFYUI_PATH is the tree that server reads. Require a root the
-  // running server actually named.
-  const resolution = lastPanelBaseResolution();
+function liveResolutionNamesTree(
+  deps: PanelInstallerDeps,
+  tree: string | undefined,
+  // Callers that also MESSAGE about the resolution pass their own read, so a
+  // cache expiry cannot split the verdict from the narration.
+  resolution: PanelBaseResolution | undefined = lastPanelBaseResolution(),
+): boolean {
   if (!isLiveDerivedBase(resolution)) return false;
-  // AND IT MUST BE THE TREE WE FROZE. Asking only "is the CURRENT resolution
-  // live-derived?" answers a question about now, while the directory we are
-  // about to mutate was chosen earlier — so a retarget in between would let a
-  // live-derived answer about server B bless a mutation of server A's tree,
-  // which is precisely the wrong-tree swap this gate exists to stop. The two
-  // must be the same directory.
-  const frozen = pinnedBaseOf(deps) ?? deps.comfyuiPath();
-  return !!frozen && !!resolution?.base && samePathCI(frozen, resolution.base, deps);
+  return !!tree && !!resolution?.base && samePathCI(tree, resolution.base, deps);
 }
 
 async function updateViaRegistryZipReinstall(opts: {

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -323,19 +323,59 @@ function interruptHonorMs(): number {
   return Number.isFinite(s) && s > 0 ? Math.round(s * 1000) : 30000;
 }
 
+/** The outcome of watching the queue for a job to leave the running slot. */
+interface RunningClearance {
+  outcome:
+    /** A successful poll observed it gone. */
+    | "cleared"
+    /** Polls kept answering, and the job was still running when time ran out. */
+    | "still-running"
+    /** The observation itself failed — nothing was determined about the job. */
+    | "unobservable";
+  /** At least one poll in the window answered (so an "unobservable" outcome
+   *  means the queue stopped answering PARTWAY through, not that it never
+   *  answered — the messages must not conflate the two). */
+  observed: boolean;
+}
+
 /** Poll /queue until the target running job is gone (or any-running is gone when
- *  no id given), or the timeout elapses. Returns true if it cleared. */
-async function waitForRunningCleared(promptId: string | undefined, timeoutMs: number): Promise<boolean> {
+ *  no id given), or the timeout elapses.
+ *
+ *  THREE outcomes, because a failed poll is not "still running": if ComfyUI
+ *  died mid-job, /queue stops answering AND the job is gone — folding that
+ *  into "still-running" ends in a confident "wedged, restart ComfyUI, do NOT
+ *  queue another run" verdict about a job that no longer exists. "Cleared"
+ *  and "still-running" both require a live observation; anything else is
+ *  "unobservable". */
+async function waitForRunningCleared(
+  promptId: string | undefined,
+  timeoutMs: number,
+): Promise<RunningClearance> {
   const start = Date.now();
+  let everObserved = false;
+  let lastPollFailed = false;
   while (Date.now() - start < timeoutMs) {
     await sleep(1500);
     const q = await getQueueSummary().catch(() => null);
-    if (!q) continue;
-    if (q.running === 0) return true;
+    if (!q) {
+      lastPollFailed = true;
+      continue;
+    }
+    everObserved = true;
+    lastPollFailed = false;
+    if (q.running === 0) return { outcome: "cleared", observed: true };
     // A DIFFERENT job is now running → the one we targeted has cleared.
-    if (promptId && !q.running_jobs.some((j) => j.prompt_id === promptId)) return true;
+    if (promptId && !q.running_jobs.some((j) => j.prompt_id === promptId)) {
+      return { outcome: "cleared", observed: true };
+    }
   }
-  return false;
+  // Timed out. "Still running" is a claim about NOW, and only a poll that is
+  // still answering at the end of the window can make it — a run of failures
+  // (or never observing at all) means the queue's state is simply unknown.
+  return {
+    outcome: everObserved && !lastPollFailed ? "still-running" : "unobservable",
+    observed: everObserved,
+  };
 }
 
 export interface EscalatedCancelResult {
@@ -343,6 +383,10 @@ export interface EscalatedCancelResult {
   honored: boolean; // did the running job actually stop?
   freed_vram: boolean; // did we escalate to POST /free?
   wedged: boolean; // still running after interrupt + free → needs a restart
+  /** The queue stopped answering mid-verification — the job's fate is UNKNOWN,
+   *  neither "stopped" nor "wedged" (a crashed ComfyUI also stops answering,
+   *  and takes the job with it). */
+  unverified?: boolean;
   pending_cleared?: number; // how many pending jobs were dropped (if clear_pending)
   running_prompt_id?: string;
   message: string;
@@ -361,15 +405,33 @@ export async function cancelRunningJobEscalating(opts: {
   clear_pending?: boolean;
 }): Promise<EscalatedCancelResult> {
   let pending_cleared: number | undefined;
+  let clearPendingFailed = false;
   if (opts.clear_pending) {
     const before = await getQueueSummary().catch(() => null);
-    await clearAllQueued().catch((err) => logger.warn("clear_pending failed (continuing)", { err }));
-    pending_cleared = before?.pending;
+    await clearAllQueued().catch((err) => {
+      clearPendingFailed = true;
+      logger.warn("clear_pending failed (continuing)", { err });
+    });
+    // Only a clear that did not fail may report a count — "cleared (N)" on a
+    // failed request is a confident false statement.
+    pending_cleared = clearPendingFailed ? undefined : before?.pending;
   }
+  // The pending half of every verdict message, true to what actually happened.
+  const pendingNote = !opts.clear_pending
+    ? `Pending jobs were NOT cleared — pass clear_pending:true or call queue (action:"clear").`
+    : clearPendingFailed
+      ? `Clearing pending jobs FAILED — they may still be queued; check queue (action:"list").`
+      : pending_cleared != null
+        ? `Pending jobs were cleared (${pending_cleared}).`
+        : `Pending jobs were cleared.`;
 
   // Identify the job we're trying to stop so we can verify it actually clears.
   const pre = await getQueueSummary().catch(() => null);
   const runningId = opts.prompt_id ?? pre?.running_jobs?.[0]?.prompt_id;
+  // "Interrupted" is only a claim we may make about a job we OBSERVED running.
+  const targetSeenRunning = opts.prompt_id
+    ? !!pre?.running_jobs.some((j) => j.prompt_id === opts.prompt_id)
+    : !!pre && pre.running > 0;
 
   if (pre && pre.running === 0 && !opts.prompt_id) {
     return {
@@ -378,14 +440,45 @@ export async function cancelRunningJobEscalating(opts: {
       freed_vram: false,
       wedged: false,
       pending_cleared,
-      message: `No job is running.${pending_cleared != null ? ` Cleared ${pending_cleared} pending.` : ""}`,
+      message: `No job is running.${opts.clear_pending ? ` ${pendingNote}` : ""}`,
+    };
+  }
+  if (pre && opts.prompt_id && !targetSeenRunning) {
+    return {
+      interrupted: false,
+      honored: true,
+      freed_vram: false,
+      wedged: false,
+      pending_cleared,
+      message:
+        `${opts.prompt_id} is not running (verified via /queue) — nothing to interrupt.` +
+        `${opts.clear_pending ? ` ${pendingNote}` : ""}`,
     };
   }
 
   await clientInterrupt(opts.prompt_id);
   logger.info("Interrupt sent (escalating cancel)", { prompt_id: runningId ?? "current" });
 
-  if (await waitForRunningCleared(runningId, interruptHonorMs())) {
+  const firstClearance = await waitForRunningCleared(runningId, interruptHonorMs());
+  if (firstClearance.outcome === "cleared") {
+    if (!targetSeenRunning) {
+      // The queue is verifiably empty NOW, but the pre-interrupt read failed —
+      // so "the interrupt stopped it" asserts a start state nobody observed.
+      return {
+        interrupted: true,
+        honored: false,
+        freed_vram: false,
+        wedged: false,
+        unverified: true,
+        pending_cleared,
+        running_prompt_id: runningId,
+        message:
+          `Interrupt sent${runningId ? ` (${runningId})` : ""}, and nothing is running now ` +
+          `(verified via /queue) — but the queue could not be read BEFORE the interrupt, so ` +
+          `whether a job was running, and whether the interrupt stopped it, is UNKNOWN.` +
+          `${opts.clear_pending ? ` ${pendingNote}` : ""}`,
+      };
+    }
     return {
       interrupted: true,
       honored: true,
@@ -394,48 +487,180 @@ export async function cancelRunningJobEscalating(opts: {
       pending_cleared,
       running_prompt_id: runningId,
       message: `Interrupted the running job${runningId ? ` (${runningId})` : ""}.${
-        pending_cleared != null ? ` Cleared ${pending_cleared} pending.` : ""
+        opts.clear_pending ? ` ${pendingNote}` : ""
       }`,
     };
   }
 
-  // Not honored — the step is long-running. Free VRAM and re-check.
+  // Not honored — the step is long-running. Free VRAM and re-check. The /free
+  // result is tracked, not swallowed into the narration: a failed escalation
+  // must not be described as a performed one — and a throw only means no
+  // successful completion was OBSERVED (the request may have applied and the
+  // response been lost), so "never reached the server" is not ours to say
+  // either. On Comfy Cloud the call is a deliberate no-op, which no message
+  // may narrate as a VRAM free.
   logger.warn("Interrupt not honored in window; escalating to /free", { prompt_id: runningId ?? "current" });
-  await clientFreeMemory({ unload_models: true, free_memory: true }).catch((err) =>
-    logger.warn("/free during cancel escalation failed (continuing)", { err }),
-  );
+  const freeRan = !isCloudMode();
+  let freeFailed = false;
+  await clientFreeMemory({ unload_models: true, free_memory: true }).catch((err) => {
+    freeFailed = true;
+    logger.warn("/free during cancel escalation failed (continuing)", { err });
+  });
+  // freed_vram is true only when the escalation RAN and did not fail.
+  const freedVram = freeRan && !freeFailed;
+  const freeFailedPhrase =
+    "the VRAM-free escalation did not complete — whether it freed anything is unknown";
 
-  if (await waitForRunningCleared(runningId, Math.min(interruptHonorMs(), 12000))) {
+  const finalClearance = await waitForRunningCleared(
+    runningId,
+    Math.min(interruptHonorMs(), 12000),
+  );
+  // The duration the message may claim: continuous verified polling only when
+  // the FIRST window was observed end-to-end; otherwise only the final check
+  // was a live observation, and the message must not claim more.
+  const watchedDuration = (first: RunningClearance): string =>
+    first.outcome === "still-running"
+      ? ` across ~${Math.round((interruptHonorMs() + Math.min(interruptHonorMs(), 12000)) / 1000)}s of verified polling`
+      : ` at a verified check ~${Math.round(Math.min(interruptHonorMs(), 12000) / 1000)}s after the escalation`;
+  // "The job stopped" (or "this job is wedged") is only ours to claim when the
+  // target was seen running BEFORE the interrupt. A named prompt first sighted
+  // in a later window may have STARTED after the interrupt — the interrupt was
+  // a no-op for it, and its later stop is not our doing.
+  const stopVerified = targetSeenRunning;
+  if (finalClearance.outcome === "cleared") {
+    // The queue is verifiably empty — but WHY is only knowable if we watched
+    // it the whole time, and WHETHER a job was running at all is only knowable
+    // if the start was observed.
+    // A job was SEEN during the window, but never tied to the interrupt.
+    const sawUntiedJob =
+      !stopVerified &&
+      (firstClearance.outcome === "still-running" || firstClearance.observed);
+    const message =
+      firstClearance.outcome === "unobservable" && targetSeenRunning
+        ? `The running job${runningId ? ` (${runningId})` : ""} has STOPPED (verified via /queue), ` +
+          `but what stopped it is unknown — the queue was unreachable for a while after the ` +
+          `interrupt${
+            freeFailed
+              ? `, and ${freeFailedPhrase} — so the interrupt may have worked late or ComfyUI restarted`
+              : freeRan
+                ? `, so the interrupt may have worked late, the VRAM free may have done it, or ComfyUI restarted`
+                : `, so the interrupt may have worked late or ComfyUI restarted`
+          }.${opts.clear_pending ? ` ${pendingNote}` : ""}`
+        : sawUntiedJob
+          ? `A job was running during the interrupt window and nothing is running now (verified ` +
+            `via /queue) — but the queue could not be read BEFORE the interrupt, so whether the ` +
+            `job that stopped is the one that was interrupted is UNKNOWN.${
+              opts.clear_pending ? ` ${pendingNote}` : ""
+            }`
+          : !stopVerified
+            ? `Nothing is running now (verified via /queue), but /queue never answered from before ` +
+              `the interrupt through the honor window — so whether a job was running at all, and ` +
+              `what stopped it if one was, is UNKNOWN.${opts.clear_pending ? ` ${pendingNote}` : ""}`
+            : freeFailed
+              ? `The job didn't stop on interrupt and ${freeFailedPhrase}, but the job ` +
+                `HAS now stopped anyway (verified via /queue)${runningId ? ` (${runningId})` : ""}.${
+                  opts.clear_pending ? ` ${pendingNote}` : ""
+                }`
+              : freeRan
+                ? `The job didn't stop within the interrupt window; after the VRAM-free escalation it ` +
+                  `has now STOPPED (verified via /queue)${runningId ? ` (${runningId})` : ""}.${
+                    opts.clear_pending ? ` ${pendingNote}` : ""
+                  }`
+                : `The job didn't stop within the interrupt window and has now STOPPED ` +
+                  `(verified via /queue)${runningId ? ` (${runningId})` : ""}.${
+                    opts.clear_pending ? ` ${pendingNote}` : ""
+                  }`;
     return {
       interrupted: true,
-      honored: true,
-      freed_vram: true,
+      honored: stopVerified,
+      freed_vram: freedVram,
       wedged: false,
+      unverified: stopVerified ? undefined : true,
       pending_cleared,
       running_prompt_id: runningId,
-      message: `The job didn't stop on interrupt; freeing VRAM cleared it${runningId ? ` (${runningId})` : ""}.${
-        pending_cleared != null ? ` Cleared ${pending_cleared} pending.` : ""
-      }`,
+      message,
+    };
+  }
+
+  if (finalClearance.outcome === "unobservable") {
+    const subject = targetSeenRunning
+      ? `⚠️ The running job${runningId ? ` (${runningId})` : ""} was sent an interrupt`
+      : `⚠️ An interrupt was sent${runningId ? ` for ${runningId}` : ""}`;
+    const unknownWhat = targetSeenRunning
+      ? `whether it is still running is UNKNOWN — ComfyUI may be down or restarting, which would ` +
+        `ALSO have stopped the job`
+      : `whether a job was running — and whether one still is — is UNKNOWN. ComfyUI may be down ` +
+        `or restarting`;
+    // "Stopped answering" is only a claim we may make if it answered at all.
+    const reachability = finalClearance.observed
+      ? `stopped answering partway through verification`
+      : `did not answer during verification`;
+    return {
+      interrupted: true,
+      honored: false,
+      freed_vram: freedVram,
+      wedged: false,
+      unverified: true,
+      pending_cleared,
+      running_prompt_id: runningId,
+      message:
+        subject +
+        (freeFailed
+          ? ` (${freeFailedPhrase})`
+          : freeRan && targetSeenRunning
+            ? ` (and a VRAM free)`
+            : ``) +
+        `, but /queue ${reachability}, so ${unknownWhat}. This is not a confirmed wedge. ` +
+        `Check ComfyUI is up (get_environment) and inspect the queue before deciding anything. ` +
+        (opts.clear_pending
+          ? pendingNote
+          : `Pending jobs were NOT cleared — pass clear_pending:true or call queue (action:"clear").`),
+    };
+  }
+
+  if (!stopVerified) {
+    // A job is verifiably wedged — but nothing established it is the job the
+    // interrupt addressed (no pre-interrupt read; a named prompt may have
+    // STARTED after it). The wedge itself is real (interrupt + VRAM free did
+    // not stop it); only the IDENTITY is unknown.
+    return {
+      interrupted: true,
+      honored: false,
+      freed_vram: freedVram,
+      wedged: true,
+      unverified: true,
+      pending_cleared,
+      running_prompt_id: runningId,
+      message:
+        `⚠️ ${opts.prompt_id ? `The job ${opts.prompt_id}` : "A job"} is still running after interrupt` +
+        (freeFailed ? ` (${freeFailedPhrase})` : freeRan ? ` + VRAM free` : ``) +
+        watchedDuration(firstClearance) +
+        ` — it is wedged inside a single step (ComfyUI only honors interrupts ` +
+        `BETWEEN steps). Whether this IS the job the interrupt addressed is UNKNOWN — ` +
+        (opts.prompt_id
+          ? `it was never observed running before the interrupt, so it may have started after. `
+          : `the queue could not be read beforehand. `) +
+        `An HTTP cancel cannot kill a wedged step; restart ` +
+        `ComfyUI (panel_restart_comfyui, or restart_comfyui) to clear it. ` +
+        `${pendingNote} Do NOT queue another run until this is gone.`,
     };
   }
 
   return {
     interrupted: true,
     honored: false,
-    freed_vram: true,
+    freed_vram: freedVram,
     wedged: true,
     pending_cleared,
     running_prompt_id: runningId,
     message:
-      `⚠️ The running job${runningId ? ` (${runningId})` : ""} did NOT stop after interrupt + VRAM free within ` +
-      `~${Math.round(interruptHonorMs() / 1000)}s — it is wedged inside a single step (ComfyUI only honors interrupts ` +
+      `⚠️ The running job${runningId ? ` (${runningId})` : ""} did NOT stop after interrupt` +
+      (freeFailed ? ` (${freeFailedPhrase})` : freeRan ? ` + VRAM free` : ``) +
+      watchedDuration(firstClearance) +
+      ` — it is wedged inside a single step (ComfyUI only honors interrupts ` +
       `BETWEEN steps, so a multi-minute step ignores cancel). An HTTP cancel cannot kill this; restart ComfyUI ` +
       `(panel_restart_comfyui, or restart_comfyui) to clear it. ` +
-      `${
-        opts.clear_pending
-          ? `Pending jobs were cleared (${pending_cleared ?? 0}).`
-          : "Pending jobs were NOT cleared — pass clear_pending:true or call queue (action:\"clear\")."
-      } Do NOT queue another run until this is gone.`,
+      `${pendingNote} Do NOT queue another run until this is gone.`,
   };
 }
 

--- a/src/services/training-jobs.ts
+++ b/src/services/training-jobs.ts
@@ -125,6 +125,9 @@ export interface TrainingJob {
      *  or pod-only delivery). */
     catalogId?: string;
     previewFile?: string;
+    /** The catalog entry failed although the LoRA itself was published —
+     *  disclosed, never allowed to mark the job failed after the fact. */
+    catalogError?: string;
     /** Pod jobs: path inside the pod's models/loras (when delivered there). */
     podLoraPath?: string;
   };
@@ -1299,34 +1302,60 @@ async function handoffToComfyUI(job: TrainingJob, deps: TrainingJobDeps): Promis
     return;
   }
 
-  const catalog = deps.catalog ?? getLoraCatalog();
-  const entry = catalog.upsert({
-    relPath: `loras/${job.name}.safetensors`,
-    displayName: job.name.replace(/_/g, " "),
-    description: `Character LoRA trained ${job.target === "pod" ? "on a RunPod pod" : "locally"} on FLUX.1-dev via ostris ai-toolkit (comfyui-mcp trainer, job ${job.id}).`,
-    setupInstructions:
-      "Load with LoraLoaderModelOnly on a FLUX.1-dev checkpoint" +
-      (job.trigger ? ` and include the trigger word "${job.trigger}" in the prompt.` : "."),
-    keywords: job.trigger ? [job.trigger] : [],
-    baseModels: ["FLUX.1-dev"],
-    strengthDefault: 1.0,
-    tags: ["trained-locally", "character", ...(job.target === "pod" ? ["trained-on-pod"] : [])],
-    // Explicitly clear the flag — retraining a LoRA whose entry was marked
-    // missing must become visible again (upsert otherwise preserves it).
-    missing: false,
-  });
-
-  // Best-effort: newest sample image becomes the catalog preview.
+  // The LoRA itself was ALREADY copied to dest above — what follows only
+  // records it in the catalog. Refuse-vs-disclose: a catalog failure must
+  // never bounce back as "output handoff failed" for a model that IS
+  // published, so it is caught here and disclosed on the result instead.
+  let catalogId: string | undefined;
   let previewFile: string | undefined;
-  const samples = findSamples(job.outputDir, job.name, 1);
-  if (samples.length > 0) {
-    try {
-      previewFile = catalog.setPreview(entry.id, samples[0]).previewFile;
-    } catch (err) {
-      logger.debug(`[training-jobs] preview copy skipped: ${err instanceof Error ? err.message : String(err)}`);
+  let catalogError: string | undefined;
+  try {
+    const catalog = deps.catalog ?? getLoraCatalog();
+    const entry = catalog.upsert({
+      relPath: `loras/${job.name}.safetensors`,
+      displayName: job.name.replace(/_/g, " "),
+      description: `Character LoRA trained ${job.target === "pod" ? "on a RunPod pod" : "locally"} on FLUX.1-dev via ostris ai-toolkit (comfyui-mcp trainer, job ${job.id}).`,
+      setupInstructions:
+        "Load with LoraLoaderModelOnly on a FLUX.1-dev checkpoint" +
+        (job.trigger ? ` and include the trigger word "${job.trigger}" in the prompt.` : "."),
+      keywords: job.trigger ? [job.trigger] : [],
+      baseModels: ["FLUX.1-dev"],
+      strengthDefault: 1.0,
+      tags: ["trained-locally", "character", ...(job.target === "pod" ? ["trained-on-pod"] : [])],
+      // Explicitly clear the flag — retraining a LoRA whose entry was marked
+      // missing must become visible again (upsert otherwise preserves it).
+      missing: false,
+    });
+    catalogId = entry.id;
+
+    // Best-effort: newest sample image becomes the catalog preview. A failure
+    // here can come AFTER the file was written (setPreview discloses exactly
+    // that) — so it is recorded, not just logged: a completed job must not
+    // report neither previewFile nor error while the preview sits unreconciled.
+    const samples = findSamples(job.outputDir, job.name, 1);
+    if (samples.length > 0) {
+      try {
+        previewFile = catalog.setPreview(entry.id, samples[0]).previewFile;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.warn(`[training-jobs] preview copy skipped: ${msg}`);
+        catalogError = catalogError ?? `preview: ${msg}`;
+      }
     }
+  } catch (err) {
+    catalogError = err instanceof Error ? err.message : String(err);
+    logger.warn(
+      `[training-jobs] the LoRA was published to ${dest} but recording it in the catalog failed: ${catalogError}`,
+    );
   }
-  job.result = { loraPath: dest!, loraRelPath: `loras/${job.name}.safetensors`, catalogId: entry.id, previewFile, podLoraPath };
+  job.result = {
+    loraPath: dest!,
+    loraRelPath: `loras/${job.name}.safetensors`,
+    catalogId,
+    previewFile,
+    podLoraPath,
+    ...(catalogError ? { catalogError } : {}),
+  };
 }
 
 async function finalizeJob(job: TrainingJob, code: number, tail: string, deps: TrainingJobDeps): Promise<void> {

--- a/src/tools/missing-models.ts
+++ b/src/tools/missing-models.ts
@@ -6,7 +6,7 @@ import { searchCivitaiModels } from "../services/civitai-resolver.js";
 import { searchHuggingFaceModels } from "../services/model-resolver.js";
 import {
   findMissingModels,
-  resolveCandidates,
+  resolveCandidatesDetailed,
   type ModelCandidate,
   type ObjectInfoLike,
   type ResolveDeps,
@@ -151,12 +151,32 @@ export function registerMissingModelTools(server: McpServer): void {
             `needed by node ${m.node_id} (${m.node_type} · ${m.widget})${m.directory ? ` → installs to \`models/${m.directory}/\`` : ""}`,
             "",
           );
-          const candidates = await resolveCandidates(m, deps, { limit: args.limit ?? 8 }).catch(() => []);
-          if (candidates.length === 0) {
-            lines.push("_No candidates found on CivitAI or HuggingFace — try search_models / search_civitai_models with a different query._", "");
+          const lookup = await resolveCandidatesDetailed(m, deps, { limit: args.limit ?? 8 }).catch(
+            (err) => ({
+              candidates: [],
+              failedProviders: [
+                `the candidate lookup itself (${err instanceof Error ? err.message : String(err)})`,
+              ],
+            }),
+          );
+          if (lookup.candidates.length === 0) {
+            lines.push(
+              lookup.failedProviders.length > 0
+                ? `_No candidates — but the lookup FAILED (${lookup.failedProviders.join("; ")}), so ` +
+                  `this is "could not look", NOT "nothing exists". Check the network/provider and retry, ` +
+                  `or try search_models / search_civitai_models with a different query._`
+                : `_No candidates found on CivitAI or HuggingFace — try search_models / search_civitai_models with a different query._`,
+              "",
+            );
             continue;
           }
-          lines.push(...candidates.map(renderCandidate), "");
+          if (lookup.failedProviders.length > 0) {
+            lines.push(
+              `_(Partial results — the ${lookup.failedProviders.join("; ")} lookup failed; other sources may have more.)_`,
+              "",
+            );
+          }
+          lines.push(...lookup.candidates.map(renderCandidate), "");
         }
 
         lines.push(


### PR DESCRIPTION
## Issues in this cluster

- #796
- #820

Grouped because they share a codepath or are variations of one defect. An agent takes the whole cluster, so a fix for one is checked against the others rather than landing five times with five different shapes.

**Not yet started** — draft until an agent picks it up.