### PR TITLE
0.50.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.2] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- a remote listing is incomplete BY CONSTRUCTION — say so, on every result (#975)
+- don't lead with an update when the disk version was never read (#974)
+- a `git pull` that exits 0 is not proof the checkout moved (#972)
+- a minted prompt_id is a receipt, not a flag (#971)
+- a run is owned by the conversation that queued it, not by the tab id (#969)
+- stop letting "fetch failed" stand in for a diagnosis (#968)
+- stop reporting an unread model list as an empty install (#967)
+- map live-canvas widgets by NAME, and disclose when we can't (#966)
+- publish the admission surface, and stop conflating "excluded" with "unknown" (#965)
+- detect panel/server vocabulary skew at the handshake, not at call time (#964)
+
+
 ## [0.50.1] - 2026-08-06
 
 Ten fixes on top of the 0.50.0 consolidation, and most of them are one defect class:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.1",
+  "version": "0.50.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.1",
+      "version": "0.50.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.1",
+  "version": "0.50.2",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **0.50.2**, reconciling the release commit onto protected `main` (the tag `v0.50.2` is already pushed and publishing).

Ten fixes, every one a correctness fix on a tool that was reporting something untrue.

### The theme

Nine of the ten are the same defect class pointed at different tools: **a check that could not establish something, reporting it as established.** In both directions —

- **False absence:** `list_local_models` printing "No local models found" when ComfyUI never answered (#967); `list_outputs` returning a confident listing that omits every VHS video by construction (#975).
- **False failure:** `panel_run` reporting "ComfyUI refused to queue" for a render already executing (#971); `install_panel`'s version-floor refusal prescribing an update when the disk was already current (#974).
- **False success:** `update_comfyui` returning `updated: true` for a `git pull` that moved nothing (#972).
- **Wrong data, silently:** `panel_strip_workflow` mapping widget values by position against a different order, swapping model filenames without an error anywhere (#966).

### Contents

| PR | Fix |
|---|---|
| #975 | remote output listings are incomplete by construction — say so on every result |
| #974 | don't lead with an update when the disk version was never read |
| #972 | a `git pull` that exits 0 is not proof the checkout moved |
| #971 | a minted `prompt_id` is a receipt, not a flag |
| #969 | a run is owned by the conversation that queued it, not by the tab id |
| #968 | stop letting "fetch failed" stand in for a diagnosis |
| #967 | stop reporting an unread model list as an empty install |
| #966 | map live-canvas widgets by NAME, and disclose when we can't |
| #965 | publish the admission surface; "excluded" ≠ "unknown" |
| #964 | detect panel/server vocabulary skew at the handshake, not at call time |

Closes #961, #955, #361, #918, #954, #944, #945, #953, #973, #704, #908.

### Verification

Full suite **321 files / 6922 passed** on `main` at `f97b4d6`, with `tsc`, `lint`, `build`, `check:vocabulary`, `vocab:export --check` and the `docs:gen` no-op gate all clean. Every fix in this release was mutation-verified before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)