### PR TITLE
fix(panel-fence): an untrusted hello must not ERASE the tab command stamp (panel #689/#688/#607/#702)

### DIFF
--- a/src/__tests__/orchestrator/hello-stamp-retention.test.ts
+++ b/src/__tests__/orchestrator/hello-stamp-retention.test.ts
@@ -1,0 +1,84 @@
+// #689/#688/#607/#702 — the panel wedges "workflow instance mismatch" on EVERY
+// command (including panel_list_workflows) after a reconnect or workflow switch,
+// and neither panel_open_workflow nor panel_set_workflow_target({mode:"current"})
+// clears it.
+//
+// The wedge is not a STALE stamp, it is an ABSENT one. The hello handler used to
+// DELETE the tab's command stamp whenever it could not derive a trusted identity
+// from the hello (`workflowIdentityParts` returns undefined when the uuid is
+// missing/malformed OR the server-observed origin is empty — a reconnect hello
+// that lands before the canvas identity is readable carries no uuid). With no
+// stamp, UiBridge sends frames with no `workflow_uuid` at all, and the panel
+// counts an unstamped command as a mismatch too (#718, deliberately fail-closed).
+// So erasing the stamp does not relax the fence — it refuses HARDER, across
+// everything the fence covers.
+//
+// The two outcomes are asymmetric in RECOVERABILITY, which is what made this
+// permanent: a stale stamp is replaced by the next hello that does resolve an
+// identity, while an absent one is not, because the panel's re-advertise repair
+// is capped (MISMATCH_REHELLO_MAX_PER_IDENTITY = 3) per identity. Once those are
+// spent against an orchestrator that still cannot derive an identity, nothing
+// retries and the tab is refused for the rest of the session.
+//
+// Retaining is SAFE, and that is the load-bearing claim these tests defend: the
+// panel authorizes a fenced command IFF stamp === the live active workflow uuid,
+// so a retained stamp can only ever authorize a command naming the canvas that
+// is actually mounted. It permits no write a correct stamp would not permit.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { workflowIdentityParts } from "../../orchestrator/session-store.js";
+
+const indexSrc = (): string =>
+  readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf8");
+
+/** The hello handler's identity block, isolated so the assertions below cannot be
+ *  satisfied (or broken) by an unrelated `tabCommandWorkflowUuid` site elsewhere
+ *  in the file — notably the legitimate migration `delete(migratedFrom)`. */
+function helloIdentityBlock(src: string): string {
+  const anchor = src.indexOf("if (newIdentity) {");
+  expect(anchor, "the hello handler's identity block must still exist").toBeGreaterThan(-1);
+  return src.slice(anchor, anchor + 400);
+}
+
+describe("an untrusted hello RETAINS the tab's command stamp (#689)", () => {
+  it("SOURCE: the untrusted branch does not delete the stamp", () => {
+    const block = helloIdentityBlock(indexSrc());
+    // A trusted identity still records the stamp — the fix must not have turned
+    // the setter off, only the eraser.
+    expect(block).toContain("tabCommandWorkflowUuid.set(panelTab, newIdentity.uuid);");
+    // The regression itself. `delete(panelTab)` here is what converts a
+    // recoverable stale stamp into an unrecoverable absent one.
+    expect(
+      block.includes("tabCommandWorkflowUuid.delete(panelTab)"),
+      "an untrusted hello must NOT erase the stamp — that is the #689 wedge",
+    ).toBe(false);
+  });
+
+  it("the identity that triggers the untrusted branch is reachable from a real reconnect hello", () => {
+    // Not a hypothetical branch: these are the exact inputs a reconnect produces.
+    const origin = "http://127.0.0.1:8188";
+    const uuid = "33333333-3333-4333-8333-333333333333";
+
+    // A hello that lands before the canvas identity is readable carries no uuid.
+    expect(workflowIdentityParts({ workflowUuid: undefined, origin })).toBeUndefined();
+    expect(workflowIdentityParts({ workflowUuid: "", origin })).toBeUndefined();
+    // …and one whose server-observed origin is not resolvable is untrusted too.
+    expect(workflowIdentityParts({ workflowUuid: uuid, origin: undefined })).toBeUndefined();
+    expect(workflowIdentityParts({ workflowUuid: uuid, origin: "" })).toBeUndefined();
+    // A fully-formed hello IS trusted — otherwise the branch above would be the
+    // only one ever taken and the test would prove nothing about untrusted input.
+    expect(workflowIdentityParts({ workflowUuid: uuid, origin })).toEqual({
+      origin,
+      uuid,
+    });
+  });
+
+  it("SOURCE: the migration path's own delete is untouched — only the untrusted-hello eraser goes", () => {
+    // #436's `delete(migratedFrom)` retires the PREVIOUS tab id's stamp on a
+    // proven workflow change. That is a different decision (a tab id going away)
+    // and must survive this fix; deleting it here would be an unrelated
+    // behavioural change smuggled in on the same line of reasoning.
+    expect(indexSrc()).toContain("tabCommandWorkflowUuid.delete(migratedFrom);");
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3422,12 +3422,38 @@ export async function runPanelOrchestrator(): Promise<void> {
 
       // Record this tab's trusted per-workflow COMMAND STAMP (#570 P0c — a
       // ROUTING fence kept under #884: a late command issued for another
-      // workflow must not mutate this one). Absent/untrusted → cleared: the
-      // graph-mutation fence then fails closed for this tab.
+      // workflow must not mutate this one).
+      //
+      // #689/#688/#607/#702 — an untrusted identity RETAINS the previous stamp
+      // instead of deleting it. Deleting looks like the conservative choice and
+      // is in fact the strictly worse one, because the two outcomes are not
+      // symmetric:
+      //
+      //   • The panel authorizes a fenced command IFF stamp === the LIVE active
+      //     workflow uuid. So a RETAINED stamp can only ever authorize a command
+      //     that names the canvas actually mounted right now — if the workflow
+      //     changed, it mismatches and is refused exactly as before. Retaining
+      //     therefore permits no write that a correct stamp would not permit.
+      //   • A DELETED stamp makes UiBridge send frames with no `workflow_uuid`
+      //     at all (`else delete frame.workflow_uuid`), and the panel counts an
+      //     unstamped command as a mismatch too (#718, deliberately fail-closed).
+      //     So deleting does not relax the fence — it refuses HARDER, and it
+      //     refuses everything the fence covers, including `workflow_list`.
+      //
+      // The asymmetry is that a stale stamp is RECOVERABLE (the next hello that
+      // does resolve an identity replaces it) while an absent one is not: the
+      // panel's re-advertise repair is capped at MISMATCH_REHELLO_MAX_PER_IDENTITY
+      // (3) per identity, so once those attempts are spent against an orchestrator
+      // that still cannot derive an identity, nothing retries and every command is
+      // refused permanently. A reconnect hello that lands before the canvas
+      // identity is readable carries no uuid, which is enough to erase the stamp
+      // and wedge the tab for the rest of the session.
+      //
+      // Untrusted identity therefore means "no NEW evidence", not "the previous
+      // evidence is now false". Keep what we last proved and let the fence judge
+      // it on equality, which is the only test that decides authorization.
       if (newIdentity) {
         tabCommandWorkflowUuid.set(panelTab, newIdentity.uuid);
-      } else {
-        tabCommandWorkflowUuid.delete(panelTab);
       }
       // Blind content mode rides the hello (issue #90) so the FIRST agent spawn
       // already carries the right tool-server env. A CHANGE against a live


### PR DESCRIPTION
Four independent live reports — panel #689, #688, #607, #702 — are one defect. The panel refuses **every** command with `workflow instance mismatch` after a reconnect or workflow switch, including `panel_list_workflows`, and neither `panel_open_workflow` nor `panel_set_workflow_target({mode:"current"})` clears it.

## The wedge is an ABSENT stamp, not a stale one

The hello handler deleted the tab's command stamp whenever it could not derive a trusted identity:

```ts
if (newIdentity) { tabCommandWorkflowUuid.set(panelTab, newIdentity.uuid); }
else { tabCommandWorkflowUuid.delete(panelTab); }   // ← removed
```

`workflowIdentityParts` returns `undefined` when the uuid is missing/malformed **or** the server-observed origin is empty — and a reconnect hello that lands before the canvas identity is readable carries no uuid. So the reconnect itself erases the stamp.

With no stamp, `UiBridge` sends frames with no `workflow_uuid` at all (`else delete frame.workflow_uuid`), and the panel counts an unstamped command as a mismatch too (#718, deliberately fail-closed). **Erasing did not relax the fence — it refused harder**, across everything the fence covers. That is why even `panel_list_workflows` was gated: it is fenced by design ("workflow_list reports the ACTIVE workflow — a stale-stamped call must not answer for the wrong tab").

## Why it was permanent rather than self-healing

The two outcomes differ in *recoverability*. A stale stamp is replaced by the next hello that does resolve an identity. An absent one is not: the panel's re-advertise repair (#607) is capped at `MISMATCH_REHELLO_MAX_PER_IDENTITY = 3` per identity. Once those attempts are spent against an orchestrator that still cannot derive an identity, nothing retries and the tab is refused for the rest of the session.

## Why retaining is safe

The load-bearing claim: **the panel authorizes a fenced command IFF `stamp === the live active workflow uuid`.** So a retained stamp can only ever authorize a command naming the canvas actually mounted right now. It permits no write that a correct stamp would not permit — if the workflow changed, the retained stamp mismatches and is refused exactly as before. An untrusted hello means "no NEW evidence", not "the previous evidence is now false".

This also makes the hello path consistent with the **refresh** path, which already retains on untrusted input — `#716`'s test asserts *"a malformed/late response cannot erase or replace the established stamp."* Same situation, opposite behaviour, now aligned.

`delete(migratedFrom)` on the migration path is a different decision (a tab id going away) and is deliberately untouched — pinned by a test so it cannot be removed as collateral.

## Verification

- New `hello-stamp-retention.test.ts` — 3 tests: the source pin, proof that the untrusted branch is reachable from real reconnect inputs (not a hypothetical), and the migration-delete pin.
- **Mutation-verified**: restoring `delete(panelTab)` fails the pin (`an untrusted hello must NOT erase the stamp`); removing the mutation restores green. My first mutation attempt applied 0 replacements (CRLF), so that pass was discarded and redone.
- `tsc --noEmit` clean; **full suite 322 files / 6921 passed**, no regressions.
- Control-byte scan clean on both changed files; no binary files in `--numstat`.
- No tool-surface change, so the vocabulary ratchet is untouched.

## Not claimed

This removes the mechanism that makes the wedge permanent. Whether it closes every reporter's case needs confirmation on a released build — per the standing rule the four issues stay **open** until someone confirms there.

Refs artokun/comfyui-mcp-panel#689, artokun/comfyui-mcp-panel#688, artokun/comfyui-mcp-panel#607, artokun/comfyui-mcp-panel#702

🤖 Generated with [Claude Code](https://claude.com/claude-code)