### PR TITLE
fix(#788, #790, #792): the first independent gate on the #842 branch

### DIFF
--- a/docs/backends.mdx
+++ b/docs/backends.mdx
@@ -221,6 +221,11 @@ audio extension is moved to the audio path automatically — including formats w
 cannot encode (`.wma`, `.mid`, `.aiff`), so you get "convert it to one of…"
 rather than an image error.
 
+Sending the same file in **both** arrays (as the example above does) is safe: a
+ref is identified by filename + subfolder + type, so it is delivered once and
+counts once against the two-attachments-per-turn limit. It is not mistaken for
+a second file and then refused for not fitting.
+
 <Note>
 A **composer control** for picking an audio file lives in the panel
 (`comfyui-mcp-panel`), which is a separate repository — that part is not in this

--- a/scripts/arena-bestof.mjs
+++ b/scripts/arena-bestof.mjs
@@ -9,7 +9,7 @@
 // Regenerates arena-report.md afterward.
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { buildArenaReport } from "./arena-report.mjs";
+import { buildArenaReport, mergeRunAxes } from "./arena-report.mjs";
 
 const [baseDir, ...runDirs] = process.argv.slice(2);
 if (!baseDir) {
@@ -55,18 +55,41 @@ for (const dir of runDirs) {
       );
       continue;
     }
+    // …and never merge two DIFFERENT quantizations of the same tag. `ollama
+    // pull` replaces the weights under the same name, so `gemma4:e4b` at Q4_K_M
+    // and at Q8_0 are two different models wearing one id — a best-of range
+    // across them is the same "scores from two conditions read as one" error the
+    // version guard above refuses, and the Quant column would name only one of
+    // them. Unknown on either side is NOT a mismatch (see mergeRunAxes: it comes
+    // out as `mixed` rather than a claim).
+    if (current.quant && candidate.quant && current.quant !== candidate.quant) {
+      console.warn(
+        `skip ${candidate.model} from ${dir}: the merge would mix quantizations ${current.quant} + ${candidate.quant} — those are different models under one tag`,
+      );
+      continue;
+    }
     const totals = [...(current.runs?.totals ?? [current.total]), candidate.total];
     const winner = better(current, candidate) > 0 ? candidate : current;
     // If either side predates version stamping, the merged range mixes a
     // stamped and an unstamped run — the entry must NOT keep claiming the
     // version (the report flags unversioned entries as not comparable).
     const mergedVersion = current.mcpVersion && candidate.mcpVersion ? winner.mcpVersion : undefined;
+    // The condition axes belong to a RUN, not to the winner: keeping the
+    // winner's Params/Quant/VRAM would state that the whole best-of range was
+    // recorded under that one condition. mergeRunAxes keeps only what both runs
+    // agree on and marks the rest `mixed`.
     base.leaderboard[i] = {
       ...winner,
       tier: current.tier,
       runs: { totals },
       mcpVersion: mergedVersion,
       mcpVersions: knownVersions,
+      params: undefined,
+      quant: undefined,
+      vramResidentBytes: undefined,
+      vramResidentBytesRange: undefined,
+      mixedAxes: undefined,
+      ...mergeRunAxes(current, candidate),
     };
     console.log(`${candidate.model}: run=${candidate.total} → keeping ${winner.total} (all: ${totals.join(", ")})`);
   }

--- a/scripts/arena-report.mjs
+++ b/scripts/arena-report.mjs
@@ -20,6 +20,87 @@ export function vramLabel(bytes) {
   return (bytes / (1024 * 1024 * 1024)).toFixed(1);
 }
 
+/**
+ * The condition axes (#792) for an entry that MERGED two runs.
+ *
+ * A best-of-N entry shows one score RANGE, and next to it one Params / Quant /
+ * VRAM cell. Keeping the winning run's axes there states that the whole range
+ * was recorded under that one condition — which is exactly what a re-pull from
+ * q4 to q8 breaks: the same tag, two different models, one displayed quant, and
+ * a reader comparing the ladder against a condition half those runs never had.
+ *
+ * So an axis survives the merge only when BOTH runs recorded the SAME value.
+ * Where they differ, or where one run recorded nothing at all, the axis is
+ * MIXED — reported as such rather than dropped, because "—" already means "not
+ * recorded" and collapsing "spans two conditions" into "unknown" would hide the
+ * thing the reader has to know. VRAM is the one exception worth a real number:
+ * it is a measurement of the same condition rather than a condition itself, so
+ * two known values become a RANGE.
+ *
+ * Callers that would rather not merge at all still have that option — the
+ * quantization guard in arena-bestof.mjs refuses outright when the two runs are
+ * demonstrably different quantizations, and this only ever sees what it lets by.
+ */
+export function mergeRunAxes(a, b) {
+  const mixedAxes = [];
+  const same = (x, y) => x !== undefined && x !== null && x === y;
+  const out = {};
+  for (const axis of ["params", "quant"]) {
+    if (same(a[axis], b[axis])) out[axis] = a[axis];
+    else if (a[axis] !== undefined || b[axis] !== undefined) mixedAxes.push(axis);
+  }
+  // An already-merged side carries a RANGE; folding only its top would quietly
+  // shrink the span each time another run joins.
+  const vramsOf = (m) =>
+    (Array.isArray(m.vramResidentBytesRange) ? m.vramResidentBytesRange : [m.vramResidentBytes]).filter(
+      (v) => typeof v === "number" && Number.isFinite(v) && v > 0,
+    );
+  const sideA = vramsOf(a);
+  const sideB = vramsOf(b);
+  const vrams = [...sideA, ...sideB];
+  if (sideA.length && sideB.length) {
+    out.vramResidentBytes = Math.max(...vrams);
+    if (Math.min(...vrams) !== Math.max(...vrams)) out.vramResidentBytesRange = [Math.min(...vrams), Math.max(...vrams)];
+  } else if (vrams.length) {
+    // One run measured it and the other did not: the range is not a measured
+    // range, so the entry must not present the one number as covering both.
+    mixedAxes.push("vram");
+  }
+  // `mixed` is STICKY. A third run that happens to match the surviving value
+  // does not un-mix a range that already spans two conditions — once an axis is
+  // unknown for some run in the range, it stays unknown for the range.
+  for (const axis of ["params", "quant", "vram"]) {
+    if (mixedAxes.includes(axis)) continue;
+    if (a.mixedAxes?.includes(axis) || b.mixedAxes?.includes(axis)) {
+      mixedAxes.push(axis);
+      delete out[axis];
+      if (axis === "vram") {
+        delete out.vramResidentBytes;
+        delete out.vramResidentBytesRange;
+      }
+    }
+  }
+  if (mixedAxes.length) out.mixedAxes = mixedAxes;
+  return out;
+}
+
+/** Cell text for an axis on a (possibly merged) entry: a value, `mixed` when
+ *  the entry's runs disagree, or `—` when nothing recorded it. */
+export function axisCell(entry, axis) {
+  if (entry.mixedAxes?.includes(axis)) return "mixed";
+  if (axis === "vram") {
+    const range = entry.vramResidentBytesRange;
+    if (Array.isArray(range) && range.length === 2) {
+      const lo = vramLabel(range[0]);
+      const hi = vramLabel(range[1]);
+      if (lo && hi) return lo === hi ? `${hi} GiB` : `${lo}–${hi} GiB`;
+    }
+    const one = vramLabel(entry.vramResidentBytes);
+    return one ? `${one} GiB` : "—";
+  }
+  return entry[axis] ?? "—";
+}
+
 const nudgesOf = (m) => m.results.reduce((s, r) => s + (r.nudges ?? 0), 0);
 const roundsOf = (m) => m.results.reduce((s, r) => s + (r.rounds ?? 0), 0);
 const secondsOf = (m) => m.results.reduce((s, r) => s + (r.seconds ?? 0), 0);
@@ -135,13 +216,20 @@ export function buildArenaReport(data) {
       totals && totals.length > 1
         ? `**${m.total}/${m.max}** (best of ${totals.length}: ${Math.min(...totals)}–${Math.max(...totals)})`
         : `**${m.total}/${m.max}**`;
-    const vram = vramLabel(m.vramResidentBytes);
     md.push(
-      `| \`${m.model}\` | ${m.tier ?? "local"} | ${m.params ?? "—"} | ${m.quant ?? "—"} | ${vram ? `${vram} GiB` : "—"} | ${cells.join(" | ")} | ${score} | ${nudgesOf(m)} | ${roundsOf(m)} | ${secondsOf(m)}s |`,
+      `| \`${m.model}\` | ${m.tier ?? "local"} | ${axisCell(m, "params")} | ${axisCell(m, "quant")} | ${axisCell(m, "vram")} | ${cells.join(" | ")} | ${score} | ${nudgesOf(m)} | ${roundsOf(m)} | ${secondsOf(m)}s |`,
     );
   }
   md.push("", `Scenarios: ${scen.map((s) => `**${s.id}** (${s.title.toLowerCase()})`).join(" · ")}`, "");
   md.push(`✅ completed & server-verified · 🟡 right tool family, incomplete outcome · ❌ failed`, "");
+  if (board.some((m) => m.mixedAxes?.length)) {
+    md.push(
+      `\`mixed\` in Params/Quant/VRAM: that row is a best-of range whose runs did not all record the same value for ` +
+        `that axis (a re-pulled tag, or a run from before the axis was recorded) — the score range there is not tied ` +
+        `to one condition. \`—\` means the axis was never recorded at all.`,
+      "",
+    );
+  }
 
   // Version comparability (#792 sequencing note): absolute scores move when the
   // tool surface changes, so the report must never invite a cross-version read.

--- a/scripts/arena-report.mjs
+++ b/scripts/arena-report.mjs
@@ -93,6 +93,9 @@ export function axisCell(entry, axis) {
     if (Array.isArray(range) && range.length === 2) {
       const lo = vramLabel(range[0]);
       const hi = vramLabel(range[1]);
+      // Two measurements that round to the same tenth print as that one figure,
+      // deliberately: "5.0–5.0 GiB" is noise, and "5.0 GiB" is true of both at
+      // the precision the column is stated in. The raw pair stays in the JSON.
       if (lo && hi) return lo === hi ? `${hi} GiB` : `${lo}–${hi} GiB`;
     }
     const one = vramLabel(entry.vramResidentBytes);

--- a/src/__tests__/arena-report.test.ts
+++ b/src/__tests__/arena-report.test.ts
@@ -8,7 +8,7 @@ import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 // @ts-expect-error plain-JS module under scripts/, no type declarations
-import { buildArenaReport, suspectScenarioLines, vramLabel } from "../../scripts/arena-report.mjs";
+import { axisCell, buildArenaReport, mergeRunAxes, suspectScenarioLines, vramLabel } from "../../scripts/arena-report.mjs";
 
 function entry(over: Record<string, unknown>) {
   return {
@@ -318,6 +318,32 @@ describe("arena-bestof cross-version merge guard (#792)", () => {
     expect(merged.leaderboard[0].runs).toBeUndefined();
   });
 
+  it("refuses to merge two different QUANTIZATIONS of one tag — those are different models", () => {
+    // `ollama pull` replaces the weights under the same name, so a q4 run and a
+    // q8 run are not two samples of one model.
+    const { base, extra } = fixture(
+      { ...mkEntry("0.49.6", 20), quant: "Q4_K_M" },
+      { ...mkEntry("0.49.6", 19), quant: "Q8_0" },
+    );
+    const { out, merged } = run(base, extra);
+    expect(out).toContain("different models under one tag");
+    expect(merged.leaderboard[0].runs).toBeUndefined(); // NOT merged
+    expect(merged.leaderboard[0].quant).toBe("Q4_K_M");
+  });
+
+  it("a merge whose runs did not all record an axis reports it as mixed, not as the winner's value", () => {
+    const { base, extra } = fixture(
+      { ...mkEntry("0.49.6", 20), quant: "Q4_K_M", vramResidentBytes: 5 * 1024 * 1024 * 1024 },
+      mkEntry("0.49.6", 19), // an older run with no axes recorded at all
+    );
+    const { merged } = run(base, extra);
+    expect(merged.leaderboard[0].runs.totals).toEqual([20, 19]);
+    // The winning run was q4 — but the RANGE was not, so the cell must not say q4.
+    expect(merged.leaderboard[0].quant).toBeUndefined();
+    expect(merged.leaderboard[0].mixedAxes).toEqual(expect.arrayContaining(["quant", "vram"]));
+    expect(readFileSync(join(base, "arena-report.md"), "utf8")).toContain("mixed");
+  });
+
   it("an unversioned intermediate merge does not launder a later cross-version run into the range", () => {
     const { base, extra } = fixture(mkEntry("0.49.6", 20), mkEntry(undefined, 19));
     run(base, extra); // merges; entry is now unversioned but remembers v0.49.6
@@ -335,5 +361,68 @@ describe("arena-bestof cross-version merge guard (#792)", () => {
     const { out, merged } = run(base, extra2);
     expect(out).toContain("not directly comparable"); // refused — v0.50.0 vs the v0.49.6 already in the range
     expect(merged.leaderboard[0].runs.totals).toEqual([20, 19]); // unchanged
+  });
+});
+
+describe("a best-of range must not display ONE condition it did not all run under (#792)", () => {
+  const GIB = 1024 * 1024 * 1024;
+
+  it("keeps an axis only when both runs recorded the SAME value", () => {
+    const merged = mergeRunAxes(
+      { params: "8.0B", quant: "Q4_K_M", vramResidentBytes: 5 * GIB },
+      { params: "8.0B", quant: "Q4_K_M", vramResidentBytes: 5 * GIB },
+    );
+    expect(merged.params).toBe("8.0B");
+    expect(merged.quant).toBe("Q4_K_M");
+    expect(merged.mixedAxes).toBeUndefined();
+  });
+
+  it("marks an axis MIXED when only one run recorded it — not `—`, which means never recorded", () => {
+    const merged = mergeRunAxes({ quant: "Q4_K_M" }, {});
+    expect(merged.quant).toBeUndefined();
+    expect(merged.mixedAxes).toContain("quant");
+    expect(axisCell(merged, "quant")).toBe("mixed");
+    // …and an axis nobody recorded stays the honest "not recorded" dash.
+    expect(axisCell({}, "quant")).toBe("—");
+  });
+
+  it("turns two measured VRAM figures into a RANGE rather than the winner's number", () => {
+    const merged = mergeRunAxes({ vramResidentBytes: 5 * GIB }, { vramResidentBytes: 6 * GIB });
+    expect(axisCell(merged, "vram")).toBe("5.0–6.0 GiB");
+    // and a third run widens it rather than folding to the last pair
+    const wider = mergeRunAxes(merged, { vramResidentBytes: 7 * GIB });
+    expect(axisCell(wider, "vram")).toBe("5.0–7.0 GiB");
+  });
+
+  it("VRAM measured by only ONE of the runs is mixed, never presented as the range's figure", () => {
+    const merged = mergeRunAxes({ vramResidentBytes: 5 * GIB }, {});
+    expect(axisCell(merged, "vram")).toBe("mixed");
+  });
+
+  it("`mixed` is sticky: a later matching run does not un-mix the range", () => {
+    const first = mergeRunAxes({ quant: "Q4_K_M" }, {});
+    const second = mergeRunAxes(first, { quant: "Q4_K_M" });
+    expect(second.mixedAxes).toContain("quant");
+    expect(axisCell(second, "quant")).toBe("mixed");
+  });
+
+  it("the report renders the merged cells and explains what `mixed` means", () => {
+    const md = buildArenaReport({
+      gpu: "4090",
+      scenarios: SCEN,
+      leaderboard: [
+        entry({
+          model: "m:e4b",
+          runs: { totals: [20, 19] },
+          quant: undefined,
+          mixedAxes: ["quant"],
+          vramResidentBytesRange: [5 * GIB, 6 * GIB],
+          vramResidentBytes: 6 * GIB,
+        }),
+      ],
+    });
+    expect(md).toContain("| mixed |"); // the quant cell
+    expect(md).toContain("5.0–6.0 GiB");
+    expect(md).toContain("not tied");
   });
 });

--- a/src/__tests__/orchestrator/audio-attachment.test.ts
+++ b/src/__tests__/orchestrator/audio-attachment.test.ts
@@ -11,6 +11,7 @@ import {
   modelLacksAudioText,
   noAudioPartText,
   openAiAudioFormat,
+  dedupeAudioRefs,
   splitAudioAttachments,
   supportedAudioFormats,
   unsupportedFormatText,
@@ -293,5 +294,39 @@ describe("fetchAudioAttachment", () => {
   it("REFUSES when no ComfyUI URL is configured, rather than returning nothing", async () => {
     const r = await fetchAudioAttachment(undefined, { filename: "a.wav" });
     expect(r.ok === false && r.outcome.status === "refused" && r.outcome.reason).toBe("fetch-failed");
+  });
+});
+
+describe("dedupeAudioRefs — one file attached on two carriers is ONE attachment", () => {
+  it("collapses the same ComfyUI file arriving in both `images` and `audio`", () => {
+    // The panel has two carriers. A composer that populates both would otherwise
+    // spend two of the turn's slots on one sound, and the SECOND copy comes back
+    // to the user as "only 2 audio file(s) fit on one turn" — a refusal of a file
+    // that is already on the request.
+    const refs = [
+      { filename: "song.wav", type: "input" },
+      { filename: "song.wav", type: "input" },
+      { filename: "voice.mp3", type: "input" },
+    ];
+    expect(dedupeAudioRefs(refs)).toEqual([
+      { filename: "song.wav", type: "input" },
+      { filename: "voice.mp3", type: "input" },
+    ]);
+  });
+
+  it("treats an absent `type` as the fetcher's own default, not as a different file", () => {
+    // fetchAudioAttachment sends type=input when the ref omits it, so these two
+    // refs address byte-for-byte the same /view response.
+    expect(dedupeAudioRefs([{ filename: "song.wav" }, { filename: "song.wav", type: "input" }])).toHaveLength(1);
+  });
+
+  it("keeps files that really are different — same name, different folder or type", () => {
+    expect(
+      dedupeAudioRefs([
+        { filename: "song.wav", type: "input" },
+        { filename: "song.wav", type: "output" },
+        { filename: "song.wav", subfolder: "takes", type: "input" },
+      ]),
+    ).toHaveLength(3);
   });
 });

--- a/src/__tests__/orchestrator/ollama-audio.test.ts
+++ b/src/__tests__/orchestrator/ollama-audio.test.ts
@@ -784,6 +784,98 @@ describe("#788 — a live model switch reconciles the tool surface", () => {
     // The explanation still catches up to the model actually in use.
     expect(anyBackend.toolModeDecision?.model).toBe("gemma4:e2b");
   });
+
+  it("the post-switch rewrite KEEPS the panel-router retraction", async () => {
+    // The rewrite replaces the whole system message. A rebuild that emitted only
+    // the mode text would silently restore "you have panel_list_tools /
+    // panel_describe_tool / panel_call_tool" in a session whose router never
+    // registered — the false capability claim the retraction exists to remove,
+    // reintroduced by the fix for a different problem.
+    const backend = new OllamaBackend({
+      model: "qwen3:4b",
+      // NOTE: no panel entry — the router is NOT registered in this session.
+      mcpServers: { comfyui: { transport: "stdio", command: "node", args: [], env: {} } },
+    });
+    const anyBackend = backend as unknown as {
+      connectTools: () => Promise<void>;
+      comfy: unknown;
+      comfyTools: unknown[];
+      comfySpecEnv: Record<string, string> | undefined;
+      toolModeDecision: unknown;
+      model: string;
+    };
+    anyBackend.connectTools = async () => {
+      anyBackend.comfySpecEnv = {};
+      anyBackend.comfy = fakeMcpClient();
+      const { comfyuiSpawnToolMode } = await import("../../orchestrator/ollama-backend.js");
+      anyBackend.toolModeDecision = comfyuiSpawnToolMode({}, {}, anyBackend.model);
+      anyBackend.comfyTools = [];
+    };
+    await backend.prepare();
+    await collect(backend, turnsOf({ text: "first" }));
+    const firstSystem = (chatRequests[0].messages as Array<Record<string, unknown>>).find(
+      (m) => m.role === "system",
+    ) as { content: string };
+    expect(firstSystem.content).toContain("DO NOT EXIST right now");
+
+    await backend.setModel("llama3.3:70b"); // respawns onto the full surface
+    await collect(backend, turnsOf({ text: "second" }));
+    const laterSystem = (chatRequests.at(-1)!.messages as Array<Record<string, unknown>>).find(
+      (m) => m.role === "system",
+    ) as { content: string };
+    expect(laterSystem.content).toContain("advertised to you DIRECTLY"); // the new surface
+    expect(laterSystem.content).toContain("DO NOT EXIST right now"); // …and the retraction survived
+  });
+
+  it("ADDS the retraction when the respawn loses a router the session had", async () => {
+    // The reconcile tears the PANEL client down too. If the respawn fails to
+    // bring it back, a session that opened WITH a working router is left holding
+    // a prompt that still names panel_list_tools / panel_describe_tool /
+    // panel_call_tool — and nothing else in the conversation retracts it. The
+    // rewrite therefore has to happen on the failure branch as well, and it has
+    // to re-derive the retraction from the router that is live NOW.
+    let first = true;
+    const backend = new OllamaBackend({
+      model: "qwen3:4b",
+      mcpServers: { comfyui: { transport: "stdio", command: "node", args: [], env: {} } },
+    });
+    const anyBackend = backend as unknown as {
+      connectTools: () => Promise<void>;
+      comfy: unknown;
+      comfyTools: unknown[];
+      panel: unknown;
+      panelTools: unknown[];
+      comfySpecEnv: Record<string, string> | undefined;
+      toolModeDecision: unknown;
+      model: string;
+    };
+    anyBackend.connectTools = async () => {
+      anyBackend.comfySpecEnv = {};
+      if (!first) throw new Error("spawn failed");
+      first = false;
+      anyBackend.comfy = fakeMcpClient();
+      anyBackend.panel = fakeMcpClient();
+      anyBackend.panelTools = [{ name: "panel_list_tools", inputSchema: { type: "object" } }];
+      const { comfyuiSpawnToolMode } = await import("../../orchestrator/ollama-backend.js");
+      anyBackend.toolModeDecision = comfyuiSpawnToolMode({}, {}, anyBackend.model);
+      anyBackend.comfyTools = [];
+    };
+    await backend.prepare();
+    await collect(backend, turnsOf({ text: "first" }));
+    const firstSystem = (chatRequests[0].messages as Array<Record<string, unknown>>).find(
+      (m) => m.role === "system",
+    ) as { content: string };
+    // The router WAS there when the session opened — nothing to retract.
+    expect(firstSystem.content).not.toContain("DO NOT EXIST right now");
+
+    await backend.setModel("llama3.3:70b");
+    await collect(backend, turnsOf({ text: "second" }));
+    expect(anyBackend.panel).toBeNull(); // the respawn really did lose it
+    const laterSystem = (chatRequests.at(-1)!.messages as Array<Record<string, unknown>>).find(
+      (m) => m.role === "system",
+    ) as { content: string };
+    expect(laterSystem.content).toContain("DO NOT EXIST right now");
+  });
 });
 
 describe("#790 — the capability probe is never memoised", () => {

--- a/src/__tests__/orchestrator/ollama-tool-mode-spawn.test.ts
+++ b/src/__tests__/orchestrator/ollama-tool-mode-spawn.test.ts
@@ -9,21 +9,33 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-/** Every env the backend handed to a spawned stdio child, in order. */
+/**
+ * Every env a stdio child was actually CONNECTED with, in order.
+ *
+ * Recorded in the mocked `Client.connect`, not in the transport constructor: a
+ * transport that is built and never connected spawns nothing, so asserting on
+ * construction alone would let "we computed the right env and never used it"
+ * pass as "the child came up in the right mode".
+ */
 const spawnEnvs: Array<Record<string, string>> = [];
 
+class FakeStdioTransport {
+  env: Record<string, string>;
+  constructor(opts: { env?: Record<string, string> }) {
+    this.env = { ...(opts.env ?? {}) };
+  }
+  async close() {}
+}
+
 vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
-  StdioClientTransport: class {
-    constructor(opts: { env?: Record<string, string> }) {
-      spawnEnvs.push({ ...(opts.env ?? {}) });
-    }
-    async close() {}
-  },
+  StdioClientTransport: FakeStdioTransport,
 }));
 
 vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
   Client: class {
-    async connect() {}
+    async connect(transport: FakeStdioTransport) {
+      spawnEnvs.push(transport.env);
+    }
     async listTools() {
       return { tools: [{ name: "list_tools", description: "d", inputSchema: { type: "object" } }] };
     }

--- a/src/__tests__/orchestrator/ollama-tool-mode-spawn.test.ts
+++ b/src/__tests__/orchestrator/ollama-tool-mode-spawn.test.ts
@@ -1,0 +1,94 @@
+// #788 — the tool mode the comfyui CHILD is actually spawned with.
+//
+// The reconcile tests in ollama-audio.test.ts stub `connectTools` wholesale, so
+// they pin the DECISION but not the wiring: production could stop passing the
+// live model into comfyuiSpawnEnv and they would all still pass, while the
+// respawned child came up compact for a 70B model — the auto-selected surface
+// silently not applied, which is the whole of #788. This file mocks the MCP SDK
+// instead and asserts on the environment the child process is really given.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Every env the backend handed to a spawned stdio child, in order. */
+const spawnEnvs: Array<Record<string, string>> = [];
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: class {
+    constructor(opts: { env?: Record<string, string> }) {
+      spawnEnvs.push({ ...(opts.env ?? {}) });
+    }
+    async close() {}
+  },
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: class {
+    async connect() {}
+    async listTools() {
+      return { tools: [{ name: "list_tools", description: "d", inputSchema: { type: "object" } }] };
+    }
+    async close() {}
+  },
+}));
+
+const { OllamaBackend } = await import("../../orchestrator/ollama-backend.js");
+
+beforeEach(() => {
+  spawnEnvs.length = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/version")) return new Response(JSON.stringify({ version: "0.31.1" }), { status: 200 });
+      return new Response("{}", { status: 200 });
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.COMFYUI_MCP_TOOL_MODE;
+});
+
+function backendFor(model: string) {
+  return new OllamaBackend({
+    model,
+    mcpServers: { comfyui: { transport: "stdio", command: "node", args: [], env: {} } },
+  });
+}
+
+describe("#788 — the spawned comfyui child really gets the mode chosen for the MODEL", () => {
+  it("spawns compact for a small model", async () => {
+    await backendFor("qwen3:4b").prepare();
+    expect(spawnEnvs).toHaveLength(1);
+    expect(spawnEnvs[0].COMFYUI_MCP_TOOL_MODE).toBe("compact");
+  });
+
+  it("spawns full for a large model", async () => {
+    await backendFor("llama3.3:70b").prepare();
+    expect(spawnEnvs[0].COMFYUI_MCP_TOOL_MODE).toBe("full");
+  });
+
+  it("a live switch RESPAWNS the child with the new model's mode, not the old one's", async () => {
+    const backend = backendFor("qwen3:4b");
+    await backend.prepare();
+    expect(spawnEnvs[0].COMFYUI_MCP_TOOL_MODE).toBe("compact");
+
+    await backend.setModel("llama3.3:70b");
+    await (backend as unknown as { reconcileToolModeForModel: () => Promise<void> }).reconcileToolModeForModel();
+    // The child the 70B model will actually call through must be the full one.
+    expect(spawnEnvs).toHaveLength(2);
+    expect(spawnEnvs[1].COMFYUI_MCP_TOOL_MODE).toBe("full");
+  });
+
+  it("an explicit user choice is still what the child is spawned with, in both directions", async () => {
+    process.env.COMFYUI_MCP_TOOL_MODE = "compact";
+    const backend = backendFor("qwen3:4b");
+    await backend.prepare();
+    expect(spawnEnvs[0].COMFYUI_MCP_TOOL_MODE).toBe("compact");
+    await backend.setModel("llama3.3:70b");
+    await (backend as unknown as { reconcileToolModeForModel: () => Promise<void> }).reconcileToolModeForModel();
+    // Pinned: no respawn at all, and certainly not a full one.
+    expect(spawnEnvs).toHaveLength(1);
+  });
+});

--- a/src/__tests__/orchestrator/ollama-tool-mode-spawn.test.ts
+++ b/src/__tests__/orchestrator/ollama-tool-mode-spawn.test.ts
@@ -10,12 +10,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
- * Every env a stdio child was actually CONNECTED with, in order.
+ * Every env a stdio child was handed by a COMPLETED `Client.connect`, in order.
  *
- * Recorded in the mocked `Client.connect`, not in the transport constructor: a
+ * Recorded in the mocked connect rather than in the transport constructor: a
  * transport that is built and never connected spawns nothing, so asserting on
  * construction alone would let "we computed the right env and never used it"
- * pass as "the child came up in the right mode".
+ * pass as "the child came up in the right mode". The mock also refuses to serve
+ * tools before that connect finishes, so a connect whose result is not waited
+ * for fails here the way it would in production — an unconnected client that
+ * still gets asked for its catalog.
  */
 const spawnEnvs: Array<Record<string, string>> = [];
 
@@ -33,10 +36,17 @@ vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
 
 vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
   Client: class {
+    connected = false;
     async connect(transport: FakeStdioTransport) {
+      // A real connect spawns a process and handshakes; it does not complete in
+      // the caller's tick. The macrotask makes "the caller didn't wait" visible
+      // rather than accidentally harmless.
+      await new Promise((r) => setTimeout(r, 0));
+      this.connected = true;
       spawnEnvs.push(transport.env);
     }
     async listTools() {
+      if (!this.connected) throw new Error("listTools before connect completed");
       return { tools: [{ name: "list_tools", description: "d", inputSchema: { type: "object" } }] };
     }
     async close() {}
@@ -62,6 +72,11 @@ afterEach(() => {
   delete process.env.COMFYUI_MCP_TOOL_MODE;
 });
 
+/** The tool surface this backend really ended up with. */
+function surfaceOf(backend: unknown) {
+  return backend as { toolModeDecision: { mode: string } | null; comfyTools: unknown[] };
+}
+
 function backendFor(model: string) {
   return new OllamaBackend({
     model,
@@ -71,9 +86,15 @@ function backendFor(model: string) {
 
 describe("#788 — the spawned comfyui child really gets the mode chosen for the MODEL", () => {
   it("spawns compact for a small model", async () => {
-    await backendFor("qwen3:4b").prepare();
+    const backend = backendFor("qwen3:4b");
+    await backend.prepare();
     expect(spawnEnvs).toHaveLength(1);
     expect(spawnEnvs[0].COMFYUI_MCP_TOOL_MODE).toBe("compact");
+    // …and the surface is LIVE: a connect that was fired and not waited for
+    // leaves the catalog unreadable, which connectTools turns into no decision
+    // at all. Asserting the env alone would not notice.
+    expect(surfaceOf(backend).toolModeDecision?.mode).toBe("compact");
+    expect(surfaceOf(backend).comfyTools).toHaveLength(1);
   });
 
   it("spawns full for a large model", async () => {

--- a/src/__tests__/orchestrator/panel-agent-audio-gate.test.ts
+++ b/src/__tests__/orchestrator/panel-agent-audio-gate.test.ts
@@ -168,3 +168,30 @@ describe("the vitest environment does not swallow the gate", () => {
     expect(onSay).toHaveBeenCalled();
   });
 });
+
+describe("two queued messages carrying the SAME file batch into one attachment", () => {
+  it("does not spend a second audio slot on bytes already attached", async () => {
+    // The batch merges the two messages into one turn. Without a dedupe the turn
+    // carries song.wav twice, which both wastes one of the two per-turn slots
+    // and — with a third, different file — refuses a real attachment out loud
+    // for "not fitting" while the duplicate rides the request.
+    const { backend, seen } = recordingBackend({ audio: true }, "ollama");
+    const { agent } = makeAgent(backend);
+    await runOneTurn(agent, () => {
+      agent.send("what key is this in?", { audio: [{ filename: "song.wav", type: "input" }] });
+      agent.send("and the tempo?", { audio: [{ filename: "song.wav", type: "input" }] });
+    });
+    expect(seen).toHaveLength(1); // they really did batch
+    expect(seen[0].audio).toEqual([{ filename: "song.wav", type: "input" }]);
+  });
+
+  it("still carries two genuinely different files", async () => {
+    const { backend, seen } = recordingBackend({ audio: true }, "ollama");
+    const { agent } = makeAgent(backend);
+    await runOneTurn(agent, () => {
+      agent.send("first", { audio: [{ filename: "a.wav", type: "input" }] });
+      agent.send("second", { audio: [{ filename: "b.wav", type: "input" }] });
+    });
+    expect(seen[0].audio).toHaveLength(2);
+  });
+});

--- a/src/orchestrator/audio-attachment.ts
+++ b/src/orchestrator/audio-attachment.ts
@@ -439,6 +439,38 @@ export async function fetchAudioAttachment(
  * `song.wma` is audio the user is trying to share, and it belongs on the path
  * that can tell them what to convert it to.
  */
+/**
+ * Collapse refs that name the SAME ComfyUI file to one attachment.
+ *
+ * The panel has two carriers for a sound — the dedicated `audio` array and the
+ * legacy `images` array a older/compatible composer still uses — and a panel
+ * that populates both sends the same file twice. Without this, one attachment
+ * counts twice against MAX_AUDIO_ATTACHMENTS: the second copy is REFUSED, and
+ * the user is told out loud that a file they attached once did not fit, while
+ * the identical bytes are also sitting on the request. A duplicate of a file we
+ * are already sending is not a second attachment.
+ *
+ * Identity is the tuple ComfyUI's /view is addressed by (filename + subfolder +
+ * type), normalised the same way `fetchAudioAttachment` builds that URL, so two
+ * refs are merged only when they would fetch byte-for-byte the same file. A
+ * missing `type` really does mean "input" on both sides — that is the fetcher's
+ * default, not a guess made here.
+ *
+ * Order is preserved and the FIRST occurrence wins, so the earlier carrier
+ * decides nothing beyond position.
+ */
+export function dedupeAudioRefs<T extends AudioRef>(refs: readonly T[]): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const ref of refs) {
+    const key = JSON.stringify([ref.filename, ref.subfolder ?? "", ref.type || "input"]);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(ref);
+  }
+  return out;
+}
+
 export function splitAudioAttachments<T extends { filename: string }>(
   refs: readonly T[] | undefined,
 ): { images: T[]; audio: T[] } {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -109,7 +109,7 @@ import { OAUTH_PROVIDERS } from "../services/oauth-flow.js";
 import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "./panel-mcp-http.js";
 import { resolveHttpLaneComfyToolMode } from "./http-backend-tools.js";
 import type { ToolMode } from "../transport/cli.js";
-import { splitAudioAttachments } from "./audio-attachment.js";
+import { dedupeAudioRefs, splitAudioAttachments } from "./audio-attachment.js";
 import { startPanelConsoleHttpServer, type PanelConsoleHttpServer } from "./panel-console-http.js";
 import type { AgentBackend } from "./agent-backend.js";
 import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
@@ -4851,7 +4851,11 @@ export async function runPanelOrchestrator(): Promise<void> {
       .audio;
     const attachmentSplit = splitAudioAttachments(rawAttached);
     const attachedImages = attachmentSplit.images;
-    const attachedAudio = [...attachmentSplit.audio, ...(declaredAudio ?? [])];
+    // Deduped across the two carriers: a panel that populates BOTH arrays for
+    // the same sound would otherwise spend two of the turn's attachment slots on
+    // one file, and the user would be told the duplicate "did not fit" while the
+    // very same bytes rode the request anyway.
+    const attachedAudio = dedupeAudioRefs([...attachmentSplit.audio, ...(declaredAudio ?? [])]);
     const tabIsBlind = blindTabs.has(event.tab_id);
     if (tabIsBlind && attachedImages?.length) {
       outText += `\n\n[panel note: ${attachedImages.length} image attachment(s) withheld — Blind mode is ON. You cannot see them; ask the user to describe the content or turn Blind off.]`;

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -1063,6 +1063,28 @@ export class OllamaBackend implements AgentBackend {
     return { content, toolCalls, usage, streamId: streamOpen ? streamId : null };
   }
 
+  /**
+   * The system prompt for the surface that ACTUALLY exists right now: the tool
+   * mode the comfyui child was really spawned with, plus the retraction for a
+   * panel router that was never registered.
+   *
+   * ONE builder, used by both the session opener and the post-switch rewrite,
+   * because those are the two places the prompt is written and they must not
+   * disagree. An earlier shape rebuilt the prompt after a live model switch
+   * WITHOUT the retraction, which silently restored the "you have panel_*"
+   * claim in a session whose router had failed to bind.
+   *
+   * `resolvePrompt` still returns a user override unchanged; the retraction is
+   * appended either way, because it corrects what was REGISTERED and no prompt
+   * override or tool mode changes that.
+   */
+  protected systemPromptForSurface(): string {
+    return (
+      resolvePrompt("backend.ollama", ollamaSystemPrompt(this.toolModeDecision?.mode ?? "compact")) +
+      ollamaPanelRetraction(this.panelRouterAvailable())
+    );
+  }
+
   async *run(opts: BackendStartOptions): AsyncIterable<AgentEvent> {
     await this.prepare();
     if (opts.model && acceptsModelId(opts.model, this.api)) this.model = opts.model;
@@ -1082,15 +1104,10 @@ export class OllamaBackend implements AgentBackend {
       // lane via systemAppend (this adapter drops that), so it is re-derived from
       // what this backend knows first-hand — whether it actually registered the
       // panel router — and appended here. Without it the prompt goes on promising
-      // panel routers that were never registered (#841 lineage).
-      this.history = [
-        {
-          role: "system",
-          content:
-            resolvePrompt("backend.ollama", ollamaSystemPrompt(this.toolModeDecision?.mode ?? "compact")) +
-            ollamaPanelRetraction(this.panelRouterAvailable()),
-        },
-      ];
+      // panel routers that were never registered (#841 lineage). Built by
+      // systemPromptForSurface(), which the post-model-switch rewrite also uses,
+      // so the two writers cannot disagree about what this session was told.
+      this.history = [{ role: "system", content: this.systemPromptForSurface() }];
     }
     yield { type: "session", sessionId: this.sessionId, model: this.model };
 
@@ -1382,20 +1399,30 @@ export class OllamaBackend implements AgentBackend {
           // build), retry ONCE with the images stripped and an honest note in
           // both directions. Any other failure re-throws to the normal handler.
           //
-          // `attachmentsAccepted` is the guard against fabricating a failure:
-          // once ANY request carrying attachments has come back successfully,
-          // this endpoint demonstrably takes them, so a later error — a middle
-          // tool round, a subsequent turn whose history still holds the earlier
-          // media — is something else. Stripping then, and telling the user
-          // "you were not heard", would report a delivery failure that never
-          // happened for media the model had already received.
-          const hadAudio = this.history.some((m) => m.audios?.length);
-          const hadImages = this.history.some((m) => m.images?.length);
-          // …and it must be an OBSERVED rejection. Only a 4xx from the endpoint
-          // is evidence that the request was refused; a connection reset, a
-          // truncated body, or a mid-stream failure after a 200 says nothing
-          // about the attachment, and stripping on those would tell the user the
+          // `turnMediaAccepted` is the guard against fabricating a failure:
+          // once a request carrying THIS TURN's attachments has come back
+          // successfully, the endpoint demonstrably took them, so a later error
+          // — a middle tool round, a subsequent turn whose history still holds
+          // the earlier media — is something else. Stripping then, and telling
+          // the user "you were not heard", would report a delivery failure that
+          // never happened for media the model had already received.
+          //
+          // …and it must be an OBSERVED rejection: the endpoint answered the
+          // request carrying the media with an error STATUS, so nothing was
+          // generated from it. A connection reset, a truncated body, or a
+          // mid-stream failure after a 200 carries no status and says nothing
+          // about the attachment — stripping on those would tell the user the
           // model "did NOT hear" something we never saw it refuse.
+          //
+          // 4xx ONLY, deliberately. A 5xx is the endpoint failing, not the
+          // endpoint refusing what we sent: an upstream outage or a crashed
+          // worker would be narrated as "${model} rejected the request carrying
+          // the audio" — a cause we never observed — and the retry cannot help
+          // anyway, because the next request meets the same broken endpoint. The
+          // media-rejection statuses this recovers from are 4xx on both wires:
+          // Ollama answers an unusable image part with 400 ("this model is
+          // missing data required for image input") and the OpenAI dialect with
+          // 400 ("invalid image input"), both reproduced live.
           const status = (err as { httpStatus?: number } | null)?.httpStatus;
           const requestWasRejected = typeof status === "number" && status >= 400 && status < 500;
           // Arm ONLY when THIS turn attached media that has not yet come back
@@ -1689,18 +1716,23 @@ export class OllamaBackend implements AgentBackend {
     } catch (err) {
       logger.warn(`[ollama-backend] tool-server respawn failed after model switch: ${msgOf(err)}`);
     }
+    // The system prompt is written once, when a session opens — but a LIVE
+    // model switch changes the surface underneath an existing conversation.
+    // Leaving the old prompt in history is not a cosmetic mismatch: it tells a
+    // model now holding the whole catalog that it "has exactly six tools" and
+    // must go through call_tool, so the auto-selected surface goes unused.
+    // Rewrite it to match what was actually spawned.
+    //
+    // Rewritten on BOTH outcomes, and always through systemPromptForSurface():
+    // the respawn tore the PANEL client down too, so the retraction has to be
+    // re-derived from the router that is live NOW. Dropping it here — or
+    // skipping the rewrite when the respawn failed — would put the "you have
+    // panel_list_tools / panel_describe_tool / panel_call_tool" claim back into
+    // a conversation whose router is gone, which is the exact false capability
+    // claim ollamaPanelRetraction exists to retract.
+    const system = this.history[0];
+    if (system?.role === "system") system.content = this.systemPromptForSurface();
     if (this.toolModeDecision) {
-      // The system prompt is written once, when a session opens — but a LIVE
-      // model switch changes the surface underneath an existing conversation.
-      // Leaving the old prompt in history is not a cosmetic mismatch: it tells a
-      // model now holding the whole catalog that it "has exactly six tools" and
-      // must go through call_tool, so the auto-selected surface goes unused.
-      // Rewrite it to match what was actually spawned. resolvePrompt still
-      // returns a USER override unchanged, so a customised prompt is untouched.
-      const system = this.history[0];
-      if (system?.role === "system") {
-        system.content = resolvePrompt("backend.ollama", ollamaSystemPrompt(this.toolModeDecision.mode));
-      }
       logger.info(`[ollama-backend] ${this.toolModeDecision.explain}`);
     } else {
       // connectTools swallows a connect failure, so an absent decision here is

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -26,7 +26,7 @@ import { logger } from "../utils/logger.js";
 import { errorText, promptText } from "./error-text.js";
 import type { SessionStore } from "./session-store.js";
 import type { AgentBackend, AgentEvent, NeutralTurn } from "./agent-backend.js";
-import { type AudioRef, noAudioPartText } from "./audio-attachment.js";
+import { type AudioRef, dedupeAudioRefs, noAudioPartText } from "./audio-attachment.js";
 import {
   ClaudeBackend,
   fetchSupportedModels,
@@ -1083,7 +1083,12 @@ export class PanelAgent {
       // ingress would otherwise stringify to "[object Object]" here (#175).
       let text = batch.map((it) => promptText(it.text)).join("\n\n");
       let images = batch.flatMap((it) => it.images ?? []);
-      let audio = batch.flatMap((it) => it.audio ?? []);
+      // Deduped across the BATCH, not just within one message: two queued
+      // messages that each carried the same file become one turn here, and the
+      // duplicate would spend a second of the turn's two audio slots on bytes
+      // already attached — the user then hears that a file they sent "does not
+      // fit" while it is on the request twice.
+      let audio = dedupeAudioRefs(batch.flatMap((it) => it.audio ?? []));
       // #790 — the SAME contract as the image gate below, for hearing. A backend
       // with no audio content part must never simply receive `turn.audio` and
       // drop it: the user would ask about a sound and get an answer composed


### PR DESCRIPTION
PR #842 merged (241777c) before it was ever reviewed by anyone but its author — the "gate pass" commits on it are self-reviews. This is that review, landed as a follow-up because the branch merged while the gate was running.

## What the gate found

**1. A live model switch silently un-retracted the panel router** (`ollama-backend.ts`, still live on main at the reconcile rewrite). `reconcileToolModeForModel` rewrites the session's system prompt to match the newly spawned tool surface — and rebuilt it from `ollamaSystemPrompt()` alone, dropping `ollamaPanelRetraction`, which the session opener appends. A conversation whose panel router never registered got "you have panel_list_tools / panel_describe_tool / panel_call_tool" handed back to it by the fix for a different problem. Worse in the other direction: the reconcile tears the panel client down, so a respawn that loses the router left a session that opened *with* one still naming it — and the rewrite was skipped entirely on the failure branch. Both writers now go through one `systemPromptForSurface()`, and the rewrite happens on both outcomes.

**2. One sound attached on both carriers was refused as two** (#790). The panel can send audio in the dedicated `audio` array and in the legacy `images` array; the orchestrator concatenated them. A composer that populates both spent two of the turn's two slots on one file and told the user out loud that the duplicate "did not fit" — while the identical bytes rode the request anyway. Deduped by the tuple `/view` is addressed by, normalised exactly as `fetchAudioAttachment` builds that URL. The same collapse now happens in the PanelAgent **batch**, where two queued messages carrying the same file merge into one turn.

**3. A best-of range displayed ONE condition it did not all run under** (#792). The merge kept the winning run's Params/Quant/VRAM next to a score range spanning both runs — re-pull a tag from q4 to q8 and the ladder reads as one quantization. Merging two known-different quantizations is now refused outright (different models under one tag, exactly like the version guard above it); an axis survives only when both runs agree; anything else renders `mixed`, which is distinct from `—` ("never recorded"); two measured VRAM figures become a range.

**4. The reconcile tests pinned the DECISION, not the wiring.** They stub `connectTools` wholesale, so production could stop passing the live model into `comfyuiSpawnEnv` and every one of them would still pass while the respawned child came up compact for a 70B model — #788's entire point, unasserted. The new file mocks the MCP SDK and asserts the env a *completed* connect handed the child.

## Considered and deliberately not changed

The strip-and-retry fires on a **4xx only**. Widening it to 5xx would restore graceful degradation on a 500-answering endpoint, but it would narrate an upstream outage as "$model rejected the request carrying the audio" — a cause never observed — and the retry meets the same broken endpoint anyway. The branch's own test pins this; the comment now records why.

Two VRAM measurements that round to the same tenth still print as that one figure: "5.0–5.0 GiB" is noise and "5.0 GiB" is true of both at the stated precision. The raw pair stays in the results JSON.

## Verification

3 gate rounds (gpt-5.6-terra, independent). `tsc` clean; full suite 271 files / 5598 tests green. Every fix is mutation-verified — reverting it fails the named test, including the unawaited-`connect` mutation that the round-2 version of the spawn test let through.

Issue #792 stays OPEN: this branch adds the axes and the suspect-scenario flag, but the community baseline the issue also asks for has not been published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)