### PR TITLE
fix(#934): two different tabs must not render identically

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -1957,6 +1957,31 @@ describe("panel-tools: session tabId self-heal (#322 reload / #331 workflow-swit
     expect(sent.at(-1)?.tabId).toBe("new-live-tab");
   });
 
+  // #934 — the note above used `.slice(0, 8)`, which renders EVERY
+  // `wf:workflows/…` tab as the literal "wf:workf". The reporter read
+  // "Rebound this session from tab wf:workf onto the active tab wf:workf"
+  // during a wedge whose entire question was whether the retarget had done
+  // anything — a real rebind between two different workflows, described as a
+  // no-op. Two different tabs must not render identically.
+  it("names workflow-keyed tabs distinguishably in the rebind note", async () => {
+    const store = new WorkflowTargetStore();
+    const from = "wf:workflows/Untitled 2026-08-06 03-58-41.json";
+    const onto = "wf:workflows/portrait-v3.json";
+    // The defect, stated: these are indistinguishable under the old rendering.
+    expect(from.slice(0, 8)).toBe(onto.slice(0, 8));
+
+    const { bridge } = fakeBridge(new Set([onto]));
+    const ctx = makePanelToolCtx(bridge, from, store);
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain("Rebound this session");
+    expect(text).toContain("portrait-v3.json");
+    expect(text).toContain("Untitled 2026-08-06 03-58-41.json");
+    // …and the collapsed rendering is gone.
+    expect(text).not.toContain("from tab wf:workf onto the active tab wf:workf");
+  });
+
   // ---- Auto-heal: an orphaned current-mode session self-recovers on the next
   // panel_* call, WITHOUT an explicit panel_set_workflow_target (#372/#178/#170/
   // #165/#166/#195). Conservative: only when the current tab is unreachable AND a

--- a/src/__tests__/services/session-scope.test.ts
+++ b/src/__tests__/services/session-scope.test.ts
@@ -12,6 +12,7 @@ import {
   shouldRetireSharedAgent,
   messageOrigin,
   workflowOriginNote,
+  shortTabId,
 } from "../../services/session-scope.js";
 
 describe("shared session scope (#884)", () => {
@@ -112,5 +113,57 @@ describe("shared session scope (#884)", () => {
       });
       expect(note).not.toBeNull();
     });
+  });
+});
+
+// #934 — two DIFFERENT tabs rendered identically, in the middle of a wedge whose
+// entire question was whether anything had changed.
+//
+// Tab ids come in two shapes. A browser tab is a uuid, where slice(0, 8) is a
+// fine abbreviation. A workflow-keyed tab is `wf:workflows/<name>.json`, and
+// there slice(0, 8) yields the literal "wf:workf" for EVERY workflow — so
+// panel_set_workflow_target reported "Rebound this session from tab wf:workf
+// onto the active tab wf:workf" for a rebind between two different workflows,
+// which reads as a no-op and told the reporter nothing.
+describe("shortTabId (#934)", () => {
+  const UUID = "3f7a1c2e-9b4d-4e5f-8a01-7c6d5e4f3a2b";
+
+  it("keeps the uuid behaviour — 8 hex chars separate any two live tabs", () => {
+    expect(shortTabId(UUID)).toBe("3f7a1c2e");
+  });
+
+  // THE bug: the old rendering collapsed the entire workflows/ namespace.
+  it("distinguishes two workflow tabs that used to render identically", () => {
+    const a = "wf:workflows/Untitled 2026-08-06 03-58-41.json";
+    const b = "wf:workflows/portrait-v3.json";
+    expect(a.slice(0, 8)).toBe(b.slice(0, 8)); // the defect, stated
+    expect(shortTabId(a)).not.toBe(shortTabId(b));
+    expect(shortTabId(b)).toBe("wf:portrait-v3.json");
+  });
+
+  it("keeps the part that varies — the filename, not the shared directory", () => {
+    expect(shortTabId("wf:workflows/deep/nested/clip.json")).toBe("wf:clip.json");
+    // Windows separators too: a tab id can carry either. (The backslashes are
+    // escaped — "\d" and "\c" are not escape sequences, so an unescaped fixture
+    // silently becomes "workflowsdeepclip.json" and tests nothing.)
+    expect(shortTabId("wf:workflows\\deep\\clip.json")).toBe("wf:clip.json");
+  });
+
+  it("stays bounded for an absurdly long name, keeping the END", () => {
+    const long = `wf:workflows/${"x".repeat(120)}-final.json`;
+    const out = shortTabId(long);
+    expect(out.length).toBeLessThanOrEqual(44);
+    // The tail is what disambiguates a set of same-prefixed names.
+    expect(out.endsWith("-final.json")).toBe(true);
+    expect(out).toContain("…");
+  });
+
+  it("does not throw on the empty / missing cases", () => {
+    // A missing id renders as empty rather than the string "undefined" — this
+    // goes into agent-facing prose, where the word "undefined" reads as a value.
+    expect(shortTabId("")).toBe("");
+    expect(shortTabId(undefined)).toBe("");
+    expect(shortTabId(null)).toBe("");
+    expect(shortTabId("wf:")).toBe("wf:");
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -46,7 +46,7 @@ import { parse as parseYaml } from "yaml";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UiBridge } from "../services/ui-bridge.js";
-import { conversationOfScopeAddress, isScopeAddress } from "../services/session-scope.js";
+import { conversationOfScopeAddress, isScopeAddress, shortTabId } from "../services/session-scope.js";
 
 /** #884 — journal TICKETS (run completions #468, ask answers #486) must be
  *  keyed by the REAL tab a run/card was routed to: the panel reports back under
@@ -7838,7 +7838,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // Detect the rebind regardless of whether awaitReachable or rebindToActiveTab
           // performed it (either mutates ctx.tabId), so the note is never swallowed.
           if (!deferredBind && ctx.tabId !== before) {
-            rebindNote = ` Rebound this session from tab ${before.slice(0, 8)} onto the active tab ${ctx.tabId.slice(0, 8)}.`;
+            // #934 — `.slice(0, 8)` renders EVERY `wf:workflows/…` tab as the
+            // literal "wf:workf", so this note read "Rebound this session from
+            // tab wf:workf onto the active tab wf:workf" for a rebind between two
+            // DIFFERENT workflows. In the middle of a wedge whose entire question
+            // was whether the retarget did anything, it read as a no-op.
+            rebindNote = ` Rebound this session from tab ${shortTabId(before)} onto the active tab ${shortTabId(ctx.tabId)}.`;
           }
         }
         // PIN: bind to the EXACT open-workflow identity from the authoritative

--- a/src/services/session-scope.ts
+++ b/src/services/session-scope.ts
@@ -152,3 +152,33 @@ export function workflowOriginNote(opts: {
     `the conversation itself continues (one session spans all open workflows).]`
   );
 }
+
+/**
+ * A SHORT, still-DISTINGUISHING rendering of a tab id (#934).
+ *
+ * Tab ids come in two shapes. A browser tab is a uuid, where `.slice(0, 8)` is a
+ * fine abbreviation — eight hex chars separate any two tabs you are likely to
+ * hold at once. A workflow-keyed tab is `wf:<path>`, and there `.slice(0, 8)`
+ * yields the literal string `wf:workf` for EVERY workflow under `workflows/`.
+ *
+ * That is how panel_set_workflow_target came to report
+ *
+ *     Rebound this session from tab wf:workf onto the active tab wf:workf
+ *
+ * for a rebind between two different workflows: the note read as a no-op, in the
+ * middle of a wedge whose whole question was whether the retarget had done
+ * anything. Two different tabs must not render identically.
+ *
+ * So: keep the uuid behaviour, and for a `wf:` id keep the part that actually
+ * varies — the tail of the path, which carries the filename.
+ */
+export function shortTabId(id: string | undefined | null): string {
+  if (!id) return String(id ?? "");
+  if (!id.startsWith("wf:")) return id.slice(0, 8);
+  const path = id.slice(3);
+  // The basename is what distinguishes two workflow tabs; the directory prefix
+  // is shared by all of them and is exactly what the old slice kept.
+  const base = path.split(/[/\\]/).pop() || path;
+  const MAX = 40;
+  return `wf:${base.length > MAX ? `…${base.slice(-MAX)}` : base}`;
+}


### PR DESCRIPTION
Refs #934, #933

## The bug

`.slice(0, 8)` is a fine abbreviation for a uuid tab id. For a workflow-keyed one — `wf:workflows/<name>.json` — it yields the literal string **`wf:workf`** for every workflow under `workflows/`.

So `panel_set_workflow_target` reported:

```
Rebound this session from tab wf:workf onto the active tab wf:workf
```

…for a rebind between two **different** workflows. The reporter read that during a wedge whose entire question was *whether the retarget had done anything*, and it read as a no-op — the tool describing real work as if nothing had happened.

## The fix

`shortTabId` keeps the uuid behaviour and, for a `wf:` id, keeps the part that actually varies — the basename. Bounded at 40 chars keeping the **end**, because a set of same-prefixed names is disambiguated by its tail. A missing id renders empty rather than the string `"undefined"`, which reads as a value in prose.

```
wf:workflows/Untitled 2026-08-06 03-58-41.json  →  wf:Untitled 2026-08-06 03-58-41.json
wf:workflows/portrait-v3.json                   →  wf:portrait-v3.json
3f7a1c2e-9b4d-…                                 →  3f7a1c2e   (unchanged)
```

## Scope — this fixes one of the four defects in #934

| # | Defect | Status |
|---|---|---|
| 2 | tab ids truncated to `wf:workf` | **fixed here** |
| 1 | `mode:'current'` reports success with no tab connected | **not fixed** — the `deferredBind` branch exists and is correct, so the question is why `awaitReachable`/`rebindToActiveTab` resolved against a tab that wasn't connected. I could not establish that from the report alone. |
| 3 | `panel_list_workflows` gated by the instance guard | **panel-side** |
| 4 | mismatch guard doesn't consult connectivity first | **panel-side** |

3 and 4 are not in this repo: `workflow instance mismatch` is emitted by `comfyui-mcp-panel.js` (lines 1859 and 13166). They need a panel change.

There are ~88 further `.slice(0, 8)` sites on tab/key values, nearly all in `logger` calls. Left alone deliberately — a blind sweep would also catch ask ids, prompt ids and shas, where 8 chars **is** correct. The agent-facing site is the one that misled a reporter.

## Verification

- 5 new unit tests + 1 end-to-end; full suite **6928 passed**; `tsc` and `check:vocabulary` clean.
- **Mutation-verified in both classes**: reverting the helper to a plain slice kills 3 unit tests; reverting the **call site** kills the end-to-end one. The call-site mutation killed nothing on the first pass — fourth time this session — so that test was added before the verification counted.
- Two of my own fixtures were caught by their own assertions: a Windows path written `"wf:workflows\deep\clip.json"` loses its separators (`\d` and `\c` are not escapes), and `shortTabId(undefined)` returns `""` not `"undefined"`. Same class as the `"C:\Comfy\output"` fixture fixed in #975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)