### PR TITLE
fix(#941): a painted card is not a loaded image

### DIFF
--- a/src/__tests__/orchestrator/panel-show-media-oversized.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-oversized.test.ts
@@ -9,7 +9,7 @@
 // MAX_BYTES is NOT raised, and these tests would not notice if it were; the
 // oversized fixtures are real files above the cap.
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -328,5 +328,55 @@ describe("panel_show_media: the other outcomes stay distinct", () => {
     const { res } = await showMedia([{ source: { path: "relative/clip.mp4" } }]);
     expect(res.isError).toBe(true);
     expect(textOf(res)).toContain("must be absolute");
+  });
+});
+
+// #941 — a /view reference forwarded to a BROWSER panel comes back described as
+// painted, and the reporter's eight painted cards were eight broken images on a
+// proxied remote ComfyUI. The panel's count is honest about the card; nothing
+// in the chain knows whether the browser's own /view fetch succeeded.
+//
+// These cover the WIRING: the note has to reach the reply. The note's own
+// wording is pinned in comfy-view-ref.test.ts.
+describe("#941: a forwarded /view reference says what 'painted' does not cover", () => {
+  const ref = { source: { filename: "a.png", subfolder: "final", type: "output" } };
+
+  beforeEach(() => {
+    // No probe response — fetch is not stubbed here, so every probe throws and
+    // is (correctly) not counted. The caveat must stand on its own regardless.
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("no network in test")));
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("appends the caveat when an item goes as a reference", async () => {
+    const { res } = await showMedia([ref]);
+    const t = textOf(res);
+    expect(t).toMatch(/NOT that the media loaded/);
+    expect(t).toMatch(/browser fetches \/view itself/);
+    expect(t).toContain("a.png");
+  });
+
+  it("still forwards the reference — the caveat replaces nothing", async () => {
+    const { calls } = await showMedia([ref]);
+    const items = calls[0]?.items as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ kind: "viewRef" });
+  });
+
+  // An inlined local path is verified bytes; hedging it would make a
+  // trustworthy result look doubtful.
+  it("says nothing for an item that was inlined from a local path", async () => {
+    const small = join(outDir, "small.png");
+    writeFileSync(small, Buffer.alloc(64));
+    const { res } = await showMedia([{ source: { path: small } }]);
+    expect(textOf(res)).not.toMatch(/NOT that the media loaded/);
+  });
+
+  it("an unreachable probe is not counted as a check", async () => {
+    const { res } = await showMedia([ref]);
+    // Every probe threw, so there is no evidence sentence to print…
+    expect(textOf(res)).not.toMatch(/Checked from HERE/);
+    // …but the caveat itself is unconditional.
+    expect(textOf(res)).toMatch(/renders BROKEN/);
   });
 });

--- a/src/__tests__/services/comfy-view-ref.test.ts
+++ b/src/__tests__/services/comfy-view-ref.test.ts
@@ -75,6 +75,7 @@ const {
   resolveServableViewRef,
   oversizedInlineRefusal,
   forwardedByReferenceNote,
+  unverifiedViewRefNote,
 } = await import("../../services/comfy-view-ref.js");
 
 let root: string;
@@ -451,5 +452,71 @@ describe("forwardedByReferenceNote", () => {
       20 * 1024 * 1024,
     );
     expect(vid).toContain("never sent to you inline");
+  });
+});
+
+// #941 — panel_show_media handed a browser panel eight ComfyUI /view references
+// and replied {"ok":true,"count":8,"painted":8,"unconfirmed":0} over eight
+// BROKEN image cards. The count was honest about what the PANEL did — it made
+// eight cards — and silent about the thing the caller cares about: the browser
+// fetches /view itself, AFTER that reply, and a proxied remote ComfyUI answering
+// HTML breaks every card with no error anywhere in the chain.
+describe("unverifiedViewRefNote (#941)", () => {
+  const refs = [
+    { filename: "a.png", subfolder: "final", type: "output" },
+    { filename: "b.png", type: "output" },
+  ];
+
+  it("says nothing when nothing was forwarded by reference", () => {
+    expect(unverifiedViewRefNote([])).toBe("");
+  });
+
+  it("separates what the panel established from what it did not", () => {
+    const note = unverifiedViewRefNote(refs);
+    expect(note).toMatch(/NOT that the media loaded/);
+    expect(note).toMatch(/browser fetches \/view itself/);
+    expect(note).toMatch(/renders BROKEN and nothing reports an error/);
+    expect(note).toContain("a.png");
+    expect(note).toContain('subfolder "final"');
+  });
+
+  it("names the remedy, and says not to re-send the same reference", () => {
+    const note = unverifiedViewRefNote(refs);
+    expect(note).toMatch(/do not re-send the same reference/i);
+    expect(note).toMatch(/absolute LOCAL path/);
+  });
+
+  // A probe from the orchestrator is EVIDENCE, not proof: this process asks its
+  // own COMFYUI_URL while the browser asks the origin its tab is on, and those
+  // are allowed to differ (#952). Overstating it here would be the same defect
+  // the note exists to fix, one layer up.
+  it("reports a failed probe as strong evidence, never as proof", () => {
+    const note = unverifiedViewRefNote(refs, {
+      checked: 2,
+      nonMedia: [{ filename: "a.png", detail: 'content-type "text/html"' }],
+    });
+    expect(note).toMatch(/1 of the 2 probed did NOT return media/);
+    expect(note).toContain('a.png → content-type "text/html"');
+    expect(note).toMatch(/strong evidence rather than proof/);
+    expect(note).toMatch(/not necessarily the origin the browser tab is on/);
+  });
+
+  it("a clean probe does not become a guarantee either", () => {
+    const note = unverifiedViewRefNote(refs, { checked: 2, nonMedia: [] });
+    expect(note).toMatch(/all 2 probed returned media/);
+    // …and still refuses to certify the browser's side.
+    expect(note).toMatch(/does not rule out the browser tab reaching a DIFFERENT ComfyUI/);
+  });
+
+  it("omits probe wording entirely when nothing could be probed", () => {
+    const note = unverifiedViewRefNote(refs, { checked: 0, nonMedia: [] });
+    expect(note).not.toMatch(/Checked from HERE/);
+  });
+
+  it("caps the listing so a large batch cannot flood the reply", () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({ filename: `f${i}.png`, type: "output" }));
+    const note = unverifiedViewRefNote(many);
+    expect(note).toMatch(/…and 4 more/);
+    expect(note).not.toContain("f11.png");
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -31,7 +31,10 @@ import {
   forwardedByReferenceNote,
   oversizedInlineRefusal,
   resolveServableViewRef,
+  unverifiedViewRefNote,
   type ForwardedByReference,
+  type UnverifiedViewRef,
+  type ViewRefProbe,
 } from "../services/comfy-view-ref.js";
 import { extname, isAbsolute, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9312,6 +9315,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         const resolved: Array<Record<string, unknown>> = [];
         /** Oversized items that took the /view reference route instead (#648). */
         const forwarded: ForwardedByReference[] = [];
+        // #941 — /view references handed to a BROWSER panel, whose rendering this
+        // process never observes. Collected so the reply can say what "painted"
+        // does and does not establish.
+        const unverifiedRefs: UnverifiedViewRef[] = [];
         for (const item of items) {
           const src = item.source;
           if ("path" in src) {
@@ -9462,6 +9469,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 filename: src.filename,
                 caption: item.caption,
               });
+              // #941 — the panel will report this as painted, meaning it made a
+              // card. Whether the IMAGE loads is decided later, by the browser's
+              // own /view fetch, and a proxied ComfyUI answering HTML breaks it
+              // with no error anywhere. Remember the ref so the reply can say so.
+              unverifiedRefs.push({
+                filename: src.filename,
+                subfolder: src.subfolder,
+                type: src.type,
+              });
             }
           }
         }
@@ -9475,6 +9491,40 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           res.content.push({
             type: "text",
             text: forwardedByReferenceNote(forwarded, MAX_BYTES),
+          });
+        }
+        // #941 — a forwarded /view reference is DISPATCHED, not displayed. Probe a
+        // bounded sample from here so the note can carry evidence instead of only
+        // a caveat; the probe is best-effort and never affects the result.
+        if (unverifiedRefs.length > 0 && !res.isError) {
+          const probe: ViewRefProbe = { checked: 0, nonMedia: [] };
+          const base = (process.env.COMFYUI_URL ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+          for (const ref of unverifiedRefs.slice(0, 3)) {
+            try {
+              const qs = new URLSearchParams({ filename: ref.filename, type: ref.type ?? "output" });
+              if (ref.subfolder) qs.set("subfolder", ref.subfolder);
+              const resp = await comfyuiFetch(`${base}/view?${qs.toString()}`, {
+                method: "HEAD",
+                signal: AbortSignal.timeout(4000),
+              });
+              probe.checked++;
+              const mime = resp.headers.get("content-type") ?? "";
+              if (!resp.ok) {
+                probe.nonMedia.push({ filename: ref.filename, detail: `HTTP ${resp.status}` });
+              } else if (!mime.startsWith("image/") && !mime.startsWith("video/")) {
+                probe.nonMedia.push({
+                  filename: ref.filename,
+                  detail: `content-type "${mime || "unset"}"`,
+                });
+              }
+            } catch {
+              // An unreachable /view from HERE says nothing reliable about the
+              // browser's origin, so it is simply not counted as checked.
+            }
+          }
+          res.content.push({
+            type: "text",
+            text: unverifiedViewRefNote(unverifiedRefs, probe),
           });
         }
         return res;

--- a/src/services/comfy-view-ref.ts
+++ b/src/services/comfy-view-ref.ts
@@ -450,3 +450,68 @@ export function forwardedByReferenceNote(
     howToSee
   );
 }
+
+/** A ComfyUI /view reference handed to a BROWSER panel without being verified. */
+export type UnverifiedViewRef = { filename: string; subfolder?: string; type?: string };
+
+/** What an orchestrator-side probe of /view found, when one was run. */
+export type ViewRefProbe = {
+  /** How many refs were probed (bounded — this is a diagnostic, not a sweep). */
+  checked: number;
+  /** Refs whose /view answered with something that is not media. */
+  nonMedia: { filename: string; detail: string }[];
+};
+
+/**
+ * The caveat a forwarded /view reference has to carry (#941).
+ *
+ * `panel_show_media` hands a browser panel a reference and the panel replies
+ * `painted: N, unconfirmed: 0`. That count is honest about what the PANEL did —
+ * it created N cards — and silent about the thing the caller cares about: the
+ * browser fetches `/view` itself, AFTER the reply, and if that fetch returns
+ * HTML the card renders broken with no error anywhere in the chain. A reporter
+ * saw `{"ok":true,"count":8,"painted":8,"unconfirmed":0}` over eight broken
+ * images on a proxied remote ComfyUI.
+ *
+ * Note what this deliberately does NOT do: inline bytes from a local workspace
+ * "mirror" when the target is REMOTE. Same-named files on a different machine
+ * are not the same files, and painting a stale local image while reporting
+ * success would replace a visibly broken card with an invisibly wrong one —
+ * strictly worse (the #877/#899 hazard).
+ */
+export function unverifiedViewRefNote(
+  refs: UnverifiedViewRef[],
+  probe?: ViewRefProbe,
+): string {
+  if (refs.length === 0) return "";
+  const one = refs.length === 1;
+  const lines = refs
+    .slice(0, 8)
+    .map((r) => `  - ${r.filename}${r.subfolder ? ` (subfolder "${r.subfolder}")` : ""}`)
+    .join("\n");
+  const more = refs.length > 8 ? `\n  - …and ${refs.length - 8} more` : "";
+
+  // A probe result is EVIDENCE, not proof: this process asks its own
+  // COMFYUI_URL, while the browser asks the origin its tab is on, and those two
+  // are allowed to differ (#952). Say which one was tested.
+  const evidence =
+    probe && probe.nonMedia.length > 0
+      ? `\nChecked from HERE: ${probe.nonMedia.length} of the ${probe.checked} probed did NOT return media ` +
+        `(${probe.nonMedia.map((n) => `${n.filename} → ${n.detail}`).join("; ")}). ` +
+        `That is this orchestrator's ComfyUI target, not necessarily the origin the browser tab is on, ` +
+        `so treat it as strong evidence rather than proof.`
+      : probe && probe.checked > 0
+        ? `\nChecked from HERE: all ${probe.checked} probed returned media, so the reference itself looks fine — ` +
+          `which does not rule out the browser tab reaching a DIFFERENT ComfyUI than this orchestrator does.`
+        : "";
+
+  return (
+    `NOTE — ${one ? "1 item was" : `${refs.length} items were`} sent to the panel as a ComfyUI /view REFERENCE, ` +
+    `not as inline bytes:\n${lines}${more}\n` +
+    `A "painted" count above means the panel created ${one ? "that card" : "those cards"} — NOT that the media loaded. ` +
+    `The browser fetches /view itself, after that reply, and when it gets HTML instead of an image (a proxied or ` +
+    `remote ComfyUI, an auth wall, an expired session) the card renders BROKEN and nothing reports an error.${evidence}\n` +
+    `If the user says the image is broken, do not re-send the same reference — pass an absolute LOCAL path instead, ` +
+    `which is verified and inlined as bytes.`
+  );
+}


### PR DESCRIPTION
Closes #941

## The bug

`panel_show_media` hands a browser panel a ComfyUI `/view` reference and the panel replies:

```json
{"ok":true,"count":8,"painted":8,"unconfirmed":0}
```

That count is honest about what the **panel** did — it made eight cards — and silent about the thing the caller cares about: **the browser fetches `/view` itself, after that reply.** On a proxied remote ComfyUI that answers HTML there, every card renders broken.

The reporter watched eight broken images while the tool reported a clean success. Their user had to tell them.

## The fix

A forwarded reference is **dispatched, not displayed**, and this process never observes the render. The reply now says what `painted` covers, why a proxied/remote `/view` breaks it silently, and the remedy — pass an absolute local path, which is verified and inlined as bytes.

An item that **was** inlined from a local path gets none of this. Hedging verified bytes would make a trustworthy result look doubtful.

It also probes a bounded sample (3 refs, `HEAD`, 4 s) so the note can carry evidence rather than only a caveat. The probe is best-effort and never affects the result, and its wording is careful in the way #952 taught — this process asks its own `COMFYUI_URL` while the browser asks the origin its tab is on, and **those are allowed to differ**:

| Probe outcome | What the note says |
|---|---|
| non-media | "strong evidence rather than proof" — and names which target was tested |
| all media | "does not rule out the browser tab reaching a DIFFERENT ComfyUI" |
| unreachable | not counted as a check at all; the caveat stands alone |

## Why the reporter's patch was not adopted

Their fix inlines bytes from the local workspace *mirror* when a viewRef is forwarded. On a **remote** target that mirror is a **different machine's files** — a same-named local file would be painted as if it were the remote one, replacing a visibly broken card with an invisibly wrong image. That's the #877/#899 hazard, and it is strictly worse than the bug.

Their diagnosis was right, and their instinct — inline verified bytes — is exactly what the local-path route already does. It's only the remote case where the local disk cannot stand in for the target.

## Verification

- 7 new unit tests + 4 end-to-end; full suite **321 files / 6933 passed**; `tsc`, `check:vocabulary`, `docs:gen` no-op all clean.
- **Mutation-verified in both classes**: blanking the note text and never recording the refs each kill the two end-to-end tests; the note's own wording is pinned separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)