### PR TITLE
0.49.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.49.7] - 2026-08-05
+
+### MCP
+
+#### Fixed
+- attribute a changelog entry to the PR, not the first issue it cites (#856)
+- the changelog generator silently dropped the entries that mattered most (#855)
+
+#### Changed
+- **panel version floor: blocked mutations with no self-service path, and "up-to-date"
+  that means "meets the minimum" (#832).** A read was being blocked by a WRITE gate: the
+  workflow fence asked "can this reach the wrong workflow's content?" and answered it with
+  a set that exists to answer "is this safe to re-dispatch after a reconnect?". Eight graph
+  commands that are genuine reads were refused as canvas mutations on older panels. There
+  is now a single effect ledger with enforcement a rename cannot step over. Separately,
+  a non-parseable advertised version (`nightly`, which is what ComfyUI-Manager reports for
+  a git-installed pack) was rendered as an observed version and an age verdict; it is now
+  screened by parseability and shown verbatim as evidence. Closes #819, #812, #806, #778;
+  #823 remains partly open.
+- give the suite a real timeout — the "rotating cast of flaky files" was runner starvation (#852) (#853)
+
+
 ## [0.49.6] - 2026-08-04
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.49.6",
+  "version": "0.49.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.49.6",
+      "version": "0.49.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.49.6",
+  "version": "0.49.7",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Contents

| PR | |
|---|---|
| **#832** | panel version floor: a **read blocked by a write gate**, and "up-to-date" that meant "meets the minimum" — closes #819, #812, #806, #778 |
| #853 | give the suite a real timeout — the "rotating cast of flaky files" was runner starvation, not shared state (#852) |
| #855 | the changelog generator silently dropped the entries that mattered most |
| #856 | attribute an entry to the PR, not the first issue it cites |

**#832 is the user-facing one.** The workflow fence asked *"can this reach the wrong workflow's content?"* and answered it with a set that exists to answer *"is this safe to re-dispatch after a reconnect?"* — so eight graph commands that are genuine **reads** were refused as canvas mutations on older panels. There is now a single effect ledger whose enforcement a rename cannot step over.

Separately, a non-parseable advertised version — `nightly`, which is what ComfyUI-Manager reports for a **git-installed pack**, so the normal case for anyone running from source — was rendered as an observed version *and* as an age verdict. It is now screened by parseability and shown verbatim as evidence.

## The generator finally worked

This is the **first release in four** that needed no hand-patching. It captured all four commits, including #832 (a descriptive PR title with no conventional prefix) and #853 (typed `test:`, previously discarded as housekeeping) — the exact two classes it used to drop. The #832 entry was expanded by hand for context only, not to add a missing line.

For contrast: 0.11.39 lost #621 (CRITICAL), 0.49.6 lost #831 (eleven issues), 0.11.40 lost three of four.

## Verification

- **252/252 files, 5062 tests pass / 2 skipped — at full concurrency, in 40s.** That is against **203s** at the `--maxWorkers=2` workaround #853 made unnecessary; the suite is now both reliable and ~5× faster here.
- `build`, `lint`, `check-tool-vocabulary`, `asset-counts --check` all clean
- Zero control bytes across changed files

After merge the tag needs pushing by hand — squash-merge orphans the tag `npm version` creates.
