### PR TITLE
restart + session reporting: stale launch arguments, a premature failure verdict, and a stale version line

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
@@ -12,9 +12,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const resetClient = vi.fn();
 const resetObjectInfoCache = vi.fn();
+// #848: the post-restart argv read goes through getSystemStats. Default REJECTS, so
+// every pre-existing test keeps the "nothing observed → say nothing" behaviour and
+// only the tests that opt in exercise the drift note.
+const getSystemStats = vi.fn(async () => {
+  throw new Error("ECONNRESET");
+});
 vi.mock("../../comfyui/client.js", () => ({
   getObjectInfo: vi.fn(),
   backfillObjectInfo: vi.fn(),
+  getSystemStats: () => getSystemStats(),
   resetClient: () => resetClient(),
   resetObjectInfoCache: () => resetObjectInfoCache(),
 }));
@@ -100,6 +107,10 @@ const DROP = markDispatched(
 beforeEach(() => {
   resetClient.mockClear();
   resetObjectInfoCache.mockClear();
+  getSystemStats.mockReset();
+  getSystemStats.mockImplementation(async () => {
+    throw new Error("ECONNRESET");
+  });
   // The #742 refuse-safe preflight passes by default here (the live one would
   // probe real processes/ports); these tests exercise the post-dispatch paths.
   __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
@@ -132,6 +143,78 @@ describe("panel_restart_comfyui recovery after an ACCEPTED reboot (coordinator p
     expect(out.via).toBe("observed-cycle");
     expect(resetClient).toHaveBeenCalledTimes(1);
     expect(resetObjectInfoCache).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // #848 — panel_restart_comfyui restarted the server and the user's newly-added
+  // Desktop launch flag was still absent. "It came back healthy" was reported, and
+  // it was true; it simply was not the answer to the question the user had.
+  // -------------------------------------------------------------------------
+
+  it("reports launch arguments UNCHANGED across a confirmed panel restart (#848)", async () => {
+    const argv = ["main.py", "--listen", "127.0.0.1", "--port", "8188"];
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => ({
+      ok: true,
+      observedArgv: argv,
+      isDesktopApp: true,
+    }));
+    // The server comes back running exactly what it ran before — the #848 shape.
+    getSystemStats.mockImplementation(async () => ({ system: { argv: [...argv] } }));
+    const seq: ProbeSeq = ["down", "healthy"];
+    let i = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => seq[Math.min(i++, seq.length - 1)]);
+    const { ctx } = makeCtx({ reboot: { rebooting: true } });
+
+    const out = parse(await rebootHandler()({ force: false }, ctx));
+    expect(out.ready).toBe(true);
+    expect(out.confirmed_cycle).toBe(true);
+    // The restart is still reported as the success it was…
+    expect(String(out.note)).toContain("healthy again");
+    // …and the thing the user actually wanted to know is now in the same sentence.
+    expect(String(out.note)).toContain("launch arguments are UNCHANGED");
+    expect(String(out.note)).toContain("Fully quit the ComfyUI Desktop app");
+  });
+
+  it("reports launch arguments CHANGED when the restart did apply them (#848)", async () => {
+    const before = ["main.py", "--port", "8188"];
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => ({
+      ok: true,
+      observedArgv: before,
+      isDesktopApp: true,
+    }));
+    getSystemStats.mockImplementation(async () => ({
+      system: { argv: [...before, "--disable-dynamic-vram"] },
+    }));
+    const seq: ProbeSeq = ["down", "healthy"];
+    let i = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => seq[Math.min(i++, seq.length - 1)]);
+    const { ctx } = makeCtx({ reboot: { rebooting: true } });
+
+    const out = parse(await rebootHandler()({ force: false }, ctx));
+    expect(out.ready).toBe(true);
+    expect(String(out.note)).toContain("launch arguments CHANGED");
+    expect(String(out.note)).toContain("--disable-dynamic-vram");
+    // A restart that DID apply the change must not send the user to redo it.
+    expect(String(out.note)).not.toContain("UNCHANGED");
+    expect(String(out.note)).not.toContain("Fully quit");
+  });
+
+  it("says nothing about launch arguments when the before-reading is missing (#848)", async () => {
+    // The preflight observed no argv (a wedged server reports none). An unread
+    // before-state is not evidence of sameness, so the note must stay silent —
+    // never "unchanged" by default.
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => ({ ok: true }));
+    getSystemStats.mockImplementation(async () => ({
+      system: { argv: ["main.py", "--port", "8188"] },
+    }));
+    const seq: ProbeSeq = ["down", "healthy"];
+    let i = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => seq[Math.min(i++, seq.length - 1)]);
+    const { ctx } = makeCtx({ reboot: { rebooting: true } });
+
+    const out = parse(await rebootHandler()({ force: false }, ctx));
+    expect(out.ready).toBe(true);
+    expect(String(out.note)).not.toMatch(/launch arguments/i);
   });
 
   it("fast restart: a SINGLE down (would-be transient) after acceptance still CONFIRMS as observed-cycle", async () => {

--- a/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
@@ -172,7 +172,11 @@ describe("panel_restart_comfyui recovery after an ACCEPTED reboot (coordinator p
     expect(String(out.note)).toContain("healthy again");
     // …and the thing the user actually wanted to know is now in the same sentence.
     expect(String(out.note)).toContain("launch arguments are UNCHANGED");
-    expect(String(out.note)).toContain("Fully quit the ComfyUI Desktop app");
+    // Exactly what equal argv establishes, with the remedy offered CONDITIONALLY —
+    // we never read the user's saved settings, so we cannot say they were ignored.
+    expect(String(out.note)).toContain("this restart did not change them");
+    expect(String(out.note)).toContain("If you were expecting different arguments");
+    expect(String(out.note)).toMatch(/fully quit the ComfyUI Desktop app/i);
   });
 
   it("reports launch arguments CHANGED when the restart did apply them (#848)", async () => {
@@ -196,7 +200,7 @@ describe("panel_restart_comfyui recovery after an ACCEPTED reboot (coordinator p
     expect(String(out.note)).toContain("--disable-dynamic-vram");
     // A restart that DID apply the change must not send the user to redo it.
     expect(String(out.note)).not.toContain("UNCHANGED");
-    expect(String(out.note)).not.toContain("Fully quit");
+    expect(String(out.note)).not.toMatch(/fully quit/i);
   });
 
   it("says nothing about launch arguments when the before-reading is missing (#848)", async () => {

--- a/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
@@ -29,7 +29,11 @@ vi.mock("../../comfyui/client.js", () => ({
 const { buildPanelToolDefs, __panelToolsTestHooks } = await import(
   "../../orchestrator/panel-tools.js"
 );
-import { getBootLocalComfyUIBaseUrl } from "../../config.js";
+import {
+  getBootLocalComfyUIBaseUrl,
+  getComfyUIBaseUrl,
+  setComfyuiTarget,
+} from "../../config.js";
 import { markDispatched } from "../../services/ui-bridge.js";
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
 
@@ -201,6 +205,38 @@ describe("panel_restart_comfyui recovery after an ACCEPTED reboot (coordinator p
     // A restart that DID apply the change must not send the user to redo it.
     expect(String(out.note)).not.toContain("UNCHANGED");
     expect(String(out.note)).not.toMatch(/fully quit/i);
+  });
+
+  it("says nothing about launch arguments when the target round-trips mid-read (#848)", async () => {
+    // A→B→A DURING the post-restart argv read. The base comparison alone cannot see
+    // this — the final state matches — and checking it only BEFORE the await could
+    // not see a retarget landing inside the await either (codex gate round 2). The
+    // monotonic generation catches both, so the note is suppressed rather than
+    // comparing instance A's arguments against whatever the read actually reached.
+    const argv = ["main.py", "--port", "8188"];
+    const original = getComfyUIBaseUrl();
+    __panelToolsTestHooks.setLocalRestartPreflight(async () => ({
+      ok: true,
+      observedArgv: argv,
+      isDesktopApp: true,
+    }));
+    getSystemStats.mockImplementation(async () => {
+      setComfyuiTarget("http://127.0.0.1:9999");
+      setComfyuiTarget(original);
+      return { system: { argv: [...argv] } };
+    });
+    const seq: ProbeSeq = ["down", "healthy"];
+    let i = 0;
+    __panelToolsTestHooks.setHealthProbe(async () => seq[Math.min(i++, seq.length - 1)]);
+    const { ctx } = makeCtx({ reboot: { rebooting: true } });
+
+    const out = parse(await rebootHandler()({ force: false }, ctx));
+
+    // The target ends where it started, so the base check would have passed.
+    expect(getComfyUIBaseUrl()).toBe(original);
+    expect(out.ready).toBe(true);
+    // Identical argv would otherwise have produced the UNCHANGED note.
+    expect(String(out.note)).not.toMatch(/launch arguments/i);
   });
 
   it("says nothing about launch arguments when the before-reading is missing (#848)", async () => {

--- a/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
@@ -178,7 +178,11 @@ describe("panel_restart_comfyui recovery after an ACCEPTED reboot (coordinator p
     expect(String(out.note)).toContain("launch arguments are UNCHANGED");
     // Exactly what equal argv establishes, with the remedy offered CONDITIONALLY —
     // we never read the user's saved settings, so we cannot say they were ignored.
-    expect(String(out.note)).toContain("this restart did not change them");
+    expect(String(out.note)).toContain(
+      "the same arguments were observed before and after",
+    );
+    // Not a causal claim about the restart — see desktop-restart.test.ts.
+    expect(String(out.note)).not.toMatch(/this restart did not change/i);
     expect(String(out.note)).toContain("If you were expecting different arguments");
     expect(String(out.note)).toMatch(/fully quit the ComfyUI Desktop app/i);
   });

--- a/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
@@ -179,7 +179,7 @@ describe("panel_restart_comfyui recovery after an ACCEPTED reboot (coordinator p
     // Exactly what equal argv establishes, with the remedy offered CONDITIONALLY —
     // we never read the user's saved settings, so we cannot say they were ignored.
     expect(String(out.note)).toContain(
-      "the same arguments were observed before and after",
+      "the same arguments were observed before this restart request and again now",
     );
     // Not a causal claim about the restart — see desktop-restart.test.ts.
     expect(String(out.note)).not.toMatch(/this restart did not change/i);

--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -338,6 +338,42 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     expect(res.message).toContain("came back ready");
   });
 
+  it("says NOTHING about launch arguments when the target moved BEFORE the reboot (#848)", async () => {
+    // The "before" argv is read by acquireProcessInfo, which runs EARLIER than the
+    // reboot helper. Capturing the fence inside that helper covered only the window
+    // it could see — a retarget between the reading and the helper left the before
+    // argv belonging to A and everything after to B, with no generation change left
+    // for the check to notice (codex gate round 2). The generation now travels WITH
+    // the reading, so this is caught.
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 1000,
+      intervalMs: 5,
+    });
+    let statsReads = 0;
+    hoisted.getSystemStats.mockImplementation(async () => {
+      // The FIRST read is acquireProcessInfo's; a retarget lands right after it,
+      // before the reboot helper would have captured a generation of its own.
+      statsReads += 1;
+      if (statsReads === 1) hoisted.targetGeneration.value += 1;
+      return { system: { argv: [...hoisted.desktopArgv] } };
+    });
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = pathOf(url);
+      if (path === "/v2/manager/reboot") return new Response("", { status: 200 });
+      if (path === "/system_stats") {
+        return new Response(JSON.stringify({ system: {} }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.ready).toBe(true);
+    expect(res.message).not.toMatch(/launch arguments/i);
+    expect(res.message).toContain("came back ready");
+  });
+
   it("refuses without killing when the Manager reboot cannot be fired (403)", async () => {
     __processControlTestHooks.setRemoteRebootTimingForTests({
       settleMs: 0,

--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -173,8 +173,16 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     expect(res.stopped).toBe(true);
     expect(res.started).toBe(true);
     expect(res.ready).toBe(true);
-    expect(res.message).toContain("rebooted via ComfyUI-Manager");
+    expect(res.message).toContain("reboot request was accepted");
     expect(res.message).toContain("Desktop/supervised");
+    // IT MUST NOT CLAIM A CYCLE IT NEVER WATCHED (codex gate round 6). This poller
+    // has no down→up requirement at all — unlike the panel path, which certifies
+    // only on an observed cycle — so all that was seen is an accepted request and a
+    // later healthy probe. A Manager that accepts and then does nothing leaves a
+    // healthy server that never restarted, and "came back" stops the user looking.
+    expect(res.message).not.toMatch(/came back/i);
+    expect(res.message).not.toMatch(/rebooted via/i);
+    expect(res.message).toMatch(/not directly observed/i);
 
     // The Manager reboot was fired.
     expect(findCall((p) => p === "/v2/manager/reboot")).toBeDefined();
@@ -242,7 +250,7 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     // reboot re-execs the running process) would assert a cause we never observed.
     expect(res.message).not.toMatch(/re-exec/i);
     // And it never contradicts the restart that genuinely happened.
-    expect(res.message).toContain("came back ready");
+    expect(res.message).toContain("ComfyUI is healthy now");
   });
 
   it("says the launch arguments CHANGED when they actually did (#848)", async () => {
@@ -313,7 +321,7 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     expect(res.message).not.toMatch(/launch arguments/i);
     // The restart itself is still reported — a missing extra detail must not
     // degrade the verdict about the thing that did happen.
-    expect(res.message).toContain("came back ready");
+    expect(res.message).toContain("ComfyUI is healthy now");
   });
 
   it("says NOTHING about launch arguments when the target moved mid-restart (#848)", async () => {
@@ -345,7 +353,7 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     expect(res.ready).toBe(true);
     // The identical argv would otherwise have produced the UNCHANGED note.
     expect(res.message).not.toMatch(/launch arguments/i);
-    expect(res.message).toContain("came back ready");
+    expect(res.message).toContain("ComfyUI is healthy now");
   });
 
   it("says NOTHING about launch arguments when the target moved BEFORE the reboot (#848)", async () => {
@@ -381,7 +389,7 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
 
     expect(res.ready).toBe(true);
     expect(res.message).not.toMatch(/launch arguments/i);
-    expect(res.message).toContain("came back ready");
+    expect(res.message).toContain("ComfyUI is healthy now");
   });
 
   it("refuses without killing when the Manager reboot cannot be fired (403)", async () => {

--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -364,13 +364,15 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     expect(res.message).toContain("ComfyUI is healthy now");
   });
 
-  it("says NOTHING about launch arguments when the target moved BEFORE the reboot (#848)", async () => {
-    // The "before" argv is read by acquireProcessInfo, which runs EARLIER than the
-    // reboot helper. Capturing the fence inside that helper covered only the window
-    // it could see — a retarget between the reading and the helper left the before
-    // argv belonging to A and everything after to B, with no generation change left
-    // for the check to notice (codex gate round 2). The generation now travels WITH
-    // the reading, so this is caught.
+  it("REFUSES, without dispatching, when the target moved while the instance was identified", async () => {
+    // A retarget landing inside `acquireProcessInfo`'s await leaves `info` describing
+    // instance A while the config — which the Manager reboot's base URL and the
+    // relaunch port both read LIVE — points at B. Every assessment that would
+    // authorize the stop was about A, so sending it is the #368/#814 lost server by
+    // another route (codex gate round 11).
+    //
+    // This case used to be covered only as "the argv note is suppressed"; suppressing
+    // a sentence was never the guarantee that mattered.
     __processControlTestHooks.setRemoteRebootTimingForTests({
       settleMs: 0,
       budgetMs: 1000,
@@ -378,8 +380,7 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     });
     let statsReads = 0;
     hoisted.getSystemStats.mockImplementation(async () => {
-      // The FIRST read is acquireProcessInfo's; a retarget lands right after it,
-      // before the reboot helper would have captured a generation of its own.
+      // The FIRST read is acquireProcessInfo's; the retarget lands during it.
       statsReads += 1;
       if (statsReads === 1) hoisted.targetGeneration.value += 1;
       return { system: { argv: [...hoisted.desktopArgv] } };
@@ -395,9 +396,21 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
 
     const res = await restartComfyUI();
 
-    expect(res.ready).toBe(true);
-    expect(res.message).not.toMatch(/launch arguments/i);
-    expect(res.message).toContain("ComfyUI is healthy now");
+    expect(res.stopped).toBe(false);
+    expect(res.started).toBe(false);
+    expect(res.startup).toBe("not-attempted");
+    expect(res.message).toMatch(/Refusing to restart/i);
+    expect(res.message).toMatch(/target changed while the running instance was being identified/i);
+    expect(res.message).toMatch(/Nothing was stopped/i);
+    // REFUSE BEFORE: no reboot may have been dispatched, and nothing killed.
+    expect(findCall((p) => p === "/v2/manager/reboot")).toBeUndefined();
+    expect(hoisted.spawn).not.toHaveBeenCalled();
+    const killed = hoisted.execSync.mock.calls.some(([c]: [string]) =>
+      /taskkill|\bkill\b|pkill/i.test(c),
+    );
+    expect(killed).toBe(false);
+    // …and the user is handed the command to start it by hand.
+    expect(res.restart_hint).toBeDefined();
   });
 
   it("refuses without killing when the Manager reboot cannot be fired (403)", async () => {

--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -222,7 +222,13 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     // change them — and offers the remedy CONDITIONALLY. It must not claim the
     // user's saved settings were ignored: we never opened them, and their edit may
     // have been to something argv does not carry (codex gate).
-    expect(res.message).toContain("the same arguments were observed before and after");
+    expect(res.message).toContain(
+      "the same arguments were observed before this restart request and again now",
+    );
+    // "before this restart REQUEST", not "across this restart": on the Manager path
+    // the observations are an accepted request and a later healthy probe — no
+    // down→up cycle is required — so a completed restart may not be taken as given.
+    expect(res.message).not.toMatch(/across this restart/i);
     // NOT "this restart did not change them" — two equal snapshots cannot show the
     // restart had no effect (a value can change and change back), and an accepted
     // Manager request is not proof a cycle even happened (codex gate round 3).

--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -171,8 +171,12 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     const res = await restartComfyUI();
 
     expect(res.stopped).toBe(true);
-    expect(res.started).toBe(true);
     expect(res.ready).toBe(true);
+    // `started:false` beside `ready:true` (codex gate round 8). This call spawned
+    // NOTHING — an acknowledged Manager request can be a no-op — so it has no
+    // positive evidence it started anything, which is all `started` claims. That it
+    // does not mean "the server is down" is exactly what `ready:true` is for.
+    expect(res.started).toBe(false);
     expect(res.message).toContain("reboot request was acknowledged");
     expect(res.message).toContain("Desktop/supervised");
     // IT MUST NOT CLAIM A CYCLE IT NEVER WATCHED (codex gate round 6). This poller

--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -13,17 +13,14 @@ const hoisted = vi.hoisted(() => ({
   resetClient: vi.fn(),
   resetObjectInfoCache: vi.fn(),
   // argv that marks this as a Comfy Desktop install (see isDesktopApp()).
-  getSystemStats: vi.fn(async () => ({
-    system: {
-      argv: [
-        "C:\\Users\\x\\AppData\\Local\\Programs\\Comfy Desktop\\resources\\ComfyUI\\main.py",
-        "--listen",
-        "127.0.0.1",
-        "--port",
-        "8188",
-      ],
-    },
-  })),
+  desktopArgv: [
+    "C:\\Users\\x\\AppData\\Local\\Programs\\Comfy Desktop\\resources\\ComfyUI\\main.py",
+    "--listen",
+    "127.0.0.1",
+    "--port",
+    "8188",
+  ],
+  getSystemStats: vi.fn(),
   execSync: vi.fn(() => ""),
   spawn: vi.fn(),
 }));
@@ -86,7 +83,13 @@ beforeEach(() => {
   hoisted.fetchMock.mockReset();
   hoisted.resetClient.mockClear();
   hoisted.resetObjectInfoCache.mockClear();
-  hoisted.getSystemStats.mockClear();
+  // RESET, not clear: a test that installs its own implementation (the #848 argv
+  // cases below do) would otherwise leak it into every later test in this file —
+  // and a getSystemStats that throws silently un-Desktops the whole fixture.
+  hoisted.getSystemStats.mockReset();
+  hoisted.getSystemStats.mockImplementation(async () => ({
+    system: { argv: [...hoisted.desktopArgv] },
+  }));
   hoisted.spawn.mockReset();
   hoisted.execSync.mockReset();
   // Map the running Desktop server's :8188 listener to a PID so gatherProcessInfo
@@ -177,6 +180,118 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     );
     expect(killed).toBe(false);
     expect(hoisted.resetClient).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // #848 — "it restarted" is not the answer to "did it pick up my new flag?"
+  //
+  // The reporter added `--disable-dynamic-vram` to their Desktop installation's
+  // launch arguments, restarted, and was told the restart succeeded. It had, and
+  // the flag was still absent: the server came back running exactly what it ran
+  // before. Nothing in the report distinguished those two things, so the only way
+  // to find out was to go and read /system_stats by hand.
+  // -------------------------------------------------------------------------
+
+  it("says the launch arguments are UNCHANGED across a Desktop reboot (#848)", async () => {
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 1000,
+      intervalMs: 5,
+    });
+    // The default getSystemStats mock returns the SAME argv before and after —
+    // which is precisely the shape #848 was filed about.
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = pathOf(url);
+      if (path === "/v2/manager/reboot") return new Response("", { status: 200 });
+      if (path === "/system_stats") {
+        return new Response(JSON.stringify({ system: {} }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.ready).toBe(true);
+    expect(res.message).toContain("launch arguments are UNCHANGED");
+    // The remedy has to be one the user can act on from where they are, and for a
+    // Desktop install that is the app — not a COMFYUI_PATH or a CLI they never use.
+    expect(res.message).toContain("Fully quit the ComfyUI Desktop app");
+    // It reports the OBSERVATION and stops there. Naming the mechanism (a Manager
+    // reboot re-execs the running process) would assert a cause we never observed.
+    expect(res.message).not.toMatch(/re-exec/i);
+    // And it never contradicts the restart that genuinely happened.
+    expect(res.message).toContain("came back ready");
+  });
+
+  it("says the launch arguments CHANGED when they actually did (#848)", async () => {
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 1000,
+      intervalMs: 5,
+    });
+    const baseArgv = hoisted.desktopArgv;
+    let rebooted = false;
+    hoisted.getSystemStats.mockImplementation(async () => ({
+      system: {
+        argv: rebooted ? [...baseArgv, "--disable-dynamic-vram"] : [...baseArgv],
+      },
+    }));
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = pathOf(url);
+      if (path === "/v2/manager/reboot") {
+        rebooted = true;
+        return new Response("", { status: 200 });
+      }
+      if (path === "/system_stats") {
+        return new Response(JSON.stringify({ system: {} }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.ready).toBe(true);
+    expect(res.message).toContain("launch arguments CHANGED");
+    expect(res.message).toContain("--disable-dynamic-vram");
+    // A genuine change must NOT be reported as the #848 no-op, and must not send
+    // the user off to restart an app that already did what they asked.
+    expect(res.message).not.toContain("UNCHANGED");
+    expect(res.message).not.toContain("Fully quit the ComfyUI Desktop app");
+  });
+
+  it("says NOTHING about launch arguments when the post-restart reading is missing (#848)", async () => {
+    // An unread argv is not evidence of sameness. Silence is the only honest
+    // output here — inferring "unchanged" from a failed read would manufacture the
+    // very claim the user would act on.
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 1000,
+      intervalMs: 5,
+    });
+    let rebooted = false;
+    hoisted.getSystemStats.mockImplementation(async () => {
+      if (rebooted) throw new Error("ECONNRESET");
+      return { system: { argv: [...hoisted.desktopArgv] } };
+    });
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = pathOf(url);
+      if (path === "/v2/manager/reboot") {
+        rebooted = true;
+        return new Response("", { status: 200 });
+      }
+      if (path === "/system_stats") {
+        return new Response(JSON.stringify({ system: {} }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.ready).toBe(true);
+    expect(res.message).not.toMatch(/launch arguments/i);
+    // The restart itself is still reported — a missing extra detail must not
+    // degrade the verdict about the thing that did happen.
+    expect(res.message).toContain("came back ready");
   });
 
   it("refuses without killing when the Manager reboot cannot be fired (403)", async () => {

--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -222,7 +222,11 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     // change them — and offers the remedy CONDITIONALLY. It must not claim the
     // user's saved settings were ignored: we never opened them, and their edit may
     // have been to something argv does not carry (codex gate).
-    expect(res.message).toContain("this restart did not change them");
+    expect(res.message).toContain("the same arguments were observed before and after");
+    // NOT "this restart did not change them" — two equal snapshots cannot show the
+    // restart had no effect (a value can change and change back), and an accepted
+    // Manager request is not proof a cycle even happened (codex gate round 3).
+    expect(res.message).not.toMatch(/this restart did not change/i);
     expect(res.message).toContain("If you were expecting different arguments");
     expect(res.message).not.toMatch(/it did NOT\./);
     // The remedy has to be one the user can act on from where they are, and for a

--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -173,7 +173,7 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     expect(res.stopped).toBe(true);
     expect(res.started).toBe(true);
     expect(res.ready).toBe(true);
-    expect(res.message).toContain("reboot request was accepted");
+    expect(res.message).toContain("reboot request was acknowledged");
     expect(res.message).toContain("Desktop/supervised");
     // IT MUST NOT CLAIM A CYCLE IT NEVER WATCHED (codex gate round 6). This poller
     // has no down→up requirement at all — unlike the panel path, which certifies
@@ -183,6 +183,10 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     expect(res.message).not.toMatch(/came back/i);
     expect(res.message).not.toMatch(/rebooted via/i);
     expect(res.message).toMatch(/not directly observed/i);
+    // …AND THE STRUCTURED FIELDS MUST AGREE WITH IT (codex gate round 7). An agent
+    // keys on the JSON, so `startup:"confirmed"` beside a message that withholds
+    // confirmation hands back the definite signal the prose just refused.
+    expect(res.startup).toBe("unconfirmed");
 
     // The Manager reboot was fired.
     expect(findCall((p) => p === "/v2/manager/reboot")).toBeDefined();

--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   remoteMode: { value: false },
+  targetGeneration: { value: 0 },
   fetchMock: vi.fn(),
   resetClient: vi.fn(),
   resetObjectInfoCache: vi.fn(),
@@ -28,6 +29,9 @@ const hoisted = vi.hoisted(() => ({
 vi.mock("../../config.js", () => ({
   config: { resolvedPort: 8188, comfyuiPath: "/fake/comfy", comfyuiBasePath: "" },
   getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  // #848 instance fence: the argv comparison is only spent while the configured
+  // target has not moved. Driven from the fixture so a retarget can be modelled.
+  getComfyuiTargetGeneration: () => hoisted.targetGeneration.value,
   isRemoteMode: () => hoisted.remoteMode.value,
 }));
 
@@ -80,6 +84,7 @@ const findCall = (pred: (path: string) => boolean): FetchCall | undefined =>
 
 beforeEach(() => {
   hoisted.remoteMode.value = false;
+  hoisted.targetGeneration.value = 0;
   hoisted.fetchMock.mockReset();
   hoisted.resetClient.mockClear();
   hoisted.resetObjectInfoCache.mockClear();
@@ -213,9 +218,16 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
 
     expect(res.ready).toBe(true);
     expect(res.message).toContain("launch arguments are UNCHANGED");
+    // It states exactly what equal argv establishes — that THIS RESTART did not
+    // change them — and offers the remedy CONDITIONALLY. It must not claim the
+    // user's saved settings were ignored: we never opened them, and their edit may
+    // have been to something argv does not carry (codex gate).
+    expect(res.message).toContain("this restart did not change them");
+    expect(res.message).toContain("If you were expecting different arguments");
+    expect(res.message).not.toMatch(/it did NOT\./);
     // The remedy has to be one the user can act on from where they are, and for a
     // Desktop install that is the app — not a COMFYUI_PATH or a CLI they never use.
-    expect(res.message).toContain("Fully quit the ComfyUI Desktop app");
+    expect(res.message).toMatch(/fully quit the ComfyUI Desktop app/i);
     // It reports the OBSERVATION and stops there. Naming the mechanism (a Manager
     // reboot re-execs the running process) would assert a cause we never observed.
     expect(res.message).not.toMatch(/re-exec/i);
@@ -256,7 +268,7 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     // A genuine change must NOT be reported as the #848 no-op, and must not send
     // the user off to restart an app that already did what they asked.
     expect(res.message).not.toContain("UNCHANGED");
-    expect(res.message).not.toContain("Fully quit the ComfyUI Desktop app");
+    expect(res.message).not.toMatch(/fully quit the ComfyUI Desktop app/i);
   });
 
   it("says NOTHING about launch arguments when the post-restart reading is missing (#848)", async () => {
@@ -291,6 +303,38 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     expect(res.message).not.toMatch(/launch arguments/i);
     // The restart itself is still reported — a missing extra detail must not
     // degrade the verdict about the thing that did happen.
+    expect(res.message).toContain("came back ready");
+  });
+
+  it("says NOTHING about launch arguments when the target moved mid-restart (#848)", async () => {
+    // Both argv readings go through the MUTABLE configured target. If it moves
+    // between them, the "before" belongs to instance A and the "after" to instance
+    // B — and reporting that as one server's arguments changing (or not) would
+    // invent a finding out of two unrelated observations (codex gate). Judged by the
+    // monotonic generation, so an A->B->A round trip is caught too.
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 1000,
+      intervalMs: 5,
+    });
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = pathOf(url);
+      if (path === "/v2/manager/reboot") {
+        // A hello retarget lands while the reboot is in flight.
+        hoisted.targetGeneration.value += 1;
+        return new Response("", { status: 200 });
+      }
+      if (path === "/system_stats") {
+        return new Response(JSON.stringify({ system: {} }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.ready).toBe(true);
+    // The identical argv would otherwise have produced the UNCHANGED note.
+    expect(res.message).not.toMatch(/launch arguments/i);
     expect(res.message).toContain("came back ready");
   });
 

--- a/src/__tests__/services/env-capabilities.test.ts
+++ b/src/__tests__/services/env-capabilities.test.ts
@@ -10,6 +10,7 @@ import {
   reconcileProbeState,
   resolveBackends,
   readInstalledPanelVersion,
+  gatherEnvCapabilities,
   type EnvCapabilities,
 } from "../../services/env-capabilities.js";
 
@@ -107,6 +108,111 @@ describe("formatEnvBlock", () => {
     expect(bare).not.toContain("comfyui-mcp ");
     expect(bare).not.toContain("panel ");
   });
+
+  // ---------------------------------------------------------------------------
+  // #846 — the version line described a moment that had passed
+  //
+  // The ENV line reported comfyui-mcp 0.48.18 while 0.49.5 was installed, because
+  // the version was read once when the orchestrator process started and then
+  // rendered forever as the current state of the machine. Every bug filed from
+  // that session carried the wrong number, and triage chased them against a build
+  // nobody was running.
+  //
+  // Both readings are separately TRUE — this process really is running the old
+  // build, and the newer one really is installed. So neither is suppressed: the
+  // running build leads (it is what the report is about) and the drift is stated.
+  // ---------------------------------------------------------------------------
+
+  it("discloses an installed version that has moved past the RUNNING one (#846)", () => {
+    const out = formatEnvBlock({
+      os: "Linux",
+      mcpVersion: "0.48.18",
+      mcpVersionInstalled: "0.49.5",
+    });
+    // The RUNNING build leads — a report generated from this session is about it.
+    expect(out).toContain("comfyui-mcp 0.48.18");
+    expect(out).toContain("RUNNING 0.48.18");
+    expect(out).toContain("0.49.5 is now installed on disk");
+    // A remedy that works from where the caller is.
+    expect(out).toContain("restart the orchestrator to load it");
+    // The newer number must never be presented as the version in use — that is the
+    // mirror-image lie, and it would re-pin bug reports to unexecuted code.
+    expect(out).not.toMatch(/comfyui-mcp 0\.49\.5/);
+  });
+
+  it("says nothing about drift when the two readings agree (#846)", () => {
+    const out = formatEnvBlock({
+      os: "Linux",
+      mcpVersion: "0.49.6",
+      mcpVersionInstalled: "0.49.6",
+    });
+    expect(out).toContain("comfyui-mcp 0.49.6");
+    expect(out).not.toMatch(/RUNNING/);
+    expect(out).not.toMatch(/installed on disk/);
+  });
+
+  it("says nothing about drift when the installed version could not be read (#846)", () => {
+    // An unread version is not evidence that nothing changed — and it is certainly
+    // not evidence that something did. Silence is the only honest output.
+    const out = formatEnvBlock({ os: "Linux", mcpVersion: "0.49.6" });
+    expect(out).toContain("comfyui-mcp 0.49.6");
+    expect(out).not.toMatch(/installed on disk/);
+    expect(out).not.toMatch(/undefined/);
+  });
+
+  it(
+    "re-reads the installed version on EVERY gather, and never caches it (#846)",
+    async () => {
+      // THE ACTUAL ROOT CAUSE, not just its rendering: the reported version was read
+      // ONCE at orchestrator startup and reused for the life of the process, so an
+      // upgrade that landed afterwards was invisible. Deleting the per-gather read
+      // must break THIS test — asserting only the formatting would leave the fix
+      // itself uncovered.
+      //
+      // Runs the real probe set (they are internally timed out and degrade to
+      // "unknown"), which is slow but is the point: it exercises the wiring end to
+      // end rather than a stub that could not go stale.
+      let onDisk: string | undefined = "0.48.18";
+      let shouldThrow = false;
+      const reads: (string | undefined)[] = [];
+      const readInstalledMcpVersion = (): string | undefined => {
+        if (shouldThrow) throw new Error("package.json unreadable");
+        reads.push(onDisk);
+        return onDisk;
+      };
+      const gather = () =>
+        gatherEnvCapabilities({
+          mcpVersion: "0.48.18",
+          readInstalledMcpVersion,
+          statsTimeoutMs: 1,
+          tritonTimeoutMs: 1,
+        });
+
+      const first = await gather();
+      expect(first.mcpVersionInstalled).toBe("0.48.18");
+      expect(formatEnvBlock(first)).not.toMatch(/installed on disk/);
+
+      // An in-place upgrade lands while this process keeps running the old build.
+      onDisk = "0.49.5";
+
+      const second = await gather();
+      expect(reads).toEqual(["0.48.18", "0.49.5"]);
+      // The RUNNING version is unchanged — this process did not hot-swap its code.
+      expect(second.mcpVersion).toBe("0.48.18");
+      // …and the drift is now visible instead of silently reported as current state.
+      expect(second.mcpVersionInstalled).toBe("0.49.5");
+      expect(formatEnvBlock(second)).toContain("0.49.5 is now installed on disk");
+
+      // A read that THROWS leaves the line silent rather than wrong: the guard is
+      // itself an operation that can fail, so it is fenced.
+      shouldThrow = true;
+      const third = await gather();
+      expect(third.mcpVersion).toBe("0.48.18");
+      expect(third.mcpVersionInstalled).toBeUndefined();
+      expect(formatEnvBlock(third)).not.toMatch(/installed on disk/);
+    },
+    60_000,
+  );
 
   it("renders ComfyUI location even when the version is unknown", () => {
     const out = formatEnvBlock({ location: "LOCAL" });

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -473,7 +473,10 @@ describe("process-control startup readiness", () => {
     // them, so the supportable statement is about the probes (codex gate round 3).
     expect(result.message).not.toMatch(/before the API came up/i);
     expect(result.message).not.toMatch(/did not become ready/i);
-    expect(result.message).toMatch(/no readiness probe got a response/i);
+    // "HEALTHY response": the poller counts any non-2xx as not-ready, so a 503 from
+    // a half-started server IS a response and "no response" would be false.
+    expect(result.message).toMatch(/no readiness probe got a healthy response/i);
+    expect(result.message).not.toMatch(/no readiness probe got a response\b/i);
     expect(result.message).toMatch(/the last one included/i);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -675,7 +675,10 @@ describe("process-control restart relaunch preflight (#368/#370)", () => {
     const result = await restartComfyUI();
 
     expect(result.stopped).toBe(true);
-    expect(result.started).toBe(true);
+    expect(result.ready).toBe(true);
+    // See desktop-restart.test.ts — a Manager reboot spawns nothing of ours, so
+    // `started` has no evidence to rest on and `ready` carries the outcome.
+    expect(result.started).toBe(false);
     expect(result.message).toMatch(/reboot request was acknowledged/i);
     expect(result.message).toMatch(/Desktop\/supervised/i);
     // Never killed / re-spawned.

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -405,8 +405,12 @@ describe("process-control startup readiness", () => {
     await vi.advanceTimersByTimeAsync(10);
     const result = await pending;
 
-    expect(result.started).toBe(false);
+    // #367: the budget expired while the launched process was STILL ALIVE, so the
+    // verdict is "not confirmed yet", not "failed". `ready` stays false — nothing
+    // answered — but the launch itself is reported as the thing that did happen.
+    expect(result.started).toBe(true);
     expect(result.ready).toBe(false);
+    expect(result.startup).toBe("unconfirmed");
     expect(result.readiness).toMatchObject({
       ready: false,
       timed_out: true,
@@ -415,7 +419,47 @@ describe("process-control startup readiness", () => {
       interval_ms: 10,
       probe_url: "http://127.0.0.1:8188/system_stats",
     });
-    expect(result.message).toMatch(/did not become ready/i);
+    expect(result.message).toMatch(/NOT CONFIRMED YET/);
+    // ASSERT THE REASON, NOT THE STATE: the whole bug was a message that read as a
+    // failure. A test that only checked "an error came back" passes either way.
+    expect(result.message).toMatch(/does NOT mean it failed/i);
+    expect(result.message).not.toMatch(/failed relaunch/i);
+    expect(result.message).not.toMatch(/ComfyUI is DOWN/);
+    // …and it must steer the caller AWAY from the destructive response.
+    expect(result.message).toMatch(/Do NOT kill it/i);
+    expect(result.message).toMatch(/health_check/);
+    expect(result.message).toMatch(/COMFYUI_STARTUP_CHECK_MAX_TRIES/);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("a launched process that DIED before the API answered is a failure, not 'not yet' (#367)", async () => {
+    // The other side of the same split. Only an OBSERVED death may produce the
+    // definite negative — and when we have one, #776's truthful DOWN report is
+    // preserved exactly.
+    vi.useFakeTimers();
+    process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+    process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "2";
+    setLaunchInfo();
+    const children = mockSpawnedChildren();
+    mockNoPortProcess();
+    const fetchMock = mockFetchOk(false);
+
+    const pending = startComfyUI();
+    // The relaunch aborts during import — the #776 shape.
+    children[0].emit("exit", 1, null);
+    await vi.advanceTimersByTimeAsync(10);
+    const result = await pending;
+
+    expect(result.started).toBe(false);
+    expect(result.ready).toBe(false);
+    expect(result.startup).toBe("failed");
+    expect(result.message).toMatch(/EXITED \(exit code 1\)/);
+    expect(result.message).toMatch(/ComfyUI is DOWN/);
+    expect(result.message).toMatch(/failed relaunch, not a slow start/i);
+    // It must NOT be softened into the unconfirmed wording — a real failure
+    // reported as "it may still be coming up" is the mirror-image lie.
+    expect(result.message).not.toMatch(/NOT CONFIRMED YET/);
+    expect(result.message).not.toMatch(/Do NOT kill it/i);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -468,6 +468,13 @@ describe("process-control startup readiness", () => {
     // a present global state from a fact about our own process (codex gate).
     expect(result.message).not.toMatch(/ComfyUI is DOWN/);
     expect(result.message).toMatch(/re-check with health_check/i);
+    // Nor may it claim the API NEVER came up. A poll establishes only what the
+    // SCHEDULED PROBES saw; the server could have answered in a gap between two of
+    // them, so the supportable statement is about the probes (codex gate round 3).
+    expect(result.message).not.toMatch(/before the API came up/i);
+    expect(result.message).not.toMatch(/did not become ready/i);
+    expect(result.message).toMatch(/no readiness probe got a response/i);
+    expect(result.message).toMatch(/the last one included/i);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -16,6 +16,8 @@ vi.mock("../../config.js", () => ({
   config: mockConfig,
   getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
   getComfyUIAuthHeaders: () => ({}),
+  // #848 instance fence — a stable target here; the retarget case has its own test.
+  getComfyuiTargetGeneration: () => 0,
   isRemoteMode: () => false,
 }));
 
@@ -454,12 +456,18 @@ describe("process-control startup readiness", () => {
     expect(result.ready).toBe(false);
     expect(result.startup).toBe("failed");
     expect(result.message).toMatch(/EXITED \(exit code 1\)/);
-    expect(result.message).toMatch(/ComfyUI is DOWN/);
-    expect(result.message).toMatch(/failed relaunch, not a slow start/i);
+    expect(result.message).toMatch(/THIS RELAUNCH FAILED/);
+    expect(result.message).toMatch(/not a slow start/i);
     // It must NOT be softened into the unconfirmed wording — a real failure
     // reported as "it may still be coming up" is the mirror-image lie.
     expect(result.message).not.toMatch(/NOT CONFIRMED YET/);
     expect(result.message).not.toMatch(/Do NOT kill it/i);
+    // …but the scope of the claim is OUR launch, not the machine. Our child dying
+    // does not establish that nothing is serving the port: an external supervisor
+    // may have brought one back since the last probe, and the old wording asserted
+    // a present global state from a fact about our own process (codex gate).
+    expect(result.message).not.toMatch(/ComfyUI is DOWN/);
+    expect(result.message).toMatch(/re-check with health_check/i);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -676,7 +676,7 @@ describe("process-control restart relaunch preflight (#368/#370)", () => {
 
     expect(result.stopped).toBe(true);
     expect(result.started).toBe(true);
-    expect(result.message).toMatch(/reboot request was accepted/i);
+    expect(result.message).toMatch(/reboot request was acknowledged/i);
     expect(result.message).toMatch(/Desktop\/supervised/i);
     // Never killed / re-spawned.
     expect(mockSpawn).not.toHaveBeenCalled();

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -676,7 +676,7 @@ describe("process-control restart relaunch preflight (#368/#370)", () => {
 
     expect(result.stopped).toBe(true);
     expect(result.started).toBe(true);
-    expect(result.message).toMatch(/rebooted via ComfyUI-Manager/i);
+    expect(result.message).toMatch(/reboot request was accepted/i);
     expect(result.message).toMatch(/Desktop\/supervised/i);
     // Never killed / re-spawned.
     expect(mockSpawn).not.toHaveBeenCalled();

--- a/src/__tests__/services/remote-restart.test.ts
+++ b/src/__tests__/services/remote-restart.test.ts
@@ -99,10 +99,15 @@ describe("restartComfyUI — remote (Manager reboot)", () => {
     // gate round 7).
     expect(res.message).toContain("dispatched but not acknowledged");
     expect(res.message).not.toMatch(/request was acknowledged/i);
-    // The OBSERVED signal is named — a proxy status here — rather than one of the
-    // two causes this branch covers being narrated as the fact (codex gate round 8).
-    expect(res.message).toContain("a proxy in front of ComfyUI answered HTTP 502");
+    // The OBSERVED signal is named — the status, and only the status — rather than
+    // one of the causes this branch covers being narrated as the fact. Two earlier
+    // wordings each named a different one: "the origin dropped as it went down"
+    // (gate round 8) and "a proxy in front of ComfyUI answered" (gate round 9).
+    // Nothing here identifies a proxy, and ComfyUI or the Manager can return a 502
+    // directly.
+    expect(res.message).toContain("the request returned HTTP 502");
     expect(res.message).not.toMatch(/connection dropped/i);
+    expect(res.message).not.toMatch(/proxy/i);
     expect(res.startup).toBe("unconfirmed");
     expect(hoisted.resetClient).toHaveBeenCalledTimes(1);
     expect(hoisted.resetObjectInfoCache).toHaveBeenCalledTimes(1);

--- a/src/__tests__/services/remote-restart.test.ts
+++ b/src/__tests__/services/remote-restart.test.ts
@@ -90,7 +90,14 @@ describe("restartComfyUI — remote (Manager reboot)", () => {
     expect(res.stopped).toBe(true);
     expect(res.started).toBe(true);
     expect(res.ready).toBe(true);
-    expect(res.message).toContain("reboot request was accepted");
+    // A 502 is INFERRED to mean the handler took it and the origin dropped — a good
+    // inference, and the reason this path works through a tunnel at all, but not an
+    // acknowledgement. A tunnel hiccup in front of a server that was never restarted
+    // produces the identical signal, so the report must not call it accepted (codex
+    // gate round 7).
+    expect(res.message).toContain("no acknowledgement came back");
+    expect(res.message).not.toMatch(/was acknowledged/i);
+    expect(res.startup).toBe("unconfirmed");
     expect(hoisted.resetClient).toHaveBeenCalledTimes(1);
     expect(hoisted.resetObjectInfoCache).toHaveBeenCalledTimes(1);
     // The 502 on the canonical POST route counts as "fired" — the legacy GET
@@ -153,7 +160,7 @@ describe("restartComfyUI — remote (Manager reboot)", () => {
     // the poller only records that no probe got a 2xx, which is equally consistent
     // with a server that was never reachable from here (codex gate round 2).
     expect(res.message).not.toMatch(/went down/i);
-    expect(res.message).toMatch(/reboot was accepted/i);
+    expect(res.message).toMatch(/reboot request was acknowledged/i);
     expect(res.message).toMatch(/NOT CONFIRMED YET/);
     expect(res.message).toMatch(/does NOT mean it failed/i);
     expect(res.message).toMatch(/health_check/);

--- a/src/__tests__/services/remote-restart.test.ts
+++ b/src/__tests__/services/remote-restart.test.ts
@@ -121,7 +121,7 @@ describe("restartComfyUI — remote (Manager reboot)", () => {
     expect(hoisted.resetClient).not.toHaveBeenCalled();
   });
 
-  it("reboot fires but readiness never returns within budget → not started, timeout message", async () => {
+  it("reboot fires but readiness never returns within budget → NOT CONFIRMED, never 'did not come back' (#367)", async () => {
     __processControlTestHooks.setRemoteRebootTimingForTests({
       settleMs: 0,
       budgetMs: 30,
@@ -137,9 +137,20 @@ describe("restartComfyUI — remote (Manager reboot)", () => {
     const res = await restartComfyUI();
 
     expect(res.stopped).toBe(true);
+    // No process of OURS was spawned here — the supervisor is what brings it back —
+    // so `started` cannot be claimed. What changed is that it may no longer be READ
+    // as the other definite answer: `startup` says which, and the sentence agrees.
     expect(res.started).toBe(false);
     expect(res.ready).toBe(false);
-    expect(res.message).toContain("did not come back within 30ms");
+    expect(res.startup).toBe("unconfirmed");
+    // ASSERT THE REASON. "did not come back" asserted a definite negative the
+    // expired budget never established — that phrasing must be gone, not merely
+    // reworded around.
+    expect(res.message).not.toMatch(/did not come back/i);
+    expect(res.message).toMatch(/NOT CONFIRMED YET/);
+    expect(res.message).toMatch(/does NOT mean it failed/i);
+    expect(res.message).toMatch(/health_check/);
+    expect(res.message).toMatch(/COMFYUI_REMOTE_REBOOT_BUDGET_S/);
     expect(hoisted.resetClient).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/services/remote-restart.test.ts
+++ b/src/__tests__/services/remote-restart.test.ts
@@ -64,7 +64,7 @@ beforeEach(() => {
 });
 
 describe("restartComfyUI — remote (Manager reboot)", () => {
-  it("reboot POST 502, then /system_stats errors twice then 200 → started + ready", async () => {
+  it("reboot POST 502, then /system_stats errors twice then 200 → ready, dispatch UNacknowledged", async () => {
     __processControlTestHooks.setRemoteRebootTimingForTests({
       settleMs: 0,
       budgetMs: 1000,
@@ -88,15 +88,21 @@ describe("restartComfyUI — remote (Manager reboot)", () => {
     const res = await restartComfyUI();
 
     expect(res.stopped).toBe(true);
-    expect(res.started).toBe(true);
     expect(res.ready).toBe(true);
+    // No process of ours was spawned, so there is no positive evidence this call
+    // started anything; `ready:true` carries the good news (codex gate round 8).
+    expect(res.started).toBe(false);
     // A 502 is INFERRED to mean the handler took it and the origin dropped — a good
     // inference, and the reason this path works through a tunnel at all, but not an
     // acknowledgement. A tunnel hiccup in front of a server that was never restarted
     // produces the identical signal, so the report must not call it accepted (codex
     // gate round 7).
-    expect(res.message).toContain("no acknowledgement came back");
-    expect(res.message).not.toMatch(/was acknowledged/i);
+    expect(res.message).toContain("dispatched but not acknowledged");
+    expect(res.message).not.toMatch(/request was acknowledged/i);
+    // The OBSERVED signal is named — a proxy status here — rather than one of the
+    // two causes this branch covers being narrated as the fact (codex gate round 8).
+    expect(res.message).toContain("a proxy in front of ComfyUI answered HTTP 502");
+    expect(res.message).not.toMatch(/connection dropped/i);
     expect(res.startup).toBe("unconfirmed");
     expect(hoisted.resetClient).toHaveBeenCalledTimes(1);
     expect(hoisted.resetObjectInfoCache).toHaveBeenCalledTimes(1);

--- a/src/__tests__/services/remote-restart.test.ts
+++ b/src/__tests__/services/remote-restart.test.ts
@@ -19,6 +19,8 @@ const hoisted = vi.hoisted(() => ({
 vi.mock("../../config.js", () => ({
   config: { resolvedPort: 8188, comfyuiPath: "/fake/comfy", comfyuiBasePath: "" },
   getComfyUIBaseUrl: () => "http://remote.example:8188",
+  // #848 instance fence — a stable target here; the retarget case has its own test.
+  getComfyuiTargetGeneration: () => 0,
   isRemoteMode: () => hoisted.remoteMode.value,
 }));
 

--- a/src/__tests__/services/remote-restart.test.ts
+++ b/src/__tests__/services/remote-restart.test.ts
@@ -149,6 +149,11 @@ describe("restartComfyUI — remote (Manager reboot)", () => {
     // expired budget never established — that phrasing must be gone, not merely
     // reworded around.
     expect(res.message).not.toMatch(/did not come back/i);
+    // Nor may it claim the server "went down": nothing observed a down transition —
+    // the poller only records that no probe got a 2xx, which is equally consistent
+    // with a server that was never reachable from here (codex gate round 2).
+    expect(res.message).not.toMatch(/went down/i);
+    expect(res.message).toMatch(/reboot was accepted/i);
     expect(res.message).toMatch(/NOT CONFIRMED YET/);
     expect(res.message).toMatch(/does NOT mean it failed/i);
     expect(res.message).toMatch(/health_check/);

--- a/src/__tests__/services/remote-restart.test.ts
+++ b/src/__tests__/services/remote-restart.test.ts
@@ -108,6 +108,13 @@ describe("restartComfyUI — remote (Manager reboot)", () => {
     expect(res.message).toContain("the request returned HTTP 502");
     expect(res.message).not.toMatch(/connection dropped/i);
     expect(res.message).not.toMatch(/proxy/i);
+    // …and no causal HEDGE either. "which usually means the handler accepted it and
+    // the server went down" made two inferences and a frequency claim nobody
+    // measured, and it undercut the very next sentence, which correctly says the
+    // cycle was not directly observed (codex gate round 10).
+    expect(res.message).not.toMatch(/usually means/i);
+    expect(res.message).not.toMatch(/went down/i);
+    expect(res.message).toMatch(/not directly observed/i);
     expect(res.startup).toBe("unconfirmed");
     expect(hoisted.resetClient).toHaveBeenCalledTimes(1);
     expect(hoisted.resetObjectInfoCache).toHaveBeenCalledTimes(1);

--- a/src/__tests__/services/remote-restart.test.ts
+++ b/src/__tests__/services/remote-restart.test.ts
@@ -90,7 +90,7 @@ describe("restartComfyUI — remote (Manager reboot)", () => {
     expect(res.stopped).toBe(true);
     expect(res.started).toBe(true);
     expect(res.ready).toBe(true);
-    expect(res.message).toContain("rebooted via ComfyUI-Manager");
+    expect(res.message).toContain("reboot request was accepted");
     expect(hoisted.resetClient).toHaveBeenCalledTimes(1);
     expect(hoisted.resetObjectInfoCache).toHaveBeenCalledTimes(1);
     // The 502 on the canonical POST route counts as "fired" — the legacy GET

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -766,6 +766,22 @@ describe("restart_comfyui — irreproducible launcher environments (#776)", () =
     await expect(preflightLocalRestart()).resolves.toMatchObject({ ok: true });
   });
 
+  it("REPORTS the launch arguments it observed, so the caller can compare them (#848)", async () => {
+    // The panel's argv-drift note is built from THIS field. Every panel test injects
+    // a fake preflight, so without a direct assertion here `observedLaunch` and both
+    // of its spreads could be deleted and the whole suite would stay green (codex
+    // gate round 4) — the note would simply go silent forever, and #848 would be
+    // un-fixed with nothing to show it.
+    usePinokio();
+    mockLivePortThenFree();
+
+    const result = await preflightLocalRestart();
+
+    expect(result.ok).toBe(true);
+    expect(result.observedArgv).toEqual([PINOKIO_MAIN, "--port", "8188"]);
+    expect(result.isDesktopApp).toBe(false);
+  });
+
   it("does NOT refuse from start_comfyui when the server is ALREADY down — it launches and warns", async () => {
     // The refusal exists to protect a RUNNING server. Once ComfyUI is already
     // stopped, refusing would leave it down forever — the one outcome worse than a

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -757,7 +757,10 @@ describe("restart_comfyui — irreproducible launcher environments (#776)", () =
     usePinokio();
     mockLivePortThenFree();
 
-    await expect(preflightLocalRestart()).resolves.toEqual({ ok: true });
+    // toMatchObject, not toEqual: the preflight also reports the launch arguments
+    // it OBSERVED (#848) so the caller can compare them after the reboot. What this
+    // test is about is the verdict.
+    await expect(preflightLocalRestart()).resolves.toMatchObject({ ok: true });
   });
 
   it("does NOT refuse from start_comfyui when the server is ALREADY down — it launches and warns", async () => {
@@ -2372,11 +2375,55 @@ n127.0.0.1:8188
     killSpy.mockRestore();
   });
 
-  it("reports the TRUTH when the relaunch never comes back (stopped, not started)", async () => {
+  it("reports the TRUTH when the relaunch has not answered YET (#367: stopped, dispatched, unconfirmed)", async () => {
     usePlainInstall();
     mockLivePortThenFree();
     spawnCapturingChildren();
-    // The process is spawned but the API never answers — the server is DOWN.
+    // The process is spawned and STILL ALIVE, but the API has not answered inside
+    // the budget. This test used to assert "stopped but could not be started",
+    // which is the #367 defect itself: the relaunched process is right there, and
+    // in the reported case it answered about two seconds after the deadline.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(true);
+    expect(result.ready).toBe(false);
+    expect(result.startup).toBe("unconfirmed");
+    // NEITHER definite verdict may be printed. Both of these have been the wording
+    // at some point, and each is a lie in the opposite direction.
+    expect(result.message).not.toMatch(/could not be started/i);
+    expect(result.message).not.toMatch(/restarted successfully/i);
+    expect(result.message).toMatch(/NOT CONFIRMED YET/);
+    expect(result.message).toMatch(/not known to have failed/i);
+    // The environment it was launched into is still named, so a slow start that
+    // turns out to be a broken one is debuggable from this same report.
+    expect(result.launch_env?.source).toBe("inherited");
+
+    killSpy.mockRestore();
+  });
+
+  it("reports the TRUTH when the relaunched process DIED (stopped, not started)", async () => {
+    // The definite negative, and the evidence that licenses it: we watched the
+    // process we launched exit. #776's truthful DOWN report is unchanged here.
+    usePlainInstall();
+    mockLivePortThenFree();
+    // The relaunched child aborts during import the instant it is spawned — the
+    // #776 shape. Wired at the spawn site rather than raced from the test, so the
+    // exit is guaranteed to land before the readiness poll concludes: a mutant that
+    // survives only because a timer won a race is not a caught mutant.
+    mockSpawn.mockImplementation(() => {
+      const child = new FakeChild();
+      child.pid = 4321;
+      queueMicrotask(() => child.emit("exit", 1, null));
+      return child;
+    });
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => {
@@ -2390,9 +2437,11 @@ n127.0.0.1:8188
     expect(result.stopped).toBe(true);
     expect(result.started).toBe(false);
     expect(result.ready).toBe(false);
+    expect(result.startup).toBe("failed");
     expect(result.message).toMatch(/stopped but could not be started/i);
-    expect(result.message).not.toMatch(/restarted successfully/i);
-    // The environment it was launched into is named, so the failure is debuggable.
+    expect(result.message).toMatch(/ComfyUI is DOWN/);
+    // A real failure must NOT be softened into "it may still be coming up".
+    expect(result.message).not.toMatch(/NOT CONFIRMED YET/);
     expect(result.launch_env?.source).toBe("inherited");
 
     killSpy.mockRestore();

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -31,6 +31,8 @@ class FakeChild extends EventEmitter {
 const mockConfig = vi.hoisted(() => ({
   resolvedPort: 8188,
   comfyuiPath: undefined as string | undefined,
+  /** Monotonic ComfyUI-target generation — bumped by the retarget tests. */
+  targetGeneration: 0,
 }));
 
 const mockExecSync = vi.hoisted(() => vi.fn());
@@ -66,11 +68,11 @@ const mockSettingsJsonRef = vi.hoisted(() => ({
 
 vi.mock("../../config.js", () => ({
   config: mockConfig,
-  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  // Reads from the fixture so a retarget mid-restart can be modelled.
+  getComfyUIBaseUrl: () => `http://127.0.0.1:${mockConfig.resolvedPort}`,
   getComfyUIAuthHeaders: () => ({}),
-  // #848 instance fence — a stable target here; the retarget cases live in
-  // desktop-restart.test.ts and panel-restart-health-readiness.test.ts.
-  getComfyuiTargetGeneration: () => 0,
+  // Stable by default; the retarget tests below drive it.
+  getComfyuiTargetGeneration: () => mockConfig.targetGeneration,
   isRemoteMode: () => false,
 }));
 
@@ -274,6 +276,7 @@ beforeEach(() => {
   process.env.PATH = ORIGINAL_ENV.PATH ?? "/usr/bin";
   mockConfig.resolvedPort = 8188;
   mockConfig.comfyuiPath = undefined;
+  mockConfig.targetGeneration = 0;
   mockResolveBase.mockReturnValue(undefined);
   mockLiveRootFromArgv.mockReturnValue(undefined);
   __processControlTestHooks.reset();
@@ -2446,6 +2449,102 @@ n127.0.0.1:8188
     // The environment it was launched into is still named, so a slow start that
     // turns out to be a broken one is debuggable from this same report.
     expect(result.launch_env?.source).toBe("inherited");
+
+    killSpy.mockRestore();
+  });
+
+  // -------------------------------------------------------------------------
+  // The ComfyUI target is MUTABLE (a panel hello can retarget it) and every step of
+  // a restart is an await. Nothing here may end with a server stopped and a
+  // relaunch aimed somewhere else.
+  // -------------------------------------------------------------------------
+
+  it("stop_comfyui REFUSES when the target moved while it resolved the instance", async () => {
+    // A DIRECT stop had no fence at all, and its saved launch record does not repair
+    // the loss: start_comfyui afterwards consults the NEW live target, so it can
+    // refuse as remote or find that port occupied rather than relaunch what was
+    // killed (codex gate round 12).
+    usePlainInstall();
+    mockLivePortThenFree();
+    mockGetSystemStats.mockImplementation(async () => {
+      mockConfig.targetGeneration += 1; // a hello retarget lands during the resolve
+      return { system: { argv: [ABS_MAIN, "--port", "8188"] } };
+    });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await stopComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.message).toMatch(/Refusing to stop/i);
+    expect(result.message).toMatch(/target changed while the running instance was being identified/i);
+    expect(result.message).toMatch(/Nothing was killed/i);
+    const killIssued = mockExecSync.mock.calls.some(([c]: [string]) =>
+      /taskkill|pkill|\bkill\b/i.test(String(c)),
+    );
+    expect(killIssued).toBe(false);
+    // A refusal has to be actionable from where the caller is.
+    expect(result.message).toMatch(/Let the target settle, then retry/i);
+    // …and it must not claim a relaunch is on file for an instance it declined to
+    // touch (#767: has_restart_info means a command was BUILT AND VALIDATED).
+    expect(result.has_restart_info).toBe(false);
+
+    killSpy.mockRestore();
+  });
+
+  it("the relaunch is ANCHORED to the instance that was stopped, not the live target", async () => {
+    // After the kill, restartComfyUI awaits the port release and a settle delay. A
+    // retarget in that window used to leave the relaunch probing the NEW target's
+    // port: if that port was occupied it returned "already running" WITHOUT
+    // spawning, and the instance just killed stayed dead (codex gate round 12).
+    //
+    // Modelled by pointing the live config at a DIFFERENT, occupied port after the
+    // stop. Anchored, the restart still relaunches and grades the original.
+    usePlainInstall();
+    mockLivePortThenFree();
+    spawnCapturingChildren();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    // The retarget lands at the KILL — after the resolve, so the pre-stop fence
+    // (which spans only the resolve) passes and the post-stop window is what is
+    // exercised. Port 9999 is OCCUPIED, which is what makes the un-anchored version
+    // bail out with "already running" instead of relaunching.
+    let killed = false;
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        mockConfig.resolvedPort = 9999; // config now points at a DIFFERENT instance
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        // `netstat -ano` carries no port argument — the caller filters the TABLE by
+        // the port it is asking about. So emit the whole table and let it choose:
+        // after the kill 8188 is free and an UNRELATED server holds 9999.
+        if (!killed) return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+        return "  TCP    0.0.0.0:9999   0.0.0.0:0   LISTENING       777";
+      }
+      if (/lsof/i.test(cmd)) {
+        // lsof IS asked per-port (`-iTCP:<port>`), so answer per-port.
+        if (!killed) return "p4321\nn127.0.0.1:8188\n";
+        if (/9999/.test(cmd)) return "p777\nn127.0.0.1:9999\n";
+        throw noListener();
+      }
+      return "";
+    });
+
+    const result = await restartComfyUI();
+
+    expect(killed).toBe(true);
+    expect(mockConfig.resolvedPort).toBe(9999); // the retarget really happened
+    // It RELAUNCHED rather than bailing out on the other target's occupied port…
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(result.message).not.toMatch(/already running/i);
+    // …and the readiness verdict is about the anchored instance's URL, not the
+    // config's current one.
+    expect(result.readiness?.probe_url).toBe("http://127.0.0.1:8188/system_stats");
+    expect(result.ready).toBe(true);
 
     killSpy.mockRestore();
   });

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -371,6 +371,15 @@ describe("restart_comfyui — Stability Matrix launcher environment (#776)", () 
     expect(result.stopped).toBe(true);
     expect(result.started).toBe(true);
     expect(result.ready).toBe(true);
+    // A HEALTHY restart whose listener could not be ATTRIBUTED is not the #367
+    // "not confirmed yet" shape, and must not be composed as one. Widening
+    // `startup:"unconfirmed"` to cover unmappable attribution briefly routed this
+    // case into that branch, telling the user "NOT CONFIRMED YET" about a server
+    // that was answering — and skipping the dispatch-record clear. `ready` is what
+    // separates the two, and the composition keys on it.
+    expect(result.startup).toBe("unconfirmed");
+    expect(result.message).not.toMatch(/NOT CONFIRMED YET/);
+    expect(result.message).toMatch(/up and ready after the restart/i);
 
     // The relaunch DID carry an explicit environment (the bug was `env` omitted,
     // silently inheriting the orchestrator's).

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -1533,6 +1533,11 @@ describe("restart_comfyui — plain installs are unchanged (#776)", () => {
     // call did not start the server. `ready` stays true — the server really is up.
     expect(result.started).toBe(false);
     expect(result.ready).toBe(true);
+    // …and `startup` must not CONFIRM the very attribution just denied (codex gate
+    // round 9). The API answered, but provably not as our relaunch: that is an
+    // OBSERVED failure of this call's launch, not a confirmation of it.
+    expect(result.startup).toBe("failed");
+    expect(JSON.parse(JSON.stringify(result)).startup).toBe("failed");
     expect(result.message).not.toMatch(/restarted successfully/i);
     expect(result.message).toMatch(/NOT as a result of this restart/i);
     expect(result.message).toMatch(/another launcher or supervisor owns it/i);

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -68,6 +68,9 @@ vi.mock("../../config.js", () => ({
   config: mockConfig,
   getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
   getComfyUIAuthHeaders: () => ({}),
+  // #848 instance fence — a stable target here; the retarget cases live in
+  // desktop-restart.test.ts and panel-restart-health-readiness.test.ts.
+  getComfyuiTargetGeneration: () => 0,
   isRemoteMode: () => false,
 }));
 

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -2333,6 +2333,10 @@ n127.0.0.1:8188
     // The claim is scoped to OUR relaunch. Our child dying does not establish that
     // nothing is serving the port now (codex gate).
     expect(result.message).not.toMatch(/ComfyUI is DOWN/);
+    // …nor that the API never came up: a poll only establishes what the SCHEDULED
+    // PROBES saw, and the server could have answered between two of them.
+    expect(result.message).not.toMatch(/before the API came up/i);
+    expect(result.message).toMatch(/the last one included/i);
 
     killSpy.mockRestore();
   });

--- a/src/__tests__/services/restart-launcher-env.test.ts
+++ b/src/__tests__/services/restart-launcher-env.test.ts
@@ -2325,7 +2325,11 @@ n127.0.0.1:8188
     expect(result.stopped).toBe(true);
     expect(result.started).toBe(false);
     expect(result.message).toMatch(/EXITED \(exit code 1\)/);
-    expect(result.message).toMatch(/failed relaunch, not a slow start/i);
+    expect(result.message).toMatch(/THIS RELAUNCH FAILED/);
+    expect(result.message).toMatch(/not a slow start/i);
+    // The claim is scoped to OUR relaunch. Our child dying does not establish that
+    // nothing is serving the port now (codex gate).
+    expect(result.message).not.toMatch(/ComfyUI is DOWN/);
 
     killSpy.mockRestore();
   });
@@ -2439,9 +2443,11 @@ n127.0.0.1:8188
     expect(result.ready).toBe(false);
     expect(result.startup).toBe("failed");
     expect(result.message).toMatch(/stopped but could not be started/i);
-    expect(result.message).toMatch(/ComfyUI is DOWN/);
+    expect(result.message).toMatch(/THIS RELAUNCH FAILED/);
     // A real failure must NOT be softened into "it may still be coming up".
     expect(result.message).not.toMatch(/NOT CONFIRMED YET/);
+    // …nor overstated into a claim about the machine we did not observe.
+    expect(result.message).not.toMatch(/ComfyUI is DOWN/);
     expect(result.launch_env?.source).toBe("inherited");
 
     killSpy.mockRestore();

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -80,6 +80,9 @@ vi.mock("../../config.js", () => ({
   config: mockConfig,
   getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
   getComfyUIAuthHeaders: () => ({}),
+  // #848 instance fence — a stable target here; the retarget cases live in
+  // desktop-restart.test.ts and panel-restart-health-readiness.test.ts.
+  getComfyuiTargetGeneration: () => 0,
   isRemoteMode: () => false,
 }));
 

--- a/src/__tests__/services/restart-posix-port-release.test.ts
+++ b/src/__tests__/services/restart-posix-port-release.test.ts
@@ -39,6 +39,9 @@ vi.mock("../../config.js", () => ({
   config: mockConfig,
   getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
   getComfyUIAuthHeaders: () => ({}),
+  // #848 instance fence — a stable target here; the retarget cases live in
+  // desktop-restart.test.ts and panel-restart-health-readiness.test.ts.
+  getComfyuiTargetGeneration: () => 0,
   isRemoteMode: () => false,
 }));
 

--- a/src/__tests__/services/restart-relaunch-lifecycle.test.ts
+++ b/src/__tests__/services/restart-relaunch-lifecycle.test.ts
@@ -73,6 +73,8 @@ const mockLiveRootFromArgv = vi.hoisted(() =>
 vi.mock("../../config.js", () => ({
   config: mockConfig,
   getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  // #848 instance fence — a stable target here; the retarget case has its own test.
+  getComfyuiTargetGeneration: () => 0,
   getComfyUIAuthHeaders: () => ({}),
   isRemoteMode: () => false,
 }));

--- a/src/__tests__/services/restart-target-anchor.test.ts
+++ b/src/__tests__/services/restart-target-anchor.test.ts
@@ -249,7 +249,10 @@ describe("a local restart never abandons the instance it stopped", () => {
       hoisted.base.value = "http://beta.example:8188";
       throw new Error("relaunch could not be spawned");
     });
-    hoisted.fetchMock.mockImplementation(async () => new Response("{}", { status: 200 }));
+    // Nothing is listening after the failed relaunch — the ordinary case.
+    hoisted.fetchMock.mockImplementation(async () => {
+      throw new Error("ECONNREFUSED");
+    });
 
     // The whole assertion is that this RESOLVES. A rejection here is the bug.
     const res = await restartComfyUI();
@@ -257,11 +260,55 @@ describe("a local restart never abandons the instance it stopped", () => {
     expect(port.killed()).toBe(true); // the stop really did happen
     expect(res.stopped).toBe(true); // ...and the report says so
     expect(res.started).toBe(false);
-    // The caller must be able to act on this: their server is down and they need
-    // to know how to bring it back.
-    expect(res.message).toMatch(/not running|could not/i);
+    // The relaunch WAS attempted and threw partway, so what we cannot say is
+    // whether it took effect. "not-attempted" would be a different claim, and a
+    // false one.
+    expect(res.startup).toBe("unconfirmed");
+    expect(res.message).toMatch(/relaunch failed partway/i);
+    // NOT a bare "ComfyUI is NOT running": nothing answered when asked, which is
+    // one observation, and this branch exists to stop exactly that becoming a
+    // verdict. The wording must keep the two apart.
+    expect(res.message).toMatch(/most likely down/i);
+    expect(res.message).toMatch(/not a settled fact/i);
     // The one thing it must never say is the remote-mode refusal, which would be
     // a bucket narrated as the cause of a dead local server.
     expect(res.message).not.toMatch(/targeting a remote/i);
+  });
+
+  it("does NOT report down when something IS answering after a failed relaunch", async () => {
+    // The other half of the same finding: a supervisor may have brought the
+    // instance back while we were unwinding, or the throw may have landed after
+    // a spawn. Reporting "down" over a live server is the unverified negative in
+    // its most misleading form — the user goes looking for a dead process.
+    hoisted.remoteMode.value = false;
+    hoisted.getSystemStats.mockResolvedValue({ system: { argv: [PY, MAIN, "--port", "8188"] } });
+    liveThenFree();
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "stable-stamp",
+      commandLine: `${PY} ${MAIN} --port 8188`,
+      argv: [PY, MAIN, "--port", "8188"],
+      argvFidelity: "exact" as const,
+    }));
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    hoisted.spawn.mockImplementation(() => {
+      throw new Error("relaunch could not be spawned");
+    });
+    // The post-failure probe finds a live server.
+    hoisted.fetchMock.mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ system: {} }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    const res = await restartComfyUI();
+
+    expect(res.startup).toBe("unconfirmed");
+    expect(res.message).toMatch(/IS answering/i);
+    expect(res.message).not.toMatch(/most likely down/i);
+    // And it must not claim that server either — this call did not start it.
+    expect(res.started).toBe(false);
+    expect(res.message).toMatch(/cannot claim that server as its own/i);
   });
 });

--- a/src/__tests__/services/restart-target-anchor.test.ts
+++ b/src/__tests__/services/restart-target-anchor.test.ts
@@ -18,6 +18,7 @@ import { join } from "node:path";
 
 const hoisted = vi.hoisted(() => ({
   remoteMode: { value: true },
+  platform: { value: "win32" as NodeJS.Platform },
   base: { value: "http://alpha.example:8188" },
   generation: { value: 0 },
   fetchMock: vi.fn(),
@@ -50,6 +51,15 @@ vi.mock("../../comfyui/client.js", () => ({
   resetClient: hoisted.resetClient,
   resetObjectInfoCache: hoisted.resetObjectInfoCache,
 }));
+
+// PLATFORM-PINNED. process-control branches on `platform()` for PID discovery,
+// termination and port probing, so an unpinned test asserts different code on
+// each CI runner — these tests passed on Windows and failed on ubuntu/macOS for
+// exactly that reason. Pin it so the suite exercises one path everywhere.
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, platform: () => hoisted.platform.value };
+});
 
 vi.mock("node:child_process", () => ({
   execSync: hoisted.execSync,
@@ -183,12 +193,12 @@ describe("startComfyUI's remote-mode refusal is for a DIRECT launch, not a relau
     // A local restart stops the instance and then calls this. Refusing here left
     // it killed and abandoned, with the exception unwinding past every report —
     // the caller learned nothing about their now-dead server.
-    hoisted.spawn.mockImplementation(() => {
-      throw new Error("spawn refused by this test harness");
-    });
-    // It RESOLVES with a StartResult rather than throwing — which is the point:
-    // past a committed stop, a describable outcome is the whole deliverable, and
-    // an exception is the one shape that cannot be reported.
+    // No saved process info, so this returns before it ever reaches spawn — which
+    // is all this case needs. It RESOLVES with a StartResult rather than throwing,
+    // and that is the point: past a committed stop a describable outcome is the
+    // whole deliverable, and an exception is the one shape that cannot be
+    // reported. (The post-stop catch is covered by the restart-level tests below,
+    // where the relaunch really does reach spawn.)
     const res = await startComfyUI({
       port: 8188,
       probeUrl: "http://alpha.example:8188/system_stats",

--- a/src/__tests__/services/restart-target-anchor.test.ts
+++ b/src/__tests__/services/restart-target-anchor.test.ts
@@ -275,6 +275,37 @@ describe("a local restart never abandons the instance it stopped", () => {
     expect(res.message).not.toMatch(/targeting a remote/i);
   });
 
+  it("does NOT say nothing answered when the endpoint returns 503 — not healthy is not not-there", async () => {
+    // `waitForApiReady` counts a 502/503/504 as not-ready, which is right for
+    // readiness and wrong as evidence of absence. Reading `ready:false` as
+    // "nothing is listening" is the same fold one level down: a proxy answering
+    // 503 in front of a starting server would be reported as a dead machine.
+    hoisted.remoteMode.value = false;
+    hoisted.getSystemStats.mockResolvedValue({ system: { argv: [PY, MAIN, "--port", "8188"] } });
+    liveThenFree();
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "stable-stamp",
+      commandLine: `${PY} ${MAIN} --port 8188`,
+      argv: [PY, MAIN, "--port", "8188"],
+      argvFidelity: "exact" as const,
+    }));
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    hoisted.spawn.mockImplementation(() => {
+      throw new Error("relaunch could not be spawned");
+    });
+    hoisted.fetchMock.mockImplementation(
+      async () => new Response("service unavailable", { status: 503 }),
+    );
+
+    const res = await restartComfyUI();
+
+    expect(res.startup).toBe("unconfirmed");
+    expect(res.message).not.toMatch(/nothing answered/i);
+    // It may still say "most likely down" — that is a hedge, not a claim — but it
+    // must carry the caveat that something could be listening.
+    expect(res.message).toMatch(/not "?not there"?|may well be listening/i);
+  });
+
   it("does NOT report down when something IS answering after a failed relaunch", async () => {
     // The other half of the same finding: a supervisor may have brought the
     // instance back while we were unwinding, or the throw may have landed after

--- a/src/__tests__/services/restart-target-anchor.test.ts
+++ b/src/__tests__/services/restart-target-anchor.test.ts
@@ -1,0 +1,165 @@
+// Restart must act on the instance it READ, not on whatever the config names by
+// the time each step runs.
+//
+// `restartViaManagerReboot` reads the serving argv, dispatches a Manager reboot,
+// records the dispatch, and polls readiness. Every one of those steps used to
+// call `getComfyUIBaseUrl()` afresh, so a retarget landing in the gaps could
+// send the reboot to one server, record a second, and report the health of a
+// third — with the argv comparison describing a fourth. Two concurrent agents on
+// one rig is the ordinary way that happens, and it is in scope.
+//
+// The tests below move the target DURING the call, which is why the base and the
+// generation are mutable here rather than the constants the sibling suites use.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  remoteMode: { value: true },
+  base: { value: "http://alpha.example:8188" },
+  generation: { value: 0 },
+  fetchMock: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+  getSystemStats: vi.fn(async () => ({ system: { argv: [] as string[] } })),
+  execSync: vi.fn(() => ""),
+  spawn: vi.fn(),
+}));
+
+/** Move the configured target, exactly as a concurrent retarget would. */
+const retargetTo = (url: string): void => {
+  hoisted.base.value = url;
+  hoisted.generation.value += 1;
+};
+
+vi.mock("../../config.js", () => ({
+  config: { resolvedPort: 8188, comfyuiPath: "/fake/comfy", comfyuiBasePath: "" },
+  getComfyUIBaseUrl: () => hoisted.base.value,
+  getComfyuiTargetGeneration: () => hoisted.generation.value,
+  isRemoteMode: () => hoisted.remoteMode.value,
+}));
+
+vi.mock("../../comfyui/fetch.js", () => ({
+  comfyuiFetch: (url: string, init?: RequestInit) => hoisted.fetchMock(url, init),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getSystemStats: hoisted.getSystemStats,
+  resetClient: hoisted.resetClient,
+  resetObjectInfoCache: hoisted.resetObjectInfoCache,
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: hoisted.execSync,
+  spawn: hoisted.spawn,
+  execFile: vi.fn(),
+}));
+
+import {
+  restartComfyUI,
+  startComfyUI,
+  __processControlTestHooks,
+} from "../../services/process-control.js";
+
+type FetchCall = [string, RequestInit | undefined];
+const calls = (): FetchCall[] => hoisted.fetchMock.mock.calls as FetchCall[];
+const hostsHit = (pathSuffix: string): string[] =>
+  calls()
+    .filter(([u]) => new URL(u).pathname.includes(pathSuffix))
+    .map(([u]) => new URL(u).host);
+
+beforeEach(() => {
+  hoisted.remoteMode.value = true;
+  hoisted.base.value = "http://alpha.example:8188";
+  hoisted.generation.value = 0;
+  hoisted.fetchMock.mockReset();
+  hoisted.resetClient.mockClear();
+  hoisted.resetObjectInfoCache.mockClear();
+  hoisted.getSystemStats.mockReset();
+  hoisted.getSystemStats.mockImplementation(async () => ({ system: { argv: [] as string[] } }));
+  hoisted.execSync.mockReset();
+  hoisted.execSync.mockImplementation(() => "");
+  __processControlTestHooks.reset();
+});
+
+describe("restart anchors to the instance it read", () => {
+  it("REFUSES without dispatching when the target moves between the argv read and the reboot", async () => {
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 200,
+      intervalMs: 5,
+    });
+    // The retarget lands DURING our own argv read — the one window the fence
+    // exists for. Everything before the dispatch is observation, so refusing is
+    // strictly right here: nothing has happened yet, and proceeding would reboot
+    // a machine the caller never named.
+    hoisted.getSystemStats.mockImplementation(async () => {
+      retargetTo("http://beta.example:8188");
+      return { system: { argv: [] as string[] } };
+    });
+    hoisted.fetchMock.mockImplementation(async () => new Response("{}", { status: 200 }));
+
+    const res = await restartComfyUI();
+
+    expect(hostsHit("/reboot")).toEqual([]); // nothing dispatched, anywhere
+    expect(res.started).toBe(false);
+    expect(res.startup).toBe("not-attempted");
+    expect(res.message).toContain("target changed");
+    // The reader must not take this for "the restart failed" — nothing was tried.
+    expect(res.message).toContain("Nothing was restarted");
+  });
+
+  it("sends the reboot, the readiness probe, and nothing else to the ANCHORED host when the target moves mid-flight", async () => {
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 500,
+      intervalMs: 5,
+    });
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = new URL(url).pathname;
+      if (path.includes("/reboot")) {
+        // The retarget lands while the reboot request is in flight — past the
+        // fence, so this call is committed to alpha and must stay on it.
+        retargetTo("http://beta.example:8188");
+        return new Response("ok", { status: 200 });
+      }
+      return new Response(JSON.stringify({ system: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    await restartComfyUI();
+
+    // A reboot posted to alpha whose success is then confirmed by a healthy beta
+    // is the failure this pins: beta was never rebooted and its health says
+    // nothing about alpha.
+    expect(hostsHit("/reboot")).toEqual(["alpha.example:8188"]);
+    expect(new Set(hostsHit("/system_stats"))).toEqual(new Set(["alpha.example:8188"]));
+    expect(calls().map(([u]) => new URL(u).host)).not.toContain("beta.example:8188");
+  });
+});
+
+describe("startComfyUI's remote-mode refusal is for a DIRECT launch, not a relaunch", () => {
+  it("still refuses a direct start while targeting remote", async () => {
+    // The other direction: the refusal is real and must not be lost. Without
+    // this, dropping the check entirely would leave the sibling test green.
+    await expect(startComfyUI()).rejects.toThrow(/not\s+available when targeting a remote/i);
+  });
+
+  it("does NOT refuse an ANCHORED relaunch, so a mid-stop retarget cannot strand a stopped instance", async () => {
+    // A local restart stops the instance and then calls this. Refusing here left
+    // it killed and abandoned, with the exception unwinding past every report —
+    // the caller learned nothing about their now-dead server.
+    hoisted.spawn.mockImplementation(() => {
+      throw new Error("spawn refused by this test harness");
+    });
+    // It RESOLVES with a StartResult rather than throwing — which is the point:
+    // past a committed stop, a describable outcome is the whole deliverable, and
+    // an exception is the one shape that cannot be reported.
+    const res = await startComfyUI({
+      port: 8188,
+      probeUrl: "http://alpha.example:8188/system_stats",
+    });
+    expect(res.message).not.toMatch(/targeting a remote/i);
+  });
+});

--- a/src/__tests__/services/restart-target-anchor.test.ts
+++ b/src/__tests__/services/restart-target-anchor.test.ts
@@ -12,6 +12,9 @@
 // generation are mutable here rather than the constants the sibling suites use.
 
 import { describe, expect, it, beforeEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const hoisted = vi.hoisted(() => ({
   remoteMode: { value: true },
@@ -108,6 +111,36 @@ describe("restart anchors to the instance it read", () => {
     expect(res.message).toContain("Nothing was restarted");
   });
 
+  it("does NOT refuse when the target is REAFFIRMED to the same URL mid-read", async () => {
+    // `setComfyuiTarget` bumps the generation on every successful call, including
+    // a same-URL reaffirmation that moves nothing. Fencing on the generation
+    // therefore refused a restart that was never in danger — this defect class
+    // pointed the other way, a bucket ("the target was touched") standing in for
+    // the question that matters ("is this the server whose argv I read?").
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 500,
+      intervalMs: 5,
+    });
+    hoisted.getSystemStats.mockImplementation(async () => {
+      hoisted.generation.value += 1; // reaffirmed, NOT moved
+      return { system: { argv: [] as string[] } };
+    });
+    hoisted.fetchMock.mockImplementation(async (url: string) =>
+      new URL(url).pathname.includes("/reboot")
+        ? new Response("ok", { status: 200 })
+        : new Response(JSON.stringify({ system: {} }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+    );
+
+    const res = await restartComfyUI();
+
+    expect(hostsHit("/reboot")).toEqual(["alpha.example:8188"]);
+    expect(res.message ?? "").not.toContain("target changed");
+  });
+
   it("sends the reboot, the readiness probe, and nothing else to the ANCHORED host when the target moves mid-flight", async () => {
     __processControlTestHooks.setRemoteRebootTimingForTests({
       settleMs: 0,
@@ -160,6 +193,75 @@ describe("startComfyUI's remote-mode refusal is for a DIRECT launch, not a relau
       port: 8188,
       probeUrl: "http://alpha.example:8188/system_stats",
     });
+    expect(res.message).not.toMatch(/targeting a remote/i);
+  });
+});
+
+describe("a local restart never abandons the instance it stopped", () => {
+  // Real on-disk paths: the restart REFUSES before stopping if the resolved
+  // interpreter or script is missing, which is correct behaviour and would mask
+  // the post-stop window this test is about.
+  const PY = process.execPath;
+  const MAIN = join(mkdtempSync(join(tmpdir(), "anchor-")), "main.py");
+  writeFileSync(MAIN, "# placeholder");
+
+  /** A live local server on 8188 that goes quiet once killed. */
+  const liveThenFree = (pid = 4321): { killed: () => boolean } => {
+    let killed = false;
+    hoisted.execSync.mockImplementation((cmd: string) => {
+      if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+        killed = true;
+        return "";
+      }
+      if (/netstat/i.test(cmd)) {
+        return killed ? "" : `  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       ${pid}`;
+      }
+      if (/lsof/i.test(cmd)) {
+        if (killed) throw Object.assign(new Error("no listener"), { status: 1 });
+        return `p${pid}\nn127.0.0.1:8188\n`;
+      }
+      return "";
+    });
+    return { killed: () => killed };
+  };
+
+  it("reports the stop honestly instead of throwing when another agent retargets to REMOTE mid-stop", async () => {
+    // The P0 in full: the stop commits, then the relaunch used to hit the
+    // remote-mode refusal and throw — unwinding past every report and leaving
+    // the caller with an exception where the fact "your server is down" should
+    // have been. This drives `restartComfyUI`, not the unit below it, so it
+    // fails if the refusal is reinstated OR if the post-stop catch is removed
+    // and something else throws past the same point.
+    hoisted.remoteMode.value = false;
+    hoisted.getSystemStats.mockResolvedValue({ system: { argv: [PY, MAIN, "--port", "8188"] } });
+    const port = liveThenFree();
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      startedAt: "stable-stamp",
+      commandLine: `${PY} ${MAIN} --port 8188`,
+      argv: [PY, MAIN, "--port", "8188"],
+      argvFidelity: "exact" as const,
+    }));
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    // The retarget lands during the post-stop window, exactly as a second agent
+    // on this rig would do it.
+    hoisted.spawn.mockImplementation(() => {
+      hoisted.remoteMode.value = true;
+      hoisted.base.value = "http://beta.example:8188";
+      throw new Error("relaunch could not be spawned");
+    });
+    hoisted.fetchMock.mockImplementation(async () => new Response("{}", { status: 200 }));
+
+    // The whole assertion is that this RESOLVES. A rejection here is the bug.
+    const res = await restartComfyUI();
+
+    expect(port.killed()).toBe(true); // the stop really did happen
+    expect(res.stopped).toBe(true); // ...and the report says so
+    expect(res.started).toBe(false);
+    // The caller must be able to act on this: their server is down and they need
+    // to know how to bring it back.
+    expect(res.message).toMatch(/not running|could not/i);
+    // The one thing it must never say is the remote-mode refusal, which would be
+    // a bucket narrated as the cause of a dead local server.
     expect(res.message).not.toMatch(/targeting a remote/i);
   });
 });

--- a/src/__tests__/tools/report-issue-version.test.ts
+++ b/src/__tests__/tools/report-issue-version.test.ts
@@ -1,0 +1,41 @@
+// #846 follow-through: the version an agent COPIES out of the ENVIRONMENT line.
+//
+// The ENV line is prose, and it grew a qualifying clause when the running build and
+// the installed one disagree ("comfyui-mcp 0.48.18 (this process is RUNNING 0.48.18;
+// 0.49.5 is now installed on disk — …)"). report_issue forwards `mcp_version`
+// straight to the triage worker, which version-matches it against the fix history to
+// tell the user whether upgrading already resolves their bug — the single most
+// common resolution, and exactly what #846 exists to protect. A sentence where a
+// version was expected defeats that match silently.
+
+import { describe, expect, it } from "vitest";
+import { normalizeReportedVersion } from "../../tools/report-issue.js";
+
+describe("normalizeReportedVersion (#846)", () => {
+  it("passes a plain version through unchanged", () => {
+    expect(normalizeReportedVersion("0.49.6")).toBe("0.49.6");
+    expect(normalizeReportedVersion(" 0.49.6 ")).toBe("0.49.6");
+    expect(normalizeReportedVersion("v0.49.6")).toBe("0.49.6");
+    expect(normalizeReportedVersion("0.50.0-rc.1")).toBe("0.50.0-rc.1");
+  });
+
+  it("extracts the RUNNING version from the drift clause, not the installed one", () => {
+    // The ENV line leads with the build that is executing, and that is the build
+    // the report is about. Taking the LAST version in the string — or the largest —
+    // would re-pin the issue to code nobody ran, which is the #846 harm restated.
+    const line =
+      "0.48.18 (this process is RUNNING 0.48.18; 0.49.5 is now installed on disk" +
+      " — restart the orchestrator to load it, and report bugs against the RUNNING version)";
+    expect(normalizeReportedVersion(line)).toBe("0.48.18");
+  });
+
+  it("returns undefined for anything not version-shaped, so the caller detects instead", () => {
+    // An unusable string is NO reading. Reporting it as one would hand the worker a
+    // version it cannot match while looking like a confident answer.
+    expect(normalizeReportedVersion("unknown")).toBeUndefined();
+    expect(normalizeReportedVersion("")).toBeUndefined();
+    expect(normalizeReportedVersion("mcp=0.49.6")).toBeUndefined();
+    expect(normalizeReportedVersion(undefined)).toBeUndefined();
+    expect(normalizeReportedVersion(0.49 as unknown as string)).toBeUndefined();
+  });
+});

--- a/src/__tests__/tools/report-issue-version.test.ts
+++ b/src/__tests__/tools/report-issue-version.test.ts
@@ -89,8 +89,12 @@ describe("normalizeReportedVersion (#846)", () => {
     // fallback — #846 again (codex gate round 4).
     expect(mcp("MCP version: 0.48.18")).toBe("0.48.18");
     expect(mcp("comfyui-mcp version 0.49.6")).toBe("0.49.6");
-    // …but the run is capped, so a label followed by prose cannot wander into some
-    // OTHER component's version further along the line.
+    // …but ONLY that named filler is skipped. Scanning ahead for "the next thing
+    // that looks like a version" walked straight over an indeterminate value into
+    // the NEXT component's, reporting the PANEL's version as the mcp one (codex gate
+    // round 6). An mcp version that cannot be determined must stay undetermined —
+    // that is the whole rule this cluster is about.
+    expect(mcp("comfyui-mcp unknown · panel 0.11.38.")).toBeUndefined();
     expect(mcp("comfyui-mcp could not be determined, torch 2.7.1")).toBeUndefined();
   });
 

--- a/src/__tests__/tools/report-issue-version.test.ts
+++ b/src/__tests__/tools/report-issue-version.test.ts
@@ -83,6 +83,22 @@ describe("normalizeReportedVersion (#846)", () => {
     expect(mcp("comfyui-mcp 2026.08.04")).toBe("2026.08.04");
   });
 
+  it("looks PAST a word standing where the number goes, but not into the next component", () => {
+    // `MCP version: 0.48.18` puts `version` in the slot the number occupies. Taking
+    // only the adjacent token dropped a perfectly good reading into the disk-read
+    // fallback — #846 again (codex gate round 4).
+    expect(mcp("MCP version: 0.48.18")).toBe("0.48.18");
+    expect(mcp("comfyui-mcp version 0.49.6")).toBe("0.49.6");
+    // …but the run is capped, so a label followed by prose cannot wander into some
+    // OTHER component's version further along the line.
+    expect(mcp("comfyui-mcp could not be determined, torch 2.7.1")).toBeUndefined();
+  });
+
+  it("does not read ANOTHER product's mcp-suffixed label as ours", () => {
+    expect(mcp("other-mcp 1.2.3")).toBeUndefined();
+    expect(mcp("somethingmcp 1.2.3")).toBeUndefined();
+  });
+
   it("strips the sentence-ending punctuation the ENV line leaves on the last token", () => {
     // The line ends in a full stop, so the LAST component's version arrives as
     // `0.11.38.` — which passes every shape test and then fails the worker's exact

--- a/src/__tests__/tools/report-issue-version.test.ts
+++ b/src/__tests__/tools/report-issue-version.test.ts
@@ -23,18 +23,31 @@ describe("normalizeReportedVersion (#846)", () => {
     // The ENV line leads with the build that is executing, and that is the build
     // the report is about. Taking the LAST version in the string — or the largest —
     // would re-pin the issue to code nobody ran, which is the #846 harm restated.
-    const line =
+    const clause =
       "0.48.18 (this process is RUNNING 0.48.18; 0.49.5 is now installed on disk" +
       " — restart the orchestrator to load it, and report bugs against the RUNNING version)";
-    expect(normalizeReportedVersion(line)).toBe("0.48.18");
+    expect(normalizeReportedVersion(clause)).toBe("0.48.18");
+
+    // …and the form an agent ACTUALLY copies is the whole labelled segment. Matching
+    // only at position 0 missed this, fell through to a fresh disk read, and returned
+    // the INSTALLED version — reintroducing #846 through the fix for it.
+    expect(normalizeReportedVersion(`comfyui-mcp ${clause}`)).toBe("0.48.18");
+    expect(normalizeReportedVersion("mcp=0.49.6")).toBe("0.49.6");
+    expect(normalizeReportedVersion("comfyui-mcp 0.49.6 · panel 0.11.38")).toBe("0.49.6");
   });
 
-  it("returns undefined for anything not version-shaped, so the caller detects instead", () => {
-    // An unusable string is NO reading. Reporting it as one would hand the worker a
-    // version it cannot match while looking like a confident answer.
-    expect(normalizeReportedVersion("unknown")).toBeUndefined();
+  it("preserves a compact non-semver version instead of swapping in a disk read", () => {
+    // A real running version need not be semver. Discarding it would send the caller
+    // to detectMcpVersion(), i.e. the INSTALLED number — the same version-swap in a
+    // different disguise.
+    expect(normalizeReportedVersion("nightly")).toBe("nightly");
+    expect(normalizeReportedVersion("  dev  ")).toBe("dev");
+  });
+
+  it("discards prose, so the caller detects a version instead of reporting a sentence", () => {
     expect(normalizeReportedVersion("")).toBeUndefined();
-    expect(normalizeReportedVersion("mcp=0.49.6")).toBeUndefined();
+    expect(normalizeReportedVersion("   ")).toBeUndefined();
+    expect(normalizeReportedVersion("I could not find the version anywhere")).toBeUndefined();
     expect(normalizeReportedVersion(undefined)).toBeUndefined();
     expect(normalizeReportedVersion(0.49 as unknown as string)).toBeUndefined();
   });

--- a/src/__tests__/tools/report-issue-version.test.ts
+++ b/src/__tests__/tools/report-issue-version.test.ts
@@ -8,7 +8,7 @@
 // common resolution, and exactly what #846 exists to protect. A sentence where a
 // version was expected defeats that match silently, and so does the WRONG version.
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   MCP_VERSION_LABEL,
   PANEL_VERSION_LABEL,
@@ -178,5 +178,59 @@ describe("report_issue actually normalizes before sending (#846 wiring)", () => 
     // The failure this pins: the raw sentence forwarded verbatim, which the
     // worker cannot version-match — it just silently stops advising upgrades.
     expect(sent.reporter_versions?.mcp).not.toContain("ENVIRONMENT");
+  });
+});
+
+// The wiring test above SUPPLIES mcp_version, so it never reaches the fallback —
+// swapping the load-time snapshot back for a fresh disk read left it green
+// (codex gate P2). This omits the field, which is the only way in.
+
+describe("the OMITTED-version fallback reports what is RUNNING, not what is installed (#846)", () => {
+  it("keeps reporting the load-time version after the package on disk changes underneath", async () => {
+    vi.resetModules();
+    const onDisk = { version: "0.49.8" };
+    vi.doMock("../../services/self-update.js", () => ({
+      detectInstallMode: () => ({ currentVersion: onDisk.version }),
+    }));
+
+    // Loaded WHILE disk says 0.49.8 — this stands in for process start.
+    const mod = await import("../../tools/report-issue.js");
+
+    // Now the user runs an in-place update. The process keeps running the old
+    // code; only the files changed.
+    onDisk.version = "0.49.99";
+
+    let handler: ((args: Record<string, unknown>) => Promise<unknown>) | undefined;
+    mod.registerReportIssueTools({
+      tool: (name: string, _d: string, _s: unknown, fn: typeof handler) => {
+        if (name === "report_issue") handler = fn;
+      },
+    } as never);
+
+    const bodies: string[] = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (_u: string, init?: RequestInit) => {
+      if (typeof init?.body === "string") bodies.push(init.body);
+      return new Response(JSON.stringify({ status: "done", url: "https://e.invalid/1" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    try {
+      // No mcp_version — the fallback is the whole point.
+      await handler!({ title: "t", body: "b", repo: "artokun/comfyui-mcp" });
+    } finally {
+      globalThis.fetch = realFetch;
+      vi.doUnmock("../../services/self-update.js");
+      vi.resetModules();
+    }
+
+    const sent = JSON.parse(bodies[0]) as { reporter_versions?: { mcp?: string } };
+    // Filing under the INSTALLED version is #846: the worker version-matches the
+    // report against the fix history, so a report stamped with a version the user
+    // is not running silently stops the upgrade advice that usually resolves it.
+    expect(sent.reporter_versions?.mcp).toBe("0.49.8");
+    expect(sent.reporter_versions?.mcp).not.toBe("0.49.99");
   });
 });

--- a/src/__tests__/tools/report-issue-version.test.ts
+++ b/src/__tests__/tools/report-issue-version.test.ts
@@ -128,3 +128,55 @@ describe("normalizeReportedVersion (#846)", () => {
     expect(mcp("comfyui-mcp is broken")).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// WIRING. Everything above tests `normalizeReportedVersion` directly, so every
+// one of those cases stays green if `report_issue` stops CALLING it (codex gate
+// P2) — and a normalizer nobody calls protects nothing. This drives the real
+// registered handler and inspects the bytes that leave for the triage worker.
+
+describe("report_issue actually normalizes before sending (#846 wiring)", () => {
+  it("sends the extracted version to the worker, not the sentence it came in", async () => {
+    const { registerReportIssueTools } = await import("../../tools/report-issue.js");
+
+    let handler: ((args: Record<string, unknown>) => Promise<unknown>) | undefined;
+    const fakeServer = {
+      tool: (name: string, _desc: string, _schema: unknown, fn: typeof handler) => {
+        if (name === "report_issue") handler = fn;
+      },
+    } as unknown as Parameters<typeof registerReportIssueTools>[0];
+    registerReportIssueTools(fakeServer);
+    expect(handler).toBeTypeOf("function");
+
+    const bodies: string[] = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      if (typeof init?.body === "string") bodies.push(init.body);
+      // A terminal ack: filed, nothing to poll.
+      return new Response(
+        JSON.stringify({ status: "done", url: "https://example.invalid/issues/1", job_id: "j1" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    try {
+      await handler!({
+        title: "t",
+        body: "b",
+        repo: "artokun/comfyui-mcp",
+        mcp_version: ENV_LINE,
+        panel_version: ENV_LINE,
+      });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+
+    expect(bodies.length).toBeGreaterThan(0);
+    const sent = JSON.parse(bodies[0]) as { reporter_versions?: { mcp?: string; panel?: string } };
+    expect(sent.reporter_versions?.mcp).toBe("0.48.18");
+    expect(sent.reporter_versions?.panel).toBe("0.11.38");
+    // The failure this pins: the raw sentence forwarded verbatim, which the
+    // worker cannot version-match — it just silently stops advising upgrades.
+    expect(sent.reporter_versions?.mcp).not.toContain("ENVIRONMENT");
+  });
+});

--- a/src/__tests__/tools/report-issue-version.test.ts
+++ b/src/__tests__/tools/report-issue-version.test.ts
@@ -65,13 +65,31 @@ describe("normalizeReportedVersion (#846)", () => {
     expect(mcp("comfyui-mcp 0.49.6 · panel 0.11.38")).toBe("0.49.6");
   });
 
-  it("preserves a compact non-semver version instead of swapping in a disk read", () => {
-    // A real running version need not be semver. Discarding it would send the caller
-    // to detectMcpVersion(), i.e. the INSTALLED number — the same version-swap in a
-    // different disguise.
+  it("preserves a non-semver running version — LABELLED as well as bare (#846)", () => {
+    // A real running version need not be semver, and requiring semver AFTER the label
+    // was a third way of getting #846 wrong: `comfyui-mcp nightly (…RUNNING nightly;
+    // 0.49.6 is now installed…)` matched nothing, fell through to a disk read, and
+    // reported the INSTALLED 0.49.6 as the running version — for exactly the user
+    // whose version needed the most care (codex gate round 3).
     expect(mcp("nightly")).toBe("nightly");
     expect(mcp("  dev  ")).toBe("dev");
     expect(panel("nightly")).toBe("nightly");
+    expect(
+      mcp(
+        "comfyui-mcp nightly (this process is RUNNING nightly; 0.49.6 is now installed on disk" +
+          " — restart the orchestrator to load it, and report bugs against the RUNNING version)",
+      ),
+    ).toBe("nightly");
+    expect(mcp("comfyui-mcp 2026.08.04")).toBe("2026.08.04");
+  });
+
+  it("strips the sentence-ending punctuation the ENV line leaves on the last token", () => {
+    // The line ends in a full stop, so the LAST component's version arrives as
+    // `0.11.38.` — which passes every shape test and then fails the worker's exact
+    // version match with a dot glued on.
+    expect(panel(ENV_LINE)).toBe("0.11.38");
+    expect(panel("panel 0.11.38.")).toBe("0.11.38");
+    expect(mcp("comfyui-mcp 0.49.6, panel 0.11.38")).toBe("0.49.6");
   });
 
   it("discards prose, so the caller detects a version instead of reporting a sentence", () => {
@@ -82,5 +100,11 @@ describe("normalizeReportedVersion (#846)", () => {
     expect(mcp(0.49 as unknown as string)).toBeUndefined();
     // A key=value fragment for some OTHER key is not our version either.
     expect(mcp("torch=2.7.1")).toBeUndefined();
+    // Words that STAND WHERE a version was expected are not versions. Forwarding
+    // them would hand the worker something unmatchable while looking confident;
+    // falling through to detection is right precisely when the agent had nothing.
+    expect(mcp("unknown")).toBeUndefined();
+    expect(mcp("comfyui-mcp unknown")).toBeUndefined();
+    expect(mcp("comfyui-mcp is broken")).toBeUndefined();
   });
 });

--- a/src/__tests__/tools/report-issue-version.test.ts
+++ b/src/__tests__/tools/report-issue-version.test.ts
@@ -6,49 +6,81 @@
 // straight to the triage worker, which version-matches it against the fix history to
 // tell the user whether upgrading already resolves their bug — the single most
 // common resolution, and exactly what #846 exists to protect. A sentence where a
-// version was expected defeats that match silently.
+// version was expected defeats that match silently, and so does the WRONG version.
 
 import { describe, expect, it } from "vitest";
-import { normalizeReportedVersion } from "../../tools/report-issue.js";
+import {
+  MCP_VERSION_LABEL,
+  PANEL_VERSION_LABEL,
+  normalizeReportedVersion,
+} from "../../tools/report-issue.js";
+
+const mcp = (raw: string | undefined): string | undefined =>
+  normalizeReportedVersion(raw, MCP_VERSION_LABEL);
+const panel = (raw: string | undefined): string | undefined =>
+  normalizeReportedVersion(raw, PANEL_VERSION_LABEL);
+
+/** The shape the ENVIRONMENT line actually renders, other components and all. */
+const ENV_LINE =
+  "ENVIRONMENT (live, this machine): Windows 11 · NVIDIA RTX 5090 32GB · torch 2.7.1 · " +
+  "python 3.12.3 · ComfyUI 0.30.0 (LOCAL) · Backend: Claude · comfyui-mcp 0.48.18 · panel 0.11.38.";
 
 describe("normalizeReportedVersion (#846)", () => {
   it("passes a plain version through unchanged", () => {
-    expect(normalizeReportedVersion("0.49.6")).toBe("0.49.6");
-    expect(normalizeReportedVersion(" 0.49.6 ")).toBe("0.49.6");
-    expect(normalizeReportedVersion("v0.49.6")).toBe("0.49.6");
-    expect(normalizeReportedVersion("0.50.0-rc.1")).toBe("0.50.0-rc.1");
+    expect(mcp("0.49.6")).toBe("0.49.6");
+    expect(mcp(" 0.49.6 ")).toBe("0.49.6");
+    expect(mcp("v0.49.6")).toBe("0.49.6");
+    expect(mcp("0.50.0-rc.1")).toBe("0.50.0-rc.1");
+  });
+
+  it("reads OUR version out of a whole ENVIRONMENT line, not torch's or python's", () => {
+    // The tool description tells the agent to source this field from the env line, so
+    // the whole line IS a realistic input. Taking the first semver anywhere returned
+    // torch 2.7.1 as the reporter's own version — wrong in a way nothing downstream
+    // could detect (codex gate round 2). The LABEL is what makes this correct.
+    expect(mcp(ENV_LINE)).toBe("0.48.18");
+    expect(panel(ENV_LINE)).toBe("0.11.38");
+    expect(mcp(ENV_LINE)).not.toBe("2.7.1");
+    expect(mcp(ENV_LINE)).not.toBe("3.12.3");
+    expect(mcp(ENV_LINE)).not.toBe("0.30.0");
+    // The panel's own label must never be read as ours, and vice versa.
+    expect(mcp("comfyui-mcp-panel 0.11.38")).toBeUndefined();
+    expect(panel("comfyui-mcp-panel 0.11.38")).toBe("0.11.38");
   });
 
   it("extracts the RUNNING version from the drift clause, not the installed one", () => {
-    // The ENV line leads with the build that is executing, and that is the build
-    // the report is about. Taking the LAST version in the string — or the largest —
-    // would re-pin the issue to code nobody ran, which is the #846 harm restated.
+    // The ENV line leads with the build that is executing, and that is the build the
+    // report is about. Taking the LAST version — or the largest — would re-pin the
+    // issue to code nobody ran, which is the #846 harm restated.
     const clause =
       "0.48.18 (this process is RUNNING 0.48.18; 0.49.5 is now installed on disk" +
       " — restart the orchestrator to load it, and report bugs against the RUNNING version)";
-    expect(normalizeReportedVersion(clause)).toBe("0.48.18");
+    expect(mcp(clause)).toBe("0.48.18");
 
     // …and the form an agent ACTUALLY copies is the whole labelled segment. Matching
     // only at position 0 missed this, fell through to a fresh disk read, and returned
     // the INSTALLED version — reintroducing #846 through the fix for it.
-    expect(normalizeReportedVersion(`comfyui-mcp ${clause}`)).toBe("0.48.18");
-    expect(normalizeReportedVersion("mcp=0.49.6")).toBe("0.49.6");
-    expect(normalizeReportedVersion("comfyui-mcp 0.49.6 · panel 0.11.38")).toBe("0.49.6");
+    expect(mcp(`comfyui-mcp ${clause}`)).toBe("0.48.18");
+    expect(mcp("mcp=0.49.6")).toBe("0.49.6");
+    expect(mcp("comfyui-mcp 0.49.6 · panel 0.11.38")).toBe("0.49.6");
   });
 
   it("preserves a compact non-semver version instead of swapping in a disk read", () => {
     // A real running version need not be semver. Discarding it would send the caller
     // to detectMcpVersion(), i.e. the INSTALLED number — the same version-swap in a
     // different disguise.
-    expect(normalizeReportedVersion("nightly")).toBe("nightly");
-    expect(normalizeReportedVersion("  dev  ")).toBe("dev");
+    expect(mcp("nightly")).toBe("nightly");
+    expect(mcp("  dev  ")).toBe("dev");
+    expect(panel("nightly")).toBe("nightly");
   });
 
   it("discards prose, so the caller detects a version instead of reporting a sentence", () => {
-    expect(normalizeReportedVersion("")).toBeUndefined();
-    expect(normalizeReportedVersion("   ")).toBeUndefined();
-    expect(normalizeReportedVersion("I could not find the version anywhere")).toBeUndefined();
-    expect(normalizeReportedVersion(undefined)).toBeUndefined();
-    expect(normalizeReportedVersion(0.49 as unknown as string)).toBeUndefined();
+    expect(mcp("")).toBeUndefined();
+    expect(mcp("   ")).toBeUndefined();
+    expect(mcp("I could not find the version anywhere")).toBeUndefined();
+    expect(mcp(undefined)).toBeUndefined();
+    expect(mcp(0.49 as unknown as string)).toBeUndefined();
+    // A key=value fragment for some OTHER key is not our version either.
+    expect(mcp("torch=2.7.1")).toBeUndefined();
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1518,7 +1518,22 @@ export async function runPanelOrchestrator(): Promise<void> {
   // reports are version-pinned without the agent digging. mcp version is a local
   // fact; panel version is learned from the panel's `hello` frame (below) and, on
   // first sight, triggers an env refresh so the block picks it up.
-  const mcpVersion = detectInstallMode().currentVersion ?? undefined;
+  // WHICH MOMENT EACH OF THESE DESCRIBES (#846).
+  //
+  // This one is read ONCE, on purpose: a running Node process cannot hot-swap its
+  // own code, so the package.json beside the dist/ we were loaded from names the
+  // build that is executing, and it stays true for the life of this process. It is
+  // the version a bug filed from this session must be pinned to.
+  //
+  // What was wrong was not the caching — it was that this was the ONLY reading, so
+  // a value captured at startup was rendered as the current state of the machine.
+  // An in-place upgrade moves the on-disk package while this process keeps running
+  // the old one; the ENV line then reported a version that had passed, triage
+  // version-matched against the wrong build, and the line offered no way to notice.
+  // So the installed version is re-read on EVERY refresh below and the difference
+  // is disclosed. Re-reading it into THIS constant instead would have been the
+  // mirror-image lie: claiming to be a build we are not running.
+  const mcpVersionRunning = detectInstallMode().currentVersion ?? undefined;
   let latestPanelVersion: string | undefined;
   let panelSystemAppend = resolvePrompt("panel.persona", PANEL_SYSTEM_APPEND);
   // Set once the manager exists so a later refresh (after a ComfyUI restart) feeds
@@ -1536,7 +1551,10 @@ export async function runPanelOrchestrator(): Promise<void> {
   async function refreshEnvCapabilities(): Promise<void> {
     const gen = ++envRefreshGen;
     try {
-      const caps = await gatherEnvCapabilities({ comfyuiUrl, comfyuiPath, backendId, mcpVersion, panelVersion: latestPanelVersion });
+      // The INSTALLED version is re-read inside gatherEnvCapabilities on every
+      // refresh (#846) — it is a machine fact that can move while we run, so it is
+      // probed there rather than captured here beside the constant below.
+      const caps = await gatherEnvCapabilities({ comfyuiUrl, comfyuiPath, backendId, mcpVersion: mcpVersionRunning, panelVersion: latestPanelVersion });
       if (gen !== envRefreshGen) return; // a newer refresh superseded us — drop this stale result
       envCaps = caps;
       panelSystemAppend = buildPanelSystemAppend(resolvePrompt("panel.persona", PANEL_SYSTEM_APPEND), envCaps);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -143,6 +143,27 @@ import {
 } from "../services/env-capabilities.js";
 import { WorkflowTargetStore } from "../services/workflow-target-store.js";
 
+/**
+ * The comfyui-mcp version THIS PROCESS IS RUNNING (#846), read at MODULE LOAD.
+ *
+ * As early as it can be read: package.json is fetched from disk immediately after
+ * these imports resolve, which is the closest observable moment to "the build that
+ * was loaded". Reading it later — inside the startup function, after the bridge and
+ * workspace awaits — left a window in which an in-place update could rewrite the
+ * package and have the NEW number reported as the executing build (codex gate round
+ * 9), which is #846's mispinning arriving just before the snapshot meant to prevent
+ * it. A running Node process cannot hot-swap its own code, so once taken this value
+ * is true for the life of the process; it is `mcpVersionInstalled`, re-read on every
+ * env refresh, that moves.
+ */
+const MCP_VERSION_RUNNING = ((): string | undefined => {
+  try {
+    return detectInstallMode().currentVersion ?? undefined;
+  } catch {
+    return undefined;
+  }
+})();
+
 const PANEL_SYSTEM_APPEND = `You are the autonomous assistant embedded directly in a ComfyUI sidebar panel. The person is working in ComfyUI and talks to you through that panel: their messages arrive as your prompts, and everything you write is shown to them in the panel chat. Write for that reader — lead with the result, keep replies short and concrete, and don't narrate routine internal steps.
 
 You can SEE and EDIT the workflow the user currently has open, via the panel_* tools (panel_graph_outline, panel_query_graph, panel_add_node, panel_connect, panel_set_widget, panel_run, panel_get_errors, panel_save_workflow, …). STRONGLY PREFER building on their live canvas: read it first (panel_graph_outline, then panel_query_graph for specifics), add/wire/configure nodes with the panel_* tools, then panel_run to queue it — so the user watches the work happen and the result loads in their own workflow with full Ctrl+Z undo. Only fall back to the headless generate_image/enqueue_workflow tools when the user explicitly wants a one-off they don't need on their canvas, or when no panel tab is connected (a panel_* call will error if so). On a LARGE graph (a loaded pack/template with dozens of nodes), do NOT dump the whole thing and scan it — and NEVER shell out to grep/jq/python over a saved workflow file. To UNDERSTAND the graph, call panel_graph_outline FIRST: a compact, dependency-ordered TEXT map (nodes topologically sorted source→sink, each with its key widgets and ← inputs / → outputs wiring, plus a groups index) made for you to read top-to-bottom. To PINPOINT and INSPECT specific nodes, use panel_query_graph: filter by types/title/widget predicates ('cfg>7'), traverse upstream_of/downstream_of a node, aggregate with group_by:'type', and read ONE node's exact slot/widget detail with {ids:[id], fields:'detail'} — output is token-bounded so it can never flood your context. panel_find_nodes remains for free-text search across all fields.
@@ -1520,10 +1541,8 @@ export async function runPanelOrchestrator(): Promise<void> {
   // first sight, triggers an env refresh so the block picks it up.
   // WHICH MOMENT EACH OF THESE DESCRIBES (#846).
   //
-  // This one is read ONCE, on purpose: a running Node process cannot hot-swap its
-  // own code, so the package.json beside the dist/ we were loaded from names the
-  // build that is executing, and it stays true for the life of this process. It is
-  // the version a bug filed from this session must be pinned to.
+  // The RUNNING version is read once, at module load — see MCP_VERSION_RUNNING. It
+  // is the version a bug filed from this session must be pinned to.
   //
   // What was wrong was not the caching — it was that this was the ONLY reading, so
   // a value captured at startup was rendered as the current state of the machine.
@@ -1531,9 +1550,9 @@ export async function runPanelOrchestrator(): Promise<void> {
   // the old one; the ENV line then reported a version that had passed, triage
   // version-matched against the wrong build, and the line offered no way to notice.
   // So the installed version is re-read on EVERY refresh below and the difference
-  // is disclosed. Re-reading it into THIS constant instead would have been the
+  // is disclosed. Re-reading it into the RUNNING slot instead would have been the
   // mirror-image lie: claiming to be a build we are not running.
-  const mcpVersionRunning = detectInstallMode().currentVersion ?? undefined;
+  const mcpVersionRunning = MCP_VERSION_RUNNING;
   let latestPanelVersion: string | undefined;
   let panelSystemAppend = resolvePrompt("panel.persona", PANEL_SYSTEM_APPEND);
   // Set once the manager exists so a later refresh (after a ComfyUI restart) feeds

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -83,6 +83,8 @@ import { convertUiToApi, collectNodeTypes } from "../services/workflow-converter
 import {
   restartComfyUI,
   preflightLocalRestart,
+  readServingArgv,
+  describeArgvDrift,
   recordRestartDispatch,
   clearRestartDispatch,
   getRestartDispatchRecord,
@@ -353,7 +355,14 @@ export const __panelToolsTestHooks = {
   /** Inject a fake #742 restart preflight so reboot tests don't probe real
    *  processes/ports. null restores the live preflightLocalRestart. */
   setLocalRestartPreflight(
-    fn: (() => Promise<{ ok: boolean; reason?: string }>) | null,
+    fn:
+      | (() => Promise<{
+          ok: boolean;
+          reason?: string;
+          observedArgv?: string[];
+          isDesktopApp?: boolean;
+        }>)
+      | null,
   ): void {
     localRestartPreflightOverride = fn;
   },
@@ -968,7 +977,12 @@ let healthProbeOverride:
 /** Test injection for the #742 refuse-safe restart preflight (the real one is
  *  preflightLocalRestart in process-control). null → the live preflight. */
 let localRestartPreflightOverride:
-  | (() => Promise<{ ok: boolean; reason?: string }>)
+  | (() => Promise<{
+      ok: boolean;
+      reason?: string;
+      observedArgv?: string[];
+      isDesktopApp?: boolean;
+    }>)
   | null = null;
 
 /** Test injection for the #742 decline-probe recheck window, so tests don't
@@ -7186,6 +7200,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         const preflightBound =
           preflightHealthBase != null &&
           sameHttpBase(getComfyUIBaseUrl(), preflightHealthBase);
+        // #848: what the instance was OBSERVED running with, taken from the preflight
+        // that already had to resolve it. Nothing new is probed before the dispatch —
+        // the no-await invariant between the binding capture and the reboot stands.
+        let preflightArgv: string[] | undefined;
+        let preflightIsDesktop = false;
         // Remote and cloud are excluded for the reason they always were: there is no
         // local process to assess, and the Manager reboot is their ONLY restart path —
         // a supervised remote (the tunnelled Desktop app) restarts through it by
@@ -7224,6 +7243,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // same base, is caught.
           const preflightTargetGeneration = getComfyuiTargetGeneration();
           const preflight = await (localRestartPreflightOverride ?? preflightLocalRestart)();
+          // #848: keep the observed launch arguments. Recorded here and spent ONLY on
+          // the success path far below, where the reboot has been proven to have
+          // cycled THIS instance — it never influences any decision above.
+          preflightArgv = preflight.observedArgv;
+          preflightIsDesktop = preflight.isDesktopApp === true;
           // r8/r9/r10: the preflight AWAIT makes the pre-decision captures
           // STALE — and the preflight itself reads MUTABLE config (target URL,
           // port, COMFYUI_PATH) throughout, so a config retarget during the
@@ -7712,6 +7736,26 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // Old/lightweight contexts have no capability accessor, so preserve their historical
         // contract rather than claiming a production tab passed a check it never ran.
         const graphToolsReady = tabBack && (ctx.tabCanMutateGraph ? ctx.tabCanMutateGraph() : true);
+        // #848: WHAT THIS RESTART DID NOT DO. "It came back healthy" answers a
+        // different question from "did it come back with the launch arguments I just
+        // configured?", and a user who had edited ComfyUI Desktop's saved launch args
+        // read the first as the second — their new flag was silently absent. Compare
+        // the two readings and report only what was observed.
+        //
+        // Gated three ways, because a wrong-instance reading would be worse than no
+        // reading: the preflight must have OBSERVED a before-argv (it only runs on the
+        // bound path), and the configured target must STILL be the boot instance this
+        // reboot was proven to cycle — a retarget during the recovery wait would point
+        // getSystemStats at some other ComfyUI. Read after recovery, so a slow or
+        // missing answer costs only detail; describeArgvDrift says nothing without both.
+        let argvNote = "";
+        if (preflightArgv?.length && sameHttpBase(getComfyUIBaseUrl(), healthBase)) {
+          argvNote = describeArgvDrift(
+            preflightArgv,
+            await readServingArgv(2000),
+            preflightIsDesktop,
+          );
+        }
         return ok({
           rebooting: true,
           ready: graphToolsReady, // graph tools require a bound AND workflow-stamp-capable tab
@@ -7738,7 +7782,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               : "; ComfyUI is back but the panel tab has NOT reconnected yet (ready:false) — " +
                 'wait a moment then retry, or rebind with panel_set_workflow_target({mode:"current"}) ' +
                 "before issuing graph tools.") +
-            "."),
+            ".") + argvNote,
         });
       },
     ),

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7477,10 +7477,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           if (
             !isRemoteMode() &&
             rebootNoEndpoint(res) &&
-            // INSTANCE BINDING: restartComfyUI() acts on the orchestrator's GLOBAL config
-            // target (a hello can retarget it). Only run it when the bound tab provably
-            // fronts our OWN boot instance AND that boot instance is the CURRENT global
-            // target — so the relaunch cycles the SAME instance this tab rebooted.
+            // ENDPOINT BINDING: restartComfyUI() acts on the orchestrator's GLOBAL config
+            // target (a hello can retarget it). Only run it when the bound tab fronts our
+            // OWN boot URL AND that URL is the CURRENT global target — so the relaunch
+            // cycles the endpoint this tab rebooted, not one it was retargeted away from.
+            //
+            // "Endpoint", not "instance": `sameHttpBase` compares URLs, which cannot see a
+            // server replaced at the same URL between the reboot and here. That gap is real
+            // and tracked in #871; this gate narrows the window, it does not close it.
             healthBase != null &&
             sameHttpBase(getComfyUIBaseUrl(), healthBase)
           ) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7480,7 +7480,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // ENDPOINT BINDING: restartComfyUI() acts on the orchestrator's GLOBAL config
             // target (a hello can retarget it). Only run it when the bound tab fronts our
             // OWN boot URL AND that URL is the CURRENT global target — so the relaunch
-            // cycles the endpoint this tab rebooted, not one it was retargeted away from.
+            // cycles the endpoint this tab TARGETED, not one it was retargeted away from.
+            // Targeted, not rebooted: this branch runs only when `rebootNoEndpoint`
+            // says the Manager reboot was refused for want of an endpoint, so nothing
+            // was rebooted here at all.
             //
             // "Endpoint", not "instance": `sameHttpBase` compares URLs, which cannot see a
             // server replaced at the same URL between the reboot and here. That gap is real

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7205,6 +7205,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // the no-await invariant between the binding capture and the reboot stands.
         let preflightArgv: string[] | undefined;
         let preflightIsDesktop = false;
+        // The target generation as of BEFORE the preflight resolved that argv, so the
+        // whole span up to the post-restart reading sits inside one instance fence.
+        let preflightArgvGeneration = -1;
         // Remote and cloud are excluded for the reason they always were: there is no
         // local process to assess, and the Manager reboot is their ONLY restart path —
         // a supervised remote (the tunnelled Desktop app) restarts through it by
@@ -7246,8 +7249,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // #848: keep the observed launch arguments. Recorded here and spent ONLY on
           // the success path far below, where the reboot has been proven to have
           // cycled THIS instance — it never influences any decision above.
+          // preflightTargetGeneration was captured before the preflight ran, so it is
+          // exactly the fence this reading needs.
           preflightArgv = preflight.observedArgv;
           preflightIsDesktop = preflight.isDesktopApp === true;
+          preflightArgvGeneration = preflightTargetGeneration;
           // r8/r9/r10: the preflight AWAIT makes the pre-decision captures
           // STALE — and the preflight itself reads MUTABLE config (target URL,
           // port, COMFYUI_PATH) throughout, so a config retarget during the
@@ -7742,19 +7748,27 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // read the first as the second — their new flag was silently absent. Compare
         // the two readings and report only what was observed.
         //
-        // Gated three ways, because a wrong-instance reading would be worse than no
-        // reading: the preflight must have OBSERVED a before-argv (it only runs on the
-        // bound path), and the configured target must STILL be the boot instance this
-        // reboot was proven to cycle — a retarget during the recovery wait would point
-        // getSystemStats at some other ComfyUI. Read after recovery, so a slow or
-        // missing answer costs only detail; describeArgvDrift says nothing without both.
+        // Gated because a wrong-instance reading would be worse than no reading: the
+        // preflight must have OBSERVED a before-argv (it only runs on the bound path),
+        // and the target must STILL be the instance that preflight described — a
+        // retarget would point getSystemStats at some other ComfyUI. Read after
+        // recovery, so a slow or missing answer costs only detail; describeArgvDrift
+        // says nothing without both readings.
+        //
+        // The generation is re-checked AFTER the await, not only before it (codex gate
+        // round 2): a base comparison taken before the read cannot see a retarget that
+        // lands DURING it, and an A→B→A round trip leaves the base equal either way.
+        // preflightArgvGeneration is captured at the preflight, so the whole span from
+        // the "before" reading to the "after" one is inside one fence.
         let argvNote = "";
-        if (preflightArgv?.length && sameHttpBase(getComfyUIBaseUrl(), healthBase)) {
-          argvNote = describeArgvDrift(
-            preflightArgv,
-            await readServingArgv(2000),
-            preflightIsDesktop,
-          );
+        if (preflightArgv?.length) {
+          const afterArgv = await readServingArgv(2000);
+          if (
+            getComfyuiTargetGeneration() === preflightArgvGeneration &&
+            sameHttpBase(getComfyUIBaseUrl(), healthBase)
+          ) {
+            argvNote = describeArgvDrift(preflightArgv, afterArgv, preflightIsDesktop);
+          }
         }
         return ok({
           rebooting: true,

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -61,9 +61,11 @@ export interface EnvCapabilities {
   otherBackendAvailable?: boolean; // is the OTHER provider resolvable?
   /**
    * The comfyui-mcp version this process is actually RUNNING, e.g. "0.48.4" — read
-   * from the package.json beside the `dist/` these modules were loaded from, at the
-   * moment the process started. A running process cannot hot-swap its own code, so
-   * this stays true for its whole life; it is `mcpVersionInstalled` that moves.
+   * from the package.json beside the `dist/` these modules were loaded from, at
+   * MODULE LOAD (the closest observable moment to "the build that was loaded"; the
+   * caller supplies it, see MCP_VERSION_RUNNING). A running process cannot hot-swap
+   * its own code, so this stays true for its whole life; `mcpVersionInstalled` is
+   * the one that moves.
    */
   mcpVersion?: string;
   /**

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -24,6 +24,7 @@ import { isForceRemoteFlagSet } from "../config.js";
 import { resolveComfyuiPython, pythonVersionsAgree } from "./workspace-env.js";
 import { resolveLiveInterpreter } from "./live-interpreter.js";
 import { parsePyproject } from "./node-authoring.js";
+import { detectInstallMode } from "./self-update.js";
 
 // The interpreter resolver lives in workspace-env (which owns ComfyUI-base
 // resolution) so get_environment and this panel probe share ONE live-first
@@ -58,7 +59,28 @@ export interface EnvCapabilities {
   sageattention?: TriState;
   backend?: string; // active provider (human label, e.g. "Claude" / "Grok" / "unknown")
   otherBackendAvailable?: boolean; // is the OTHER provider resolvable?
-  mcpVersion?: string; // comfyui-mcp package version, e.g. "0.48.4"
+  /**
+   * The comfyui-mcp version this process is actually RUNNING, e.g. "0.48.4" — read
+   * from the package.json beside the `dist/` these modules were loaded from, at the
+   * moment the process started. A running process cannot hot-swap its own code, so
+   * this stays true for its whole life; it is `mcpVersionInstalled` that moves.
+   */
+  mcpVersion?: string;
+  /**
+   * The comfyui-mcp version installed ON DISK right now, re-read at each refresh.
+   *
+   * #846: only `mcpVersion` was ever carried, so the ENV line reported a version
+   * captured once at orchestrator startup as though it were still the current state
+   * of the machine. After an in-place upgrade the two diverge, and BOTH readings are
+   * separately true — the process really is running the old build, and the newer one
+   * really is installed. Reporting either alone is what misleads: a bug filed from
+   * that session gets version-pinned to a build nobody is running, and triage chases
+   * it against the wrong code.
+   *
+   * Carried so the line can DISCLOSE the drift instead of picking a side. Equal to
+   * `mcpVersion` in the ordinary case, where nothing is rendered.
+   */
+  mcpVersionInstalled?: string;
   panelVersion?: string; // sidebar panel version from the panel's hello, e.g. "0.11.3" / "nightly"
 }
 
@@ -541,8 +563,22 @@ export interface GatherOptions {
   comfyuiPath?: string;
   /** "claude" | "codex" — the active PANEL_AGENT_BACKEND. */
   backendId?: string;
-  /** comfyui-mcp package version (caller supplies; kept out of this module). */
+  /** comfyui-mcp package version this process is RUNNING (caller supplies; kept out
+   *  of this module). */
   mcpVersion?: string;
+  /**
+   * Read the comfyui-mcp version currently INSTALLED on disk (#846). Injectable
+   * for tests; defaults to the live package read.
+   *
+   * This is GATHERED here rather than supplied by the caller, and that placement
+   * is the fix. `mcpVersion` is the caller's own build — a constant for the life
+   * of its process — so it is passed in. The installed version is a fact about the
+   * MACHINE that can change while we run, which makes it a probe like every other
+   * one in this module, refreshed on every gather by construction. The bug was a
+   * caller reading it ONCE at startup beside the version it was legitimately
+   * caching; there is now no place left to cache it by accident.
+   */
+  readInstalledMcpVersion?: () => string | undefined;
   /** Sidebar panel version, learned from the panel's `hello` frame. */
   panelVersion?: string;
   /** Port the connected ComfyUI listens on — used to find the server PROCESS and read
@@ -592,11 +628,35 @@ export function readInstalledPanelVersion(comfyuiPath?: string): string | undefi
   return undefined;
 }
 
+/**
+ * The comfyui-mcp version INSTALLED on disk right now (#846) — undefined when it
+ * cannot be read.
+ *
+ * Distinct from the version the calling process is RUNNING, which cannot change
+ * while it runs (a Node process cannot hot-swap its own code) and is therefore
+ * passed in. After an in-place upgrade the two diverge, and reporting only the
+ * cached one described a moment that had passed.
+ */
+export function readInstalledMcpVersion(): string | undefined {
+  try {
+    return detectInstallMode().currentVersion ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCapabilities> {
   const caps: EnvCapabilities = {};
 
   // --- our own build versions (caller-supplied; panel version rides the hello) ---
   caps.mcpVersion = opts.mcpVersion;
+  // Re-read EVERY gather (#846). Guarded: a failed read must leave the line saying
+  // nothing about drift, never invent a mismatch out of a missing reading.
+  try {
+    caps.mcpVersionInstalled = (opts.readInstalledMcpVersion ?? readInstalledMcpVersion)();
+  } catch {
+    caps.mcpVersionInstalled = undefined;
+  }
   // Prefer the live hello's panel version; fall back to the INSTALLED panel's
   // pyproject version so a stale (cached) panel that omits it from the hello
   // still gets the agent's ENV line stamped (report_issue can version-match).
@@ -801,8 +861,22 @@ export function formatEnvBlock(caps: EnvCapabilities): string {
 
   // Our own build versions — so the agent can stamp them into bug reports without
   // digging (report-bug skill requires both).
+  //
+  // #846: the version named FIRST is the one this process is RUNNING, because that
+  // is the build whose behaviour the agent is about to describe in a bug report. An
+  // upgrade that landed while the orchestrator was up does not change that, and
+  // silently reporting the newer on-disk number instead would pin every issue to
+  // code nobody executed. So the drift is DISCLOSED, with the action that resolves
+  // it — a restart is the only thing that makes the two agree.
+  const upgradeClause =
+    caps.mcpVersion &&
+    caps.mcpVersionInstalled &&
+    caps.mcpVersionInstalled !== caps.mcpVersion
+      ? ` (this process is RUNNING ${caps.mcpVersion}; ${caps.mcpVersionInstalled} is now installed on disk` +
+        " — restart the orchestrator to load it, and report bugs against the RUNNING version)"
+      : "";
   const versions = [
-    caps.mcpVersion && `comfyui-mcp ${caps.mcpVersion}`,
+    caps.mcpVersion && `comfyui-mcp ${caps.mcpVersion}${upgradeClause}`,
     caps.panelVersion && `panel ${caps.panelVersion}`,
   ].filter(Boolean);
   if (versions.length) parts.push(versions.join(" · "));

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -202,12 +202,14 @@ interface StopResult {
 
 interface StartResult {
   /**
-   * Did THIS call start the server?
+   * Does THIS call have positive evidence it started the server?
    *
    * READ IT WITH `startup`, never alone. `started:false` paired with
    * `startup:"unconfirmed"` means NOT CONFIRMED STARTED — it never means CONFIRMED
-   * NOT STARTED. The boolean cannot carry a third state, so `startup` is the
-   * authoritative field and this one is a conservative projection of it.
+   * NOT STARTED, and it is emphatically not "the server is down": check `ready`,
+   * which is the field that answers that. The boolean cannot carry a third state,
+   * so `startup` is the authoritative field and this one is a conservative
+   * projection of it.
    */
   started: boolean;
   message: string;
@@ -2983,7 +2985,10 @@ async function rebootViaManager(): Promise<RebootResult> {
           acked: false, // inferred from the proxy status, not acknowledged
           endpoint: path,
           method,
-          note: `reboot fired — the origin dropped behind a proxy (HTTP ${res.status}) as it went down`,
+          // The OBSERVED fact only. "the origin dropped … as it went down" narrated
+          // one of the two causes this branch covers as though it were established
+          // (codex gate round 8); what we saw is a status code from a proxy.
+          note: `a proxy in front of ComfyUI answered HTTP ${res.status}`,
         };
       }
       // 404 / other non-OK: wrong route for this Manager build — try the next.
@@ -2995,7 +3000,7 @@ async function rebootViaManager(): Promise<RebootResult> {
           acked: false, // inferred from the dropped connection, not acknowledged
           endpoint: path,
           method,
-          note: "connection dropped (origin going down) — reboot fired",
+          note: "the connection dropped mid-request",
         };
       }
       failures.push(
@@ -3168,7 +3173,7 @@ async function restartViaManagerReboot(context: {
         // claimed.
         (reboot.acked
           ? "The ComfyUI-Manager reboot request was acknowledged"
-          : "A ComfyUI-Manager reboot was dispatched (no acknowledgement came back)") +
+          : `A ComfyUI-Manager reboot was dispatched but not acknowledged (${reboot.note ?? "no reply"})`) +
         ", but no readiness probe got a " +
         `healthy response from ${readiness.probe_url} within ${waitedS}s ` +
         `(${readiness.attempts}/${readiness.max_tries} probes over a ` +
@@ -3213,17 +3218,25 @@ async function restartViaManagerReboot(context: {
 
   return {
     stopped: true,
-    // THE FIELDS MUST AGREE WITH THE SENTENCE (codex gate round 7). A message that
-    // says the cycle was not observed, beside `startup:"confirmed"`, hands a caller
-    // reading the JSON the definite signal the prose just withheld — and the JSON is
-    // what an agent keys on.
+    // THE FIELDS MUST AGREE WITH THE SENTENCE (codex gate rounds 7 and 8). A message
+    // saying the cycle was not observed, beside `startup:"confirmed"` and
+    // `started:true`, hands a caller reading the JSON the definite signal the prose
+    // just withheld — and the JSON is what an agent keys on.
     //
-    // `started` stays TRUE on the same standing ruling as `listener_ownership`: a
-    // restart WAS dispatched and the server IS serving, and denying that would
-    // report every ordinary Desktop and remote restart as failed — a far more
-    // common and more damaging lie than an unconfirmed success the message
-    // qualifies. `startup` is what carries the gap.
-    started: true,
+    // I twice kept `started:true` here by analogy with `listener_ownership`, where
+    // an unconfirmed attribution deliberately keeps it. That analogy does not
+    // transfer, and the difference is the whole point: THERE, a process of ours
+    // demonstrably existed and only its attribution was uncertain. HERE this call
+    // spawned nothing at all, and an acknowledged Manager request can be a no-op —
+    // so there is no positive evidence that this call started anything, and
+    // `started` is exactly the claim that it did.
+    //
+    // The fear that drove the earlier choice — that `false` reads as a failed
+    // restart — is answered by the fields beside it rather than by overstating this
+    // one: `stopped:true` and `ready:true` say the server is up, and the message
+    // leads with it. `started` now means the same thing on every path in this file:
+    // THIS CALL HAS POSITIVE EVIDENCE IT STARTED SOMETHING.
+    started: false,
     ready: true,
     startup: "unconfirmed",
     readiness,
@@ -3241,10 +3254,14 @@ async function restartViaManagerReboot(context: {
     // apply. Both halves are therefore stated as what they are.
     message:
       (reboot.acked
-        ? "The ComfyUI-Manager reboot request was acknowledged"
-        : "A ComfyUI-Manager reboot was dispatched (no acknowledgement came back — the " +
-          "connection dropped as it was sent, which usually means the handler took it)") +
-      ` and ComfyUI is healthy now (${readiness.waited_ms}ms) — ${context.label}/supervised ` +
+        ? "The ComfyUI-Manager reboot request was acknowledged."
+        : // The OBSERVED signal is named, not a cause chosen for it: this branch
+          // covers a proxy status AND a dropped connection, and the earlier sentence
+          // told every user the connection dropped (codex gate round 8). The
+          // inference is offered as one, which is all it is.
+          `A ComfyUI-Manager reboot was dispatched but not acknowledged (${reboot.note ?? "no reply"}), ` +
+          "which usually means the handler accepted it and the server went down.") +
+      ` ComfyUI is healthy now (${readiness.waited_ms}ms) — ${context.label}/supervised ` +
       "restart. The cycle itself was not directly observed from here, so verify with " +
       "health_check if you need certainty that it actually restarted." +
       argvNote,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -3230,8 +3230,14 @@ async function restartViaManagerReboot(context: {
   // generation on every successful call, including a same-URL reaffirmation
   // that moves nothing — refusing on that would be this very defect class
   // pointed the other way: a bucket ("the target was touched") standing in for
-  // the question that actually matters ("is the server I am about to reboot the
-  // one whose argv I just read?"). The base answers that directly.
+  // the question that actually matters.
+  //
+  // What this fences is the ENDPOINT: the reboot will go to the URL whose argv
+  // we read. It does NOT establish that the same INSTANCE is still serving that
+  // URL — a same-URL replacement moves neither the base nor the generation and
+  // is invisible to both. Closing that needs a per-instance identity this
+  // codebase does not have yet; tracked in #871. Do not read this fence as more
+  // than it is.
   //
   // The generation still governs the ARGV COMPARISON further down, where it is
   // the right test for a different question: an A→B→A round trip leaves the base
@@ -3629,9 +3635,11 @@ export async function restartComfyUI(): Promise<RestartResult> {
           ? `Something IS answering on ${restartProbeUrl} now — possibly a supervisor ` +
             `brought it back, or the relaunch got further than the error suggests. ` +
             `This call cannot claim that server as its own.`
-          : `Nothing answered on ${restartProbeUrl} when asked just now, so ComfyUI ` +
-            `is most likely down — but the relaunch failed in a way this call could ` +
-            `not interpret, so that is a single observation and not a settled fact. ` +
+          : `No healthy response from ${restartProbeUrl} when asked just now, so ` +
+            `ComfyUI is most likely down — but "not healthy" is not "not there": a ` +
+            `502/503/504 from a proxy counts as not-ready here, and something may ` +
+            `well be listening. The relaunch also failed in a way this call could ` +
+            `not interpret. Treat this as one observation, not a settled fact. ` +
             `Check the server, and use start_comfyui once the cause is cleared.`) +
         stopCaveat,
       listener_ownership: unclassifiedOwnership(),

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -719,10 +719,14 @@ function getRestartPolicy(): RestartPolicy {
  * env-tuned default; the remote reboot passes a longer budget.
  */
 async function waitForApiReady(
-  cfg?: { intervalMs: number; maxTries: number },
+  cfg?: { intervalMs: number; maxTries: number; probeUrl?: string },
 ): Promise<StartupReadinessResult> {
   const { intervalMs, maxTries } = cfg ?? getStartupReadinessConfig();
-  const probeUrl = `${getComfyUIBaseUrl()}/system_stats`;
+  // ANCHORABLE (codex gate round 12). The configured target is mutable, so a
+  // relaunch that resolved its instance before a retarget must be able to poll the
+  // instance it actually relaunched — not whatever the config points at by the time
+  // the probes run.
+  const probeUrl = cfg?.probeUrl ?? `${getComfyUIBaseUrl()}/system_stats`;
   const start = Date.now();
   let attempts = 0;
 
@@ -2270,6 +2274,15 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
 
   // Gather info before we kill it (or reuse the caller's pre-validated info so a
   // relaunch preflight in restartComfyUI is not discarded).
+  //
+  // The generation is captured BEFORE the resolve so a retarget landing inside that
+  // await is caught (codex gate round 12). `restartComfyUI` fences its own window
+  // and hands us pre-validated info; a DIRECT `stop_comfyui` had no fence at all,
+  // and its saved launch record does not repair the loss: `start_comfyui` afterwards
+  // consults the NEW live target, so it can refuse as remote or find that port
+  // occupied rather than relaunch what was killed. That falsifies this tool's whole
+  // contract — "captures process info so it can be restarted with start_comfyui".
+  const stopGeneration = getComfyuiTargetGeneration();
   let info = preInfo ?? null;
   let acquireDiagnostic: string | undefined;
   if (!info) {
@@ -2297,6 +2310,26 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
   // teardown below. A refusal leaves a still-RUNNING server, and tearing down its
   // crash supervision first would silently disarm auto-restart for a server we
   // then declined to touch — turning a safe refusal into a later lost server.
+  // …and the same refusal for a target that moved while we resolved it. Placed
+  // beside the identity check for the same reason it is: nothing has been touched
+  // yet, so refusing costs a stop and never the server. `preInfo` callers were
+  // already fenced by restartComfyUI, and re-checking here is harmless for them —
+  // their generation has not moved either.
+  if (getComfyuiTargetGeneration() !== stopGeneration) {
+    const retargetHint = recoveryHint(info);
+    return {
+      stopped: false,
+      message:
+        "Refusing to stop: the ComfyUI target changed while the running instance was being " +
+        "identified, so the instance resolved here is not provably the one this server is now " +
+        "configured for — and start_comfyui afterwards would consult the NEW target, which may " +
+        "not bring this one back. Nothing was killed. Let the target settle, then retry." +
+        describeRecovery(retargetHint),
+      has_restart_info: false,
+      restart_hint: retargetHint,
+    };
+  }
+
   const identity = processIdentityStillValid(info);
   if (!identity.ok) {
     return {
@@ -2509,14 +2542,30 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
   };
 }
 
-export async function startComfyUI(): Promise<StartResult> {
+/**
+ * `anchor` pins the relaunch to a SPECIFIC instance (codex gate round 12).
+ *
+ * `restartComfyUI` resolves and validates its instance, then kills it, then waits
+ * for the port to free and sleeps — and only then starts. The configured target is
+ * mutable across all of that. Left unanchored, the relaunch spawned the right
+ * command (it comes from the saved ProcessInfo) but probed the NEW target's port:
+ * if that port was occupied it returned "already running" WITHOUT spawning, and the
+ * instance we had just killed stayed dead. Anchoring the port and the readiness URL
+ * to the values captured before the stop makes the whole sequence act on one
+ * instance. A direct `start_comfyui` passes nothing and reads the live config, which
+ * is right for it — there is no earlier moment it is bound to.
+ */
+export async function startComfyUI(anchor?: {
+  port?: number;
+  probeUrl?: string;
+}): Promise<StartResult> {
   if (isRemoteMode()) {
     throw new ProcessControlError(
       "start_comfyui launches ComfyUI on the local machine and is not " +
         "available when targeting a remote instance via --comfyui-url.",
     );
   }
-  const port = config.resolvedPort;
+  const port = anchor?.port ?? config.resolvedPort;
 
   // Check if already running. TRI-STATE: "the lookup could not run" is NOT "the
   // port is free". Collapsing them let us spawn into a port the old server may
@@ -2628,9 +2677,14 @@ export async function startComfyUI(): Promise<StartResult> {
   // Manager upgrade), so re-probe rather than trust it (#646).
   resetManagerApiCache("comfyui started");
 
-  // Wait for API to become ready
+  // Wait for API to become ready — on the ANCHORED instance when we were given one,
+  // so a retarget during the launch cannot make us grade a different server.
   const startupResult = await Promise.race([
-    waitForApiReady().then((readiness) => ({ readiness })),
+    waitForApiReady(
+      anchor?.probeUrl
+        ? { ...getStartupReadinessConfig(), probeUrl: anchor.probeUrl }
+        : undefined,
+    ).then((readiness) => ({ readiness })),
     spawnError.then((error) => ({ spawn_error: error })),
   ]);
   if ("spawn_error" in startupResult) {
@@ -3158,18 +3212,21 @@ async function restartViaManagerReboot(context: {
     };
   }
 
-  logger.info("ComfyUI-Manager reboot fired", {
-    endpoint: reboot.endpoint,
-    method: reboot.method,
-    note: reboot.note,
-  });
+  logger.info(
+    reboot.acked
+      ? "ComfyUI-Manager reboot request acknowledged"
+      : "ComfyUI-Manager reboot dispatched, not acknowledged",
+    { endpoint: reboot.endpoint, method: reboot.method, note: reboot.note },
+  );
 
-  // The reboot HAS been accepted, so the server MAY cycle at any moment from here
-  // — whatever the readiness poll below concludes, and whether or not we ever see
-  // it happen (codex gate round 6: "the server is going down regardless" asserted a
-  // cycle nothing observed). Dropping the detected dialect now is the conservative
-  // move either way: the timed-out branch returns early, and must not leave the
-  // pre-reboot dialect pinned for an instance that may come back different (#646).
+  // The request is out, so the server MAY cycle at any moment from here — whatever
+  // the readiness poll below concludes, and whether or not we ever see it happen.
+  // (Not "HAS been accepted": on the unacknowledged branch nothing accepted
+  // anything that we saw — codex gate rounds 6 and 12, which caught this claim in
+  // the prose and then again in the comment and the log line beside it.) Dropping
+  // the detected dialect now is the conservative move either way: the timed-out
+  // branch returns early, and must not leave the pre-reboot dialect pinned for an
+  // instance that may come back different (#646).
   resetManagerApiCache("comfyui reboot fired via Manager");
   // #742 r4/r5: record the dispatch — a later decline-path DOWN report may
   // name restart causation only against such a record. No session identity
@@ -3325,6 +3382,14 @@ export async function restartComfyUI(): Promise<RestartResult> {
   // from. It travels with the argv into the Desktop reboot below; capturing it
   // there instead would leave the read itself outside the fence (codex gate r2).
   const infoGeneration = getComfyuiTargetGeneration();
+  // …and the ADDRESS of the instance this call is about, captured at the same
+  // moment. The stop, the port-free wait and the settle delay are all awaits, and
+  // the configured target is mutable across every one of them, so the relaunch is
+  // anchored to these rather than to whatever the config says when it finally runs
+  // (codex gate round 12 — otherwise the relaunch probes the NEW target's port,
+  // finds it occupied, returns "already running", and the instance we killed stays
+  // dead).
+  const restartProbeUrl = `${getComfyUIBaseUrl()}/system_stats`;
 
   // Preflight: resolve the RUNNING instance and confirm we can relaunch it
   // BEFORE stopping anything. A restart must be atomic-ish — if the relaunch
@@ -3461,8 +3526,11 @@ export async function restartComfyUI(): Promise<RestartResult> {
     ? ` NOTE from the stop: ${stopResult.unverified_exit}.`
     : "";
 
-  // Start
-  const startResult = await startComfyUI();
+  // Start — ANCHORED to the instance that was just stopped (see restartProbeUrl).
+  const startResult = await startComfyUI({
+    port: info.port,
+    probeUrl: restartProbeUrl,
+  });
   // #367: the relaunch was DISPATCHED and its process is alive, but the readiness
   // budget expired before the API answered. This is neither a success to claim nor
   // a failure to report, and it is checked BEFORE the `!started` branch so that it

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -815,6 +815,18 @@ function seconds(ms: number): number {
   return Math.max(1, Math.round(ms / 1000));
 }
 
+/**
+ * How long to tell the caller to wait before looking again.
+ *
+ * Deliberately NOT the budget that just expired. "Re-check in another 120s" is
+ * advice nobody follows, and the whole purpose of the sentence is to get the user
+ * to look once more instead of reaching for the kill. A short, fixed interval is
+ * also the safe direction to be wrong in: checking too early costs one cheap
+ * health probe, while checking too late is the window the destructive response
+ * happens in.
+ */
+const RECHECK_HINT_S = 30;
+
 /** A probe interval a human can read — sub-second budgets must not render as "0s". */
 function describeInterval(ms: number): string {
   return ms >= 1000 ? `${Math.round(ms / 1000)}s` : `${ms}ms`;
@@ -2643,9 +2655,10 @@ export async function startComfyUI(): Promise<StartResult> {
         "the startup is NOT CONFIRMED YET — it does NOT mean it failed: ComfyUI with a normal " +
         "set of custom nodes routinely answers well after this window. " +
         "Do NOT kill it and do NOT launch a second copy onto this port. " +
-        `Re-check with health_check in another ${waitedS}s; if it is still silent then, the ` +
-        "ComfyUI logs will say why. To wait longer next time, raise " +
-        `COMFYUI_STARTUP_CHECK_MAX_TRIES (currently ${readiness.max_tries}, one probe every ` +
+        `Re-check with health_check in another ${RECHECK_HINT_S}s; if it is still silent then, ` +
+        "the ComfyUI logs will say why. To wait longer next time, raise " +
+        `COMFYUI_STARTUP_CHECK_MAX_TRIES (currently ${readiness.max_tries} ` +
+        `${readiness.max_tries === 1 ? "probe" : "probes"}, one every ` +
         `${describeInterval(readiness.interval_ms)}).` +
         (env ? ` Launch environment: ${env.note}.` : "") +
         launchEnvWarning(info),
@@ -3029,13 +3042,14 @@ async function restartViaManagerReboot(context: {
       message:
         "The ComfyUI-Manager reboot was accepted and ComfyUI went down, but it had not " +
         `answered on ${readiness.probe_url} within ${waitedS}s ` +
-        `(${readiness.attempts}/${readiness.max_tries} probes). The budget expiring means the ` +
-        "restart is NOT CONFIRMED YET — it does NOT mean it failed; a supervised cold start " +
-        `can take longer than this. Re-check with health_check in another ${waitedS}s before ` +
-        "intervening. If it is still down then, start ComfyUI from whatever supervises it (" +
+        `(${readiness.attempts}/${readiness.max_tries} probes over a ` +
+        `COMFYUI_REMOTE_REBOOT_BUDGET_S=${seconds(timing.budgetMs)}s budget). That budget ` +
+        "expiring means the restart is NOT CONFIRMED YET — it does NOT mean it failed; a " +
+        "supervised cold start can take longer than this. Re-check with health_check in " +
+        `another ${RECHECK_HINT_S}s before intervening. If it is still down then, start ` +
+        "ComfyUI from whatever supervises it (" +
         (context.label === "Desktop" ? "the ComfyUI Desktop app" : "its host") +
-        "). To wait longer next time, raise COMFYUI_REMOTE_REBOOT_BUDGET_S (currently " +
-        `${seconds(timing.budgetMs)}s).`,
+        "), or raise that budget to wait longer next time.",
       listener_ownership: unclassifiedOwnership(),
     };
   }
@@ -3209,8 +3223,8 @@ export async function restartComfyUI(): Promise<RestartResult> {
       startup: "unconfirmed",
       readiness: startResult.readiness,
       message:
-        "ComfyUI was stopped and relaunched, but the restart is NOT CONFIRMED YET " +
-        `(it is not known to have failed either): ${startResult.message}` +
+        "ComfyUI was stopped and relaunched; the restart is NOT CONFIRMED YET, and it is " +
+        `not known to have failed either — ${startResult.message}` +
         stopCaveat,
       auto_restart: startResult.auto_restart,
       launch_env: startResult.launch_env,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -196,10 +196,21 @@ interface StopResult {
 }
 
 interface StartResult {
+  /**
+   * Did THIS call start the server?
+   *
+   * READ IT WITH `startup`, never alone. `started:false` paired with
+   * `startup:"unconfirmed"` means NOT CONFIRMED STARTED — it never means CONFIRMED
+   * NOT STARTED. The boolean cannot carry a third state, so `startup` is the
+   * authoritative field and this one is a conservative projection of it.
+   */
   started: boolean;
   message: string;
   pid?: number;
   ready?: boolean;
+  /** See StartupConfirmation. REQUIRED on every path, including the ones that
+   *  never launched anything (#367). */
+  startup: StartupConfirmation;
   readiness?: StartupReadinessResult;
   auto_restart?: SupervisorResult;
   spawn_error?: ChildProcessErrorDetails;
@@ -221,7 +232,10 @@ interface StartResult {
 
 interface RestartResult {
   stopped: boolean;
+  /** Same contract as StartResult.started — read it with `startup`. */
   started: boolean;
+  /** See StartupConfirmation. REQUIRED on every path (#367). */
+  startup: StartupConfirmation;
   message: string;
   /** How to start it by hand — carried on every refusal, so a user who is told
    *  "not restarting" is never left to dig the command out of the process table
@@ -256,6 +270,41 @@ interface StartupReadinessResult {
   waited_ms: number;
   probe_url: string;
 }
+
+/**
+ * Did this call CONFIRM that ComfyUI is serving after the launch/reboot it made?
+ *
+ * A STRING tri-state (four-state, with the never-tried case named) for the same
+ * reason `listener_ownership` is one: the uncertain case has to survive
+ * `JSON.stringify`, and it must be impossible to read as the definite negative.
+ *
+ *   "confirmed"     — the API answered. Observed.
+ *   "failed"        — the process this call launched is GONE: a spawn error, a
+ *                     recorded exit, or a liveness probe that came back
+ *                     DEFINITELY dead. ComfyUI is down, and that is observed too.
+ *   "unconfirmed"   — the readiness budget expired with nothing contradicting the
+ *                     start.
+ *   "not-attempted" — this call never launched or rebooted anything (a refusal, or
+ *                     a server that was already running). Stated rather than
+ *                     omitted so it can never be mistaken for an older build that
+ *                     did not carry the field.
+ *
+ * A DEADLINE EXPIRING ESTABLISHES THAT STARTUP WAS NOT CONFIRMED YET — NOT THAT IT
+ * FAILED (#367). The two were one verdict, and the message asserted whichever it
+ * happened to name: "the API did not become ready … Check the ComfyUI logs", with
+ * `started:false`, reported seconds before a healthy instance came up. That lie is
+ * worse than an unconfirmed success, because a user told their restart broke
+ * reaches for the thing that actually breaks it — kill the process, launch a second
+ * copy onto the same port — on a server that was about to be fine.
+ *
+ * Only an OBSERVATION may turn "not yet" into "no": we know the launch failed when
+ * we watched the process die, and never merely because we stopped waiting.
+ */
+type StartupConfirmation =
+  | "confirmed"
+  | "failed"
+  | "unconfirmed"
+  | "not-attempted";
 
 interface SupervisorResult {
   enabled: boolean;
@@ -759,6 +808,85 @@ function describeLaunchedChildExit(
 ): string {
   if (!exit) return "";
   return ` The process this call launched EXITED (${exitCause(exit)}) before the API came up, so ComfyUI is DOWN — this was a failed relaunch, not a slow start.`;
+}
+
+/** Whole seconds, never rounded down to a "within 0s" that reads as no wait. */
+function seconds(ms: number): number {
+  return Math.max(1, Math.round(ms / 1000));
+}
+
+/** A probe interval a human can read — sub-second budgets must not render as "0s". */
+function describeInterval(ms: number): string {
+  return ms >= 1000 ? `${Math.round(ms / 1000)}s` : `${ms}ms`;
+}
+
+/**
+ * The argv the server is serving with RIGHT NOW, or undefined when it could not be
+ * read. Bounded and total: it is called on a success path where the only thing at
+ * stake is how much detail the report carries, so it must never throw and never
+ * hang the tool. The timer resolves the race without awaiting anything, so it is
+ * genuinely outside the window it bounds.
+ */
+export async function readServingArgv(
+  timeoutMs = 3000,
+): Promise<string[] | undefined> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const argv = await Promise.race([
+      getSystemStats().then((s) => s.system.argv),
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => resolve(undefined), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+    return Array.isArray(argv) && argv.length > 0 ? [...argv] : undefined;
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * The sentence about whether the launch ARGUMENTS survived a restart (#848).
+ *
+ * #848 is this cluster's defect pointed at a POSITIVE: "the restart succeeded" was
+ * read as the answer to a question it was never computed for — "did it come back
+ * with the arguments I just configured?" The server came back healthy, the report
+ * said so, and the user's newly-added flag was silently absent.
+ *
+ * This is strictly a report of TWO OBSERVATIONS: what the server ran before, and
+ * what it reports running now. It deliberately does NOT explain WHY they match. A
+ * Manager reboot re-execing the running process is a plausible cause and not one we
+ * observed, and naming it would assert a cause the evidence only permits as a
+ * possibility. What the user needs — that the change did not take, and what does
+ * apply it — is sayable from the observation alone.
+ *
+ * Silent when either reading is missing: an unread argv is not evidence of sameness.
+ */
+export function describeArgvDrift(
+  before: string[] | undefined,
+  after: string[] | undefined,
+  isDesktop: boolean,
+): string {
+  if (!before?.length || !after?.length) return "";
+  const unchanged =
+    before.length === after.length && before.every((tok, i) => tok === after[i]);
+  if (!unchanged) {
+    return (
+      ` Its launch arguments CHANGED across this restart: before ${before
+        .map(quoteToken)
+        .join(" ")} / now ${after.map(quoteToken).join(" ")}.`
+    );
+  }
+  return (
+    ` Its launch arguments are UNCHANGED (${after.map(quoteToken).join(" ")}), so if you edited ` +
+    (isDesktop
+      ? "ComfyUI Desktop's saved launch arguments expecting this restart to pick them up, it did NOT. " +
+        "Fully quit the ComfyUI Desktop app and relaunch it, so it spawns the server from those saved settings."
+      : "the launch arguments on the host expecting this restart to pick them up, it did NOT. " +
+        "Stop ComfyUI and start it again from its own launcher so the new arguments are used.")
+  );
 }
 
 /**
@@ -2319,6 +2447,8 @@ export async function startComfyUI(): Promise<StartResult> {
   if (preLaunchProbe.state === "owned") {
     return {
       started: false,
+      // Nothing was launched, so there is no startup of ours to have confirmed.
+      startup: "not-attempted",
       message: `ComfyUI is already running on port ${port} (PID ${preLaunchProbe.pid})`,
       pid: preLaunchProbe.pid,
       // Something is serving the port and we never got as far as spawning. We did
@@ -2351,6 +2481,7 @@ export async function startComfyUI(): Promise<StartResult> {
     } else {
       return {
         started: false,
+        startup: "not-attempted",
         message:
           "No previous process info and could not find ComfyUI Desktop app. Start ComfyUI manually.",
         listener_ownership: unclassifiedOwnership(),
@@ -2367,6 +2498,8 @@ export async function startComfyUI(): Promise<StartResult> {
   if (!launched) {
     return {
       started: false,
+      // No command was ever spawned — a refusal, not a startup that went wrong.
+      startup: "not-attempted",
       message: info.isDesktopApp
         ? "Could not determine ComfyUI Desktop executable path. Please start it manually."
         : "No command-line info captured from previous run. Start ComfyUI manually.",
@@ -2424,6 +2557,9 @@ export async function startComfyUI(): Promise<StartResult> {
     return {
       started: false,
       ready: false,
+      // OBSERVED: the spawn itself errored. This is the definite negative, and the
+      // only kind of evidence allowed to produce one.
+      startup: "failed",
       message:
         `ComfyUI process failed to launch: ${startupResult.spawn_error.message}`,
       spawn_error: startupResult.spawn_error,
@@ -2438,23 +2574,86 @@ export async function startComfyUI(): Promise<StartResult> {
   const readiness = startupResult.readiness;
   if (!readiness.ready) {
     const env = launchEnvInfo(info);
+    // WHAT A DEADLINE ACTUALLY ESTABLISHES (#367).
+    //
+    // The budget expiring is a fact about how long WE waited, not a fact about the
+    // server. It says startup was not confirmed WITHIN it. Only an observation of
+    // the launched process being GONE turns that into a failure — and we can make
+    // that observation, so the two stop sharing a verdict whose message asserted
+    // whichever it happened to name.
+    //
+    // The old branch reported the #776 failure shape (ComfyUI aborting during
+    // import) for BOTH, because for a dead child it was right and nobody separated
+    // the live one. #776's truthfulness is preserved exactly — a child that died
+    // still reports DOWN, with the same sentence — while the live child stops being
+    // told it failed.
+    //
+    // `launchedChildStillRunning` is tri-state on purpose: `undefined` is "cannot
+    // tell", and it must not be spent as either answer, so it falls on the
+    // unconfirmed side with the uncertainty stated. Only a DEFINITE death fails.
+    const childAlive = launchedChildStillRunning(launched.child);
+    const childIsGone =
+      launchedSpawnFailed || launchedChildExit != null || childAlive === false;
+    const waitedS = seconds(readiness.waited_ms);
+    if (childIsGone) {
+      return {
+        started: false,
+        ready: false,
+        // OBSERVED death. ComfyUI is down, and we watched it happen.
+        startup: "failed",
+        readiness,
+        // TRUTHFUL FAILURE (#776): the process was spawned and then died, so
+        // ComfyUI is DOWN. Report that plainly — and name the environment it was
+        // launched into, which is the first thing to check when a relaunch of an
+        // otherwise-healthy install fails during import.
+        message:
+          `ComfyUI process was launched but the API did not become ready after ${readiness.waited_ms}ms (${readiness.attempts}/${readiness.max_tries} probes).` +
+          (launchedChildExit
+            ? describeLaunchedChildExit(launchedChildExit)
+            : launchedSpawnFailed
+              ? " The launch itself failed — the process could not be spawned — so ComfyUI is DOWN; this was a failed relaunch, not a slow start."
+              : " The process this call launched is no longer running, so ComfyUI is DOWN — this was a failed relaunch, not a slow start.") +
+          " Check the ComfyUI logs." +
+          (env ? ` Launch environment: ${env.note}.` : "") +
+          launchEnvWarning(info),
+        auto_restart: supervisorResult(info),
+        launch_env: env,
+        // Nothing is serving the port, so there is no listener to attribute — the
+        // down state is already carried by started:false / ready:false.
+        listener_ownership: unclassifiedOwnership(),
+      };
+    }
     return {
-      started: false,
+      // The launch HAPPENED and nothing observed contradicts it: a process was
+      // spawned, no spawn error fired, and no exit has been seen. `started` reports
+      // that dispatch; `ready:false` and `startup:"unconfirmed"` carry what is still
+      // unknown. Refuse before, disclose after — the irreversible step is behind us,
+      // so the honest move is to describe it, not to deny it happened.
+      started: true,
       ready: false,
+      startup: "unconfirmed",
       readiness,
-      // TRUTHFUL FAILURE (#776): the process was spawned but never answered, so
-      // ComfyUI is DOWN. Report that plainly — and name the environment it was
-      // launched into, which is the first thing to check when a relaunch of an
-      // otherwise-healthy install fails during import.
       message:
-        `ComfyUI process was launched but the API did not become ready after ${readiness.waited_ms}ms (${readiness.attempts}/${readiness.max_tries} probes). Check the ComfyUI logs.` +
-        describeLaunchedChildExit(launchedChildExit) +
+        `ComfyUI was launched${launched.child.pid ? ` (PID ${launched.child.pid})` : ""} and ` +
+        (childAlive === true
+          ? "that process is still running"
+          : "no exit has been observed from that process") +
+        `, but the API had not answered on ${readiness.probe_url} within ${waitedS}s ` +
+        `(${readiness.attempts}/${readiness.max_tries} probes). The budget expiring means ` +
+        "the startup is NOT CONFIRMED YET — it does NOT mean it failed: ComfyUI with a normal " +
+        "set of custom nodes routinely answers well after this window. " +
+        "Do NOT kill it and do NOT launch a second copy onto this port. " +
+        `Re-check with health_check in another ${waitedS}s; if it is still silent then, the ` +
+        "ComfyUI logs will say why. To wait longer next time, raise " +
+        `COMFYUI_STARTUP_CHECK_MAX_TRIES (currently ${readiness.max_tries}, one probe every ` +
+        `${describeInterval(readiness.interval_ms)}).` +
         (env ? ` Launch environment: ${env.note}.` : "") +
         launchEnvWarning(info),
+      pid: launched.child.pid,
       auto_restart: supervisorResult(info),
       launch_env: env,
-      // Nothing is serving the port, so there is no listener to attribute — the
-      // down state is already carried by started:false / ready:false.
+      // Nothing has answered on the port yet, so there is no listener to attribute.
+      // This says nothing about the launched process, which is reported above.
       listener_ownership: unclassifiedOwnership(),
     };
   }
@@ -2527,6 +2726,8 @@ export async function startComfyUI(): Promise<StartResult> {
     // needless recovery.
     started: mayClaimStart,
     ready: true,
+    // The API answered. This is the one path that may say so.
+    startup: "confirmed",
     readiness,
     message:
       `ComfyUI ${ownership === "not-ours" ? "is ready" : "started"} on port ${port}${newPid ? ` (PID ${newPid})` : ""}` +
@@ -2751,14 +2952,32 @@ function getRemoteRebootTiming(): RemoteRebootTiming {
 async function restartViaManagerReboot(context: {
   /** Human label for logs and the success message ("remote" | "Desktop"). */
   label: string;
+  /**
+   * The arguments the server was ALREADY observed running with (#848), when the
+   * caller gathered them anyway. Supplied rather than re-read so no extra probe is
+   * inserted ahead of an irreversible dispatch; when absent it is read here, from a
+   * call that can neither throw nor hang.
+   */
+  priorArgv?: string[];
+  /** Is this a ComfyUI Desktop instance? Selects the remedy in the #848 sentence. */
+  isDesktop?: boolean;
 }): Promise<RestartResult> {
   logger.info(`Restarting ${context.label} ComfyUI via ComfyUI-Manager reboot...`);
+
+  // #848: capture what it is running BEFORE the reboot, so the report afterwards can
+  // say whether that changed. Total and bounded (see readServingArgv) — it is only
+  // ever detail in a message, and must not be able to cost anyone their restart.
+  const priorArgv = context.priorArgv?.length
+    ? context.priorArgv
+    : await readServingArgv();
 
   const reboot = await rebootViaManager();
   if (!reboot.rebooting) {
     return {
       stopped: false,
       started: false,
+      // Nothing was dispatched — this is a refusal, not an uncertain outcome.
+      startup: "not-attempted",
       message: reboot.note ?? "ComfyUI-Manager reboot could not be triggered.",
       // The Manager reboot path never spawns a process of ours, so ownership of
       // whatever serves the port is never something this call can claim.
@@ -2794,14 +3013,29 @@ async function restartViaManagerReboot(context: {
   const readiness = await waitForApiReady({ intervalMs, maxTries });
 
   if (!readiness.ready) {
+    const waitedS = seconds(readiness.waited_ms);
     return {
       stopped: true,
+      // NO POSITIVE EVIDENCE EITHER WAY, and the two halves of that are not
+      // symmetric here. Unlike the local relaunch, this call spawned nothing: the
+      // SUPERVISOR is what brings the process back, so there is no child of ours
+      // whose liveness could stand in for a start. `started` therefore cannot be
+      // claimed — but the reader must not take the `false` for the other definite
+      // answer, which is exactly what `startup` is here to prevent (#367).
       started: false,
       ready: false,
+      startup: "unconfirmed",
       readiness,
       message:
-        `Reboot was triggered but ComfyUI did not come back within ${timing.budgetMs}ms — ` +
-        "check the host (is it the Desktop app / supervised?).",
+        "The ComfyUI-Manager reboot was accepted and ComfyUI went down, but it had not " +
+        `answered on ${readiness.probe_url} within ${waitedS}s ` +
+        `(${readiness.attempts}/${readiness.max_tries} probes). The budget expiring means the ` +
+        "restart is NOT CONFIRMED YET — it does NOT mean it failed; a supervised cold start " +
+        `can take longer than this. Re-check with health_check in another ${waitedS}s before ` +
+        "intervening. If it is still down then, start ComfyUI from whatever supervises it (" +
+        (context.label === "Desktop" ? "the ComfyUI Desktop app" : "its host") +
+        "). To wait longer next time, raise COMFYUI_REMOTE_REBOOT_BUDGET_S (currently " +
+        `${seconds(timing.budgetMs)}s).`,
       listener_ownership: unclassifiedOwnership(),
     };
   }
@@ -2818,14 +3052,25 @@ async function restartViaManagerReboot(context: {
   // (the process-wide slot only; never another session's record).
   clearRestartDispatch(PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
 
+  // #848: it is back — now say whether it came back as the SAME thing. Read after
+  // readiness, on a path where nothing destructive is pending, so a slow or missing
+  // answer costs only the detail (describeArgvDrift stays silent without both).
+  const argvNote = describeArgvDrift(
+    priorArgv,
+    await readServingArgv(),
+    context.isDesktop === true,
+  );
+
   return {
     stopped: true,
     started: true,
     ready: true,
+    startup: "confirmed",
     readiness,
     message:
       `ComfyUI rebooted via ComfyUI-Manager and came back ready (${readiness.waited_ms}ms) — ` +
-      `${context.label}/supervised restart.`,
+      `${context.label}/supervised restart.` +
+      argvNote,
     // The supervisor that owns the process cycled it; we launched nothing, so we
     // cannot (and must not) claim the listener as ours.
     listener_ownership: unclassifiedOwnership(),
@@ -2850,6 +3095,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
     return {
       stopped: false,
       started: false,
+      startup: "not-attempted",
       message:
         diagnostic ??
         `No ComfyUI process found on port ${config.resolvedPort} to restart. Is ComfyUI running?`,
@@ -2873,6 +3119,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
       return {
         stopped: false,
         started: false,
+        startup: "not-attempted",
         message:
           `Refusing to restart: ${desktop.reason} ComfyUI was left running (not stopped) so ` +
           `you don't lose the server. Restart it from the ComfyUI Desktop app.` +
@@ -2882,7 +3129,13 @@ export async function restartComfyUI(): Promise<RestartResult> {
         listener_ownership: unclassifiedOwnership(),
       };
     }
-    return restartViaManagerReboot({ label: "Desktop" });
+    // #848: hand over the argv already gathered by acquireProcessInfo moments ago —
+    // no extra probe, and it is the reading taken closest to the stop.
+    return restartViaManagerReboot({
+      label: "Desktop",
+      priorArgv: info.argv,
+      isDesktop: true,
+    });
   }
 
   // requireReproducibleEnv: this path KILLS the process and spawns a fresh one, so
@@ -2892,6 +3145,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
     return {
       stopped: false,
       started: false,
+      startup: "not-attempted",
       restart_hint: recoveryHint(info),
       message:
         `Refusing to restart: ${relaunch.reason} ComfyUI was left running (not stopped) ` +
@@ -2912,6 +3166,8 @@ export async function restartComfyUI(): Promise<RestartResult> {
     return {
       stopped: false,
       started: false,
+      // The stop failed, so no relaunch was ever attempted.
+      startup: "not-attempted",
       message: `Could not stop ComfyUI: ${stopResult.message}`,
       // Nothing was stopped and nothing launched — whatever is on the port is not
       // this call's doing.
@@ -2936,10 +3192,41 @@ export async function restartComfyUI(): Promise<RestartResult> {
 
   // Start
   const startResult = await startComfyUI();
+  // #367: the relaunch was DISPATCHED and its process is alive, but the readiness
+  // budget expired before the API answered. This is neither a success to claim nor
+  // a failure to report, and it is checked BEFORE the `!started` branch so that it
+  // can never fall through to either of them: `started` is TRUE here, so without
+  // this the composition below would have printed "ComfyUI restarted successfully"
+  // over a server nobody has heard from — fabricated success, the worst outcome.
+  // The old `started:false` sent it down the other branch instead, printing "could
+  // not be started" over a server that was usually seconds from ready. Both are the
+  // same mistake: a boolean answering a question the evidence does not settle.
+  if (startResult.startup === "unconfirmed") {
+    return {
+      stopped: true,
+      started: true,
+      ready: false,
+      startup: "unconfirmed",
+      readiness: startResult.readiness,
+      message:
+        "ComfyUI was stopped and relaunched, but the restart is NOT CONFIRMED YET " +
+        `(it is not known to have failed either): ${startResult.message}` +
+        stopCaveat,
+      auto_restart: startResult.auto_restart,
+      launch_env: startResult.launch_env,
+      listener_ownership: startResult.listener_ownership,
+    };
+  }
   if (!startResult.started) {
     return {
       stopped: true,
       started: false,
+      // Forwarded, never re-derived: startComfyUI is the only thing that watched
+      // the launch, so it is the only thing entitled to name the verdict. Reaching
+      // here with started:false means it was "failed" (observed death) or
+      // "not-attempted" (nothing was spawnable), or the healthy listener is provably
+      // somebody else's — never "unconfirmed", which returned above.
+      startup: startResult.startup,
       ready: startResult.ready,
       readiness: startResult.readiness,
       // Two distinct failures share this branch, and they must NOT read alike: the
@@ -2966,6 +3253,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
   return {
     stopped: true,
     started: true,
+    startup: startResult.startup,
     ready: startResult.ready,
     readiness: startResult.readiness,
     // Reached only when startComfyUI reported started:true — i.e. the healthy
@@ -3081,6 +3369,16 @@ export function getRestartDispatchRecord(
 export async function preflightLocalRestart(): Promise<{
   ok: boolean;
   reason?: string;
+  /**
+   * The arguments the instance being assessed was OBSERVED running with (#848).
+   * Reported so a caller that dispatches an out-of-band reboot can compare them
+   * against what comes back WITHOUT inserting a probe of its own ahead of the
+   * dispatch. Absent whenever nothing was observed — an unread argv is not
+   * evidence, and callers must treat it as "say nothing" rather than "unchanged".
+   */
+  observedArgv?: string[];
+  /** Whether the assessed instance is ComfyUI Desktop — selects the #848 remedy. */
+  isDesktopApp?: boolean;
 }> {
   if (isRemoteMode()) return { ok: true };
   const { info, diagnostic } = await acquireProcessInfo();
@@ -3111,7 +3409,7 @@ export async function preflightLocalRestart(): Promise<{
     // property of the install. See assessDesktopSupervision for why UNCONFIRMED
     // refuses here while it is merely disclosed on the post-launch ownership path.
     const desktop = assessDesktopSupervision(info);
-    if (desktop.ok) return { ok: true };
+    if (desktop.ok) return { ok: true, ...observedLaunch(info) };
     return { ok: false, reason: `${desktop.reason}${describeRecovery(recoveryHint(info))}` };
   }
   // NOTE (#776): the launch-ENVIRONMENT check is deliberately NOT applied here.
@@ -3120,8 +3418,23 @@ export async function preflightLocalRestart(): Promise<{
   // Stability Matrix / Pinokio environment survives that restart for free.
   // Refusing on it would cost those users a restart path that actually works.
   const relaunch = assessRelaunch(info);
-  if (relaunch.ok) return { ok: true };
+  if (relaunch.ok) return { ok: true, ...observedLaunch(info) };
   return { ok: false, reason: relaunch.reason };
+}
+
+/**
+ * The launch facts this preflight OBSERVED, in the shape preflightLocalRestart
+ * reports them. `argv` is omitted when empty — a wedged server reports none, and an
+ * empty array would read as "it was running with no arguments" (#848).
+ */
+function observedLaunch(info: ProcessInfo): {
+  observedArgv?: string[];
+  isDesktopApp?: boolean;
+} {
+  return {
+    observedArgv: info.argv.length > 0 ? [...info.argv] : undefined,
+    isDesktopApp: info.isDesktopApp === true,
+  };
 }
 
 export const __processControlTestHooks = {

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -823,7 +823,7 @@ function describeLaunchedChildExit(
   // SCHEDULED PROBE got a 2xx, and the server could have answered between two of
   // them. So "before the API came up" is gone too — every clause here now names an
   // observation rather than an inference from a gap between observations.
-  return ` The process this call launched EXITED (${exitCause(exit)}), so THIS RELAUNCH FAILED — it was not a slow start. No readiness probe got a response, the last one included.`;
+  return ` The process this call launched EXITED (${exitCause(exit)}), so THIS RELAUNCH FAILED — it was not a slow start. No readiness probe got a healthy response, the last one included.`;
 }
 
 /** Whole seconds, never rounded down to a "within 0s" that reads as no wait. */
@@ -871,7 +871,15 @@ export async function readServingArgv(
   } catch {
     return undefined;
   } finally {
-    clearTimeout(timer);
+    // THE GUARD IS ITSELF AN OPERATION THAT CAN FAIL (codex gate round 4). A throw
+    // from `finally` REPLACES the guarded result and escapes this function, which
+    // would turn a best-effort detail into a thrown restart. Nothing here may be
+    // allowed to do that.
+    try {
+      clearTimeout(timer);
+    } catch {
+      /* a timer we cannot clear is a leak at worst; it is unref'd and self-resolves */
+    }
   }
 }
 
@@ -901,8 +909,12 @@ export function describeArgvDrift(
   const unchanged =
     before.length === after.length && before.every((tok, i) => tok === after[i]);
   if (!unchanged) {
+    // "before this restart REQUEST", not "across this restart" (codex gate round 4).
+    // On the Manager path the only observations are an accepted request and a later
+    // healthy probe — no down→up cycle is required there — so a completed restart is
+    // not something these two readings may take as given.
     return (
-      ` Its launch arguments CHANGED across this restart: before ${before
+      ` Its launch arguments CHANGED between the reading taken before this restart request and the one taken now: before ${before
         .map(quoteToken)
         .join(" ")} / now ${after.map(quoteToken).join(" ")}.`
     );
@@ -920,7 +932,7 @@ export function describeArgvDrift(
   // old ones — so the remedy hangs off that, conditioned on the user's own
   // expectation, which only they can check.
   return (
-    ` Its launch arguments are UNCHANGED (${after.map(quoteToken).join(" ")}) — the same arguments were observed before and after this restart. ` +
+    ` Its launch arguments are UNCHANGED (${after.map(quoteToken).join(" ")}) — the same arguments were observed before this restart request and again now. ` +
     "If you were expecting different arguments" +
     (isDesktop
       ? " (after editing ComfyUI Desktop's saved launch settings, say), they are not in effect here: fully quit the ComfyUI Desktop app and relaunch it so it spawns the server from those settings."
@@ -2648,15 +2660,29 @@ export async function startComfyUI(): Promise<StartResult> {
         // environment it was launched into, which is the first thing to check when a
         // relaunch of an otherwise-healthy install fails during import.
         message:
-          // "no probe got a response in Nms", not "the API did not become ready": a
-          // poll establishes only what the SCHEDULED PROBES saw, and the server could
-          // have answered in a gap between two of them (codex gate round 3).
-          `ComfyUI process was launched, but no readiness probe got a response in ${readiness.waited_ms}ms (${readiness.attempts}/${readiness.max_tries} probes).` +
-          (launchedChildExit
-            ? describeLaunchedChildExit(launchedChildExit)
-            : launchedSpawnFailed
-              ? " The launch itself failed — the process could not be spawned — so THIS RELAUNCH FAILED; it was not a slow start."
-              : " The process this call launched is no longer running, so THIS RELAUNCH FAILED — it was not a slow start.") +
+          // "no probe got a HEALTHY response", not "the API did not become ready":
+          // a poll establishes only what the SCHEDULED PROBES saw (the server could
+          // have answered in a gap between two of them), and the poller treats any
+          // non-2xx as not-ready — so a 503 from a half-started server IS a
+          // response, and saying none came back would be false (codex gate r3/r4).
+          //
+          // A SPAWN FAILURE DOES NOT LEAD WITH "was launched" (codex gate round 4):
+          // the readiness race can resolve first and the `error` event land before
+          // the liveness check, which produced a report that said the process was
+          // launched and then that it could not be spawned.
+          //
+          // DEFENSIVE AND UNCOVERED, stated so nobody mistakes it for tested: an
+          // `error` arriving before the race settles makes `spawnError` win instead,
+          // and that path returns above. Reaching HERE needs the event to land in
+          // the microtask window between the readiness result resolving and this
+          // line reading the flag — an interleaving no test can schedule. The branch
+          // costs nothing and removes a self-contradictory verdict if it ever runs.
+          (launchedSpawnFailed && !launchedChildExit
+            ? `The ComfyUI process could not be spawned, and no readiness probe got a healthy response in ${readiness.waited_ms}ms (${readiness.attempts}/${readiness.max_tries} probes). THIS RELAUNCH FAILED — it was not a slow start.`
+            : `ComfyUI process was launched, but no readiness probe got a healthy response in ${readiness.waited_ms}ms (${readiness.attempts}/${readiness.max_tries} probes).` +
+              (launchedChildExit
+                ? describeLaunchedChildExit(launchedChildExit)
+                : " The process this call launched is no longer running, so THIS RELAUNCH FAILED — it was not a slow start.")) +
           " Check the ComfyUI logs, and re-check with health_check before assuming nothing is serving the port — an external launcher or supervisor may have brought one back since." +
           (env ? ` Launch environment: ${env.note}.` : "") +
           launchEnvWarning(info),
@@ -2682,7 +2708,10 @@ export async function startComfyUI(): Promise<StartResult> {
         (childAlive === true
           ? "that process is still running"
           : "no exit has been observed from that process") +
-        `, but the API had not answered on ${readiness.probe_url} within ${waitedS}s ` +
+        // "no healthy response" rather than "had not answered": the poller counts
+        // any non-2xx as not-ready, so a 503 from a half-started server is an
+        // answer, and claiming none came would be false (codex gate round 4).
+        `, but no readiness probe got a healthy response from ${readiness.probe_url} within ${waitedS}s ` +
         `(${readiness.attempts}/${readiness.max_tries} probes). The budget expiring means ` +
         "the startup is NOT CONFIRMED YET — it does NOT mean it failed: ComfyUI with a normal " +
         "set of custom nodes routinely answers well after this window. " +
@@ -3102,8 +3131,8 @@ async function restartViaManagerReboot(context: {
         // equally consistent with a server that was never reachable from here. The
         // accepted reboot is the one thing we did observe, so it is the one thing
         // claimed.
-        "The ComfyUI-Manager reboot was accepted, but ComfyUI had not " +
-        `answered on ${readiness.probe_url} within ${waitedS}s ` +
+        "The ComfyUI-Manager reboot was accepted, but no readiness probe got a " +
+        `healthy response from ${readiness.probe_url} within ${waitedS}s ` +
         `(${readiness.attempts}/${readiness.max_tries} probes over a ` +
         `COMFYUI_REMOTE_REBOOT_BUDGET_S=${seconds(timing.budgetMs)}s budget). That budget ` +
         "expiring means the restart is NOT CONFIRMED YET — it does NOT mean it failed; a " +

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -292,14 +292,17 @@ interface StartupReadinessResult {
  * `JSON.stringify`, and it must be impossible to read as the definite negative.
  *
  *   "confirmed"     — the API answered. Observed.
- *   "failed"        — THIS RELAUNCH failed: the process this call launched is GONE —
- *                     a spawn error, a recorded exit, or a liveness probe that came
- *                     back DEFINITELY dead. (The spawn-error path can return before
- *                     the readiness poll has run at all, so this verdict carries no
- *                     claim about probes; the ones that DID poll say so in their own
- *                     message.) It does NOT say the port is unserved either — an
- *                     external launcher or supervisor may have restored one, which
- *                     is why the message tells the caller to re-check.
+ *   "failed"        — THIS CALL'S LAUNCH did not produce the serving instance, and
+ *                     that is OBSERVED rather than merely unproven. Two shapes: the
+ *                     process it launched is GONE (a spawn error, a recorded exit, or
+ *                     a liveness probe that came back DEFINITELY dead); or the port
+ *                     is provably owned by a DIFFERENT process, so something else is
+ *                     serving and our relaunch is not it. (The spawn-error path can
+ *                     return before the readiness poll has run at all, so this
+ *                     verdict carries no claim about probes; the ones that DID poll
+ *                     say so in their own message.) It does NOT say the port is
+ *                     unserved — an external launcher or supervisor may be serving
+ *                     it, which is why the message tells the caller to re-check.
  *   "unconfirmed"   — this call cannot tie what is (or is not) serving to the
  *                     launch/reboot it made. Two shapes reach it, and neither is a
  *                     failure: the readiness budget expired with nothing
@@ -2819,8 +2822,11 @@ export async function startComfyUI(): Promise<StartResult> {
     // needless recovery.
     started: mayClaimStart,
     ready: true,
-    // The API answered. This is the one path that may say so.
-    startup: "confirmed",
+    // The API answered — but WHOSE api (codex gate round 9). When the port is
+    // provably owned by a DIFFERENT process, this call's launch demonstrably did not
+    // produce the serving instance, and the message says exactly that. Emitting
+    // "confirmed" beside it would confirm the one thing just denied.
+    startup: ownership === "not-ours" ? "failed" : "confirmed",
     readiness,
     message:
       `ComfyUI ${ownership === "not-ours" ? "is ready" : "started"} on port ${port}${newPid ? ` (PID ${newPid})` : ""}` +
@@ -2985,10 +2991,12 @@ async function rebootViaManager(): Promise<RebootResult> {
           acked: false, // inferred from the proxy status, not acknowledged
           endpoint: path,
           method,
-          // The OBSERVED fact only. "the origin dropped … as it went down" narrated
-          // one of the two causes this branch covers as though it were established
-          // (codex gate round 8); what we saw is a status code from a proxy.
-          note: `a proxy in front of ComfyUI answered HTTP ${res.status}`,
+          // The OBSERVED fact ONLY. Two earlier versions of this string named a
+          // cause: "the origin dropped … as it went down" (gate round 8), then
+          // "a proxy in front of ComfyUI answered …" (gate round 9) — but nothing
+          // here identifies a proxy, and ComfyUI or the Manager can return these
+          // statuses directly. All that was seen is the status.
+          note: `the request returned HTTP ${res.status}`,
         };
       }
       // 404 / other non-OK: wrong route for this Manager build — try the next.

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -277,16 +277,25 @@ interface StartupReadinessResult {
 }
 
 /**
- * Did this call CONFIRM that ComfyUI is serving after the launch/reboot it made?
+ * Did this call CONFIRM that the launch/reboot IT MADE is serving?
+ *
+ * THE SUBJECT IS THIS CALL'S OWN ATTEMPT, never the machine (codex gate round 5 —
+ * the wording below said "ComfyUI is down" after the messages had already been
+ * corrected not to, which is the same bucket-narrated-as-a-cause defect hiding in a
+ * doc comment). Whatever else may be serving the port is `listener_ownership`'s
+ * subject, and on the failure path nothing has been observed about it at all.
  *
  * A STRING tri-state (four-state, with the never-tried case named) for the same
  * reason `listener_ownership` is one: the uncertain case has to survive
  * `JSON.stringify`, and it must be impossible to read as the definite negative.
  *
  *   "confirmed"     — the API answered. Observed.
- *   "failed"        — the process this call launched is GONE: a spawn error, a
- *                     recorded exit, or a liveness probe that came back
- *                     DEFINITELY dead. ComfyUI is down, and that is observed too.
+ *   "failed"        — THIS RELAUNCH failed: the process this call launched is GONE
+ *                     (a spawn error, a recorded exit, or a liveness probe that came
+ *                     back DEFINITELY dead) and no readiness probe got a healthy
+ *                     response. It does NOT say the port is unserved — an external
+ *                     launcher or supervisor may have restored one since the last
+ *                     probe, which is why the message tells the caller to re-check.
  *   "unconfirmed"   — the readiness budget expired with nothing contradicting the
  *                     start.
  *   "not-attempted" — this call never launched or rebooted anything (a refusal, or

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -298,8 +298,14 @@ interface StartupReadinessResult {
  *                     message.) It does NOT say the port is unserved either — an
  *                     external launcher or supervisor may have restored one, which
  *                     is why the message tells the caller to re-check.
- *   "unconfirmed"   — the readiness budget expired with nothing contradicting the
- *                     start.
+ *   "unconfirmed"   — this call cannot tie what is (or is not) serving to the
+ *                     launch/reboot it made. Two shapes reach it, and neither is a
+ *                     failure: the readiness budget expired with nothing
+ *                     contradicting the start; or the server IS healthy but no cycle
+ *                     was observed, which is every ComfyUI-Manager reboot — that
+ *                     path watches for a healthy probe, never for a down→up, so an
+ *                     accepted request in front of a server that never restarted
+ *                     looks identical to a successful one.
  *   "not-attempted" — this call never launched or rebooted anything (a refusal, or
  *                     a server that was already running). Stated rather than
  *                     omitted so it can never be mistaken for an older build that
@@ -2857,6 +2863,19 @@ export async function startComfyUI(): Promise<StartResult> {
 
 interface RebootResult {
   rebooting: boolean;
+  /**
+   * Did the Manager ACKNOWLEDGE the request, or is `rebooting` an INFERENCE?
+   *
+   * Only a non-catchall 2xx is an acknowledgement. A 502/503/504 from a proxy, or a
+   * connection dropping mid-request, are read as "the handler took it and the origin
+   * went down" — a good inference, and the reason this path works at all through a
+   * tunnel, but not something anybody observed. A tunnel hiccup in front of a server
+   * that was never restarted produces exactly the same signals (codex gate round 7).
+   *
+   * Carried so the report can say which of the two happened instead of calling both
+   * "accepted".
+   */
+  acked?: boolean;
   endpoint?: string;
   method?: string;
   reason?: string;
@@ -2946,7 +2965,8 @@ async function rebootViaManager(): Promise<RebootResult> {
           failures.push(`${method} ${path} → HTTP 200 (frontend catchall, not a reboot route)`);
           continue;
         }
-        return { rebooting: true, endpoint: path, method };
+        // The one path with a real acknowledgement from the Manager itself.
+        return { rebooting: true, acked: true, endpoint: path, method };
       }
       if (res.status === 403) {
         return {
@@ -2960,6 +2980,7 @@ async function rebootViaManager(): Promise<RebootResult> {
       if (res.status === 502 || res.status === 503 || res.status === 504) {
         return {
           rebooting: true,
+          acked: false, // inferred from the proxy status, not acknowledged
           endpoint: path,
           method,
           note: `reboot fired — the origin dropped behind a proxy (HTTP ${res.status}) as it went down`,
@@ -2971,6 +2992,7 @@ async function rebootViaManager(): Promise<RebootResult> {
       if (isConnectionDrop(err)) {
         return {
           rebooting: true,
+          acked: false, // inferred from the dropped connection, not acknowledged
           endpoint: path,
           method,
           note: "connection dropped (origin going down) — reboot fired",
@@ -3144,7 +3166,10 @@ async function restartViaManagerReboot(context: {
         // equally consistent with a server that was never reachable from here. The
         // accepted reboot is the one thing we did observe, so it is the one thing
         // claimed.
-        "The ComfyUI-Manager reboot was accepted, but no readiness probe got a " +
+        (reboot.acked
+          ? "The ComfyUI-Manager reboot request was acknowledged"
+          : "A ComfyUI-Manager reboot was dispatched (no acknowledgement came back)") +
+        ", but no readiness probe got a " +
         `healthy response from ${readiness.probe_url} within ${waitedS}s ` +
         `(${readiness.attempts}/${readiness.max_tries} probes over a ` +
         `COMFYUI_REMOTE_REBOOT_BUDGET_S=${seconds(timing.budgetMs)}s budget). That budget ` +
@@ -3166,8 +3191,11 @@ async function restartViaManagerReboot(context: {
   resetClient();
   resetObjectInfoCache();
   resetManagerApiCache("comfyui rebooted via Manager");
-  // #742 r4/r5: the dispatched restart was observed back — clear OUR record
-  // (the process-wide slot only; never another session's record).
+  // #742 r4/r5: the instance this restart was dispatched to is ANSWERING again, so
+  // the record has served its purpose — a later DOWN report can no longer be about
+  // this dispatch. (Not "observed back": nothing here watched a cycle. Clearing on a
+  // healthy endpoint is the conservative direction — it only ever REMOVES grounds
+  // for naming causation.)
   clearRestartDispatch(PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
 
   // #848: it is back — now say whether it came back as the SAME thing. Read after
@@ -3185,27 +3213,44 @@ async function restartViaManagerReboot(context: {
 
   return {
     stopped: true,
+    // THE FIELDS MUST AGREE WITH THE SENTENCE (codex gate round 7). A message that
+    // says the cycle was not observed, beside `startup:"confirmed"`, hands a caller
+    // reading the JSON the definite signal the prose just withheld — and the JSON is
+    // what an agent keys on.
+    //
+    // `started` stays TRUE on the same standing ruling as `listener_ownership`: a
+    // restart WAS dispatched and the server IS serving, and denying that would
+    // report every ordinary Desktop and remote restart as failed — a far more
+    // common and more damaging lie than an unconfirmed success the message
+    // qualifies. `startup` is what carries the gap.
     started: true,
     ready: true,
-    startup: "confirmed",
+    startup: "unconfirmed",
     readiness,
-    // WHAT THIS PATH ACTUALLY SAW (codex gate round 6): the reboot request was
-    // ACCEPTED, and a later probe found the server healthy. It never watched
-    // ComfyUI go down and come back — this poller has no down→up requirement at
-    // all, unlike the panel path, which certifies only on an observed cycle. So
-    // "rebooted and came back ready" claimed the one thing nobody here observed.
+    // WHAT THIS PATH ACTUALLY SAW (codex gate rounds 6 and 7): a reboot request that
+    // was either acknowledged or INFERRED to have landed, and a later probe finding
+    // the server healthy. It never watched ComfyUI go down and come back — this
+    // poller has no down→up requirement at all, unlike the panel path, which
+    // certifies only on an observed cycle. So "rebooted and came back ready" claimed
+    // the one thing nobody here observed.
     //
     // The distinction is not academic: a Manager that accepts the request and then
-    // does nothing leaves a healthy server that was never restarted, and a user
-    // told it "came back" stops looking for the reason their change did not apply.
+    // does nothing — or a tunnel hiccup read as "the origin went down" in front of a
+    // server that never restarted — leaves a healthy instance that was never cycled,
+    // and a user told it "came back" stops looking for why their change did not
+    // apply. Both halves are therefore stated as what they are.
     message:
-      `The ComfyUI-Manager reboot request was accepted and ComfyUI is healthy now ` +
-      `(${readiness.waited_ms}ms) — ${context.label}/supervised restart. The cycle itself ` +
-      `was not directly observed from here, so verify with health_check if you need ` +
-      `certainty that it actually restarted.` +
+      (reboot.acked
+        ? "The ComfyUI-Manager reboot request was acknowledged"
+        : "A ComfyUI-Manager reboot was dispatched (no acknowledgement came back — the " +
+          "connection dropped as it was sent, which usually means the handler took it)") +
+      ` and ComfyUI is healthy now (${readiness.waited_ms}ms) — ${context.label}/supervised ` +
+      "restart. The cycle itself was not directly observed from here, so verify with " +
+      "health_check if you need certainty that it actually restarted." +
       argvNote,
-    // The supervisor that owns the process cycled it; we launched nothing, so we
-    // cannot (and must not) claim the listener as ours.
+    // We launched nothing on this path — a supervisor is what would have cycled the
+    // process — so the listener is never ours to claim. (Nor is it established that
+    // one DID cycle it; that is `startup`'s business, and it says "unconfirmed".)
     listener_ownership: unclassifiedOwnership(),
   };
 }

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -304,13 +304,20 @@ interface StartupReadinessResult {
  *                     unserved — an external launcher or supervisor may be serving
  *                     it, which is why the message tells the caller to re-check.
  *   "unconfirmed"   — this call cannot tie what is (or is not) serving to the
- *                     launch/reboot it made. Two shapes reach it, and neither is a
- *                     failure: the readiness budget expired with nothing
- *                     contradicting the start; or the server IS healthy but no cycle
- *                     was observed, which is every ComfyUI-Manager reboot — that
- *                     path watches for a healthy probe, never for a down→up, so an
- *                     accepted request in front of a server that never restarted
- *                     looks identical to a successful one.
+ *                     launch/reboot it made. THREE shapes reach it, none a failure,
+ *                     and `ready` is what tells them apart:
+ *                       • ready:false — the readiness budget expired with nothing
+ *                         contradicting the start (#367);
+ *                       • ready:true, local — the server is up but the port owner
+ *                         could not be mapped, so our process cannot be shown to be
+ *                         the listener (the #449 shape);
+ *                       • ready:true, Manager reboot — the server is up but no cycle
+ *                         was observed, which is EVERY Manager reboot: that path
+ *                         watches for a healthy probe, never for a down→up, so an
+ *                         accepted request in front of a server that never restarted
+ *                         looks identical to a successful one.
+ *                     A caller composing its own message MUST check `ready` before
+ *                     saying anything about the server being up.
  *   "not-attempted" — this call never launched or rebooted anything (a refusal, or
  *                     a server that was already running). Stated rather than
  *                     omitted so it can never be mistaken for an older build that
@@ -2822,11 +2829,26 @@ export async function startComfyUI(): Promise<StartResult> {
     // needless recovery.
     started: mayClaimStart,
     ready: true,
-    // The API answered — but WHOSE api (codex gate round 9). When the port is
-    // provably owned by a DIFFERENT process, this call's launch demonstrably did not
-    // produce the serving instance, and the message says exactly that. Emitting
-    // "confirmed" beside it would confirm the one thing just denied.
-    startup: ownership === "not-ours" ? "failed" : "confirmed",
+    // The API answered — but WHOSE API (codex gate rounds 9 and 10). `startup`
+    // answers "did this call confirm that the launch IT MADE is serving?", so on
+    // this path it simply MIRRORS the attribution verdict rather than reporting the
+    // healthy probe and stopping there:
+    //   ours        → confirmed. Our process is the listener.
+    //   not-ours    → failed. Observed: something else is serving, so our relaunch
+    //                 is not what came up.
+    //   unconfirmed → unconfirmed. The port owner could not be mapped; the message
+    //                 says so in as many words, and emitting "confirmed" beside it
+    //                 handed a structured consumer the attribution the prose had
+    //                 just withheld.
+    // `started` deliberately does NOT follow it down on `unconfirmed`: a process of
+    // ours demonstrably exists there and only its attribution is uncertain, which is
+    // the standing listener_ownership ruling. `startup` is what carries that gap.
+    startup:
+      ownership === "ours"
+        ? "confirmed"
+        : ownership === "not-ours"
+          ? "failed"
+          : "unconfirmed",
     readiness,
     message:
       `ComfyUI ${ownership === "not-ours" ? "is ready" : "started"} on port ${port}${newPid ? ` (PID ${newPid})` : ""}` +
@@ -3267,8 +3289,12 @@ async function restartViaManagerReboot(context: {
           // covers a proxy status AND a dropped connection, and the earlier sentence
           // told every user the connection dropped (codex gate round 8). The
           // inference is offered as one, which is all it is.
-          `A ComfyUI-Manager reboot was dispatched but not acknowledged (${reboot.note ?? "no reply"}), ` +
-          "which usually means the handler accepted it and the server went down.") +
+          // No "which usually means the handler accepted it and the server went
+          // down" (codex gate round 10). Handler acceptance and a down transition
+          // are both inferences, "usually" is a frequency claim nobody measured, and
+          // the sentence undercut the very next one, which correctly says the cycle
+          // was not observed. What was seen is enough.
+          `A ComfyUI-Manager reboot was dispatched but not acknowledged (${reboot.note ?? "no reply"}).`) +
       ` ComfyUI is healthy now (${readiness.waited_ms}ms) — ${context.label}/supervised ` +
       "restart. The cycle itself was not directly observed from here, so verify with " +
       "health_check if you need certainty that it actually restarted." +
@@ -3410,7 +3436,14 @@ export async function restartComfyUI(): Promise<RestartResult> {
   // The old `started:false` sent it down the other branch instead, printing "could
   // not be started" over a server that was usually seconds from ready. Both are the
   // same mistake: a boolean answering a question the evidence does not settle.
-  if (startResult.startup === "unconfirmed") {
+  // `ready !== true` is load-bearing, not belt-and-braces (caught by the suite when
+  // round 10 widened `unconfirmed` to cover unmappable ATTRIBUTION as well as an
+  // expired budget). Both are "we cannot tie the serving instance to our launch",
+  // but only one of them has nothing serving — and this composition is about that
+  // one. A healthy-but-unattributed restart taking this branch would have been told
+  // "NOT CONFIRMED YET" about a server that was answering, and would also have
+  // skipped the dispatch-record clear below.
+  if (startResult.startup === "unconfirmed" && startResult.ready !== true) {
     return {
       stopped: true,
       started: true,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -2990,8 +2990,15 @@ async function restartViaManagerReboot(context: {
    * caller gathered them anyway. Supplied rather than re-read so no extra probe is
    * inserted ahead of an irreversible dispatch; when absent it is read here, from a
    * call that can neither throw nor hang.
+   *
+   * The target GENERATION AT THE MOMENT THOSE ARGUMENTS WERE READ travels with them
+   * and is not optional (codex gate round 2). Capturing the generation here instead
+   * would fence only the window this function can see, while the reading itself
+   * happened earlier in the caller — a retarget in between would leave the "before"
+   * argv belonging to instance A and everything afterwards to B, with no generation
+   * change left for the check to notice.
    */
-  priorArgv?: string[];
+  prior?: { argv: string[]; generation: number };
   /** Is this a ComfyUI Desktop instance? Selects the remedy in the #848 sentence. */
   isDesktop?: boolean;
 }): Promise<RestartResult> {
@@ -3009,11 +3016,18 @@ async function restartViaManagerReboot(context: {
   //
   // Judged by the monotonic GENERATION, not by a final-state base comparison: an
   // A→B→A round trip leaves the base equal and is exactly what the generation exists
-  // to catch (the same r11 rule the panel restart's preflight uses).
-  const argvGeneration = getComfyuiTargetGeneration();
-  const priorArgv = context.priorArgv?.length
-    ? context.priorArgv
+  // to catch (the same r11 rule the panel restart's preflight uses). The generation
+  // is taken FROM THE READING, not from this moment — see `prior`.
+  // Captured BEFORE our own read, not after it: a retarget landing mid-read would
+  // otherwise be stamped with the NEW generation and sail through the check below
+  // while the reading itself came from the old instance.
+  const selfReadGeneration = getComfyuiTargetGeneration();
+  const priorArgv = context.prior?.argv.length
+    ? context.prior.argv
     : await readServingArgv();
+  const argvGeneration = context.prior?.argv.length
+    ? context.prior.generation
+    : selfReadGeneration;
 
   const reboot = await rebootViaManager();
   if (!reboot.rebooting) {
@@ -3071,7 +3085,12 @@ async function restartViaManagerReboot(context: {
       startup: "unconfirmed",
       readiness,
       message:
-        "The ComfyUI-Manager reboot was accepted and ComfyUI went down, but it had not " +
+        // NOT "and ComfyUI went down" (codex gate round 2). Nothing observed a down
+        // transition: the poller only records that no probe got a 2xx, which is
+        // equally consistent with a server that was never reachable from here. The
+        // accepted reboot is the one thing we did observe, so it is the one thing
+        // claimed.
+        "The ComfyUI-Manager reboot was accepted, but ComfyUI had not " +
         `answered on ${readiness.probe_url} within ${waitedS}s ` +
         `(${readiness.attempts}/${readiness.max_tries} probes over a ` +
         `COMFYUI_REMOTE_REBOOT_BUDGET_S=${seconds(timing.budgetMs)}s budget). That budget ` +
@@ -3134,6 +3153,12 @@ export async function restartComfyUI(): Promise<RestartResult> {
   }
   logger.info("Restarting ComfyUI...");
 
+  // #848: the target generation as of BEFORE the instance is resolved, so the argv
+  // that resolution observes can be fenced to the instance it was actually read
+  // from. It travels with the argv into the Desktop reboot below; capturing it
+  // there instead would leave the read itself outside the fence (codex gate r2).
+  const infoGeneration = getComfyuiTargetGeneration();
+
   // Preflight: resolve the RUNNING instance and confirm we can relaunch it
   // BEFORE stopping anything. A restart must be atomic-ish — if the relaunch
   // command can't be built/validated (stale COMFYUI_PATH, unknown Desktop exe),
@@ -3182,7 +3207,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
     // no extra probe, and it is the reading taken closest to the stop.
     return restartViaManagerReboot({
       label: "Desktop",
-      priorArgv: info.argv,
+      prior: { argv: info.argv, generation: infoGeneration },
       isDesktop: true,
     });
   }

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -3600,15 +3600,39 @@ export async function restartComfyUI(): Promise<RestartResult> {
       probeUrl: restartProbeUrl,
     });
   } catch (err) {
+    // DISCLOSE, do not refuse: the stop is not undoable, so the caller needs a
+    // description of where things stand rather than "nothing happened".
+    //
+    // But do not overclaim the other way either. An earlier draft of this said
+    // "ComfyUI is NOT running" — an unverified negative, and this branch's own
+    // defect class (a throw we could not interpret, reported as a definite
+    // down). We do not know that: the throw may have landed AFTER a spawn, or a
+    // supervisor may have brought the instance back while we were unwinding. So
+    // ASK, once, and say only what the answer supports.
+    const probe = await waitForApiReady({
+      intervalMs: 250,
+      maxTries: 1,
+      probeUrl: restartProbeUrl,
+    });
     return {
       stopped: true,
       started: false,
-      // DISCLOSE, do not refuse: the stop is not undoable and the caller's server
-      // really is down. A refusal here would read as "nothing happened".
-      startup: "not-attempted",
+      ready: probe.ready,
+      // Not "not-attempted": the relaunch WAS attempted and threw partway. What
+      // we cannot say is whether it took effect — which is what `unconfirmed`
+      // means, and why it exists (#367).
+      startup: "unconfirmed",
+      readiness: probe,
       message:
-        `ComfyUI was stopped, but the relaunch could not be attempted: ${errorText(err)}. ` +
-        `ComfyUI is NOT running. Start it with start_comfyui once the cause is cleared.` +
+        `ComfyUI was stopped, and the relaunch failed partway: ${errorText(err)}. ` +
+        (probe.ready
+          ? `Something IS answering on ${restartProbeUrl} now — possibly a supervisor ` +
+            `brought it back, or the relaunch got further than the error suggests. ` +
+            `This call cannot claim that server as its own.`
+          : `Nothing answered on ${restartProbeUrl} when asked just now, so ComfyUI ` +
+            `is most likely down — but the relaunch failed in a way this call could ` +
+            `not interpret, so that is a single observation and not a settled fact. ` +
+            `Check the server, and use start_comfyui once the cause is cleared.`) +
         stopCaveat,
       listener_ownership: unclassifiedOwnership(),
     };

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -3225,7 +3225,20 @@ async function restartViaManagerReboot(context: {
   // been dispatched yet, so this is a REFUSAL, not an uncertain outcome — the
   // one shape where refusing is strictly right (nothing has happened, and
   // proceeding would act on the wrong machine).
-  if (getComfyuiTargetGeneration() !== selfReadGeneration) {
+  //
+  // Tested on the BASE, not the generation. `setComfyuiTarget` bumps the
+  // generation on every successful call, including a same-URL reaffirmation
+  // that moves nothing — refusing on that would be this very defect class
+  // pointed the other way: a bucket ("the target was touched") standing in for
+  // the question that actually matters ("is the server I am about to reboot the
+  // one whose argv I just read?"). The base answers that directly.
+  //
+  // The generation still governs the ARGV COMPARISON further down, where it is
+  // the right test for a different question: an A→B→A round trip leaves the base
+  // equal but means the two readings may not describe the same server, so that
+  // comparison declines while this dispatch correctly proceeds — the reboot goes
+  // to the URL we read either way.
+  if (getComfyUIBaseUrl() !== anchoredBase) {
     return {
       stopped: false,
       started: false,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -290,12 +290,14 @@ interface StartupReadinessResult {
  * `JSON.stringify`, and it must be impossible to read as the definite negative.
  *
  *   "confirmed"     — the API answered. Observed.
- *   "failed"        — THIS RELAUNCH failed: the process this call launched is GONE
- *                     (a spawn error, a recorded exit, or a liveness probe that came
- *                     back DEFINITELY dead) and no readiness probe got a healthy
- *                     response. It does NOT say the port is unserved — an external
- *                     launcher or supervisor may have restored one since the last
- *                     probe, which is why the message tells the caller to re-check.
+ *   "failed"        — THIS RELAUNCH failed: the process this call launched is GONE —
+ *                     a spawn error, a recorded exit, or a liveness probe that came
+ *                     back DEFINITELY dead. (The spawn-error path can return before
+ *                     the readiness poll has run at all, so this verdict carries no
+ *                     claim about probes; the ones that DID poll say so in their own
+ *                     message.) It does NOT say the port is unserved either — an
+ *                     external launcher or supervisor may have restored one, which
+ *                     is why the message tells the caller to re-check.
  *   "unconfirmed"   — the readiness budget expired with nothing contradicting the
  *                     start.
  *   "not-attempted" — this call never launched or rebooted anything (a refusal, or
@@ -3099,10 +3101,12 @@ async function restartViaManagerReboot(context: {
     note: reboot.note,
   });
 
-  // The reboot HAS been accepted — the server is going down regardless of what
-  // the readiness poll below concludes. Drop the detected dialect now so the
-  // timed-out branch (which returns early) can't leave the pre-reboot dialect
-  // pinned for the instance that eventually comes back (#646).
+  // The reboot HAS been accepted, so the server MAY cycle at any moment from here
+  // — whatever the readiness poll below concludes, and whether or not we ever see
+  // it happen (codex gate round 6: "the server is going down regardless" asserted a
+  // cycle nothing observed). Dropping the detected dialect now is the conservative
+  // move either way: the timed-out branch returns early, and must not leave the
+  // pre-reboot dialect pinned for an instance that may come back different (#646).
   resetManagerApiCache("comfyui reboot fired via Manager");
   // #742 r4/r5: record the dispatch — a later decline-path DOWN report may
   // name restart causation only against such a record. No session identity
@@ -3185,9 +3189,20 @@ async function restartViaManagerReboot(context: {
     ready: true,
     startup: "confirmed",
     readiness,
+    // WHAT THIS PATH ACTUALLY SAW (codex gate round 6): the reboot request was
+    // ACCEPTED, and a later probe found the server healthy. It never watched
+    // ComfyUI go down and come back — this poller has no down→up requirement at
+    // all, unlike the panel path, which certifies only on an observed cycle. So
+    // "rebooted and came back ready" claimed the one thing nobody here observed.
+    //
+    // The distinction is not academic: a Manager that accepts the request and then
+    // does nothing leaves a healthy server that was never restarted, and a user
+    // told it "came back" stops looking for the reason their change did not apply.
     message:
-      `ComfyUI rebooted via ComfyUI-Manager and came back ready (${readiness.waited_ms}ms) — ` +
-      `${context.label}/supervised restart.` +
+      `The ComfyUI-Manager reboot request was accepted and ComfyUI is healthy now ` +
+      `(${readiness.waited_ms}ms) — ${context.label}/supervised restart. The cycle itself ` +
+      `was not directly observed from here, so verify with health_check if you need ` +
+      `certainty that it actually restarted.` +
       argvNote,
     // The supervisor that owns the process cycled it; we launched nothing, so we
     // cannot (and must not) claim the listener as ours.

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -9,7 +9,12 @@ import { existsSync, readlinkSync, statSync } from "node:fs";
 import { platform } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { getSystemStats, resetClient, resetObjectInfoCache } from "../comfyui/client.js";
-import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
+import {
+  config,
+  getComfyUIBaseUrl,
+  getComfyuiTargetGeneration,
+  isRemoteMode,
+} from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -807,7 +812,16 @@ function describeLaunchedChildExit(
   exit: { code: number | null; signal: NodeJS.Signals | null } | undefined,
 ): string {
   if (!exit) return "";
-  return ` The process this call launched EXITED (${exitCause(exit)}) before the API came up, so ComfyUI is DOWN — this was a failed relaunch, not a slow start.`;
+  // WHAT THE EXIT PROVES, AND WHAT IT DOES NOT (codex gate). It proves THIS
+  // RELAUNCH failed — decisively, and that is the point: it separates a real
+  // failure from a slow start (#367). It does NOT prove ComfyUI is down NOW. The
+  // only evidence about the port is the readiness poll, whose last probe is already
+  // in the past, and an external supervisor restarting the server a moment later is
+  // exactly the case this file spends its length refusing to guess about. The
+  // earlier wording said "so ComfyUI is DOWN" — a claim about the machine's present
+  // state derived from a fact about our own child, which is the same
+  // observed-earlier-reported-as-now defect this change exists to remove.
+  return ` The process this call launched EXITED (${exitCause(exit)}) before the API came up, so THIS RELAUNCH FAILED — it was not a slow start. The API was still not answering at the last probe.`;
 }
 
 /** Whole seconds, never rounded down to a "within 0s" that reads as no wait. */
@@ -891,13 +905,17 @@ export function describeArgvDrift(
         .join(" ")} / now ${after.map(quoteToken).join(" ")}.`
     );
   }
+  // WHAT EQUAL ARGV ESTABLISHES (codex gate). It establishes that THIS RESTART did
+  // not change them — nothing more. It is not a reading of the user's saved settings
+  // (we never opened them), so it cannot say a saved change "was ignored": the edit
+  // may have been to something argv does not carry at all. The remedy is therefore
+  // offered CONDITIONALLY, on the user's own expectation, which only they can check.
   return (
-    ` Its launch arguments are UNCHANGED (${after.map(quoteToken).join(" ")}), so if you edited ` +
+    ` Its launch arguments are UNCHANGED (${after.map(quoteToken).join(" ")}) — this restart did not change them. ` +
+    "If you were expecting different arguments" +
     (isDesktop
-      ? "ComfyUI Desktop's saved launch arguments expecting this restart to pick them up, it did NOT. " +
-        "Fully quit the ComfyUI Desktop app and relaunch it, so it spawns the server from those saved settings."
-      : "the launch arguments on the host expecting this restart to pick them up, it did NOT. " +
-        "Stop ComfyUI and start it again from its own launcher so the new arguments are used.")
+      ? " (after editing ComfyUI Desktop's saved launch settings, say), they are not in effect here: fully quit the ComfyUI Desktop app and relaunch it so it spawns the server from those settings."
+      : " (after editing the launch command on the host, say), they are not in effect here: stop ComfyUI and start it again from its own launcher so the new arguments are used.")
   );
 }
 
@@ -2611,27 +2629,29 @@ export async function startComfyUI(): Promise<StartResult> {
       return {
         started: false,
         ready: false,
-        // OBSERVED death. ComfyUI is down, and we watched it happen.
+        // OBSERVED death of the process WE launched. `startup` is a verdict about
+        // this call's own launch, which is precisely the thing we watched — it never
+        // claimed to describe whatever may be serving the port.
         startup: "failed",
         readiness,
-        // TRUTHFUL FAILURE (#776): the process was spawned and then died, so
-        // ComfyUI is DOWN. Report that plainly — and name the environment it was
-        // launched into, which is the first thing to check when a relaunch of an
-        // otherwise-healthy install fails during import.
+        // TRUTHFUL FAILURE (#776): the process was spawned and then died, so the
+        // relaunch failed during startup. Report that plainly — and name the
+        // environment it was launched into, which is the first thing to check when a
+        // relaunch of an otherwise-healthy install fails during import.
         message:
           `ComfyUI process was launched but the API did not become ready after ${readiness.waited_ms}ms (${readiness.attempts}/${readiness.max_tries} probes).` +
           (launchedChildExit
             ? describeLaunchedChildExit(launchedChildExit)
             : launchedSpawnFailed
-              ? " The launch itself failed — the process could not be spawned — so ComfyUI is DOWN; this was a failed relaunch, not a slow start."
-              : " The process this call launched is no longer running, so ComfyUI is DOWN — this was a failed relaunch, not a slow start.") +
-          " Check the ComfyUI logs." +
+              ? " The launch itself failed — the process could not be spawned — so THIS RELAUNCH FAILED; it was not a slow start. The API was still not answering at the last probe."
+              : " The process this call launched is no longer running, so THIS RELAUNCH FAILED — it was not a slow start. The API was still not answering at the last probe.") +
+          " Check the ComfyUI logs, and re-check with health_check before assuming nothing is serving the port — an external launcher or supervisor may have brought one back since." +
           (env ? ` Launch environment: ${env.note}.` : "") +
           launchEnvWarning(info),
         auto_restart: supervisorResult(info),
         launch_env: env,
-        // Nothing is serving the port, so there is no listener to attribute — the
-        // down state is already carried by started:false / ready:false.
+        // Nothing answered during the poll, so there is no listener to attribute.
+        // This is the ABSENCE of an attribution, not a claim that the port is free.
         listener_ownership: unclassifiedOwnership(),
       };
     }
@@ -2980,6 +3000,17 @@ async function restartViaManagerReboot(context: {
   // #848: capture what it is running BEFORE the reboot, so the report afterwards can
   // say whether that changed. Total and bounded (see readServingArgv) — it is only
   // ever detail in a message, and must not be able to cost anyone their restart.
+  //
+  // INSTANCE FENCE (codex gate). Both argv reads go through the MUTABLE configured
+  // target, so a retarget between them would compare instance A's arguments against
+  // instance B's and narrate the difference as a change to one server. Comparing two
+  // readings of DIFFERENT servers is worse than not comparing at all — it would
+  // invent both the "UNCHANGED" no-op and the "CHANGED" confirmation.
+  //
+  // Judged by the monotonic GENERATION, not by a final-state base comparison: an
+  // A→B→A round trip leaves the base equal and is exactly what the generation exists
+  // to catch (the same r11 rule the panel restart's preflight uses).
+  const argvGeneration = getComfyuiTargetGeneration();
   const priorArgv = context.priorArgv?.length
     ? context.priorArgv
     : await readServingArgv();
@@ -3069,11 +3100,15 @@ async function restartViaManagerReboot(context: {
   // #848: it is back — now say whether it came back as the SAME thing. Read after
   // readiness, on a path where nothing destructive is pending, so a slow or missing
   // answer costs only the detail (describeArgvDrift stays silent without both).
-  const argvNote = describeArgvDrift(
-    priorArgv,
-    await readServingArgv(),
-    context.isDesktop === true,
-  );
+  // Suppressed entirely if the configured target moved at ANY point since the first
+  // reading — including during this one — because the two readings would then
+  // describe two different servers. The generation is re-checked AFTER the read, so
+  // a retarget that lands mid-read is caught too.
+  const afterArgv = await readServingArgv();
+  const argvNote =
+    getComfyuiTargetGeneration() === argvGeneration
+      ? describeArgvDrift(priorArgv, afterArgv, context.isDesktop === true)
+      : "";
 
   return {
     stopped: true,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -812,16 +812,18 @@ function describeLaunchedChildExit(
   exit: { code: number | null; signal: NodeJS.Signals | null } | undefined,
 ): string {
   if (!exit) return "";
-  // WHAT THE EXIT PROVES, AND WHAT IT DOES NOT (codex gate). It proves THIS
+  // WHAT THE EXIT PROVES, AND WHAT IT DOES NOT (codex gate, twice). It proves THIS
   // RELAUNCH failed — decisively, and that is the point: it separates a real
-  // failure from a slow start (#367). It does NOT prove ComfyUI is down NOW. The
+  // failure from a slow start (#367). It does NOT prove ComfyUI is down NOW: the
   // only evidence about the port is the readiness poll, whose last probe is already
   // in the past, and an external supervisor restarting the server a moment later is
-  // exactly the case this file spends its length refusing to guess about. The
-  // earlier wording said "so ComfyUI is DOWN" — a claim about the machine's present
-  // state derived from a fact about our own child, which is the same
-  // observed-earlier-reported-as-now defect this change exists to remove.
-  return ` The process this call launched EXITED (${exitCause(exit)}) before the API came up, so THIS RELAUNCH FAILED — it was not a slow start. The API was still not answering at the last probe.`;
+  // exactly the case this file spends its length refusing to guess about.
+  //
+  // Nor does it prove the API never came up: a poll only establishes that no
+  // SCHEDULED PROBE got a 2xx, and the server could have answered between two of
+  // them. So "before the API came up" is gone too — every clause here now names an
+  // observation rather than an inference from a gap between observations.
+  return ` The process this call launched EXITED (${exitCause(exit)}), so THIS RELAUNCH FAILED — it was not a slow start. No readiness probe got a response, the last one included.`;
 }
 
 /** Whole seconds, never rounded down to a "within 0s" that reads as no wait. */
@@ -905,13 +907,20 @@ export function describeArgvDrift(
         .join(" ")} / now ${after.map(quoteToken).join(" ")}.`
     );
   }
-  // WHAT EQUAL ARGV ESTABLISHES (codex gate). It establishes that THIS RESTART did
-  // not change them — nothing more. It is not a reading of the user's saved settings
-  // (we never opened them), so it cannot say a saved change "was ignored": the edit
-  // may have been to something argv does not carry at all. The remedy is therefore
-  // offered CONDITIONALLY, on the user's own expectation, which only they can check.
+  // WHAT EQUAL ARGV ESTABLISHES (codex gate, twice). Two readings matched. That is
+  // all — and it is deliberately phrased as the pair of observations it is:
+  //   - it is NOT a reading of the user's saved settings (we never opened them), so
+  //     it cannot say a saved change "was ignored"; the edit may have been to
+  //     something argv does not carry at all; and
+  //   - it is NOT a causal claim about the restart either. "This restart did not
+  //     change them" says the restart had no effect on argv, which two equal
+  //     snapshots cannot show: a value can change and change back, and an accepted
+  //     Manager request is not proof a cycle even happened.
+  // What IS supportable is the present state — the arguments in force NOW are the
+  // old ones — so the remedy hangs off that, conditioned on the user's own
+  // expectation, which only they can check.
   return (
-    ` Its launch arguments are UNCHANGED (${after.map(quoteToken).join(" ")}) — this restart did not change them. ` +
+    ` Its launch arguments are UNCHANGED (${after.map(quoteToken).join(" ")}) — the same arguments were observed before and after this restart. ` +
     "If you were expecting different arguments" +
     (isDesktop
       ? " (after editing ComfyUI Desktop's saved launch settings, say), they are not in effect here: fully quit the ComfyUI Desktop app and relaunch it so it spawns the server from those settings."
@@ -2639,12 +2648,15 @@ export async function startComfyUI(): Promise<StartResult> {
         // environment it was launched into, which is the first thing to check when a
         // relaunch of an otherwise-healthy install fails during import.
         message:
-          `ComfyUI process was launched but the API did not become ready after ${readiness.waited_ms}ms (${readiness.attempts}/${readiness.max_tries} probes).` +
+          // "no probe got a response in Nms", not "the API did not become ready": a
+          // poll establishes only what the SCHEDULED PROBES saw, and the server could
+          // have answered in a gap between two of them (codex gate round 3).
+          `ComfyUI process was launched, but no readiness probe got a response in ${readiness.waited_ms}ms (${readiness.attempts}/${readiness.max_tries} probes).` +
           (launchedChildExit
             ? describeLaunchedChildExit(launchedChildExit)
             : launchedSpawnFailed
-              ? " The launch itself failed — the process could not be spawned — so THIS RELAUNCH FAILED; it was not a slow start. The API was still not answering at the last probe."
-              : " The process this call launched is no longer running, so THIS RELAUNCH FAILED — it was not a slow start. The API was still not answering at the last probe.") +
+              ? " The launch itself failed — the process could not be spawned — so THIS RELAUNCH FAILED; it was not a slow start."
+              : " The process this call launched is no longer running, so THIS RELAUNCH FAILED — it was not a slow start.") +
           " Check the ComfyUI logs, and re-check with health_check before assuming nothing is serving the port — an external launcher or supervisor may have brought one back since." +
           (env ? ` Launch environment: ${env.note}.` : "") +
           launchEnvWarning(info),

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -16,6 +16,7 @@ import {
   isRemoteMode,
 } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
+import { errorText } from "../orchestrator/error-text.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { findComfyuiPython } from "./env-capabilities.js";
@@ -2559,7 +2560,15 @@ export async function startComfyUI(anchor?: {
   port?: number;
   probeUrl?: string;
 }): Promise<StartResult> {
-  if (isRemoteMode()) {
+  // The refusal is for a DIRECT `start_comfyui`, which has no instance in mind
+  // and would otherwise launch a local server while the caller is looking at a
+  // remote one. An ANCHORED call is a different question: a restart already
+  // stopped a specific local instance and is putting it back. Refusing there
+  // because another agent retargeted to remote during the stop window left that
+  // instance killed and abandoned, with the exception escaping past the point of
+  // no return (codex gate P0). The anchor is the evidence that this is a
+  // relaunch, not a fresh launch.
+  if (isRemoteMode() && !anchor) {
     throw new ProcessControlError(
       "start_comfyui launches ComfyUI on the local machine and is not " +
         "available when targeting a remote instance via --comfyui-url.",
@@ -3034,8 +3043,13 @@ async function looksLikeSpaCatchall(res: Response): Promise<boolean> {
   }
 }
 
-async function rebootViaManager(): Promise<RebootResult> {
-  const base = getComfyUIBaseUrl();
+/**
+ * @param base the ALREADY-PINNED target. Not re-read from config here (codex
+ * gate P0): the caller resolved which instance it is restarting before its own
+ * awaits, and re-reading the mutable base at dispatch time is how a reboot
+ * meant for A gets posted to B.
+ */
+async function rebootViaManager(base: string): Promise<RebootResult> {
   const failures: string[] = [];
 
   for (const { path, method } of REBOOT_ROUTES) {
@@ -3191,6 +3205,12 @@ async function restartViaManagerReboot(context: {
   // otherwise be stamped with the NEW generation and sail through the check below
   // while the reading itself came from the old instance.
   const selfReadGeneration = getComfyuiTargetGeneration();
+  // Pinned HERE, with the generation, and used for every step below: the
+  // dispatch, the dispatch record, and the readiness probe. Each of those used
+  // to call `getComfyUIBaseUrl()` afresh, so a retarget landing in any of the
+  // gaps between them sent the reboot to one server, recorded a second, and
+  // reported the health of a third (codex gate P0/P1).
+  const anchoredBase = getComfyUIBaseUrl();
   const priorArgv = context.prior?.argv.length
     ? context.prior.argv
     : await readServingArgv();
@@ -3198,7 +3218,28 @@ async function restartViaManagerReboot(context: {
     ? context.prior.generation
     : selfReadGeneration;
 
-  const reboot = await rebootViaManager();
+  // FENCE BEFORE DISPATCH. Everything above this line is observation; the reboot
+  // below is the irreversible act. A retarget that landed during the argv read
+  // means the arguments we hold describe a different server than the one the
+  // config now names, and we cannot know which the caller meant. Nothing has
+  // been dispatched yet, so this is a REFUSAL, not an uncertain outcome — the
+  // one shape where refusing is strictly right (nothing has happened, and
+  // proceeding would act on the wrong machine).
+  if (getComfyuiTargetGeneration() !== selfReadGeneration) {
+    return {
+      stopped: false,
+      started: false,
+      startup: "not-attempted",
+      message:
+        "The configured ComfyUI target changed while this restart was preparing, " +
+        "so the reboot was not sent — it would have gone to a different server " +
+        "than the one this call read. Nothing was restarted. Re-run the restart " +
+        "to act on the current target.",
+      listener_ownership: unclassifiedOwnership(),
+    };
+  }
+
+  const reboot = await rebootViaManager(anchoredBase);
   if (!reboot.rebooting) {
     return {
       stopped: false,
@@ -3232,7 +3273,7 @@ async function restartViaManagerReboot(context: {
   // name restart causation only against such a record. No session identity
   // exists here, so stamp the shared PROCESS-WIDE slot (never grounds
   // causation on its own).
-  recordRestartDispatch(getComfyUIBaseUrl(), PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
+  recordRestartDispatch(anchoredBase, PROCESS_WIDE_RESTART_DISPATCH_TOKEN);
 
   const timing = getRemoteRebootTiming();
   if (timing.settleMs > 0) await sleep(timing.settleMs);
@@ -3242,7 +3283,14 @@ async function restartViaManagerReboot(context: {
   // hanging the tool call if the host never returns.
   const intervalMs = Math.max(250, timing.intervalMs);
   const maxTries = Math.max(1, Math.ceil(timing.budgetMs / intervalMs));
-  const readiness = await waitForApiReady({ intervalMs, maxTries });
+  const readiness = await waitForApiReady({
+    intervalMs,
+    maxTries,
+    // Poll the instance we rebooted, not whatever the config names by now —
+    // otherwise a retarget during the reboot window lets a healthy B stand in as
+    // proof that A came back (codex gate P1).
+    probeUrl: `${anchoredBase}/system_stats`,
+  });
 
   if (!readiness.ready) {
     const waitedS = seconds(readiness.waited_ms);
@@ -3527,10 +3575,31 @@ export async function restartComfyUI(): Promise<RestartResult> {
     : "";
 
   // Start — ANCHORED to the instance that was just stopped (see restartProbeUrl).
-  const startResult = await startComfyUI({
-    port: info.port,
-    probeUrl: restartProbeUrl,
-  });
+  //
+  // The stop already committed, so from here a THROWN error is the worst outcome
+  // available: it unwinds past every report below and leaves the caller with an
+  // exception instead of the fact that their server is now down (codex gate P0).
+  // Whatever went wrong, the relaunch attempt is describable — so describe it.
+  let startResult: StartResult;
+  try {
+    startResult = await startComfyUI({
+      port: info.port,
+      probeUrl: restartProbeUrl,
+    });
+  } catch (err) {
+    return {
+      stopped: true,
+      started: false,
+      // DISCLOSE, do not refuse: the stop is not undoable and the caller's server
+      // really is down. A refusal here would read as "nothing happened".
+      startup: "not-attempted",
+      message:
+        `ComfyUI was stopped, but the relaunch could not be attempted: ${errorText(err)}. ` +
+        `ComfyUI is NOT running. Start it with start_comfyui once the cause is cleared.` +
+        stopCaveat,
+      listener_ownership: unclassifiedOwnership(),
+    };
+  }
   // #367: the relaunch was DISPATCHED and its process is alive, but the readiness
   // budget expired before the API answered. This is neither a success to claim nor
   // a failure to report, and it is checked BEFORE the `!started` branch so that it

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -2930,9 +2930,15 @@ const REBOOT_ROUTES: ReadonlyArray<{ path: string; method: "POST" | "GET" }> = [
 ];
 
 /**
- * A dropped/aborted connection is the SUCCESS signal for a reboot: the Manager
- * handler calls exit(0) the instant it accepts the request, so the origin dies
- * before it can send an HTTP response and `fetch` rejects.
+ * A dropped/aborted connection is the signal this path READS AS a fired reboot: the
+ * Manager handler calls exit(0) the instant it accepts the request, so the origin
+ * dies before it can send an HTTP response and `fetch` rejects.
+ *
+ * It is an INFERENCE, not a success signal (codex gate round 11 — this contract
+ * still said "SUCCESS" after the code and the messages had stopped treating it as
+ * one). The same drop is produced by a tunnel or a network blip in front of a server
+ * that was never rebooted, which is why the caller marks it `acked: false` and the
+ * report says the request was not acknowledged.
  */
 function isConnectionDrop(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
@@ -3334,6 +3340,36 @@ export async function restartComfyUI(): Promise<RestartResult> {
       message:
         diagnostic ??
         `No ComfyUI process found on port ${config.resolvedPort} to restart. Is ComfyUI running?`,
+      listener_ownership: unclassifiedOwnership(),
+    };
+  }
+  // NEVER STOP AN INSTANCE THE REST OF THIS CALL WILL NOT BE ACTING ON (codex gate
+  // round 11). `acquireProcessInfo` is awaited, and the target is MUTABLE: a hello
+  // retarget landing inside that await leaves `info` describing instance A while the
+  // config — which `stopComfyUI`'s port waits, the Manager reboot's base URL, and
+  // `startComfyUI`'s relaunch port all read LIVE — now points at B.
+  //
+  // The loss is concrete and is the #368/#814 shape again: A is killed from its
+  // already-resolved pid, then the relaunch consults B's port, finds it occupied,
+  // and returns "already running" without spawning anything. A is down, nothing
+  // brings it back, and every assessment that authorized the stop was about A.
+  //
+  // Judged by the monotonic GENERATION captured before the resolve, so a retarget
+  // that lands mid-await is caught and an A→B→A round trip cannot slip through a
+  // final-state comparison. REFUSE, because nothing has been stopped yet — the
+  // refuse-before/disclose-after rule this whole path is built on.
+  if (getComfyuiTargetGeneration() !== infoGeneration) {
+    return {
+      stopped: false,
+      started: false,
+      startup: "not-attempted",
+      restart_hint: recoveryHint(info),
+      message:
+        "Refusing to restart: the ComfyUI target changed while the running instance was " +
+        "being identified, so the instance that was checked is not provably the one this " +
+        "restart would act on — and a stop is never sent to an instance whose relaunch was " +
+        "not the one verified. Nothing was stopped. Let the target settle, then retry." +
+        describeRecovery(recoveryHint(info)),
       listener_ownership: unclassifiedOwnership(),
     };
   }

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -339,6 +339,47 @@ export const PANEL_VERSION_LABEL = String.raw`(?:comfyui-mcp-panel|panel)`;
  * Reading the label is the only rule that survives the input the tool actually asks
  * for.
  */
+/** Release channels that are legitimate version values without carrying a digit. */
+const CHANNEL_TAGS = new Set([
+  "nightly",
+  "dev",
+  "development",
+  "edge",
+  "canary",
+  "beta",
+  "alpha",
+  "rc",
+  "latest",
+  "main",
+  "master",
+  "local",
+]);
+
+/**
+ * Is this token a VERSION, as opposed to a word that merely stands where one was
+ * expected? Semver wins outright; otherwise it must carry a digit (`0.49.6-dev3`,
+ * `2026.08.04`) or be a recognised channel name.
+ *
+ * The point is what it REJECTS: `unknown`, `unspecified`, `none`, and any stray word
+ * an agent might drop in ("comfyui-mcp is broken"). Those are not versions, and
+ * forwarding them would hand the triage worker something unmatchable while looking
+ * like a confident answer — the caller falls through to detection instead, which is
+ * the right move precisely when the agent had nothing.
+ */
+function asVersionToken(rawToken: string): string | undefined {
+  // The ENVIRONMENT line ends in a full stop, so the last component's token arrives
+  // as `0.11.38.` — which passes every shape test and is then reported with the
+  // trailing dot attached, defeating the exact-version match downstream. No version
+  // ends in punctuation, so stripping it is unambiguous.
+  const token = rawToken.replace(/[.,;:)\]}]+$/, "");
+  if (token === "") return undefined;
+  const semver = new RegExp(`^${SEMVER_BODY}$`, "i").exec(token);
+  if (semver) return semver[1];
+  if (!/^[A-Za-z0-9][A-Za-z0-9._+-]{0,31}$/.test(token)) return undefined;
+  if (/\d/.test(token)) return token;
+  return CHANNEL_TAGS.has(token.toLowerCase()) ? token : undefined;
+}
+
 export function normalizeReportedVersion(
   raw: string | undefined,
   label: string,
@@ -349,8 +390,18 @@ export function normalizeReportedVersion(
 
   // 1. LABELLED — survives a whole ENVIRONMENT line, other components' versions and
   //    all. The separator covers both `comfyui-mcp 0.49.6` and `mcp=0.49.6`.
-  const labelled = new RegExp(`${label}[\\s:=]+${SEMVER_BODY}`, "i").exec(trimmed);
-  if (labelled) return labelled[1];
+  //
+  //    The value is captured as a TOKEN and validated after, not required to be
+  //    semver in the pattern (codex gate round 3). Requiring semver here meant a
+  //    non-semver running build — `comfyui-mcp nightly (this process is RUNNING
+  //    nightly; 0.49.6 is now installed on disk …)` — matched nothing, fell through
+  //    to a disk read, and reported the INSTALLED 0.49.6 as the running version.
+  //    That is #846 exactly, for the one user whose version needed the most care.
+  const labelled = new RegExp(`${label}[\\s:=]+([^\\s·,;)]+)`, "i").exec(trimmed);
+  if (labelled) {
+    const value = asVersionToken(labelled[1]);
+    if (value) return value;
+  }
 
   // 2. LEADING — the caller sent the version itself, possibly with the #846 drift
   //    clause after it. The clause names a NEWER installed version second, so
@@ -360,11 +411,10 @@ export function normalizeReportedVersion(
   const leading = new RegExp(`^${SEMVER_BODY}`).exec(trimmed);
   if (leading) return leading[1];
 
-  // 3. A COMPACT TAG is still a real version someone may be running ("nightly",
-  //    "dev") and is PRESERVED — discarding it would send the caller to a disk
-  //    read, i.e. the same version-swap in a different disguise. Required to start
-  //    with a letter so that key=value fragments and prose fall through instead.
-  return /^[A-Za-z][A-Za-z0-9._-]{0,31}$/.test(trimmed) ? trimmed : undefined;
+  // 3. THE WHOLE STRING as a version token — the caller sent just `nightly`, with no
+  //    label. Preserved for the same reason as above: discarding it would send the
+  //    caller to a disk read, i.e. the version-swap in a different disguise.
+  return asVersionToken(trimmed);
 }
 
 export function registerReportIssueTools(server: McpServer): void {

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -397,10 +397,24 @@ export function normalizeReportedVersion(
   //    nightly; 0.49.6 is now installed on disk …)` — matched nothing, fell through
   //    to a disk read, and reported the INSTALLED 0.49.6 as the running version.
   //    That is #846 exactly, for the one user whose version needed the most care.
-  const labelled = new RegExp(`${label}[\\s:=]+([^\\s·,;)]+)`, "i").exec(trimmed);
-  if (labelled) {
-    const value = asVersionToken(labelled[1]);
-    if (value) return value;
+  //
+  //    A SHORT RUN of tokens is examined, not just the first (codex gate round 4):
+  //    `MCP version: 0.48.18` puts the word `version` where the number goes, and
+  //    taking only the adjacent token dropped a perfectly good reading straight
+  //    into the disk-read fallback — #846 again. The run is capped at three so a
+  //    label followed by prose cannot wander into some OTHER component's version
+  //    further along the line.
+  //
+  //    The left boundary keeps `other-mcp 1.2.3` from being read as ours.
+  const after = new RegExp(
+    `(?<![A-Za-z0-9-])${label}[\\s:=]+(.{0,64})`,
+    "is",
+  ).exec(trimmed);
+  if (after) {
+    for (const token of after[1].split(/[\s·,;]+/).slice(0, 3)) {
+      const value = asVersionToken(token);
+      if (value) return value;
+    }
   }
 
   // 2. LEADING — the caller sent the version itself, possibly with the #846 drift

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -297,6 +297,30 @@ function detectMcpVersion(): string | undefined {
   }
 }
 
+/**
+ * Reduce a caller-supplied version to the VERSION IN IT, or undefined.
+ *
+ * These strings are copied by an agent out of a prose ENVIRONMENT line, and that
+ * line grew a qualifying clause (#846: "…0.48.18 (this process is RUNNING …;
+ * 0.49.6 is now installed on disk …)"). Passed through whole, the triage worker's
+ * version match sees a sentence instead of a version and cannot tell the user that
+ * upgrading already fixes their bug — which is the single most common resolution,
+ * and the outcome #846 was filed to protect.
+ *
+ * Deliberately anchored at the START, so the FIRST version wins: the ENV line leads
+ * with the RUNNING build, which is the one the report is about. A clause naming a
+ * newer installed version must never be the one that gets extracted.
+ *
+ * Returns undefined rather than a guess when nothing version-shaped is there, so
+ * the caller falls back to detecting it — an unusable string is no reading at all,
+ * and must not be reported as one.
+ */
+export function normalizeReportedVersion(raw: string | undefined): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const m = /^\s*v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/.exec(raw);
+  return m ? m[1] : undefined;
+}
+
 export function registerReportIssueTools(server: McpServer): void {
   server.tool(
     "report_issue",
@@ -355,8 +379,12 @@ export function registerReportIssueTools(server: McpServer): void {
         const repoName = repo.split("/")[1];
 
         const reporterVersions: ReporterVersions = {
-          mcp: args.mcp_version ?? detectMcpVersion(),
-          panel: args.panel_version ?? process.env.COMFYUI_MCP_PANEL_VERSION ?? undefined,
+          mcp: normalizeReportedVersion(args.mcp_version) ?? detectMcpVersion(),
+          panel:
+            normalizeReportedVersion(args.panel_version) ??
+            args.panel_version ??
+            process.env.COMFYUI_MCP_PANEL_VERSION ??
+            undefined,
         };
 
         try {

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -398,23 +398,26 @@ export function normalizeReportedVersion(
   //    to a disk read, and reported the INSTALLED 0.49.6 as the running version.
   //    That is #846 exactly, for the one user whose version needed the most care.
   //
-  //    A SHORT RUN of tokens is examined, not just the first (codex gate round 4):
-  //    `MCP version: 0.48.18` puts the word `version` where the number goes, and
-  //    taking only the adjacent token dropped a perfectly good reading straight
-  //    into the disk-read fallback — #846 again. The run is capped at three so a
-  //    label followed by prose cannot wander into some OTHER component's version
-  //    further along the line.
+  //    ONE named filler word may stand between the label and the number (codex gate
+  //    round 4): `MCP version: 0.48.18` puts `version` where the value goes, and
+  //    taking only the adjacent token dropped a perfectly good reading straight into
+  //    the disk-read fallback — #846 again.
+  //
+  //    It is a NAMED filler and not "scan the next few tokens" (codex gate round 6).
+  //    Scanning walked straight over an indeterminate value into the NEXT
+  //    component's: `comfyui-mcp unknown · panel 0.11.38.` returned the PANEL's
+  //    version as the mcp one. An mcp version that cannot be determined has to stay
+  //    undetermined — that is the whole rule this cluster is about — so anything that
+  //    is neither the filler nor a version stops the search here.
   //
   //    The left boundary keeps `other-mcp 1.2.3` from being read as ours.
   const after = new RegExp(
-    `(?<![A-Za-z0-9-])${label}[\\s:=]+(.{0,64})`,
-    "is",
+    `(?<![A-Za-z0-9-])${label}[\\s:=]+(?:versions?[\\s:=]+)?([^\\s·,;)]+)`,
+    "i",
   ).exec(trimmed);
   if (after) {
-    for (const token of after[1].split(/[\s·,;]+/).slice(0, 3)) {
-      const value = asVersionToken(token);
-      if (value) return value;
-    }
+    const value = asVersionToken(after[1]);
+    if (value) return value;
   }
 
   // 2. LEADING — the caller sent the version itself, possibly with the #846 drift

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -297,34 +297,74 @@ function detectMcpVersion(): string | undefined {
   }
 }
 
+/** A semver body, with the optional `v` prefix stripped by the capture group. */
+const SEMVER_BODY = String.raw`v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)`;
+
+/**
+ * How each version is LABELLED in the ENVIRONMENT line.
+ *
+ * `comfyui-mcp-panel 0.11.38` is not readable as the mcp version because the label
+ * has to be followed by a separator and then A VERSION, and the word `panel` sits
+ * in between — the version is simply not adjacent to the mcp label. Stated plainly
+ * because two stronger-looking guards were tried here and both turned out to change
+ * no input at all: negative lookaheads on the label, and forbidding the hyphen as a
+ * separator. Neither was falsifiable, so neither is kept as protection; the covering
+ * test asserts the BEHAVIOUR (`comfyui-mcp-panel 0.11.38` yields no mcp version)
+ * rather than the mechanism.
+ */
+export const MCP_VERSION_LABEL = String.raw`(?:comfyui-mcp|mcp)`;
+/** Same, for the sidebar panel. The longer alias is listed first so it wins. */
+export const PANEL_VERSION_LABEL = String.raw`(?:comfyui-mcp-panel|panel)`;
+
 /**
  * Reduce a caller-supplied version to the VERSION IN IT, or undefined.
  *
  * These strings are copied by an agent out of a prose ENVIRONMENT line, and that
- * line grew a qualifying clause (#846: "…0.48.18 (this process is RUNNING …;
- * 0.49.6 is now installed on disk …)"). Passed through whole, the triage worker's
- * version match sees a sentence instead of a version and cannot tell the user that
- * upgrading already fixes their bug — which is the single most common resolution,
- * and the outcome #846 was filed to protect.
+ * line grew a qualifying clause (#846: "comfyui-mcp 0.48.18 (this process is
+ * RUNNING 0.48.18; 0.49.5 is now installed on disk …)"). Passed through whole, the
+ * triage worker's version match sees a sentence instead of a version and cannot
+ * tell the user that upgrading already fixes their bug — the single most common
+ * resolution, and the outcome #846 was filed to protect.
  *
- * THE FIRST version in the string wins, wherever it appears. Anchoring at the very
- * start was wrong twice over (codex gate): an agent copying the natural segment
- * ("comfyui-mcp 0.48.18 …") matched nothing and fell through to a fresh disk read,
- * which returns the INSTALLED version — silently swapping in exactly the number
- * #846 exists to stop us reporting. First-wins keeps that fallback rare AND
- * correct: the ENV line leads with the RUNNING build, so a clause naming a newer
- * installed version can never be the one extracted.
+ * THE LABEL IS TRIED FIRST, and it is what makes this correct rather than merely
+ * lucky (codex gate round 2). Two simpler rules were tried and both mis-read a
+ * realistic input:
+ *   - anchored at position 0: an agent pasting the natural segment
+ *     ("comfyui-mcp 0.48.18 …") matched nothing, fell through to a fresh disk read,
+ *     and reported the INSTALLED version — reintroducing #846 through its own fix;
+ *   - first semver ANYWHERE: the ENVIRONMENT line names `torch 2.7.1 · python
+ *     3.12.3` BEFORE `comfyui-mcp 0.48.18`, so an agent pasting the whole line —
+ *     which the tool description tells it to do — reported TORCH's version as the
+ *     reporter's. Wrong in a way nobody downstream could detect.
+ * Reading the label is the only rule that survives the input the tool actually asks
+ * for.
  */
-export function normalizeReportedVersion(raw: string | undefined): string | undefined {
+export function normalizeReportedVersion(
+  raw: string | undefined,
+  label: string,
+): string | undefined {
   if (typeof raw !== "string") return undefined;
-  const m = /v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/.exec(raw);
-  if (m) return m[1];
-  // No semver anywhere. A COMPACT token is still a real version someone may be
-  // running ("nightly", "dev") and is PRESERVED — replacing it with a disk read
-  // would be the same version-swap in a different disguise. Only prose is
-  // discarded, and only then does the caller fall back to detecting a version.
-  const token = raw.trim();
-  return token !== "" && token.length <= 32 && !/\s/.test(token) ? token : undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+
+  // 1. LABELLED — survives a whole ENVIRONMENT line, other components' versions and
+  //    all. The separator covers both `comfyui-mcp 0.49.6` and `mcp=0.49.6`.
+  const labelled = new RegExp(`${label}[\\s:=]+${SEMVER_BODY}`, "i").exec(trimmed);
+  if (labelled) return labelled[1];
+
+  // 2. LEADING — the caller sent the version itself, possibly with the #846 drift
+  //    clause after it. The clause names a NEWER installed version second, so
+  //    taking the leading one keeps the RUNNING build, which is what the report is
+  //    about. Nothing in the ENV line begins with a bare version, so this cannot
+  //    pick up another component's.
+  const leading = new RegExp(`^${SEMVER_BODY}`).exec(trimmed);
+  if (leading) return leading[1];
+
+  // 3. A COMPACT TAG is still a real version someone may be running ("nightly",
+  //    "dev") and is PRESERVED — discarding it would send the caller to a disk
+  //    read, i.e. the same version-swap in a different disguise. Required to start
+  //    with a letter so that key=value fragments and prose fall through instead.
+  return /^[A-Za-z][A-Za-z0-9._-]{0,31}$/.test(trimmed) ? trimmed : undefined;
 }
 
 export function registerReportIssueTools(server: McpServer): void {
@@ -385,9 +425,11 @@ export function registerReportIssueTools(server: McpServer): void {
         const repoName = repo.split("/")[1];
 
         const reporterVersions: ReporterVersions = {
-          mcp: normalizeReportedVersion(args.mcp_version) ?? detectMcpVersion(),
+          mcp:
+            normalizeReportedVersion(args.mcp_version, MCP_VERSION_LABEL) ??
+            detectMcpVersion(),
           panel:
-            normalizeReportedVersion(args.panel_version) ??
+            normalizeReportedVersion(args.panel_version, PANEL_VERSION_LABEL) ??
             process.env.COMFYUI_MCP_PANEL_VERSION ??
             undefined,
         };

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -288,13 +288,32 @@ function isTerminalError(frame: StatusFrame): boolean {
   return frame.status === "error" && !frame.url && !frame.payload;
 }
 
-/** The running comfyui-mcp version (best-effort; undefined if undetectable). */
-function detectMcpVersion(): string | undefined {
+/**
+ * The RUNNING comfyui-mcp version, snapshotted once at module load.
+ *
+ * `detectInstallMode().currentVersion` reads the package on disk, which answers
+ * a different question: what is INSTALLED. Those agree until someone updates in
+ * place, and then every issue filed by the still-running old process is stamped
+ * with the new version — the exact misreport #846 was opened for, reintroduced
+ * through the auto-detect fallback after round 9 fixed the explicit path (codex
+ * gate P1).
+ *
+ * Reading at load time is not a perfect proxy for "the code executing right
+ * now", but it is bounded by process start, which is the property that matters:
+ * it cannot drift underneath a long-lived process the way a report-time read
+ * does.
+ */
+const RUNNING_MCP_VERSION: string | undefined = (() => {
   try {
     return detectInstallMode().currentVersion ?? undefined;
   } catch {
     return undefined;
   }
+})();
+
+/** The running comfyui-mcp version (best-effort; undefined if undetectable). */
+function detectMcpVersion(): string | undefined {
+  return RUNNING_MCP_VERSION;
 }
 
 /** A semver body, with the optional `v` prefix stripped by the capture group. */

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -307,18 +307,24 @@ function detectMcpVersion(): string | undefined {
  * upgrading already fixes their bug — which is the single most common resolution,
  * and the outcome #846 was filed to protect.
  *
- * Deliberately anchored at the START, so the FIRST version wins: the ENV line leads
- * with the RUNNING build, which is the one the report is about. A clause naming a
- * newer installed version must never be the one that gets extracted.
- *
- * Returns undefined rather than a guess when nothing version-shaped is there, so
- * the caller falls back to detecting it — an unusable string is no reading at all,
- * and must not be reported as one.
+ * THE FIRST version in the string wins, wherever it appears. Anchoring at the very
+ * start was wrong twice over (codex gate): an agent copying the natural segment
+ * ("comfyui-mcp 0.48.18 …") matched nothing and fell through to a fresh disk read,
+ * which returns the INSTALLED version — silently swapping in exactly the number
+ * #846 exists to stop us reporting. First-wins keeps that fallback rare AND
+ * correct: the ENV line leads with the RUNNING build, so a clause naming a newer
+ * installed version can never be the one extracted.
  */
 export function normalizeReportedVersion(raw: string | undefined): string | undefined {
   if (typeof raw !== "string") return undefined;
-  const m = /^\s*v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/.exec(raw);
-  return m ? m[1] : undefined;
+  const m = /v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/.exec(raw);
+  if (m) return m[1];
+  // No semver anywhere. A COMPACT token is still a real version someone may be
+  // running ("nightly", "dev") and is PRESERVED — replacing it with a disk read
+  // would be the same version-swap in a different disguise. Only prose is
+  // discarded, and only then does the caller fall back to detecting a version.
+  const token = raw.trim();
+  return token !== "" && token.length <= 32 && !/\s/.test(token) ? token : undefined;
 }
 
 export function registerReportIssueTools(server: McpServer): void {
@@ -382,7 +388,6 @@ export function registerReportIssueTools(server: McpServer): void {
           mcp: normalizeReportedVersion(args.mcp_version) ?? detectMcpVersion(),
           panel:
             normalizeReportedVersion(args.panel_version) ??
-            args.panel_version ??
             process.env.COMFYUI_MCP_PANEL_VERSION ??
             undefined,
         };


### PR DESCRIPTION
## Issues in this cluster

- #848 — `panel_restart_comfyui` ignores **updated** Desktop launch arguments
- #367 — `restart_comfyui` reports a **failed startup just before a healthy one**
- #846 — the session ENVIRONMENT line reports a **stale `comfyui-mcp` version**

Grouped because they are one defect seen three ways: **something observed earlier is reported as if it were still true now.** Stale argv, a verdict rendered before the thing it judges finished, and a version string captured at a moment that has passed.

#367 is the sharpest: reporting a failed startup *immediately before* the server comes up healthy is a "could not determine" folded into a definite negative — the deadline expired, which establishes that startup was not confirmed **yet**, not that it failed. The user is told their restart broke, seconds before it works.

**Not yet started** — draft until an agent picks it up.