### PR TITLE
0.50.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.3] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- a path in `filename` is a subfolder request, not a broken upload (#985)
+- two different tabs must not render identically (#984)
+- a painted card is not a loaded image (#982)
+- an untrusted hello must not ERASE the tab's command stamp (#976)
+
+#### Changed
+- stop betting on 25ms to decide when the abort lands (#981)
+
+
 ## [0.50.2] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.2",
+  "version": "0.50.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.2",
+      "version": "0.50.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.2",
+  "version": "0.50.3",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **0.50.3**, reconciling the release commit onto protected `main` (the tag `v0.50.3` is already pushed and publishing).

### Contents

| PR | Fix |
|---|---|
| #985 | a path in `filename` is a subfolder request, not a broken upload |
| #984 | two different tabs must not render identically |
| #982 | a painted card is not a loaded image |
| #976 | an untrusted hello must not ERASE the tab's command stamp |
| #981 | *(test)* stop betting on 25 ms to decide when the abort lands |

Closes #946, #934 (partly), #941, #980.

### The changelog was generated wrong, and corrected by hand

`gen-changelog` produced a 0.50.3 section listing **all fifteen** commits since `v0.50.1` — re-announcing the ten fixes that already shipped in 0.50.2. The generated section was replaced with the five commits that are actually new here.

**Why it happened, and why it will happen again:** the release flow pushes the tag from a local commit, then reconciles the version bump onto protected `main` via a squash-merge — which creates a *different* sha. So `v0.50.2` is not an ancestor of `main`, and `git log v0.50.2..HEAD` walks past it into everything since `v0.50.1`.

Worth fixing at the source rather than by hand each time. Two options: have `gen-changelog` bound its range by the newest version already present in `CHANGELOG.md` rather than by the last reachable tag, or move the tag onto the merged commit after reconciliation. I have not done either here — flagging it rather than changing release machinery inside a release.

### Verification

Full suite **321 files / 6957 passed** on `main` at `b59c470`, with `tsc`, `lint`, `build`, `check:vocabulary`, `vocab:export --check` and the `docs:gen` no-op gate all clean. Every fix in this release was mutation-verified before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)