### PR TITLE
generations.db inside the ComfyUI install breaks ComfyUI's git updater (#872)

### DIFF
--- a/src/__tests__/services/generation-tracker-path.test.ts
+++ b/src/__tests__/services/generation-tracker-path.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, existsSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -92,13 +92,105 @@ describe("GenerationTracker default DB path", () => {
     t.close();
   });
 
-  it("local install: DB stays inside the install's comfyui-mcp dir (unchanged)", async () => {
+  it("local install: the DB is NEVER written inside the ComfyUI install (#872)", async () => {
+    // This asserted the opposite, and that placement was the bug: a live WAL
+    // SQLite database — three open files — sitting inside ComfyUI's own git
+    // working tree, in a directory its .gitignore does not cover. ComfyUI's
+    // updater commits it with `git add -A`, then `git reset --hard` cannot delete
+    // it because we hold the handle, so the user's update aborts AND its rollback
+    // fails.
     const install = tmp("gt-install-");
     process.env.COMFYUI_PATH = install;
     const { GenerationTracker } = await import("../../services/generation-tracker.js");
     const t = new GenerationTracker();
-    const expected = join(install, "comfyui-mcp", "generations.db");
-    expect(existsSync(expected)).toBe(true);
-    t.close();
+    try {
+      expect(existsSync(join(install, "comfyui-mcp", "generations.db"))).toBe(false);
+      // …and nothing of ours is anywhere under the install at all.
+      expect(existsSync(join(install, "comfyui-mcp"))).toBe(false);
+    } finally {
+      t.close();
+    }
+  });
+
+  it("MOVES a legacy in-tree DB out, with its -wal and -shm", async () => {
+    // Existing installs have real history at the old path. Changing where we look
+    // without bringing it along would silently orphan it — the tracker comes up
+    // empty and every past generation looks like it never happened. The -wal has
+    // to travel too: a .db carried across without it loses every transaction that
+    // had not been checkpointed.
+    const install = tmp("gt-legacy-");
+    // Own data dir: the instance slug (host+port) is the same for every test here,
+    // so a sibling test's database would otherwise already occupy the target and
+    // the migration would correctly refuse to clobber it.
+    process.env.COMFYUI_MCP_DATA_DIR = tmp("gt-target-");
+    process.env.COMFYUI_PATH = install;
+    const legacyDir = join(install, "comfyui-mcp");
+    mkdirSync(legacyDir, { recursive: true });
+
+    const { GenerationTracker } = await import("../../services/generation-tracker.js");
+    // A REAL database at the legacy path — a text fixture would be moved
+    // correctly and then rejected by SQLite, which tests the fixture rather than
+    // the migration.
+    const legacy = new GenerationTracker(join(legacyDir, "generations.db"));
+    legacy.close();
+    expect(existsSync(join(legacyDir, "generations.db"))).toBe(true);
+    // A clean close CHECKPOINTS the -wal away, so one has to be put back by hand
+    // or this test cannot tell a migration that carries it from one that drops
+    // it. Dropping it is the case that matters: a .db moved without its -wal
+    // loses every transaction that had not been checkpointed — silent data loss
+    // dressed as a successful migration.
+    writeFileSync(join(legacyDir, "generations.db-wal"), "pending-wal");
+    writeFileSync(join(legacyDir, "generations.db-shm"), "shm");
+
+    const targetDb = join(
+      process.env.COMFYUI_MCP_DATA_DIR as string,
+      "instances",
+      "localhost_8188",
+      "generations.db",
+    );
+
+    const t = new GenerationTracker();
+    try {
+      // Gone from the install…
+      expect(existsSync(join(legacyDir, "generations.db"))).toBe(false);
+      expect(existsSync(join(legacyDir, "generations.db-wal"))).toBe(false);
+      expect(existsSync(join(legacyDir, "generations.db-shm"))).toBe(false);
+      // …and the -wal ARRIVED, not merely vanished.
+      expect(existsSync(`${targetDb}-wal`)).toBe(true);
+    } finally {
+      t.close();
+    }
+  });
+
+  it("does NOT clobber an existing new-location DB with a legacy one", async () => {
+    // Both present. The new one is authoritative and may already have been
+    // written to this session; overwriting either destroys history. Leave the
+    // legacy file alone and say where it is.
+    const install = tmp("gt-both-");
+    // Own data dir: the instance slug (host+port) is the same for every test here,
+    // so a sibling test's database would otherwise already occupy the target and
+    // the migration would correctly refuse to clobber it.
+    process.env.COMFYUI_MCP_DATA_DIR = tmp("gt-target-");
+    process.env.COMFYUI_PATH = install;
+    const legacyDir = join(install, "comfyui-mcp");
+    mkdirSync(legacyDir, { recursive: true });
+
+    const { GenerationTracker } = await import("../../services/generation-tracker.js");
+    // ORDER MATTERS: the new-location DB must exist BEFORE the legacy one, or the
+    // first construction simply migrates it and there is nothing to clobber. (My
+    // first attempt had these reversed and the test proved nothing.)
+    const first = new GenerationTracker();
+    first.close();
+    const legacy = new GenerationTracker(join(legacyDir, "generations.db"));
+    legacy.close();
+
+    const second = new GenerationTracker();
+    try {
+      // Both exist, so the legacy one is left exactly where it is — moving it
+      // would overwrite history the new location may already hold.
+      expect(existsSync(join(legacyDir, "generations.db"))).toBe(true);
+    } finally {
+      second.close();
+    }
   });
 });

--- a/src/services/generation-tracker.ts
+++ b/src/services/generation-tracker.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { join } from "node:path";
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import BetterSqlite3 from "better-sqlite3";
 import type Database from "better-sqlite3";
@@ -145,6 +145,13 @@ export class GenerationTracker {
     const dir = join(resolvedPath, "..");
     mkdirSync(dir, { recursive: true });
 
+    // Existing installs have real generation history at the OLD in-tree path.
+    // Moving where we look without bringing it along would silently orphan it —
+    // the tracker would come up empty and every past generation would look like
+    // it never happened. Only when the caller did not name a path: an explicit
+    // `dbPath` is the caller's business.
+    if (!dbPath) this.migrateLegacyInTreeDb(resolvedPath);
+
     this.db = new BetterSqlite3(resolvedPath);
     this.db.pragma("journal_mode = WAL");
     this.db.pragma("foreign_keys = ON");
@@ -155,12 +162,77 @@ export class GenerationTracker {
     logger.info(`Generation tracker DB: ${resolvedPath}`);
   }
 
-  private defaultDbPath(): string {
-    if (config.comfyuiPath) {
-      return join(config.comfyuiPath, "comfyui-mcp", "generations.db");
+  /**
+   * One-time move of the pre-#872 database out of the ComfyUI git tree.
+   *
+   * WAL means THREE files (`.db`, `-wal`, `-shm`) and all of them have to travel
+   * together: a `.db` carried across without its `-wal` loses every transaction
+   * that had not been checkpointed, which is silent data loss dressed as a
+   * successful migration.
+   *
+   * Best-effort by design. This runs at construction, and failing to move an old
+   * database is not a reason to refuse to track new generations — but it IS a
+   * reason to say so loudly, because the alternative is a user quietly wondering
+   * where their history went.
+   */
+  private migrateLegacyInTreeDb(target: string): void {
+    if (!config.comfyuiPath) return;
+    const legacy = join(config.comfyuiPath, "comfyui-mcp", "generations.db");
+    if (legacy === target || !existsSync(legacy)) return;
+
+    if (existsSync(target)) {
+      // Both exist. The new one is authoritative — this process may already have
+      // written to it — and overwriting either would destroy history. Say where
+      // the old one is and leave it alone.
+      logger.warn(
+        `[generation-tracker] a legacy generation database is still at ${legacy}, inside the ` +
+          `ComfyUI install, but ${target} already exists so it was NOT moved. The legacy file ` +
+          `is not being read. Note that its presence can break ComfyUI's own git updater ` +
+          `(#872) — move or delete it once you have salvaged anything you need.`,
+      );
+      return;
     }
-    // Remote/cloud/undetected: comfyuiPath is undefined by design. Use a stable
-    // per-user data dir (override: COMFYUI_MCP_DATA_DIR) instead of littering CWD.
+
+    const suffixes = ["", "-wal", "-shm"];
+    try {
+      for (const suffix of suffixes) {
+        const from = `${legacy}${suffix}`;
+        if (existsSync(from)) renameSync(from, `${target}${suffix}`);
+      }
+      logger.info(
+        `[generation-tracker] moved the generation database out of the ComfyUI install ` +
+          `(${legacy} → ${target}). It lived inside ComfyUI's git working tree, where it could ` +
+          `break ComfyUI's updater (#872).`,
+      );
+    } catch (err) {
+      // A partial move is the dangerous outcome: the `.db` here and its `-wal`
+      // there is a corrupt pair. Report the whole state rather than a bare error.
+      logger.warn(
+        `[generation-tracker] could not move the legacy generation database out of the ComfyUI ` +
+          `install (${legacy} → ${target}): ${err instanceof Error ? err.message : String(err)}. ` +
+          `Some of the .db/-wal/-shm set may have moved and some may not — check BOTH locations ` +
+          `before deleting anything, and keep the .db together with its -wal.`,
+      );
+    }
+  }
+
+  private defaultDbPath(): string {
+    // NEVER inside the ComfyUI install (#872). This used to return
+    // `<comfyuiPath>/comfyui-mcp/generations.db` for every local install, which
+    // put a live WAL SQLite database — three open files — inside ComfyUI's own
+    // GIT WORKING TREE, in a directory its `.gitignore` does not cover.
+    //
+    // ComfyUI's updater saves uncommitted work with `git add -A`, so it commits
+    // our database, then `git reset --hard` tries to remove it — and Windows
+    // refuses to delete a file whose handle we hold for the orchestrator's entire
+    // lifetime. The user's ComfyUI update ABORTS, and its rollback fails too,
+    // leaving them on a backup branch. Writing our state into someone else's
+    // version-controlled tree was the mistake; the file being locked is just what
+    // made it visible.
+    //
+    // The per-user data dir was already the path for remote/cloud, and its
+    // instance slug (host+port) keeps separate installs separate — which is the
+    // only thing the in-tree location was really achieving.
     const baseDir = process.env.COMFYUI_MCP_DATA_DIR?.trim() || join(homedir(), ".comfyui-mcp");
     return join(baseDir, "instances", getInstanceSlug(), "generations.db");
   }


### PR DESCRIPTION
Fixes #872.

`GenerationTracker` wrote a live WAL SQLite database — three open files — at `<comfyuiPath>/comfyui-mcp/generations.db`, **inside ComfyUI's own git working tree**, in a directory its `.gitignore` does not cover.

ComfyUI's updater saves uncommitted work with `git add -A`, so it committed our database onto a backup branch; `git reset --hard` then tried to remove it, and Windows refuses to delete a file whose handle we hold for the orchestrator's entire lifetime. **The user's ComfyUI update aborted, and its rollback failed too**, leaving them on the backup branch. Reported twice within five minutes on one machine.

The locked handle is only what made it visible. The mistake was writing our own state into a tree we do not own.

## The fix

The per-user data dir (`~/.comfyui-mcp/instances/<slug>/`) was **already** the path for remote/cloud installs, and its instance slug (host+port) keeps separate installs apart — the only thing the in-tree location was really achieving. That path is now used always.

## Migration

Existing installs have real history at the old location, so it is moved on first construction:

- **All three WAL files travel together.** A `.db` carried across without its `-wal` loses every transaction that had not been checkpointed — silent data loss dressed as a successful migration.
- **An existing database at the new location is never clobbered.** The legacy file is left where it is and its path reported, with the note that its presence can break ComfyUI's updater.
- **A failed move says so**, and says that part of the set may have moved — a `.db` here and its `-wal` there is a corrupt pair.

## On the tests

The existing test asserted the in-tree placement as correct — *"local install: DB stays inside the install's comfyui-mcp dir (unchanged)"*. It now asserts the opposite, plus that nothing of ours lands anywhere under the install.

**Three mutations, each caught by exactly the intended test.** The `-wal` case needed the file recreated by hand first: a clean SQLite close checkpoints it away, so without that the test could not distinguish a migration that carries it from one that drops it.

Full suite: 6006 passing. Control bytes 0, no git-binary files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)