### PR TITLE
fix(release): attribute a changelog entry to the PR, not the first issue it cites

### DIFF
--- a/scripts/gen-changelog.mjs
+++ b/scripts/gen-changelog.mjs
@@ -102,12 +102,21 @@ function parseCommits(range) {
   for (const subject of raw.split("\n")) {
     if (isReleaseSubject(subject)) continue; // release commits describe themselves
     const m = subject.match(/^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/);
-    // Read the PR number from the DESCRIPTION when the subject is conventional, and only
-    // from the whole subject otherwise. `fix(#809): … (#818)` puts an ISSUE number in the
-    // scope and the PR number at the end; scanning the whole subject would take #809 and
-    // mis-attribute the entry — and, worse, break the dedupe against hand-written
-    // highlights, which is keyed on the PR number.
-    const prIn = (s) => (s.match(/\(#(\d+)\)/) || [])[1] || null;
+    // The LAST `(#N)`, not the first: GitHub appends the PR reference at the end of a
+    // squash subject, so anything earlier is an ISSUE the author cited. Both shapes occur —
+    // `fix(#809): … (#818)` puts the issue in the SCOPE, and
+    // `test: … (#852) (#853)` puts it INLINE — and taking the first match attributes the
+    // entry to the issue. (Reading only the description fixes the first shape and not the
+    // second, which is why this reads positionally rather than by field.)
+    //
+    // Beyond a wrong link, this breaks the dedupe against hand-written highlights, which is
+    // keyed on the PR number — so a hand-written entry would be DUPLICATED by the
+    // auto-generated one instead of suppressed. That is the same class of failure as the
+    // silent drop this file was just fixed for, in the opposite direction.
+    const prIn = (s) => {
+      const all = [...s.matchAll(/\(#(\d+)\)/g)];
+      return all.length ? all[all.length - 1][1] : null;
+    };
     if (!m) {
       // Non-conventional. Keep it if it names a PR; otherwise it is a local commit
       // that a squash will have superseded, and dropping it is right.


### PR DESCRIPTION
Follow-up to #855.

**This change was written alongside #855 but never reached the branch.** I committed it onto a detached HEAD in a worktree and read my own echo of the local commit as proof of a push. #855 merged without it. Recording that plainly, because *"I pushed it"* and *"the remote has it"* are different claims and I asserted the first while verifying neither. This PR's push is verified against `git ls-remote`.

## The defect

The PR reference is the **last** `(#N)` in a squash subject — GitHub appends it — so anything earlier is an **issue** the author cited. Two shapes occur here, and only one is fixed by reading the description instead of the whole subject:

| subject | issue is |
|---|---|
| `fix(#809): truncated results … (#818)` | in the **scope** |
| `test: give the suite a real timeout (#852) (#853)` | **inline** |

The second is why this now reads *positionally* rather than by field.

## Measured, not reasoned

Parsing the real `v0.49.6..HEAD` range and diffing first-match against last-match:

```
   same     first=#855  last=#855   fix(release): the changelog generator silently…
   same     first=#832  last=#832   panel version floor: blocked mutations with no…
  CHANGED   first=#852  last=#853   test: give the suite a real timeout — the "rota…
```

That entry was attributed to **#852, the issue**.

## Why it matters beyond a wrong link

The dedupe against hand-written highlights is **keyed on the PR number**. A hand-written entry citing the PR would be **duplicated** by the auto-generated one instead of suppressed — the same class of failure as the silent drop #855 fixed, in the opposite direction.

The panel's copy (panel #657) already shipped with last-match; this brings the two back in sync.