### PR TITLE
fix(#959): map live-canvas widgets by NAME, and disclose when we can't

### DIFF
--- a/src/__tests__/services/live-widget-overlay.test.ts
+++ b/src/__tests__/services/live-widget-overlay.test.ts
@@ -1,0 +1,277 @@
+// #959 — one bug reported three times: #961 (Eclipse wildcards), #955 (the same
+// node with numeric seeds), #361 (five model/LoRA/VAE filenames each replaced by a
+// different file on disk). The mechanism is shared: `graph_serialize` stores widget
+// values POSITIONALLY in the FRONTEND's order, and the converter names those
+// positions from object_info's input order. Custom nodes that add or reorder
+// widgets in JS make the two disagree, and every value from the first disagreement
+// onward lands on the wrong widget — silently, with a valid-looking graph.
+//
+// These tests cover both halves of the fix: the overlay decides whether the
+// name-keyed capture describes the SAME nodes as the serialized graph (refusing
+// when it can't tell), and the converter then maps by name instead of by index.
+
+import { describe, expect, it } from "vitest";
+import { applyCapturedWidgetValues } from "../../services/live-widget-overlay.js";
+import { convertUiToApi } from "../../services/workflow-converter.js";
+
+// ── the reported node ───────────────────────────────────────────────────────
+// object_info orders `seed` BEFORE `wildcards`; the Eclipse frontend serializes
+// `wildcards` BEFORE `seed`. That single inversion is the whole bug.
+const ECLIPSE = "Wildcard Processor [Eclipse]";
+const OBJECT_INFO = {
+  [ECLIPSE]: {
+    input: {
+      required: {
+        wildcard_text: ["STRING"],
+        populated_text: ["STRING"],
+        mode: [["populate", "fixed"]],
+        seed: ["INT"],
+        wildcards: [["Select a Wildcard", "__smart_prompt/01_subjects/10_face__"]],
+      },
+    },
+  },
+} as never;
+
+const WILDCARD = "__smart_prompt/01_subjects/10_face__";
+
+/** The live canvas as `graph_serialize` returns it: frontend widget order. */
+const serializedCanvas = () => ({
+  nodes: [
+    {
+      id: 296,
+      type: ECLIPSE,
+      mode: 0,
+      inputs: [],
+      outputs: [],
+      // frontend order — wildcards BEFORE seed
+      widgets_values: ["a cat", "a cat", "populate", WILDCARD, 101],
+    },
+  ],
+  links: [],
+});
+
+/** The same canvas as `graph_get_state` returns it: name-keyed, order-free. */
+const nameKeyedState = () => ({
+  viewing: { scope: "root" },
+  node_count: 1,
+  truncated: false,
+  nodes: [
+    {
+      id: 296,
+      type: ECLIPSE,
+      widgets: {
+        wildcard_text: "a cat",
+        populated_text: "a cat",
+        mode: "populate",
+        seed: 101,
+        wildcards: WILDCARD,
+      },
+    },
+  ],
+});
+
+describe("#959: the bug, reproduced", () => {
+  // This is the failure the three reports describe. It is asserted deliberately:
+  // if this test ever stops failing on its own, the positional path changed and
+  // the overlay below is no longer testing what it claims to.
+  it("without the capture, the wildcard STRING is emitted as the seed", () => {
+    const { workflow } = convertUiToApi(serializedCanvas() as never, OBJECT_INFO);
+    expect(workflow["296"].inputs.seed).toBe(WILDCARD);
+    expect(workflow["296"].inputs.seed).not.toBe(101);
+  });
+});
+
+describe("#959: the capture fixes it", () => {
+  it("with the name-keyed capture, every widget gets its own value", () => {
+    const ui = serializedCanvas();
+    const out = applyCapturedWidgetValues(ui, nameKeyedState());
+    expect(out.applied).toBe(1);
+    expect(out.refused).toBeUndefined();
+    // A fully covered graph has nothing left to caveat, so it says nothing.
+    expect(out.notes).toEqual([]);
+
+    const { workflow } = convertUiToApi(ui as never, OBJECT_INFO);
+    expect(workflow["296"].inputs.seed).toBe(101);
+    expect(workflow["296"].inputs.wildcards).toBe(WILDCARD);
+    expect(workflow["296"].inputs.mode).toBe("populate");
+    expect(workflow["296"].inputs.wildcard_text).toBe("a cat");
+  });
+
+  // The shift compounds: `seed` is an INT with control_after_generate, so the
+  // positional pass consumes a PHANTOM slot after it. Having already taken the
+  // wildcard string as the seed, it then swallows the real seed as that phantom
+  // and runs out of values — so `wildcards` is never assigned at all and falls
+  // back to the node default. One inverted pair costs BOTH widgets, and nothing
+  // in the output says so.
+  it("the trailing widget is lost entirely, not merely misassigned", () => {
+    const before = convertUiToApi(serializedCanvas() as never, OBJECT_INFO);
+    expect(before.workflow["296"].inputs.wildcards).not.toBe(WILDCARD);
+
+    const ui = serializedCanvas();
+    applyCapturedWidgetValues(ui, nameKeyedState());
+    const after = convertUiToApi(ui as never, OBJECT_INFO);
+    expect(after.workflow["296"].inputs.wildcards).toBe(WILDCARD);
+  });
+
+  // #361's severity case: the values that shifted were model filenames, so the
+  // user rendered with a different checkpoint and nothing reported a problem.
+  it("an asset filename is not swapped onto a neighbouring widget", () => {
+    const ui = serializedCanvas();
+    ui.nodes[0].widgets_values = ["a cat", "a cat", "populate", WILDCARD, 202];
+    applyCapturedWidgetValues(ui, {
+      ...nameKeyedState(),
+      nodes: [
+        {
+          id: 296,
+          type: ECLIPSE,
+          widgets: { ...nameKeyedState().nodes[0].widgets, seed: 202 },
+        },
+      ],
+    });
+    const { workflow } = convertUiToApi(ui as never, OBJECT_INFO);
+    expect(workflow["296"].inputs.seed).toBe(202);
+    expect(workflow["296"].inputs.wildcards).toBe(WILDCARD);
+  });
+});
+
+describe("#959: the overlay refuses what it cannot match", () => {
+  // THE catastrophic case. graph_serialize always serializes the ROOT graph, but
+  // graph_get_state reports whichever graph the user is INSIDE. Overlaying a
+  // subgraph's node 296 onto the root's node 296 would apply an unrelated node's
+  // values — a worse bug than the one being fixed.
+  it("refuses when the panel is viewing a subgraph, not the root", () => {
+    const ui = serializedCanvas();
+    const out = applyCapturedWidgetValues(ui, {
+      ...nameKeyedState(),
+      viewing: { scope: "subgraph", owner_node_id: 12, title: "sampler" },
+    });
+    expect(out.applied).toBe(0);
+    expect(out.refused).toMatch(/subgraph/i);
+    expect(ui.nodes[0]).not.toHaveProperty("capturedWidgetValues");
+    // and it must SAY the mapping stayed positional rather than staying quiet.
+    expect(out.notes.join("\n")).toMatch(/mapped by POSITION/);
+  });
+
+  it("refuses when the capture does not say which graph it describes", () => {
+    const state = nameKeyedState() as Record<string, unknown>;
+    delete state.viewing;
+    const out = applyCapturedWidgetValues(serializedCanvas(), state);
+    expect(out.applied).toBe(0);
+    expect(out.refused).toBeTruthy();
+  });
+
+  it("refuses a reply with no nodes at all", () => {
+    const out = applyCapturedWidgetValues(serializedCanvas(), null);
+    expect(out.applied).toBe(0);
+    expect(out.refused).toMatch(/no live widget capture/i);
+  });
+
+  // The wording is load-bearing: we did not verify the order, which is NOT the
+  // same as having found it wrong. Reporting the stronger claim is the exact
+  // defect class this repo keeps hitting.
+  it("reports an unverified mapping as unverified, never as wrong", () => {
+    const out = applyCapturedWidgetValues(serializedCanvas(), null);
+    const text = out.notes.join("\n");
+    expect(text).toMatch(/MAY be attributed to the wrong widget/);
+    expect(text).toMatch(/unverified, not known wrong/);
+    expect(text).not.toMatch(/values are wrong|is incorrect/i);
+  });
+});
+
+describe("#959: partial coverage is disclosed, not hidden", () => {
+  const twoNodes = () => {
+    const ui = serializedCanvas();
+    ui.nodes.push({
+      id: 297,
+      type: ECLIPSE,
+      mode: 0,
+      inputs: [],
+      outputs: [],
+      widgets_values: ["a dog", "a dog", "populate", WILDCARD, 202],
+    });
+    return ui;
+  };
+
+  it("covers the nodes it can and names the ones it could not", () => {
+    const ui = twoNodes();
+    const out = applyCapturedWidgetValues(ui, nameKeyedState());
+    expect(out.applied).toBe(1);
+    expect(out.uncovered).toBe(1);
+    expect(out.notes.join("\n")).toMatch(/1 of 2 node\(s\)/);
+    // The covered node is still fixed — partial coverage beats none.
+    const { workflow } = convertUiToApi(ui as never, OBJECT_INFO);
+    expect(workflow["296"].inputs.seed).toBe(101);
+  });
+
+  it("names the per-read node cap when that is why coverage was partial", () => {
+    const out = applyCapturedWidgetValues(twoNodes(), {
+      ...nameKeyedState(),
+      node_count: 2,
+      truncated: true,
+    });
+    expect(out.notes.join("\n")).toMatch(/at most 1 nodes per read/);
+  });
+
+  // Two entries claiming one id can't be attributed to either, so neither wins.
+  it("drops a duplicated node id instead of picking one", () => {
+    const state = nameKeyedState();
+    state.nodes.push({ ...state.nodes[0], widgets: { ...state.nodes[0].widgets, seed: 999 } });
+    const ui = serializedCanvas();
+    const out = applyCapturedWidgetValues(ui, state);
+    expect(out.applied).toBe(0);
+    expect(out.notes.join("\n")).toMatch(/more than once/);
+    expect(ui.nodes[0]).not.toHaveProperty("capturedWidgetValues");
+  });
+});
+
+describe("#959: the overlay does not disturb index-read widget values", () => {
+  // Several call sites read widgets_values BY INDEX — a subgraph node's
+  // proxyWidgets, a PrimitiveNode's literal at [0], a Set/Get node's bus name.
+  // Writing an object into that array would silently drop all three, which is
+  // why the capture lives in its own field.
+  it("leaves widgets_values an array", () => {
+    const ui = serializedCanvas();
+    applyCapturedWidgetValues(ui, nameKeyedState());
+    expect(Array.isArray(ui.nodes[0].widgets_values)).toBe(true);
+    expect(ui.nodes[0].widgets_values).toEqual(["a cat", "a cat", "populate", WILDCARD, 101]);
+  });
+
+  it("a PrimitiveNode's literal still reaches its consumer", () => {
+    const objectInfo = {
+      KSampler: { input: { required: { seed: ["INT"], steps: ["INT"] } } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "INT", type: "INT", links: [1] }],
+          widgets_values: [42, "fixed"],
+        },
+        {
+          id: 2,
+          type: "KSampler",
+          mode: 0,
+          inputs: [{ name: "seed", type: "INT", link: 1, widget: { name: "seed" } }],
+          outputs: [],
+          widgets_values: [0, 20],
+        },
+      ],
+      links: [[1, 1, 0, 2, 0, "INT"]],
+    };
+    applyCapturedWidgetValues(ui, {
+      viewing: { scope: "root" },
+      nodes: [
+        { id: 1, type: "PrimitiveNode", widgets: { value: 42, control_after_generate: "fixed" } },
+        { id: 2, type: "KSampler", widgets: { seed: 0, steps: 20 } },
+      ],
+    });
+    const { workflow } = convertUiToApi(ui as never, objectInfo);
+    // The literal is read from widgets_values[0]; the capture must not have
+    // replaced that array with an object, or 42 would vanish and seed keep 0.
+    expect(workflow["2"].inputs.seed).toBe(42);
+    expect(workflow["2"].inputs.steps).toBe(20);
+  });
+});

--- a/src/comfyui/types.ts
+++ b/src/comfyui/types.ts
@@ -177,6 +177,22 @@ export interface UiNode {
    * drop them or land them on the wrong widget (issue #361).
    */
   resolvedWidgetValues?: Record<string, unknown>;
+  /**
+   * INTERNAL, never serialized: the panel's AUTHORITATIVE name→value map for this
+   * node's widgets, captured from the live canvas alongside the serialized graph
+   * (see applyCapturedWidgetValues). When present it REPLACES `widgets_values` as
+   * the converter's widget source, which is the whole point: `widgets_values` is a
+   * bare positional array whose order is the FRONTEND's, while the converter can
+   * only reconstruct an order from object_info's — and for custom nodes that add or
+   * reorder widgets in JS the two disagree, silently landing each value on the wrong
+   * widget (#961/#955/#361). A name-keyed map has no order to disagree about.
+   *
+   * It is deliberately a SEPARATE field rather than an object written into
+   * `widgets_values`: several call sites legitimately read that array BY INDEX
+   * (a subgraph node's proxyWidgets, a PrimitiveNode's literal at [0], a Set/Get
+   * node's bus name), and handing them an object would silently drop those values.
+   */
+  capturedWidgetValues?: Record<string, unknown>;
 }
 
 // link: [link_id, source_node_id, source_slot, target_node_id, target_slot, type_name]

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -86,6 +86,7 @@ import {
   type SecretSaveReceipt,
 } from "../services/panel-secrets.js";
 import { flattenUiWorkflow } from "../services/flatten-workflow.js";
+import { applyCapturedWidgetValues } from "../services/live-widget-overlay.js";
 import { listWorkflowLibraryKeys, userdataFetch } from "../services/userdata-library.js";
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
 import { QueueMonitor } from "../services/queue-monitor.js";
@@ -4904,6 +4905,11 @@ async function resolveWorkflowInput(
   // they must NOT take this fallback — they keep the actionable "update your
   // panel" error instead. Only strip opts in.
   allowStateFallback = false,
+  // Collects disclosure lines about the live widget capture (#959). Only the
+  // live-canvas path writes here, and only when something was left mapped by
+  // POSITION — the caller surfaces these alongside the converter's warnings so an
+  // unverified widget mapping is never presented as a verified one.
+  notes?: string[],
 ): Promise<Record<string, unknown>> {
   if (args.pack) return readPackWorkflow(args.pack as string);
   if (args.path) return await readWorkflowFromPath(args.path as string);
@@ -4972,6 +4978,39 @@ async function resolveWorkflowInput(
   const wf = (reply as { workflow?: unknown } | null)?.workflow;
   if (!wf || typeof wf !== "object") {
     throw new Error("The live canvas returned no graph — pass pack, path, or graph explicitly.");
+  }
+
+  // #959: the serialized graph's widget values are POSITIONAL, and their order is
+  // the frontend's — which object_info's input order does not reproduce for custom
+  // nodes that add or reorder widgets in JS. Take a second, name-keyed read of the
+  // same canvas so the converter can map by NAME instead of by index. Structure
+  // still comes from graph_serialize (this adds values only, never nodes or links),
+  // so a panel too old to answer, a slow read, or a mismatched scope costs nothing
+  // but the disclosure that the mapping stayed positional and is UNVERIFIED.
+  if (allowStateFallback && notes) {
+    let stateReply: unknown;
+    try {
+      const target = ctx.workflowTarget?.get(ctx.tabId);
+      const stateCmd = target
+        ? withWorkflowTarget({ cmd: "graph_get_state" }, target)
+        : { cmd: "graph_get_state" };
+      stateReply = await ctx.bridge.send(stateCmd as { cmd: string }, {
+        tabId: ctx.tabId,
+        timeoutMs: 30000,
+      });
+    } catch (err) {
+      // Never fatal: strip already HAS a usable graph. Losing the cross-check
+      // degrades fidelity, and that degradation is what gets reported.
+      stateReply = null;
+      notes.push(
+        `note: the live widget cross-check could not be read (${err instanceof Error ? err.message : String(err)}); ` +
+          `an older panel may not support it. Widget values were mapped by position and MAY be attributed to the ` +
+          `wrong widget on custom nodes — verify with panel_query_graph {fields:'detail'} if one looks off.`,
+      );
+    }
+    if (stateReply) {
+      notes.push(...applyCapturedWidgetValues(wf, stateReply).notes);
+    }
   }
   return wf as Record<string, unknown>;
 }
@@ -6146,11 +6185,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       async (args: A, ctx) => {
         // strip opts into the lossy live-canvas fallback (#384) — its API/prompt
         // output is for inspection/execution, never reloaded onto the canvas.
-        const raw = await resolveWorkflowInput(args, ctx, true);
+        // `captureNotes` collects the #959 widget-capture disclosures: they say
+        // which nodes' widget values are UNVERIFIED, so they belong with the
+        // conversion notes rather than being dropped.
+        const captureNotes: string[] = [];
+        const raw = await resolveWorkflowInput(args, ctx, true, captureNotes);
         const ui = raw as unknown as UiWorkflow;
         const bulk = await getObjectInfo();
         const objectInfo = await backfillObjectInfo(bulk, collectNodeTypes(ui));
-        const { workflow, warnings } = convertUiToApi(ui, objectInfo);
+        const converted = convertUiToApi(ui, objectInfo);
+        const workflow = converted.workflow;
+        const warnings = [...captureNotes, ...converted.warnings];
 
         const hist: Record<string, number> = {};
         for (const node of Object.values(workflow)) {

--- a/src/services/live-widget-overlay.ts
+++ b/src/services/live-widget-overlay.ts
@@ -19,6 +19,17 @@
 // live litegraph node objects — the frontend's own truth, with no order to
 // disagree about. So capture both and hand the converter the named map.
 //
+// Why the named map can't be LESS complete than the array (the load-bearing
+// point — if it could, this fix would trade a wrong value for a missing one):
+// both are derived from the SAME list, `node.widgets`. litegraph builds
+// `widgets_values` by walking that list and taking each `w.value`; the capture
+// walks the same list and takes each `w.name`/`w.value` pair. The array is that
+// list with the names thrown away, which is precisely why naming its positions
+// requires a guess. Anything absent from the capture was absent from
+// `node.widgets`, so it had no serialized value either. (The asymmetry runs the
+// other way in some frontend versions, which skip `serialize:false` widgets when
+// building the array — one more reason position is not a reliable key.)
+//
 // This module decides ONLY whether the two captures describe the same nodes. It
 // refuses rather than guesses, and every refusal is disclosed to the caller: a
 // positional mapping that could not be verified is reported as UNVERIFIED, never

--- a/src/services/live-widget-overlay.ts
+++ b/src/services/live-widget-overlay.ts
@@ -1,0 +1,167 @@
+// Live-canvas widget capture: the authoritative name→value overlay (#959).
+//
+// `graph_serialize` gives a faithful STRUCTURE (links, groups, properties,
+// subgraph definitions) but stores widget values as a bare positional array. The
+// converter has to name those positions, and the only order it can reconstruct is
+// object_info's input order — which is NOT the frontend's widget order. Custom
+// nodes that add, hide, or reorder widgets in JS make the two disagree, and every
+// value from the first disagreement onward lands on the wrong widget.
+//
+// Reported three times against three different node packs before it was read as
+// one bug: #961 (Eclipse wildcards — `wildcards` serialized before `seed`, so a
+// wildcard STRING was emitted as the seed), #955 (the same node with numeric seeds
+// 101/202 swapped out), #361 (a SteadyDancer canvas where five model/LoRA/VAE
+// filenames were each replaced by a DIFFERENT model on disk). The last one is the
+// severity argument: a shifted asset widget silently renders something the user
+// never asked for, with no error anywhere.
+//
+// `graph_get_state` already reports each node's widgets BY NAME, straight off the
+// live litegraph node objects — the frontend's own truth, with no order to
+// disagree about. So capture both and hand the converter the named map.
+//
+// This module decides ONLY whether the two captures describe the same nodes. It
+// refuses rather than guesses, and every refusal is disclosed to the caller: a
+// positional mapping that could not be verified is reported as UNVERIFIED, never
+// as correct and never as wrong.
+
+/** A node summary from the panel's `graph_get_state` reply. */
+type StateNode = {
+  id?: unknown;
+  type?: unknown;
+  widgets?: unknown;
+};
+
+export type WidgetOverlayOutcome = {
+  /** Nodes handed an authoritative name-keyed widget map. */
+  applied: number;
+  /** Graph nodes the capture did not cover; these stay on positional mapping. */
+  uncovered: number;
+  /** Set when the overlay was refused for the WHOLE graph, with the reason. */
+  refused?: string;
+  /**
+   * Lines the caller should surface to the user. Present only when something was
+   * left positional — a fully covered graph says nothing, because there is
+   * nothing left to caveat.
+   */
+  notes: string[];
+};
+
+/** The caveat that a positionally-mapped node carries. Deliberately says MAY: we
+ *  did not verify the order, which is not the same as having found it wrong. */
+const POSITIONAL_CAVEAT =
+  "their widget values were mapped by POSITION against the server's input order, " +
+  "which is not guaranteed to match the frontend's widget order for custom nodes — " +
+  "so a value MAY be attributed to the wrong widget (this is unverified, not known wrong). " +
+  "Compare against panel_query_graph {fields:'detail'} before trusting a widget value that looks off.";
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Overlay the panel's name-keyed widget capture onto a serialized live graph,
+ * IN PLACE, by setting each node's `capturedWidgetValues`.
+ *
+ * `widgets_values` is deliberately left untouched — a subgraph node's
+ * proxyWidgets, a PrimitiveNode's literal at [0], and a Set/Get node's bus name
+ * are all read from that array BY INDEX, and replacing it with an object would
+ * silently drop them. The converter prefers `capturedWidgetValues` where it
+ * exists and falls back to the array everywhere else.
+ */
+export function applyCapturedWidgetValues(
+  ui: unknown,
+  stateReply: unknown,
+): WidgetOverlayOutcome {
+  const graphNodes = (ui as { nodes?: unknown } | null)?.nodes;
+  if (!Array.isArray(graphNodes) || graphNodes.length === 0) {
+    return { applied: 0, uncovered: 0, notes: [] };
+  }
+  const refuse = (why: string): WidgetOverlayOutcome => ({
+    applied: 0,
+    uncovered: graphNodes.length,
+    refused: why,
+    notes: [`note: ${why} All ${graphNodes.length} node(s) kept the serialized values, so ${POSITIONAL_CAVEAT}`],
+  });
+
+  const state = stateReply as
+    | { nodes?: unknown; viewing?: unknown; truncated?: unknown; node_count?: unknown }
+    | null;
+  if (!isPlainObject(state) || !Array.isArray(state.nodes)) {
+    return refuse("The panel returned no live widget capture to cross-check the serialized graph against.");
+  }
+
+  // THE catastrophic case, and the reason this refuses instead of best-efforting.
+  // `graph_serialize` always serializes the ROOT graph, but `graph_get_state`
+  // reports whichever graph the user is currently INSIDE. With a subgraph open,
+  // the two id spaces are different graphs' — and node 7 in the subgraph would
+  // overwrite node 7 of the root with a completely unrelated node's widget values.
+  // That is a worse bug than the one being fixed, so scope must be proven root.
+  const scope = isPlainObject(state.viewing) ? state.viewing.scope : undefined;
+  if (scope !== "root") {
+    return refuse(
+      scope === undefined
+        ? "The panel's widget capture did not say which graph it describes, so it can't be matched to the serialized root graph."
+        : `The panel is currently viewing a ${String(scope)}, so its widget capture describes that graph's nodes rather than the serialized root graph's.`,
+    );
+  }
+
+  // Build the id→widgets index. A duplicate id can't be attributed to either
+  // claimant, so drop BOTH rather than pick one (the same fail-closed rule the
+  // converter applies to an ambiguous widget name).
+  const widgetsById = new Map<string, Record<string, unknown>>();
+  const duplicated = new Set<string>();
+  for (const raw of state.nodes) {
+    const n = raw as StateNode;
+    if (n?.id == null) continue;
+    const key = String(n.id);
+    if (widgetsById.has(key) || duplicated.has(key)) {
+      widgetsById.delete(key);
+      duplicated.add(key);
+      continue;
+    }
+    // A node with no widgets at all reports `{}`. Indexing it is correct — it
+    // means "this node genuinely has no widget values", which is a fact worth
+    // honouring rather than a reason to fall back to a positional array.
+    if (isPlainObject(n.widgets)) widgetsById.set(key, n.widgets);
+  }
+
+  let applied = 0;
+  const uncoveredTypes = new Map<string, number>();
+  for (const raw of graphNodes) {
+    const node = raw as { id?: unknown; type?: unknown; capturedWidgetValues?: unknown };
+    const captured = node?.id == null ? undefined : widgetsById.get(String(node.id));
+    if (captured) {
+      node.capturedWidgetValues = captured;
+      applied++;
+    } else {
+      const t = typeof node?.type === "string" ? node.type : "?";
+      uncoveredTypes.set(t, (uncoveredTypes.get(t) ?? 0) + 1);
+    }
+  }
+
+  const uncovered = graphNodes.length - applied;
+  const notes: string[] = [];
+  if (uncovered > 0) {
+    // Name the cap explicitly when that is what happened, so the reader knows the
+    // remedy (strip a smaller selection) rather than suspecting a broken panel.
+    const capped =
+      state.truncated === true ||
+      (typeof state.node_count === "number" && state.node_count > state.nodes.length);
+    const types = [...uncoveredTypes.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([t, c]) => `${c}× ${t}`)
+      .join(", ");
+    notes.push(
+      `note: ${uncovered} of ${graphNodes.length} node(s) (${types}) were not covered by the panel's live widget capture` +
+        (capped ? ` (it reports at most ${state.nodes.length} nodes per read)` : "") +
+        `, so ${POSITIONAL_CAVEAT}`,
+    );
+  }
+  if (duplicated.size > 0) {
+    notes.push(
+      `note: the live widget capture reported ${duplicated.size} node id(s) more than once, so those nodes' values could not be attributed and were left as serialized.`,
+    );
+  }
+  return { applied, uncovered, notes };
+}

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -2377,7 +2377,16 @@ export function convertUiToApi(
     // Some INT inputs with "control_after_generate": true (like seed, noise_seed) have
     // a phantom widget value in widgets_values ("fixed"/"randomize"/"increment"/"decrement")
     // that doesn't correspond to any named input — we must skip those.
-    const widgetValues = node.widgets_values ?? [];
+    //
+    // A live-canvas capture may carry the panel's AUTHORITATIVE name→value widget
+    // map (capturedWidgetValues). Prefer it: the positional array below is ordered
+    // by the FRONTEND, while the only order we can reconstruct is object_info's, and
+    // custom nodes that add or reorder widgets in JS make the two disagree — which
+    // silently shifts every value onto the wrong widget (#961/#955/#361: a wildcard
+    // string landing on `seed`, a LoRA name landing on a VAE). A name-keyed map has
+    // no order to disagree about, so it routes into the object branch below, which
+    // already fails CLOSED when a name is ambiguous.
+    const widgetValues = node.capturedWidgetValues ?? node.widgets_values ?? [];
 
     // Some nodes (e.g. VHS_VideoCombine) store widgets_values as a name->value
     // object instead of a positional array — as does the #384 live-canvas


### PR DESCRIPTION
Closes #961
Closes #955
Closes #361

## The bug

`panel_strip_workflow` mapped widget values by **position**. The positions come from `graph_serialize`, whose order is the **frontend's**; the names come from `object_info`, whose order is the **server's**. For custom nodes that add, hide, or reorder widgets in JS the two disagree, and every value from the first disagreement onward lands on the wrong widget — with no error anywhere.

Reported three times against three node packs before it read as one bug:

| Issue | Symptom |
|---|---|
| #961 | Eclipse `wildcards` serialized before `seed` → a wildcard **string** emitted as the seed |
| #955 | Same node, seeds 101/202 swapped out for combo strings |
| #361 | SteadyDancer canvas: five model/LoRA/VAE filenames each replaced by a **different file on disk** |

#361 is the severity argument — the user renders something they never asked for, and nothing reports a problem.

The shift also **compounds**: `seed` carries a `control_after_generate` phantom slot, so once the string is taken as the seed the real seed is swallowed as the phantom and the trailing widget is never assigned at all. One inverted pair costs both widgets.

## The fix

Take a second, name-keyed read of the same canvas — `graph_get_state` already reports each node's widgets **by name**, straight off the live litegraph objects — and hand the converter the named map. A name-keyed map has no order to disagree about, and it routes into the converter's existing object branch, which already fails closed on an ambiguous name.

The capture lands in its own `capturedWidgetValues` field rather than being written into `widgets_values`. Several call sites read that array **by index** — a subgraph node's `proxyWidgets`, a `PrimitiveNode`'s literal at `[0]`, a Set/Get node's bus name — and handing them an object would silently drop all three. A test pins the PrimitiveNode case.

## What it refuses

It refuses rather than guesses, and every refusal is disclosed:

- **Subgraph scope.** `graph_serialize` always serializes the ROOT graph, but `graph_get_state` reports whichever graph the user is *inside*. With a subgraph open the two id spaces belong to different graphs — overlaying node 7 of a subgraph onto node 7 of the root would be a worse bug than the one being fixed. Scope must be proven `root`; an absent scope refuses too.
- **Duplicate node id** — can't be attributed to either claimant, so neither wins.
- **Partial capture** (the panel reports at most 100 nodes per read) — fixes what it covers, names what it didn't.

Every refusal says the mapping stayed positional and **MAY** be wrong. Unverified is not the same as known wrong, and asserting the stronger claim is the defect class this repo keeps hitting. The notes ride with strip's existing conversion notes.

## Why this shape and not the narrower one

#361 has survived earlier passes. That longevity is the signal: any fix that keeps mapping by position keeps failing, and keeps producing one report per node pack. #961 arriving as a *third* instance is the evidence the earlier narrowing was wrong.

## Verification

- 13 new tests; full suite **318 files / 6853 passed**; `tsc --noEmit` and `check:vocabulary` clean.
- **Mutation-verified**: reverting the converter to the positional source kills 5 tests including all three corruption cases; removing the root-scope guard kills 2; accepting duplicate ids kills 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)