### PR TITLE
fix(#945): a `git pull` that exits 0 is not proof the checkout moved

### DIFF
--- a/src/__tests__/services/update-comfyui.test.ts
+++ b/src/__tests__/services/update-comfyui.test.ts
@@ -205,8 +205,13 @@ describe("updateComfyUICore", () => {
       expect(r.updated).toBe(true);
       expect(r.comfyui_path).toBe("/fake/ComfyUI");
 
-      // First call is git pull in the comfyui path.
-      const gitCall = mockedExec.mock.calls.find((c) => c[0] === "git");
+      // `git pull` runs in the comfyui path. It is no longer the FIRST git call:
+      // #945 brackets the pull with read-only `rev-parse`/`symbolic-ref` probes,
+      // because a pull exiting 0 is not evidence that the checkout moved. Find
+      // the pull rather than assuming its position.
+      const gitCall = mockedExec.mock.calls.find(
+        (c) => c[0] === "git" && Array.isArray(c[1]) && c[1][0] === "pull",
+      );
       expect(gitCall).toBeDefined();
       expect(gitCall![1]).toEqual(["pull"]);
       expect(gitCall![2].cwd).toBe("/fake/ComfyUI");
@@ -219,6 +224,108 @@ describe("updateComfyUICore", () => {
       expect(pipCall![1]).toContain("install");
       expect(pipCall![1]).toContain("requirements.txt");
       expect(pipCall![0]).toMatch(/python/);
+    });
+  });
+
+  // #945 — the false success, end to end. The pure classifier is covered in
+  // update-core-verification.test.ts; these cover the WIRING, which is what
+  // actually reached the user: `updated: true` plus a requirements reinstall
+  // for a checkout that never moved.
+  describe("#945: a pull that moved nothing is not an update", () => {
+    /** Scripts the git probes; everything else answers "ok". */
+    const scriptGit = (probe: (args: string[]) => string | undefined) => {
+      mockedExists.mockImplementation((p: string) => {
+        if (p === "/fake/ComfyUI") return true;
+        if (p.endsWith("requirements.txt")) return true;
+        return false;
+      });
+      mockedExec.mockImplementation((file: string, args: string[]) => {
+        if (file === "uv" || file === "uv.exe") throw new Error("uv not found"); // force pip
+        if (file === "git") {
+          const out = probe(args);
+          if (out === undefined) throw new Error(`git ${args.join(" ")} failed`);
+          return out;
+        }
+        return "ok";
+      });
+    };
+    const pipCallsIn = (m: Mock) =>
+      m.mock.calls.filter((c) => Array.isArray(c[1]) && c[1].includes("-r"));
+
+    it("a DETACHED HEAD reports updated:false and skips the requirements reinstall", async () => {
+      scriptGit((args) => {
+        if (args[0] === "pull") return "Already up to date.";
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "dec5d945";
+        if (args[0] === "symbolic-ref") return undefined; // detached
+        return undefined; // no upstream either
+      });
+
+      const r = await updateComfyUICore();
+      expect(r.updated).toBe(false);
+      expect(r.message).toMatch(/was NOT updated/);
+      expect(r.message).toMatch(/DETACHED/);
+      expect(r.revision).toMatchObject({ before: "dec5d945", after: "dec5d945", branch: null });
+      // The part that made the lie convincing: it looked like work.
+      expect(pipCallsIn(mockedExec)).toHaveLength(0);
+      expect(r.message).toMatch(/requirements were NOT reinstalled/);
+    });
+
+    it("an upstream that is AHEAD reports updated:false and names both shas", async () => {
+      scriptGit((args) => {
+        if (args[0] === "pull") return "Already up to date.";
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "dec5d945aaaa";
+        if (args[0] === "symbolic-ref") return "master";
+        if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") return "origin/master";
+        if (args[0] === "rev-parse" && args[1] === "origin/master") return "2eb60796bbbb";
+        return undefined;
+      });
+
+      const r = await updateComfyUICore();
+      expect(r.updated).toBe(false);
+      expect(r.message).toContain("dec5d945");
+      expect(r.message).toContain("2eb60796");
+      expect(r.revision?.matches_upstream).toBe(false);
+      expect(pipCallsIn(mockedExec)).toHaveLength(0);
+    });
+
+    it("a HEAD that MOVED reports updated:true and does reinstall requirements", async () => {
+      let pulled = false;
+      scriptGit((args) => {
+        if (args[0] === "pull") {
+          pulled = true;
+          return "Updating dec5d94..2eb6079";
+        }
+        if (args[0] === "rev-parse" && args[1] === "HEAD") {
+          return pulled ? "2eb60796bbbb" : "dec5d945aaaa";
+        }
+        if (args[0] === "symbolic-ref") return "master";
+        if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") return "origin/master";
+        if (args[0] === "rev-parse" && args[1] === "origin/master") return "2eb60796bbbb";
+        return undefined;
+      });
+
+      const r = await updateComfyUICore();
+      expect(r.updated).toBe(true);
+      expect(r.message).toMatch(/dec5d945 → 2eb60796/);
+      expect(pipCallsIn(mockedExec).length).toBeGreaterThan(0);
+    });
+
+    it("HEAD already AT the upstream tip is a success, and says nothing was pulled", async () => {
+      scriptGit((args) => {
+        if (args[0] === "pull") return "Already up to date.";
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "2eb60796bbbb";
+        if (args[0] === "symbolic-ref") return "master";
+        if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") return "origin/master";
+        if (args[0] === "rev-parse" && args[1] === "origin/master") return "2eb60796bbbb";
+        return undefined;
+      });
+
+      const r = await updateComfyUICore();
+      expect(r.updated).toBe(true);
+      expect(r.message).toMatch(/nothing to pull/);
+      expect(r.revision?.matches_upstream).toBe(true);
+      // This IS a legitimate update call, so the dependency sync still runs.
+      expect(pipCallsIn(mockedExec).length).toBeGreaterThan(0);
     });
   });
 

--- a/src/__tests__/services/update-core-verification.test.ts
+++ b/src/__tests__/services/update-core-verification.test.ts
@@ -1,0 +1,163 @@
+// #945 — `git pull` exiting 0 is not evidence that anything moved.
+//
+// On a DETACHED HEAD — how Comfy Desktop's release-tag installs sit — `git pull`
+// prints "Already up to date." and exits 0 while moving nothing. The same happens
+// when `remote.origin.fetch` carries only a tag refspec, so `origin/master` is
+// never fetched and stays stale or absent.
+//
+// Both were reported as `updated: true`, and the Python requirements were then
+// reinstalled for a checkout that had not moved — which is what made the false
+// success convincing: it looked like work. The reporter's install stayed pinned
+// at v0.30.2 (dec5d945) while master had advanced to 2eb60976, and the tool said
+// it had updated.
+//
+// The rule under test: a sha that CHANGED proves an update. A sha that did not
+// change proves nothing on its own — it is "already current" only if it can be
+// shown equal to the upstream tip. Everything else reports NOT updated, with the
+// reason.
+
+import { describe, expect, it } from "vitest";
+import { classifyCoreUpdate } from "../../services/update-comfyui.js";
+
+const TAG_SHA = "dec5d9451111111111111111111111111111111a";
+const MASTER_SHA = "2eb607962222222222222222222222222222222b";
+
+describe("#945: a changed sha is the only self-sufficient proof", () => {
+  it("reports updated when HEAD moved", () => {
+    const v = classifyCoreUpdate({
+      before: TAG_SHA,
+      after: MASTER_SHA,
+      branch: "master",
+      upstream: "origin/master",
+      upstreamSha: MASTER_SHA,
+    });
+    expect(v.updated).toBe(true);
+    expect(v.blocker).toBeUndefined();
+  });
+
+  // A moved sha needs no corroboration — not even a readable upstream.
+  it("reports updated when HEAD moved even with nothing else knowable", () => {
+    expect(
+      classifyCoreUpdate({
+        before: TAG_SHA,
+        after: MASTER_SHA,
+        branch: null,
+        upstream: null,
+        upstreamSha: null,
+      }).updated,
+    ).toBe(true);
+  });
+});
+
+describe("#945: an unmoved sha is not a success", () => {
+  // THE reported case.
+  it("a detached HEAD is reported as NOT updated, with the reason and the remedy", () => {
+    const v = classifyCoreUpdate({
+      before: TAG_SHA,
+      after: TAG_SHA,
+      branch: null,
+      upstream: null,
+      upstreamSha: null,
+    });
+    expect(v.updated).toBe(false);
+    expect(v.blocker?.reason).toBe("detached");
+    expect(v.blocker?.message).toMatch(/DETACHED/);
+    expect(v.blocker?.message).toMatch(/Already up to date/);
+    expect(v.blocker?.message).toMatch(/git checkout master/);
+    // It must NOT offer to move the user's HEAD for them — a detached checkout
+    // may carry local edits, and switching branches is theirs to decide.
+    expect(v.blocker?.message).toMatch(/will not move your HEAD/);
+  });
+
+  it("a branch with no upstream is reported as NOT updated", () => {
+    const v = classifyCoreUpdate({
+      before: TAG_SHA,
+      after: TAG_SHA,
+      branch: "master",
+      upstream: null,
+      upstreamSha: null,
+    });
+    expect(v.updated).toBe(false);
+    expect(v.blocker?.reason).toBe("no-upstream");
+    expect(v.blocker?.message).toMatch(/--set-upstream-to=origin\/master/);
+  });
+
+  // The tag-only refspec: an upstream is configured but was never fetched, so
+  // its ref does not resolve. "I could not check" must not become "it is fine".
+  it("an unresolvable upstream is UNVERIFIABLE, not current", () => {
+    const v = classifyCoreUpdate({
+      before: TAG_SHA,
+      after: TAG_SHA,
+      branch: "master",
+      upstream: "origin/master",
+      upstreamSha: null,
+    });
+    expect(v.updated).toBe(false);
+    expect(v.blocker?.reason).toBe("unverifiable");
+    expect(v.matchesUpstream).toBeNull(); // null ≠ false: we did not check
+    expect(v.blocker?.message).toMatch(/only a tag refspec/);
+    expect(v.blocker?.message).toMatch(/remote\.origin\.fetch/);
+    expect(v.blocker?.message).toMatch(/\+refs\/heads\/master:refs\/remotes\/origin\/master/);
+  });
+
+  it("a resolvable upstream that is AHEAD is reported as not updated, with both shas", () => {
+    const v = classifyCoreUpdate({
+      before: TAG_SHA,
+      after: TAG_SHA,
+      branch: "master",
+      upstream: "origin/master",
+      upstreamSha: MASTER_SHA,
+    });
+    expect(v.updated).toBe(false);
+    expect(v.blocker?.reason).toBe("behind-upstream");
+    expect(v.matchesUpstream).toBe(false);
+    expect(v.blocker?.message).toContain("dec5d945");
+    expect(v.blocker?.message).toContain("2eb60796");
+    expect(v.blocker?.message).toMatch(/merge --ff-only origin\/master/);
+  });
+
+  it("an unreadable revision is UNKNOWN, never a success", () => {
+    const v = classifyCoreUpdate({
+      before: null,
+      after: null,
+      branch: null,
+      upstream: null,
+      upstreamSha: null,
+    });
+    expect(v.updated).toBe(false);
+    expect(v.blocker?.reason).toBe("unverifiable");
+    expect(v.blocker?.message).toMatch(/UNKNOWN/);
+  });
+});
+
+describe("#945: the one honest 'nothing to do'", () => {
+  it("HEAD proven equal to the upstream tip IS a success", () => {
+    const v = classifyCoreUpdate({
+      before: MASTER_SHA,
+      after: MASTER_SHA,
+      branch: "master",
+      upstream: "origin/master",
+      upstreamSha: MASTER_SHA,
+    });
+    expect(v.updated).toBe(true);
+    expect(v.matchesUpstream).toBe(true);
+    expect(v.blocker).toBeUndefined();
+  });
+
+  // The distinction that was missing: "already current" is only claimable when
+  // the upstream was actually READ. Without that read it is the detached/
+  // tag-refspec case, and those must not share this verdict.
+  it("is not reachable without a resolved upstream sha", () => {
+    for (const upstreamSha of [null, ""]) {
+      expect(
+        classifyCoreUpdate({
+          before: MASTER_SHA,
+          after: MASTER_SHA,
+          branch: "master",
+          upstream: "origin/master",
+          upstreamSha: upstreamSha as string | null,
+        }).updated,
+      ).toBe(false);
+    }
+  });
+});

--- a/src/services/update-comfyui.ts
+++ b/src/services/update-comfyui.ts
@@ -29,6 +29,25 @@ export interface UpdateCoreResult {
   package_manager: "uv" | "pip";
   steps: CommandResult[];
   message: string;
+  /** The checkout's git state before and after the pull (#945). Present
+   *  whenever it could be read; absent for a non-git install. */
+  revision?: {
+    before: string | null;
+    after: string | null;
+    /** Branch name, or null when HEAD is DETACHED (a release tag checkout). */
+    branch: string | null;
+    /** The configured upstream (e.g. "origin/master"), when there is one. */
+    upstream: string | null;
+    /** Whether `after` was proven equal to the upstream's tip. `null` = could
+     *  not be checked, which is NOT the same as false. */
+    matches_upstream: boolean | null;
+  };
+}
+
+/** Why a `git pull` that exited 0 nevertheless moved nothing (#945). */
+export interface CoreUpdateBlocker {
+  reason: "detached" | "no-upstream" | "behind-upstream" | "unverifiable";
+  message: string;
 }
 
 export interface UpdateNodesResult {
@@ -75,6 +94,146 @@ function runCommand(
       `Command failed: ${command}\n${out || e.message || "unknown error"}`,
     );
   }
+}
+
+/**
+ * Read-only git probe. Returns trimmed stdout, or null when the command fails
+ * for ANY reason — not a git repo, no upstream, an unknown ref. Never throws:
+ * these calls exist to describe the checkout, and a failed description must not
+ * take down the update itself.
+ */
+function gitProbe(args: string[], cwd: string): string | null {
+  try {
+    const out = execFileSync("git", args, {
+      cwd,
+      encoding: "utf-8",
+      timeout: 30_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const t = (out ?? "").trim();
+    return t === "" ? null : t;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decide whether `git pull` actually updated the checkout (#945).
+ *
+ * A `git pull` on a DETACHED HEAD — which is how Comfy Desktop's release-tag
+ * installs sit — prints "Already up to date." and exits 0 while moving nothing.
+ * The same happens when `remote.origin.fetch` carries only a tag refspec, so
+ * `origin/master` is never fetched and stays stale (or absent). Both were
+ * reported as `updated: true`, and the requirements were then reinstalled for a
+ * checkout that had not moved. The reporter's install stayed pinned at v0.30.2
+ * while master had advanced.
+ *
+ * The rule: a sha that CHANGED proves an update. A sha that did not change
+ * proves nothing on its own — it is only "already current" if it can be shown
+ * equal to the upstream tip. Everything else is reported as NOT updated, with
+ * the reason, because the alternative is the false success above.
+ */
+export function classifyCoreUpdate(state: {
+  before: string | null;
+  after: string | null;
+  branch: string | null;
+  upstream: string | null;
+  upstreamSha: string | null;
+}): { updated: boolean; matchesUpstream: boolean | null; blocker?: CoreUpdateBlocker } {
+  // The sha moved: the pull did something. Nothing else needs proving.
+  if (state.before && state.after && state.before !== state.after) {
+    return { updated: true, matchesUpstream: null };
+  }
+  // Not a git checkout at all (both probes failed) — say so rather than guess.
+  if (!state.after) {
+    return {
+      updated: false,
+      matchesUpstream: null,
+      blocker: {
+        reason: "unverifiable",
+        message:
+          "the ComfyUI directory's git revision could not be read, so whether the pull changed anything is UNKNOWN. " +
+          "If this is not a git checkout, `git pull` cannot update it at all — update through the installer you used.",
+      },
+    };
+  }
+
+  if (!state.branch) {
+    return {
+      updated: false,
+      matchesUpstream: null,
+      blocker: {
+        reason: "detached",
+        message:
+          "HEAD is DETACHED (a tag or bare commit, which is how release-tag and Comfy Desktop installs are set up), so " +
+          "`git pull` has no branch to fast-forward and reports \"Already up to date.\" without moving anything. " +
+          "Switch to a branch first, e.g. `git checkout master && git pull --ff-only`. " +
+          "Check for local edits before switching (`git status`) — this tool will not move your HEAD for you.",
+      },
+    };
+  }
+
+  if (!state.upstream) {
+    return {
+      updated: false,
+      matchesUpstream: null,
+      blocker: {
+        reason: "no-upstream",
+        message:
+          `branch "${state.branch}" has no upstream configured, so \`git pull\` has nothing to pull from and exits ` +
+          `without changing the checkout. Set one with \`git branch --set-upstream-to=origin/${state.branch} ${state.branch}\`.`,
+      },
+    };
+  }
+
+  // Upstream is configured but its tip is unreadable — classically a
+  // `remote.origin.fetch` that only carries `+refs/tags/*`, so the remote branch
+  // ref was never created locally. This is the reported install's exact shape.
+  if (!state.upstreamSha) {
+    return {
+      updated: false,
+      matchesUpstream: null,
+      blocker: {
+        reason: "unverifiable",
+        message:
+          `the upstream "${state.upstream}" could not be resolved locally, so there is no way to tell whether this ` +
+          `checkout is current. That usually means \`remote.origin.fetch\` carries only a tag refspec, so the remote ` +
+          `branch is never fetched. Check it with \`git config --get-all remote.origin.fetch\`, and add the branch ` +
+          `refspec if it is missing: \`git config --add remote.origin.fetch +refs/heads/${state.branch}:refs/remotes/origin/${state.branch}\`.`,
+      },
+    };
+  }
+
+  if (state.after === state.upstreamSha) {
+    // The one honest "nothing to do": proven equal to the upstream tip.
+    return { updated: true, matchesUpstream: true };
+  }
+
+  return {
+    updated: false,
+    matchesUpstream: false,
+    blocker: {
+      reason: "behind-upstream",
+      message:
+        `the pull exited cleanly but the checkout is still at ${state.after.slice(0, 8)} while ${state.upstream} is at ` +
+        `${state.upstreamSha.slice(0, 8)} — so it did NOT update. Fetch and fast-forward explicitly ` +
+        `(\`git fetch origin && git merge --ff-only ${state.upstream}\`) and check \`git status\` for local changes that block it.`,
+    },
+  };
+}
+
+/** Read the checkout's git state. Every field is best-effort and may be null. */
+function readGitState(cwd: string): {
+  head: string | null;
+  branch: string | null;
+  upstream: string | null;
+} {
+  return {
+    head: gitProbe(["rev-parse", "HEAD"], cwd),
+    // --quiet + --short: prints the branch name, fails (→ null) when detached.
+    branch: gitProbe(["symbolic-ref", "--quiet", "--short", "HEAD"], cwd),
+    upstream: gitProbe(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], cwd),
+  };
 }
 
 /**
@@ -157,8 +316,43 @@ export async function updateComfyUICore(): Promise<UpdateCoreResult> {
     pythonReason = ` ${resolved.reason}`;
   }
 
-  // 1. git pull the core repo.
+  // 1. git pull the core repo — bracketed by a revision read, because a pull
+  //    that exits 0 is NOT evidence that anything moved (#945).
+  const before = readGitState(comfyuiPath);
   steps.push(runCommand("git", ["pull"], comfyuiPath));
+  const after = readGitState(comfyuiPath);
+  const verdict = classifyCoreUpdate({
+    before: before.head,
+    after: after.head,
+    branch: after.branch,
+    upstream: after.upstream,
+    upstreamSha: after.upstream ? gitProbe(["rev-parse", after.upstream], comfyuiPath) : null,
+  });
+  const revision = {
+    before: before.head,
+    after: after.head,
+    branch: after.branch,
+    upstream: after.upstream,
+    matches_upstream: verdict.matchesUpstream,
+  };
+
+  // The checkout did not move and could not be shown to be current. Reinstalling
+  // requirements here is what made the old false success convincing — it looked
+  // like work. Stop before it and report the reason, so nothing is done in the
+  // name of an update that did not happen.
+  if (!verdict.updated) {
+    return {
+      updated: false,
+      comfyui_path: comfyuiPath,
+      package_manager: pm,
+      steps,
+      revision,
+      message:
+        `ComfyUI core was NOT updated in ${comfyuiPath}: ${verdict.blocker?.message ?? "the checkout did not change."} ` +
+        `\`git pull\` exited cleanly, which is why this used to be reported as a successful update — it is not one. ` +
+        `Python requirements were NOT reinstalled, because nothing changed that would need them.`,
+    };
+  }
 
   // 2. Reinstall requirements into the resolved interpreter's env (never this
   //    server's Python). requirements.txt lives in the repo root.
@@ -185,12 +379,19 @@ export async function updateComfyUICore(): Promise<UpdateCoreResult> {
     logger.warn(`No requirements.txt found at ${requirements}; skipping dependency install`);
   }
 
+  // Distinguish "moved" from "already at the upstream tip" — both are honest
+  // successes, but they are different facts and the caller may care which.
+  const moved = revision.before !== revision.after;
+  const what = moved
+    ? `updated ${String(revision.before).slice(0, 8)} → ${String(revision.after).slice(0, 8)}`
+    : `already at ${after.upstream} (${String(revision.after).slice(0, 8)}) — nothing to pull`;
   return {
     updated: true,
     comfyui_path: comfyuiPath,
     package_manager: pm,
     steps,
-    message: `ComfyUI core updated in ${comfyuiPath} using ${pm}.${pythonReason}`,
+    revision,
+    message: `ComfyUI core ${what} in ${comfyuiPath} using ${pm}.${pythonReason}`,
   };
 }
 


### PR DESCRIPTION
Closes #945

## The bug

On a **detached HEAD** — how Comfy Desktop's release-tag installs sit — `git pull` prints `Already up to date.` and exits 0 while moving nothing. The same happens when `remote.origin.fetch` carries only a tag refspec, so `origin/master` is never fetched and stays stale or absent.

`updated: true` was **hardcoded** in the return. Nothing compared the revision before and after.

The reporter's install stayed pinned at `v0.30.2` (`dec5d945`) while master had advanced to `2eb60976`, and the tool said it had updated — then reinstalled the Python requirements for the stale checkout. That's what made the false success convincing: **it looked like work.**

## The fix

A sha that **changed** proves an update. A sha that did not change proves nothing on its own — it is "already current" only when it can be shown equal to the upstream tip. Everything else reports **not updated**, with the reason and the exact command:

| Reason | Meaning |
|---|---|
| `detached` | HEAD is not on a branch, so there is nothing to fast-forward |
| `no-upstream` | the branch has no upstream to pull from |
| `behind-upstream` | the pull was clean but HEAD is still behind (both shas named) |
| `unverifiable` | the upstream ref does not resolve — usually the tag-only refspec — or the revision could not be read at all |

`unverifiable` is deliberately distinct from `behind-upstream`, and `matches_upstream` is `null` rather than `false` there: **we did not check**, which is not the same as having checked and found a mismatch.

On a non-update the requirements install is now **skipped, and said to be skipped**. Doing dependency work in the name of an update that did not happen is the part that sold the lie.

## What it deliberately does not do

It does **not repair** the checkout — no branch switch, no refspec write, no upstream set. That was the reporter's manual workaround, and a detached install may carry local edits (theirs did: a modified `server.py`). The tool reports and prescribes; moving someone's HEAD is theirs to decide.

## Verification

- 13 new tests (9 on the classifier, 4 end-to-end); full suite **321 files / 6912 passed**; `tsc --noEmit` and `check:vocabulary` clean.
- **Mutation-verified**: treating an unmoved sha as current kills 1; removing the detached-HEAD block kills 2; removing the requirements skip kills 2.
- As with #971, the first mutation pass had **no coverage of the wiring** — only the pure classifier, so removing the requirements skip broke nothing visible. The end-to-end tests were added before the verification counted.
- One pre-existing test asserted `git pull` was the *first* git call; it now finds the pull rather than assuming its position, since the pull is bracketed by read-only probes. Its intent (the pull runs in the ComfyUI path) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)