### PR TITLE
0.50.0: flip the default to full; --compact becomes the opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ per-harness setup, troubleshooting:
 | Flag | Env | Default | Description |
 |------|-----|---------|-------------|
 | `setup <agent>` | | | Write the comfyui entry into hermes / openclaw / copilot config, then exit |
-| `--full` / `--tool-mode full` | `COMFYUI_MCP_TOOL_MODE=full` | `compact` | Opt into the full ~200-schema surface; the default compact mode registers 3 meta-tools instead |
+| `--compact` / `--tool-mode compact` | `COMFYUI_MCP_TOOL_MODE=compact` | `full` | Opt into the 3 meta-tools (`list_tools` / `describe_tool` / `call_tool`) instead of the direct surface — recommended for small local models. `--full` is still accepted and is now a no-op |
 
 ### Remote ComfyUI
 

--- a/docs/using-tools.mdx
+++ b/docs/using-tools.mdx
@@ -295,11 +295,15 @@ Ask the agent, in plain words:
   <Step title="Ask what it can see">
     > What tools do you have from comfyui-mcp? Just list the names.
 
-    **Three names** — `list_tools`, `describe_tool`, `call_tool` — is normal and
-    healthy. That is [compact mode](#if-you-run-a-small-local-model), the default:
-    the rest of the catalogue is one `list_tools` call away, so ask it to run that
-    and you will see the real list. A long list is equally fine; that is the same
-    surface with nothing held back.
+    A list of a few dozen names is normal and healthy — that is the direct
+    surface, which has been the default since 0.50.0.
+
+    **Three names** — `list_tools`, `describe_tool`, `call_tool` — is *also*
+    normal and healthy. That is [compact mode](#if-you-run-a-small-local-model),
+    which you get by passing `--compact`, and which small local models still
+    select automatically. The rest of the catalogue is one `list_tools` call
+    away, so ask it to run that and you will see the real list. Neither answer
+    means anything is held back.
 
     **No names at all**, or "I don't have any tools for ComfyUI", rules out the
     third case and nothing else. It does **not** mean absent. A permission policy

--- a/src/__tests__/transport/cli.test.ts
+++ b/src/__tests__/transport/cli.test.ts
@@ -13,7 +13,7 @@ describe("parseCliArgs", () => {
     expect(parseCliArgs(base, {})).toEqual({
       help: false,
       transport: "stdio",
-      toolMode: "compact",
+      toolMode: "full",
       toolModeExplicit: false,
       host: "127.0.0.1",
       port: 9100,
@@ -37,38 +37,49 @@ describe("parseCliArgs", () => {
 
   it("supports --port value and --host value", () => {
     const o = parseCliArgs([...base, "--http", "--host", "0.0.0.0", "--port", "8080"], {});
-    expect(o).toEqual({ help: false, transport: "http", toolMode: "compact", toolModeExplicit: false, host: "0.0.0.0", port: 8080, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
+    expect(o).toEqual({ help: false, transport: "http", toolMode: "full", toolModeExplicit: false, host: "0.0.0.0", port: 8080, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
   });
 
   it("supports --flag=value form", () => {
     const o = parseCliArgs([...base, "--transport=http", "--port=3000", "--host=0.0.0.0"], {});
-    expect(o).toEqual({ help: false, transport: "http", toolMode: "compact", toolModeExplicit: false, host: "0.0.0.0", port: 3000, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
+    expect(o).toEqual({ help: false, transport: "http", toolMode: "full", toolModeExplicit: false, host: "0.0.0.0", port: 3000, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
   });
 
   it("reads env defaults", () => {
     const o = parseCliArgs(base, { MCP_TRANSPORT: "http", MCP_HOST: "0.0.0.0", MCP_PORT: "5000" });
-    expect(o).toEqual({ help: false, transport: "http", toolMode: "compact", toolModeExplicit: false, host: "0.0.0.0", port: 5000, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
+    expect(o).toEqual({ help: false, transport: "http", toolMode: "full", toolModeExplicit: false, host: "0.0.0.0", port: 5000, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
   });
 
-  it("compact is the DEFAULT tool mode; --full / COMFYUI_MCP_TOOL_MODE=full opts out (#667)", () => {
-    expect(parseCliArgs(base, {}).toolMode).toBe("compact");
+  it("FULL is the default tool mode since 0.50.0; --compact / COMFYUI_MCP_TOOL_MODE=compact opts in (#726)", () => {
+    // The flip. Compact was the default from #667 only because the surface was
+    // too big to ship — 154 names, ~50k tokens per tools/list. Consolidation
+    // took it to 37, so the classic surface is affordable again and compact
+    // becomes the opt-in for small local models (#97).
+    expect(parseCliArgs(base, {}).toolMode).toBe("full");
+    expect(parseCliArgs([...base, "--full"], {}).toolMode).toBe("full");
+    expect(parseCliArgs([...base, "--tool-mode", "full"], {}).toolMode).toBe("full");
+    expect(parseCliArgs([...base, "--tool-mode=full"], {}).toolMode).toBe("full");
+    expect(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "full" }).toolMode).toBe("full");
+    // compact is still fully available — it is the opt-in now, not gone
     expect(parseCliArgs([...base, "--compact"], {}).toolMode).toBe("compact");
     expect(parseCliArgs([...base, "--tool-mode", "compact"], {}).toolMode).toBe("compact");
     expect(parseCliArgs([...base, "--tool-mode=compact"], {}).toolMode).toBe("compact");
     expect(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "compact" }).toolMode).toBe("compact");
-    // the full surface is still available, explicitly
-    expect(parseCliArgs([...base, "--full"], {}).toolMode).toBe("full");
-    expect(parseCliArgs([...base, "--tool-mode", "full"], {}).toolMode).toBe("full");
-    expect(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "full" }).toolMode).toBe("full");
+    // `--full` stays an ACCEPTED no-op so existing scripts and docs snippets
+    // that pass it keep working rather than erroring on an unknown flag.
+    expect(parseCliArgs([...base, "--full"], {}).toolModeExplicit).toBe(true);
     // explicit CLI wins over env, in both directions
     expect(
       parseCliArgs([...base, "--tool-mode", "full"], { COMFYUI_MCP_TOOL_MODE: "compact" }).toolMode,
     ).toBe("full");
     expect(parseCliArgs([...base, "--full"], { COMFYUI_MCP_TOOL_MODE: "compact" }).toolMode).toBe("full");
     expect(parseCliArgs([...base, "--compact"], { COMFYUI_MCP_TOOL_MODE: "full" }).toolMode).toBe("compact");
-    // unknown values fall back to the compact default
-    expect(parseCliArgs([...base, "--tool-mode", "bogus"], {}).toolMode).toBe("compact");
-    expect(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "bogus" }).toolMode).toBe("compact");
+    // Unknown values fall back to THE DEFAULT — which is now full. The rule is
+    // unchanged ("only the exact opt-in string counts"); the default moved under
+    // it. Note this is the one caller-visible behaviour change beyond the
+    // default itself: `--tool-mode bogus` used to yield compact.
+    expect(parseCliArgs([...base, "--tool-mode", "bogus"], {}).toolMode).toBe("full");
+    expect(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "bogus" }).toolMode).toBe("full");
     // either explicit env mode counts as an explicit choice (for `setup`)
     expect(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "compact" }).toolModeExplicit).toBe(true);
     expect(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "full" }).toolModeExplicit).toBe(true);

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,10 +130,12 @@ async function createConfiguredServer(toolMode: ToolMode = "compact"): Promise<M
     // into a catalog and expose only the list_tools/describe_tool/call_tool
     // meta-tools, keeping the client's context cost near-zero until a tool is
     // actually needed. Built for small/local LLMs (Hermes Agent, Ollama —
-    // issue #97), but the right default for every harness that injects
-    // tools/list into context: the full surface is ~200KB (~50k tokens) per
-    // read. --full / COMFYUI_MCP_TOOL_MODE=full opts back into the classic
-    // direct surface below.
+    // issue #97), and the DEFAULT from #667 until 0.50.0, when it became the
+    // OPT-IN: the reason it was default was that the direct surface cost
+    // ~200KB (~50k tokens) per tools/list at 154 tools, and consolidation took
+    // that to 37. Reach for `--compact` when the client's context is the
+    // binding constraint — a small local model, or a harness that re-injects
+    // tools/list on every read.
     const catalog = await collectToolCatalog();
     registerCompactTools(server, catalog);
     logger.info(

--- a/src/orchestrator/http-backend-tools.ts
+++ b/src/orchestrator/http-backend-tools.ts
@@ -21,6 +21,20 @@ import type { ToolMode } from "../transport/cli.js";
  *
  * An explicit `COMFYUI_MCP_TOOL_MODE=full` in the orchestrator env opts back into
  * the full surface (accepting the panel_* crowd-out) for a user who wants it.
+ *
+ * SINCE 0.50.0 THIS DELIBERATELY DIVERGES FROM THE TOP-LEVEL DEFAULT. The flip
+ * made `full` the default for the MCP server itself, because consolidation took
+ * the core surface from 154 names to 37. This lane keeps COMPACT anyway: the
+ * argument here was never only about the core count, it is that this connection
+ * also carries ~91 `panel_*` tools, and the budget they share is what gets
+ * crowded. 37 + 91 is a much better position than 154 + 91, but it is still the
+ * fullest surface any single connection in this system advertises, and the
+ * backends on this path are the non-Claude ones with the least room.
+ *
+ * The divergence is safe because cli.ts exports COMFYUI_MCP_TOOL_MODE only when
+ * the user chose a mode EXPLICITLY — a defaulted `full` upstream leaves the env
+ * unset, so this function still sees "nothing chosen" and answers compact.
+ * Revisit if the panel surface shrinks (phase 6 `canvas_*`).
  */
 export function resolveHttpLaneComfyToolMode(
   env: NodeJS.ProcessEnv = process.env,

--- a/src/services/agent-setup.ts
+++ b/src/services/agent-setup.ts
@@ -58,8 +58,12 @@ export function defaultCompact(agent: AgentName): boolean {
 }
 
 function serverArgs(compact: boolean): string[] {
-  // Explicit on BOTH sides: bare `npx comfyui-mcp` means compact since #667,
-  // so a full-mode entry must pin --full to survive the default flip.
+  // Explicit on BOTH sides, which is what made this survive the 0.50.0 flip
+  // untouched. Bare `npx comfyui-mcp` meant compact from #667 and means FULL
+  // from 0.50.0; because every generated entry pins its mode, no config written
+  // before the flip changed meaning after it. `defaultCompact` below is a
+  // PER-AGENT judgement (hermes/openclaw run small local models, copilot does
+  // not) and is deliberately independent of whatever the server default is.
   return compact ? ["-y", "comfyui-mcp", "--compact"] : ["-y", "comfyui-mcp", "--full"];
 }
 

--- a/src/services/tool-mode-policy.ts
+++ b/src/services/tool-mode-policy.ts
@@ -178,7 +178,9 @@ export function resolveToolModeForModel(opts: ResolveToolModeOptions = {}): Tool
       mode: "compact",
       source: "no-model-fallback",
       explain:
-        "Tool mode: compact — no model is known at this point, so the documented fallback applies. Set COMFYUI_MCP_TOOL_MODE=full to opt into the full surface.",
+        "Tool mode: compact — no model is known at this point, so this lane falls back to the small-model-safe choice. " +
+        "(The server's own default is full since 0.50.0; auto-selection is deliberately more conservative, because it " +
+        "cannot rule out a model that would drown in the full surface.) Set COMFYUI_MCP_TOOL_MODE=full to override.",
     };
   }
 
@@ -189,8 +191,9 @@ export function resolveToolModeForModel(opts: ResolveToolModeOptions = {}): Tool
       source: "unknown-model-fallback",
       model,
       explain:
-        `Tool mode: compact — "${model}" carries no parameter count I can read, so the documented fallback ` +
-        `applies. Set COMFYUI_MCP_TOOL_MODE=full if this model can hold the full tool surface.`,
+        `Tool mode: compact — "${model}" carries no parameter count I can read, so this lane falls back to the ` +
+        `small-model-safe choice rather than the server's full default. ` +
+        `Set COMFYUI_MCP_TOOL_MODE=full if this model can hold the full tool surface.`,
     };
   }
 

--- a/src/transport/cli.ts
+++ b/src/transport/cli.ts
@@ -10,12 +10,22 @@ export interface CliOptions {
    *  users with no local way to discover the flag that controls it (#860). */
   help: boolean;
   transport: TransportMode;
-  /** --compact / --tool-mode compact / COMFYUI_MCP_TOOL_MODE=compact (DEFAULT,
-   *  #667): register only the list_tools/describe_tool/call_tool meta-tools
-   *  instead of the full ~200-schema surface — the full surface costs a client
-   *  ~200KB (~50k tokens) per tools/list, which harnesses that inject schemas
-   *  into context pay on every read. --full / COMFYUI_MCP_TOOL_MODE=full opts
-   *  back into the classic surface (frontier-model harnesses). */
+  /** --full / --tool-mode full / COMFYUI_MCP_TOOL_MODE=full (DEFAULT since
+   *  0.50.0): register the direct tool surface.
+   *
+   *  Compact was the default from #667 only because the surface was too big to
+   *  ship: ~200 schemas cost a client ~200KB (~50k tokens) on every tools/list,
+   *  which harnesses that inject schemas into context pay on every read. The
+   *  0.50.0 consolidation folded 154 names into 37 action-parameterized tools,
+   *  so the same read is now roughly a fifth of that — a reasonable default for
+   *  a frontier harness, and the owner's stated goal ("get the tool count down,
+   *  then make --compact the optional one").
+   *
+   *  --compact / COMFYUI_MCP_TOOL_MODE=compact opts INTO the three
+   *  list_tools/describe_tool/call_tool meta-tools, which is still the right
+   *  choice for small local models (#97) — and remains the DEFAULT on the two
+   *  lanes that serve them, deliberately diverging from this one. See
+   *  resolveHttpLaneComfyToolMode and comfyuiSpawnEnv. */
   toolMode: ToolMode;
   host: string;
   port: number;
@@ -75,7 +85,10 @@ export function parseCliArgs(
 
   let help = false;
   let transport: TransportMode = env.MCP_TRANSPORT === "http" ? "http" : "stdio";
-  let toolMode: ToolMode = env.COMFYUI_MCP_TOOL_MODE === "full" ? "full" : "compact";
+  // 0.50.0 flip: full is the default, compact is the opt-in. Only the exact
+  // string "compact" selects it, so a typo'd value falls back to the default
+  // exactly as a typo'd value used to fall back to compact.
+  let toolMode: ToolMode = env.COMFYUI_MCP_TOOL_MODE === "compact" ? "compact" : "full";
   let host = env.MCP_HOST ?? DEFAULT_HOST;
   let port = env.MCP_PORT ? Number(env.MCP_PORT) : DEFAULT_PORT;
   let panelOrchestrator =
@@ -150,7 +163,10 @@ export function parseCliArgs(
       toolModeExplicit = true;
     } else if (a === "--tool-mode" || a.startsWith("--tool-mode=")) {
       const [v, ni] = valueOf(a, "--tool-mode", i);
-      toolMode = v === "full" ? "full" : "compact";
+      // Inverted with the 0.50.0 default: only the exact string "compact"
+      // selects compact, so `--tool-mode bogus` falls back to the default, which
+      // is what it always did — the default just changed under it.
+      toolMode = v === "compact" ? "compact" : "full";
       toolModeExplicit = true;
       i = ni;
     } else if (a === "setup") {
@@ -204,8 +220,18 @@ export function parseCliArgs(
  * comfyuiSpawnEnv for the Ollama family) — a bare --full/--compact flag
  * otherwise never reaches them, so `--full --panel-orchestrator` silently ran
  * compact downstream. A DEFAULTED mode is deliberately NOT exported: unset env
- * is how children tell "user chose nothing" from "user chose compact", and
- * unset resolves to the documented compact default on its own.
+ * is how children tell "user chose nothing" from "user chose compact".
+ *
+ * The 0.50.0 flip changed what unset MEANS, and the distinction now carries
+ * real weight rather than being a tidiness argument. Before, unset resolved to
+ * compact everywhere, so exporting or not exporting a defaulted mode was
+ * unobservable. Now the top-level default is FULL while both child lanes still
+ * default to COMPACT on purpose — the HTTP lane shares its tool budget with ~91
+ * `panel_*` tools, and the Ollama lane feeds a small local model's 16k context
+ * (#97). Not exporting a defaulted mode is what lets those lanes keep their own
+ * default; exporting it would silently push the full surface into exactly the
+ * two places compact exists to protect. An EXPLICIT --full still reaches them,
+ * which is the documented way to opt a child lane in.
  */
 export function exportExplicitToolMode(
   cli: Pick<CliOptions, "toolMode" | "toolModeExplicit">,


### PR DESCRIPTION
The last step of #726, as its own PR so it reviews like the one-line default change it mostly is.

## Why now

Compact has been the default since #667 for exactly one reason: the direct surface was too big to ship. 154 tools cost a client ~200KB (~50k tokens) on every `tools/list`, which harnesses that re-inject schemas pay on every read.

The consolidation took the core surface **154 → 37**, so that argument no longer holds — and the directive was explicit: *"get the tool count down, then make `--compact` the optional one."*

## What a client sees

| invocation | tools/list |
|---|---|
| default (no flags) | **40** = 37 direct + 3 facade |
| `--compact` | 3 meta-tools |
| `--full` | accepted **no-op** — existing scripts and docs snippets keep working |

The facade survives twice, as the RFC specified: as the whole of compact mode, and as the `call_tool` escape hatch layered on full (#616).

## What did NOT flip, and why

This is the part worth reviewing. **Two child lanes keep compact as their default, deliberately:**

- **`resolveHttpLaneComfyToolMode`** — this connection also carries ~91 `panel_*` tools, and the shared budget is what gets crowded. 37+91 is far better than 154+91, but it is still the fullest surface any single connection advertises, on the backends with the least room.
- **The Ollama lane** — `resolveToolModeForModel` already selects per model parameter count, honouring explicit overrides in both directions. For an unknown or small model it falls back to compact, which is the entire point of #97. 37 schemas beats ~200 but is still a real slice of a 16k `num_ctx`.

That divergence is only safe because **`exportExplicitToolMode` exports the mode only when the user chose one explicitly** — so a defaulted `full` upstream leaves the env unset and each lane still applies its own default. Its doc comment claimed unset "resolves to the documented compact default on its own": true while every default was compact, **false now**. Rewritten to state what the mechanism actually buys, because that reasoning is now load-bearing rather than decorative.

## One caller-visible change beyond the default

`--tool-mode bogus` now yields `full` rather than `compact`. The rule is unchanged — only the exact opt-in string counts — but the default moved under it. Pinned in the test rather than left implicit.

## Verified on the real binary

Driven over stdio as a client, not asserted from internals — all five modes (default, `--compact`, `--full`, and both env values). Counts as in the table; facade present in both modes; and a retired name (`list_workflows`) answers with the ledger redirect in **every** mode:

```
Unknown tool 'list_workflows' — removed in 0.50.0. Call get_workflow (action:"list") instead.
```

That last point is why #895 and #911 had to land first: before them, direct `tools/call` returned a bare `-32602 not found` and admission returned a misleading "not permitted". Flipping the default without those would have broken rule 6 in the exact release that retires 160 names.

## Not touched

`agent-setup` needed no behavioural change — `serverArgs` already pinned `--compact`/`--full` explicitly on both sides, with a comment anticipating this flip, so no config written before today changed meaning after it.

Ledger untouched: no change to `TOOL_NAMES`, `MAX_TOOLS`, `DEAD_NAMES`, `tool-surface.txt` or `BASELINE_SHA256`.

## Gates

Full suite 305 files / 6675 passed · `lint` · `check:vocabulary` (1111 files, 160 dead, no live references) · `asset-counts --check` · control-byte scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)