### PR TITLE
docs: .env.example advertised the wrong default, and the README shipped a section twice

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ COMFYUI_PORT=8188
 
 # Compact tool mode for small/local LLMs (Hermes Agent, Ollama, ...): register
 # only the list_tools/describe_tool/call_tool meta-tools instead of the full
-# ~200-schema surface. Same as the --compact flag. Values: full (default) | compact
+# ~200-schema surface. Same as the --compact flag. Values: compact (default) | full
 # COMFYUI_MCP_TOOL_MODE=compact
 
 # Stable phone-pairing token for the mobile app. Without it, the pairing token is

--- a/README.md
+++ b/README.md
@@ -677,43 +677,6 @@ per-harness setup, troubleshooting:
 | `setup <agent>` | | | Write the comfyui entry into hermes / openclaw / copilot config, then exit |
 | `--full` / `--tool-mode full` | `COMFYUI_MCP_TOOL_MODE=full` | `compact` | Opt into the full ~200-schema surface; the default compact mode registers 3 meta-tools instead |
 
-### Other agents & local LLMs (Hermes, OpenClaw, Copilot CLI, Ollama)
-
-comfyui-mcp has **first-class support for non-Claude harnesses**. One command
-writes the server entry into the harness's own config (merging, not
-clobbering):
-
-```bash
-npx -y comfyui-mcp setup hermes     # → ~/.hermes/config.yaml      (compact by default)
-npx -y comfyui-mcp setup openclaw   # → ~/.openclaw/openclaw.json  (compact by default)
-npx -y comfyui-mcp setup copilot    # → ~/.copilot/mcp-config.json (full by default)
-# flags: --compact | --full, --comfyui-url <url>, --dry-run
-```
-
-**Model requirements**: tool calling is a hard requirement (no tool calling =
-doesn't work). Thinking and vision are strongly recommended — without
-thinking, multi-step tool chains degrade; without vision the agent can
-generate but can't see its own outputs.
-
-**Compact tool mode is the default**: the server registers 3 meta-tools
-(`list_tools` → `describe_tool` → `call_tool`) instead of the full ~200-schema
-surface (~200 KB / ~50k tokens per `tools/list`), pulling schemas into context
-one tool at a time. Frontier-model harnesses opt back into the full surface
-with `--full` / `COMFYUI_MCP_TOOL_MODE=full`. **Run it locally
-for free with our fine-tuned models**: `ollama pull artokun/gemma4-comfyui-mcp:e4b`
-(also `:e2b` for ~2 GB VRAM, `:12b` for ~8 GB) — Gemma 4 QLoRA-trained on 1,055
-server-verified trajectories over the full comfyui-mcp tool surface, and the
-panel's Ollama default. Stock `gemma4:*`/`qwen3:4b` also validated end-to-end
-(`npm run test:local-llm`); gemma3 has no native tool calling and is
-unsupported. Full guide — hosted-model guidance (DeepSeek/MiMo/GLM class),
-per-harness setup, troubleshooting:
-**[Local LLMs & other agents](https://comfyui-mcp.artokun.io/docs/local-llms)**.
-
-| Flag | Env | Default | Description |
-|------|-----|---------|-------------|
-| `setup <agent>` | | | Write the comfyui entry into hermes / openclaw / copilot config, then exit |
-| `--full` / `--tool-mode full` | `COMFYUI_MCP_TOOL_MODE=full` | `compact` | Opt into the full ~200-schema surface; the default compact mode registers 3 meta-tools instead |
-
 ### Remote ComfyUI
 
 Point the server at a ComfyUI running anywhere — no local install required:


### PR DESCRIPTION
Two defects found while verifying panel #111's discoverability triage. Both small, both actively misleading. Part of #860.

## `.env.example` advertised the wrong default

```diff
-# ~200-schema surface. Same as the --compact flag. Values: full (default) | compact
+# ~200-schema surface. Same as the --compact flag. Values: compact (default) | full
```

The default has been **compact since #667** — `http-backend-tools.ts:28` returns `compact` unless the env var is explicitly `"full"` — and the README's own flag table already documents `compact` as the default. So the example file contradicted **both the code and our own documentation**.

It taught the opposite of the truth to exactly the audience the setting exists for: someone configuring a small or local model. That is the worst shape a doc defect can take — a missing line leaves a user searching, a confidently wrong one sends them to change a setting that was already correct.

## The README shipped a section twice

`### Other agents & local LLMs (Hermes, OpenClaw, Copilot CLI, Ollama)` appeared **twice, verbatim** — 36 identical lines.

Verified byte-identical before deleting, and the script that did it **refuses to delete if the two blocks ever differ**, so this cannot silently drop content that had diverged. Pure deletion: **zero added lines**.

## Not in scope

The remaining #860 item — `npx comfyui-mcp --help` does not exist at all, so nothing teaches `--compact`/`--full` at the CLI — is a real change rather than a doc fix, and #860 stays open for it. That one is the product-level instance of what #841 just closed at the tool level.
