### PR TITLE
fix(admission): report a retired tool name as retired, not as unpermitted

### DIFF
--- a/src/__tests__/orchestrator/call-tool-admission.test.ts
+++ b/src/__tests__/orchestrator/call-tool-admission.test.ts
@@ -318,8 +318,17 @@ describe("call_tool admission", () => {
     it("the retired standalone names are no longer admitted under their own names", () => {
       // They are not registered tools any more, so the channel must refuse them at
       // the NAME level rather than silently accepting a name nothing serves.
+      //
+      // The REFUSAL is the invariant; its wording is not. This assertion used to
+      // spell `tool "x" is not permitted`, which was the honest answer only while
+      // admission ran ahead of the retirement ledger — it told a caller its
+      // PERMISSION was wrong when the truth was that the tool had been RENAMED,
+      // sending them to check tokens and whitelists instead of to the new name.
+      // Admission now consults the ledger first, so the correct expectation is
+      // the redirect. What must never change is that the result is non-null.
       for (const name of ["list_workflows", "analyze_workflow", "query_workflow"]) {
-        expect(callToolAdmission(name, {}), name).toBe(`tool "${name}" is not permitted`);
+        expect(callToolAdmission(name, {}), `${name} must not be admitted`).not.toBeNull();
+        expect(callToolAdmission(name, {}), name).toBe(retiredToolMessage(name));
       }
     });
   });
@@ -330,9 +339,25 @@ describe("call_tool admission", () => {
   // more candidates. Slice-agnostic, so it keeps holding as 0.50.0 lands.
   it("no name the ledger declares dead is admitted by the whitelist", () => {
     for (const dead of DEAD_NAMES) {
-      expect(callToolAdmission(dead.name, {}), dead.name).toBe(
-        `tool "${dead.name}" is not permitted`,
-      );
+      // NEVER ADMITTED is the property under test — assert that first and on its
+      // own, so this keeps failing loudly if a future change makes a dead name
+      // return null, regardless of how refusals are worded.
+      expect(callToolAdmission(dead.name, {}), `${dead.name} must not be admitted`).not.toBeNull();
+      // And the refusal must be the ledger's redirect rather than a permission
+      // error: for a name that no longer exists, "not permitted" is a wrong
+      // answer, not merely a terse one.
+      //
+      // Anchored on a LITERAL as well as on the helper. Comparing only against
+      // `retiredToolMessage(...)` would be tautological for the wording — the
+      // implementation calls that same helper, so the assertion would hold no
+      // matter what the helper returned. vocabulary.test.ts owns the exact
+      // phrasing against a literal; here we independently require that the
+      // answer identifies the tool by name and does NOT claim a permission
+      // problem, which is the specific wrong answer this change removes.
+      const refusal = callToolAdmission(dead.name, {});
+      expect(refusal, dead.name).toBe(retiredToolMessage(dead.name));
+      expect(refusal, dead.name).toContain(`Unknown tool '${dead.name}'`);
+      expect(refusal, dead.name).not.toContain("is not permitted");
     }
   });
 

--- a/src/__tests__/orchestrator/call-tool-admission.test.ts
+++ b/src/__tests__/orchestrator/call-tool-admission.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { callToolAdmission } from "../../orchestrator/call-tool-admission.js";
-import { DEAD_NAMES } from "../../tools/vocabulary.js";
+import {
+  CALL_TOOL_ACTION_WHITELIST,
+  CALL_TOOL_WHITELIST,
+  callToolAdmission,
+} from "../../orchestrator/call-tool-admission.js";
+import { DEAD_NAMES, TOOL_NAMES, retiredToolMessage } from "../../tools/vocabulary.js";
 
 /**
  * The call_tool dispatcher authorizes by tool NAME and forwards arbitrary
@@ -446,14 +450,200 @@ describe("call_tool admission", () => {
     // …including a consolidated tool whose whole-tool posture was judged at
     // whitelist time (apps, 0.49.0 slice 2) — deliberately NOT rescoped here.
     expect(callToolAdmission("apps", { action: "run" })).toBeNull();
-    // A non-whitelisted tool is refused with the byte-identical pre-change
-    // string the dispatcher produced.
-    expect(callToolAdmission("clear_vram", {})).toBe('tool "clear_vram" is not permitted');
-    expect(callToolAdmission("restart_comfyui", {})).toBe(
-      'tool "restart_comfyui" is not permitted',
-    );
+    // A genuinely unknown name — in no ledger and no registry, so neither live
+    // nor retired — keeps the byte-identical pre-change string. Asserted to be
+    // absent from the ledger first, so the case still means "unknown" rather
+    // than quietly becoming a second retired-name case.
+    expect(retiredToolMessage("not_a_real_tool")).toBeUndefined();
     expect(callToolAdmission("not_a_real_tool", {})).toBe(
       'tool "not_a_real_tool" is not permitted',
     );
+  });
+
+  /**
+   * The refusal a LIVE, non-whitelisted tool gets, asserted over the whole live
+   * surface rather than over two spelled names.
+   *
+   * This replaces the spelled `clear_vram` / `restart_comfyui` cases that stood
+   * here. Making retirement win ahead of the whitelist is exactly what turns
+   * "is this name still live?" into a load-bearing precondition for this string,
+   * and a spelled live name is a name a later 0.50.0 slice may fold away at any
+   * hour — at which point the assertion would fail for a reason that has nothing
+   * to do with what it is testing. Derived from TOOL_NAMES it cannot rot, and it
+   * covers the whole surface instead of a sample.
+   */
+  it("refuses every live non-whitelisted tool with the byte-identical legacy string", () => {
+    const notWhitelisted = TOOL_NAMES.filter((n) => !CALL_TOOL_WHITELIST.has(n));
+    expect(notWhitelisted.length).toBeGreaterThan(0);
+    for (const name of notWhitelisted) {
+      expect(callToolAdmission(name, {}), name).toBe(`tool "${name}" is not permitted`);
+    }
+  });
+
+  /**
+   * A retired name reports as RETIRED — the ledger's redirect, not a permission
+   * refusal.
+   *
+   * "not permitted" reads as *you lack permission* and sends a developer to check
+   * tokens, whitelists and trust boundaries; the truth is *this tool no longer
+   * exists under that name*, which the ledger already knows how to say. The other
+   * two call paths — the compact `call_tool` facade and the direct MCP
+   * `tools/call` (#895) — have always answered a retired name from the ledger.
+   * This channel overwrote it, and it is the channel the panel's RunPod control
+   * panel and the mobile app use for the runpod_* names slice 8 folded away.
+   *
+   * Every case below DERIVES its subject from DEAD_NAMES rather than spelling
+   * one. A literal retired name anywhere in `src/` is itself a dead-name-gate
+   * violation (scripts/check-tool-vocabulary.mts), and this file holds no
+   * `allowedIn` exemption — but the better reason is that deriving makes the
+   * assertion exhaustive over the ledger and keeps it true as the remaining
+   * slices append to it.
+   */
+  describe("a retired name reports as retired, not as unpermitted", () => {
+    it("answers every ledger name with the ledger's own redirect", () => {
+      expect(DEAD_NAMES.length).toBeGreaterThan(0);
+      for (const { name, replacement } of DEAD_NAMES) {
+        const answer = callToolAdmission(name, {});
+        // The claim, stated the way it fails: NOT the permission refusal…
+        expect(answer, name).not.toBe(`tool "${name}" is not permitted`);
+        // …and not null either, because retirement is still a refusal — a name
+        // that does not exist must never be dispatched.
+        expect(answer, name).toBe(retiredToolMessage(name));
+        // …and actionable: it names what to call instead.
+        expect(answer, name).toContain(replacement);
+        // The equality above is deliberately against retiredToolMessage(), the
+        // helper the branch delegates to, so this file does not become a second
+        // home for the ledger's wording — vocabulary.test.ts owns that contract
+        // and pins the whole sentence against a literal. What that equality
+        // alone cannot say is that the answer is a RETIREMENT rather than
+        // whatever else the helper might one day return, so anchor the one token
+        // that distinguishes the two answers, independently of the helper.
+        expect(answer, name).toContain(`Unknown tool '${name}'`);
+      }
+    });
+
+    it("keeps serving the redirect in the mcp__<server>__ prefixed form", () => {
+      // The form tool names take in MCP clients that namespace them, which
+      // findDeadName() already accepts — so the two must not disagree here.
+      // Over the whole ledger, not just its first entry: prefix matching is
+      // per-name regex construction, so a name with regex-significant characters
+      // is exactly where it would come apart.
+      for (const { name, replacement } of DEAD_NAMES) {
+        const prefixed = `mcp__comfyui__${name}`;
+        expect(callToolAdmission(prefixed, {}), prefixed).toBe(retiredToolMessage(prefixed));
+        expect(callToolAdmission(prefixed, {}), prefixed).toContain(replacement);
+      }
+    });
+
+    it("is not routed away by the arguments — including money-shaped ones", () => {
+      // A retired name is retired whatever it is called with. Worth stating
+      // explicitly because the branch sits ahead of the action scope: args must
+      // not be able to steer a retired name onto some other answer, and in
+      // particular a billing-shaped call on a retired runpod_* name must come
+      // back as the redirect rather than anything that reads like progress.
+      for (const { name } of DEAD_NAMES) {
+        expect(callToolAdmission(name, { action: "create", pod_id: "pod123" }), name).toBe(
+          retiredToolMessage(name),
+        );
+      }
+    });
+  });
+
+  /**
+   * THE MONEY GUARD, pinned structurally.
+   *
+   * The hazard in serving retirement early is the #839 pattern: an early return
+   * placed slightly wrong turns a refusal into an admission, here on the one code
+   * path that guards real money (`runpod` action:"create"/"start" both put a pod
+   * into a billing state). The behavioural half is asserted above; these are the
+   * invariants that make the early return unable to reach an action-scoped call
+   * in the first place, and they fail loudly rather than silently if a later
+   * slice breaks them.
+   */
+  describe("the retirement branch cannot swallow an action-scoped refusal", () => {
+    it("never retires a whitelisted name, so the branch cannot shadow an admitted tool", () => {
+      // The property that actually matters, stated against the thing the branch
+      // tests. Membership in DEAD_NAMES is what makes it intercept — NOT absence
+      // from TOOL_NAMES — and the two coincide only because vocabulary.test.ts
+      // pins the ledgers disjoint, in another file. Asserting liveness here would
+      // therefore be a guard that means what it says only by borrowing someone
+      // else's invariant: a name in BOTH ledgers would pass it and still be
+      // intercepted ahead of the whitelist, turning an admitted tool into a false
+      // refusal.
+      for (const tool of CALL_TOOL_WHITELIST) {
+        expect(retiredToolMessage(tool), tool).toBeUndefined();
+      }
+    });
+
+    it("carries only LIVE names in the whitelist", () => {
+      // Separate failure, separate test: a whitelisted name that is not a
+      // registered tool is unreachable whatever the retirement branch does — the
+      // dispatch below admission would 404 it. Kept because it is the earlier
+      // and more legible signal for a slice that swapped a name in one place and
+      // not the other.
+      const alive = new Set<string>(TOOL_NAMES);
+      expect([...CALL_TOOL_WHITELIST].filter((n) => !alive.has(n))).toEqual([]);
+    });
+
+    it("never retires an action-scoped name, so the branch is never reached for one", () => {
+      // This is the invariant, stated directly: control cannot return early for a
+      // tool whose actions are individually judged, because retiredToolMessage()
+      // is undefined for every one of them.
+      for (const tool of CALL_TOOL_ACTION_WHITELIST.keys()) {
+        expect(retiredToolMessage(tool), tool).toBeUndefined();
+      }
+    });
+
+    it("whitelists every action-scoped name, so the scope is reachable at all", () => {
+      // A scope on a name the whitelist does not carry is dead configuration:
+      // the name-level refusal fires first and the scope never runs, so a later
+      // widening of that set would look reviewed and mean nothing.
+      for (const tool of CALL_TOOL_ACTION_WHITELIST.keys()) {
+        expect(CALL_TOOL_WHITELIST.has(tool), tool).toBe(true);
+      }
+    });
+
+    it("refuses every action outside a scoped tool's own set — over the whole map", () => {
+      // Exhaustive rather than sampled: probe each scoped tool with every action
+      // any scoped tool admits, plus the two BILLING actions and a nonsense one.
+      // A retirement-shaped early return that let an action-scoped call through
+      // (`if (…) return null` ahead of the action check, say) fails here for
+      // every tool in the map at once, not just the one a test remembered.
+      const probes = new Set<string>([
+        ...[...CALL_TOOL_ACTION_WHITELIST.values()].flatMap((s) => [...s]),
+        "create",
+        "start",
+        "__no_such_action__",
+      ]);
+      expect(CALL_TOOL_ACTION_WHITELIST.size).toBeGreaterThan(0);
+      for (const [tool, allowed] of CALL_TOOL_ACTION_WHITELIST) {
+        for (const action of probes) {
+          if (allowed.has(action)) continue;
+          expect(callToolAdmission(tool, { action }), `${tool} / ${action}`).toBe(
+            `tool "${tool}" is not permitted for action "${action}"`,
+          );
+        }
+      }
+    });
+
+    it("keeps the two BILLING actions refused independently of the map (#269/#278)", () => {
+      // The probe above reads the map and SKIPS whatever a set allows, so it goes
+      // quiet on exactly the actions a widening would expose: adding "create" to
+      // runpod's set makes the loop above pass by skipping it. The two names that
+      // spend money are therefore spelled here and asserted twice — that the set
+      // does not carry them, and that the call is refused — so a slice that
+      // widens the set fails rather than silently disarming the probe.
+      //
+      // Distinct from the slice-8 behavioural test above, which asserts the same
+      // refusal to guard the whitelist SWAP. This one guards the probe.
+      const runpod = CALL_TOOL_ACTION_WHITELIST.get("runpod");
+      expect(runpod, "runpod must stay action-scoped").toBeDefined();
+      for (const action of ["create", "start"]) {
+        expect(runpod?.has(action), `${action} must stay out of the scope set`).toBe(false);
+        expect(callToolAdmission("runpod", { action }), action).toBe(
+          `tool "runpod" is not permitted for action "${action}"`,
+        );
+      }
+    });
   });
 });

--- a/src/orchestrator/call-tool-admission.ts
+++ b/src/orchestrator/call-tool-admission.ts
@@ -5,11 +5,20 @@
  * call site.
  */
 
+import { retiredToolMessage } from "../tools/vocabulary.js";
+
 /** The direct tool channel: a mobile client can invoke these READ/DOWNLOAD backend
  *  tools without an agent turn (structured nav data + rig downloads). The
  *  bridge is already token-gated; this whitelist keeps call_tool to non-destructive
- *  tools (no restart/remove/clear/install). */
-const CALL_TOOL_WHITELIST = new Set<string>([
+ *  tools (no restart/remove/clear/install).
+ *
+ *  Exported for the tests only — nothing outside this module reads it, and no
+ *  package entry point re-exports it. The tests need it to assert two properties
+ *  over the WHOLE set rather than over a handful of spelled names that the 0.50.0
+ *  consolidation would rot within hours: that every whitelisted name is still a
+ *  LIVE tool, and that every live tool it does NOT carry is refused with the
+ *  byte-identical legacy string. */
+export const CALL_TOOL_WHITELIST = new Set<string>([
   // The canvas-less client's whole read side of the saved-workflow library.
   // FIVE separate entries lived here — the library listing, the file read, the
   // summary, the graph query and the PNG-metadata extractor — until 0.50.0
@@ -161,8 +170,12 @@ const CALL_TOOL_WHITELIST = new Set<string>([
  * whitelist entry was already judged over the whole tool).
  *
  * Wired ONLY where a slice's whitelist swap would otherwise broaden admission.
+ *
+ * Exported for the tests only, on the same terms as CALL_TOOL_WHITELIST above:
+ * the money guard has to be asserted over every entry in this map, not over the
+ * one or two a test happened to spell.
  */
-const CALL_TOOL_ACTION_WHITELIST: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+export const CALL_TOOL_ACTION_WHITELIST: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   // The `queue` entry above replaces the retired standalone cancel entry
   // (0.49.0 slice 4), which admitted CANCEL semantics only: interrupt the
   // running job, optionally prompt_id-matched, optionally with clear_pending —
@@ -300,6 +313,42 @@ export function callToolAdmission(
   tool: string,
   args: Record<string, unknown>,
 ): string | null {
+  // A name the consolidation RETIRED reports as RETIRED — ahead of the whitelist,
+  // for ANY retired name, whether or not it was ever whitelisted.
+  //
+  // Without this, a client calling a folded-away name gets `tool "X" is not
+  // permitted`, which is not merely a worse answer than the ledger's — it is a
+  // WRONG one. "Not permitted" says *you lack permission*, and sends a developer
+  // to check tokens, whitelists and trust boundaries. The truth is *that tool no
+  // longer exists under that name*, and the ledger already knows what to call
+  // instead. Both the compact `call_tool` facade and the direct MCP `tools/call`
+  // path (#895) answer a retired name from the ledger; this channel was the one
+  // that overwrote it, and it is exactly the channel the panel's RunPod control
+  // panel and the mobile app reach for the eleven runpod_* names 0.50.0 slice 8
+  // folded away.
+  //
+  // Ahead of the whitelist, and not merely for names the whitelist once carried,
+  // because a name that no longer exists cannot meaningfully be "permitted": the
+  // retirement is the prior fact. A caller who migrates to the surviving name then
+  // receives the action-scoped or permission answer below, which is the accurate
+  // answer AT THAT POINT. Two truthful steps beat one misleading dead end — and
+  // "was it previously whitelisted?" is not even derivable, because a slice SWAPS
+  // the retired entry for its survivor, so answering it would need a second
+  // append-only artifact whose omissions nothing gates.
+  //
+  // SAFETY — why this cannot weaken the money guard below (#269/#278). This branch
+  // has exactly two outcomes: return a non-empty refusal string, or fall through to
+  // the untouched original code. There is no input for which it returns null, so it
+  // cannot turn a refusal into an admission — the "false refusal becomes false
+  // acceptance" failure the #839 gate was about. Beyond that it is never even
+  // REACHED for an action-scoped tool: every key of CALL_TOOL_ACTION_WHITELIST is a
+  // live name, so retiredToolMessage() is undefined for it and control reaches the
+  // action check unchanged. Both properties are pinned in the tests, the second
+  // structurally, so a future slice that retires an action-scoped name (folding
+  // `runpod` onward, say) fails loudly here rather than quietly returning early.
+  const retired = retiredToolMessage(tool);
+  if (retired !== undefined) return retired;
+
   if (!CALL_TOOL_WHITELIST.has(tool)) return `tool "${tool}" is not permitted`;
   const actions = CALL_TOOL_ACTION_WHITELIST.get(tool);
   if (actions !== undefined) {


### PR DESCRIPTION
## The defect

`callToolAdmission()` gates the orchestrator's direct `call_tool` channel — the one a canvas-less client (the panel's RunPod control panel, the mobile app) uses to invoke a backend tool without an agent turn. It ran **ahead of** the retired-name path, so a client calling a name the 0.50.0 consolidation folded away got a permission refusal instead of the ledger's redirect. Measured on `c338158`:

```
runpod_pod_stop
   admission says : tool "runpod_pod_stop" is not permitted
   ledger knows   : Unknown tool 'runpod_pod_stop' — removed in 0.50.0.
                    Call runpod (action:"stop") instead.
```

Same for the other three whose standalone names this whitelist used to carry.

**This is a wrong answer, not merely a worse one.** "Not permitted" says *you lack permission*, and sends a developer to check tokens, whitelists and trust boundaries. The truth is *that tool no longer exists under that name*, and the ledger already knows what to call instead. It is the difference between a five-minute fix and an afternoon.

It is live right now, not hypothetical — `comfyui-mcp-panel` on `main` (`web/js/cmcp-runpod-ui.js`) and `comfyui-mcp-mobile` (`lib/features/runpod/runpod_control_sheet.dart`) both still reach this channel with `runpod_list_pods`, `runpod_pod_stop`, `runpod_pod_connect`, `runpod_use_local` and `runpod_deploy_link`. And it would hit every name the remaining slices retire — `list_workflows`, `list_installed_nodes`, `extract_workflow_dependencies` and more — precisely during the cross-repo migration when clear guidance matters most.

The other two call paths already answer from the ledger: the compact `call_tool` facade, and the direct MCP `tools/call` since #895. This channel was the one that overwrote it.

## The design decision

**Retirement is checked ahead of the whitelist for ANY retired name, not only for names the whitelist once carried.**

- A name that no longer exists cannot meaningfully be "permitted" — the retirement is the prior fact.
- Nothing actionable is lost. A caller who migrates to the surviving name then receives the action-scoped or permission answer, which is the accurate answer *at that point*. `remove_model` (never whitelisted, retired by a later slice) redirects to `list_local_models action:"remove"`, and the caller who follows that redirect gets the honest action-scoped refusal. Two truthful steps beat one misleading dead end.
- It keeps the three call paths agreeing. Neither the facade nor direct `tools/call` has any notion of whitelisting; a "was it previously whitelisted?" rule would give this channel a third, unique semantics.
- "Was it previously whitelisted?" is not even derivable. A slice **swaps** the retired entry for its survivor, so answering it would need a second append-only artifact whose omissions nothing gates — a new ratchet whose failure mode is silently reverting to today's wrong answer.

## The money guard does not move

`runpod` `action:"create"` and `action:"start"` both put a pod into a **billing** state and stay refused (#269/#278), as does every other action scope.

The new branch has exactly two outcomes: return a non-empty refusal string, or fall through to the untouched original code. **There is no input for which it returns null**, so it cannot turn a refusal into an admission — the "false refusal becomes false acceptance" failure the #839 gate was about. Beyond that it is never *reached* for an action-scoped tool: every key of `CALL_TOOL_ACTION_WHITELIST` is a live name, so `retiredToolMessage()` is `undefined` for it and control reaches the action check unchanged.

Both properties are pinned, the second structurally, so a slice that retires an action-scoped name fails loudly here rather than quietly returning early.

`CALL_TOOL_WHITELIST` and `CALL_TOOL_ACTION_WHITELIST` are exported **for the tests alone** — nothing else reads them and no entry point re-exports them — so the guards can be asserted over the whole set rather than over names a test happened to spell. The surface is moving hourly.

## Tests

Every subject is derived from the ledger rather than spelled: a literal retired name in `src/` is itself a dead-name-gate violation, and this file carries no `allowedIn` exemption.

- every `DEAD_NAMES` entry answers with the ledger's redirect, is **not** the permission string, is not null, names its replacement, and reads as a retirement
- the `mcp__<server>__` prefixed form, over the whole ledger
- args cannot route a retired name elsewhere, money-shaped args included
- every live non-whitelisted tool keeps the **byte-identical** legacy string, asserted over the whole live surface (replaces two spelled live names a later slice could retire at any hour)
- no whitelisted name is retired — the property the branch actually tests — and separately, every whitelisted name is live
- no action-scoped name is retired; every action-scoped name is whitelisted
- every action outside a scoped tool's own set is refused, probed exhaustively across the map, **plus create/start asserted independently of the map** (the exhaustive probe skips whatever a set allows, so it would go quiet on exactly the actions a widening would expose)

## Mutation verification

Eight mutations, each applied to the source, run, and restored:

| | mutation | tests that fail |
|---|---|---|
| M1 | fix removed | 3 retirement tests |
| M2 | retirement returns `null` (admits) | the same 3 |
| M3 | **retirement-shaped early return that admits action-scoped tools** | **7, both billing tests among them** |
| M4 | retirement served only AFTER the whitelist (the rejected design) | 3 retirement tests |
| M5 | `runpod` scope widened to admit `create` | both billing tests |
| M6 | action scope keyed on a retired name | the 3 structural guards |
| M7 | legacy refusal string reworded | both byte-identity tests |
| M8 | a retired name left in the whitelist | both whitelist guards |

M3 is the hazard the brief named; M4 is the rejected design option, and it fails — the tests encode the decision rather than merely tolerating it.

## Gates

- `npm run lint`, `npm run check:vocabulary`, `npm run vocab:export -- --check` — clean
- `npm test` — 288 files, 6120 passed, 1 expected fail, 2 skipped, **0 failures**
- control-byte scan on every changed file — clean; no git-binary files
- two adversarial codex rounds (`gpt-5.6-terra`). Round 1: **no P0** — the branch cannot admit, since a string (empty included) is still a refusal under the string-or-null contract; two P1s and two P2s, all four accepted and fixed. Round 2, on the fix itself: **SHIP**, no new findings.

`TOOL_NAMES`, `MAX_TOOLS`, `DEAD_NAMES`, `docs/design/tool-surface.txt` and `BASELINE_SHA256` are untouched. No service, return shape or other error path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
