### PR TITLE
fix(#948): a remedy has to work from where the user is reading it

### DIFF
--- a/src/__tests__/orchestrator/cli-remedy.test.ts
+++ b/src/__tests__/orchestrator/cli-remedy.test.ts
@@ -1,0 +1,114 @@
+// #948 — a correct instruction delivered to the wrong place is a wrong instruction.
+//
+// A user saw `Not logged in, please run /login` in the PANEL CHAT and reported
+// that `/login` "doesn't exist as a command". They were right: it is typed at the
+// `pi` CLI's own prompt. In a chat box a leading `/` reads as "type this here",
+// so the remedy was accurate and unusable at the same time — and it pointed at
+// the one place it could not work.
+//
+// It is also wrong across providers: a user on the Claude or Codex chip has no
+// `/login` at all, so a passed-through string naming it is false, not just
+// unhelpful.
+
+import { describe, expect, it } from "vitest";
+import {
+  looksLikeAuthFailure,
+  providerAuthRemedy,
+  qualifySlashCommands,
+} from "../../orchestrator/cli-remedy.js";
+
+describe("#948: a bare slash command never reaches chat unqualified", () => {
+  it("says WHERE the prompt is, not just what to type", () => {
+    const out = qualifySlashCommands("Not logged in, please run /login", "pi");
+    expect(out).toMatch(/`pi`, then type `\/login` at its prompt/);
+    // The bare form — the thing that read as a chat command — is gone.
+    expect(out).not.toMatch(/run \/login/);
+  });
+
+  it("shortens repeats instead of restating the whole clause", () => {
+    const out = qualifySlashCommands("try /login, then /status", "pi");
+    expect(out).toMatch(/`pi`, then type `\/login` at its prompt/);
+    expect(out).toMatch(/`\/status` \(at the `pi` prompt\)/);
+  });
+
+  // Paths, URLs and dates are VALUES, not instructions. Rewriting them would
+  // corrupt the very detail that makes an error diagnosable.
+  it("leaves paths and URLs alone", () => {
+    for (const s of [
+      "spawn /usr/bin/pi ENOENT",
+      "see https://pi.dev/docs for setup",
+      "config at /home/u/.pi/agent/auth.json",
+      "C:/Users/x/pi.exe not found",
+    ]) {
+      expect(qualifySlashCommands(s, "pi")).toBe(s);
+    }
+  });
+
+  it("is a no-op on text with no slash command", () => {
+    expect(qualifySlashCommands("pi exited with code 1", "pi")).toBe("pi exited with code 1");
+    expect(qualifySlashCommands("", "pi")).toBe("");
+  });
+});
+
+describe("#948: the auth remedy names the place, not only the keystrokes", () => {
+  it("tells a pi user to go to a terminal, and what that writes", () => {
+    const msg = providerAuthRemedy("pi");
+    expect(msg).toMatch(/TERMINAL/);
+    expect(msg).toMatch(/type `\/login` at its prompt/);
+    expect(msg).toMatch(/~\/\.pi\/agent\/auth\.json/);
+    expect(msg).toMatch(/Disconnect → Connect/);
+  });
+
+  // The cross-provider half: these users have no /login at all, so naming it
+  // would be false rather than merely unhelpful.
+  it("never mentions /login for a provider that has no such command", () => {
+    expect(providerAuthRemedy("codex")).toMatch(/codex login/);
+    expect(providerAuthRemedy("codex")).not.toMatch(/\/login/);
+    expect(providerAuthRemedy("claude")).toMatch(/claude setup-token/);
+    expect(providerAuthRemedy("claude")).not.toMatch(/\/login/);
+    expect(providerAuthRemedy("gemini")).not.toMatch(/\/login/);
+  });
+
+  it("has a usable answer for a backend it does not know by name", () => {
+    const msg = providerAuthRemedy("some-new-provider");
+    expect(msg).toContain("some-new-provider");
+    expect(msg).toMatch(/API Keys card|TERMINAL/);
+    expect(msg).not.toMatch(/\/login/);
+  });
+
+  // The CLI's own tail carries the real reason (expired token vs missing file),
+  // so it is kept — but it is the exact channel the bare /login came through,
+  // so it must be qualified on the way in.
+  it("keeps the CLI's detail but strips its bare slash command", () => {
+    const msg = providerAuthRemedy("pi", "Not logged in, please run /login");
+    expect(msg).toMatch(/Not logged in/);
+    expect(msg).not.toMatch(/please run \/login/);
+    expect(msg).toMatch(/at its prompt|at the `pi` prompt/);
+  });
+
+  it("omits the detail block entirely when there is nothing to say", () => {
+    expect(providerAuthRemedy("pi", "   ")).not.toMatch(/\(\s*\)/);
+  });
+});
+
+describe("#948: recognising the condition", () => {
+  it("matches the phrasings CLIs actually use", () => {
+    for (const s of [
+      "Not logged in, please run /login",
+      "you have been logged out",
+      "unauthorized",
+      "missing API key",
+      "no provider credentials configured",
+      "please sign in",
+      "authentication failed",
+    ]) {
+      expect(looksLikeAuthFailure(s), s).toBe(true);
+    }
+  });
+
+  it("does not claim an unrelated failure is about credentials", () => {
+    for (const s of ["ENOENT: no such file", "exited with code 137", "connection reset"]) {
+      expect(looksLikeAuthFailure(s), s).toBe(false);
+    }
+  });
+});

--- a/src/__tests__/orchestrator/pi-backend.test.ts
+++ b/src/__tests__/orchestrator/pi-backend.test.ts
@@ -499,6 +499,40 @@ describe("PiBackend turns", () => {
     expect(err.message).toMatch(/provider credentials|API key|login/i);
   });
 
+  // #948 — a user saw pi's own "Not logged in, please run /login" in the PANEL
+  // CHAT and reported that /login "doesn't exist as a command". They were right:
+  // it is typed at pi's prompt, and in a chat box a leading `/` reads as "type
+  // this here". The remedy was accurate and unusable at the same time.
+  //
+  // The helper's rules are pinned in cli-remedy.test.ts; this covers the WIRING,
+  // because the bare string reached chat through THIS passthrough.
+  it("#948: pi's own '/login' never reaches chat as a bare command", async () => {
+    hoisted.script.push({ stdout: [], stderr: "Not logged in, please run /login", exit: 1 });
+    const backend = new PiBackend({ cwd: workDir });
+    const events = await collect(backend.run({ channel: channelOf([{ text: "hi" }]) }));
+    const err = events.find((e) => e.type === "error") as { message: string };
+
+    // The exact string the user was told to type into the panel.
+    expect(err.message).not.toMatch(/please run \/login/);
+    // Replaced by one that says where its prompt is…
+    expect(err.message).toMatch(/at its prompt|at the `pi` prompt/);
+    expect(err.message).toMatch(/TERMINAL/);
+    // …and pi's own detail is kept, since it carries the real reason.
+    expect(err.message).toMatch(/Not logged in/);
+  });
+
+  // A NON-auth failure can name a slash command too, so the qualification is not
+  // limited to the credentials branch.
+  it("#948: qualifies a slash command on a plain non-zero exit as well", async () => {
+    hoisted.script.push({ stdout: [], stderr: "unknown flag; try /help", exit: 2 });
+    const backend = new PiBackend({ cwd: workDir });
+    const events = await collect(backend.run({ channel: channelOf([{ text: "hi" }]) }));
+    const err = events.find((e) => e.type === "error") as { message: string };
+    expect(err.message).toMatch(/exited with code 2/);
+    expect(err.message).not.toMatch(/try \/help/);
+    expect(err.message).toMatch(/`\/help`/);
+  });
+
   it("interrupt kills the in-flight child tree and yields a cancelled result", async () => {
     hoisted.script.push({ hang: true });
     const backend = new PiBackend({ cwd: workDir });

--- a/src/orchestrator/cli-remedy.ts
+++ b/src/orchestrator/cli-remedy.ts
@@ -1,0 +1,104 @@
+// #948 — a correct instruction delivered to the wrong place is a wrong instruction.
+//
+// A user saw `Not logged in, please run /login` in the PANEL CHAT and reported
+// that `/login` "doesn't exist as a command". They were right: `/login` is typed
+// at the `pi` CLI's own prompt. It is not a panel command, not a ComfyUI command,
+// and not a shell command — and the message named none of that.
+//
+// In a chat box a leading `/` reads as "type this here". That is the whole defect:
+// the remedy was accurate and unusable at the same time, and it points the reader
+// at the one place it cannot work.
+//
+// It also misleads ACROSS providers. A user on the Claude or Codex chip has no
+// `/login` at all (`claude setup-token`, `codex login`), so a passed-through
+// string naming it is not merely unhelpful there — it is false.
+//
+// Two rules follow, and both are about the reader's location rather than the
+// text's accuracy:
+//   1. Never let a bare `/command` reach chat. Say where its prompt is.
+//   2. When we wrap a provider's auth failure, name the tool, the place, and the
+//      follow-up — not just the keystrokes.
+
+/** The CLI whose prompt a backend's slash commands belong to, when it has one. */
+const SLASH_CLI_BY_BACKEND: Record<string, string> = {
+  pi: "pi",
+  grok: "grok",
+};
+
+/**
+ * Rewrite bare `/command` mentions so they cannot read as "type this here".
+ *
+ * Only touches a slash-command that stands as its own word — `/login`,
+ * `/status` — and leaves paths (`/usr/bin/pi`), URLs and dates alone, since
+ * those are not instructions and rewriting them would corrupt real values.
+ *
+ * The first occurrence gets the full "at <cli>'s prompt" qualification; later
+ * ones in the same message get a shorter form, because repeating the whole
+ * clause reads as noise and noise is what gets skimmed past.
+ */
+export function qualifySlashCommands(text: string, cli: string): string {
+  if (!text) return text;
+  let seen = 0;
+  return text.replace(/(^|[\s("'`])\/([a-z][a-z0-9-]{1,24})\b(?!\/)/gi, (match, lead: string, cmd: string) => {
+    // A path segment (`/foo/bar`) or a URL is not an instruction.
+    seen += 1;
+    const qualified =
+      seen === 1
+        ? `\`${cli}\`, then type \`/${cmd}\` at its prompt`
+        : `\`/${cmd}\` (at the \`${cli}\` prompt)`;
+    return `${lead}${qualified}`;
+  });
+}
+
+/** True when a CLI's failure text is about missing/expired credentials. */
+export function looksLikeAuthFailure(text: string): boolean {
+  return /sign.?in|log.?in|logged.?out|auth|credential|unauthoriz|api.?key|no provider/i.test(text);
+}
+
+/**
+ * OUR wrapper for a provider's not-authenticated failure.
+ *
+ * Names the tool, WHERE to run it, and the follow-up — a raw CLI string assumes
+ * the reader is already standing in that CLI, which from a panel chat is exactly
+ * the assumption that fails.
+ *
+ * `detail` is the CLI's own tail, kept because it often carries the real reason
+ * (an expired token vs a missing file) — but passed through `qualifySlashCommands`
+ * first, so the child's phrasing can never smuggle a bare `/login` into chat.
+ */
+export function providerAuthRemedy(backend: string, detail?: string): string {
+  const cli = SLASH_CLI_BY_BACKEND[backend];
+  const tail = detail?.trim()
+    ? ` (${cli ? qualifySlashCommands(detail.trim(), cli) : detail.trim()})`
+    : "";
+
+  switch (backend) {
+    case "pi":
+      return (
+        `pi has no usable provider credentials. Fix it in a TERMINAL, not here: either set a provider ` +
+        `API key (ANTHROPIC_API_KEY / OPENAI_API_KEY / …), or run \`pi\` once and type \`/login\` at its ` +
+        `prompt — that writes ~/.pi/agent/auth.json. Then Disconnect → Connect and send your message ` +
+        `again.${tail}`
+      );
+    case "codex":
+      return (
+        `Codex is not logged in. In a TERMINAL run \`codex login\` (ChatGPT sign-in) or set CODEX_API_KEY, ` +
+        `then Disconnect → Connect.${tail}`
+      );
+    case "claude":
+      return (
+        `Claude has no usable credentials. In a TERMINAL run \`claude setup-token\`, or set ANTHROPIC_API_KEY, ` +
+        `then Disconnect → Connect.${tail}`
+      );
+    case "gemini":
+      return (
+        `Gemini is not authenticated. In a TERMINAL run \`gemini\` once and complete its sign-in, or set ` +
+        `GEMINI_API_KEY, then Disconnect → Connect.${tail}`
+      );
+    default:
+      return (
+        `${backend} has no usable credentials. Set the provider's API key in the API Keys card, or complete ` +
+        `its CLI sign-in in a TERMINAL, then Disconnect → Connect.${tail}`
+      );
+  }
+}

--- a/src/orchestrator/pi-backend.ts
+++ b/src/orchestrator/pi-backend.ts
@@ -61,6 +61,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { logger } from "../utils/logger.js";
 import { errorText, promptText } from "./error-text.js";
+import { looksLikeAuthFailure, providerAuthRemedy, qualifySlashCommands } from "./cli-remedy.js";
 import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
@@ -584,16 +585,18 @@ export class PiBackend implements AgentBackend {
         push({ type: "result", ok: false, subtype: "timeout" });
       } else if (spawnErr || code !== 0) {
         const stderrTail = stripAnsi(errOut).trim().split(/\r?\n/).slice(-3).join(" ").trim();
-        const authish = /sign.?in|log.?in|auth|credential|unauthoriz|api.?key|no provider/i.test(
-          stderrTail + finalText,
-        );
+        const authish = looksLikeAuthFailure(stderrTail + finalText);
+        // #948 — pi's own text says "please run /login", which in a chat panel
+        // reads as "type this here" and sends the user somewhere it cannot work.
+        // Every path that passes the child's words through is qualified, not just
+        // the auth one: a non-auth failure can name a slash command too.
         const message = spawnErr
           ? /ENOENT/i.test(spawnErr.message)
             ? "pi CLI (`pi`) could not be launched — it may have been uninstalled. Reinstall from https://pi.dev and reconnect."
             : `pi failed to start: ${spawnErr.message}`
           : authish
-            ? `pi has no usable provider credentials. Configure one — set a provider API key (e.g. ANTHROPIC_API_KEY / OPENAI_API_KEY) or run \`pi\` once and \`/login\` — then send your message again.${stderrTail ? ` (pi: ${stderrTail})` : ""}`
-            : `pi exited with code ${code}.${stderrTail ? ` ${stderrTail}` : ""}`;
+            ? providerAuthRemedy("pi", stderrTail)
+            : `pi exited with code ${code}.${stderrTail ? ` ${qualifySlashCommands(stderrTail, "pi")}` : ""}`;
         push({ type: "error", message });
         push({ type: "result", ok: false, subtype: "error" });
       } else {


### PR DESCRIPTION
Closes #948

## The bug

A user saw pi's own message in the **panel chat**:

> Not logged in, please run `/login`

and reported that `/login` "doesn't exist as a command." They were right. `/login` is typed at the **`pi` CLI's own prompt** — not a panel command, not a ComfyUI command, not a shell command — and the message named none of that.

In a chat box a leading `/` reads as *"type this here"*. The instruction was **accurate and unusable at the same time**, and it pointed at the one place it could not work.

It is also wrong **across providers**: a user on the Claude or Codex chip has no `/login` at all (`claude setup-token`, `codex login`), so a passed-through string naming it is false there, not merely unhelpful.

## The fix

Two rules, both about the reader's *location* rather than the text's accuracy.

**1. A bare `/command` never reaches chat.**

```
"Not logged in, please run /login"
  →  "Not logged in, please run `pi`, then type `/login` at its prompt"
```

Paths, URLs and dates are left alone — `/usr/bin/pi`, `https://pi.dev/docs`, `~/.pi/agent/auth.json` are **values, not instructions**, and rewriting them would corrupt the detail that makes an error diagnosable.

**2. Our auth wrapper names the tool, the place, and the follow-up.**

> pi has no usable provider credentials. Fix it in a **TERMINAL**, not here: either set a provider API key, or run `pi` once and type `/login` at its prompt — that writes `~/.pi/agent/auth.json`. Then Disconnect → Connect…

Per backend, so a Codex user is sent to `codex login` and never to a `/login` they don't have.

The CLI's own tail is still kept — it carries the real reason (expired token vs missing file) — but qualified on the way in, since that passthrough is exactly the channel the bare `/login` came through. The qualification also applies to the **non-auth** exit path: a plain failure can name a slash command just as easily.

## Not addressed

The reporter's second observation — that it *"logged me out"*. It's still unestablished whether the session was invalidated or whether the panel merely lost the ability to **read** an existing credential; a stale or unreadable `~/.pi/agent/auth.json` presents identically from the panel's side. If those are indistinguishable today, the panel is reporting a cause it cannot determine — its own defect, needing its own investigation. Left noted on the issue.

## Verification

- 11 new unit tests + 2 end-to-end through `PiBackend`; full suite **321 files / 6979 passed**; `tsc` and `check:vocabulary` clean.
- **Mutation-verified in both classes**: reverting the auth branch to a raw passthrough kills the end-to-end test; dropping the qualification on the non-zero-exit branch kills the other.
- Unlike the last five changes this session, the **call sites were covered on the first pass** rather than after the mutation found the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)