### PR TITLE
fix(#973): don't lead with an update when the disk version was never read

### DIFF
--- a/src/__tests__/services/panel-recovery-cluster.test.ts
+++ b/src/__tests__/services/panel-recovery-cluster.test.ts
@@ -2920,3 +2920,74 @@ describe("the panel's ComfyUI root is the RUNNING server's (#766, #769)", () => 
     expect(defaultDeps.comfyuiPath()).toBe(liveRoot);
   });
 });
+
+// #973 — the remedy that leads must be one the message can justify.
+//
+// The stale-bundle check returns a skew only on POSITIVE proof, and an
+// unreadable on-disk version resolves to "no skew". That then fell through to
+// "Run install_comfyui(action:'panel', panel_action:'update')" — correct when the install really is behind, wrong
+// when it is already current, and this branch cannot tell which. A reporter
+// followed it, found their pack was already at origin/main HEAD running 0.11.41,
+// and had spent a round trip on an update that could not have helped (#950/#973).
+//
+// The check already re-primes the panel base in the background so a retry can
+// answer definitively — so the fix is to SAY the disk version is unconfirmed and
+// put the two free checks first, not to guess a cause.
+describe("#973: an unconfirmed disk version does not get an update-first remedy", () => {
+  const ctx = {
+    installPanelUsable: true,
+    comfyuiPath: "/comfy",
+    blocker: undefined,
+  } as unknown as Parameters<typeof describePanelUpdateRecovery>[0];
+
+  it("discloses that the on-disk version was not read", () => {
+    const text = describePanelUpdateRecovery(ctx, undefined, true);
+    expect(text).toMatch(/could not be read just now/);
+    expect(text).toMatch(/UNCONFIRMED/);
+  });
+
+  it("puts the two free checks BEFORE the update", () => {
+    const text = describePanelUpdateRecovery(ctx, undefined, true);
+    const retryAt = text.search(/RETRY this command/);
+    const refreshAt = text.search(/HARD-REFRESH/);
+    const updateAt = text.search(/panel_action:'update'/);
+    expect(retryAt).toBeGreaterThan(-1);
+    expect(refreshAt).toBeGreaterThan(-1);
+    expect(updateAt).toBeGreaterThan(-1);
+    expect(retryAt).toBeLessThan(updateAt);
+    expect(refreshAt).toBeLessThan(updateAt);
+  });
+
+  // The update is still the right answer when the install genuinely IS behind,
+  // so it must remain present — demoted, not deleted.
+  it("still names the update as the remedy when the install really is behind", () => {
+    const text = describePanelUpdateRecovery(ctx, undefined, true);
+    expect(text).toMatch(/If it is genuinely behind/);
+    expect(text).toMatch(/panel_action:'update'/);
+  });
+
+  // The default path is untouched: a CONFIRMED-behind install still leads with
+  // the update, with no hedging that would make a real problem look optional.
+  it("says none of this when the disk version WAS read", () => {
+    const text = describePanelUpdateRecovery(ctx, undefined, false);
+    expect(text).not.toMatch(/UNCONFIRMED/);
+    expect(text).not.toMatch(/RETRY this command/);
+    expect(text.trimStart().startsWith("Run install_comfyui")).toBe(true);
+  });
+
+  // A PROVEN skew still outranks everything — that branch already leads with
+  // "do not update" and must not be diluted by the unconfirmed wording.
+  it("a proven skew still wins over the unconfirmed prefix", () => {
+    const text = describePanelUpdateRecovery(
+      ctx,
+      {
+        diskVersion: "0.11.41",
+        requiredVersion: "0.11.35",
+        handshakeVersion: "0.11.20",
+      } as never,
+      true,
+    );
+    expect(text).toMatch(/Do NOT update the panel/);
+    expect(text).not.toMatch(/UNCONFIRMED/);
+  });
+});

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2482,6 +2482,49 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     }
   });
 
+  // #973 — the third state, and the one the reporter landed in. The skew check
+  // proves a stale bundle only when it can READ the pack's on-disk version; when
+  // it cannot, it proved nothing — and the fall-through led with
+  // "Run install_comfyui(action:'panel', panel_action:'update')" anyway. The reporter followed that, found their
+  // pack was already at origin/main HEAD running 0.11.41, and had spent a round
+  // trip on an update that could not have helped.
+  it("an UNREADABLE disk version leads with the two free checks, not with an update", async () => {
+    // No pack on disk at all → verifiedPanelDiskVersion() answers nothing, which
+    // is exactly the state that used to be indistinguishable from "behind".
+    clearPanelDiskObservation();
+    const unknown = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      unknown.on("open", () => {
+        unknown.send(JSON.stringify({ type: "hello", tab_id: "disk-unknown", title: "wf" }));
+        res();
+      });
+      unknown.on("error", rej);
+    });
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "disk-unknown")).toBe(true),
+    );
+    const err = await bridge
+      .send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "disk-unknown" })
+      .catch((e: Error) => e);
+    const msg = (err as Error).message;
+
+    // It must SAY it could not check, rather than implying an answer.
+    expect(msg).toMatch(/UNCONFIRMED/);
+    expect(msg).toMatch(/could not be read just now/);
+    // …and the two costless checks must come before the remedy that has a cost.
+    expect(msg.search(/RETRY this command/)).toBeLessThan(
+      msg.search(/panel_action:'update'/),
+    );
+    expect(msg.search(/HARD-REFRESH/)).toBeLessThan(msg.search(/panel_action:'update'/));
+    // The update is DEMOTED, not deleted — it is still right when the install
+    // really is behind, and this branch cannot rule that out either.
+    expect(msg).toMatch(/If it is genuinely behind/);
+    expect(msg).toMatch(/panel_action:'update'/);
+    // The gate itself is unchanged: the write is still refused.
+    expect(isCapabilityRefusal(err as Error)).toBe(true);
+    unknown.close();
+  });
+
   it("an install that is genuinely BEHIND still gets the update remedy, never a refresh", async () => {
     // The guard on the branch above: a stale-install user must not be told their
     // install is fine. Only a disk version at or above the floor earns the

--- a/src/services/panel-recovery.ts
+++ b/src/services/panel-recovery.ts
@@ -293,6 +293,21 @@ const COMPACT_ROUTER_FALLBACK = (action: string): string =>
 export function describePanelUpdateRecovery(
   ctx: PanelRecoveryContext = panelRecoveryContext(),
   skew?: PanelBundleSkew,
+  /**
+   * #973 — set when the stale-bundle check could not read the pack's ON-DISK
+   * version at all, so it proved nothing either way.
+   *
+   * The skew check returns a skew only on positive proof, and an unreadable disk
+   * version resolves to "no skew" — which then falls through to "Run
+   * install_comfyui(action:'panel', panel_action:'update')". That fall-through is right when the install is
+   * genuinely behind and WRONG when it is already current, and this branch
+   * cannot tell which. A reporter followed it, found their pack was already at
+   * origin/main HEAD, and had spent a round trip on an update that could not
+   * have helped. Leading with an unproven remedy is the thing to fix; the check
+   * itself already re-reads the base in the background, so the cheap move is to
+   * say so and let one retry answer properly.
+   */
+  diskVersionUnconfirmed = false,
 ): string {
   // STALE BUNDLE FIRST. When the caller has PROVEN the pack on disk already
   // satisfies the requirement, no update of any kind is the answer — not
@@ -355,9 +370,24 @@ export function describePanelUpdateRecovery(
     );
   }
 
+  // #973 — the on-disk version could not be read, so "your install is behind" is
+  // NOT established and must not lead. Two remedies are live and one of them is
+  // free, so name the free one first and keep the update as the fallback it is.
+  // (The check re-primes the panel base in the background precisely so a retry
+  // can answer this properly, which is why retrying is the first suggestion.)
+  const unconfirmedPrefix = diskVersionUnconfirmed
+    ? `NOTE: the panel version ON DISK could not be read just now, so whether the install is ` +
+      `actually behind is UNCONFIRMED — an already-current pack behind a stale cached browser ` +
+      `tab looks identical from here. Two cheap checks before updating anything: (1) RETRY this ` +
+      `command once — the disk version is being re-read in the background and a retry usually ` +
+      `answers definitively; (2) HARD-REFRESH the ComfyUI tab (Ctrl+Shift+R, Cmd+Shift+R on ` +
+      `macOS), which costs nothing and fixes it outright if the tab is the stale part. ` +
+      `If it is genuinely behind: `
+    : "";
+
   if (ctx.installPanelUsable) {
     return (
-      `Run install_comfyui(action:'panel', panel_action:'update'). ${COMPACT_ROUTER_FALLBACK("update")} ` +
+      `${unconfirmedPrefix}Run install_comfyui(action:'panel', panel_action:'update'). ${COMPACT_ROUTER_FALLBACK("update")} ` +
       `If neither route exists on this surface, update the pack on the ComfyUI host: ` +
       // No trailing period: every caller of this function appends its own
       // sentence break, and adding one here rendered ".." to the user.
@@ -365,7 +395,7 @@ export function describePanelUpdateRecovery(
     );
   }
   return (
-    `Update the panel ON THE COMFYUI HOST — ${blockerPhrase(ctx.blocker)}. On the host ` +
+    `${unconfirmedPrefix}Update the panel ON THE COMFYUI HOST — ${blockerPhrase(ctx.blocker)}. On the host ` +
     `run: ${manualPanelUpdateCommands(ctx.comfyuiPath)}. Then ${RESTART_AND_REFRESH}`
   );
 }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -491,7 +491,9 @@ export function requiredPanelVersionForWorkflowFence(): string | undefined {
  *  never `conn.panelVersion` raw, which is inherited across an omitted-version
  *  reconnect. Reasoning about an inherited value here would let a previous
  *  connection's reading decide whether the CURRENT tab is the stale part. */
-function resolveStaleBundleSkew(panelVersion?: string): PanelBundleSkew | undefined {
+function resolveStaleBundleSkew(
+  panelVersion?: string,
+): PanelBundleSkew | { diskVersionUnconfirmed: true } | undefined {
   const disk = verifiedPanelDiskVersion()?.trim();
   if (!disk) {
     // Could not confirm — most often because the live-base resolution has gone
@@ -499,7 +501,11 @@ function resolveStaleBundleSkew(panelVersion?: string): PanelBundleSkew | undefi
     // the background (never awaited; building an error message must not block on
     // I/O) so a retry, which agents reliably make, can answer properly.
     void primePanelBase().catch(() => {});
-    return undefined;
+    // #973 — but say so. Returning a bare `undefined` here is indistinguishable
+    // from "checked, and the install really is behind", and the recovery text
+    // then leads with an update this branch never established was needed. The
+    // reporter followed exactly that and found their pack already current.
+    return { diskVersionUnconfirmed: true };
   }
   // THE FENCE's floor, not the aggregate requiredPanelVersion() (codex gate).
   // This function answers one question — "is the install sufficient for the
@@ -3302,9 +3308,13 @@ export class UiBridge {
         const reading = connPanelVersionReading(conn);
         const rawAdvertised = reading.raw;
         const advertised = reading.version;
+        const skewReading = resolveStaleBundleSkew(advertised);
+        const unconfirmed =
+          skewReading != null && "diskVersionUnconfirmed" in skewReading;
         const recovery = describePanelUpdateRecovery(
           undefined,
-          resolveStaleBundleSkew(advertised),
+          unconfirmed ? undefined : (skewReading as PanelBundleSkew | undefined),
+          unconfirmed,
         );
         // #819/#823 — do not fold an ABSENT reading into a definite verdict.
         // "detected panel version unknown; this MCP requires panel 0.11.35+"


### PR DESCRIPTION
Closes #973

## The bug

The stale-bundle check returns a skew only on **positive proof** — it re-reads the pack's `pyproject.toml` at the moment of use, and any unknown resolves to "no skew". That part is right.

What was wrong is what happened next: "no skew" fell through to *"Run `install_comfyui(action:'panel', panel_action:'update')`"* — correct when the install is genuinely behind, **wrong when it is already current**, and that branch cannot tell which.

A reporter followed it. Their pack was a clean checkout at `origin/main` HEAD running **0.11.41** — comfortably above the 0.11.35 floor — and the stale copy was the JS bundle in an already-open ComfyUI browser tab. The prescribed remedy could not have worked, and they spent a round trip finding that out.

## The fix

An unreadable disk version now says so, and puts the two **free** checks first:

> NOTE: the panel version ON DISK could not be read just now, so whether the install is actually behind is UNCONFIRMED — an already-current pack behind a stale cached browser tab looks identical from here. Two cheap checks before updating anything: (1) RETRY this command once — the disk version is being re-read in the background and a retry usually answers definitively; (2) HARD-REFRESH the ComfyUI tab (Ctrl+Shift+R, Cmd+Shift+R on macOS), which costs nothing and fixes it outright if the tab is the stale part. **If it is genuinely behind:** …

The retry suggestion isn't filler — the check already re-primes the panel base in the background *precisely* so a retry can answer definitively. It just never told anyone.

The update is **demoted, not deleted**. It is still right when the install really is behind, and this branch cannot rule that out either.

## Deliberately unchanged

- A **proven** skew still outranks everything and still leads with "Do NOT update the panel". Diluting that branch with hedging would undo #819/#823.
- A **confirmed-behind** install still leads with the update, with no hedging that would make a real problem look optional.
- **The gate itself is untouched.** The write is still refused; only the diagnosis attached to it changed.

## Provenance

Split out of #950, which turned out to be **already fixed in 0.50.0** (the #824 work — I found that by implementing it and breaking eight of its tests, then reverting). This was the half of that report still live.

## Verification

- 6 new tests (5 unit, 1 end-to-end through the real refusal path); full suite **321 files / 6918 passed**; `tsc --noEmit` clean.
- **Mutation-verified**: suppressing the prefix kills 3 tests; making the resolver report a bare `undefined` again kills the end-to-end one.
- That end-to-end test was added *after* the first mutation pass showed the wiring was uncovered — the **third time in a row this session** that a helper was tested and its call site was not.
- `check:vocabulary` caught `install_panel` (retired in 0.50.0) in three of this change's own comments — third catch this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)