### PR TITLE
0.50.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.1] - 2026-08-06
+
+Ten fixes on top of the 0.50.0 consolidation, and most of them are one defect class:
+a tool reporting something it had not actually established.
+
+A restart fenced the endpoint rather than the instance, so a same-URL reaffirmation
+bumped a generation without moving anything. A backend stall reached the agent as a
+USER rejection. `panel_run` could stack a duplicate after a reconnect, because the
+self-queue ledger is prompt-id based and in-memory — so the agent's OWN earlier render
+read as unattributed; the fence now demands PROVEN self-attribution and refuses with the
+override named rather than silently duplicating. A "panel install did NOT land" warning
+fired against a tree the retarget had already corrected. And `self_update` on Windows
+could never succeed at all: the running orchestrator holds its own sharp DLL open, the
+in-place npm replace failed EBUSY, and the error was swallowed.
+
+Also here: the test suite could rewrite the developer's real `~/.comfyui-mcp` state. That
+had been fixed four separate times per-test and kept coming back, so the whole run is now
+redirected before workers fork. And the vocabulary gate was counting mentions by raw
+substring while every other check is token-bounded — where a live name contains a dead one
+(`self_update_action` vs `self_update`) it overcounted and silently denied valid exemptions.
+
+### MCP
+
+#### Fixed
+- a failed clone must not leave something ComfyUI will try to load (#917)
+- redirect every persistent store for the whole run (#930)
+- say where the listing came from, instead of making callers guess (#915)
+- count mentions the way the gate detects them; stop welding doc lines together (#951)
+
+#### Changed
+- warn that Manager's "Nightly" is not nightly, and is routinely older than Latest (#931)
+- self_update on Windows: EBUSY on own sharp dll, npm error swallowed; updater failure + cancelled restart disconnects bridge (#924)
+- VRAM handoff during renders skips the llama.cpp backend (#927)
+- panel run/sync truthfulness: duplicate run after reconnect + false 'panel install did NOT land' warning (#926)
+- turn lifecycle: Claude backend stall still reported as user rejection + turn registry does not survive reconnect (#923)
+- restart fences the endpoint, not the instance + cannot identify local process without start times (#925)
+
+
 ## [0.50.0] - 2026-08-06
 
 The tool surface consolidates. Roughly 143 individually-registered tools fold into

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.0",
+      "version": "0.50.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Ten PRs merged since v0.50.0. Version bump + changelog only.

## Contents

| PR | Fix |
|---|---|
| #925 | restart fences the endpoint, not the instance (#871, #914) |
| #923 | backend stall reported as USER rejection; turn registry lost on reconnect (#885, #886) |
| #926 | duplicate `panel_run` after reconnect; false "panel install did NOT land" (#862, #888) |
| #924 | `self_update` on Windows EBUSY, npm error swallowed (#912, #916) |
| #917 | failed clone leaves a .git-only husk ComfyUI tries to load (#900) |
| #927 | VRAM handoff skips the llama.cpp backend (#874) |
| #915 | `list_output_images` says where the listing came from (#899) |
| #930 | suite could rewrite the real `~/.comfyui-mcp` state (#866, #879) |
| #951 | vocabulary gate counted mentions differently than it detected them |
| #931 | docs: Manager's "Nightly" is not nightly |

## Pre-release verification (local, on this exact main)

- `tsc` clean
- `check:vocabulary` OK — 1127 files, 160 dead names, no live references
- `vocab:export --check` OK — artefact matches the ledger (37 core, 91 panel, 160 dead)
- `asset-counts --check` — counts match the source of truth
- `docs:gen` is a no-op (the 15 "dirty" files on a Windows checkout are CRLF-only, zero content diff)
- Full suite: **315 files, 6824 passed**, 1 expected fail, 2 skipped
- main CI: `success` on `1fd2f802`

## Live browser check — partial, and worth reading

ComfyUI (0.30.2) loaded clean, panel served and reported its version correctly, and the junction-linked panel served **0.11.42 with `maxTools: 37`** after a hard refresh — so panel #683's fix is real and live-verifiable.

**What could NOT be verified:** the Training tab end-to-end. The MCP server running on this rig is still **pre-0.50.0** — `list_tools` reports **151 tools** with the old training names (`train_status`, `train_list_datasets`, `train_job_config`). So the tab could not be exercised against the consolidated surface.

That exposes a real risk worth naming: the panel↔server skew breaks in **both** directions. #683 fixed panel-pinned-151 against server-37; this rig is the inverse, panel-37 against server-151. The version floor should refuse the mismatch rather than let either side fail at call time. Filed as a follow-up rather than blocking this release, since 0.50.1 changes nothing about that seam.

The panel checkout was restored to `release/0.11.40` exactly as found.