### PR TITLE
0.49.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.49.8] - 2026-08-05
+
+### MCP
+
+#### Added
+- add --help, deriving every default from the parser rather than restating it (#864)
+
+#### Fixed
+- **a zero-byte pending-ops marker wedged `update_all` permanently (#847).** The wedge was
+  self-perpetuating: `recordPanelPendingOp` threw on any unreadable prior marker, and
+  `JSON.parse("")` throws — so a zero-byte `~/.comfyui-mcp/panel-pending-ops.json` made it
+  throw forever. It runs BEFORE the ComfyUI-Manager handoff by design, so `update_all` could
+  never start again, and the write that would have replaced the bad file was gated behind the
+  same check the bad file failed. Deleting the file by hand was the only escape.
+
+  An empty file and an undecodable one now answer different questions: overwriting an empty
+  one loses nothing (so it is superseded), while content we cannot decode may describe a real
+  queued operation (so it is still refused). Both refusals name the file path, and the two
+  warnings differ in what they tell you to do. Both writers are now atomic (temp + fsync +
+  rename), so a crash can no longer leave a zero-byte file at all, and superseding a
+  pre-existing one carries an indeterminate record forward — the block lifts, the warning
+  does not.
+
+  Also fixed on the way: the test suite was writing live pending-op markers into the real
+  `~/.comfyui-mcp`, where the orchestrator reads them and warns on every pin write about
+  operations that never happened. Third such leak found (after the real `.env` and the real
+  OAuth mirror); a runtime guard covering all of them is tracked in #866.
+- readOAuthStatus threaded home to one of its two halves (#863)
+
+#### Changed
+- .env.example advertised the wrong default, and the README shipped a section twice (#861)
+- tell absent from blocked from undiscoverable — and stop our own messages asserting causes they did not observe (#841)
+- truncated results fit the budget they report, and a library listing that looks in the folders (#807, #810) (#838)
+
+
 ## [0.49.7] - 2026-08-05
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.49.7",
+  "version": "0.49.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.49.7",
+      "version": "0.49.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.49.7",
+  "version": "0.49.8",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
## Contents

| PR | |
|---|---|
| **#847** | a zero-byte pending-ops marker wedged `update_all` **permanently** (the only open P1) |
| #841 | tell *absent* from *blocked* from *undiscoverable* — and stop our own messages asserting causes they did not observe (closes #815, #804, #777) |
| #838 | truncated results fit the budget they report, and a library listing that looks in the folders (closes #807, #810) |
| #860 | add `--help`, deriving every default from the parser rather than restating it |
| #859 | `readOAuthStatus` threaded `home` to one of its two halves |
| #861 | `.env.example` advertised the wrong default; the README shipped a section twice |

## #847 is the one to take

The wedge was **self-perpetuating**. `recordPanelPendingOp` threw on any unreadable prior marker, and `JSON.parse("")` throws — so a zero-byte `~/.comfyui-mcp/panel-pending-ops.json` made it throw forever. It runs *before* the ComfyUI-Manager handoff by design, so `update_all` could never start again — and the write that would have replaced the bad file was gated behind the same check the bad file failed. **Deleting the file by hand was the only escape.**

Empty and undecodable now answer different questions: overwriting an empty file loses nothing, while content we cannot decode may describe a real queued operation. Both writers are also atomic now (temp + `fsync` + rename), so a crash can no longer produce that state at all.

**Found on the way:** the test suite was writing live pending-op markers into the real `~/.comfyui-mcp`, where the orchestrator reads them and warns on every pin write about operations that never happened. Third such leak (after the real `.env` and the real OAuth mirror) — a runtime guard covering all of them is #866.

## Three of these are one defect in different clothes

A claim stated more confidently than the evidence supports:

- **#841** — two retractions promised a fallback and a remedy that a failed bind does not establish
- **#859** — a docstring guaranteed tests never read the developer's real logins, while half the function did
- **#861** — an example file asserted the opposite of the code

In each case the fix was to **narrow the claim**, not to add a feature.

## The generator worked again

Second consecutive release captured with **no hand-patching** — all six commits, correctly bucketed, every PR number attributed to the PR rather than an issue it cites. #838's title carries `(#807, #810)` inline with `(#838)` last, which is exactly the case the last-match fix in #856 existed for. The #847 entry was expanded by hand for context only.

## Verification

- **255 files / 5144 tests** at full concurrency in 37s
- `build`, `lint`, `check-tool-vocabulary`, `asset-counts --check` clean; zero control bytes

After merge the tag needs pushing by hand — squash-merge orphans the tag `npm version` creates.
