### PR TITLE
fix(#962): list what the server REGISTERS, not 15 hardcoded folder names

### DIFF
--- a/src/__tests__/services/list-local-models.test.ts
+++ b/src/__tests__/services/list-local-models.test.ts
@@ -132,12 +132,23 @@ describe("listLocalModels — HTTP-first with FS fallback", () => {
     expect(readdir).not.toHaveBeenCalled();
   });
 
-  it("#526: discovery is scoped to *_gguf categories, ignoring non-gguf / non-model keys", async () => {
-    // `/models` lists the whole registry: core categories, other loaders' non-gguf
-    // categories (tensorrt/.engine), and extension-BLIND non-model registries
-    // (custom_nodes/datasets — empty extension sets that would list arbitrary files).
-    // Only the `*_gguf` categories are safe to fold in; everything else must be
-    // neither queried nor listed. Core categories are not re-queried.
+  it("#526/#962: a discovered category contributes only WEIGHTS, never arbitrary files", async () => {
+    // `/models` lists the whole registry: core categories, other loaders'
+    // non-gguf categories (tensorrt/.engine), and extension-BLIND non-model
+    // registries (custom_nodes/datasets — empty extension sets, so
+    // `/models/<that>` returns every file in the folder).
+    //
+    // #526 answered that by folding in ONLY `*_gguf` and querying nothing else.
+    // Sound at the time, but it left #962: MODEL_SUBDIRS is 15 hardcoded names,
+    // and a reporter's UNETLoader was loading a .safetensors registered under a
+    // key none of them covered, while this tool reported no models at all. A
+    // denylist of category NAMES cannot fix that — the set is open, since any
+    // custom node can register its own.
+    //
+    // So discovery now folds in the whole registry and the FILES are filtered by
+    // weight extension instead. The anti-flood guarantee #526 was protecting is
+    // unchanged and asserted below; what changed is that it is now enforced per
+    // FILE rather than by refusing to look.
     getClient.mockReturnValue({ fetchApi });
     const queried: string[] = [];
     fetchApi.mockImplementation(async (path: string) => {
@@ -154,20 +165,37 @@ describe("listLocalModels — HTTP-first with FS fallback", () => {
           { status: 200 },
         );
       }
-      return path === "/models/unet_gguf"
-        ? new Response(JSON.stringify(["flux-Q4.gguf"]), { status: 200 })
-        : new Response("[]", { status: 200 });
+      if (path === "/models/unet_gguf") {
+        return new Response(JSON.stringify(["flux-Q4.gguf"]), { status: 200 });
+      }
+      // An extension-BLIND registry: it answers with whatever is in the folder.
+      if (path === "/models/custom_nodes") {
+        return new Response(
+          JSON.stringify(["__init__.py", "requirements.txt", "README.md"]),
+          { status: 200 },
+        );
+      }
+      if (path === "/models/datasets") {
+        return new Response(JSON.stringify(["captions.json", "img_001.png"]), { status: 200 });
+      }
+      // A real non-gguf weight category, invisible to the old name-scoped rule.
+      if (path === "/models/tensorrt") {
+        return new Response(JSON.stringify(["unet_fp8.engine", "build.log"]), { status: 200 });
+      }
+      return new Response("[]", { status: 200 });
     });
 
     const result = await listLocalModels();
-    // Only the gguf model is surfaced by discovery.
-    expect(result.map((m) => ({ name: m.name, type: m.type }))).toEqual([
-      { name: "flux-Q4.gguf", type: "unet_gguf" },
-    ]);
-    // Non-gguf / non-model categories are never even queried.
-    expect(queried).not.toContain("/models/tensorrt");
-    expect(queried).not.toContain("/models/custom_nodes");
-    expect(queried).not.toContain("/models/datasets");
+    const got = result.map((m) => ({ name: m.name, type: m.type }));
+
+    // THE FLOOD GUARANTEE, unchanged: not one .py / .txt / .md / .json / .png
+    // reaches the listing, even though those categories WERE queried.
+    expect(got.some((m) => /\.(py|txt|md|json|png|log)$/i.test(m.name))).toBe(false);
+
+    // …and the weights under keys MODEL_SUBDIRS never heard of now appear (#962).
+    expect(got).toContainEqual({ name: "flux-Q4.gguf", type: "unet_gguf" });
+    expect(got).toContainEqual({ name: "unet_fp8.engine", type: "tensorrt" });
+
     // `checkpoints` is core → queried exactly once by the core scan, not by discovery.
     expect(queried.filter((p) => p === "/models/checkpoints")).toHaveLength(1);
   });
@@ -539,5 +567,55 @@ describe("listLocalModels — HTTP-first with FS fallback", () => {
     fetchApi.mockResolvedValue(new Response("Not Found", { status: 404 }));
     const result = await listLocalModels("checkpoints");
     expect(result).toEqual([]);
+  });
+});
+
+// #962 — the reported shape, end to end. A remote server whose UNETLoader listed
+// and loaded `krastBf16_v3.safetensors` answered "No diffusion_models models
+// found" AND "No unet models found": the weights were registered under a key
+// MODEL_SUBDIRS does not contain, and a hardcoded list of 15 folder names can
+// never find them. /models is ComfyUI's own answer to "what do I serve?".
+describe("#962: weights under an UNKNOWN registered category are found", () => {
+  it("surfaces a .safetensors from a category MODEL_SUBDIRS does not list", async () => {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockImplementation(async (path: string) => {
+      if (path === "/models") {
+        // The core names answer empty; the real weights live elsewhere.
+        return new Response(
+          JSON.stringify(["diffusion_models", "unet", "krast_weights"]),
+          { status: 200 },
+        );
+      }
+      if (path === "/models/krast_weights") {
+        return new Response(JSON.stringify(["krastBf16_v3.safetensors"]), { status: 200 });
+      }
+      return new Response("[]", { status: 200 });
+    });
+
+    const result = await listLocalModels();
+    expect(result).toContainEqual({
+      name: "krastBf16_v3.safetensors",
+      path: "krast_weights/krastBf16_v3.safetensors",
+      size: 0,
+      modified: "",
+      type: "krast_weights",
+    });
+  });
+
+  // A FILTERED call names its category outright, so it must not pay for
+  // discovery — and must still answer for a category it was handed directly.
+  it("a filtered call does not run discovery", async () => {
+    getClient.mockReturnValue({ fetchApi });
+    const queried: string[] = [];
+    fetchApi.mockImplementation(async (path: string) => {
+      queried.push(path);
+      return path === "/models/checkpoints"
+        ? new Response(JSON.stringify(["sd_xl.safetensors"]), { status: 200 })
+        : new Response("[]", { status: 200 });
+    });
+
+    const result = await listLocalModels("checkpoints");
+    expect(result).toHaveLength(1);
+    expect(queried).not.toContain("/models");
   });
 });

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -334,7 +334,36 @@ function makeModelDeduper(): { add: (category: string, name: string) => boolean 
   };
 }
 
-async function discoverGgufCategories(
+/**
+ * Weight-file extensions. The gate that makes discovering the WHOLE registry
+ * safe (#962).
+ *
+ * #526 deliberately scoped discovery to `*_gguf` because `/models` also lists
+ * extension-BLIND registries — `custom_nodes`, `datasets` and friends register
+ * an EMPTY extension set, so `/models/<that>` returns every file in the folder
+ * and folding one in would flood the listing with arbitrary files. That reason
+ * is sound, and a denylist of category NAMES cannot answer it: the set is open,
+ * since any custom node can register its own.
+ *
+ * Filtering the FILES instead closes it for good. A discovered category
+ * contributes only recognisable weights, so an extension-blind registry full of
+ * .txt/.json/.py contributes nothing — while a `.safetensors` under a key
+ * MODEL_SUBDIRS never heard of finally becomes visible, which is the whole of
+ * #962.
+ */
+const WEIGHT_EXTS = new Set([
+  ".safetensors",
+  ".ckpt",
+  ".pt",
+  ".pth",
+  ".bin",
+  ".gguf",
+  ".sft",
+  ".onnx",
+  ".engine", // TensorRT
+]);
+
+async function discoverExtraCategories(
   client: ReturnType<typeof getClient>,
 ): Promise<string[]> {
   try {
@@ -343,13 +372,22 @@ async function discoverGgufCategories(
     const json = (await res.json()) as unknown;
     if (!Array.isArray(json)) return [];
     const core = new Set<string>(MODEL_SUBDIRS);
-    // Keep `*_gguf` categories only, deduped, minus any the core scan already covers.
+    // EVERY registered category we don't already scan, not just `*_gguf` (#962).
+    //
+    // MODEL_SUBDIRS is a hardcoded list of 15 folder names. Anything ComfyUI
+    // registers outside it — a custom node's own folder, an extra_model_paths
+    // entry, a fork's renamed weights dir — was invisible to this tool BY
+    // CONSTRUCTION. A reporter had a remote server whose UNETLoader listed and
+    // loaded `krastBf16_v3.safetensors` while `list_local_models` answered "no
+    // diffusion_models models found" AND "no unet models found": the weights
+    // were registered under a key neither name covers, and a hardcoded list can
+    // never find them.
+    //
+    // `/models` is ComfyUI's own answer to "what folders do I serve?", so
+    // discovery replaces the guess rather than supplementing it.
     return [
       ...new Set(
-        json.filter(
-          (c): c is string =>
-            typeof c === "string" && /_gguf$/i.test(c) && !core.has(c),
-        ),
+        json.filter((c): c is string => typeof c === "string" && c.trim() !== "" && !core.has(c)),
       ),
     ];
   } catch (err) {
@@ -420,15 +458,21 @@ async function collectLocalModels(
   // those, and they fail entirely in remote/cloud mode where comfyuiPath is
   // undefined. Originally contributed by João Lucas (github.com/joaolvivas) in
   // joaolvivas/comfyui-mcp-byjlucas@e2ae39c8 (2026-05-12).
+  const coreDirs = new Set<string>(MODEL_SUBDIRS);
   let httpReturnedAny = false;
   try {
     const client = getClient(); // throws CLOUD_UNSUPPORTED in cloud mode
-    // For an unfiltered listing, also scan ComfyUI-GGUF's registered `*_gguf`
-    // categories (`unet_gguf`/`clip_gguf`, …) holding the `.gguf` weights that core
-    // `/models/<dir>` omits. A filtered call already targets its exact category via
-    // dirsToScan, so it needs no discovery. See #526.
+    // For an unfiltered listing, scan every category the server REGISTERS that
+    // MODEL_SUBDIRS doesn't already cover. That began as ComfyUI-GGUF's `*_gguf`
+    // views (#526, the `.gguf` weights core `/models/<dir>` omits) and is now the
+    // whole registry (#962): a hardcoded list of 15 folder names cannot find
+    // weights a custom node, a fork, or an extra_model_paths entry registered
+    // under some other key — and a reporter's UNETLoader was loading exactly such
+    // a file while this tool reported none.
+    //
+    // A FILTERED call already names its exact category, so it needs no discovery.
     if (!modelType) {
-      for (const cat of await discoverGgufCategories(client)) dirsToScan.push(cat);
+      for (const cat of await discoverExtraCategories(client)) dirsToScan.push(cat);
     }
     // A `*_gguf` view aliases real folders, so the same file can be reported both
     // via the view and via a core category (e.g. a custom node that re-registers
@@ -479,6 +523,14 @@ async function collectLocalModels(
           // lists every file) over a shared dir — without this guard that would flood
           // the output. Core categories never contain `.gguf`, so this stays additive.
           if (isGgufCategory(dir) && !name.toLowerCase().endsWith(".gguf")) continue;
+          // #962 — the same hardening, generalised to every DISCOVERED category.
+          // Discovery now folds in the whole registry, which includes
+          // extension-blind entries (custom_nodes, datasets, a custom node's own)
+          // whose `/models/<dir>` returns every file in the folder. Requiring a
+          // weight extension is what keeps that from flooding the listing, and it
+          // is the reason discovery can be widened at all. CORE categories are
+          // untouched — their behaviour is unchanged.
+          if (!coreDirs.has(dir) && !WEIGHT_EXTS.has(extname(name).toLowerCase())) continue;
           if (!dedup.add(dir, name)) continue; // same file already surfaced elsewhere
           httpReturnedAny = true;
           results.push({


### PR DESCRIPTION
Closes #962

## The bug

A reporter's remote ComfyUI answered **"No diffusion_models models found"** *and* **"No unet models found"** while its live `UNETLoader` listed and loaded `krastBf16_v3.safetensors` from that same server.

The weights were registered under a category `MODEL_SUBDIRS` does not contain — and `MODEL_SUBDIRS` is a hardcoded list of 15 folder names. **No amount of retrying could ever have found them.** Invisible by construction.

## The fix

`/models` is ComfyUI's own answer to *"what folders do I serve?"*. Discovery now folds in **every** registered category the core list doesn't already cover, instead of only `*_gguf`.

## Which required solving why #526 scoped it to `*_gguf`

`/models` also lists **extension-blind** registries — `custom_nodes`, `datasets`, and whatever a custom node registers — whose entries have an *empty* extension set, so `/models/<that>` returns every file in the folder. Folding one in would flood the listing with `.py` / `.json` / `.png`.

That reason was sound. And a denylist of category **names** cannot answer it — the set is open by definition, since any custom node can register its own.

So the guarantee moved from the **category** to the **file**:

| | Before | After |
|---|---|---|
| `unet_gguf/flux-Q4.gguf` | listed | listed |
| `krast_weights/krastBf16_v3.safetensors` | **invisible** | listed |
| `tensorrt/unet_fp8.engine` | not even queried | listed |
| `custom_nodes/__init__.py` | not queried | queried, **contributes nothing** |
| `datasets/img_001.png` | not queried | queried, **contributes nothing** |

Core categories are untouched — byte-for-byte unchanged behaviour; only non-core dirs pay the filter.

## On updating #526's test

I updated its regression test rather than working around it. Its **intent** — never flood the listing with arbitrary files — is preserved and now asserted *more* directly: the extension-blind categories are queried **and** contribute zero entries, which is a stronger claim than "we never looked." Its other assertion, that core categories are queried exactly once, is unchanged.

## Verification

- 2 new tests + 1 rewritten; full suite **321 files / 7021 passed**; `tsc` and `check:vocabulary` clean.
- **Mutation-verified on both halves** — the fix and the guarantee it had to preserve: scoping discovery back to `*_gguf` kills 2 tests; removing the weight-extension filter kills the flood test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)