### PR TITLE
0.49.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.49.6] - 2026-08-04
+
+### MCP
+
+#### Fixed
+- **`download_model`: large-file timeouts, no resume, wrong base on Windows portable,
+  and non-unique job ids (#831).** Large HuggingFace downloads timed out at 600s with no
+  way to resume; a resume could silently discard a 96%-complete partial; a remote CivitAI
+  auth/error page could be saved as if it were a model; and `download_status` lost
+  in-flight ids. Destroying a staged file now requires re-proving, immediately before each
+  syscall, that it is still the file the caller checked — so a second download of the same
+  model can no longer delete the first one's resumable bytes or its validator. An
+  unreadable staged file is reported as unknown rather than folded into "absent", which
+  previously let a fresh response truncate an existing partial.
+  Fixes #343, #401, #467, #470, #473, #529, #547, #761, #813, #817, #822.
+- test reliability: a fixture bound a guessed random port and hung ~1 in 8 when that port
+  was already held; it now binds `listen(0)` and reads the assigned port back, and a bind
+  failure reports as a setup failure instead of a timeout in the behaviour under test (#843, #821)
+- preserve AUTOGROW dotted workflow inputs (#763)
+- truncated results name their own remedy — and one that works from where the caller is (#818)
+- never stop a ComfyUI that cannot be proven relaunchable, and attribute a listener without lsof (#814) (#830)
+
+
 ## [0.49.5] - 2026-08-04
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.49.5",
+  "version": "0.49.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.49.5",
+      "version": "0.49.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.49.5",
+  "version": "0.49.6",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Contents

| PR | |
|---|---|
| **#831** | `download_model`: large-file timeouts, no resume, wrong base on Windows portable, non-unique job ids — **closes 11 issues** |
| #830 | never stop a ComfyUI that cannot be proven relaunchable; attribute a listener without `lsof` (#814) |
| #818 | truncated results name their own remedy — one actionable from where the caller is |
| #763 | preserve AUTOGROW dotted workflow inputs |
| #843 | test reliability: a random-port bind that hung ~1 in 8 (#821) |

**#831 is the reason to take this release.** Large HuggingFace downloads timed out at 600s with no way to resume; a resume could silently discard a 96%-complete partial; a remote CivitAI auth/error page could be saved as if it were a model; `download_status` lost in-flight ids.

The structural part: destroying a staged file now requires re-proving, *immediately before each syscall*, that it is still the file the caller checked — carried by the path's type rather than by a call at the top, so a new destructive step cannot be added without one. A single check at a helper's entry authorises the first act and then goes stale; every `await` after it is a window. That mattered concretely here, because two agents downloading the same model on this rig is ordinary, and the old code could delete the other download's resumable bytes *and* its validator while reporting its own rejection.

Also fixed: an unreadable staged file was folded into "absent", which let a fresh 200 truncate an existing partial. It is now reported as unknown and refuses before any request is issued.

## The changelog generator missed two entries

It caught 3 of 5. **#831 and #843 were absent** because their squash titles do not begin with a conventional `fix(`/`feat(` prefix — so the release's headline fix would have shipped undocumented. Added by hand, #831 first.

The panel's 0.11.39 hit the identical trap an hour earlier (#621, a CRITICAL fix, was missing from its generated list). Worth fixing properly: either widen `gen-changelog` to fall back on the PR title/labels, or require conventional prefixes on squash titles. Right now the failure is silent and lands on exactly the entries that matter most.

## Verification

- **4997 tests pass / 2 skipped across 251 files**, run at `--maxWorkers=2` — this machine is loaded enough that full-concurrency runs flake in a rotating cast of unrelated suites, so a single clean full-speed run would not have been honest evidence
- `build`, `lint`, `check-tool-vocabulary` and `asset-counts --check` all clean
- Zero control bytes across changed files

After merge the tag needs pushing by hand — squash-merge orphans the tag `npm version` creates, which is what happened for 0.49.5.