### PR TITLE
fix(#918): stop reporting an unread model list as an empty install

### DIFF
--- a/src/__tests__/services/model-listing-coverage.test.ts
+++ b/src/__tests__/services/model-listing-coverage.test.ts
@@ -1,0 +1,207 @@
+// #918 — "No local models found." was printed for three different situations, one
+// of which was "we never got an answer".
+//
+// Against a remote ComfyUI that was still warming up, every `/models/<dir>` read
+// failed silently, `httpReturnedAny` stayed false, the filesystem fallback returned
+// [] because a remote setup has no comfyuiPath, and the tool printed the empty
+// install sentence. A reporter read it as a misconfigured URL and told the user so.
+// The same call returned the full list minutes later.
+//
+// The listing therefore has to carry HOW it knows, and the renderer has to decline
+// to claim "none" when nothing answered.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mode = vi.hoisted(() => ({ remote: false }));
+vi.mock("../../config.js", () => ({
+  config: { comfyuiPath: "/comfy" as string | undefined },
+  isRemoteMode: () => mode.remote,
+}));
+
+const fetchApi = vi.fn();
+const getClient = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getClient: (...args: unknown[]) => getClient(...args),
+}));
+
+const readdir = vi.fn();
+const stat = vi.fn();
+const readFile = vi.fn();
+vi.mock("node:fs/promises", () => ({
+  readdir: (...a: unknown[]) => readdir(...a),
+  stat: (...a: unknown[]) => stat(...a),
+  readFile: (...a: unknown[]) => readFile(...a),
+  copyFile: vi.fn(),
+  link: vi.fn(),
+  mkdir: vi.fn(),
+  rename: vi.fn(),
+  rm: vi.fn(),
+  utimes: vi.fn(),
+}));
+
+const { config } = await import("../../config.js");
+const { listLocalModelsWithCoverage } = await import("../../services/model-resolver.js");
+const { describeEmptyModelListing } = await import("../../tools/model-management.js");
+
+beforeEach(() => {
+  getClient.mockReset();
+  fetchApi.mockReset();
+  readdir.mockReset();
+  stat.mockReset();
+  readFile.mockReset();
+  readFile.mockRejectedValue(new Error("ENOENT"));
+  config.comfyuiPath = "/comfy";
+  mode.remote = false;
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("#918: the listing records whether ComfyUI actually answered", () => {
+  it("an OK empty array is an ANSWER — emptiness here is a verified fact", async () => {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockResolvedValue(new Response("[]", { status: 200 }));
+    readdir.mockRejectedValue(new Error("ENOENT"));
+    const { models, coverage } = await listLocalModelsWithCoverage("checkpoints");
+    expect(models).toEqual([]);
+    expect(coverage.answered).toEqual(["checkpoints"]);
+    expect(coverage.unanswered).toEqual([]);
+  });
+
+  it("a non-OK status is NOT an answer, and the status is kept", async () => {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockResolvedValue(new Response("nope", { status: 503 }));
+    readdir.mockRejectedValue(new Error("ENOENT"));
+    const { coverage } = await listLocalModelsWithCoverage("checkpoints");
+    expect(coverage.answered).toEqual([]);
+    expect(coverage.unanswered).toEqual([{ dir: "checkpoints", reason: "HTTP 503" }]);
+  });
+
+  // The reported shape: a proxy or a still-starting server answers 200 with an
+  // HTML login/placeholder page. The old code `continue`d and the category
+  // vanished without trace; res.json() would have raised the bare
+  // `Unexpected token '<', "<!doctype "...` the reporter flagged on the sibling
+  // tool. Name the condition instead of leaking the parser's message.
+  it("a 200 carrying HTML is reported as HTML, not as a JSON parser error", async () => {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockResolvedValue(new Response("<!doctype html><html>…", { status: 200 }));
+    readdir.mockRejectedValue(new Error("ENOENT"));
+    const { coverage } = await listLocalModelsWithCoverage("checkpoints");
+    expect(coverage.answered).toEqual([]);
+    expect(coverage.unanswered[0].reason).toMatch(/returned HTML instead of JSON/);
+    expect(coverage.unanswered[0].reason).toMatch(/still starting/);
+    expect(coverage.unanswered[0].reason).not.toMatch(/Unexpected token/);
+  });
+
+  it("valid JSON of the wrong shape is distinguished from HTML", async () => {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockResolvedValue(new Response('{"error":"unauthorized"}', { status: 200 }));
+    readdir.mockRejectedValue(new Error("ENOENT"));
+    const { coverage } = await listLocalModelsWithCoverage("checkpoints");
+    expect(coverage.unanswered[0].reason).toMatch(/JSON but not an array/);
+  });
+
+  it("a thrown fetch is recorded with its message, not swallowed", async () => {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockRejectedValue(new Error("connect ECONNREFUSED 10.0.0.4:8188"));
+    readdir.mockRejectedValue(new Error("ENOENT"));
+    const { coverage } = await listLocalModelsWithCoverage("checkpoints");
+    expect(coverage.unanswered[0].reason).toMatch(/ECONNREFUSED/);
+  });
+
+  // The exact #918 shape: remote (no comfyuiPath), so there is no second source
+  // to consult, and the empty array carries no information whatsoever.
+  it("remote + no answer sets noSourceAvailable — nothing was learned at all", async () => {
+    config.comfyuiPath = undefined;
+    mode.remote = true;
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockRejectedValue(new Error("fetch failed"));
+    const { models, coverage } = await listLocalModelsWithCoverage("checkpoints");
+    expect(models).toEqual([]);
+    expect(coverage.noSourceAvailable).toBe(true);
+    expect(coverage.unanswered).toHaveLength(1);
+  });
+
+  it("a local install with an unreachable server still reports the categories it could not read", async () => {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockRejectedValue(new Error("fetch failed"));
+    readdir.mockResolvedValue(["sd_xl.safetensors"]);
+    stat.mockResolvedValue({ isFile: () => true, size: 1024, mtime: new Date(0) });
+    const { models, coverage } = await listLocalModelsWithCoverage("checkpoints");
+    expect(models).toHaveLength(1); // the FS scan saved it
+    expect(coverage.usedFilesystem).toBe(true);
+    expect(coverage.noSourceAvailable).toBeUndefined();
+    expect(coverage.unanswered).toHaveLength(1);
+  });
+
+  // getClient throws in cloud mode, before any per-category read runs. Every
+  // requested category is then unanswered — not answered-and-empty.
+  it("an outright unavailable client marks EVERY requested category unanswered", async () => {
+    config.comfyuiPath = undefined;
+    mode.remote = true;
+    getClient.mockImplementation(() => {
+      throw new Error("CLOUD_UNSUPPORTED");
+    });
+    const { coverage } = await listLocalModelsWithCoverage();
+    expect(coverage.httpUnavailable).toMatch(/CLOUD_UNSUPPORTED/);
+    expect(coverage.answered).toEqual([]);
+    expect(coverage.unanswered.length).toBeGreaterThan(10); // all of MODEL_SUBDIRS
+    expect(coverage.noSourceAvailable).toBe(true);
+  });
+});
+
+describe("#918: what an empty listing is allowed to say", () => {
+  const empty = { answered: [] as string[], unanswered: [], usedFilesystem: false };
+
+  it("says 'no models' ONLY when every category answered", () => {
+    expect(describeEmptyModelListing(undefined, { ...empty, answered: ["checkpoints"] })).toBe(
+      "No local models found.",
+    );
+    expect(describeEmptyModelListing("loras", { ...empty, answered: ["loras"] })).toBe(
+      "No loras models found.",
+    );
+  });
+
+  // THE fix. The old text asserted an empty install from zero information.
+  it("refuses to claim 'none' when nothing answered", () => {
+    const text = describeEmptyModelListing("checkpoints", {
+      ...empty,
+      unanswered: [{ dir: "checkpoints", reason: "fetch failed" }],
+      noSourceAvailable: true,
+    });
+    expect(text).toMatch(/Could not determine/);
+    expect(text).toMatch(/NOT the same as having none/);
+    expect(text).not.toMatch(/^No checkpoints models found\.$/);
+    // and it names the reason, so the reader can act instead of guessing
+    expect(text).toMatch(/fetch failed/);
+    expect(text).toMatch(/get_system_stats/);
+  });
+
+  it("names the missing fallback so remote isn't mistaken for a bad path", () => {
+    const text = describeEmptyModelListing(undefined, {
+      ...empty,
+      unanswered: [{ dir: "checkpoints", reason: "HTTP 502" }],
+      noSourceAvailable: true,
+    });
+    expect(text).toMatch(/no local ComfyUI path to scan/);
+  });
+
+  it("calls a mixed result PARTIAL rather than empty", () => {
+    const text = describeEmptyModelListing(undefined, {
+      answered: ["checkpoints", "loras"],
+      unanswered: [{ dir: "vae", reason: "HTTP 500" }],
+      usedFilesystem: false,
+    });
+    expect(text).toMatch(/PARTIAL/);
+    expect(text).toMatch(/checkpoints, loras/);
+    expect(text).toMatch(/vae: HTTP 500/);
+    expect(text).toMatch(/before concluding they are absent/);
+  });
+
+  it("does not dump an unbounded list of failed categories", () => {
+    const text = describeEmptyModelListing(undefined, {
+      ...empty,
+      unanswered: Array.from({ length: 15 }, (_, i) => ({ dir: `d${i}`, reason: "fetch failed" })),
+    });
+    expect(text).toMatch(/…and 7 more/);
+  });
+});

--- a/src/__tests__/tools/model-management.test.ts
+++ b/src/__tests__/tools/model-management.test.ts
@@ -19,6 +19,13 @@ vi.mock("../../services/model-resolver.js", async () => {
     ...actual,
     downloadModel: (...a: unknown[]) => downloadModelMock(...a),
     listLocalModels: (...a: unknown[]) => listLocalModelsMock(...a),
+    // #918: the rendering path reads the coverage-carrying entry point. Wrap the
+    // existing mock so a test only has to say what the listing CONTAINS; the
+    // default coverage is the verified-answered case (nothing to caveat).
+    listLocalModelsWithCoverage: async (...a: unknown[]) => ({
+      models: (await listLocalModelsMock(...a)) ?? [],
+      coverage: { answered: ["checkpoints"], unanswered: [], usedFilesystem: false },
+    }),
     // Deterministic local routing (no live server probe) so startDownloadJob keys
     // the job locally and threads dispatchToManager=false into downloadModel.
     shouldDispatchDownloadToManager: async () => false,

--- a/src/__tests__/tools/models-consolidated.test.ts
+++ b/src/__tests__/tools/models-consolidated.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   // model-resolver
   searchHuggingFaceModels: vi.fn(),
   listLocalModels: vi.fn(),
+  listLocalModelsWithCoverage: vi.fn(),
   resolveExistingModelFile: vi.fn(),
   // download-jobs
   startDownloadJob: vi.fn(),
@@ -57,6 +58,7 @@ vi.mock("../../services/model-resolver.js", async () => {
     ...actual,
     searchHuggingFaceModels: (...a: unknown[]) => mocks.searchHuggingFaceModels(...a),
     listLocalModels: (...a: unknown[]) => mocks.listLocalModels(...a),
+    listLocalModelsWithCoverage: (...a: unknown[]) => mocks.listLocalModelsWithCoverage(...a),
     resolveExistingModelFile: (...a: unknown[]) => mocks.resolveExistingModelFile(...a),
     currentLiveModelsRoot: async () => undefined,
   };
@@ -196,6 +198,12 @@ beforeEach(() => {
   mocks.cancelDownloadJob.mockReturnValue({ found: false, owned: false, aborted: false });
   mocks.searchHuggingFaceModels.mockResolvedValue([]);
   mocks.listLocalModels.mockResolvedValue([]);
+  // #918: the listing now carries HOW it knows. An empty list with every category
+  // ANSWERED is the verified-empty case these tests mean by "no models".
+  mocks.listLocalModelsWithCoverage.mockResolvedValue({
+    models: [],
+    coverage: { answered: ["checkpoints"], unanswered: [], usedFilesystem: false },
+  });
   mocks.searchCivitaiModels.mockResolvedValue({ hits: [] });
   mocks.searchCivitaiCreators.mockResolvedValue({ hits: [] });
   mocks.fetchCivitaiTopCreators.mockResolvedValue([]);
@@ -425,9 +433,11 @@ describe("download_model dispatch", () => {
 });
 
 describe("list_local_models dispatch", () => {
-  it('action:"list" reaches listLocalModels with the model_type filter', async () => {
+  it('action:"list" reaches the model listing with the model_type filter', async () => {
     await inventory()({ action: "list", model_type: "loras" });
-    expect(mocks.listLocalModels).toHaveBeenCalledWith("loras");
+    // #918 moved the call to the coverage-carrying entry point. The filter still
+    // has to reach the resolver, which is what this has always been pinning.
+    expect(mocks.listLocalModelsWithCoverage).toHaveBeenCalledWith("loras");
   });
 
   it('action:"embeddings" reads the connected server\'s /api/embeddings', async () => {

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -358,8 +358,58 @@ async function discoverGgufCategories(
   }
 }
 
+/**
+ * Where a model listing's emptiness came from (#918).
+ *
+ * An empty `LocalModel[]` used to be indistinguishable from "ComfyUI never
+ * answered": every per-category read swallowed its error, `httpReturnedAny`
+ * stayed false, the filesystem fallback returned [] because a remote setup has
+ * no `comfyuiPath`, and the tool printed "No local models found." A reporter
+ * read that as a misconfigured URL and told the user so — the listing was
+ * correct minutes later, once the server finished warming up.
+ *
+ * So the listing now carries HOW it knows. "The server said zero" and "the
+ * server said nothing" are different facts and must not render the same way.
+ */
+export type ModelListingCoverage = {
+  /** Categories ComfyUI answered for — an OK response with an array body.
+   *  Their emptiness is a verified fact. */
+  answered: string[];
+  /** Categories whose read failed or returned an unusable body, with why. Their
+   *  emptiness is UNKNOWN, not zero. */
+  unanswered: { dir: string; reason: string }[];
+  /** Set when HTTP listing was unavailable as a whole (no client, cloud mode,
+   *  category discovery threw) — every category is then unanswered. */
+  httpUnavailable?: string;
+  /** True when results came from the filesystem scan rather than HTTP. */
+  usedFilesystem: boolean;
+  /** Set when neither path could run: no HTTP answer AND no local install path
+   *  to scan, which is the exact shape that produced the false "no models". */
+  noSourceAvailable?: boolean;
+};
+
+/** Model listing plus the provenance needed to describe it honestly. */
+export async function listLocalModelsWithCoverage(
+  modelType?: string,
+): Promise<{ models: LocalModel[]; coverage: ModelListingCoverage }> {
+  const coverage: ModelListingCoverage = {
+    answered: [],
+    unanswered: [],
+    usedFilesystem: false,
+  };
+  const models = await collectLocalModels(modelType, coverage);
+  return { models, coverage };
+}
+
 export async function listLocalModels(
   modelType?: string,
+): Promise<LocalModel[]> {
+  return (await listLocalModelsWithCoverage(modelType)).models;
+}
+
+async function collectLocalModels(
+  modelType: string | undefined,
+  coverage: ModelListingCoverage,
 ): Promise<LocalModel[]> {
   const dirsToScan: string[] = modelType ? [modelType] : [...MODEL_SUBDIRS];
   const results: LocalModel[] = [];
@@ -388,9 +438,39 @@ export async function listLocalModels(
     for (const dir of dirsToScan) {
       try {
         const res = await client.fetchApi(`/models/${dir}`);
-        if (!res.ok) continue;
-        const files = (await res.json()) as unknown;
-        if (!Array.isArray(files)) continue;
+        // A non-OK status or a non-array body means we did NOT learn what this
+        // category holds. Recording the reason is the whole point: continuing
+        // silently is what let a warming-up server look like an empty install.
+        if (!res.ok) {
+          coverage.unanswered.push({ dir, reason: `HTTP ${res.status}` });
+          continue;
+        }
+        // Parse from TEXT rather than res.json(): a proxy, login page, or a
+        // still-starting server answers 200 with HTML, and res.json() then throws
+        // `Unexpected token '<', "<!doctype "...` — a raw parser message that says
+        // nothing about what actually happened. #918 called that out on the sibling
+        // tool; classify it here instead of leaking it.
+        const body = await res.text();
+        let files: unknown;
+        try {
+          files = JSON.parse(body);
+        } catch {
+          coverage.unanswered.push({
+            dir,
+            reason:
+              `ComfyUI returned ${/^\s*</.test(body) ? "HTML" : "a non-JSON body"} instead of JSON ` +
+              `(a proxy, login page, or a server still starting answers this way)`,
+          });
+          continue;
+        }
+        if (!Array.isArray(files)) {
+          coverage.unanswered.push({
+            dir,
+            reason: `the response was JSON but not an array (got ${files === null ? "null" : typeof files})`,
+          });
+          continue;
+        }
+        coverage.answered.push(dir);
         for (const name of files) {
           if (typeof name !== "string") continue;
           // Hardening for any `*_gguf` category (discovered OR explicitly requested):
@@ -411,6 +491,10 @@ export async function listLocalModels(
         }
       } catch (err) {
         logger.debug(`HTTP /models/${dir} failed, continuing`, { err });
+        coverage.unanswered.push({
+          dir,
+          reason: err instanceof Error ? err.message : String(err),
+        });
       }
     }
     if (httpReturnedAny) {
@@ -419,13 +503,25 @@ export async function listLocalModels(
     }
   } catch (err) {
     logger.debug("HTTP model listing unavailable, trying filesystem", { err });
+    coverage.httpUnavailable = err instanceof Error ? err.message : String(err);
+    // The outer throw (no client / cloud mode / GGUF discovery) aborts before any
+    // per-category read, so nothing below it was answered either.
+    for (const dir of dirsToScan) {
+      if (!coverage.answered.includes(dir) && !coverage.unanswered.some((u) => u.dir === dir)) {
+        coverage.unanswered.push({ dir, reason: coverage.httpUnavailable });
+      }
+    }
   }
 
   // Path 2 — filesystem fallback. Only useful in pure local mode without
-  // extra_model_paths.yaml. Return empty (don't throw) when there's no local
-  // path: that's the correct answer for remote/cloud setups where ComfyUI
-  // simply didn't return anything over HTTP.
-  if (!config.comfyuiPath) return results;
+  // extra_model_paths.yaml. Returning empty here is only the RIGHT answer when
+  // HTTP actually answered; when it didn't, this is the false-empty path from
+  // #918 and the caller has to be told the difference (coverage.noSourceAvailable).
+  if (!config.comfyuiPath) {
+    coverage.noSourceAvailable = coverage.unanswered.length > 0;
+    return results;
+  }
+  coverage.usedFilesystem = true;
   const modelsRoot = join(config.comfyuiPath, "models");
   const dedup = makeModelDeduper();
   for (const dir of dirsToScan) {

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -4,9 +4,11 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import {
   searchHuggingFaceModels,
   listLocalModels,
+  listLocalModelsWithCoverage,
   currentLiveModelsRoot,
   MODEL_SUBDIRS,
 } from "../services/model-resolver.js";
+import type { ModelListingCoverage } from "../services/model-resolver.js";
 import { EXTRA_PATH_TARGETS } from "../services/extra-paths.js";
 import {
   startDownloadJob,
@@ -1044,19 +1046,83 @@ async function cancelAction(args: { id: string; tray_id?: string }): Promise<Cal
       }
 }
 
+/**
+ * What an EMPTY model listing is entitled to claim (#918).
+ *
+ * Three different situations used to print the same sentence:
+ *   1. ComfyUI answered for every category and every one was empty — a genuinely
+ *      empty install. "No models found" is true, and only here.
+ *   2. Some categories answered, others didn't — we know less than we're asked.
+ *   3. Nothing answered and there is no local path to scan (the remote/warming-up
+ *      case) — we know NOTHING, and the old text asserted an empty install.
+ *
+ * Exported for tests: the distinction is the fix, so it is pinned directly.
+ */
+export function describeEmptyModelListing(
+  modelType: string | undefined,
+  coverage: ModelListingCoverage,
+): string {
+  const scope = modelType ? `${modelType} models` : "local models";
+  if (coverage.unanswered.length === 0) {
+    // Verified: the server was asked and said zero.
+    return modelType ? `No ${modelType} models found.` : "No local models found.";
+  }
+
+  const detail = coverage.unanswered
+    .slice(0, 8)
+    .map((u) => `- ${u.dir}: ${u.reason}`)
+    .join("\n");
+  const more =
+    coverage.unanswered.length > 8 ? `\n- …and ${coverage.unanswered.length - 8} more` : "";
+
+  if (coverage.answered.length === 0) {
+    // We learned nothing at all. Say that, and do NOT say "none".
+    return (
+      `Could not determine which ${scope} are installed — ComfyUI did not answer the model listing. ` +
+      `This is NOT the same as having none: the models may be present and simply unlistable right now.\n\n` +
+      `Categories that could not be read:\n${detail}${more}\n\n` +
+      (coverage.noSourceAvailable
+        ? `There is also no local ComfyUI path to scan as a fallback (this is a remote/cloud setup), so there is no second source to check.\n\n`
+        : "") +
+      `Most often the server is still starting, or a proxy is returning HTML instead of JSON. ` +
+      `Retry in a few seconds; if it persists, check the ComfyUI URL with get_system_stats (action:"health") before concluding anything about the install.`
+    );
+  }
+
+  return (
+    `No ${scope} were found in the categories ComfyUI answered for (${coverage.answered.join(", ")}), ` +
+    `but ${coverage.unanswered.length} categor${coverage.unanswered.length === 1 ? "y" : "ies"} could not be read, ` +
+    `so this is a PARTIAL answer — models may exist in the categories below.\n\n${detail}${more}\n\n` +
+    `Retry before concluding they are absent.`
+  );
+}
+
 /** ← list_local_models (the pre-fold single-purpose tool) */
 async function listAction(args: {
   model_type?: z.infer<typeof modelTypeEnum>;
 }): Promise<CallToolResult> {
       try {
-        const models = await listLocalModels(args.model_type);
+        const { models, coverage } = await listLocalModelsWithCoverage(args.model_type);
 
         if (models.length === 0) {
-          const scope = args.model_type
-            ? `No ${args.model_type} models found.`
-            : "No local models found.";
-          return { content: [{ type: "text", text: scope }] };
+          // #918: "found none" is a CLAIM, and it may not be one we're entitled
+          // to make. When a category never answered — server warming up, a proxy
+          // returning HTML, no route to it at all — its emptiness is unknown, and
+          // saying "No models found" reads as a verified empty install. A reporter
+          // acted on exactly that and told a user their URL was misconfigured; the
+          // same call succeeded minutes later.
+          return {
+            content: [{ type: "text", text: describeEmptyModelListing(args.model_type, coverage) }],
+          };
         }
+        // Some categories answered and some didn't: the list below is real but
+        // PARTIAL, and a missing model may simply be in the part we couldn't read.
+        const partial =
+          coverage.unanswered.length > 0 && !coverage.usedFilesystem
+            ? `\n\n⚠ Partial listing — ${coverage.unanswered.length} categor${coverage.unanswered.length === 1 ? "y" : "ies"} could not be read ` +
+              `(${coverage.unanswered.map((u) => `${u.dir}: ${u.reason}`).join("; ")}). ` +
+              `Models in those categories are NOT absent, they are unlisted — retry if something you expect is missing.`
+            : "";
 
         // Group by type
         const grouped = new Map<string, typeof models>();
@@ -1099,7 +1165,7 @@ async function listAction(args: {
           lines.push("");
         }
 
-        return { content: [{ type: "text", text: lines.join("\n") }] };
+        return { content: [{ type: "text", text: lines.join("\n") + partial }] };
       } catch (err) {
         return errorToToolResult(err);
       }


### PR DESCRIPTION
Closes #918

## The bug

`list_local_models` printed **"No local models found."** for three different situations, and only one of them was an empty install:

| | Situation | What the tool said | What it should say |
|---|---|---|---|
| 1 | ComfyUI answered for every category, all empty | "No local models found." | ✅ correct |
| 2 | Some categories answered, others didn't | "No local models found." | partial — these went unread |
| 3 | Nothing answered, no local path to scan | "No local models found." | **we don't know** |

Case 3 is what shipped against a remote ComfyUI that was still warming up. Every `/models/<dir>` read failed into a `logger.debug` and continued; a non-OK status and a non-array body did the same; `httpReturnedAny` stayed false; and the filesystem fallback returned `[]` because a remote setup has no `comfyuiPath`. The reporter read the output as a misconfigured URL and **told the user so**. The same call returned the full, correct list minutes later.

The existing comment even called the empty return *"the correct answer for remote/cloud setups"* — but it's only correct when the server actually responded.

## The fix

The listing now carries **how it knows**. `listLocalModelsWithCoverage` returns which categories ComfyUI actually *answered* for (OK status + array body), which ones didn't and why, whether the filesystem fallback ran, and whether there was any source at all. `listLocalModels` keeps its old signature as a wrapper, so no existing caller changes.

- **Case 1** may say "No models found" — it's the only one entitled to.
- **Case 3** says it could not determine what is installed, that this is **not** the same as having none, names the per-category reason, and points at `get_system_stats(action:"health")` rather than letting the reader conclude anything about the install.
- **Case 2** says PARTIAL and lists what went unread.
- A **non-empty** listing with unread categories now carries the same caveat — those models are unlisted, not absent.

Also fixes the sibling leak the reporter flagged: `/models/<dir>` is parsed from text, so a proxy or still-starting server answering `200` with HTML is reported as *"returned HTML instead of JSON (a proxy, login page, or a server still starting answers this way)"* instead of surfacing a raw `Unexpected token '<', "<!doctype "...`.

## Does NOT fix #962

Different mechanism, stated plainly because the two read alike: there the server *does* answer, with `200` and `[]`, while a loader combo still offers files. This change can't see that — and arguably makes it worse by upgrading a vague claim to a confident one. Findings and the concrete direction are [recorded on #962](https://github.com/artokun/comfyui-mcp/issues/962).

## Verification

- 13 new tests; full suite **319 files / 6866 passed**; `tsc --noEmit` clean.
- `check:vocabulary` **caught a real defect in this PR** — the new remedy text named `health_check`, retired in 0.50.0. Fixed to `get_system_stats (action:"health")`.
- **Mutation-verified**: making the renderer claim "none" regardless of coverage kills 4 tests; swallowing a non-OK status again kills 1.
- Two pre-existing tests mocked `listLocalModels` and were updated to the new entry point; their intent (the `model_type` filter reaches the resolver; sidecar hints render) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)