### PR TITLE
test(#980): stop betting on 25ms to decide when the abort lands

### DIFF
--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -184,11 +184,23 @@ describe("downloadModel cache", () => {
   it("#515: aborting mid-stream rejects and never finalizes the target (integrity preserved)", async () => {
     // A body that emits one chunk then STALLS forever, so we can abort it mid-transfer.
     let cancelled = false;
+    // #980 — the abort used to fire on a 25 ms timer, which is a BET that the
+    // pipeline has attached to the body and entered pull() first. On a loaded
+    // macOS runner that bet loses: the abort lands before anything reads the
+    // stream, the transfer rejects without ever cancelling the body, and
+    // `cancelled` stays false. The download behaviour was fine every time — only
+    // the corroborating observation raced — but it took main red intermittently,
+    // which costs more than the assertion is worth. Wait for the EVENT instead.
+    let sawFirstPull!: () => void;
+    const firstPull = new Promise<void>((resolve) => {
+      sawFirstPull = resolve;
+    });
     const body = new ReadableStream<Uint8Array>({
       start(c) {
         c.enqueue(new TextEncoder().encode("partial-bytes-on-disk"));
       },
       pull() {
+        sawFirstPull(); // the pipeline IS reading — safe to abort now
         return new Promise<void>(() => {}); // never resolves — the stream stalls
       },
       cancel() {
@@ -213,8 +225,9 @@ describe("downloadModel cache", () => {
       undefined,
       controller.signal,
     );
-    // Let the stream begin, then abort it.
-    await new Promise((r) => setTimeout(r, 25));
+    // Deterministic: block until the pipeline has actually pulled from the body,
+    // then abort. No wall-clock bet, so runner load cannot change the outcome.
+    await firstPull;
     controller.abort();
 
     // The transfer rejects (aborted) — it is NOT reported as a successful download.


### PR DESCRIPTION
Closes #980

## The flake

`#515: aborting mid-stream` aborted on a wall-clock timer and then asserted the body's `cancel()` had fired:

```js
await new Promise((r) => setTimeout(r, 25));
controller.abort();
await expect(p).rejects.toThrow();
expect(cancelled).toBe(true);   // ← lost the race
```

That 25 ms is a bet that the pipeline attached to the stream and entered `pull()` first. On a loaded macOS runner the bet loses: the abort lands before anything reads the body, the transfer rejects without cancelling it, and `cancelled` stays `false`.

**The download behaviour was correct every time** — the first assertion (`rejects.toThrow()`) passed even in the failing run. Only the corroborating observation raced.

## Why fix it rather than shrug

It took `main` red at `4f2a24f` while ubuntu and windows passed in the same run, and the next commit passed on all three with the test untouched. An intermittently red main costs more than that one assertion is worth: it trains readers to discount CI, which weakens the signal for every other change.

## The fix

Wait on the **event**. The stream resolves a promise from its own `pull()`, so the abort fires only once the pipeline is provably reading:

```js
await firstPull;
controller.abort();
```

No timer, so runner load cannot change the outcome.

## Verification

A test that stops flaking by becoming vacuous is worse than the flake, so this was checked in both directions:

| Mutation | Result |
|---|---|
| `cancel()` no longer records itself | test **fails** → the assertion kept its teeth |
| delete the `await firstPull` | test **fails, the same way it failed on macOS** → the wait is load-bearing |

The second one matters most: it *reproduces* the diagnosed race rather than merely being consistent with it.

Ran the file five times locally, clean each time. Full suite **6925 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)