### PR TITLE
0.50.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.4] - 2026-08-07
+
+### MCP
+
+#### Added
+- summary_only, so the report costs a report (panel#690(5)) (#992)
+- expose the filter/limit the panel now honours (panel#690(5)) (#990)
+
+#### Fixed
+- list what the server REGISTERS, not 15 hardcoded folder names (#995)
+- a batch queues N runs, so ticket N runs (#994)
+- extend the unapplied-filter guard past `creator` (#993)
+- a run-error notice must not assert who queued the run (#991)
+- a remedy has to work from where the user is reading it (#989)
+- a slice that matches no output node explains why (panel#690(4)) (#986)
+
+
 ## [0.50.3] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.3",
+  "version": "0.50.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.3",
+      "version": "0.50.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.3",
+  "version": "0.50.4",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **0.50.4**, reconciling the release commit onto protected `main` (the tag `v0.50.4` is already pushed and publishing).

### Contents

**Fixed**

| PR | Issue | Fix |
|---|---|---|
| #995 | #962 | list what the server REGISTERS, not 15 hardcoded folder names |
| #994 | #949 | a batch queues N runs, so ticket N runs |
| #993 | #935 | extend the unapplied-filter guard past `creator` |
| #991 | #889 | a run-error notice must not assert who queued the run |
| #989 | #948 | a remedy has to work from where the user is reading it |
| #986 | — | a slice that matches no output node explains why |

**Added**

| PR | Change |
|---|---|
| #992 | `panel_flatten_workflow`: `summary_only`, so the report costs a report |
| #990 | `panel_list_subgraphs`: expose the filter/limit the panel now honours |

### The theme, again

Every fix in this release is the same defect class as 0.50.2's: **a claim the code was not entitled to make.**

- #962 — "No models found" for weights the server was actively loading, because the category list was hardcoded and could not see them.
- #949 — "does NOT match any run you queued" for renders the agent queued itself, seconds earlier, in one call.
- #889 — "the workflow run **you just queued** ERRORED" sent to a session that had never queued anything.
- #948 — `/login`, a CLI command, printed into a chat box where a leading `/` reads as "type this here".
- #935 — a sort silently not applied, answered with a plausible list nobody could tell was unsorted.

### Changelog was hand-corrected again (#988)

`gen-changelog` produced a section listing **23** commits since `v0.50.1` — walking past both the `v0.50.2` and `v0.50.3` tags, because neither is an ancestor of `main`. Trimmed to the 8 that are actually new.

This is the second release in a row it has happened, exactly as #988 predicted. The root cause is structural: the flow tags a local commit and then squash-merges the version bump, so the tag can never be an ancestor. Worth fixing before the next release — tag the merged commit, or fast-forward instead of squashing.

### Verification

Full suite **329 files / 7021 passed** on `main` at `a4859fe`, with `tsc`, `lint`, `build`, `check:vocabulary`, `vocab:export --check` and the `docs:gen` no-op gate all clean. Every fix was mutation-verified before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)