### PR TITLE
fix(#952, #954): stop letting "fetch failed" stand in for a diagnosis

### DIFF
--- a/src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
+++ b/src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
@@ -5,7 +5,8 @@
 // or a certificate. The real reason sits one level down on `.cause`, and
 // `errorToToolResult` kept only `err.message`.
 //
-// #954 saw it from list_workflow_templates and could not tell which target was
+// #954 saw it from the workflow-templates listing (now `list_packs`
+// action:"list_templates") and could not tell which target was
 // tried. #952 saw it from the readonly tools while the panel bridge was working
 // fine — and read it, reasonably, as "these tools are broken". They weren't: the
 // panel talks to whichever ComfyUI its browser tab is on, while these calls go to
@@ -108,9 +109,9 @@ describe("comfyuiFetch names the target it could not reach", () => {
     await expect(comfyuiFetch("http://127.0.0.1:8188/api/x")).rejects.toThrow(
       /CONNECTED sidebar panel does not imply/,
     );
-    // Remedies must be NAMED, or the reader is still guessing. (The vocabulary
-    // gate keeps these two names live — it caught an earlier draft pointing at
-    // get_environment, retired in 0.50.0.)
+    // Remedies must be NAMED, or the reader is still guessing. The vocabulary
+    // gate keeps these two names live — it caught an earlier draft of this very
+    // change pointing at the environment tool's pre-0.50.0 name.
     await expect(comfyuiFetch("http://127.0.0.1:8188/api/x")).rejects.toThrow(
       /install_comfyui \(action:"environment"\)/,
     );

--- a/src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
+++ b/src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
@@ -1,0 +1,149 @@
+// #954 / #952 — `fetch failed` is not a diagnostic.
+//
+// undici gives every network-layer failure the same four characters. Not the
+// host, not the port, not whether it was DNS, a refused connection, a timeout,
+// or a certificate. The real reason sits one level down on `.cause`, and
+// `errorToToolResult` kept only `err.message`.
+//
+// #954 saw it from list_workflow_templates and could not tell which target was
+// tried. #952 saw it from the readonly tools while the panel bridge was working
+// fine — and read it, reasonably, as "these tools are broken". They weren't: the
+// panel talks to whichever ComfyUI its browser tab is on, while these calls go to
+// the configured COMFYUI_URL, and those two addresses are allowed to differ. That
+// distinction is invisible unless the failure names the address it used.
+//
+// Same defect had already been fixed once for HuggingFace downloads (#411) in a
+// private helper. It is now shared, which is why this file also pins that the
+// original message survives at the FRONT of the expansion: transient-error
+// matchers elsewhere test for /fetch failed/.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  getComfyUIAuthHeaders: () => ({}),
+}));
+
+const { comfyuiFetch } = await import("../../comfyui/fetch.js");
+const { describeFetchFailure, isBareFetchFailure, errorToToolResult, ComfyUIError } =
+  await import("../../utils/errors.js");
+
+/** The exact shape undici throws: an opaque top-level, detail on `.cause`. */
+function undiciFailure(code: string, detail: string): Error {
+  const cause = new Error(detail);
+  (cause as { code?: string }).code = code;
+  return new TypeError("fetch failed", { cause });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("describeFetchFailure", () => {
+  it("unwraps the cause chain and surfaces the syscall code", () => {
+    const { message, code } = describeFetchFailure(
+      undiciFailure("ECONNREFUSED", "connect ECONNREFUSED 127.0.0.1:8188"),
+    );
+    expect(code).toBe("ECONNREFUSED");
+    expect(message).toContain("connect ECONNREFUSED 127.0.0.1:8188");
+  });
+
+  // Load-bearing: process-control classifies transient network errors with a
+  // /fetch failed/ regex. Expanding the message must not break that.
+  it("keeps the ORIGINAL message at the front", () => {
+    const { message } = describeFetchFailure(undiciFailure("ENOTFOUND", "getaddrinfo ENOTFOUND gpu.local"));
+    expect(message.startsWith("fetch failed")).toBe(true);
+    expect(message).toMatch(/fetch failed/);
+  });
+
+  it("survives a self-referential cause chain", () => {
+    const err = new Error("boom") as Error & { cause?: unknown };
+    err.cause = err;
+    expect(describeFetchFailure(err).message).toBe("boom");
+  });
+
+  it("handles a non-Error throw", () => {
+    expect(describeFetchFailure("just a string").message).toBe("just a string");
+  });
+
+  it("recognises only the bare opaque failure", () => {
+    expect(isBareFetchFailure(new TypeError("fetch failed"))).toBe(true);
+    expect(isBareFetchFailure(new Error("  fetch failed  "))).toBe(true);
+    // Anything that already says something is left alone.
+    expect(isBareFetchFailure(new Error("fetch failed to parse the manifest"))).toBe(false);
+    expect(isBareFetchFailure(new Error("The operation was aborted"))).toBe(false);
+    expect(isBareFetchFailure("fetch failed")).toBe(false);
+  });
+});
+
+describe("errorToToolResult", () => {
+  it("expands a bare fetch failure instead of printing four useless words", () => {
+    const res = errorToToolResult(undiciFailure("ECONNREFUSED", "connect ECONNREFUSED 10.0.0.4:8188"));
+    const text = String(res.content[0].text);
+    expect(res.isError).toBe(true);
+    expect(text).not.toBe("fetch failed");
+    expect(text).toContain("ECONNREFUSED");
+    expect(text).toContain("10.0.0.4:8188");
+  });
+
+  it("leaves an error that already explains itself untouched", () => {
+    expect(String(errorToToolResult(new Error("Workflow node 7 is missing")).content[0].text)).toBe(
+      "Workflow node 7 is missing",
+    );
+  });
+
+  it("still routes a ComfyUIError through its own envelope", () => {
+    const res = errorToToolResult(new ComfyUIError("nope", "SOME_CODE"));
+    expect(String(res.content[0].text)).toContain("SOME_CODE");
+  });
+});
+
+describe("comfyuiFetch names the target it could not reach", () => {
+  it("reports the URL, the cause, and that a live panel proves nothing about it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(undiciFailure("ECONNREFUSED", "connect ECONNREFUSED 127.0.0.1:8188")),
+    );
+    await expect(comfyuiFetch("http://127.0.0.1:8188/api/workflow_templates")).rejects.toThrow(
+      /http:\/\/127\.0\.0\.1:8188\/api\/workflow_templates/,
+    );
+    // The #952 misreading, addressed directly.
+    await expect(comfyuiFetch("http://127.0.0.1:8188/api/x")).rejects.toThrow(
+      /CONNECTED sidebar panel does not imply/,
+    );
+    // Remedies must be NAMED, or the reader is still guessing. (The vocabulary
+    // gate keeps these two names live — it caught an earlier draft pointing at
+    // get_environment, retired in 0.50.0.)
+    await expect(comfyuiFetch("http://127.0.0.1:8188/api/x")).rejects.toThrow(
+      /install_comfyui \(action:"environment"\)/,
+    );
+    await expect(comfyuiFetch("http://127.0.0.1:8188/api/x")).rejects.toThrow(/get_system_stats/);
+  });
+
+  it("preserves the original error as `cause` and the syscall code", async () => {
+    const original = undiciFailure("ENOTFOUND", "getaddrinfo ENOTFOUND gpu.local");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(original));
+    const err = await comfyuiFetch("http://gpu.local:8188/x").catch((e) => e);
+    expect((err as { cause?: unknown }).cause).toBe(original);
+    expect((err as { code?: string }).code).toBe("ENOTFOUND");
+  });
+
+  // Rewriting an error that ALREADY carries information would be a downgrade —
+  // the same class of mistake in the other direction.
+  it("does NOT rewrite an error that already says what happened", async () => {
+    const abort = new Error("The operation was aborted due to timeout");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(abort));
+    await expect(comfyuiFetch("http://127.0.0.1:8188/x")).rejects.toBe(abort);
+  });
+
+  it("passes a successful response straight through", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("[]", { status: 200 })));
+    const res = await comfyuiFetch("http://127.0.0.1:8188/x");
+    expect(res.status).toBe(200);
+  });
+
+  // An HTTP error status is NOT a fetch failure — it must reach the caller as a
+  // Response so the existing #828 HTML/proxy classification still runs.
+  it("does not touch a non-OK response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("<html>", { status: 502 })));
+    const res = await comfyuiFetch("http://127.0.0.1:8188/x");
+    expect(res.status).toBe(502);
+  });
+});

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -1,4 +1,43 @@
 import { getComfyUIAuthHeaders } from "../config.js";
+import { describeFetchFailure, isBareFetchFailure } from "../utils/errors.js";
+
+/** The request target, for the diagnostic. Never throws on an odd input. */
+function targetOf(input: string | URL | Request): string {
+  try {
+    if (typeof input === "string") return input;
+    if (input instanceof URL) return input.href;
+    return (input as Request).url ?? String(input);
+  } catch {
+    return String(input);
+  }
+}
+
+/**
+ * Turn a network-layer throw into a diagnostic that says WHAT was attempted.
+ *
+ * `TypeError: fetch failed` was reaching tool results verbatim: #954 saw it from
+ * the workflow-templates listing (now `list_packs` action:"list_templates") and
+ * could not tell which host was tried, and #952 saw it from the readonly tools
+ * while the panel bridge was working fine — reading it, reasonably, as "the tool
+ * is broken" when the headless target was simply a different (unreachable)
+ * address than the one the panel is bound to.
+ *
+ * The two ARE separate targets by design: the panel talks to whichever ComfyUI
+ * the browser is on, while these calls go to the configured COMFYUI_URL. That is
+ * not a bug, but it is invisible unless the failure names the address.
+ */
+function describeComfyFetchFailure(err: unknown, target: string): Error {
+  const { message, code } = describeFetchFailure(err);
+  const wrapped = new Error(
+    `${message} — while requesting ${target}. ` +
+      `That is the headless ComfyUI target (COMFYUI_URL); a CONNECTED sidebar panel does not imply this address is reachable, ` +
+      `because the panel talks to whichever ComfyUI its browser tab is on. ` +
+      `Check the target with install_comfyui (action:"environment"), and confirm the server is up with get_system_stats (action:"health").`,
+    { cause: err },
+  );
+  if (code) (wrapped as { code?: string }).code = code;
+  return wrapped;
+}
 
 /**
  * `fetch` wrapper for ComfyUI HTTP requests that injects the configured generic
@@ -10,15 +49,28 @@ import { getComfyUIAuthHeaders } from "../config.js";
  * server. Non-ComfyUI requests (HuggingFace, Civitai, Comfy Cloud) keep using
  * plain `fetch` — Comfy Cloud has its own X-API-Key path in cloud-client.ts.
  */
-export function comfyuiFetch(
+export async function comfyuiFetch(
   input: string | URL | Request,
   init: RequestInit = {},
 ): Promise<Response> {
   const auth = getComfyUIAuthHeaders();
-  if (Object.keys(auth).length === 0) return fetch(input, init);
-  const headers = new Headers(init.headers);
-  for (const [name, value] of Object.entries(auth)) {
-    if (!headers.has(name)) headers.set(name, value);
+  let request: Promise<Response>;
+  if (Object.keys(auth).length === 0) {
+    request = fetch(input, init);
+  } else {
+    const headers = new Headers(init.headers);
+    for (const [name, value] of Object.entries(auth)) {
+      if (!headers.has(name)) headers.set(name, value);
+    }
+    request = fetch(input, { ...init, headers });
   }
-  return fetch(input, { ...init, headers });
+  try {
+    return await request;
+  } catch (err) {
+    // ONLY the opaque undici failure is rewritten. An AbortError, a timeout with
+    // its own message, or anything else already says what happened, and
+    // replacing that text would be a downgrade.
+    if (!isBareFetchFailure(err)) throw err;
+    throw describeComfyFetchFailure(err, targetOf(input));
+  }
 }

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -17,7 +17,7 @@ import { homedir } from "node:os";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import { ModelError } from "../utils/errors.js";
+import { ModelError, describeFetchFailure } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { redactUrlForLogs } from "./download-auth.js";
 import { reportDownloadProgress, type DownloadProgress } from "./download-progress.js";
@@ -1003,23 +1003,12 @@ async function partialConfirmedDiscarded(path: string): Promise<boolean> {
  * a TLS `ERR_TLS_CERT_ALTNAME_INVALID`). The top-level message is the useless
  * generic "fetch failed" (issue #411) — the actionable detail is one level
  * down, so unwrap the cause chain into a single readable string.
+ *
+ * Lives in utils/errors.ts now: the identical "fetch failed says nothing"
+ * defect was reported again against ComfyUI's OWN endpoints (#952, #954), so
+ * there is one implementation and one place to fix it.
  */
-function describeFetchError(err: unknown): { message: string; code?: string } {
-  const parts: string[] = [];
-  let code: string | undefined;
-  let cur: unknown = err;
-  const seen = new Set<unknown>();
-  while (cur instanceof Error && !seen.has(cur)) {
-    seen.add(cur);
-    const c = (cur as { code?: unknown }).code;
-    if (typeof c === "string" && !code) code = c;
-    const label = typeof c === "string" ? `${cur.message} (${c})` : cur.message;
-    if (label && !parts.includes(label)) parts.push(label);
-    cur = (cur as { cause?: unknown }).cause;
-  }
-  if (parts.length === 0) parts.push(String(err));
-  return { message: parts.join(": "), code };
-}
+const describeFetchError = describeFetchFailure;
 
 /**
  * Fetch that converts a network-layer failure into a ModelError carrying the

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -6,7 +6,8 @@ import { fileURLToPath } from "node:url";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { parse as parseYaml } from "yaml";
 import { errorToToolResult, ValidationError } from "../utils/errors.js";
-import { getComfyUIBaseUrl, getComfyUIAuthHeaders } from "../config.js";
+import { getComfyUIBaseUrl } from "../config.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 import { checkWorkflowRuntime, extractWorkflowClassTypes } from "../services/api-nodes.js";
 import {
   extractWorkflowDependencies,
@@ -527,8 +528,12 @@ async function listWorkflowTemplatesAction(): Promise<ToolText> {
   // consistently between listing and schema lookup.
   const base = getComfyUIBaseUrl();
   const url = `${base}/api/workflow_templates`;
-  const res = await fetch(url, {
-    headers: getComfyUIAuthHeaders(),
+  // #954: a bare `fetch` here rejected with the opaque `TypeError: fetch failed`
+  // and the reader had no way to see WHICH target was tried — the reported
+  // symptom, from a session where the panel bridge was connected and this
+  // headless address was not. comfyuiFetch names the target on a network throw,
+  // and it is the same auth path every other ComfyUI call uses.
+  const res = await comfyuiFetch(url, {
     signal: AbortSignal.timeout(8000),
   });
   if (!res.ok) {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -105,9 +105,52 @@ export class NodeBisectError extends ComfyUIError {
   }
 }
 
+/**
+ * Unwrap the `cause` chain of an error thrown by `fetch()` itself — a
+ * network-layer failure, not an HTTP status.
+ *
+ * undici surfaces every one of these as `TypeError: fetch failed`, a message
+ * that says nothing: not the host, not the port, not whether it was DNS, a
+ * refused connection, a timeout, or a bad certificate. The actionable detail is
+ * one level down on `.cause`, as an Error carrying a `code` (ENOTFOUND,
+ * ECONNREFUSED, ECONNRESET, UND_ERR_CONNECT_TIMEOUT, ERR_TLS_CERT_ALTNAME_INVALID…).
+ *
+ * The returned message always BEGINS with the original text, so existing
+ * transient-error matchers that look for /fetch failed/ keep matching.
+ */
+export function describeFetchFailure(err: unknown): { message: string; code?: string } {
+  const parts: string[] = [];
+  let code: string | undefined;
+  let cur: unknown = err;
+  const seen = new Set<unknown>();
+  while (cur instanceof Error && !seen.has(cur)) {
+    seen.add(cur);
+    const c = (cur as { code?: unknown }).code;
+    if (typeof c === "string" && !code) code = c;
+    const label = typeof c === "string" ? `${cur.message} (${c})` : cur.message;
+    if (label && !parts.includes(label)) parts.push(label);
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  if (parts.length === 0) parts.push(String(err));
+  return { message: parts.join(": "), code };
+}
+
+/** True for the opaque undici network failure whose detail lives on `.cause`. */
+export function isBareFetchFailure(err: unknown): boolean {
+  return err instanceof Error && /^fetch failed$/i.test(err.message.trim());
+}
+
 export function errorToToolResult(err: unknown): CallToolResult {
   if (err instanceof ComfyUIError) return err.toToolResult();
-  const message = err instanceof Error ? err.message : String(err);
+  // A bare "fetch failed" reaching a tool result tells the reader nothing and
+  // has repeatedly been read as "ComfyUI is broken" when it was a wrong port or
+  // a stale target (#952, #954, #411). Expand the cause chain; the original
+  // message stays at the front so nothing matching on it changes.
+  const message = isBareFetchFailure(err)
+    ? describeFetchFailure(err).message
+    : err instanceof Error
+      ? err.message
+      : String(err);
   return {
     isError: true,
     content: [{ type: "text", text: message }],


### PR DESCRIPTION
Closes #954
Refs #952

## The bug

undici gives every network-layer failure the same four characters: `fetch failed`. Not the host, not the port, not whether it was DNS, a refused connection, a timeout, or a certificate. The real reason sits one level down on `.cause`, and `errorToToolResult` kept only `err.message`.

- **#954** saw it from the workflow-templates listing and could not tell which target was tried.
- **#952** saw it from the readonly tools (`get_node_info`, `validate_workflow`, `check_workflow_runtime`) *while the panel bridge was working fine*, and read it — reasonably — as "these tools are broken."

They weren't. The panel talks to whichever ComfyUI its browser tab is on; these calls go to the configured `COMFYUI_URL`. Those two addresses are **allowed** to differ. That's invisible unless the failure names the one it used.

## The fix

```
fetch failed: connect ECONNREFUSED 127.0.0.1:8188 (ECONNREFUSED) — while requesting
http://127.0.0.1:8188/api/workflow_templates. That is the headless ComfyUI target
(COMFYUI_URL); a CONNECTED sidebar panel does not imply this address is reachable,
because the panel talks to whichever ComfyUI its browser tab is on. Check the target
with install_comfyui (action:"environment"), and confirm the server is up with
get_system_stats (action:"health").
```

Three changes:

- **`describeFetchFailure`** unwraps the cause chain into a readable string with the syscall code. It's the #411 helper, promoted out of `download-cache.ts` — the identical defect was reported again against ComfyUI's own endpoints, so there's one implementation now.
- **`comfyuiFetch`** — already the choke point every ComfyUI call goes through, and the only place that knows the URL — attaches the target and the caveat.
- The **templates listing** used a bare `fetch`, so nothing knew its URL. It now goes through `comfyuiFetch`, which also means it finally sends the configured auth headers by the same path as every other call instead of its own copy.

## Deliberately not done

- **An error that already explains itself** (an abort, a timeout with its own message) passes through untouched. Overwriting it would be the same mistake pointed the other way.
- **The expanded message keeps the original text at the front**, because `process-control.ts` classifies transient network errors with a `/fetch failed/` regex. Rewording would have silently disarmed that. Pinned by a test.
- **The two targets are not merged.** #952 also asks whether readonly tools should bind to the panel's connected server — a design question with real consequences for remote setups, and not answered here. That's why it's `Refs`, not `Closes`.

## Verification

- 13 new tests; full suite **320 files / 6879 passed**; `tsc --noEmit` clean.
- **Mutation-verified**: dropping the bare-failure guard in `comfyuiFetch` kills 2 tests; stopping the expansion in `errorToToolResult` kills 1. (My first mutation run reported *no* kills — the perl anchors missed because the files are CRLF. Caught by grepping for the mutation marker before trusting the result.)
- `check:vocabulary` caught **two retired names in this change's own text** (`get_environment`, `list_workflow_templates`, both retired in 0.50.0) — the second time this session it has caught me pointing a user at a dead tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)