### PR TITLE
fix(#946): a path in `filename` is a subfolder request, not a broken upload

### DIFF
--- a/src/__tests__/comfyui/upload-subfolder-wiring.test.ts
+++ b/src/__tests__/comfyui/upload-subfolder-wiring.test.ts
@@ -1,0 +1,107 @@
+// #946 — the WIRING half. `splitUploadTarget`'s own rules are pinned in
+// upload-subfolder.test.ts; these prove `uploadImageHttp` actually USES it: the
+// multipart filename carries the bare name and the subfolder rides in the form
+// field ComfyUI's /upload/image reads. Without this, deleting the split at the
+// call site breaks nothing visible.
+//
+// Also pins the second defect: a non-JSON body must not surface as a raw
+// `Unexpected non-whitespace character after JSON at position 4`, which is
+// exactly what the reporter got — a parser message in place of a diagnosis.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
+  return {
+    ...actual,
+    isCloudMode: () => false,
+    getComfyUIApiHost: () => "127.0.0.1:8188",
+  };
+});
+
+const fetchApi = vi.fn();
+vi.mock("@stable-canvas/comfyui-client", () => ({
+  Client: class {
+    fetchApi = fetchApi;
+    close() {}
+  },
+}));
+
+const { uploadImageHttp } = await import("../../comfyui/client.js");
+
+/** The FormData the last upload sent. */
+function sentForm(): FormData {
+  const init = fetchApi.mock.calls.at(-1)?.[1] as { body?: unknown } | undefined;
+  return init?.body as FormData;
+}
+
+const okJson = (obj: unknown) =>
+  new Response(JSON.stringify(obj), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+beforeEach(() => fetchApi.mockReset());
+afterEach(() => vi.clearAllMocks());
+
+describe("#946: uploadImageHttp sends the subfolder as its own field", () => {
+  it("splits a path filename — bare name in the part, subfolder in the field", async () => {
+    fetchApi.mockResolvedValue(okJson({ name: "clip.mp4", subfolder: "assets", type: "input" }));
+    await uploadImageHttp("assets/clip.mp4", Buffer.from("x"), "video/mp4");
+
+    const form = sentForm();
+    expect(form.get("subfolder")).toBe("assets");
+    // The multipart part's own filename must be the BARE name — sending the
+    // whole path there is what produced the reported failure.
+    const part = form.get("image") as File;
+    expect(part.name).toBe("clip.mp4");
+    expect(fetchApi.mock.calls.at(-1)?.[0]).toBe("/upload/image");
+  });
+
+  it("sends NO subfolder field for a plain filename (unchanged behaviour)", async () => {
+    fetchApi.mockResolvedValue(okJson({ name: "clip.mp4", subfolder: "", type: "input" }));
+    await uploadImageHttp("clip.mp4", Buffer.from("x"), "video/mp4");
+    expect(sentForm().has("subfolder")).toBe(false);
+    expect((sentForm().get("image") as File).name).toBe("clip.mp4");
+  });
+
+  it("refuses a traversal before anything is sent", async () => {
+    await expect(uploadImageHttp("../escape.png", Buffer.from("x"))).rejects.toThrow(
+      /walks outside/,
+    );
+    expect(fetchApi).not.toHaveBeenCalled();
+  });
+});
+
+describe("#946: a non-JSON upload reply is diagnosed, not parsed at the caller", () => {
+  it("does not surface a bare JSON parser message", async () => {
+    // A proxy or a still-starting server answering 200 with HTML. The old
+    // res.json() gave the reporter "Unexpected non-whitespace character after
+    // JSON at position 4" and nothing else.
+    fetchApi.mockResolvedValue(
+      new Response("<!doctype html><html>login</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+    const err = await uploadImageHttp("clip.mp4", Buffer.from("x")).catch((e: Error) => e);
+    const msg = String((err as Error).message);
+    expect(msg).not.toMatch(/Unexpected non-whitespace character/);
+    expect(msg).not.toMatch(/Unexpected token/);
+    // It names what was asked for instead.
+    expect(msg).toMatch(/upload\/image/);
+  });
+
+  it("still rejects a JSON body of the wrong shape rather than returning it", async () => {
+    fetchApi.mockResolvedValue(okJson({ error: "nope" }));
+    await expect(uploadImageHttp("clip.mp4", Buffer.from("x"))).rejects.toThrow();
+  });
+
+  it("passes a well-formed reply straight through", async () => {
+    fetchApi.mockResolvedValue(okJson({ name: "clip.mp4", subfolder: "assets", type: "input" }));
+    await expect(uploadImageHttp("assets/clip.mp4", Buffer.from("x"))).resolves.toMatchObject({
+      name: "clip.mp4",
+      subfolder: "assets",
+    });
+  });
+});

--- a/src/__tests__/comfyui/upload-subfolder.test.ts
+++ b/src/__tests__/comfyui/upload-subfolder.test.ts
@@ -1,0 +1,94 @@
+// #946 — a `filename` carrying a path was neither uploaded nor refused.
+//
+// `upload_image` accepts a `filename` override on both its image and
+// action:"video" forms (the report predates the 0.50.0 fold, which is why it
+// names the video upload as a separate tool). A caller who
+// wants the file in a subfolder of ComfyUI's input/ writes it the obvious way:
+// "assets/clip.mp4". That whole string went into the multipart filename, and the
+// call came back as a bare
+//
+//     Unexpected non-whitespace character after JSON at position 4
+//
+// — no upload, and a parser message in place of a diagnosis. The same call with
+// the slash removed succeeded, which is what makes it a real report rather than
+// a general "slashes break things": `source_path` is full of slashes and is fine.
+//
+// ComfyUI's /upload/image has a `subfolder` FORM FIELD for exactly this. Two
+// separate defects, so two sets of tests: the split (send the field the API has)
+// and the parse (never let a parser message stand in for a diagnosis).
+
+import { describe, expect, it } from "vitest";
+import { splitUploadTarget } from "../../comfyui/client.js";
+import { ValidationError } from "../../utils/errors.js";
+
+describe("#946: a path in `filename` is a subfolder request", () => {
+  it("leaves a bare filename alone", () => {
+    expect(splitUploadTarget("clip.mp4")).toEqual({ subfolder: "", name: "clip.mp4" });
+  });
+
+  it("splits the reported case into the two fields ComfyUI actually takes", () => {
+    expect(splitUploadTarget("assets/clip.mp4")).toEqual({
+      subfolder: "assets",
+      name: "clip.mp4",
+    });
+  });
+
+  it("handles a nested subfolder", () => {
+    expect(splitUploadTarget("a/b/c/clip.mp4")).toEqual({ subfolder: "a/b/c", name: "clip.mp4" });
+  });
+
+  // A caller on Windows writes it with backslashes; the reporter was on Windows 11.
+  it("treats backslashes as separators too", () => {
+    expect(splitUploadTarget("assets\\clip.mp4")).toEqual({
+      subfolder: "assets",
+      name: "clip.mp4",
+    });
+    expect(splitUploadTarget("a\\b/c.png")).toEqual({ subfolder: "a/b", name: "c.png" });
+  });
+
+  it("collapses redundant separators and '.' segments", () => {
+    expect(splitUploadTarget("assets//./clip.mp4")).toEqual({
+      subfolder: "assets",
+      name: "clip.mp4",
+    });
+  });
+});
+
+describe("#946: traversal is refused, never sanitised", () => {
+  // Rewriting "../../x.png" into something safe would upload to a place the
+  // caller did not name and then report the name they asked for — a wrong answer
+  // dressed as a right one. Refuse and say why.
+  it("refuses a subfolder that walks upwards", () => {
+    expect(() => splitUploadTarget("../escape.png")).toThrow(ValidationError);
+    expect(() => splitUploadTarget("a/../../escape.png")).toThrow(/walks outside/);
+  });
+
+  it("refuses a value that names no file", () => {
+    expect(() => splitUploadTarget("assets/")).toThrow(/does not name a file/);
+    expect(() => splitUploadTarget("")).toThrow(/does not name a file/);
+    expect(() => splitUploadTarget("..")).toThrow(/does not name a file/);
+  });
+
+  it("names the accepted shape in the refusal, so the caller can act", () => {
+    let msg = "";
+    try {
+      splitUploadTarget("../x.png");
+    } catch (e) {
+      msg = e instanceof Error ? e.message : String(e);
+    }
+    expect(msg).toContain("assets/clip.mp4");
+    expect(msg).toContain("..");
+  });
+
+  // A leading separator is an absolute-looking path; it must not silently become
+  // a relative one that lands somewhere plausible.
+  it("does not turn a rooted path into a quietly different destination", () => {
+    // "/assets/clip.mp4" has no upward segment, so it is accepted — but as the
+    // subfolder "assets", which is the only reading ComfyUI's field supports.
+    // Pinned so the behaviour is a decision rather than an accident.
+    expect(splitUploadTarget("/assets/clip.mp4")).toEqual({
+      subfolder: "assets",
+      name: "clip.mp4",
+    });
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -8,11 +8,17 @@ import {
   isRemoteMode,
 } from "../config.js";
 import { logger } from "../utils/logger.js";
-import { ComfyUIError, ConnectionError, WorkflowExecutionError } from "../utils/errors.js";
+import {
+  ComfyUIError,
+  ConnectionError,
+  ValidationError,
+  WorkflowExecutionError,
+} from "../utils/errors.js";
 import { comfyuiFetch } from "./fetch.js";
 import {
   fetchComfyJson,
   looksLikeHtmlParsedAsJson,
+  readComfyJson,
   redactErrorMessage,
   rethrowWithJsonDiagnosis,
 } from "./json-guard.js";
@@ -794,11 +800,20 @@ export async function uploadImageHttp(
 ): Promise<{ name: string; subfolder: string; type: string }> {
   if (isCloudMode()) return cloudClient.uploadImageHttp(filename, data, mimeType);
   const client = getClient();
+  // #946 — a `filename` carrying a path ("assets/clip.mp4") is a SUBFOLDER
+  // request, and ComfyUI's /upload/image takes that as its own form field, not
+  // as a slash inside the multipart filename. Sending the whole path as the
+  // filename put it somewhere between the transport and ComfyUI's handler and
+  // came back as a bare `Unexpected non-whitespace character after JSON at
+  // position 4` — no upload, no usable error. Split it and use the field the
+  // API actually has, which is also what the caller was asking for.
+  const { subfolder, name } = splitUploadTarget(filename);
   const formData = new FormData();
   const blob = new Blob([data], { type: mimeType });
-  formData.append("image", blob, filename);
+  formData.append("image", blob, name);
   formData.append("type", "input");
   formData.append("overwrite", "true");
+  if (subfolder) formData.append("subfolder", subfolder);
   const res = await client.fetchApi("/upload/image", {
     method: "POST",
     body: formData,
@@ -807,5 +822,48 @@ export async function uploadImageHttp(
     const text = await res.text().catch(() => "");
     throw new Error(`ComfyUI /upload/image returned ${res.status}: ${text}`);
   }
-  return res.json() as Promise<{ name: string; subfolder: string; type: string }>;
+  // Never let a parser message stand in for a diagnosis: a proxy or a
+  // still-starting server answering 200 with HTML used to surface as a raw
+  // SyntaxError with no mention of what was requested (#946, and the same class
+  // as #918/#952).
+  return readComfyJson<{ name: string; subfolder: string; type: string }>(res, {
+    url: "/upload/image",
+    expectShape: (v: unknown) => !!v && typeof v === "object" && typeof (v as { name?: unknown }).name === "string",
+    shapeHint: 'the upload result ({ name, subfolder, type })',
+  });
+}
+
+/**
+ * Split an upload target into ComfyUI's two fields (#946).
+ *
+ * `filename` is the caller's whole intent — "clip.mp4" or "assets/clip.mp4" —
+ * while ComfyUI's /upload/image wants a bare filename plus a separate
+ * `subfolder`. Backslashes count as separators too: a caller on Windows
+ * naturally writes "assets\clip.mp4".
+ *
+ * Traversal is REFUSED rather than sanitised. Silently rewriting "../../x.png"
+ * into something safe would upload to a place the caller did not name and then
+ * report the name they asked for — a wrong answer dressed as a right one. The
+ * caller gets told instead.
+ */
+export function splitUploadTarget(filename: string): { subfolder: string; name: string } {
+  // A TRAILING separator has to be caught before the empty segments are filtered
+  // out: "assets/" would otherwise leave ["assets"], and the directory would be
+  // adopted as the filename — an upload to a name the caller never wrote.
+  const endsInSeparator = /[/\\]\s*$/.test(filename);
+  const parts = filename.split(/[/\\]+/).filter((p) => p !== "" && p !== ".");
+  const name = endsInSeparator ? "" : (parts.pop() ?? "");
+  if (name === "" || name === "..") {
+    throw new ValidationError(
+      `"${filename}" does not name a file to upload — it ends in a path separator or a "..". ` +
+        `Pass a filename, optionally prefixed with a subfolder (e.g. "assets/clip.mp4").`,
+    );
+  }
+  if (parts.some((p) => p === "..")) {
+    throw new ValidationError(
+      `"${filename}" walks outside ComfyUI's input directory with "..". ` +
+        `A subfolder prefix may only go downwards (e.g. "assets/clip.mp4").`,
+    );
+  }
+  return { subfolder: parts.join("/"), name };
 }


### PR DESCRIPTION
Closes #946

## The bug

Uploading with a `filename` override containing a slash — `"assets/clip.mp4"`, the obvious way to ask for a subfolder of ComfyUI's `input/` — failed with:

```
Unexpected non-whitespace character after JSON at position 4
```

and no upload. The same call **without** the slash worked, which is what makes the report precise rather than "slashes break things": `source_path` is full of slashes and is fine.

Two separate defects met there.

### 1. The whole path went into the multipart filename

ComfyUI's `/upload/image` has a **`subfolder` form field** for exactly this, and it was never sent. Now the value is split — bare name in the part, subfolder in the field — so the call does what the caller was asking for instead of failing.

```
"assets/clip.mp4"  →  part filename "clip.mp4",  subfolder "assets"
"clip.mp4"         →  part filename "clip.mp4",  no subfolder field
"assets\clip.mp4"  →  same as the first (the reporter is on Windows)
```

Traversal is **refused, not sanitised**: quietly rewriting `"../../x.png"` into something safe would upload to a place the caller did not name and then report the name they asked for. A trailing separator (`"assets/"`) is refused too — **my own test caught that the first implementation adopted the directory as the filename.**

### 2. `res.json()` leaked a raw parser message

A proxy or a still-starting server answering `200` with HTML gave the reporter a `SyntaxError` naming neither the request nor the response. It now goes through `readComfyJson`, which already exists for this and names both (#918/#952, same class).

## On the report

The reporter said they could not locate the fault in the installed `dist/` and filed with a repro rather than guessing at a patch. That was the right call — the fault is in `client.ts`'s form construction, which is not where the error surfaced, and both of their hypotheses (transport re-serialization, or special `filename` handling) would have led elsewhere.

## Verification

- 15 new tests (9 on the split, 6 end-to-end on the wiring); full suite **321 files / 6937 passed**; `tsc`, `check:vocabulary`, `docs:gen` no-op clean.
- **Mutation-verified in both classes**: bypassing the split at the call site kills 2, accepting traversal kills 2, removing the trailing-separator guard kills 1, restoring `res.json()` kills 2.
- The call-site mutation killed nothing on the first pass — **fifth time this session** — so that suite was added before the verification counted.
- `check:vocabulary` caught `upload_video` (folded into `upload_image action:"video"` in 0.50.0) in my own comment, twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)