### PR TITLE
fix(#944): a minted prompt_id is a receipt, not a flag

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -851,6 +851,130 @@ describe("panel-tools: detectRunRejection helper", () => {
     const err: ToolResult = { content: [{ type: "text", text: "Error: boom" }], isError: true };
     expect(detectRunRejection(err)).toBe(err);
   });
+
+  // #944 — ComfyUI's PARTIAL-validation path: some outputs fail, at least one
+  // valid output remains, so it drops the bad ones ("Output will be ignored"),
+  // MINTS A PROMPT ID, and runs the rest. The reply carries node_errors and a
+  // prompt id together, and the #213 rule read that as a total refusal.
+  //
+  // What it cost: the agent was told nothing was queued while a render was
+  // already running. It diagnosed a live graph, asked the user to mute a node
+  // mid-render, and twice tried to "retry" — only the #556 graph-changed guard
+  // stopped it double-queueing a 20-minute video.
+  describe("#944: a minted prompt_id outranks the rejection signals", () => {
+    const partial = {
+      queued: true,
+      prompt_id: "abc-123",
+      node_errors: {
+        "92": {
+          class_type: "SaveVideo",
+          errors: [{ message: "Exception when validating node", details: "'43069'" }],
+        },
+      },
+    };
+
+    it("does NOT report a refusal for a prompt ComfyUI accepted", () => {
+      expect(detectRunRejection(jsonReply(partial))).toBeNull();
+    });
+
+    // A prompt id paired with a TOP-LEVEL error is a contradiction, not a
+    // partial acceptance: the panel's own refusals (the #556/#772 run-to-node
+    // race) arrive that way, and a prompt id there may be echoed from an earlier
+    // run. Asserting either reading would be guessing, so it reports the conflict.
+    it("a prompt id ALONGSIDE a top-level error is reported as uncertain, not as either", () => {
+      const rej = detectRunRejection(
+        jsonReply({ ...partial, error: { type: "prompt_outputs_failed_validation" } }),
+      );
+      expect(rej?.isError).toBe(true);
+      const text = String(rej?.content?.[0]?.text ?? "");
+      expect(text).toContain("[UNCERTAIN]");
+      expect(text).toContain("abc-123");
+      expect(text).toMatch(/Do NOT re-run/);
+      // It must not resolve the conflict in either direction.
+      expect(text).not.toMatch(/was queued successfully|nothing was queued$/i);
+    });
+
+    it("queued:false with a prompt id is uncertain too, never a clean queue", () => {
+      const rej = detectRunRejection(jsonReply({ ...partial, queued: false }));
+      expect(rej?.isError).toBe(true);
+      expect(String(rej?.content?.[0]?.text ?? "")).toContain("[UNCERTAIN]");
+    });
+
+    // The #213 reply had NO prompt id, which is exactly why it still fails.
+    it("still rejects when there is no prompt id (does not regress #213)", () => {
+      expect(
+        detectRunRejection(jsonReply({ queued: true, error: { type: "missing_node_type" } }))?.isError,
+      ).toBe(true);
+      expect(detectRunRejection(jsonReply({ queued: true, prompt_id: "" , error: { type: "x" } }))?.isError).toBe(true);
+      expect(
+        detectRunRejection(jsonReply({ queued: true, prompt_id: "   ", error: { type: "x" } }))?.isError,
+      ).toBe(true);
+    });
+
+    it("an isError transport reply is still never a queue, prompt id or not", () => {
+      const err: ToolResult = {
+        content: [{ type: "text", text: JSON.stringify({ prompt_id: "abc" }) }],
+        isError: true,
+      };
+      expect(detectRunRejection(err)).toBe(err);
+    });
+  });
+
+  // Silence would be the opposite error: the caller would wait for a file that
+  // is never written. The disclosure has to name the dropped outputs AND stop
+  // the two harmful reflexes the report recorded (re-run, edit mid-render).
+  describe("#944: the dropped outputs are disclosed on the success path", () => {
+    const { describeDroppedOutputs } = __panelRunTestHooks;
+
+    it("names the dropped output and what it means", () => {
+      const note = describeDroppedOutputs({
+        prompt_id: "abc-123",
+        node_errors: {
+          "92": { class_type: "SaveVideo", errors: [{ message: "Exception when validating node", details: "'43069'" }] },
+        },
+      });
+      expect(note).toContain("ACCEPTED");
+      expect(note).toContain("SaveVideo (node 92)");
+      expect(note).toContain("'43069'");
+      expect(note).toMatch(/Output will be ignored/);
+      expect(note).toMatch(/Do NOT re-run/);
+      expect(note).toMatch(/render is IN FLIGHT/);
+    });
+
+    it("says nothing for a clean run", () => {
+      expect(describeDroppedOutputs({ prompt_id: "abc", queued: true })).toBe("");
+      expect(describeDroppedOutputs({ prompt_id: "abc", node_errors: {} })).toBe("");
+    });
+
+    // Without a prompt id this is a real refusal, and detectRunRejection already
+    // reports it. Emitting a "partial" note there would claim a queue that
+    // does not exist — the #213 failure, re-created.
+    it("says nothing when there is no prompt id", () => {
+      expect(
+        describeDroppedOutputs({ node_errors: { "92": { class_type: "SaveVideo", errors: [] } } }),
+      ).toBe("");
+      expect(describeDroppedOutputs(null)).toBe("");
+    });
+
+    // The contradiction case was reported as UNCERTAIN and never reaches the
+    // success path; calling it an accepted-but-partial run would contradict that.
+    it("says nothing for the uncertain (prompt id + top-level error) reply", () => {
+      expect(
+        describeDroppedOutputs({
+          prompt_id: "abc",
+          error: { type: "x" },
+          node_errors: { "92": { class_type: "SaveVideo", errors: [] } },
+        }),
+      ).toBe("");
+      expect(
+        describeDroppedOutputs({
+          prompt_id: "abc",
+          queued: false,
+          node_errors: { "92": { class_type: "SaveVideo", errors: [] } },
+        }),
+      ).toBe("");
+    });
+  });
 });
 
 describe("panel-tools: panel_auto_layout (one-shot canvas arrange)", () => {
@@ -5797,6 +5921,41 @@ describe("panel-tools: panel_run scoped-run stamp-race retry (#772)", () => {
 
     expect(res.isError).toBe(true);
     expect(runs).toHaveLength(1);
+    // #944: the reply claims both a refusal and a prompt id. It is reported as a
+    // failure (unchanged), but the text no longer settles the contradiction it
+    // has no way to settle.
+    expect(runText(res)).toContain("[UNCERTAIN]");
+  });
+
+  // #944 END-TO-END. The unit tests above cover the decision; this covers the
+  // WIRING — that the disclosure actually reaches the caller's text. Without it,
+  // deleting the append at the call site breaks nothing visible.
+  it("a partially-validated run comes back as a QUEUE, with the dropped output named", async () => {
+    const { ctx, runs } = runCtx([
+      {
+        queued: true,
+        prompt_id: "p-partial",
+        node_errors: {
+          "92": {
+            class_type: "SaveVideo",
+            errors: [{ message: "Exception when validating node", details: "'43069'" }],
+          },
+        },
+      },
+    ]);
+    const res = await defByName("panel_run").handler({}, ctx);
+
+    // The reported bug: this was `isError` with "ComfyUI refused to queue".
+    expect(res.isError).toBeFalsy();
+    expect(runs).toHaveLength(1);
+    const text = runText(res);
+    expect(text).not.toMatch(/refused to queue/i);
+    expect(text).toContain("[PARTIAL]");
+    expect(text).toContain("SaveVideo (node 92)");
+    expect(text).toMatch(/Do NOT re-run/);
+    // The partial notice must lead the appendices — it changes what to expect
+    // from this run, so it cannot trail behind the anti-poll boilerplate.
+    expect(text.indexOf("[PARTIAL]")).toBeLessThan(text.indexOf("[IMPORTANT]"));
   });
 
   it("does NOT retry an unparseable reply — unreadable is an unknown, not a clean queue", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2134,6 +2134,30 @@ function formatRunRejection(payload: { error?: unknown; node_errors?: unknown })
  *  - Anything else (a plain `queued:true`, or an unparseable reply we must not
  *    regress) returns null and is treated as a genuine queue.
  */
+/**
+ * #944 — a `prompt_id` is not a flag, it is a RECEIPT.
+ *
+ * ComfyUI has a PARTIAL-validation path: when some output nodes fail validation
+ * but at least one valid output remains, it drops the bad ones ("Output will be
+ * ignored"), returns a prompt_id, and executes the rest. That reply carries
+ * `node_errors` AND a prompt id at the same time.
+ *
+ * The #213 rule — node_errors means rejection, even alongside queued:true — read
+ * that as a total refusal and reported "ComfyUI refused to queue the workflow"
+ * for a render that was already running. The agent then diagnosed a live graph,
+ * asked the user to mute a node mid-render, and twice tried to "retry"; only the
+ * #556 graph-changed guard stopped it double-queueing a 20-minute video.
+ *
+ * `queued:true` is a flag the panel sets. A prompt_id is an identifier ComfyUI
+ * MINTED, and it only mints one when it accepted the prompt — which is why this
+ * overrides the flag-based rule and #213 does not regress: that reply had no
+ * prompt id. The same asymmetry the retry guard already relies on.
+ */
+function acceptedPromptId(parsed: Record<string, unknown> | null): string | null {
+  const pid = parsed?.prompt_id;
+  return typeof pid === "string" && pid.trim() !== "" ? pid.trim() : null;
+}
+
 function detectRunRejection(res: ToolResult): ToolResult | null {
   // Bridge/transport/executor error: never a queue. Preserve it verbatim (#248),
   // no success note (#331). fail() already carries err.message (incl. any stack).
@@ -2148,7 +2172,78 @@ function detectRunRejection(res: ToolResult): ToolResult | null {
     hasTopLevelError(topError) || hasNodeErrors(nodeErrors) || parsed.queued === false;
   if (!rejected) return null; // genuine queue (queued:true / no rejection signal)
 
+  const promptId = acceptedPromptId(parsed);
+  if (promptId) {
+    // THE #944 SHAPE, and only this shape: node_errors WITHOUT a top-level error
+    // and without queued:false. That is literally what ComfyUI returns from its
+    // partial-validation path (validate_prompt keeps the good outputs, so the
+    // server answers 200 with prompt_id + node_errors and no `error` key). The
+    // prompt is in the queue; the failing outputs were dropped, not refused.
+    if (!hasTopLevelError(topError) && parsed.queued !== false) return null;
+
+    // Anything else pairing a prompt id with a rejection is a CONTRADICTION, and
+    // the two claims come from different places — the panel's own refusals (the
+    // #556/#772 run-to-node race) are prose it wrote, while a prompt id may be a
+    // field echoed from an earlier run. We cannot tell which is true, so we must
+    // not assert either. Saying "refused" here would be the #944 lie in miniature;
+    // saying "queued" would invite the caller to wait on a render that may not
+    // exist. Report the conflict and send them to the queue to settle it.
+    return fail(
+      `${formatRunRejection({ error: topError, node_errors: nodeErrors })}\n\n` +
+        `[UNCERTAIN] That rejection arrived in the SAME reply as a prompt id (${promptId}), and the two ` +
+        `contradict each other — a prompt id normally means ComfyUI accepted the work. This tool cannot ` +
+        `tell which is true, so it is not claiming either. Do NOT re-run: check queue (action:"list") and ` +
+        `get_history first, because a render may already be in flight.`,
+    );
+  }
+
   return fail(formatRunRejection({ error: topError, node_errors: nodeErrors }));
+}
+
+/**
+ * The disclosure for a run ComfyUI accepted while dropping some outputs (#944).
+ * Returns null when nothing was dropped — a clean run says nothing extra.
+ *
+ * This has to be loud. The failure it replaces was loud and WRONG; a partial run
+ * that stays silent would be the opposite error, letting the agent believe every
+ * output is coming and wait for a file that will never be written.
+ */
+function describeDroppedOutputs(parsed: Record<string, unknown> | null): string {
+  if (!parsed || !acceptedPromptId(parsed)) return "";
+  // Mirrors detectRunRejection's acceptance test exactly: only the partial-
+  // validation shape reaches the success path, so only it gets this note. A
+  // reply that ALSO carried a top-level error was reported as UNCERTAIN and
+  // never got here — describing it as an accepted-but-partial run would
+  // contradict that.
+  if (hasTopLevelError(parsed.error) || parsed.queued === false) return "";
+  const ne = parsed.node_errors;
+  if (!hasNodeErrors(ne)) return "";
+
+  const lines: string[] = [];
+  if (ne && typeof ne === "object") {
+    for (const [nodeId, info] of Object.entries(ne as Record<string, unknown>)) {
+      const i = (info ?? {}) as { class_type?: unknown; errors?: unknown };
+      const cls = typeof i.class_type === "string" ? i.class_type : "node";
+      const errs = Array.isArray(i.errors) ? i.errors : [];
+      if (errs.length === 0) {
+        lines.push(`- ${cls} (node ${nodeId}): validation failed`);
+        continue;
+      }
+      for (const e of errs as Array<{ message?: unknown; details?: unknown }>) {
+        const detail = typeof e?.details === "string" && e.details ? ` (${e.details})` : "";
+        const m = typeof e?.message === "string" ? e.message : "validation failed";
+        lines.push(`- ${cls} (node ${nodeId}): ${m}${detail}`);
+      }
+    }
+  }
+  return (
+    `\n\n[PARTIAL] ComfyUI ACCEPTED this prompt and is running it, but it dropped ` +
+    `${lines.length || "one or more"} output(s) that failed validation — its "Output will be ignored" path. ` +
+    `The remaining outputs ARE executing.\n${lines.join("\n")}\n` +
+    `Do NOT re-run and do NOT edit the graph to "fix" this right now: a render is IN FLIGHT, ` +
+    `and ComfyUI has already excluded the failing output(s) itself. Expect no file from them. ` +
+    `Repair them after this run finishes, or interrupt it deliberately with queue (action:"cancel").`
+  );
 }
 
 /**
@@ -2200,6 +2295,7 @@ export const __panelRunTestHooks = {
   detectRunRejection,
   formatRunRejection,
   isRetryableRunToNodeStampRace,
+  describeDroppedOutputs,
 };
 
 /** Drop a trailing .json (case-insensitive) so filename/path forms compare equal. */
@@ -6706,11 +6802,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // same batch recognizes the in-flight job as our own and doesn't false-warn
         // (#559). The panel forwards ComfyUI's /prompt reply, which carries the
         // prompt_id; when it doesn't, the timestamp still marks a recent self-queue.
-        const queuedId = ((): string | null => {
-          const parsed = parseToolResultJson(res);
-          const pid = parsed?.prompt_id;
-          return typeof pid === "string" && pid ? pid : null;
-        })();
+        const runReply = parseToolResultJson(res);
+        const queuedId = acceptedPromptId(runReply);
+        // #944: a run ComfyUI accepted while dropping some outputs reaches here
+        // (a minted prompt id outranks the rejection signals). Say which outputs
+        // were dropped, or the caller waits for files that will never be written.
+        const droppedNote = describeDroppedOutputs(runReply);
         QueueMonitor.markSelfQueued(queuedId);
         // #468 — open a run ticket so the render's completion can be CORRELATED
         // to this exact call by prompt id. This is what lets the orchestrator
@@ -6777,7 +6874,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           return {
             ...res,
             content: [
-              { type: "text", text: res.content[0].text + retryNote + warn + note },
+              // droppedNote sits FIRST among the appendices: "some outputs were
+              // dropped" changes what the caller should expect from this run, so
+              // it must not trail behind the anti-poll boilerplate (#944).
+              { type: "text", text: res.content[0].text + droppedNote + retryNote + warn + note },
               ...res.content.slice(1),
             ],
           };


### PR DESCRIPTION
Closes #944

## The bug

ComfyUI has a **partial-validation** path. When some output nodes fail validation but at least one valid output remains, it drops the bad ones (`Output will be ignored`), **mints a prompt id**, and executes the rest. That reply carries `node_errors` *and* a prompt id at the same time.

The #213 rule — `node_errors` means rejection, even alongside `queued:true` — read that as a total refusal:

```
Error: ComfyUI refused to queue the workflow
- SaveVideo (node 92): Exception when validating node ('43069')
```

…for a render that was already running. ComfyUI's own log for the same submission: `got prompt` → `Output will be ignored` → execution proceeds.

**What it cost**, from the report: the agent believed nothing was queued, so it diagnosed a graph that was mid-render, asked the user to mute a node *while a render was in flight*, and twice tried to "retry". Only the #556 graph-changed guard stopped it double-queueing a 20-minute video. When the user later asked "did you queue this?", the agent said no — because the tool said so — and both were left with a running job neither believed they started.

This is the exact inverse of the failure `panel_run` was built to avoid. A false *refused* is as damaging as a false *queued*.

## The fix

`queued:true` is a flag the panel sets. **A prompt id is an identifier ComfyUI minted**, and it only mints one when it accepted the prompt. #213 does not regress because that reply had no prompt id — the same asymmetry the #772 retry guard already relies on.

Three states now, not two:

| Reply | Verdict |
|---|---|
| prompt id + `node_errors`, no top-level error, not `queued:false` | **queue**, with a `[PARTIAL]` notice |
| prompt id + top-level error, or + `queued:false` | **failure**, marked `[UNCERTAIN]` |
| no prompt id | unchanged |

The first row is literally what ComfyUI returns from its partial path — `validate_prompt` keeps the good outputs, so the server answers 200 with `prompt_id` + `node_errors` and no `error` key. The `[PARTIAL]` notice names each dropped output, says the rest are executing, and says not to re-run or edit while a render is in flight. **Silence there would be the opposite error** — the caller would wait for a file that is never written.

The second row is a genuine contradiction: the panel's own refusals (the #556/#772 run-to-node race) arrive as a top-level error, and a prompt id there may be echoed from an earlier run. We can't tell which is true, so we assert neither — the failure carries `[UNCERTAIN]`, the prompt id, and "check the queue before re-running". Saying *refused* would be this bug in miniature; saying *queued* would park the caller on a render that may not exist.

## Verification

- Full suite **320 files / 6889 passed**; `tsc --noEmit` and `check:vocabulary` clean.
- **Mutation-verified**: dropping the prompt-id override kills the acceptance test; blanking the disclosure kills the end-to-end test; moving it after the anti-poll boilerplate kills it too.
- The first mutation pass found **no end-to-end coverage of the wiring** — deleting the append at the call site broke nothing visible, because every test called the helper directly. That test was added before the verification counted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)