### PR TITLE
fix(vocabulary-gate): count mentions token-bounded; stop welding generated doc lines together

### DIFF
--- a/docs/tools/api-nodes.mdx
+++ b/docs/tools/api-nodes.mdx
@@ -18,7 +18,8 @@ Discover and run hosted partner/API nodes on the connected ComfyUI (e.g. Flux/BF
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which API-node operation to perform. "list" takes an optional `filter`; "schema" requires `class_type`; "generate" requires `class_type` + `inputs` (optional `disable_random_seed`). Options: `action:"list"`, `action:"schema"`, `action:"generate"`.
+  Which API-node operation to perform. "list" takes an optional `filter`; "schema" requires `class_type`; "generate" requires `class_type` + `inputs` (optional `disable_random_seed`).
+  Options: `action:"list"`, `action:"schema"`, `action:"generate"`.
 </ParamField>
 <ParamField path="filter" type="string">
   action:"list" — case-insensitive substring to narrow results, matched against class_type, display name, or category (e.g. "image", "video", "kling").

--- a/docs/tools/apps.mdx
+++ b/docs/tools/apps.mdx
@@ -22,7 +22,8 @@ Micro-apps on this ComfyUI (panel Apps feature): named workflows packaged for on
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which apps operation to perform. "list" takes no other parameters; "get"/"run" require `app_id`; "run_status" requires `app_id` + `prompt_id`; "import" requires `registry_url` + `app_id`. Options: `action:"list"`, `action:"get"`, `action:"run"`, `action:"run_status"`, `action:"import"`.
+  Which apps operation to perform. "list" takes no other parameters; "get"/"run" require `app_id`; "run_status" requires `app_id` + `prompt_id`; "import" requires `registry_url` + `app_id`.
+  Options: `action:"list"`, `action:"get"`, `action:"run"`, `action:"run_status"`, `action:"import"`.
 </ParamField>
 <ParamField path="app_id" type="string">
   The app's uuid. REQUIRED for actions "get", "run", "run_status" (from action:"list") and "import" (the REGISTRY app's uuid, from the explore list).

--- a/docs/tools/assets-images.mdx
+++ b/docs/tools/assets-images.mdx
@@ -24,7 +24,8 @@ Fetch, browse and inspect ComfyUI images and registered assets. Driven by the `a
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which image/asset operation to perform. "get" requires `filename`; "view" and "asset_metadata" require `asset_id`; "convert" requires `format` plus exactly one of `asset_id`/`path`; action:"analyze_color" takes one source (`asset_id`, `filename`, or `path`); "list_outputs" and action:"list_assets" take no required parameters. Options: `action:"get"`, `action:"view"`, `action:"list_outputs"`, `action:"convert"`, `action:"analyze_color"`, `action:"list_assets"`, `action:"asset_metadata"`.
+  Which image/asset operation to perform. "get" requires `filename`; "view" and "asset_metadata" require `asset_id`; "convert" requires `format` plus exactly one of `asset_id`/`path`; action:"analyze_color" takes one source (`asset_id`, `filename`, or `path`); "list_outputs" and action:"list_assets" take no required parameters.
+  Options: `action:"get"`, `action:"view"`, `action:"list_outputs"`, `action:"convert"`, `action:"analyze_color"`, `action:"list_assets"`, `action:"asset_metadata"`.
 </ParamField>
 <ParamField path="filename" type="string">
   Output image filename, e.g. PulID_Klein_00001_.png. REQUIRED for action:"get". OPTIONAL for action:"analyze_color", where it is one of the three ways to name a source (pair it with subfolder/type).
@@ -33,7 +34,8 @@ Fetch, browse and inspect ComfyUI images and registered assets. Driven by the `a
   Asset id returned by action:"list_assets" or job completion. REQUIRED for actions "view" and "asset_metadata". OPTIONAL for "convert" (provide exactly one of asset_id or path) and action:"analyze_color" (one of asset_id, filename, or path).
 </ParamField>
 <ParamField path="type" type="enum">
-  ComfyUI directory the file lives in: output (default), input, or temp. Used by action:"get" and by action:"analyze_color" when the source is a `filename`. Options: `output`, `input`, `temp`.
+  ComfyUI directory the file lives in: output (default), input, or temp. Used by action:"get" and by action:"analyze_color" when the source is a `filename`.
+  Options: `output`, `input`, `temp`.
 </ParamField>
 <ParamField path="subfolder" type="string">
   Subfolder within the directory, if any (default empty). Used by action:"get" and by action:"analyze_color" when the source is a `filename`.
@@ -51,7 +53,8 @@ Fetch, browse and inspect ComfyUI images and registered assets. Driven by the `a
   action:"list_outputs" — filter by filename pattern (case-insensitive substring match).
 </ParamField>
 <ParamField path="format" type="enum">
-  Two unrelated meanings, one per action — the enum is the union of both and each action accepts only its own half. action:"list_outputs" — RESPONSE SHAPE: "markdown" (default, human/agent-readable) or "json" (&#123;images:[&#123;filename,subfolder,kind,size,modified&#125;]&#125; — for app clients building pick grids). action:"convert" — REQUIRED target encoded image format: "png", "jpeg" or "webp". Options: `markdown`, `json`, `png`, `jpeg`, `webp`.
+  Two unrelated meanings, one per action — the enum is the union of both and each action accepts only its own half. action:"list_outputs" — RESPONSE SHAPE: "markdown" (default, human/agent-readable) or "json" (&#123;images:[&#123;filename,subfolder,kind,size,modified&#125;]&#125; — for app clients building pick grids). action:"convert" — REQUIRED target encoded image format: "png", "jpeg" or "webp".
+  Options: `markdown`, `json`, `png`, `jpeg`, `webp`.
 </ParamField>
 <ParamField path="quality" type="integer">
   action:"convert" — encoder quality, 1-100. Applies where supported by the selected format.
@@ -215,7 +218,8 @@ Put a file where ComfyUI (or cloud storage) can read it. Driven by the `action` 
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  What to upload and where. "image"/"video"/"audio" send a LOCAL file (`source_path`) to ComfyUI's input/ directory; "stage" re-registers an EXISTING server-side output (`filename`) as an input; "output" ships a generated output to cloud storage (`destination`). Options: `action:"image"`, `action:"video"`, `action:"audio"`, `action:"output"`, `action:"stage"`.
+  What to upload and where. "image"/"video"/"audio" send a LOCAL file (`source_path`) to ComfyUI's input/ directory; "stage" re-registers an EXISTING server-side output (`filename`) as an input; "output" ships a generated output to cloud storage (`destination`).
+  Options: `action:"image"`, `action:"video"`, `action:"audio"`, `action:"output"`, `action:"stage"`.
 </ParamField>
 <ParamField path="source_path" type="string">
   Absolute path to the local file to upload. REQUIRED for actions "image", "video" and "audio".
@@ -227,10 +231,12 @@ Put a file where ComfyUI (or cloud storage) can read it. Driven by the `action` 
   action:"stage" — subfolder the source asset currently lives in, if any.
 </ParamField>
 <ParamField path="type" type="enum">
-  action:"stage" — source directory the asset lives in: output (default) or temp (previews). Options: `output`, `temp`.
+  action:"stage" — source directory the asset lives in: output (default) or temp (previews).
+  Options: `output`, `temp`.
 </ParamField>
 <ParamField path="kind" type="enum">
-  action:"stage" — force the media kind instead of inferring it from the file extension. Options: `image`, `video`, `audio`.
+  action:"stage" — force the media kind instead of inferring it from the file extension.
+  Options: `image`, `video`, `audio`.
 </ParamField>
 <ParamField path="as_filename" type="string">
   action:"stage" — override the filename it is registered under in the input/ directory (defaults to the source filename).

--- a/docs/tools/comfy-cli.mdx
+++ b/docs/tools/comfy-cli.mdx
@@ -29,10 +29,12 @@ Drive the official comfy-cli (envelope/1 JSON contract) for the selected ComfyUI
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which comfy-cli operation to perform. Families: status; server_* (lifecycle); jobs_* (list/status/wait/watch/cancel); search_nodes; workflow_* (validate/run); transfer_* (upload/download); models_* (list_folders/list_folder/search/show/download/remove); skills_* (list/show/validate/install/status/uninstall). Options: `action:"status"`, `action:"server_start"`, `action:"server_stop"`, `action:"server_restart"`, `action:"jobs_list"`, `action:"jobs_status"`, `action:"jobs_wait"`, `action:"jobs_watch"`, `action:"jobs_cancel"`, `action:"search_nodes"`, `action:"workflow_validate"`, `action:"workflow_run"`, `action:"transfer_upload"`, `action:"transfer_download"`, `action:"models_list_folders"`, `action:"models_list_folder"`, `action:"models_search"`, `action:"models_show"`, `action:"models_download"`, `action:"models_remove"`, `action:"skills_list"`, `action:"skills_show"`, `action:"skills_validate"`, `action:"skills_install"`, `action:"skills_status"`, `action:"skills_uninstall"`.
+  Which comfy-cli operation to perform. Families: status; server_* (lifecycle); jobs_* (list/status/wait/watch/cancel); search_nodes; workflow_* (validate/run); transfer_* (upload/download); models_* (list_folders/list_folder/search/show/download/remove); skills_* (list/show/validate/install/status/uninstall).
+  Options: `action:"status"`, `action:"server_start"`, `action:"server_stop"`, `action:"server_restart"`, `action:"jobs_list"`, `action:"jobs_status"`, `action:"jobs_wait"`, `action:"jobs_watch"`, `action:"jobs_cancel"`, `action:"search_nodes"`, `action:"workflow_validate"`, `action:"workflow_run"`, `action:"transfer_upload"`, `action:"transfer_download"`, `action:"models_list_folders"`, `action:"models_list_folder"`, `action:"models_search"`, `action:"models_show"`, `action:"models_download"`, `action:"models_remove"`, `action:"skills_list"`, `action:"skills_show"`, `action:"skills_validate"`, `action:"skills_install"`, `action:"skills_status"`, `action:"skills_uninstall"`.
 </ParamField>
 <ParamField path="detail" type="enum" default="env">
-  action:"status" — which inspection to run. Options: `version`, `which`, `env`, `discover`.
+  action:"status" — which inspection to run.
+  Options: `version`, `which`, `env`, `discover`.
 </ParamField>
 <ParamField path="workspace" type="string">
   Optional ComfyUI workspace override. Otherwise COMFYUI_PATH/auto-detection is used.
@@ -56,7 +58,8 @@ Drive the official comfy-cli (envelope/1 JSON contract) for the selected ComfyUI
   actions "jobs_wait"/"jobs_watch"/"workflow_run" — max seconds to wait.
 </ParamField>
 <ParamField path="where" type="enum">
-  Target for the jobs/search_nodes/workflow/transfer/models actions: "local" (default) or "cloud" (Comfy Cloud). Options: `local`, `cloud`.
+  Target for the jobs/search_nodes/workflow/transfer/models actions: "local" (default) or "cloud" (Comfy Cloud).
+  Options: `local`, `cloud`.
 </ParamField>
 <ParamField path="query" type="string">
   action:"search_nodes" — fuzzy search text. REQUIRED.
@@ -107,7 +110,8 @@ Drive the official comfy-cli (envelope/1 JSON contract) for the selected ComfyUI
   action:"skills_validate" — path to the skill to validate. REQUIRED.
 </ParamField>
 <ParamField path="scope" type="enum">
-  actions "skills_install"/"skills_uninstall"/"skills_status" — install scope. Options: `user`, `project`.
+  actions "skills_install"/"skills_uninstall"/"skills_status" — install scope.
+  Options: `user`, `project`.
 </ParamField>
 <ParamField path="projectDir" type="string">
   Working directory for project-scoped skill operations. Required when scope='project'.

--- a/docs/tools/custom-nodes.mdx
+++ b/docs/tools/custom-nodes.mdx
@@ -19,7 +19,8 @@ Discover ComfyUI custom node PACKS in the public ComfyUI Registry (registry.comf
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which registry lookup to perform. "search" requires `query` (and takes optional `limit`/`page`); "details" requires `id`. Options: `action:"search"`, `action:"details"`.
+  Which registry lookup to perform. "search" requires `query` (and takes optional `limit`/`page`); "details" requires `id`.
+  Options: `action:"search"`, `action:"details"`.
 </ParamField>
 <ParamField path="query" type="string">
   action:"search" — REQUIRED. Keyword(s) to match against pack name/description, e.g. 'impact', 'controlnet aux'.
@@ -85,13 +86,15 @@ Install, repair, enable/disable and remove ComfyUI custom node packs on this Com
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which custom-node operation to perform. "install", "update", "reinstall", "fix", "uninstall", "enable" and "disable" require `id`; "list" and "sync_deps" take no required parameters. Options: `action:"install"`, `action:"update"`, `action:"reinstall"`, `action:"fix"`, `action:"uninstall"`, `action:"enable"`, `action:"disable"`, `action:"list"`, `action:"sync_deps"`.
+  Which custom-node operation to perform. "install", "update", "reinstall", "fix", "uninstall", "enable" and "disable" require `id`; "list" and "sync_deps" take no required parameters.
+  Options: `action:"install"`, `action:"update"`, `action:"reinstall"`, `action:"fix"`, `action:"uninstall"`, `action:"enable"`, `action:"disable"`, `action:"list"`, `action:"sync_deps"`.
 </ParamField>
 <ParamField path="id" type="string">
   The pack to act on. REQUIRED for actions "install", "update", "reinstall", "fix", "uninstall", "enable" and "disable". For "install" this is a registry id, git URL, or node-pack name (find one with search_custom_nodes); for "update"/"fix" it may also be 'all' (every installed pack); for "update"/"reinstall"/"fix"/"uninstall"/"enable"/"disable" it is a registry id / module name of an INSTALLED pack.
 </ParamField>
 <ParamField path="source" type="enum">
-  action:"install" — how to interpret `id` (default 'auto', which detects git URLs vs registry ids). Options: `registry`, `git`, `auto`.
+  action:"install" — how to interpret `id` (default 'auto', which detects git URLs vs registry ids).
+  Options: `registry`, `git`, `auto`.
 </ParamField>
 <ParamField path="version" type="string">
   Version to install. action:"install" — e.g. 'latest', 'nightly', or a semver; for git installs this is treated as a git ref unless `ref` is also provided, and registry installs default to 'latest'. action:"reinstall" — version to reinstall (default 'latest').
@@ -100,7 +103,8 @@ Install, repair, enable/disable and remove ComfyUI custom node packs on this Com
   action:"install" — git ref (commit SHA, branch, or tag) to pin when installing a git URL. Overrides any ref parsed from the URL and any `version` value. Ignored for registry-id installs.
 </ParamField>
 <ParamField path="mode" type="enum">
-  Two distinct meanings, one per action group. For actions "install"/"update"/"reinstall"/"fix": the ComfyUI-Manager data source (default 'remote'); 'remote' fetches the live node list, 'local'/'cache' use bundled/cached data. For action:"list": 'default' lists all installed packs, 'imported' lists only those successfully imported this session. Passing a value from the wrong group is refused, naming the ones the action accepts. Options: `remote`, `local`, `cache`, `default`, `imported`.
+  Two distinct meanings, one per action group. For actions "install"/"update"/"reinstall"/"fix": the ComfyUI-Manager data source (default 'remote'); 'remote' fetches the live node list, 'local'/'cache' use bundled/cached data. For action:"list": 'default' lists all installed packs, 'imported' lists only those successfully imported this session. Passing a value from the wrong group is refused, naming the ones the action accepts.
+  Options: `remote`, `local`, `cache`, `default`, `imported`.
 </ParamField>
 <ParamField path="channel" type="string">
   ComfyUI-Manager channel name (default 'default').
@@ -206,7 +210,8 @@ Author, edit, test and publish YOUR OWN ComfyUI custom-node pack under &lt;COMFY
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which node-pack operation to perform. "scaffold" requires `name` + `display_name`; "list_files" requires `pack`; "read" requires `path`; "search" requires `query`; "write" requires `path` + `content`; "patch" requires `patch`; "git" requires `pack` + `git_action`. "verify" and "publish" have no required parameters — "verify" resolves the pack from `name` (or checks `class_types` directly), "publish" from `name` or `path`. Options: `action:"scaffold"`, `action:"verify"`, `action:"publish"`, `action:"list_files"`, `action:"read"`, `action:"search"`, `action:"write"`, `action:"patch"`, `action:"git"`.
+  Which node-pack operation to perform. "scaffold" requires `name` + `display_name`; "list_files" requires `pack`; "read" requires `path`; "search" requires `query`; "write" requires `path` + `content`; "patch" requires `patch`; "git" requires `pack` + `git_action`. "verify" and "publish" have no required parameters — "verify" resolves the pack from `name` (or checks `class_types` directly), "publish" from `name` or `path`.
+  Options: `action:"scaffold"`, `action:"verify"`, `action:"publish"`, `action:"list_files"`, `action:"read"`, `action:"search"`, `action:"write"`, `action:"patch"`, `action:"git"`.
 </ParamField>
 <ParamField path="name" type="string">
   Pack folder name under &lt;COMFYUI_PATH&gt;/custom_nodes/. REQUIRED for action:"scaffold" — a safe lowercase slug (letters, digits, hyphens, underscores), e.g. 'my-cool-nodes', which becomes the directory under custom_nodes/ and the pyproject [project].name. For action:"verify", the pack whose __init__.py NODE_CLASS_MAPPINGS keys are inferred and checked when `class_types` is omitted. For action:"publish", the pack folder to publish (give this or `path`).
@@ -278,7 +283,8 @@ Author, edit, test and publish YOUR OWN ComfyUI custom-node pack under &lt;COMFY
   action:"search" — match case-sensitively (default false).
 </ParamField>
 <ParamField path="git_action" type="enum">
-  action:"git" — REQUIRED. Which git operation to run: status/diff/log are read-only; commit/push require COMFYUI_MCP_ALLOW_GIT_WRITES=1. Named `git_action` rather than `action` only because `action` is this tool's dispatch field; the git operation itself is unchanged. Options: `status`, `diff`, `log`, `commit`, `push`.
+  action:"git" — REQUIRED. Which git operation to run: status/diff/log are read-only; commit/push require COMFYUI_MCP_ALLOW_GIT_WRITES=1. Named `git_action` rather than `action` only because `action` is this tool's dispatch field; the git operation itself is unchanged.
+  Options: `status`, `diff`, `log`, `commit`, `push`.
 </ParamField>
 <ParamField path="message" type="string">
   action:"git" — commit message (required for git_action 'commit').
@@ -416,7 +422,8 @@ Custom-node snapshots via ComfyUI-Manager (mirrors `comfy node save-snapshot` / 
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which snapshot operation to perform. "list" takes no other parameters; "save" takes an optional `name`; "restore" requires `name`. Options: `action:"list"`, `action:"save"`, `action:"restore"`.
+  Which snapshot operation to perform. "list" takes no other parameters; "save" takes an optional `name`; "restore" requires `name`.
+  Options: `action:"list"`, `action:"save"`, `action:"restore"`.
 </ParamField>
 <ParamField path="name" type="string">
   Snapshot name (no extension, no path separators). REQUIRED for action:"restore" (as shown by action:"list"). OPTIONAL for action:"save" — omit to let ComfyUI-Manager assign a timestamped name. Ignored by action:"list".
@@ -469,7 +476,8 @@ All actions are argument-free; `action` is the only parameter. `good`/`bad` requ
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which bisect operation to perform. "start" begins a session; "good"/"bad" narrow it (require a running session); "reset" clears it and re-enables everything; "status" reports state. No other arguments are needed for any action. Options: `action:"start"`, `action:"good"`, `action:"bad"`, `action:"reset"`, `action:"status"`.
+  Which bisect operation to perform. "start" begins a session; "good"/"bad" narrow it (require a running session); "reset" clears it and re-enables everything; "status" reports state. No other arguments are needed for any action.
+  Options: `action:"start"`, `action:"good"`, `action:"bad"`, `action:"reset"`, `action:"status"`.
 </ParamField>
 
 ### Example

--- a/docs/tools/defaults-stats-skills.mdx
+++ b/docs/tools/defaults-stats-skills.mdx
@@ -21,7 +21,8 @@ Read and write settings — either OUR generation defaults or ComfyUI's own fron
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which settings operation to perform, and on WHICH store. "get"/"set" are the MCP server's own generation defaults (width, steps, cfg, …); "get_ui"/"set_ui" are ComfyUI's separate frontend UI settings (the Comfy.* ids). "get" takes no other parameters; "set" requires `values` (optional `persist`); "get_ui" takes an optional `id` or `filter`; "set_ui" requires `id` + `value`. Options: `action:"get"`, `action:"set"`, `action:"get_ui"`, `action:"set_ui"`.
+  Which settings operation to perform, and on WHICH store. "get"/"set" are the MCP server's own generation defaults (width, steps, cfg, …); "get_ui"/"set_ui" are ComfyUI's separate frontend UI settings (the Comfy.* ids). "get" takes no other parameters; "set" requires `values` (optional `persist`); "get_ui" takes an optional `id` or `filter`; "set_ui" requires `id` + `value`.
+  Options: `action:"get"`, `action:"set"`, `action:"get_ui"`, `action:"set_ui"`.
 </ParamField>
 <ParamField path="values" type="object">
   action:"set" — REQUIRED. Key/value map of GENERATION defaults to set. Keys are typically lowercase (e.g. width, steps). Not for Comfy.* UI ids — those go through action:"set_ui".

--- a/docs/tools/image-generation.mdx
+++ b/docs/tools/image-generation.mdx
@@ -26,7 +26,8 @@ Generate media from a prompt or an existing image — the high-level entry point
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  What to generate. action:"image"/action:"video" require `prompt`; action:"audio" requires `model_family`+`prompt`+`duration`; action:"3d" requires `mode` (+ `prompt` or `image`); action:"controlnet" requires `prompt`+`control_image`; action:"ip_adapter" requires `prompt`+`reference_image`; action:"regenerate" requires `asset_id`; action:"upscale" and action:"remove_background" require `image`. Options: `action:"image"`, `action:"audio"`, `action:"video"`, `action:"3d"`, `action:"controlnet"`, `action:"ip_adapter"`, `action:"regenerate"`, `action:"upscale"`, `action:"remove_background"`.
+  What to generate. action:"image"/action:"video" require `prompt`; action:"audio" requires `model_family`+`prompt`+`duration`; action:"3d" requires `mode` (+ `prompt` or `image`); action:"controlnet" requires `prompt`+`control_image`; action:"ip_adapter" requires `prompt`+`reference_image`; action:"regenerate" requires `asset_id`; action:"upscale" and action:"remove_background" require `image`.
+  Options: `action:"image"`, `action:"audio"`, `action:"video"`, `action:"3d"`, `action:"controlnet"`, `action:"ip_adapter"`, `action:"regenerate"`, `action:"upscale"`, `action:"remove_background"`.
 </ParamField>
 <ParamField path="prompt" type="string">
   Positive text prompt. REQUIRED for actions "image", "audio", "video", "controlnet" and "ip_adapter"; for action:"3d" it is required in mode "text" and optional (passed through only if the chosen node accepts it) in mode "image". Unused by action:"regenerate", action:"upscale" and action:"remove_background".
@@ -89,7 +90,8 @@ Generate media from a prompt or an existing image — the high-level entry point
   action:"ip_adapter" — IPAdapterUnifiedLoader preset (default 'PLUS (high strength)').
 </ParamField>
 <ParamField path="weight_type" type="enum">
-  action:"ip_adapter" — IPAdapter weight mode (default 'standard' — required by current IPAdapter_plus builds). Options: `standard`, `prompt is more important`, `style transfer`.
+  action:"ip_adapter" — IPAdapter weight mode (default 'standard' — required by current IPAdapter_plus builds).
+  Options: `standard`, `prompt is more important`, `style transfer`.
 </ParamField>
 <ParamField path="strength" type="number">
   Two DIFFERENT knobs sharing one field, each with its own range, checked when the action runs: action:"video" (i2v only) — adherence to the start frame, 0-1 inclusive (default 0.6; higher = LESS motion); action:"controlnet" — conditioning strength, must be &gt; 0, typically 0.0-2.0 (default 1.0; higher = stronger adherence to the control image).
@@ -104,7 +106,8 @@ Generate media from a prompt or an existing image — the high-level entry point
   action:"video" — frames per second (default 25).
 </ParamField>
 <ParamField path="mode" type="enum">
-  action:"3d" — "text" = text-to-3D from `prompt`; "image" = image-to-3D from an uploaded input `image`. REQUIRED for that action. Options: `text`, `image`.
+  action:"3d" — "text" = text-to-3D from `prompt`; "image" = image-to-3D from an uploaded input `image`. REQUIRED for that action.
+  Options: `text`, `image`.
 </ParamField>
 <ParamField path="node" type="string">
   action:"3d" — explicit 3D API node class_type to use (e.g. "MeshyTextToModelNode"); auto-selected if omitted. Use list_api_nodes with filter "3d" to see options.
@@ -113,7 +116,8 @@ Generate media from a prompt or an existing image — the high-level entry point
   action:"3d" — provider-specific extra inputs passed through to the node (e.g. style, texture, quality). Use list_api_nodes (action:"schema") on the chosen node for valid keys.
 </ParamField>
 <ParamField path="model_family" type="enum">
-  action:"audio" — audio model family; determines which workflow template and model loaders to use. REQUIRED for that action. Options: `ace_step_1.5`, `stable_audio_3`.
+  action:"audio" — audio model family; determines which workflow template and model loaders to use. REQUIRED for that action.
+  Options: `ace_step_1.5`, `stable_audio_3`.
 </ParamField>
 <ParamField path="duration" type="number">
   action:"audio" — audio duration in seconds. REQUIRED for that action.
@@ -152,7 +156,8 @@ Generate media from a prompt or an existing image — the high-level entry point
   action:"audio" — TextEncodeAceStepAudio1.5 tempo in beats per minute (ACE only, 10-300, default: 120).
 </ParamField>
 <ParamField path="timesignature" type="enum">
-  action:"audio" — TextEncodeAceStepAudio1.5 time signature (ACE only, one of '2'/'3'/'4'/'6', default: '4'). Options: `2`, `3`, `4`, `6`.
+  action:"audio" — TextEncodeAceStepAudio1.5 time signature (ACE only, one of '2'/'3'/'4'/'6', default: '4').
+  Options: `2`, `3`, `4`, `6`.
 </ParamField>
 <ParamField path="temperature" type="number">
   action:"audio" — TextEncodeAceStepAudio1.5 LLM sampling temperature (ACE only, 0-2, default: 0.85).
@@ -170,7 +175,8 @@ Generate media from a prompt or an existing image — the high-level entry point
   action:"audio" — generate audio codes via the TextEncodeAceStepAudio1.5 LLM (ACE only, default: true).
 </ParamField>
 <ParamField path="audio_quality" type="enum">
-  action:"audio" — SaveAudioMP3 bitrate/quality (ACE only, one of 'V0'/'128k'/'320k', default: '320k'). Options: `V0`, `128k`, `320k`.
+  action:"audio" — SaveAudioMP3 bitrate/quality (ACE only, one of 'V0'/'128k'/'320k', default: '320k').
+  Options: `V0`, `128k`, `320k`.
 </ParamField>
 <ParamField path="asset_id" type="string">
   action:"regenerate" — asset id of the source generation. REQUIRED for that action.

--- a/docs/tools/install-environment.mdx
+++ b/docs/tools/install-environment.mdx
@@ -24,7 +24,8 @@ Install, update and configure the local ComfyUI installation, its sidebar panel,
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which install/environment operation to perform. action:"update", action:"update_all" and action:"environment" take no other parameters; action:"install" requires `target_path`; action:"panel" takes `panel_action` (+ `version`/`reason` for a pin); action:"self_update" takes `self_update_action`; action:"configure_manager" requires `manager_setting` (+ `value`). Options: `action:"install"`, `action:"update"`, `action:"update_all"`, `action:"panel"`, `action:"self_update"`, `action:"environment"`, `action:"configure_manager"`.
+  Which install/environment operation to perform. action:"update", action:"update_all" and action:"environment" take no other parameters; action:"install" requires `target_path`; action:"panel" takes `panel_action` (+ `version`/`reason` for a pin); action:"self_update" takes `self_update_action`; action:"configure_manager" requires `manager_setting` (+ `value`).
+  Options: `action:"install"`, `action:"update"`, `action:"update_all"`, `action:"panel"`, `action:"self_update"`, `action:"environment"`, `action:"configure_manager"`.
 </ParamField>
 <ParamField path="target_path" type="string">
   action:"install" — REQUIRED absolute path to the workspace directory to install ComfyUI into. Must be empty or non-existent.
@@ -39,16 +40,19 @@ Install, update and configure the local ComfyUI installation, its sidebar panel,
   action:"install" — ComfyUI version to install (comfy-cli semantics): "nightly" (default-branch HEAD), "latest" (newest release tag), or a semantic version like "0.3.40" (checked out as tag v0.3.40). Raw git refs/branches are rejected. Omit to track the default branch HEAD. ALSO used by action:"panel" + panel_action:"pin", where it is the PANEL version to hold at, e.g. '0.11.20' (take it from the installedVersion that panel_action:"status" reports).
 </ParamField>
 <ParamField path="panel_action" type="enum" default="status">
-  action:"panel" — which sidebar-panel operation to run. status: report installed/version/dev-symlink/pin plus a sync assessment (never errors). sync: bring the panel up to what this orchestrator needs — no-ops when already current, WARNS ONLY when pinned, and reports the version re-read from disk afterwards. install: add the panel (nightly). update: pull the latest nightly. Works on either install shape — a git checkout is fast-forwarded, and a Comfy Registry ZIP install (which has no .git) is replaced with a verified fresh clone, keeping the previous copy outside custom_nodes. Success is always re-read from disk. reinstall: uninstall + reinstall (nightly). pin: hold the panel at a version (requires `version`). unpin: clear the pin so a sync can proceed. unlock: recover from a crashed/killed orchestrator's leftover panel operation lock — reclaims it ONLY when it is provably abandoned (older than the stale threshold AND its recorded owner process is dead), and refuses with the observed state otherwise. install/update/reinstall/sync refuse on a dev symlink or an active pin, and require a local workspace (COMFYUI_PATH or the saved default workspace). Options: `status`, `install`, `update`, `reinstall`, `sync`, `pin`, `unpin`, `unlock`.
+  action:"panel" — which sidebar-panel operation to run. status: report installed/version/dev-symlink/pin plus a sync assessment (never errors). sync: bring the panel up to what this orchestrator needs — no-ops when already current, WARNS ONLY when pinned, and reports the version re-read from disk afterwards. install: add the panel (nightly). update: pull the latest nightly. Works on either install shape — a git checkout is fast-forwarded, and a Comfy Registry ZIP install (which has no .git) is replaced with a verified fresh clone, keeping the previous copy outside custom_nodes. Success is always re-read from disk. reinstall: uninstall + reinstall (nightly). pin: hold the panel at a version (requires `version`). unpin: clear the pin so a sync can proceed. unlock: recover from a crashed/killed orchestrator's leftover panel operation lock — reclaims it ONLY when it is provably abandoned (older than the stale threshold AND its recorded owner process is dead), and refuses with the observed state otherwise. install/update/reinstall/sync refuse on a dev symlink or an active pin, and require a local workspace (COMFYUI_PATH or the saved default workspace).
+  Options: `status`, `install`, `update`, `reinstall`, `sync`, `pin`, `unpin`, `unlock`.
 </ParamField>
 <ParamField path="reason" type="string">
   action:"panel" + panel_action:"pin" only: why the user is pinning (stored with the pin).
 </ParamField>
 <ParamField path="self_update_action" type="enum" default="status">
-  action:"self_update" — status: report install mode + current vs latest version + dev-link note (never errors). update: update to the latest published version (refuses on a dev link; no-op when already up to date or for npx). Options: `status`, `update`.
+  action:"self_update" — status: report install mode + current vs latest version + dev-link note (never errors). update: update to the latest published version (refuses on a dev link; no-op when already up to date or for npx).
+  Options: `status`, `update`.
 </ParamField>
 <ParamField path="manager_setting" type="enum">
-  action:"configure_manager" — REQUIRED. Which ComfyUI-Manager setting to change. HTTP API: set_preview_method, set_db_mode, set_component_policy, set_update_policy, set_channel, reset_queue. config.ini fallback: set_network_mode, set_security_level. Options: `set_preview_method`, `set_db_mode`, `set_component_policy`, `set_update_policy`, `set_channel`, `reset_queue`, `set_network_mode`, `set_security_level`.
+  action:"configure_manager" — REQUIRED. Which ComfyUI-Manager setting to change. HTTP API: set_preview_method, set_db_mode, set_component_policy, set_update_policy, set_channel, reset_queue. config.ini fallback: set_network_mode, set_security_level.
+  Options: `set_preview_method`, `set_db_mode`, `set_component_policy`, `set_update_policy`, `set_channel`, `reset_queue`, `set_network_mode`, `set_security_level`.
 </ParamField>
 <ParamField path="value" type="string">
   action:"configure_manager" — value for the chosen `manager_setting` (omit only for reset_queue). Allowed values per setting — set_preview_method: auto | latent2rgb | taesd | none; set_db_mode: local | cache | remote; set_component_policy: workflow | higher | mine; set_update_policy: stable-comfyui | nightly-comfyui; set_channel: a channel name (e.g. default); set_network_mode: public | private | offline; set_security_level: strong | normal | normal- | weak. HTTP-API settings take effect live; the config.ini ones (set_network_mode, set_security_level) apply only after a ComfyUI restart.
@@ -182,7 +186,8 @@ Inspect and manage ComfyUI workspaces (local installs). Driven by the `action` p
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which workspace operation to perform. "get" and "list" take no other parameters; "set_default" requires `path`. Options: `action:"get"`, `action:"set_default"`, `action:"list"`.
+  Which workspace operation to perform. "get" and "list" take no other parameters; "set_default" requires `path`.
+  Options: `action:"get"`, `action:"set_default"`, `action:"list"`.
 </ParamField>
 <ParamField path="path" type="string">
   action:"set_default" — REQUIRED absolute path to a ComfyUI installation directory to remember as the default workspace.

--- a/docs/tools/models.mdx
+++ b/docs/tools/models.mdx
@@ -25,7 +25,8 @@ Find model weights and get them onto the connected ComfyUI, and track the transf
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which model operation to perform. "download" requires `url` + `target_subfolder`; "status" takes an optional `id`/`tray_id`/`url` (omit all three to list everything); "cancel" requires `id` (optional `tray_id`); "search" requires `query`; "search_civitai" requires `query` and/or `creator`; "search_creators" takes an optional `query` (omit for the leaderboard `board`); "download_civitai" requires `target_subfolder` plus `model_id` and/or `model_version_id`; "resolve_missing" requires `workflow`. Options: `action:"download"`, `action:"status"`, `action:"cancel"`, `action:"search"`, `action:"search_civitai"`, `action:"search_creators"`, `action:"download_civitai"`, `action:"resolve_missing"`.
+  Which model operation to perform. "download" requires `url` + `target_subfolder`; "status" takes an optional `id`/`tray_id`/`url` (omit all three to list everything); "cancel" requires `id` (optional `tray_id`); "search" requires `query`; "search_civitai" requires `query` and/or `creator`; "search_creators" takes an optional `query` (omit for the leaderboard `board`); "download_civitai" requires `target_subfolder` plus `model_id` and/or `model_version_id`; "resolve_missing" requires `workflow`.
+  Options: `action:"download"`, `action:"status"`, `action:"cancel"`, `action:"search"`, `action:"search_civitai"`, `action:"search_creators"`, `action:"download_civitai"`, `action:"resolve_missing"`.
 </ParamField>
 <ParamField path="url" type="string">
   REQUIRED for action:"download" — the direct download URL for the model file. OPTIONAL for action:"status" — adopt an in-flight download by its source URL when you don't have the id (e.g. after a reconnect); reports the matching job without starting a duplicate.
@@ -64,13 +65,15 @@ Find model weights and get them onto the connected ComfyUI, and track the transf
   action:"search_civitai" — only these base-model families, CivitAI labels: 'Flux.1 D', 'SDXL 1.0', 'SD 1.5', 'Pony', 'Illustrious', 'Wan Video', …
 </ParamField>
 <ParamField path="sort" type="enum">
-  action:"search_civitai" — ranking (default 'Highest Rated'). Options: `Highest Rated`, `Most Downloaded`, `Newest`.
+  action:"search_civitai" — ranking (default 'Highest Rated').
+  Options: `Highest Rated`, `Most Downloaded`, `Newest`.
 </ParamField>
 <ParamField path="nsfw" type="boolean">
   action:"search_civitai" — include NSFW results (default false).
 </ParamField>
 <ParamField path="board" type="enum">
-  action:"search_creators" — leaderboard to rank by when no query is given (default 'overall'). Ignored with a query. Options: `overall`, `overall_90`, `overall_nsfw`, `new_creators`.
+  action:"search_creators" — leaderboard to rank by when no query is given (default 'overall'). Ignored with a query.
+  Options: `overall`, `overall_90`, `overall_nsfw`, `new_creators`.
 </ParamField>
 <ParamField path="model_version_id" type="integer">
   action:"download_civitai" — CivitAI model-version id (from the URL ?modelVersionId=...). If both model_id and model_version_id are given, this selects the specific version of that model.
@@ -179,16 +182,19 @@ Inspect what models this ComfyUI has installed, and where it looks for them. Dri
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which inventory operation to perform. "list" (optional `model_type`), "embeddings" and "list_paths" are READ-ONLY. "remove" DELETES the model file named by `path` — required, and destructive. "add_path"/"remove_path" edit the extra-search-path YAML and require `category` + `path`; they never touch model files. Options: `action:"list"`, `action:"remove"`, `action:"embeddings"`, `action:"list_paths"`, `action:"add_path"`, `action:"remove_path"`.
+  Which inventory operation to perform. "list" (optional `model_type`), "embeddings" and "list_paths" are READ-ONLY. "remove" DELETES the model file named by `path` — required, and destructive. "add_path"/"remove_path" edit the extra-search-path YAML and require `category` + `path`; they never touch model files.
+  Options: `action:"list"`, `action:"remove"`, `action:"embeddings"`, `action:"list_paths"`, `action:"add_path"`, `action:"remove_path"`.
 </ParamField>
 <ParamField path="model_type" type="enum">
-  action:"list" — filter by model type (e.g. 'checkpoints', 'loras'). Lists all types if omitted. Options: `checkpoints`, `loras`, `vae`, `upscale_models`, `controlnet`, `embeddings`, `clip`, `diffusers`, `diffusion_models`, `gligen`, `hypernetworks`, `photomaker`, `style_models`, `text_encoders`, `unet`.
+  action:"list" — filter by model type (e.g. 'checkpoints', 'loras'). Lists all types if omitted.
+  Options: `checkpoints`, `loras`, `vae`, `upscale_models`, `controlnet`, `embeddings`, `clip`, `diffusers`, `diffusion_models`, `gligen`, `hypernetworks`, `photomaker`, `style_models`, `text_encoders`, `unet`.
 </ParamField>
 <ParamField path="path" type="string">
   REQUIRED by three actions, and it means two DIFFERENT things — read this before calling. action:"remove": the MODEL FILE to DELETE, relative to the ComfyUI models/ directory (e.g. 'checkpoints/sd_xl_base_1.0.safetensors'); the leading segment is the category used to locate the file in extra roots too. action:"add_path" / action:"remove_path": a DIRECTORY to add to / remove from the extra-search-path YAML for `category` (absolute paths are safest; relative paths are resolved by ComfyUI) — no file is deleted.
 </ParamField>
 <ParamField path="target" type="enum">
-  action:"list_paths" / "add_path" / "remove_path" — config target. auto (default) is LIVE-FIRST: the running ComfyUI's own --extra-model-paths-config, else the extra_model_paths.yaml next to its main.py. When no server is reachable, auto shows the Desktop config if one exists, otherwise standalone. When a reachable LOCAL server does not expose main.py, listing degrades to the server-named config (if it exists here) or the local auto-selected one, explicitly marked as an unconfirmed display fallback; mutations refuse instead. standalone forces &lt;ComfyUI root&gt;/extra_model_paths.yaml, where the root is COMFYUI_PATH (or an auto-detected install) and falls back to the saved default workspace; desktop forces the OS app-data extra_models_config.yaml. Use standalone/desktop (or config_path) to deliberately target a file the running server does not read. Options: `auto`, `standalone`, `desktop`.
+  action:"list_paths" / "add_path" / "remove_path" — config target. auto (default) is LIVE-FIRST: the running ComfyUI's own --extra-model-paths-config, else the extra_model_paths.yaml next to its main.py. When no server is reachable, auto shows the Desktop config if one exists, otherwise standalone. When a reachable LOCAL server does not expose main.py, listing degrades to the server-named config (if it exists here) or the local auto-selected one, explicitly marked as an unconfirmed display fallback; mutations refuse instead. standalone forces &lt;ComfyUI root&gt;/extra_model_paths.yaml, where the root is COMFYUI_PATH (or an auto-detected install) and falls back to the saved default workspace; desktop forces the OS app-data extra_models_config.yaml. Use standalone/desktop (or config_path) to deliberately target a file the running server does not read.
+  Options: `auto`, `standalone`, `desktop`.
 </ParamField>
 <ParamField path="config_path" type="string">
   action:"list_paths" / "add_path" / "remove_path" — explicit YAML config path override, mainly for advanced/manual installs.
@@ -288,7 +294,8 @@ Curate a model file's embedded .safetensors metadata (Model Explorer). Driven by
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which metadata operation to perform. All three actions require `category` + `name`; "propose" also requires `fields` (optional `note`); "fetch_civitai" takes an optional `version_id`. Options: `action:"read"`, `action:"propose"`, `action:"fetch_civitai"`.
+  Which metadata operation to perform. All three actions require `category` + `name`; "propose" also requires `fields` (optional `note`); "fetch_civitai" takes an optional `version_id`.
+  Options: `action:"read"`, `action:"propose"`, `action:"fetch_civitai"`.
 </ParamField>
 <ParamField path="category" type="string">
   ComfyUI model folder, e.g. 'loras'. REQUIRED for all three actions.

--- a/docs/tools/process-control.mdx
+++ b/docs/tools/process-control.mdx
@@ -20,7 +20,8 @@ Control the lifecycle of the ComfyUI server process. Driven by the `action` para
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which process operation to perform. None of them takes any other parameter. "restart" stops and relaunches in one call (and is the only action that also works against a remote/tunnelled ComfyUI); "start" relaunches from the info a previous "stop" saved; "stop" kills the running process tree. Options: `action:"restart"`, `action:"start"`, `action:"stop"`.
+  Which process operation to perform. None of them takes any other parameter. "restart" stops and relaunches in one call (and is the only action that also works against a remote/tunnelled ComfyUI); "start" relaunches from the info a previous "stop" saved; "stop" kills the running process tree.
+  Options: `action:"restart"`, `action:"start"`, `action:"stop"`.
 </ParamField>
 
 ### Examples

--- a/docs/tools/runpod.mdx
+++ b/docs/tools/runpod.mdx
@@ -25,7 +25,8 @@ Deploy, start, stop, inspect and connect to RunPod cloud GPU pods, and switch re
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which RunPod operation to perform. "start", "stop", "status" and "connect" require `pod_id`; "create" takes the optional deploy parameters (name/gpu_type/cloud_type/connect/deadman); "list", "use_local" and "deploy_link" take no other parameters. "create" and "start" BILL; "stop" ends billing. Options: `action:"create"`, `action:"start"`, `action:"stop"`, `action:"status"`, `action:"list"`, `action:"connect"`, `action:"use_local"`, `action:"deploy_link"`.
+  Which RunPod operation to perform. "start", "stop", "status" and "connect" require `pod_id`; "create" takes the optional deploy parameters (name/gpu_type/cloud_type/connect/deadman); "list", "use_local" and "deploy_link" take no other parameters. "create" and "start" BILL; "stop" ends billing.
+  Options: `action:"create"`, `action:"start"`, `action:"stop"`, `action:"status"`, `action:"list"`, `action:"connect"`, `action:"use_local"`, `action:"deploy_link"`.
 </ParamField>
 <ParamField path="pod_id" type="string">
   The RunPod pod ID (from console.runpod.io, or action:"list"). REQUIRED for actions "start", "stop", "status" and "connect". Ignored by "create", "list", "use_local" and "deploy_link".
@@ -40,7 +41,8 @@ Deploy, start, stop, inspect and connect to RunPod cloud GPU pods, and switch re
   action:"create" — GPU type to prefer, e.g. "NVIDIA GeForce RTX 4090". Default tries: NVIDIA GeForce RTX 4090, NVIDIA RTX A6000, NVIDIA RTX PRO 4500 Blackwell, NVIDIA A40, NVIDIA RTX A5000.
 </ParamField>
 <ParamField path="cloud_type" type="enum">
-  action:"create" — COMMUNITY (cheaper, default) or SECURE. Options: `COMMUNITY`, `SECURE`.
+  action:"create" — COMMUNITY (cheaper, default) or SECURE.
+  Options: `COMMUNITY`, `SECURE`.
 </ParamField>
 <ParamField path="connect" type="boolean">
   action:"create" — auto-connect when booted: the ORCHESTRATOR waits for ComfyUI to answer (1-3min), then retargets + watches — this call returns immediately (default false: deploy only; connect later with action:"connect"). This is the create-time flag, NOT the action of the same name.
@@ -139,7 +141,8 @@ Watch a RunPod pod's live status in the control panel, stop watching it, or diag
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which watch operation to perform. "watch" and "troubleshoot" require `pod_id`; "unwatch" takes no other parameters (it clears whichever pod is currently watched). Options: `action:"watch"`, `action:"unwatch"`, `action:"troubleshoot"`.
+  Which watch operation to perform. "watch" and "troubleshoot" require `pod_id`; "unwatch" takes no other parameters (it clears whichever pod is currently watched).
+  Options: `action:"watch"`, `action:"unwatch"`, `action:"troubleshoot"`.
 </ParamField>
 <ParamField path="pod_id" type="string">
   The RunPod pod ID. REQUIRED for actions "watch" and "troubleshoot". Ignored by "unwatch", which clears the single currently watched pod.

--- a/docs/tools/training.mdx
+++ b/docs/tools/training.mdx
@@ -23,7 +23,8 @@ Stage and curate the training DATASETS a LoRA run consumes — the images and th
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which dataset operation to perform. "list" takes no other parameters; "prepare" requires `name` + `items`; "detail", "update", "delete" and "caption_dataset" require `name`; "file" and "caption_image" require `path`. NOTE "delete" here destroys a DATASET (images + captions) — deleting a training JOB is train_start action:"delete". Options: `action:"prepare"`, `action:"list"`, `action:"detail"`, `action:"update"`, `action:"delete"`, `action:"file"`, `action:"caption_image"`, `action:"caption_dataset"`.
+  Which dataset operation to perform. "list" takes no other parameters; "prepare" requires `name` + `items`; "detail", "update", "delete" and "caption_dataset" require `name`; "file" and "caption_image" require `path`. NOTE "delete" here destroys a DATASET (images + captions) — deleting a training JOB is train_start action:"delete".
+  Options: `action:"prepare"`, `action:"list"`, `action:"detail"`, `action:"update"`, `action:"delete"`, `action:"file"`, `action:"caption_image"`, `action:"caption_dataset"`.
 </ParamField>
 <ParamField path="name" type="string">
   Dataset name — the staging dir name. REQUIRED for actions "prepare" (it is created), "detail", "update", "delete" and "caption_dataset" (from action:"list"). This is a DATASET name, never a training job id.
@@ -90,7 +91,8 @@ Run and inspect LoRA training JOBS — launch a run, poll it, stop it, delete it
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which training-job operation to perform. "list_flows" takes no other parameters; "status" takes an OPTIONAL `id` (omit for all jobs); "cancel", "delete" and "job_config" require `id`; "start" and "preview_config" require `name` + `datasetPath`. NOTE "delete" here destroys a training JOB — deleting a staged DATASET is train_prepare_dataset action:"delete". Options: `action:"start"`, `action:"status"`, `action:"cancel"`, `action:"delete"`, `action:"list_flows"`, `action:"job_config"`, `action:"preview_config"`.
+  Which training-job operation to perform. "list_flows" takes no other parameters; "status" takes an OPTIONAL `id` (omit for all jobs); "cancel", "delete" and "job_config" require `id`; "start" and "preview_config" require `name` + `datasetPath`. NOTE "delete" here destroys a training JOB — deleting a staged DATASET is train_prepare_dataset action:"delete".
+  Options: `action:"start"`, `action:"status"`, `action:"cancel"`, `action:"delete"`, `action:"list_flows"`, `action:"job_config"`, `action:"preview_config"`.
 </ParamField>
 <ParamField path="id" type="string">
   Training job id, as returned by action:"start" (e.g. "t8f3k2ab") — NEVER a dataset name. REQUIRED and must be non-empty for actions "cancel", "delete" and "job_config". OPTIONAL for action:"status": omit it (or pass an empty string) to list every job newest-first. Unused by "start", "list_flows" and "preview_config".
@@ -99,10 +101,12 @@ Run and inspect LoRA training JOBS — launch a run, poll it, stop it, delete it
   Job name — becomes the output .safetensors basename (e.g. 'aria_character'). REQUIRED for actions "start" and "preview_config". This names the RUN, not the dataset it reads.
 </ParamField>
 <ParamField path="flow" type="enum" default="character">
-  action:"start" — training flow (see action:"list_flows"). Options: `character`.
+  action:"start" — training flow (see action:"list_flows").
+  Options: `character`.
 </ParamField>
 <ParamField path="model" type="enum" default="flux1-dev">
-  action:"start" — base model (see action:"list_flows"). Options: `flux1-dev`.
+  action:"start" — base model (see action:"list_flows").
+  Options: `flux1-dev`.
 </ParamField>
 <ParamField path="datasetPath" type="string">
   Dataset dir from train_prepare_dataset (images + same-basename .txt captions). REQUIRED for actions "start" and "preview_config".
@@ -117,13 +121,15 @@ Run and inspect LoRA training JOBS — launch a run, poll it, stop it, delete it
   action:"start" — GPU selector, default cuda:0.
 </ParamField>
 <ParamField path="target" type="enum" default="local">
-  action:"start" — 'local' = docker on this rig; 'pod' = pod-native over ssh on a RunPod pod. Options: `local`, `pod`.
+  action:"start" — 'local' = docker on this rig; 'pod' = pod-native over ssh on a RunPod pod.
+  Options: `local`, `pod`.
 </ParamField>
 <ParamField path="pod_id" type="string">
   action:"start" — RunPod pod to train on (target 'pod'). Default: the connector's currently connected/watched pod.
 </ParamField>
 <ParamField path="deliverTo" type="enum" default="both">
-  action:"start", pod jobs only: where the finished LoRA lands. Options: `pod`, `local`, `both`.
+  action:"start", pod jobs only: where the finished LoRA lands.
+  Options: `pod`, `local`, `both`.
 </ParamField>
 <ParamField path="model_path" type="string">
   action:"start" — override the base model path AS THE TRAINER SEES IT (pod path for target 'pod', container path for 'local') — e.g. a pre-uploaded local HF snapshot dir when the default HF repo id is gated/unreachable.
@@ -160,10 +166,12 @@ Preflight and set up the TRAINER ITSELF — the docker/GPU/venv machinery every 
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which trainer-setup operation to perform. "doctor" is read-only and takes no other parameters; "bootstrap" takes `target` (+ `pod_id` for target 'pod'); "build_image" takes an optional `aiToolkitRef`. None of them touches a dataset or a job. Options: `action:"doctor"`, `action:"bootstrap"`, `action:"build_image"`.
+  Which trainer-setup operation to perform. "doctor" is read-only and takes no other parameters; "bootstrap" takes `target` (+ `pod_id` for target 'pod'); "build_image" takes an optional `aiToolkitRef`. None of them touches a dataset or a job.
+  Options: `action:"doctor"`, `action:"bootstrap"`, `action:"build_image"`.
 </ParamField>
 <ParamField path="target" type="enum" default="local">
-  action:"bootstrap" — where to install the native trainer. Default local. Options: `local`, `pod`.
+  action:"bootstrap" — where to install the native trainer. Default local.
+  Options: `local`, `pod`.
 </ParamField>
 <ParamField path="pod_id" type="string">
   action:"bootstrap" — pod to bootstrap (target 'pod'). Default: the connected pod.

--- a/docs/tools/workflow-authoring.mdx
+++ b/docs/tools/workflow-authoring.mdx
@@ -21,10 +21,12 @@ Author and check ComfyUI workflow JSON. Driven by the `action` parameter:
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which authoring operation to perform. "create" requires `template` (optional `params`); "modify" requires `workflow` + `operations`; "validate" requires `workflow` (optional `health`); "node_info" takes no required parameters (optional `node_type`, `verbose`, `refresh`). Options: `action:"create"`, `action:"modify"`, `action:"validate"`, `action:"node_info"`.
+  Which authoring operation to perform. "create" requires `template` (optional `params`); "modify" requires `workflow` + `operations`; "validate" requires `workflow` (optional `health`); "node_info" takes no required parameters (optional `node_type`, `verbose`, `refresh`).
+  Options: `action:"create"`, `action:"modify"`, `action:"validate"`, `action:"node_info"`.
 </ParamField>
 <ParamField path="template" type="enum">
-  action:"create" (REQUIRED) — Template name: txt2img, img2img, upscale, or inpaint Options: `txt2img`, `img2img`, `upscale`, `inpaint`, `controlnet`, `ip_adapter`, `ace_step_15`, `stable_audio_3`, `remove_background`, `ltx_video`.
+  action:"create" (REQUIRED) — Template name: txt2img, img2img, upscale, or inpaint
+  Options: `txt2img`, `img2img`, `upscale`, `inpaint`, `controlnet`, `ip_adapter`, `ace_step_15`, `stable_audio_3`, `remove_background`, `ltx_video`.
 </ParamField>
 <ParamField path="params" type="object" default="[object Object]">
   action:"create" — Template parameters; recognized keys depend on the template. txt2img: checkpoint, positive_prompt, negative_prompt, width, height, steps, cfg, seed, sampler_name, scheduler. img2img/inpaint add image_path (and mask_path for inpaint) and denoise. upscale adds upscale_model. Unknown keys are ignored; omitted keys use template defaults.
@@ -172,7 +174,8 @@ DRAW a diagram of, or convert, workflow JSON you PASS IN (a JSON string or objec
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which rendering/conversion to perform. "render", "render_hierarchical" and "to_dsl" require `workflow`; "mermaid" requires `mermaid`; "from_dsl" requires `dsl`. Options: `action:"render"`, `action:"render_hierarchical"`, `action:"mermaid"`, `action:"to_dsl"`, `action:"from_dsl"`.
+  Which rendering/conversion to perform. "render", "render_hierarchical" and "to_dsl" require `workflow`; "mermaid" requires `mermaid`; "from_dsl" requires `dsl`.
+  Options: `action:"render"`, `action:"render_hierarchical"`, `action:"mermaid"`, `action:"to_dsl"`, `action:"from_dsl"`.
 </ParamField>
 <ParamField path="workflow" type="string | object">
   ComfyUI workflow JSON (as a JSON string or object; API or UI format is auto-detected). REQUIRED for action:"render", action:"render_hierarchical" and action:"to_dsl" — "to_dsl" expects API format (node ID -&gt; &#123;class_type, inputs&#125;).
@@ -181,10 +184,12 @@ DRAW a diagram of, or convert, workflow JSON you PASS IN (a JSON string or objec
   action:"render" / action:"render_hierarchical" — Include widget values (seed, steps, cfg, etc.) in node labels (detail view only, for the hierarchical action).
 </ParamField>
 <ParamField path="direction" type="enum">
-  action:"render" / action:"render_hierarchical" — Flowchart direction: LR (left-to-right) or TB (top-to-bottom). Default LR for "render" and for the hierarchical detail view, TB for the hierarchical overview. Options: `LR`, `TB`.
+  action:"render" / action:"render_hierarchical" — Flowchart direction: LR (left-to-right) or TB (top-to-bottom). Default LR for "render" and for the hierarchical detail view, TB for the hierarchical overview.
+  Options: `LR`, `TB`.
 </ParamField>
 <ParamField path="view" type="enum" default="overview">
-  action:"render_hierarchical" — overview: compact diagram with sections as summary nodes; detail: full diagram for one section; list: text summary of all sections; summary: structured text optimized for AI ingestion with node IDs, key settings, virtual wires, and full connection graph Options: `overview`, `detail`, `list`, `summary`.
+  action:"render_hierarchical" — overview: compact diagram with sections as summary nodes; detail: full diagram for one section; list: text summary of all sections; summary: structured text optimized for AI ingestion with node IDs, key settings, virtual wires, and full connection graph
+  Options: `overview`, `detail`, `list`, `summary`.
 </ParamField>
 <ParamField path="section" type="string">
   action:"render_hierarchical" — Section name to show in detail view (required when view=detail). Use view=list to see available section names.

--- a/docs/tools/workflow-execution.mdx
+++ b/docs/tools/workflow-execution.mdx
@@ -22,7 +22,8 @@ Submit work to the ComfyUI execution queue — the primary way an agent starts a
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which enqueue entry point to use. action:"enqueue" requires `workflow`; action:"rerun" takes an optional `prompt_id` (+ `inputs`); action:"run_url" requires `url` (+ `run`/`inputs`); action:"template_schema" and action:"run_template" require `template`; with action:"run_template" you may also pass `overrides`/`wait`/`timeout_s`. Options: `action:"enqueue"`, `action:"rerun"`, `action:"run_url"`, `action:"template_schema"`, `action:"run_template"`.
+  Which enqueue entry point to use. action:"enqueue" requires `workflow`; action:"rerun" takes an optional `prompt_id` (+ `inputs`); action:"run_url" requires `url` (+ `run`/`inputs`); action:"template_schema" and action:"run_template" require `template`; with action:"run_template" you may also pass `overrides`/`wait`/`timeout_s`.
+  Options: `action:"enqueue"`, `action:"rerun"`, `action:"run_url"`, `action:"template_schema"`, `action:"run_template"`.
 </ParamField>
 <ParamField path="workflow" type="object">
   action:"enqueue" — ComfyUI workflow in API format (node ID -&gt; &#123;class_type, inputs&#125;). REQUIRED for that action.
@@ -154,7 +155,8 @@ Inspect the connected ComfyUI server: what it is running on, what it has logged,
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which read to perform. "stats" takes no other parameters; "logs" takes `max_lines`/`keyword`; "health" takes `model_categories`/`recent_errors`. None of them is required. Options: `action:"stats"`, `action:"logs"`, `action:"health"`.
+  Which read to perform. "stats" takes no other parameters; "logs" takes `max_lines`/`keyword`; "health" takes `model_categories`/`recent_errors`. None of them is required.
+  Options: `action:"stats"`, `action:"logs"`, `action:"health"`.
 </ParamField>
 <ParamField path="max_lines" type="integer">
   action:"logs" — maximum number of log lines to return from the end (default: 100).
@@ -247,7 +249,8 @@ Inspect and manage the ComfyUI execution queue. Driven by the `action` parameter
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which queue operation to perform. "list" and "clear" take no other parameters; "status", "get_workflow" and "cancel_queued" require `prompt_id`; "move" requires `prompt_id` + `position`; "edit" requires `prompt_id` (optional `workflow`/`node_inputs`/`position`); "cancel" takes an optional `prompt_id` and `clear_pending`. Options: `action:"list"`, `action:"status"`, `action:"get_workflow"`, `action:"move"`, `action:"edit"`, `action:"cancel"`, `action:"cancel_queued"`, `action:"clear"`.
+  Which queue operation to perform. "list" and "clear" take no other parameters; "status", "get_workflow" and "cancel_queued" require `prompt_id`; "move" requires `prompt_id` + `position`; "edit" requires `prompt_id` (optional `workflow`/`node_inputs`/`position`); "cancel" takes an optional `prompt_id` and `clear_pending`.
+  Options: `action:"list"`, `action:"status"`, `action:"get_workflow"`, `action:"move"`, `action:"edit"`, `action:"cancel"`, `action:"cancel_queued"`, `action:"clear"`.
 </ParamField>
 <ParamField path="prompt_id" type="string">
   The prompt_id of a job (the id returned by enqueue_workflow). REQUIRED for actions "status", "get_workflow", "move", "edit" and "cancel_queued" (a PENDING queue item for all but "status"). OPTIONAL for action:"cancel" — if given, only interrupts the running job when its prompt_id matches; omit to interrupt whatever is currently running.
@@ -256,7 +259,8 @@ Inspect and manage the ComfyUI execution queue. Driven by the `action` parameter
   action:"list" — include each running/pending job's workflow payload and extra_data. Can be large.
 </ParamField>
 <ParamField path="position" type="enum">
-  Where to requeue the job. REQUIRED for action:"move". OPTIONAL for action:"edit" — defaults to back. Options: `front`, `back`.
+  Where to requeue the job. REQUIRED for action:"move". OPTIONAL for action:"edit" — defaults to back.
+  Options: `front`, `back`.
 </ParamField>
 <ParamField path="workflow" type="object">
   action:"edit" — optional complete replacement API-format workflow. If omitted, the existing queued workflow is patched with `node_inputs`.
@@ -294,7 +298,8 @@ Read what has already been generated on this machine — execution history, why 
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which history view to return. "list" and "diagnose" read ComfyUI's execution history and take an optional `prompt_id`; "stats" and "suggest" read this server's own local generation-settings database and take `model_family` (plus `lora_hash`/`search`/`limit` for "suggest"). No action requires any other field. Options: `action:"list"`, `action:"diagnose"`, `action:"stats"`, `action:"suggest"`.
+  Which history view to return. "list" and "diagnose" read ComfyUI's execution history and take an optional `prompt_id`; "stats" and "suggest" read this server's own local generation-settings database and take `model_family` (plus `lora_hash`/`search`/`limit` for "suggest"). No action requires any other field.
+  Options: `action:"list"`, `action:"diagnose"`, `action:"stats"`, `action:"suggest"`.
 </ParamField>
 <ParamField path="prompt_id" type="string">
   Actions "list" and "diagnose" — the prompt ID to look up (returned by enqueue_workflow). For action:"list", if omitted, returns the most recent COMMITTED execution (chosen by ComfyUI's queue number, not dict order); immediately after a run finishes it can briefly lag by one until ComfyUI commits the new entry, so pass the prompt_id from enqueue_workflow to get that exact run, and prefer the run-finished event for naming a just-produced output. For action:"diagnose", omit to diagnose the most recent FAILED run — preferred over a newer successful one — falling back to the most recent run if nothing failed.
@@ -382,7 +387,8 @@ Batch ids are durable — they survive server restarts.
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which batch operation to perform. "submit" takes workflows | workflow+sweep; "status"/"output"/"wait" each require `batch_id` ("wait" also takes `timeout_s`). Options: `action:"submit"`, `action:"status"`, `action:"output"`, `action:"wait"`.
+  Which batch operation to perform. "submit" takes workflows | workflow+sweep; "status"/"output"/"wait" each require `batch_id` ("wait" also takes `timeout_s`).
+  Options: `action:"submit"`, `action:"status"`, `action:"output"`, `action:"wait"`.
 </ParamField>
 <ParamField path="workflows" type="object[]">
   action:"submit" — array of ComfyUI workflows in API format (node ID -&gt; &#123;class_type, inputs&#125;). Mutually exclusive with workflow+sweep.

--- a/docs/tools/workflow-library.mdx
+++ b/docs/tools/workflow-library.mdx
@@ -25,13 +25,15 @@ Return, list, summarize or query a SAVED workflow FILE — files on disk, named 
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which read to perform. "list" and "prompt_director" take no required parameters; "get" and "analyze" require `filename`; "strip", "slice" and "query" require exactly one of `path`/`filename`/`graph` (and "slice" also requires `groups`); "from_image" requires `image_path`. Options: `action:"get"`, `action:"list"`, `action:"strip"`, `action:"slice"`, `action:"from_image"`, `action:"analyze"`, `action:"query"`, `action:"prompt_director"`.
+  Which read to perform. "list" and "prompt_director" take no required parameters; "get" and "analyze" require `filename`; "strip", "slice" and "query" require exactly one of `path`/`filename`/`graph` (and "slice" also requires `groups`); "from_image" requires `image_path`.
+  Options: `action:"get"`, `action:"list"`, `action:"strip"`, `action:"slice"`, `action:"from_image"`, `action:"analyze"`, `action:"query"`, `action:"prompt_director"`.
 </ParamField>
 <ParamField path="filename" type="string">
   Workflow library name, exactly as action:"list" reports it. A workflow filed in a folder keeps its folder in the name ('VIDEO/MiniMaxH3/clip.json') and that whole string goes here. REQUIRED for action:"get" and action:"analyze"; one of the three sources for "strip", "slice" and "query".
 </ParamField>
 <ParamField path="format" type="enum" default="api">
-  action:"get" — 'api' (default, recommended) converts to compact API format with named inputs, connection references, and _meta.mode flags for muted/bypassed nodes; 'ui' returns the raw UI format with layout positions and links arrays. action:"strip" — 'api' (default) strips to the flat resolved graph; 'raw' returns the file/graph unchanged. Each action accepts only its own two values (this field is the union of what the two tools it replaces accepted) and refuses the third rather than guessing at an alias. Options: `ui`, `api`, `raw`.
+  action:"get" — 'api' (default, recommended) converts to compact API format with named inputs, connection references, and _meta.mode flags for muted/bypassed nodes; 'ui' returns the raw UI format with layout positions and links arrays. action:"strip" — 'api' (default) strips to the flat resolved graph; 'raw' returns the file/graph unchanged. Each action accepts only its own two values (this field is the union of what the two tools it replaces accepted) and refuses the third rather than guessing at an alias.
+  Options: `ui`, `api`, `raw`.
 </ParamField>
 <ParamField path="path" type="string">
   action:"strip" / "slice" / "query" — Absolute server-side path to a workflow .json on disk (e.g. C:\\Users\\you\\ComfyUI\\user\\default\\workflows\\pusa_extend.json). Read directly from disk — no library lookup.
@@ -46,7 +48,8 @@ Return, list, summarize or query a SAVED workflow FILE — files on disk, named 
   action:"from_image" (REQUIRED) — Absolute path to a ComfyUI-generated PNG file
 </ParamField>
 <ParamField path="view" type="enum" default="summary">
-  action:"analyze" — summary (default): structured text with sections, node IDs, key settings, virtual wires, and full connection graph — best for AI understanding. overview: mermaid diagram showing sections as summary nodes with cross-section data flow. detail: mermaid diagram for one section (requires section parameter). list: text listing of all sections with data flow summary. flat: single mermaid flowchart of the entire workflow (best for small workflows). health: graph-health heuristics (disconnected nodes, duplicate model loads, orphaned branches, muted/bypassed). Options: `summary`, `overview`, `detail`, `list`, `flat`, `health`.
+  action:"analyze" — summary (default): structured text with sections, node IDs, key settings, virtual wires, and full connection graph — best for AI understanding. overview: mermaid diagram showing sections as summary nodes with cross-section data flow. detail: mermaid diagram for one section (requires section parameter). list: text listing of all sections with data flow summary. flat: single mermaid flowchart of the entire workflow (best for small workflows). health: graph-health heuristics (disconnected nodes, duplicate model loads, orphaned branches, muted/bypassed).
+  Options: `summary`, `overview`, `detail`, `list`, `flat`, `health`.
 </ParamField>
 <ParamField path="section" type="string">
   action:"analyze" — Section name for detail view. Use view='list' first to see available section names.
@@ -76,10 +79,12 @@ Return, list, summarize or query a SAVED workflow FILE — files on disk, named 
   action:"query" — Max hops from the traversal seed (seed=0). Absent = full closure.
 </ParamField>
 <ParamField path="fields" type="enum">
-  action:"query" — Projection: compact one-liners (default), bare ids, or detail JSON rows. Options: `ids`, `compact`, `detail`.
+  action:"query" — Projection: compact one-liners (default), bare ids, or detail JSON rows.
+  Options: `ids`, `compact`, `detail`.
 </ParamField>
 <ParamField path="group_by" type="enum">
-  action:"query" — Aggregate: counts per class_type instead of listing. Options: `type`.
+  action:"query" — Aggregate: counts per class_type instead of listing.
+  Options: `type`.
 </ParamField>
 <ParamField path="limit" type="integer">
   action:"query" — Max nodes listed (default 40, max 200).
@@ -223,7 +228,8 @@ WRITE to the ComfyUI user library: persist a workflow, or capture/verify its pro
 ### Parameters
 
 <ParamField path="action" type="enum" required>
-  Which write/provenance operation to perform. All three require `filename`; "save" also requires `workflow`. Options: `action:"save"`, `action:"lock"`, `action:"verify_lock"`.
+  Which write/provenance operation to perform. All three require `filename`; "save" also requires `workflow`.
+  Options: `action:"save"`, `action:"lock"`, `action:"verify_lock"`.
 </ParamField>
 <ParamField path="filename" type="string">
   Workflow filename in the ComfyUI user library (e.g. 'my_workflow.json'). REQUIRED for every action. For action:"save" this OVERWRITES an existing file of the same name; for "lock"/"verify_lock" the lock is read/written as '&lt;filename&gt;.lock.json' alongside it.

--- a/scripts/check-tool-vocabulary.mts
+++ b/scripts/check-tool-vocabulary.mts
@@ -49,6 +49,7 @@ import {
   TOOL_NAMES,
   baselineIntegrity,
   actionLiteralSpans,
+  deadNameMentions,
   deadNameRe,
   panelBaselineIntegrity,
   rotMentions,
@@ -377,7 +378,19 @@ for (const path of files) {
       // instruction, not the history. Binding the name to the context string means the
       // exempted text must itself contain the name, so an instruction added beside it is
       // a second occurrence and fails.
-      const occurrences = text.split(dead.name).length - 1;
+      // COUNT THE WAY EVERY OTHER CHECK HERE DETECTS. `split(dead.name)` is a raw
+      // SUBSTRING split, while `deadNameRe`/`rotMentions`/`actionLiteralSpans` are all
+      // token-bounded — so the two disagreed exactly where a live name CONTAINS a dead
+      // one. With `self_update` retired, a line naming `self_update_action` (the real
+      // parameter on the consolidated tool) counted as an occurrence here while matching
+      // nowhere else, pushing a legitimately exempted line to `occurrences === 2` and
+      // failing it. That is a FALSE REFUSAL: the gate rejecting a valid `allowedIn`
+      // entry over a name that is not a mention at all.
+      //
+      // The fail-closed intent above is unchanged — a line carrying two REAL mentions
+      // still fails, because the ambiguity it guards against is real. This only stops
+      // counting things that were never mentions.
+      const occurrences = deadNameMentions(dead.name, text).length;
       if (
         occurrences === 1 &&
         dead.allowedIn?.some(

--- a/scripts/gen-tool-docs.ts
+++ b/scripts/gen-tool-docs.ts
@@ -299,7 +299,16 @@ function renderParam(name: string, schema: JsonSchema, required: boolean): strin
     const opt = (e: unknown) => (name === "action" ? `\`action:"${String(e)}"\`` : `\`${String(e)}\``);
     body.push(`Options: ${schema.enum.map(opt).join(", ")}.`);
   }
-  return `<ParamField ${attrs.join(" ")}>\n  ${body.join(" ") || "—"}\n</ParamField>`;
+  // A description and its `Options:` list go on SEPARATE lines. Joining them with a
+  // space is not merely cosmetic here: the dead-name gate reasons PER LINE, and its
+  // exemptions cover one occurrence of a name per line on purpose (a line carrying two
+  // mentions is ambiguous, so it fails closed and "must be split"). Welding the two
+  // pieces together manufactures exactly that ambiguity — a description that mentions a
+  // retired name as history, glued to an `action:"…"` option that legitimately contains
+  // it, becomes one unsplittable line the gate cannot accept and no author can fix
+  // without editing generated output. Emitting them separately keeps each piece
+  // individually judgeable, which is what the per-line rule assumes.
+  return `<ParamField ${attrs.join(" ")}>\n  ${body.join("\n  ") || "—"}\n</ParamField>`;
 }
 
 // Most examples can be derived from JSON Schema required fields. Flat action


### PR DESCRIPTION
Two defects in the vocabulary gate's own machinery, both surfaced while rescuing the stranded 0.50.0 cluster branches (#923–#927).

## 1. The occurrence count did not match the detector

`scripts/check-tool-vocabulary.mts` counted with `text.split(dead.name).length - 1` — a **raw substring** split — while every other check in the file (`deadNameRe`, `rotMentions`, `actionLiteralSpans`) is token-bounded. They disagree exactly where a **live** name contains a **dead** one.

Measured on a real line (one I wrote while resolving #924):

```
verify with install_comfyui (action:"self_update") using self_update_action:'status'
  old split count : 2
  new token count : 1
```

An `allowedIn` exemption requires `occurrences === 1`, so the overcount silently **denied valid exemptions** — the gate refusing a legitimate entry over text that is not a mention at all. A false refusal, which is the defect class this repo keeps hunting.

Fail-closed intent is unchanged: a line with two **real** mentions still fails.

## 2. Generated docs welded two judgeable pieces into one unsplittable line

`scripts/gen-tool-docs.ts` joined a param description and its `Options:` list with a space. The gate reasons **per line**, and deliberately refuses a line carrying two mentions with "must be split". Welding them manufactures precisely that ambiguity in **generated** output — which no author can split without hand-editing generated files.

Now emitted on separate lines, so each piece stays individually judgeable.

## Verification

- `tsc` clean, `npm run check:vocabulary` passes
- Docs regenerated: 15 files, +136/−68 (one line becoming two)
- The count fix is demonstrated above against the live/dead name pair that motivated it

Note: CI is currently unable to run (GitHub Actions major outage, ~2026-08-06 17:00 UTC onward — webhooks throttled to ~15%, so pushes are not triggering runs). Everything above was verified locally.