### PR TITLE
test: give the suite a real timeout — the "rotating cast of flaky files" was runner starvation (#852)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,5 +12,35 @@ export default defineConfig({
       "**/.git/**",
       "**/.claude/**",
     ],
+    // Vitest defaults both of these to 5s, which is too tight for THIS suite on a
+    // loaded machine, and that produced a long-running myth of "the suite flakes in
+    // a rotating cast of unrelated files" (#852). It is not flaky in the usual
+    // sense: two full-concurrency runs on the same commit failed in almost
+    // disjoint sets — grok-backend + training-jobs, then node-dev,
+    // panel-recovery-cluster, panel-status-base-path and two training-jobs cases —
+    // and every one of them failed with vitest's own "If this is a long-running
+    // test/hook, pass a timeout value", i.e. a TIMEOUT, never an assertion. Each
+    // passes in isolation.
+    //
+    // WHY THIS IS NOT "WIDENING A TOLERANCE TO HIDE A RACE", which we deliberately
+    // refuse to do elsewhere (#821/#843 rebuilt a fixture around `listen(0)` rather
+    // than raising its timeout; panel #652 made an injected delay instant rather
+    // than lengthening the budget). Those guarded races in PRODUCT code, where a
+    // longer fuse leaves the bug and moves the symptom. This guards the RUNNER
+    // being starved of CPU: several of these tests do real work — `node-dev`
+    // shells out to real git — and 5s is simply not a meaningful budget for that
+    // when the machine is saturated. Nothing about the code under test is racy;
+    // the measurement apparatus was.
+    //
+    // The cost is bounded and falls only on failures: a genuinely hung test now
+    // takes 30s to report instead of 5s. Suite wall-clock is unchanged, because a
+    // passing test still returns when it returns — raising a ceiling nobody reaches
+    // costs nothing.
+    //
+    // If a test starts needing MORE than this, that is a signal to make it
+    // deterministic (inject the clock, remove the real timer), not to raise this
+    // number again.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 });


### PR DESCRIPTION
Agents in this repo keep reporting that full-suite runs *"flake in a rotating cast of unrelated files"*, and work around it with `--maxWorkers=2`. Stated that way it is unactionable, and it costs real time: **an agent cannot tell a load flake from a real failure**, so it either burns a cycle debugging a non-bug or — worse — "fixes" something that was never broken.

## Measured, not guessed

Two full-concurrency runs on the same commit (`main`, `f7b5b2c`) under the same load failed in **almost disjoint sets**:

| run | failing files |
|---|---|
| 1 | `grok-backend`, `training-jobs` (CAS) |
| 2 | `node-dev`, `panel-recovery-cluster`, `panel-status-base-path`, `training-jobs` ×2 |

**Every one failed with vitest's own `If this is a long-running test/hook, pass a timeout value`** — a timeout, never an assertion. Every one passes in isolation.

I ruled out the alternatives rather than assuming:
- **Shared state** — vitest's default isolation is per-*file*, so the 10 test files that mutate `process.env` without restoring cannot leak across files.
- **Port contention** — no test binds a fixed port; the `127.0.0.1:8188` occurrences are mocked URLs, not real binds.

I also specifically checked whether the CAS case (*"two non-owner processes racing recovery hand off EXACTLY once"*) was a **real concurrency bug hiding as a flake** — a correct CAS should hold regardless of timing, so a load-dependent failure there would be alarming. It is not: it times out, never fails its assertion, and passes 6/6 in isolation.

## Why this is not "widening a tolerance to hide a race"

We deliberately refuse to do that, and did so twice this week: **#821/#843** rebuilt a fixture around `listen(0)` rather than raising its timeout, and **panel #652** made an injected delay resolve instantly rather than lengthening the budget. Both guarded races in **product code**, where a longer fuse leaves the bug and only moves the symptom.

This guards the **runner** being starved of CPU. Several of these tests do real work — `node-dev` shells out to real git — and 5s is not a meaningful budget for that on a saturated machine. Nothing about the code under test is racy; **the measurement apparatus was.**

## Verification

- **Two consecutive full-concurrency runs: 251/251 files, 4997 passed | 2 skipped** — under the same load that failed 5 files minutes earlier.
- Bonus worth having: **71s at full concurrency vs 203s** at the `--maxWorkers=2` workaround. This returns reliability *and* ~3× the speed.

## Cost

Bounded, and falls only on failures: a genuinely hung test now takes 30s to report instead of 5s. Suite wall-clock is unchanged — raising a ceiling nobody reaches costs nothing.

If a test ever needs **more** than 30s, that is a signal to make it deterministic (inject the clock, drop the real timer), not to raise this again. That intent is in the config comment so the next person does not read this as licence.

Closes #852.