### PR TITLE
fix(vocabulary): teach the dead-name gate the difference between a dead TOOL and a live ACTION

### DIFF
--- a/scripts/check-tool-vocabulary.mts
+++ b/scripts/check-tool-vocabulary.mts
@@ -48,6 +48,7 @@ import {
   retirementBaseline,
   TOOL_NAMES,
   baselineIntegrity,
+  actionLiteralSpans,
   deadNameRe,
   panelBaselineIntegrity,
   rotMentions,
@@ -261,6 +262,8 @@ const hits: Hit[] = [];
 const splitHits: Array<{ path: string; line: number; text: string }> = [];
 /** `${name}\u0000${path}` → the lines it was seen on, to expire stale exceptions. */
 const seenIn = new Map<string, string[]>();
+/** Same key, for `implementedIn` paths that actually licensed an action literal. */
+const implementedUsed = new Set<string>();
 const seenKey = (name: string, path: string) => `${name}\u0000${path}`;
 
 for (const path of files) {
@@ -307,7 +310,11 @@ for (const path of files) {
       // point, it needs no ledger entry (it is self-derived), and a line carrying
       // BOTH an allowedIn-covered mention and a replacement form still fails the
       // occurrence count below — fail-closed on the ambiguous case.
-      if (rotMentions(dead, text).length === 0) continue;
+      // `path` enables the `implementedIn` rule for this file — see rotMentions.
+      if (dead.implementedIn?.includes(path) && actionLiteralSpans(dead.name, text).length > 0) {
+        implementedUsed.add(seenKey(dead.name, path));
+      }
+      if (rotMentions(dead, text, path).length === 0) continue;
       const key = seenKey(dead.name, path);
       if (!seenIn.has(key)) seenIn.set(key, []);
       seenIn.get(key)!.push(text);
@@ -422,6 +429,29 @@ if (stale.length > 0) {
       "",
       "Delete the exception. Leaving it means a future reference to that file is",
       "pre-approved by an entry nobody re-reviewed.",
+    ].join("\n"),
+  );
+}
+
+// Same expiry rule for `implementedIn`, and for the same reason: a path that no
+// longer spells the name as a quoted action literal has stopped meaning anything,
+// and leaving it there pre-approves whatever lands in that file next. This is the
+// half of the exemption that is scoped by PATH rather than by syntax, so it is the
+// half that can rot.
+const staleImplemented = DEAD_NAMES.flatMap((d) =>
+  (d.implementedIn ?? [])
+    .filter((p) => !implementedUsed.has(seenKey(d.name, p)))
+    .map((p) => `  ${d.name} → ${p}`),
+);
+if (staleImplemented.length > 0) {
+  errors.push(
+    [
+      `${staleImplemented.length} stale implementedIn path(s) — no quoted action literal remains:`,
+      "",
+      ...staleImplemented,
+      "",
+      "Either the file no longer implements that action, or the path is wrong. Delete",
+      "it: an implementedIn path is an exception, and exceptions expire.",
     ].join("\n"),
   );
 }

--- a/scripts/check-tool-vocabulary.mts
+++ b/scripts/check-tool-vocabulary.mts
@@ -50,6 +50,7 @@ import {
   baselineIntegrity,
   deadNameRe,
   panelBaselineIntegrity,
+  rotMentions,
   type DeadName,
 } from "../src/tools/vocabulary.js";
 import { buildPanelToolDefs } from "../src/orchestrator/panel-tools.js";
@@ -292,6 +293,21 @@ for (const path of files) {
     const re = deadNameRe(dead.name);
     for (const [i, text] of lines.entries()) {
       if (!re.test(text)) continue;
+      // A mention sitting inside a verbatim copy of this name's OWN declared
+      // replacement is the migration target, not rot — see rotMentions() in
+      // src/tools/vocabulary.ts for why that is principled rather than a loophole.
+      //
+      // Checked BEFORE `seenIn` on purpose: a replacement form is not a mention of
+      // the dead name for ANY purpose, staleness included. Recording it would let a
+      // file whose only remaining occurrences are legitimate replacement forms keep
+      // an obsolete `allowedIn` entry looking fresh — and a stale exception is a
+      // hole that opens later, which is the whole reason the expiry check exists.
+      //
+      // Also BEFORE `allowedIn`, and independent of it: this is the one new decision
+      // point, it needs no ledger entry (it is self-derived), and a line carrying
+      // BOTH an allowedIn-covered mention and a replacement form still fails the
+      // occurrence count below — fail-closed on the ambiguous case.
+      if (rotMentions(dead, text).length === 0) continue;
       const key = seenKey(dead.name, path);
       if (!seenIn.has(key)) seenIn.set(key, []);
       seenIn.get(key)!.push(text);

--- a/src/__tests__/tools/vocabulary.test.ts
+++ b/src/__tests__/tools/vocabulary.test.ts
@@ -6,9 +6,12 @@ import {
   retirementBaseline,
   TOOL_NAMES,
   baselineIntegrity,
+  deadNameMentions,
   deadNameRe,
   findDeadName,
   retiredToolMessage,
+  rotMentions,
+  type DeadName,
 } from "../../tools/vocabulary.js";
 
 /**
@@ -60,6 +63,316 @@ describe("deadNameRe", () => {
     expect(() => deadNameRe("weird.name+v2")).not.toThrow();
     expect(matches("weird.name+v2", "weird.name+v2")).toBe(true);
     expect(matches("weird.name+v2", "weirdXnameXv2")).toBe(false);
+  });
+});
+
+/**
+ * The replacement-form exemption — the one place the dead-name gate is allowed to
+ * see its own name and stay quiet.
+ *
+ * Every test here is about the SAME question asked from a different angle: can
+ * this exemption be used to launder a live instruction? Because the ratchet is
+ * the whole migration's safety net, and a too-broad exemption is the same class
+ * of harm as deleting a baseline line — just less visible in a diff. The
+ * mutation-check that matters is therefore not "does the exemption work" but
+ * "does a WIDER exemption fail a test": ignore which tool the replacement names,
+ * or exempt the line rather than the span, and one of these must go red.
+ */
+describe("rotMentions", () => {
+  /**
+   * The brief's worked example. `clear_vram` is the OOM panic button and folds
+   * into get_system_stats under its own name, so the migration target the prose
+   * sweep is required to write contains the retired token verbatim.
+   */
+  const clearVram: DeadName = {
+    name: "clear_vram",
+    since: "0.50.0",
+    replacement: 'get_system_stats (action:"clear_vram")',
+  };
+  const rot = (dead: DeadName, line: string) => rotMentions(dead, line);
+
+  it("exempts a mention inside the name's own declared replacement", () => {
+    expect(rot(clearVram, 'get_system_stats (action:"clear_vram")')).toEqual([]);
+    expect(rot(clearVram, 'Call `get_system_stats (action:"clear_vram")` to free VRAM.')).toEqual(
+      [],
+    );
+  });
+
+  it("still reports a bare mention", () => {
+    expect(rot(clearVram, "clear_vram")).toHaveLength(1);
+    expect(rot(clearVram, "| `clear_vram` | frees VRAM |")).toHaveLength(1);
+  });
+
+  it("still reports prose that instructs a model to call it", () => {
+    expect(rot(clearVram, "call clear_vram to free VRAM")).toHaveLength(1);
+  });
+
+  // The exemption is per-name and SELF-derived: it is the ledger's own output for
+  // THIS name, not "any tool with a matching action". A mention pointing at the
+  // wrong migration target sends the model somewhere that will not answer, which
+  // is a defect worth catching rather than one to wave through.
+  it("still reports a mention that names the WRONG replacement tool", () => {
+    expect(rot(clearVram, 'some_other_tool (action:"clear_vram")')).toHaveLength(1);
+    expect(rot(clearVram, 'queue (action:"clear_vram")')).toHaveLength(1);
+  });
+
+  /**
+   * The wrong tool CAN be a superstring of the right one, and a plain substring
+   * search does not notice: `not_get_system_stats (action:"clear_vram")` contains
+   * the declared replacement starting at index 4. The copy has to BEGIN at a token
+   * boundary, exactly as a name does — otherwise any tool whose name merely ends
+   * with the survivor's is a free pass.
+   */
+  it("still reports a wrong tool whose name merely ENDS with the right one", () => {
+    expect(rot(clearVram, 'not_get_system_stats (action:"clear_vram")')).toHaveLength(1);
+    expect(rot(clearVram, 'xget_system_stats (action:"clear_vram")')).toHaveLength(1);
+    // The mcp__<server>__ allowance must not become a hole either: only a real
+    // prefix passes, `xmcp__…` is just another identifier run.
+    expect(rot(clearVram, 'xmcp__comfyui__get_system_stats (action:"clear_vram")')).toHaveLength(1);
+  });
+
+  /**
+   * The `mcp__<server>__` allowance is where a wrong tool could sneak back in, so
+   * the server segment forbids `__`. Otherwise `[A-Za-z0-9_]+` swallows
+   * `comfyui__wrong` and the line — which reads as server `comfyui`'s tool
+   * `wrong__get_system_stats` — is exempted. `deadNameRe`'s own prefix is looser on
+   * purpose: there greediness only MATCHES more, which is fail-safe; here it would
+   * EXEMPT more, which is not.
+   */
+  it("does not let the mcp server segment swallow a second name", () => {
+    expect(
+      rot(clearVram, 'mcp__comfyui__wrong__get_system_stats (action:"clear_vram")'),
+    ).toHaveLength(1);
+    // A single underscore in the server name is ordinary and must still work.
+    expect(rot(clearVram, 'mcp__comfyui_panel__get_system_stats (action:"clear_vram")')).toEqual([]);
+  });
+
+  /**
+   * The boundary rule stops at the LEFT on purpose — a replacement names its tool
+   * at the start, so trailing text cannot change which tool is named. Pinning the
+   * asymmetry: a copy followed by more identifier characters is still the correct
+   * call form and must not be reported, or a sweep gets sent to "fix" right text.
+   */
+  it("does not require a boundary after the replacement copy", () => {
+    const trailing: DeadName = {
+      name: "clear_vram",
+      since: "0.50.0",
+      replacement: 'get_system_stats (action:"clear_vram") see docs',
+    };
+    expect(rot(trailing, `${trailing.replacement}_v2`)).toEqual([]);
+  });
+
+  // THE SUBTLEST CASE, and the one that separates a positional exemption from a
+  // line-wide one. A line-wide `text.includes(replacement)` check passes this line
+  // — and that is exactly how a live instruction launders itself by standing next
+  // to correct prose, the same laundering the allowedIn logic already had to close.
+  // Asserting the SPAN, not just the count, pins which mention survived.
+  it("reports the bare mention on a line that also carries the replacement form", () => {
+    const line = 'Use get_system_stats (action:"clear_vram"); the old clear_vram is gone.';
+    const hits = rot(clearVram, line);
+    expect(hits).toHaveLength(1);
+    expect(line.slice(hits[0]!.start, hits[0]!.end)).toBe("clear_vram");
+    // ...and it is the SECOND one — the bare instruction, not the one inside the
+    // replacement. Without this the test would pass on an implementation that
+    // exempted the wrong occurrence.
+    expect(hits[0]!.start).toBe(line.lastIndexOf("clear_vram"));
+  });
+
+  it("does not match a longer action name that merely starts with the dead name", () => {
+    expect(deadNameMentions("clear_vram", 'get_system_stats (action:"clear_vram_now")')).toEqual([]);
+    expect(rot(clearVram, 'get_system_stats (action:"clear_vram_now")')).toEqual([]);
+  });
+
+  // deadNameRe deliberately matches through an mcp__<server>__ prefix, so both
+  // directions need pinning: a prefixed replacement form is still the migration
+  // target, and a prefixed BARE name is still rot.
+  it("handles the mcp__<server>__ prefix form in both directions", () => {
+    expect(rot(clearVram, 'mcp__comfyui__get_system_stats (action:"clear_vram")')).toEqual([]);
+    expect(rot(clearVram, "mcp__comfyui__clear_vram")).toHaveLength(1);
+    // A prefixed name INSIDE the action slot is not the declared replacement.
+    expect(rot(clearVram, 'get_system_stats (action:"mcp__comfyui__clear_vram")')).toHaveLength(1);
+  });
+
+  it("exempts every copy when the replacement form repeats, and only those", () => {
+    const twice = 'get_system_stats (action:"clear_vram") get_system_stats (action:"clear_vram")';
+    expect(rot(clearVram, twice)).toEqual([]);
+    expect(rot(clearVram, `${twice} — formerly clear_vram`)).toHaveLength(1);
+  });
+
+  /**
+   * The copies above are ADJACENT; these OVERLAP, which needs the scan to advance
+   * one character at a time rather than by the replacement's length. A real call
+   * form cannot overlap itself (it starts with a tool name and ends with `)`), so
+   * this uses a deliberately self-bordering replacement. The failure it prevents is
+   * a false POSITIVE — a legitimate replacement form reported as rot, which is how
+   * a sweep gets told to "fix" text that is already correct.
+   */
+  it("finds overlapping copies of the replacement, not just adjacent ones", () => {
+    const replacement = "get_system_stats-clear_vram-get_system_stats-";
+    const bordering: DeadName = { name: "clear_vram", since: "0.50.0", replacement };
+    const line = `${replacement}clear_vram-get_system_stats-`;
+    // Sanity: two copies, and the second starts before the first one ends.
+    expect(line.indexOf(replacement)).toBe(0);
+    expect(line.indexOf(replacement, 1)).toBe(28);
+    expect(28).toBeLessThan(replacement.length);
+    expect(rot(bordering, line)).toEqual([]);
+  });
+
+  /**
+   * The replacements are full call forms, so they carry `(`, `)`, `"` and `|`.
+   * Matching them as a compiled PATTERN rather than a literal would be a silent
+   * widening: `/comfy_cli \(action:"models_list"|"models_show"\)/` alternates, so
+   * the partial form below would match its left branch and be exempted. Literal
+   * `indexOf` means the exemption covers the declared string and nothing else.
+   */
+  it("matches the replacement literally, so regex metacharacters cannot widen it", () => {
+    const multi: DeadName = {
+      name: "models_list",
+      since: "0.50.0",
+      replacement: 'comfy_cli (action:"models_list"|"models_show")',
+    };
+    expect(rot(multi, 'comfy_cli (action:"models_list"|"models_show")')).toEqual([]);
+    // A PARTIAL of the declared replacement is not the declared replacement.
+    expect(rot(multi, 'comfy_cli (action:"models_list")')).toHaveLength(1);
+  });
+
+  /**
+   * Degenerate ledger data must fail CLOSED, because `DEAD_NAMES` is
+   * hand-maintained: `"".indexOf` semantics would make an empty replacement match
+   * at every index and exempt every line, and a replacement that says nothing
+   * beyond the dead name would exempt every mention of it — blinding the gate for
+   * that name entirely, which is exactly the bypass this rule must not become.
+   */
+  it("exempts nothing for a degenerate replacement", () => {
+    const empty: DeadName = { name: "clear_vram", since: "0.50.0", replacement: "" };
+    expect(rot(empty, "call clear_vram now")).toHaveLength(1);
+    expect(rot(empty, 'get_system_stats (action:"clear_vram")')).toHaveLength(1);
+    // "call the tool that no longer exists" — no migration target, so no exemption.
+    // Punctuation, markup and PROSE do not make one: `Use` is an identifier but not
+    // a tool, so what must survive cutting the name out is the name of a tool that
+    // actually exists.
+    const useless = [
+      "clear_vram",
+      " clear_vram ",
+      "`clear_vram`",
+      "clear_vram.",
+      '"clear_vram"',
+      "Use clear_vram",
+      "call clear_vram instead",
+      // A survivor that is not a real tool — a typo in the ledger, or a name the
+      // slice forgot to register. Nothing to migrate to, so nothing is exempted.
+      'get_system_stat (action:"clear_vram")',
+    ];
+    for (const replacement of useless) {
+      const circular: DeadName = { name: "clear_vram", since: "0.50.0", replacement };
+      expect(rot(circular, replacement), replacement).toHaveLength(1);
+      expect(rot(circular, "call clear_vram now"), replacement).toHaveLength(1);
+    }
+    // ...while a replacement that DOES name another tool still works, markup and all.
+    const real: DeadName = {
+      name: "clear_vram",
+      since: "0.50.0",
+      replacement: '`get_system_stats (action:"clear_vram")`',
+    };
+    expect(rot(real, real.replacement)).toEqual([]);
+  });
+
+  /**
+   * A replacement may spell the retired name exactly ONCE — in the action slot,
+   * which is the whole reason this exemption exists. A second mention makes the
+   * ledger entry carry its own live instruction, and exempting a verbatim copy
+   * would launder that instruction into every page that quotes the ledger. Note the
+   * bare mention here is INSIDE the declared replacement, so span containment alone
+   * would exempt it; only counting the mentions in the ledger data catches it.
+   */
+  it("exempts nothing when the replacement spells the dead name more than once", () => {
+    const chatty: DeadName = {
+      name: "clear_vram",
+      since: "0.50.0",
+      replacement: 'get_system_stats (action:"clear_vram") then call clear_vram',
+    };
+    expect(rot(chatty, chatty.replacement)).toHaveLength(2);
+    expect(rot(chatty, 'get_system_stats (action:"clear_vram")')).toHaveLength(1);
+  });
+
+  /**
+   * CONTAINMENT, not overlap — the difference only shows up on a mention that
+   * STRADDLES the edge of a replacement copy, which a truncated `replacement`
+   * produces. It is contrived data on purpose: the point is that one mistyped
+   * ledger string must not be able to silence a real mention next to it, and an
+   * overlap test would let it.
+   */
+  it("does not exempt a mention that merely straddles the replacement's edge", () => {
+    const truncated: DeadName = {
+      name: "clear_vram",
+      since: "0.50.0",
+      // Pasted with a truncated tail, so a verbatim copy of it ends mid-mention.
+      replacement: 'get_system_stats (action:"clear_vram") not clear_vr',
+    };
+    const line = 'get_system_stats (action:"clear_vram") not clear_vram")';
+    // Sanity: the copy really is present and really does end inside the second
+    // mention, which is therefore overlapped but NOT contained.
+    expect(line.startsWith(truncated.replacement)).toBe(true);
+    const hits = rot(truncated, line);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.start).toBe(line.lastIndexOf("clear_vram"));
+  });
+
+  /**
+   * The live end-to-end proof. These are the slice-13 folds whose natural action
+   * name IS the retired tool name — the collision that made this change necessary.
+   *
+   * Slice 13 owns the actual fold map, so the survivors here are illustrative; what
+   * is under test is the SHAPE, which is fixed: `<tool> (action:"<dead>")`. They are
+   * nonetheless all names that are LIVE in TOOL_NAMES, because the exemption
+   * requires the replacement to name a tool that exists — an invented survivor
+   * would (correctly) not be exempted at all.
+   */
+  it("passes the slice-13 replacement forms while their bare forms still fail", () => {
+    const folds: Array<[string, string]> = [
+      ["update_all", 'update_comfyui (action:"update_all")'],
+      ["self_update", 'install_panel (action:"self_update")'],
+      ["configure_manager", 'install_custom_node (action:"configure_manager")'],
+      ["apply_manifest", 'install_workflow_dependencies (action:"apply_manifest")'],
+      ["clear_vram", 'get_system_stats (action:"clear_vram")'],
+      ["report_issue", 'health_check (action:"report_issue")'],
+      ["calculate", 'get_environment (action:"calculate")'],
+    ];
+    // The fold map is slice 13's, but "the survivor must be a real tool" is not.
+    for (const [, replacement] of folds) {
+      expect(TOOL_NAMES as readonly string[]).toContain(replacement.split(" ")[0]);
+    }
+    for (const [name, replacement] of folds) {
+      const dead: DeadName = { name, since: "0.50.0", replacement };
+      expect(rot(dead, replacement), `${name}: its own replacement must pass`).toEqual([]);
+      expect(rot(dead, `call ${name} now`), `${name}: a bare mention must fail`).toHaveLength(1);
+      expect(
+        rot(dead, `other_tool (action:"${name}")`),
+        `${name}: the wrong replacement tool must fail`,
+      ).toHaveLength(1);
+    }
+  });
+
+  // Ledger-wide, and true no matter what future slices append: the exemption can
+  // never silence a BARE mention of any dead name. If a change to rotMentions ever
+  // makes it whole-line or name-agnostic, this goes red across the whole ledger.
+  it("still reports a bare mention of every name in the real ledger", () => {
+    const silenced = DEAD_NAMES.filter(
+      (d) => rotMentions(d, `call ${d.name} now`).length !== 1,
+    ).map((d) => d.name);
+    expect(silenced).toEqual([]);
+  });
+
+  // The no-op guarantee for the majority. An entry whose replacement does not spell
+  // its own name cannot have a mention contained in a replacement copy, so its
+  // verdicts must be identical to plain deadNameRe matching — byte for byte.
+  it("is inert for entries whose replacement does not name them", () => {
+    const unaffected = DEAD_NAMES.filter((d) => !d.replacement.includes(d.name));
+    expect(unaffected.length).toBeGreaterThan(0);
+    for (const d of unaffected) {
+      const line = `${d.replacement} replaces ${d.name}, formerly mcp__comfyui__${d.name}`;
+      expect(rotMentions(d, line), d.name).toEqual(deadNameMentions(d.name, line));
+    }
   });
 });
 
@@ -126,6 +439,32 @@ describe("DEAD_NAMES ledger", () => {
 
   it("gives every dead name an actionable replacement", () => {
     expect(DEAD_NAMES.filter((d) => !d.replacement.trim()).map((d) => d.name)).toEqual([]);
+  });
+
+  /**
+   * The obligation that arrived with the replacement-form exemption. An entry whose
+   * replacement spells its own name is only usable if `rotMentions` actually
+   * exempts that replacement — and it refuses to when the replacement names no LIVE
+   * tool, e.g. a mistyped survivor (`get_system_stat`) or one the slice forgot to
+   * register. Left to CI that surfaces as an unfixable prose sweep: every mention
+   * flagged, and rewriting it to the documented form flagged too. Here it surfaces
+   * as one clear failure naming the entry.
+   *
+   * Vacuous today (no entry spells its own name) and binding from slice 13 on.
+   * Scoped to self-naming entries deliberately: an entry whose replacement does not
+   * spell its own name is never exempted anyway, which is what keeps the PANEL
+   * replacements — whose targets are not in the core TOOL_NAMES — out of scope.
+   */
+  it("makes every self-naming replacement usable (it must point at a live tool)", () => {
+    const unusable = DEAD_NAMES.filter((d) => d.replacement.includes(d.name)).filter(
+      (d) => rotMentions(d, d.replacement).length !== 0,
+    );
+    expect(
+      unusable.map((d) => `${d.name} → ${d.replacement}`),
+      "This replacement spells its own dead name but names no live tool, so the gate " +
+        "will flag the very text the prose sweep is required to write. Name the " +
+        "surviving tool exactly as it appears in TOOL_NAMES.",
+    ).toEqual([]);
   });
 
   // An exception without a reason is indistinguishable from someone silencing

--- a/src/__tests__/tools/vocabulary.test.ts
+++ b/src/__tests__/tools/vocabulary.test.ts
@@ -6,6 +6,7 @@ import {
   retirementBaseline,
   TOOL_NAMES,
   baselineIntegrity,
+  declaredActions,
   deadNameMentions,
   deadNameRe,
   findDeadName,
@@ -89,7 +90,7 @@ describe("rotMentions", () => {
     since: "0.50.0",
     replacement: 'get_system_stats (action:"clear_vram")',
   };
-  const rot = (dead: DeadName, line: string) => rotMentions(dead, line);
+  const rot = (dead: DeadName, line: string, path?: string) => rotMentions(dead, line, path);
 
   it("exempts a mention inside the name's own declared replacement", () => {
     expect(rot(clearVram, 'get_system_stats (action:"clear_vram")')).toEqual([]);
@@ -353,6 +354,227 @@ describe("rotMentions", () => {
     }
   });
 
+  /**
+   * RULE (b) — the name used as an ACTION VALUE.
+   *
+   * Slice 16 swept every mention it controlled into the exact replacement form and
+   * then classified the 84 hits that remained: 27 were prose (rule (a)) and 57 were
+   * the token used as a value or identifier, where no replacement string can wrap
+   * it. Slice 15 measured the same shape independently (77 hits). These lines say
+   * the word `action` themselves, so the rule is self-evidencing and needs no
+   * ledger entry — which is also what makes it stable across `docs:gen`, since the
+   * generated `"action": "regenerate"` is covered by the same rule as the source
+   * string it was generated from.
+   */
+  const regenerate: DeadName = {
+    name: "regenerate",
+    since: "0.50.0",
+    replacement: 'generate_image (action:"regenerate")',
+  };
+
+  it("exempts the name used as an action value, in every form the slices measured", () => {
+    const forms = [
+      '- action:"regenerate" — Re-enqueue the workflow that produced an image.',
+      '.describe(\'action:"regenerate" — max seconds to wait\')',
+      '  "action": "regenerate",',
+      "  action: 'regenerate',",
+      'c.args?.action === "regenerate"',
+      'if (args.action !== "regenerate") return;',
+      '{ action:"regenerate", asset_id: "x" }',
+    ];
+    for (const line of forms) expect(rot(regenerate, line), line).toEqual([]);
+  });
+
+  // THE CONSTRAINT THAT MATTERS MOST. Rule (b) as "the line matches action:\"N\""
+  // would exempt EVERY occurrence on the line, including a genuinely rotten one
+  // beside it. Containment means only the matched occurrence is exempt.
+  it("still reports a bare mention sharing a line with an action value", () => {
+    const line = '- action:"regenerate" — replaces the old regenerate tool; call regenerate';
+    const hits = rot(regenerate, line);
+    expect(hits).toHaveLength(2);
+    for (const h of hits) {
+      // Neither surviving hit is the one inside the action:"…" construct.
+      expect(h.start).toBeGreaterThan(line.indexOf('action:"regenerate"') + 18);
+    }
+  });
+
+  /**
+   * A tool-call form CLAIMS a tool, so it is judged by rule (a) — which exempts it
+   * only when the tool is the declared survivor. Without this exclusion, rule (b)
+   * would exempt `some_other_tool (action:"regenerate")`, breaking the wrong-tool
+   * guarantee outright.
+   */
+  it("does not let the action-value rule launder a wrong tool", () => {
+    expect(rot(regenerate, 'generate_image (action:"regenerate")')).toEqual([]);
+    for (const wrong of [
+      'some_other_tool (action:"regenerate")',
+      'queue (action:"regenerate")',
+      'not_generate_image (action:"regenerate")',
+      'generate_images (action:"regenerate")',
+    ]) {
+      expect(rot(regenerate, wrong), wrong).toHaveLength(1);
+    }
+  });
+
+  /**
+   * A wrong tool names itself just as much through `?.()`, through a comment, or
+   * with no space — so the call-form test is "an `action:` key opening ANY paren",
+   * not "an identifier immediately before the paren". The narrower shape let all
+   * three of these through.
+   */
+  it("treats every call syntax as a tool-call form, not just `<ident> (`", () => {
+    for (const wrong of [
+      'some_other_tool?.(action:"regenerate")',
+      "some_other_tool /* traced */ (action:\"regenerate\")",
+      'some_other_tool(action:"regenerate")',
+      'obj.method(action:"regenerate")',
+    ]) {
+      expect(rot(regenerate, wrong), wrong).toHaveLength(1);
+    }
+    // ...while the forms separated from a call by a quote or a brace are still
+    // action vocabulary. This is the line the paren rule must not cross.
+    expect(rot(regenerate, '.describe(\'action:"regenerate" — seconds\')')).toEqual([]);
+    expect(rot(regenerate, 'callTool({ name: "x", args: { action:"regenerate" } })')).toEqual([]);
+  });
+
+  it("does not exempt an action value for a name the replacement never declares", () => {
+    // The fold RENAMED the action (slice 9's escape hatch), so there is no
+    // collision and rule (b) must not fire for the old name.
+    const renamed: DeadName = {
+      name: "list_skills",
+      since: "0.50.0",
+      replacement: 'comfy_cli (action:"skill_list") — was list_skills',
+    };
+    expect(rot(renamed, 'action:"list_skills"')).toHaveLength(1);
+    // A DIFFERENT tool's action slot is not this name's licence either.
+    expect(rot(regenerate, 'action:"regenerate_all"')).toEqual([]); // no mention at all
+  });
+
+  /**
+   * The declaration is the `action:` CLAUSE, not any quoted token anywhere in the
+   * replacement. Here the fold renamed the action to `upscale` and the prose merely
+   * quotes the retired name — reading that as a declaration would switch rules (b)
+   * and (c) on for a name that has no action at all.
+   */
+  it("reads the action clause, not any quoted token in the replacement", () => {
+    const quoted: DeadName = {
+      name: "regenerate",
+      since: "0.50.0",
+      replacement: 'generate_image (action:"upscale") — replaces "regenerate"',
+    };
+    expect(declaredActions(quoted.replacement)).toEqual(["upscale"]);
+    expect(rot(quoted, 'action:"regenerate"')).toHaveLength(1);
+    expect(rot(quoted, '  case "regenerate":', "src/tools/generate-image.ts")).toHaveLength(1);
+  });
+
+  /**
+   * The declaration must be the call form's OWN action clause, anchored at the
+   * start of the replacement. Prose that merely spells `action:"N"` further along
+   * is not a declaration — reading it as one would switch both action rules on for
+   * a name the surviving tool has no action for, from a replacement that otherwise
+   * looks well-formed.
+   */
+  it("does not read a declaration out of prose after the call form", () => {
+    const prose: DeadName = {
+      name: "regenerate",
+      since: "0.50.0",
+      replacement: 'generate_image (mode:"fast") — old syntax action:"regenerate" is retired',
+      implementedIn: ["src/tools/generate-image.ts"],
+    };
+    expect(declaredActions(prose.replacement)).toEqual([]);
+    expect(rot(prose, 'action:"regenerate"')).toHaveLength(1);
+    expect(rot(prose, '  ["a", "regenerate"]', "src/tools/generate-image.ts")).toHaveLength(1);
+  });
+
+  it("reads a multi-action clause, and only from inside the parens", () => {
+    expect(declaredActions('comfy_cli (action:"models_list"|"models_show")')).toEqual([
+      "models_list",
+      "models_show",
+    ]);
+    expect(declaredActions('mcp__comfyui__apps (action:"run")')).toEqual(["run"]);
+    expect(declaredActions("panel_get_errors")).toEqual([]);
+    expect(declaredActions("panel_query_graph (token-bounded) or panel_graph_outline")).toEqual([]);
+  });
+
+  /**
+   * RULE (c) — the residue slice 16 measured inside the file that registers the
+   * surviving tool: `z.enum` members, `case` labels, arguments to per-action error
+   * builders. Nothing on those lines says "action", so only a declared path can
+   * license them.
+   */
+  const implemented: DeadName = {
+    ...regenerate,
+    implementedIn: ["src/tools/generate-image.ts"],
+  };
+
+  it("exempts a bare quoted action literal, but only in a declared file", () => {
+    const forms = [
+      '  .enum(["image", "audio", "regenerate", "upscale"])',
+      '    case "regenerate":',
+      '      need(args.asset_id, "regenerate", "asset_id", "the asset to re-run");',
+    ];
+    for (const line of forms) {
+      expect(rot(implemented, line, "src/tools/generate-image.ts"), line).toEqual([]);
+      // Same text, undeclared file — still rot. The licence is the path.
+      expect(rot(implemented, line, "src/tools/other.ts"), line).not.toEqual([]);
+      // ...and an entry with no implementedIn licenses nothing anywhere.
+      expect(rot(regenerate, line, "src/tools/generate-image.ts"), line).not.toEqual([]);
+    }
+  });
+
+  /**
+   * NOT a whole-file pass, which is the entire reason this is a structural form
+   * rather than a `SELF` entry. generate-image.ts is thousands of lines of
+   * model-facing description strings; a live instruction added there later must
+   * still fail, exactly as it would anywhere else.
+   */
+  it("still reports a live instruction inside a declared implementing file", () => {
+    const path = "src/tools/generate-image.ts";
+    for (const line of [
+      '    description: "Call regenerate to redo the last render",',
+      "    // TODO: regenerate is faster here",
+      '    hint: "use regenerate",',
+      // A markdown code span in a JSDoc block is PROSE, not an enum member, which
+      // is why the literal rule takes `"` and `'` but not backticks. Doc comments
+      // in the implementing file are exactly what a whole-file pass would swallow.
+      "     * Re-runs the last generation. See `regenerate`.",
+    ]) {
+      expect(rot(implemented, line, path), line).toHaveLength(1);
+    }
+    // The quoted literal is exempt; a bare mention BESIDE it on the same line is not.
+    const mixed = '    case "regenerate": // falls through to regenerate';
+    const hits = rot(implemented, mixed, path);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.start).toBe(mixed.lastIndexOf("regenerate"));
+  });
+
+  /**
+   * The literal must sit in an ACTION position — an enum/array member or a `case`
+   * label. A call's first argument is not one: `callTool("regenerate", …)` is a
+   * live dispatch BY TOOL NAME, and the implementing file is a perfectly normal
+   * place for one to appear. It is indistinguishable from `z.literal("regenerate")`
+   * by syntax alone, so this fails closed and a real case takes an `allowedIn`.
+   */
+  it("still reports a dispatch by tool name inside a declared file", () => {
+    const path = "src/tools/generate-image.ts";
+    for (const line of [
+      '  await callTool("regenerate", payload);',
+      '  return client.call("regenerate");',
+      '  const TOOL = "regenerate";',
+    ]) {
+      expect(rot(implemented, line, path), line).toHaveLength(1);
+    }
+    // The measured forms all lead with `[`, `,` or `case`, and still pass.
+    for (const line of [
+      '  .enum(["regenerate", "upscale"])',
+      '  .enum(["image", "regenerate"])',
+      '    case "regenerate":',
+      '      need(args.asset_id, "regenerate", "asset_id", "the asset");',
+    ]) {
+      expect(rot(implemented, line, path), line).toEqual([]);
+    }
+  });
+
   // Ledger-wide, and true no matter what future slices append: the exemption can
   // never silence a BARE mention of any dead name. If a change to rotMentions ever
   // makes it whole-line or name-agnostic, this goes red across the whole ledger.
@@ -464,6 +686,25 @@ describe("DEAD_NAMES ledger", () => {
       "This replacement spells its own dead name but names no live tool, so the gate " +
         "will flag the very text the prose sweep is required to write. Name the " +
         "surviving tool exactly as it appears in TOOL_NAMES.",
+    ).toEqual([]);
+  });
+
+  /**
+   * `implementedIn` licenses a bare `"name"` literal, and it only means anything
+   * when the fold reused the retired TOOL name as its ACTION name. On an entry
+   * whose replacement declares no such action it is inert — and an inert exemption
+   * is worse than none, because it reads in review as though it were doing
+   * something. Vacuous today, binding from slice 13 on.
+   */
+  it("only lets implementedIn appear where the action reuses the retired name", () => {
+    const inert = DEAD_NAMES.filter(
+      (d) => d.implementedIn?.length && !declaredActions(d.replacement).includes(d.name),
+    );
+    expect(
+      inert.map((d) => `${d.name} → ${d.replacement}`),
+      "implementedIn licenses a quoted action literal, but this entry's replacement " +
+        "does not declare the retired name as an action, so it licenses nothing. " +
+        "Either fix the replacement or drop implementedIn.",
     ).toEqual([]);
   });
 

--- a/src/__tests__/tools/vocabulary.test.ts
+++ b/src/__tests__/tools/vocabulary.test.ts
@@ -328,17 +328,27 @@ describe("rotMentions", () => {
    * nonetheless all names that are LIVE in TOOL_NAMES, because the exemption
    * requires the replacement to name a tool that exists — an invented survivor
    * would (correctly) not be exempted at all.
+   *
+   * The survivor is one of the eight tools the 0.50.0 plan FREEZES (`queue`, shipped
+   * in the 0.49.0 slices and explicitly "do not re-open"), rather than whichever tool
+   * slice 13 happens to fold these into. An earlier revision spelled real mid-flight
+   * survivors and broke the moment a DIFFERENT slice landed: slice 9 retired
+   * `install_workflow_dependencies`, and this test started failing for a reason that
+   * had nothing to do with the rule under test. Anchoring to a frozen name keeps the
+   * fixture about the SHAPE, which is the stated intent, and immune to every
+   * remaining slice.
    */
   it("passes the slice-13 replacement forms while their bare forms still fail", () => {
+    const SURVIVOR = "queue"; // frozen by the 0.50.0 plan; see above
     const folds: Array<[string, string]> = [
-      ["update_all", 'update_comfyui (action:"update_all")'],
-      ["self_update", 'install_panel (action:"self_update")'],
-      ["configure_manager", 'install_custom_node (action:"configure_manager")'],
-      ["apply_manifest", 'install_workflow_dependencies (action:"apply_manifest")'],
-      ["clear_vram", 'get_system_stats (action:"clear_vram")'],
-      ["report_issue", 'health_check (action:"report_issue")'],
-      ["calculate", 'get_environment (action:"calculate")'],
-    ];
+      "update_all",
+      "self_update",
+      "configure_manager",
+      "apply_manifest",
+      "clear_vram",
+      "report_issue",
+      "calculate",
+    ].map((name) => [name, `${SURVIVOR} (action:"${name}")`]);
     // The fold map is slice 13's, but "the survivor must be a real tool" is not.
     for (const [, replacement] of folds) {
       expect(TOOL_NAMES as readonly string[]).toContain(replacement.split(" ")[0]);

--- a/src/tools/vocabulary.ts
+++ b/src/tools/vocabulary.ts
@@ -323,6 +323,30 @@ export interface DeadName {
    * added to an exempted file still fails.
    */
   allowedIn?: Array<{ path: string; context: string; why: string }>;
+  /**
+   * Files that IMPLEMENT the surviving tool, where this name still appears as a
+   * bare quoted action literal — `"regenerate"` as a `z.enum` member, a
+   * `case "regenerate":` label, an argument to a per-action error builder.
+   *
+   * Only meaningful when the fold reused the retired tool name as its action name
+   * (`replacement: 'generate_image (action:"regenerate")'`), which is what
+   * `declaredActions` checks. If the slice renamed the action, this licenses
+   * nothing.
+   *
+   * NOT a whole-file pass, and the difference is the whole point. It licenses ONE
+   * structural form: a complete quoted string literal whose entire content is the
+   * name. src/tools/generate-image.ts is thousands of lines of model-facing
+   * description strings, and `SELF`-listing it would pre-approve every live
+   * instruction added there later — the exact reasoning that made `allowedIn`
+   * per-occurrence. Here, `"Call regenerate to redo the render"` is still reported,
+   * because the literal's content is not the name; only `"regenerate"` standing
+   * alone is the action vocabulary.
+   *
+   * Exact paths, never globs, for the same reason as `allowedIn.path`. An entry
+   * whose file no longer contains such a literal is reported as stale by
+   * scripts/check-tool-vocabulary.mts — exceptions expire.
+   */
+  implementedIn?: string[];
 }
 
 /**
@@ -402,6 +426,137 @@ const MCP_PREFIX_END = /(?:^|[^A-Za-z0-9_])mcp__[A-Za-z0-9]+(?:_[A-Za-z0-9]+)*__
 /** Live tool names, for the "the replacement must name a real tool" guard below. */
 const LIVE_TOOLS: ReadonlySet<string> = new Set<string>(TOOL_NAMES);
 
+/** Escape for embedding in a RegExp source. */
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * The action names a replacement declares:
+ *
+ *     'generate_image (action:"regenerate")'                  → ["regenerate"]
+ *     'comfy_cli (action:"models_list"|"models_show")'        → ["models_list", "models_show"]
+ *     'queue (action:"list")'                                 → ["list"]
+ *     'panel_get_errors'                                      → []
+ *
+ * This is how the ledger tells us that a retired TOOL name is now an ACTION name.
+ * Everything the action-form rules license keys off it, so a fold that RENAMED its
+ * action (slice 9's `list_skills` → `skill_list`) declares no collision and gets
+ * no new exemptions at all — the same self-derivation the replacement-copy rule
+ * uses, applied to the other half of the call form.
+ */
+export function declaredActions(replacement: string): string[] {
+  // ANCHORED to the call form: `<tool> (action:…)` at the START of the
+  // replacement, not the first `action:` anywhere in it. Otherwise prose that
+  // merely quotes the old spelling —
+  //     'generate_image (mode:"fast") — old syntax action:"regenerate" is retired'
+  // — reads as a declaration and switches the action rules on for a name the
+  // surviving tool has no action for.
+  const call =
+    /^\s*(?:mcp__[A-Za-z0-9_]+__)?[A-Za-z0-9_]+\s*\(\s*action\s*:\s*((?:["'`][A-Za-z0-9_]+["'`]\s*\|?\s*)+)\)/.exec(
+      replacement,
+    );
+  if (!call) return [];
+  return [...call[1]!.matchAll(/["'`]([A-Za-z0-9_]+)["'`]/g)].map((m) => m[1]!);
+}
+
+/**
+ * An `action:` key opening a call's argument list — `tool (action:"N")`.
+ *
+ * Just `\(\s*$`, not `<identifier>\s*\(\s*$`: the narrower shape missed
+ * `some_other_tool?.(action:"N")` and `some_other_tool /* note *\/ (action:"N")`,
+ * which name a tool exactly as much as the plain form does. Any `(` is the
+ * conservative reading, and it costs nothing — the legitimate forms are separated
+ * from a call by a quote (`fn('action:"N" …')`) or a brace (`{ action:"N" }`),
+ * never by a bare paren.
+ */
+const TOOL_CALL_OPEN = /\(\s*$/;
+
+/**
+ * Positions where a quoted literal is an ACTION rather than a tool argument:
+ * an array/enum member (`[` or `,` before it) or a `case` label. These are the
+ * three forms the slices measured.
+ *
+ * A call's FIRST argument — `callTool("regenerate", payload)` — is deliberately
+ * NOT one of them. It is indistinguishable from `z.literal("regenerate")`, and one
+ * of those two is a live dispatch to the retired tool. Fail closed: report it, and
+ * let a real case be an `allowedIn` with a reason.
+ */
+const ACTION_LITERAL_LEAD = /(?:[[,]|(?<![A-Za-z0-9_])case)\s*$/;
+
+/**
+ * Where `line` uses `name` as an ACTION VALUE — `action:"regenerate"`,
+ * `"action": "regenerate"`, `c.args?.action === "regenerate"`.
+ *
+ * WHY THIS IS NOT ROT AT ALL. After a fold, `regenerate` is no longer a tool name,
+ * but it IS a live action name, and `deadNameRe` cannot tell the two apart because
+ * they are spelled identically. The replacement-copy rule only covers prose that
+ * quotes the whole call form; slice 16 measured the rest and it is the majority —
+ * 57 of 84 hits are the token used as a value or identifier, where no replacement
+ * string can wrap it. The text here says `action` itself, so it is self-evidencing
+ * and needs no ledger entry, which is also what keeps `docs:gen` output stable:
+ * the generated `"action": "regenerate"` in docs/tools/*.mdx is covered by the same
+ * rule as the source string it was generated from.
+ *
+ * THE EXCLUSION IS THE LOAD-BEARING PART. `some_other_tool (action:"regenerate")`
+ * also contains `action:"regenerate"` — and it must still fail, because it names
+ * the WRONG tool. So an `action` key sitting directly in a `<identifier> (`
+ * argument position is a TOOL-CALL form: it claims a specific tool, and it is
+ * judged by the replacement-copy rule instead, which exempts it only when the tool
+ * is the declared survivor. A bare `- action:"regenerate" — …` bullet claims no
+ * tool and is licensed here.
+ *
+ * The prefix is measured to the `action` TOKEN, not to the match start, and that
+ * is what separates a call form from a string: `.describe('action:"regenerate" …')`
+ * has a quote between the `(` and the key, so a string opened and the text inside
+ * is prose, not an argument list. Testing from the match start instead classified
+ * every `fn('action:"…"')` as a tool call and flagged it — one of the measured
+ * forms.
+ *
+ * ACCEPTED LIMIT: a quoted key inside a call, `some_other_tool ("action": "x")`,
+ * is therefore not treated as a call form. It is not a shape anyone writes — the
+ * documented call form is `tool (action:"x")` — and the canonical one is excluded.
+ */
+export function actionValueSpans(name: string, line: string): Span[] {
+  const re = new RegExp(
+    `(?<![A-Za-z0-9_])(["'\`]?)action["'\`]?\\s*(?::|={1,3}|!={1,2})\\s*["'\`]${escapeRe(name)}["'\`]`,
+    "g",
+  );
+  const spans: Span[] = [];
+  for (let m = re.exec(line); m !== null; m = re.exec(line)) {
+    const keyStart = m.index + m[1]!.length;
+    if (TOOL_CALL_OPEN.test(line.slice(0, keyStart))) continue;
+    spans.push({ start: m.index, end: m.index + m[0].length });
+  }
+  return spans;
+}
+
+/**
+ * Where `line` spells `name` as a COMPLETE quoted string literal — `"regenerate"`.
+ *
+ * This is the residue slice 16 measured inside the file that registers the
+ * surviving tool: `z.enum([… "regenerate" …])`, `case "regenerate":`,
+ * `need(args.asset_id, "regenerate", …)`. Nothing on those lines says the word
+ * "action", so no self-evidencing rule can reach them; they are licensed only in
+ * the paths an entry names in `implementedIn`.
+ *
+ * Narrow on purpose, in two dimensions. The literal's ENTIRE content must be the
+ * name, so `"Call regenerate to redo the render"` is a quoted string in the same
+ * file and is still reported; backticks are excluded, so a markdown code span
+ * `` `regenerate` `` in a JSDoc block there is still reported too. And it must sit
+ * in an action POSITION — see ACTION_LITERAL_LEAD — so a dispatch by tool name,
+ * `callTool("regenerate", payload)`, is still reported even in a declared file.
+ */
+export function actionLiteralSpans(name: string, line: string): Span[] {
+  const re = new RegExp(`(["'])${escapeRe(name)}\\1`, "g");
+  const spans: Span[] = [];
+  for (let m = re.exec(line); m !== null; m = re.exec(line)) {
+    if (!ACTION_LITERAL_LEAD.test(line.slice(0, m.index))) continue;
+    spans.push({ start: m.index, end: m.index + m[0].length });
+  }
+  return spans;
+}
+
 /**
  * Every verbatim occurrence of `needle` in `line` that BEGINS at a token
  * boundary, INCLUDING occurrences that overlap each other.
@@ -439,59 +594,11 @@ function literalSpans(needle: string, line: string): Span[] {
 }
 
 /**
- * The mentions of a dead name on one line that are ROT — i.e. all of them except
- * those sitting inside a verbatim copy of THAT SAME name's own declared
- * `replacement`.
- *
- * WHY THIS EXEMPTION EXISTS. For many 0.50.0 folds the natural action name IS the
- * retired tool name, so the migration target the prose sweep is REQUIRED to write —
- *
- *     get_system_stats (action:"clear_vram")
- *
- * — contains the bare token `clear_vram`, and `deadNameRe("clear_vram")` matches
- * it (`"` is a non-word character on both sides). Without this rule the gate
- * flags the very text it demands, and no sweep for those names can ever go green.
- * That is not hypothetical: 14 names across slices 13/15/16 collide this way, and
- * slice 9 only escaped by RENAMING its actions (`list_skills` → `skill_list`).
- * Renaming does not scale to `apply_manifest` (93 mentions) or `clear_vram` (35) —
- * contorting exactly the names models reach for is a real discoverability
- * regression.
- *
- * WHY IT DOES NOT WEAKEN THE RATCHET. The exempted string is not chosen by a
- * human; it is the ledger's OWN generated output, per name, self-derived. There is
- * no knob. Concretely, all four of these still fail:
- *
- *   - a bare `clear_vram` anywhere on the line;
- *   - `call clear_vram to free VRAM` — prose naming it;
- *   - `some_other_tool (action:"clear_vram")` — a mention naming the WRONG
- *     migration target, which is itself a defect worth catching;
- *   - a bare mention sharing a line with a legitimate replacement form. The
- *     exemption is POSITIONAL (span containment), never line-wide, so a live
- *     instruction cannot launder itself by standing next to the migration target —
- *     the same laundering the `allowedIn` logic already had to close.
- *
- * Matching is LITERAL (`indexOf`), never a regex built from `replacement`: the
- * replacements are full call forms containing `(`, `)`, `"` and `|`, and a
- * pattern compiled from `comfy_cli (action:"a"|"b")` would alternate rather than
- * match. Literal also means an accidental partial cannot widen the exemption.
- *
- * Names whose replacement does not contain their own name — the large majority,
- * and every entry in the ledger today — are byte-for-byte unaffected. That is
- * structural, not a claim: a mention contained in a replacement copy would BE a
- * copy of the name inside `replacement`, so the early return below cannot change
- * a verdict, it only skips work.
- *
- * NOTE for a fold whose replacement names several actions: declare the SAME
- * combined string (`manager (action:"update_all"|"self_update")`) on every entry
- * it covers. The rule is per-name and self-derived on purpose, so a name is
- * exempted only inside ITS OWN declared target — a name mentioned inside some
- * OTHER entry's replacement is still reported, which is the correct answer when
- * the two disagree about where a caller should go.
+ * Is this entry a usable migration instruction at all? Every exemption below
+ * reads it as one, so a broken entry must license nothing.
  */
-export function rotMentions(dead: DeadName, line: string): Span[] {
-  const mentions = deadNameMentions(dead.name, line);
-  if (mentions.length === 0) return mentions;
-  if (!dead.replacement.includes(dead.name)) return mentions;
+function usableTarget(dead: DeadName): boolean {
+  if (!dead.replacement.includes(dead.name)) return false;
   // The replacement must spell the retired name EXACTLY ONCE. One mention is the
   // action slot — the whole reason this exemption exists. A second is something
   // else, and `get_system_stats (action:"clear_vram") then call clear_vram` is a
@@ -500,7 +607,7 @@ export function rotMentions(dead: DeadName, line: string): Span[] {
   // means the name only occurs inside a longer identifier (`clear_vram_stats`), so
   // there is nothing to exempt either. Both fail CLOSED.
   const inReplacement = deadNameMentions(dead.name, dead.replacement);
-  if (inReplacement.length !== 1) return mentions;
+  if (inReplacement.length !== 1) return false;
 
   // The replacement must also name a tool that ACTUALLY EXISTS, other than the dead
   // one. A replacement carrying nothing beyond the dead name — `clear_vram`,
@@ -521,15 +628,101 @@ export function rotMentions(dead: DeadName, line: string): Span[] {
   const rest =
     dead.replacement.slice(0, inReplacement[0]!.start) +
     dead.replacement.slice(inReplacement[0]!.end);
-  if (!(rest.match(/[A-Za-z0-9_]+/g) ?? []).some((token) => LIVE_TOOLS.has(token))) {
-    return mentions;
-  }
+  return (rest.match(/[A-Za-z0-9_]+/g) ?? []).some((token) => LIVE_TOOLS.has(token));
+}
+
+/**
+ * The mentions of a dead name on one line that are ROT.
+ *
+ * WHY ANY EXEMPTION EXISTS. For many 0.50.0 folds the natural action name IS the
+ * retired tool name. So `regenerate` stops being a tool and becomes an ACTION of
+ * `generate_image` — and `deadNameRe` cannot tell those apart, because they are
+ * spelled identically. Every remaining use of the token is then flagged, including
+ * the migration text the prose sweep is REQUIRED to write:
+ *
+ *     generate_image (action:"regenerate")
+ *
+ * Without a rule, no sweep for those names can ever go green. Slice 9 escaped only
+ * by RENAMING its actions (`list_skills` → `skill_list`); that does not scale to
+ * `apply_manifest` (93 mentions) or `clear_vram` (35), where contorting exactly the
+ * names models reach for is a real discoverability regression.
+ *
+ * THE THREE RULES, each self-derived from the entry and each POSITIONAL:
+ *
+ *   (a) MIGRATION TARGET — inside a verbatim copy of the entry's own
+ *       `replacement`. Covers prose: comments, README rows, docs. Measured at 27
+ *       of slice 16's 84 hits.
+ *   (b) ACTION VALUE — `action:"regenerate"`, `"action": "regenerate"`,
+ *       `args.action === "regenerate"`. Self-evidencing (the text says `action`),
+ *       so repo-wide and no ledger entry, which is what keeps `docs:gen` output
+ *       stable across regeneration. See actionValueSpans.
+ *   (c) ACTION LITERAL — `"regenerate"` as a complete quoted string, ONLY in the
+ *       paths the entry lists in `implementedIn`: enum members, `case` labels,
+ *       arguments to per-action helpers. See actionLiteralSpans.
+ *
+ * (b) and (c) require the entry's `replacement` to declare this exact name as an
+ * action (`declaredActions`), so a fold that renamed its action gets nothing.
+ *
+ * WHY THIS DOES NOT WEAKEN THE RATCHET. Nothing here is a human-chosen string:
+ * (a) is the ledger's own output, (b) is a syntactic form that names itself, (c) is
+ * one structural form in explicitly declared files. All of these still fail:
+ *
+ *   - a bare `regenerate` anywhere, and `call regenerate to redo the render`;
+ *   - `some_other_tool (action:"regenerate")` — the WRONG tool. (b) deliberately
+ *     skips any match preceded by `<identifier> (`, handing it to (a), which
+ *     exempts it only when the tool is the declared survivor;
+ *   - `not_generate_image (action:"regenerate")` — a tool whose name merely ENDS
+ *     with the survivor's;
+ *   - `"Call regenerate now"` in an `implementedIn` file — a quoted string whose
+ *     content is not exactly the name;
+ *   - a rotten bare mention sharing a line with a legitimate replacement form or
+ *     `action:"N"`. Exemption is by span CONTAINMENT, never line-wide.
+ *
+ * (a) matches LITERALLY (`indexOf`), never a regex built from `replacement`: the
+ * replacements are call forms containing `(`, `)`, `"` and `|`, and a pattern
+ * compiled from `comfy_cli (action:"a"|"b")` would alternate rather than match.
+ *
+ * Entries whose replacement does not contain their own name — the large majority,
+ * and every entry in the ledger today — are byte-for-byte unaffected by all three.
+ *
+ * NOTE for a fold whose replacement names several actions: declare the SAME
+ * combined string (`manager (action:"update_all"|"self_update")`) on every entry it
+ * covers. The rules are per-name and self-derived on purpose, so a name is exempted
+ * only against ITS OWN declared target.
+ *
+ * `path` is the repo-relative file being scanned; omit it and rule (c) is off.
+ */
+export function rotMentions(dead: DeadName, line: string, path?: string): Span[] {
+  const mentions = deadNameMentions(dead.name, line);
+  if (mentions.length === 0) return mentions;
+  // Every rule below reads the ledger entry as a migration instruction, so a broken
+  // entry licenses nothing at all. One gate, three rules, fail-closed.
+  if (!usableTarget(dead)) return mentions;
+
+  // (a) The migration TARGET, spelled exactly — the form the prose sweep writes.
   const targets = literalSpans(dead.replacement, line);
+
+  // (b) and (c) apply only when the fold reused the retired TOOL name as its
+  // ACTION name, which is the collision that creates the problem. A fold that
+  // renamed its action declares nothing here and gains nothing.
+  if (declaredActions(dead.replacement).includes(dead.name)) {
+    // (b) The name used as an action VALUE. Self-evidencing, so repo-wide.
+    targets.push(...actionValueSpans(dead.name, line));
+    // (c) The name as a bare quoted action literal, only in the declared
+    // implementing files. `path` is optional so a caller with no file context
+    // (call_tool, a unit test) simply never gets this rule.
+    if (path !== undefined && dead.implementedIn?.includes(path)) {
+      targets.push(...actionLiteralSpans(dead.name, line));
+    }
+  }
+
   if (targets.length === 0) return mentions;
-  // CONTAINMENT, not overlap. A mention that merely straddles the edge of a
-  // replacement copy — which a truncated or mistyped `replacement` produces — is
-  // not "inside a verbatim copy" of anything, and treating it as exempt would let
-  // one bad ledger string silence real mentions beside it.
+  // CONTAINMENT, not overlap, and it is what makes all three rules per-OCCURRENCE
+  // rather than per-line. A mention that merely straddles the edge of a replacement
+  // copy — which a truncated or mistyped `replacement` produces — is not "inside" a
+  // verbatim copy of anything; and a rotten bare mention sitting beside a legitimate
+  // `action:"N"` is outside that span, so it is still reported. A line-wide test
+  // would exempt both, which is the single most dangerous way to widen this.
   return mentions.filter((m) => !targets.some((t) => m.start >= t.start && m.end <= t.end));
 }
 

--- a/src/tools/vocabulary.ts
+++ b/src/tools/vocabulary.ts
@@ -346,6 +346,193 @@ export function deadNameRe(name: string): RegExp {
   return new RegExp(`(?<![A-Za-z0-9_])(?:mcp__[A-Za-z0-9_]+__)?${escaped}(?![A-Za-z0-9_])`);
 }
 
+/** A half-open `[start, end)` slice of one line. */
+export interface Span {
+  start: number;
+  end: number;
+}
+
+/**
+ * WHERE on a line `deadNameRe(name)` matches, not merely whether.
+ *
+ * `deadNameRe` answers a boolean, which is all the scanner needed while every
+ * mention of a dead name was equally bad. `rotMentions` below has to tell two
+ * mentions on the SAME line apart, so it needs positions — and it must get them
+ * from the identical pattern, or the exemption would be reasoning about spans the
+ * gate does not actually flag. Hence the shared `.source` rather than a second
+ * hand-written regex.
+ *
+ * The `g` flag is applied to a FRESH RegExp each call: `deadNameRe`'s result is
+ * unflagged and shared with `.test()` callers, and a stateful `lastIndex` leaking
+ * between them is the classic way a scan starts skipping matches.
+ */
+export function deadNameMentions(name: string, line: string): Span[] {
+  const re = new RegExp(deadNameRe(name).source, "g");
+  const spans: Span[] = [];
+  for (let m = re.exec(line); m !== null; m = re.exec(line)) {
+    // Defensive: a zero-length match would spin forever. Unreachable for a
+    // non-empty name, and a ledger entry with an empty name is already a bug.
+    if (m[0].length === 0) {
+      re.lastIndex += 1;
+      continue;
+    }
+    spans.push({ start: m.index, end: m.index + m[0].length });
+  }
+  return spans;
+}
+
+const IDENT = /[A-Za-z0-9_]/;
+
+/**
+ * The `mcp__<server>__` prefix, anchored to end exactly where a replacement copy
+ * begins.
+ *
+ * The server segment forbids `__` — `[A-Za-z0-9]+(?:_[A-Za-z0-9]+)*` allows
+ * `comfyui_panel` but not `comfyui__wrong`. `deadNameRe`'s own prefix is the
+ * looser `[A-Za-z0-9_]+`, and that difference is deliberate rather than an
+ * oversight: there, greediness only makes it MATCH more, which is fail-safe for a
+ * gate that hunts mentions. Here the same greediness EXEMPTS more, and
+ * `mcp__comfyui__wrong__get_system_stats (action:"clear_vram")` would slip
+ * through by letting the segment swallow `comfyui__wrong` — a line that, read the
+ * ordinary way, names server `comfyui`'s tool `wrong__get_system_stats`. Strict
+ * where it exempts, loose where it flags.
+ */
+const MCP_PREFIX_END = /(?:^|[^A-Za-z0-9_])mcp__[A-Za-z0-9]+(?:_[A-Za-z0-9]+)*__$/;
+
+/** Live tool names, for the "the replacement must name a real tool" guard below. */
+const LIVE_TOOLS: ReadonlySet<string> = new Set<string>(TOOL_NAMES);
+
+/**
+ * Every verbatim occurrence of `needle` in `line` that BEGINS at a token
+ * boundary, INCLUDING occurrences that overlap each other.
+ *
+ * The boundary rule is not decoration. Without it `indexOf` treats the
+ * replacement as an unbounded substring, and
+ *
+ *     not_get_system_stats (action:"clear_vram")
+ *
+ * contains `get_system_stats (action:"clear_vram")` starting at index 4 — so a
+ * mention naming a DIFFERENT tool would be exempted by the mere suffix of that
+ * tool's name, which is precisely the case this whole exemption must not admit.
+ * Requiring a non-identifier character (or start of line) before the copy is the
+ * same contract `deadNameRe` already applies to names, `mcp__<server>__` allowance
+ * included: a namespacing client writes `mcp__comfyui__get_system_stats (…)`,
+ * which is the same tool and must still count. See MCP_PREFIX_END for why that
+ * allowance is stricter here than in `deadNameRe`.
+ *
+ * The asymmetry is deliberate: there is no matching rule on the RIGHT. A
+ * replacement names its tool at the START, so an identifier run before the copy
+ * changes WHICH tool is named, while one after it only extends trailing prose —
+ * `foo (action:"old_tool") x` inside `foo (action:"old_tool") xy` still names foo
+ * and still carries the correct call form, so flagging it would be a false
+ * positive that sends a sweep to "fix" text that is already right.
+ */
+function literalSpans(needle: string, line: string): Span[] {
+  const spans: Span[] = [];
+  if (needle.length === 0) return spans;
+  for (let i = line.indexOf(needle); i !== -1; i = line.indexOf(needle, i + 1)) {
+    const startsAtBoundary =
+      i === 0 || !IDENT.test(line[i - 1]!) || MCP_PREFIX_END.test(line.slice(0, i));
+    if (startsAtBoundary) spans.push({ start: i, end: i + needle.length });
+  }
+  return spans;
+}
+
+/**
+ * The mentions of a dead name on one line that are ROT — i.e. all of them except
+ * those sitting inside a verbatim copy of THAT SAME name's own declared
+ * `replacement`.
+ *
+ * WHY THIS EXEMPTION EXISTS. For many 0.50.0 folds the natural action name IS the
+ * retired tool name, so the migration target the prose sweep is REQUIRED to write —
+ *
+ *     get_system_stats (action:"clear_vram")
+ *
+ * — contains the bare token `clear_vram`, and `deadNameRe("clear_vram")` matches
+ * it (`"` is a non-word character on both sides). Without this rule the gate
+ * flags the very text it demands, and no sweep for those names can ever go green.
+ * That is not hypothetical: 14 names across slices 13/15/16 collide this way, and
+ * slice 9 only escaped by RENAMING its actions (`list_skills` → `skill_list`).
+ * Renaming does not scale to `apply_manifest` (93 mentions) or `clear_vram` (35) —
+ * contorting exactly the names models reach for is a real discoverability
+ * regression.
+ *
+ * WHY IT DOES NOT WEAKEN THE RATCHET. The exempted string is not chosen by a
+ * human; it is the ledger's OWN generated output, per name, self-derived. There is
+ * no knob. Concretely, all four of these still fail:
+ *
+ *   - a bare `clear_vram` anywhere on the line;
+ *   - `call clear_vram to free VRAM` — prose naming it;
+ *   - `some_other_tool (action:"clear_vram")` — a mention naming the WRONG
+ *     migration target, which is itself a defect worth catching;
+ *   - a bare mention sharing a line with a legitimate replacement form. The
+ *     exemption is POSITIONAL (span containment), never line-wide, so a live
+ *     instruction cannot launder itself by standing next to the migration target —
+ *     the same laundering the `allowedIn` logic already had to close.
+ *
+ * Matching is LITERAL (`indexOf`), never a regex built from `replacement`: the
+ * replacements are full call forms containing `(`, `)`, `"` and `|`, and a
+ * pattern compiled from `comfy_cli (action:"a"|"b")` would alternate rather than
+ * match. Literal also means an accidental partial cannot widen the exemption.
+ *
+ * Names whose replacement does not contain their own name — the large majority,
+ * and every entry in the ledger today — are byte-for-byte unaffected. That is
+ * structural, not a claim: a mention contained in a replacement copy would BE a
+ * copy of the name inside `replacement`, so the early return below cannot change
+ * a verdict, it only skips work.
+ *
+ * NOTE for a fold whose replacement names several actions: declare the SAME
+ * combined string (`manager (action:"update_all"|"self_update")`) on every entry
+ * it covers. The rule is per-name and self-derived on purpose, so a name is
+ * exempted only inside ITS OWN declared target — a name mentioned inside some
+ * OTHER entry's replacement is still reported, which is the correct answer when
+ * the two disagree about where a caller should go.
+ */
+export function rotMentions(dead: DeadName, line: string): Span[] {
+  const mentions = deadNameMentions(dead.name, line);
+  if (mentions.length === 0) return mentions;
+  if (!dead.replacement.includes(dead.name)) return mentions;
+  // The replacement must spell the retired name EXACTLY ONCE. One mention is the
+  // action slot — the whole reason this exemption exists. A second is something
+  // else, and `get_system_stats (action:"clear_vram") then call clear_vram` is a
+  // ledger entry carrying its own live instruction: exempting a verbatim copy would
+  // launder that instruction into every page that quotes the ledger. Zero mentions
+  // means the name only occurs inside a longer identifier (`clear_vram_stats`), so
+  // there is nothing to exempt either. Both fail CLOSED.
+  const inReplacement = deadNameMentions(dead.name, dead.replacement);
+  if (inReplacement.length !== 1) return mentions;
+
+  // The replacement must also name a tool that ACTUALLY EXISTS, other than the dead
+  // one. A replacement carrying nothing beyond the dead name — `clear_vram`,
+  // `` `clear_vram` ``, `clear_vram.`, and equally the prose `Use clear_vram` — is
+  // not a migration target; it says "call the tool that no longer exists".
+  // Exempting against it would blind the gate for that name completely, which is
+  // the one way this rule could turn into the bypass it is meant not to be. Merely
+  // requiring "some identifier survives" was not enough, because `Use` is an
+  // identifier. Requiring a LIVE tool name turns a heuristic into a checkable
+  // property, and catches a mistyped survivor in the ledger as a bonus.
+  //
+  // KNOWN LIMIT: `TOOL_NAMES` is core-only, so a fold whose replacement names a
+  // PANEL tool AND whose action reuses the retired name would not be exempted. No
+  // such entry exists (every panel replacement in the ledger names a different
+  // tool, so the `includes` guard above already returns first), and the failure
+  // direction is a visible false positive — the gate reports the line, and the
+  // DEAD_NAMES ledger test names the entry — never a silent pass.
+  const rest =
+    dead.replacement.slice(0, inReplacement[0]!.start) +
+    dead.replacement.slice(inReplacement[0]!.end);
+  if (!(rest.match(/[A-Za-z0-9_]+/g) ?? []).some((token) => LIVE_TOOLS.has(token))) {
+    return mentions;
+  }
+  const targets = literalSpans(dead.replacement, line);
+  if (targets.length === 0) return mentions;
+  // CONTAINMENT, not overlap. A mention that merely straddles the edge of a
+  // replacement copy — which a truncated or mistyped `replacement` produces — is
+  // not "inside a verbatim copy" of anything, and treating it as exempt would let
+  // one bad ledger string silence real mentions beside it.
+  return mentions.filter((m) => !targets.some((t) => m.start >= t.start && m.end <= t.end));
+}
+
 /**
  * Seeded with real rot rather than a hypothetical, so the gate proves itself on
  * day one: `panel_get_graph` was removed upstream but survives in FIVE live


### PR DESCRIPTION
Unblocks slices **13, 15 and 16** of #726. Gate-logic only — no `TOOL_NAMES`, `MAX_TOOLS`, `DEAD_NAMES` entry, `docs/design/tool-surface.txt` or `BASELINE_SHA256` change.

## The problem, in one sentence

After a fold, `regenerate` is no longer a **tool** name but it *is* a live **action** name of the surviving tool — and `deadNameRe` cannot tell them apart, because they are spelled identically.

So the gate fails CI on every remaining use of the token, including the migration text the prose sweep is *required* to write:

```
generate_image (action:"regenerate")
```

No sweep for those names can ever go green. Slice 9 escaped by renaming its actions (`list_skills` → `skill_list`); that does not scale to `apply_manifest` (93 mentions, the most-referenced name on the surface) or `clear_vram` (35), where contorting exactly the names models reach for is a real discoverability regression.

**Measured, not assumed.** Slice 16 swept every mention it controls into the exact replacement form, then classified the 84 hits that remained: 27 prose, and **57 the token used as a value or identifier**, where no replacement string can wrap it. Slice 15 reports the same shape independently (77 hits).

## Three rules, all self-derived, all positional

| | rule | scope | covers |
|---|---|---|---|
| **(a)** | inside a verbatim copy of the entry's own `replacement` | repo-wide, no ledger entry | prose: comments, README rows, docs |
| **(b)** | the name used as an **action value** — `action:"N"`, `"action": "N"`, `args.action === "N"` | repo-wide, no ledger entry | description bullets, `.describe()`, generated `docs/tools/*.mdx`, arena matchers |
| **(c)** | the name as a **complete quoted literal** in an action position | only paths listed in the new `implementedIn` | `z.enum` members, `case "N":`, per-action error builders |

(b) and (c) are gated on the entry's `replacement` **declaring** this exact name as an action (`declaredActions`, anchored to the `<tool> (action:…)` call form). A fold that renamed its action declares no collision and gains nothing. All three sit behind the base commit's `usableTarget()` — the replacement must spell the name exactly once and name a live tool.

Rule (b) needs **no ledger entry**, which is what keeps `docs:gen` stable: the generated `"action": "regenerate"` is covered by the same rule as the source string it was generated from, so regeneration cannot reintroduce failures.

## What still fails — every one has a test

| input | verdict |
|---|---|
| `regenerate` bare, `call regenerate to redo` | **fails** — real rot |
| `some_other_tool (action:"regenerate")` | **fails** — wrong tool |
| `some_other_tool?.(action:"N")`, `tool /* c */ (action:"N")` | **fails** — the call-form test is any `(`, not `<ident> (` |
| `not_generate_image (action:"N")` | **fails** — a name that merely *ends* with the survivor's |
| `mcp__comfyui__wrong__get_system_stats (…)` | **fails** — reads as tool `wrong__get_system_stats` |
| `- action:"N" — … but never call regenerate` | **fails on the bare one only** — containment, never line-wide |
| `case "N": // falls through to regenerate` | **fails on the comment only** |
| `description: "Call regenerate to redo"` in a declared file | **fails** — the literal's content is not the name |
| ``  * See `regenerate`.`` (JSDoc) in a declared file | **fails** — backticks excluded |
| `callTool("regenerate", payload)` in a declared file | **fails** — dispatch by tool name, not an action position |
| `.enum([…"regenerate"…])` in an **un**declared file | **fails** — the licence is the path |

## `implementedIn` is not a whole-file pass

That distinction is the point. `generate-image.ts` is thousands of lines of model-facing description strings; a `SELF` entry would pre-approve every live instruction added there later — precisely the reasoning that made `allowedIn` per-occurrence. `implementedIn` licenses **one structural form**: a complete quoted literal whose entire content is the name, in an action position (`[`, `,`, or a `case` label). A call's first argument is deliberately excluded — `callTool("regenerate", …)` and `z.literal("regenerate")` are indistinguishable by syntax and one of them is rot, so it fails closed. And like `allowedIn`, an `implementedIn` path that no longer contains such a literal is reported **stale**: exceptions expire.

## Coverage against the measured hits

- **Slice 16 (84):** 27 prose → (a). Bullets, `.describe()`, generated `.mdx`, arena matcher → (b). Enum members, `case` labels, `need(…)` arguments → (c) with `src/tools/generate-image.ts` + `workflow-execute.ts` declared. **Deliberately not cleared:** the unknown-action error text (`Expected one of: image, audio, …, regenerate, …`) — a bare token in a prose list, one occurrence per tool. Build it from the action array (`ACTIONS.join(", ")`, which also cannot drift from the enum) or take one `allowedIn`.
- **Slice 15 (77):** same forms, same outcome.
- Any worked example shaped `{ action: "N" }` is (b); a bare `"N"` argument in `scripts/tool-doc-examples.ts` needs that path in `implementedIn`.

## Verification

- **Byte-for-byte inert on main.** No ledger entry declares an action collision today (0 of 58), so `check:vocabulary` output is character-identical before and after.
- **53 unit tests**; full suite **288 files / 6139 tests** green; `lint`, `check:vocabulary`, `vocab:export --check` green.
- **29 mutations, zero survivors** across both commits, weighted toward the too-BROAD direction: whole-line exemption; tool-agnostic action shape; replacement-as-regex; containment→overlap; each degenerate-data guard removed and weakened to its earlier form; self-derivation dropped; left boundary removed; server segment allowing `__`; tool-call exclusion removed, narrowed, and measured from the wrong offset; each new rule ungated and dropped; `implementedIn` ignored; the literal widened, backtick-enabled, and position-rule removed; `declaredActions` un-anchored.
- **Scanner-level end-to-end**, not just units: a synthetic colliding entry over 21 probe lines across a doc and a declared implementing file — all 10 legitimate forms pass, all 11 rot lines reported, including both mixed lines. Stale-`implementedIn` verified separately.
- **Four rounds** of independent adversarial review (gpt-5.6-terra), **nine findings, all nine fixed and re-gated**: wrong-tool-by-suffix, malformed-ledger blinding, stale-`allowedIn` refresh, prose-as-replacement (`Use clear_vram`), the `mcp__a__b__` server-segment hole, a replacement embedding its own live instruction, call syntaxes evading the tool-call exclusion, dispatch-by-name inside a declared file, and `declaredActions` over-reading prose.
- Control-byte scan clean on all three changed files; no git-binary files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
