### PR TITLE
fix(#704): a run is owned by the conversation that queued it, not by the tab id

### DIFF
--- a/src/__tests__/orchestrator/ask-answer-journal.test.ts
+++ b/src/__tests__/orchestrator/ask-answer-journal.test.ts
@@ -1054,7 +1054,11 @@ describe("ask-answer journal — bounds may LABEL, never silently lose (#486)", 
     // being added to one and forgotten in the other — which is exactly how a late
     // answer reached a conversation that never asked the question, twice.
     const pairs: Array<[RegExp, string, boolean]> = [
-      [/RunCompletions\.closeRuns\((\w+)\)/g, "AskAnswers.closeAsks($1)", true],
+      // The run journal also closes by CONVERSATION (#704 — a ticket whose tab id
+      // churned on a reconnect is in no member-tab sweep), so the site carries an
+      // optional second argument. The PAIRING is still on the tab: that is the
+      // argument both journals share.
+      [/RunCompletions\.closeRuns\((\w+)(?:, \w+)?\)/g, "AskAnswers.closeAsks($1)", true],
       // #884 removed every forget() site: an unproven workflow transition no
       // longer purges the journals, because the conversation is orchestrator-
       // scoped and deliberately CONTINUES across a workflow switch (pending

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -809,6 +809,30 @@ describe("panel-tools: panel_run verdict is derived from the ComfyUI reply", () 
     expect(RunCompletions.ticketFor("p-ok")).toBeDefined();
   });
 
+  it("#704: the ticket records the CONVERSATION that queued the run, not just the routed tab", async () => {
+    // The tool session is bound to the shared conversation (#884), and the run is
+    // routed to whichever tab is active. The journal needs BOTH: the tab is where
+    // the completion will arrive from, the conversation is who gets to call it its
+    // own — and only the second survives the panel re-registering under a new tab
+    // id, which is what made an agent's own render come back "origin UNDETERMINED".
+    const reply: ToolResult = {
+      content: [
+        { type: "text", text: JSON.stringify({ queued: true, batch_count: 1, prompt_id: "p-conv" }) },
+      ],
+    };
+    const { ctx } = makeRunCtx(reply);
+    ctx.tabId = "orchestrator::claude"; // the agent key this MCP session binds
+    (ctx as { bridge: unknown }).bridge = {
+      resolveSharedTabId: (scopeId?: string) =>
+        scopeId === "orchestrator::claude" ? "tmp:active" : undefined,
+    };
+    const res = await defByName("panel_run").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    const ticket = RunCompletions.ticketFor("p-conv");
+    expect(ticket?.tabId).toBe("tmp:active");
+    expect(ticket?.conversation).toBe("orchestrator::claude");
+  });
+
   it("#468: a queue with NO prompt id does NOT promise automatic delivery — it says UNDETERMINED", async () => {
     // The panel forwards ComfyUI's /prompt reply; without a prompt_id there is
     // nothing to correlate a later completion to, so telling the agent to idle

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -937,6 +937,29 @@ describe("run completion journal correlation (#468)", () => {
     expect(resend.possibleRepeat).toBe(true); // flagged, never suppressed
   });
 
+  it("#704: a New chat on ANOTHER backend does not close this conversation's ticket", () => {
+    // Boundaries are per conversation, and a tab can change which conversation it
+    // belongs to. Closing by tab as well looked like the safe direction — closing
+    // too much only weakens a verdict — but it is the #704 failure in miniature:
+    // claude queues on tab T, T switches to codex, a codex New chat runs, and
+    // claude's own render comes back UNDETERMINED (adversarial gate, round 2).
+    journal.openRun(PROMPT_A, { tabId: "wf:one", conversation: "orchestrator::claude" });
+    journal.closeRuns("wf:one", "orchestrator::codex"); // codex's boundary, same tab
+    expect(journal.ticketFor(PROMPT_A)).toBeDefined();
+    expect(
+      journal.correlate("wf:one", { prompt_id: PROMPT_A }, "orchestrator::claude").status,
+    ).toBe("matched");
+    // …and codex still cannot claim it.
+    expect(
+      journal.correlate("wf:one", { prompt_id: PROMPT_A }, "orchestrator::codex").status,
+    ).toBe("foreign");
+    // A ticket with no conversation to name is still closed by its tab, so the
+    // legacy path keeps a boundary rather than leaking one.
+    journal.openRun(PROMPT_B, { tabId: "wf:one" });
+    journal.closeRuns("wf:one", "orchestrator::codex");
+    expect(journal.ticketFor(PROMPT_B)).toBeUndefined();
+  });
+
   it("#704 NEGATIVE: a REUSED prompt id is still detected when the delivery was acked under a different tab id", () => {
     // Ownership and the already-delivered MEMO have to agree about who a run
     // belongs to. When the memo was still filed under the tab, a delivery acked

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -937,6 +937,34 @@ describe("run completion journal correlation (#468)", () => {
     expect(resend.possibleRepeat).toBe(true); // flagged, never suppressed
   });
 
+  it("#704 NEGATIVE: a REUSED prompt id is still detected when the delivery was acked under a different tab id", () => {
+    // Ownership and the already-delivered MEMO have to agree about who a run
+    // belongs to. When the memo was still filed under the tab, a delivery acked
+    // after a reconnect became invisible to the reuse check: the id looked like a
+    // clean identity when ComfyUI handed it out again, and the EARLIER
+    // generation's late completion could then be presented as the new run's
+    // result (found by the adversarial gate).
+    const CLAUDE = "orchestrator::claude";
+    journal.openRun(PROMPT_A, { tabId: "tmp:before", conversation: CLAUDE });
+    const first = journal.record(
+      "tmp:after",
+      { kind: "executed", prompt_id: PROMPT_A },
+      { conversation: CLAUDE },
+    );
+    journal.deliverPending("tmp:after", () => true);
+    journal.ack(first.token); // delivered + memoized, entry gone
+    // A busy session evicts the settled ticket…
+    for (let i = 0; i < 80; i++) {
+      journal.openRun(`later-${i}`, { tabId: "tmp:after", conversation: CLAUDE });
+    }
+    expect(journal.ticketFor(PROMPT_A)).toBeUndefined();
+    // …and ComfyUI hands the same id out again, queued from a third tab id.
+    journal.openRun(PROMPT_A, { tabId: "tmp:third", conversation: CLAUDE });
+    expect(journal.ticketFor(PROMPT_A)?.reused).toBe(true);
+    // So neither generation's completion may claim to be the run now outstanding.
+    expect(journal.correlate("tmp:third", { prompt_id: PROMPT_A }, CLAUDE).status).toBe("foreign");
+  });
+
   it("forget drops the tab's RUN TICKETS too, so a late completion reads as undetermined", () => {
     journal.openRun(PROMPT_A, { tabId: "wf:one" });
     journal.forget("wf:one");

--- a/src/__tests__/orchestrator/run-completion-continuation.test.ts
+++ b/src/__tests__/orchestrator/run-completion-continuation.test.ts
@@ -809,6 +809,134 @@ describe("run completion journal correlation (#468)", () => {
     expect(journal.correlate("wf:two", { prompt_id: PROMPT_A }).status).toBe("foreign");
   });
 
+  // ── #704 — WHOSE run is it: the conversation, not the tab ──────────────────
+  //
+  // The reported failure: `panel_run` returned prompt bc023bc3…, that exact run
+  // came back RE-DELIVERED, and it was annotated "does NOT match any run you
+  // queued with panel_run — its origin is UNDETERMINED. Do NOT treat it as the
+  // render you are waiting on." That does not merely mislabel a correct result —
+  // it instructs the agent to discard it and go re-verify.
+  //
+  // Why it happened: the ticket was owned by the panel TAB ID, which is a routing
+  // address, not an identity. A panel that reconnects re-registers under a new id
+  // (an unsaved workflow mints a fresh `tmp:<uuid>` on every page load) and only a
+  // SAME-SOCKET re-hello carries the `migrated_from` that moveKey follows — so the
+  // ticket was stranded under a dead id while the completion arrived under the
+  // live one. The conversation (#884: one orchestrator-scoped session across every
+  // tab and workflow) is the thing that actually queued the run and does not churn.
+  //
+  // Both directions are locked below: an own run stays attributable across the
+  // gap, and a run this conversation did NOT queue stays unattributable.
+
+  it("#704: a run this CONVERSATION queued still matches after the panel reconnects under a NEW tab id", () => {
+    const CLAUDE = "orchestrator::claude";
+    journal.openRun(PROMPT_A, { tabId: "tmp:before-reload", conversation: CLAUDE });
+    // The browser reloaded mid-render: same panel, same conversation, new socket,
+    // and the unsaved workflow minted a fresh tmp: id — no migration alias exists
+    // for moveKey to follow, so the ticket's tab is simply gone.
+    expect(journal.correlate("tmp:after-reload", { prompt_id: PROMPT_A }, CLAUDE)).toEqual({
+      status: "matched",
+      promptId: PROMPT_A,
+    });
+  });
+
+  it("#704: the RE-DELIVERED completion carries the matched verdict, not the UNDETERMINED warning", () => {
+    // End to end through the journal, in the shape the issue reported: the
+    // completion lands when no agent can take it (so it is replayed later), and
+    // the tab it lands on is not the one the run was queued from.
+    const CLAUDE = "orchestrator::claude";
+    journal.openRun(PROMPT_A, { tabId: "tmp:before-reload", conversation: CLAUDE });
+    const entry = journal.record(
+      "tmp:after-reload",
+      { kind: "executed", prompt_id: PROMPT_A },
+      { conversation: CLAUDE },
+    );
+    expect(entry.correlation.status).toBe("matched");
+    journal.deliverPending("tmp:after-reload", () => false); // no agent — journaled
+    const seen: CompletionPayload[] = [];
+    journal.deliverPending("tmp:after-reload", (p) => {
+      seen.push(p);
+      return true;
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].replayed).toBe(true); // …the "RE-DELIVERED" prefix
+    expect(seen[0].run_correlation).toBe("matched"); // …but NOT "its origin is UNDETERMINED"
+  });
+
+  it("#704 NEGATIVE: a run this conversation never queued is STILL unattributable", () => {
+    // The user pressing Queue Prompt themselves, or any render nothing ticketed:
+    // there is no ticket, so nothing to own, and the warning must still fire.
+    const CLAUDE = "orchestrator::claude";
+    journal.openRun(PROMPT_A, { tabId: "wf:one", conversation: CLAUDE });
+    expect(journal.correlate("wf:one", { prompt_id: PROMPT_B }, CLAUDE)).toEqual({
+      status: "foreign",
+      promptId: PROMPT_B,
+    });
+    // …including on the very tab that queued A, and for a near-miss id.
+    expect(journal.correlate("wf:one", { prompt_id: `${PROMPT_A}x` }, CLAUDE).status).toBe(
+      "foreign",
+    );
+  });
+
+  it("#704 NEGATIVE: ANOTHER conversation's run never matches, even on the same tab", () => {
+    // Two backends are two conversations. A render codex queued must never be
+    // handed to claude as "the run YOU queued" — and this is STRICTER than the old
+    // by-tab rule, which matched on the tab alone and would have.
+    journal.openRun(PROMPT_A, { tabId: "wf:one", conversation: "orchestrator::codex" });
+    expect(
+      journal.correlate("wf:one", { prompt_id: PROMPT_A }, "orchestrator::claude").status,
+    ).toBe("foreign");
+    expect(
+      journal.correlate("wf:one", { prompt_id: PROMPT_A }, "orchestrator::codex").status,
+    ).toBe("matched");
+  });
+
+  it("#704 NEGATIVE: New chat still ends ownership, even for a ticket whose tab id has churned", () => {
+    // The replacement conversation reuses the SAME key string
+    // (`orchestrator::<backend>`), so the boundary cannot rest on the key — the
+    // ticket has to be deleted. Closing by conversation is what reaches a ticket
+    // whose tab was re-registered and is therefore in no member-tab sweep.
+    const CLAUDE = "orchestrator::claude";
+    journal.openRun(PROMPT_A, { tabId: "tmp:gone", conversation: CLAUDE });
+    const arrived = journal.record(
+      "tmp:live",
+      { kind: "executed", prompt_id: PROMPT_A },
+      { conversation: CLAUDE },
+    );
+    expect(arrived.correlation.status).toBe("matched");
+    journal.closeRuns("tmp:live", CLAUDE); // New chat, swept over the LIVE tab only
+    expect(journal.ticketFor(PROMPT_A)).toBeUndefined();
+    expect(journal.correlate("tmp:live", { prompt_id: PROMPT_A }, CLAUDE).status).toBe("foreign");
+    // …and the already-arrived one is downgraded, never swallowed.
+    expect(journal.pending("tmp:live")).toHaveLength(1);
+    expect(journal.pending("tmp:live")[0].correlation.status).toBe("foreign");
+  });
+
+  it("#704: an own run keeps its dedupe identity across the tab change (no phantom duplicate)", () => {
+    // Ownership drives the GENERATION too. If it did not, a completion that
+    // correlates as ours would still be stamped generation 0 — "no identity" — and
+    // lose both its ack memo and its already-delivered flag, so a panel re-sending
+    // the frame would look like a brand-new render.
+    const CLAUDE = "orchestrator::claude";
+    journal.openRun(PROMPT_A, { tabId: "tmp:before", conversation: CLAUDE });
+    const entry = journal.record(
+      "tmp:after",
+      { kind: "executed", prompt_id: PROMPT_A },
+      { conversation: CLAUDE },
+    );
+    expect(entry.ticketSeq).toBeGreaterThan(0);
+    expect(entry.ambiguousId).toBeUndefined();
+    journal.deliverPending("tmp:after", () => true);
+    journal.ack(entry.token);
+    expect(journal.ticketFor(PROMPT_A)?.settled).toBe(true);
+    const resend = journal.record(
+      "tmp:after",
+      { kind: "executed", prompt_id: PROMPT_A },
+      { conversation: CLAUDE },
+    );
+    expect(resend.possibleRepeat).toBe(true); // flagged, never suppressed
+  });
+
   it("forget drops the tab's RUN TICKETS too, so a late completion reads as undetermined", () => {
     journal.openRun(PROMPT_A, { tabId: "wf:one" });
     journal.forget("wf:one");

--- a/src/__tests__/orchestrator/shared-session-invariant.test.ts
+++ b/src/__tests__/orchestrator/shared-session-invariant.test.ts
@@ -234,6 +234,28 @@ describe("sessions are orchestrator-scoped, never workflow-scoped (#884)", () =>
     expect(tools).toContain("const tabId = journalTabFor(ctx);");
   });
 
+  it("SOURCE: a run ticket also records the CONVERSATION that queued it (#704)", () => {
+    // The routed tab is the run's ADDRESS and it churns — a reconnecting panel
+    // re-registers under a new id, and only a same-socket re-hello leaves a
+    // migration alias to follow — so a by-tab-only ticket made the agent's own
+    // render come back "does NOT match any run you queued … its origin is
+    // UNDETERMINED". The conversation is orchestrator-scoped and does not churn,
+    // so both ends of the journal must speak it: the queue side stamps it, the
+    // arrival side asks with it, and the conversation boundary closes by it.
+    const tools = readFileSync(
+      new URL("../../orchestrator/panel-tools.ts", import.meta.url),
+      "utf8",
+    );
+    expect(tools).toContain("const runTicketConversation = journalConversationFor(ctx);");
+    expect(tools).toContain("conversation: runTicketConversation");
+    const src = indexSrc();
+    expect(src).toContain("conversation: agentKeyFor(event.tab_id),");
+    // Both conversation boundaries (New chat, resume switch) close by conversation
+    // as well as by member tab — a ticket whose tab id churned is in no tab sweep.
+    expect([...src.matchAll(/RunCompletions\.closeRuns\(t, key\)/g)]).toHaveLength(2);
+    expect(src).not.toMatch(/RunCompletions\.closeRuns\(t\)/);
+  });
+
   it("SOURCE: hello.resume is a last-resort hint — the orchestrator's disk store wins", () => {
     const src = indexSrc();
     const at = src.indexOf("manager.setResume(key, resumeHint)");

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -4411,7 +4411,14 @@ export async function runPanelOrchestrator(): Promise<void> {
         // Journal the BLIND-STRIPPED copy: a replay must not resurrect pixels
         // the blind gate removed on arrival. `null` = the panel re-sent a
         // completion this tab was already given; suppressed, never duplicated.
-        const entry = RunCompletions.record(event.tab_id, evForTab as CompletionPayload);
+        // #704 — WHO this completion is being reported to. The tab it arrived on
+        // is an address that churns across a panel reconnect (a new `tmp:` id, no
+        // same-socket migration to follow); the conversation is what actually
+        // queued the run, so it is what decides "this is the run YOU queued"
+        // versus the origin-UNDETERMINED warning.
+        const entry = RunCompletions.record(event.tab_id, evForTab as CompletionPayload, {
+          conversation: agentKeyFor(event.tab_id),
+        });
         logger.info(
           `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} run completion for ${describeCorrelation(entry.correlation)}${entry.possibleRepeat ? " (flagged as a possible repeat)" : ""}`,
         );
@@ -4499,8 +4506,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       // their arrival and are still delivered.
       // #486 — and the questions it asked: answers stay journaled and are still
       // reported, but lose the fingerprint that let them satisfy a re-ask.
+      // #704 — close by CONVERSATION as well as by member tab: a ticket whose tab
+      // was re-registered under a new id on a reconnect is reachable from no member
+      // tab at all, and the replacement conversation reuses the same key string, so
+      // only deleting it ends the old conversation's ownership.
       for (const t of conversationMemberTabs(tabId)) {
-        RunCompletions.closeRuns(t);
+        RunCompletions.closeRuns(t, key);
         AskAnswers.closeAsks(t);
       }
       pushToConversation(key, { type: "session", session_id: null });
@@ -4595,8 +4606,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       // historical session's own render. #884: the boundary is conversation-wide.
       // #486 — likewise its questions: answers stay journaled and are still
       // reported, but lose the fingerprint that let them satisfy a re-ask.
+      // #704 — close by CONVERSATION as well as by member tab: a ticket whose tab
+      // was re-registered under a new id on a reconnect is reachable from no member
+      // tab at all, and the replacement conversation reuses the same key string, so
+      // only deleting it ends the old conversation's ownership.
       for (const t of conversationMemberTabs(tabId)) {
-        RunCompletions.closeRuns(t);
+        RunCompletions.closeRuns(t, key);
         AskAnswers.closeAsks(t);
       }
       if (sid) manager.setResume(key, sid);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -43,7 +43,7 @@ import { parse as parseYaml } from "yaml";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UiBridge } from "../services/ui-bridge.js";
-import { isScopeAddress } from "../services/session-scope.js";
+import { conversationOfScopeAddress, isScopeAddress } from "../services/session-scope.js";
 
 /** #884 — journal TICKETS (run completions #468, ask answers #486) must be
  *  keyed by the REAL tab a run/card was routed to: the panel reports back under
@@ -58,6 +58,17 @@ function journalTabFor(ctx: PanelToolCtx): string {
   // conversation's in-flight-turn pin is consulted (#884 P0).
   const b = ctx.bridge as { resolveSharedTabId?: (scopeId?: string) => string | undefined };
   return b.resolveSharedTabId?.(ctx.tabId) ?? ctx.tabId;
+}
+
+/** #704 — the CONVERSATION a ticket belongs to: the backend-qualified agent key
+ *  (`orchestrator::<backend>`) this tool session is bound to. The tab a run was
+ *  routed to is only its address and it churns across a panel reconnect (a new
+ *  `tmp:` id, no same-socket migration to follow), which is what made an agent's
+ *  own render come back as "origin UNDETERMINED"; the conversation does not.
+ *  Undefined for the bare scope / a real-tab binding, which leaves the journal on
+ *  its by-tab ownership rule. */
+function journalConversationFor(ctx: PanelToolCtx): string | undefined {
+  return conversationOfScopeAddress(ctx.tabId);
 }
 import {
   dispatchOutcomeOf,
@@ -6647,6 +6658,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // the completion. Resolving AFTER the (seconds-long) queue round-trip
         // could key a tab the user has since moved to (codex r3/r4 timing).
         const runTicketTab = journalTabFor(ctx);
+        // #704 — the OWNER of the run. Unlike the tab, this cannot drift between
+        // the queue and the completion: it is this tool session's own binding.
+        const runTicketConversation = journalConversationFor(ctx);
         let res = await ctx.call(runCmd, 20000);
         // Derive the verdict from the AUTHORITATIVE reply, not a bare `queued`
         // flag. A rejection — a no-connected-tab / thrown-queuePrompt error
@@ -6720,6 +6734,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // #884 — the REAL routed tab, captured at dispatch (see runTicketTab):
           // the panel's `executed` event arrives under that id.
           tabId: runTicketTab,
+          // #704 — …and WHOSE run it is. The tab is where the completion is
+          // expected FROM; this is the conversation that gets to call it its own,
+          // which is what still holds after the panel reconnects under a new id.
+          ...(runTicketConversation !== undefined ? { conversation: runTicketConversation } : {}),
           ...(typeof args.to_node_id === "number" ? { toNodeId: args.to_node_id } : {}),
         });
         // Append anti-poll guidance: the agent should go idle after queuing so the

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -1033,20 +1033,27 @@ export class RunCompletionJournalImpl {
    * conversation was owed is still reported to it correctly if it is still
    * deliverable.
    *
-   * `conversation` is the boundary that matters once tickets are owned by a
-   * conversation rather than a tab (#704), and it is what makes this closure
-   * COMPLETE: a ticket whose tab has since been re-registered under a new id is
-   * no longer reachable by ANY member tab, and left open it would go on matching
-   * — the replacement conversation reuses the same key string
-   * (`orchestrator::<backend>`), so only DELETING the ticket ends the old
-   * conversation's ownership. Closing by tab as well is kept: closing too much
-   * only ever weakens a verdict (matched → foreign), which is the safe direction.
+   * A TICKET is closed when the ending party OWNS it — the same predicate that
+   * decides a match (ownsRun), which is the whole rule: whatever this party could
+   * be told is "the run YOU queued" it can also end, and nothing else.
+   *  • It reaches a ticket whose tab was re-registered under a new id on a
+   *    reconnect (#704) and is therefore in NO member-tab sweep. That matters
+   *    because the replacement conversation reuses the same key string
+   *    (`orchestrator::<backend>`), so only DELETING the ticket ends ownership.
+   *  • It does NOT delete another conversation's ticket that merely shares this
+   *    tab. Closing by tab as well looked like the safe direction, but it is the
+   *    #704 failure in miniature: claude queues on tab T, T switches to codex, a
+   *    codex New chat runs — and claude's own render would come back UNDETERMINED
+   *    (adversarial gate, round 2).
+   *
+   * ENTRIES are different and keep the tab arm: an entry is ADDRESSED to a tab
+   * and will be handed to whichever conversation serves that tab at flush time,
+   * so one addressed to a swept tab must lose its "YOUR run" claim regardless of
+   * who queued it.
    */
   closeRuns(key: string, conversation?: string): void {
-    const closed = (t: RunTicket): boolean =>
-      t.tabId === key || (conversation !== undefined && t.conversation === conversation);
     for (const [pid, ticket] of [...this.tickets]) {
-      if (closed(ticket)) this.tickets.delete(pid);
+      if (ownsRun(ticket, key, conversation)) this.tickets.delete(pid);
     }
     // Entries still undelivered were addressed to the conversation that just
     // went away, so their `matched` verdict no longer holds for whoever receives

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -30,6 +30,17 @@
 // self-restart loop — each of which tears the listener down (windows 2 and 3)
 // underneath the very render whose completion is in flight.
 //
+// WHOSE RUN IS IT (#704). A ticket is owned by the CONVERSATION that queued it
+// (the orchestrator-scoped agent key, #884), not by the panel tab it was queued
+// from. The tab is an ADDRESS and it churns: a panel that reconnects re-registers
+// under a new id (an unsaved workflow mints a fresh `tmp:<uuid>` every page load)
+// and only a SAME-SOCKET re-hello carries the `migrated_from` that moveKey
+// follows — so a reconnect used to strand the ticket under a dead id and the
+// agent's OWN render came back "does NOT match any run you queued with panel_run
+// — its origin is UNDETERMINED", which does not merely mislabel it: it TELLS THE
+// AGENT TO DISBELIEVE A CORRECT RESULT. The conversation spans every tab and
+// workflow and outlives the address, so it is the fact worth keying on.
+//
 // THE CONTRACT HERE.
 //  • Runs are ticketed by ComfyUI's `prompt_id`, opened by `panel_run`.
 //  • Every completion is CORRELATED ONCE, AT ARRIVAL, by EXACT prompt-id
@@ -75,12 +86,29 @@ export interface CompletionPayload {
 /** A run `panel_run` queued and is waiting on. */
 export interface RunTicket {
   promptId: string;
-  /** Panel tab the run was queued from. Part of the MATCH: a completion is only
-   *  "the run YOU queued" for the tab that queued it, so a workflow switch or a
-   *  cross-tab completion reads as foreign instead of being misattributed. A
-   *  proven tab-id migration moves it (moveKey) so the tab's own runs still
-   *  match. */
+  /** Panel tab the run was queued from — the run's ORIGIN ADDRESS: where its
+   *  completion is expected from, which tab the injected turn pins to, and (for
+   *  a caller that names no conversation) the ownership test. A proven tab-id
+   *  migration moves it (moveKey) so the tab's own runs still line up. */
   tabId: string;
+  /**
+   * The CONVERSATION that queued this run — the agent key `orchestrator::<backend>`
+   * (#884). THE ownership fact, and the one that survives (#704).
+   *
+   * The tab id is an ADDRESS, not an identity: a panel that reconnects re-registers
+   * under a new id (an unsaved workflow mints a fresh `tmp:<uuid>` on every page
+   * load), and only a SAME-SOCKET re-hello carries `migrated_from` for moveKey to
+   * follow. So a reconnect stranded the ticket under a dead id and the agent's OWN
+   * render came back "does NOT match any run you queued — its origin is
+   * UNDETERMINED", telling it to distrust a correct result. The conversation does
+   * not churn: it is the orchestrator-scoped session (one agent across every tab
+   * and workflow), so "did I queue this?" is answerable across the whole gap.
+   *
+   * Optional only for callers that have no conversation to name (tests, a legacy
+   * binding); ownership then falls back to the tab, i.e. exactly the pre-#704
+   * rule. See ownsRun().
+   */
+  conversation?: string;
   queuedAt: number;
   toNodeId?: number;
   /**
@@ -110,6 +138,31 @@ export interface RunTicket {
   reused?: boolean;
 }
 
+/**
+ * Does `ticket` belong to the party a completion is being reported to — the
+ * conversation `conversation`, receiving it on panel tab `key`?
+ *
+ * ONE rule, in priority order:
+ *  • BOTH sides name a conversation → the CONVERSATION decides, and the tab is
+ *    irrelevant. That is what makes a run survive its tab being re-registered
+ *    under a new id (#704), and it is strictly narrower than the tab rule where
+ *    the two disagree: a completion landing on a tab whose backend has since
+ *    changed reaches a DIFFERENT conversation, which never queued the run and is
+ *    now told so instead of being handed "the run YOU queued".
+ *  • EITHER side names none (tests, a legacy binding) → the pre-#704 tab rule,
+ *    unchanged.
+ *
+ * It is never "the newest run" and never a cross-conversation match: ownership
+ * still requires a ticket THIS party opened, so a render the panel queued on its
+ * own (the user pressing Queue Prompt) has no ticket and stays unattributable.
+ */
+function ownsRun(ticket: RunTicket, key: string, conversation?: string): boolean {
+  if (ticket.conversation !== undefined && conversation !== undefined) {
+    return ticket.conversation === conversation;
+  }
+  return ticket.tabId === key;
+}
+
 export type EntryState =
   /** Waiting for a delivery attempt. */
   | "pending"
@@ -124,6 +177,11 @@ export interface JournalEntry {
   key: string;
   payload: CompletionPayload;
   correlation: RunCorrelation;
+  /** The conversation this completion was correlated FOR, frozen at arrival with
+   *  the verdict. `ack()` re-checks ownership long after the fact and must use the
+   *  same party the correlation was computed against, not whatever the tab means
+   *  by then. Undefined when the caller named none (see ownsRun). */
+  conversation?: string;
   arrivedAt: number;
   attempts: number;
   state: EntryState;
@@ -246,13 +304,15 @@ export class RunCompletionJournalImpl {
   /** Monotonic ticket-generation counter — see RunTicket.seq. */
   private ticketSeq = 0;
 
-  /** The generation this tab's ticket for `promptId` is currently on, or 0 when
+  /** The generation this party's ticket for `promptId` is currently on, or 0 when
    *  it has none. THE run identity: every proof and every merge is keyed on it,
    *  so an id reused (or a ticket evicted and recreated) can never let one run's
-   *  bookkeeping answer for another's. */
-  private generationOf(key: string, promptId: string): number {
+   *  bookkeeping answer for another's. Ownership is judged exactly as `correlate`
+   *  judges it (ownsRun), or a run that correlates as ours would still be given
+   *  generation 0 — "no identity" — and lose its dedupe and its ack memo. */
+  private generationOf(key: string, promptId: string, conversation?: string): number {
     const ticket = this.tickets.get(promptId);
-    return ticket && ticket.tabId === key ? ticket.seq : 0;
+    return ticket && ownsRun(ticket, key, conversation) ? ticket.seq : 0;
   }
   /** Pull a still-queued completion back off its agent (see setRevoker). */
   private revoke: ((key: string, token: string) => boolean) | null = null;
@@ -321,18 +381,24 @@ export class RunCompletionJournalImpl {
     }
   }
 
-  /** Has this tab ALREADY seen a completion for this prompt id — delivered (a
+  /** Has this party ALREADY seen a completion for this prompt id — delivered (a
    *  memo from any generation) or still journaled? If so the id is not a fresh
    *  identity, however long ago that was and whether or not its ticket survives.
-   *  Both stores are bounded, so this is a small scan. */
-  private hasHistoryFor(key: string, promptId: string): boolean {
+   *  Both stores are bounded, so this is a small scan.
+   *
+   *  Scanned by tab AND by conversation: a journaled entry whose tab id has since
+   *  been re-registered (the #704 gap) is still this conversation's own history,
+   *  and missing it would let the re-queued id be treated as a clean identity —
+   *  the exact misattribution-plus-loss the `reused` flag exists to prevent. */
+  private hasHistoryFor(key: string, promptId: string, conversation?: string): boolean {
     const prefix = `${key}|${promptId}|`;
     for (const memo of this.delivered) {
       if (memo.startsWith(prefix)) return true;
     }
     for (const entry of this.entries.values()) {
       if (
-        entry.key === key &&
+        (entry.key === key ||
+          (conversation !== undefined && entry.conversation === conversation)) &&
         entry.correlation.status !== "unidentified" &&
         entry.correlation.promptId === promptId
       ) {
@@ -346,7 +412,10 @@ export class RunCompletionJournalImpl {
    *  no prompt id — the caller MUST then tell the agent its completion cannot be
    *  correlated rather than promising a notification it may not be able to
    *  attribute. */
-  openRun(promptId: string | null | undefined, meta: { tabId: string; toNodeId?: number }): boolean {
+  openRun(
+    promptId: string | null | undefined,
+    meta: { tabId: string; conversation?: string; toNodeId?: number },
+  ): boolean {
     if (typeof promptId !== "string" || !promptId) return false;
     // NOTE: no memo clearing is needed here. The delivered memo is keyed by
     // ticket GENERATION, and every path below either bumps the generation (a
@@ -360,6 +429,12 @@ export class RunCompletionJournalImpl {
       // prompt id always means one run.
       existing.settled = false;
       existing.tabId = meta.tabId;
+      // The REOPENING caller owns this generation of the id — including when a
+      // different conversation re-queued it. (It is `reused` from here on, so
+      // every completion for it reads UNDETERMINED for everyone regardless; this
+      // just keeps the record honest about who queued it last.)
+      if (meta.conversation !== undefined) existing.conversation = meta.conversation;
+      else delete existing.conversation;
       existing.queuedAt = Date.now();
       existing.seq = ++this.ticketSeq; // a NEW generation of this id
       // The id no longer identifies ONE run. Every completion for it from here
@@ -377,10 +452,11 @@ export class RunCompletionJournalImpl {
     // ambiguous: had it been treated as a clean identity, A's resend would
     // correlate as B, its ack would settle B, and B's real completion would then
     // be suppressed by B's own settled flag — misattribution AND loss.
-    const hasHistory = this.hasHistoryFor(meta.tabId, promptId);
+    const hasHistory = this.hasHistoryFor(meta.tabId, promptId, meta.conversation);
     this.tickets.set(promptId, {
       promptId,
       tabId: meta.tabId,
+      ...(meta.conversation !== undefined ? { conversation: meta.conversation } : {}),
       seq: ++this.ticketSeq,
       queuedAt: Date.now(),
       ...(typeof meta.toNodeId === "number" ? { toNodeId: meta.toNodeId } : {}),
@@ -402,23 +478,25 @@ export class RunCompletionJournalImpl {
   }
 
   /**
-   * Classify a completion that arrived for panel tab `key` against the open runs.
+   * Classify a completion that arrived on panel tab `key`, for conversation
+   * `conversation`, against the open runs.
    *
    * TWO conditions, both required: EXACT prompt-id equality AND the ticket must
-   * belong to THIS panel tab. There is deliberately no "the newest outstanding
-   * run" fallback and no cross-tab match, because attributing a completion to
-   * the wrong run — or to a different workflow's agent — is worse than not
-   * attributing it at all. A run whose ticket belongs to another tab reads as
-   * `foreign`, i.e. UNDETERMINED, which is the honest answer.
+   * be OWNED by the party being reported to (ownsRun — the conversation that
+   * queued it, else the tab). There is deliberately no "the newest outstanding
+   * run" fallback and no cross-CONVERSATION match, because attributing a
+   * completion to the wrong run — or to a conversation that never queued it — is
+   * worse than not attributing it at all. Anything unowned reads as `foreign`,
+   * i.e. UNDETERMINED, which is the honest answer.
    */
-  correlate(key: string, payload: CompletionPayload): RunCorrelation {
+  correlate(key: string, payload: CompletionPayload, conversation?: string): RunCorrelation {
     const pid = typeof payload.prompt_id === "string" ? payload.prompt_id.trim() : "";
     if (!pid) return { status: "unidentified" };
     const ticket = this.tickets.get(pid);
     // A REUSED id proves nothing: the panel sends only the id, so a completion
     // for it could belong to either generation. Report it as foreign — real, but
     // UNDETERMINED — rather than claiming it is the run now outstanding.
-    return ticket && ticket.tabId === key && !ticket.reused
+    return ticket && ownsRun(ticket, key, conversation) && !ticket.reused
       ? { status: "matched", promptId: pid }
       : { status: "foreign", promptId: pid };
   }
@@ -442,8 +520,13 @@ export class RunCompletionJournalImpl {
    * kept re-growing, because each proof it rested on is bounded and any expiry at
    * the wrong moment turned a new run's result into a discarded "duplicate".
    */
-  record(key: string, payload: CompletionPayload): JournalEntry {
-    const correlation = this.correlate(key, payload);
+  record(
+    key: string,
+    payload: CompletionPayload,
+    opts: { conversation?: string } = {},
+  ): JournalEntry {
+    const conversation = opts.conversation;
+    const correlation = this.correlate(key, payload, conversation);
     let idlessRepeat = false;
     /** This id already stands for more than one run (see RunTicket.reused). */
     let idReused = false;
@@ -468,12 +551,12 @@ export class RunCompletionJournalImpl {
       // generation a completion belongs to, so suppressing on them could swallow
       // the newer run's real result. A duplicate delivery (labelled UNDETERMINED)
       // is the correct trade here.
-      idReused = settledTicket?.reused === true && settledTicket.tabId === key;
+      idReused = settledTicket?.reused === true && ownsRun(settledTicket, key, conversation);
       // The memo is keyed by GENERATION, so an older run's delivery can never
       // suppress a newer one that merely reuses the id (or that got a fresh
       // ticket after the old one was evicted): different generation, different
       // key, no match.
-      gen = this.generationOf(key, correlation.promptId);
+      gen = this.generationOf(key, correlation.promptId, conversation);
       // UNPROVABLE identity — no dedupe of any kind is safe:
       //  • `reused`: the id stands for more than one run (see RunTicket.reused).
       //  • gen 0: this tab never ticketed the id, so there is NO generation to
@@ -503,7 +586,7 @@ export class RunCompletionJournalImpl {
       if (
         !idUnprovable &&
         (this.delivered.has(deliveredKey(key, correlation.promptId, gen)) ||
-          (settledTicket?.settled === true && settledTicket.tabId === key))
+          (settledTicket?.settled === true && ownsRun(settledTicket, key, conversation)))
       ) {
         logger.info(
           `[run-completions] a completion for ${describe(correlation)} was already delivered to tab ${key.slice(0, 8)} — forwarding this one FLAGGED as a possible repeat (never suppressed)`,
@@ -588,6 +671,9 @@ export class RunCompletionJournalImpl {
       key,
       payload,
       correlation,
+      // Frozen WITH the verdict: ack() re-checks ownership later and must ask
+      // about the same party this was correlated for.
+      ...(conversation !== undefined ? { conversation } : {}),
       arrivedAt: Date.now(),
       attempts: 0,
       state: "pending",
@@ -772,7 +858,7 @@ export class RunCompletionJournalImpl {
       // completion for it — memoizing there would let one external render's
       // delivery suppress a different one that happens to reuse the id.
       const provable = (entry.ticketSeq ?? 0) > 0;
-      if (provable && !(ticket?.reused === true && ticket.tabId === entry.key)) {
+      if (provable && !(ticket?.reused === true && ownsRun(ticket, entry.key, entry.conversation))) {
         // Memoize against THIS entry's own generation, never the id's current
         // meaning: an older run's ack must not write a proof that then suppresses
         // the newer run which reused the id (or got a fresh ticket after the old
@@ -925,10 +1011,21 @@ export class RunCompletionJournalImpl {
    * arrived keep the verdict frozen at THEIR arrival, so a completion the old
    * conversation was owed is still reported to it correctly if it is still
    * deliverable.
+   *
+   * `conversation` is the boundary that matters once tickets are owned by a
+   * conversation rather than a tab (#704), and it is what makes this closure
+   * COMPLETE: a ticket whose tab has since been re-registered under a new id is
+   * no longer reachable by ANY member tab, and left open it would go on matching
+   * — the replacement conversation reuses the same key string
+   * (`orchestrator::<backend>`), so only DELETING the ticket ends the old
+   * conversation's ownership. Closing by tab as well is kept: closing too much
+   * only ever weakens a verdict (matched → foreign), which is the safe direction.
    */
-  closeRuns(key: string): void {
+  closeRuns(key: string, conversation?: string): void {
+    const closed = (t: RunTicket): boolean =>
+      t.tabId === key || (conversation !== undefined && t.conversation === conversation);
     for (const [pid, ticket] of [...this.tickets]) {
-      if (ticket.tabId === key) this.tickets.delete(pid);
+      if (closed(ticket)) this.tickets.delete(pid);
     }
     // Entries still undelivered were addressed to the conversation that just
     // went away, so their `matched` verdict no longer holds for whoever receives
@@ -938,7 +1035,10 @@ export class RunCompletionJournalImpl {
     // gone" event. Without it a completion journaled before New chat would be
     // replayed to the replacement agent as "the run YOU queued".
     for (const entry of this.entries.values()) {
-      if (entry.key === key && entry.correlation.status === "matched") {
+      const mine =
+        entry.key === key ||
+        (conversation !== undefined && entry.conversation === conversation);
+      if (mine && entry.correlation.status === "matched") {
         entry.correlation = { status: "foreign", promptId: entry.correlation.promptId };
         // Same as the reused-id downgrade: the queued copy still claims to be the
         // run this (now-replaced) conversation queued. Recall it if we still can.

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -257,16 +257,30 @@ const MAX_CARRIED_RELEASES = 3;
 const IDLESS_REPEAT_HINT_MS = 10 * 60_000;
 
 /**
- * Memo key for an already-delivered run: (tab, prompt id, TICKET GENERATION).
+ * Memo key for an already-delivered run: (OWNER, prompt id, TICKET GENERATION).
  *
  * The generation is what makes this an identity rather than a guess. A prompt id
  * alone is not one — ComfyUI reuses ids, and a ticket can be evicted and
  * recreated — so a memo keyed on the id would let run A's delivery suppress run
- * B's real completion. `gen` is `RunTicket.seq`, or 0 when this tab has no
+ * B's real completion. `gen` is `RunTicket.seq`, or 0 when the owner has no
  * ticket for the id at all (an unqueued, foreign run).
+ *
+ * The OWNER is the same party ownership is judged against (ownsRun): the
+ * CONVERSATION when one is known, else the tab. It has to be, or the memo stops
+ * agreeing with the ownership rule the moment a tab id churns — a delivery
+ * recorded under the old tab id would be invisible to `hasHistoryFor`, the
+ * re-queued id would look like a clean identity instead of a REUSED one, and the
+ * earlier generation's late completion could then be presented as the new run's
+ * result (codex gate, P1).
  */
-function deliveredKey(key: string, promptId: string, gen: number): string {
-  return `${key}|${promptId}|${gen}`;
+function deliveredKey(owner: string, promptId: string, gen: number): string {
+  return `${owner}|${promptId}|${gen}`;
+}
+
+/** The party a run's bookkeeping is filed under — the conversation when there is
+ *  one, else the panel tab. Mirrors ownsRun(): the two must never disagree. */
+function ownerOf(key: string, conversation?: string): string {
+  return conversation ?? key;
 }
 
 /**
@@ -391,9 +405,12 @@ export class RunCompletionJournalImpl {
    *  and missing it would let the re-queued id be treated as a clean identity —
    *  the exact misattribution-plus-loss the `reused` flag exists to prevent. */
   private hasHistoryFor(key: string, promptId: string, conversation?: string): boolean {
-    const prefix = `${key}|${promptId}|`;
+    // BOTH owners: the memo may have been written under the tab (no conversation
+    // known at the time, or an older entry) or under the conversation.
+    const prefixes = [`${key}|${promptId}|`];
+    if (conversation !== undefined) prefixes.push(`${conversation}|${promptId}|`);
     for (const memo of this.delivered) {
-      if (memo.startsWith(prefix)) return true;
+      if (prefixes.some((p) => memo.startsWith(p))) return true;
     }
     for (const entry of this.entries.values()) {
       if (
@@ -585,7 +602,7 @@ export class RunCompletionJournalImpl {
       // saying "this may be the same render", not silence.
       if (
         !idUnprovable &&
-        (this.delivered.has(deliveredKey(key, correlation.promptId, gen)) ||
+        (this.delivered.has(deliveredKey(ownerOf(key, conversation), correlation.promptId, gen)) ||
           (settledTicket?.settled === true && ownsRun(settledTicket, key, conversation)))
       ) {
         logger.info(
@@ -863,7 +880,11 @@ export class RunCompletionJournalImpl {
         // meaning: an older run's ack must not write a proof that then suppresses
         // the newer run which reused the id (or got a fresh ticket after the old
         // one was evicted).
-        this.memoDelivered(entry.key, entry.correlation.promptId, entry.ticketSeq ?? 0);
+        this.memoDelivered(
+          ownerOf(entry.key, entry.conversation),
+          entry.correlation.promptId,
+          entry.ticketSeq ?? 0,
+        );
       }
     } else if (entry.fingerprint) {
       // ID-LESS: memoize the CONTENT so a re-sent identical frame after the ack

--- a/src/services/session-scope.ts
+++ b/src/services/session-scope.ts
@@ -53,6 +53,24 @@ export function isScopeAddress(id: string | undefined | null): id is string {
 }
 
 /**
+ * The CONVERSATION a scope address names: the backend-qualified agent key
+ * (`orchestrator::<backend>`), or undefined for the bare scope and for a real
+ * panel tab id.
+ *
+ * This is the identity a journal ticket is OWNED by (#704). A panel tab id is a
+ * routing address and it churns — a reconnecting panel re-registers under a new
+ * id, and only a same-socket re-hello leaves a migration trail to follow — so a
+ * run ticketed by tab alone stopped being recognizable as the agent's own after
+ * a reconnect. The conversation spans every tab and workflow (#884) and outlives
+ * the address. Deliberately NOT the bare scope: the conversation is per BACKEND
+ * (two providers are two conversations), so an unqualified address names no one
+ * and yields undefined rather than a value that could match the wrong one.
+ */
+export function conversationOfScopeAddress(id: string | undefined | null): string | undefined {
+  return typeof id === "string" && id.startsWith(SHARED_SESSION_SCOPE + "::") ? id : undefined;
+}
+
+/**
  * The connected panel tabs participating in a backend's shared conversation —
  * every tab whose selected backend matches. Agent output (say/stream/turn/…)
  * fans out to ALL of them: the same conversation is visible from every tab.


### PR DESCRIPTION
Fixes the false-negative provenance verdict reported in artokun/comfyui-mcp-panel#704.

## The defect

A run queued with `panel_run` came back to the agent as:

> `(RE-DELIVERED — this completion could not be handed to you when it arrived.)`
> `This run (prompt bc023bc3-…) does NOT match any run you queued with panel_run — its origin is UNDETERMINED. Do NOT treat it as the render you are waiting on; if you are still waiting on your own run, verify it with get_history before acting.`

`bc023bc3-…` was exactly the `prompt_id` `panel_run` had returned. The message does not merely mislabel a correct result — it instructs the agent to **discard** it and go re-verify with `get_history`, which is the opposite of `panel_run`'s own anti-poll guidance. A working path becomes a wasted turn or a duplicate render.

The warning itself is worth keeping: an unattributable completion genuinely should be flagged, because acting on someone else's render is worse. The bug is that a completion whose `prompt_id` is a known `panel_run` result was being classified as unattributable.

## Where the mapping was lost, and why

The #468 run ticket was owned by the panel **tab id** (`ticket.tabId === key` in `correlate`). A tab id is a routing **address**, not an identity:

* a panel that reconnects re-registers under a new id — an unsaved workflow mints a fresh `tmp:<uuid>` on every page load (`workflowTabId()` keys the id on the in-memory workflow object);
* only a **same-socket** re-hello carries `migrated_from`, and that is the only signal `RunCompletions.moveKey` follows.

So a reconnect stranded the ticket under a dead id while the completion arrived under the live one, and `correlate` answered `foreign`. It is **not specific to the re-delivery path**: the verdict is computed once at arrival, so the very first delivery is mislabelled the same way — the replay only made it loud enough to notice.

## The fix: preserve the mapping, don't widen the lookup

#884 made the session orchestrator-scoped: one conversation (`orchestrator::<backend>`) spans every tab and every workflow, and it does not churn. So the ticket now records the **conversation that queued it**, and ownership is:

```
ownsRun(ticket, key, conversation) =
  both name a conversation ? ticket.conversation === conversation
                           : ticket.tabId === key      // the pre-#704 rule, unchanged
```

The tab keeps its two real jobs — where the completion is expected from, and what the injected turn pins to.

**Nothing else may attribute.** `matched` still requires a ticket that `panel_run` opened, for the exact prompt id, owned by the party being reported to. A render the panel queued on its own (the user pressing Queue Prompt) has no ticket at all, so the UNDETERMINED warning fires exactly as before.

**It is stricter where the two rules disagree.** A completion landing on a tab whose backend has since changed reaches a *different* conversation, which never queued the run. By tab that matched and was announced as "the run YOU queued" — a false **positive** this removes (`#704 NEGATIVE: ANOTHER conversation's run never matches` fails on `main` with `expected 'matched' to be 'foreign'`).

Conversation boundaries (New chat, resume switch) now close by conversation as well as by member tab: the replacement conversation reuses the same key string, so only *deleting* the ticket ends ownership — and a ticket whose tab id churned is reachable from no member-tab sweep.

**Bounds:** no new store. Ownership rides the existing `RunTicket` (`MAX_TICKETS = 64`, unchanged eviction) and the existing delivered memo (`MAX_DELIVERED_MEMO = 512`). At the cap the behaviour is what it already was: an evicted ticket makes a later completion read UNDETERMINED, which is the honest answer once the run is forgotten.

## Verification

Failing-test-first, both directions, with mutations:

| mutation | result |
| --- | --- |
| revert the fix (keep the tests) | 5 of the new tests fail, incl. `a run this CONVERSATION queued still matches after the panel reconnects under a NEW tab id` (`expected foreign to deeply equal matched`) |
| make `ownsRun` return `true` (attribute everything) | 3 different tests fail: the new cross-conversation negative, the pre-existing `cross-tab is foreign`, and `moveKey carries the run tickets` |
| file the memo by tab again (`ownerOf` → `key`) | only `a REUSED prompt id is still detected when the delivery was acked under a different tab id` fails |
| re-add the tab arm to ticket closure | only `a New chat on ANOTHER backend does not close this conversation's ticket` fails |

Full suite: **318 files / 6863 tests green**, plus `tsc --noEmit` and `check:vocabulary`.

## Adversarial gate (3 rounds, independent codex)

* **R1 P1 — the delivered memo missed history across a tab change**, so a reused prompt id was not detected and an earlier generation's late completion could be presented as the new run's result. **Fixed** (`cef2862`): the memo key's first segment is the owner, `hasHistoryFor` scans both prefixes.
* **R1 P1 — rewind leaves the ticket live.** **Disposed, not fixed.** Pre-existing and deliberate: the rewind handler has never closed run tickets (the ask-journal boundary test records "a rewind is a boundary with no run-journal counterpart"), and on unfixed code a post-anchor run still correlates `matched` on the same tab — verified. Closing there would be wrong *here*: `closeRuns` is conversation-wide and not anchor-aware, so it would also strip provenance from runs queued long before the anchor, which the fork genuinely remembers — a new false negative of exactly the class this PR removes. Worth its own issue if the policy should change.
* **R2 P1 — `closeRuns` over-closed another conversation's ticket that merely shared the tab** (claude queues on T → T switches to codex → codex New chat → claude's own render comes back UNDETERMINED). **Fixed** (`afc7c3b`): ticket closure uses `ownsRun`, the same predicate that decides a match. Entries deliberately keep the tab arm — an entry is *addressed* to a tab and is handed to whoever serves it at flush time.
* **R3: `VERDICT: PASS`.**

## Related, not fixed here

The ask-answer journal (#486) attributes by ask id, so it does **not** have this loss. It does have the mirror-image boundary gap: `AskAnswers.closeAsks` bumps a per-tab epoch, so an ask **ticket** whose tab id churned (and that has no journaled answer yet) is in no member-tab sweep and would keep its epoch current across a New chat. Separate change, separate gate.

Refs artokun/comfyui-mcp-panel#704

🤖 Generated with [Claude Code](https://claude.com/claude-code)
