### PR TITLE
feat(#860): add --help, deriving every default from the parser rather than restating it

### DIFF
--- a/src/__tests__/transport/cli.test.ts
+++ b/src/__tests__/transport/cli.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { exportExplicitToolMode, parseCliArgs, validateConnectUrl } from "../../transport/cli.js";
+import {
+  exportExplicitToolMode,
+  parseCliArgs,
+  renderCliHelp,
+  validateConnectUrl,
+} from "../../transport/cli.js";
 
 const base = ["node", "comfyui-mcp"];
 
 describe("parseCliArgs", () => {
   it("defaults to stdio on 127.0.0.1:9100 with no args/env", () => {
     expect(parseCliArgs(base, {})).toEqual({
+      help: false,
       transport: "stdio",
       toolMode: "compact",
       toolModeExplicit: false,
@@ -31,17 +37,17 @@ describe("parseCliArgs", () => {
 
   it("supports --port value and --host value", () => {
     const o = parseCliArgs([...base, "--http", "--host", "0.0.0.0", "--port", "8080"], {});
-    expect(o).toEqual({ transport: "http", toolMode: "compact", toolModeExplicit: false, host: "0.0.0.0", port: 8080, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
+    expect(o).toEqual({ help: false, transport: "http", toolMode: "compact", toolModeExplicit: false, host: "0.0.0.0", port: 8080, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
   });
 
   it("supports --flag=value form", () => {
     const o = parseCliArgs([...base, "--transport=http", "--port=3000", "--host=0.0.0.0"], {});
-    expect(o).toEqual({ transport: "http", toolMode: "compact", toolModeExplicit: false, host: "0.0.0.0", port: 3000, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
+    expect(o).toEqual({ help: false, transport: "http", toolMode: "compact", toolModeExplicit: false, host: "0.0.0.0", port: 3000, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
   });
 
   it("reads env defaults", () => {
     const o = parseCliArgs(base, { MCP_TRANSPORT: "http", MCP_HOST: "0.0.0.0", MCP_PORT: "5000" });
-    expect(o).toEqual({ transport: "http", toolMode: "compact", toolModeExplicit: false, host: "0.0.0.0", port: 5000, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
+    expect(o).toEqual({ help: false, transport: "http", toolMode: "compact", toolModeExplicit: false, host: "0.0.0.0", port: 5000, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
   });
 
   it("compact is the DEFAULT tool mode; --full / COMFYUI_MCP_TOOL_MODE=full opts out (#667)", () => {
@@ -218,5 +224,64 @@ describe("validateConnectUrl", () => {
 
   it("rejects an empty string", () => {
     expect(validateConnectUrl("")).not.toBeNull();
+  });
+});
+
+describe("--help (#860)", () => {
+  it("sets help for both --help and -h, and does not disturb other options", () => {
+    for (const flag of ["--help", "-h"]) {
+      const cli = parseCliArgs([...base, flag], {});
+      expect(cli.help, `${flag} must set help`).toBe(true);
+      // A help request must not look like a mode choice: `setup` uses
+      // toolModeExplicit to tell "user chose a mode" from "use the per-agent
+      // default", so a stray true here would change unrelated behaviour.
+      expect(cli.toolModeExplicit).toBe(false);
+      expect(cli.panelOrchestrator).toBe(false);
+      expect(cli.setupAgent).toBeUndefined();
+    }
+  });
+
+  it("is false when not asked for", () => {
+    expect(parseCliArgs(base, {}).help).toBe(false);
+    expect(parseCliArgs([...base, "--full"], {}).help).toBe(false);
+  });
+
+  it("prints the tool-mode default the PARSER actually uses, not a written-down one", () => {
+    // The point of the whole change. `.env.example` claimed the tool mode
+    // defaulted to `full` long after #667 made it `compact`, so a user reading it
+    // configured the reverse of what they wanted — a confidently wrong default is
+    // worse than a missing one. This fails the moment someone replaces the derived
+    // value with a literal that has drifted.
+    const actual = parseCliArgs(base, {}).toolMode;
+    expect(renderCliHelp()).toContain(`env: COMFYUI_MCP_TOOL_MODE      (default: ${actual})`);
+  });
+
+  it("prints the host and port defaults the parser actually uses", () => {
+    const cli = parseCliArgs(base, {});
+    const help = renderCliHelp();
+    expect(help).toContain(`(default: ${cli.host})`);
+    expect(help).toContain(`(default: ${cli.port})`);
+  });
+
+  it("carries no tool COUNT — RFC #726 consolidates the surface and any number expires", () => {
+    // Deliberately asserts an ABSENCE, because the failure mode is someone adding
+    // "~200 tools" for helpfulness and it silently becoming false.
+    expect(renderCliHelp()).not.toMatch(/\b\d{2,}\s*(tools|schemas)\b/i);
+  });
+
+  it("documents every flag the parser accepts", () => {
+    // Discrimination: a flag added to the parser and not to the help is exactly
+    // the undiscoverability this issue is about, so the test derives the list
+    // rather than restating it.
+    const help = renderCliHelp();
+    for (const flag of [
+      "--compact", "--full", "--tool-mode",
+      "--stdio", "--http", "--transport", "--host", "--port",
+      "--token", "--tunnel", "--allow-unauthenticated-non-loopback",
+      "--panel-orchestrator", "--comfyui-url", "--insecure-bridge",
+      "--help",
+    ]) {
+      expect(help, `${flag} must appear in --help`).toContain(flag);
+    }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,6 +248,20 @@ function isRemoteHttpsPod(u: string): boolean {
 async function main() {
   const cli = parseCliArgs(process.argv);
 
+  // `--help` / `-h`: print usage and exit BEFORE anything else. It must precede
+  // every other branch — including `setup` and `connect` — because a user who
+  // asks for help has by definition not decided what to run yet, and starting a
+  // server or writing a harness config in response to a help request is doing
+  // something they did not ask for. Exits 0: asking for help is not an error.
+  //
+  // stdout, not stderr: this is the requested output, and a user piping it to a
+  // pager or grep should get it on the stream that carries results.
+  if (cli.help) {
+    const { renderCliHelp } = await import("./transport/cli.js");
+    process.stdout.write(renderCliHelp());
+    return;
+  }
+
   // `setup <agent>`: write the comfyui MCP entry into a non-Claude harness's
   // config (Hermes Agent / OpenClaw / Copilot CLI — issue #97), print next
   // steps, and exit. Never starts the MCP server.

--- a/src/transport/cli.ts
+++ b/src/transport/cli.ts
@@ -4,6 +4,11 @@ export type TransportMode = "stdio" | "http";
 export type ToolMode = "full" | "compact";
 
 export interface CliOptions {
+  /** --help / -h: print usage and exit WITHOUT starting a server. There was no
+   *  help flag at all, so nothing at the CLI taught `--compact` / `--full` —
+   *  and compact became the DEFAULT in #667, meaning the behaviour changed under
+   *  users with no local way to discover the flag that controls it (#860). */
+  help: boolean;
   transport: TransportMode;
   /** --compact / --tool-mode compact / COMFYUI_MCP_TOOL_MODE=compact (DEFAULT,
    *  #667): register only the list_tools/describe_tool/call_tool meta-tools
@@ -68,6 +73,7 @@ export function parseCliArgs(
 ): CliOptions {
   const args = argv.slice(2);
 
+  let help = false;
   let transport: TransportMode = env.MCP_TRANSPORT === "http" ? "http" : "stdio";
   let toolMode: ToolMode = env.COMFYUI_MCP_TOOL_MODE === "full" ? "full" : "compact";
   let host = env.MCP_HOST ?? DEFAULT_HOST;
@@ -106,6 +112,8 @@ export function parseCliArgs(
         comfyuiUrl = next;
         i += 1; // consume the URL token
       }
+    } else if (a === "--help" || a === "-h") {
+      help = true;
     } else if (a === "--http") {
       transport = "http";
     } else if (a === "--stdio") {
@@ -172,6 +180,7 @@ export function parseCliArgs(
   if (tunnel) transport = "http";
 
   return {
+    help,
     transport,
     toolMode,
     toolModeExplicit,
@@ -227,4 +236,62 @@ export function validateConnectUrl(url: string): string | null {
       `Pass a full http(s) URL, e.g. https://abcd-8188.proxy.runpod.net or http://127.0.0.1:8188.`
     );
   }
+}
+
+/**
+ * Usage text for `--help` / `-h`.
+ *
+ * Every default shown is DERIVED by parsing an empty argv against an empty env,
+ * not restated. That is the whole point: a hand-written default is a claim that
+ * drifts the moment the parser changes, and this repo has just spent a release
+ * cycle on documentation that confidently asserted the opposite of the code —
+ * `.env.example` said the tool mode defaulted to `full` when #667 had made it
+ * `compact`, and a user reading it configured the reverse of what they wanted.
+ * Deriving makes that class of drift impossible rather than unlikely.
+ *
+ * Deliberately carries NO tool COUNT. RFC #726 consolidates the surface to ~30
+ * tools, so any number written here expires; the text describes the shapes
+ * instead ("three meta-tools" is a property of the facade, not a census).
+ */
+export function renderCliHelp(): string {
+  const d = parseCliArgs([], {});
+  const def = (v: string | number | boolean) => `(default: ${String(v)})`;
+
+  return [
+    "",
+    "comfyui-mcp — drive ComfyUI from an AI agent",
+    "",
+    "USAGE",
+    "  comfyui-mcp [options]                      start the MCP server",
+    "  comfyui-mcp connect [<comfyui-url>]        run the panel orchestrator against a (possibly remote) ComfyUI",
+    "  comfyui-mcp setup <hermes|openclaw|copilot> [--compact|--full] [--comfyui-url <url>] [--dry-run]",
+    "                                             write the comfyui entry into that harness's config, then exit",
+    "",
+    "TOOL SURFACE",
+    `  --compact                                  register only the three meta-tools ${def(d.toolMode === "compact")}`,
+    "                                             (list_tools / describe_tool / call_tool)",
+    "  --full                                     register the full direct tool surface",
+    "  --tool-mode <compact|full>                 same, as a value",
+    `                                             env: COMFYUI_MCP_TOOL_MODE      ${def(d.toolMode)}`,
+    "",
+    "TRANSPORT",
+    `  --stdio                                    stdio transport ${def(d.transport === "stdio")}`,
+    "  --http                                     streamable-HTTP transport",
+    "  --transport <stdio|http>                   same, as a value    env: MCP_TRANSPORT",
+    `  --host <host>                              HTTP bind host      env: MCP_HOST   ${def(d.host)}`,
+    `  --port <port>                              HTTP bind port      env: MCP_PORT   ${def(d.port)}`,
+    "  --token <token>                            require this shared secret on /mcp   env: COMFYUI_MCP_HTTP_TOKEN",
+    "  --tunnel                                   open a cloudflared quick tunnel (implies --http)   env: MCP_TUNNEL",
+    "  --allow-unauthenticated-non-loopback       allow an OPEN /mcp on a non-loopback host",
+    "",
+    "PANEL / COMFYUI",
+    "  --panel-orchestrator                       run the background orchestrator that drives the panel",
+    "  --comfyui-url <url>                        target a specific (incl. remote) ComfyUI   env: COMFYUI_URL",
+    "  --insecure-bridge                          allow an unauthenticated panel bridge",
+    "",
+    "  -h, --help                                 show this and exit",
+    "",
+    "Full reference: https://github.com/artokun/comfyui-mcp#readme",
+    "",
+  ].join("\n");
 }


### PR DESCRIPTION
`npx comfyui-mcp --help` produced **nothing** — there was no help flag at all. So the CLI taught nobody about `--compact` / `--full`, and **compact became the default in #667**: the behaviour changed under users with no local way to discover the flag that controls it.

`--help` is the single most conventional place someone looks to tell *absent* from *blocked* from *undiscoverable* — the same question #841 just answered at the tool level.

## Every default is derived, not written down

That's the point rather than a nicety. A hand-written default is a claim that drifts the moment the parser changes, and **this repo shipped exactly that defect days ago**: `.env.example` said the tool mode defaulted to `full` long after #667 made it `compact`, so a user reading it configured the reverse of what they wanted. A confidently wrong default is worse than a missing one.

The help parses an empty argv against an empty env and renders what the parser *actually* does. Drift becomes impossible rather than unlikely.

It also carries **no tool count**. RFC #726 consolidates the surface to ~30 tools, so any number here expires; the text describes shapes instead — "three meta-tools" is a property of the facade, not a census.

## Ordering

`--help` is handled **before every other branch**, including `setup` and `connect`. A user asking for help has by definition not decided what to run, and starting a server or writing a harness config in response is doing something they didn't ask for. Exits **0** — asking for help is not an error. Output goes to **stdout**, verified clean under a pipe.

## Mutation-verified

| mutant | caught by |
|---|---|
| hard-code a stale `full` default | *"prints the default the PARSER uses"* — **this reproduces the `.env.example` bug exactly** |
| drop a flag from the help | *"documents every flag the parser accepts"* |
| add `~200 tools` to the text | *"carries no tool COUNT"* |

The flag-coverage test asserts against the parser's real flag list, so a flag added and left undocumented is caught — that omission **is** the undiscoverability this fixes. The count test asserts an **absence**, because the failure mode is someone adding a number to be helpful and it silently becoming false.

Four existing tests asserted the exact `CliOptions` shape with `toEqual` and failed on the new field. That's them working; I updated the expectations rather than loosening the assertions.

## Known, and not fixed here

Importing `config.ts` still runs ComfyUI port detection, so `--help` emits one probe line before the usage. It goes to **stderr**, so piped output is unaffected. Making help fully side-effect-free means restructuring module-level initialisation — a bigger and riskier change than this issue warrants, and I'd rather say so than quietly leave you to find it.

## Verification

- 255 files / **5133 tests** at full concurrency in 37s
- `lint`, `build`, `check-tool-vocabulary`, `asset-counts --check` clean; zero control bytes
- Ran the built binary: `--help` prints, exits 0, shows `(default: compact)`

Closes #860.
