### PR TITLE
fix(vocabulary): detect panel/server vocabulary skew at the handshake, not at call time

### DIFF
--- a/scripts/export-vocabulary.mts
+++ b/scripts/export-vocabulary.mts
@@ -46,7 +46,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { DEAD_NAMES, MAX_TOOLS, TOOL_NAMES } from "../src/tools/vocabulary.js";
+import { computeVocabularyHash, DEAD_NAMES, MAX_TOOLS, TOOL_NAMES } from "../src/tools/vocabulary.js";
 import { buildPanelToolDefs } from "../src/orchestrator/panel-tools.js";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -77,10 +77,17 @@ const core = [...TOOL_NAMES];
 const panelSorted = [...panel].sort();
 const dead = DEAD_NAMES.map((d) => ({ name: d.name, since: d.since, replacement: d.replacement }));
 
-/** Identifies the VOCABULARY, not the build that produced it. */
-const vocabularyHash = createHash("sha256")
-  .update(JSON.stringify({ core, panel: panelSorted, dead: dead.map((d) => d.name) }))
-  .digest("hex");
+/** Identifies the VOCABULARY, not the build that produced it.
+ *
+ *  Computed by computeVocabularyHash() in src/tools/vocabulary.ts rather than
+ *  inline here, because the RUNTIME handshake compares against this value. Two
+ *  copies of the rule would drift, and a drifted hash reports a mismatch that is
+ *  not real — which is worse than having no check at all. */
+const vocabularyHash = computeVocabularyHash({
+  core,
+  panel: panelSorted,
+  dead: dead.map((d) => d.name),
+});
 
 const artefact = {
   $comment:

--- a/src/__tests__/tools/vocabulary-handshake.test.ts
+++ b/src/__tests__/tools/vocabulary-handshake.test.ts
@@ -1,0 +1,101 @@
+// The cross-repo seam that #683 exposed, and the handshake that closes it.
+//
+// The panel calls tool names as bare string literals and vendors a generated copy
+// of the vocabulary to validate them. Nothing compared that copy against the
+// server it was actually talking to: `vocab:export --check` proves the artefact
+// matches THIS repo's ledger, and the panel's gate proves its vendored file
+// matches its own contents. Both are self-consistency; neither sees across the
+// boundary. The skew then surfaces at CALL time as "unknown tool".
+
+import { describe, expect, it } from "vitest";
+import {
+  computeVocabularyHash,
+  describeVocabularySkew,
+  DEAD_NAMES,
+  TOOL_NAMES,
+} from "../../tools/vocabulary.js";
+
+const HASH = "0d805152a369dc0bfcc8bd2b96cdcbbe2f139d5b46e71857701e2ea132f5f05e";
+
+describe("computeVocabularyHash", () => {
+  it("is stable for the same names regardless of the array identity", () => {
+    const a = computeVocabularyHash({ core: ["x", "y"], panel: ["p"], dead: ["d"] });
+    const b = computeVocabularyHash({ core: [...["x", "y"]], panel: ["p"], dead: ["d"] });
+    expect(a).toBe(b);
+  });
+
+  it("changes when ANY of the three lists changes", () => {
+    const base = computeVocabularyHash({ core: ["x"], panel: ["p"], dead: ["d"] });
+    expect(computeVocabularyHash({ core: ["x", "z"], panel: ["p"], dead: ["d"] })).not.toBe(base);
+    expect(computeVocabularyHash({ core: ["x"], panel: ["p", "q"], dead: ["d"] })).not.toBe(base);
+    expect(computeVocabularyHash({ core: ["x"], panel: ["p"], dead: ["d", "e"] })).not.toBe(base);
+  });
+
+  it("distinguishes order, because registration order is part of the core surface", () => {
+    expect(computeVocabularyHash({ core: ["a", "b"], panel: [], dead: [] })).not.toBe(
+      computeVocabularyHash({ core: ["b", "a"], panel: [], dead: [] }),
+    );
+  });
+
+  // The whole handshake is worthless if this function and the export script
+  // disagree: a drifted hash reports a mismatch that is not real, which is worse
+  // than no check. This pins that they are the same rule over the same inputs.
+  it("reproduces the committed artefact's hash from the live ledger", async () => {
+    const { buildPanelToolDefs } = await import("../../orchestrator/panel-tools.js");
+    const live = computeVocabularyHash({
+      core: [...TOOL_NAMES],
+      panel: buildPanelToolDefs()
+        .map((d) => d.name)
+        .sort(),
+      dead: DEAD_NAMES.map((d) => d.name),
+    });
+    expect(live).toBe(HASH);
+  });
+});
+
+describe("describeVocabularySkew", () => {
+  it("reports a match when the two agree", () => {
+    expect(describeVocabularySkew(HASH, HASH).status).toBe("match");
+  });
+
+  // THE load-bearing case. An older panel advertises nothing, and silence must
+  // never be read as disagreement — that is the exact defect class this handshake
+  // exists to catch, and committing it here would be self-refuting.
+  it("treats a MISSING panel hash as unknown, never as a mismatch", () => {
+    const r = describeVocabularySkew(HASH, undefined);
+    expect(r.status).toBe("unknown");
+    expect(r.status === "unknown" && r.reason).toMatch(/UNVERIFIED/);
+  });
+
+  it("treats an empty-string hash as unknown too, not as a differing value", () => {
+    expect(describeVocabularySkew(HASH, "").status).toBe("unknown");
+  });
+
+  it("reports a mismatch when the two genuinely differ", () => {
+    const r = describeVocabularySkew(HASH, "ffffffff".repeat(8));
+    expect(r.status).toBe("mismatch");
+  });
+
+  it("does NOT claim which side is stale — it cannot know, and a guess sends half of users the wrong way", () => {
+    const r = describeVocabularySkew(HASH, "ffffffff".repeat(8), "0.11.42");
+    expect(r.status).toBe("mismatch");
+    const msg = r.status === "mismatch" ? r.message : "";
+    // It must name BOTH digests and prescribe updating both...
+    expect(msg).toContain("0d805152");
+    expect(msg).toContain("ffffffff");
+    expect(msg).toMatch(/update BOTH/i);
+    // ...and must not assert a direction it has no basis for.
+    expect(msg).not.toMatch(/panel is (out of date|stale|older)/i);
+    expect(msg).not.toMatch(/server is (out of date|stale|older)/i);
+  });
+
+  it("names the panel version when it has one, so the report is actionable", () => {
+    const r = describeVocabularySkew(HASH, "ab".repeat(32), "0.11.40");
+    expect(r.status === "mismatch" && r.message).toContain("panel 0.11.40");
+  });
+
+  it("explains that a resulting 'unknown tool' is the skew, not a broken panel", () => {
+    const r = describeVocabularySkew(HASH, "ab".repeat(32));
+    expect(r.status === "mismatch" && r.message).toMatch(/unknown tool/i);
+  });
+});

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -136,6 +136,11 @@ interface Conn {
    *  (see makeUnknownCommandError) — the panel gained these bridge commands in
    *  0.11.4, so older builds reject graph_* / ui_* with a raw dispatch error. */
   panelVersion?: string;
+  /** The `vocabularyHash` of the tool vocabulary this panel build VENDORED, as sent
+   *  in its `hello`. Undefined when the panel did not advertise one — an older
+   *  build, which means UNVERIFIED, not disagreeing. Never inherited across a
+   *  hello: a reconnect may be a freshly updated build with a different copy. */
+  panelVocabularyHash?: string;
   /** True only when THIS hello actually CARRIED a `panel_version` (not inherited from
    *  a prior connection under the same tab id). `panelVersion` is deliberately
    *  inherited across a reconnect that omits the field (line ~849) so the reactive
@@ -1910,6 +1915,15 @@ export class UiBridge {
           panelVersionAdvertised:
             typeof (msg as { panel_version?: unknown }).panel_version === "string" &&
             !!(msg as { panel_version?: string }).panel_version,
+          // The vocabulary the panel VENDORED, so the skew that #683 exposed can be
+          // detected at the handshake instead of at call time as "unknown tool".
+          // Re-read from THIS hello and never inherited: a reconnect may be a freshly
+          // updated build carrying a different vendored copy, and inheriting would
+          // report the OLD build's agreement as if it were this one's.
+          panelVocabularyHash:
+            typeof (msg as { vocabulary_hash?: unknown }).vocabulary_hash === "string"
+              ? ((msg as { vocabulary_hash?: string }).vocabulary_hash || undefined)
+              : undefined,
           // #570 P0c — re-read from THIS hello, never inherited (a reconnect may be a newly
           // updated build). Strict === true so any non-true / absent value is non-enforcing.
           enforcesWorkflowStamp:

--- a/src/tools/vocabulary.ts
+++ b/src/tools/vocabulary.ts
@@ -2095,3 +2095,111 @@ export function retiredToolMessage(name: string): string | undefined {
   const removed = dead.since.startsWith("removed") ? dead.since : `removed in ${dead.since}`;
   return `Unknown tool '${name}' — ${removed}. Call ${dead.replacement} instead.`;
 }
+
+/**
+ * The identity of the TOOL VOCABULARY, as a hash — the primitive the panel
+ * handshake compares (#683 follow-up).
+ *
+ * ## Why this exists
+ *
+ * The panel calls these names as bare string literals from browser JS and vendors
+ * a generated copy of this vocabulary to validate them against. Nothing checks
+ * that its copy still matches the server it is talking to. `vocab:export --check`
+ * proves the artefact matches THIS repo's ledger; the panel's own gate verifies
+ * its vendored file against its own contents. Both are self-consistency checks,
+ * and neither can see across the repo boundary.
+ *
+ * That gap has now cost twice, in both directions. Panel #683: the panel sat at
+ * 145 tools while core had finished at 37, and the whole Training tab called
+ * names that no longer existed. The mirror case is just as real — a rig running
+ * an updated panel against a not-yet-updated server, where the panel calls the
+ * consolidated names and the server only answers the old ones. Either way the
+ * failure surfaces at CALL time as "unknown tool", which reads to a user as "the
+ * panel is broken" and gives an agent nothing to act on.
+ *
+ * A version string cannot close this: two builds of the same version can carry
+ * different vocabularies, and two different versions can carry identical ones.
+ * Hashing the vocabulary itself is stable across releases and changes exactly
+ * when the thing it identifies changes.
+ *
+ * ## What it deliberately does NOT cover
+ *
+ * Names only. Schemas, descriptions, annotations and handlers can all change
+ * while every name stays identical, and this will read as a match — the same
+ * scope `vocab:export` documents for the artefact. It answers "do we agree on
+ * what exists", not "do we agree on what it does".
+ *
+ * MUST stay byte-identical to the artefact's `vocabularyHash`, so
+ * scripts/export-vocabulary.mts calls THIS function rather than repeating the
+ * expression. Two copies of a hash rule drift, and a handshake that compares a
+ * drifted hash reports a mismatch that is not real — worse than no check.
+ */
+export function computeVocabularyHash(input: {
+  core: readonly string[];
+  panel: readonly string[];
+  dead: readonly string[];
+}): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        core: [...input.core],
+        panel: [...input.panel],
+        dead: [...input.dead],
+      }),
+    )
+    .digest("hex");
+}
+
+/** What a vocabulary comparison concluded. `unknown` is a first-class outcome. */
+export type VocabularySkew =
+  | { status: "match" }
+  /** The panel did not advertise a hash at all — an older build. NOT a mismatch. */
+  | { status: "unknown"; reason: string }
+  | { status: "mismatch"; message: string };
+
+/**
+ * Compare the server's vocabulary against the one the panel vendored.
+ *
+ * ## The one rule that matters here
+ *
+ * A panel that sends NO hash is `unknown`, never `mismatch`. Older panels do not
+ * advertise one, and "it did not tell us" is not "it disagrees" — folding those
+ * together would fire a scary, actionable-sounding warning at every user on an
+ * older panel whose vocabulary is very likely fine. That is the same
+ * could-not-determine-reported-as-determined defect this function exists to catch
+ * in the tool surface, and it would be embarrassing to commit it here.
+ *
+ * ## Why the message does not name which side is stale
+ *
+ * It cannot, and guessing would be worse than not saying. Both sides are opaque
+ * digests; there is no ordering between two hashes and no history to rank them
+ * against. The server knows only that they differ. So the message states exactly
+ * that, and gives the one remedy that is correct in both directions — bring both
+ * to the same release — rather than a 50/50 guess that sends half of users to
+ * update the component that was already current.
+ */
+export function describeVocabularySkew(
+  serverHash: string,
+  panelHash: string | undefined,
+  panelVersion?: string,
+): VocabularySkew {
+  if (!panelHash) {
+    return {
+      status: "unknown",
+      reason:
+        "the panel did not advertise a vocabulary hash (builds before this handshake do not) — " +
+        "its vocabulary is UNVERIFIED, which is not the same as wrong",
+    };
+  }
+  if (panelHash === serverHash) return { status: "match" };
+  const who = panelVersion ? `panel ${panelVersion}` : "the panel";
+  return {
+    status: "mismatch",
+    message:
+      `The tool vocabulary ${who} vendored does not match this server's ` +
+      `(panel ${panelHash.slice(0, 8)} vs server ${serverHash.slice(0, 8)}). One of the two is ` +
+      `behind the other — a hash cannot say which, so update BOTH to the same release rather ` +
+      `than guessing. Until then, tool calls can fail as "unknown tool" for names one side has ` +
+      `and the other does not: that is this skew surfacing at call time, not a broken panel.`,
+  };
+}


### PR DESCRIPTION
Closes the cross-repo gap #683 exposed, using the primitive `export-vocabulary.mts` was explicitly written for:

> Provenance is a HASH OF THE VOCABULARY ITSELF … the better primitive for the **Phase 7 handshake**: a server can report its `vocabularyHash` at runtime and the panel can compare, which a version string can never do reliably.

and, from the same header, why nothing existing can do it:

> What `--check` proves is narrow … It says nothing about whether the PANEL's vendored copy is current (**nothing cross-repo can, short of the Phase 7 runtime handshake**).

## The gap

The panel calls tool names as **bare string literals** from browser JS, and vendors a generated copy of this vocabulary to validate them. Nothing compared that copy against the server it was talking to:

- `vocab:export --check` proves the artefact matches **this repo's** ledger.
- The panel's own gate verifies its vendored file against **its own contents**.

Both are self-consistency checks. Neither sees across the repo boundary — so skew only surfaces at **call time** as `unknown tool`, which reads to a user as "the panel is broken" and gives an agent nothing to act on.

It has cost in **both** directions: #683 (panel pinned at 145 while core finished at 37 — the entire Training tab calling names that no longer existed), and the mirror case, an updated panel against a not-yet-updated server. I hit the mirror case on my own rig while verifying 0.50.1.

A version string cannot close this: two builds of one version can carry different vocabularies, and two versions can carry identical ones.

## What this does

**One hash rule, shared.** `computeVocabularyHash()` lives in `vocabulary.ts`; `export-vocabulary.mts` now calls it instead of repeating the expression. Two copies of a hash rule drift, and a drifted hash reports a mismatch that *is not real* — strictly worse than no check. The artefact still hashes byte-identically (`vocab:export --check` passes untouched).

**`describeVocabularySkew()`**, with two deliberate refusals:

1. **A panel that sends no hash is `unknown`, never `mismatch`.** Older builds do not advertise one, and "did not tell us" is not "disagrees". Folding those together would fire an actionable-sounding warning at every user on an older panel whose vocabulary is very likely fine — the exact could-not-determine-reported-as-determined defect this handshake exists to catch. Committing it here would be self-refuting.
2. **It does not name which side is stale.** It cannot: both are opaque digests, with no ordering between them and no history to rank them against. The server knows only that they differ. So it says that, and prescribes the one remedy correct in both directions — bring both to the same release — rather than a 50/50 guess that sends half of users to update the component that was already current.

**Wired into `hello`** as `vocabulary_hash`, re-read per hello and **never inherited**: a reconnect may be a freshly updated build carrying a different vendored copy, and inheriting would report the OLD build's agreement as if it were this one's.

## Scope, stated in the code so it is not over-trusted

**Names only.** Schemas, descriptions, annotations and handlers can all change while every name stays identical, and this will read as a match. It answers "do we agree on what exists", not "do we agree on what it does" — the same boundary `vocab:export` documents for the artefact.

## The other half

The panel sending `vocabulary_hash` in its `hello` is a separate `comfyui-mcp-panel` change that this enables. Until it ships, every panel reads as `unknown` — correct, and quiet.

## Verification

- 11 tests, including one pinning that the **live ledger reproduces the committed artefact's hash** — the whole handshake is worthless if this function and the export script disagree.
- **Mutation-checked**: collapsing absent→mismatch fails exactly the two tests guarding it; restore is clean.
- Full suite **316 files / 6835 passed**; `tsc` and `check:vocabulary` clean; no control bytes in any changed file.