### PR TITLE
Redirect every persistent store for the whole test run (#866, #879)

### DIFF
--- a/src/__tests__/services/secret-store-test-isolation.test.ts
+++ b/src/__tests__/services/secret-store-test-isolation.test.ts
@@ -223,13 +223,47 @@ describe("secret-store test isolation", () => {
     }
   });
 
+  /**
+   * Files allowed to name the real store, each with its reason.
+   *
+   * DECLARED, not evaded. The pattern below could be side-stepped by assembling
+   * the same path from pieces — and that is precisely what must not happen: an
+   * exception nobody can see is how a guard quietly stops guarding. Anything
+   * added here needs a reason that survives being read aloud.
+   */
+  const ALLOWED_TO_NAME_THE_REAL_STORE = new Map<string, string>([
+    [
+      "suite-state-isolation.test.ts",
+      "asserts that NO redirect points inside the real store, so it has to name " +
+        "the store to check nothing resolves there — the inverse of this hazard.",
+    ],
+  ]);
+
+  const baseName = (p: string): string => p.split(/[\\/]/).pop() ?? "";
+
   it("no test hardcodes the real home credential path", () => {
     const offenders: string[] = [];
     for (const file of files) {
+      const rel = relative(testsRoot, file);
+      if (ALLOWED_TO_NAME_THE_REAL_STORE.has(baseName(rel))) continue;
       const src = readFileSync(file, "utf-8");
       // homedir()-based store paths in a test are the same hazard wearing a hat.
-      if (/homedir\(\)[^\n]*\.comfyui-mcp/.test(src)) offenders.push(relative(testsRoot, file));
+      if (/homedir\(\)[^\n]*\.comfyui-mcp/.test(src)) offenders.push(rel);
     }
     expect(offenders).toEqual([]);
+  });
+
+  it("the allowlist cannot become a place to quietly park offenders", () => {
+    // An allowlist that grows without anyone noticing IS the bypass. Every entry
+    // must carry a real reason and must still name a file that exists — a stale
+    // name left behind after a rename silently widens the exemption to nothing,
+    // or worse, to whatever later takes that name.
+    for (const [name, reason] of ALLOWED_TO_NAME_THE_REAL_STORE) {
+      expect(reason.length, `${name} has no real reason`).toBeGreaterThan(40);
+      expect(
+        files.some((f) => baseName(relative(testsRoot, f)) === name),
+        `${name} is allowlisted but no such test file exists`,
+      ).toBe(true);
+    }
   });
 });

--- a/src/__tests__/suite-state-isolation.test.ts
+++ b/src/__tests__/suite-state-isolation.test.ts
@@ -1,0 +1,72 @@
+// The suite must not be able to write the developer's real state, and that has
+// to be checkable rather than hoped for.
+//
+// Four separate times a test wrote to the real `~/.comfyui-mcp`: the credential
+// `.env` (#837), the OAuth mirror (#859), `panel-pending-ops.json` (#866), and
+// then the `.env` again on a full parallel run (#879). Every one was fixed where
+// it was found; the class returned because each fix was per-test and the next
+// test to reach for a store did not know it had to opt in.
+//
+// A clean run proves nothing on its own — #879 was INTERMITTENT, touching the
+// real file on one full run and not on two others. So this asserts the mechanism
+// instead of the outcome: the redirect is in effect, in this worker, pointing
+// somewhere disposable.
+
+import { describe, expect, it } from "vitest";
+import { homedir } from "node:os";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+/** Every env var that steers a persistent store away from the user's home. */
+const REDIRECTS = [
+  "COMFYUI_MCP_ENV_FILE",
+  "COMFYUI_MCP_PANEL_SECRETS",
+  "COMFYUI_MCP_PANEL_PENDING",
+  "COMFYUI_MCP_PANEL_LOCK",
+  "COMFYUI_MCP_DATA_DIR",
+] as const;
+
+describe("suite state isolation (#866 / #879)", () => {
+  it("every persistent store is redirected, in this worker", () => {
+    // Worker scope is the part that matters: `globalSetup` runs in the MAIN
+    // process, and this passing is what shows the values were inherited across
+    // the fork rather than set somewhere the tests cannot see.
+    for (const key of REDIRECTS) {
+      expect(process.env[key], `${key} is not redirected`).toBeTruthy();
+    }
+  });
+
+  // NOTE on the two below: both SKIP a var that is unset, so on their own they
+  // pass vacuously when nothing is redirected at all. They are meaningful only
+  // together with the test above, which is what establishes that the values
+  // exist. Said out loud because "3 passing tests" would otherwise read as three
+  // independent guarantees.
+  it("no redirect points inside the real ~/.comfyui-mcp", () => {
+    // Being SET is not enough — a redirect aimed at the real directory would
+    // satisfy the check above while doing exactly the damage it exists to stop.
+    const realStore = resolve(homedir(), ".comfyui-mcp");
+    for (const key of REDIRECTS) {
+      const value = process.env[key];
+      if (!value) continue;
+      expect(
+        resolve(value).toLowerCase().startsWith(realStore.toLowerCase()),
+        `${key} points inside the real store at ${realStore}`,
+      ).toBe(false);
+    }
+  });
+
+  it("the redirects land in a temp directory, not somewhere durable", () => {
+    // The other way this could be satisfied while still being wrong: pointed at
+    // the repo, or the CWD, or anywhere a stray file outlives the run. The old
+    // in-tree generations.db (#872) is what that looks like in practice.
+    const temp = resolve(tmpdir()).toLowerCase();
+    for (const key of REDIRECTS) {
+      const value = process.env[key];
+      if (!value) continue;
+      expect(
+        resolve(value).toLowerCase().startsWith(temp),
+        `${key} is not under the OS temp dir: ${value}`,
+      ).toBe(true);
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -45,6 +45,12 @@ export default defineConfig({
     // If a test starts needing MORE than this, that is a signal to make it
     // deterministic (inject the clock, remove the real timer), not to raise this
     // number again.
+    // Redirect every store this app persists to at a throwaway directory for the
+    // whole run, BEFORE any worker forks. Four separate times a test wrote to the
+    // developer's real ~/.comfyui-mcp (#837, #859, #866, #879); the runtime
+    // guards cannot close it because they only see worker scope. See the file for
+    // why this is a floor rather than a replacement for them.
+    globalSetup: ["./vitest.global-setup.ts"],
     testTimeout: 30_000,
     hookTimeout: 30_000,
   },

--- a/vitest.global-setup.ts
+++ b/vitest.global-setup.ts
@@ -1,0 +1,69 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Point every store this app persists to at a throwaway directory, for the WHOLE
+ * run, before a single test file is collected.
+ *
+ * ## Why this exists
+ *
+ * Four separate times, a test wrote to the developer's REAL `~/.comfyui-mcp`:
+ * the credential `.env` (#837), the OAuth mirror (#859), `panel-pending-ops.json`
+ * (#866), and then the `.env` again, intermittently, on a full run (#879). Each
+ * was fixed where it was found. The class kept coming back because each fix was
+ * per-test, and the next test to reach for a store did not know it had to opt in.
+ *
+ * ## Why the runtime guards do not close it
+ *
+ * `assertStoreIsRedirectedInTests` / `assertPanelSecretsRedirectedInTests` refuse
+ * a write unless the redirect is set — but they key off globals Vitest injects
+ * into WORKER scope, and they deliberately ALLOW the write when they cannot prove
+ * they are under the runner. That trade-off is correct and is not being changed:
+ * refusing a real user their own credential is a worse failure than a stray test
+ * write. The consequence is that anything writing from OUTSIDE a worker — the
+ * main process, a global setup, a module-level side effect evaluated during
+ * collection — sails straight through. That matches what #879 measured: no single
+ * test file reproduced it, only the full parallel run.
+ *
+ * A guard at the write cannot see what it cannot see. Redirecting the whole run
+ * removes the question instead of asking it more loudly.
+ *
+ * ## Why here and not in `setupFiles`
+ *
+ * `setupFiles` run per test FILE, inside a worker — already too late for anything
+ * evaluated at collection, and too late for the main process. `globalSetup` runs
+ * once in the main process before workers are forked, so the workers inherit
+ * these values rather than each having to set them.
+ *
+ * Tests that need their own store still override these per-test, as they do now;
+ * this is the floor, not a replacement. And a test that deliberately unsets one
+ * to exercise a default is unaffected — it is choosing, which is the point.
+ */
+let dir: string | undefined;
+
+export function setup(): void {
+  dir = mkdtempSync(join(tmpdir(), "cmcp-suite-state-"));
+
+  // The canonical credential store, and the legacy JSON one beside it.
+  process.env.COMFYUI_MCP_ENV_FILE = join(dir, ".env");
+  process.env.COMFYUI_MCP_PANEL_SECRETS = join(dir, "panel-secrets.json");
+  // The crash-recovery marker a pin write reads and warns on.
+  process.env.COMFYUI_MCP_PANEL_PENDING = join(dir, "panel-pending-ops.json");
+  // The panel mutation lock. Also gives parallel workers their own file instead
+  // of serializing on one shared path.
+  process.env.COMFYUI_MCP_PANEL_LOCK = join(dir, "panel-op.lock");
+  // The per-user data dir: generation tracker, lora catalog, batch manager,
+  // training jobs, trainer bootstrap and ai-toolkit all derive from this one.
+  process.env.COMFYUI_MCP_DATA_DIR = dir;
+}
+
+export function teardown(): void {
+  if (!dir) return;
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // A leftover temp directory is not worth failing a green run over, and it is
+    // in the OS temp dir where it harms nothing.
+  }
+}


### PR DESCRIPTION
Fixes #879. Closes the remaining half of #866.

## The recurring class

Four separate times a test wrote the developer's **real** `~/.comfyui-mcp`:

| | store | issue |
|---|---|---|
| 1 | credential `.env` | #837 |
| 2 | OAuth mirror | #859 |
| 3 | `panel-pending-ops.json` | #866 |
| 4 | credential `.env` again, intermittently, on a full parallel run | #879 |

Each was fixed where it was found. The class kept returning because every fix was **per-test**, and the next test to reach for a store did not know it had to opt in.

## Why the runtime guards can't close it — and aren't being changed

`assertStoreIsRedirectedInTests` keys off globals Vitest injects into **worker** scope, and deliberately **allows** the write when it cannot prove it is under the runner. That trade-off is correct: refusing a real user their own credential is a worse failure than a stray test write.

The consequence is that anything writing from **outside a worker** — the main process, a global setup, a module-level side effect evaluated at collection — sails straight through. That is precisely what #879 measured: no single test file reproduced it, only the full parallel run.

A guard at the write cannot see what it cannot see.

## The fix

`globalSetup` runs once in the main process **before workers fork**, so all five redirects are inherited rather than opted into: the `.env`, the legacy JSON store, the pending-ops marker, the panel lock, and the data dir that six services derive from. `setupFiles` would be too late — per file, inside a worker, after collection.

A floor, not a replacement. Tests that need their own store still override per-test, and a test that deliberately unsets one to exercise a default is unaffected.

## Verified by mechanism, not by a clean run

#879 was **intermittent**, so a green run proves little. The new test asserts the redirects are in effect **in a worker**, point outside the real store, and land in a temp dir. **Removing `globalSetup` fails it.**

Two further full runs additionally left the real `.env` byte-identical and untouched, and recreated no pending-ops marker.

## On the static sweep

It correctly flagged the new file for naming the real store — it has to, to check nothing resolves there. That exemption is **declared with its reason** rather than evaded by assembling the path from pieces, and a second test keeps the allowlist honest: every entry must carry a reason and name a file that still exists, so it cannot quietly become the bypass.

## One honesty note

Two of the new test's three cases **skip** an unset variable, so on their own they pass vacuously. They are meaningful only alongside the case that establishes the values exist — the file says so, because "3 passing tests" would otherwise read as three independent guarantees.

Full suite: 6217 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)