### PR TITLE
follow-up to #839: fix the three gate findings that merged unaddressed

### DIFF
--- a/src/__tests__/services/lora-catalog.test.ts
+++ b/src/__tests__/services/lora-catalog.test.ts
@@ -642,6 +642,31 @@ describe("two writers racing the catalog: no write is silently erased", () => {
     },
   );
 
+  it("the contender that gets its turn is refused on the STALE BASELINE, then reconciles", () => {
+    // What the same race looks like once serialized, which is the ordinary
+    // outcome: B waits a few milliseconds, gets the lock, and finds the file is
+    // no longer the one it read. It must be told — and telling it must not be
+    // terminal, or the lock would have traded a silent loss for a dead end.
+    writeFileSync(catalogPath, V1);
+    const catalogA = new LoraCatalog();
+    const catalogB = new LoraCatalog();
+
+    catalogA.upsert({ relPath: "loras/from-a.safetensors" });
+    expect(existsSync(lockPath())).toBe(false); // A's turn is over
+
+    expect(() => catalogB.upsert({ relPath: "loras/from-b.safetensors" })).toThrow(
+      /changed on disk since it was read/,
+    );
+    // The refusal re-synced B onto A's state, so the retry lands on top of it
+    // instead of erasing it.
+    expect(catalogB.get("from-a")?.id).toBe("loras-from-a");
+    catalogB.upsert({ relPath: "loras/from-b.safetensors" });
+    const onDisk = JSON.parse(realFs.readFileSync(catalogPath, "utf-8") as string) as {
+      entries: Record<string, unknown>;
+    };
+    expect(Object.keys(onDisk.entries).sort()).toEqual(["loras-from-a", "loras-from-b"]);
+  });
+
   it("a write waits out, then refuses, while another writer holds the lock", { timeout: 30000 }, () => {
     writeFileSync(catalogPath, V1);
     const catalog = new LoraCatalog();
@@ -686,6 +711,68 @@ describe("two writers racing the catalog: no write is silently erased", () => {
     expect(catalog.get("after-crash")?.id).toBe("loras-after-crash");
   });
 
+  it("a lock with NO recorded owner is not reclaimed on age alone", { timeout: 30000 }, () => {
+    // A crash between the exclusive create and the record write leaves exactly
+    // this, and so does a process paused between those two syscalls. Age past
+    // the ordinary threshold does not distinguish them, and "no owner recorded"
+    // is an absence of evidence, not evidence of absence.
+    writeFileSync(catalogPath, V1);
+    const catalog = new LoraCatalog();
+    writeFileSync(lockPath(), "");
+    const old = new Date(Date.now() - 60_000);
+    utimesSync(lockPath(), old, old);
+    expect(() => catalog.upsert({ relPath: "loras/nope.safetensors" })).toThrow(
+      /held the LoRA catalog lock/,
+    );
+    expect(existsSync(lockPath())).toBe(true);
+  });
+
+  it("but time settles it: a very old lock is reclaimed whatever its record says", () => {
+    // Otherwise a crash — or a pid the OS later handed to an unrelated live
+    // process — refuses every catalog write FOREVER. The critical section is
+    // two small reads and one write, so at this age there is no live holder to
+    // rob; a live pid in the record is a reused number, not a writer.
+    writeFileSync(catalogPath, V1);
+    const catalog = new LoraCatalog();
+    writeFileSync(
+      lockPath(),
+      JSON.stringify({ pid: process.pid, token: "reused-pid", at: new Date().toISOString() }),
+    );
+    const ancient = new Date(Date.now() - 15 * 60_000);
+    utimesSync(lockPath(), ancient, ancient);
+    catalog.upsert({ relPath: "loras/unwedged.safetensors" });
+    expect(catalog.get("unwedged")?.id).toBe("loras-unwedged");
+  });
+
+  it("a lock that CHANGES mid-reclaim is put back, not stolen", { timeout: 30000 }, () => {
+    // The reclaim takes the lock aside before judging it, because a
+    // stat-then-unlink can free a path a third writer has already taken. If
+    // what it took is not the instance it judged, it must go back — and go back
+    // in a way that cannot clobber whatever landed in the meantime.
+    writeFileSync(catalogPath, V1);
+    const catalog = new LoraCatalog();
+    writeFileSync(
+      lockPath(),
+      JSON.stringify({ pid: DEAD_PID, token: "crashed", at: new Date().toISOString() }),
+    );
+    const old = new Date(Date.now() - 120_000);
+    utimesSync(lockPath(), old, old);
+    // Stand in for the fresh lock that replaced the stale one in the gap: what
+    // the reclaim lifts off the path is not what it judged.
+    vi.mocked(renameSync).mockImplementation(((from: string, to: string) => {
+      (realFs.renameSync as (a: string, b: string) => void)(from, to);
+      if (from === lockPath()) {
+        const now = new Date();
+        utimesSync(to, now, now);
+      }
+    }) as never);
+    expect(() => catalog.upsert({ relPath: "loras/nope.safetensors" })).toThrow(
+      /held the LoRA catalog lock/,
+    );
+    expect(existsSync(lockPath())).toBe(true);
+    expect(realFs.readFileSync(catalogPath, "utf-8")).toBe(V1);
+  });
+
   it("an OLD lock whose owner is still alive is never reclaimed", { timeout: 30000 }, () => {
     // Age alone does not license a reclaim: freeing a path a live writer is
     // still inside reintroduces exactly the loss the lock prevents.
@@ -701,6 +788,40 @@ describe("two writers racing the catalog: no write is silently erased", () => {
       /held the LoRA catalog lock/,
     );
     expect(existsSync(lockPath())).toBe(true);
+  });
+
+  it("a write that FAILED after its bytes landed is disclosed, not reported as unsaved", () => {
+    // writeFileDurable is strict by design: it throws when the directory entry's
+    // durability is unproven, which happens AFTER the atomic rename — the bytes
+    // are already on the path. Rethrowing that as a failed save tells the caller
+    // its change was not applied when it was: this file's own defect pointed the
+    // other way. Only the read-back can tell the two sides of the rename apart.
+    writeFileSync(catalogPath, V1);
+    const catalog = new LoraCatalog();
+    vi.mocked(renameSync).mockImplementation(((from: string, to: string) => {
+      (realFs.renameSync as (a: string, b: string) => void)(from, to);
+      if (to === catalogPath) {
+        throw Object.assign(new Error("EIO: directory fsync failed"), { code: "EIO" });
+      }
+    }) as never);
+    catalog.upsert({ relPath: "loras/landed.safetensors" });
+    expect(catalog.get("landed")?.id).toBe("loras-landed");
+    const onDisk = JSON.parse(realFs.readFileSync(catalogPath, "utf-8") as string) as {
+      entries: Record<string, unknown>;
+    };
+    expect(Object.keys(onDisk.entries)).toEqual(["loras-landed"]);
+  });
+
+  it("a write that failed BEFORE its bytes landed still fails (control)", () => {
+    writeFileSync(catalogPath, V1);
+    const catalog = new LoraCatalog();
+    vi.mocked(renameSync).mockImplementation(((from: string, to: string) => {
+      if (to === catalogPath) throw Object.assign(new Error("ENOSPC: no space"), { code: "ENOSPC" });
+      return (realFs.renameSync as (a: string, b: string) => void)(from, to);
+    }) as never);
+    expect(() => catalog.upsert({ relPath: "loras/lost.safetensors" })).toThrow(/ENOSPC/);
+    expect(realFs.readFileSync(catalogPath, "utf-8")).toBe(V1);
+    expect(catalog.get("lost")).toBeNull();
   });
 
   it("a write that does not read back as what was written is reported, not assumed", () => {

--- a/src/__tests__/services/lora-catalog.test.ts
+++ b/src/__tests__/services/lora-catalog.test.ts
@@ -13,6 +13,7 @@ const realFs = vi.hoisted(() => ({
   existsSync: undefined as unknown as typeof import("node:fs").existsSync,
   writeFileSync: undefined as unknown as typeof import("node:fs").writeFileSync,
   renameSync: undefined as unknown as typeof import("node:fs").renameSync,
+  rmSync: undefined as unknown as typeof import("node:fs").rmSync,
 }));
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
@@ -20,6 +21,7 @@ vi.mock("node:fs", async (importOriginal) => {
   realFs.existsSync = actual.existsSync;
   realFs.writeFileSync = actual.writeFileSync;
   realFs.renameSync = actual.renameSync;
+  realFs.rmSync = actual.rmSync;
   return {
     ...actual,
     readFileSync: vi.fn(actual.readFileSync),
@@ -28,6 +30,7 @@ vi.mock("node:fs", async (importOriginal) => {
     // read-to-write window: every check has passed and the bytes have not
     // reached the catalog path yet.
     renameSync: vi.fn(actual.renameSync),
+    rmSync: vi.fn(actual.rmSync),
   };
 });
 import {
@@ -594,6 +597,7 @@ describe("two writers racing the catalog: no write is silently erased", () => {
 
   afterEach(() => {
     vi.mocked(renameSync).mockImplementation(realFs.renameSync as never);
+    vi.mocked(rmSync).mockImplementation(realFs.rmSync as never);
   });
 
   it(
@@ -778,9 +782,8 @@ describe("two writers racing the catalog: no write is silently erased", () => {
   });
 
   it("a reclaim claim left by a DEAD reclaimer does not disable reclaim forever", () => {
-    // A claim covers a few syscalls, so one this old is a corpse. Sweeping it
-    // wrongly costs only serialization — never a stolen lock — which is the
-    // right way round for a self-heal.
+    // The claim is cleared by the SAME rule as the lock — a recorded owner that
+    // is provably gone — so a crashed reclaimer cannot disable reclaim for good.
     writeFileSync(catalogPath, V1);
     const catalog = new LoraCatalog();
     writeFileSync(
@@ -789,10 +792,65 @@ describe("two writers racing the catalog: no write is silently erased", () => {
     );
     const old = new Date(Date.now() - 120_000);
     utimesSync(lockPath(), old, old);
-    writeFileSync(`${lockPath()}.reclaim`, "");
+    writeFileSync(
+      `${lockPath()}.reclaim`,
+      JSON.stringify({ pid: DEAD_PID, token: "dead-reclaimer" }),
+    );
     utimesSync(`${lockPath()}.reclaim`, old, old);
     catalog.upsert({ relPath: "loras/unwedged.safetensors" });
     expect(catalog.get("unwedged")?.id).toBe("loras-unwedged");
+  });
+
+  it("a claim whose owner is ALIVE is never cleared, however old", { timeout: 30000 }, () => {
+    // An age rule here would be the fold the main lock stopped committing, one
+    // level down: a reclaimer PAUSED inside its claim is not a dead one, and
+    // clearing its claim lets a second reclaimer run concurrently — the exact
+    // sequence the claim exists to prevent.
+    writeFileSync(catalogPath, V1);
+    const catalog = new LoraCatalog();
+    writeFileSync(
+      lockPath(),
+      JSON.stringify({ pid: DEAD_PID, token: "crashed", at: new Date().toISOString() }),
+    );
+    const old = new Date(Date.now() - 60 * 60_000);
+    utimesSync(lockPath(), old, old);
+    writeFileSync(
+      `${lockPath()}.reclaim`,
+      JSON.stringify({ pid: process.pid, token: "paused-reclaimer" }),
+    );
+    utimesSync(`${lockPath()}.reclaim`, old, old);
+    // The LOCK is reclaimable, but not by this call: the claim says someone
+    // else is already deciding.
+    expect(() => catalog.upsert({ relPath: "loras/nope.safetensors" })).toThrow(
+      /held the LoRA catalog lock/,
+    );
+    expect(existsSync(`${lockPath()}.reclaim`)).toBe(true);
+  });
+
+  it("a lock this process could not RELEASE is cleared by its own next write", () => {
+    // Nothing else can ever clear it: reclaim needs a provably dead owner, and
+    // the owner is this process, alive. Without a token-proved retry, one
+    // transient rmSync failure refuses every catalog write for the life of the
+    // server — a wedge born of the fix.
+    writeFileSync(catalogPath, V1);
+    const catalog = new LoraCatalog();
+    let failed = false;
+    vi.mocked(rmSync).mockImplementation(((target: string, opts?: unknown) => {
+      if (!failed && target === lockPath()) {
+        failed = true;
+        throw Object.assign(new Error("EBUSY: resource busy or locked"), { code: "EBUSY" });
+      }
+      return (realFs.rmSync as (a: string, b?: unknown) => void)(target, opts);
+    }) as never);
+
+    // The write itself succeeds — only its lock is left behind.
+    catalog.upsert({ relPath: "loras/first.safetensors" });
+    expect(failed).toBe(true);
+    expect(existsSync(lockPath())).toBe(true);
+
+    catalog.upsert({ relPath: "loras/second.safetensors" });
+    expect(catalog.get("second")?.id).toBe("loras-second");
+    expect(existsSync(lockPath())).toBe(false);
   });
 
   it("a lock that CHANGES mid-reclaim is put back, not stolen", { timeout: 30000 }, () => {

--- a/src/__tests__/services/lora-catalog.test.ts
+++ b/src/__tests__/services/lora-catalog.test.ts
@@ -711,7 +711,7 @@ describe("two writers racing the catalog: no write is silently erased", () => {
     expect(catalog.get("after-crash")?.id).toBe("loras-after-crash");
   });
 
-  it("a lock with NO recorded owner is not reclaimed on age alone", { timeout: 30000 }, () => {
+  it("a lock with NO recorded owner is never reclaimed", { timeout: 30000 }, () => {
     // A crash between the exclusive create and the record write leaves exactly
     // this, and so does a process paused between those two syscalls. Age past
     // the ordinary threshold does not distinguish them, and "no owner recorded"
@@ -727,19 +727,70 @@ describe("two writers racing the catalog: no write is silently erased", () => {
     expect(existsSync(lockPath())).toBe(true);
   });
 
-  it("but time settles it: a very old lock is reclaimed whatever its record says", () => {
-    // Otherwise a crash — or a pid the OS later handed to an unrelated live
-    // process — refuses every catalog write FOREVER. The critical section is
-    // two small reads and one write, so at this age there is no live holder to
-    // rob; a live pid in the record is a reused number, not a writer.
+  it("age alone never licenses a reclaim, however old the lock", { timeout: 30000 }, () => {
+    // A process can be suspended, debugger-paused, or blocked in I/O for an
+    // arbitrary time while inside the critical section, so "old" is not "gone".
+    // Reclaiming on age would be "could not determine the holder is gone" acted
+    // on as "the holder is gone" — with two writers and a silent loss as the
+    // payout. Refuse, and say what a person needs to clear it.
     writeFileSync(catalogPath, V1);
     const catalog = new LoraCatalog();
     writeFileSync(
       lockPath(),
-      JSON.stringify({ pid: process.pid, token: "reused-pid", at: new Date().toISOString() }),
+      JSON.stringify({ pid: process.pid, token: "paused-holder", at: new Date().toISOString() }),
     );
-    const ancient = new Date(Date.now() - 15 * 60_000);
+    const ancient = new Date(Date.now() - 60 * 60_000);
     utimesSync(lockPath(), ancient, ancient);
+    const err = (() => {
+      try {
+        catalog.upsert({ relPath: "loras/nope.safetensors" });
+        return undefined;
+      } catch (e) {
+        return e as Error;
+      }
+    })();
+    // The refusal has to hand over what it knows, or the wedge is unactionable.
+    expect(err?.message).toMatch(/still running/);
+    expect(err?.message).toContain(`pid ${process.pid}`);
+    expect(err?.message).toMatch(/delete that file/);
+    expect(existsSync(lockPath())).toBe(true);
+  });
+
+  it("a reclaim CLAIM held by another reclaimer stops this one from acting", { timeout: 30000 }, () => {
+    // Two reclaimers acting on one stale lock is the whole danger: the first
+    // frees the path, a third writer takes the freed pathname, and the second
+    // lifts THAT one off — two writers in the critical section. Serializing
+    // reclaim makes the sequence unreachable.
+    writeFileSync(catalogPath, V1);
+    const catalog = new LoraCatalog();
+    writeFileSync(
+      lockPath(),
+      JSON.stringify({ pid: DEAD_PID, token: "crashed", at: new Date().toISOString() }),
+    );
+    const old = new Date(Date.now() - 120_000);
+    utimesSync(lockPath(), old, old);
+    writeFileSync(`${lockPath()}.reclaim`, ""); // another reclaimer is deciding
+    expect(() => catalog.upsert({ relPath: "loras/nope.safetensors" })).toThrow(
+      /held the LoRA catalog lock/,
+    );
+    // Untouched: the other reclaimer's decision is the one that counts.
+    expect(existsSync(lockPath())).toBe(true);
+  });
+
+  it("a reclaim claim left by a DEAD reclaimer does not disable reclaim forever", () => {
+    // A claim covers a few syscalls, so one this old is a corpse. Sweeping it
+    // wrongly costs only serialization — never a stolen lock — which is the
+    // right way round for a self-heal.
+    writeFileSync(catalogPath, V1);
+    const catalog = new LoraCatalog();
+    writeFileSync(
+      lockPath(),
+      JSON.stringify({ pid: DEAD_PID, token: "crashed", at: new Date().toISOString() }),
+    );
+    const old = new Date(Date.now() - 120_000);
+    utimesSync(lockPath(), old, old);
+    writeFileSync(`${lockPath()}.reclaim`, "");
+    utimesSync(`${lockPath()}.reclaim`, old, old);
     catalog.upsert({ relPath: "loras/unwedged.safetensors" });
     expect(catalog.get("unwedged")?.id).toBe("loras-unwedged");
   });

--- a/src/__tests__/services/lora-catalog.test.ts
+++ b/src/__tests__/services/lora-catalog.test.ts
@@ -12,16 +12,22 @@ const realFs = vi.hoisted(() => ({
   readFileSync: undefined as unknown as typeof import("node:fs").readFileSync,
   existsSync: undefined as unknown as typeof import("node:fs").existsSync,
   writeFileSync: undefined as unknown as typeof import("node:fs").writeFileSync,
+  renameSync: undefined as unknown as typeof import("node:fs").renameSync,
 }));
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   realFs.readFileSync = actual.readFileSync;
   realFs.existsSync = actual.existsSync;
   realFs.writeFileSync = actual.writeFileSync;
+  realFs.renameSync = actual.renameSync;
   return {
     ...actual,
     readFileSync: vi.fn(actual.readFileSync),
     existsSync: vi.fn(actual.existsSync),
+    // The durable write's final step, and the only hook that lands INSIDE the
+    // read-to-write window: every check has passed and the bytes have not
+    // reached the catalog path yet.
+    renameSync: vi.fn(actual.renameSync),
   };
 });
 import {
@@ -30,8 +36,10 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
   statSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -520,9 +528,11 @@ describe("cleanup never deletes on a corrupt read", () => {
     const catalog = new LoraCatalog();
     let catalogReads = 0;
     vi.mocked(readFileSync).mockImplementation(((p: unknown, ...rest: unknown[]) => {
-      if (p === catalogPath && ++catalogReads === 3) {
-        // persist's two reads passed; the preview-cleanup read finds the file
-        // crash-truncated — nothing is known about what references the preview.
+      if (p === catalogPath && ++catalogReads === 4) {
+        // persist's two identity reads and its post-write read-back passed; the
+        // preview-cleanup read finds the file crash-truncated — nothing is
+        // known about what references the preview. (Index only; the assertion
+        // below is about the cleanup, not about how many reads persist makes.)
         return `{"version": 1, "entries": {"truncated": `;
       }
       return (realFs.readFileSync as (...a: unknown[]) => unknown)(p, ...rest);
@@ -568,5 +578,152 @@ describe("inaccessible is not absent", () => {
       vi.mocked(existsSync).mockImplementation(realFs.existsSync as never);
       vi.mocked(readFileSync).mockImplementation(realFs.readFileSync as never);
     }
+  });
+});
+
+// The gate on #839: persist() had no atomic exclusion between its last read and
+// its write. Two processes both read healthy V1, both pass `unchanged`, A
+// writes entry A, B writes entry B — and B's write silently erases A's. Because
+// both probes were healthy neither takes the corrupt-file backup, so there is
+// nothing to recover from either. Two agents on one rig is ordinary here.
+describe("two writers racing the catalog: no write is silently erased", () => {
+  const lockPath = () => `${catalogPath}.lock`;
+  const V1 = JSON.stringify({ version: 1, entries: {} });
+  /** A pid that cannot be running (the max Node will accept, never allocated). */
+  const DEAD_PID = 2147483646;
+
+  afterEach(() => {
+    vi.mocked(renameSync).mockImplementation(realFs.renameSync as never);
+  });
+
+  it(
+    "a second writer landing between the first's checks and its WRITE is refused, not lost",
+    { timeout: 30000 },
+    () => {
+      // A genuine interleaving, not a simulation of one: catalogB's whole
+      // read-modify-write runs from inside catalogA's window, at the last
+      // moment before A's bytes reach the path. Both instances were built from
+      // the same healthy V1, so both pass every staleness check — which is
+      // exactly the state the loss needs.
+      writeFileSync(catalogPath, V1);
+      const catalogA = new LoraCatalog();
+      const catalogB = new LoraCatalog();
+
+      let bError: Error | undefined;
+      let raced = false;
+      vi.mocked(renameSync).mockImplementation(((from: string, to: string) => {
+        if (to === catalogPath && !raced) {
+          raced = true;
+          try {
+            catalogB.upsert({ relPath: "loras/from-b.safetensors" });
+          } catch (e) {
+            bError = e as Error;
+          }
+        }
+        return (realFs.renameSync as (a: string, b: string) => void)(from, to);
+      }) as never);
+
+      catalogA.upsert({ relPath: "loras/from-a.safetensors" });
+      expect(raced).toBe(true);
+
+      // B was TOLD. Silence is the defect: a write that reports success and is
+      // then overwritten is indistinguishable, to its caller, from one that
+      // stuck.
+      expect(bError?.message).toMatch(/held the LoRA catalog lock/);
+
+      // A's write is intact and B's entry is not half-there.
+      const onDisk = JSON.parse(realFs.readFileSync(catalogPath, "utf-8") as string) as {
+        entries: Record<string, unknown>;
+      };
+      expect(Object.keys(onDisk.entries)).toEqual(["loras-from-a"]);
+
+      // And B did not keep a mutation it was told did not land.
+      expect(catalogB.get("from-b")).toBeNull();
+    },
+  );
+
+  it("a write waits out, then refuses, while another writer holds the lock", { timeout: 30000 }, () => {
+    writeFileSync(catalogPath, V1);
+    const catalog = new LoraCatalog();
+    // A live holder: this process's own pid, so no staleness rule can reclaim it.
+    writeFileSync(
+      lockPath(),
+      JSON.stringify({ pid: process.pid, token: "another-writer", at: new Date().toISOString() }),
+    );
+    expect(() => catalog.upsert({ relPath: "loras/blocked.safetensors" })).toThrow(
+      /held the LoRA catalog lock/,
+    );
+    // Nothing was written past the holder, and nothing lingered in memory.
+    expect(realFs.readFileSync(catalogPath, "utf-8")).toBe(V1);
+    expect(catalog.get("blocked")).toBeNull();
+    // The lock is the OTHER writer's: refusing must not free it.
+    expect(existsSync(lockPath())).toBe(true);
+  });
+
+  it("the refusal is not permanent — the next write goes through (no false refusal)", () => {
+    writeFileSync(catalogPath, V1);
+    const catalog = new LoraCatalog();
+    rmSync(lockPath(), { force: true });
+    catalog.upsert({ relPath: "loras/allowed.safetensors" });
+    expect(catalog.get("allowed")?.id).toBe("loras-allowed");
+    // The lock does not outlive the write it guarded.
+    expect(existsSync(lockPath())).toBe(false);
+  });
+
+  it("an ABANDONED lock is reclaimed rather than wedging the catalog forever", () => {
+    // A crashed writer leaves its lock behind. Treating that as a live holder
+    // is the fold pointed the other way: every later write refused because a
+    // file exists that nothing is using.
+    writeFileSync(catalogPath, V1);
+    const catalog = new LoraCatalog();
+    writeFileSync(
+      lockPath(),
+      JSON.stringify({ pid: DEAD_PID, token: "crashed", at: new Date().toISOString() }),
+    );
+    const old = new Date(Date.now() - 120_000);
+    utimesSync(lockPath(), old, old);
+    catalog.upsert({ relPath: "loras/after-crash.safetensors" });
+    expect(catalog.get("after-crash")?.id).toBe("loras-after-crash");
+  });
+
+  it("an OLD lock whose owner is still alive is never reclaimed", { timeout: 30000 }, () => {
+    // Age alone does not license a reclaim: freeing a path a live writer is
+    // still inside reintroduces exactly the loss the lock prevents.
+    writeFileSync(catalogPath, V1);
+    const catalog = new LoraCatalog();
+    writeFileSync(
+      lockPath(),
+      JSON.stringify({ pid: process.pid, token: "slow-but-alive", at: new Date().toISOString() }),
+    );
+    const old = new Date(Date.now() - 120_000);
+    utimesSync(lockPath(), old, old);
+    expect(() => catalog.upsert({ relPath: "loras/nope.safetensors" })).toThrow(
+      /held the LoRA catalog lock/,
+    );
+    expect(existsSync(lockPath())).toBe(true);
+  });
+
+  it("a write that does not read back as what was written is reported, not assumed", () => {
+    // The write returned without throwing, which is not the same as the bytes
+    // having arrived. Taking the INTENDED bytes as the new baseline is what
+    // would let the next persist pass its unchanged check against a file
+    // nobody ever wrote, and quietly overwrite whatever is really there.
+    writeFileSync(catalogPath, V1);
+    const catalog = new LoraCatalog();
+    vi.mocked(renameSync).mockImplementation(((from: string, to: string) => {
+      if (to === catalogPath) {
+        // The rename "succeeds" but something else is at the path.
+        realFs.writeFileSync(catalogPath, JSON.stringify({ version: 1, entries: {} }, null, 2));
+        rmSync(from, { force: true });
+        return;
+      }
+      return (realFs.renameSync as (a: string, b: string) => void)(from, to);
+    }) as never);
+    expect(() => catalog.upsert({ relPath: "loras/ghost.safetensors" })).toThrow(
+      /does not read back as what was just written/,
+    );
+    // Refuse-vs-disclose: the message says NOT CONFIRMED, never that the file
+    // was left alone — and memory is re-synced onto whatever is really there.
+    expect(catalog.get("ghost")).toBeNull();
   });
 });

--- a/src/__tests__/services/queue-manager-escalation.test.ts
+++ b/src/__tests__/services/queue-manager-escalation.test.ts
@@ -26,6 +26,7 @@ const queueBehavior = vi.hoisted(() => ({
     | "dies-late"
     | "named-late"
     | "unwatched-then-wedged"
+    | "gapped-then-wedged"
     | "stops-on-interrupt",
   calls: 0,
   freeFails: false,
@@ -64,6 +65,14 @@ vi.mock("../../comfyui/client.js", () => ({
     // Pre-check and first window fail; the named prompt appears in the FINAL window.
     if (queueBehavior.mode === "named-late") {
       if (queueBehavior.calls <= 3) throw new Error("ECONNRESET");
+      return { queue_running: [[1, "prompt-xyz"]], queue_pending: [] };
+    }
+    // Running at every poll that answers, but one poll in the MIDDLE of the
+    // honor window fails — so the window has a hole in it while still ending on
+    // a live reading. (With COMFYUI_MCP_INTERRUPT_S=3.2 the honor window fits
+    // three polls, calls 2–4; call 3 is the hole.)
+    if (queueBehavior.mode === "gapped-then-wedged") {
+      if (queueBehavior.calls === 3) throw new Error("ECONNRESET");
       return { queue_running: [[1, "prompt-xyz"]], queue_pending: [] };
     }
     // Observed running at pre-check, honor window fails, final window: running.
@@ -139,6 +148,9 @@ describe("cancel escalation never folds a dead queue into a wedge verdict", () =
       expect(res.wedged).toBe(false);
       expect(res.unverified).toBe(true);
       expect(res.honored).toBe(false);
+      // Nothing about the queue was established, so nothing may read this as
+      // permission to carry on (the tool turns this into isError).
+      expect(res.target_state).toBe("unknown");
       expect(res.message).toMatch(/UNKNOWN/);
       // It never answered — the message must not claim a transition.
       expect(res.message).toMatch(/did not answer during verification/);
@@ -156,6 +168,7 @@ describe("cancel escalation never folds a dead queue into a wedge verdict", () =
       const res = await cancelRunningJobEscalating({});
       expect(res.wedged).toBe(false);
       expect(res.unverified).toBe(true);
+      expect(res.target_state).toBe("unknown");
       expect(res.message).toMatch(/UNKNOWN/);
       // The final verification window never answered.
       expect(res.message).toMatch(/did not answer during verification/);
@@ -188,6 +201,31 @@ describe("cancel escalation never folds a dead queue into a wedge verdict", () =
     },
   );
 
+  // `lastPollFailed` was cleared by any later successful poll, so a window that
+  // went running → poll failure → running came back as plain "still-running"
+  // and the wedge message called it "~Ns of VERIFIED polling". A restart or a
+  // disconnect inside that hole is exactly the case the "restart ComfyUI, do
+  // NOT queue another run" guidance would be wrong about — a sampled
+  // observation with a gap narrated as continuous verification.
+  it(
+    "a window with a FAILED poll in the middle is not narrated as verified polling",
+    { timeout: 30000 },
+    async () => {
+      process.env.COMFYUI_MCP_INTERRUPT_S = "3.2"; // two polls per window
+      queueBehavior.mode = "gapped-then-wedged";
+      const res = await cancelRunningJobEscalating({});
+      // The verdict itself is unchanged: the last poll of each window answered
+      // and showed it running, and that IS a live reading of now. Only the
+      // claim about the window narrows — turning this into "unobservable"
+      // would be the overshoot, refusing a wedge that was actually observed.
+      expect(res.wedged).toBe(true);
+      expect(res.target_state).toBe("running");
+      expect(res.message).toMatch(/wedged inside a single step/);
+      expect(res.message).not.toMatch(/of verified polling/);
+      expect(res.message).toMatch(/did NOT answer throughout/);
+    },
+  );
+
   it(
     "a wedged verdict with a failed /free does not claim freed VRAM",
     { timeout: 20000 },
@@ -209,6 +247,7 @@ describe("cancel escalation never folds a dead queue into a wedge verdict", () =
       const res = await cancelRunningJobEscalating({});
       expect(res.wedged).toBe(true);
       expect(res.unverified).toBeUndefined();
+      expect(res.target_state).toBe("running");
       expect(res.message).toMatch(/wedged inside a single step/);
       // The stated duration must be BOTH windows (2s honor + 2s re-check here),
       // not just the first.
@@ -281,7 +320,11 @@ describe("cancel escalation never folds a dead queue into a wedge verdict", () =
       const res = await cancelRunningJobEscalating({});
       expect(res.honored).toBe(true);
       expect(res.wedged).toBe(false);
-      // The stop is verified; its cause is not.
+      // The stop is verified; its cause is not. `unverified` covers the CAUSE
+      // here, and target_state must not borrow that doubt: /queue was read and
+      // is empty, so a consumer treating this as unsettled would refuse a
+      // caller the free queue it can see.
+      expect(res.target_state).toBe("stopped");
       expect(res.message).toMatch(/what stopped it is unknown/);
       expect(res.message).not.toMatch(/freeing VRAM cleared it/);
     },
@@ -299,6 +342,9 @@ describe("cancel escalation never folds a dead queue into a wedge verdict", () =
       expect(res.honored).toBe(false);
       expect(res.unverified).toBe(true);
       expect(res.wedged).toBe(false);
+      // Same split: the START was never observed, but the queue is verifiably
+      // empty NOW.
+      expect(res.target_state).toBe("stopped");
       expect(res.message).toMatch(/nothing is running now/);
       expect(res.message).toMatch(/UNKNOWN/);
       expect(res.message).not.toMatch(/Interrupted the running job/);

--- a/src/__tests__/services/queue-manager-escalation.test.ts
+++ b/src/__tests__/services/queue-manager-escalation.test.ts
@@ -489,6 +489,10 @@ describe("cancel escalation never folds a dead queue into a wedge verdict", () =
       // A job IS verifiably wedged — but its identity was never established.
       expect(res.wedged).toBe(true);
       expect(res.unverified).toBe(true);
+      // …so the FIELD must not claim the identity the prose disclaims. With no
+      // prompt_id and no pre-interrupt read, the poll established that SOME job
+      // is running, not that it is the one the interrupt addressed.
+      expect(res.target_state).toBe("unknown");
       expect(res.message).toMatch(/wedged inside a single step/);
       expect(res.message).toMatch(/Whether this IS the job the interrupt addressed is UNKNOWN/);
       expect(res.message).not.toMatch(/The running job/);

--- a/src/__tests__/services/queue-manager-escalation.test.ts
+++ b/src/__tests__/services/queue-manager-escalation.test.ts
@@ -27,6 +27,8 @@ const queueBehavior = vi.hoisted(() => ({
     | "named-late"
     | "unwatched-then-wedged"
     | "gapped-then-wedged"
+    | "gapped-final-wedged"
+    | "target-clears-other-starts"
     | "stops-on-interrupt",
   calls: 0,
   freeFails: false,
@@ -74,6 +76,19 @@ vi.mock("../../comfyui/client.js", () => ({
     if (queueBehavior.mode === "gapped-then-wedged") {
       if (queueBehavior.calls === 3) throw new Error("ECONNRESET");
       return { queue_running: [[1, "prompt-xyz"]], queue_pending: [] };
+    }
+    // Mirror image: the honor window answers throughout, and the hole is in the
+    // FINAL window instead (calls 5-7; call 6 is the hole).
+    if (queueBehavior.mode === "gapped-final-wedged") {
+      if (queueBehavior.calls === 6) throw new Error("ECONNRESET");
+      return { queue_running: [[1, "prompt-xyz"]], queue_pending: [] };
+    }
+    // The NAMED target is running at the pre-check, and a DIFFERENT job holds
+    // the running slot from the first poll on: the target cleared, the queue
+    // did not go idle.
+    if (queueBehavior.mode === "target-clears-other-starts") {
+      if (queueBehavior.calls === 1) return { queue_running: [[1, "prompt-xyz"]], queue_pending: [] };
+      return { queue_running: [[2, "someone-else"]], queue_pending: [] };
     }
     // Observed running at pre-check, honor window fails, final window: running.
     if (queueBehavior.mode === "unwatched-then-wedged") {
@@ -223,6 +238,40 @@ describe("cancel escalation never folds a dead queue into a wedge verdict", () =
       expect(res.message).toMatch(/wedged inside a single step/);
       expect(res.message).not.toMatch(/of verified polling/);
       expect(res.message).toMatch(/did NOT answer throughout/);
+    },
+  );
+
+  // The stated duration spans BOTH windows, so a hole in either one makes the
+  // span not continuously verified. Checking only the first window left the
+  // same overclaim standing over a gap in the second (codex gate).
+  it(
+    "a gap in the FINAL window is not narrated as verified polling either",
+    { timeout: 30000 },
+    async () => {
+      process.env.COMFYUI_MCP_INTERRUPT_S = "3.2";
+      queueBehavior.mode = "gapped-final-wedged";
+      const res = await cancelRunningJobEscalating({});
+      expect(res.wedged).toBe(true);
+      expect(res.target_state).toBe("running");
+      expect(res.message).not.toMatch(/of verified polling/);
+      expect(res.message).toMatch(/did NOT answer throughout/);
+    },
+  );
+
+  // target_state answers for the JOB THIS CALL ADDRESSED, not for the queue.
+  // The cancel did exactly what it promised; the queue advancing to the next
+  // job is normal, and failing the call for it would be a false failure —
+  // clear_pending is the switch for emptying the queue.
+  it(
+    "a named target that clears while ANOTHER job runs is stopped, not unsettled",
+    { timeout: 20000 },
+    async () => {
+      queueBehavior.mode = "target-clears-other-starts";
+      const res = await cancelRunningJobEscalating({ prompt_id: "prompt-xyz" });
+      expect(res.target_state).toBe("stopped");
+      expect(res.wedged).toBe(false);
+      expect(res.honored).toBe(true);
+      expect(res.message).toMatch(/Interrupted the running job/);
     },
   );
 

--- a/src/__tests__/tools/queue-management.test.ts
+++ b/src/__tests__/tools/queue-management.test.ts
@@ -171,7 +171,11 @@ describe("queue actions call the same services with the same arguments", () => {
   });
 
   it('action:"cancel" returns the escalation message as text, and isError when wedged', async () => {
-    mocks.cancelRunningJobEscalating.mockResolvedValueOnce({ wedged: false, message: "Job interrupted." });
+    mocks.cancelRunningJobEscalating.mockResolvedValueOnce({
+      wedged: false,
+      target_state: "stopped",
+      message: "Job interrupted.",
+    });
     const ok = await handler()({ action: "cancel", prompt_id: "p1", clear_pending: true });
     expect(mocks.cancelRunningJobEscalating).toHaveBeenCalledWith({
       prompt_id: "p1",
@@ -180,7 +184,11 @@ describe("queue actions call the same services with the same arguments", () => {
     expect(ok.isError).toBeUndefined();
     expect(text(ok)).toBe("Job interrupted.");
 
-    mocks.cancelRunningJobEscalating.mockResolvedValueOnce({ wedged: true, message: "WEDGED — restart." });
+    mocks.cancelRunningJobEscalating.mockResolvedValueOnce({
+      wedged: true,
+      target_state: "running",
+      message: "WEDGED — restart.",
+    });
     const wedged = await handler()({ action: "cancel" });
     expect(mocks.cancelRunningJobEscalating).toHaveBeenCalledWith({
       prompt_id: undefined,
@@ -188,6 +196,57 @@ describe("queue actions call the same services with the same arguments", () => {
     });
     expect(wedged.isError).toBe(true);
     expect(text(wedged)).toBe("WEDGED — restart.");
+  });
+
+  // The tri-state reached the service in #839 but not this consumer: `isError`
+  // keyed off `wedged` alone, so an unreadable /queue — reported honestly by
+  // the service as target_state:"unknown", wedged:false — came back as an MCP
+  // SUCCESS. A caller reads that as permission to queue more work against a
+  // queue whose state nobody established.
+  describe('action:"cancel" only reports success for an outcome /queue settled', () => {
+    it("an unreadable queue is NOT a success — and the disclosure survives", async () => {
+      mocks.cancelRunningJobEscalating.mockResolvedValueOnce({
+        wedged: false,
+        unverified: true,
+        target_state: "unknown",
+        message: "⚠️ /queue did not answer during verification, so whether it is still running is UNKNOWN.",
+      });
+      const res = await handler()({ action: "cancel" });
+      expect(res.isError).toBe(true);
+      // isError marks the outcome unsettled; it must not swallow the detail,
+      // which is the only thing telling the caller what to check.
+      expect(text(res)).toMatch(/UNKNOWN/);
+    });
+
+    it("a clear_pending that FAILED is not a success either", async () => {
+      mocks.cancelRunningJobEscalating.mockResolvedValueOnce({
+        wedged: false,
+        target_state: "stopped",
+        pending_clear_failed: true,
+        message: "Interrupted the running job. Clearing pending jobs FAILED — they may still be queued.",
+      });
+      const res = await handler()({ action: "cancel", clear_pending: true });
+      expect(res.isError).toBe(true);
+      expect(text(res)).toMatch(/FAILED/);
+    });
+
+    // THE INVERSE, which is how this fix would overshoot: `unverified` also
+    // covers "it demonstrably stopped, we just cannot say our interrupt is
+    // why". /queue was read and is empty. Failing that would refuse a caller
+    // the queue it can see is free.
+    it("a verifiably empty queue is a success even when the CAUSE is unverified", async () => {
+      mocks.cancelRunningJobEscalating.mockResolvedValueOnce({
+        wedged: false,
+        unverified: true,
+        target_state: "stopped",
+        message:
+          "Nothing is running now (verified via /queue), but the queue could not be read " +
+          "BEFORE the interrupt, so what stopped it is UNKNOWN.",
+      });
+      const res = await handler()({ action: "cancel" });
+      expect(res.isError).toBeUndefined();
+      expect(text(res)).toMatch(/verified via \/queue/);
+    });
   });
 
   it('action:"cancel_queued" returns the exact prose confirmation', async () => {

--- a/src/services/lora-catalog.ts
+++ b/src/services/lora-catalog.ts
@@ -280,14 +280,6 @@ const CATALOG_LOCK_WAIT_MS = 2_000;
  *  safe (see there). */
 const CATALOG_LOCK_STALE_MS = 30_000;
 
-/**
- * A reclaim CLAIM is held for a few syscalls. One this old belongs to a
- * reclaimer that died mid-decision, and leaving it would disable reclaim for
- * good. Sweeping one wrongly costs only the serialization it provides — i.e.
- * the behaviour before that serialization existed — never a stolen lock.
- */
-const CATALOG_RECLAIM_CLAIM_STALE_MS = 60_000;
-
 /** Cross-platform pid liveness. EPERM means a process with that number EXISTS
  *  and is simply not ours to signal — alive, not dead. Reading it as dead is
  *  what would let a live holder's lock be reclaimed out from under it. */
@@ -306,31 +298,103 @@ function napSync(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-/** Whoever holds the lock, as far as the file can say. An unreadable or
- *  truncated record names NO holder — which is not evidence of an abandoned
- *  lock, only an absence of evidence: the age check below is what licenses a
- *  reclaim. */
-function readCatalogLockPid(lockPath: string): number | undefined {
+/** Whoever holds a lock or claim, as far as the file can say. An unreadable or
+ *  truncated record names NO holder — which is not evidence of abandonment,
+ *  only an absence of evidence, and nothing here may act on it as if it were
+ *  the former. */
+function readLockRecord(path: string): { pid?: number; token?: string } {
   try {
-    const rec = JSON.parse(readFileSync(lockPath, "utf-8")) as { pid?: unknown };
-    return typeof rec.pid === "number" ? rec.pid : undefined;
+    const rec = JSON.parse(readFileSync(path, "utf-8")) as { pid?: unknown; token?: unknown };
+    return {
+      pid: typeof rec.pid === "number" ? rec.pid : undefined,
+      token: typeof rec.token === "string" ? rec.token : undefined,
+    };
   } catch {
-    return undefined;
+    return {};
   }
 }
 
+/** The bytes that make a lock or claim attributable. */
+function lockRecordBytes(token: string): string {
+  return JSON.stringify({ pid: process.pid, token, at: new Date().toISOString() });
+}
+
 /**
- * Sweep a reclaim claim whose holder died mid-decision. Only the exact instance
- * observed, and only when it is far older than the few syscalls a claim covers.
+ * Take the reclaim claim that serializes reclaimers, or answer undefined.
+ *
+ * A dead claimant's claim is removed by the SAME rule as the main lock — a
+ * recorded pid that is provably not running — and by no other. An age rule here
+ * would be the fold the main lock just stopped committing, one level down: a
+ * reclaimer paused inside its claim is not a dead one, and deleting its claim
+ * lets a second reclaimer run concurrently, which is the sequence the claim
+ * exists to prevent.
+ *
+ * WHERE THE REGRESS STOPS: two processes may still remove the same DEAD claim
+ * and reclaim concurrently. That is exactly the behaviour before this claim
+ * existed — the claim narrows a race, it never grants an authority — so it does
+ * not need a claim of its own.
  */
-function sweepStaleReclaimClaim(claimPath: string): void {
+function takeReclaimClaim(claimPath: string): string | undefined {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const token = randomUUID();
+    try {
+      const fd = openSync(claimPath, "wx");
+      try {
+        try {
+          writeFileSync(fd, lockRecordBytes(token));
+        } finally {
+          closeSync(fd);
+        }
+      } catch (initErr) {
+        // A claim nothing can attribute is one no later reclaimer can ever
+        // prove dead — remove our own husk rather than create that state.
+        try {
+          rmSync(claimPath, { force: true });
+        } catch {
+          // The init failure is the one that matters.
+        }
+        throw initErr;
+      }
+      return token;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== "EEXIST") return undefined;
+      if (!removeDeadReclaimClaim(claimPath)) return undefined;
+    }
+  }
+  return undefined;
+}
+
+/** Remove a reclaim claim only when its recorded owner is provably gone. */
+function removeDeadReclaimClaim(claimPath: string): boolean {
+  let observed: number;
   try {
-    const observed = statSync(claimPath).mtimeMs;
-    if (Date.now() - observed < CATALOG_RECLAIM_CLAIM_STALE_MS) return;
-    if (statSync(claimPath).mtimeMs !== observed) return;
+    observed = statSync(claimPath).mtimeMs;
+  } catch {
+    return true; // already gone
+  }
+  if (Date.now() - observed < CATALOG_LOCK_STALE_MS) return false;
+  const { pid } = readLockRecord(claimPath);
+  if (pid === undefined || catalogLockOwnerAlive(pid)) return false;
+  try {
+    // Only the exact instance judged: a claim taken in the gap is brand new, so
+    // its mtime cannot match one already CATALOG_LOCK_STALE_MS old.
+    if (statSync(claimPath).mtimeMs !== observed) return false;
+    rmSync(claimPath, { force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Give up the reclaim claim this call took — and only that one. */
+function releaseReclaimClaim(claimPath: string, token: string): void {
+  const holder = readLockRecord(claimPath).token;
+  if (holder !== undefined && holder !== token) return; // a later reclaimer's
+  try {
     rmSync(claimPath, { force: true });
   } catch {
-    // Gone, replaced, or unreadable — a claim is advisory; leave it.
+    // It records this process's pid, so it clears when this process exits —
+    // and until then reclaim is merely serialized behind it, not blocked.
   }
 }
 
@@ -366,24 +430,15 @@ function sweepStaleReclaimClaim(claimPath: string): void {
  */
 function reclaimAbandonedCatalogLock(lockPath: string): boolean {
   const claimPath = `${lockPath}.reclaim`;
-  try {
-    closeSync(openSync(claimPath, "wx"));
-  } catch (err) {
-    // Another reclaimer is deciding right now, or the claim cannot be created
-    // at all. Either way, acting concurrently is the thing that breaks
-    // exclusion — wait instead.
-    if ((err as NodeJS.ErrnoException)?.code === "EEXIST") sweepStaleReclaimClaim(claimPath);
-    return false;
-  }
+  // Another reclaimer is deciding right now, or the claim cannot be created at
+  // all. Either way, acting concurrently is the thing that breaks exclusion —
+  // wait instead.
+  const claim = takeReclaimClaim(claimPath);
+  if (claim === undefined) return false;
   try {
     return reclaimUnderClaim(lockPath);
   } finally {
-    try {
-      rmSync(claimPath, { force: true });
-    } catch {
-      // Best effort; a leftover claim only costs reclaim serialization, and
-      // sweepStaleReclaimClaim clears it.
-    }
+    releaseReclaimClaim(claimPath, claim);
   }
 }
 
@@ -396,7 +451,7 @@ function reclaimUnderClaim(lockPath: string): boolean {
   }
   const ageMs = Date.now() - observed;
   if (ageMs < CATALOG_LOCK_STALE_MS) return false;
-  const pid = readCatalogLockPid(lockPath);
+  const { pid } = readLockRecord(lockPath);
   if (pid === undefined || catalogLockOwnerAlive(pid)) return false;
 
   const aside = `${lockPath}.stale-${randomUUID()}`;
@@ -442,6 +497,38 @@ function reclaimUnderClaim(lockPath: string): boolean {
   return false;
 }
 
+/**
+ * Locks THIS process created and could not remove — a transient rmSync failure
+ * (a scanner holding the handle open on Windows, say) after the write itself
+ * completed and was reported as saved.
+ *
+ * Nothing else can ever clear one: reclaim requires a provably dead owner, and
+ * the owner is this very process, alive. So without this the next write refuses,
+ * and so does every write after it, for the life of the server. The token is
+ * what makes clearing it provable rather than assumed — it identifies the file
+ * at the path as the lock this process already finished with.
+ */
+const unreleasedOwnLocks = new Map<string, string>();
+
+/** Retry removing a lock this process took and failed to release. */
+function dropOwnUnreleasedLock(lockPath: string): boolean {
+  const token = unreleasedOwnLocks.get(lockPath);
+  if (token === undefined) return false;
+  if (readLockRecord(lockPath).token !== token) {
+    // Somebody else's lock is at the path now, so ours is long gone.
+    unreleasedOwnLocks.delete(lockPath);
+    return false;
+  }
+  try {
+    rmSync(lockPath, { force: true });
+    unreleasedOwnLocks.delete(lockPath);
+    logger.warn(`[lora-catalog] cleared this process's own unreleased write lock at ${lockPath}.`);
+    return true;
+  } catch {
+    return false; // still stuck — the caller reports the refusal
+  }
+}
+
 /** Take the catalog write lock, or THROW. Refuse-vs-disclose: nothing has been
  *  written yet, so a failure here refuses the change outright and says so. */
 function acquireCatalogLock(path: string): { lockPath: string; token: string } {
@@ -454,7 +541,7 @@ function acquireCatalogLock(path: string): { lockPath: string; token: string } {
       const fd = openSync(lockPath, "wx");
       try {
         try {
-          writeFileSync(fd, JSON.stringify({ pid: process.pid, token, at: new Date().toISOString() }));
+          writeFileSync(fd, lockRecordBytes(token));
         } finally {
           closeSync(fd);
         }
@@ -481,6 +568,9 @@ function acquireCatalogLock(path: string): { lockPath: string; token: string } {
             `(${err instanceof Error ? err.message : String(err)}). This change was NOT saved.`,
         );
       }
+      // Ours from a failed release, before anything else: it is the one state
+      // reclaim can never resolve, because this process is alive.
+      if (dropOwnUnreleasedLock(lockPath)) continue;
       if (reclaimAbandonedCatalogLock(lockPath)) continue;
       if (Date.now() >= deadline) {
         // Reclaim deliberately refuses the two states a pid cannot settle (no
@@ -488,7 +578,7 @@ function acquireCatalogLock(path: string): { lockPath: string; token: string } {
         // there means two writers and a silent loss. So the refusal has to hand
         // over what it DOES know: a person can settle in one look what this
         // process cannot settle at all.
-        const pid = readCatalogLockPid(lockPath);
+        const { pid } = readLockRecord(lockPath);
         let ageNote = "";
         try {
           ageNote = ` (${Math.round((Date.now() - statSync(lockPath).mtimeMs) / 1000)}s old)`;
@@ -520,13 +610,7 @@ function releaseCatalogLock(lockPath: string, token: string): void {
   // taken and replaced. The token check makes that reasoning checkable instead
   // of assumed: if what is at the path is somehow not ours, leave it alone
   // rather than free a path another writer owns.
-  let holder: string | undefined;
-  try {
-    holder = (JSON.parse(readFileSync(lockPath, "utf-8")) as { token?: string }).token;
-  } catch {
-    // Unreadable: no other writer could have put it there (see above), and
-    // leaving it would stall every write for CATALOG_LOCK_STALE_MS.
-  }
+  const holder = readLockRecord(lockPath).token;
   if (holder !== undefined && holder !== token) {
     logger.warn(
       `[lora-catalog] the write lock at ${lockPath} is no longer the one this write took; ` +
@@ -536,11 +620,17 @@ function releaseCatalogLock(lockPath: string, token: string): void {
   }
   try {
     rmSync(lockPath, { force: true });
+    unreleasedOwnLocks.delete(lockPath);
   } catch (err) {
+    // NOT "it will age out": reclaim requires a provably dead owner and this
+    // process is alive, so nothing external will ever clear this. Remember it
+    // instead, and let the next write in this process clear it on the token —
+    // otherwise one transient failure refuses every catalog write from here on.
+    unreleasedOwnLocks.set(lockPath, token);
     logger.warn(
       `[lora-catalog] could not release the write lock at ${lockPath} ` +
-        `(${err instanceof Error ? err.message : String(err)}). Catalog writes will wait ` +
-        `and then refuse until it is removed or ages out.`,
+        `(${err instanceof Error ? err.message : String(err)}). The write itself is saved; ` +
+        `the next catalog write will clear this lock.`,
     );
   }
 }

--- a/src/services/lora-catalog.ts
+++ b/src/services/lora-catalog.ts
@@ -7,9 +7,11 @@ import {
   closeSync,
   copyFileSync,
   existsSync,
+  linkSync,
   mkdirSync,
   openSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
   unlinkSync,
@@ -278,6 +280,24 @@ const CATALOG_LOCK_WAIT_MS = 2_000;
  *  safe (see there). */
 const CATALOG_LOCK_STALE_MS = 30_000;
 
+/**
+ * Past this, a lock is reclaimed WITHOUT asking about its recorded owner.
+ *
+ * Two states cannot be settled by a pid: one that was never recorded (a crash
+ * between the exclusive create and the record write), and one whose pid the OS
+ * has since handed to an unrelated live process. Both make `process.kill(pid,0)`
+ * answer about the wrong thing forever, so a pid-only rule turns a crash into a
+ * PERMANENT refusal of every catalog write — the fold pointed the other way,
+ * and the wedge class this repo keeps re-fixing (#760, #847).
+ *
+ * Time settles it instead, because the critical section is bounded by
+ * construction: two small reads, a parse, an optional copy of a small JSON
+ * file, and one durable write. Nothing in it waits on a network, a subprocess
+ * or a user. Ten minutes of slack over a milliseconds-long section is not a
+ * judgement call about a live holder; it is a statement that no holder is live.
+ */
+const CATALOG_LOCK_HARD_STALE_MS = 10 * 60_000;
+
 /** Cross-platform pid liveness. EPERM means a process with that number EXISTS
  *  and is simply not ours to signal — alive, not dead. Reading it as dead is
  *  what would let a live holder's lock be reclaimed out from under it. */
@@ -309,10 +329,21 @@ function readCatalogLockPid(lockPath: string): number | undefined {
   }
 }
 
-/** Remove a lock ONLY when it is provably abandoned: older than any live holder
- *  could be, AND owned by a pid that is gone (or by no readable pid at all).
- *  Every other state waits — deleting a lock whose holder is still inside its
- *  critical section reintroduces exactly the loss the lock prevents. */
+/**
+ * Free the lock path ONLY when nothing can still be holding it: old enough that
+ * no live holder could be inside its critical section, AND either owned by a pid
+ * that is gone or older than CATALOG_LOCK_HARD_STALE_MS. Every other state
+ * waits — freeing a lock whose holder is still working reintroduces exactly the
+ * loss the lock prevents.
+ *
+ * RENAME FIRST, then judge. A stat-then-unlink is TOCTOU: a second reclaimer can
+ * free the path and a third writer can take the freed pathname in the gap, so
+ * the unlink lands on a stranger's fresh lock and two writers end up inside
+ * `persistLocked` together. A rename atomically removes whatever is at the path
+ * and puts it somewhere only this call knows, so the file inspected afterwards
+ * is the file this call will act on. (Same technique, for the same reason, as
+ * the panel op lock in panel-pin-guard.)
+ */
 function reclaimAbandonedCatalogLock(lockPath: string): boolean {
   let observed: number;
   try {
@@ -320,24 +351,53 @@ function reclaimAbandonedCatalogLock(lockPath: string): boolean {
   } catch {
     return true; // already gone — the path is free, retry the create
   }
-  if (Date.now() - observed < CATALOG_LOCK_STALE_MS) return false;
+  const ageMs = Date.now() - observed;
+  if (ageMs < CATALOG_LOCK_STALE_MS) return false;
   const pid = readCatalogLockPid(lockPath);
-  if (pid !== undefined && catalogLockOwnerAlive(pid)) return false;
+  const ownerGone = pid !== undefined && !catalogLockOwnerAlive(pid);
+  if (!ownerGone && ageMs < CATALOG_LOCK_HARD_STALE_MS) return false;
+
+  const aside = `${lockPath}.stale-${randomUUID()}`;
   try {
-    // Delete only the exact instance just judged. A lock taken in the gap is
-    // brand new, so its mtime cannot match one already CATALOG_LOCK_STALE_MS
-    // old — and freeing a fresh holder's path is the one mistake a reclaim
-    // must never make.
-    if (statSync(lockPath).mtimeMs !== observed) return false;
-    rmSync(lockPath, { force: true });
+    renameSync(lockPath, aside);
+  } catch {
+    return false; // gone, or not ours to move — wait rather than assume
+  }
+  // The path is free from here on, so the only question left is whether it was
+  // right to free it.
+  let takenMtime: number | undefined;
+  try {
+    takenMtime = statSync(aside).mtimeMs;
+  } catch {
+    // Cannot confirm identity → treat it as somebody else's and restore.
+  }
+  if (takenMtime === observed) {
+    try {
+      rmSync(aside, { force: true });
+    } catch {
+      // The path is already free; a leftover copy blocks nothing.
+    }
     logger.warn(
       `[lora-catalog] reclaimed an abandoned write lock at ${lockPath} (owner ` +
-        `${pid === undefined ? "unrecorded" : `pid ${pid}`} is no longer running).`,
+        `${pid === undefined ? "unrecorded" : `pid ${pid}`}, ${Math.round(ageMs / 1000)}s old).`,
     );
     return true;
-  } catch {
-    return false; // could not remove it — wait it out rather than assume
   }
+  // NOT the lock that was judged — a fresh one landed in the gap and this call
+  // just took it off the path. Put it back with linkSync, NOT renameSync: link
+  // fails if the path is occupied, where a rename would silently clobber a lock
+  // that appeared in the meantime.
+  try {
+    linkSync(aside, lockPath);
+    rmSync(aside, { force: true });
+  } catch {
+    logger.warn(
+      `[lora-catalog] a write lock at ${lockPath} changed mid-reclaim and could not be ` +
+        `put back; the replaced lock is preserved at ${aside}. Catalog writes are not ` +
+        `blocked by it.`,
+    );
+  }
+  return false;
 }
 
 /** Take the catalog write lock, or THROW. Refuse-vs-disclose: nothing has been
@@ -666,7 +726,19 @@ export class LoraCatalog {
         }
       }
       const intended = JSON.stringify(this.data, null, 2);
-      writeCatalogFile(this.data);
+      // The durable write can throw on EITHER side of its atomic rename: with
+      // nothing on the path, or with the new bytes already there and only their
+      // directory entry's durability unproven (writeFileDurable is strict about
+      // that by design, for callers whose next action depends on the record
+      // surviving a crash). Only the read-back can tell those apart, and
+      // reporting the second as an unapplied save is this file's own defect
+      // pointed the other way — the mutation DID happen.
+      let writeError: unknown;
+      try {
+        writeCatalogFile(this.data);
+      } catch (err) {
+        writeError = err;
+      }
       // The baseline is what is ACTUALLY on disk, read back — not what we meant
       // to put there. Taking the intended bytes on faith is how a write that
       // landed somewhere else, or landed short, becomes the state every later
@@ -674,9 +746,21 @@ export class LoraCatalog {
       // file nobody ever wrote, and quietly overwrite whatever is really there.
       const written = readCatalogRaw(path);
       if (written.raw === intended) {
+        if (writeError) {
+          // Refuse-vs-disclose: the bytes are on the path, so this is a
+          // disclosure about durability, not a failed save.
+          logger.warn(
+            `[lora-catalog] ${path} holds this write, but completing it durably failed ` +
+              `(${writeError instanceof Error ? writeError.message : String(writeError)}) — ` +
+              `the change is saved and readable; it may not survive a power loss.`,
+          );
+        }
         this.baseline = { raw: written.raw };
         return;
       }
+      // Nothing of ours is on the path: the write genuinely failed, and its own
+      // error says why far better than a read-back mismatch would.
+      if (writeError) throw writeError;
       if (written.unreadable && probe.unreadable) {
         // The catalog could not be read BEFORE this write either, so the
         // read-back carries no new information — and refusing on it would

--- a/src/services/lora-catalog.ts
+++ b/src/services/lora-catalog.ts
@@ -281,22 +281,12 @@ const CATALOG_LOCK_WAIT_MS = 2_000;
 const CATALOG_LOCK_STALE_MS = 30_000;
 
 /**
- * Past this, a lock is reclaimed WITHOUT asking about its recorded owner.
- *
- * Two states cannot be settled by a pid: one that was never recorded (a crash
- * between the exclusive create and the record write), and one whose pid the OS
- * has since handed to an unrelated live process. Both make `process.kill(pid,0)`
- * answer about the wrong thing forever, so a pid-only rule turns a crash into a
- * PERMANENT refusal of every catalog write — the fold pointed the other way,
- * and the wedge class this repo keeps re-fixing (#760, #847).
- *
- * Time settles it instead, because the critical section is bounded by
- * construction: two small reads, a parse, an optional copy of a small JSON
- * file, and one durable write. Nothing in it waits on a network, a subprocess
- * or a user. Ten minutes of slack over a milliseconds-long section is not a
- * judgement call about a live holder; it is a statement that no holder is live.
+ * A reclaim CLAIM is held for a few syscalls. One this old belongs to a
+ * reclaimer that died mid-decision, and leaving it would disable reclaim for
+ * good. Sweeping one wrongly costs only the serialization it provides — i.e.
+ * the behaviour before that serialization existed — never a stolen lock.
  */
-const CATALOG_LOCK_HARD_STALE_MS = 10 * 60_000;
+const CATALOG_RECLAIM_CLAIM_STALE_MS = 60_000;
 
 /** Cross-platform pid liveness. EPERM means a process with that number EXISTS
  *  and is simply not ours to signal — alive, not dead. Reading it as dead is
@@ -330,21 +320,74 @@ function readCatalogLockPid(lockPath: string): number | undefined {
 }
 
 /**
+ * Sweep a reclaim claim whose holder died mid-decision. Only the exact instance
+ * observed, and only when it is far older than the few syscalls a claim covers.
+ */
+function sweepStaleReclaimClaim(claimPath: string): void {
+  try {
+    const observed = statSync(claimPath).mtimeMs;
+    if (Date.now() - observed < CATALOG_RECLAIM_CLAIM_STALE_MS) return;
+    if (statSync(claimPath).mtimeMs !== observed) return;
+    rmSync(claimPath, { force: true });
+  } catch {
+    // Gone, replaced, or unreadable — a claim is advisory; leave it.
+  }
+}
+
+/**
  * Free the lock path ONLY when nothing can still be holding it: old enough that
- * no live holder could be inside its critical section, AND either owned by a pid
- * that is gone or older than CATALOG_LOCK_HARD_STALE_MS. Every other state
- * waits — freeing a lock whose holder is still working reintroduces exactly the
- * loss the lock prevents.
+ * no live holder could be inside its critical section, AND owned by a pid that
+ * is provably gone. Every other state waits — freeing a lock whose holder is
+ * still working reintroduces exactly the loss the lock prevents.
  *
- * RENAME FIRST, then judge. A stat-then-unlink is TOCTOU: a second reclaimer can
- * free the path and a third writer can take the freed pathname in the gap, so
- * the unlink lands on a stranger's fresh lock and two writers end up inside
- * `persistLocked` together. A rename atomically removes whatever is at the path
- * and puts it somewhere only this call knows, so the file inspected afterwards
- * is the file this call will act on. (Same technique, for the same reason, as
- * the panel op lock in panel-pin-guard.)
+ * PROVEN-DEAD OWNER, NOT AGE. Age cannot settle the two states a pid leaves
+ * open — a lock whose owner was never recorded, and one whose pid the OS has
+ * since handed to an unrelated live process — because a process can also be
+ * suspended or blocked in I/O for an arbitrarily long time while inside the
+ * critical section. Reclaiming on age alone would be "could not determine the
+ * holder is gone" acted on as "the holder is gone", with silent data loss as
+ * the payout. So those two states REFUSE, and the refusal names the file and
+ * its recorded owner so a person can clear it in one command (codex gate).
+ *
+ * SERIALIZED against other reclaimers by an exclusive claim, because the
+ * dangerous move is taking a lock OFF the path at all: two reclaimers judging
+ * the same stale lock can have the first free it, a third writer acquire the
+ * freed pathname, and the second lift THAT one off — leaving two writers inside
+ * the critical section. One reclaimer at a time makes that unreachable: the
+ * second re-reads the path under the claim, finds a FRESH lock, and never
+ * touches it.
+ *
+ * RENAME FIRST, then judge. A stat-then-unlink is TOCTOU: the file at the path
+ * when the unlink lands need not be the one that was judged. A rename
+ * atomically removes whatever is there and puts it somewhere only this call
+ * knows, so the file inspected afterwards is the file this call will act on.
+ * (Same technique, for the same reason, as the panel op lock in
+ * panel-pin-guard.)
  */
 function reclaimAbandonedCatalogLock(lockPath: string): boolean {
+  const claimPath = `${lockPath}.reclaim`;
+  try {
+    closeSync(openSync(claimPath, "wx"));
+  } catch (err) {
+    // Another reclaimer is deciding right now, or the claim cannot be created
+    // at all. Either way, acting concurrently is the thing that breaks
+    // exclusion — wait instead.
+    if ((err as NodeJS.ErrnoException)?.code === "EEXIST") sweepStaleReclaimClaim(claimPath);
+    return false;
+  }
+  try {
+    return reclaimUnderClaim(lockPath);
+  } finally {
+    try {
+      rmSync(claimPath, { force: true });
+    } catch {
+      // Best effort; a leftover claim only costs reclaim serialization, and
+      // sweepStaleReclaimClaim clears it.
+    }
+  }
+}
+
+function reclaimUnderClaim(lockPath: string): boolean {
   let observed: number;
   try {
     observed = statSync(lockPath).mtimeMs;
@@ -354,8 +397,7 @@ function reclaimAbandonedCatalogLock(lockPath: string): boolean {
   const ageMs = Date.now() - observed;
   if (ageMs < CATALOG_LOCK_STALE_MS) return false;
   const pid = readCatalogLockPid(lockPath);
-  const ownerGone = pid !== undefined && !catalogLockOwnerAlive(pid);
-  if (!ownerGone && ageMs < CATALOG_LOCK_HARD_STALE_MS) return false;
+  if (pid === undefined || catalogLockOwnerAlive(pid)) return false;
 
   const aside = `${lockPath}.stale-${randomUUID()}`;
   try {
@@ -378,8 +420,8 @@ function reclaimAbandonedCatalogLock(lockPath: string): boolean {
       // The path is already free; a leftover copy blocks nothing.
     }
     logger.warn(
-      `[lora-catalog] reclaimed an abandoned write lock at ${lockPath} (owner ` +
-        `${pid === undefined ? "unrecorded" : `pid ${pid}`}, ${Math.round(ageMs / 1000)}s old).`,
+      `[lora-catalog] reclaimed an abandoned write lock at ${lockPath} ` +
+        `(owner pid ${pid} is no longer running; ${Math.round(ageMs / 1000)}s old).`,
     );
     return true;
   }
@@ -441,10 +483,28 @@ function acquireCatalogLock(path: string): { lockPath: string; token: string } {
       }
       if (reclaimAbandonedCatalogLock(lockPath)) continue;
       if (Date.now() >= deadline) {
+        // Reclaim deliberately refuses the two states a pid cannot settle (no
+        // owner recorded, or a pid the OS may have reused), because guessing
+        // there means two writers and a silent loss. So the refusal has to hand
+        // over what it DOES know: a person can settle in one look what this
+        // process cannot settle at all.
+        const pid = readCatalogLockPid(lockPath);
+        let ageNote = "";
+        try {
+          ageNote = ` (${Math.round((Date.now() - statSync(lockPath).mtimeMs) / 1000)}s old)`;
+        } catch {
+          // The lock went away as this message was being built; the retry below
+          // is the right advice either way.
+        }
         throw new Error(
-          `Another writer has held the LoRA catalog lock at ${lockPath} for more than ` +
-            `${Math.round(CATALOG_LOCK_WAIT_MS / 1000)}s. This change was NOT saved — re-read ` +
-            `and retry. If no other comfyui-mcp process is running, delete that file.`,
+          `Another writer has held the LoRA catalog lock at ${lockPath}${ageNote} for more ` +
+            `than ${Math.round(CATALOG_LOCK_WAIT_MS / 1000)}s. This change was NOT saved — ` +
+            `re-read and retry. ` +
+            (pid === undefined
+              ? `The lock records no owner, so nothing here can prove it abandoned. If no ` +
+                `other comfyui-mcp process is running, delete that file.`
+              : `It records pid ${pid}, which is still running. If that process is not a ` +
+                `comfyui-mcp writing this catalog, delete that file.`),
         );
       }
       napSync(25);

--- a/src/services/lora-catalog.ts
+++ b/src/services/lora-catalog.ts
@@ -4,18 +4,23 @@
 // flagged without dropping curated notes.
 
 import {
+  closeSync,
   copyFileSync,
   existsSync,
   mkdirSync,
+  openSync,
   readFileSync,
+  rmSync,
   statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { basename, dirname, extname, join } from "node:path";
 import { getInstanceSlug } from "../config.js";
 import { listLocalModels, type LocalModel } from "./model-resolver.js";
+import { writeFileDurable } from "../utils/durable-write.js";
 import { logger } from "../utils/logger.js";
 
 /** ComfyUI-relative path under models/ (e.g. "loras/style/foo.safetensors"). */
@@ -231,11 +236,204 @@ function parseCatalogRaw(raw: string): CatalogRead {
 function writeCatalogFile(data: LoraCatalogFile): void {
   const path = loraCatalogPath();
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify(data, null, 2));
+  // Temp + fsync + atomic rename (#798): a truncate-and-write can leave a TORN
+  // catalog after a crash, which every later read then correctly refuses to
+  // trust — the curation is not lost but it is unusable until someone repairs
+  // the file by hand.
+  writeFileDurable(path, JSON.stringify(data, null, 2));
 }
 
 /** Monotonic suffix so two backups in the same millisecond never collide. */
 let backupSeq = 0;
+
+// ---------------------------------------------------------------------------
+// Cross-process write lock
+//
+// `persist()` is a read-modify-write, and two agents on one rig is ordinary
+// here. Without exclusion both processes read the same healthy bytes, both pass
+// the unchanged check, and the second write silently erases the first — and
+// because BOTH probes were healthy neither takes the corrupt-file backup, so
+// there is nothing to recover from either.
+//
+// Re-reading immediately before the write does NOT close that. It shrinks the
+// window to microseconds and leaves the loss silent, which is the same fold one
+// order of magnitude smaller: "we did not catch a concurrent writer" read as
+// "there is no concurrent writer". Only an exclusive create ("wx" = O_EXCL,
+// atomic across processes) actually excludes one.
+//
+// The lock covers writers running THIS code. A hand-edit lands wherever it
+// lands — that is the user editing their own file, and the baseline check
+// already catches the ones that complete before our read.
+// ---------------------------------------------------------------------------
+
+/** How long a write waits for another writer's turn before refusing. A held
+ *  lock covers one read and one write — milliseconds — so this is already a
+ *  long queue, and the caller gets an honest "not saved, retry" rather than an
+ *  unbounded stall. */
+const CATALOG_LOCK_WAIT_MS = 2_000;
+
+/** Three orders of magnitude past how long a holder is ever inside the critical
+ *  section, so no live writer can age its own lock into reclaimability. Only a
+ *  crash leaves a lock this old — which is also what makes the release below
+ *  safe (see there). */
+const CATALOG_LOCK_STALE_MS = 30_000;
+
+/** Cross-platform pid liveness. EPERM means a process with that number EXISTS
+ *  and is simply not ours to signal — alive, not dead. Reading it as dead is
+ *  what would let a live holder's lock be reclaimed out from under it. */
+function catalogLockOwnerAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException)?.code === "EPERM";
+  }
+}
+
+/** Block this thread briefly. persist() and every caller of it are synchronous
+ *  all the way up, and a contended wait here is milliseconds long. */
+function napSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/** Whoever holds the lock, as far as the file can say. An unreadable or
+ *  truncated record names NO holder — which is not evidence of an abandoned
+ *  lock, only an absence of evidence: the age check below is what licenses a
+ *  reclaim. */
+function readCatalogLockPid(lockPath: string): number | undefined {
+  try {
+    const rec = JSON.parse(readFileSync(lockPath, "utf-8")) as { pid?: unknown };
+    return typeof rec.pid === "number" ? rec.pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Remove a lock ONLY when it is provably abandoned: older than any live holder
+ *  could be, AND owned by a pid that is gone (or by no readable pid at all).
+ *  Every other state waits — deleting a lock whose holder is still inside its
+ *  critical section reintroduces exactly the loss the lock prevents. */
+function reclaimAbandonedCatalogLock(lockPath: string): boolean {
+  let observed: number;
+  try {
+    observed = statSync(lockPath).mtimeMs;
+  } catch {
+    return true; // already gone — the path is free, retry the create
+  }
+  if (Date.now() - observed < CATALOG_LOCK_STALE_MS) return false;
+  const pid = readCatalogLockPid(lockPath);
+  if (pid !== undefined && catalogLockOwnerAlive(pid)) return false;
+  try {
+    // Delete only the exact instance just judged. A lock taken in the gap is
+    // brand new, so its mtime cannot match one already CATALOG_LOCK_STALE_MS
+    // old — and freeing a fresh holder's path is the one mistake a reclaim
+    // must never make.
+    if (statSync(lockPath).mtimeMs !== observed) return false;
+    rmSync(lockPath, { force: true });
+    logger.warn(
+      `[lora-catalog] reclaimed an abandoned write lock at ${lockPath} (owner ` +
+        `${pid === undefined ? "unrecorded" : `pid ${pid}`} is no longer running).`,
+    );
+    return true;
+  } catch {
+    return false; // could not remove it — wait it out rather than assume
+  }
+}
+
+/** Take the catalog write lock, or THROW. Refuse-vs-disclose: nothing has been
+ *  written yet, so a failure here refuses the change outright and says so. */
+function acquireCatalogLock(path: string): { lockPath: string; token: string } {
+  const lockPath = `${path}.lock`;
+  const token = randomUUID();
+  const deadline = Date.now() + CATALOG_LOCK_WAIT_MS;
+  for (;;) {
+    try {
+      mkdirSync(dirname(lockPath), { recursive: true });
+      const fd = openSync(lockPath, "wx");
+      try {
+        try {
+          writeFileSync(fd, JSON.stringify({ pid: process.pid, token, at: new Date().toISOString() }));
+        } finally {
+          closeSync(fd);
+        }
+      } catch (initErr) {
+        // Created but not identified. A lock nothing can attribute is one no
+        // later writer can wait on intelligently, so remove our own husk rather
+        // than leave it for the staleness timer.
+        try {
+          rmSync(lockPath, { force: true });
+        } catch {
+          // The init failure is the one worth reporting.
+        }
+        throw initErr;
+      }
+      return { lockPath, token };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      // ONLY EEXIST is contention. A create that fails because the volume is
+      // full or read-only must surface now, not burn the whole budget first
+      // and then be reported as somebody else's lock.
+      if (code !== "EEXIST") {
+        throw new Error(
+          `Could not take the LoRA catalog write lock at ${lockPath} ` +
+            `(${err instanceof Error ? err.message : String(err)}). This change was NOT saved.`,
+        );
+      }
+      if (reclaimAbandonedCatalogLock(lockPath)) continue;
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Another writer has held the LoRA catalog lock at ${lockPath} for more than ` +
+            `${Math.round(CATALOG_LOCK_WAIT_MS / 1000)}s. This change was NOT saved — re-read ` +
+            `and retry. If no other comfyui-mcp process is running, delete that file.`,
+        );
+      }
+      napSync(25);
+    }
+  }
+}
+
+/** Release the lock this call took. */
+function releaseCatalogLock(lockPath: string, token: string): void {
+  // A lock is reclaimed only when it is BOTH older than CATALOG_LOCK_STALE_MS
+  // and owned by a pid that is gone — and this process is alive and has been
+  // inside the critical section for milliseconds, so ours cannot have been
+  // taken and replaced. The token check makes that reasoning checkable instead
+  // of assumed: if what is at the path is somehow not ours, leave it alone
+  // rather than free a path another writer owns.
+  let holder: string | undefined;
+  try {
+    holder = (JSON.parse(readFileSync(lockPath, "utf-8")) as { token?: string }).token;
+  } catch {
+    // Unreadable: no other writer could have put it there (see above), and
+    // leaving it would stall every write for CATALOG_LOCK_STALE_MS.
+  }
+  if (holder !== undefined && holder !== token) {
+    logger.warn(
+      `[lora-catalog] the write lock at ${lockPath} is no longer the one this write took; ` +
+        `leaving it in place for its owner.`,
+    );
+    return;
+  }
+  try {
+    rmSync(lockPath, { force: true });
+  } catch (err) {
+    logger.warn(
+      `[lora-catalog] could not release the write lock at ${lockPath} ` +
+        `(${err instanceof Error ? err.message : String(err)}). Catalog writes will wait ` +
+        `and then refuse until it is removed or ages out.`,
+    );
+  }
+}
+
+/** Run `fn` with the catalog write lock held. */
+function withCatalogWriteLock<T>(path: string, fn: () => T): T {
+  const { lockPath, token } = acquireCatalogLock(path);
+  try {
+    return fn();
+  } finally {
+    releaseCatalogLock(lockPath, token);
+  }
+}
 
 function normalizeRelPath(path: string): string {
   const p = path.replace(/\\/g, "/").replace(/^\/+/, "");
@@ -389,16 +587,25 @@ export class LoraCatalog {
    * If it cannot even be copied, refuse the write outright: a loud failure
    * beats silent data loss.
    *
-   * TWO checks before anything is replaced:
+   * All of it runs under the cross-process write lock, because every check
+   * below is a read and the write is a separate syscall: without exclusion two
+   * processes can each pass every check against the same healthy bytes and the
+   * second write erases the first, silently and with no backup taken (both
+   * probes were healthy, so neither branch preserves anything).
+   *
+   * THREE checks before anything is replaced:
    *  - STALE-INSTANCE: the file must still be the state this.data was built
    *    from. Another writer's COMPLETED, healthy update is refused (re-read
    *    and retry) rather than silently overwritten; a file that became
    *    CORRUPT since our read is preserved and then replaced (nothing
    *    readable is lost — our in-memory state is the newer good copy of it).
    *  - MID-PERSIST RACE: the bytes probed must still be the bytes on disk
-   *    when the write begins. The window cannot be zero without a lock (none
-   *    exists for this file); the check covers the realistic interleaving — a
-   *    whole recovery landing between the two reads.
+   *    when the write begins. The lock excludes every writer running this
+   *    code, so what is left for this to catch is a foreign one — a hand-edit
+   *    landing between the two reads.
+   *  - POST-WRITE: what is actually ON DISK afterwards, not what we intended
+   *    to put there. A write that returned without throwing is not by itself
+   *    proof the bytes arrived.
    *
    * And on ANY failure, re-sync from disk before rethrowing: the caller is
    * about to see this mutation as FAILED, so it must not linger in memory —
@@ -407,6 +614,17 @@ export class LoraCatalog {
   private persist(): void {
     try {
       const path = loraCatalogPath();
+      withCatalogWriteLock(path, () => this.persistLocked(path));
+    } catch (err) {
+      // reload() never throws (a failed read degrades to empty + corrupt).
+      this.reload();
+      throw err;
+    }
+  }
+
+  /** The persist itself, with the write lock already held. */
+  private persistLocked(path: string): void {
+    {
       const probe = readCatalogRaw(path);
       const now = readCatalogRaw(path);
       if (now.raw !== probe.raw || now.unreadable !== probe.unreadable) {
@@ -447,14 +665,48 @@ export class LoraCatalog {
           );
         }
       }
+      const intended = JSON.stringify(this.data, null, 2);
       writeCatalogFile(this.data);
-      // The file on disk is now exactly what we wrote — that is the baseline
-      // the NEXT persist compares against.
-      this.baseline = { raw: JSON.stringify(this.data, null, 2) };
-    } catch (err) {
-      // reload() never throws (a failed read degrades to empty + corrupt).
-      this.reload();
-      throw err;
+      // The baseline is what is ACTUALLY on disk, read back — not what we meant
+      // to put there. Taking the intended bytes on faith is how a write that
+      // landed somewhere else, or landed short, becomes the state every later
+      // persist compares against: the next unchanged check would then pass on a
+      // file nobody ever wrote, and quietly overwrite whatever is really there.
+      const written = readCatalogRaw(path);
+      if (written.raw === intended) {
+        this.baseline = { raw: written.raw };
+        return;
+      }
+      if (written.unreadable && probe.unreadable) {
+        // The catalog could not be read BEFORE this write either, so the
+        // read-back carries no new information — and refusing on it would
+        // refuse every write to a catalog this process can write but not read,
+        // permanently, for a write that most likely landed. That is the fold
+        // pointed the other way. DISCLOSE instead: the write has happened, only
+        // its confirmation is missing, and the baseline records what was
+        // actually observed rather than what we hoped for.
+        logger.warn(
+          `[lora-catalog] wrote ${path}, but it still cannot be read back ` +
+            `(${written.unreadable}) — the write is UNCONFIRMED. Check the file's ` +
+            `permissions if entries appear to go missing.`,
+        );
+        this.baseline = { unreadable: written.unreadable };
+        return;
+      }
+      // The file was readable going in and does not hold what we just wrote, so
+      // something is genuinely wrong with the write path. Say only that — NOT
+      // that the change was discarded; persist()'s reload picks it up if it did
+      // in fact land.
+      throw new Error(
+        `The LoRA catalog at ${path} does not read back as what was just written ` +
+          `(${
+            written.unreadable
+              ? `it could not be read: ${written.unreadable}`
+              : written.raw === undefined
+                ? "it is not there"
+                : "its contents differ"
+          }). This change is NOT confirmed saved — inspect the file, then retry.`,
+      );
     }
   }
 

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -401,8 +401,14 @@ export interface EscalatedCancelResult {
    *  and takes the job with it). */
   unverified?: boolean;
   /**
-   * What a LIVE /queue read established about the target when the call ended —
-   * the one question a caller has to answer before dispatching more work.
+   * What a LIVE /queue read established about THE JOB THIS CALL ADDRESSED —
+   * which is the whole of what a cancel promises, and the question that decides
+   * whether its result is settled.
+   *
+   * NOT a statement that the queue is idle. With a `prompt_id`, "stopped" means
+   * that job is gone; another job may have advanced into the running slot, and
+   * pending jobs run next unless `clear_pending` was asked for (see
+   * `pending_cleared` / `pending_clear_failed`, and the message, for that half).
    *
    * Deliberately separate from `unverified`, which covers a DIFFERENT unknown:
    * `unverified` can mean "it demonstrably stopped, but we cannot say our
@@ -412,7 +418,7 @@ export interface EscalatedCancelResult {
    * caught, treating an unreadable queue as an empty one.
    *
    *  - "stopped" — a live read showed the target gone (or showed nothing to
-   *    interrupt in the first place). Safe to queue.
+   *    interrupt in the first place).
    *  - "running" — a live read showed it STILL running: the wedge.
    *  - "unknown" — /queue could not be read, so neither is established.
    */
@@ -568,13 +574,18 @@ export async function cancelRunningJobEscalating(opts: {
   // "restart ComfyUI, do NOT queue another run" sound settled. A restart or a
   // disconnect inside the gap is exactly the case that guidance would be wrong
   // about, so the gap is named rather than smoothed over.
+  // BOTH windows, because the duration claimed spans both: a hole anywhere in
+  // the stated span makes the span not continuously verified, and checking only
+  // the first window would leave the same claim standing over a gap in the
+  // second (codex gate).
   const escalationWindowS = Math.round(Math.min(interruptHonorMs(), 12000) / 1000);
-  const watchedDuration = (first: RunningClearance): string => {
+  const watchedDuration = (first: RunningClearance, final: RunningClearance): string => {
     if (first.outcome !== "still-running") {
+      // One check, not a window — a gap before it does not touch this claim.
       return ` at a verified check ~${escalationWindowS}s after the escalation`;
     }
     const totalS = Math.round((interruptHonorMs() + Math.min(interruptHonorMs(), 12000)) / 1000);
-    return first.continuous
+    return first.continuous && final.continuous
       ? ` across ~${totalS}s of verified polling`
       : ` across ~${totalS}s of polling that /queue did NOT answer throughout — it was ` +
           `seen running by the polls that did answer, including the most recent one, but ` +
@@ -698,7 +709,7 @@ export async function cancelRunningJobEscalating(opts: {
       message:
         `⚠️ ${opts.prompt_id ? `The job ${opts.prompt_id}` : "A job"} is still running after interrupt` +
         (freeFailed ? ` (${freeFailedPhrase})` : freeRan ? ` + VRAM free` : ``) +
-        watchedDuration(firstClearance) +
+        watchedDuration(firstClearance, finalClearance) +
         ` — it is wedged inside a single step (ComfyUI only honors interrupts ` +
         `BETWEEN steps). Whether this IS the job the interrupt addressed is UNKNOWN — ` +
         (opts.prompt_id
@@ -722,7 +733,7 @@ export async function cancelRunningJobEscalating(opts: {
     message:
       `⚠️ The running job${runningId ? ` (${runningId})` : ""} did NOT stop after interrupt` +
       (freeFailed ? ` (${freeFailedPhrase})` : freeRan ? ` + VRAM free` : ``) +
-      watchedDuration(firstClearance) +
+      watchedDuration(firstClearance, finalClearance) +
       ` — it is wedged inside a single step (ComfyUI only honors interrupts ` +
       `BETWEEN steps, so a multi-minute step ignores cancel). An HTTP cancel cannot kill this; restart ComfyUI ` +
       `(panel_restart_comfyui, or restart_comfyui) to clear it. ` +

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -702,7 +702,13 @@ export async function cancelRunningJobEscalating(opts: {
       freed_vram: freedVram,
       wedged: true,
       unverified: true,
-      target_state: "running",
+      // Only a NAMED target gets "running": waitForRunningCleared matched that
+      // prompt_id in the running slot, so the job this call addressed is the one
+      // observed. Without an id and with no pre-interrupt read, `runningId` is
+      // undefined and the poll only established that SOME job is running — which
+      // is what the message below already says. Calling that "running" would
+      // make the field claim the identity the prose disclaims (codex gate).
+      target_state: opts.prompt_id ? "running" : "unknown",
       pending_clear_failed: clearPendingFailed || undefined,
       pending_cleared,
       running_prompt_id: runningId,

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -336,6 +336,13 @@ interface RunningClearance {
    *  means the queue stopped answering PARTWAY through, not that it never
    *  answered — the messages must not conflate the two). */
   observed: boolean;
+  /** EVERY poll in the window answered. A single failure in the middle is a
+   *  HOLE in the observation: the job could have stopped and another started
+   *  inside it, or ComfyUI could have restarted. The outcome is still whatever
+   *  the last live poll saw — a hole does not make a present-tense reading
+   *  wrong — but nothing may narrate a gapped window as continuous verified
+   *  polling. */
+  continuous: boolean;
 }
 
 /** Poll /queue until the target running job is gone (or any-running is gone when
@@ -354,19 +361,24 @@ async function waitForRunningCleared(
   const start = Date.now();
   let everObserved = false;
   let lastPollFailed = false;
+  // Sticky, unlike `lastPollFailed`: a later successful poll re-establishes the
+  // PRESENT state, but it cannot retroactively fill in what happened while the
+  // queue was not answering.
+  let anyPollFailed = false;
   while (Date.now() - start < timeoutMs) {
     await sleep(1500);
     const q = await getQueueSummary().catch(() => null);
     if (!q) {
       lastPollFailed = true;
+      anyPollFailed = true;
       continue;
     }
     everObserved = true;
     lastPollFailed = false;
-    if (q.running === 0) return { outcome: "cleared", observed: true };
+    if (q.running === 0) return { outcome: "cleared", observed: true, continuous: !anyPollFailed };
     // A DIFFERENT job is now running → the one we targeted has cleared.
     if (promptId && !q.running_jobs.some((j) => j.prompt_id === promptId)) {
-      return { outcome: "cleared", observed: true };
+      return { outcome: "cleared", observed: true, continuous: !anyPollFailed };
     }
   }
   // Timed out. "Still running" is a claim about NOW, and only a poll that is
@@ -375,6 +387,7 @@ async function waitForRunningCleared(
   return {
     outcome: everObserved && !lastPollFailed ? "still-running" : "unobservable",
     observed: everObserved,
+    continuous: !anyPollFailed,
   };
 }
 
@@ -387,6 +400,27 @@ export interface EscalatedCancelResult {
    *  neither "stopped" nor "wedged" (a crashed ComfyUI also stops answering,
    *  and takes the job with it). */
   unverified?: boolean;
+  /**
+   * What a LIVE /queue read established about the target when the call ended —
+   * the one question a caller has to answer before dispatching more work.
+   *
+   * Deliberately separate from `unverified`, which covers a DIFFERENT unknown:
+   * `unverified` can mean "it demonstrably stopped, but we cannot say our
+   * interrupt is why". That is a caveat on the narration, not on the queue.
+   * Folding both into one flag is how a caller ends up refusing to proceed
+   * against a queue that is verifiably empty — or, the way round the gate
+   * caught, treating an unreadable queue as an empty one.
+   *
+   *  - "stopped" — a live read showed the target gone (or showed nothing to
+   *    interrupt in the first place). Safe to queue.
+   *  - "running" — a live read showed it STILL running: the wedge.
+   *  - "unknown" — /queue could not be read, so neither is established.
+   */
+  target_state: "stopped" | "running" | "unknown";
+  /** clear_pending was asked for and the clear did not complete — the pending
+   *  jobs may still be queued. Distinct from `pending_cleared: undefined`,
+   *  which is also what "clear_pending was never requested" looks like. */
+  pending_clear_failed?: boolean;
   pending_cleared?: number; // how many pending jobs were dropped (if clear_pending)
   running_prompt_id?: string;
   message: string;
@@ -439,6 +473,8 @@ export async function cancelRunningJobEscalating(opts: {
       honored: true,
       freed_vram: false,
       wedged: false,
+      target_state: "stopped",
+      pending_clear_failed: clearPendingFailed || undefined,
       pending_cleared,
       message: `No job is running.${opts.clear_pending ? ` ${pendingNote}` : ""}`,
     };
@@ -449,6 +485,8 @@ export async function cancelRunningJobEscalating(opts: {
       honored: true,
       freed_vram: false,
       wedged: false,
+      target_state: "stopped",
+      pending_clear_failed: clearPendingFailed || undefined,
       pending_cleared,
       message:
         `${opts.prompt_id} is not running (verified via /queue) — nothing to interrupt.` +
@@ -470,6 +508,8 @@ export async function cancelRunningJobEscalating(opts: {
         freed_vram: false,
         wedged: false,
         unverified: true,
+        target_state: "stopped",
+        pending_clear_failed: clearPendingFailed || undefined,
         pending_cleared,
         running_prompt_id: runningId,
         message:
@@ -484,6 +524,8 @@ export async function cancelRunningJobEscalating(opts: {
       honored: true,
       freed_vram: false,
       wedged: false,
+      target_state: "stopped",
+      pending_clear_failed: clearPendingFailed || undefined,
       pending_cleared,
       running_prompt_id: runningId,
       message: `Interrupted the running job${runningId ? ` (${runningId})` : ""}.${
@@ -518,10 +560,26 @@ export async function cancelRunningJobEscalating(opts: {
   // The duration the message may claim: continuous verified polling only when
   // the FIRST window was observed end-to-end; otherwise only the final check
   // was a live observation, and the message must not claim more.
-  const watchedDuration = (first: RunningClearance): string =>
-    first.outcome === "still-running"
-      ? ` across ~${Math.round((interruptHonorMs() + Math.min(interruptHonorMs(), 12000)) / 1000)}s of verified polling`
-      : ` at a verified check ~${Math.round(Math.min(interruptHonorMs(), 12000) / 1000)}s after the escalation`;
+  //
+  // "End-to-end" means EVERY poll answered. A window with a hole in it still
+  // supports the present-tense reading its last live poll made — but calling it
+  // "~Ns of verified polling" is a sampled observation with a gap narrated as
+  // continuous verification, and this claim is load-bearing: it is what makes
+  // "restart ComfyUI, do NOT queue another run" sound settled. A restart or a
+  // disconnect inside the gap is exactly the case that guidance would be wrong
+  // about, so the gap is named rather than smoothed over.
+  const escalationWindowS = Math.round(Math.min(interruptHonorMs(), 12000) / 1000);
+  const watchedDuration = (first: RunningClearance): string => {
+    if (first.outcome !== "still-running") {
+      return ` at a verified check ~${escalationWindowS}s after the escalation`;
+    }
+    const totalS = Math.round((interruptHonorMs() + Math.min(interruptHonorMs(), 12000)) / 1000);
+    return first.continuous
+      ? ` across ~${totalS}s of verified polling`
+      : ` across ~${totalS}s of polling that /queue did NOT answer throughout — it was ` +
+          `seen running by the polls that did answer, including the most recent one, but ` +
+          `the gap could hide a restart`;
+  };
   // "The job stopped" (or "this job is wedged") is only ours to claim when the
   // target was seen running BEFORE the interrupt. A named prompt first sighted
   // in a later window may have STARTED after the interrupt — the interrupt was
@@ -576,6 +634,8 @@ export async function cancelRunningJobEscalating(opts: {
       freed_vram: freedVram,
       wedged: false,
       unverified: stopVerified ? undefined : true,
+      target_state: "stopped",
+      pending_clear_failed: clearPendingFailed || undefined,
       pending_cleared,
       running_prompt_id: runningId,
       message,
@@ -601,6 +661,8 @@ export async function cancelRunningJobEscalating(opts: {
       freed_vram: freedVram,
       wedged: false,
       unverified: true,
+      target_state: "unknown",
+      pending_clear_failed: clearPendingFailed || undefined,
       pending_cleared,
       running_prompt_id: runningId,
       message:
@@ -629,6 +691,8 @@ export async function cancelRunningJobEscalating(opts: {
       freed_vram: freedVram,
       wedged: true,
       unverified: true,
+      target_state: "running",
+      pending_clear_failed: clearPendingFailed || undefined,
       pending_cleared,
       running_prompt_id: runningId,
       message:
@@ -651,6 +715,8 @@ export async function cancelRunningJobEscalating(opts: {
     honored: false,
     freed_vram: freedVram,
     wedged: true,
+    target_state: "running",
+    pending_clear_failed: clearPendingFailed || undefined,
     pending_cleared,
     running_prompt_id: runningId,
     message:

--- a/src/tools/queue-management.ts
+++ b/src/tools/queue-management.ts
@@ -29,7 +29,8 @@ import { errorToToolResult } from "../utils/errors.js";
  * the one deliberate behavioural difference a flat enum permits. Each branch
  * calls the same service function the old tool called, with the same arguments,
  * and returns the identical content block (JSON for the query actions, the
- * prose messages for cancel/cancel_queued/clear, isError on a wedged cancel).
+ * prose messages for cancel/cancel_queued/clear, isError on a cancel whose
+ * outcome no live /queue read settled).
  */
 export function registerQueueManagementTools(server: McpServer): void {
   server.tool(
@@ -139,9 +140,30 @@ export function registerQueueManagementTools(server: McpServer): void {
               prompt_id: args.prompt_id,
               clear_pending: args.clear_pending,
             });
+            // An MCP success is read as permission to carry on and queue more
+            // work, so it may only be given for an outcome a LIVE /queue read
+            // settled. `wedged` alone is not that test: an unreachable /queue
+            // makes the service report `target_state:"unknown"` with
+            // `wedged:false`, and answering that with a plain success turns the
+            // service's honest "could not determine" back into "determined it
+            // stopped" — one level up. Same for a `clear_pending` the caller
+            // asked for that did not complete: the backlog it was meant to
+            // remove may still be there to stack behind.
+            //
+            // DISCLOSE, DO NOT HIDE: `result.message` is returned unchanged in
+            // both cases. The cancel may well have happened — for an unreadable
+            // queue that is one of the live possibilities — and the message says
+            // so, along with what to check. isError marks the outcome unsettled;
+            // it does not claim the cancel failed.
+            //
+            // And NOT on `unverified`, which is a caveat about WHY the job
+            // stopped, not WHETHER: `target_state:"stopped"` there comes from a
+            // live read of an empty queue. Failing that would refuse a caller
+            // the queue it can see is free.
+            const unsettled = result.target_state !== "stopped" || !!result.pending_clear_failed;
             return {
               content: [{ type: "text" as const, text: result.message }],
-              ...(result.wedged ? { isError: true } : {}),
+              ...(unsettled ? { isError: true } : {}),
             };
           }
           case "cancel_queued": {

--- a/src/tools/queue-management.ts
+++ b/src/tools/queue-management.ts
@@ -140,9 +140,12 @@ export function registerQueueManagementTools(server: McpServer): void {
               prompt_id: args.prompt_id,
               clear_pending: args.clear_pending,
             });
-            // An MCP success is read as permission to carry on and queue more
-            // work, so it may only be given for an outcome a LIVE /queue read
-            // settled. `wedged` alone is not that test: an unreachable /queue
+            // An MCP success is read as "the cancel did what it said", so it
+            // may only be given for an outcome a LIVE /queue read settled —
+            // about the job this call addressed, which is all a cancel ever
+            // promised (a queue that advances to the next job is not an error;
+            // clear_pending is the switch for emptying it). `wedged` alone is
+            // not that test: an unreachable /queue
             // makes the service report `target_state:"unknown"` with
             // `wedged:false`, and answering that with a plain success turns the
             // service's honest "could not determine" back into "determined it


### PR DESCRIPTION
Follow-up to #839, which merged 12 hours after its independent gate posted **NO-SHIP (2 P0, 1 P1)** without those findings being addressed. They were live on `main`; this fixes them, plus everything three further gate rounds found in the fix itself.

## The findings from #839's gate

**P0 — an unverified cancel came back as an MCP success.** The service did the right thing: when `/queue` is unreachable it reported `unverified: true, wedged: false`. `src/tools/queue-management.ts` set `isError` from `wedged` alone, so the service's honest "could not determine" became "determined it stopped" one level up — and a calling agent reads a success as permission to dispatch more work. *A tri-state introduced without updating its consumers turns a false refusal into a false acceptance.*

`unverified` is not the right discriminator, because it covers two different unknowns: "we cannot say WHY it stopped" (the queue is verifiably empty — proceeding is fine) and "we cannot say WHETHER it stopped". Keying `isError` off `unverified` would refuse a caller the free queue it can see. So the service now reports `target_state: "stopped" | "running" | "unknown"` — what a live `/queue` read established about the job this call addressed — and the tool marks anything but `"stopped"` unsettled. **The message is returned unchanged either way**: the cancel may well have happened, and `isError` says the outcome is unsettled, not that it failed. A `clear_pending` the caller asked for that did not complete is unsettled for the same reason.

**P0 — silent data loss in `LoraCatalog.persist()`.** No atomic exclusion between its last read and its write: two agents on one rig both read healthy `V1`, both pass `unchanged`, A writes and B writes, and B's write silently erases A's — with no backup, because both probes were healthy so neither took the corrupt-file branch. A re-read just before the write does not close that; it shrinks the window and leaves the loss silent, which is the same fold one order of magnitude smaller. Writes now take a cross-process lock (`O_EXCL`), write durably (temp + `fsync` + atomic rename, #798), and take the next baseline from what is **actually on disk** afterwards rather than from what was intended.

**P1 — a verification window with a hole narrated as continuous.** `lastPollFailed` was cleared by any later successful poll, so `running → poll failure → running` was described as "~Ns of VERIFIED polling". The verdict is right — the last poll answered and showed it running — but that claim is what makes "restart ComfyUI, do NOT queue another run" sound settled, and a restart inside the gap is exactly what it would be wrong about. The gap is now tracked and named.

## What the three gate rounds on the fix found

- The abandoned-lock reclaim was `stat`-then-`unlink`, which is TOCTOU. Now: **serialized by its own exclusive claim** (two reclaimers acting on one stale lock is the whole danger), **renames the lock aside before judging it**, and restores via `linkSync` — which fails on an occupied path where a rename would clobber.
- A hard-age expiry I added would have **stolen a live lock**: a process can be suspended or blocked in I/O longer than any timeout while inside the critical section, so "old" is not "gone" — this file's own defect, written into its fix. Removed. Reclaim requires a **provably dead owner**; the two states a pid cannot settle (none recorded, or one the OS may have reused) deliberately **refuse**, and the refusal names the file, the owner and the age so a person can clear it in one command.
- The claim sweep was then the same fold one level down (age-only). The claim now carries an owner and is cleared by the same proven-dead rule. Where the regress stops is written into the code: two processes may still clear the same *dead* claim, which is exactly the behaviour before the claim existed — it narrows a race, it never grants an authority.
- `writeFileDurable` throws on **either side** of its atomic rename. `persist()` rethrew both as "not saved", but the post-rename case has the bytes already on the path — a durability disclosure, not a failed save. The read-back now decides which it was.
- A lock this process took and failed to remove could never be cleared by anything (reclaim needs a dead owner; the owner is this process, alive), so one transient `EBUSY` would refuse every catalog write for the life of the server. Such locks are remembered by token and cleared by the next write that can prove they are its own.
- The continuous-polling claim spans **both** verification windows but checked only the first.
- `target_state: "running"` claimed an identity its own message disclaims: with no `prompt_id` and a failed pre-interrupt read, the poll established that *some* job is running. That branch reports `"unknown"`.

## Verification

Every fix was mutation-verified — the fix temporarily removed, the specific new test confirmed failing, restored. 15 mutations, each caught by exactly the intended test(s), including both directions of the `isError` rule (revert to `wedged`-only → the unknown/failed-clear tests fail; widen to `unverified` → the verifiably-empty-queue test fails).

The catalog concurrency test is a real interleaving: `catalogB`'s whole read-modify-write runs from inside `catalogA`'s window, at the last moment before A's bytes reach the path, both built from the same healthy `V1`. With the lock removed, B **succeeds silently** and A's rename erases it — which is the bug, and what the test detects.

`tsc --noEmit` clean; 270 files / 5601 tests pass. Control-byte scan clean on every touched file; no file is git-binary.

Refs artokun/comfyui-mcp#796, artokun/comfyui-mcp#820
