### PR TITLE
fix(#947): the Manager route is a routing fallback, not a remote server

### DIFF
--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -8,10 +8,20 @@ vi.mock("../../config.js", () => {
     huggingfaceToken: undefined as string | undefined,
     civitaiApiToken: undefined as string | undefined,
   };
-  // downloadModel routes to the Manager install-model path in remote mode
-  // (comfyuiPath unset). Most tests set comfyuiPath, so this is false for them.
-  return { config, isRemoteMode: () => !config.comfyuiPath };
+  // #947 — this stub USED to be exactly `() => !config.comfyuiPath`, which is the
+  // very conflation the issue is about: the real isRemoteMode() classifies by
+  // HOST (a loopback target is local whether or not COMFYUI_PATH is set), and
+  // "no local path" is a different fact entirely. The default is kept so every
+  // existing test behaves as before; `remoteOverride` lets a test state the
+  // reporter's actual configuration — a LOCAL server with no resolvable models
+  // directory — which the old stub could not express at all.
+  return {
+    config,
+    isRemoteMode: () => remoteOverride.value ?? !config.comfyuiPath,
+  };
 });
+/** Per-test override for isRemoteMode; null = derive from comfyuiPath (legacy). */
+const remoteOverride = vi.hoisted(() => ({ value: null as boolean | null }));
 
 // Stub the Manager install-model dispatch so remote-mode downloadModel can be
 // asserted without a live ComfyUI-Manager.
@@ -125,6 +135,7 @@ function flipFetch(pageResp: () => Response): void {
 }
 
 beforeEach(() => {
+  remoteOverride.value = null; // back to the legacy comfyuiPath-derived default
   vi.stubGlobal("fetch", fetchMock);
   fetchMock.mockReset();
   mkdirMock.mockReset().mockResolvedValue(undefined);
@@ -815,6 +826,34 @@ describe("downloadModel — threaded routing decision (#420 split-brain guard)",
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(mkdirMock).not.toHaveBeenCalled();
     expect(out).toContain("ComfyUI-Manager");
+  });
+
+  // #947 — a reporter on http://127.0.0.1:8188 was told their download went "to
+  // the REMOTE ComfyUI", concluded the orchestrator had misclassified a local
+  // server, and filed against the classification. isRemoteMode() was right the
+  // whole time: the Manager route is taken whenever no local models directory
+  // can be resolved, which a loopback server hits routinely (no COMFYUI_PATH, no
+  // saved workspace, a `python main.py` argv with no derivable root). The
+  // SENTENCE was wrong, and it named a cause the code had not established.
+  it("#947: a LOCAL server is not described as remote when the Manager route is taken", async () => {
+    config.comfyuiPath = undefined; // no local models dir to stream into…
+    remoteOverride.value = false; // …but the target is 127.0.0.1, i.e. LOCAL
+    fetchMock.mockResolvedValue(binaryProbeResponse());
+    const out = await downloadModel(
+      "https://example.com/model.safetensors",
+      "checkpoints",
+      "model.safetensors",
+      undefined,
+      true,
+    );
+    // Still names the route — that part was never wrong.
+    expect(out).toContain("ComfyUI-Manager");
+    // …but no longer asserts a remote server.
+    expect(out).not.toMatch(/remote ComfyUI/);
+    // It says what was ACTUALLY decided, and what would change it.
+    expect(out).toMatch(/could not resolve a local models directory/);
+    expect(out).toMatch(/NOT a claim that the server is remote/);
+    expect(out).toMatch(/COMFYUI_PATH/);
   });
 
   it("forces local streaming when dispatchToManager=false, even in remote-like config", async () => {

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -2119,7 +2119,24 @@ async function downloadModelViaManagerRemote(
   // "cancelled" (the tool message notes the server may still be fetching).
   if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
 
-  return `${normalizedSubfolder}/${resolvedFilename} (dispatched to the remote ComfyUI via ComfyUI-Manager — download continues server-side; the file lists under /models when complete)${authGateWarning}${authWarning}`;
+  // #947 — "the REMOTE ComfyUI" is not what this decision established. The route
+  // is chosen by shouldDispatchDownloadToManager(), which sends work to the
+  // Manager whenever it cannot resolve a local models directory to stream into —
+  // and a LOOPBACK server does that routinely: no COMFYUI_PATH, no saved
+  // workspace, and a `python main.py` argv whose root cannot be derived.
+  //
+  // A reporter on http://127.0.0.1:8188 was told their download went "to the
+  // remote ComfyUI", concluded the orchestrator had misclassified a local server,
+  // and filed against the classification. isRemoteMode() was right the whole
+  // time; the SENTENCE was wrong. Say what was actually decided, and name the
+  // setting that would have kept the download local.
+  const routeNote = isRemoteMode()
+    ? "dispatched to the remote ComfyUI via ComfyUI-Manager"
+    : "dispatched to the connected ComfyUI via ComfyUI-Manager — this MCP could not resolve a " +
+      "local models directory to stream into (no COMFYUI_PATH, no saved workspace, and the " +
+      "running server's launch arguments did not identify one). That is a routing fallback, NOT " +
+      "a claim that the server is remote; set COMFYUI_PATH to stream directly instead";
+  return `${normalizedSubfolder}/${resolvedFilename} (${routeNote} — download continues server-side; the file lists under /models when complete)${authGateWarning}${authWarning}`;
 }
 
 /**

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -10,6 +10,7 @@ import {
 } from "../services/model-resolver.js";
 import type { ModelListingCoverage } from "../services/model-resolver.js";
 import { EXTRA_PATH_TARGETS } from "../services/extra-paths.js";
+import { isRemoteMode } from "../config.js";
 import {
   startDownloadJob,
   getDownloadJob,
@@ -848,7 +849,11 @@ async function statusAction(args: {
           const detail =
             j.status === "done" && placement
               ? j.viaManager
-                ? `\n    dispatched to the remote ComfyUI via ComfyUI-Manager (server-side fetch): ${j.path}\n    NOTE: ${placement.warning}`
+                ? // #947 — say what the ROUTE was, not that the server is remote.
+                  // The Manager route is taken whenever no local models directory
+                  // could be resolved, which a loopback server hits routinely; a
+                  // reporter on 127.0.0.1 read "remote" as a misclassification.
+                  `\n    dispatched to the ${isRemoteMode() ? "remote" : "connected"} ComfyUI via ComfyUI-Manager (server-side fetch)${isRemoteMode() ? "" : " — no local models directory was resolvable, so this MCP could not stream it itself; that is a routing fallback, not a remote server"}: ${j.path}\n    NOTE: ${placement.warning}`
                 : placement.confirmed
                   ? `\n    ${placement.pathLabel}${placement.pathQualifier}: ${j.path}`
                   : `\n    ${placement.pathLabel}${placement.pathQualifier}: ${j.path}\n    ${placement.wrongPlace ? "WARNING" : "NOTE"}: ${placement.warning}`


### PR DESCRIPTION
Closes #947

## The report

A reporter on `http://127.0.0.1:8188` was told:

> dispatched to the **remote** ComfyUI via ComfyUI-Manager … the dispatch was ACCEPTED, NOT verified as landed

…concluded the orchestrator had misclassified a local server, and filed against the classification.

## The classification was right

`isRemoteMode()` is host-based (`!isLoopbackHost(...)`) and correctly said **local** the whole time.

What went wrong is the **sentence**. `shouldDispatchDownloadToManager()` hands work to the Manager whenever it cannot resolve a local models directory to stream into — and a loopback server hits that routinely: no `COMFYUI_PATH`, no saved workspace, and a `python main.py` argv whose root cannot be derived.

So the message named a cause the code had never established, and named the one thing the user couldn't act on. Both dispatch messages now say what was actually decided:

> dispatched to the connected ComfyUI via ComfyUI-Manager — this MCP could not resolve a local models directory to stream into (no COMFYUI_PATH, no saved workspace, and the running server's launch arguments did not identify one). **That is a routing fallback, NOT a claim that the server is remote**; set `COMFYUI_PATH` to stream directly instead

"Remote" is now reserved for a target that *is* remote.

## The harness encoded the same bug

`model-resolver.test.ts` stubbed:

```js
isRemoteMode: () => !config.comfyuiPath
```

That **is** the conflation this issue is about, sitting in the test file as the model of reality — and it cannot express the reporter's configuration at all (a local server with no resolvable models directory). The stub now takes an override, defaulting to the old expression so every existing test behaves exactly as before, and the new test states the real shape.

Worth flagging beyond this fix: **a mock that encodes a wrong model will keep agreeing with wrong code.** No test in that file could have caught this.

## Not addressed here

The reporter also saw `No text_encoders models found` after the dispatch. That listing half is separately fixed by #918 (an unread listing no longer reports emptiness as fact) and #962 (categories are discovered rather than hardcoded), released in 0.50.2 and 0.50.4.

## Verification

- 1 new test; full suite **329 files / 7026 passed**; `tsc`, `check:vocabulary`, `docs:gen` no-op clean.
- **Mutation-verified**: forcing the remote wording back kills the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)