### PR TITLE
A failed node install leaves a .git-only husk ComfyUI fails to import forever (#900)

### DIFF
--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -90,12 +90,23 @@ vi.mock("node:child_process", () => ({
 const fsCtl = vi.hoisted(() => ({
   readdirSync: undefined as ((path: string) => unknown[]) | undefined,
   readFileSync: undefined as ((path: string) => string) | undefined,
+  /** Paths passed to rmSync this test (#900 cleanup observation). */
+  removed: [] as string[],
+  /** Make removal fail, so the leftover has to be disclosed rather than swallowed. */
+  rmThrows: false,
 }));
 vi.mock("node:fs", async (importOriginal) => {
   const real = await importOriginal<typeof import("node:fs")>();
   return {
     ...real,
     existsSync: vi.fn(() => true),
+    // Tracked so a test can observe that a failed clone REMOVED what it created
+    // — and, just as importantly, that it left an existing pack alone (#900).
+    rmSync: vi.fn((path: unknown, options?: unknown) => {
+      fsCtl.removed.push(String(path));
+      if (fsCtl.rmThrows) throw new Error("EPERM: removal refused");
+      return (real.rmSync as (p: unknown, o?: unknown) => unknown)(path, options);
+    }),
     readdirSync: vi.fn((path: unknown, options?: unknown) =>
       fsCtl.readdirSync
         ? fsCtl.readdirSync(String(path))
@@ -250,6 +261,8 @@ describe("node-management service", () => {
     // Default: no custom_nodes fixture — the #797 disk scan delegates to the
     // real fs (which throws on the fake root) unless a test installs one.
     fsCtl.readdirSync = undefined;
+    fsCtl.removed = [];
+    fsCtl.rmThrows = false;
     fsCtl.readFileSync = undefined;
     savedDefault.value = undefined;
     config.comfyuiPath = "/fake/comfy";
@@ -721,6 +734,116 @@ describe("node-management service", () => {
           (c) => c[0] === "git" && (c[1] as string[]).includes("checkout"),
         ),
       ).toBe(true);
+    });
+
+    it("removes the directory a FAILED clone created, instead of leaving a husk", async () => {
+      // #900, observed on a real machine: a clone that did not produce a pack left
+      // a directory holding only `.git` in custom_nodes. ComfyUI loads
+      // DIRECTORIES, so it tried to import it on every start and logged an error
+      // — for over a month, long after anyone remembered running the install.
+      stubFetch({ installedBody: {} });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const str = String(p);
+        if (str.includes("requirements.txt") || str.includes("install.py")) return false;
+        if (str.includes(".venv") || str.includes("cm-cli.py")) return false;
+        if (str.includes(NODE_DIR_UTILS)) return cloned; // git created it, then failed
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") {
+          cloned = true; // the directory now exists…
+          throw new Error("fatal: could not read from remote repository");
+        }
+        return "";
+      }) as never);
+
+      await expect(
+        installCustomNode({ id: "https://github.com/teskor-hub/comfyui-teskors-utils" }),
+      ).rejects.toThrow(/Failed to clone/);
+
+      expect(fsCtl.removed).toContain(NODE_DIR_UTILS);
+    });
+
+    it("does NOT remove a PRE-EXISTING pack when a clone/update fails", async () => {
+      // The inverse, and the one that would do real damage: an existing pack is
+      // the user's, and a failed operation must never take it away.
+      //
+      // Note what this test does and does not prove. It passes STRUCTURALLY —
+      // with the pack already present the clone block is skipped entirely, so the
+      // cleanup is never reached — which means removing the ownership check
+      // inside `discardFailedClone` does not fail it. That check is a documented
+      // precondition rather than live logic. What this DOES pin is the property
+      // that matters to a user: run an install against a pack that is already
+      // there, have it fail, and still have your pack.
+      stubFetch({ installedBody: {} });
+      mockedExists.mockImplementation((p: unknown) => {
+        const str = String(p);
+        if (str.includes("requirements.txt") || str.includes("install.py")) return false;
+        if (str.includes(".venv") || str.includes("cm-cli.py")) return false;
+        if (str.includes(NODE_DIR_UTILS)) return true; // already there, before we ran
+        return false;
+      });
+      fsCtl.readdirSync = () => ["__init__.py", ".git"]; // a real pack
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") throw new Error("should not clone");
+        return "";
+      }) as never);
+
+      await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+      }).catch(() => undefined);
+
+      expect(fsCtl.removed).not.toContain(NODE_DIR_UTILS);
+    });
+
+    it("REJECTS a clone that produced only git metadata — an existing directory is not a pack", async () => {
+      // `existsSync(nodeDir)` was the whole post-clone check, and it passes for a
+      // husk. "The directory exists" was never the question ComfyUI asks.
+      stubFetch({ installedBody: {} });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const str = String(p);
+        if (str.includes("requirements.txt") || str.includes("install.py")) return false;
+        if (str.includes(".venv") || str.includes("cm-cli.py")) return false;
+        if (str.includes(NODE_DIR_UTILS)) return cloned;
+        return false;
+      });
+      fsCtl.readdirSync = () => [".git"]; // git and nothing else
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+
+      await expect(
+        installCustomNode({ id: "https://github.com/teskor-hub/comfyui-teskors-utils" }),
+      ).rejects.toThrow(/no loadable pack/i);
+      expect(fsCtl.removed).toContain(NODE_DIR_UTILS);
+    });
+
+    it("DISCLOSES a leftover it could not remove, rather than swallowing it", async () => {
+      // A husk nobody was told about is how the one in #900 survived a month.
+      stubFetch({ installedBody: {} });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const str = String(p);
+        if (str.includes("requirements.txt") || str.includes("install.py")) return false;
+        if (str.includes(".venv") || str.includes("cm-cli.py")) return false;
+        if (str.includes(NODE_DIR_UTILS)) return cloned;
+        return false;
+      });
+      fsCtl.rmThrows = true;
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") {
+          cloned = true;
+          throw new Error("fatal: repository not found");
+        }
+        return "";
+      }) as never);
+
+      await expect(
+        installCustomNode({ id: "https://github.com/teskor-hub/comfyui-teskors-utils" }),
+      ).rejects.toThrow(/could NOT be removed/i);
     });
 
     it("throws ProcessControlError on clone fallback when comfyuiPath is unset", async () => {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
 import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
@@ -1903,6 +1903,53 @@ export function assertSafeRepoName(repoName: string): void {
  * Dep failures DON'T fail the install (clone succeeded) — they're surfaced as
  * warnings. A clone failure throws NodeManagementError.
  */
+/**
+ * Does this directory hold something ComfyUI could actually load?
+ *
+ * A clone that git created and then abandoned leaves a directory containing only
+ * `.git`. ComfyUI loads DIRECTORIES, so it will try to import that on every
+ * start and fail — forever, silently, long after whoever ran the install has
+ * forgotten about it (#900). "The directory exists" was never the question.
+ */
+function looksLikeAPack(dir: string): boolean {
+  try {
+    return readdirSync(dir).some((entry) => entry !== ".git");
+  } catch {
+    // Unreadable is not a finding either way; let the caller's other checks
+    // speak rather than condemning a pack we could not look at.
+    return true;
+  }
+}
+
+/**
+ * Remove a clone directory THIS call created, after the clone failed.
+ *
+ * Returns a sentence to append to the error — a leftover nobody was told about
+ * is how the husk in #900 survived a month.
+ *
+ * `alreadyPresent` is a PRECONDITION, not live logic: every call site today sits
+ * inside `if (!alreadyPresent)`, so it is always false here and the guard below
+ * cannot fire. It is kept, and named, because the rule it encodes is the one that
+ * would do real damage if a later caller broke it — an existing pack is the
+ * user's, and a failed operation must never take it away. Being explicit about
+ * its unreachability is deliberate: an unreachable check that reads like live
+ * protection is worse than one that says what it is.
+ */
+function discardFailedClone(nodeDir: string, alreadyPresent: boolean): string {
+  if (alreadyPresent) return ""; // precondition — see above; unreachable today
+  if (!existsSync(nodeDir)) return ""; // git cleaned up after itself
+  try {
+    rmSync(nodeDir, { recursive: true, force: true });
+    return "";
+  } catch (rmErr) {
+    return (
+      ` NOTE: the partial clone at ${nodeDir} could NOT be removed ` +
+      `(${rmErr instanceof Error ? rmErr.message : String(rmErr)}). ComfyUI will try to ` +
+      `import it on every start and log an error — delete that directory by hand.`
+    );
+  }
+}
+
 async function cloneCustomNodeFallback(
   gitId: string,
   repoName: string,
@@ -1976,21 +2023,52 @@ async function cloneCustomNodeFallback(
         stdout?: Buffer | string;
         stderr?: Buffer | string;
       };
+      const leftover = discardFailedClone(nodeDir, alreadyPresent);
       throw new NodeManagementError(
-        `Failed to clone "${gitId}" into custom_nodes/${repoName}: ${e.message}`,
+        `Failed to clone "${gitId}" into custom_nodes/${repoName}: ${e.message}${leftover}`,
         {
           stdout: e.stdout ? e.stdout.toString() : "",
           stderr: e.stderr ? e.stderr.toString() : "",
         },
       );
     }
-    if (gitRef) runGitCheckout(gitId, gitRef, comfyuiBase);
+    if (gitRef) {
+      // The checkout is part of producing the pack, so its failure leaves the
+      // same husk as a failed clone — and the clone directory is ours either way.
+      try {
+        runGitCheckout(gitId, gitRef, comfyuiBase);
+      } catch (err) {
+        const leftover = discardFailedClone(nodeDir, alreadyPresent);
+        throw new NodeManagementError(
+          `Cloned "${gitId}" but could not check out "${gitRef}": ` +
+            `${err instanceof Error ? err.message : String(err)}${leftover}`,
+        );
+      }
+    }
   }
 
-  // VERIFY the clone landed before attempting deps.
+  // VERIFY the clone produced a PACK, not merely a directory (#900).
+  //
+  // `existsSync(nodeDir)` passed for a directory containing nothing but `.git` —
+  // which is exactly what a clone killed by the timeout leaves behind. One such
+  // husk sat in a user's custom_nodes for over a month, and ComfyUI logged an
+  // import failure for it on EVERY boot, because ComfyUI loads directories and
+  // does not care what we think we installed.
+  //
+  // Worse than useless: to any later reader — including our own disk-presence
+  // checks — it is indistinguishable from a pack the user installed on purpose
+  // that is now broken.
   if (!existsSync(nodeDir)) {
     throw new NodeManagementError(
       `Clone of "${gitId}" reported success but ${nodeDir} is missing.`,
+    );
+  }
+  if (!alreadyPresent && !looksLikeAPack(nodeDir)) {
+    const leftover = discardFailedClone(nodeDir, alreadyPresent);
+    throw new NodeManagementError(
+      `Clone of "${gitId}" reported success but produced no loadable pack in ` +
+        `custom_nodes/${repoName} — the directory holds nothing but git metadata, which ` +
+        `ComfyUI cannot import and would log an error for on every start.${leftover}`,
     );
   }
 


### PR DESCRIPTION
Fixes #900. Found on the rig during a live pass, then confirmed on disk.

```
custom_nodes\comfyui-does-not-exist-99999\
  .git/          <- and nothing else,  created 2026-06-27
```

ComfyUI had been logging an import failure for it **on every boot for over a month**.

## The defect

`git clone <url> <dir>` creates the directory itself. When the clone failed — or was killed by our own `GIT_CLONE_TIMEOUT` — the catch threw **without removing it**. And the post-clone verification was `existsSync(nodeDir)`, which a husk passes.

"The directory exists" was never the question ComfyUI asks. It loads **directories**, and does not care what we think we installed.

It is worse than doing nothing: to any later reader — including our own disk-presence checks, which #834 just taught to trust the disk — a husk is indistinguishable from a pack the user installed deliberately that is now broken.

## What changed

- A failed clone **and a failed ref checkout** remove the directory this call created. The checkout counts because it is part of producing the pack, so its failure leaves the same husk.
- The post-clone check asks whether the directory holds anything but `.git`.
- A removal that itself fails is **disclosed** in the error, naming the path — a leftover nobody was told about is exactly how this one survived a month.

## On the ownership guard

"Never remove a pack that was already there" is documented as a **precondition**, not dressed up as live protection: every call site already sits inside `if (!alreadyPresent)`, so it cannot fire today. Its test says the same — it pins the property a user cares about (a failed install leaves your existing pack alone) while being explicit that it passes structurally rather than by exercising the check.

That is deliberate. An unreachable check that reads like live protection is worse than one that says what it is — the lesson from #850, where an unreachable `STILL RUNNING` branch was removed for exactly this reason.

**Two mutations caught by their own tests**: leaving the husk, and accepting a bare directory as a pack.

Full suite: 6142 passing. Control bytes 0, no git-binary files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)