### PR TITLE
0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,91 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.0] - 2026-08-06
+
+The tool surface consolidates. Roughly 143 individually-registered tools fold into
+an action-parameterized core (37 tools), cutting what a client sees on `tools/list`
+by well over half — and with the surface small enough to carry, the default flips
+back to FULL, so `--compact` becomes the opt-in rather than the way most clients
+have to run.
+
+Every folded name is redirected rather than removed: calling a retired name reports
+what it became and which action replaces it, instead of failing as an unknown tool.
+That is enforced mechanically — every name that has ever existed and no longer does
+must be declared dead — so a tool cannot quietly vanish and leave rot behind.
+
+The per-slice entries are under **Changed** below.
+
+### MCP
+
+#### Added
+- flip the default to full; --compact becomes the opt-in (#942)
+- arena records VRAM/quant/version axes and flags suspect scenarios
+- audio attachments on the agent turn, and per-model tool mode
+
+#### Fixed
+- sessions are orchestrator-scoped — one agent across all tabs and workflows (#884) (#897)
+- report a retired tool name as retired, not as unpermitted (#911)
+- main is red — a retired name came back in generate_image (#936)
+- gate round 3 — a stale-but-alive sibling also suppresses the tray-row clear (#858)
+- gate round 2 — disclose when the dead record file can't be deleted (#858)
+- stop refusing correct destinations — diffusers contract-empty listing (#844) + in-tree junction escapes (#870)
+- codex gate r2 — positive identification for 'incapable', integer-safe seed bounds
+- gate round 1 — don't claim the tray row was removed; count both live row ids (#858)
+- codex gate r1 — refuse unsafe declared ranges, honest capability claims, sharper tests
+- cancel a stale download once its writer is proven gone + deterministic interference test (#858, #869)
+- seed draws honor declared max, explicit seeds survive, auto-select skips non-txt2img checkpoints
+- teach the dead-name gate the difference between a dead TOOL and a live ACTION (#905)
+- never write our database inside someone else's git tree (#891)
+- serve the retirement ledger on direct tools/call, not only through the facade (#895)
+- the first independent gate on the #842 branch (#880)
+- rename before you inspect — a path read is not an ownership proof
+- once a lock can be taken away, every path must prove it owns it
+- explicit reclaim for a proven-abandoned op lock, durable marker/pin writes, honest panel_reload scope (#760, #798, #765)
+- mixed-version best-of ranges are not one known version
+- suspect analysis pools only one comfyui-mcp version
+- the suspect signal counts distinct models, not leaderboard entries
+- legacy okTools are not selection evidence in the suspect analysis
+- a pending triage may have no job_id — say so (codex gate r2)
+- a live model switch must not be silently ignored on the OpenAI dialect
+- bracket EVERY entry, and stop the guard claiming more than it observed (codex gate r1)
+- a snapshot of the queue is not an exclusion — bracket the merge (codex gate)
+- a live switch rewrites the prompt; the audio table covers real containers
+- codex gate r2 — a malformed historical counter is not 'missing'
+- codex gate r1 — name partial vs incoherent truthfully; drop the false ~5-minute ceiling
+- git-verify a provably-idle incoherent Manager queue; report_issue sets blocking-wait expectation
+- five findings from the seventh gate pass
+- audio survives re-delivery, and the delivery proof is per TURN
+- acceptance proof is per media KIND, and the refusal's remedy is honest
+- the attachment-acceptance proof must not survive a model switch
+- honest delivery boundaries, and drop the ACP path we cannot exercise
+- five more findings from the second gate pass
+- the auto-install gate must name the tree it installs into; sweep "could not determine" folds (#820, #796)
+- five findings from the adversarial gate
+
+#### Changed
+- 0.50.0 slice 13: consolidate install/environment and stats/diagnostics (10 to 2) (#909)
+- 0.50.0 slice 16: consolidate execution, generation and observability (18→3) (#907)
+- 0.50.0 slice 15: consolidate images and assets (12 to 2) (#903)
+- 0.50.0 slice 12: consolidate custom nodes and node authoring (20 to 3) (#904)
+- 0.50.0 slice 14: consolidate workflow authoring and library (20→4) (#906)
+- 0.50.0 slice 11: consolidate models (14→2) (#901)
+- a late probe must not overwrite a newer cache entry (#879)
+- 0.50.0 slice 10: consolidate training (18→3) (#898)
+- 0.50.0 slice 9: consolidate knowledge (9→1) (#896)
+- list_output_images returns [] on a local install whose path comes from the saved workspace (#877) (#883)
+- 0.50.0 slice 7: consolidate process control, API nodes and defaults (10→3) (#894)
+- 0.50.0 slice 8: consolidate runpod (11→2) (#893)
+- remote ComfyUI and secrets: HTML where JSON was promised, and a secret that reports success without reaching the child (#837)
+- path + environment probing: 'could not determine' is not 'determined it is not' (#835)
+- follow-up to #839: fix the three gate findings that merged unaddressed (#882)
+- install_panel git fallback: four claims the concurrency bracket could not establish (follow-up to #840) (#878)
+- node search + install: registry packs that exist on disk read as absent, results that cannot be installed as returned (#834)
+- graph binding after reconnect/retarget: a documented recovery that could not recover (#803, #770, #772) (#833)
+- restart + session reporting: stale launch arguments, a premature failure verdict, and a stale version line (#850)
+- the 20 MB refusal is a dead end for local video (orchestrator half of #648) (#854)
+
+
 ## [0.49.8] - 2026-08-05
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.49.8",
+  "version": "0.50.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.49.8",
+      "version": "0.50.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.49.8",
+  "version": "0.50.0",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **0.50.0**.

## What ships

The **tool-surface consolidation** (#726) completes: roughly 143 individually-registered tools fold into an action-parameterized core. `MAX_TOOLS` is now **37**, cutting what a client sees on `tools/list` by well over half.

Every folded name is **redirected, not removed** — calling a retired name reports what it became and which action replaces it, rather than failing as an unknown tool. That is enforced mechanically: `RETIREMENT_BASELINE \ TOOL_NAMES ⊆ DEAD_NAMES`, so a name cannot quietly vanish and leave rot behind.

Alongside it, a large stabilization pass: atomic credential-store writes with honest save receipts, a panel operation lock that can be reclaimed when its owner is provably gone, restart reporting what it *verified* rather than what it attempted, and a long run of "could not determine X" being reported as "determined X is false" swept out of path resolution, node install, download and graph binding.

## Verification on this branch

- `tsc` clean
- **6730 tests passing**
- `check:vocabulary` — OK, no live references to retired names
- `asset-counts --check` — counts match the source of truth
- Baseline ratchet intact

## Note on the changelog

Generated with the repo's own tooling. The headline paragraph is hand-written: the per-slice squash subjects land under **Changed** and, on their own, do not say what the release actually is.

Merging this, then tagging `v0.50.0`, is what triggers the npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)