### PR TITLE
fix(#908): publish the admission surface, and stop conflating "excluded" with "unknown"

### DIFF
--- a/docs/design/tool-vocabulary.json
+++ b/docs/design/tool-vocabulary.json
@@ -940,5 +940,23 @@
       "since": "0.50.0",
       "replacement": "get_system_stats (action:\"health\")"
     }
+  ],
+  "directCallable": [
+    "apps",
+    "download_model",
+    "enqueue_workflow",
+    "get_history",
+    "get_image",
+    "get_workflow",
+    "install_custom_node",
+    "list_local_models",
+    "list_packs",
+    "queue",
+    "runpod",
+    "runpod_watch",
+    "save_workflow",
+    "train_doctor",
+    "train_prepare_dataset",
+    "train_start"
   ]
 }

--- a/scripts/export-vocabulary.mts
+++ b/scripts/export-vocabulary.mts
@@ -107,8 +107,8 @@ const artefact = {
    * Core tools the DIRECT `call_tool` channel will admit — the canvas-less path
    * mobile, mirrored tabs and the panel's own buttons use.
    *
-   * Exists because #908: PR #278 correctly removed `runpod_pod_create` and
-   * `runpod_pod_start` from that channel (both start BILLING, and a
+   * Exists because #908: PR #278 correctly removed pod create/start (now
+   * `runpod` actions) from that channel (both start BILLING, and a
    * confirmation-less mirrored tab must not spend money), but the panel's
    * cmcp-runpod-ui.js kept calling them over exactly that channel. Both buttons
    * were inert for about two weeks, returning a bare "not permitted". Each repo

--- a/scripts/export-vocabulary.mts
+++ b/scripts/export-vocabulary.mts
@@ -47,6 +47,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { computeVocabularyHash, DEAD_NAMES, MAX_TOOLS, TOOL_NAMES } from "../src/tools/vocabulary.js";
+import { CALL_TOOL_WHITELIST } from "../src/orchestrator/call-tool-admission.js";
 import { buildPanelToolDefs } from "../src/orchestrator/panel-tools.js";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -102,6 +103,26 @@ const artefact = {
   panel: panelSorted,
   /** Removed names, with what to use instead. `allowedIn` is repo-local and omitted. */
   dead,
+  /**
+   * Core tools the DIRECT `call_tool` channel will admit — the canvas-less path
+   * mobile, mirrored tabs and the panel's own buttons use.
+   *
+   * Exists because #908: PR #278 correctly removed `runpod_pod_create` and
+   * `runpod_pod_start` from that channel (both start BILLING, and a
+   * confirmation-less mirrored tab must not spend money), but the panel's
+   * cmcp-runpod-ui.js kept calling them over exactly that channel. Both buttons
+   * were inert for about two weeks, returning a bare "not permitted". Each repo
+   * was correct alone; nothing could see across the seam.
+   *
+   * Publishing the admitted set lets the panel gate its OWN call sites the same
+   * way it already gates retired names — at build time, instead of a user
+   * discovering it by clicking a dead button.
+   *
+   * NOT part of `vocabularyHash`, deliberately. The hash identifies which tools
+   * EXIST; admission is a separate question about one channel, and folding it in
+   * would invalidate every vendored copy on a policy change that renamed nothing.
+   */
+  directCallable: [...CALL_TOOL_WHITELIST].sort(),
 };
 
 const serialized = `${JSON.stringify(artefact, null, 2)}\n`;

--- a/src/__tests__/orchestrator/admission-excluded-vs-unknown.test.ts
+++ b/src/__tests__/orchestrator/admission-excluded-vs-unknown.test.ts
@@ -1,6 +1,6 @@
 // #908 — "not permitted" was a dead end.
 //
-// PR #278 correctly removed runpod_pod_create / runpod_pod_start from the direct
+// PR #278 correctly removed pod create/start (now `runpod` actions) from the direct
 // call_tool whitelist: both put a pod into a BILLING state, and a
 // confirmation-less mirrored tab must not be able to spend money. The exclusion
 // is right and stays. What was wrong is that the panel's RunPod Deploy/Start

--- a/src/__tests__/orchestrator/admission-excluded-vs-unknown.test.ts
+++ b/src/__tests__/orchestrator/admission-excluded-vs-unknown.test.ts
@@ -1,0 +1,78 @@
+// #908 — "not permitted" was a dead end.
+//
+// PR #278 correctly removed runpod_pod_create / runpod_pod_start from the direct
+// call_tool whitelist: both put a pod into a BILLING state, and a
+// confirmation-less mirrored tab must not be able to spend money. The exclusion
+// is right and stays. What was wrong is that the panel's RunPod Deploy/Start
+// buttons then returned the bare refusal verbatim for ~2 weeks, which reads as
+// "the panel is broken" rather than "this channel deliberately does not carry
+// this tool, ask the agent".
+//
+// A tool that EXISTS but is withheld from one channel, and a tool that does not
+// exist at all, are different facts and must not produce the same sentence.
+
+import { describe, expect, it } from "vitest";
+import {
+  callToolAdmission,
+  CALL_TOOL_ACTION_WHITELIST,
+  CALL_TOOL_WHITELIST,
+} from "../../orchestrator/call-tool-admission.js";
+import { TOOL_NAMES } from "../../tools/vocabulary.js";
+
+/** The refusal string, or undefined when admitted. */
+const refuse = (tool: string, args: Record<string, unknown> = {}) =>
+  callToolAdmission(tool, args as never);
+
+describe("admission: excluded is not the same as unknown (#908)", () => {
+  // #278 withheld pod create/start because both START BILLING and this channel
+  // cannot confirm with the user. 0.50.0 folded those names into
+  // runpod(action:"create"|"start"), so the protection now lives at ACTION level —
+  // and it survived the fold intact. If this ever flips, someone re-admitted a
+  // money-spending action on a confirmation-less channel.
+  it("the billing-sensitive RunPod ACTIONS are still excluded after the 0.50.0 fold", () => {
+    const actions = CALL_TOOL_ACTION_WHITELIST.get("runpod");
+    expect(actions, "runpod must be action-scoped, or create/start ride in free").toBeDefined();
+    expect(actions!.has("create")).toBe(false);
+    expect(actions!.has("start")).toBe(false);
+    // ...while the read-only / non-billing ones stay usable.
+    expect(actions!.has("status")).toBe(true);
+    expect(actions!.has("stop")).toBe(true);
+  });
+
+  it("an EXISTING but excluded tool is told it exists, and where to go instead", () => {
+    const msg = refuse("generate_image");
+    expect(msg).toBeTruthy();
+    expect(String(msg)).toMatch(/exists but is not available/i);
+    expect(String(msg)).toMatch(/deliberate exclusion, not a missing tool/i);
+    // The remedy has to be named, or it is still a dead end.
+    expect(String(msg)).toMatch(/ask the agent/i);
+  });
+
+  it("an UNKNOWN tool does NOT claim to exist", () => {
+    const msg = String(refuse("definitely_not_a_real_tool_xyz"));
+    expect(msg).toMatch(/not permitted/);
+    expect(msg).not.toMatch(/exists but is not available/i);
+  });
+
+  // The distinction is only meaningful if it tracks the real tool list rather
+  // than a hardcoded pair — otherwise the next excluded tool regresses silently.
+  it("the distinction is driven by the actual tool surface, not a hardcoded name", () => {
+    const excluded = (TOOL_NAMES as readonly string[]).filter((t) => !CALL_TOOL_WHITELIST.has(t));
+    expect(excluded.length).toBeGreaterThan(0);
+    for (const t of excluded.slice(0, 5)) {
+      expect(String(refuse(t)), `${t} should be reported as existing-but-excluded`).toMatch(
+        /exists but is not available/i,
+      );
+    }
+  });
+
+  it("admitted tools are still admitted — the message change refuses nothing new", () => {
+    const admitted = [...CALL_TOOL_WHITELIST].filter((t) => (TOOL_NAMES as readonly string[]).includes(t));
+    expect(admitted.length).toBeGreaterThan(0);
+    // Admission may still refuse on ACTION grounds; what must not happen is the
+    // whitelist itself rejecting a tool it contains.
+    for (const t of admitted.slice(0, 5)) {
+      expect(String(refuse(t, { action: "status" }) ?? "")).not.toMatch(/is not permitted$/);
+    }
+  });
+});

--- a/src/__tests__/orchestrator/call-tool-admission.test.ts
+++ b/src/__tests__/orchestrator/call-tool-admission.test.ts
@@ -435,16 +435,16 @@ describe("call_tool admission", () => {
      */
     it("search_custom_nodes is not whitelisted at all — it was never reachable here", () => {
       for (const action of ["search", "details"]) {
-        expect(callToolAdmission("search_custom_nodes", { action }), `action:"${action}"`).toBe(
-          'tool "search_custom_nodes" is not permitted',
+        expect(callToolAdmission("search_custom_nodes", { action }), `action:"${action}"`).toEqual(
+          expect.stringContaining('tool "search_custom_nodes" exists but is not available'),
         );
       }
       // …including the shapes a client would actually send.
       expect(
         callToolAdmission("search_custom_nodes", { action: "search", query: "impact", limit: 5 }),
-      ).toBe('tool "search_custom_nodes" is not permitted');
-      expect(callToolAdmission("search_custom_nodes", {})).toBe(
-        'tool "search_custom_nodes" is not permitted',
+      ).toEqual(expect.stringContaining('tool "search_custom_nodes" exists but is not available'));
+      expect(callToolAdmission("search_custom_nodes", {})).toEqual(
+        expect.stringContaining('tool "search_custom_nodes" exists but is not available'),
       );
     });
 
@@ -462,8 +462,8 @@ describe("call_tool admission", () => {
 
     it("node_pack is not whitelisted at all — it writes files and runs git", () => {
       for (const action of ["scaffold", "verify", "publish", "list_files", "read", "search", "write", "patch", "git"]) {
-        expect(callToolAdmission("node_pack", { action }), `action:"${action}"`).toBe(
-          'tool "node_pack" is not permitted',
+        expect(callToolAdmission("node_pack", { action }), `action:"${action}"`).toEqual(
+          expect.stringContaining('tool "node_pack" exists but is not available'),
         );
       }
     });
@@ -535,12 +535,12 @@ describe("call_tool admission", () => {
       // server-side output into that directory, and output ships bytes off the
       // machine to a caller-named cloud destination.
       for (const action of ["image", "video", "audio", "stage", "output"]) {
-        expect(callToolAdmission("upload_image", { action }), `action:"${action}"`).toBe(
-          'tool "upload_image" is not permitted',
+        expect(callToolAdmission("upload_image", { action }), `action:"${action}"`).toEqual(
+          expect.stringContaining('tool "upload_image" exists but is not available'),
         );
       }
-      expect(callToolAdmission("upload_image", {})).toBe(
-        'tool "upload_image" is not permitted',
+      expect(callToolAdmission("upload_image", {})).toEqual(
+        expect.stringContaining('tool "upload_image" exists but is not available'),
       );
     });
 
@@ -671,11 +671,11 @@ describe("call_tool admission", () => {
     // to this channel. Asserted rather than assumed: `apps` action:"run" IS
     // admitted and queues a render, so "generation is reachable from here" is a
     // plausible-sounding mistake to make.
-    expect(callToolAdmission("generate_image", { action: "image" })).toBe(
-      'tool "generate_image" is not permitted',
+    expect(callToolAdmission("generate_image", { action: "image" })).toEqual(
+      expect.stringContaining('tool "generate_image" exists but is not available'),
     );
-    expect(callToolAdmission("generate_image", { action: "regenerate", asset_id: "a" })).toBe(
-      'tool "generate_image" is not permitted',
+    expect(callToolAdmission("generate_image", { action: "regenerate", asset_id: "a" })).toEqual(
+      expect.stringContaining('tool "generate_image" exists but is not available'),
     );
   });
 
@@ -738,11 +738,19 @@ describe("call_tool admission", () => {
    * to do with what it is testing. Derived from TOOL_NAMES it cannot rot, and it
    * covers the whole surface instead of a sample.
    */
-  it("refuses every live non-whitelisted tool with the byte-identical legacy string", () => {
+  it("refuses every live non-whitelisted tool with ONE consistent excluded-not-missing string", () => {
     const notWhitelisted = TOOL_NAMES.filter((n) => !CALL_TOOL_WHITELIST.has(n));
     expect(notWhitelisted.length).toBeGreaterThan(0);
     for (const name of notWhitelisted) {
-      expect(callToolAdmission(name, {}), name).toBe(`tool "${name}" is not permitted`);
+      // #908 changed this string: a LIVE tool withheld from this channel now says
+      // it exists and names the remedy, instead of the bare "is not permitted"
+      // that read identically to "no such tool". The property this test was
+      // written to hold is unchanged and is what still matters — every live
+      // non-whitelisted name gets the SAME refusal, derived from TOOL_NAMES so it
+      // covers the whole surface and cannot rot when a slice folds a name away.
+      const msg = String(callToolAdmission(name, {}));
+      expect(msg, name).toContain(`tool "${name}" exists but is not available`);
+      expect(msg, name).toContain("deliberate exclusion, not a missing tool");
     }
   });
 
@@ -950,12 +958,14 @@ describe("0.50.0 slice 13 — install/environment and stats/diagnostics", () => 
       expect(CALL_TOOL_WHITELIST.has(tool), `${tool} must stay off the whitelist`).toBe(false);
       expect(CALL_TOOL_ACTION_WHITELIST.has(tool), `${tool} needs no action scope`).toBe(false);
       for (const action of actions) {
-        expect(callToolAdmission(tool, { action }), `${tool}/${action}`).toBe(
-          `tool "${tool}" is not permitted`,
+        expect(callToolAdmission(tool, { action }), `${tool}/${action}`).toEqual(
+          expect.stringContaining(`tool "${tool}" exists but is not available`),
         );
       }
       // ...including with no action at all, the shape a stale client would send.
-      expect(callToolAdmission(tool, {})).toBe(`tool "${tool}" is not permitted`);
+      expect(callToolAdmission(tool, {})).toEqual(
+        expect.stringContaining(`tool "${tool}" exists but is not available`),
+      );
     }
   });
 

--- a/src/orchestrator/call-tool-admission.ts
+++ b/src/orchestrator/call-tool-admission.ts
@@ -5,7 +5,7 @@
  * call site.
  */
 
-import { retiredToolMessage } from "../tools/vocabulary.js";
+import { retiredToolMessage, TOOL_NAMES } from "../tools/vocabulary.js";
 
 /** The direct tool channel: a mobile client can invoke these READ/DOWNLOAD backend
  *  tools without an agent turn (structured nav data + rig downloads). The
@@ -441,7 +441,23 @@ export function callToolAdmission(
   const retired = retiredToolMessage(tool);
   if (retired !== undefined) return retired;
 
-  if (!CALL_TOOL_WHITELIST.has(tool)) return `tool "${tool}" is not permitted`;
+  if (!CALL_TOOL_WHITELIST.has(tool)) {
+    // Distinguish "does not exist" from "exists, but not on THIS channel" (#908).
+    // The bare "is not permitted" was a dead end: the panel's RunPod Deploy/Start
+    // buttons returned it verbatim for ~2 weeks after #278 correctly removed those
+    // two tools from this whitelist (both start BILLING, and a confirmation-less
+    // mirrored tab must not spend money). The exclusion was right; the message
+    // told nobody what had happened or what to do instead, so it read as "the
+    // panel is broken" rather than "this channel deliberately does not carry it".
+    const exists = (TOOL_NAMES as readonly string[]).includes(tool);
+    return exists
+      ? `tool "${tool}" exists but is not available on the direct call_tool channel ` +
+        `(the canvas-less path used by mobile, mirrored tabs and panel buttons). This is a ` +
+        `deliberate exclusion, not a missing tool — some tools are withheld here because they ` +
+        `spend money or mutate state that this channel cannot confirm with the user. Ask the ` +
+        `agent to run it instead: the agent session carries the full tool surface and can confirm.`
+      : `tool "${tool}" is not permitted`;
+  }
   const actions = CALL_TOOL_ACTION_WHITELIST.get(tool);
   if (actions !== undefined) {
     const action = typeof args.action === "string" ? args.action : undefined;


### PR DESCRIPTION
Closes the second half of the cross-repo seam. #964 made tool **existence** checkable across repos; this does the same for **admission**.

## What #908 turned out to be

The issue reports the panel's RunPod Deploy/Start buttons failing with `not permitted`. **That is no longer the failure.** 0.50.0 slice 13 folded `runpod_pod_create` → `runpod (action:"create")` and `runpod_pod_start` → `runpod (action:"start")`, so those names are now **retired** and the buttons fail earlier as **"Unknown tool"** — the retired-name check runs before the whitelist check.

**#278's billing protection survived the fold, intact**, having moved to action level: `runpod` is action-scoped to `status, list, stop, connect, use_local, deploy_link`, with `create` and `start` deliberately absent. A test now pins that, so re-admitting a money-spending action on a confirmation-less channel fails loudly instead of silently.

**Consequence for whoever fixes the panel:** it is *not* "call the new name". `runpod(action:"create")` over the direct channel is still correctly refused and should stay refused. Those buttons need the agent path or a confirmation-carrying flow.

## 1. The artefact publishes `directCallable`

The core tools the direct `call_tool` channel admits — the canvas-less path mobile, mirrored tabs and the panel's buttons use. The panel can now gate its **own** call sites the same way it already gates retired names: at build time, rather than a user discovering it by clicking a dead button.

**Deliberately not part of `vocabularyHash`.** The hash identifies which tools *exist*; admission is a separate question about one channel, and folding it in would invalidate every vendored copy on a policy change that renamed nothing. Verified: hash unchanged at `0d805152`, so no re-vendor is forced.

## 2. `not permitted` stops being a dead end

It said the same thing whether a tool does not exist or exists and is withheld from *this* channel — different facts needing different actions. An existing-but-excluded tool now says so and names the remedy (ask the agent, which carries the full surface and can confirm). **21 core tools** are in that state today.

## Verification

- 5 new tests; the surface-driven one asserts the distinction tracks the real tool list rather than a hardcoded pair, so the next excluded tool cannot regress silently.
- `tsc`, `check:vocabulary`, and `vocab:export --check` all clean.

One process note, recorded in the branch rather than amended away: I pushed the first commit **before** reading the gate output, in a commit whose own message is about gates catching this class. `check:vocabulary` then refused my comments for naming the retired tools while explaining what #278 did to them. Fixed in `310b341` by describing them under their current names.