### PR TITLE
feat(panel_flatten_workflow): summary_only, so the report costs a report (panel#690(5))

### DIFF
--- a/src/__tests__/orchestrator/flatten-summary-only.test.ts
+++ b/src/__tests__/orchestrator/flatten-summary-only.test.ts
@@ -1,0 +1,72 @@
+// panel#690(5) — `panel_flatten_workflow` with `apply:false` returned the entire
+// flattened graph JSON and offered no way to ask for less, so a caller who only
+// wanted to know WHAT flattening did paid tens of thousands of tokens to find out.
+//
+// The graph is deliberately NOT clipped when it IS returned: a truncated JSON
+// document is not a smaller answer, it is an invalid one — unparseable, unloadable,
+// undiffable. So the choice is whole-or-not-at-all, and `summary_only` is how the
+// caller makes it.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const src = (): string =>
+  readFileSync(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf8");
+
+/** The panel_flatten_workflow def block, isolated so an assertion cannot be met by
+ *  an unrelated tool that happens to share a parameter name. */
+function flattenDef(): string {
+  const s = src();
+  const start = s.indexOf('"panel_flatten_workflow"');
+  expect(start).toBeGreaterThan(-1);
+  return s.slice(start, s.indexOf('def(', start + 10));
+}
+
+describe("flatten can return the report without the graph (panel#690(5))", () => {
+  it("declares summary_only", () => {
+    expect(flattenDef()).toContain("summary_only: z");
+  });
+
+  it("only omits the graph on the apply:false path", () => {
+    // Applying to the canvas returns a load result, not JSON, so the flag has
+    // nothing to suppress there — claiming otherwise in the description would send a
+    // caller looking for an effect that does not exist.
+    const def = flattenDef();
+    const applyFalse = def.slice(def.indexOf("if (args.apply === false)"));
+    expect(applyFalse).toContain("if (args.summary_only)");
+    expect(flattenDef()).toMatch(/Ignored when the graph is being applied/);
+  });
+
+  it("reports the SIZE it withheld, so 'summary only' is never read as 'that is all'", () => {
+    // The rule the bounded reads follow: an omission that does not announce itself is
+    // a silent-omission bug wearing a smaller token count.
+    const def = flattenDef();
+    expect(def).toContain("Graph JSON omitted (summary_only)");
+    expect(def).toMatch(/node\(s\), \$\{links\} link\(s\)/);
+    expect(def).toMatch(/KB/);
+    expect(def).toMatch(/Re-run without summary_only to get it/);
+  });
+
+  it("NEVER clips the JSON when it does return it", () => {
+    // The load-bearing negative. Clipping would turn a large correct result into a
+    // small useless one, which is worse than the token cost being fixed.
+    const def = flattenDef();
+    // The whole `json` binding is interpolated into the reply, unsliced.
+    expect(def).toContain("const json = JSON.stringify(graph);");
+    expect(def).toMatch(/\$\{json\}`\);/);
+    expect(def).not.toMatch(/json\.slice\(/);
+    expect(def).not.toMatch(/json\.substring\(/);
+    expect(def).not.toMatch(/json\.substr\(/);
+  });
+
+  it("still defaults to returning the whole graph — apply:false's contract is unchanged", () => {
+    // summary_only is opt-in. Flipping the default would break every caller that
+    // uses apply:false precisely to consume the JSON.
+    const def = flattenDef();
+    const applyFalse = def.slice(def.indexOf("if (args.apply === false)"));
+    const summaryBranch = applyFalse.indexOf("if (args.summary_only)");
+    const wholeReturn = applyFalse.search(/\$\{json\}`\);/);
+    expect(summaryBranch).toBeGreaterThan(-1);
+    expect(wholeReturn).toBeGreaterThan(summaryBranch);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6361,6 +6361,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .boolean()
           .optional()
           .describe("Load the flattened graph onto the canvas (default true). false = return the graph JSON only."),
+        summary_only: z
+          .boolean()
+          .optional()
+          .describe(
+            "With apply:false, return ONLY the flatten report (what was removed/rewired, plus the size of the result) and omit the graph JSON. Use this when you want to know WHAT flattening did rather than to consume the graph — a flattened workflow's JSON is often tens of thousands of tokens. Ignored when the graph is being applied to the canvas.",
+          ),
       },
       async (args: A, ctx) => {
         const raw = await resolveWorkflowInput(args, ctx);
@@ -6376,7 +6382,32 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             ? `\nWarnings:\n${report.warnings.map((w) => `- ${w}`).join("\n")}`
             : "");
         if (args.apply === false) {
-          return ok(`${summary}\n\n${JSON.stringify(graph)}`);
+          // panel#690(5) — `apply:false` returned the entire flattened graph JSON with
+          // no way to ask for less, so a caller who only wanted to know WHAT flattening
+          // did paid tens of thousands of tokens to find out.
+          //
+          // The graph is NOT clipped when it is returned. A truncated JSON document is
+          // not a smaller answer, it is an invalid one — it cannot be parsed, loaded or
+          // diffed, so clipping would turn a large correct result into a small useless
+          // one. The choice is therefore whole-or-not-at-all, and `summary_only` is how
+          // the caller makes it.
+          const json = JSON.stringify(graph);
+          if (args.summary_only) {
+            const nodes = Array.isArray((graph as { nodes?: unknown[] }).nodes)
+              ? (graph as { nodes: unknown[] }).nodes.length
+              : 0;
+            const links = Array.isArray((graph as { links?: unknown[] }).links)
+              ? (graph as { links: unknown[] }).links.length
+              : 0;
+            // State the size that was withheld, so "summary only" never reads as "that
+            // is all there was" — the same rule the bounded reads follow.
+            return ok(
+              `${summary}\n\nGraph JSON omitted (summary_only): ${nodes} node(s), ${links} link(s), ` +
+                `~${Math.round(json.length / 1024)} KB. Re-run without summary_only to get it, ` +
+                `or with apply:true to load it onto the canvas.`,
+            );
+          }
+          return ok(`${summary}\n\n${json}`);
         }
         const loaded = await ctx.call({ cmd: "graph_load", graph: graph as never }, 30000);
         // ctx.call returns an error ToolResult for an outcome-unknown graph_load


### PR DESCRIPTION
Refs artokun/comfyui-mcp-panel#690 — completes defect **(5)** alongside the `list_subgraphs` bound (comfyui-mcp-panel#734 / #990).

`apply:false` returned the entire flattened graph JSON with no way to ask for less, so a caller who only wanted to know *what flattening did* paid tens of thousands of tokens to find out.

## Why the JSON is omitted rather than clipped

A truncated JSON document is **not a smaller answer, it's an invalid one** — unparseable, unloadable, undiffable. Clipping would turn a large correct result into a small useless one, which is worse than the cost being fixed. So the choice is whole-or-not-at-all, and `summary_only` is how the caller makes it. There's a test asserting no `.slice(` / `.substring(` / `.substr(` ever touches the JSON.

**Opt-in**, so `apply:false` keeps its contract — callers using it precisely to consume the JSON are unaffected. A test pins that the whole-graph return still follows the `summary_only` branch rather than replacing it.

## The omission announces its own size

Node count, link count and KB. "Summary only" must never read as "that is all there was" — the same rule the bounded reads follow, and the reason a silent bound is worse than a large payload.

## Verification

- 5 tests, including the two load-bearing negatives (never clips; default unchanged).
- **Three mutations**, replacement counts checked: dropping the `summary_only` branch fails 2; clipping the JSON instead of omitting it fails 1; dropping the withheld-size report fails 1.
- `tsc --noEmit` clean. Full suite **6988 passed**. Control-byte scan 0. Parameter-only, so the vocabulary ratchet is untouched.

One process note: my first two assertions matched a literal `\n` that got mangled through heredoc escaping, so they failed against correct code. Rewritten to assert on backslash-free fragments rather than fighting the escaping — a test that fails for its own quoting reasons teaches nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)