### PR TITLE
fix(#949): a batch queues N runs, so ticket N runs

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -16,6 +16,7 @@ import { getNsfwConsent, setNsfwConsent } from "../../services/panel-settings.js
 import { getBootLocalComfyUIBaseUrl } from "../../config.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
+  acceptedPromptIds,
   buildPanelToolDefs,
   makePanelToolCtx,
   registerPanelTools,
@@ -29,6 +30,7 @@ import {
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 import { markReplyTimeout } from "../../services/ui-bridge.js";
 import { RunCompletions } from "../../orchestrator/run-completion-journal.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
 import { AskAnswers } from "../../orchestrator/ask-answer-journal.js";
 
 type Forwarded = Record<string, unknown>;
@@ -807,6 +809,75 @@ describe("panel-tools: panel_run verdict is derived from the ComfyUI reply", () 
     // #468 — the anti-poll instruction is only safe because the completion can be
     // correlated back to this exact run; the ticket is what makes that possible.
     expect(RunCompletions.ticketFor("p-ok")).toBeDefined();
+  });
+
+  // #949 — batch_count > 1 makes the panel report `prompt_ids` for EVERY queued
+  // render alongside `prompt_id` for the first. Only the first was ticketed, so
+  // completions 2..N came back as "does NOT match any run you queued … its
+  // origin is UNDETERMINED" — for runs the agent had just queued itself.
+  it("#949: a BATCH tickets every prompt id, not just the first", async () => {
+    const reply: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            queued: true,
+            batch_count: 3,
+            prompt_id: "p-batch-1",
+            prompt_ids: ["p-batch-1", "p-batch-2", "p-batch-3"],
+          }),
+        },
+      ],
+    };
+    const { ctx } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({ batch_count: 3 }, ctx);
+    expect(res.isError).toBeFalsy();
+    for (const id of ["p-batch-1", "p-batch-2", "p-batch-3"]) {
+      expect(RunCompletions.ticketFor(id), id).toBeDefined();
+    }
+    // Every one of them is also OURS, so a later backlog warning does not call
+    // the agent's own batch a foreign job (#559).
+    for (const id of ["p-batch-2", "p-batch-3"]) {
+      expect(QueueMonitor.attributeRun(id), id).toBe("mine");
+    }
+    // The batch is correlatable, so the anti-poll promise still stands.
+    expect(textOf(res)).toContain(QUEUED_NOTE);
+  });
+
+  it("#949: prompt_id repeated inside prompt_ids opens ONE ticket, not two", async () => {
+    const reply: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            queued: true,
+            batch_count: 2,
+            prompt_id: "p-dup-1",
+            prompt_ids: ["p-dup-1", "p-dup-2"],
+          }),
+        },
+      ],
+    };
+    const { ctx } = makeRunCtx(reply);
+    await defByName("panel_run").handler({ batch_count: 2 }, ctx);
+    // One prompt id always means one run — a duplicate must not stack a second
+    // ticket, which openRun would otherwise treat as a re-queue.
+    expect(RunCompletions.ticketFor("p-dup-1")).toBeDefined();
+    expect(RunCompletions.ticketFor("p-dup-2")).toBeDefined();
+    expect(acceptedPromptIds({ prompt_id: "p-dup-1", prompt_ids: ["p-dup-1", "p-dup-2"] })).toEqual([
+      "p-dup-1",
+      "p-dup-2",
+    ]);
+  });
+
+  it("#949: a malformed prompt_ids does not break the single-id path", async () => {
+    // Junk entries are skipped, not ticketed, and prompt_id still works.
+    expect(acceptedPromptIds({ prompt_id: "p-a", prompt_ids: [null, 7, "", "  ", "p-b"] })).toEqual([
+      "p-a",
+      "p-b",
+    ]);
+    expect(acceptedPromptIds({ prompt_ids: "not-an-array" })).toEqual([]);
+    expect(acceptedPromptIds(null)).toEqual([]);
   });
 
   it("#704: the ticket records the CONVERSATION that queued the run, not just the routed tab", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2173,6 +2173,31 @@ function acceptedPromptId(parsed: Record<string, unknown> | null): string | null
   return typeof pid === "string" && pid.trim() !== "" ? pid.trim() : null;
 }
 
+/**
+ * EVERY prompt id a graph_run reply minted, first one first (#949).
+ *
+ * `batch_count > 1` makes the panel report `prompt_ids` for all N renders
+ * alongside `prompt_id` for the first. Reading only `prompt_id` ticketed one run
+ * and left 2..N uncorrelated, so their completions came back as "does NOT match
+ * any run you queued … its origin is UNDETERMINED" — for runs the agent had just
+ * queued itself.
+ *
+ * Deduped and order-preserving: `prompt_id` normally repeats the first entry of
+ * `prompt_ids`, and a duplicate would open two tickets for one render.
+ */
+export function acceptedPromptIds(parsed: Record<string, unknown> | null): string[] {
+  const out: string[] = [];
+  const add = (v: unknown) => {
+    if (typeof v !== "string") return;
+    const id = v.trim();
+    if (id !== "" && !out.includes(id)) out.push(id);
+  };
+  add(parsed?.prompt_id);
+  const many = parsed?.prompt_ids;
+  if (Array.isArray(many)) for (const v of many) add(v);
+  return out;
+}
+
 function detectRunRejection(res: ToolResult): ToolResult | null {
   // Bridge/transport/executor error: never a queue. Preserve it verbatim (#248),
   // no success note (#331). fail() already carries err.message (incl. any stack).
@@ -6852,17 +6877,26 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // (#559). The panel forwards ComfyUI's /prompt reply, which carries the
         // prompt_id; when it doesn't, the timestamp still marks a recent self-queue.
         const runReply = parseToolResultJson(res);
-        const queuedId = acceptedPromptId(runReply);
+        // #949 — batch_count > 1 makes the panel report `prompt_ids` for EVERY
+        // queued render alongside `prompt_id` for the first. Only the first was
+        // ever ticketed, so completions 2..N came back as
+        // "does NOT match any run you queued … its origin is UNDETERMINED" — for
+        // runs the agent had just queued itself. Ticket all of them.
+        const queuedIds = acceptedPromptIds(runReply);
+        const queuedId = queuedIds[0];
         // #944: a run ComfyUI accepted while dropping some outputs reaches here
         // (a minted prompt id outranks the rejection signals). Say which outputs
         // were dropped, or the caller waits for files that will never be written.
         const droppedNote = describeDroppedOutputs(runReply);
-        QueueMonitor.markSelfQueued(queuedId);
+        // markSelfQueued with NO id still stamps the recent-self-queue timestamp,
+        // so the id-less case must still call it exactly once (#559).
+        if (queuedIds.length === 0) QueueMonitor.markSelfQueued(null);
+        for (const id of queuedIds) QueueMonitor.markSelfQueued(id);
         // #468 — open a run ticket so the render's completion can be CORRELATED
         // to this exact call by prompt id. This is what lets the orchestrator
         // journal an undelivered completion and replay it into the right run
         // instead of losing it while the agent works through a goal.
-        const correlatable = RunCompletions.openRun(queuedId, {
+        const ticketOpts = {
           // #884 — the REAL routed tab, captured at dispatch (see runTicketTab):
           // the panel's `executed` event arrives under that id.
           tabId: runTicketTab,
@@ -6871,7 +6905,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // which is what still holds after the panel reconnects under a new id.
           ...(runTicketConversation !== undefined ? { conversation: runTicketConversation } : {}),
           ...(typeof args.to_node_id === "number" ? { toNodeId: args.to_node_id } : {}),
-        });
+        };
+        // Every id gets its own ticket. `correlatable` stays the promise the
+        // anti-poll note is allowed to make — true only if at least one run can
+        // actually be correlated back.
+        const correlatable =
+          queuedIds.length === 0
+            ? RunCompletions.openRun(undefined, ticketOpts)
+            : queuedIds.map((id) => RunCompletions.openRun(id, ticketOpts)).some(Boolean);
         // Append anti-poll guidance: the agent should go idle after queuing so the
         // executed event auto-injects the output image, rather than busy-polling.
         //


### PR DESCRIPTION
Closes #949

## The bug

`batch_count > 1` makes the panel report `prompt_ids` for **every** queued render alongside `prompt_id` for the first. Only `prompt_id` was ever read, so runs 2..N got no `RunCompletions` ticket and no self-queue attribution.

Their completions then came back as:

```
This run (prompt <uuid>) does NOT match any run you queued with panel_run —
its origin is UNDETERMINED.
```

…for renders the agent had queued itself, seconds earlier, in one call.

## The fix

`acceptedPromptIds` collects every id, first one first, and each gets its own ticket and its own `markSelfQueued`.

**Deduped**, because `prompt_id` normally repeats the first entry of `prompt_ids` — and `openRun` treats a repeat as a *re-queue* of the same id, reopening the ticket. One prompt id must always mean one run.

## Two things kept deliberately intact

- **The id-less path still calls `markSelfQueued(null)` exactly once.** That call stamps the recent-self-queue *timestamp* even with no id, which is what stops a later backlog warning calling the agent's own job foreign (#559). Looping over an empty array would have silently dropped it.
- **`correlatable` still gates the anti-poll promise**, now as *"at least one of these can be correlated back"* rather than *"the first one could"*. The note it guards promises automatic delivery, and that promise must not outrun what the journal can actually attribute (#468).

## Credit

The reporter had already applied this fix locally and described it precisely. This is their change, with the dedupe and the id-less-path preservation added.

## Verification

- 3 new tests; full suite **321 files / 7019 passed**; `tsc` and `check:vocabulary` clean.
- **Mutation-verified through the real `panel_run` handler**, not the extractor alone: ticketing only the first id kills 2, ignoring `prompt_ids` kills 3, removing the dedupe kills 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)