### PR TITLE
feat(panel_list_subgraphs): expose the filter/limit the panel now honours (panel#690(5))

### DIFF
--- a/src/__tests__/orchestrator/list-subgraphs-bounded.test.ts
+++ b/src/__tests__/orchestrator/list-subgraphs-bounded.test.ts
@@ -1,0 +1,54 @@
+// panel#690(5) — panel_list_subgraphs was the one panel READ tool with no token
+// bound: an install with the bundled globals returned all 90 blueprints with full
+// descriptions in a single reply.
+//
+// The panel now bounds it. This pins the ORCHESTRATOR half: the parameters have to
+// exist and actually reach the panel, and the description has to warn that a
+// truncated list is not evidence of absence — a bounded read whose caller cannot
+// tell it was bounded is a silent-omission bug, which is worse than the token cost.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const src = (): string =>
+  readFileSync(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf8");
+
+/** The panel_list_subgraphs def block, isolated so an assertion cannot be satisfied
+ *  by an unrelated tool that happens to use the same parameter names. */
+function listSubgraphsDef(): string {
+  const s = src();
+  const start = s.indexOf('"panel_list_subgraphs"');
+  expect(start).toBeGreaterThan(-1);
+  return s.slice(start, s.indexOf('def(', start + 10));
+}
+
+describe("panel_list_subgraphs is bounded end to end (panel#690(5))", () => {
+  it("declares the filter and limit parameters", () => {
+    const def = listSubgraphsDef();
+    expect(def).toContain("filter: z");
+    expect(def).toContain("limit: z");
+  });
+
+  it("FORWARDS them to the panel — a declared-but-dropped param is the worst case", () => {
+    // Declaring the parameters without passing them would advertise a bound the
+    // panel never receives, so every call would silently use the default while the
+    // caller believed their filter applied.
+    expect(listSubgraphsDef()).toContain(
+      'ctx.call({ cmd: "graph_list_subgraphs", filter: args.filter, limit: args.limit }, 15000)',
+    );
+  });
+
+  it("warns that a truncated list is not evidence a blueprint is absent", () => {
+    // The load-bearing sentence. Without it an agent reads a bounded list as the
+    // whole library and rebuilds a blueprint that already exists.
+    const def = listSubgraphsDef();
+    expect(def).toMatch(/NOT evidence the blueprint does not exist/i);
+    expect(def).toMatch(/truncated/);
+  });
+
+  it("explains matched vs count, so an empty filter result is not read as an empty library", () => {
+    const def = listSubgraphsDef();
+    expect(def).toMatch(/matched field reports how many the filter selected/);
+    expect(def).toMatch(/means the filter missed, not that the library is empty/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -8098,9 +8098,23 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_list_subgraphs",
-      "List the saved subgraph BLUEPRINTS in the user's library (from panel_save_subgraph, plus any global/bundled ones). Each entry has {name, type, display_name, description, is_global} — use name/type with panel_add_subgraph to drop it onto the canvas. Read-only.",
-      {},
-      async (_args, ctx) => ctx.call({ cmd: "graph_list_subgraphs" }, 15000),
+      "List the saved subgraph BLUEPRINTS in the user's library (from panel_save_subgraph, plus any global/bundled ones). Each entry has {name, type, display_name, description, is_global} — use name/type with panel_add_subgraph to drop it onto the canvas. Read-only.\n\nTOKEN-BOUNDED like the other reads (panel#690). The reply's count field is always the LIBRARY TOTAL, so compare it against the returned array. When entries are withheld the reply carries truncated:true, a returned field, and a note — an absent entry in a TRUNCATED list is NOT evidence the blueprint does not exist, so narrow with `filter` (or raise `limit`, up to 500) before concluding anything. When a filter is applied the reply's matched field reports how many the filter selected, distinct from the count field, so matched:0 against a non-zero count means the filter missed, not that the library is empty.",
+      {
+        filter: z
+          .string()
+          .optional()
+          .describe(
+            "Case-insensitive substring matched against the blueprint's name, display name AND description. Use this rather than a bigger limit when you know roughly what you want.",
+          ),
+        limit: z
+          .number()
+          .optional()
+          .describe(
+            "Maximum entries to return (default 40, max 500). A value <= 0 or non-numeric falls back to the default rather than returning nothing.",
+          ),
+      },
+      async (args: A, ctx) =>
+        ctx.call({ cmd: "graph_list_subgraphs", filter: args.filter, limit: args.limit }, 15000),
     ),
     def(
       "panel_add_subgraph",


### PR DESCRIPTION
Refs artokun/comfyui-mcp-panel#690 — the orchestrator half of defect **(5)**. Pairs with comfyui-mcp-panel#734, which bounds the read panel-side. Either order is safe: an old panel ignores the parameters, and an old orchestrator sends none and gets the default bound.

Without these parameters the tool would silently take the default bound with **no way to page or narrow** — a worse shape than the unbounded dump it replaces.

## The description carries the contract

- the reply's **count** field is the library total (compare it to the returned array);
- a withheld entry is reported explicitly (`truncated:true` + a returned field);
- and the load-bearing sentence: **an absent entry in a truncated list is NOT evidence the blueprint does not exist.**

A bounded read whose caller can't tell it was bounded is a silent-omission defect, and that costs more than the tokens it saves.

## The #809 gate caught two real defects in my own prose

Both worth recording, because they're the kind of thing that reads fine and isn't:

1. **I backticked `truncated` / `returned` / `matched`.** Backticks in this codebase mean *"a lever on THIS tool"*, and those are **result fields**, not parameters — so the prose pointed a caller at knobs that don't exist. Rewritten as plain field names; only `filter`/`limit` stay backticked.
2. **"raise `limit`" named no ceiling**, which sends a caller already at the maximum on a retry that cannot change anything — the gate's words: *"the same wasted round trip as naming a parameter that does not exist."* Now "up to 500".

That gate is doing real work; it rejected two plausible-looking sentences I'd have shipped.

## Verification

- 4 tests pinning the parameters, the **forwarding**, and the two contract sentences.
- **Mutation**: declaring the parameters but dropping them from the `ctx.call` fails the forwarding test. That's the dangerous shape — it would advertise a bound the panel never receives, so every call would silently use the default while the caller believed their filter applied.
- `tsc --noEmit` clean. Full suite **326 files / 6970 passed**. Control-byte scan 0.
- No tool-name change, so the vocabulary ratchet is untouched (parameters only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)