### PR TITLE
direct tools/call answers a retired name with a bare 404, not the ledger redirect — blocks the 0.50.0 flip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@comfyorg/sdk": "^0.1.5",
-        "@modelcontextprotocol/sdk": "^1.12.1",
+        "@modelcontextprotocol/sdk": "~1.29.0",
         "@stable-canvas/comfyui-client": "^1.5.9",
         "better-sqlite3": "^12.6.2",
         "dotenv": "^16.4.7",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@comfyorg/sdk": "^0.1.5",
-    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@modelcontextprotocol/sdk": "~1.29.0",
     "@stable-canvas/comfyui-client": "^1.5.9",
     "better-sqlite3": "^12.6.2",
     "dotenv": "^16.4.7",

--- a/src/__tests__/tools/registry-surface.test.ts
+++ b/src/__tests__/tools/registry-surface.test.ts
@@ -28,15 +28,21 @@ import { MAX_TOOLS, TOOL_NAMES } from "../../tools/vocabulary.js";
  */
 describe("registered tool surface", () => {
   let names: string[];
+  let served: string[];
   const saved: Record<string, string | undefined> = {};
 
   beforeAll(async () => {
-    for (const key of ["COMFYUI_WORKFLOWS_DIR", "COMFYUI_MCP_TOOL_MODE"]) {
+    for (const key of ["COMFYUI_WORKFLOWS_DIR", "COMFYUI_MCP_TOOL_MODE", "COMFYUI_MCP_NO_FACADE"]) {
       saved[key] = process.env[key];
     }
     process.env.COMFYUI_WORKFLOWS_DIR = await mkdtemp(join(tmpdir(), "comfyui-mcp-surface-"));
     delete process.env.COMFYUI_MCP_TOOL_MODE;
+    // The served-surface assertions below are about the DEFAULT full-mode surface,
+    // which layers the facade. `=1` in a dev shell would drop the three meta-tools and
+    // fail those with an off-by-three nobody would guess the cause of.
+    delete process.env.COMFYUI_MCP_NO_FACADE;
     names = await listRegisteredToolNames();
+    served = await listRegisteredToolNames("served");
   });
 
   afterAll(() => {
@@ -78,6 +84,38 @@ describe("registered tool surface", () => {
   // runtime. That gap is the point of Phase 4, not an oversight here.
   it(`stays within the ${MAX_TOOLS}-tool budget`, () => {
     expect(names.length).toBeLessThanOrEqual(MAX_TOOLS);
+  });
+
+  // What a full-mode client is OFFERED is not the ledger — it is the ledger plus the
+  // three facade meta-tools layered on for reconnect resilience (#616,
+  // registerFullTools). `call_tool` / `list_tools` / `describe_tool` are in no ledger
+  // and no baseline by design (they are the meta-surface, not capabilities), so
+  // full-mode `tools/list` returns MAX_TOOLS + 3 while every gate in this repo counts
+  // MAX_TOOLS. That off-by-three is exactly the kind of thing the 0.50.0 flip (#726)
+  // has to assert against, and it was previously asserted nowhere: every surface test
+  // above stops at registerAllTools and never sees the facade.
+  //
+  // Expressed against MAX_TOOLS rather than today's number so it survives each
+  // consolidation slice landing — only the "+ 3" is the claim being pinned.
+  const FACADE = ["list_tools", "describe_tool", "call_tool"] as const;
+  it(`serves exactly MAX_TOOLS + ${FACADE.length} tools in full mode`, () => {
+    expect(served.length).toBe(MAX_TOOLS + FACADE.length);
+  });
+
+  // Separate from the count, because a count alone would still pass if the facade
+  // vanished and three ledger names appeared twice, or if a rename made one of them
+  // something else. This says WHICH three the surplus is.
+  it("adds exactly the three facade meta-tools over the ledger surface", () => {
+    const ledger = new Set<string>(TOOL_NAMES);
+    expect(served.filter((n) => !ledger.has(n)).sort()).toEqual([...FACADE].sort());
+  });
+
+  // The direction that matters for the ledger gate: layering the facade must not DROP
+  // or reorder a ledger tool. Without this, "served = ledger + 3" would also hold if
+  // the facade replaced three ledger names with itself.
+  it("serves every ledger tool, in ledger order, alongside the facade", () => {
+    const facade = new Set<string>(FACADE);
+    expect(served.filter((n) => !facade.has(n))).toEqual([...TOOL_NAMES]);
   });
 
   // A duplicate in the ledger makes the set comparison above silently weaker

--- a/src/__tests__/tools/retired-redirect.test.ts
+++ b/src/__tests__/tools/retired-redirect.test.ts
@@ -1,0 +1,370 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  RetiredRedirectUnavailableError,
+  installRetiredNameRedirect,
+  tryInstallRetiredNameRedirect,
+} from "../../tools/retired-redirect.js";
+import { DEAD_NAMES, retiredToolMessage } from "../../tools/vocabulary.js";
+import { logger } from "../../utils/logger.js";
+
+/**
+ * Two things are under test here and they fail for different reasons, so keep them
+ * apart when reading:
+ *
+ *  1. BEHAVIOUR — a retired name gets the ledger redirect on the DIRECT `tools/call`
+ *     path, and nothing else about dispatch changes.
+ *  2. THE INTERCEPTION ITSELF — the wrapper is genuinely installed where the SDK
+ *     dispatches from. Group 1 alone is not enough: the SDK answers an unregistered
+ *     name with `{isError: true, content:[{text: "Tool X not found"}]}`, so a lazy
+ *     assertion (`isError === true`, or a match on /not found/) passes with the whole
+ *     wrapper removed. Group 2 exists because the capture reads two PRIVATE fields of
+ *     @modelcontextprotocol/sdk: the failure mode we cannot afford is the wrapper
+ *     silently becoming a no-op on an SDK bump, with CI green and every retired name
+ *     back to a bare 404. package.json caps the SDK at the verified minor so the bump
+ *     is always a deliberate edit; these tests are what that edit has to survive.
+ */
+
+/**
+ * A real retired name, taken FROM the ledger rather than spelled out.
+ *
+ * Two reasons, and the second is the load-bearing one:
+ *
+ *  1. A literal would rot. DEAD_NAMES is append-only, so the first entry is stable, but
+ *     nothing here should depend on WHICH name that is.
+ *  2. A hard-coded retired name in `src/` is itself a dead-name-gate violation
+ *     (scripts/check-tool-vocabulary.mts fails CI on every live mention), and the fix
+ *     for that is a per-occurrence `allowedIn` exemption in vocabulary.ts pinned to a
+ *     substring of this line. Earning three exemptions so a test can say a string it
+ *     can equally well read from the ledger is how exemption lists grow until they stop
+ *     meaning anything. Deriving needs none.
+ *
+ * The expected MESSAGE is derived the same way — via `retiredToolMessage` — so the
+ * wording lives only in vocabulary.ts and this file asserts DELIVERY, not prose.
+ *
+ * The `??` is not defensive noise: `DEAD_NAMES[0]!.name` would throw at MODULE LOAD on
+ * an empty ledger, which takes the premise assertion below down with it and reports a
+ * TypeError instead of the actual cause. The placeholder lets that assertion run and
+ * say what happened.
+ */
+const RETIRED = DEAD_NAMES[0]?.name ?? "__ledger_is_empty__";
+
+function toolResultText(result: unknown): string {
+  const content = (result as { content?: Array<{ type: string; text?: string }> }).content ?? [];
+  return content
+    .filter((c) => c.type === "text")
+    .map((c) => c.text ?? "")
+    .join("\n");
+}
+
+/** A tiny REAL McpServer: real SDK registration, real dispatch, no ComfyUI. */
+function makeServer(register?: (server: McpServer) => void): McpServer {
+  const server = new McpServer({ name: "retired-redirect-test", version: "0.0.0" });
+  server.tool("echo", "Echo a string.", { value: z.string().describe("Anything.") }, async (args) => ({
+    content: [{ type: "text" as const, text: `echo:${args.value}` }],
+  }));
+  register?.(server);
+  return server;
+}
+
+async function connect(server: McpServer): Promise<Client> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "retired-redirect-test-client", version: "0.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+/** Server + install + connected client, the shape most behaviour tests want. */
+async function connectedWithRedirect(register?: (server: McpServer) => void): Promise<Client> {
+  const server = makeServer(register);
+  await installRetiredNameRedirect(server);
+  return connect(server);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("the ledger this file reads from", () => {
+  // Every test below is meaningless against an empty ledger — and would pass, because
+  // "no retired name redirects" is vacuously true. Assert the premise so an emptied
+  // DEAD_NAMES fails HERE, saying what actually happened, rather than turning the whole
+  // file green.
+  it("holds at least one retired name, with a replacement to redirect to", () => {
+    expect(
+      DEAD_NAMES.length,
+      "DEAD_NAMES is APPEND-ONLY history; emptying it is the documented ratchet bypass.",
+    ).toBeGreaterThan(0);
+    expect(retiredToolMessage(RETIRED)).toMatch(/Call \S+ .*instead\./);
+  });
+});
+
+describe("direct tools/call serves the retirement ledger", () => {
+  it("answers a retired name with its ledger redirect instead of a bare 404", async () => {
+    const client = await connectedWithRedirect();
+    const result = await client.callTool({ name: RETIRED, arguments: {} });
+    const text = toolResultText(result);
+
+    // Compared against the ledger's own rendering, so the wording lives in exactly one
+    // place (vocabulary.ts) and this file cannot drift from it. What this asserts is
+    // DELIVERY: that the message reaches a direct caller at all.
+    expect(text).toBe(retiredToolMessage(RETIRED));
+    // …and that what got delivered is actually rule 6's shape — which version removed
+    // it AND what to call instead. A redirect naming no replacement is still a dead
+    // end, and the equality above would happily pass for one.
+    expect(text).toContain("removed in");
+    expect(text).toMatch(/Call \S+ \(action:"\w+"\) instead\./);
+    expect(result.isError).toBe(true);
+  });
+
+  it("recognises the namespaced form MCP clients actually send", async () => {
+    // Clients that namespace tools send `mcp__comfyui__<tool>` rather than the bare
+    // name; findDeadName accepts that prefix, and this proves the wrapper hands it the
+    // raw wire name rather than something it pre-stripped or rejected.
+    const client = await connectedWithRedirect();
+    const namespaced = `mcp__comfyui__${RETIRED}`;
+    expect(toolResultText(await client.callTool({ name: namespaced, arguments: {} }))).toBe(
+      retiredToolMessage(namespaced),
+    );
+  });
+
+  it("leaves a genuinely unknown name with the SDK's own error", async () => {
+    // The whole point of consulting the ledger rather than answering every miss with a
+    // redirect: a made-up name is NOT a retired name and must not claim to be. A model
+    // told "totally_made_up_xyz was removed in 0.49.0" would go looking for a
+    // replacement that never existed.
+    const client = await connectedWithRedirect();
+    const text = toolResultText(await client.callTool({ name: "totally_made_up_xyz", arguments: {} }));
+    expect(text).toContain("Tool totally_made_up_xyz not found");
+    expect(text).not.toContain("removed in");
+  });
+
+  it("still dispatches a real tool", async () => {
+    const client = await connectedWithRedirect();
+    const result = await client.callTool({ name: "echo", arguments: { value: "hi" } });
+    expect(toolResultText(result)).toBe("echo:hi");
+    expect(result.isError ?? false).toBe(false);
+  });
+
+  it("lets a REGISTERED name win over the ledger", async () => {
+    // registerAutoloadedWorkflows reserves DEAD_NAMES as well as TOOL_NAMES, so this
+    // collision cannot happen today — but that is a DIFFERENT module's invariant, and
+    // if it regresses the failure must be a tool that runs, not a live capability
+    // shadowed by a redirect that sends its caller somewhere else. Wrong answers are
+    // worse than missing ones.
+    const client = await connectedWithRedirect((server) => {
+      server.tool(RETIRED, "A live tool that happens to carry a retired name.", {}, async () => ({
+        content: [{ type: "text" as const, text: "live-tool-ran" }],
+      }));
+    });
+    const result = await client.callTool({ name: RETIRED, arguments: {} });
+    expect(toolResultText(result)).toBe("live-tool-ran");
+    expect(result.isError ?? false).toBe(false);
+  });
+
+  it("leaves argument-validation errors to the SDK", async () => {
+    const client = await connectedWithRedirect();
+    const text = toolResultText(await client.callTool({ name: "echo", arguments: { value: 42 } }));
+    expect(text).toContain("Invalid arguments for tool echo");
+    expect(text).not.toContain("removed in");
+  });
+
+  it("leaves a DISABLED tool's error to the SDK", async () => {
+    // A disabled tool stays in the registration table, so it is "registered" for our
+    // purposes and must keep the SDK's own "disabled" answer rather than being
+    // reported as unknown or retired.
+    const client = await connectedWithRedirect((server) => {
+      server.tool("parked", "Registered but switched off.", {}, async () => ({
+        content: [{ type: "text" as const, text: "never" }],
+      })).disable();
+    });
+    expect(toolResultText(await client.callTool({ name: "parked", arguments: {} }))).toContain(
+      "Tool parked disabled",
+    );
+  });
+
+  it("does not change tools/list", async () => {
+    const plain = await connect(makeServer());
+    const wrapped = await connectedWithRedirect();
+    expect((await wrapped.listTools()).tools.map((t) => t.name)).toEqual(
+      (await plain.listTools()).tools.map((t) => t.name),
+    );
+  });
+
+  it("answers concurrent calls independently", async () => {
+    // The wrapper holds no per-call state; this pins that, so a later refactor that
+    // hoists something out of the handler shows up here rather than as an occasional
+    // wrong answer under load.
+    const client = await connectedWithRedirect();
+    const [retired, real, unknown] = await Promise.all([
+      client.callTool({ name: RETIRED, arguments: {} }),
+      client.callTool({ name: "echo", arguments: { value: "concurrent" } }),
+      client.callTool({ name: "totally_made_up_xyz", arguments: {} }),
+    ]);
+    expect(toolResultText(retired)).toBe(retiredToolMessage(RETIRED));
+    expect(toolResultText(real)).toBe("echo:concurrent");
+    expect(toolResultText(unknown)).toContain("Tool totally_made_up_xyz not found");
+  });
+});
+
+describe("the interception itself", () => {
+  /**
+   * THE SDK-BUMP CANARY.
+   *
+   * Everything above tests behaviour through a client; this tests the mechanism, and
+   * it is the one that has to fail when @modelcontextprotocol/sdk moves. It runs the
+   * real install against a real McpServer, so any rename of `_requestHandlers` or
+   * `_registeredTools`, or any change to what `setRequestHandler` writes, fails HERE,
+   * on the bump's own PR, with the failed assumption named in the error.
+   */
+  it("installs against the real SDK, and the failure names what moved", async () => {
+    await expect(
+      installRetiredNameRedirect(makeServer()),
+      "The retired-name redirect could not attach to @modelcontextprotocol/sdk. If this " +
+        "started failing after an SDK upgrade, the private fields it captures have moved — " +
+        "the thrown message names which one. Do NOT delete this test or soften the install: " +
+        "without the wrapper every name retired by a consolidation slice answers with a bare " +
+        "404 instead of naming its replacement, and nothing else in CI notices.",
+    ).resolves.toBeUndefined();
+  });
+
+  it("actually replaces the entry the SDK dispatches through", async () => {
+    // The post-condition, asserted from outside. If a future SDK keeps
+    // `_requestHandlers` but routes setRequestHandler somewhere else, our wrapper is
+    // installed into a table nobody reads: every retired name 404s and NO behaviour
+    // test can tell, because the SDK's own handler is still there answering.
+    const server = makeServer();
+    const handlers = (server.server as unknown as { _requestHandlers: Map<string, unknown> })
+      ._requestHandlers;
+    const before = handlers.get("tools/call");
+    expect(typeof before).toBe("function");
+
+    await installRetiredNameRedirect(server);
+
+    const after = handlers.get("tools/call");
+    expect(typeof after).toBe("function");
+    expect(after).not.toBe(before);
+  });
+
+  it("refuses when the map holds a THIRD function that is not the wrapper", async () => {
+    // Identity with our own handler is not assertable — setRequestHandler stores its
+    // own closure around it — so "the entry changed" is all a comparison can say, and
+    // that passes for anything that is merely not the original. This is the case it
+    // waves through: an SDK that writes some OTHER function into the slot would report
+    // the redirect ACTIVE while this wrapper never runs. Only driving the installed
+    // entry and demanding the ledger's answer catches it.
+    const server = makeServer();
+    const handlers = (server.server as unknown as { _requestHandlers: Map<string, unknown> })
+      ._requestHandlers;
+    vi.spyOn(server.server, "setRequestHandler").mockImplementation(() => {
+      handlers.set("tools/call", () => Promise.resolve({ content: [], isError: true }));
+    });
+    await expect(installRetiredNameRedirect(server)).rejects.toThrow(
+      /did not serve the ledger for the retired name/,
+    );
+    await expect(installRetiredNameRedirect(server)).rejects.toThrow(
+      /Something other than this wrapper is answering tools\/call/,
+    );
+  });
+
+  it("refuses when the installed handler throws on the self-test", async () => {
+    const server = makeServer();
+    const handlers = (server.server as unknown as { _requestHandlers: Map<string, unknown> })
+      ._requestHandlers;
+    vi.spyOn(server.server, "setRequestHandler").mockImplementation(() => {
+      handlers.set("tools/call", () => {
+        throw new Error("dispatch exploded");
+      });
+    });
+    await expect(installRetiredNameRedirect(server)).rejects.toThrow(
+      /threw on a self-test call for the retired name/,
+    );
+  });
+
+  it("refuses when server.server._requestHandlers is not a Map", async () => {
+    const server = makeServer();
+    (server.server as unknown as { _requestHandlers: unknown })._requestHandlers = {};
+    await expect(installRetiredNameRedirect(server)).rejects.toThrow(
+      RetiredRedirectUnavailableError,
+    );
+    await expect(installRetiredNameRedirect(server)).rejects.toThrow(
+      /_requestHandlers is not a Map/,
+    );
+  });
+
+  it("refuses when there is no tools/call handler to wrap", async () => {
+    // Reachable by our own mistake, not only by an SDK change: the SDK installs
+    // tools/call LAZILY on the first server.tool(), so installing before any
+    // registration silently wraps nothing. The message says so instead of blaming the
+    // dependency.
+    const bare = new McpServer({ name: "no-tools", version: "0.0.0" });
+    await expect(installRetiredNameRedirect(bare)).rejects.toThrow(/no 'tools\/call' function/);
+    await expect(installRetiredNameRedirect(bare)).rejects.toThrow(
+      /install this AFTER registering tools/,
+    );
+  });
+
+  it("refuses when server._registeredTools is missing", async () => {
+    const server = makeServer();
+    delete (server as unknown as { _registeredTools?: unknown })._registeredTools;
+    await expect(installRetiredNameRedirect(server)).rejects.toThrow(
+      /_registeredTools is missing/,
+    );
+  });
+
+  it("refuses when server._registeredTools is empty despite a live tools/call handler", async () => {
+    // The decoy case: the field exists and is an object, but is not the table the SDK
+    // is filling. Proceeding would treat every name as unregistered and let the ledger
+    // shadow live tools.
+    const server = makeServer();
+    (server as unknown as { _registeredTools: unknown })._registeredTools = {};
+    await expect(installRetiredNameRedirect(server)).rejects.toThrow(/_registeredTools is empty/);
+  });
+
+  it("refuses when setRequestHandler does not land in the captured map", async () => {
+    // Simulates the silent-no-op an SDK change could cause: the install "succeeds",
+    // the wrapper exists, and nothing dispatches to it.
+    const server = makeServer();
+    vi.spyOn(server.server, "setRequestHandler").mockImplementation(() => undefined);
+    await expect(installRetiredNameRedirect(server)).rejects.toThrow(
+      /did not replace the 'tools\/call' entry/,
+    );
+    await expect(installRetiredNameRedirect(server)).rejects.toThrow(
+      /so the wrapper would never run/,
+    );
+  });
+
+  it("degrades loudly rather than throwing, and says live tools are unaffected", async () => {
+    // The production call sites use tryInstall…: refusing to BOOT to protect the
+    // quality of one error message is the worse outage. The canary above, plus the
+    // `~1.29.0` cap in package.json, are what stop a broken capture from shipping.
+    const error = vi.spyOn(logger, "error").mockImplementation(() => undefined);
+    const bare = new McpServer({ name: "no-tools", version: "0.0.0" });
+
+    await expect(tryInstallRetiredNameRedirect(bare)).resolves.toBe(false);
+    expect(error).toHaveBeenCalledTimes(1);
+    const logged = error.mock.calls[0]?.[0] ?? "";
+    expect(logged).toContain("NOT active");
+    expect(logged).toContain("Live tools are unaffected");
+    expect(logged).toContain("no 'tools/call' function");
+
+    // …and the server it declined to patch is still usable, which is the whole point
+    // of degrading: a bare 404 beats a dead server.
+    bare.tool("echo", "Echo.", { value: z.string() }, async (args) => ({
+      content: [{ type: "text" as const, text: `echo:${args.value}` }],
+    }));
+    const client = await connect(bare);
+    expect(toolResultText(await client.callTool({ name: "echo", arguments: { value: "ok" } }))).toBe(
+      "echo:ok",
+    );
+  });
+
+  it("reports success on a healthy server", async () => {
+    const error = vi.spyOn(logger, "error").mockImplementation(() => undefined);
+    await expect(tryInstallRetiredNameRedirect(makeServer())).resolves.toBe(true);
+    expect(error).not.toHaveBeenCalled();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { collectToolCatalog, registerFullTools } from "./tools/index.js";
 import { registerCompactTools } from "./tools/compact.js";
+import { tryInstallRetiredNameRedirect } from "./tools/retired-redirect.js";
 import { logger } from "./utils/logger.js";
 import { JobWatcher } from "./services/job-watcher.js";
 import { parseCliArgs, validateConnectUrl, exportExplicitToolMode, type ToolMode } from "./transport/cli.js";
@@ -146,6 +147,42 @@ async function createConfiguredServer(toolMode: ToolMode = "compact"): Promise<M
     // with COMFYUI_MCP_NO_FACADE=1.
     await registerFullTools(server);
   }
+
+  // Serve the retirement ledger on the DIRECT tools/call path too, not only through
+  // the call_tool facade — see src/tools/retired-redirect.ts. Installed here, after
+  // BOTH branches, because both need it and for different reasons:
+  //
+  //  - full mode is the one the 0.50.0 flip (#726) makes the default, where 121
+  //    retired names would otherwise answer with a bare "Tool X not found";
+  //  - compact mode advertises only the 3 meta-tools, so a client calling a retired
+  //    name DIRECTLY is exactly the stale-snapshot client the facade exists for (#616)
+  //    — it holds a cached binding for a name this surface no longer lists, and the
+  //    ledger is the only thing that can tell it where the capability went.
+  //
+  // Additive: a registered name, and any name the ledger does not know, dispatches
+  // through the SDK unchanged. Deliberately BEFORE server.connect() (the callers
+  // below connect the returned server), so no request can arrive mid-swap.
+  //
+  // The result is REPORTED rather than discarded. If it is false the server still
+  // boots (see tryInstallRetiredNameRedirect for why bricking startup is the worse
+  // failure), but "boots normally while silently answering 121 retired names with a
+  // bare 404" is exactly the shape of failure this whole change exists to remove — so
+  // it is stated on the same startup line an operator already reads to confirm the
+  // surface came up, not left as one error line among registration noise.
+  //
+  // Residual risk, stated plainly rather than papered over: nothing here can make the
+  // degraded state visible to the CALLER, because the wrapper is the only thing that
+  // could have changed what the caller sees. What actually holds the guarantee is the
+  // `~1.29.0` cap on `@modelcontextprotocol/sdk` in package.json — this is normally run
+  // as `npx comfyui-mcp`, which resolves fresh, so an open range would have let a user
+  // silently pick up internals nothing ever ran against.
+  const redirects = await tryInstallRetiredNameRedirect(server);
+  logger.info(
+    `Tool mode: ${toolMode}. Retired-name redirects on direct tools/call: ` +
+      (redirects
+        ? "active"
+        : "INACTIVE — a call to a name removed in an earlier release will 404 without naming its replacement"),
+  );
 
   server.server.setRequestHandler(ListResourcesRequestSchema, async () => ({
     resources: [],

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -77,6 +77,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { registerAllTools } from "../tools/index.js";
+import { tryInstallRetiredNameRedirect } from "../tools/retired-redirect.js";
 import { isForceRemoteFlagSet, isLoopbackHost, detectLocalComfyUIPath, setComfyuiTarget, onComfyuiTargetChanged, isTargetingLocal, isTargetingLocalOrLan, isTargetingPod, getComfyUIBaseUrl, getLocalComfyuiUrl, rescopeLocalTargetFile, getComfyUIAuthHeaders } from "../config.js";
 import {
   buildComfyuiMcpEnv,
@@ -785,10 +786,18 @@ function getCallToolClient(): Promise<Client> {
     callToolClientPromise = (async () => {
       const server = new McpServer({ name: "comfyui-mcp-calltool", version: "1.0.0" });
       await registerAllTools(server);
+      // The panel's `call_tool` bridge command dispatches through client.callTool()
+      // below, i.e. the DIRECT tools/call path — the same gap the MCP server had, and
+      // it is not new in 0.50.0: a retired name here has always come back to the panel
+      // as `error: "Tool <name> not found"` with nothing to act on. Same one-line fix.
+      const redirects = await tryInstallRetiredNameRedirect(server);
       const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
       const client = new Client({ name: "orchestrator-calltool", version: "1.0.0" });
       await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
-      logger.info("[panel-orchestrator] call_tool in-process MCP client ready");
+      logger.info(
+        `[panel-orchestrator] call_tool in-process MCP client ready ` +
+          `(retired-name redirects: ${redirects ? "active" : "INACTIVE"})`,
+      );
       return client;
     })().catch((err) => {
       callToolClientPromise = null; // allow retry on next call

--- a/src/tools/introspect.ts
+++ b/src/tools/introspect.ts
@@ -34,7 +34,24 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { registerAllTools } from "./index.js";
+import { registerAllTools, registerFullTools } from "./index.js";
+
+/**
+ * Which registration pass to introspect.
+ *
+ * `"registration"` — `registerAllTools()`: the surface the vocabulary ledger
+ * describes, one entry per `TOOL_NAMES` name. This is what the ledger gate compares
+ * against.
+ *
+ * `"served"` — `registerFullTools()`: what a full-mode client is actually OFFERED,
+ * which is the ledger surface PLUS the three facade meta-tools layered on top for
+ * reconnect resilience (#616). The two counts differ by exactly 3, and that gap is
+ * real rather than cosmetic — a client's `tools/list` returns `MAX_TOOLS + 3`, so any
+ * consumer that expects the ledger count off the wire is off by three. Kept as an
+ * explicit mode rather than a second copy of this function so the pagination and
+ * cleanup below stay in one place.
+ */
+export type ToolSurface = "registration" | "served";
 
 export interface RegisteredTool {
   name: string;
@@ -51,9 +68,12 @@ export interface RegisteredTool {
  * Follows `nextCursor` to completion: `tools/list` is a paginated request, and a
  * single-page assumption would silently under-report once the surface grows.
  */
-export async function listRegisteredTools(): Promise<RegisteredTool[]> {
+export async function listRegisteredTools(
+  surface: ToolSurface = "registration",
+): Promise<RegisteredTool[]> {
   const server = new McpServer({ name: "comfyui-mcp-introspect", version: "0.0.0" });
-  await registerAllTools(server);
+  if (surface === "served") await registerFullTools(server);
+  else await registerAllTools(server);
 
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const client = new Client({ name: "comfyui-mcp-introspect", version: "0.0.0" });
@@ -103,6 +123,6 @@ export async function listRegisteredTools(): Promise<RegisteredTool[]> {
 }
 
 /** Just the names, in registration order (which `tools/list` preserves). */
-export async function listRegisteredToolNames(): Promise<string[]> {
-  return (await listRegisteredTools()).map((t) => t.name);
+export async function listRegisteredToolNames(surface: ToolSurface = "registration"): Promise<string[]> {
+  return (await listRegisteredTools(surface)).map((t) => t.name);
 }

--- a/src/tools/retired-redirect.ts
+++ b/src/tools/retired-redirect.ts
@@ -1,0 +1,317 @@
+/**
+ * The retirement ledger, served on the DIRECT `tools/call` path.
+ *
+ * Consolidation rule 6 is that a retired tool name answers with a self-explaining
+ * redirect — "Unknown tool 'X' — removed in 0.49.0. Call Y (action:"z") instead." —
+ * rather than a bare 404. That is the whole reason retiring a high-traffic name is
+ * acceptable: the caller is told, in the error, what to call next.
+ *
+ * Before this module, `retiredToolMessage()` was wired into exactly two call paths —
+ * the `call_tool` facade (src/tools/compact.ts) and the Ollama backend's tool router
+ * (src/orchestrator/ollama-backend.ts). Nothing served it on a direct MCP
+ * `tools/call`, where the SDK's own handler answers `Tool <name> not found` and stops.
+ * Measured on 0.49.0, full mode, against a name the 0.49.0 slices had already retired:
+ *
+ *   direct tools/call        → "Tool get_workspace not found"       ← bare 404
+ *   call_tool (compact)      → the ledger redirect                  ← correct
+ *   call_tool on full (#616) → the ledger redirect                  ← correct
+ *
+ * That gap is invisible today only because compact mode is the DEFAULT, so every
+ * call goes through the facade. The 0.50.0 flip (#726) makes direct `tools/call` the
+ * default path in the same release that retires 121 names, so rule 6 would break for
+ * the entire surface at once. Hence this.
+ *
+ * ## Why this reaches into SDK internals
+ *
+ * @modelcontextprotocol/sdk offers no supported way to see or extend the `tools/call`
+ * dispatch it installs. Everything else was considered first:
+ *
+ *  - `setRequestHandler(CallToolRequestSchema, …)` BEFORE registering any tool: the
+ *    SDK's `setToolRequestHandlers()` calls `assertCanSetRequestHandler('tools/call')`
+ *    and throws if a handler already exists, so registration itself would fail.
+ *  - `fallbackRequestHandler`: only consulted when NO handler exists for a method.
+ *    `tools/call` always has one, so it is never reached.
+ *  - Registering each dead name as a real tool: they would appear in `tools/list`,
+ *    which is precisely what the consolidation removes. Registering them disabled
+ *    short-circuits with "Tool X disabled" before the handler runs.
+ *  - Wrapping the transport's `onmessage`: means fabricating JSON-RPC frames outside
+ *    the Protocol's request bookkeeping, at every connect site. Strictly worse.
+ *
+ * So we capture the handler the SDK installed and put a wrapper in front of it. The
+ * wrapper is additive: for any name that is registered, or that the ledger does not
+ * know, it delegates to the original handler with the same request object, and the
+ * SDK's behaviour — argument validation, disabled tools, task augmentation, output
+ * validation, its own "not found" for a genuinely unknown name — is untouched.
+ *
+ * ## The failure mode this module is built around
+ *
+ * `server.server._requestHandlers` and `server._registeredTools` are PRIVATE in SDK
+ * 1.29.0. If a future SDK renames or reshapes either, the natural failure is that the
+ * wrapper quietly stops intercepting — CI stays green, and every retired name silently
+ * reverts to a bare 404. A fix that can turn itself off without saying so is worse
+ * than no fix.
+ *
+ * Two things prevent it:
+ *
+ *  1. Every assumption is asserted at install time and named in the failure, including
+ *     a POST-condition: after installing, the entry the dispatcher reads must actually
+ *     be our wrapper. That is the one check that catches "setRequestHandler no longer
+ *     writes to the map we captured from", which is the silent-no-op case a
+ *     pre-condition check alone cannot see.
+ *  2. `src/__tests__/tools/retired-redirect.test.ts` runs the install against a REAL
+ *     McpServer and asserts it succeeds, so an SDK bump that breaks the capture fails
+ *     CI on the bump's own PR, naming the field that moved.
+ */
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult, ServerResult } from "@modelcontextprotocol/sdk/types.js";
+import { logger } from "../utils/logger.js";
+import { DEAD_NAMES, retiredToolMessage } from "./vocabulary.js";
+
+/** The JSON-RPC method whose dispatch we wrap. */
+const CALL_TOOL = "tools/call";
+
+/**
+ * Raised when the SDK does not look the way this interception needs it to.
+ *
+ * Carries the specific assumption that failed, because "the redirect could not be
+ * installed" is not actionable and "server.server._requestHandlers is not a Map —
+ * @modelcontextprotocol/sdk internals changed" is.
+ */
+export class RetiredRedirectUnavailableError extends Error {
+  constructor(detail: string) {
+    super(
+      `Cannot install the retired-tool-name redirect on tools/call: ${detail}. ` +
+        `This interception depends on @modelcontextprotocol/sdk internals ` +
+        `(server.server._requestHandlers, server._registeredTools), which are private. ` +
+        `package.json caps the SDK at the verified minor (~1.29.0) precisely so this ` +
+        `cannot happen by resolution alone — see src/tools/retired-redirect.ts.`,
+    );
+    this.name = "RetiredRedirectUnavailableError";
+  }
+}
+
+/** The private SDK shape we depend on, named so the checks below read as prose. */
+interface SdkShape {
+  /** Protocol._requestHandlers — the map `Protocol._onrequest` dispatches through. */
+  handlers: Map<string, (request: unknown, extra: unknown) => Promise<unknown>>;
+  /** The `tools/call` entry the SDK's `setToolRequestHandlers()` installed. */
+  original: (request: unknown, extra: unknown) => Promise<unknown>;
+  /** McpServer._registeredTools — the live registration table, keyed by tool name. */
+  registered: Record<string, unknown>;
+}
+
+function inspect(server: McpServer): SdkShape {
+  const inner = (server as unknown as { server?: unknown }).server;
+  if (!inner || typeof inner !== "object") {
+    throw new RetiredRedirectUnavailableError("server.server is missing or not an object");
+  }
+  const handlers = (inner as { _requestHandlers?: unknown })._requestHandlers;
+  if (!(handlers instanceof Map)) {
+    throw new RetiredRedirectUnavailableError(
+      `server.server._requestHandlers is ${handlers === undefined ? "missing" : "not a Map"}`,
+    );
+  }
+  const original: unknown = handlers.get(CALL_TOOL);
+  if (typeof original !== "function") {
+    // Reachable by our own mistake as well as by an SDK change: the SDK installs the
+    // tools/call handler LAZILY, on the first `server.tool()`. Calling this before any
+    // tool is registered lands here, and saying so beats blaming the dependency.
+    throw new RetiredRedirectUnavailableError(
+      `server.server._requestHandlers has no '${CALL_TOOL}' function ` +
+        `(the SDK installs it on the first tool registration — install this AFTER registering tools)`,
+    );
+  }
+  const registered = (server as unknown as { _registeredTools?: unknown })._registeredTools;
+  if (!registered || typeof registered !== "object" || Array.isArray(registered)) {
+    throw new RetiredRedirectUnavailableError(
+      `server._registeredTools is ${registered === undefined ? "missing" : "not a plain object"}`,
+    );
+  }
+  if (Object.keys(registered).length === 0) {
+    // Catches the one shape a `!registered` test cannot: the field still exists and is
+    // still an object, but is not the table the SDK is filling. Treating that decoy as
+    // the truth would mark every name unregistered and let the ledger shadow a live
+    // tool — a wrong answer rather than a missing one.
+    //
+    // The honest caveat: an empty table alongside a live tools/call handler is not
+    // strictly impossible. Registering a tool and then removing it again leaves exactly
+    // this state, because the SDK never tears the handler back down. Nothing in this
+    // repo does that, and both call sites install immediately after a registration
+    // pass — and tryInstallRetiredNameRedirect degrades rather than throwing, so even
+    // that unreachable case would cost a log line, not a startup.
+    throw new RetiredRedirectUnavailableError(
+      `server._registeredTools is empty although '${CALL_TOOL}' is already handled — ` +
+        `the registration table is not where we are looking`,
+    );
+  }
+  return {
+    handlers: handlers as SdkShape["handlers"],
+    original: original as SdkShape["original"],
+    registered: registered as Record<string, unknown>,
+  };
+}
+
+/**
+ * Put the retirement ledger in front of the SDK's `tools/call` dispatch.
+ *
+ * Call AFTER the registration pass — the SDK installs its `tools/call` handler on the
+ * first `server.tool()`, so there is nothing to capture before then — and BEFORE
+ * `server.connect()`, so no request can arrive mid-swap.
+ *
+ * Throws `RetiredRedirectUnavailableError` if any assumption about the SDK fails, or if
+ * the installed wrapper cannot be shown to actually answer. Production callers should
+ * prefer {@link tryInstallRetiredNameRedirect}, which logs instead — see its comment
+ * for why the runtime does not fail hard here.
+ *
+ * Async only because of the self-test at the end, which drives the installed handler
+ * once. Nothing is in flight yet at that point: this runs before `server.connect()`.
+ */
+export async function installRetiredNameRedirect(server: McpServer): Promise<void> {
+  const { handlers, original, registered } = inspect(server);
+
+  server.server.setRequestHandler(
+    CallToolRequestSchema,
+    async (request, extra): Promise<ServerResult> => {
+      const name = request.params.name;
+      // A REGISTERED name always wins, even against the ledger. The two sets cannot
+      // overlap today — registerAutoloadedWorkflows reserves DEAD_NAMES as well as
+      // TOOL_NAMES, so a saved workflow file whose name slugifies onto a retired tool
+      // is skipped rather than registered — but that is another module's invariant.
+      // If it ever regresses, a live tool
+      // must still run rather than be shadowed by a redirect telling its caller to go
+      // somewhere else, which is a wrong answer rather than a missing one.
+      //
+      // `hasOwnProperty` rather than a truthiness test on the value: the table is a
+      // plain object, so `registered['constructor']` is a function by inheritance and
+      // `registered['toString']` is truthy. A tool named `constructor` is a legal MCP
+      // tool name and an autoloaded `constructor.json` produces exactly that.
+      if (!Object.prototype.hasOwnProperty.call(registered, name)) {
+        const message = retiredToolMessage(name);
+        if (message) {
+          // Shaped like the SDK's own `createToolError` — a text block with
+          // `isError: true` — so a client that already handles a failed tool call
+          // handles this one identically, and reads the reason out of the same place.
+          const result: CallToolResult = {
+            isError: true,
+            content: [{ type: "text", text: message }],
+          };
+          return result;
+        }
+      }
+      // Everything else is the SDK's business, with the request object unchanged:
+      // argument validation, disabled tools, task augmentation, output-schema
+      // validation, and its own "Tool <name> not found" for a name the ledger does not
+      // know. A made-up name is NOT a retired name and must not be told it was.
+      return (await original(request, extra)) as ServerResult;
+    },
+  );
+
+  // POST-CONDITION, and the point of the whole module. `setRequestHandler` is
+  // documented to replace the handler for a method, but "replace" is only useful here
+  // if it replaces the entry in the map we captured from and that `Protocol._onrequest`
+  // dispatches through. If a future SDK routes registrations somewhere else, our
+  // wrapper would be installed into a table nobody reads: every call would still reach
+  // the SDK's handler, every retired name would 404, and nothing would say so.
+  //
+  // The cheap half — "the entry changed" — is only a smell test, and a misleading one.
+  // It passes for ANY function that is not the original, so a future SDK that writes
+  // some third thing into the slot would report the redirect as ACTIVE while this
+  // wrapper never runs. That is the same false-acceptance shape the check exists to
+  // prevent, one level up. It stays because it produces the clearest message for the
+  // likeliest failure, but it does not decide anything.
+  const installed = handlers.get(CALL_TOOL);
+  if (typeof installed !== "function" || installed === original) {
+    throw new RetiredRedirectUnavailableError(
+      `setRequestHandler did not replace the '${CALL_TOOL}' entry in server.server._requestHandlers ` +
+        `(it still holds ${installed === original ? "the SDK's original handler" : String(installed)}), ` +
+        `so the wrapper would never run`,
+    );
+  }
+
+  // What actually decides: DRIVE the installed entry and require the redirect back.
+  // Identity is not assertable — `setRequestHandler` stores its own closure around our
+  // handler, so the map never holds the function we wrote — and identity would be the
+  // weaker question anyway. This asks the only one that matters: if the dispatcher
+  // routes a retired name through what is now in that slot, does the ledger answer?
+  // Any rename, re-route, or reshape that leaves the wrapper unreachable fails HERE,
+  // whatever it did to the plumbing.
+  //
+  // The probe is side-effect-free by construction: it names a RETIRED tool that is not
+  // registered, so the only two outcomes are our redirect (pass) or the SDK's
+  // "not found" (fail). No tool handler runs either way.
+  const probe = DEAD_NAMES.find((d) => !Object.prototype.hasOwnProperty.call(registered, d.name));
+  if (!probe) {
+    // Every retired name is also a live tool — impossible while the vocabulary gate and
+    // registerAutoloadedWorkflows both hold, and it would make the whole ledger
+    // unreachable anyway. Refuse rather than skip the self-test and claim success.
+    throw new RetiredRedirectUnavailableError(
+      `no retired name is available to self-test with — all ${DEAD_NAMES.length} are also registered tools`,
+    );
+  }
+  const expected = retiredToolMessage(probe.name);
+  let answered: unknown;
+  try {
+    answered = await installed(
+      { method: CALL_TOOL, params: { name: probe.name, arguments: {} } },
+      // `extra` is never dereferenced on the redirect path — the wrapper returns before
+      // delegating — so a placeholder is honest here rather than a fake handshake.
+      {} as never,
+    );
+  } catch (err) {
+    throw new RetiredRedirectUnavailableError(
+      `the installed '${CALL_TOOL}' handler threw on a self-test call for the retired name ` +
+        `'${probe.name}': ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  const text = (answered as CallToolResult | undefined)?.content
+    ?.map((c) => (c.type === "text" ? c.text : ""))
+    .join("");
+  if (text !== expected) {
+    throw new RetiredRedirectUnavailableError(
+      `the installed '${CALL_TOOL}' handler did not serve the ledger for the retired name ` +
+        `'${probe.name}' — expected ${JSON.stringify(expected)}, got ${JSON.stringify(text)}. ` +
+        `Something other than this wrapper is answering tools/call`,
+    );
+  }
+}
+
+/**
+ * {@link installRetiredNameRedirect}, degraded to a loud log instead of a throw.
+ * Returns whether the redirect is active.
+ *
+ * Why the runtime does not fail hard: throwing here would mean the MCP server does not
+ * START — a total outage — in order to protect the QUALITY of one error message.
+ * Degrading instead restores exactly the pre-fix behaviour: retired names get the SDK's
+ * bare "Tool X not found", every live tool keeps working, and the server boots.
+ *
+ * That trade is only defensible because the SDK a user can resolve is BOUNDED. This
+ * package is normally run as `npx comfyui-mcp`, which resolves dependencies fresh —
+ * package-lock.json protects `npm ci` in CI and nothing else — so a caret range would
+ * have made "internals nothing ever ran against" the COMMON case rather than an edge
+ * one. package.json therefore caps `@modelcontextprotocol/sdk` below the first
+ * unverified minor, and raising that cap is a deliberate, reviewed edit that runs the
+ * canary in src/__tests__/tools/retired-redirect.test.ts against the new SDK. Inside
+ * the cap the install additionally SELF-TESTS on every boot (see
+ * installRetiredNameRedirect), so "active" is measured rather than assumed.
+ *
+ * What remains, said plainly: nothing here can make a degraded state visible to the
+ * CALLER, because the wrapper is the sole thing that could have changed what the caller
+ * sees. The log below and the boolean the call sites report are the only signals, and
+ * they reach an operator, not a model. That is the residual cost of not bricking
+ * startup, and it is why the cap — not the log — is what actually holds the guarantee.
+ */
+export async function tryInstallRetiredNameRedirect(server: McpServer): Promise<boolean> {
+  try {
+    await installRetiredNameRedirect(server);
+    return true;
+  } catch (err) {
+    logger.error(
+      `[tools] retired-tool-name redirects are NOT active on direct tools/call — ` +
+        `a call to a name removed in an earlier release will answer with the SDK's bare ` +
+        `"Tool <name> not found" instead of naming its replacement. Live tools are unaffected. ` +
+        (err instanceof Error ? err.message : String(err)),
+    );
+    return false;
+  }
+}

--- a/src/tools/vocabulary.ts
+++ b/src/tools/vocabulary.ts
@@ -384,6 +384,11 @@ export const DEAD_NAMES: readonly DeadName[] = [
         context: "| `get_workspace` | `workspace` with `action: \"get\"` |",
         why: "The old-name → new-form migration table on the human-facing tools guide. A community reader (#660-adjacent confusion) read the 0.49.0 consolidation as capability being REMOVED; the table exists to show the same behaviour under a new label, so the left column must spell the retired name. It is a mapping AWAY from the name, never an instruction to call it.",
       },
+      {
+        path: "src/tools/retired-redirect.ts",
+        context: '"Tool get_workspace not found"',
+        why: "A verbatim quotation of MEASURED output: the three-row table in that module's header records what each call path actually answered on 0.49.0 for an already-retired name, which is the evidence the module exists at all. Quoting the SDK's bare 404 is the opposite of instructing anyone to call the name — it is the defect being removed. Deliberately the ONLY mention left in that file: the surrounding prose was reworded to say 'a name the 0.49.0 slices had already retired', and its test file derives the name from this ledger rather than spelling it, so this exemption covers one quoted line instead of seven comments. Pinned to the quotation because a quotation is the part least likely to be reworded — and if it IS reworded the gate should fire.",
+      },
     ],
   },
   {


### PR DESCRIPTION
## Why now

Consolidation rule 6 is that every RETIRED tool name answers with a self-explaining
redirect — `Unknown tool 'X' — removed in 0.49.0. Call Y (action:"z") instead.` — rather
than a bare 404. That is what makes retiring even a high-traffic name acceptable: the
caller is told, in the error, what to call next.

`retiredToolMessage()` was wired into exactly **two** call paths: the `call_tool` facade
(`src/tools/compact.ts`) and the Ollama backend's router
(`src/orchestrator/ollama-backend.ts`). **Nothing served it on a direct MCP `tools/call`.**
There, `@modelcontextprotocol/sdk`'s own handler answers `Tool <name> not found` and stops.

Measured on `d9e8971` (full mode) against a name the 0.49.0 slices had already retired:

| path | answer |
| --- | --- |
| direct `tools/call` | `MCP error -32602: Tool <name> not found` — **bare 404, rule 6 broken** |
| `call_tool` (compact) | the ledger redirect — correct |
| `call_tool` on full (#616 hatch) | the ledger redirect — correct |

This is invisible today only because compact mode is the DEFAULT, so every call goes
through the facade. **The 0.50.0 flip (#726) makes direct `tools/call` the default path in
the same release that retires 121 names**, so rule 6 would break for the whole surface at
once. Landing this first means every slice's retirements are covered on both paths from
day one. It touches no tool family, so it does not collide with the slice PRs.

## What it does

`src/tools/retired-redirect.ts` captures the `tools/call` handler the SDK installed and
puts a wrapper in front of it. A name that is (a) absent from the SDK's registration table
and (b) present in `DEAD_NAMES` gets the ledger message; **everything else delegates to
the original handler with the request unchanged.**

Installed at the two choke points that serve a direct `tools/call`:

- `createConfiguredServer()` (`src/index.ts`) — after BOTH branches. Full mode is what the
  flip makes default; compact mode matters too, because a client calling a retired name
  directly there is exactly the stale-snapshot client the facade exists for (#616).
- `getCallToolClient()` (`src/orchestrator/index.ts`) — the panel's `call_tool` bridge
  dispatches through `client.callTool()`, i.e. the same direct path. Same gap, never
  covered by the facade, and **not new in 0.50.0**: a retired name has always come back to
  the panel as `error: "Tool <name> not found"`.

### A/B on the real 154-tool surface

With and without the wrapper, **exactly one line differs**:

```
              WITHOUT                                    WITH
RETIRED   Tool get_workspace not found     ->  Unknown tool '…' — removed in 0.49.0. Call workspace (action:"get") instead.
UNKNOWN   Tool totally_made_up_xyz not found            (identical)
REAL-OK   results: [1] 6*7 => 42                        (identical)
BAD-ARGS  Input validation error: …                     (identical)
NOARGS    Input validation error: …                     (identical)
PROTO     Tool __proto__ disabled                       (identical)
CTOR      Tool constructor disabled                     (identical)
EMPTY     Tool not found                                (identical)
```

A genuinely made-up name keeps the SDK's own error. A model told
`totally_made_up_xyz was removed in 0.49.0` would go hunting for a replacement that never
existed, so the ledger is consulted rather than every miss being answered with a redirect.

## The crux: this reads two PRIVATE SDK fields

`server.server._requestHandlers` and `server._registeredTools`. There is no public API for
this — `setRequestHandler` before registration trips the SDK's own
`assertCanSetRequestHandler`; `fallbackRequestHandler` is only consulted when no handler
exists; registering dead names as tools puts them back in `tools/list`; wrapping
`transport.onmessage` means fabricating JSON-RPC outside the Protocol's bookkeeping. All
four are written down in the module header with why they were rejected.

The failure we cannot afford is that a future SDK renames one and the wrapper **quietly**
stops intercepting — CI green, every retired name back to a bare 404. Three things stop it:

1. **Pre-conditions**, each asserted at install time and named in the failure message.
2. **A FUNCTIONAL post-condition.** Identity is not assertable (`setRequestHandler` stores
   its own closure, so the map never holds the function we wrote), and `!== original`
   would pass for any third function an SDK might write into the slot. So after
   installing, the code **drives** the entry in the dispatch map with a synthesized
   `tools/call` for a retired, unregistered name and requires the ledger's exact message
   back. Any rename, re-route or reshape that leaves the wrapper unreachable fails there,
   whatever it did to the plumbing. The probe is side-effect-free by construction: the two
   possible outcomes are our redirect (pass) or the SDK's "not found" (fail); no tool
   handler runs either way.
3. **A canary test** running the real install against a real `McpServer`. Simulating a
   field rename fails 18 of that file's 21 tests, the canary among them, with the moved
   field named.

**Throw vs log.** Production calls a log-and-degrade variant and reports the result on the
startup line. Refusing to BOOT in order to protect the quality of one error message is the
worse outage — degrading restores exactly today's shipped behaviour. That is only
defensible if the SDK a user can resolve is BOUNDED, and it was not: this is normally run
as `npx comfyui-mcp`, which resolves fresh (package-lock protects `npm ci` and nothing
else), so a caret range made "internals nothing ever ran against" the COMMON case. So
`package.json` now caps `@modelcontextprotocol/sdk` at `~1.29.0` (was `^1.12.1`).
`npm install` resolves 1.29.0 unchanged; the lockfile delta is only the range string;
`@anthropic-ai/claude-agent-sdk` declares `^1.29.0` and still dedupes onto the same copy.

## Also: the served surface is `MAX_TOOLS + 3`

The three facade names (`call_tool`, `list_tools`, `describe_tool`) live in no ledger and
no baseline, so full-mode `tools/list` returns 157 against a `MAX_TOOLS` of 154 at the time of measurement. Nothing
asserted that before — every surface test stopped at `registerAllTools` and never saw the
facade. `registry-surface.test.ts` now pins it three ways (the count, WHICH three the
surplus is, and that no ledger tool is dropped or reordered), expressed against
`MAX_TOOLS` so it survives every slice landing.

## Adversarial gate — 3 rounds, both findings fixed

| # | Finding | Disposition |
| --- | --- | --- |
| P1 | Fail-open leaves the guarantee unenforced for any SDK resolved through the caret range | **FIXED** — `~1.29.0` cap; the boolean is reported at both call sites instead of discarded |
| P2 | The post-condition accepted any function that was not the original, so a third function would report "active" while the wrapper never ran | **FIXED** — replaced with the functional self-test above (the reviewer's proposed identity check is not implementable; the SDK stores its own closure) |

Round 3 verdict: **SHIP**, no P0–P3 findings.

## Verification

- Full suite green post-rebase onto slice 8 (286 files / 6059 tests). `origin/main` baseline has one unrelated
  flaky `download-cache` failure this branch does not.
- `npm run lint`, `check:vocabulary`, `vocab:export --check` all pass.
- Every test in the new file mutation-verified: 21 mutations, each producing exactly the
  expected specific failure. Notably, deleting the whole wrapper fails 5 tests — and the
  real-dispatch / validation / disabled / unknown-name tests all still PASS, which is why
  the mechanism tests exist.
- Ratchet artifacts untouched: no change to `TOOL_NAMES`, `MAX_TOOLS`, `BASELINE_SHA256`,
  `docs/design/tool-surface.txt`, or `docs/design/tool-vocabulary.json`. The only
  `vocabulary.ts` change is one per-occurrence `allowedIn` entry for a verbatim quotation
  of measured output.

## Known adjacent gap, deliberately NOT fixed

The panel's own MCP HTTP surface (`registerPanelTools`, `src/orchestrator/panel-mcp-http.ts`)
has the same direct-`tools/call` gap, and the ledger holds two retired `panel_*` names.
It is left alone on purpose: `DEAD_NAMES` is one ledger spanning both surfaces, so
installing there would answer a retired CORE name by naming a core replacement that the
panel surface does not serve — trading a bare 404 for a redirect into a second dead end.
Fixing it properly needs a per-surface ledger view, which is its own change.

Unblocks the #726 flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
