### PR TITLE
install_panel git fallback: four claims the concurrency bracket could not establish (follow-up to #840)

### DIFF
--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -133,6 +133,13 @@ function makeDeps(opts: {
    */
   gitStatusSeq?: string[];
   /**
+   * Zero-based `git status --porcelain` call index at which the mock THROWS —
+   * how a case models a checkout that cannot be read at all at one specific
+   * point (the guard is itself an operation that can fail). Index 2 is the
+   * fallback's post-merge re-read.
+   */
+  gitStatusThrowsAt?: number;
+  /**
    * Fires from the ignored-file gate — the LAST read the fallback takes before
    * its pre-merge compare-and-swap. How a case models a concurrent writer
    * acting inside exactly the window the CAS exists to catch.
@@ -166,10 +173,15 @@ function makeDeps(opts: {
     readdir: (p) => (p === CUSTOM_NODES ? dirs : []),
     readFile: (p) => files[p] ?? "",
     gitRevision: (dir) => revs[dir],
-    gitStatusPorcelain: () =>
-      statusCalls < (opts.gitStatusSeq?.length ?? 0)
+    gitStatusPorcelain: () => {
+      if (statusCalls === opts.gitStatusThrowsAt) {
+        statusCalls++;
+        throw new Error("fatal: not a git repository (or any parent up to mount point)");
+      }
+      return statusCalls < (opts.gitStatusSeq?.length ?? 0)
         ? (opts.gitStatusSeq as string[])[statusCalls++]
-        : ((statusCalls++, opts.gitStatus) ?? ""),
+        : ((statusCalls++, opts.gitStatus) ?? "");
+    },
     fetchLiveQueueCounts: async () => {
       const i = counters.liveQueueProbes++;
       const seq = opts.liveQueue;
@@ -1250,6 +1262,129 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     expect(msg).toMatch(/is_processing=true/);
     expect(h.gitPulls).toEqual([dir]);
     expect(h.counters.liveQueueProbes).toBe(2);
+  });
+
+  it("#824 P0: the merge leaves a THIRD HEAD on a clean tree -> disclosed, never reported as success", async () => {
+    // The dirty-worktree case above cannot reach this guard: here the tree ends
+    // CLEAN, so only the HEAD comparison can catch it. A fast-forward pinned to
+    // REV_B leaves HEAD at REV_B (or, if it was already there, unmoved) — a
+    // third revision means somebody else's commit landed inside the window.
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: IDLE_SNAPSHOT,
+      upstreamRev: REV_B,
+      onGitPull: ({ files, revs }) => {
+        files[pyPath] = pyproject(PANEL_REGISTRY_ID, "0.11.35");
+        revs[dir] = REV_C; // NOT the pinned target, NOT the pre-merge rev
+        return FF;
+      },
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/ALREADY RAN/);
+    expect(msg).toMatch(/neither the merged upstream/);
+    expect(msg).toMatch(/may now be INCONSISTENT/);
+    // The merge ran — refusal language would be a lie about a mutation.
+    expect(msg).not.toMatch(/NO git mutation was made/);
+    expect(h.gitPulls).toEqual([dir]);
+  });
+
+  it("#824 P0: the checkout cannot be re-read AFTER the merge -> disclosed as UNKNOWN, not as success", async () => {
+    // The post-merge guard is itself an operation that can fail. Failing to
+    // read is "could not determine whether anything else wrote here", which is
+    // not "nothing else did" — and the merge has run, so the honest register is
+    // disclosure, not a claim that nothing happened.
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: IDLE_SNAPSHOT,
+      upstreamRev: REV_B,
+      // 0 = cleanliness gate, 1 = pre-merge CAS, 2 = the post-merge re-read.
+      gitStatusThrowsAt: 2,
+      onGitPull: ({ files, revs }) => {
+        files[pyPath] = pyproject(PANEL_REGISTRY_ID, "0.11.35");
+        revs[dir] = REV_B;
+        return FF;
+      },
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/ALREADY RAN/);
+    expect(msg).toMatch(/could not be re-read afterwards/);
+    expect(msg).toMatch(/is UNKNOWN/);
+    expect(msg).not.toMatch(/NO git mutation was made/);
+    expect(h.gitPulls).toEqual([dir]);
+  });
+
+  it("#824: a FAILED merge does not get to claim the disk is unchanged — it re-reads and says what moved", async () => {
+    // "The merge exited non-zero" is a bucket; "nothing changed on disk" is a
+    // fact about the disk. The first does not establish the second — and the
+    // likeliest cause of the failure (another writer in this checkout) is
+    // precisely the case where the second is FALSE.
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: IDLE_SNAPSHOT,
+      upstreamRev: REV_B,
+      // 0 = cleanliness gate, 1 = pre-merge CAS, 2 = the post-failure re-read.
+      gitStatusSeq: ["", "", " M web/js/comfyui-mcp-panel.js"],
+      // onGitPull omitted -> the pinned merge THROWS.
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/did NOT apply/);
+    expect(msg).toMatch(/NOT what it was before the attempt/);
+    expect(msg).toMatch(/the worktree is dirty/);
+    expect(msg).not.toMatch(/nothing changed on disk/);
+    expect(h.gitPulls).toEqual([dir]);
+  });
+
+  it("#824: a FAILED merge that re-reads UNCHANGED still reports the version unchanged (no false alarm)", async () => {
+    // The other side of the same guard: observing an untouched tree is exactly
+    // what licenses the reassuring wording, so it must still be given. A fix
+    // that refused to say anything here would have overshot into alarm.
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: IDLE_SNAPSHOT,
+      upstreamRev: REV_B,
+      // onGitPull omitted -> the pinned merge THROWS; the tree stays clean.
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/re-read afterwards and is unchanged/);
+    expect(msg).toMatch(/installed version is still 0\.11\.32/);
+    expect(msg).not.toMatch(/NOT what it was before/);
+  });
+
+  it("#824: 'already at the upstream tip' claims only what git proved, not an untouched directory", async () => {
+    // HEAD === the FETCHED upstream proves the TRACKED checkout is current. It
+    // does not prove the directory was untouched: porcelain never reports
+    // ignored paths, and nothing is observed after the final read.
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: IDLE_SNAPSHOT,
+      upstreamRev: REV_A, // HEAD already IS the upstream tip
+      onGitPull: () => "Already up to date.",
+    });
+    const r = await runPanelAction("update", h.deps);
+    expect(r.restartRequired).toBe(false);
+    expect(r.message).toMatch(/already at the upstream tip/);
+    expect(r.message).toMatch(/fast-forwarded nothing and moved nothing itself/);
+    expect(r.message).toMatch(/git does not compare ignored files/);
+    // The overclaim this replaced.
+    expect(r.message).not.toMatch(/Nothing changed on disk/);
   });
 
   it("#824: a genuinely quiescent window brackets the merge - probed before AND after", async () => {

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -1251,6 +1251,59 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     expect(h.gitPulls).toEqual([dir]);
   });
 
+  it("#824: unreadable HEAD AND a dirty worktree before the merge -> the DIRTY evidence wins", async () => {
+    // The mirror of the case above. An unreadable HEAD leaves the revision
+    // comparison undetermined, but porcelain answered — and the cleanliness
+    // gate had proved this tree clean, so a dirty status here IS proof it
+    // changed. Reporting "not proof that anything changed" while holding that
+    // status would be the same defect pointed the other way.
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: IDLE_SNAPSHOT,
+      upstreamRev: REV_B,
+      // 0 = cleanliness gate (clean), 1 = the pre-merge CAS (dirty).
+      gitStatusSeq: ["", " M web/js/comfyui-mcp-panel.js"],
+      onBeforeMerge: ({ revs }) => {
+        delete revs[dir];
+      },
+      onGitPull: () => FF,
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/CHANGED between the safety gates/);
+    expect(msg).toMatch(/no longer clean/);
+    expect(msg).not.toMatch(/NOT proof that anything changed/);
+    expect(h.gitPulls).toEqual([]);
+  });
+
+  it("#824: unreadable HEAD AND a dirty worktree AFTER the merge -> the DIRTY evidence wins", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: IDLE_SNAPSHOT,
+      upstreamRev: REV_B,
+      // 0 = cleanliness gate, 1 = pre-merge CAS, 2 = the post-merge re-read.
+      gitStatusSeq: ["", "", " M web/js/comfyui-mcp-panel.js"],
+      onGitPull: ({ files, revs }) => {
+        files[pyPath] = pyproject(PANEL_REGISTRY_ID, "0.11.35");
+        delete revs[dir];
+        return FF;
+      },
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/ALREADY RAN/);
+    expect(msg).toMatch(/the worktree is dirty/);
+    expect(msg).toMatch(/may now be INCONSISTENT/);
+    expect(msg).not.toMatch(/NOT evidence that something else did/);
+    expect(h.gitPulls).toEqual([dir]);
+  });
+
   it("#824 P0: the worktree goes dirty between the cleanliness gate and the merge -> REFUSED", async () => {
     const h = makeDeps({
       comfyuiPath: COMFY,
@@ -1435,6 +1488,30 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     expect(msg).not.toMatch(/applied PARTIALLY/);
     // The original merge failure still survives into the message.
     expect(msg).toMatch(/local changes would be overwritten/);
+    expect(h.gitPulls).toEqual([dir]);
+  });
+
+  it("#824: a failed merge with an unreadable HEAD AND a dirty tree reports the DIRTY evidence", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: IDLE_SNAPSHOT,
+      upstreamRev: REV_B,
+      // 0 = cleanliness gate, 1 = pre-merge CAS, 2 = the post-failure re-read.
+      gitStatusSeq: ["", "", " M web/js/comfyui-mcp-panel.js"],
+      onGitPull: ({ revs }) => {
+        delete revs[dir];
+        throw new Error("error: Your local changes would be overwritten by merge");
+      },
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/could NOT be confirmed/);
+    expect(msg).toMatch(/the worktree is dirty/);
+    expect(msg).toMatch(/NOT what it was before the attempt/);
+    expect(msg).not.toMatch(/is UNKNOWN/);
     expect(h.gitPulls).toEqual([dir]);
   });
 

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -1195,6 +1195,62 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     expect(h.gitPulls).toEqual([]);
   });
 
+  it("#824: HEAD becomes UNREADABLE before the merge -> REFUSED as undetermined, not as 'HEAD moved'", async () => {
+    // `gitRevision` reports an unresolvable HEAD as undefined rather than by
+    // throwing. Refusing is right — an unverifiable tree does not license a
+    // merge — but the refusal must say the comparison could not be MADE, not
+    // that the checkout changed. "Could not determine" is not "determined not".
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: IDLE_SNAPSHOT,
+      upstreamRev: REV_B,
+      onBeforeMerge: ({ revs }) => {
+        delete revs[dir]; // git can no longer resolve HEAD at all
+      },
+      onGitPull: () => FF,
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/UNREADABLE HEAD \(git resolved no revision/);
+    expect(msg).toMatch(/could NOT be determined/);
+    expect(msg).toMatch(/NOT proof that anything changed/);
+    // The claims the "it moved" arm is allowed to make, and this one is not.
+    expect(msg).not.toMatch(/HEAD moved/);
+    expect(msg).not.toMatch(/evidently DID change/);
+    expect(msg).toMatch(/NO git mutation was made/);
+    expect(h.gitPulls).toEqual([]);
+  });
+
+  it("#824: HEAD is UNREADABLE after the merge -> disclosed as undetermined, no writer blamed", async () => {
+    // Same fold on the far side of the mutation. The merge HAS run, so this
+    // discloses rather than refuses — but an unreadable HEAD is not evidence
+    // that another writer touched the tree, and must not be reported as such.
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: IDLE_SNAPSHOT,
+      upstreamRev: REV_B,
+      onGitPull: ({ files, revs }) => {
+        files[pyPath] = pyproject(PANEL_REGISTRY_ID, "0.11.35");
+        delete revs[dir];
+        return FF;
+      },
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/ALREADY RAN/);
+    expect(msg).toMatch(/UNREADABLE HEAD \(git resolved no revision/);
+    expect(msg).toMatch(/NOT evidence that something else did/);
+    expect(msg).not.toMatch(/Another writer/);
+    expect(msg).not.toMatch(/may now be INCONSISTENT/);
+    expect(h.gitPulls).toEqual([dir]);
+  });
+
   it("#824 P0: the worktree goes dirty between the cleanliness gate and the merge -> REFUSED", async () => {
     const h = makeDeps({
       comfyuiPath: COMFY,
@@ -1349,6 +1405,36 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     expect(msg).not.toMatch(/nothing changed on disk/);
     // The original merge failure survives into the message either way.
     expect(msg).toMatch(/persona has no working git fallback/);
+    expect(h.gitPulls).toEqual([dir]);
+  });
+
+  it("#824: a failed merge over an UNREADABLE HEAD is UNKNOWN, not 'the tree is not what it was'", async () => {
+    // The third instance of the same fold. Here the re-read SUCCEEDS — status
+    // answers, HEAD simply cannot be resolved — so the failed-read catch never
+    // fires; without its own branch this lands in the "tree moved" arm and
+    // tells the user the directory is no longer in its pre-update state, which
+    // nothing established.
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: IDLE_SNAPSHOT,
+      upstreamRev: REV_B,
+      onGitPull: ({ revs }) => {
+        delete revs[dir];
+        throw new Error("error: Your local changes would be overwritten by merge");
+      },
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/could NOT be confirmed/);
+    expect(msg).toMatch(/UNREADABLE HEAD \(git resolved no revision/);
+    expect(msg).toMatch(/is UNKNOWN/);
+    expect(msg).not.toMatch(/NOT what it was before the attempt/);
+    expect(msg).not.toMatch(/applied PARTIALLY/);
+    // The original merge failure still survives into the message.
+    expect(msg).toMatch(/local changes would be overwritten/);
     expect(h.gitPulls).toEqual([dir]);
   });
 
@@ -1703,8 +1789,12 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     });
     const err = await runPanelAction("update", h.deps).catch((e) => e);
     expect(err).toBeInstanceOf(PanelInstallError);
-    expect(String(err?.message ?? err)).toMatch(/unreadable|UNVERIFIABLE/);
+    expect(String(err?.message ?? err)).toMatch(/unreadable|UNREADABLE|UNVERIFIABLE/);
     expect(String(err?.message ?? err)).not.toMatch(/already at the upstream tip/);
+    // #824: the post-merge bracket now answers this case first. Same verdict —
+    // never "at tip" — but it must not upgrade "we could not read HEAD" into an
+    // accusation that some other writer touched the tree.
+    expect(String(err?.message ?? err)).not.toMatch(/Another writer/);
   });
 
   it("legacy no-op + pull finds nothing newer → honest 'already at tip' (NOT 'updated', no restart)", async () => {

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -1339,10 +1339,44 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     const err = await runPanelAction("update", h.deps).catch((e) => e);
     expect(err).toBeInstanceOf(PanelInstallError);
     const msg = String(err?.message ?? err);
-    expect(msg).toMatch(/did NOT apply/);
+    // The HEADLINE moves with the observation: a tree that moved means the
+    // merge may have applied PARTIALLY, so "did NOT apply" is not available.
+    expect(msg).toMatch(/could NOT be confirmed/);
+    expect(msg).not.toMatch(/did NOT apply/);
     expect(msg).toMatch(/NOT what it was before the attempt/);
     expect(msg).toMatch(/the worktree is dirty/);
+    expect(msg).toMatch(/may therefore have applied PARTIALLY/);
     expect(msg).not.toMatch(/nothing changed on disk/);
+    // The original merge failure survives into the message either way.
+    expect(msg).toMatch(/persona has no working git fallback/);
+    expect(h.gitPulls).toEqual([dir]);
+  });
+
+  it("#824: a failed merge whose OWN re-read fails is disclosed as UNKNOWN, never as 'did NOT apply'", async () => {
+    // The re-read added above is itself two operations that can fail. Both live
+    // in one try, so an unreadable HEAD and an unreadable status reach the same
+    // handler; this drives it through `git status`. Failing to read is "could
+    // not determine whether the merge applied partially", which is not "it did
+    // not apply" — and it must not swallow the merge error either.
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: REV_A },
+      updateDetails: IDLE_SNAPSHOT,
+      upstreamRev: REV_B,
+      // 0 = cleanliness gate, 1 = pre-merge CAS, 2 = the post-failure re-read.
+      gitStatusThrowsAt: 2,
+      // onGitPull omitted -> the pinned merge THROWS.
+    });
+    const err = await runPanelAction("update", h.deps).catch((e) => e);
+    expect(err).toBeInstanceOf(PanelInstallError);
+    const msg = String(err?.message ?? err);
+    expect(msg).toMatch(/could NOT be confirmed/);
+    expect(msg).not.toMatch(/did NOT apply/);
+    expect(msg).toMatch(/could not be re-read afterwards/);
+    expect(msg).toMatch(/is UNKNOWN/);
+    // The merge error is what the user needs most; it must not be lost.
+    expect(msg).toMatch(/persona has no working git fallback/);
     expect(h.gitPulls).toEqual([dir]);
   });
 
@@ -1364,6 +1398,9 @@ describe("runPanelAction #724 git fallback (legacy Manager 3.x no-op)", () => {
     expect(msg).toMatch(/re-read afterwards and is unchanged/);
     expect(msg).toMatch(/installed version is still 0\.11\.32/);
     expect(msg).not.toMatch(/NOT what it was before/);
+    // Only an OBSERVED untouched tree earns the flat "did NOT apply" headline.
+    expect(msg).toMatch(/did NOT apply/);
+    expect(msg).not.toMatch(/could NOT be confirmed/);
   });
 
   it("#824: 'already at the upstream tip' claims only what git proved, not an untouched directory", async () => {

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -2723,12 +2723,41 @@ async function updateViaGitCheckoutFallback(opts: {
     assertSameTarget("before fast-forwarding the panel checkout");
     gitOutput = deps.gitMergeFfOnly(dir, targetRev);
   } catch (err) {
-    // The Manager path failed AND the direct merge failed — name both, truthfully.
+    // The Manager path failed AND the direct merge failed — name both,
+    // truthfully. "Truthfully" is the whole point of the re-read below: a
+    // failed `merge --ff-only` USUALLY leaves the tree exactly as it was, but
+    // "usually" is not "provably", and the very thing most likely to make it
+    // fail here is another writer landing in this checkout — which by
+    // definition already changed it. Asserting "nothing changed on disk" from
+    // the merge's exit status alone would be a bucket ("the merge failed")
+    // narrated as a fact about the disk (codex gate). So OBSERVE it: report
+    // unchanged only when a fresh read says so, report what moved when it did,
+    // and say UNKNOWN when the read itself fails.
+    let treeNote: string;
+    try {
+      const afterRev = deps.gitRevision(dir);
+      const afterPorcelain = deps.gitStatusPorcelain(dir).trim();
+      treeNote =
+        afterRev === prePullRev && afterPorcelain === ""
+          ? `The checkout was re-read afterwards and is unchanged (HEAD still ` +
+            `${prePullRev.slice(0, 8)}, worktree clean), so the installed version is ` +
+            `still ${previousVersion ?? "unknown"}.`
+          : `The checkout was re-read afterwards and is NOT what it was before the ` +
+            `attempt — ` +
+            `${afterRev !== prePullRev ? `HEAD is ${afterRev ? afterRev.slice(0, 8) : "unreadable"}, not ${prePullRev.slice(0, 8)}` : `the worktree is dirty:\n${afterPorcelain}`}. ` +
+            `Something changed ${dir}; inspect it (git status / git log) before ` +
+            `retrying, and do NOT assume the pre-update state.`;
+    } catch (readErr) {
+      treeNote =
+        `The checkout could not be re-read afterwards ` +
+        `(${readErr instanceof Error ? readErr.message : String(readErr)}), so ` +
+        `whether anything changed in ${dir} is UNKNOWN — inspect it (git status / ` +
+        `git log) before retrying.`;
+    }
     throw new PanelInstallError(
-      `Panel update did NOT apply: nothing changed on disk at ${dir} (installed ` +
-        `version still ${previousVersion ?? "unknown"}). ${managerReason}, and ` +
-        `the direct git fallback on the panel repo failed too — ` +
-        `${err instanceof Error ? err.message : String(err)}. ` +
+      `Panel update did NOT apply: ${managerReason}, and the direct git fallback ` +
+        `on the panel repo failed too — ` +
+        `${err instanceof Error ? err.message : String(err)}. ${treeNote} ` +
         `Fix: update ComfyUI-Manager on the host (git pull in custom_nodes/` +
         `ComfyUI-Manager, or pip install -U comfyui_manager) and retry, or update ` +
         `the panel repo manually (git pull in ${dir}), then RESTART ComfyUI.`,
@@ -2898,11 +2927,19 @@ async function updateViaGitCheckoutFallback(opts: {
   // from the Manager call that no-op'd — override its message too, so the
   // report never credits the Manager for a verification git did (codex gate).
   assertSameTarget("before reporting the checkout as current");
+  // Scope the closing claim to what was actually established. HEAD equalling
+  // the FETCHED upstream proves the tracked checkout is current; it does not
+  // prove the directory was untouched — `git status --porcelain` never reports
+  // ignored paths, and nothing is observed after the final read. So say what
+  // this fallback did (nothing: there was nothing to fast-forward) rather than
+  // issuing a whole-disk guarantee it is not in a position to make (codex gate).
   const atTipMessage =
     `Panel is already at the upstream tip (${post.version}) — ${managerReason}, ` +
     `but a pinned git merge --ff-only on ${dir} verified the checkout is ` +
-    `current (git: ${gitOutput || "no output"}). Nothing changed on disk; no ` +
-    `restart needed.`;
+    `current (git: ${gitOutput || "no output"}). HEAD already WAS the fetched ` +
+    `upstream, so this fallback fast-forwarded nothing and moved nothing itself; ` +
+    `no restart is needed on its account. (That verifies the TRACKED checkout — ` +
+    `git does not compare ignored files.)`;
   return {
     action: "update",
     result: { ...result, message: atTipMessage },

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -2733,29 +2733,46 @@ async function updateViaGitCheckoutFallback(opts: {
     // narrated as a fact about the disk (codex gate). So OBSERVE it: report
     // unchanged only when a fresh read says so, report what moved when it did,
     // and say UNKNOWN when the read itself fails.
+    //
+    // The HEADLINE moves with that observation too (codex gate r2). "Panel
+    // update did NOT apply" is a claim about the disk, so it is only earned by
+    // the reading that shows an untouched tree. When the tree moved, or could
+    // not be read, the merge may have applied PARTIALLY — the register there is
+    // disclosure, not a flat denial that anything happened. Both reads live in
+    // ONE try, so an unreadable HEAD and an unreadable status land in the same
+    // honest answer; neither can escape and lose the merge error below.
+    let headline: string;
     let treeNote: string;
     try {
       const afterRev = deps.gitRevision(dir);
       const afterPorcelain = deps.gitStatusPorcelain(dir).trim();
-      treeNote =
-        afterRev === prePullRev && afterPorcelain === ""
-          ? `The checkout was re-read afterwards and is unchanged (HEAD still ` +
-            `${prePullRev.slice(0, 8)}, worktree clean), so the installed version is ` +
-            `still ${previousVersion ?? "unknown"}.`
-          : `The checkout was re-read afterwards and is NOT what it was before the ` +
-            `attempt — ` +
-            `${afterRev !== prePullRev ? `HEAD is ${afterRev ? afterRev.slice(0, 8) : "unreadable"}, not ${prePullRev.slice(0, 8)}` : `the worktree is dirty:\n${afterPorcelain}`}. ` +
-            `Something changed ${dir}; inspect it (git status / git log) before ` +
-            `retrying, and do NOT assume the pre-update state.`;
+      if (afterRev === prePullRev && afterPorcelain === "") {
+        headline = `Panel update did NOT apply`;
+        treeNote =
+          `The checkout was re-read afterwards and is unchanged (HEAD still ` +
+          `${prePullRev.slice(0, 8)}, worktree clean), so the installed version is ` +
+          `still ${previousVersion ?? "unknown"}.`;
+      } else {
+        headline = `Panel update could NOT be confirmed`;
+        treeNote =
+          `The checkout was re-read afterwards and is NOT what it was before the ` +
+          `attempt — ` +
+          `${afterRev !== prePullRev ? `HEAD is ${afterRev ? afterRev.slice(0, 8) : "unreadable"}, not ${prePullRev.slice(0, 8)}` : `the worktree is dirty:\n${afterPorcelain}`}. ` +
+          `The fast-forward may therefore have applied PARTIALLY, or another ` +
+          `writer touched ${dir} — either way the panel directory is NOT in the ` +
+          `pre-update state. Inspect it (git status / git log) before retrying, ` +
+          `and do not assume the version above is what is on disk.`;
+      }
     } catch (readErr) {
+      headline = `Panel update could NOT be confirmed`;
       treeNote =
         `The checkout could not be re-read afterwards ` +
         `(${readErr instanceof Error ? readErr.message : String(readErr)}), so ` +
-        `whether anything changed in ${dir} is UNKNOWN — inspect it (git status / ` +
-        `git log) before retrying.`;
+        `whether the fast-forward applied partially — or anything else changed ` +
+        `${dir} — is UNKNOWN. Inspect it (git status / git log) before retrying.`;
     }
     throw new PanelInstallError(
-      `Panel update did NOT apply: ${managerReason}, and the direct git fallback ` +
+      `${headline}: ${managerReason}, and the direct git fallback ` +
         `on the panel repo failed too — ` +
         `${err instanceof Error ? err.message : String(err)}. ${treeNote} ` +
         `Fix: update ComfyUI-Manager on the host (git pull in custom_nodes/` +

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -2711,7 +2711,14 @@ async function updateViaGitCheckoutFallback(opts: {
   // Both arms REFUSE (that is right: this is before the mutation, and an
   // unverifiable tree does not license a merge), but only the arm with two
   // readable, DIFFERENT revisions may say something changed.
-  if (!casRev) {
+  //
+  // A DIRTY worktree is answered first, because it is established evidence in
+  // its own right and does not depend on HEAD resolving: the cleanliness gate
+  // proved this tree clean, so a non-empty porcelain here IS proof it changed.
+  // Only over a still-clean worktree does an unreadable HEAD mean "the
+  // comparison could not be made" — saying "not proof that anything changed"
+  // while holding a dirty status would be the mirror defect (codex gate r4).
+  if (casPorcelain === "" && !casRev) {
     throw new PanelInstallError(
       `Panel update did NOT apply: ${managerReason}, and the git fallback is ` +
         `REFUSED: the panel checkout at ${dir} has an UNREADABLE HEAD (git ` +
@@ -2729,7 +2736,7 @@ async function updateViaGitCheckoutFallback(opts: {
       `Panel update did NOT apply: ${managerReason}, and the git fallback is ` +
         `REFUSED: the panel checkout at ${dir} CHANGED between the safety gates ` +
         `and the merge — ` +
-        `${casRev !== prePullRev ? `HEAD moved ${prePullRev.slice(0, 8)} → ${casRev.slice(0, 8)}` : `the worktree is no longer clean:\n${casPorcelain}`}. ` +
+        `${casPorcelain !== "" ? `the worktree is no longer clean:\n${casPorcelain}` : `HEAD moved ${prePullRev.slice(0, 8)} → ${casRev ? casRev.slice(0, 8) : "an unresolvable revision"}`}. ` +
         `Something other than this update is writing to that tree, and a ` +
         `fast-forward would race it. NO git mutation was made by this fallback ` +
         `— but something else evidently DID change the checkout, so re-read it ` +
@@ -2766,11 +2773,13 @@ async function updateViaGitCheckoutFallback(opts: {
     try {
       const afterRev = deps.gitRevision(dir);
       const afterPorcelain = deps.gitStatusPorcelain(dir).trim();
-      if (!afterRev) {
+      if (afterPorcelain === "" && !afterRev) {
         // `gitRevision` answers an unresolvable HEAD with undefined, not by
         // throwing. "Could not read HEAD" is the same answer as a failed
         // status read — UNKNOWN — and must not be routed into the arm that
         // tells the user the tree is no longer in its pre-update state.
+        // A dirty status is checked FIRST though: that IS evidence of change,
+        // and it stands whether or not HEAD resolved (codex gate r4).
         headline = `Panel update could NOT be confirmed`;
         treeNote =
           `The checkout was re-read afterwards but has an UNREADABLE HEAD ` +
@@ -2788,7 +2797,7 @@ async function updateViaGitCheckoutFallback(opts: {
         treeNote =
           `The checkout was re-read afterwards and is NOT what it was before the ` +
           `attempt — ` +
-          `${afterRev !== prePullRev ? `HEAD is ${afterRev ? afterRev.slice(0, 8) : "unreadable"}, not ${prePullRev.slice(0, 8)}` : `the worktree is dirty:\n${afterPorcelain}`}. ` +
+          `${afterPorcelain !== "" ? `the worktree is dirty:\n${afterPorcelain}` : `HEAD is ${afterRev ? afterRev.slice(0, 8) : "unresolvable"}, not ${prePullRev.slice(0, 8)}`}. ` +
           `The fast-forward may therefore have applied PARTIALLY, or another ` +
           `writer touched ${dir} — either way the panel directory is NOT in the ` +
           `pre-update state. Inspect it (git status / git log) before retrying, ` +
@@ -2843,8 +2852,10 @@ async function updateViaGitCheckoutFallback(opts: {
   // Same distinction as the pre-merge CAS: an unresolvable HEAD comes back as
   // undefined, not as a throw, and "we could not read HEAD" is not "another
   // writer touched this tree". Both DISCLOSE — the merge has run either way —
-  // but only the readable third-revision arm may name a cause.
-  if (!postMergeRev) {
+  // but only the readable third-revision arm may name a cause. A DIRTY
+  // worktree is answered first either way: that is established evidence of an
+  // outside write, and it stands whether or not HEAD resolved (codex gate r4).
+  if (postMergePorcelain === "" && !postMergeRev) {
     throw new PanelInstallError(
       `Could not verify the panel update: the pinned fast-forward ALREADY RAN in ` +
         `${dir}, but the checkout afterwards has an UNREADABLE HEAD (git ` +
@@ -2860,7 +2871,7 @@ async function updateViaGitCheckoutFallback(opts: {
       `Could not verify the panel update: the pinned fast-forward ALREADY RAN in ` +
         `${dir}, but the checkout afterwards is not what that merge alone would ` +
         `leave — ` +
-        `${postMergePorcelain !== "" ? `the worktree is dirty:\n${postMergePorcelain}` : `HEAD is ${postMergeRev.slice(0, 8)}, neither the merged upstream (${targetRev.slice(0, 8)}) nor the pre-merge revision (${prePullRev.slice(0, 8)})`}. ` +
+        `${postMergePorcelain !== "" ? `the worktree is dirty:\n${postMergePorcelain}` : `HEAD is ${postMergeRev ? postMergeRev.slice(0, 8) : "unresolvable"}, neither the merged upstream (${targetRev.slice(0, 8)}) nor the pre-merge revision (${prePullRev.slice(0, 8)})`}. ` +
         `Another writer (a ComfyUI-Manager task, or a manual git operation) ` +
         `touched this tree during the merge, so the panel directory may now be ` +
         `INCONSISTENT. NOT reporting success. Inspect the panel repo (git ` +

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -2704,12 +2704,32 @@ async function updateViaGitCheckoutFallback(opts: {
         `(git pull in ${dir}), then RESTART ComfyUI.`,
     );
   }
+  // An ABSENT revision is its own answer. `gitRevision` reports an unresolvable
+  // HEAD as undefined rather than by throwing, so folding it into the
+  // "HEAD moved" arm would narrate "could not determine what HEAD is" as
+  // "determined HEAD changed" — the defect this file keeps being fixed for.
+  // Both arms REFUSE (that is right: this is before the mutation, and an
+  // unverifiable tree does not license a merge), but only the arm with two
+  // readable, DIFFERENT revisions may say something changed.
+  if (!casRev) {
+    throw new PanelInstallError(
+      `Panel update did NOT apply: ${managerReason}, and the git fallback is ` +
+        `REFUSED: the panel checkout at ${dir} has an UNREADABLE HEAD (git ` +
+        `resolved no revision at all) ` +
+        `immediately before the merge, so whether it is still the tree the safety ` +
+        `gates inspected (${prePullRev.slice(0, 8)}) could NOT be determined — that ` +
+        `is unknown, NOT proof that anything changed. NO git mutation was made — ` +
+        `though whether the Manager call itself changed anything is precisely what ` +
+        `its own status could not say. Check the panel repo (git status / git log), ` +
+        `then re-check install_panel(action='status').`,
+    );
+  }
   if (casRev !== prePullRev || casPorcelain !== "") {
     throw new PanelInstallError(
       `Panel update did NOT apply: ${managerReason}, and the git fallback is ` +
         `REFUSED: the panel checkout at ${dir} CHANGED between the safety gates ` +
         `and the merge — ` +
-        `${casRev !== prePullRev ? `HEAD moved ${prePullRev.slice(0, 8)} → ${casRev ? casRev.slice(0, 8) : "unreadable"}` : `the worktree is no longer clean:\n${casPorcelain}`}. ` +
+        `${casRev !== prePullRev ? `HEAD moved ${prePullRev.slice(0, 8)} → ${casRev.slice(0, 8)}` : `the worktree is no longer clean:\n${casPorcelain}`}. ` +
         `Something other than this update is writing to that tree, and a ` +
         `fast-forward would race it. NO git mutation was made by this fallback ` +
         `— but something else evidently DID change the checkout, so re-read it ` +
@@ -2746,7 +2766,18 @@ async function updateViaGitCheckoutFallback(opts: {
     try {
       const afterRev = deps.gitRevision(dir);
       const afterPorcelain = deps.gitStatusPorcelain(dir).trim();
-      if (afterRev === prePullRev && afterPorcelain === "") {
+      if (!afterRev) {
+        // `gitRevision` answers an unresolvable HEAD with undefined, not by
+        // throwing. "Could not read HEAD" is the same answer as a failed
+        // status read — UNKNOWN — and must not be routed into the arm that
+        // tells the user the tree is no longer in its pre-update state.
+        headline = `Panel update could NOT be confirmed`;
+        treeNote =
+          `The checkout was re-read afterwards but has an UNREADABLE HEAD ` +
+          `(git resolved no revision at all), so ` +
+          `whether the fast-forward applied partially — or anything else changed ` +
+          `${dir} — is UNKNOWN. Inspect it (git status / git log) before retrying.`;
+      } else if (afterRev === prePullRev && afterPorcelain === "") {
         headline = `Panel update did NOT apply`;
         treeNote =
           `The checkout was re-read afterwards and is unchanged (HEAD still ` +
@@ -2809,12 +2840,27 @@ async function updateViaGitCheckoutFallback(opts: {
         `restarting ComfyUI.`,
     );
   }
+  // Same distinction as the pre-merge CAS: an unresolvable HEAD comes back as
+  // undefined, not as a throw, and "we could not read HEAD" is not "another
+  // writer touched this tree". Both DISCLOSE — the merge has run either way —
+  // but only the readable third-revision arm may name a cause.
+  if (!postMergeRev) {
+    throw new PanelInstallError(
+      `Could not verify the panel update: the pinned fast-forward ALREADY RAN in ` +
+        `${dir}, but the checkout afterwards has an UNREADABLE HEAD (git ` +
+        `resolved no revision at all), so what ` +
+        `it now contains — and whether anything else wrote to it during the merge ` +
+        `— could NOT be determined. That is unknown, NOT evidence that something ` +
+        `else did. NOT reporting success. Inspect the panel repo (git status / ` +
+        `git log) before restarting ComfyUI.`,
+    );
+  }
   if (postMergePorcelain !== "" || (postMergeRev !== targetRev && postMergeRev !== prePullRev)) {
     throw new PanelInstallError(
       `Could not verify the panel update: the pinned fast-forward ALREADY RAN in ` +
         `${dir}, but the checkout afterwards is not what that merge alone would ` +
         `leave — ` +
-        `${postMergePorcelain !== "" ? `the worktree is dirty:\n${postMergePorcelain}` : `HEAD is ${postMergeRev ? postMergeRev.slice(0, 8) : "unreadable"}, neither the merged upstream (${targetRev.slice(0, 8)}) nor the pre-merge revision (${prePullRev.slice(0, 8)})`}. ` +
+        `${postMergePorcelain !== "" ? `the worktree is dirty:\n${postMergePorcelain}` : `HEAD is ${postMergeRev.slice(0, 8)}, neither the merged upstream (${targetRev.slice(0, 8)}) nor the pre-merge revision (${prePullRev.slice(0, 8)})`}. ` +
         `Another writer (a ComfyUI-Manager task, or a manual git operation) ` +
         `touched this tree during the merge, so the panel directory may now be ` +
         `INCONSISTENT. NOT reporting success. Inspect the panel repo (git ` +


### PR DESCRIPTION
## Why this exists

PR #840 merged (`8f434b1`) while an independent gate was still running against its diff. That gate — and three follow-up rounds against each fix — found **four real defects in the concurrency bracket #840 shipped**, all the same family: an observation the code could not make, reported as an observation that came out negative. None of them change what the bracket *allows*; all of them change what it *claims*.

Nothing here loosens a guard. Every change either narrows a claim to what was actually observed, or splits one message into the two different answers it was conflating. Follow-up to #840; `artokun/comfyui-mcp#824` stays the tracking issue.

## The four findings

**R1 — a failed merge is not proof the disk is unchanged.** The merge-failure catch asserted `nothing changed on disk at <dir> (installed version still X)` purely from the merge's exit status. A failed `merge --ff-only` usually leaves the tree alone, but the likeliest thing to make it fail *here* is another writer landing in the checkout — exactly the case where the sentence is false. It now re-reads HEAD and porcelain and reports what it observes: unchanged when it is, what moved when it moved, UNKNOWN when the read itself fails.

**R1 — "Nothing changed on disk; no restart needed."** HEAD equalling the fetched upstream proves the TRACKED checkout is current. It does not prove the directory was untouched: `git status --porcelain` never reports ignored paths, and nothing is observed after the final read. The at-tip report now claims only that this fallback fast-forwarded nothing and moved nothing itself.

**R2 — a failed merge may have applied PARTIALLY.** R1's re-read reported the tree honestly but left the headline saying `Panel update did NOT apply` in every case, including the one where the re-read had just observed the checkout MOVED. That headline is a claim about the disk, and only the untouched reading earns it. It now says `could NOT be confirmed` whenever the tree moved or could not be read, and names partial application as a live possibility. The original merge error survives into the message on every branch.

**R3 — an UNREADABLE HEAD is not a HEAD that moved.** `deps.gitRevision` answers an unresolvable HEAD with `undefined`, not by throwing — so all three of the bracket's HEAD comparisons folded "could not read HEAD" into their "HEAD changed" arm and narrated it: the pre-merge CAS said the checkout `CHANGED between the safety gates and the merge` and that `something else evidently DID change` it; the post-merge check blamed `another writer (a ComfyUI-Manager task, or a manual git operation)` and called the directory possibly INCONSISTENT; the merge-failure re-read said the tree `is NOT what it was before the attempt`. Each site now answers the absent revision on its own branch, in its own register — the two pre-mutation ones still REFUSE, the post-merge one still DISCLOSES and still never reports success.

**R4 — a dirty worktree is evidence even when HEAD will not resolve.** R3's fix put the unreadable-HEAD branch FIRST, so an unreadable HEAD over a worktree porcelain had just reported DIRTY answered `unknown, NOT proof that anything changed` — while holding proof that it did (the cleanliness gate had established that tree clean). The same fold, pointed the other way. Each site now answers the dirty status first and reaches the undetermined branch only over a still-clean worktree; the evidence clauses were reordered so none can print "HEAD is unreadable, not `<sha>`" while holding a dirty status.

## Verification

- Full suite green: 263 files, 5471 tests.
- **12 new cases, every one mutation-verified** — the fix was temporarily removed and the specific test confirmed to fail, and no other test changed state:

| Guard removed | Fails |
|---|---|
| post-merge third-HEAD clause | the third-clean-HEAD case only |
| post-merge re-read catch | the unreadable-re-read case only |
| failed-merge verdict forced to "unchanged" | the moved case only |
| failed-merge verdict forced to "moved" | the unchanged case (+ one pre-existing case asserting the flat headline) |
| catch headline forced to "did NOT apply" | the unreadable case only |
| at-tip wording reverted | its own case only |
| pre-merge unreadable-HEAD branch | that case only |
| post-merge unreadable-HEAD branch | that case (+ the pre-existing unreadable-HEAD case) |
| failed-merge unreadable-HEAD branch | that case only |
| each site's dirty-first ordering (×3) | that site's dirty+unreadable case only |

- One pre-existing case (`post-pull HEAD revision is UNREADABLE`) now lands on the new post-merge branch. Its assertion is widened for the casing and **strengthened** to forbid the accusation it must no longer make.
- Committed blobs scanned for control bytes: zero across both files.
- Adversarial gate (codex `gpt-5.6-terra`, read-only): four rounds, each finding above is one round's P1. The last round's finding is fixed and mutation-verified here.

**Only a live rig can confirm** the end-to-end behaviour against a real stale Manager 3.x host — every path here is exercised through stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
