### PR TITLE
model destination visibility: nested Diffusers false mismatch + StabilityMatrix junction refusal

### DIFF
--- a/src/__tests__/services/download-dest-roots.test.ts
+++ b/src/__tests__/services/download-dest-roots.test.ts
@@ -7,16 +7,22 @@ import { join, resolve } from "node:path";
 //
 //   (a) #346 — a server with --base-directory != COMFYUI_PATH roots the download
 //       at the SERVER's models dir (where the running ComfyUI actually reads).
-//   (b) #633 — a symlinked target_subfolder resolving into a LIVE, authoritatively
-//       registered extra_model_path is ALLOWED (that's where ComfyUI reads).
-//   (c) path-safety — the symlink allowance never becomes an arbitrary-write /
-//       write-into-code-dir (RCE) hole. Covers the codex + independent-codex P0s:
+//   (b) #633/#870 — a symlink/junction INSIDE the models tree may redirect the
+//       write: into a live-registered extra root (#633), or anywhere else the
+//       code-root veto does not cover (#870 — the StabilityMatrix layout, where
+//       junctioned category folders ARE the registration mechanism and no config
+//       can vouch for their targets; ComfyUI's scanner follows the links).
+//   (c) path-safety — the symlink allowance never becomes a write-into-code-dir
+//       (RCE) hole, and a broken link is never silently followed. Covers:
 //         P0a  dangling / uncanonicalizable symlink -> REFUSED (not skipped).
 //         P0b  primary models root that resolves into custom_nodes -> REFUSED.
 //         P0c  (TOCTOU — inherent to pathname checks in Node; not asserted here).
-//         P0d  authorization is FAIL-CLOSED: only a LIVE, server-authoritative
-//              config may authorize an escape — a stale/static config cannot, and
-//              an unreachable server authorizes nothing.
+//         P0d  SUPERSEDED by #870: authorization used to require a LIVE,
+//              server-authoritative registration of the escape target. That
+//              rule could never cover a junction the server never declares, so
+//              it refused correct StabilityMatrix installs. Authorization now
+//              comes from the symlink's LOCATION (inside the user's own models
+//              tree); the code-root veto below is unaffected by the change.
 //
 // The REAL resolver + guard run; only /system_stats, the filesystem, config, and
 // the static/live registered roots are controlled.
@@ -55,10 +61,11 @@ vi.mock("../../comfyui/client.js", () => ({
   getClient: () => ({ fetchApi: (...a: unknown[]) => fetchApi(...(a as [])) }),
 }));
 
-// Two injected root sources:
+// Two injected root sources, both feeding the code-root VETO only:
 //  - getExtraModelRoots (STATIC-capable): contributes to the code-root VETO only.
-//  - getLiveExtraModelRoots (LIVE, server-authoritative): the ONLY source that may
-//    AUTHORIZE an escaping symlink (fail-closed), plus its custom_nodes veto.
+//  - getLiveExtraModelRoots (LIVE, server-authoritative): its custom_nodes roots
+//    also feed the veto. Since #870 NEITHER source authorizes anything — an
+//    in-tree symlink's redirect is authorized by its location.
 const getExtraModelRootsMock = vi.fn();
 const getLiveExtraModelRootsMock = vi.fn();
 vi.mock("../../services/extra-paths.js", () => ({
@@ -218,30 +225,53 @@ describe("(b) #633 — a symlink into a LIVE authoritatively-registered model ro
   });
 });
 
-describe("(c) P0d — fail-closed authorization", () => {
-  it("REFUSES an escape a STATIC config would list but the LIVE server does NOT (no stale authorization)", async () => {
+describe("(b) #870 — a StabilityMatrix junction into UNDECLARED storage is allowed", () => {
+  it("permits models/vae -> E:/StabilityMatrix/models/VAE with NO registered root covering it", async () => {
+    // The reported #870 shape: StabilityMatrix junctions each shared model folder
+    // into the package's models dir and registers nothing — the junction IS the
+    // registration, and ComfyUI's scanner follows it (followlinks=True). The old
+    // live-roots authorization could never vouch for the target, so a correct
+    // install was refused.
+    getSystemStats.mockResolvedValue({ system: { argv: ["python", "main.py"] } });
+    const modelsRoot = resolve(COMFYUI_PATH, "models");
+    const linkDir = resolve(modelsRoot, "vae");
+    const junctionTarget = resolve("/E/comfy/StabilityMatrix/models/VAE");
+
+    // Nothing authorizes this target: no static config, no live roots.
+    getExtraModelRootsMock.mockResolvedValue([]);
+    getLiveExtraModelRootsMock.mockResolvedValue({ authoritative: false, roots: [] });
+    symlinkTo(linkDir, junctionTarget);
+
+    const dir = await resolveModelSubfolderPreferServer("vae");
+    expect(dir).toBe(linkDir);
+  });
+});
+
+describe("(b) #870 — authorization comes from the symlink's LOCATION, not from any config", () => {
+  it("ALLOWS an escape a STATIC config would list but the LIVE server does NOT (config no longer AUTHORIZES — it feeds the veto only)", async () => {
+    // Pre-#870 this was refused ("no stale authorization", codex P0d). The symlink
+    // sits inside the user's own models tree, so its redirect needs no config's
+    // blessing — staleness is moot when authorization never came from config.
     getSystemStats.mockResolvedValue({ system: { argv: ["python", "main.py"] } });
     const modelsRoot = resolve(COMFYUI_PATH, "models");
     const linkDir = resolve(modelsRoot, "external_unet_download");
     const externalRoot = resolve("/Volumes/Render/00_AI/models/unet");
 
-    // Only the STATIC config lists it; the live server is NOT authoritative for it.
     getExtraModelRootsMock.mockResolvedValue([{ category: "unet", dir: externalRoot, group: "static" }]);
     getLiveExtraModelRootsMock.mockResolvedValue({ authoritative: false, roots: [] });
     symlinkTo(linkDir, externalRoot);
 
     await expect(
       resolveModelSubfolderPreferServer("external_unet_download"),
-    ).rejects.toBeInstanceOf(ModelError);
+    ).resolves.toBe(linkDir);
   });
 
-  it("REFUSES an escape when the live-root lookup is non-authoritative even if it returns roots", async () => {
+  it("ALLOWS an escape when the live-root lookup is non-authoritative (the lookup feeds the veto only)", async () => {
     getSystemStats.mockResolvedValue({ system: { argv: ["python", "main.py"] } });
     const modelsRoot = resolve(COMFYUI_PATH, "models");
     const linkDir = resolve(modelsRoot, "external_unet_download");
     const externalRoot = resolve("/Volumes/Render/00_AI/models/unet");
 
-    // authoritative:false must NOT authorize, regardless of any roots present.
     getLiveExtraModelRootsMock.mockResolvedValue({
       authoritative: false,
       roots: [{ category: "unet", dir: externalRoot, group: "x" }],
@@ -250,23 +280,30 @@ describe("(c) P0d — fail-closed authorization", () => {
 
     await expect(
       resolveModelSubfolderPreferServer("external_unet_download"),
-    ).rejects.toBeInstanceOf(ModelError);
+    ).resolves.toBe(linkDir);
   });
 });
 
-describe("(c) escape floor + code-root veto", () => {
-  it("rejects models/<link> -> /tmp/evil when it lands in NO registered root", async () => {
+describe("(c) escape landing — only a CODE-root landing is still refused", () => {
+  it("ALLOWS models/<link> -> an unregistered location (the user's own redirect; post-write reports visibility)", async () => {
+    // Pre-#870 this was the "escape floor" refusal. There is no structural
+    // difference between `E:\StabilityMatrix\models\VAE` (legitimate) and
+    // `/tmp/evil` (pointless) — both are undeclared targets of an in-tree link —
+    // so the guard no longer refuses either. A landing the server cannot see is
+    // reported honestly by the post-write check instead of being pre-emptively
+    // refused (and a pre-existing in-tree symlink is the user's own fixture on
+    // their own machine — single trust domain).
     getSystemStats.mockResolvedValue({ system: { argv: ["python", "main.py"] } });
     const modelsRoot = resolve(COMFYUI_PATH, "models");
     const linkDir = resolve(modelsRoot, "external_unet_download");
-    const evilOutside = resolve("/tmp/evil-outside");
+    const outside = resolve("/tmp/evil-outside");
 
     liveAuthoritative([{ category: "unet", dir: resolve("/Volumes/Render/00_AI/models/unet"), group: "comfyui" }]);
-    symlinkTo(linkDir, evilOutside);
+    symlinkTo(linkDir, outside);
 
-    await expect(
-      resolveModelSubfolderPreferServer("external_unet_download"),
-    ).rejects.toThrow(/outside the models directory/i);
+    await expect(resolveModelSubfolderPreferServer("external_unet_download")).resolves.toBe(
+      linkDir,
+    );
   });
 
   it("REFUSES a symlink into a registered custom_nodes root (no arbitrary CODE write)", async () => {
@@ -280,7 +317,7 @@ describe("(c) escape floor + code-root veto", () => {
     symlinkTo(linkDir, customNodesRoot);
 
     await expect(resolveModelSubfolderPreferServer("sneaky")).rejects.toThrow(
-      /outside the models directory/i,
+      /code directory/i,
     );
   });
 

--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -330,6 +330,47 @@ describe("pre-write: a destination the LIVE server does not read from is refused
       resolveModelSubfolderPreferServer("diffusion_models"),
     ).resolves.toBeTruthy();
   });
+
+  it("PROCEEDS when the only 'mismatch' is a diffusers folder the server CONTRACTUALLY never lists (#844)", async () => {
+    // The exact reported shape: nested Diffusers component files under
+    // models/diffusers that /models/diffusers never lists — ComfyUI registers
+    // that category with a ["folder"] extension contract (no file matches it),
+    // so the component files' absence is contractual, not evidence of a
+    // different install. The old rule read it as positive proof and refused a
+    // correct workspace.
+    h.onDisk = {
+      vae: [],
+      diffusers: [
+        "hunyuan3d-paint-v2-0-turbo/vae/diffusion_pytorch_model.bin",
+        "hunyuan3d-paint-v2-0-turbo/text_encoder/pytorch_model.bin",
+      ],
+    };
+    h.liveListings["vae"] = ["server-vae.safetensors"];
+    h.liveListings["diffusers"] = []; // what the real endpoint answers, by contract
+    await expect(resolveModelSubfolderPreferServer("vae")).resolves.toBe(
+      resolve("/comfy/models/vae"),
+    );
+    // Assert the REASON, not just the state: the category was excused by its
+    // enumeration contract, so the server was never even asked about it.
+    expect(h.fetchCalls).not.toContain("/models/diffusers");
+  });
+
+  it("STILL REFUSES a real mismatch in a sibling category when a diffusers folder is present (#844 is not a blind spot)", async () => {
+    // Excusing the contract-empty category must not excuse anything else: a
+    // populated checkpoints/ the server demonstrably does not read is still the
+    // #369 signature.
+    h.onDisk = {
+      diffusers: ["hunyuan3d-paint-v2-0-turbo/vae/diffusion_pytorch_model.bin"],
+      checkpoints: ["stale-ckpt.safetensors"],
+    };
+    h.liveListings["diffusers"] = [];
+    h.liveListings["checkpoints"] = ["live-ckpt.safetensors"];
+    const err = await resolveModelSubfolderPreferServer("vae").catch((e: Error) => e);
+    expect(err).toBeInstanceOf(ModelError);
+    expect((err as Error).message).toMatch(/DIFFERENT install/);
+    // The refusal must name the category with REAL evidence, not the excused one.
+    expect((err as Error).message).toMatch(/"checkpoints"/);
+  });
 });
 
 describe("currentLiveModelsRoot — only a LIVE-AUTHORITATIVE answer (#369)", () => {
@@ -645,5 +686,77 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     h.liveListings["loras"] = ["sub\\new.safetensors"];
     const res = await verifyLandedModel(target, "loras/sub", { attempts: 1, retryMs: 0 });
     expect(res.liveVisible).toBe("visible");
+  });
+
+  it("confirms a file landed through a category-level JUNCTION onto undeclared storage (StabilityMatrix, #870)", async () => {
+    // `models/vae` is a junction to the StabilityMatrix shared store. The server
+    // scans that path THROUGH the junction (its recursive_search follows links)
+    // and lists the file, so membership is answered by the LEXICAL write path —
+    // a realpath-only check would call the file "outside every directory the
+    // server reads", the post-write twin of the pre-write refusal.
+    const smTarget = resolve("/comfy/models/vae/new.safetensors");
+    const real = resolve("/E/StabilityMatrix/models/VAE/new.safetensors");
+    realpathMock.mockImplementation(async (p: string) => {
+      const s = String(p);
+      if (s === smTarget) return real;
+      if (resolve(s) === resolve("/comfy/models/vae")) {
+        return resolve("/E/StabilityMatrix/models/VAE");
+      }
+      return resolve(s);
+    });
+    h.modelsDirSource = "observed-root";
+    h.destModelsDir = "/comfy/models";
+    h.liveExtraRoots = { authoritative: true, roots: [] };
+    h.liveListings["vae"] = ["new.safetensors"];
+    const res = await verifyLandedModel(smTarget, "vae", {
+      attempts: 1,
+      retryMs: 0,
+      listedBefore: false,
+    });
+    expect(res.liveVisible).toBe("visible");
+    expect(res.verifiedPath).toBe(real);
+  });
+
+  it("confirms a file landed through a NESTED in-tree link (`models/vae/vendor -> ...`, #870 gate)", async () => {
+    // The junction need not sit at the category folder: the server follows links
+    // at any depth, so a file under `models/vae/vendor` is listed as
+    // "vendor/new.safetensors" wherever that link points.
+    const nestedTarget = resolve("/comfy/models/vae/vendor/new.safetensors");
+    const real = resolve("/E/shared/vendor/new.safetensors");
+    realpathMock.mockImplementation(async (p: string) => {
+      const s = String(p);
+      if (s === nestedTarget) return real;
+      if (resolve(s) === resolve("/comfy/models/vae/vendor")) {
+        return resolve("/E/shared/vendor");
+      }
+      return resolve(s);
+    });
+    h.modelsDirSource = "observed-root";
+    h.destModelsDir = "/comfy/models";
+    h.liveExtraRoots = { authoritative: true, roots: [] };
+    h.liveListings["vae"] = ["vendor/new.safetensors"];
+    const res = await verifyLandedModel(nestedTarget, "vae/vendor", {
+      attempts: 1,
+      retryMs: 0,
+      listedBefore: false,
+    });
+    expect(res.liveVisible).toBe("visible");
+    expect(res.verifiedPath).toBe(real);
+  });
+
+  it("reports UNKNOWN — never a false not-visible — for a diffusers file the listing contractually cannot contain (#844)", async () => {
+    // /models/diffusers can never list FILES (the folder is registered with a
+    // ["folder"] extension contract no file matches), so a landed file's absence
+    // from it is the contract speaking, not the server. The verdict must be an
+    // honest unconfirmed, not "the server does NOT list it".
+    const dTarget = resolve("/live/ComfyUI/models/diffusers/model.safetensors");
+    h.modelsDirSource = "observed-root";
+    h.destModelsDir = "/live/ComfyUI/models";
+    h.liveListings["diffusers"] = []; // what the real endpoint answers, by contract
+    const res = await verifyLandedModel(dTarget, "diffusers", { attempts: 1, retryMs: 0 });
+    expect(res.liveVisible).toBe("unknown");
+    expect(res.verifiedPath).toBe(dTarget);
+    expect(res.note).toMatch(/never lists individual files/);
+    expect(res.note).not.toMatch(/does NOT list/);
   });
 });

--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -67,10 +67,11 @@ vi.mock("../../services/output-dir.js", () => ({
     s === "argv-flag" || s === "live-root" || s === "observed-root",
 }));
 
-// The symlink-escape guard consults registered extra_model_paths roots (#633).
-// Stub to none (and non-authoritative live roots) so these path-safety tests stay
-// hermetic and an escaping symlink is still refused (nothing authorizes an escape).
-// The #633 allowance + fail-closed authorization are covered in a dedicated file.
+// The symlink-escape guard consults registered extra_model_paths roots (#633) for
+// its code-root VETO. Stub to none (and non-authoritative live roots) so these
+// path-safety tests stay hermetic. Since #870 an in-tree symlink's redirect is
+// authorized by its location, not by any registered root — the veto and the
+// dangling-link refusal are what these tests exercise.
 vi.mock("../../services/extra-paths.js", () => ({
   getExtraModelRoots: vi.fn(async () => []),
   getLiveExtraModelRoots: vi.fn(async () => ({ authoritative: false, roots: [] })),
@@ -208,10 +209,14 @@ describe("downloadModel — filename path safety", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("rejects a destination whose ancestor is a symlink escaping the models dir, and never fetches (#490)", async () => {
-    // The write-target resolver must guard the ACTUAL destination: a symlinked
-    // subfolder that realpaths OUTSIDE models/ can't be used as a write root even
-    // though the path string stays within models/.
+  it("ALLOWS a destination whose ancestor is an in-tree symlink redirecting outside the models dir (#870)", async () => {
+    // The write-target resolver guards the ACTUAL destination: the segment IS
+    // inspected (a dangling link is still refused), but a resolvable redirect no
+    // longer needs a registered root to vouch for the target. #490's blanket
+    // refusal of any escape could not tell `models/vae -> E:\StabilityMatrix\...`
+    // (a mainstream layout ComfyUI's own scanner follows) from a genuinely broken
+    // path, so #870 superseded it: authorization comes from the symlink's
+    // location inside the user's models tree; the code-root veto still applies.
     const escapeDir = resolve("/comfy/models/checkpoints");
     lstatMock.mockImplementation((p: string) =>
       Promise.resolve({ isSymbolicLink: () => p === escapeDir }),
@@ -220,10 +225,12 @@ describe("downloadModel — filename path safety", () => {
       Promise.resolve(p === escapeDir ? resolve("/tmp/outside") : p),
     );
 
-    await expect(
-      downloadModel("https://example.com/x.safetensors", "checkpoints", "x.safetensors"),
-    ).rejects.toThrow(/symlink in the path escapes it|outside the models/i);
-    expect(fetchMock).not.toHaveBeenCalled();
+    const target = await resolveDownloadTarget(
+      "https://example.com/x.safetensors",
+      "checkpoints",
+      "x.safetensors",
+    );
+    expect(target.targetDir).toBe(escapeDir);
   });
 
   it("allows a models ROOT that is itself a symlink/junction to another location", async () => {

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -610,6 +610,28 @@ const CORE_MODEL_EXTENSIONS = new Set([
   ".sft",
 ]);
 
+/**
+ * Model categories whose `/models/<category>` endpoint can NEVER enumerate FILES,
+ * so "the server does not list this file" is not evidence about the server at all.
+ * ComfyUI core registers `diffusers` with the extension contract `["folder"]`
+ * (folder_paths.py) — an extension no real file ever matches — so the listing is
+ * empty BY DESIGN: ComfyUI loads a diffusers model as a whole directory and never
+ * lists the component files inside one (`hunyuan3d-paint-v2-0-turbo/vae/diffusion_pytorch_model.bin`,
+ * `.../text_encoder/pytorch_model.bin`). Sampling those component files and
+ * finding them "missing" from the listing was the #844 false "a DIFFERENT install"
+ * refusal — the omission is CONTRACTUAL, not evidential.
+ * For these categories the listing is inconclusive about files in BOTH directions:
+ * absence proves nothing (the pre-write refusal) and a landed file's presence
+ * cannot be confirmed from it either (the post-write check) — both must report
+ * "unknown", never a determined negative.
+ */
+const CATEGORIES_WITHOUT_FILE_ENUMERATION = new Set(["diffusers"]);
+
+/** Is this category's live listing contractually incapable of naming FILES? */
+function categoryCannotEnumerateFiles(category: string): boolean {
+  return CATEGORIES_WITHOUT_FILE_ENUMERATION.has(category.trim().toLowerCase());
+}
+
 /** The models/ CATEGORY a target subfolder belongs to — its first path segment
  *  (`"loras/sdxl"` → `"loras"`), which is the folder name ComfyUI's `/models/<cat>`
  *  endpoint is keyed by. */
@@ -632,13 +654,17 @@ function subfolderRemainder(targetSubfolder: string): string {
  * COMFYUI_PATH, and the two disagreed silently.
  *
  * Returns `undefined` (INCONCLUSIVE — never an empty array) when the server is
- * unreachable, the endpoint is absent/errors, or the body is not a string array.
- * Callers must treat inconclusive as "no evidence", never as "no files".
+ * unreachable, the endpoint is absent/errors, the body is not a string array, OR
+ * the category's enumeration contract cannot name files at all
+ * (CATEGORIES_WITHOUT_FILE_ENUMERATION — there an answered-but-empty listing is
+ * the contract speaking, not the server's contents). Callers must treat
+ * inconclusive as "no evidence", never as "no files".
  */
 export async function liveCategoryListing(
   category: string,
 ): Promise<string[] | undefined> {
   if (!category) return undefined;
+  if (categoryCannotEnumerateFiles(category)) return undefined;
   try {
     const client = getClient();
     const res = await client.fetchApi(`/models/${encodeURIComponent(category)}`);
@@ -725,8 +751,10 @@ async function categoriesUnder(modelsRoot: string): Promise<string[]> {
  * the end of the body.
  *
  * Fails OPEN on anything inconclusive — server unreachable, endpoint missing, an
- * empty candidate directory, or full containment. It must never block a legitimate
- * download into a fresh or shared models tree.
+ * empty candidate directory, a category whose listing contractually cannot name
+ * files (`diffusers`, #844: its component files are absent from the listing by
+ * DESIGN, so their "absence" is not disagreement), or full containment. It must
+ * never block a legitimate download into a fresh or shared models tree.
  */
 async function assertDestinationVisibleToLiveServer(
   modelsRoot: string,
@@ -1086,7 +1114,19 @@ export async function verifyLandedModel(
   // codex gate, round 4); `undefined` means only local configuration could answer,
   // so a pre-existing listing entry proves nothing about OUR bytes.
   const landed = verifiedPath ?? resolve(targetPath);
-  const membership = await isUnderLiveModelRoots(landed, category);
+  // Membership is checked on the LEXICAL write path, not the realpath'd landed
+  // path: the server scans `<modelsRoot>/<category>` RECURSIVELY FOLLOWING LINKS
+  // (folder_paths.recursive_search walks with followlinks=True), so "this file
+  // sits at a path the server walks" is answered by the path as written. Checking
+  // the realpath instead called a file landed through an in-tree junction —
+  // `models/vae -> E:\StabilityMatrix\models\VAE` (#870), or a nested link like
+  // `models/vae/vendor -> ...` — "outside every directory the server reads", a
+  // false not-visible for a file the server demonstrably lists. The canonical
+  // forms inside still cover a junctioned ROOT (compared by where it really
+  // lives), and a host path that merely aliases a container-side root was already
+  // vouched lexically whenever no link was involved — this extends that existing,
+  // accepted exposure to linked paths rather than adding a new one.
+  const membership = await isUnderLiveModelRoots(resolve(targetPath), category);
   const destinationIsLiveAuthoritative = membership.inRoots === true;
   if (membership.inRoots === false) {
     const liveRoot = membership.liveRoot;
@@ -1117,6 +1157,26 @@ export async function verifyLandedModel(
   // live root cannot be pinned; it never refuses, never fails, and never lies.
   const ambiguous = !destinationIsLiveAuthoritative;
 
+  // A category whose listing contractually contains NO files (`diffusers`, #844)
+  // can neither confirm nor deny a landed FILE — its absence from the listing is
+  // the contract speaking, not the server. Without this branch the loop below
+  // would read that contractual absence as "the server does NOT list it" — the
+  // same could-not-determine → determined-not fold as the pre-write refusal,
+  // pointed at the user whose download just succeeded.
+  if (categoryCannotEnumerateFiles(category)) {
+    return {
+      verifiedPath,
+      liveVisible: "unknown",
+      note:
+        `The file IS on disk at ${verifiedPath}, but the connected ComfyUI ` +
+        `(${getComfyUIBaseUrl()}) cannot confirm it from its model listing: ComfyUI ` +
+        `never lists individual files under "${category}" (it loads a "${category}" ` +
+        "model as a whole directory, and the endpoint's listing is empty by design), " +
+        "so absence there is contractual, not a mismatch. Confirm the model's " +
+        "directory is complete on disk.",
+    };
+  }
+
   let sawListing = false;
   for (let i = 0; i < attempts; i++) {
     const listing = await liveCategoryListing(category);
@@ -1127,7 +1187,7 @@ export async function verifyLandedModel(
         // two separate observations; a ComfyUI restart onto a DIFFERENT install
         // between them would otherwise let the NEW server's own same-named model
         // confirm OUR file, which that server cannot read (codex gate, round 11).
-        const still = await isUnderLiveModelRoots(landed, category);
+        const still = await isUnderLiveModelRoots(resolve(targetPath), category);
         if (still.inRoots === false) {
           return {
             verifiedPath,
@@ -1288,12 +1348,11 @@ export async function resolveModelSubfolderWithLiveRoot(
 
 /**
  * Enforce that a local model download can ONLY land where the running ComfyUI
- * actually reads model WEIGHTS — never in a directory it imports Python from, and
- * never in an arbitrary location a symlink redirects to. Applied to the resolved
- * write target BEFORE any mkdir/write.
+ * actually reads model WEIGHTS — never in a directory it imports Python from.
+ * Applied to the resolved write target BEFORE any mkdir/write.
  *
- * Two canonical (realpath-collapsed) root sets are built from the running server's
- * OWN configuration so they match by real on-disk location regardless of mounts:
+ * The veto set is built from the running server's OWN configuration and canonical
+ * (realpath-collapsed) so it matches by real on-disk location regardless of mounts:
  *   • codeRoots (VETO, inclusive/over-veto) — the dirs ComfyUI IMPORTS PYTHON from
  *     (`custom_nodes`): each base-install dir's `custom_nodes` (from the base dirs
  *     the caller derived from the SAME /system_stats call), the models-root sibling,
@@ -1301,13 +1360,21 @@ export async function resolveModelSubfolderWithLiveRoot(
  *     must NEVER land inside one — that is arbitrary CODE execution, not a model
  *     install — so this is checked by RESOLVED REAL PATH, not category label, and
  *     it wins even when a model category also claims the same physical dir.
- *   • modelRoots (ALLOW, fail-closed) — the extra MODEL dirs the LIVE server
- *     authoritatively registers (getLiveExtraModelRoots). A symlink escaping the
- *     primary models root is permitted ONLY into one of these (the #633 case:
- *     `models/external_unet_download -> /Volumes/Render/00_AI/models/unet`). A
- *     STALE/STATIC config never authorizes an escape, and an unreachable server
- *     authorizes nothing (codex P0d) — so authorization is always anchored to what
- *     the running server really loads.
+ *
+ * A symlink/junction INSIDE the models tree may redirect the write anywhere that
+ * veto does not cover (#870 — this SUPERSEDES the #633-era "only a live-registered
+ * extra root authorizes an escape" rule, codex P0d). The redirect is a physical
+ * fixture of the user's own models directory — placed there by the user or their
+ * launcher — and ComfyUI's own scanner FOLLOWS directory symlinks
+ * (`folder_paths.recursive_search` walks with `followlinks=True`), so a write
+ * through one lands where the server actually reads. The earlier rule could never
+ * authorize the mainstream StabilityMatrix layout: it junctions each shared model
+ * folder (`models/vae` → `E:\comfy\StabilityMatrix\models\VAE`) and registers
+ * NOTHING — the junction IS the registration, so no live-root lookup can vouch
+ * for the target, and requiring one refused a correct install (a
+ * could-not-determine → determined-not fold, pointed at refusal). An exotic
+ * redirect that lands somewhere the server does not list is not hidden: the
+ * post-write check (verifyLandedModel) reports it honestly.
  *
  * Hardening invariants (codex P0a/P0b):
  *   - The PRIMARY models root itself is code-root-vetoed: if it canonicalizes into
@@ -1319,21 +1386,24 @@ export async function resolveModelSubfolderWithLiveRoot(
  *     as an absent segment (which would let a later recursive mkdir FOLLOW the link
  *     out of every root). Only a genuinely-absent segment (ENOENT/ENOTDIR from
  *     lstat) is safe to skip; any other lstat error fails closed.
+ *   - An escaping symlink whose REAL target falls under a code root is REJECTED —
+ *     the in-tree authorization above never extends to a directory ComfyUI imports
+ *     Python from.
  *
  * ACCEPTED RESIDUAL (P0c — TOCTOU): this is a pathname-time check. The Node runtime
  * has no `openat`/per-segment `O_NOFOLLOW` traversal, so a LOCAL process that can
  * replace an accepted directory/symlink AFTER this check but BEFORE the writer's
  * mkdir/rename could still redirect the write. This race is inherent to pathname
- * validation and pre-exists the #633 allowance (it affects any accepted path,
- * symlinked or not). It is ACCEPTED as a non-blocker: this runs on the user's OWN
- * single-user machine, so a concurrently-racing local process is out of scope
- * (maintainer ruling — "downloads should go where the user wants; it's their
- * computer"). We deliberately do NOT reject symlinked/external destinations to
- * defend against it — that would break the legitimate #633 external-drive use case.
+ * validation (it affects any accepted path, symlinked or not). It is ACCEPTED as a
+ * non-blocker: this runs on the user's OWN single-user machine, so a
+ * concurrently-racing local process is out of scope (maintainer ruling —
+ * "downloads should go where the user wants; it's their computer"). We deliberately
+ * do NOT reject symlinked/external destinations to defend against it — that would
+ * break the legitimate #633 external-drive and #870 StabilityMatrix use cases.
  * The refusals this guard DOES make are the ACCIDENTAL-corruption ones only: a
- * dangling/unresolvable escape (P0a), a write into a code dir / custom_nodes (P0b),
- * and an unauthorized/unresolvable root (P0d). Fully eliminating the race would
- * require trusted directory-handle traversal (native support) and is out of scope.
+ * dangling/unresolvable escape (P0a) and a write into a code dir / custom_nodes
+ * (P0b). Fully eliminating the race would require trusted directory-handle
+ * traversal (native support) and is out of scope.
  */
 async function assertNoEscapingSymlinkAncestor(
   root: string,
@@ -1345,10 +1415,11 @@ async function assertNoEscapingSymlinkAncestor(
    *  rather than re-fetched here so it can never disagree with the models dir a
    *  divergent --models-directory produced (fail-open race; #633 codex round 4). */
   baseInstallDirs: string[] = [],
-  /** The SAME /system_stats snapshot the models/base dirs came from — used to
-   *  AUTHORIZE an escaping symlink (getLiveExtraModelRoots), so authorization and
-   *  the code-root veto reflect ONE consistent server state (codex inter-snapshot
-   *  race). Default = unreachable → nothing is authorized (fail closed). */
+  /** The SAME /system_stats snapshot the models/base dirs came from — its live
+   *  extra roots feed the code-root VETO (a live-registered custom_nodes dir is
+   *  refused as a destination), so the veto reflects ONE consistent server state
+   *  (codex inter-snapshot race). Since #870 it no longer AUTHORIZES anything:
+   *  an in-tree symlink's redirect is authorized by its location, not by config. */
   liveSnapshot: LiveServerSnapshot = { reachable: false },
 ): Promise<void> {
   // Canonical root: if the models dir is itself a symlink/junction, resolve it so
@@ -1395,8 +1466,8 @@ async function assertNoEscapingSymlinkAncestor(
   const underAny = (real: string, roots: string[]): boolean =>
     roots.some((r) => real === r || real.startsWith(r + sep));
 
-  // Build the CODE roots (veto) and MODEL roots (allow) EAGERLY — the code veto must
-  // also cover the primary root (P0b), so it can't be deferred to an escape.
+  // Build the CODE roots (veto) EAGERLY — the code veto must also cover the
+  // primary root (P0b), so it can't be deferred to an escape.
   const baseDirSet = new Set<string>([
     dirname(realRoot),
     ...baseInstallDirs.map((b) => resolve(b)),
@@ -1416,11 +1487,13 @@ async function assertNoEscapingSymlinkAncestor(
   for (const er of staticExtra) {
     if (isCodeCategory(er.category)) codeRoots.push(await canon(er.dir));
   }
-  // LIVE, server-authoritative roots: the ONLY source that may AUTHORIZE an escape
-  // (fail-closed, P0d). Self-derived from the live /system_stats snapshot (the
-  // launched --extra-model-paths-config files + the live install's own
-  // extra_model_paths.yaml) — NEVER a stale local workspace config. Their
-  // custom_nodes also feed the veto.
+  // LIVE, server-authoritative roots contribute their custom_nodes to the VETO.
+  // Self-derived from the live /system_stats snapshot (the launched
+  // --extra-model-paths-config files + the live install's own extra_model_paths.yaml)
+  // — NEVER a stale local workspace config. They no longer form an ALLOW list
+  // (#870): an in-tree symlink redirect is authorized by sitting inside the user's
+  // own models tree, not by appearing in a server-declared root set (a
+  // StabilityMatrix junction target is declared nowhere).
   let live: Awaited<ReturnType<typeof getLiveExtraModelRoots>> = {
     authoritative: false,
     roots: [],
@@ -1433,17 +1506,8 @@ async function assertNoEscapingSymlinkAncestor(
   for (const er of live.roots) {
     if (isCodeCategory(er.category)) codeRoots.push(await canon(er.dir));
   }
-  const modelRoots: string[] = [];
-  if (live.authoritative) {
-    for (const er of live.roots) {
-      if (!isCodeCategory(er.category)) modelRoots.push(await canon(er.dir));
-    }
-  }
 
   const isUnderCode = (real: string): boolean => underAny(real, codeRoots);
-  const isAllowedReal = (real: string): boolean =>
-    (real === realRoot || real.startsWith(realRoot + sep) || underAny(real, modelRoots)) &&
-    !isUnderCode(real);
 
   // P0b: the PRIMARY models root must not itself resolve into a code directory
   // (e.g. `--models-directory <base>/custom_nodes`, or a models junction into
@@ -1488,9 +1552,17 @@ async function assertNoEscapingSymlinkAncestor(
           `Refusing to write through a symlink that cannot be resolved (dangling or circular): ${label}`,
         );
       }
-      if (!isAllowedReal(real)) {
+      // The segment is a symlink/junction INSIDE the models tree (every cursor in
+      // this walk is under the root by construction). Wherever it points, the
+      // redirect is a fixture of the user's own models directory and ComfyUI's
+      // scanner follows it (recursive_search walks with followlinks=True) — so the
+      // write stays where the server reads. This is the StabilityMatrix layout
+      // (#870): junctioned category folders whose targets no config declares. The
+      // ONLY remaining refusal is a landing inside a CODE root — a model download
+      // must never become a Python import.
+      if (isUnderCode(real)) {
         throw new ModelError(
-          `Refusing to write outside the models directory (a symlink in the path escapes every registered model root): ${label}`,
+          `Refusing to write through a symlink that resolves into a ComfyUI code directory (custom_nodes): ${label}`,
         );
       }
     }


### PR DESCRIPTION
Both defects lived in src/services/model-resolver.ts and both are the same fold — a listing/registration the server never makes, read as proof of a negative.

## #844 — nested Diffusers files caused a false "DIFFERENT install" refusal

Verified against ComfyUI master `folder_paths.py`: the `diffusers` category is registered with the extension contract `["folder"]`, which no file matches — so `/models/diffusers` **never lists files** (it loads those models as whole directories). The pre-write workspace check sampled nested component files (`hunyuan3d-paint-v2-0-turbo/vae/diffusion_pytorch_model.bin`, …) and read their contractual absence as proof the server doesn't read the tree.

- Categories whose listing contractually cannot name files (`CATEGORIES_WITHOUT_FILE_ENUMERATION`) now make `liveCategoryListing` return `undefined` (inconclusive = no evidence), which every caller — the pre-write refusal, `verifyLandedModel`, the manifest skip/pending paths — already honors.
- `verifyLandedModel` reports a landed diffusers file as **unknown** with an accurate note, instead of a false "the server does NOT list it".
- A test pins that a real sibling-category mismatch still refuses (the excusal is not a blind spot).

## #870 — StabilityMatrix junction model folders refused

StabilityMatrix junctions `models/vae`, `models/diffusion_models`, … into its shared store and registers nothing — the junction IS the registration, so no live-root lookup could ever authorize the escape. Per the maintainer's ruling in the issue, an in-tree symlink/junction redirect is now authorized by its **location** inside the user's own models tree (ComfyUI's scanner follows it: `recursive_search` walks with `followlinks=True`). This supersedes the #633-era P0d fail-closed authorization.

- **Kept:** the code-root (`custom_nodes`) veto — including a symlink *landing* inside one — the dangling/unresolvable-symlink refusal, and the primary-root code veto.
- **Companion honesty fix:** `verifyLandedModel`'s live-roots membership now runs on the **lexical write path** — the path the server actually scans, following links at any depth — so a file landed through a category-level or nested in-tree junction is not falsely reported "outside every directory the server reads" post-write.

## Accepted residual (called out in code + tests)

An in-tree symlink to an unregistered, non-code location (e.g. `/tmp/evil`) is now allowed: there is no structural property separating it from a legitimate junction target, both are the user's own fixture on their own machine, and a landing the server cannot see is reported honestly by the post-write check rather than pre-emptively refused.

## Verification

- Full suite: 290 files / 6219 tests green; `tsc --noEmit` clean.
- Mutation-verified: removing the contract-skip fails the #844 pre-write test; removing the verifyLandedModel branch fails its note assertion; reinstating the escape refusal fails 8 allowance tests; reverting membership to the realpath'd input fails both junction post-write tests.
- Codex adversarial gate: round 1 FAIL (3 findings — all addressed, incl. a factual error in the first message draft), round 2 PASS.

closes #844
closes #870