### PR TITLE
fix(#935): extend the unapplied-filter guard past `creator`

### DIFF
--- a/src/__tests__/orchestrator/civitai-filter-guard.test.ts
+++ b/src/__tests__/orchestrator/civitai-filter-guard.test.ts
@@ -1,0 +1,110 @@
+// #935 — a supplied-but-unapplied filter answered with a plausible result set.
+//
+// #374 fixed this for ONE parameter. `creator` used to be dropped silently: the
+// tool echoed creator:null with zero results, so "filter never applied" and
+// "this creator has no content" were indistinguishable. The guard added there
+// warns on divergence — and covers `creator` and nothing else.
+//
+// So modelSort / baseModels / period could be supplied, ignored, and answered
+// with a full, ordinary-looking list. A reporter saw download counts in no order
+// at all (48, 53, 53, 64, 1468) for a "Most Downloaded" sort. An agent asked for
+// "most-downloaded Flux LoRAs" presents that confidently; nothing in the reply
+// says the sort never happened.
+
+import { describe, expect, it } from "vitest";
+import { describeUnappliedFilters } from "../../orchestrator/civitai-filter-guard.js";
+
+const FILTERS = { modelSort: "Most Downloaded", baseModels: ["Flux.1 D"] };
+
+describe("#935: nothing to warn about", () => {
+  it("says nothing when no filters were supplied", () => {
+    expect(describeUnappliedFilters(undefined, { applied_filters: {} })).toBe("");
+    expect(describeUnappliedFilters({}, { applied_filters: {} })).toBe("");
+  });
+
+  // An empty array is "no constraint", not a filter that got dropped.
+  it("ignores empty and null values rather than reporting them as dropped", () => {
+    const r = { applied_filters: {} };
+    expect(describeUnappliedFilters({ baseModels: [], period: null }, r)).toBe("");
+  });
+
+  it("says nothing when the panel applied exactly what was asked", () => {
+    expect(describeUnappliedFilters(FILTERS, { applied_filters: FILTERS })).toBe("");
+  });
+
+  // A false alarm on every search trains the reader to skip the warning, which
+  // is how a guard stops working. Case, whitespace and array order are not
+  // divergence.
+  it("does not cry wolf over formatting differences", () => {
+    const echoed = { modelSort: "most downloaded ", baseModels: ["flux.1 d"] };
+    expect(describeUnappliedFilters(FILTERS, { applied_filters: echoed })).toBe("");
+    // A scalar echoed where a single-element array was sent is the same request.
+    expect(
+      describeUnappliedFilters({ baseModels: ["Flux.1 D"] }, { applied_filters: { baseModels: "Flux.1 D" } }),
+    ).toBe("");
+  });
+
+  it("reads the echo from either field name the panel may use", () => {
+    expect(describeUnappliedFilters(FILTERS, { filters: FILTERS })).toBe("");
+  });
+});
+
+describe("#935: a real divergence is named precisely", () => {
+  it("reports asked-vs-applied per filter, not a vague 'filters may not apply'", () => {
+    const w = describeUnappliedFilters(FILTERS, {
+      applied_filters: { modelSort: "Newest", baseModels: ["SDXL 1.0"] },
+    });
+    expect(w).toMatch(/2 of the 2 filter\(s\)/);
+    expect(w).toContain("modelSort: asked \"Most Downloaded\", applied \"Newest\"");
+    expect(w).toContain("baseModels: asked [\"Flux.1 D\"], applied [\"SDXL 1.0\"]");
+  });
+
+  it("calls a missing echo 'not applied' rather than printing undefined", () => {
+    const w = describeUnappliedFilters(FILTERS, { applied_filters: { modelSort: "Most Downloaded" } });
+    expect(w).toMatch(/1 of the 2 filter\(s\)/);
+    expect(w).toContain("baseModels: asked [\"Flux.1 D\"], applied not applied");
+    // The one that DID apply is not listed.
+    expect(w).not.toMatch(/modelSort: asked/);
+  });
+
+  // The actionable half: the results are real, they are just not what was asked
+  // for, and the agent must not describe them as sorted.
+  it("tells the caller not to describe the results as sorted or narrowed", () => {
+    const w = describeUnappliedFilters(FILTERS, { applied_filters: {} });
+    expect(w).toMatch(/produced WITHOUT them/);
+    expect(w).toMatch(/do not describe them as sorted or narrowed/);
+    expect(w).toMatch(/silently returns nothing/);
+  });
+});
+
+describe("#935: an absent echo is UNVERIFIED, not failed", () => {
+  // An older panel echoes nothing. Absence is not evidence the filters were
+  // dropped — and a reader told "failed" goes and fixes something that may not
+  // be broken, while a reader told "unverified" re-checks.
+  it("declines to claim the filters were ignored", () => {
+    const w = describeUnappliedFilters(FILTERS, { results: [] });
+    expect(w).toMatch(/UNVERIFIED/);
+    expect(w).toMatch(/not the same as knowing they were ignored/);
+    expect(w).not.toMatch(/were NOT applied/);
+  });
+
+  it("names the filters at stake and how to judge the result by eye", () => {
+    const w = describeUnappliedFilters(FILTERS, { results: [] });
+    expect(w).toContain("`modelSort`");
+    expect(w).toContain("`baseModels`");
+    expect(w).toMatch(/check that the list is actually in that order/);
+  });
+
+  // The ambiguity #374 existed to remove, restated for this parameter: the
+  // panel's own client documents that a bad baseModels value returns nothing.
+  it("says an empty result is not evidence the model does not exist", () => {
+    expect(describeUnappliedFilters(FILTERS, { results: [] })).toMatch(
+      /not evidence that no such model exists/,
+    );
+  });
+
+  it("says nothing at all when the reply is not an object to inspect", () => {
+    expect(describeUnappliedFilters(FILTERS, null)).toBe("");
+    expect(describeUnappliedFilters(FILTERS, "oops")).toBe("");
+  });
+});

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -2464,6 +2464,46 @@ describe("panel-tools: agent-driven CivitAI + training modals", () => {
     });
   });
 
+  // #935 — the #374 guard below covers `creator` and nothing else, so
+  // modelSort/baseModels/period could be supplied, ignored, and answered with a
+  // full plausible list. A reporter saw download counts in no order at all
+  // (48, 53, 53, 64, 1468) for a "Most Downloaded" sort. The guard's own rules
+  // are pinned in civitai-filter-guard.test.ts; these cover the WIRING.
+  it("panel_civitai_search WARNS when a supplied filter was not applied (#935)", async () => {
+    const { ctx } = makeFakeCtx({
+      creator: null,
+      applied_filters: { modelSort: "Newest" },
+    });
+    const res = await defByName("panel_civitai_search").handler(
+      { query: "flux lora", filters: { modelSort: "Most Downloaded" } },
+      ctx,
+    );
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toMatch(/were NOT applied/);
+    expect(text).toContain("Most Downloaded");
+    expect(text).toContain("Newest");
+    expect(text).toMatch(/do not describe them as sorted or narrowed/);
+  });
+
+  it("panel_civitai_search stays SILENT when the panel applied what was asked (#935)", async () => {
+    const filters = { modelSort: "Most Downloaded" };
+    const { ctx } = makeFakeCtx({ creator: null, applied_filters: filters });
+    const res = await defByName("panel_civitai_search").handler({ query: "x", filters }, ctx);
+    expect((res.content[0] as { text: string }).text).not.toMatch(/NOT applied|UNVERIFIED/);
+  });
+
+  it("panel_civitai_search reports an un-echoed filter as UNVERIFIED, not failed (#935)", async () => {
+    // An older panel echoes no applied_filters. Absence is not evidence.
+    const { ctx } = makeFakeCtx({ creator: null });
+    const res = await defByName("panel_civitai_search").handler(
+      { query: "x", filters: { baseModels: ["Flux.1 D"] } },
+      ctx,
+    );
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toMatch(/UNVERIFIED/);
+    expect(text).not.toMatch(/were NOT applied/);
+  });
+
   it("panel_civitai_search folds a creator into the query as an @creator token (#374)", async () => {
     const { ctx, calls } = makeFakeCtx({ creator: "tenstrip" });
     await defByName("panel_civitai_search").handler(

--- a/src/orchestrator/civitai-filter-guard.ts
+++ b/src/orchestrator/civitai-filter-guard.ts
@@ -1,0 +1,99 @@
+// #935 — a supplied-but-unapplied filter answered with a plausible result set.
+//
+// `panel_civitai_search` already guards ONE parameter. #374 fixed `creator`
+// being silently dropped: the tool echoed `creator:null` with zero results and
+// no explanation, so "filter never applied" and "this creator has no content"
+// were indistinguishable. The guard added there warns on divergence.
+//
+// It covers `creator` and nothing else. `modelSort`, `baseModels` and `period`
+// could be supplied, ignored, and answered with a full, ordinary-looking list —
+// which is what a reporter saw: download counts in no order at all
+// (48, 53, 53, 64, 1468) for a "Most Downloaded" sort. An agent asked for
+// "most-downloaded Flux LoRAs" presents that confidently, and nothing in the
+// reply says the sort never happened.
+//
+// The panel's own CivitAI client documents that an unrecognised `baseModels`
+// value "silently returns nothing", so an EMPTY result here is ambiguous in
+// exactly the way #374 existed to remove. That ambiguity is the part worth
+// closing permanently, independently of wherever the filters actually stop
+// taking effect — which is panel-side and not fixed here.
+
+/** What the caller asked for. Shape mirrors the tool's `filters` argument. */
+export type CivitaiFilters = Record<string, unknown> | undefined;
+
+/** Compare loosely: the panel may echo a scalar where an array was sent, or
+ *  differ only in case/whitespace. Only a REAL divergence should warn — a
+ *  false alarm on every search would train the reader to skip the warning,
+ *  which is how a guard stops working. */
+function sameValue(want: unknown, got: unknown): boolean {
+  if (want === got) return true;
+  const norm = (v: unknown): string =>
+    Array.isArray(v)
+      ? v.map((x) => String(x).trim().toLowerCase()).sort().join("|")
+      : String(v ?? "").trim().toLowerCase();
+  return norm(want) === norm(got);
+}
+
+/**
+ * The warning for filters the panel did not apply, or "" when there is nothing
+ * to say.
+ *
+ * Deliberately conservative about what it CLAIMS. The panel echoes back an
+ * `filters`/`applied_filters` object on newer builds; on an older one it echoes
+ * nothing, and absence is NOT evidence the filters were dropped. So:
+ *
+ *   - echoed and equal      → silent. Nothing happened worth reporting.
+ *   - echoed and different  → name each one, with asked-vs-applied.
+ *   - not echoed at all     → say the application could not be VERIFIED, and
+ *                             say plainly that this is not the same as knowing
+ *                             it failed. A reader who is told "unverified"
+ *                             re-checks; one told "failed" goes and fixes
+ *                             something that may not be broken.
+ */
+export function describeUnappliedFilters(filters: unknown, reply: unknown): string {
+  const supplied: CivitaiFilters =
+    filters && typeof filters === "object" && !Array.isArray(filters)
+      ? (filters as Record<string, unknown>)
+      : undefined;
+  const asked = Object.entries(supplied ?? {}).filter(
+    ([, v]) => v !== undefined && v !== null && !(Array.isArray(v) && v.length === 0),
+  );
+  if (asked.length === 0) return "";
+  if (!reply || typeof reply !== "object") return "";
+
+  const r = reply as Record<string, unknown>;
+  const echoed = (r.applied_filters ?? r.filters) as Record<string, unknown> | undefined;
+
+  if (!echoed || typeof echoed !== "object") {
+    return (
+      `This panel build did not echo back which filters it applied, so whether ` +
+      `${asked.map(([k]) => `\`${k}\``).join(", ")} took effect is UNVERIFIED — which is not the same as ` +
+      `knowing they were ignored. Judge the results before trusting the ordering or the narrowing: if a ` +
+      `sort was requested, check that the list is actually in that order. An unrecognised \`baseModels\` ` +
+      `value makes CivitAI return nothing at all, so an empty result here is not evidence that no such ` +
+      `model exists.`
+    );
+  }
+
+  const dropped = asked.filter(([k, v]) => !sameValue(v, echoed[k]));
+  if (dropped.length === 0) return "";
+
+  const lines = dropped
+    .map(([k, v]) => {
+      const got = echoed[k];
+      const gotStr =
+        got === undefined || got === null
+          ? "not applied"
+          : JSON.stringify(got);
+      return `  - ${k}: asked ${JSON.stringify(v)}, applied ${gotStr}`;
+    })
+    .join("\n");
+
+  return (
+    `${dropped.length} of the ${asked.length} filter(s) you supplied were NOT applied by the CivitAI ` +
+    `browser:\n${lines}\n` +
+    `The results below were produced WITHOUT them, so do not describe them as sorted or narrowed the way ` +
+    `you asked. Re-run with values the browser accepts (an out-of-enum sort/period is rejected outright, ` +
+    `and an unrecognised baseModels silently returns nothing), or read the list on its own terms.`
+  );
+}

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -100,6 +100,7 @@ import {
   type SecretSaveReceipt,
 } from "../services/panel-secrets.js";
 import { flattenUiWorkflow } from "../services/flatten-workflow.js";
+import { describeUnappliedFilters } from "./civitai-filter-guard.js";
 import { applyCapturedWidgetValues } from "../services/live-widget-overlay.js";
 import { listWorkflowLibraryKeys, userdataFetch } from "../services/userdata-library.js";
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
@@ -7614,6 +7615,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   `the logged-in browser session directly.`,
               });
             }
+          }
+          // #935 — the #374 guard above covers `creator` and NOTHING else, so
+          // modelSort / baseModels / period could be supplied, silently ignored,
+          // and answered with a full, plausible result set. An agent asked for
+          // "most-downloaded Flux LoRAs" then presents whatever came back, and
+          // neither it nor the user can tell the sort never applied. Same failure
+          // as #374, one parameter over.
+          const filterWarning = describeUnappliedFilters(args.filters, reply);
+          if (filterWarning) {
+            return ok({
+              ...(reply as Record<string, unknown>),
+              warning: filterWarning,
+            });
           }
           return ok(reply);
         } catch (err) {


### PR DESCRIPTION
Refs #935

## The bug

`panel_civitai_search` already guards **one** parameter. #374 fixed `creator` being dropped silently — the tool echoed `creator:null` with zero results, so *"filter never applied"* and *"this creator has no content"* were indistinguishable — and the guard added there warns on divergence.

**It covers `creator` and nothing else.** `modelSort` / `baseModels` / `period` could be supplied, ignored, and answered with a full, ordinary-looking list. A reporter saw download counts in no order at all — **48, 53, 53, 64, 1468** — for a "Most Downloaded" sort.

An agent asked for "most-downloaded Flux LoRAs" presents that confidently, and nothing in the reply says the sort never happened. Same failure as #374, one parameter over.

## The fix

| Panel echo | Result |
|---|---|
| equal to what was asked | **silent** — nothing worth reporting |
| different | each filter named, asked-vs-applied, plus *"do not describe them as sorted or narrowed"* |
| **absent** | **UNVERIFIED**, said as such |

The third row is what keeps this honest. An older panel echoes nothing, and absence is not evidence the filters were dropped — a reader told *"failed"* goes and fixes something that may not be broken; one told *"unverified"* re-checks.

Comparison is deliberately **loose**: case, whitespace, array order, and a scalar echoed where a single-element array was sent all count as agreement. A guard that cries wolf on every search trains the reader to skip it, which is how a guard stops working.

The ambiguity #374 existed to remove is restated for this parameter: the panel's own CivitAI client documents that an unrecognised `baseModels` value **silently returns nothing**, so an empty result here is not evidence that no such model exists. The warning now says so.

## Not fixed

**Part 1 of the report** — threading the incoming `filters` into the client's filter state — is panel-side (`web/js/cmcp-civitai.js`, `h.civitai.search`), and the reporter could not pinpoint where they stop taking effect either. Left open; this is `Refs`, not `Closes`.

This half stands on its own. The reporter argued it matters even if the first turns out to be narrow, and it does: it converts a silent wrong answer into a visible one regardless of the cause.

## Verification

- 12 new unit tests + 3 end-to-end through the handler; full suite **321 files / 7011 passed**; `tsc` and `check:vocabulary` clean.
- **Mutation-verified in both classes on the first pass**: bypassing the guard at the call site kills 2 wiring tests; collapsing UNVERIFIED into "not applied" kills 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)