### PR TITLE
fix(#937): name our own User-Agent, and stop pushing Windows onto Python

### DIFF
--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -165,8 +165,15 @@ touched and nothing is done as the user. That is the default and needs no ask.
   # body has newlines/quotes). --max-time bounds the request so a hung
   # connection can't wedge us.
   # body: { "repo": "comfyui-mcp" | "comfyui-mcp-panel", "title", "body", "labels": ["via-panel"] }
+  # The User-Agent is EXPLICIT and load-bearing (#937). Cloudflare bans some
+  # default client signatures outright — a Python `urllib.request` POST to this
+  # endpoint returns 403 with `error code: 1010` (the browser-signature ban),
+  # while the byte-identical request with any ordinary UA succeeds seconds later.
+  # Sending a named UA keeps every client path on a known-good signature instead
+  # of whatever its stdlib happens to advertise.
   RESP=$(curl -fsS --max-time 15 -X POST "$WORKER_URL" \
     -H "Content-Type: application/json" -H "X-Client-Key: $CLIENT_KEY" \
+    -H "User-Agent: comfyui-mcp-report-bug/1.0" -H "Accept: application/json" \
     --data @"$BODY_JSON_FILE" || true)
 
   # 2) VALIDATE THE WHOLE BODY FIRST with `jq -e .` — it rejects anything that
@@ -188,6 +195,37 @@ touched and nothing is done as the user. That is the default and needs no ask.
     fi
   fi
   ```
+  **On Windows, use this instead — it needs no `jq` and no Python** (#937). The
+  `jq` requirement above is what pushed Windows agents onto Python's
+  `urllib.request` in the first place, and that client's default User-Agent is
+  exactly the signature Cloudflare rejects. PowerShell parses JSON natively, so
+  this path has neither problem:
+
+  ```powershell
+  $WorkerUrl = if ($env:COMFYUI_MCP_ISSUE_WORKER_URL) { $env:COMFYUI_MCP_ISSUE_WORKER_URL }
+               else { "https://comfyui-mcp-issue-worker.artokun.workers.dev" }
+  $ClientKey = if ($env:COMFYUI_MCP_ISSUE_CLIENT_KEY) { $env:COMFYUI_MCP_ISSUE_CLIENT_KEY }
+               else { "9b6f2abf09b64006dc6e033f59d2dc8112e34d8347a923c2" }
+
+  # Invoke-RestMethod parses the JSON body itself and THROWS on a non-2xx, so
+  # both failure shapes land in the same catch — no partial-output window.
+  try {
+    $resp = Invoke-RestMethod -Method Post -Uri $WorkerUrl -TimeoutSec 15 `
+      -ContentType "application/json" `
+      -Headers @{ "X-Client-Key" = $ClientKey; "User-Agent" = "comfyui-mcp-report-bug/1.0"; "Accept" = "application/json" } `
+      -InFile $BodyJsonFile
+  } catch { $resp = $null }
+
+  # Same single "filed" condition as the bash path: ok==true, status not "error",
+  # and a url matching the exact GitHub issue shape. Anything else falls back.
+  if ($resp -and $resp.ok -eq $true -and $resp.status -ne "error" -and
+      $resp.url -match '^https://github\.com/[^/]+/[^/]+/issues/\d+$') {
+    "filed: $($resp.url)"
+  } else {
+    "worker did not return an issue link — fall back to the report_issue tool for a prefilled GitHub link"
+  }
+  ```
+
   A real `url` from the POST is the only "filed" outcome. Any submit failure
   (`401`/non-2xx/timeout/unreachable), `ok` not `true`, a `status:"error"` body,
   a missing/invalid url, or invalid JSON → fall back to `report_issue` for a

--- a/src/tools/report-issue.test.ts
+++ b/src/tools/report-issue.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { normalizeRepo, buildIssueUrl, isOurRepo, submitAndPoll, registerReportIssueTools } from "./report-issue.js";
+import { normalizeRepo, buildIssueUrl, isOurRepo, submitAndPoll, registerReportIssueTools, REPORT_UA } from "./report-issue.js";
 
 const noSleep = async () => {};
 
@@ -439,5 +439,70 @@ describe("report_issue tool (registered handler)", () => {
   it("invalid repo → isError", async () => {
     const { isError } = await callTool({ title: "t", body: "b", repo: "not-a-repo" });
     expect(isError).toBe(true);
+  });
+});
+
+// #937 — Cloudflare fronts the intake endpoint and bans some default client
+// signatures outright. A Python `urllib.request` POST returns 403 with
+// `error code: 1010` (the browser-signature ban) while the byte-identical
+// request with an ordinary UA succeeds 13 seconds later, same IP, same key,
+// same body.
+//
+// Node fetch happens to be allowed today — a WAF disposition we neither control
+// nor chose. Sending a named UA makes the path deterministic rather than
+// incidentally lucky, and it is the one header a future WAF rule would key on.
+describe("#937: every intake request carries a named User-Agent", () => {
+  it("sends it on the SUBMIT", async () => {
+    const seen: Array<Record<string, string>> = [];
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      seen.push((init?.headers ?? {}) as Record<string, string>);
+      return new Response(JSON.stringify({ ok: true, job_id: "j1" }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await submitAndPoll({
+      workerUrl: "https://w.example",
+      clientKey: "k",
+      repoName: "comfyui-mcp",
+      title: "t",
+      body: "b",
+      fetchImpl,
+      maxPolls: 0,
+      sleep: async () => {},
+    });
+
+    expect(seen[0]["User-Agent"]).toBe(REPORT_UA);
+    expect(seen[0]["Accept"]).toBe("application/json");
+    // The signature is NAMED, not a browser impersonation — we are a tool, and
+    // claiming to be Chrome to get past a bot check would be the wrong fix.
+    expect(REPORT_UA).toMatch(/^comfyui-mcp-report-bug\//);
+    expect(REPORT_UA).not.toMatch(/Mozilla|Chrome|Safari/);
+  });
+
+  it("sends it on the STATUS poll too", async () => {
+    const seen: Array<Record<string, string>> = [];
+    let call = 0;
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      seen.push((init?.headers ?? {}) as Record<string, string>);
+      call += 1;
+      return call === 1
+        ? new Response(JSON.stringify({ ok: true, job_id: "j1" }), { status: 200 })
+        : new Response(JSON.stringify({ state: "CLOSED", payload: { url: "u" } }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await submitAndPoll({
+      workerUrl: "https://w.example",
+      clientKey: "k",
+      repoName: "comfyui-mcp",
+      title: "t",
+      body: "b",
+      fetchImpl,
+      maxPolls: 1,
+      pollDelayMs: 0,
+      sleep: async () => {},
+    });
+
+    // The poll is a separate request and would be judged by the WAF separately.
+    expect(seen.length).toBeGreaterThan(1);
+    expect(seen[1]["User-Agent"]).toBe(REPORT_UA);
   });
 });

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -22,6 +22,10 @@ const OUR_REPO_NAMES = new Set(["comfyui-mcp", "comfyui-mcp-panel"]);
 const DEFAULT_WORKER_URL = "https://comfyui-mcp-issue-worker.artokun.workers.dev";
 const DEFAULT_CLIENT_KEY = "9b6f2abf09b64006dc6e033f59d2dc8112e34d8347a923c2";
 
+/** The User-Agent every report-bug request sends (#937). Named on purpose: a
+ *  default runtime signature is a WAF disposition we do not control. */
+export const REPORT_UA = "comfyui-mcp-report-bug/1.0";
+
 export function normalizeRepo(input: string | undefined): string {
   const repo = (input || DEFAULT_REPO)
     .trim()
@@ -169,6 +173,15 @@ export async function submitAndPoll(opts: {
         headers: {
           "Content-Type": "application/json",
           "X-Client-Key": opts.clientKey,
+          // #937 — an EXPLICIT, named signature rather than whatever the runtime
+          // advertises. Cloudflare fronts this endpoint and bans some default
+          // client UAs outright: a Python urllib POST gets 403 / `error code:
+          // 1010` while the byte-identical request with an ordinary UA succeeds
+          // seconds later. Node fetch happens to be allowed today — a WAF
+          // disposition we neither control nor chose. Naming ourselves makes the
+          // path deterministic instead of incidentally lucky.
+          "User-Agent": REPORT_UA,
+          Accept: "application/json",
           // Opt into the async AI-triage contract. Absent this header the worker
           // runs its legacy synchronous dumb-file path (old clients stay working).
           "X-Triage-Async": "1",
@@ -220,7 +233,7 @@ export async function submitAndPoll(opts: {
       parsed = await withTimeout(async (signal): Promise<StatusFrame> => {
         const r = await doFetch(`${base}/status/${jobId}`, {
           signal,
-          headers: { "X-Client-Key": opts.clientKey },
+          headers: { "X-Client-Key": opts.clientKey, "User-Agent": REPORT_UA, Accept: "application/json" },
         });
         if (!r.ok) throw new Error(`poll failed: HTTP ${r.status}`);
         return (await r.json()) as StatusFrame;


### PR DESCRIPTION
Closes #937

## The evidence

Cloudflare fronts the issue-intake endpoint and bans some default client signatures outright. The reporter's repro is single-variable — three POSTs, same machine, same IP, same client key, **byte-identical body**, within 14 seconds:

| # | client | User-Agent | result |
|---|---|---|---|
| 1 | `urllib.request` | default | **403** |
| 2 | `urllib.request` | default | **403**, `error code: 1010` |
| 3 | `urllib.request` | browser UA | **200** → filed |

`1010` is the browser-signature ban. Request 3 differs from 2 in exactly the User-Agent.

## What's ours

Two of their four suggested fixes; the WAF ones aren't.

**1. Every request sends an explicit `comfyui-mcp-report-bug/1.0`** — the tool's submit *and* its status poll (a separate request the WAF judges separately), plus the documented shell snippet.

Node fetch happens to be allowed today, which is a WAF disposition we neither control nor chose. Naming ourselves makes the path deterministic instead of incidentally lucky.

**Not a browser UA.** We are a tool, and impersonating Chrome to get past a bot check would be the wrong fix — a test pins that the signature stays named.

**2. A PowerShell variant of the fallback snippet**, needing neither `jq` nor Python.

This is the reporter's sharpest observation: **the `jq` dependency is what pushed Windows agents onto `urllib.request` in the first place**, so the missing tool and the banned signature are the same defect one step apart. `Invoke-RestMethod` parses JSON natively and throws on non-2xx, so both failure shapes land in one catch — and it applies the identical single "filed" condition (`ok==true`, `status!="error"`, url matching the exact issue shape).

## Not fixed here

The WAF allowlist and returning JSON instead of the Cloudflare HTML interstitial (their fixes 1 and 2). Both are `comfyui-mcp-issue-worker` / Cloudflare configuration, not this repo. Worth doing — a blocked client still gets an unparseable HTML body — but they belong where that config lives.

## On the report

Their first diagnosis of this — *"non-browser clients silently can't file"* — was wrong, and they said so plainly, then re-derived the narrower explanation that fits every observation **including the ones that refuted them**. The single-variable repro is why this was fixable at all rather than another "sometimes it 403s".

## Verification

- 2 new tests; full suite **329 files / 7028 passed**; `tsc` and `check:vocabulary` clean.
- **Mutation-verified**: dropping the UA from the submit kills one test, from the poll kills the other. The first mutation initially reported a *false pass* because the replacement never applied — caught by checking the marker rather than trusting the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)