### PR TITLE
fix(#996): say WHY the caller is holding a tool that does not exist

### DIFF
--- a/src/__tests__/tools/vocabulary.test.ts
+++ b/src/__tests__/tools/vocabulary.test.ts
@@ -767,8 +767,35 @@ describe("findDeadName", () => {
 
 describe("retiredToolMessage", () => {
   it("quotes the removing version and the replacement", () => {
-    expect(retiredToolMessage("apps_run")).toBe(
-      `Unknown tool 'apps_run' — removed in 0.49.0. Call apps (action:"run") instead.`,
+    // Leads with exactly this — the redirect is the first thing a caller reads.
+    // Asserted as a PREFIX rather than the whole string so the message can carry
+    // further diagnosis (see the #996 case below) without this test having to
+    // restate it; the claim here is about the version and the replacement.
+    expect(retiredToolMessage("apps_run")).toMatch(
+      /^Unknown tool 'apps_run' — removed in 0\.49\.0\. Call apps \(action:"run"\) instead\./,
+    );
+  });
+
+  // #996 — a reporter saw list_tools advertise `read_skill`, describe_tool
+  // succeed on it, then got this error, and filed a catalog/dispatcher mismatch.
+  // The catalog is built by re-running the SAME registration pass, so it cannot
+  // contain a retired name: what they were reading was a tool list captured
+  // BEFORE the upgrade and cached by their client. Without saying so, the only
+  // available reading is "the server is inconsistent" — wrong and unactionable.
+  it("#996: explains why the caller was holding a name that does not exist", () => {
+    const m = retiredToolMessage("read_skill") ?? "";
+    expect(m).toMatch(/captured before this server was upgraded/);
+    expect(m).toMatch(/reconnect the MCP client/);
+    // …and states the fact that rules out the mismatch they suspected.
+    expect(m).toMatch(/cannot contain a retired name/);
+  });
+
+  it("#996: the stale-catalog note never displaces the redirect", () => {
+    const m = retiredToolMessage("read_skill") ?? "";
+    // The replacement still comes first; diagnosis is an addendum, not a
+    // replacement for the answer.
+    expect(m.indexOf('list_packs (action:"skill_read")')).toBeLessThan(
+      m.indexOf("reconnect the MCP client"),
     );
   });
 
@@ -784,5 +811,35 @@ describe("retiredToolMessage", () => {
 
   it("returns undefined for a genuinely unknown name", () => {
     expect(retiredToolMessage("definitely_not_a_tool")).toBeUndefined();
+  });
+});
+
+// #996 — the message now asserts something structural: "The catalog this server
+// serves cannot contain a retired name." That is only honest if it is enforced.
+//
+// It holds by construction — collectToolCatalog re-runs the SAME registration
+// pass the live server uses, so a name nobody registers cannot appear — but
+// "holds by construction" is exactly the kind of claim that quietly stops
+// holding. Pin it against the real catalog.
+describe("#996: the catalog and the dead-name ledger cannot disagree", () => {
+  it("advertises no name the ledger has retired", async () => {
+    const { collectToolCatalog } = await import("../../tools/index.js");
+    const catalog = await collectToolCatalog();
+    const advertised = new Set(catalog.tools.keys());
+    const retired = DEAD_NAMES.map((d) => d.name).filter((n) => advertised.has(n));
+    expect(retired, `catalog advertises retired name(s): ${retired.join(", ")}`).toEqual([]);
+  });
+
+  it("advertises exactly the live tool surface", async () => {
+    const { collectToolCatalog } = await import("../../tools/index.js");
+    const catalog = await collectToolCatalog();
+    // Every catalogued tool is a live name (saved-workflow tools are registered
+    // dynamically and are not part of the fixed vocabulary, so allow those).
+    const live = new Set<string>(TOOL_NAMES);
+    const unknown = [...catalog.tools.values()]
+      .filter((t) => t.category !== "saved-workflows")
+      .map((t) => t.name)
+      .filter((n) => !live.has(n));
+    expect(unknown, `catalogued but not in TOOL_NAMES: ${unknown.join(", ")}`).toEqual([]);
   });
 });

--- a/src/tools/vocabulary.ts
+++ b/src/tools/vocabulary.ts
@@ -2093,7 +2093,24 @@ export function retiredToolMessage(name: string): string | undefined {
   const dead = findDeadName(name);
   if (!dead) return undefined;
   const removed = dead.since.startsWith("removed") ? dead.since : `removed in ${dead.since}`;
-  return `Unknown tool '${name}' — ${removed}. Call ${dead.replacement} instead.`;
+  return (
+    `Unknown tool '${name}' — ${removed}. Call ${dead.replacement} instead.` +
+    // #996 — the redirect answered WHAT to call and never WHY the caller was
+    // holding a name that does not exist. A reporter saw list_tools advertise
+    // read_skill and describe_tool succeed on it, then got this error, and
+    // filed a catalog/dispatcher mismatch. The catalog is built by re-running
+    // the SAME registration pass, so it cannot contain a retired name — what
+    // they were reading was a tool list captured BEFORE the upgrade and cached
+    // by the client (MCP clients hold tools/list until told otherwise).
+    //
+    // Without this sentence the only reading available is "the server is
+    // inconsistent", which is both wrong and unactionable. One line converts it
+    // into a stale-cache diagnosis with a remedy — the same job the rest of this
+    // message already does for the name itself.
+    ` If your tool list still shows '${name}', it was captured before this server` +
+    ` was upgraded: reconnect the MCP client (/mcp) to pick up the current` +
+    ` surface. The catalog this server serves cannot contain a retired name.`
+  );
 }
 
 /**


### PR DESCRIPTION
Closes #996

## The report

A reporter saw `list_tools` advertise `read_skill`, `describe_tool` succeed on it, then got:

```
Unknown tool 'read_skill' — removed in 0.50.0. Call list_packs (action:"skill_read") instead.
```

…and filed a catalog/dispatcher mismatch. Entirely reasonable: from where they stood, the server was advertising a tool it then refused.

## The catalog is not stale

It's built by re-running the **same registration pass** the live server uses, so it cannot contain a retired name. Verified against the real thing rather than reasoned about:

```
catalog size: 37
read_skill          -> absent
list_skills         -> absent
generate_node_skill -> absent
has list_packs: true
```

What they were reading was a tool list captured **before** the upgrade and cached by their client — MCP clients hold `tools/list` until told otherwise.

## The fix

The redirect answered *what* to call and never *why* they were holding the name at all, so the only available reading was "the server is inconsistent" — wrong, and unactionable. One sentence turns it into a stale-cache diagnosis with a remedy:

> …Call `list_packs (action:"skill_read")` instead. **If your tool list still shows 'read_skill', it was captured before this server was upgraded: reconnect the MCP client (/mcp) to pick up the current surface. The catalog this server serves cannot contain a retired name.**

The redirect still comes **first**; the diagnosis is an addendum, never a replacement for the answer. A test pins that ordering.

## Pinning the claim it now makes

The message asserts something structural — *"the catalog this server serves cannot contain a retired name"* — so that is now enforced rather than merely true today:

- a test builds the **real** catalog and intersects it with `DEAD_NAMES`
- a second checks every catalogued tool is in `TOOL_NAMES`

"Holds by construction" is exactly the kind of claim that quietly stops holding.

## Test note

One existing test asserted the whole message with `toBe`. Its stated intent is that the message *quotes* the removing version and the replacement, so it now asserts that as a **prefix** — same claim, and the message can carry further diagnosis without the test restating it.

## Verification

- 4 new tests; full suite **329 files / 7025 passed**; `tsc`, `check:vocabulary`, `docs:gen` no-op clean.
- **Mutation-verified**: dropping the new sentence kills its test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)