### PR TITLE
fix(#847): a zero-byte pending-ops marker wedged update_all permanently

### DIFF
--- a/src/__tests__/services/node-snapshots.test.ts
+++ b/src/__tests__/services/node-snapshots.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { join } from "node:path";
+import { writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 
 // The product builds snapshot paths with node:path.join, so separators differ
@@ -345,10 +346,23 @@ describe("restoreNodeSnapshot", () => {
   });
 
   it("refuses before contacting Manager when the deferred-restore marker cannot persist", async () => {
-    // NUL is rejected by fs before a record can be read/written. The mutation
-    // must not run without the durable warning a later pin depends on.
+    // Make the marker's PARENT a regular file, so every read/write against it
+    // fails. The mutation must not run without the durable warning a later pin
+    // depends on.
+    //
+    // This used to set the env var to "\0", intending an fs-rejected path. It did
+    // not do that: Node truncates a NUL assignment to "", and `panelPendingOpsPath`
+    // treats an empty env var as UNSET — so the test silently fell back to the
+    // developer's REAL ~/.comfyui-mcp/panel-pending-ops.json. It therefore tested
+    // nothing it claimed, and wrote live pending-op markers into the user's own
+    // state, where the orchestrator reads them and warns on every pin write. Same
+    // class as #837 (the suite writing to the real .env) and #859 (the real OAuth
+    // mirror). The blocker technique below is what update-comfyui.test.ts already
+    // uses correctly for this same assertion.
+    const blocker = join(tmpdir(), `cmcp-snapshot-pending-blocker-${process.pid}-${Date.now()}`);
+    writeFileSync(blocker, "not a directory");
     const previous = process.env.COMFYUI_MCP_PANEL_PENDING;
-    process.env.COMFYUI_MCP_PANEL_PENDING = "\0";
+    process.env.COMFYUI_MCP_PANEL_PENDING = join(blocker, "pending.json");
     try {
       await expect(restoreNodeSnapshot("prod")).rejects.toThrow(
         /Could not persist the pending snapshot-restore marker/i,
@@ -357,6 +371,7 @@ describe("restoreNodeSnapshot", () => {
     } finally {
       if (previous === undefined) delete process.env.COMFYUI_MCP_PANEL_PENDING;
       else process.env.COMFYUI_MCP_PANEL_PENDING = previous;
+      rmSync(blocker, { force: true });
     }
   });
 });

--- a/src/__tests__/services/panel-pin-bypass.test.ts
+++ b/src/__tests__/services/panel-pin-bypass.test.ts
@@ -15,6 +15,20 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+// The pending-operation marker is a REAL file (panel-pin-guard). Point it at a
+// temp path at MODULE scope so the suite never touches ~/.comfyui-mcp, and so
+// parallel vitest workers get their own file instead of racing on one.
+//
+// Without this, every call here wrote live pending-op markers into the developer's
+// own state, where the orchestrator reads them and warns on every pin write that a
+// queued update or deferred restore may be outstanding. Same class as #837 (the
+// suite writing to the real .env) and #859 (the real OAuth mirror).
+process.env.COMFYUI_MCP_PANEL_PENDING = join(
+  tmpdir(),
+  `cmcp-pending-pin-bypass-${process.pid}.json`,
+);
+
+
 vi.mock("../../config.js", () => {
   const config = {
     comfyuiPath: undefined as string | undefined,

--- a/src/__tests__/services/panel-pin-guard.test.ts
+++ b/src/__tests__/services/panel-pin-guard.test.ts
@@ -7,7 +7,15 @@
 // the guard. A pinned user was one generic call away from being moved.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, existsSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import {
+  mkdtempSync,
+  existsSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -500,5 +508,50 @@ describe("#847 — a zero-byte pending-ops file must not wedge update_all foreve
     // other needs a human decision, and telling a user the wrong one wastes the
     // trip either way.
     expect(active[0].detail).not.toMatch(/clears on its own/);
+  });
+});
+
+describe("#847 gate P0 — superseding an empty marker must not hide a queued op", () => {
+  const pendingPath = () => process.env.COMFYUI_MCP_PANEL_PENDING as string;
+
+  it("carries an indeterminate record forward when it supersedes an EMPTY marker", () => {
+    // The independent gate found the hole in my first cut: writeFileSync
+    // TRUNCATES, so a crash after truncation and before content leaves a
+    // zero-byte file that DID hold a real op. Superseding it silently dropped
+    // that warning. The block is lifted; the warning must survive it.
+    writeFileSync(pendingPath(), "", "utf-8");
+
+    recordPanelPendingOp("update-all", "after an empty marker", 60_000);
+
+    const active = activePanelPendingOps();
+    expect(active.some((o) => o.kind === "update-all")).toBe(true);
+    const carried = active.find((o) => o.kind === "unknown");
+    expect(carried, "an indeterminate record must be carried forward").toBeDefined();
+    expect(carried?.detail).toMatch(/EMPTY pending-operation marker/);
+    expect(carried?.detail).toMatch(/may still be outstanding/);
+  });
+
+  it("does NOT invent an indeterminate record when the prior marker was absent", () => {
+    // Discrimination: the carry-forward must be tied to the empty case, not
+    // emitted on every write. An absent file is genuinely proof of nothing
+    // pending, and warning there would be the fold pointed the other way.
+    expect(existsSync(pendingPath())).toBe(false);
+
+    recordPanelPendingOp("update-all", "clean start", 60_000);
+
+    const active = activePanelPendingOps();
+    expect(active.some((o) => o.kind === "update-all")).toBe(true);
+    expect(active.some((o) => o.kind === "unknown")).toBe(false);
+  });
+
+  it("writes atomically — no zero-byte window, and no staging file left behind", () => {
+    recordPanelPendingOp("update-all", "atomic", 60_000);
+
+    // A truncating writer can be observed mid-write as zero bytes; a rename
+    // cannot. The observable proxy for "the temp path was cleaned up" is that
+    // nothing but the marker remains in the directory.
+    const dirEntries = readdirSync(dirname(pendingPath()));
+    expect(dirEntries.filter((f) => f.includes(".tmp"))).toEqual([]);
+    expect(readFileSync(pendingPath(), "utf-8").length).toBeGreaterThan(0);
   });
 });

--- a/src/__tests__/services/panel-pin-guard.test.ts
+++ b/src/__tests__/services/panel-pin-guard.test.ts
@@ -421,3 +421,84 @@ describe("pending-op markers — record, read, and clear (#689)", () => {
     expect(activePanelPendingOps()[0].kind).toBe("unknown");
   });
 });
+
+describe("#847 — a zero-byte pending-ops file must not wedge update_all forever", () => {
+  const pendingPath = () => process.env.COMFYUI_MCP_PANEL_PENDING as string;
+
+  it("records a new op over an EMPTY marker instead of refusing forever", () => {
+    // The wedge: recordPanelPendingOp threw on any unreadable prior, and it runs
+    // BEFORE the Manager handoff — so the only thing that could replace the bad
+    // file was the very operation the bad file blocked. update_all could never
+    // start again until a human deleted the file by hand.
+    writeFileSync(pendingPath(), "", "utf-8");
+
+    const op = recordPanelPendingOp("update-all", "after an empty marker", 60_000);
+
+    expect(op, "an empty marker records no operation, so it is safe to supersede").toBeTruthy();
+    expect(op?.kind).toBe("update-all");
+    // And it really landed — recordPanelPendingOp read-back verifies, but assert
+    // the observable outcome too, since that is what unwedges the next run.
+    expect(activePanelPendingOps().some((o) => o.kind === "update-all")).toBe(true);
+  });
+
+  it("treats a WHITESPACE-ONLY marker the same as empty", () => {
+    writeFileSync(pendingPath(), "  \n\t \n", "utf-8");
+    expect(recordPanelPendingOp("update-all", "after whitespace", 60_000)).toBeTruthy();
+  });
+
+  it("STILL refuses when the marker has content it cannot decode", () => {
+    // The safety property the original refusal existed for, and it must survive:
+    // content we cannot decode may describe a real queued operation, and
+    // overwriting it destroys a warning we were never able to read.
+    writeFileSync(pendingPath(), '{"ops":[{"kind":"update-all","queuedAt":', "utf-8");
+
+    expect(() => recordPanelPendingOp("update-all", "over undecodable content", 60_000)).toThrow(
+      /could not be decoded/,
+    );
+  });
+
+  it("names the file path in the refusal, so it is actionable", () => {
+    // Plain substring, deliberately: building a RegExp from a Windows path means
+    // escaping backslashes, and an escape written through a shell heredoc is
+    // exactly how this repo has produced literal control bytes and broken
+    // character classes before. A `toThrow(string)` does a substring match and
+    // needs no escaping at all.
+    writeFileSync(pendingPath(), "not json at all", "utf-8");
+    let message = "";
+    try {
+      recordPanelPendingOp("update-all", "x", 60_000);
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toContain(pendingPath());
+    expect(message).toContain("delete it to clear this");
+  });
+
+  it("an EMPTY marker still WARNS — it cannot prove nothing is pending", () => {
+    // Deliberately still conservative on the READ question. An interrupted write
+    // is indistinguishable from a file that never got content, so claiming
+    // nothing is pending would be the fabrication. Only the WRITE question
+    // changed, because that one asks whether overwriting loses information.
+    writeFileSync(pendingPath(), "", "utf-8");
+
+    const active = activePanelPendingOps();
+    expect(active).toHaveLength(1);
+    expect(active[0].kind).toBe("unknown");
+    // The detail must say it self-clears — that is the half that made this a dead
+    // end. Asserting the REASON, not merely that a warning exists.
+    expect(active[0].detail).toMatch(/EMPTY/);
+    expect(active[0].detail).toMatch(/clears on its own|replaces it/);
+  });
+
+  it("an UNDECODABLE marker warns differently — it does NOT self-clear", () => {
+    writeFileSync(pendingPath(), "not json at all", "utf-8");
+
+    const active = activePanelPendingOps();
+    expect(active).toHaveLength(1);
+    expect(active[0].detail).toMatch(/NOT replaced automatically/);
+    // The two branches must not give the same advice: one clears itself, the
+    // other needs a human decision, and telling a user the wrong one wastes the
+    // trip either way.
+    expect(active[0].detail).not.toMatch(/clears on its own/);
+  });
+});

--- a/src/__tests__/services/update-comfyui.test.ts
+++ b/src/__tests__/services/update-comfyui.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it, beforeEach, vi, type Mock } from "vitest";
 
+// The pending-operation marker is a REAL file (panel-pin-guard). Point it at a
+// temp path at MODULE scope so the suite never touches ~/.comfyui-mcp, and so
+// parallel vitest workers get their own file instead of racing on one.
+//
+// Without this, every call here wrote live pending-op markers into the developer's
+// own state, where the orchestrator reads them and warns on every pin write that a
+// queued update or deferred restore may be outstanding. Same class as #837 (the
+// suite writing to the real .env) and #859 (the real OAuth mirror).
+process.env.COMFYUI_MCP_PANEL_PENDING = join(
+  tmpdir(),
+  `cmcp-pending-update-comfyui-${process.pid}.json`,
+);
+
+
 // --- Mocks --------------------------------------------------------------
 
 // Mutable config the service reads via property access.

--- a/src/__tests__/tools/node-snapshots-tool.test.ts
+++ b/src/__tests__/tools/node-snapshots-tool.test.ts
@@ -1,6 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { DEAD_NAMES, TOOL_NAMES } from "../../tools/vocabulary.js";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// The pending-operation marker is a REAL file (panel-pin-guard). Point it at a
+// temp path at MODULE scope so the suite never touches ~/.comfyui-mcp, and so
+// parallel vitest workers get their own file instead of racing on one.
+//
+// Without this, every call here wrote live pending-op markers into the developer's
+// own state, where the orchestrator reads them and warns on every pin write that a
+// queued update or deferred restore may be outstanding. Same class as #837 (the
+// suite writing to the real .env) and #859 (the real OAuth mirror).
+process.env.COMFYUI_MCP_PANEL_PENDING = join(
+  tmpdir(),
+  `cmcp-pending-snapshots-tool-${process.pid}.json`,
+);
+
 
 /**
  * The consolidated `node_snapshot` tool (0.49.0 slice 2): save/restore/list

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -26,9 +26,11 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
 import {
   closeSync,
+  fsyncSync,
   mkdirSync,
   openSync,
   readFileSync,
+  renameSync,
   rmSync,
   writeFileSync,
   writeSync,
@@ -513,6 +515,45 @@ interface PendingOpsRead {
   state: PendingOpsReadState;
 }
 
+/**
+ * Replace the marker atomically: write a uniquely-named temp beside it, fsync,
+ * then rename over the target.
+ *
+ * `writeFileSync` TRUNCATES in place, so a crash after truncation and before the
+ * content lands leaves a ZERO-BYTE file that previously held real operations.
+ * That is what made "an empty file records nothing" untrue for this writer, and
+ * it is the hole the independent gate found in the first cut of #847 — the write
+ * path would have superseded such a file and silently dropped a queued
+ * operation's warning. A rename is atomic: a reader sees the whole old content or
+ * the whole new content, never nothing.
+ *
+ * The temp name carries a uuid because two agents share this rig, and a fixed
+ * `.tmp` would let concurrent writers clobber each other's staging file.
+ */
+function writePanelPendingOpsAtomic(path: string, body: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  const fd = openSync(tmp, "wx");
+  try {
+    writeSync(fd, body);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  try {
+    renameSync(tmp, path);
+  } catch (err) {
+    // Never leave staging debris behind: it is not the marker, and a stray file
+    // beside it is one more thing for a later reader to misinterpret.
+    try {
+      rmSync(tmp, { force: true });
+    } catch {
+      /* best effort */
+    }
+    throw err;
+  }
+}
+
 function readPanelPendingOpsFile(): PendingOpsRead {
   const path = panelPendingOpsPath();
   let raw: string;
@@ -605,8 +646,27 @@ export function recordPanelPendingOp(
       );
     }
     const kept = prior.ops.filter((o) => o.kind !== kind);
-    mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, JSON.stringify({ ops: [...kept, op] }, null, 2), "utf-8");
+    // Superseding an EMPTY marker unwedges the operation, but it must not also
+    // erase the possibility that the empty file masked a real queued op. A
+    // pre-existing zero-byte file (written by the old truncating writer, before
+    // writePanelPendingOpsAtomic) genuinely CAN be an interrupted write. So carry
+    // an explicit indeterminate record forward: the block is lifted, the warning
+    // is not. It warns rather than blocks, and clearPanelPendingOp can retire it.
+    const carried: PanelPendingOp[] =
+      prior.state === "empty"
+        ? [
+            {
+              kind: "unknown",
+              queuedAt: new Date(now).toISOString(),
+              expiresAt: new Date(now + ttlMs).toISOString(),
+              detail:
+                `an EMPTY pending-operation marker was found at ${path} and superseded. It recorded ` +
+                "no operation, but an interrupted write cannot be told from a file that never got " +
+                "content, so a previously queued update or deferred restore may still be outstanding.",
+            },
+          ]
+        : [];
+    writePanelPendingOpsAtomic(path, JSON.stringify({ ops: [...carried, ...kept, op] }, null, 2));
 
     // Verify the exact replacement record, not merely that JSON still parses.
     // A partial/redirected write that drops this operation would recreate the
@@ -665,8 +725,7 @@ export function clearPanelPendingOp(op: PanelPendingOp): boolean {
     if (prior.unreadable) return false;
     if (!prior.ops.some(matches)) return true; // already gone
     const kept = prior.ops.filter((candidate) => !matches(candidate));
-    mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, JSON.stringify({ ops: kept }, null, 2), "utf-8");
+    writePanelPendingOpsAtomic(path, JSON.stringify({ ops: kept }, null, 2));
     const confirmed = readPanelPendingOpsFile();
     return !confirmed.unreadable && !confirmed.ops.some(matches);
   } catch (err) {

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -494,7 +494,26 @@ function isPanelPendingOp(value: unknown): value is PanelPendingOp {
   );
 }
 
-function readPanelPendingOpsFile(): { ops: PanelPendingOp[]; unreadable: boolean } {
+/** Why a read produced no usable ops. The distinction that matters is `empty`
+ *  vs `unparseable`, and it exists because collapsing them wedged `update_all`
+ *  permanently (#847).
+ *
+ *  A ZERO-BYTE file is not "a record we cannot read" — it is a file with no
+ *  bytes, so there is no operation recorded in it and nothing to lose by
+ *  superseding it. An unparseable file with CONTENT may well describe a real
+ *  queued operation whose warning we simply cannot decode, and overwriting that
+ *  destroys the warning. Same "we got nothing usable", two different questions. */
+type PendingOpsReadState = "absent" | "empty" | "readable" | "unparseable";
+
+interface PendingOpsRead {
+  ops: PanelPendingOp[];
+  /** True when we cannot prove nothing is pending — `empty` counts, because an
+   *  interrupted write is indistinguishable from a file that never got content. */
+  unreadable: boolean;
+  state: PendingOpsReadState;
+}
+
+function readPanelPendingOpsFile(): PendingOpsRead {
   const path = panelPendingOpsPath();
   let raw: string;
   try {
@@ -503,9 +522,17 @@ function readPanelPendingOpsFile(): { ops: PanelPendingOp[]; unreadable: boolean
     // Only ENOENT proves there is no marker. Permission/I/O errors are
     // indeterminate and must keep a later pin from claiming clean protection.
     if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
-      return { ops: [], unreadable: false };
+      return { ops: [], unreadable: false, state: "absent" };
     }
-    return { ops: [], unreadable: true };
+    return { ops: [], unreadable: true, state: "unparseable" };
+  }
+  // A zero-byte (or whitespace-only) file: `JSON.parse("")` throws, so this used
+  // to land in `unparseable` and refuse forever. It stays `unreadable` for the
+  // READ question — an interrupted write is indistinguishable from a file that
+  // never got content, so a pin must still warn — but it is separately marked so
+  // the WRITE path can supersede it. See the type comment above.
+  if (raw.trim() === "") {
+    return { ops: [], unreadable: true, state: "empty" };
   }
   try {
     const parsed = JSON.parse(raw) as unknown;
@@ -514,12 +541,12 @@ function readPanelPendingOpsFile(): { ops: PanelPendingOp[]; unreadable: boolean
         ? (parsed as { ops?: unknown }).ops
         : undefined;
     if (Array.isArray(ops) && ops.every(isPanelPendingOp)) {
-      return { ops, unreadable: false };
+      return { ops, unreadable: false, state: "readable" };
     }
   } catch {
     // fall through
   }
-  return { ops: [], unreadable: true };
+  return { ops: [], unreadable: true, state: "unparseable" };
 }
 
 /**
@@ -557,7 +584,26 @@ export function recordPanelPendingOp(
   try {
     const path = panelPendingOpsPath();
     const prior = readPanelPendingOpsFile();
-    if (prior.unreadable) throw new Error("existing pending-operation record is unreadable");
+    // Refuse only when the prior file has CONTENT we cannot decode: that content
+    // may describe a real queued operation, and overwriting it destroys a warning
+    // we were never able to read.
+    //
+    // A zero-byte file is NOT that. It records no operation, so superseding it
+    // loses nothing — and refusing on it was self-perpetuating (#847): this write
+    // is gated behind the check, so the only thing that could replace the bad file
+    // was the thing the bad file blocked. Because `recordPanelPendingOp` runs
+    // BEFORE the Manager handoff, that wedged `update_all` permanently, until a
+    // human deleted the file by hand.
+    //
+    // The path is named either way. A refusal a user cannot act on from where they
+    // are is the other half of what made this a dead end.
+    if (prior.unreadable && prior.state !== "empty") {
+      throw new Error(
+        `existing pending-operation record at ${path} has content that could not be ` +
+          `decoded, so it may describe a queued operation whose warning would be lost. ` +
+          `Inspect it, then delete it to clear this.`,
+      );
+    }
     const kept = prior.ops.filter((o) => o.kind !== kind);
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, JSON.stringify({ ops: [...kept, op] }, null, 2), "utf-8");
@@ -642,16 +688,27 @@ export function clearPanelPendingOp(op: PanelPendingOp): boolean {
  * expiry are kept (indeterminate = still warn), never dropped.
  */
 export function activePanelPendingOps(now: number = Date.now()): PanelPendingOp[] {
-  const { ops, unreadable } = readPanelPendingOpsFile();
+  const { ops, unreadable, state } = readPanelPendingOpsFile();
   if (unreadable) {
+    // Both branches still WARN — for this question an empty file is genuinely
+    // indeterminate, because an interrupted write cannot be told from a file that
+    // never got content, and claiming nothing is pending would be the fabrication.
+    // They differ only in what the user is told to do, which is the part that was
+    // missing: the empty case clears itself, the other needs a decision (#847).
     return [
       {
         kind: "unknown",
         queuedAt: new Date(0).toISOString(),
         expiresAt: new Date(0).toISOString(),
         detail:
-          "the pending panel-operation record could not be read, so a queued " +
-          "update or deferred restore may still be outstanding",
+          state === "empty"
+            ? `the pending panel-operation record at ${panelPendingOpsPath()} is EMPTY, so a queued ` +
+              "update or deferred restore may still be outstanding and cannot be confirmed either way. " +
+              "It records no operation, so the next panel operation replaces it and this clears on its own — " +
+              "deleting the file also clears it immediately."
+            : `the pending panel-operation record at ${panelPendingOpsPath()} could not be read, so a queued ` +
+              "update or deferred restore may still be outstanding. Its content could not be decoded, so it " +
+              "is NOT replaced automatically — inspect it, then delete it to clear this.",
       },
     ];
   }


### PR DESCRIPTION
## The wedge was self-perpetuating

`recordPanelPendingOp` threw on **any** unreadable prior marker, and `JSON.parse("")` throws — so a zero-byte `panel-pending-ops.json` made it throw forever. It runs **before** the Manager handoff by design (*"a mutation whose out-of-band window cannot be durably recorded must not start"*), so `update_all` could never start again. And the write that would have replaced the bad file was gated behind the same check the bad file failed: **the only thing that could fix it was the thing it blocked.** A human deleting the file by hand was the sole escape.

## The missing distinction

`EMPTY` vs `UNPARSEABLE-WITH-CONTENT`, because they answer different questions:

- **"would overwriting lose information?"** — content we cannot decode may describe a real queued operation whose warning we were never able to read, and overwriting destroys it. The **write** path still refuses on that.
- **"can we prove nothing is pending?"** — no, in **both** cases. An interrupted write cannot be told from a file that never got content, so claiming nothing is pending would be the fabrication. The **read** path still warns for empty.

Not inconsistent readings of one fact — two questions with legitimately different answers.

Both refusals now name the path, and the two warnings differ in what they tell you to do: empty says the next panel operation supersedes it and it clears itself; undecodable says it is **not** replaced automatically and needs a look.

## The gate caught me being wrong, and it mattered

I claimed a zero-byte file "records no operation, so nothing can be lost". **False for this writer** — `writeFileSync` truncates in place, so a crash after truncation and before content leaves a zero-byte file that *did* hold real ops.

Fixed at the cause, not by reverting:
- **both writers are now atomic** (temp + `fsync` + rename), so a reader sees the whole old content or the whole new content, never nothing — making "empty ⇒ never held an op" *true* going forward rather than assumed;
- a **pre-existing** zero-byte file can still be an interrupted write from the old writer, so superseding one **carries an indeterminate record forward**. The block is lifted; the warning is not.

## And it surfaced a live one: the suite was writing to the real home

`node-snapshots.test.ts` set `COMFYUI_MCP_PANEL_PENDING = "\0"` intending an fs-rejected path. **Node truncates a NUL assignment to `""`**, and `panelPendingOpsPath` treats an empty env var as *unset* — so it fell back to the developer's real `~/.comfyui-mcp/panel-pending-ops.json`. It asserted nothing it claimed **and** wrote live markers into user state, where the orchestrator reads them and warns on every pin write about operations that never happened.

Not alone: `update-comfyui.test.ts` scoped the path inside **one** test while seven other `updateAllCustomNodes()` calls did not; `panel-pin-bypass.test.ts` and `node-snapshots-tool.test.ts` never scoped it at all.

Fixed here (NUL sentinel → the blocker technique `update-comfyui.test.ts` already used correctly; module-level scoping in all three files). **Verified by deleting the real file and re-running the whole suite — it is not recreated.** Two markers already written this session were backed up and removed.

Third instance after #837 (real `.env`) and #859 (real OAuth mirror). Per-test scoping is what keeps failing, so the runtime-guard follow-up is **#866**.

## Mutation-verified, in both directions

| mutant | caught by |
|---|---|
| collapse empty back into unparseable | the two supersede tests — the wedge returns |
| treat empty as absent on the read side | the conservative-warn test — it becomes permissive |
| drop the carried indeterminate record | the carry-forward test — the gate's P0 returns |

So it unwedges **without** becoming permissive.

**Honest gap:** the uuid in the temp filename (for two agents sharing this rig) is **not** covered — a fixed `.tmp` survives the suite, because nothing here exercises concurrent writers.

## Verification

255 files / **5138 tests** pass at full concurrency; lint clean; zero control bytes; `~/.comfyui-mcp` untouched by the suite.

Closes #847.
