### PR TITLE
fix(#859): readOAuthStatus threaded home to one of its two halves

### DIFF
--- a/src/__tests__/services/code-provider-auth.test.ts
+++ b/src/__tests__/services/code-provider-auth.test.ts
@@ -259,27 +259,67 @@ describe("nativeCliStatus (CLI-auth detection for oauth_status)", () => {
 });
 
 describe("readOAuthStatus — home scoping (#859)", () => {
-  let tmp: string;
+  // A SECOND temp dir stands in for the developer's real home, and `os.homedir()`
+  // is pointed at it. That is what makes these deterministic: the failure mode is
+  // "the mirror read falls through to the real home", and without a real home we
+  // control, a test can only assert the absence of its own fixture — which proves
+  // nothing, because a genuine leak surfaces a REAL provider like `codex`, not the
+  // fixture. (That was the first version of this test, and the gate was right to
+  // reject it: it passed identically whether the fix was present or reverted.)
+  let scopedHome: string;
+  let pretendRealHome: string;
 
   beforeEach(async () => {
-    tmp = await mkdtemp(join(tmpdir(), "cmcp-oauth-home-"));
-    // The panel-secrets env override is the OTHER redirect and must stay unset
-    // here: this test exists to prove the `home` ARGUMENT alone scopes the read.
+    scopedHome = await mkdtemp(join(tmpdir(), "cmcp-oauth-scoped-"));
+    pretendRealHome = await mkdtemp(join(tmpdir(), "cmcp-oauth-realish-"));
+    // The env override is the OTHER redirect and outranks `home` by design; it must
+    // stay unset so these prove the `home` ARGUMENT alone scopes the read.
     delete process.env.COMFYUI_MCP_PANEL_SECRETS;
+
+    // The stand-in real home holds an ordinary, plausible signed-in provider —
+    // exactly what a developer machine signed into codex would have.
+    await mkdir(join(pretendRealHome, ".comfyui-mcp"), { recursive: true });
+    await writeFile(
+      join(pretendRealHome, ".comfyui-mcp", "panel-secrets.json"),
+      JSON.stringify({
+        oauthStatus: {
+          codex: { provider: "codex", account_label: "dev@example.test", obtained_at: 1_700_000_000 },
+        },
+      }),
+      "utf-8",
+    );
+
+    vi.doMock("node:os", async () => {
+      const actual = await vi.importActual<typeof import("node:os")>("node:os");
+      return { ...actual, homedir: () => pretendRealHome };
+    });
+    vi.resetModules();
   });
 
   afterEach(async () => {
-    await rm(tmp, { recursive: true, force: true });
+    vi.doUnmock("node:os");
+    vi.resetModules();
+    await rm(scopedHome, { recursive: true, force: true });
+    await rm(pretendRealHome, { recursive: true, force: true });
   });
 
-  it("reads the mirror from the injected home, not the developer's real one", async () => {
-    // A provider id no real machine would have signed in. If the mirror read
-    // falls through to the real home, this record is simply absent — which is
-    // exactly the failure #859 describes, and why the assertion is on THIS
-    // record rather than on a count (a count passes on a signed-out machine).
-    await mkdir(join(tmp, ".comfyui-mcp"), { recursive: true });
+  it("an EMPTY injected home yields no records — the real home's logins do not leak in", async () => {
+    const { readOAuthStatus } = await import("../../services/code-provider-auth.js");
+    const records = readOAuthStatus(scopedHome);
+
+    // The assertion that actually discriminates: with the fix reverted, the mirror
+    // read resolves against homedir() and returns the `codex` record above.
+    expect(
+      records.find((r) => r.provider === "codex"),
+      "a provider from the real home must not appear for an empty injected home",
+    ).toBeUndefined();
+    expect(records, "nothing at all should be found under an empty home").toEqual([]);
+  });
+
+  it("reads the mirror from the injected home, not the real one", async () => {
+    await mkdir(join(scopedHome, ".comfyui-mcp"), { recursive: true });
     await writeFile(
-      join(tmp, ".comfyui-mcp", "panel-secrets.json"),
+      join(scopedHome, ".comfyui-mcp", "panel-secrets.json"),
       JSON.stringify({
         oauthStatus: {
           "fixture-only-provider": {
@@ -293,23 +333,12 @@ describe("readOAuthStatus — home scoping (#859)", () => {
     );
 
     const { readOAuthStatus } = await import("../../services/code-provider-auth.js");
-    const records = readOAuthStatus(tmp);
+    const records = readOAuthStatus(scopedHome);
 
     const scoped = records.find((r) => r.provider === "fixture-only-provider");
     expect(scoped, "the injected home's mirror entry must be returned").toBeDefined();
     expect(scoped?.account_label).toBe("scoped@example.test");
-  });
-
-  it("returns no mirror entries for an EMPTY injected home", async () => {
-    // The inverse, and the half that actually catches a developer's real logins
-    // leaking in: with nothing written under `tmp`, anything returned here that
-    // is not a detected native CLI session came from outside the fixture.
-    const { readOAuthStatus } = await import("../../services/code-provider-auth.js");
-    const records = readOAuthStatus(tmp);
-
-    expect(
-      records.find((r) => r.provider === "fixture-only-provider"),
-      "no record may survive from a previous test's home",
-    ).toBeUndefined();
+    // Both directions in one place: the right file was read AND the wrong one was not.
+    expect(records.find((r) => r.provider === "codex")).toBeUndefined();
   });
 });

--- a/src/__tests__/services/code-provider-auth.test.ts
+++ b/src/__tests__/services/code-provider-auth.test.ts
@@ -257,3 +257,59 @@ describe("nativeCliStatus (CLI-auth detection for oauth_status)", () => {
     expect(JSON.stringify(rec)).not.toContain("rt-2");
   });
 });
+
+describe("readOAuthStatus — home scoping (#859)", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), "cmcp-oauth-home-"));
+    // The panel-secrets env override is the OTHER redirect and must stay unset
+    // here: this test exists to prove the `home` ARGUMENT alone scopes the read.
+    delete process.env.COMFYUI_MCP_PANEL_SECRETS;
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it("reads the mirror from the injected home, not the developer's real one", async () => {
+    // A provider id no real machine would have signed in. If the mirror read
+    // falls through to the real home, this record is simply absent — which is
+    // exactly the failure #859 describes, and why the assertion is on THIS
+    // record rather than on a count (a count passes on a signed-out machine).
+    await mkdir(join(tmp, ".comfyui-mcp"), { recursive: true });
+    await writeFile(
+      join(tmp, ".comfyui-mcp", "panel-secrets.json"),
+      JSON.stringify({
+        oauthStatus: {
+          "fixture-only-provider": {
+            provider: "fixture-only-provider",
+            account_label: "scoped@example.test",
+            obtained_at: 1_700_000_000,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const { readOAuthStatus } = await import("../../services/code-provider-auth.js");
+    const records = readOAuthStatus(tmp);
+
+    const scoped = records.find((r) => r.provider === "fixture-only-provider");
+    expect(scoped, "the injected home's mirror entry must be returned").toBeDefined();
+    expect(scoped?.account_label).toBe("scoped@example.test");
+  });
+
+  it("returns no mirror entries for an EMPTY injected home", async () => {
+    // The inverse, and the half that actually catches a developer's real logins
+    // leaking in: with nothing written under `tmp`, anything returned here that
+    // is not a detected native CLI session came from outside the fixture.
+    const { readOAuthStatus } = await import("../../services/code-provider-auth.js");
+    const records = readOAuthStatus(tmp);
+
+    expect(
+      records.find((r) => r.provider === "fixture-only-provider"),
+      "no record may survive from a previous test's home",
+    ).toBeUndefined();
+  });
+});

--- a/src/services/code-provider-auth.ts
+++ b/src/services/code-provider-auth.ts
@@ -783,7 +783,10 @@ function nativeCliStatus(providerId: string, home = homedir()): OAuthStatusRecor
  *  CLI-authenticated provider never asks the user to sign in a second time.
  *  `home` is injectable so tests never read the developer's real logins. */
 export function readOAuthStatus(home = homedir()): OAuthStatusRecord[] {
-  const mirror = listOAuthStatus();
+  // `home` goes to BOTH halves. It used to reach only `nativeCliStatus` below,
+  // while the mirror read fell through to the real home — so the promise in this
+  // docstring held for the detection half and not the mirror half (#859).
+  const mirror = listOAuthStatus(home);
   const seen = new Set(mirror.map((r) => r.provider));
   for (const providerId of ["codex", "grok", "copilot"]) {
     if (seen.has(providerId)) continue;

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -99,11 +99,23 @@ export function isAllowedAgentSecretKey(key: string): boolean {
   return AGENT_ALLOWLIST_SET.has(key);
 }
 
-/** Secrets file path. Overridable for tests. */
-export function panelSecretsPath(): string {
+/** Secrets file path. Overridable for tests.
+ *
+ *  `home` scopes the read to a caller-supplied home directory. It exists because
+ *  `readOAuthStatus(home)` already took one and threaded it to `nativeCliStatus`,
+ *  while the mirror half reached this function and silently used the REAL home —
+ *  so a test that injected a temp home still read the developer's actual logins,
+ *  and its result flipped depending on whether that machine happened to be signed
+ *  into codex (#859). The docstring there promised "tests never read the
+ *  developer's real logins"; for one of its two halves that was false.
+ *
+ *  Precedence is deliberately env > `home` > real home. `COMFYUI_MCP_PANEL_SECRETS`
+ *  is the explicit global redirect and must keep winning, so this adds scoping
+ *  where a `home` is passed without changing any path that already worked. */
+export function panelSecretsPath(home?: string): string {
   return (
     process.env.COMFYUI_MCP_PANEL_SECRETS ||
-    join(homedir(), ".comfyui-mcp", "panel-secrets.json")
+    join(home ?? homedir(), ".comfyui-mcp", "panel-secrets.json")
   );
 }
 
@@ -142,8 +154,8 @@ export function onComfyuiSecretsChanged(cb: (change: ComfyuiSecretChange) => voi
   };
 }
 
-function read(): PanelSecrets {
-  const p = panelSecretsPath();
+function read(home?: string): PanelSecrets {
+  const p = panelSecretsPath(home);
   if (!existsSync(p)) return {};
   try {
     const parsed = JSON.parse(readFileSync(p, "utf-8")) as unknown;
@@ -362,9 +374,10 @@ export function setOAuthStatus(rec: OAuthStatusRecord): void {
   write(secrets);
 }
 
-/** All stored OAuth status records (re-sanitized on read, defense in depth). */
-export function listOAuthStatus(): OAuthStatusRecord[] {
-  const status = read().oauthStatus;
+/** All stored OAuth status records (re-sanitized on read, defense in depth).
+ *  `home` scopes the read — see `panelSecretsPath` (#859). */
+export function listOAuthStatus(home?: string): OAuthStatusRecord[] {
+  const status = read(home).oauthStatus;
   if (!status || typeof status !== "object") return [];
   return Object.values(status).map(sanitizeOAuthStatus);
 }


### PR DESCRIPTION
`readOAuthStatus(home = homedir())` says in its own docstring that `home` is injectable *"so tests never read the developer's real logins."* It threaded that home to `nativeCliStatus`, then called `listOAuthStatus()` **with no argument** — which resolved `panelSecretsPath()` against the **real** home.

So the promise held for the detection half and was false for the mirror half.

The consequence is a test whose result depends on whether the developer's machine happens to be signed into codex. **CI never sees it** (runners are never signed in), which is what makes it corrosive: it only fails locally, so it reads as a flake and gets worked around rather than fixed. Two agents on unrelated clusters reported it independently and neither could attribute it to their own branch — both were right not to.

## The fix

`panelSecretsPath` takes an optional `home`, `read` passes it through, `listOAuthStatus` accepts it, and `readOAuthStatus` threads its own `home` in — so **one injection point covers both halves**, which is what the docstring already claimed.

Precedence is deliberately **env > home > real home**. `COMFYUI_MCP_PANEL_SECRETS` is the explicit global redirect and keeps winning, so this adds scoping where a `home` is passed without altering any path that already worked.

`backend-readiness.ts:143` already called `readOAuthStatus(opts?.home)` with a comment saying *"thread the (test-injectable) home through"* — the intent was documented all along; only one half honoured it.

## Third instance of one pattern

This is the third docstring this week asserting a guarantee the code did not provide, after **#490** (`resolveEffectiveComfyUIBase` promising it never returns a local workspace in remote mode, while returning one) and its `comfy-cli.ts` twin, which **named an enforcer and also bypassed it**. A confident absolute stops the next reader re-deriving — which is precisely how each one survived.

## My first tests were not good enough, and the gate caught it

The independent gate rejected the original "EMPTY injected home" test: it asserted only the absence of `fixture-only-provider`, but a genuine leak surfaces a **real** provider like `codex`, which that assertion never looked at. Revert the fix, give the real mirror any ordinary record, and it passed identically. **It protected against nothing** — the exact defect I have been sending back to other agents.

Fixed by controlling what the failure mode depends on: a second temp dir stands in for the developer's real home, `os.homedir()` is mocked to it, and it holds a plausible signed-in `codex` record. Both tests are now deterministic on any machine — including this one, whose real mirror is empty and therefore **could not have exercised the leak at all**.

**Mutation-verified:** reverting `listOAuthStatus(home)` → `listOAuthStatus()` now fails **both** tests. Before, neither.

## Verification

- 255 files / **5129 tests** pass at full concurrency in ~37s
- `lint` clean; zero control bytes
- Independent codex gate: **no P0**; its one P1 is the test weakness above, now closed

Closes #859.
