### PR TITLE
panel_show_media: the 20 MB refusal is a dead end for local video (orchestrator half of #648)

### DIFF
--- a/src/__tests__/orchestrator/panel-show-media-oversized.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-oversized.test.ts
@@ -24,6 +24,8 @@ const state = vi.hoisted(() => ({
   cloud: false,
   /** Paths statSync should fail on with a non-ENOENT error. */
   statEacces: new Set<string>(),
+  /** absolute path -> errno code readFileSync should fail with. */
+  readFail: new Map<string, string>(),
 }));
 
 vi.mock("../../services/output-dir.js", async (importOriginal) => {
@@ -66,6 +68,17 @@ vi.mock("node:fs", async (importOriginal) => {
       }
       return (actual.statSync as (...a: unknown[]) => unknown)(p, ...rest);
     }) as typeof actual.statSync,
+    // A file whose METADATA reads fine but whose CONTENTS do not — statSync
+    // proves the former, never the latter.
+    readFileSync: ((p: Parameters<typeof actual.readFileSync>[0], ...rest: unknown[]) => {
+      const code = typeof p === "string" ? state.readFail.get(p) : undefined;
+      if (code) {
+        const err = new Error(`${code}: injected read failure, open '${String(p)}'`) as NodeJS.ErrnoException;
+        err.code = code;
+        throw err;
+      }
+      return (actual.readFileSync as (...a: unknown[]) => unknown)(p, ...rest);
+    }) as typeof actual.readFileSync,
   };
 });
 
@@ -144,6 +157,7 @@ beforeEach(() => {
   state.remote = false;
   state.cloud = false;
   state.statEacces.clear();
+  state.readFail.clear();
 });
 
 describe("panel_show_media: an oversized file UNDER a ComfyUI root is forwarded", () => {
@@ -288,6 +302,26 @@ describe("panel_show_media: the other outcomes stay distinct", () => {
     expect(text).not.toContain("file not found");
     expect(text).not.toContain("file too large");
     expect(text).not.toContain("inline cap");
+  });
+
+  it("does not claim a file was readable when only its metadata was", async () => {
+    // statSync proves METADATA access; a mode/ACL can permit that and deny the
+    // read. Asserting "it was readable a moment ago" would state something this
+    // process never observed (codex finding).
+    state.readFail.set(smallImage, "EACCES");
+    const { res } = await showMedia([{ source: { path: smallImage } }]);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain("metadata was readable but its contents were not");
+    expect(text).not.toContain("was readable a moment ago");
+    expect(text).not.toContain("size limit,"); // not misreported as a cap problem
+  });
+
+  it("reports a file deleted mid-call as having disappeared, not as unreadable", async () => {
+    state.readFail.set(smallImage, "ENOENT");
+    const { res } = await showMedia([{ source: { path: smallImage } }]);
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain("disappeared between being measured and being read");
   });
 
   it("still rejects a relative path", async () => {

--- a/src/__tests__/orchestrator/panel-show-media-oversized.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-oversized.test.ts
@@ -1,0 +1,298 @@
+// #648 — panel_show_media's 20 MB ceiling stops being a dead end.
+//
+// The panel half (panel #649) already gives an oversized video a sampled preview
+// with full disclosure, but it was never reached: the orchestrator refused first,
+// naming a limit and no way past it. These tests pin the routing that closes the
+// gap — a file ComfyUI already serves goes as a /view reference (no cap on that
+// path), anything else gets a refusal that names a remedy the caller can act on.
+//
+// MAX_BYTES is NOT raised, and these tests would not notice if it were; the
+// oversized fixtures are real files above the cap.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const state = vi.hoisted(() => ({
+  outputDir: "" as string,
+  inputDir: "" as string,
+  outputError: null as string | null,
+  inputError: null as string | null,
+  remote: false,
+  cloud: false,
+  /** Paths statSync should fail on with a non-ENOENT error. */
+  statEacces: new Set<string>(),
+}));
+
+vi.mock("../../services/output-dir.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../services/output-dir.js")>();
+  return {
+    ...actual,
+    resolveOutputDir: async () => {
+      if (state.outputError) throw new Error(state.outputError);
+      return state.outputDir;
+    },
+    resolveInputDir: async () => {
+      if (state.inputError) throw new Error(state.inputError);
+      return state.inputDir;
+    },
+  };
+});
+
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return {
+    ...actual,
+    isRemoteMode: () => state.remote,
+    isCloudMode: () => state.cloud,
+  };
+});
+
+// An existing file that cannot be stat'ed is the third outcome the old
+// existsSync+statSync pair had no branch for. It cannot be produced portably on
+// Windows, so the syscall is made to fail for one designated path.
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    statSync: ((p: Parameters<typeof actual.statSync>[0], ...rest: unknown[]) => {
+      if (typeof p === "string" && state.statEacces.has(p)) {
+        const err = new Error(`EACCES: permission denied, stat '${p}'`) as NodeJS.ErrnoException;
+        err.code = "EACCES";
+        throw err;
+      }
+      return (actual.statSync as (...a: unknown[]) => unknown)(p, ...rest);
+    }) as typeof actual.statSync,
+  };
+});
+
+const { buildPanelToolDefs } = await import("../../orchestrator/panel-tools.js");
+
+type Forwarded = Record<string, unknown>;
+
+function makeCtx(): { ctx: PanelToolCtx; calls: Forwarded[] } {
+  const calls: Forwarded[] = [];
+  const ctx = {
+    call: async (cmd: Forwarded) => {
+      calls.push(cmd);
+      return { content: [{ type: "text", text: JSON.stringify(cmd) }] } as ToolResult;
+    },
+    confirm: async () => "yes" as const,
+    bridge: { isHeadless: () => false } as unknown as PanelToolCtx["bridge"],
+    tabId: "test-tab",
+  } as PanelToolCtx;
+  return { ctx, calls };
+}
+
+async function showMedia(
+  items: Array<Record<string, unknown>>,
+): Promise<{ res: ToolResult; calls: Forwarded[] }> {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_show_media");
+  if (!def) throw new Error("panel_show_media not found");
+  const { ctx, calls } = makeCtx();
+  const res = (await def.handler({ items }, ctx)) as ToolResult;
+  return { res, calls };
+}
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => ("text" in c ? c.text : "")).join("\n");
+
+const OVERSIZE = 21 * 1024 * 1024; // > the tool's 20 MB inline cap
+
+let root: string;
+let outDir: string;
+let inDir: string;
+let bigVideoUnderRoot: string;
+let bigImageUnderRoot: string;
+let bigVideoOutside: string;
+let smallImage: string;
+let bigTextUnderRoot: string;
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "cmcp-showmedia-"));
+  outDir = join(root, "ComfyUI", "output");
+  inDir = join(root, "ComfyUI", "input");
+  mkdirSync(join(outDir, "takes"), { recursive: true });
+  mkdirSync(inDir, { recursive: true });
+  mkdirSync(join(root, "elsewhere"), { recursive: true });
+
+  const big = Buffer.alloc(OVERSIZE);
+  bigVideoUnderRoot = join(outDir, "takes", "reference.mp4");
+  writeFileSync(bigVideoUnderRoot, big);
+  bigImageUnderRoot = join(outDir, "plate.png");
+  writeFileSync(bigImageUnderRoot, big);
+  bigVideoOutside = join(root, "elsewhere", "reference.mp4");
+  writeFileSync(bigVideoOutside, big);
+  bigTextUnderRoot = join(outDir, "notes.txt");
+  writeFileSync(bigTextUnderRoot, big);
+  smallImage = join(outDir, "small.png");
+  writeFileSync(smallImage, Buffer.alloc(1024));
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  state.outputDir = outDir;
+  state.inputDir = inDir;
+  state.outputError = null;
+  state.inputError = null;
+  state.remote = false;
+  state.cloud = false;
+  state.statEacces.clear();
+});
+
+describe("panel_show_media: an oversized file UNDER a ComfyUI root is forwarded", () => {
+  it("sends a /view reference instead of refusing, and inlines nothing", async () => {
+    const { res, calls } = await showMedia([{ source: { path: bigVideoUnderRoot } }]);
+    expect(res.isError).toBeFalsy();
+    expect(calls).toHaveLength(1);
+    const items = calls[0].items as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(1);
+    // The reason, not just the state: it must be a REFERENCE, with the ref the
+    // file's real location implies — not inline bytes, and not a bare success.
+    expect(items[0].kind).toBe("viewRef");
+    expect(items[0].viewRef).toEqual({
+      filename: "reference.mp4",
+      subfolder: "takes",
+      type: "output",
+    });
+    expect(items[0].dataUrl).toBeUndefined();
+    // 21 MB of base64 would be ~28 MB of text; assert it is nowhere in the frame.
+    expect(JSON.stringify(calls[0]).length).toBeLessThan(4096);
+  });
+
+  it("tells the agent the bytes were not sent, and does not claim a display", async () => {
+    const { res } = await showMedia([{ source: { path: bigVideoUnderRoot } }]);
+    const text = textOf(res);
+    expect(text).toContain("NOT sent the bytes");
+    expect(text).toContain("inline cap");
+    // The panel's reply is the only thing that observed a paint.
+    expect(text).toContain("in its reply above");
+    expect(text).not.toMatch(/was shown to you/i);
+  });
+
+  it("forwards an oversized IMAGE too, and points the agent at get_image", async () => {
+    // Decision: the reference route is not video-only. An oversized image has no
+    // storyboard, but the panel still displays it same-origin at full size, and
+    // refusing would leave the same dead end for stills.
+    const { res, calls } = await showMedia([{ source: { path: bigImageUnderRoot } }]);
+    expect(res.isError).toBeFalsy();
+    const items = calls[0].items as Array<Record<string, unknown>>;
+    expect(items[0].kind).toBe("viewRef");
+    expect(items[0].viewRef).toEqual({ filename: "plate.png", type: "output" });
+    expect(textOf(res)).toContain("get_image");
+  });
+
+  it("forwards a file under the INPUT directory with type input", async () => {
+    const staged = join(inDir, "staged.mp4");
+    writeFileSync(staged, Buffer.alloc(OVERSIZE));
+    const { calls } = await showMedia([{ source: { path: staged } }]);
+    const items = calls[0].items as Array<Record<string, unknown>>;
+    expect(items[0].viewRef).toEqual({ filename: "staged.mp4", type: "input" });
+  });
+
+  it("still inlines the small items in the same batch", async () => {
+    const { calls } = await showMedia([
+      { source: { path: bigVideoUnderRoot } },
+      { source: { path: smallImage } },
+    ]);
+    const items = calls[0].items as Array<Record<string, unknown>>;
+    expect(items[0].kind).toBe("viewRef");
+    expect(items[1].kind).toBe("image");
+    expect(String(items[1].dataUrl)).toMatch(/^data:image\/png;base64,/);
+  });
+});
+
+describe("panel_show_media: an oversized file NOT under a root is refused with a remedy", () => {
+  it("names the cap, the directories checked, and what to do next", async () => {
+    const { res, calls } = await showMedia([{ source: { path: bigVideoOutside } }]);
+    expect(res.isError).toBe(true);
+    // Nothing was sent to the panel, so nothing may be reported as shown.
+    expect(calls).toHaveLength(0);
+    const text = textOf(res);
+    expect(text).toContain("21.0 MB");
+    expect(text).toContain("20.0 MB");
+    expect(text).toContain(outDir);
+    expect(text).toContain(inDir);
+    expect(text).toMatch(/Copy or move it/);
+    expect(text).toContain("panel_show_media");
+  });
+
+  it("does not blame the file's location when the roots could not be resolved", async () => {
+    state.outputError = "COMFYUI_PATH is not configured";
+    state.inputError = "COMFYUI_PATH is not configured";
+    const { res } = await showMedia([{ source: { path: bigVideoOutside } }]);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain("could NOT be determined");
+    expect(text).not.toContain("This file is not under any directory");
+    expect(text).toContain("COMFYUI_PATH");
+  });
+
+  it("gives a remote session a remedy that works from a different host", async () => {
+    state.remote = true;
+    // Under the output dir — but the server is elsewhere and cannot open it.
+    const { res, calls } = await showMedia([{ source: { path: bigVideoUnderRoot } }]);
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    const text = textOf(res);
+    expect(text).toContain("REMOTE ComfyUI");
+    expect(text).not.toMatch(/Copy or move it/);
+    expect(text).toContain('type: "input"');
+  });
+});
+
+describe("panel_show_media: the other outcomes stay distinct", () => {
+  it("leaves under-cap files inlined, with no reference note", async () => {
+    const { res, calls } = await showMedia([{ source: { path: smallImage } }]);
+    expect(res.isError).toBeFalsy();
+    const items = calls[0].items as Array<Record<string, unknown>>;
+    expect(items[0].kind).toBe("image");
+    expect(String(items[0].dataUrl)).toMatch(/^data:image\/png;base64,/);
+    expect(items[0].viewRef).toBeUndefined();
+    expect(textOf(res)).not.toContain("inline cap");
+  });
+
+  it("refuses an oversized UNSUPPORTED type for what is actually wrong with it", async () => {
+    // A .txt is not displayable at any size, so the reference route is not a
+    // remedy for it and must not be offered.
+    const { res } = await showMedia([{ source: { path: bigTextUnderRoot } }]);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain("unsupported file type");
+    expect(text).not.toContain("too large");
+  });
+
+  it("reports a missing file as missing", async () => {
+    const { res } = await showMedia([{ source: { path: join(outDir, "nope.mp4") } }]);
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain("file not found");
+  });
+
+  it("reports an unreadable file as unreadable — not as missing, and not as too large", async () => {
+    state.statEacces.add(bigVideoUnderRoot);
+    const { res, calls } = await showMedia([{ source: { path: bigVideoUnderRoot } }]);
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    const text = textOf(res);
+    expect(text).toContain("could not read file metadata");
+    expect(text).toContain("EACCES");
+    // Neither of the two answers it is NOT. Matched on the phrasing the real
+    // refusals use, so this cannot be satisfied by a message that merely avoids
+    // the words while still reporting the wrong cause.
+    expect(text).not.toContain("file not found");
+    expect(text).not.toContain("file too large");
+    expect(text).not.toContain("inline cap");
+  });
+
+  it("still rejects a relative path", async () => {
+    const { res } = await showMedia([{ source: { path: "relative/clip.mp4" } }]);
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain("must be absolute");
+  });
+});

--- a/src/__tests__/services/comfy-view-ref.test.ts
+++ b/src/__tests__/services/comfy-view-ref.test.ts
@@ -217,6 +217,45 @@ describe("resolveServableViewRef — a failed canonicalisation is a doubt, not a
     expect(res.reason).toContain("real location could not be resolved");
   });
 
+  // The two cases above both use a file lexically OUTSIDE every root, so they
+  // exercise only the matched-NOTHING path — where the doubt was already being
+  // consulted. They passed identically while a lexical fallback that landed
+  // UNDER a root still returned `servable` without ever looking at the doubt
+  // (independent gate P0). These two put the lexical path INSIDE the candidate
+  // root, which is the only shape that reaches the match.
+
+  it("does NOT claim servable when the FILE's realpath failed but its lexical path is UNDER a root", async () => {
+    const target = touch(join(outDir, "takes", "clip.mp4"));
+    state.realpathFail.set(resolve(target), "ELOOP");
+    const res = await resolveServableViewRef(target);
+    // A /view reference derived from an unverified path is a 404, or a different
+    // file, presented to the caller as servable.
+    expect(res.status).toBe("unknown");
+    if (res.status !== "unknown") return;
+    expect(res.reason).toContain("unverified path");
+    expect(res.reason).toContain("real location could not be resolved");
+  });
+
+  it("does NOT claim servable when the matching ROOT could not be canonicalised", async () => {
+    const target = touch(join(outDir, "takes", "clip2.mp4"));
+    state.realpathFail.set(resolve(outDir), "EACCES");
+    const res = await resolveServableViewRef(target);
+    expect(res.status).toBe("unknown");
+    if (res.status !== "unknown") return;
+    expect(res.reason).toContain("unverified path");
+    expect(res.reason).toContain("could not be canonicalised");
+  });
+
+  it("STILL serves a file under a root when both sides canonicalise — the doubt is tied to the matching pair", async () => {
+    // Discrimination in the other direction: a failure canonicalising an
+    // UNRELATED root says nothing about the one that matched, and refusing on it
+    // would be the same fold pointed the other way.
+    const target = touch(join(outDir, "takes", "clip3.mp4"));
+    state.realpathFail.set(resolve(inDir), "EACCES");
+    const res = await resolveServableViewRef(target);
+    expect(res.status).toBe("servable");
+  });
+
   it("reports UNKNOWN when a ROOT could not be canonicalised for a reason other than absence", async () => {
     state.realpathFail.set(resolve(outDir), "EACCES");
     const res = await resolveServableViewRef(touch(join(root, "elsewhere", "b.mp4")));

--- a/src/__tests__/services/comfy-view-ref.test.ts
+++ b/src/__tests__/services/comfy-view-ref.test.ts
@@ -16,11 +16,31 @@ const state = vi.hoisted(() => ({
   inputDir: "" as string,
   outputError: null as string | null,
   inputError: null as string | null,
+  /** A raw value (not necessarily an Error) the resolvers should reject with. */
+  rejectWith: null as { value: unknown } | null,
   remote: false,
   cloud: false,
   outputCalls: 0,
   inputCalls: 0,
+  /** absolute path -> errno code that realpath should fail with. */
+  realpathFail: new Map<string, string>(),
 }));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    realpath: (async (p: string, ...rest: unknown[]) => {
+      const code = state.realpathFail.get(String(p));
+      if (code) {
+        const err = new Error(`${code}: injected realpath failure`) as NodeJS.ErrnoException;
+        err.code = code;
+        throw err;
+      }
+      return (actual.realpath as (...a: unknown[]) => unknown)(p, ...rest);
+    }) as unknown as typeof actual.realpath,
+  };
+});
 
 vi.mock("../../services/output-dir.js", async (importOriginal) => {
   const actual =
@@ -29,11 +49,13 @@ vi.mock("../../services/output-dir.js", async (importOriginal) => {
     ...actual,
     resolveOutputDir: async () => {
       state.outputCalls += 1;
+      if (state.rejectWith) throw state.rejectWith.value;
       if (state.outputError) throw new Error(state.outputError);
       return state.outputDir;
     },
     resolveInputDir: async () => {
       state.inputCalls += 1;
+      if (state.rejectWith) throw state.rejectWith.value;
       if (state.inputError) throw new Error(state.inputError);
       return state.inputDir;
     },
@@ -73,6 +95,8 @@ beforeEach(() => {
   state.cloud = false;
   state.outputCalls = 0;
   state.inputCalls = 0;
+  state.rejectWith = null;
+  state.realpathFail.clear();
 });
 
 afterEach(() => {
@@ -177,6 +201,60 @@ describe("resolveServableViewRef — unknown is not 'outside'", () => {
     state.outputDir = "";
     state.inputDir = "";
     const res = await resolveServableViewRef(join(root, "elsewhere", "clip.mp4"));
+    expect(res.status).toBe("unknown");
+  });
+});
+
+describe("resolveServableViewRef — a failed canonicalisation is a doubt, not a verdict", () => {
+  it("reports UNKNOWN when the FILE's real location could not be resolved", async () => {
+    // A link this process cannot follow may point straight into a served
+    // directory, so a lexical miss is not evidence the file is elsewhere.
+    const target = touch(join(root, "elsewhere", "clip.mp4"));
+    state.realpathFail.set(resolve(target), "ELOOP");
+    const res = await resolveServableViewRef(target);
+    expect(res.status).toBe("unknown");
+    if (res.status !== "unknown") return;
+    expect(res.reason).toContain("real location could not be resolved");
+  });
+
+  it("reports UNKNOWN when a ROOT could not be canonicalised for a reason other than absence", async () => {
+    state.realpathFail.set(resolve(outDir), "EACCES");
+    const res = await resolveServableViewRef(touch(join(root, "elsewhere", "b.mp4")));
+    expect(res.status).toBe("unknown");
+    if (res.status !== "unknown") return;
+    expect(res.reason).toContain("could not be canonicalised");
+  });
+
+  it("still reports OUTSIDE when a root merely does not exist", async () => {
+    // ENOENT carries no uncertainty: a directory that is not there cannot hold
+    // the file, so this must NOT be softened into "unknown".
+    state.inputDir = join(root, "ComfyUI", "never-created");
+    const res = await resolveServableViewRef(touch(join(root, "elsewhere", "c.mp4")));
+    expect(res.status).toBe("outside");
+  });
+});
+
+describe("resolveServableViewRef — never throws", () => {
+  it("returns UNKNOWN when a resolver rejects with a value that cannot be stringified", async () => {
+    // Object.create(null) has no toString; an unguarded String(err) inside the
+    // catch would reject this function instead of reporting the failure — the
+    // agent would get an opaque transport error with no remedy in it.
+    state.rejectWith = { value: Object.create(null) as never };
+    const res = await resolveServableViewRef(join(root, "elsewhere", "d.mp4"));
+    expect(res.status).toBe("unknown");
+    if (res.status !== "unknown") return;
+    expect(res.reason).toContain("could not be described");
+  });
+
+  it("returns UNKNOWN when an Error's message getter throws", async () => {
+    const nasty = new Error("x");
+    Object.defineProperty(nasty, "message", {
+      get() {
+        throw new Error("the message getter itself failed");
+      },
+    });
+    state.rejectWith = { value: nasty };
+    const res = await resolveServableViewRef(join(root, "elsewhere", "e.mp4"));
     expect(res.status).toBe("unknown");
   });
 });

--- a/src/__tests__/services/comfy-view-ref.test.ts
+++ b/src/__tests__/services/comfy-view-ref.test.ts
@@ -246,12 +246,29 @@ describe("resolveServableViewRef — a failed canonicalisation is a doubt, not a
     expect(res.reason).toContain("could not be canonicalised");
   });
 
-  it("STILL serves a file under a root when both sides canonicalise — the doubt is tied to the matching pair", async () => {
-    // Discrimination in the other direction: a failure canonicalising an
-    // UNRELATED root says nothing about the one that matched, and refusing on it
-    // would be the same fold pointed the other way.
-    const target = touch(join(outDir, "takes", "clip3.mp4"));
-    state.realpathFail.set(resolve(inDir), "EACCES");
+  it("does NOT claim servable when the matching ROOT is ENOENT — absence only settles the NON-match", async () => {
+    // The ENOENT carve-out is sound in the negative direction: a directory that
+    // does not exist cannot contain the file. It is not sound here, past a
+    // containment test that passed against the root's lexical fallback — a
+    // concurrent agent renaming the directory between our stat and our realpath
+    // would otherwise yield a /view ref for a root that is no longer there.
+    const target = touch(join(outDir, "takes", "gone.mp4"));
+    state.realpathFail.set(resolve(outDir), "ENOENT");
+    const res = await resolveServableViewRef(target);
+    expect(res.status).toBe("unknown");
+  });
+
+  it("STILL serves a file under a root when an UNRELATED root failed — the doubt is tied to the matching pair", async () => {
+    // Discrimination in the other direction: a failure canonicalising a root the
+    // file is not under says nothing about the one that matched, and refusing on
+    // it would be the same fold pointed the other way — an over-strict check
+    // refusing something real. The target is under `inDir` and the FAILING root
+    // is `outDir`, which is visited FIRST: an earlier draft had these swapped, so
+    // the resolver matched and returned before ever touching the failing root and
+    // the test proved nothing. This ordering is what makes it fail against a
+    // whole-`inconclusive` check at the match point.
+    const target = touch(join(inDir, "clip3.mp4"));
+    state.realpathFail.set(resolve(outDir), "EACCES");
     const res = await resolveServableViewRef(target);
     expect(res.status).toBe("servable");
   });

--- a/src/__tests__/services/comfy-view-ref.test.ts
+++ b/src/__tests__/services/comfy-view-ref.test.ts
@@ -1,0 +1,321 @@
+// #648 — an oversized local file is not a dead end when ComfyUI already serves
+// the directory it lives in.
+//
+// The load-bearing distinction here is between "this file is in the wrong place"
+// and "we could not find out where the right places are". Collapsing the second
+// into the first tells a caller to move a file that may already be exactly where
+// it needs to be, so the tests below assert the REASON, not just the outcome.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const state = vi.hoisted(() => ({
+  outputDir: "" as string,
+  inputDir: "" as string,
+  outputError: null as string | null,
+  inputError: null as string | null,
+  remote: false,
+  cloud: false,
+  outputCalls: 0,
+  inputCalls: 0,
+}));
+
+vi.mock("../../services/output-dir.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../services/output-dir.js")>();
+  return {
+    ...actual,
+    resolveOutputDir: async () => {
+      state.outputCalls += 1;
+      if (state.outputError) throw new Error(state.outputError);
+      return state.outputDir;
+    },
+    resolveInputDir: async () => {
+      state.inputCalls += 1;
+      if (state.inputError) throw new Error(state.inputError);
+      return state.inputDir;
+    },
+  };
+});
+
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return {
+    ...actual,
+    isRemoteMode: () => state.remote,
+    isCloudMode: () => state.cloud,
+  };
+});
+
+const {
+  resolveServableViewRef,
+  oversizedInlineRefusal,
+  forwardedByReferenceNote,
+} = await import("../../services/comfy-view-ref.js");
+
+let root: string;
+let outDir: string;
+let inDir: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "cmcp-viewref-"));
+  outDir = join(root, "ComfyUI", "output");
+  inDir = join(root, "ComfyUI", "input");
+  mkdirSync(outDir, { recursive: true });
+  mkdirSync(inDir, { recursive: true });
+  state.outputDir = outDir;
+  state.inputDir = inDir;
+  state.outputError = null;
+  state.inputError = null;
+  state.remote = false;
+  state.cloud = false;
+  state.outputCalls = 0;
+  state.inputCalls = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function touch(path: string): string {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, "x");
+  return path;
+}
+
+describe("resolveServableViewRef — servable", () => {
+  it("derives a top-level ref with NO subfolder key", async () => {
+    const file = touch(join(outDir, "clip.mp4"));
+    const res = await resolveServableViewRef(file);
+    expect(res.status).toBe("servable");
+    if (res.status !== "servable") return;
+    expect(res.ref).toEqual({ filename: "clip.mp4", type: "output" });
+    // An empty subfolder must be ABSENT, not "" — the panel forwards this object
+    // straight into a /view query string.
+    expect("subfolder" in res.ref).toBe(false);
+    expect(res.root.kind).toBe("output");
+  });
+
+  it("derives a nested subfolder with forward slashes", async () => {
+    const file = touch(join(outDir, "video", "takes", "clip.mp4"));
+    const res = await resolveServableViewRef(file);
+    expect(res.status).toBe("servable");
+    if (res.status !== "servable") return;
+    expect(res.ref).toEqual({
+      filename: "clip.mp4",
+      subfolder: "video/takes",
+      type: "output",
+    });
+    // Never a backslash, whatever the host separator is.
+    expect(res.ref.subfolder).not.toContain("\\");
+  });
+
+  it("recognises the INPUT directory and types the ref accordingly", async () => {
+    const file = touch(join(inDir, "refs", "plate.mp4"));
+    const res = await resolveServableViewRef(file);
+    expect(res.status).toBe("servable");
+    if (res.status !== "servable") return;
+    expect(res.ref.type).toBe("input");
+    expect(res.ref.subfolder).toBe("refs");
+  });
+
+  it("stays servable when the OTHER directory cannot be resolved", async () => {
+    // Independence: the input dir failing must not discard a proven output hit.
+    state.inputError = "COMFYUI_PATH is not configured";
+    const file = touch(join(outDir, "clip.mp4"));
+    const res = await resolveServableViewRef(file);
+    expect(res.status).toBe("servable");
+  });
+});
+
+describe("resolveServableViewRef — outside", () => {
+  it("refuses a file in a sibling directory and names both roots checked", async () => {
+    const file = touch(join(root, "elsewhere", "clip.mp4"));
+    const res = await resolveServableViewRef(file);
+    expect(res.status).toBe("outside");
+    if (res.status !== "outside") return;
+    expect(res.checked.map((c) => c.kind).sort()).toEqual(["input", "output"]);
+    expect(res.checked.find((c) => c.kind === "output")?.dir).toBe(resolve(outDir));
+  });
+
+  it("does not treat a PREFIX-sharing sibling as inside the root", async () => {
+    // "<...>/output-old/clip.mp4" starts with the output dir's string but is a
+    // different directory. A prefix test without the separator would mint a ref
+    // whose subfolder ("-old") resolves to nothing.
+    const file = touch(join(root, "ComfyUI", "output-old", "clip.mp4"));
+    const res = await resolveServableViewRef(file);
+    expect(res.status).toBe("outside");
+  });
+});
+
+describe("resolveServableViewRef — unknown is not 'outside'", () => {
+  it("reports UNKNOWN when neither directory resolves", async () => {
+    state.outputError = "COMFYUI_PATH is not configured";
+    state.inputError = "COMFYUI_PATH is not configured";
+    const res = await resolveServableViewRef(join(root, "elsewhere", "clip.mp4"));
+    expect(res.status).toBe("unknown");
+    if (res.status !== "unknown") return;
+    expect(res.reason).toContain("COMFYUI_PATH is not configured");
+  });
+
+  it("reports UNKNOWN — never 'outside' — when one directory is unresolved and the other did not match", async () => {
+    // The whole point of the three-way answer: the file could be sitting in the
+    // directory that failed to resolve. Calling this "outside" would send the
+    // caller to move a file that may already be in the right place.
+    state.inputError = "the server did not answer /system_stats";
+    const res = await resolveServableViewRef(join(root, "elsewhere", "clip.mp4"));
+    expect(res.status).toBe("unknown");
+    if (res.status !== "unknown") return;
+    expect(res.reason).toContain("undetermined");
+    expect(res.reason).toContain("the server did not answer /system_stats");
+  });
+
+  it("treats an empty resolved directory as unresolved, not as a root", async () => {
+    // "" would make every absolute path look contained.
+    state.outputDir = "";
+    state.inputDir = "";
+    const res = await resolveServableViewRef(join(root, "elsewhere", "clip.mp4"));
+    expect(res.status).toBe("unknown");
+  });
+});
+
+describe("resolveServableViewRef — remote", () => {
+  it("answers REMOTE without resolving any directory", async () => {
+    state.remote = true;
+    const file = touch(join(outDir, "clip.mp4"));
+    const res = await resolveServableViewRef(file);
+    expect(res.status).toBe("remote");
+    // Load-bearing: a remote session can still have COMFYUI_PATH set, so the
+    // roots would resolve to LOCAL-looking paths and this very file would be
+    // called servable — against a server that cannot open it. The check has to
+    // happen before any root is consulted.
+    expect(state.outputCalls).toBe(0);
+    expect(state.inputCalls).toBe(0);
+  });
+
+  it("answers REMOTE for cloud mode too", async () => {
+    state.cloud = true;
+    const res = await resolveServableViewRef(touch(join(outDir, "clip.mp4")));
+    expect(res.status).toBe("remote");
+    if (res.status !== "remote") return;
+    expect(res.reason).toContain("Cloud");
+  });
+});
+
+describe("oversizedInlineRefusal — every branch ends in something the caller can do", () => {
+  const base = {
+    path: "/refs/clip.mp4",
+    sizeBytes: 72 * 1024 * 1024,
+    capBytes: 20 * 1024 * 1024,
+    kind: "video" as const,
+  };
+
+  it("states the size, the cap, and why the cap exists", () => {
+    const msg = oversizedInlineRefusal({
+      ...base,
+      resolution: { status: "outside", checked: [{ kind: "output", dir: "/c/output" }] },
+    });
+    expect(msg).toContain("72.0 MB");
+    expect(msg).toContain("20.0 MB");
+    expect(msg).toContain("base64");
+  });
+
+  it("names the ACTUAL directories to move the file into", () => {
+    const msg = oversizedInlineRefusal({
+      ...base,
+      resolution: {
+        status: "outside",
+        checked: [
+          { kind: "output", dir: "/c/output" },
+          { kind: "input", dir: "/c/input" },
+        ],
+      },
+    });
+    // A remedy the caller can act on names the destination, not just the rule.
+    expect(msg).toContain("/c/output");
+    expect(msg).toContain("/c/input");
+    expect(msg).toMatch(/Copy or move it/);
+    expect(msg).toContain("panel_show_media");
+  });
+
+  it("tells a VIDEO caller it still will not be sent the video", () => {
+    const msg = oversizedInlineRefusal({
+      ...base,
+      resolution: { status: "outside", checked: [{ kind: "output", dir: "/c/output" }] },
+    });
+    expect(msg).toContain("SAMPLED");
+    expect(msg).not.toContain("get_image with its filename");
+  });
+
+  it("points an IMAGE caller at get_image, which a storyboard cannot serve", () => {
+    const msg = oversizedInlineRefusal({
+      ...base,
+      kind: "image",
+      resolution: { status: "outside", checked: [{ kind: "output", dir: "/c/output" }] },
+    });
+    expect(msg).toContain("get_image");
+    expect(msg).not.toContain("SAMPLED");
+  });
+
+  it("does NOT blame the file's location when the answer was unknown", () => {
+    const msg = oversizedInlineRefusal({
+      ...base,
+      resolution: { status: "unknown", reason: "the output directory could not be resolved (no COMFYUI_PATH)" },
+    });
+    expect(msg).toContain("could NOT be determined");
+    expect(msg).toContain("not the same as knowing the file is in the wrong place");
+    // The false claim this branch exists to avoid.
+    expect(msg).not.toContain("This file is not under any directory");
+    // Still actionable: the remedy addresses the thing that is actually broken.
+    expect(msg).toContain("COMFYUI_PATH");
+  });
+
+  it("gives a remote caller a remedy that works from a different host", () => {
+    const msg = oversizedInlineRefusal({
+      ...base,
+      resolution: { status: "remote", reason: "this session targets a REMOTE ComfyUI on a different host" },
+    });
+    // Moving the file locally is NOT a remedy here, so it must not be offered.
+    expect(msg).not.toMatch(/Copy or move it/);
+    expect(msg).toContain("input directory");
+    expect(msg).toContain('type: "input"');
+  });
+});
+
+describe("forwardedByReferenceNote", () => {
+  it("says the bytes were not sent and never claims anything was displayed", () => {
+    const note = forwardedByReferenceNote(
+      [
+        {
+          path: "/c/output/clip.mp4",
+          sizeBytes: 72 * 1024 * 1024,
+          kind: "video",
+          ref: { filename: "clip.mp4", subfolder: "takes", type: "output" },
+        },
+      ],
+      20 * 1024 * 1024,
+    );
+    expect(note).toContain("NOT sent the bytes");
+    expect(note).toContain('subfolder "takes"');
+    // The panel's reply is the only thing that knows what was painted.
+    expect(note).toContain("in its reply above");
+    expect(note).not.toMatch(/was displayed to the user/i);
+  });
+
+  it("offers get_image for an image and warns it is never inline for a video", () => {
+    const img = forwardedByReferenceNote(
+      [{ path: "/c/output/a.png", sizeBytes: 3e7, kind: "image", ref: { filename: "a.png", type: "output" } }],
+      20 * 1024 * 1024,
+    );
+    expect(img).toContain("get_image");
+    expect(img).toContain("comes back inline");
+
+    const vid = forwardedByReferenceNote(
+      [{ path: "/c/output/a.mp4", sizeBytes: 3e7, kind: "video", ref: { filename: "a.mp4", type: "output" } }],
+      20 * 1024 * 1024,
+    );
+    expect(vid).toContain("never sent to you inline");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7870,14 +7870,26 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             try {
               buf = readFileSync(p);
             } catch (err) {
-              // The file was stat-able a moment ago, so this is a read failure —
-              // not a missing file, and not a size problem.
+              // statSync proves METADATA access, not read access — a mode/ACL
+              // can permit one and deny the other — so "it was readable a moment
+              // ago" would assert something never observed. State only what the
+              // stat established, and keep ENOENT (a delete that raced this
+              // read) distinct from a permission wall.
+              const code = (err as NodeJS.ErrnoException)?.code;
+              const detail = err instanceof Error ? err.message : String(err);
+              if (code === "ENOENT") {
+                return fail(
+                  "the file disappeared between being measured and being read: " +
+                    p +
+                    " — it existed a moment ago; re-check the path and retry",
+                );
+              }
               return fail(
                 "could not read file contents for " +
                   p +
                   ": " +
-                  (err instanceof Error ? err.message : String(err)) +
-                  " — it was readable a moment ago, so this is not an absent file and not a size limit",
+                  detail +
+                  " — its metadata was readable but its contents were not, which is a permissions or device problem, not a size limit",
               );
             }
             const dataUrl = "data:" + mime + ";base64," + buf.toString("base64");

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -26,6 +26,13 @@
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import type { Stats } from "node:fs";
+import {
+  forwardedByReferenceNote,
+  oversizedInlineRefusal,
+  resolveServableViewRef,
+  type ForwardedByReference,
+} from "../services/comfy-view-ref.js";
 import { extname, isAbsolute, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { comfyuiFetch } from "../comfyui/fetch.js";
@@ -7777,6 +7784,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         const MAX_BYTES = 20 * 1024 * 1024; // 20 MB
 
         const resolved: Array<Record<string, unknown>> = [];
+        /** Oversized items that took the /view reference route instead (#648). */
+        const forwarded: ForwardedByReference[] = [];
         for (const item of items) {
           const src = item.source;
           if ("path" in src) {
@@ -7785,32 +7794,93 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             if (!isAbsolute(p)) {
               return fail("path must be absolute: " + p);
             }
-            if (!existsSync(p)) {
-              return fail("file not found: " + p);
+            // ONE stat, three distinct outcomes. existsSync + statSync split the
+            // question across two syscalls and left the third case unhandled: a
+            // file that EXISTS but cannot be stat'ed (permissions, a broken
+            // symlink, an unreachable share) threw straight out of the handler
+            // as an opaque transport error. "Could not read it" is neither "not
+            // found" nor "too large", and reporting it as either sends the
+            // caller to fix the wrong thing.
+            let stat: Stats;
+            try {
+              stat = statSync(p);
+            } catch (err) {
+              const code = (err as NodeJS.ErrnoException)?.code;
+              if (code === "ENOENT") {
+                return fail("file not found: " + p);
+              }
+              return fail(
+                "could not read file metadata for " +
+                  p +
+                  ": " +
+                  (err instanceof Error ? err.message : String(err)) +
+                  " — that is not the same as the file being absent, and it is not a size limit; " +
+                  "check permissions and that the path is reachable, then retry",
+              );
             }
-            const stat = statSync(p);
             if (!stat.isFile()) {
               return fail("not a regular file: " + p);
             }
-            if (stat.size > MAX_BYTES) {
-              return fail(
-                "file too large (" + (stat.size / 1024 / 1024).toFixed(1) + " MB > 20 MB): " + p,
-              );
-            }
+            // Type BEFORE size: a file this tool can never display is refused for
+            // what is actually wrong with it, and only real media is considered
+            // for the reference route.
             const ext = extname(p).toLowerCase();
             let mime: string;
+            let kind: "image" | "video";
             if (IMAGE_EXTS.has(ext)) {
               mime = ext === ".jpg" ? "image/jpeg" : "image/" + ext.slice(1);
+              kind = "image";
             } else if (VIDEO_EXTS.has(ext)) {
               mime = "video/" + ext.slice(1);
+              kind = "video";
             } else {
               return fail(
                 "unsupported file type \"" + ext + "\" (allowed: " + [...IMAGE_EXTS, ...VIDEO_EXTS].join(", ") + "): " + p,
               );
             }
-            const buf = readFileSync(p);
+            if (stat.size > MAX_BYTES) {
+              // Too big to INLINE is not the same as too big to SHOW. When the
+              // file already sits under a directory ComfyUI serves, the panel
+              // can fetch it same-origin with no cap at all — so forward a ref
+              // rather than dead-ending the caller at a ceiling it cannot pass.
+              // MAX_BYTES stays exactly where it is; it guards the inline path,
+              // which this route does not use.
+              const servable = await resolveServableViewRef(p);
+              if (servable.status === "servable") {
+                resolved.push({
+                  kind: "viewRef",
+                  viewRef: servable.ref,
+                  filename: servable.ref.filename,
+                  caption: item.caption,
+                });
+                forwarded.push({ path: p, sizeBytes: stat.size, kind, ref: servable.ref });
+                continue;
+              }
+              return fail(
+                oversizedInlineRefusal({
+                  path: p,
+                  sizeBytes: stat.size,
+                  capBytes: MAX_BYTES,
+                  kind,
+                  resolution: servable,
+                }),
+              );
+            }
+            let buf: Buffer;
+            try {
+              buf = readFileSync(p);
+            } catch (err) {
+              // The file was stat-able a moment ago, so this is a read failure —
+              // not a missing file, and not a size problem.
+              return fail(
+                "could not read file contents for " +
+                  p +
+                  ": " +
+                  (err instanceof Error ? err.message : String(err)) +
+                  " — it was readable a moment ago, so this is not an absent file and not a size limit",
+              );
+            }
             const dataUrl = "data:" + mime + ";base64," + buf.toString("base64");
-            const kind = IMAGE_EXTS.has(ext) ? "image" : "video";
             const filename = p.replace(/.*[\/]/, "");
             resolved.push({ kind, dataUrl, filename, caption: item.caption });
           } else {
@@ -7858,7 +7928,18 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           }
         }
 
-        return ctx.call({ cmd: "show_media", items: resolved }, 60000);
+        const res = await ctx.call({ cmd: "show_media", items: resolved }, 60000);
+        // Why an item the caller passed as a PATH came back described as a
+        // reference — the panel cannot say, because it never saw the path or the
+        // size. Appended as a separate block so the panel's own reply (which is
+        // the only thing that knows what was actually painted) is left intact.
+        if (forwarded.length > 0 && !res.isError) {
+          res.content.push({
+            type: "text",
+            text: forwardedByReferenceNote(forwarded, MAX_BYTES),
+          });
+        }
+        return res;
       },
     ),
     def(

--- a/src/services/comfy-view-ref.ts
+++ b/src/services/comfy-view-ref.ts
@@ -1,0 +1,372 @@
+// Decide whether an absolute path on the ORCHESTRATOR host names a file the
+// connected ComfyUI can serve over /view — and, when it can, produce the exact
+// ref to hand the panel.
+//
+// WHY THIS EXISTS (#648). panel_show_media's absolute-path branch base64-encodes
+// the whole file into the tool reply, so it must cap the payload. The cap is
+// correct — a 72 MB inline payload is not something to send an agent, and
+// raising it is not the fix. But on its own the cap is a DEAD END: an agent
+// asked to preview an ordinary local reference video was told only that a
+// ceiling exists, with nothing it could do about it, so it concluded the task
+// was impossible.
+//
+// A file that ALREADY lives under a directory ComfyUI serves needs no inline
+// payload at all. The panel is a browser tab on ComfyUI's own origin, so it
+// fetches /view directly; there is no size cap on that path, and a viewRef
+// video arriving at the panel gets the full sampled-frame preview and
+// disclosure. So the remedy is to forward a ref instead of refusing.
+//
+// THREE ANSWERS, NOT TWO. The naive check ("is the path under the output dir?")
+// collapses "we could not find out" into "no", which sends the caller to move a
+// file that may already be in exactly the right place. This module keeps them
+// apart:
+//
+//   servable — PROVEN inside a directory this ComfyUI serves. Emits the ref.
+//   outside  — the roots WERE resolved and the file is provably in none of them.
+//   unknown  — the roots could not be resolved. NOT "outside".
+//   remote   — ComfyUI runs on another host, so a path on THIS machine names a
+//              file that server cannot open, whatever the path says.
+//
+// EVIDENCE, NOT ASSUMPTION. The roots come from resolveOutputDir/resolveInputDir,
+// which ask the RUNNING server for its launch argv (--output-directory /
+// --base-directory) before falling back to <COMFYUI_PATH>/output. That matters:
+// ComfyUI is routinely launched with its output elsewhere, and assuming
+// <COMFYUI_PATH>/output would mint refs that resolve to nothing.
+//
+// Deliberately NOT resolveEffectiveComfyUIBase(): it returns config.comfyuiPath
+// BEFORE it checks remote mode, contradicting its own docstring (#490, owned
+// elsewhere — not fixed here, and not built on either). The same exposure reaches
+// this module by another route, because localOutputDirFallback() also reads
+// config.comfyuiPath directly, and an explicitly-set COMFYUI_PATH survives into
+// remote mode. That is exactly why the remote check runs FIRST, before any root
+// is resolved: otherwise a remote session with COMFYUI_PATH set would compare a
+// local file against a local-looking root and call it servable, and the panel
+// would resolve that ref against the REMOTE server — showing a different file,
+// or nothing. Never let a coincidence of path strings stand in for evidence that
+// the server can reach the file.
+//
+// NOT COVERED: ComfyUI's temp directory. There is no --temp-directory parser in
+// this codebase, so a file under it cannot be recognised. The refusal therefore
+// names the directories it actually checked rather than claiming no directory
+// could serve the file.
+
+import { realpath } from "node:fs/promises";
+import { basename, dirname, relative, resolve, sep } from "node:path";
+import { isCloudMode, isRemoteMode } from "../config.js";
+import { resolveInputDir, resolveOutputDir } from "./output-dir.js";
+
+/** The /view directories this module can establish from evidence. */
+export type ViewRefKind = "output" | "input";
+
+/** A ref in exactly the shape panel_show_media forwards and /view accepts. */
+export type ComfyServableRef = {
+  filename: string;
+  subfolder?: string;
+  type: ViewRefKind;
+};
+
+export type CheckedRoot = { kind: ViewRefKind; dir: string };
+
+export type ViewRefResolution =
+  | { status: "servable"; ref: ComfyServableRef; root: CheckedRoot }
+  | { status: "outside"; checked: CheckedRoot[] }
+  | { status: "remote"; reason: string }
+  | { status: "unknown"; reason: string };
+
+const errText = (err: unknown): string =>
+  err instanceof Error ? err.message : String(err);
+
+/** Windows compares paths case-insensitively; POSIX does not. */
+const norm = (p: string): string =>
+  process.platform === "win32" ? p.toLowerCase() : p;
+
+/**
+ * The real path, or the lexical one when it cannot be resolved.
+ *
+ * Resolving a symlink is itself an operation that can fail (a broken link, a
+ * permission wall, a dead network share). Falling back to the lexical path keeps
+ * this a guard rather than a new failure mode — and the containment test below
+ * is still applied to whatever comes back, so a fallback can only ever make the
+ * check stricter, never let something through.
+ */
+async function realOrLexical(p: string): Promise<string> {
+  try {
+    return await realpath(p);
+  } catch {
+    return p;
+  }
+}
+
+/**
+ * STRICT containment: `child` sits somewhere beneath `root`.
+ *
+ * Equality is deliberately excluded — the caller has already established the
+ * path is a regular file, so a path equal to the root is a contradiction, and
+ * admitting it would derive an empty filename.
+ *
+ * The separator is required, so `/comfy/output-old/x.mp4` is not treated as
+ * living under `/comfy/output`.
+ */
+function isStrictlyInside(child: string, root: string): boolean {
+  const r = norm(root);
+  const withSep = r.endsWith(sep) ? r : r + sep;
+  return norm(child).startsWith(withSep);
+}
+
+/**
+ * Why a derived ref is not safe to forward, or null when it is.
+ *
+ * Containment should already guarantee this shape, but the ref is about to be
+ * handed to ComfyUI's /view, which has historically been permissive about ".."
+ * and absolute values in these parameters. A derived value that fails here means
+ * the derivation did something this module did not predict — so the answer is
+ * "unknown", never a silently-emitted bad ref.
+ */
+function refShapeProblem(filename: string, subfolder: string): string | null {
+  if (!filename) return "the derived filename is empty";
+  if (filename.includes("\0") || subfolder.includes("\0")) {
+    return "the derived ref contains a NUL byte";
+  }
+  if (filename.includes("/") || filename.includes("\\")) {
+    return "the derived filename is not a single path segment";
+  }
+  if (filename === "." || filename === "..") {
+    return "the derived filename is a directory entry, not a file";
+  }
+  if (subfolder.startsWith("/") || /^[A-Za-z]:/.test(subfolder)) {
+    return "the derived subfolder is not relative to the media directory";
+  }
+  if (subfolder.split("/").some((s) => s === "..")) {
+    return "the derived subfolder escapes the media directory";
+  }
+  return null;
+}
+
+/**
+ * Establish whether `absPath` is servable by the connected ComfyUI over /view.
+ *
+ * Never throws: every step (a network probe for the launch argv, a realpath, the
+ * path arithmetic) is an operation that can fail, and a guard that throws is not
+ * a guard — a failure here has to come back as `unknown`, which the caller can
+ * report honestly, not as an exception that reaches the agent as a transport
+ * error with no remedy in it.
+ */
+export async function resolveServableViewRef(
+  absPath: string,
+): Promise<ViewRefResolution> {
+  // FIRST, before any root is resolved — see the module header. A local path
+  // cannot be servable by a server on another machine, and a root that merely
+  // looks local is not evidence that it is.
+  if (isCloudMode()) {
+    return {
+      status: "remote",
+      reason:
+        "this session targets ComfyUI Cloud, which has no access to this machine's filesystem",
+    };
+  }
+  if (isRemoteMode()) {
+    return {
+      status: "remote",
+      reason:
+        "this session targets a REMOTE ComfyUI on a different host, which has no access to this machine's filesystem",
+    };
+  }
+
+  const roots: CheckedRoot[] = [];
+  const failures: string[] = [];
+  // Resolved INDEPENDENTLY: one directory failing must not discard the other.
+  // A file proven to be under a resolved output dir is servable whether or not
+  // the input dir could be resolved.
+  for (const kind of ["output", "input"] as const) {
+    try {
+      const dir = await (kind === "output"
+        ? resolveOutputDir()
+        : resolveInputDir());
+      if (typeof dir === "string" && dir.length > 0) {
+        roots.push({ kind, dir: resolve(dir) });
+      } else {
+        failures.push(`the ${kind} directory resolved to an empty value`);
+      }
+    } catch (err) {
+      failures.push(`the ${kind} directory could not be resolved (${errText(err)})`);
+    }
+  }
+
+  if (roots.length === 0) {
+    return {
+      status: "unknown",
+      reason:
+        failures.join("; ") ||
+        "no ComfyUI media directory could be resolved",
+    };
+  }
+
+  try {
+    const real = await realOrLexical(resolve(absPath));
+    for (const root of roots) {
+      const realRoot = await realOrLexical(root.dir);
+      if (!isStrictlyInside(real, realRoot)) continue;
+      // Derived from the REAL paths on both sides, so a symlinked entry inside
+      // the root cannot name a file outside it. realRoot and root.dir are the
+      // same directory, so the relative path is valid against either — which is
+      // what ComfyUI joins onto its own configured root.
+      const rel = relative(realRoot, real);
+      const filename = basename(rel);
+      const parent = dirname(rel);
+      const subfolder =
+        parent === "." || parent === "" ? "" : parent.split(sep).join("/");
+      const problem = refShapeProblem(filename, subfolder);
+      if (problem) {
+        return {
+          status: "unknown",
+          reason: `the file is under ComfyUI's ${root.kind} directory but ${problem}`,
+        };
+      }
+      return {
+        status: "servable",
+        ref: { filename, ...(subfolder ? { subfolder } : {}), type: root.kind },
+        root,
+      };
+    }
+  } catch (err) {
+    return {
+      status: "unknown",
+      reason: `the path could not be compared against ComfyUI's media directories (${errText(err)})`,
+    };
+  }
+
+  // Matched nothing. Whether that means "outside" depends on whether every
+  // directory was actually checked: with one unresolved, the file could be
+  // sitting in it, and reporting "outside" would send the caller to move a file
+  // that is already in the right place.
+  if (failures.length > 0) {
+    return {
+      status: "unknown",
+      reason:
+        `it is not under ${roots.map((r) => `ComfyUI's ${r.kind} directory (${r.dir})`).join(" or ")}, ` +
+        `but ${failures.join("; ")} — so whether ComfyUI can serve it is undetermined`,
+    };
+  }
+  return { status: "outside", checked: roots };
+}
+
+const mb = (bytes: number): string => `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+
+/**
+ * The refusal for a file too large to inline that could NOT be forwarded by
+ * reference — stating the limit, why it exists, and a remedy that works from
+ * where the caller actually is.
+ *
+ * Every branch ends in something the caller can do NEXT, from its current state.
+ * A bare ceiling is not a remedy: it names a fact and leaves the caller with no
+ * move, which is the whole defect this addresses.
+ */
+export function oversizedInlineRefusal(opts: {
+  path: string;
+  sizeBytes: number;
+  capBytes: number;
+  kind: "image" | "video";
+  resolution: ViewRefResolution;
+}): string {
+  const { path, sizeBytes, capBytes, kind, resolution } = opts;
+
+  const seeItYourself =
+    kind === "video"
+      ? "The panel then builds a SAMPLED contact sheet of the video for you; you are still not sent the video itself."
+      : "The panel then displays it to the USER at full size. To look at it YOURSELF, call get_image with its filename/subfolder/type — that returns the image inline.";
+
+  const head =
+    `file too large to send inline (${mb(sizeBytes)} > ${mb(capBytes)} cap): ${path}\n` +
+    `The cap applies to the INLINE path only: this tool base64-encodes the file into the reply, and a payload that size would swamp the context. ` +
+    `There is a route with no size limit — a file that lives under a directory ComfyUI serves is displayed BY REFERENCE, because the panel is a browser tab on ComfyUI's own origin and fetches it directly.`;
+
+  if (resolution.status === "remote") {
+    return (
+      `${head}\n` +
+      `That route is unavailable here: ${resolution.reason}. A path on this machine names a file that server cannot open, so no reference to it would resolve.\n` +
+      `What you can do:\n` +
+      `  1. Put the file on the ComfyUI host — upload it into that server's input directory — then call panel_show_media with a ComfyUI reference ({ filename, type: "input" }) instead of a path.\n` +
+      `  2. Ask the user to open the file themselves; it is on the machine they are at.`
+    );
+  }
+
+  if (resolution.status === "unknown") {
+    return (
+      `${head}\n` +
+      `Whether that route is available could NOT be determined: ${resolution.reason}. ` +
+      `That is not the same as knowing the file is in the wrong place — it may already be under a directory ComfyUI serves.\n` +
+      `What you can do:\n` +
+      `  1. Make the directories resolvable and retry: check ComfyUI is running and reachable (its launch arguments are the primary source), or set COMFYUI_PATH to the ComfyUI install.\n` +
+      `  2. Copy the file under ComfyUI's output directory and call panel_show_media again with the new path.\n` +
+      `  3. Ask the user to open the file themselves.`
+    );
+  }
+
+  if (resolution.status === "outside") {
+    const list = resolution.checked
+      .map((r) => `    - ${r.kind}: ${r.dir}`)
+      .join("\n");
+    return (
+      `${head}\n` +
+      `This file is not under any directory this ComfyUI serves. Checked:\n${list}\n` +
+      `What you can do:\n` +
+      `  1. Copy or move it under one of the directories above (a subfolder is fine) and call panel_show_media again with the NEW path. ${seeItYourself}\n` +
+      `  2. Ask the user to move it, or to open it themselves; it is on the machine they are at.`
+    );
+  }
+
+  // A servable file is not refused — reaching here means the caller ignored the
+  // resolution. Say so rather than inventing a reason it could not be shown.
+  return (
+    `file too large to send inline (${mb(sizeBytes)} > ${mb(capBytes)} cap): ${path}\n` +
+    `This file IS servable by reference and should not have been refused; this is a bug in panel_show_media, not a problem with the file.`
+  );
+}
+
+/** One item that was forwarded by reference instead of inlined. */
+export type ForwardedByReference = {
+  path: string;
+  sizeBytes: number;
+  kind: "image" | "video";
+  ref: ComfyServableRef;
+};
+
+/**
+ * What the agent is told about items that took the reference route.
+ *
+ * States ONLY what this process did — it forwarded a reference. Whether the
+ * panel actually displayed anything is in the panel's own reply, which reports
+ * its paint outcomes; claiming a display here would be fabricating a result this
+ * code never observed.
+ */
+export function forwardedByReferenceNote(
+  items: ForwardedByReference[],
+  capBytes: number,
+): string {
+  const lines = items.map((it) => {
+    const where = it.ref.subfolder
+      ? `type "${it.ref.type}", subfolder "${it.ref.subfolder}"`
+      : `type "${it.ref.type}"`;
+    return `  - ${it.ref.filename} (${mb(it.sizeBytes)}, ${it.kind}) — ${where}`;
+  });
+  const anyVideo = items.some((it) => it.kind === "video");
+  const anyImage = items.some((it) => it.kind === "image");
+  const howToSee = [
+    anyImage
+      ? `To look at an IMAGE yourself, call get_image with the filename/type/subfolder above — it comes back inline.`
+      : null,
+    anyVideo
+      ? `A VIDEO is never sent to you inline; the panel's reply above carries a sampled contact sheet and says what it does and does not show. get_image on a video saves it to disk and returns the path.`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    `NOTE — ${items.length === 1 ? "1 item was" : `${items.length} items were`} over the ${mb(capBytes)} inline cap, ` +
+    `so ${items.length === 1 ? "it was" : "they were"} sent to the panel as ComfyUI /view reference${items.length === 1 ? "" : "s"} instead of inline data ` +
+    `(that path has no size limit):\n${lines.join("\n")}\n` +
+    `You were NOT sent the bytes of ${items.length === 1 ? "this file" : "these files"}. Whether the panel displayed ${items.length === 1 ? "it" : "them"} is in its reply above, not here. ` +
+    howToSee
+  );
+}

--- a/src/services/comfy-view-ref.ts
+++ b/src/services/comfy-view-ref.ts
@@ -73,27 +73,59 @@ export type ViewRefResolution =
   | { status: "remote"; reason: string }
   | { status: "unknown"; reason: string };
 
-const errText = (err: unknown): string =>
-  err instanceof Error ? err.message : String(err);
+/**
+ * Describe a caught failure, without becoming one.
+ *
+ * `String(err)` is itself an operation that can fail — a rejection carrying
+ * `Object.create(null)` has no `toString`, and a getter on `.message` can throw.
+ * Unguarded, describing the error rejected the function that was handling it, so
+ * a resolver failure that should have become `unknown` reached the agent as an
+ * opaque transport error with no remedy in it. A catch that can throw is not a
+ * catch (codex finding).
+ */
+const errText = (err: unknown): string => {
+  try {
+    if (err instanceof Error) {
+      const m = err.message;
+      if (typeof m === "string" && m) return m;
+    }
+    const s = String(err);
+    return s || "an error with no description";
+  } catch {
+    return "an error that could not be described";
+  }
+};
 
 /** Windows compares paths case-insensitively; POSIX does not. */
 const norm = (p: string): string =>
   process.platform === "win32" ? p.toLowerCase() : p;
 
 /**
- * The real path, or the lexical one when it cannot be resolved.
+ * A path canonicalised as far as it could be, and whether that succeeded.
  *
- * Resolving a symlink is itself an operation that can fail (a broken link, a
- * permission wall, a dead network share). Falling back to the lexical path keeps
- * this a guard rather than a new failure mode — and the containment test below
- * is still applied to whatever comes back, so a fallback can only ever make the
- * check stricter, never let something through.
+ * `canonical` is never allowed to reject — resolving a symlink can fail on a
+ * broken link, a permission wall or a dead share — but WHETHER it failed is
+ * load-bearing and must not be swallowed. A lexical fallback that misses every
+ * root is not evidence the file is outside them: the link it could not follow
+ * may well point straight into one. Callers that find no match while `resolved`
+ * is false owe the caller "unknown", not "move your file" (codex finding).
+ *
+ * `code` distinguishes the one failure that carries NO uncertainty: a root that
+ * does not exist (ENOENT) cannot contain anything, so missing it is a real
+ * "outside", not an open question.
  */
-async function realOrLexical(p: string): Promise<string> {
+type Canonical = { path: string; resolved: boolean; code?: string; why?: string };
+
+async function canonical(p: string): Promise<Canonical> {
   try {
-    return await realpath(p);
-  } catch {
-    return p;
+    return { path: await realpath(p), resolved: true };
+  } catch (err) {
+    return {
+      path: p,
+      resolved: false,
+      code: (err as NodeJS.ErrnoException)?.code,
+      why: errText(err),
+    };
   }
 }
 
@@ -201,16 +233,33 @@ export async function resolveServableViewRef(
     };
   }
 
+  // Canonicalisations that FAILED, and so left a comparison inconclusive. A miss
+  // against a root we could not canonicalise is not a proven miss.
+  const inconclusive: string[] = [];
   try {
-    const real = await realOrLexical(resolve(absPath));
+    const file = await canonical(resolve(absPath));
+    if (!file.resolved) {
+      // The caller already stat'ed this file successfully, so it exists and is
+      // reachable; a realpath that still fails means a link this process cannot
+      // follow, which could point into a served directory.
+      inconclusive.push(
+        `the file's real location could not be resolved (${file.why ?? "unknown error"})`,
+      );
+    }
     for (const root of roots) {
-      const realRoot = await realOrLexical(root.dir);
-      if (!isStrictlyInside(real, realRoot)) continue;
-      // Derived from the REAL paths on both sides, so a symlinked entry inside
-      // the root cannot name a file outside it. realRoot and root.dir are the
-      // same directory, so the relative path is valid against either — which is
-      // what ComfyUI joins onto its own configured root.
-      const rel = relative(realRoot, real);
+      const realRoot = await canonical(root.dir);
+      // A root that does not exist cannot contain anything, so failing to
+      // canonicalise it carries no uncertainty. Any OTHER failure does.
+      if (!realRoot.resolved && realRoot.code !== "ENOENT") {
+        inconclusive.push(
+          `ComfyUI's ${root.kind} directory could not be canonicalised (${realRoot.why ?? "unknown error"})`,
+        );
+      }
+      if (!isStrictlyInside(file.path, realRoot.path)) continue;
+      // Derived from the same pair the containment test just passed, so the
+      // relative path is exactly the one ComfyUI joins onto its own configured
+      // root — whether that pair was canonical or lexical.
+      const rel = relative(realRoot.path, file.path);
       const filename = basename(rel);
       const parent = dirname(rel);
       const subfolder =
@@ -236,15 +285,17 @@ export async function resolveServableViewRef(
   }
 
   // Matched nothing. Whether that means "outside" depends on whether every
-  // directory was actually checked: with one unresolved, the file could be
-  // sitting in it, and reporting "outside" would send the caller to move a file
-  // that is already in the right place.
-  if (failures.length > 0) {
+  // comparison was actually conclusive — a directory that would not resolve, or
+  // a path that would not canonicalise, leaves room for the file to be sitting
+  // somewhere ComfyUI serves. Reporting "outside" then would send the caller to
+  // move a file that is already in the right place.
+  const doubts = [...failures, ...inconclusive];
+  if (doubts.length > 0) {
     return {
       status: "unknown",
       reason:
         `it is not under ${roots.map((r) => `ComfyUI's ${r.kind} directory (${r.dir})`).join(" or ")}, ` +
-        `but ${failures.join("; ")} — so whether ComfyUI can serve it is undetermined`,
+        `but ${doubts.join("; ")} — so whether ComfyUI can serve it is undetermined`,
     };
   }
   return { status: "outside", checked: roots };

--- a/src/services/comfy-view-ref.ts
+++ b/src/services/comfy-view-ref.ts
@@ -256,9 +256,34 @@ export async function resolveServableViewRef(
         );
       }
       if (!isStrictlyInside(file.path, realRoot.path)) continue;
+      // A MATCH made against a path we could not canonicalise is not a proven
+      // match (independent gate P0). `inconclusive` was consulted only on the
+      // matched-nothing path below, so a lexical fallback that happened to land
+      // under a root returned `servable` and forwarded a /view reference nobody
+      // had verified — a 404, or a different file, presented as servable.
+      //
+      // The doubt is tested against THIS pair rather than the whole run: a
+      // failure canonicalising some OTHER root says nothing about the one that
+      // matched, and refusing on it would be the same fold pointed the other way.
+      // An ENOENT root is excluded for the reason given above — a directory that
+      // does not exist cannot contain anything, so failing to canonicalise it
+      // carries no uncertainty.
+      const rootUnproven = !realRoot.resolved && realRoot.code !== "ENOENT";
+      if (!file.resolved || rootUnproven) {
+        return {
+          status: "unknown",
+          reason:
+            `it looks like it is under ComfyUI's ${root.kind} directory, but ` +
+            `${
+              !file.resolved
+                ? `the file's real location could not be resolved (${file.why ?? "unknown error"})`
+                : `that directory could not be canonicalised (${realRoot.why ?? "unknown error"})`
+            } — so the match was made against an unverified path and whether ComfyUI can serve it is undetermined`,
+        };
+      }
       // Derived from the same pair the containment test just passed, so the
       // relative path is exactly the one ComfyUI joins onto its own configured
-      // root — whether that pair was canonical or lexical.
+      // root — and both sides of that pair are now proven canonical.
       const rel = relative(realRoot.path, file.path);
       const filename = basename(rel);
       const parent = dirname(rel);

--- a/src/services/comfy-view-ref.ts
+++ b/src/services/comfy-view-ref.ts
@@ -265,10 +265,14 @@ export async function resolveServableViewRef(
       // The doubt is tested against THIS pair rather than the whole run: a
       // failure canonicalising some OTHER root says nothing about the one that
       // matched, and refusing on it would be the same fold pointed the other way.
-      // An ENOENT root is excluded for the reason given above — a directory that
-      // does not exist cannot contain anything, so failing to canonicalise it
-      // carries no uncertainty.
-      const rootUnproven = !realRoot.resolved && realRoot.code !== "ENOENT";
+      // ENOENT is NOT carved out here, unlike on the non-match path below. That
+      // exclusion is sound only in the negative direction: an absent directory
+      // cannot contain the file, so it adds no doubt to an "outside" answer. This
+      // line is reached only AFTER containment passed against the root's lexical
+      // fallback, and there an ENOENT root is load-bearing — a concurrent agent
+      // renaming the directory between our stat and our realpath would hand back
+      // a /view ref for a root that is no longer there.
+      const rootUnproven = !realRoot.resolved;
       if (!file.resolved || rootUnproven) {
         return {
           status: "unknown",


### PR DESCRIPTION
## Issue

- #648 — `panel_show_media` cannot preview local reference videos over 20 MB

## Why this exists separately

Panel PR **#649** fixed the panel half: video now routes through the existing storyboard pipeline with full disclosure (the video was NOT sent, N *sampled* frames, source size or explicit UNKNOWN, `get_image` as the way to actually see it). It also fixed a worse bug found on the way — **under** the ceiling the panel painted a player for the *user* and returned `{ok:true,count:1}` to an agent that had been shown nothing.

But **#648's literal repro still fails**, because the refusal is raised here, before the panel is ever called:

`src/orchestrator/panel-tools.ts` — `panel_show_media`, absolute-path branch:

```ts
if (stat.size > MAX_BYTES) {
  return fail(
    "file too large (" + (stat.size / 1024 / 1024).toFixed(1) + " MB > 20 MB): " + p,
  );
}
```

## What to do

The refusal itself is **correct** — a 72 MB inline payload is not something to send an agent, and raising the cap is not the fix. The bug is that it is a **dead end**: it names a ceiling with no way past it, so an agent asked to inspect an ordinary local reference video concludes the task is impossible.

Two cases, and they need different answers:

1. **The file is under a ComfyUI root.** Forward it as a `viewRef` instead of refusing — there is no size cap on that path, and it is what a browser panel resolves same-origin anyway. A `viewRef` video arriving at the panel **already** gets the full preview and disclosure today (#649), so this one change completes the feature end to end.
2. **The file is not under a root.** Keep the refusal, but make it name a remedy that works from where the caller is — the size limit, why it exists, and what they can do (move/copy it under a root, or ask the user). **A remedy must be actionable from the caller's current state**; a bare ceiling is not one.

## Constraints

- **Do not raise `MAX_BYTES`.** The cap protects the inline payload path and is doing its job.
- Establish "under a ComfyUI root" from evidence, not assumption. Note **#490 is reopened**: `resolveEffectiveComfyUIBase()` returns `config.comfyuiPath` before checking remote mode, and `comfy-cli.ts` bypasses it entirely. Another agent owns that fix — **do not fix it here**, but do not build on the broken guarantee either. If the root cannot be established, that is *unknown*, not *not-under-a-root*.
- A `stat` that throws is not a "file too large" and not a "file not found" — check what the surrounding branch does with an unreadable file.
- This is the same split-halves pattern as #614 / #809. The panel half is merged-pending; this half closes the issue.

**Not yet started** — draft until an agent picks it up.