### PR TITLE
fix(slice): a slice that matches no output node explains why (panel#690(4))

### DIFF
--- a/src/__tests__/services/slice-miss-diagnostic.test.ts
+++ b/src/__tests__/services/slice-miss-diagnostic.test.ts
@@ -1,0 +1,119 @@
+// panel#690(4) — `panel_slice_workflow` refused with a message that named only the
+// substrings the caller had just supplied and nothing about the workflow. The
+// reporter tried SIX different `groups` values against one file and got the same
+// dead end each time, with no way to converge except guessing.
+//
+// Their workflow did have an output node (a `SaveVideo`, node 92), and `SaveVideo`
+// is in SINK_TYPES — so the sink type was never the problem, and the report's
+// suspicion there was unfounded. Group matching is what failed: a node belongs to a
+// group purely by falling inside its bounding box.
+
+import { describe, expect, it } from "vitest";
+import { describeSliceMiss, sliceWorkflow } from "../../services/workflow-slicer.js";
+import type { UiWorkflow } from "../../comfyui/types.js";
+
+describe("slice miss explains itself (panel#690(4))", () => {
+  it("names the groups that ACTUALLY exist, so the caller stops guessing", () => {
+    const msg = describeSliceMiss({
+      groupSubstrings: ["video", "minimax"],
+      groupTitles: ["Load & Prep", "H3 Pipeline", "Post"],
+      sinks: [{ id: 92, type: "SaveVideo", group: "H3 Pipeline" }],
+    });
+    expect(msg).toContain("Load & Prep, H3 Pipeline, Post");
+    // …and what it searched for, so the mismatch is visible side by side.
+    expect(msg).toContain("video, minimax");
+  });
+
+  it("names every output node found and the group it is in", () => {
+    // This is what distinguishes "wrong substring" from "not in any group" — two
+    // different fixes that the old message collapsed into one.
+    const msg = describeSliceMiss({
+      groupSubstrings: ["save"],
+      groupTitles: ["H3 Pipeline"],
+      sinks: [{ id: 92, type: "SaveVideo", group: "H3 Pipeline" }],
+    });
+    expect(msg).toContain("#92 SaveVideo");
+    expect(msg).toContain('"H3 Pipeline"');
+    expect(msg).toContain("Pass a substring of one of the group titles listed above.");
+  });
+
+  it("says outright when NO output node is inside any group — no substring can help", () => {
+    // The load-bearing case: telling this caller to try another substring would send
+    // them in circles, because geometry, not naming, is the problem.
+    const msg = describeSliceMiss({
+      groupSubstrings: ["save", "output", "video"],
+      groupTitles: ["Pipeline A", "Pipeline B"],
+      sinks: [
+        { id: 92, type: "SaveVideo", group: "" },
+        { id: 93, type: "PreviewImage", group: "" },
+      ],
+    });
+    expect(msg).toContain("NO group");
+    expect(msg).toMatch(/None of them is inside ANY group/);
+    expect(msg).toMatch(/Move the output node into the group's bounds/);
+    expect(msg).not.toContain("Pass a substring of one of the group titles");
+  });
+
+  it("says when the workflow has NO recognized output node at all", () => {
+    const msg = describeSliceMiss({
+      groupSubstrings: ["x"],
+      groupTitles: ["A"],
+      sinks: [],
+    });
+    expect(msg).toMatch(/contains NO output node of any recognized type/);
+  });
+
+  it("lists SaveVideo among the recognized types — the report suspected it was missing", () => {
+    const msg = describeSliceMiss({ groupSubstrings: ["x"], groupTitles: [], sinks: [] });
+    expect(msg).toContain("SaveVideo");
+  });
+
+  it("caps huge enumerations but always reports the exact count", () => {
+    // A truncated list must say how much it is hiding, or it implies that is all
+    // there is — which would resume the guessing this fixes.
+    const titles = Array.from({ length: 40 }, (_, i) => `Group ${i}`);
+    const msg = describeSliceMiss({ groupSubstrings: ["z"], groupTitles: titles, sinks: [] });
+    expect(msg).toContain("Groups in this workflow (40)");
+    expect(msg).toMatch(/… and 15 more/);
+    expect(msg).not.toContain("Group 39");
+  });
+
+  it("blank/whitespace group titles are not offered as suggestions", () => {
+    const msg = describeSliceMiss({
+      groupSubstrings: ["x"],
+      groupTitles: ["", "   ", "Real"],
+      sinks: [],
+    });
+    expect(msg).toContain("Groups in this workflow (1): Real");
+  });
+
+  it("WIRING: sliceWorkflow throws the diagnostic, not the old bare string", () => {
+    // The tests above cannot prove the helper is reached. This drives the real
+    // sliceWorkflow with the reporter's shape: a SaveVideo outside every group.
+    const wf = {
+      nodes: [
+        { id: 92, type: "SaveVideo", pos: [5000, 5000] },
+        { id: 1, type: "CheckpointLoaderSimple", pos: [0, 0] },
+      ],
+      links: [],
+      groups: [{ title: "H3 Pipeline", bounding: [0, 0, 100, 100] }],
+    } as unknown as UiWorkflow;
+
+    expect(() => sliceWorkflow(wf, ["video", "minimax"])).toThrow(/H3 Pipeline/);
+    expect(() => sliceWorkflow(wf, ["video", "minimax"])).toThrow(/#92 SaveVideo in NO group/);
+    expect(() => sliceWorkflow(wf, ["video", "minimax"])).toThrow(/None of them is inside ANY group/);
+  });
+
+  it("a successful slice is unaffected", () => {
+    const wf = {
+      nodes: [
+        { id: 92, type: "SaveVideo", pos: [10, 10] },
+        { id: 1, type: "CheckpointLoaderSimple", pos: [20, 20] },
+      ],
+      links: [],
+      groups: [{ title: "H3 Pipeline", bounding: [0, 0, 100, 100] }],
+    } as unknown as UiWorkflow;
+    const { stats } = sliceWorkflow(wf, ["h3"]);
+    expect(stats.seeds).toBe(1);
+  });
+});

--- a/src/services/workflow-slicer.ts
+++ b/src/services/workflow-slicer.ts
@@ -118,8 +118,18 @@ export function sliceWorkflow(
 
   const seeds = allNodes.filter((n) => SINK_TYPES.has(n.type) && wantNode(n)).map((n) => n.id);
   if (!seeds.length) {
+    // #690(4) — the old message named only what was searched FOR, never what was
+    // there, so six different substrings produced six identical dead ends and the
+    // caller had no way to converge except guessing. Everything needed to explain
+    // the miss is already in hand here.
     throw new Error(
-      `No output node (SaveImage / VHS_VideoCombine / …) found in groups matching: ${groupSubstrings.join(", ")}`,
+      describeSliceMiss({
+        groupSubstrings,
+        groupTitles: groups.map((gr) => gr.title ?? ""),
+        sinks: allNodes
+          .filter((n) => SINK_TYPES.has(n.type))
+          .map((n) => ({ id: n.id, type: n.type, group: groupOf(n) })),
+      }),
     );
   }
   const keep = closure(seeds);
@@ -163,4 +173,75 @@ export function sliceWorkflow(
     workflow: newWf,
     stats: { nodes: newNodes.length, unbypassed, links: newLinks.length, subgraphs: keptDefs.length, seeds: seeds.length, badLinks, orphanGets },
   };
+}
+
+/** Cap the enumerations so a 200-group workflow cannot turn one refusal into a wall
+ *  of text. The counts are always exact, so a truncated list still says how much it
+ *  is hiding rather than quietly implying that is all there is. */
+const SLICE_MISS_LIST_CAP = 25;
+
+function capped(items: string[], cap = SLICE_MISS_LIST_CAP): string {
+  if (!items.length) return "(none)";
+  if (items.length <= cap) return items.join(", ");
+  return `${items.slice(0, cap).join(", ")} … and ${items.length - cap} more`;
+}
+
+/**
+ * #690(4) — explain a slice that matched no output node.
+ *
+ * The reporter tried six different `groups` substrings against one workflow and got
+ * the same message every time: it named the substrings they had just supplied and
+ * nothing about the workflow, so there was no way to converge except blind trial and
+ * error. Their workflow DID have an output node (a `SaveVideo`, node 92) — and
+ * `SaveVideo` is in SINK_TYPES, so the sink type was never the problem. What failed
+ * was group matching: a node belongs to a group only by falling inside its bounding
+ * box, so an output node sitting outside every group, or inside one whose title none
+ * of the substrings match, yields no seeds.
+ *
+ * Both facts are known at the throw site, so the refusal now carries them:
+ *   • the group titles that actually exist — no more guessing at names;
+ *   • every output node found ANYWHERE in the workflow and the group it falls in,
+ *     which distinguishes "your substring is wrong" from "this output node is not
+ *     inside any group at all" — two different fixes that produced one message.
+ *
+ * Deliberately still a REFUSAL. Falling back to "slice from any output node" would
+ * silently produce a different workflow than the caller asked for, which is worse
+ * than a clear stop.
+ */
+export function describeSliceMiss(info: {
+  groupSubstrings: string[];
+  groupTitles: string[];
+  sinks: Array<{ id: number; type: string; group: string }>;
+}): string {
+  const { groupSubstrings, groupTitles, sinks } = info;
+  const titles = groupTitles.map((t) => String(t ?? "").trim()).filter(Boolean);
+  const lines = [
+    `No output node (SaveImage / VHS_VideoCombine / SaveVideo / SaveAudio / PreviewImage) ` +
+      `found in groups matching: ${groupSubstrings.join(", ")}`,
+    `Groups in this workflow (${titles.length}): ${capped(titles)}`,
+  ];
+  if (!sinks.length) {
+    lines.push(
+      "This workflow contains NO output node of any recognized type, so no substring can " +
+        "match — slicing needs one to seed from.",
+    );
+  } else {
+    lines.push(
+      `Output nodes present (${sinks.length}): ` +
+        capped(sinks.map((s) => `#${s.id} ${s.type} in ${s.group ? `"${s.group}"` : "NO group"}`)),
+    );
+    // The distinction that decides what to do next. A node belongs to a group purely
+    // by geometry, so an output node outside every box can never be matched by any
+    // substring, and telling the caller to try another one would send them in circles.
+    if (sinks.every((s) => !s.group)) {
+      lines.push(
+        "None of them is inside ANY group, so no `groups` value can match. Move the output " +
+          "node into the group's bounds on the canvas, or slice a workflow whose pipelines " +
+          "are grouped.",
+      );
+    } else {
+      lines.push("Pass a substring of one of the group titles listed above.");
+    }
+  }
+  return lines.join("\n");
 }


### PR DESCRIPTION
Refs artokun/comfyui-mcp-panel#690 — defect **(4)**.

`panel_slice_workflow`'s refusal named only the substrings the caller had just supplied and nothing about the workflow, so six different `groups` values against one file produced six identical dead ends with no way to converge except guessing.

## The report's suspicion was unfounded — and that matters

It asks whether `SaveVideo` is in the recognized output-node set. **It is**, and has been, alongside `SaveImage`, `VHS_VideoCombine`, `SaveAudio` and `PreviewImage`. So adding it would have been a no-op fix for a real bug.

What actually failed is **group matching**. A node belongs to a group purely by falling inside its bounding box (`inBox(n.pos, gr.bounding)`), so an output node sitting outside every group — or inside one whose title none of the substrings match — yields no seeds. Their `SaveVideo` (node 92) existed; it just wasn't matched.

## What the refusal says now

Everything needed was already in hand at the throw site:

- **the group titles that actually exist** — no more guessing at names;
- **every output node found anywhere in the workflow, and the group it falls in.**

That second part is the one that changes behaviour, because it separates two failures the old message collapsed into one:

| observed | fix |
|---|---|
| `#92 SaveVideo in "H3 Pipeline"` | your substring is wrong — try one of the listed titles |
| `#92 SaveVideo in NO group` | **no substring can ever match** — move the node into the group's bounds |

The second case is called out explicitly, because telling that caller to try another substring sends them in circles.

## Judgement calls

- **Still a refusal.** Falling back to "slice from any output node" would silently produce a different workflow than the one asked for — worse than a clear stop.
- **Enumerations capped at 25, with the exact count always reported.** A truncated list that didn't say how much it was hiding would imply that's all there is, resuming the guessing this removes.

## Verification

- 9 tests, including the reporter's exact shape and a successful slice (unaffected).
- **Three mutations**, markers checked: throwing the old bare string fails the wiring test — which drives the real `sliceWorkflow`, not just the helper; dropping the not-in-any-group branch fails two; capping without the count fails one.
- My first call-site mutation attempt mangled the file via shell substitution and reported "no tests" — that run was discarded and redone with the marker count verified, since a broken file passing nothing is not evidence.
- `tsc --noEmit` clean. Full suite **325 files / 6966 passed**. Control-byte scan 0. No tool-surface change, so the vocabulary ratchet is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)