### PR TITLE
list_output_images returns [] on a local install whose path comes from the saved workspace (#877)

### DIFF
--- a/src/__tests__/services/image-convert.test.ts
+++ b/src/__tests__/services/image-convert.test.ts
@@ -7,10 +7,24 @@ import { resolve } from "node:path";
 const OUTPUT_DIR = resolve("/comfy", "output");
 const outPath = (...segments: string[]): string => resolve(OUTPUT_DIR, ...segments);
 
+const cfgRef = vi.hoisted(() => ({
+  config: { comfyuiPath: "/comfy" as string | undefined },
+}));
 vi.mock("../../config.js", () => ({
-  config: {
-    comfyuiPath: "/comfy" as string | undefined,
-  },
+  config: cfgRef.config,
+  // Needed since #877 routed the output/input dir fallbacks through the shared
+  // workspace resolver, and #835 made that resolver consult remote mode FIRST —
+  // before, it returned `config.comfyuiPath` early and this export was never
+  // reached, so its absence from the mock went unnoticed. A merge seam, not a
+  // product change.
+  isRemoteMode: () => false,
+}));
+
+// Stubbed to the env var alone so "there is a local install path" is a property
+// of the TEST and not of whichever machine runs it: the real resolver also
+// consults the SAVED DEFAULT WORKSPACE, and this rig has one.
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveEffectiveComfyUIBase: () => cfgRef.config.comfyuiPath,
 }));
 
 const getOutputImageMock = vi.fn();

--- a/src/__tests__/services/list-output-images.test.ts
+++ b/src/__tests__/services/list-output-images.test.ts
@@ -258,9 +258,13 @@ describe("listOutputImages — remote mode (derived from /history)", () => {
     expect((await listOutputImages({ limit: 1 })).length).toBe(1);
   });
 
-  it("returns [] when history is unavailable rather than throwing", async () => {
+  it("does NOT return [] when history is UNAVAILABLE — a failed request is not an empty history", async () => {
+    // This asserted the opposite, and that was the fold (#877): in remote mode
+    // /history is the ONLY source, so returning `[]` when the request failed made
+    // "we never got an answer" indistinguishable from "there are no outputs" —
+    // and `[]` was the whole reply.
     getHistoryMock.mockRejectedValue(new Error("unreachable"));
-    await expect(listOutputImages()).resolves.toEqual([]);
+    await expect(listOutputImages()).rejects.toThrow(/NOT a finding that there are no outputs/i);
   });
 
   it("uses /history even when comfyuiPath IS set, as long as isRemoteMode() is true", async () => {

--- a/src/__tests__/services/list-output-images.test.ts
+++ b/src/__tests__/services/list-output-images.test.ts
@@ -6,8 +6,13 @@ import { join } from "node:path";
 // Mock resolveOutputDir so the scan targets our temp dir; everything else
 // (readdir/stat/extname classification) runs for real.
 let outputDir = "";
+// #877 needs the FAILING resolution too: "the output dir could not be
+// determined" is a distinct state from "it resolved and was empty", and the bug
+// was those two producing the same answer.
+let outputDirError: Error | null = null;
 vi.mock("../../services/output-dir.js", () => ({
-  resolveOutputDir: () => Promise.resolve(outputDir),
+  resolveOutputDir: () =>
+    outputDirError ? Promise.reject(outputDirError) : Promise.resolve(outputDir),
   resolveInputDir: () => Promise.resolve(outputDir),
 }));
 
@@ -162,8 +167,17 @@ describe("listOutputImages", () => {
 
 describe("listOutputImages — remote mode (derived from /history)", () => {
   beforeEach(() => {
-    // No local filesystem → the history-derived branch is used.
+    // ACTUALLY remote (#877). This block called itself "remote mode" while only
+    // clearing `config.comfyuiPath` — which is the very conflation the bug was:
+    // one env var being unset is not "there is no local filesystem", because a
+    // local portable install is located by the SAVED DEFAULT WORKSPACE. Keying
+    // the /history branch off that check sent a local install to a data source
+    // that cannot see its disk, and an emptied history then read as "no outputs".
+    remoteFlag = true;
     config.comfyuiPath = undefined;
+  });
+  afterEach(() => {
+    remoteFlag = false;
   });
 
   it("derives images + videos from history, newest-first, with kind", async () => {
@@ -274,5 +288,69 @@ describe("listOutputImages — remote mode (derived from /history)", () => {
     // …and ONLY the history-derived entry came back (readdir scan did NOT run).
     expect(results.map((r) => r.filename)).toEqual(["from_history.png"]);
     expect(results.find((r) => r.filename === "local_only.png")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #877 — a LOCAL portable install with COMFYUI_PATH unset. `get_environment`
+// locates it perfectly well from the saved default workspace, but
+// list_output_images keyed its remote branch off `!config.comfyuiPath` and so
+// asked /history, which had been emptied by a restart. It returned `[]` over a
+// directory holding exactly the files the caller was asking about — a silent
+// wrong answer, not an error, and the agent concludes the file does not exist.
+
+describe("#877 — a local install whose path comes from the saved workspace, not COMFYUI_PATH", () => {
+  beforeEach(() => {
+    remoteFlag = false; // LOCAL…
+    config.comfyuiPath = undefined; // …but the env var is unset
+    outputDirError = null;
+  });
+  afterEach(() => {
+    outputDirError = null;
+  });
+
+  it("scans the resolved output dir instead of falling back to /history", async () => {
+    // The output dir resolves (as it does from a saved default workspace), and
+    // the files are right there.
+    await writeFile(join(outputDir, "fairy_redhair_00001_.png"), "x");
+    // /history is EMPTY — a restart cleared it. Under the bug this is what the
+    // caller got back, dressed as an answer.
+    getHistoryMock.mockResolvedValue({});
+
+    const images = await listOutputImages({});
+
+    expect(images.map((i) => i.filename)).toContain("fairy_redhair_00001_.png");
+    // And it never consulted the source that cannot see the disk.
+    expect(getHistoryMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT report an empty result when the output dir could not be determined", async () => {
+    // No local root AND nothing in history. Returning `[]` here asserts there are
+    // no outputs, which neither source established: one was never consulted and
+    // the other cannot see files on disk.
+    outputDirError = new Error("no COMFYUI_PATH, no saved workspace");
+    getHistoryMock.mockResolvedValue({});
+
+    await expect(listOutputImages({})).rejects.toThrow(/NOT a finding that there are no outputs/i);
+  });
+
+  it("still ANSWERS from history when the dir is unknown but history has something", async () => {
+    // The inverse: falling back is right, and refusing when the fallback actually
+    // produced an answer would be a false refusal of a real result.
+    outputDirError = new Error("no local root");
+    getHistoryMock.mockResolvedValue({
+      j1: { outputs: { "9": { images: [{ filename: "from-history.png", subfolder: "", type: "output" }] } } },
+    });
+
+    const images = await listOutputImages({});
+    expect(images.map((i) => i.filename)).toEqual(["from-history.png"]);
+  });
+
+  it("does NOT report an empty result when the output dir is known but unreadable", async () => {
+    // We know WHERE the outputs are and could not read them. That is not an empty
+    // directory, and `[]` told the caller their file does not exist.
+    outputDir = join(outputDir, "does-not-exist-at-all");
+
+    await expect(listOutputImages({})).rejects.toThrow(/could not be listed at all/i);
   });
 });

--- a/src/__tests__/services/media-upload.test.ts
+++ b/src/__tests__/services/media-upload.test.ts
@@ -1,8 +1,26 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { resolve } from "node:path";
 
-vi.mock("../../config.js", () => ({
+// `isRemoteMode` is needed because the input/output dir fallbacks now resolve
+// through the shared workspace resolver (#877) rather than reading
+// `config.comfyuiPath` directly — a saved default workspace locates a local
+// install perfectly well, and the bare env-var check made one look pathless.
+const cfgRef = vi.hoisted(() => ({
   config: { comfyuiPath: "/comfy" as string | undefined },
+}));
+vi.mock("../../config.js", () => ({
+  config: cfgRef.config,
+  isRemoteMode: () => false,
+}));
+
+// The input/output dir fallbacks now resolve through the shared workspace
+// resolver (#877): a saved default workspace locates a local install perfectly
+// well, and the bare `config.comfyuiPath` check made one look pathless. Stubbed
+// to the env var alone so "no local path" is a property of the TEST rather than
+// of whichever machine runs it — this rig has a real saved workspace, which
+// otherwise silently satisfies the case below.
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveEffectiveComfyUIBase: () => cfgRef.config.comfyuiPath,
 }));
 
 const copyFileMock = vi.fn();
@@ -110,7 +128,7 @@ describe("uploadVideoLocal / uploadAudioLocal (filesystem)", () => {
     expect(copyFileMock).not.toHaveBeenCalled();
   });
 
-  it("errors clearly when COMFYUI_PATH is unset (remote mode)", async () => {
+  it("errors clearly when NO local install path can be established", async () => {
     (config as { comfyuiPath?: string }).comfyuiPath = undefined;
     await expect(uploadVideoLocal("/src/clip.mp4")).rejects.toBeInstanceOf(
       ValidationError,

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -237,23 +237,40 @@ export async function listOutputImages(options?: {
   // REMOTE mode: no local filesystem to scan. Derive the output media from
   // ComfyUI's /history (HTTP, works against a remote instance) instead. Size and
   // modification time are unavailable over HTTP, so they come back as 0 / "".
-  // Key off isRemoteMode() (not mere comfyuiPath absence): when a remote target
-  // coexists with an unrelated local COMFYUI_PATH, scanning the local output dir
-  // would report the wrong machine's outputs. Also fall back to /history when no
-  // local path is configured at all.
-  if (isRemoteMode() || !config.comfyuiPath) {
+  // Keyed off isRemoteMode() ALONE (#877): when a remote target coexists with an
+  // unrelated local COMFYUI_PATH, scanning the local output dir would report the
+  // wrong machine's outputs — but the converse test, `!config.comfyuiPath`, was
+  // never a test for "no local path". It reads one ENV VAR, while a local
+  // portable install is perfectly well located by the SAVED DEFAULT WORKSPACE,
+  // which `resolveOutputDir` consults and `get_environment` reports. So a local
+  // install with `COMFYUI_PATH` unset silently took the remote branch, asked
+  // /history — which had been emptied by a restart — and returned `[]` over an
+  // output directory holding the files the caller was asking about. A silent
+  // wrong answer, not an error: the agent concludes the file does not exist.
+  if (isRemoteMode()) {
     return listOutputImagesFromHistory(limit, pattern);
   }
 
-  // Resolve the real local output dir. Asking the running ComfyUI can fail
-  // (unreachable, or a non-local --output-directory we can't read); treat any
-  // failure as "nothing to list" rather than throwing, so the tool degrades to
-  // an empty result instead of an opaque error.
+  // Local. `resolveOutputDir` already knows every way this path can be
+  // established, so let it answer rather than pre-judging on one env var.
   let outputDir: string;
   try {
     outputDir = await resolveOutputDir();
-  } catch {
-    return [];
+  } catch (err) {
+    // The local root could not be established. /history is the only source left,
+    // and it CANNOT see the disk — so a zero result from it does not establish
+    // that there are no outputs. Falling back is right; reporting its emptiness
+    // as an answer is not.
+    const fromHistory = await listOutputImagesFromHistory(limit, pattern);
+    if (fromHistory.length > 0) return fromHistory;
+    throw new ComfyUIError(
+      `Could not determine this ComfyUI's output directory (${err instanceof Error ? err.message : String(err)}), ` +
+        `so the local output folder was never scanned. ComfyUI's /history was asked instead and ` +
+        `returned nothing — but history is emptied by a restart and cannot see files on disk, so ` +
+        `that is NOT a finding that there are no outputs. Set COMFYUI_PATH, or save a default ` +
+        `workspace (workspace tool, action 'set_default'), so the output folder can be read directly.`,
+      "OUTPUT_DIR_UNKNOWN",
+    );
   }
 
   // RECURSIVE scan: ComfyUI writes to subfolders when a node's filename_prefix
@@ -263,8 +280,16 @@ export async function listOutputImages(options?: {
   let dirents;
   try {
     dirents = await readdir(outputDir, { recursive: true, withFileTypes: true });
-  } catch {
-    return [];
+  } catch (err) {
+    // We know WHERE the outputs are and could not read them. That is not an
+    // empty directory, and returning `[]` told the caller their file does not
+    // exist when the truth is we could not look (#877).
+    throw new ComfyUIError(
+      `Could not read the ComfyUI output directory "${outputDir}": ` +
+        `${err instanceof Error ? err.message : String(err)}. This is NOT a finding that there ` +
+        `are no outputs — the directory could not be listed at all.`,
+      "OUTPUT_DIR_UNREADABLE",
+    );
   }
 
   const images: OutputImage[] = [];

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -293,6 +293,11 @@ export async function listOutputImages(options?: {
   }
 
   const images: OutputImage[] = [];
+  // How many entries MATCHED the query, versus how many we could actually stat.
+  // A per-file stat failure is skipped silently, which is fine when it is one
+  // file among many — but if it swallows every match, the caller gets `[]` over
+  // a directory that demonstrably held what they asked for (codex gate).
+  let matched = 0;
 
   for (const dirent of dirents) {
     if (!dirent.isFile()) continue;
@@ -307,6 +312,7 @@ export async function listOutputImages(options?: {
     if (pattern && !relPath.toLowerCase().includes(pattern)) continue;
 
     const filePath = join(parent, dirent.name);
+    matched += 1;
     try {
       const info = await stat(filePath);
       images.push({
@@ -318,8 +324,24 @@ export async function listOutputImages(options?: {
         kind: mediaKind(ext),
       });
     } catch {
+      // One file that vanished between readdir and stat, or that we cannot read,
+      // is not worth failing the whole listing over — skip it. But see the check
+      // below: skipping EVERY match is a different statement entirely.
       continue;
     }
+  }
+
+  if (matched > 0 && images.length === 0) {
+    // Every entry that matched the query failed to stat. Returning `[]` here says
+    // "there are none" over a directory that demonstrably held what was asked for
+    // — the same fold as the two above, at the last place it can still happen
+    // (codex gate).
+    throw new ComfyUIError(
+      `Found ${matched} matching file(s) under "${outputDir}", but none of them could be read ` +
+        `(every stat failed — a permissions or I/O problem, or they were all removed mid-scan). ` +
+        `This is NOT a finding that there are no outputs.`,
+      "OUTPUT_ENTRIES_UNREADABLE",
+    );
   }
 
   // Sort newest first
@@ -344,8 +366,16 @@ async function listOutputImagesFromHistory(
   try {
     history = await getHistory();
   } catch (err) {
-    logger.debug("getHistory failed while listing remote output media", { err });
-    return [];
+    // A FAILED request is not an empty history (codex gate). Returning `[]` here
+    // told the caller there are no outputs when we never got an answer at all —
+    // and in remote mode this is the only source, so that `[]` was the whole
+    // reply. Throwing makes the difference visible; the caller upstream already
+    // distinguishes "history had nothing" from "history could not be asked".
+    throw new ComfyUIError(
+      `Could not read ComfyUI's generation history (${err instanceof Error ? err.message : String(err)}). ` +
+        `This is NOT a finding that there are no outputs — the history could not be read at all.`,
+      "HISTORY_UNREADABLE",
+    );
   }
 
   const seen = new Set<string>();

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -868,12 +868,26 @@ export async function resolveServerExtraModelConfig(): Promise<string | undefine
 
 /** <COMFYUI_PATH>/output fallback. Throws if COMFYUI_PATH is unset. */
 export function localOutputDirFallback(): string {
-  if (!config.comfyuiPath) {
+  // THE SAVED DEFAULT WORKSPACE COUNTS (#877). Reading `config.comfyuiPath`
+  // alone asks whether ONE ENVIRONMENT VARIABLE is set, and that is not the
+  // question — a local portable install is located perfectly well by the saved
+  // default workspace, which `get_environment` reports and every other resolver
+  // in this codebase already consults. Keying off the env var made a perfectly
+  // locatable install look pathless, and the caller upstream then fell through
+  // to a data source that cannot see the disk and reported no outputs at all.
+  //
+  // `resolveEffectiveComfyUIBase` is that shared resolver: COMFYUI_PATH, then
+  // the saved default workspace, and nothing in remote mode (where a local path
+  // would name the wrong machine).
+  const base = resolveEffectiveComfyUIBase();
+  if (!base) {
     throw new ValidationError(
-      "COMFYUI_PATH is not configured. Set the COMFYUI_PATH environment variable.",
+      "No local ComfyUI install path could be established: COMFYUI_PATH is not set and no " +
+        "default workspace is saved. Set COMFYUI_PATH, or save one with the workspace tool " +
+        "(action 'set_default').",
     );
   }
-  return resolve(config.comfyuiPath, "output");
+  return resolve(base, "output");
 }
 
 // ---------------------------------------------------------------------------
@@ -911,12 +925,18 @@ export function parseInputDirFromArgv(argv: string[] | undefined): string | unde
 
 /** <COMFYUI_PATH>/input fallback. Throws if COMFYUI_PATH is unset. */
 export function localInputDirFallback(): string {
-  if (!config.comfyuiPath) {
+  // The exact mirror of the output fallback above, and the same #877 reasoning:
+  // these two must agree about where the install is, or an upload and the listing
+  // of what was uploaded would disagree.
+  const base = resolveEffectiveComfyUIBase();
+  if (!base) {
     throw new ValidationError(
-      "COMFYUI_PATH is not configured. Set the COMFYUI_PATH environment variable.",
+      "No local ComfyUI install path could be established: COMFYUI_PATH is not set and no " +
+        "default workspace is saved. Set COMFYUI_PATH, or save one with the workspace tool " +
+        "(action 'set_default').",
     );
   }
-  return resolve(config.comfyuiPath, "input");
+  return resolve(base, "input");
 }
 
 /**


### PR DESCRIPTION
Fixes #877.

`list_output_images` returned `[]` for every query on a local Windows portable install while `output/` demonstrably held the files being asked about. A silent wrong answer, not an error — the agent concludes the file does not exist.

## Root cause

The remote branch was gated on `isRemoteMode() || !config.comfyuiPath`. That second test reads **one environment variable** and was standing in for "there is no local filesystem to scan". Those are different questions: a local portable install is located perfectly well by the **saved default workspace**, which `resolveOutputDir` already consults and `get_environment` already reports. So a local install with `COMFYUI_PATH` unset took the remote path, asked ComfyUI's `/history` — emptied by a restart — and reported nothing.

Same family as #490: a bare `config.comfyuiPath` check standing in for the resolver.

## What changed

- The gate is `isRemoteMode()` alone. Everything else is left to `resolveOutputDir`, which knows every way the path can be established.
- **Output dir could not be resolved** → previously `[]`. `/history` is the only source left and it cannot see the disk, so its emptiness establishes nothing. It still falls back, but refuses to report a zero result as an answer, and names what to set. If history *does* produce results, they are returned — refusing there would be a false refusal of a real result.
- **Output dir resolved but `readdir` failed** → previously `[]`. We knew where the outputs were and could not read them; that is not an empty directory.

## On the tests

The existing "remote mode" describe block only cleared `config.comfyuiPath` and **never set remote mode** — the conflation itself, encoded in a test, which is a large part of why this shipped. It now actually sets remote mode.

Four new tests pin: the local-install case (and assert `/history` is never consulted), both unknown-dir directions, and the known-but-unreadable dir.

**Three mutations, each caught by exactly the intended tests**: restoring the env-var gate fails three; swallowing either error back to `[]` fails its own.

Full suite: 5614 passing. Control bytes 0, no git-binary files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)