### PR TITLE
generation defaults: seed randomization ignores declared max + checkpoint auto-select picks video models

### DIFF
--- a/docs/tools/image-generation.mdx
+++ b/docs/tools/image-generation.mdx
@@ -10,7 +10,7 @@ icon: "image"
 
 ## generate_image
 
-Generate an image from a text prompt — the high-level entry point. Builds a txt2img workflow, filling any unspecified parameter from your configured defaults (get_defaults (action:"set") / COMFYUI_DEFAULT_* / config file), auto-selecting a txt2img-capable local checkpoint when none is given (checkpoints without a text encoder, e.g. video models, are skipped). Returns the prompt_id immediately; the resulting asset_id arrives in the completion notification and can be passed to view_image or regenerate. For full control over the node graph, use create_workflow + enqueue_workflow instead.
+Generate an image from a text prompt — the high-level entry point. Builds a txt2img workflow, filling any unspecified parameter from your configured defaults (get_defaults (action:"set") / COMFYUI_DEFAULT_* / config file), auto-selecting a local checkpoint when none is given — checkpoints known to lack a text encoder (e.g. video models) are skipped. Returns the prompt_id immediately; the resulting asset_id arrives in the completion notification and can be passed to view_image or regenerate. For full control over the node graph, use create_workflow + enqueue_workflow instead.
 
 <Tip>**In plain terms:** The one-line way to get a picture. You do not need a workflow open, or any workflow at all — describe the image and this builds and runs a sensible graph for you. Everything except the prompt is optional and falls back to your saved defaults.</Tip>
 

--- a/docs/tools/image-generation.mdx
+++ b/docs/tools/image-generation.mdx
@@ -10,7 +10,7 @@ icon: "image"
 
 ## generate_image
 
-Generate an image from a text prompt — the high-level entry point. Builds a txt2img workflow, filling any unspecified parameter from your configured defaults (get_defaults (action:"set") / COMFYUI_DEFAULT_* / config file), auto-selecting a local checkpoint when none is given. Returns the prompt_id immediately; the resulting asset_id arrives in the completion notification and can be passed to view_image or regenerate. For full control over the node graph, use create_workflow + enqueue_workflow instead.
+Generate an image from a text prompt — the high-level entry point. Builds a txt2img workflow, filling any unspecified parameter from your configured defaults (get_defaults (action:"set") / COMFYUI_DEFAULT_* / config file), auto-selecting a txt2img-capable local checkpoint when none is given (checkpoints without a text encoder, e.g. video models, are skipped). Returns the prompt_id immediately; the resulting asset_id arrives in the completion notification and can be passed to view_image or regenerate. For full control over the node graph, use create_workflow + enqueue_workflow instead.
 
 <Tip>**In plain terms:** The one-line way to get a picture. You do not need a workflow open, or any workflow at all — describe the image and this builds and runs a sensible graph for you. Everything except the prompt is optional and falls back to your saved defaults.</Tip>
 

--- a/docs/tools/workflow-execution.mdx
+++ b/docs/tools/workflow-execution.mdx
@@ -10,7 +10,7 @@ icon: "play"
 
 ## enqueue_workflow
 
-Submit a ComfyUI workflow for execution and return immediately with the prompt_id and queue position. Does not wait for completion. Use queue (action:"status") to check progress later, or get_history to retrieve results and images after completion.
+Submit a ComfyUI workflow for execution and return immediately with the prompt_id and queue position. Does not wait for completion. Seed values in the workflow are used exactly as supplied — they are NOT re-randomized, so a run is reproducible by resubmitting the same workflow (for a fresh-seed re-run of a past job, use rerun_generation). Use queue (action:"status") to check progress later, or get_history to retrieve results and images after completion.
 
 <Tip>**In plain terms:** Runs a workflow that the agent is holding in the conversation — one it just built or loaded from a file. If you want to run the graph you are LOOKING at in ComfyUI, that is the panel's run tool instead, and if you just want a picture, use generate_image.</Tip>
 
@@ -20,7 +20,7 @@ Submit a ComfyUI workflow for execution and return immediately with the prompt_i
   ComfyUI workflow in API format (node ID -&gt; &#123;class_type, inputs&#125;)
 </ParamField>
 <ParamField path="disable_random_seed" type="boolean">
-  If true, do not randomize seed values
+  No-op kept for backward compatibility: seed values are always used exactly as supplied.
 </ParamField>
 
 ### Example
@@ -61,7 +61,7 @@ Submit a ComfyUI workflow for execution and return immediately with the prompt_i
 
 ## rerun_generation
 
-Re-run the workflow behind a previous generation. Retrieves the prompt graph from execution history (by prompt_id, or the most recent run when omitted — chosen by ComfyUI's queue number, same logic as get_history) and re-enqueues it, optionally applying `inputs` overrides. Seeds are re-randomized unless disable_random_seed is set. Returns the new prompt_id and the source prompt_id it came from. Clear error if no matching history exists.
+Re-run the workflow behind a previous generation. Retrieves the prompt graph from execution history (by prompt_id, or the most recent run when omitted — chosen by ComfyUI's queue number, same logic as get_history) and re-enqueues it, optionally applying `inputs` overrides. Seeds are re-randomized (within each node's declared range) unless disable_random_seed is set or the seed is pinned via `inputs`. Returns the new prompt_id and the source prompt_id it came from. Clear error if no matching history exists.
 
 ### Parameters
 

--- a/src/__tests__/services/checkpoint-capability.test.ts
+++ b/src/__tests__/services/checkpoint-capability.test.ts
@@ -81,8 +81,7 @@ describe("headerKeysHaveTextEncoder", () => {
 
   it("rejects an empty header", () => {
     expect(headerKeysHaveTextEncoder([])).toBe(false);
-  });
-});
+  });});
 
 describe("selectTxt2ImgCheckpoint (#892)", () => {
   it("skips a video checkpoint and picks the txt2img-capable one", async () => {
@@ -165,6 +164,19 @@ describe("selectTxt2ImgCheckpoint (#892)", () => {
     const choice = await selectTxt2ImgCheckpoint([
       model("corrupt.safetensors", filePath),
     ]);
+    expect(choice?.capability).toBe("unknown");
+  });
+
+  it("treats a readable header with an UNRECOGNIZED layout as unknown, not incapable", async () => {
+    // No text-encoder prefix, but also no recognized diffusion/VAE layout:
+    // absence of evidence is not evidence of absence.
+    const exotic = model(
+      "exotic.safetensors",
+      await writeFakeSafetensors("exotic.safetensors", [
+        "some_future_arch.encoder.weight",
+      ]),
+    );
+    const choice = await selectTxt2ImgCheckpoint([exotic]);
     expect(choice?.capability).toBe("unknown");
   });
 });

--- a/src/__tests__/services/checkpoint-capability.test.ts
+++ b/src/__tests__/services/checkpoint-capability.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// The probe must never read a remote server's filesystem through a local path;
+// pin local mode regardless of the dev machine's env.
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return { ...actual, isRemoteMode: () => false };
+});
+
+import {
+  headerKeysHaveTextEncoder,
+  resetCheckpointCapabilityCache,
+  selectTxt2ImgCheckpoint,
+} from "../../services/checkpoint-capability.js";
+import type { LocalModel } from "../../services/model-resolver.js";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "ckpt-cap-"));
+  resetCheckpointCapabilityCache();
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+/** Minimal well-formed safetensors file: 8-byte LE header length + header JSON. */
+async function writeFakeSafetensors(
+  name: string,
+  tensorKeys: string[],
+): Promise<string> {
+  const header = JSON.stringify(
+    Object.fromEntries(tensorKeys.map((k) => [k, { dtype: "F16" }])),
+  );
+  const lenBuf = Buffer.alloc(8);
+  lenBuf.writeBigUInt64LE(BigInt(Buffer.byteLength(header)));
+  const filePath = join(dir, name);
+  await writeFile(filePath, Buffer.concat([lenBuf, Buffer.from(header)]));
+  return filePath;
+}
+
+function model(name: string, filePath: string): LocalModel {
+  return { name, path: filePath, size: 0, modified: "", type: "checkpoints" };
+}
+
+const SD15_KEYS = [
+  "model.diffusion_model.input_blocks.0.0.weight",
+  "cond_stage_model.transformer.text_model.encoder.layers.0.self_attn.weight",
+];
+const SDXL_KEYS = [
+  "model.diffusion_model.input_blocks.0.0.weight",
+  "conditioner.embedders.0.transformer.text_model.encoder.layers.0.weight",
+];
+const LTX_VIDEO_KEYS = [
+  "model.diffusion_model.transformer_blocks.0.attn1.weight",
+  "vae.encoder.conv_in.weight",
+];
+
+describe("headerKeysHaveTextEncoder", () => {
+  it("recognizes SD1.x cond_stage_model weights", () => {
+    expect(headerKeysHaveTextEncoder(SD15_KEYS)).toBe(true);
+  });
+
+  it("recognizes SDXL conditioner weights", () => {
+    expect(headerKeysHaveTextEncoder(SDXL_KEYS)).toBe(true);
+  });
+
+  it("recognizes SD3/Flux text_encoders weights", () => {
+    expect(headerKeysHaveTextEncoder(["text_encoders.clip_l.weight"])).toBe(
+      true,
+    );
+  });
+
+  it("rejects video-model headers (transformer + VAE, no text encoder)", () => {
+    expect(headerKeysHaveTextEncoder(LTX_VIDEO_KEYS)).toBe(false);
+  });
+
+  it("rejects an empty header", () => {
+    expect(headerKeysHaveTextEncoder([])).toBe(false);
+  });
+});
+
+describe("selectTxt2ImgCheckpoint (#892)", () => {
+  it("skips a video checkpoint and picks the txt2img-capable one", async () => {
+    const video = model(
+      "ltx_video.safetensors",
+      await writeFakeSafetensors("ltx_video.safetensors", LTX_VIDEO_KEYS),
+    );
+    const sd15 = model(
+      "sd15.safetensors",
+      await writeFakeSafetensors("sd15.safetensors", SD15_KEYS),
+    );
+    const choice = await selectTxt2ImgCheckpoint([video, sd15]);
+    expect(choice?.name).toBe("sd15.safetensors");
+    expect(choice?.capability).toBe("capable");
+    expect(choice?.skippedIncapable).toEqual(["ltx_video.safetensors"]);
+  });
+
+  it("marks GGUF checkpoints incapable (CheckpointLoaderSimple cannot load them)", async () => {
+    const gguf = model("flux-q4.gguf", join(dir, "flux-q4.gguf")); // never read
+    const sd15 = model(
+      "sd15.safetensors",
+      await writeFakeSafetensors("sd15.safetensors", SD15_KEYS),
+    );
+    const choice = await selectTxt2ImgCheckpoint([gguf, sd15]);
+    expect(choice?.name).toBe("sd15.safetensors");
+    expect(choice?.skippedIncapable).toEqual(["flux-q4.gguf"]);
+  });
+
+  it("returns null when every candidate is known incapable", async () => {
+    const v1 = model(
+      "a_ltx.safetensors",
+      await writeFakeSafetensors("a_ltx.safetensors", LTX_VIDEO_KEYS),
+    );
+    const v2 = model(
+      "b_wan.safetensors",
+      await writeFakeSafetensors("b_wan.safetensors", LTX_VIDEO_KEYS),
+    );
+    expect(await selectTxt2ImgCheckpoint([v1, v2])).toBeNull();
+  });
+
+  it("returns null for an empty listing", async () => {
+    expect(await selectTxt2ImgCheckpoint([])).toBeNull();
+  });
+
+  it("falls back to an undeterminable checkpoint rather than refusing it", async () => {
+    // .ckpt has no cheap header: capability unknown ≠ incapable.
+    const legacy = model("legacy.ckpt", join(dir, "legacy.ckpt"));
+    const video = model(
+      "ltx_video.safetensors",
+      await writeFakeSafetensors("ltx_video.safetensors", LTX_VIDEO_KEYS),
+    );
+    const choice = await selectTxt2ImgCheckpoint([legacy, video]);
+    expect(choice?.name).toBe("legacy.ckpt");
+    expect(choice?.capability).toBe("unknown");
+  });
+
+  it("prefers a later known-capable checkpoint over an earlier unknown one", async () => {
+    const legacy = model("aaa_legacy.ckpt", join(dir, "aaa_legacy.ckpt"));
+    const sd15 = model(
+      "zzz_sd15.safetensors",
+      await writeFakeSafetensors("zzz_sd15.safetensors", SD15_KEYS),
+    );
+    const choice = await selectTxt2ImgCheckpoint([legacy, sd15]);
+    expect(choice?.name).toBe("zzz_sd15.safetensors");
+    expect(choice?.capability).toBe("capable");
+  });
+
+  it("re-probes when the file on disk changes (cache invalidation)", async () => {
+    const filePath = await writeFakeSafetensors("m.safetensors", SD15_KEYS);
+    const m = model("m.safetensors", filePath);
+    expect((await selectTxt2ImgCheckpoint([m]))?.capability).toBe("capable");
+    // Overwrite with a video-model header (different size → stale cache entry).
+    await writeFakeSafetensors("m.safetensors", LTX_VIDEO_KEYS);
+    expect(await selectTxt2ImgCheckpoint([m])).toBeNull();
+  });
+
+  it("treats an unreadable/corrupt header as unknown, not incapable", async () => {
+    const filePath = join(dir, "corrupt.safetensors");
+    await writeFile(filePath, Buffer.from([1, 2, 3])); // < 8 bytes
+    const choice = await selectTxt2ImgCheckpoint([
+      model("corrupt.safetensors", filePath),
+    ]);
+    expect(choice?.capability).toBe("unknown");
+  });
+});

--- a/src/__tests__/services/workflow-executor.test.ts
+++ b/src/__tests__/services/workflow-executor.test.ts
@@ -124,6 +124,15 @@ describe("seedInputRange", () => {
     expect(seedInputRange(huge, "Huge", "seed")).toBeNull();
   });
 
+  it("rounds fractional declared bounds inward to integers inside the range", () => {
+    const frac = {
+      Frac: {
+        input: { required: { seed: ["INT", { min: 0.5, max: 10.9 }] } },
+      },
+    } as unknown as ObjectInfo;
+    expect(seedInputRange(frac, "Frac", "seed")).toEqual([1, 10]);
+  });
+
   it("honors a declared max wider than int32 (KSampler 2^64-1)", () => {
     const [min, max] = seedInputRange(OBJECT_INFO, "KSampler", "seed");
     expect(min).toBe(0);

--- a/src/__tests__/services/workflow-executor.test.ts
+++ b/src/__tests__/services/workflow-executor.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
+
+// Mock the ComfyUI client so enqueue + /object_info are observable, and the
+// job watcher so no background state is created.
+const enqueuePromptMock = vi.fn(async () => ({
+  prompt_id: "pid-1",
+  queue_remaining: 0,
+}));
+const getObjectInfoMock = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  enqueuePrompt: (...a: unknown[]) => enqueuePromptMock(...a),
+  getSystemStats: vi.fn(),
+  getObjectInfo: (...a: unknown[]) => getObjectInfoMock(...a),
+}));
+
+const watchMock = vi.fn();
+vi.mock("../../services/job-watcher.js", () => ({
+  JobWatcher: { watch: (...a: unknown[]) => watchMock(...a) },
+}));
+
+import {
+  enqueueWorkflow,
+  seedInputRange,
+} from "../../services/workflow-executor.js";
+import type { ObjectInfo, WorkflowJSON } from "../../comfyui/types.js";
+
+const INT32_MAX = 2147483647;
+
+const OBJECT_INFO: ObjectInfo = {
+  ClaudeNode: {
+    input: {
+      required: {
+        prompt: ["STRING", {}],
+        seed: [
+          "INT",
+          { default: 0, min: 0, max: INT32_MAX, control_after_generate: true },
+        ],
+      },
+    },
+    output: ["STRING"],
+    output_is_list: [false],
+    output_name: ["text"],
+    name: "ClaudeNode",
+    display_name: "Claude",
+    description: "",
+    category: "api node/text",
+    output_node: false,
+  },
+  KSampler: {
+    input: {
+      required: {
+        seed: ["INT", { default: 0, min: 0, max: 0xffffffffffffffff }],
+      },
+    },
+    output: ["LATENT"],
+    output_is_list: [false],
+    output_name: ["latent"],
+    name: "KSampler",
+    display_name: "KSampler",
+    description: "",
+    category: "sampling",
+    output_node: false,
+  },
+};
+
+function enqueuedWorkflow(): WorkflowJSON {
+  return enqueuePromptMock.mock.calls[0][0] as WorkflowJSON;
+}
+
+beforeEach(() => {
+  enqueuePromptMock.mockClear();
+  watchMock.mockClear();
+  getObjectInfoMock.mockReset();
+  getObjectInfoMock.mockResolvedValue(OBJECT_INFO);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("seedInputRange", () => {
+  it("uses the node's declared [min, max] when present", () => {
+    expect(seedInputRange(OBJECT_INFO, "ClaudeNode", "seed")).toEqual([
+      0,
+      INT32_MAX,
+    ]);
+  });
+
+  it("falls back to the int32 range for an unknown class_type", () => {
+    expect(seedInputRange(OBJECT_INFO, "NoSuchNode", "seed")).toEqual([
+      0,
+      INT32_MAX,
+    ]);
+  });
+
+  it("falls back to the int32 range when object_info is unavailable", () => {
+    expect(seedInputRange(undefined, "ClaudeNode", "seed")).toEqual([
+      0,
+      INT32_MAX,
+    ]);
+  });
+
+  it("falls back when the declared bounds are incoherent (min > max)", () => {
+    const broken = {
+      Weird: {
+        input: { required: { seed: ["INT", { min: 100, max: 5 }] } },
+      },
+    } as unknown as ObjectInfo;
+    expect(seedInputRange(broken, "Weird", "seed")).toEqual([0, INT32_MAX]);
+  });
+
+  it("honors a declared max wider than int32 (KSampler 2^64-1)", () => {
+    const [min, max] = seedInputRange(OBJECT_INFO, "KSampler", "seed");
+    expect(min).toBe(0);
+    expect(max).toBeGreaterThan(INT32_MAX);
+    // …but the draw ceiling is clamped to exactly-representable doubles.
+    expect(max).toBeLessThanOrEqual(Number.MAX_SAFE_INTEGER);
+  });
+});
+
+describe("enqueueWorkflow seed randomization (#865)", () => {
+  it("never draws above the node's declared max (ClaudeNode int32)", async () => {
+    // With the old fixed 2**32 range this draw lands at 4294967291, which
+    // ComfyUI rejects with "Value 4294967291 bigger than max of 2147483647".
+    vi.spyOn(Math, "random").mockReturnValue(0.9999999);
+    await enqueueWorkflow({
+      "1": { class_type: "ClaudeNode", inputs: { prompt: "hi", seed: 1 } },
+    });
+    const seed = enqueuedWorkflow()["1"].inputs.seed as number;
+    expect(seed).toBeLessThanOrEqual(INT32_MAX);
+    // Assert the exact draw, not just the bound: min + floor(r * (max-min+1)).
+    expect(seed).toBe(Math.floor(0.9999999 * (INT32_MAX + 1)));
+  });
+
+  it("uses the int32 fallback when the class_type is unknown to object_info", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.9999999);
+    await enqueueWorkflow({
+      "1": { class_type: "CustomNodeNotInObjectInfo", inputs: { seed: 1 } },
+    });
+    const seed = enqueuedWorkflow()["1"].inputs.seed as number;
+    expect(seed).toBeLessThanOrEqual(INT32_MAX);
+    expect(seed).toBe(Math.floor(0.9999999 * (INT32_MAX + 1)));
+  });
+
+  it("still enqueues with the int32 fallback when /object_info cannot be fetched", async () => {
+    getObjectInfoMock.mockRejectedValue(new Error("server mid-restart"));
+    vi.spyOn(Math, "random").mockReturnValue(0.9999999);
+    const result = await enqueueWorkflow({
+      "1": { class_type: "ClaudeNode", inputs: { seed: 1 } },
+    });
+    expect(result.prompt_id).toBe("pid-1");
+    const seed = enqueuedWorkflow()["1"].inputs.seed as number;
+    expect(seed).toBeLessThanOrEqual(INT32_MAX);
+  });
+
+  it("draws within a wider declared range when the node allows it", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    await enqueueWorkflow({
+      "3": { class_type: "KSampler", inputs: { seed: 1 } },
+    });
+    const seed = enqueuedWorkflow()["3"].inputs.seed as number;
+    // 0 + floor(0.5 * 2**64) — above the int32 range the old code capped at.
+    expect(seed).toBeGreaterThan(INT32_MAX);
+  });
+
+  it("leaves inputs named in preserve_seed_inputs exactly as supplied", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    await enqueueWorkflow(
+      {
+        "3": {
+          class_type: "KSampler",
+          inputs: { seed: 42, noise_seed: 7 },
+        },
+      },
+      { preserve_seed_inputs: ["seed"] },
+    );
+    const inputs = enqueuedWorkflow()["3"].inputs;
+    expect(inputs.seed).toBe(42); // caller-fixed, untouched
+    expect(inputs.noise_seed).not.toBe(7); // still re-randomized
+  });
+
+  it("does not touch any seed when disable_random_seed is set", async () => {
+    await enqueueWorkflow(
+      {
+        "1": { class_type: "ClaudeNode", inputs: { seed: 1 } },
+        "3": { class_type: "KSampler", inputs: { seed: 42 } },
+      },
+      { disable_random_seed: true },
+    );
+    const wf = enqueuedWorkflow();
+    expect(wf["1"].inputs.seed).toBe(1);
+    expect(wf["3"].inputs.seed).toBe(42);
+  });
+
+  it("registers the job watcher with the workflow actually sent", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    await enqueueWorkflow({
+      "1": { class_type: "ClaudeNode", inputs: { seed: 1 } },
+    });
+    expect(watchMock).toHaveBeenCalledTimes(1);
+    expect(watchMock.mock.calls[0][0]).toBe("pid-1");
+    expect(watchMock.mock.calls[0][1]).toEqual(enqueuedWorkflow());
+  });
+});

--- a/src/__tests__/services/workflow-executor.test.ts
+++ b/src/__tests__/services/workflow-executor.test.ts
@@ -100,13 +100,28 @@ describe("seedInputRange", () => {
     ]);
   });
 
-  it("falls back when the declared bounds are incoherent (min > max)", () => {
+  it("returns null when the declared bounds are incoherent (min > max)", () => {
     const broken = {
       Weird: {
         input: { required: { seed: ["INT", { min: 100, max: 5 }] } },
       },
     } as unknown as ObjectInfo;
-    expect(seedInputRange(broken, "Weird", "seed")).toEqual([0, INT32_MAX]);
+    // No safely-drawable value exists inside the declared range; the int32
+    // fallback would be OUTSIDE it, so the range is refused, not substituted.
+    expect(seedInputRange(broken, "Weird", "seed")).toBeNull();
+  });
+
+  it("returns null when the declared minimum is above the safe draw ceiling", () => {
+    const huge = {
+      Huge: {
+        input: {
+          required: {
+            seed: ["INT", { min: 2 ** 60, max: 2 ** 64 - 1 }],
+          },
+        },
+      },
+    } as unknown as ObjectInfo;
+    expect(seedInputRange(huge, "Huge", "seed")).toBeNull();
   });
 
   it("honors a declared max wider than int32 (KSampler 2^64-1)", () => {
@@ -149,8 +164,26 @@ describe("enqueueWorkflow seed randomization (#865)", () => {
       "1": { class_type: "ClaudeNode", inputs: { seed: 1 } },
     });
     expect(result.prompt_id).toBe("pid-1");
+    // Exact fallback draw — proves the seed WAS re-randomized within the
+    // int32 range (seed 1 passing `<= INT32_MAX` alone would also pass if
+    // the failure path silently stopped randomizing).
     const seed = enqueuedWorkflow()["1"].inputs.seed as number;
-    expect(seed).toBeLessThanOrEqual(INT32_MAX);
+    expect(seed).toBe(Math.floor(0.9999999 * (INT32_MAX + 1)));
+  });
+
+  it("leaves the seed untouched when the declared range has no safe draw", async () => {
+    getObjectInfoMock.mockResolvedValue({
+      HugeMin: {
+        input: {
+          required: { seed: ["INT", { min: 2 ** 60, max: 2 ** 64 - 1 }] },
+        },
+      },
+    });
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    await enqueueWorkflow({
+      "1": { class_type: "HugeMin", inputs: { seed: 2 ** 60 } },
+    });
+    expect(enqueuedWorkflow()["1"].inputs.seed).toBe(2 ** 60);
   });
 
   it("draws within a wider declared range when the node allows it", async () => {
@@ -159,8 +192,10 @@ describe("enqueueWorkflow seed randomization (#865)", () => {
       "3": { class_type: "KSampler", inputs: { seed: 1 } },
     });
     const seed = enqueuedWorkflow()["3"].inputs.seed as number;
-    // 0 + floor(0.5 * 2**64) — above the int32 range the old code capped at.
-    expect(seed).toBeGreaterThan(INT32_MAX);
+    // Exact draw distinguishes the declared range (clamped to
+    // MAX_SAFE_INTEGER) from the old fixed 2**32 range: 0.5 * 2**32 would
+    // give 2**31, not 2**52.
+    expect(seed).toBe(0.5 * (Number.MAX_SAFE_INTEGER + 1));
   });
 
   it("leaves inputs named in preserve_seed_inputs exactly as supplied", async () => {

--- a/src/__tests__/tools/enqueue-workflow-seed.test.ts
+++ b/src/__tests__/tools/enqueue-workflow-seed.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const enqueueWorkflowMock = vi.fn(async () => ({
+  prompt_id: "pid-1",
+  queue_remaining: 0,
+}));
+vi.mock("../../services/workflow-executor.js", () => ({
+  enqueueWorkflow: (...a: unknown[]) => enqueueWorkflowMock(...a),
+  getSystemInfo: vi.fn(),
+}));
+
+// generation-tracker is used by enqueue_workflow; stub it so registering the
+// tools doesn't pull in real tracker state.
+vi.mock("../../services/generation-tracker.js", () => ({
+  getTracker: () => ({
+    fileHasher: {},
+    logGeneration: () => ({ settingsHash: "x", reuseCount: 0 }),
+  }),
+}));
+vi.mock("../../services/workflow-settings-extractor.js", () => ({
+  extractSettings: async () => null,
+}));
+
+import { registerWorkflowExecuteTools } from "../../tools/workflow-execute.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerWorkflowExecuteTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+beforeEach(() => {
+  enqueueWorkflowMock.mockClear();
+});
+
+describe("enqueue_workflow seed handling (#865)", () => {
+  it("never re-randomizes the caller's seeds, with no flag set", async () => {
+    const workflow = {
+      "1": { class_type: "ClaudeNode", inputs: { prompt: "hi", seed: 1 } },
+    };
+    const res = await getHandler("enqueue_workflow")({ workflow });
+    expect(res.isError).toBeFalsy();
+    // Every seed in a caller-built workflow is caller-fixed: the executor is
+    // told to leave all values exactly as supplied.
+    expect(enqueueWorkflowMock).toHaveBeenCalledWith(workflow, {
+      disable_random_seed: true,
+    });
+  });
+});

--- a/src/__tests__/tools/generate-image-tool.test.ts
+++ b/src/__tests__/tools/generate-image-tool.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+// Mock the three boundaries the tool's resolveCheckpoint/Enqueue path touches;
+// keep generateImage, the workflow composer and DefaultsManager real so the
+// graph actually gets built.
+const listLocalModelsMock = vi.fn();
+vi.mock("../../services/model-resolver.js", () => ({
+  listLocalModels: (...a: unknown[]) => listLocalModelsMock(...a),
+}));
+
+const selectMock = vi.fn();
+vi.mock("../../services/checkpoint-capability.js", () => ({
+  selectTxt2ImgCheckpoint: (...a: unknown[]) => selectMock(...a),
+}));
+
+const enqueueWorkflowMock = vi.fn(async () => ({
+  prompt_id: "pid-1",
+  queue_remaining: 0,
+}));
+vi.mock("../../services/workflow-executor.js", () => ({
+  enqueueWorkflow: (...a: unknown[]) => enqueueWorkflowMock(...a),
+}));
+
+import { registerGenerateImageTool } from "../../tools/generate-image.js";
+import { DefaultsManager } from "../../services/defaults-manager.js";
+import type { WorkflowJSON } from "../../comfyui/types.js";
+
+type ToolResult = {
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+};
+type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+
+function getHandler(): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === "generate_image") handler = h;
+    },
+  };
+  registerGenerateImageTool(server as never);
+  if (!handler) throw new Error("generate_image not registered");
+  return handler;
+}
+
+function enqueuedWorkflow(): WorkflowJSON {
+  return enqueueWorkflowMock.mock.calls[0][0] as WorkflowJSON;
+}
+
+function ckptName(wf: WorkflowJSON): unknown {
+  return Object.values(wf).find((n) => n.class_type === "CheckpointLoaderSimple")
+    ?.inputs.ckpt_name;
+}
+
+beforeEach(() => {
+  listLocalModelsMock.mockReset();
+  selectMock.mockReset();
+  enqueueWorkflowMock.mockClear();
+  DefaultsManager.reset();
+  DefaultsManager.configure({ configPath: "/tmp/__never__.json", env: {} });
+});
+
+describe("generate_image checkpoint auto-select (#892)", () => {
+  it("enqueues with the txt2img-capable checkpoint the selector picked", async () => {
+    listLocalModelsMock.mockResolvedValue([{ name: "x" }, { name: "y" }]);
+    selectMock.mockResolvedValue({
+      name: "good.safetensors",
+      capability: "capable",
+      skippedIncapable: ["ltx_video.safetensors"],
+    });
+    const res = await getHandler()({ prompt: "a red apple" });
+    expect(res.isError).toBeFalsy();
+    expect(selectMock).toHaveBeenCalledOnce();
+    expect(ckptName(enqueuedWorkflow())).toBe("good.safetensors");
+    const out = JSON.parse(res.content[0].text);
+    expect(out.checkpoint).toBe("good.safetensors");
+  });
+
+  it("fails fast with an honest, actionable error when no checkpoint is txt2img-capable", async () => {
+    listLocalModelsMock.mockResolvedValue([
+      { name: "a_ltx.safetensors" },
+      { name: "b_wan.safetensors" },
+    ]);
+    selectMock.mockResolvedValue(null);
+    const res = await getHandler()({ prompt: "a red apple" });
+    expect(res.isError).toBe(true);
+    const text = res.content[0].text;
+    expect(text).toMatch(/none appears txt2img-capable/i);
+    // Names the offending models and the remedy.
+    expect(text).toContain("a_ltx.safetensors");
+    expect(text).toContain("b_wan.safetensors");
+    expect(text).toContain("checkpoint");
+    expect(text).toContain("download_model");
+    // Nothing was enqueued — no guaranteed-to-fail graph.
+    expect(enqueueWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the generic 'no checkpoint' error when the listing fails", async () => {
+    listLocalModelsMock.mockRejectedValue(new Error("connection refused"));
+    const res = await getHandler()({ prompt: "a red apple" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/No checkpoint/i);
+    expect(enqueueWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  it("does not consult the listing when a checkpoint is passed explicitly", async () => {
+    const res = await getHandler()({
+      prompt: "a red apple",
+      checkpoint: "explicit.safetensors",
+    });
+    expect(res.isError).toBeFalsy();
+    expect(listLocalModelsMock).not.toHaveBeenCalled();
+    expect(ckptName(enqueuedWorkflow())).toBe("explicit.safetensors");
+  });
+});
+
+describe("generate_image seed handling (#865)", () => {
+  it("passes the caller's seed through and shields it from re-randomization", async () => {
+    const res = await getHandler()({ prompt: "p", checkpoint: "x.safetensors", seed: 12345 });
+    expect(res.isError).toBeFalsy();
+    const wf = enqueuedWorkflow();
+    const sampler = Object.values(wf).find((n) => n.class_type === "KSampler");
+    expect(sampler?.inputs.seed).toBe(12345);
+    // The composer already drew/used the seed; the executor must not touch it.
+    expect(enqueueWorkflowMock).toHaveBeenCalledWith(expect.anything(), {
+      disable_random_seed: true,
+    });
+  });
+
+  it("still randomizes when no seed is given (composer-side draw)", async () => {
+    const res = await getHandler()({ prompt: "p", checkpoint: "x.safetensors" });
+    expect(res.isError).toBeFalsy();
+    const sampler = Object.values(enqueuedWorkflow()).find(
+      (n) => n.class_type === "KSampler",
+    );
+    expect(typeof sampler?.inputs.seed).toBe("number");
+  });
+});

--- a/src/__tests__/tools/generate-image-tool.test.ts
+++ b/src/__tests__/tools/generate-image-tool.test.ts
@@ -128,11 +128,18 @@ describe("generate_image seed handling (#865)", () => {
   });
 
   it("still randomizes when no seed is given (composer-side draw)", async () => {
-    const res = await getHandler()({ prompt: "p", checkpoint: "x.safetensors" });
-    expect(res.isError).toBeFalsy();
-    const sampler = Object.values(enqueuedWorkflow()).find(
-      (n) => n.class_type === "KSampler",
-    );
-    expect(typeof sampler?.inputs.seed).toBe("number");
+    // Pin the draw: a hardcoded/default seed would leave this green if the
+    // assertion were only "is a number".
+    const spy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    try {
+      const res = await getHandler()({ prompt: "p", checkpoint: "x.safetensors" });
+      expect(res.isError).toBeFalsy();
+      const sampler = Object.values(enqueuedWorkflow()).find(
+        (n) => n.class_type === "KSampler",
+      );
+      expect(sampler?.inputs.seed).toBe(Math.floor(0.5 * 2 ** 48));
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/__tests__/tools/rerun-generation.test.ts
+++ b/src/__tests__/tools/rerun-generation.test.ts
@@ -104,6 +104,21 @@ describe("rerun_generation", () => {
     expect(enqueued["1"].inputs.cfg).toBe(12);
   });
 
+  it("pins an override-supplied seed against re-randomization (#865)", async () => {
+    getHistoryMock.mockResolvedValue({ "abc-123": entry(7, "abc-123", GRAPH_A) });
+    const handler = getHandler("rerun_generation");
+
+    await handler({ prompt_id: "abc-123", inputs: { seed: 42 } });
+
+    const enqueued = enqueueWorkflowMock.mock.calls[0][0] as typeof GRAPH_A;
+    expect(enqueued["1"].inputs.seed).toBe(42);
+    // The executor is told which inputs the caller fixed, so randomization
+    // skips them instead of silently replacing the explicit seed.
+    expect(enqueueWorkflowMock.mock.calls[0][1]).toMatchObject({
+      preserve_seed_inputs: ["seed"],
+    });
+  });
+
   it("errors clearly when there is no history", async () => {
     getHistoryMock.mockResolvedValue({});
     const handler = getHandler("rerun_generation");

--- a/src/services/checkpoint-capability.ts
+++ b/src/services/checkpoint-capability.ts
@@ -9,13 +9,14 @@
  *
  * ComfyUI exposes no "does this checkpoint contain a CLIP" endpoint, so the
  * probe reads the safetensors header (first bytes only, never the multi-GB
- * tensor payload) and looks for known text-encoder tensor prefixes. The probe
- * is three-valued on purpose: "unknown" is NOT folded into "incapable" —
- * remote servers, non-safetensors formats and unreadable files all mean we
- * could not determine capability, and treating that as a definite negative
- * would refuse checkpoints that actually work. Selection prefers known-capable,
- * falls back to unknown, and refuses only when EVERY candidate is known
- * incapable (where enqueueing would be a guaranteed CLIPTextEncode failure).
+ * tensor payload). A header WITH known text-encoder tensor prefixes is
+ * "capable"; a header with a recognized diffusion/VAE layout but no text
+ * encoder is "incapable" (an observed absence, e.g. the video models this
+ * fix targets); anything else — remote servers, non-safetensors formats,
+ * unreadable files, unrecognized layouts — is "unknown", never folded into
+ * "incapable". Selection prefers known-capable, falls back to unknown, and
+ * refuses only when EVERY candidate is known incapable (where enqueueing
+ * would be a guaranteed CLIPTextEncode failure).
  */
 import { open, stat } from "node:fs/promises";
 import { isAbsolute } from "node:path";
@@ -47,9 +48,35 @@ const TEXT_ENCODER_KEY_PREFIXES = [
   "text_encoder.",
 ] as const;
 
+/**
+ * Tensor-key prefixes that positively identify a recognized diffusion/VAE
+ * checkpoint layout. "incapable" is only reported when the header shows one
+ * of these layouts AND no text encoder — an observed absence inside a
+ * recognized layout, not an unrecognized layout. A header matching NEITHER
+ * list is "unknown" (could not determine), never "incapable".
+ */
+const DIFFUSION_LAYOUT_KEY_PREFIXES = [
+  "model.diffusion_model.",
+  "diffusion_model.",
+  "double_blocks.",
+  "single_blocks.",
+  "first_stage_model.",
+  "vae.",
+] as const;
+
 export function headerKeysHaveTextEncoder(keys: Iterable<string>): boolean {
   for (const key of keys) {
     for (const prefix of TEXT_ENCODER_KEY_PREFIXES) {
+      if (key.startsWith(prefix)) return true;
+    }
+  }
+  return false;
+}
+
+/** True when the header keys show a recognized diffusion/VAE checkpoint layout. */
+export function headerKeysHaveDiffusionLayout(keys: Iterable<string>): boolean {
+  for (const key of keys) {
+    for (const prefix of DIFFUSION_LAYOUT_KEY_PREFIXES) {
       if (key.startsWith(prefix)) return true;
     }
   }
@@ -157,7 +184,11 @@ async function probeCheckpoint(model: LocalModel): Promise<Txt2ImgCapability> {
       ? "unknown"
       : headerKeysHaveTextEncoder(keys)
         ? "capable"
-        : "incapable";
+        : // No text encoder — but only a RECOGNIZED diffusion/VAE layout makes
+          // that an observed absence; an unrecognized layout is "unknown".
+          headerKeysHaveDiffusionLayout(keys)
+          ? "incapable"
+          : "unknown";
   probeCache.set(filePath, { mtimeMs, size, capability });
   return capability;
 }

--- a/src/services/checkpoint-capability.ts
+++ b/src/services/checkpoint-capability.ts
@@ -1,0 +1,211 @@
+/**
+ * txt2img capability probing for checkpoint auto-select (issue #892).
+ *
+ * `generate_image`'s auto-select used to take the alphabetically-first entry
+ * of the checkpoints listing — which fails 100% of the time when that entry
+ * is a video model (LTX, Wan, HunyuanVideo), because the txt2img graph wires
+ * CheckpointLoaderSimple's CLIP output into CLIPTextEncode and a video
+ * checkpoint contains no text encoder weights (clip arrives as None).
+ *
+ * ComfyUI exposes no "does this checkpoint contain a CLIP" endpoint, so the
+ * probe reads the safetensors header (first bytes only, never the multi-GB
+ * tensor payload) and looks for known text-encoder tensor prefixes. The probe
+ * is three-valued on purpose: "unknown" is NOT folded into "incapable" —
+ * remote servers, non-safetensors formats and unreadable files all mean we
+ * could not determine capability, and treating that as a definite negative
+ * would refuse checkpoints that actually work. Selection prefers known-capable,
+ * falls back to unknown, and refuses only when EVERY candidate is known
+ * incapable (where enqueueing would be a guaranteed CLIPTextEncode failure).
+ */
+import { open, stat } from "node:fs/promises";
+import { isAbsolute } from "node:path";
+import { isRemoteMode } from "../config.js";
+import {
+  resolveExistingModelFile,
+  type LocalModel,
+} from "./model-resolver.js";
+import { logger } from "../utils/logger.js";
+
+export type Txt2ImgCapability = "capable" | "incapable" | "unknown";
+
+/** Same cap as model-explorer's header reader: far beyond any real checkpoint
+ *  header (KBs–low MBs); guards against a corrupt length prefix making us
+ *  allocate the file's whole size. */
+const SAFETENSORS_HEADER_MAX_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Tensor-key prefixes that mark embedded text-encoder weights. Covers the
+ * single-file image checkpoint families CheckpointLoaderSimple can serve CLIP
+ * from: SD1.x/SD2.x ("cond_stage_model."), SDXL ("conditioner."), SD3/Flux
+ * ("text_encoders."), PixArt/Hunyuan-DiT ("text_encoder."). Video checkpoints
+ * (LTX, Wan, HunyuanVideo) carry transformer+VAE only and match none of these.
+ */
+const TEXT_ENCODER_KEY_PREFIXES = [
+  "cond_stage_model.",
+  "conditioner.",
+  "text_encoders.",
+  "text_encoder.",
+] as const;
+
+export function headerKeysHaveTextEncoder(keys: Iterable<string>): boolean {
+  for (const key of keys) {
+    for (const prefix of TEXT_ENCODER_KEY_PREFIXES) {
+      if (key.startsWith(prefix)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Read just a safetensors file's header (8-byte little-endian length + that
+ * many bytes of JSON) and return its top-level keys. Returns null for
+ * anything that isn't a well-formed, capped header — the probe is
+ * best-effort and never throws.
+ */
+async function readSafetensorsHeaderKeys(
+  filePath: string,
+): Promise<string[] | null> {
+  let fh: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    fh = await open(filePath, "r");
+    const lenBuf = Buffer.alloc(8);
+    if ((await fh.read(lenBuf, 0, 8, 0)).bytesRead < 8) return null;
+    const headerLen = Number(lenBuf.readBigUInt64LE(0));
+    if (
+      !Number.isSafeInteger(headerLen) ||
+      headerLen <= 0 ||
+      headerLen > SAFETENSORS_HEADER_MAX_BYTES
+    ) {
+      return null;
+    }
+    const headerBuf = Buffer.alloc(headerLen);
+    if ((await fh.read(headerBuf, 0, headerLen, 8)).bytesRead < headerLen) {
+      return null;
+    }
+    const header = JSON.parse(headerBuf.toString("utf8")) as unknown;
+    if (!header || typeof header !== "object" || Array.isArray(header)) {
+      return null;
+    }
+    return Object.keys(header as Record<string, unknown>);
+  } catch {
+    return null;
+  } finally {
+    await fh?.close().catch(() => undefined);
+  }
+}
+
+interface ProbeCacheEntry {
+  mtimeMs: number;
+  size: number;
+  capability: Txt2ImgCapability;
+}
+
+/** Header reads are cheap but not free; invalidated by mtime+size change. */
+const probeCache = new Map<string, ProbeCacheEntry>();
+
+/** Test hook: drop all cached probe results. */
+export function resetCheckpointCapabilityCache(): void {
+  probeCache.clear();
+}
+
+/**
+ * Probe one listed checkpoint for txt2img capability. Never throws: any
+ * observation failure resolves to "unknown", never to a definite negative.
+ */
+async function probeCheckpoint(model: LocalModel): Promise<Txt2ImgCapability> {
+  const lower = model.name.toLowerCase();
+  // CheckpointLoaderSimple cannot load GGUF at all (needs UnetLoaderGGUF).
+  if (lower.endsWith(".gguf")) return "incapable";
+  // .ckpt/.pt/.bin have no cheap metadata header to inspect.
+  if (!lower.endsWith(".safetensors")) return "unknown";
+  // The header lives on the server's filesystem; in remote mode that is not
+  // ours to read (config.ts warns when COMFYUI_PATH points elsewhere).
+  if (isRemoteMode()) return "unknown";
+
+  let filePath: string;
+  let mtimeMs: number;
+  let size: number;
+  try {
+    if (isAbsolute(model.path)) {
+      const info = await stat(model.path);
+      if (!info.isFile()) return "unknown";
+      filePath = model.path;
+      mtimeMs = info.mtimeMs;
+      size = info.size;
+    } else {
+      // HTTP listing: path is "<dir>/<name>" relative to models/. Resolve via
+      // the shared resolver so extra_model_paths.yaml roots are honoured.
+      const resolved = await resolveExistingModelFile(
+        `checkpoints/${model.name}`,
+      );
+      if (!resolved.info.isFile()) return "unknown";
+      filePath = resolved.path;
+      mtimeMs = resolved.info.mtimeMs;
+      size = resolved.info.size;
+    }
+  } catch {
+    return "unknown";
+  }
+
+  const cached = probeCache.get(filePath);
+  if (cached && cached.mtimeMs === mtimeMs && cached.size === size) {
+    return cached.capability;
+  }
+  const keys = await readSafetensorsHeaderKeys(filePath);
+  const capability =
+    keys === null
+      ? "unknown"
+      : headerKeysHaveTextEncoder(keys)
+        ? "capable"
+        : "incapable";
+  probeCache.set(filePath, { mtimeMs, size, capability });
+  return capability;
+}
+
+export interface Txt2ImgCheckpointChoice {
+  /** Checkpoint name as listed (what CheckpointLoaderSimple's ckpt_name takes). */
+  name: string;
+  capability: Txt2ImgCapability;
+  /** Names skipped because they are known NOT to drive a txt2img graph. */
+  skippedIncapable: string[];
+}
+
+/**
+ * Pick a checkpoint that can drive the txt2img graph: the first known-capable
+ * candidate in listing order, else the first whose capability could not be
+ * determined (status-quo behaviour — the graph may still work). Returns null
+ * only when every candidate is known incapable, where enqueueing would be a
+ * guaranteed failure.
+ */
+export async function selectTxt2ImgCheckpoint(
+  models: readonly LocalModel[],
+): Promise<Txt2ImgCheckpointChoice | null> {
+  // Sequential with early exit on the first known-capable candidate: the
+  // common case (first checkpoint is a normal image model) costs one header
+  // read. An unknown candidate is only a fallback — a LATER known-capable
+  // entry still beats an earlier unknown one.
+  const incapable: string[] = [];
+  let firstUnknown: LocalModel | undefined;
+  for (const model of models) {
+    const capability = await probeCheckpoint(model);
+    if (capability === "capable") {
+      if (incapable.length > 0) {
+        logger.debug("checkpoint auto-select skipped non-txt2img checkpoints", {
+          picked: model.name,
+          skipped: incapable,
+        });
+      }
+      return { name: model.name, capability, skippedIncapable: incapable };
+    }
+    if (capability === "incapable") incapable.push(model.name);
+    else if (!firstUnknown) firstUnknown = model;
+  }
+  if (firstUnknown) {
+    return {
+      name: firstUnknown.name,
+      capability: "unknown",
+      skippedIncapable: incapable,
+    };
+  }
+  return null;
+}

--- a/src/services/workflow-executor.ts
+++ b/src/services/workflow-executor.ts
@@ -40,14 +40,18 @@ const FALLBACK_SEED_MAX = 2147483647; // 2^31 - 1
 /**
  * Declared `[min, max]` for one node's seed input, from the /object_info
  * snapshot. Falls back to the int32 range when the node or the input's bounds
- * are unknown, or when the declared bounds are incoherent (min > max, NaN) —
- * an unreadable observation is never treated as a definite range.
+ * are unknown — an unreadable observation is never treated as a definite
+ * range. Returns null when bounds ARE declared but no safely-drawable value
+ * exists inside them (incoherent min > max, or a minimum above
+ * MAX_SAFE_INTEGER): drawing the int32 fallback there would land OUTSIDE the
+ * declared range and fail validation — the very bug this fixes — so the
+ * caller's value must be left untouched instead.
  */
 export function seedInputRange(
   objectInfo: ObjectInfo | undefined,
   classType: string,
   inputName: string,
-): [number, number] {
+): [number, number] | null {
   const def = objectInfo?.[classType];
   const spec =
     def?.input?.required?.[inputName] ?? def?.input?.optional?.[inputName];
@@ -65,7 +69,7 @@ export function seedInputRange(
   // (KSampler declares 2^64-1) are inexact doubles, and a top-of-range draw
   // could round UP past the true maximum and fail validation.
   const max = Math.min(declaredMax ?? FALLBACK_SEED_MAX, Number.MAX_SAFE_INTEGER);
-  if (min > max) return [FALLBACK_SEED_MIN, FALLBACK_SEED_MAX];
+  if (min > max) return null;
   return [min, max];
 }
 
@@ -107,8 +111,11 @@ async function randomizeSeeds(
           key in node.inputs &&
           typeof node.inputs[key] === "number"
         ) {
-          const [min, max] = seedInputRange(objectInfo, node.class_type, key);
-          node.inputs[key] = drawSeed(min, max);
+          const range = seedInputRange(objectInfo, node.class_type, key);
+          // null: bounds are declared but hold no safely-drawable value —
+          // keep the caller's seed rather than draw out of range.
+          if (!range) continue;
+          node.inputs[key] = drawSeed(range[0], range[1]);
         }
       }
     }

--- a/src/services/workflow-executor.ts
+++ b/src/services/workflow-executor.ts
@@ -69,8 +69,12 @@ export function seedInputRange(
   // (KSampler declares 2^64-1) are inexact doubles, and a top-of-range draw
   // could round UP past the true maximum and fail validation.
   const max = Math.min(declaredMax ?? FALLBACK_SEED_MAX, Number.MAX_SAFE_INTEGER);
-  if (min > max) return null;
-  return [min, max];
+  // ceil/floor fractional declared bounds inward so the draw is always an
+  // integer INSIDE the declared range (the input type is INT).
+  const safeMin = Math.ceil(min);
+  const safeMax = Math.floor(max);
+  if (safeMin > safeMax) return null;
+  return [safeMin, safeMax];
 }
 
 function drawSeed(min: number, max: number): number {

--- a/src/services/workflow-executor.ts
+++ b/src/services/workflow-executor.ts
@@ -1,8 +1,10 @@
 import {
   enqueuePrompt as clientEnqueuePrompt,
   getSystemStats as clientGetSystemStats,
+  getObjectInfo as clientGetObjectInfo,
 } from "../comfyui/client.js";
 import type {
+  ObjectInfo,
   WorkflowJSON,
   SystemStats,
 } from "../comfyui/types.js";
@@ -11,25 +13,102 @@ import { JobWatcher } from "./job-watcher.js";
 
 export interface EnqueueWorkflowOptions {
   disable_random_seed?: boolean;
+  /**
+   * Seed input names (e.g. "seed") whose values the caller fixed deliberately
+   * and which re-randomization must NOT overwrite (issue #865: an explicit
+   * seed replaced by a random one silently loses a reproducible run). Used by
+   * rerun/regenerate so an override like `{ seed: 42 }` survives while the
+   * remaining seeds still get fresh values.
+   */
+  preserve_seed_inputs?: readonly string[];
   /** Extra data attached to the /prompt request (e.g. comfy.org API-node creds). */
   extra_data?: Record<string, unknown>;
+}
+
+const SEED_INPUT_NAMES = ["seed", "noise_seed"] as const;
+
+/**
+ * Fallback draw range when a node's declared seed bounds are unavailable
+ * (unknown class_type, /object_info unreachable): int32 `0..2147483647`.
+ * Every stock ComfyUI seed widget is int32 or int64, so int32 draws are valid
+ * for both — the previous fixed `2 ** 32` range overflowed int32-max nodes
+ * (e.g. core's ClaudeNode) and was rejected with a 400 (issue #865).
+ */
+const FALLBACK_SEED_MIN = 0;
+const FALLBACK_SEED_MAX = 2147483647; // 2^31 - 1
+
+/**
+ * Declared `[min, max]` for one node's seed input, from the /object_info
+ * snapshot. Falls back to the int32 range when the node or the input's bounds
+ * are unknown, or when the declared bounds are incoherent (min > max, NaN) —
+ * an unreadable observation is never treated as a definite range.
+ */
+export function seedInputRange(
+  objectInfo: ObjectInfo | undefined,
+  classType: string,
+  inputName: string,
+): [number, number] {
+  const def = objectInfo?.[classType];
+  const spec =
+    def?.input?.required?.[inputName] ?? def?.input?.optional?.[inputName];
+  const config = Array.isArray(spec) ? spec[1] : undefined;
+  const declaredMin =
+    config && typeof config.min === "number" && Number.isFinite(config.min)
+      ? config.min
+      : undefined;
+  const declaredMax =
+    config && typeof config.max === "number" && Number.isFinite(config.max)
+      ? config.max
+      : undefined;
+  const min = declaredMin ?? FALLBACK_SEED_MIN;
+  // Clamp the draw ceiling to MAX_SAFE_INTEGER: declared maxes above 2^53
+  // (KSampler declares 2^64-1) are inexact doubles, and a top-of-range draw
+  // could round UP past the true maximum and fail validation.
+  const max = Math.min(declaredMax ?? FALLBACK_SEED_MAX, Number.MAX_SAFE_INTEGER);
+  if (min > max) return [FALLBACK_SEED_MIN, FALLBACK_SEED_MAX];
+  return [min, max];
+}
+
+function drawSeed(min: number, max: number): number {
+  return min + Math.floor(Math.random() * (max - min + 1));
 }
 
 /**
  * Randomize seed and noise_seed fields in a workflow.
  * Replicates the behavior that the SDK's `enqueue()` does internally,
  * since `_enqueue_prompt()` is the raw HTTP POST without seed randomization.
+ *
+ * Each draw respects the target node's DECLARED `[min, max]` for that input
+ * (from the memoized /object_info snapshot — the same one get_node_info
+ * serves), so nodes with a sub-2^32 seed max no longer fail validation with a
+ * 400. Inputs named in `preserveInputs` are left exactly as supplied.
  */
-function randomizeSeeds(workflow: WorkflowJSON): WorkflowJSON {
+async function randomizeSeeds(
+  workflow: WorkflowJSON,
+  preserveInputs?: ReadonlySet<string>,
+): Promise<WorkflowJSON> {
   const copy = JSON.parse(JSON.stringify(workflow)) as WorkflowJSON;
+  // Best-effort: without the snapshot every draw uses the int32 fallback,
+  // which is still in range for every stock seed widget.
+  let objectInfo: ObjectInfo | undefined;
+  try {
+    objectInfo = await clientGetObjectInfo();
+  } catch (err) {
+    logger.debug(
+      "object_info unavailable for seed range lookup; using int32 fallback",
+      { error: err instanceof Error ? err.message : String(err) },
+    );
+  }
   for (const node of Object.values(copy)) {
     if (node.inputs) {
-      for (const key of ["seed", "noise_seed"]) {
+      for (const key of SEED_INPUT_NAMES) {
+        if (preserveInputs?.has(key)) continue;
         if (
           key in node.inputs &&
           typeof node.inputs[key] === "number"
         ) {
-          node.inputs[key] = Math.floor(Math.random() * 2 ** 32);
+          const [min, max] = seedInputRange(objectInfo, node.class_type, key);
+          node.inputs[key] = drawSeed(min, max);
         }
       }
     }
@@ -47,7 +126,10 @@ export async function enqueueWorkflow(
 ): Promise<{ prompt_id: string; queue_remaining?: number }> {
   const workflow = options?.disable_random_seed
     ? workflowJson
-    : randomizeSeeds(workflowJson);
+    : await randomizeSeeds(
+        workflowJson,
+        new Set(options?.preserve_seed_inputs ?? []),
+      );
 
   logger.info("Enqueueing workflow (fire-and-forget)");
   const result = await clientEnqueuePrompt(

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -179,7 +179,12 @@ export function registerAssetTools(server: McpServer): void {
           );
         }
         const next = applyOverrides(record.workflow, overrides);
-        const result = await enqueueWorkflow(next, { disable_random_seed });
+        // An override like overrides.seed is a caller-fixed value; keep it
+        // while the other seeds re-randomize (issue #865).
+        const result = await enqueueWorkflow(next, {
+          disable_random_seed,
+          preserve_seed_inputs: Object.keys(overrides ?? {}),
+        });
         return {
           content: [
             {

--- a/src/tools/generate-image.ts
+++ b/src/tools/generate-image.ts
@@ -35,9 +35,10 @@ async function resolveCheckpoint(): Promise<string | undefined> {
     `Found ${models.length} local checkpoint(s), but none appears txt2img-capable: ` +
       `every one lacks text-encoder weights in its safetensors header (a video or ` +
       `UNet-only model) or is a GGUF file CheckpointLoaderSimple cannot load ` +
-      `(${listed}${more}). Pass \`checkpoint\` explicitly to use one anyway, set a ` +
-      `default with get_defaults (action:"set"), or download an image checkpoint ` +
-      `with download_model.`,
+      `(${listed}${more}). Download an image checkpoint with download_model ` +
+      `(search_civitai_models can find one), then pass it as \`checkpoint\` or save ` +
+      `it with get_defaults (action:"set"). If you believe one was misdetected, ` +
+      `pass \`checkpoint\` explicitly to bypass this check.`,
   );
 }
 
@@ -46,8 +47,8 @@ export function registerGenerateImageTool(server: McpServer): void {
     "generate_image",
     "Generate an image from a text prompt — the high-level entry point. Builds a txt2img workflow, " +
       "filling any unspecified parameter from your configured defaults (get_defaults (action:\"set\") / COMFYUI_DEFAULT_* / config file), " +
-      "auto-selecting a txt2img-capable local checkpoint when none is given (checkpoints without a text " +
-      "encoder, e.g. video models, are skipped). Returns the prompt_id immediately; the resulting " +
+      "auto-selecting a local checkpoint when none is given — checkpoints known to lack a text encoder " +
+      "(e.g. video models) are skipped. Returns the prompt_id immediately; the resulting " +
       "asset_id arrives in the completion notification and can be passed to view_image or regenerate. " +
       "For full control over the node graph, use create_workflow + enqueue_workflow instead.",
     {

--- a/src/tools/generate-image.ts
+++ b/src/tools/generate-image.ts
@@ -2,16 +2,43 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { generateImage } from "../services/generate-image.js";
 import { enqueueWorkflow } from "../services/workflow-executor.js";
-import { listLocalModels } from "../services/model-resolver.js";
-import { errorToToolResult } from "../utils/errors.js";
+import {
+  listLocalModels,
+  type LocalModel,
+} from "../services/model-resolver.js";
+import { selectTxt2ImgCheckpoint } from "../services/checkpoint-capability.js";
+import { errorToToolResult, ValidationError } from "../utils/errors.js";
 
 async function resolveCheckpoint(): Promise<string | undefined> {
+  let models: LocalModel[];
   try {
-    const models = await listLocalModels("checkpoints");
-    return models[0]?.name;
+    models = await listLocalModels("checkpoints");
   } catch {
+    // Listing failed (server unreachable, …) — the caller's generic
+    // "no checkpoint found" error is the accurate report for that.
     return undefined;
   }
+  if (models.length === 0) return undefined;
+  // Skip checkpoints that cannot drive a txt2img graph (video models without
+  // a text encoder, GGUF files) instead of taking the alphabetically-first
+  // entry and failing at CLIPTextEncode every time (issue #892).
+  const choice = await selectTxt2ImgCheckpoint(models);
+  if (choice) return choice.name;
+  const MAX_LISTED = 5;
+  const listed = models
+    .slice(0, MAX_LISTED)
+    .map((m) => m.name)
+    .join(", ");
+  const more =
+    models.length > MAX_LISTED ? `, … and ${models.length - MAX_LISTED} more` : "";
+  throw new ValidationError(
+    `Found ${models.length} local checkpoint(s), but none appears txt2img-capable: ` +
+      `every one lacks text-encoder weights in its safetensors header (a video or ` +
+      `UNet-only model) or is a GGUF file CheckpointLoaderSimple cannot load ` +
+      `(${listed}${more}). Pass \`checkpoint\` explicitly to use one anyway, set a ` +
+      `default with get_defaults (action:"set"), or download an image checkpoint ` +
+      `with download_model.`,
+  );
 }
 
 export function registerGenerateImageTool(server: McpServer): void {
@@ -19,7 +46,8 @@ export function registerGenerateImageTool(server: McpServer): void {
     "generate_image",
     "Generate an image from a text prompt — the high-level entry point. Builds a txt2img workflow, " +
       "filling any unspecified parameter from your configured defaults (get_defaults (action:\"set\") / COMFYUI_DEFAULT_* / config file), " +
-      "auto-selecting a local checkpoint when none is given. Returns the prompt_id immediately; the resulting " +
+      "auto-selecting a txt2img-capable local checkpoint when none is given (checkpoints without a text " +
+      "encoder, e.g. video models, are skipped). Returns the prompt_id immediately; the resulting " +
       "asset_id arrives in the completion notification and can be passed to view_image or regenerate. " +
       "For full control over the node graph, use create_workflow + enqueue_workflow instead.",
     {
@@ -42,7 +70,12 @@ export function registerGenerateImageTool(server: McpServer): void {
       try {
         const result = await generateImage(args, {
           resolveCheckpoint,
-          enqueue: (workflow) => enqueueWorkflow(workflow),
+          // The workflow composer already draws a random seed when none is
+          // given, so executor-side re-randomization would only ever clobber
+          // the seed this tool just resolved — including an explicit one
+          // (issue #865).
+          enqueue: (workflow) =>
+            enqueueWorkflow(workflow, { disable_random_seed: true }),
         });
         return {
           content: [

--- a/src/tools/workflow-execute.ts
+++ b/src/tools/workflow-execute.ts
@@ -18,7 +18,7 @@ import { logger } from "../utils/logger.js";
 export function registerWorkflowExecuteTools(server: McpServer): void {
   server.tool(
     "enqueue_workflow",
-    "Submit a ComfyUI workflow for execution and return immediately with the prompt_id and queue position. Does not wait for completion. Use queue (action:\"status\") to check progress later, or get_history to retrieve results and images after completion.",
+    "Submit a ComfyUI workflow for execution and return immediately with the prompt_id and queue position. Does not wait for completion. Seed values in the workflow are used exactly as supplied — they are NOT re-randomized, so a run is reproducible by resubmitting the same workflow (for a fresh-seed re-run of a past job, use rerun_generation). Use queue (action:\"status\") to check progress later, or get_history to retrieve results and images after completion.",
     {
       workflow: z
         .record(z.string(), z.any())
@@ -26,12 +26,17 @@ export function registerWorkflowExecuteTools(server: McpServer): void {
       disable_random_seed: z
         .boolean()
         .optional()
-        .describe("If true, do not randomize seed values"),
+        .describe(
+          "No-op kept for backward compatibility: seed values are always used exactly as supplied.",
+        ),
     },
     async (args) => {
       try {
+        // Every seed in this caller-built workflow is caller-fixed; replacing
+        // one with a random value silently destroyed reproducible runs and
+        // could exceed the node's declared max (issue #865).
         const result = await enqueueWorkflow(args.workflow, {
-          disable_random_seed: args.disable_random_seed,
+          disable_random_seed: true,
         });
 
         // Log generation settings (best-effort, don't fail the response)
@@ -75,7 +80,8 @@ export function registerWorkflowExecuteTools(server: McpServer): void {
     "Re-run the workflow behind a previous generation. Retrieves the prompt graph from " +
       "execution history (by prompt_id, or the most recent run when omitted — chosen by " +
       "ComfyUI's queue number, same logic as get_history) and re-enqueues it, optionally " +
-      "applying `inputs` overrides. Seeds are re-randomized unless disable_random_seed is set. " +
+      "applying `inputs` overrides. Seeds are re-randomized (within each node's declared " +
+      "range) unless disable_random_seed is set or the seed is pinned via `inputs`. " +
       "Returns the new prompt_id and the source prompt_id it came from. Clear error if no " +
       "matching history exists.",
     {
@@ -120,6 +126,9 @@ export function registerWorkflowExecuteTools(server: McpServer): void {
         const next = applyOverrides(workflow, args.inputs);
         const result = await enqueueWorkflow(next, {
           disable_random_seed: args.disable_random_seed,
+          // An override like inputs.seed is a caller-fixed value; keep it while
+          // the other seeds re-randomize (issue #865).
+          preserve_seed_inputs: Object.keys(args.inputs ?? {}),
         });
 
         return {


### PR DESCRIPTION
## What

**#865 — seed randomization vs. declared max + explicit seeds.** `randomizeSeeds` drew `Math.random()*2**32`, overwrote even explicit seeds, and never consulted the node's declared max — a node like core's ClaudeNode (seed max 2147483647) failed validation with a 400 on every enqueue.

- Draws now respect the node's declared `[min, max]` from the memoized `/object_info` snapshot; unknown node/bounds → int32 fallback (valid for every stock seed widget). Declared maxes above 2^53 (KSampler's 2^64-1) clamp the draw ceiling to `MAX_SAFE_INTEGER` so a top-of-range draw can't round past the true max; fractional declared bounds are rounded inward; bounds with no safely-drawable integer range refuse the draw and keep the caller's value.
- **`enqueue_workflow` no longer re-randomizes at all** — every seed in a caller-built workflow is caller-fixed (the issue's core complaint). The `disable_random_seed` param is kept as a documented no-op for compatibility. `rerun_generation`/`regenerate` keep their documented re-randomize-by-default, and a new `preserve_seed_inputs` executor option stops that from clobbering a seed the caller pinned via overrides (regenerate's own description already promised this).
- `generate_image` enqueues with executor randomization off: the composer already draws a random seed when none is given, so the executor pass only ever clobbered the resolved seed (explicit `seed:` was silently broken before).

**#892 — checkpoint auto-select picks video models.** `resolveCheckpoint` returned the alphabetically-first checkpoint; on a rig whose first checkpoint is an LTX/Wan video model (no text encoder) the txt2img graph fails at CLIPTextEncode 100% of the time.

- New `checkpoint-capability` service probes each listed checkpoint's safetensors header (first bytes only, mtime+size-cached): known TE prefixes → `capable`; recognized diffusion/VAE layout with no TE → `incapable`; anything undeterminable (remote server, .ckpt/.pt/.bin, unreadable or unrecognized layout) → `unknown`, deliberately never folded into `incapable`.
- Auto-select prefers known-capable, falls back to unknown (status quo), and fails fast with an actionable error only when EVERY candidate is known incapable.

## Behavior-change note

`enqueue_workflow` no longer randomizes seeds by default — resubmitting the same workflow now reproduces the run (ComfyUI cache included). Fresh-seed re-runs are `rerun_generation`'s documented job. `run_template`/`batches`/`run_workflow_url` keep randomize-by-default (now range-safe).

## Verification

- Full suite green (294 files / 6246 tests), `tsc --noEmit` clean, docs regenerated (`gen-tool-docs`), vocabulary gate OK.
- Mutation-verified: old 2^32 draw (4 tests fail), preserve-guard removal, `min>max → fallback` instead of null (3 fail), capability filter removal (5 fail), tool-layer selection bypass (2 fail), diffusion-layout tier removal (3 fail), ceil/floor removal (1 fail).
- Codex gate: 3 rounds — r1 NO-SHIP (5 findings: unsafe-range fallback, unobserved capability claim in description, non-actionable remedies, 2 weak tests) → fixed; r2 (2 findings: unrecognized-layout-as-incapable, fractional/unsafe declared bounds) → fixed; r3 (1 test-quality finding) → fixed.

## Deliberate non-fixes

- Other generate-* tools (video/audio/conditioned/upscale/remove-background) have the same explicit-seed clobber; untouched here — PR #907 is rewriting those call sites, flagged for coordination.
- Omitted seed inputs are not injected (the issue's optional "at minimum" extension); omitted required inputs fail ComfyUI validation with its own clear error.
- `batches` sweep sets naming `seed` still get re-randomized per that tool's documented behavior.

closes #865
closes #892