### PR TITLE
fix(vocabulary): main is red — a retired name came back in generate_image

### DIFF
--- a/src/tools/generate-image.ts
+++ b/src/tools/generate-image.ts
@@ -36,7 +36,7 @@ async function resolveCheckpoint(): Promise<string | undefined> {
       `every one lacks text-encoder weights in its safetensors header (a video or ` +
       `UNet-only model) or is a GGUF file CheckpointLoaderSimple cannot load ` +
       `(${listed}${more}). Download an image checkpoint with download_model ` +
-      `(search_civitai_models can find one), then pass it as \`checkpoint\` or save ` +
+      `(action:"search_civitai" can find one), then pass it as \`checkpoint\` or save ` +
       `it with get_defaults (action:"set"). If you believe one was misdetected, ` +
       `pass \`checkpoint\` explicitly to bypass this check.`,
   );


### PR DESCRIPTION
## `check:vocabulary` fails on `origin/main` right now

```
[check-tool-vocabulary] FAIL
  src/tools/generate-image.ts:39  search_civitai_models
```

Reproduce on a clean checkout of `main`: `npx tsx scripts/check-tool-vocabulary.mts`.

## What happened

The #865/#892 generation-defaults cluster (#921) added a genuinely good actionable error for "none of your checkpoints is txt2img-capable" — and it tells the model to reach for **`search_civitai_models`**, a name slice 11 (#901) retired into `download_model (action:"search_civitai")`.

That is a live instruction telling a model to call a tool that will 404, which is precisely the rot the dead-name gate exists to prevent. A model hitting the no-capable-checkpoint path gets sent straight to a dead end.

## Why the gate did not stop it

Not really the cluster author's error. **#921's checks were green against a `main` that predated #901.** Both PRs were correct against the base they ran on; the combination was never tested. This is the "a green check is only green for the `main` it ran against" failure mode.

The durable fix is repo settings — **"Require branches up to date before merging"** — not catching each instance by hand. Worth enabling on both repos; the consolidation is landing large slices fast and this will recur.

## The fix

The surrounding sentence already names `download_model`, so the action form reads naturally with no restructuring:

```diff
-      `(search_civitai_models can find one), then pass it as \`checkpoint\` or save ` +
+      `(action:"search_civitai" can find one), then pass it as \`checkpoint\` or save ` +
```

## Verification

- `check:vocabulary` — **OK**, 1113 files, 93 dead names, no live references (was FAIL)
- `tsc --noEmit` clean
- `generate-image-tool.test.ts` + `models-consolidated.test.ts` — 40 passed. No test asserted the retired substring; the capability test matches `/none appears txt2img-capable/i`, which is unaffected.
- control-byte scan clean, no git-binary files
- Ledger untouched: no change to `TOOL_NAMES`, `MAX_TOOLS`, `DEAD_NAMES`, `tool-surface.txt` or `BASELINE_SHA256`

## Note

There is a second instance of this same root cause that is **not** fixable on `main` yet: `src/services/workflow-executor.ts:90` names `get_node_info`, which slice 14 (#906) retires into `create_workflow (action:"node_info")`. `get_node_info` is still live on `main`, so that one lands with slice 14 rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)