### PR TITLE
fix(release): the changelog generator silently dropped the entries that mattered most

### DIFF
--- a/scripts/gen-changelog.mjs
+++ b/scripts/gen-changelog.mjs
@@ -66,20 +66,77 @@ function prevTag() {
   return git("rev-list --max-parents=0 HEAD").split(/\s+/)[0]; // first commit
 }
 
-/** Parsed conventional commits since `range`, newest-first, minus noise. */
+/** A release commit, in either shape we actually produce: `release: 0.49.6`, or the
+ *  squash-merge form GitHub writes from a PR titled with the bare version — `0.49.6 (#849)`.
+ *  Only the first was recognised, so the second fell through to the non-conventional
+ *  path and was silently dropped along with everything else there. */
+const isReleaseSubject = (s) => /^release:/i.test(s) || /^v?\d+\.\d+\.\d+\s*(\(#\d+\))?$/.test(s);
+
+/** Parsed commits since `range`, newest-first, minus noise.
+ *
+ *  A NON-CONVENTIONAL subject that carries a PR number is INCLUDED, not skipped. The
+ *  old code dropped it on the assumption it was "usually already covered by a PR merge"
+ *  — but a squash merge's subject IS the PR title, and this project's PR titles are
+ *  descriptive prose ("download_model: large-file timeouts…"), not `fix(scope):`. So the
+ *  assumption inverted the outcome: the entries most likely to be dropped were the
+ *  substantial ones, because a big PR gets a written title and a small one gets a
+ *  conventional prefix.
+ *
+ *  That silently omitted the headline entry from three consecutive releases — panel
+ *  0.11.39 lost #621 (a CRITICAL wrong-graph fix), mcp 0.49.6 lost #831 (which closed
+ *  eleven issues), and panel 0.11.40 lost three of its four. Each was caught by hand
+ *  only because someone read the generated output against the commit list.
+ *
+ *  Two rules now, and the second matters as much as the first:
+ *   1. anything with a PR number is emitted (defaulting to "Changed" when the type is
+ *      unstated) — a human editing a slightly-noisy line is cheap; a missing headline
+ *      fix is not;
+ *   2. NOTHING is dropped silently. Whatever is still skipped is reported to stderr, so
+ *      a release always shows what it chose to leave out. A generator whose output looks
+ *      complete when it is not is worse than no generator. */
 function parseCommits(range) {
   const raw = git(`log ${range} --no-merges --pretty=format:%s`);
   if (!raw) return [];
   const out = [];
+  const skipped = [];
   for (const subject of raw.split("\n")) {
-    if (/^release:/i.test(subject)) continue; // release commits describe themselves
+    if (isReleaseSubject(subject)) continue; // release commits describe themselves
     const m = subject.match(/^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/);
-    if (!m) continue; // non-conventional → skip (usually already covered by a PR merge)
+    // Read the PR number from the DESCRIPTION when the subject is conventional, and only
+    // from the whole subject otherwise. `fix(#809): … (#818)` puts an ISSUE number in the
+    // scope and the PR number at the end; scanning the whole subject would take #809 and
+    // mis-attribute the entry — and, worse, break the dedupe against hand-written
+    // highlights, which is keyed on the PR number.
+    const prIn = (s) => (s.match(/\(#(\d+)\)/) || [])[1] || null;
+    if (!m) {
+      // Non-conventional. Keep it if it names a PR; otherwise it is a local commit
+      // that a squash will have superseded, and dropping it is right.
+      const pr = prIn(subject);
+      if (pr) {
+        out.push({ type: "", scope: "", desc: subject.trim(), section: "Changed", pr });
+      } else {
+        skipped.push(subject);
+      }
+      continue;
+    }
     const [, type, scope, , desc] = m;
-    const section = TYPE_SECTION[type.toLowerCase()];
-    if (!section) continue;
-    const pr = (desc.match(/\(#(\d+)\)/) || [])[1] || null;
+    const pr = prIn(desc);
+    // An UNMAPPED type (chore/ci/test/build/style/docs) is housekeeping and stays out —
+    // but only when it has no PR number. A `test(...)` or `docs(...)` PR is a real
+    // shipped change; panel 0.11.40's de-flake landed that way.
+    const section = TYPE_SECTION[type.toLowerCase()] ?? (pr ? "Changed" : null);
+    if (!section) {
+      skipped.push(subject);
+      continue;
+    }
     out.push({ type, scope: scope || "", desc: desc.trim(), section, pr });
+  }
+  if (skipped.length) {
+    process.stderr.write(
+      `changelog: left out ${skipped.length} commit(s) with no PR number — check none belong:\n` +
+        skipped.map((s) => `  · ${s}`).join("\n") +
+        "\n",
+    );
   }
   return out;
 }


### PR DESCRIPTION
Three consecutive releases shipped with the **headline entry missing**, each caught only because someone read the generated output against the commit list:

| release | lost |
|---|---|
| panel 0.11.39 | **#621** — a CRITICAL wrong-graph fix |
| mcp 0.49.6 | **#831** — which closed eleven issues |
| panel 0.11.40 | 3 of its 4 commits |

## One line caused it

```js
if (!m) continue; // non-conventional → skip (usually already covered by a PR merge)
```

The comment states the assumption, and **the assumption is backwards for this project.** A squash merge's subject *is* the PR title, and our PR titles are descriptive prose — `download_model: large-file timeouts, no resume, wrong base on Windows portable` — not `fix(scope):`.

So the rule selected against exactly the wrong commits: **a large PR gets a written title and is dropped; a small one gets a conventional prefix and is kept.** A generator whose output *looks* complete when it is not is worse than no generator.

## Two rules now

1. **Anything carrying a PR number is emitted**, defaulting to `Changed` when the type is unstated. A human editing a slightly noisy line is cheap; a missing headline fix is not. This also covers `test(...)`/`docs(...)` PRs — panel 0.11.40's de-flake landed as `test:` and was dropped as housekeeping when it was a shipped change.
2. **Nothing is dropped silently.** Whatever is still skipped (a local commit with no PR, which a squash supersedes) is listed on stderr, so a release always shows what it chose to leave out.

Also recognises the release-commit shape GitHub actually writes: `^release:` matched `release: 0.49.6`, but a PR titled with the bare version squashes to `0.49.6 (#849)` and fell through to the non-conventional path.

## A regression I introduced, and caught

Reading the PR number from the whole subject makes `fix(#809): … (#818)` pick up **#809** — the *issue* in the scope — instead of #818. That would mis-attribute the entry and break the dedupe against hand-written highlights, which is keyed on the PR number.

I found it by **simulating the new parser over a real tag range before committing**, rather than trusting the change. The number is now read from the description for conventional subjects and from the whole subject only otherwise.

## Verification

Re-parsed `v0.49.5..v0.49.6`:
- **5 of 5** real commits captured (was 3)
- **0** skipped
- release commit correctly ignored
- every PR number attributed to the PR, not an issue
- generated output is valid UTF-8, **zero** control bytes, **zero** U+FFFD

The panel ships its own copy of this generator with the same line — fixing it there too, separately.