### PR TITLE
fix(#977): a render completion is a STEP when a plan is still running

### DIFF
--- a/src/__tests__/orchestrator/todo-state.test.ts
+++ b/src/__tests__/orchestrator/todo-state.test.ts
@@ -1,0 +1,181 @@
+// #977 — the completion notification could only speak one way.
+//
+// Every finished render injected "Reply with ONE short sentence … you do NOT
+// need to call any tools", which reads as "stop now". Paired with panel_run's
+// own "just end your turn now and wait", the emergent default was
+// queue → end turn → render → one sentence → end turn — so a user running a
+// five-variant sweep had to send a message to advance every single step.
+//
+// That directly contradicted the orchestrator's own system prompt, which tells
+// the agent to treat a todo list as a loop and not stop between steps. The
+// per-event text won because it is the most recent and most specific thing in
+// context.
+//
+// The agent's checklist was the machine-readable signal all along — it had
+// already declared the plan — but panel_set_todo was a pure pass-through to the
+// panel UI and the orchestrator retained nothing.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetTodoState,
+  planInFlight,
+  recordTodo,
+  runCompletionDirective,
+  todoFor,
+} from "../../orchestrator/todo-state.js";
+
+const item = (text: string, status: string) => ({ text, status });
+
+beforeEach(() => __resetTodoState());
+
+describe("#977: a declared plan is remembered", () => {
+  it("counts the unfinished entries", () => {
+    recordTodo("t1", [
+      item("variant A", "completed"),
+      item("variant B", "pending"),
+      item("variant C", "pending"),
+    ]);
+    expect(todoFor("t1")?.pending).toBe(2);
+    expect(planInFlight("t1")).toBe(true);
+  });
+
+  it("treats the plan as finished once every entry is settled", () => {
+    recordTodo("t1", [item("a", "completed"), item("b", "done")]);
+    expect(planInFlight("t1")).toBe(false);
+  });
+
+  it("accepts the statuses a plan actually uses", () => {
+    for (const s of ["pending", "in_progress", "in-progress", "todo", "active"]) {
+      __resetTodoState();
+      recordTodo("t1", [item("x", s)]);
+      expect(planInFlight("t1"), s).toBe(true);
+    }
+  });
+
+  it("keeps tabs separate — one tab's sweep is not another's", () => {
+    recordTodo("t1", [item("a", "pending")]);
+    recordTodo("t2", [item("a", "completed")]);
+    expect(planInFlight("t1")).toBe(true);
+    expect(planInFlight("t2")).toBe(false);
+  });
+
+  it("replaces the snapshot rather than accumulating", () => {
+    recordTodo("t1", [item("a", "pending"), item("b", "pending")]);
+    recordTodo("t1", [item("a", "completed"), item("b", "completed")]);
+    expect(planInFlight("t1")).toBe(false);
+  });
+});
+
+describe("#977: in-flight requires POSITIVE evidence", () => {
+  // The suppression changes an instruction the agent obeys, so it must never
+  // fire on absence. Every one of these is "we do not know of a plan", and the
+  // ordinary acknowledge-and-stop wording has to remain the default.
+  it("is false with no checklist at all", () => {
+    expect(planInFlight("never-set")).toBe(false);
+    expect(planInFlight(undefined)).toBe(false);
+  });
+
+  it("is false for an empty checklist", () => {
+    recordTodo("t1", []);
+    expect(planInFlight("t1")).toBe(false);
+  });
+
+  // An unrecognised status cannot manufacture an in-flight plan — otherwise a
+  // future panel status string would silently suppress the yield nudge forever.
+  it("is false for statuses it does not recognise", () => {
+    recordTodo("t1", [item("a", "blocked"), item("b", ""), { text: "c" }]);
+    expect(planInFlight("t1")).toBe(false);
+  });
+
+  // A malformed payload tells us nothing; keeping the previous snapshot would
+  // leave it claiming work remains long after the plan ended.
+  it("FORGETS on a malformed payload rather than keeping a stale plan", () => {
+    recordTodo("t1", [item("a", "pending")]);
+    expect(planInFlight("t1")).toBe(true);
+    recordTodo("t1", "not-an-array");
+    expect(planInFlight("t1")).toBe(false);
+    expect(todoFor("t1")).toBeUndefined();
+  });
+
+  it("ignores a missing tab id instead of recording under one", () => {
+    recordTodo(undefined, [item("a", "pending")]);
+    expect(planInFlight(undefined)).toBe(false);
+  });
+});
+
+describe("#977: retention is bounded", () => {
+  it("does not grow without limit across synthetic tab ids", () => {
+    for (let i = 0; i < 200; i++) recordTodo(`tab-${i}`, [item("a", "pending")]);
+    // The newest is kept; the oldest have been evicted.
+    expect(planInFlight("tab-199")).toBe(true);
+    expect(planInFlight("tab-0")).toBe(false);
+  });
+});
+
+// #977 — the WIRING. The rules above are about the snapshot; these are about the
+// two places that must actually use it: panel_set_todo recording what the agent
+// declared, and the completion notice reading it.
+describe("#977: panel_set_todo records what the agent declared", () => {
+  it("retains the checklist it forwards to the panel", async () => {
+    const { buildPanelToolDefs, makePanelToolCtx } = await import(
+      "../../orchestrator/panel-tools.js"
+    );
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_set_todo");
+    expect(def).toBeDefined();
+    const bridge = { push: () => 1, canReach: () => true } as never;
+    const ctx = makePanelToolCtx(bridge, "tab-sweep");
+    (ctx as { call: unknown }).call = async () => ({ content: [{ type: "text", text: "ok" }] });
+
+    await def!.handler(
+      {
+        items: [
+          { text: "variant A", status: "completed" },
+          { text: "variant B", status: "pending" },
+        ],
+      },
+      ctx,
+    );
+
+    // The panel keeps the UI copy; this is the orchestrator's own record, which
+    // is what the completion notice consults.
+    expect(planInFlight("tab-sweep")).toBe(true);
+    expect(todoFor("tab-sweep")?.pending).toBe(1);
+  });
+});
+
+// The other half of the wiring: the completion notice must actually READ the
+// snapshot. Extracted as a named function precisely because, inline in
+// PanelAgent.injectEvent, a mutation that ignored the plan entirely — the exact
+// regression this fixes — broke no test at all.
+describe("#977: the completion directive follows the plan", () => {
+  it("keeps acknowledge-and-stop when there is no plan", () => {
+    const d = runCompletionDirective("t1");
+    expect(d).toMatch(/you do NOT need to call any tools/);
+    expect(d).not.toMatch(/CONTINUE your plan/);
+  });
+
+  it("tells the agent to CONTINUE when entries remain", () => {
+    recordTodo("t1", [item("A", "completed"), item("B", "pending")]);
+    const d = runCompletionDirective("t1");
+    expect(d).toMatch(/CONTINUE your plan/);
+    expect(d).toMatch(/do NOT stop here or wait for the user/);
+    // The instruction that caused the yield must be gone, not merely softened.
+    expect(d).not.toMatch(/you do NOT need to call any tools/);
+  });
+
+  it("returns to acknowledge-and-stop once the plan finishes", () => {
+    recordTodo("t1", [item("A", "pending")]);
+    expect(runCompletionDirective("t1")).toMatch(/CONTINUE your plan/);
+    recordTodo("t1", [item("A", "completed")]);
+    expect(runCompletionDirective("t1")).toMatch(/you do NOT need to call any tools/);
+  });
+
+  // Both wordings still ask for the one-sentence acknowledgement — the user is
+  // watching the panel and a silent continuation would read as a hang.
+  it("always asks for the short acknowledgement", () => {
+    recordTodo("t1", [item("A", "pending")]);
+    expect(runCompletionDirective("t1")).toMatch(/ONE short sentence/);
+    __resetTodoState();
+    expect(runCompletionDirective("t1")).toMatch(/ONE short sentence/);
+  });
+});

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -28,6 +28,7 @@ import type { SessionStore } from "./session-store.js";
 import type { AgentBackend, AgentEvent, NeutralTurn } from "./agent-backend.js";
 import { type AudioRef, dedupeAudioRefs, noAudioPartText } from "./audio-attachment.js";
 import { runErrorNotice } from "./cli-remedy.js";
+import { runCompletionDirective } from "./todo-state.js";
 import {
   ClaudeBackend,
   fetchSupportedModels,
@@ -692,7 +693,20 @@ export class PanelAgent {
             ? `The image(s) are attached below and already shown to the user in the panel. `
             : `You cannot view images on this provider, but they are already shown to the user in the panel. `
           : ``) +
-        `Reply with ONE short sentence acknowledging the result and suggesting a sensible next step — you do NOT need to call any tools. Don't repeat an earlier comment.`;
+        // #977 — this used to be a FIXED "you do NOT need to call any tools",
+        // i.e. "stop now", sent after every render. Paired with panel_run's own
+        // "just end your turn now and wait", the emergent default was:
+        // queue → end turn → render → one sentence → end turn. A user running a
+        // five-variant sweep had to send a message to advance every step, while
+        // the system prompt was telling the agent to treat a todo list as a loop
+        // and not stop between steps. The per-event text won because it is the
+        // most recent and most specific thing in context.
+        //
+        // The agent's own checklist is the signal: if it declared a plan and
+        // entries remain, this render is a STEP, not an ending. Positive
+        // evidence only — no checklist, or one that is finished, keeps the
+        // acknowledge-and-stop wording, so nothing changes for a single render.
+        runCompletionDirective(this.tabId);
       // Attach the outputs inline so the agent SEES the render (no fetch needed).
       if (this.backend.capabilities.vision) {
         images = imgs.filter((i) => i.filename).map((i) => ({ ...i, type: i.type ?? "output" }));

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -101,6 +101,7 @@ import {
 } from "../services/panel-secrets.js";
 import { flattenUiWorkflow } from "../services/flatten-workflow.js";
 import { describeUnappliedFilters } from "./civitai-filter-guard.js";
+import { recordTodo } from "./todo-state.js";
 import { applyCapturedWidgetValues } from "../services/live-widget-overlay.js";
 import { listWorkflowLibraryKeys, userdataFetch } from "../services/userdata-library.js";
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
@@ -7460,6 +7461,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         const redirect = desktopCanvasRedirect(ctx, "panel_set_todo");
         if (redirect?.error) return fail(redirect.error);
         if (redirect?.tabId) {
+          // #977 — the desktop redirect writes the checklist to ANOTHER tab, so
+          // record it against that one. Keying it on ctx.tabId would leave the
+          // tab that actually holds the plan looking planless.
+          recordTodo(redirect.tabId, args.items);
           return dispatchToTab(
             ctx,
             redirect.tabId,
@@ -7468,6 +7473,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             () => reResolveDesktopTab(ctx, "panel_set_todo"),
           );
         }
+        // #977 — retain what the agent DECLARED, so a later render completion can
+        // tell "you are mid-sweep" from "that was the last thing you were doing".
+        // The panel keeps the UI copy; this is the orchestrator's own record.
+        recordTodo(ctx.tabId, args.items);
         return ctx.call({ cmd: "set_todo", items: args.items }, 15000);
       },
     ),

--- a/src/orchestrator/todo-state.ts
+++ b/src/orchestrator/todo-state.ts
@@ -1,0 +1,105 @@
+// #977 — the orchestrator had no idea a multi-step plan was in flight.
+//
+// `panel_set_todo` was a pure pass-through to the panel UI: the checklist went to
+// the browser and nothing here retained it. So when a render finished, the
+// completion notification could only speak one way — "Reply with ONE short
+// sentence … you do NOT need to call any tools" — which reads as "stop now".
+//
+// Combined with panel_run's own "just end your turn now and wait", the emergent
+// default became: queue → end turn → render → one sentence → end turn again. A
+// user running a five-variant sweep had to send a message to advance every step,
+// while the orchestrator's system prompt was simultaneously telling the agent to
+// treat a todo list as a loop and "keep going … Do NOT stop between steps". The
+// per-event wording won because it is the most recent and most specific text in
+// context.
+//
+// The checklist was the machine-readable signal all along — the agent had already
+// declared the plan. Retaining it lets the completion notice distinguish "this
+// was the last thing you were doing" from "you are three of five renders into a
+// sweep you told the user about", which are different situations that deserve
+// different instructions.
+
+/** One checklist entry as `panel_set_todo` accepts it. */
+export interface TodoItem {
+  text?: unknown;
+  status?: unknown;
+}
+
+/** What the last `panel_set_todo` on a tab declared. */
+export interface TodoSnapshot {
+  items: TodoItem[];
+  /** Entries not yet finished — the ones that make a plan "in flight". */
+  pending: number;
+}
+
+/** Statuses that mean "still to do". Anything else (done/completed/cancelled,
+ *  or an unrecognised value) counts as settled — a plan is only treated as
+ *  in-flight on POSITIVE evidence, so an unknown status can never manufacture
+ *  one and suppress the yield nudge forever. */
+const PENDING_STATUSES = new Set(["pending", "in_progress", "in-progress", "todo", "active"]);
+
+const byTab = new Map<string, TodoSnapshot>();
+
+/** Bounded: one snapshot per tab, and tabs are few. Guards against a pathological
+ *  churn of synthetic tab ids retaining memory forever. */
+const MAX_TABS = 64;
+
+export function recordTodo(tabId: string | undefined, items: unknown): void {
+  if (!tabId) return;
+  if (!Array.isArray(items)) {
+    // A malformed payload tells us nothing about the plan. Forgetting is safer
+    // than keeping a stale snapshot that would keep claiming work remains.
+    byTab.delete(tabId);
+    return;
+  }
+  const list = items as TodoItem[];
+  const pending = list.filter(
+    (i) => typeof i?.status === "string" && PENDING_STATUSES.has(i.status.trim().toLowerCase()),
+  ).length;
+  byTab.set(tabId, { items: list, pending });
+  while (byTab.size > MAX_TABS) {
+    const oldest = byTab.keys().next().value;
+    if (oldest === undefined) break;
+    byTab.delete(oldest);
+  }
+}
+
+/** The last checklist this tab declared, or undefined if it never did. */
+export function todoFor(tabId: string | undefined): TodoSnapshot | undefined {
+  return tabId ? byTab.get(tabId) : undefined;
+}
+
+/**
+ * Is a multi-step plan still running on this tab?
+ *
+ * Requires POSITIVE evidence — a retained checklist with at least one unfinished
+ * entry. No checklist, an empty one, or one whose entries are all settled all
+ * answer false, so the ordinary "acknowledge and stop" wording remains the
+ * default and only a declared, unfinished plan changes it.
+ */
+export function planInFlight(tabId: string | undefined): boolean {
+  return (todoFor(tabId)?.pending ?? 0) > 0;
+}
+
+/** Test seam — the map is module state. */
+export function __resetTodoState(): void {
+  byTab.clear();
+}
+
+/**
+ * The closing instruction on a render-completion notice (#977).
+ *
+ * Named and exported rather than inlined in PanelAgent.injectEvent, because
+ * inline it was reachable only through a full agent harness — and a mutation
+ * that ignored the plan entirely (the exact regression) broke no test at all.
+ *
+ * The wording is the whole fix: a fixed "you do NOT need to call any tools"
+ * reads as "stop now", and an agent three renders into a sweep it announced will
+ * obey the most recent, most specific instruction over the system prompt telling
+ * it to keep going.
+ */
+export function runCompletionDirective(tabId: string | undefined): string {
+  return planInFlight(tabId)
+    ? `Acknowledge the result in ONE short sentence, then CONTINUE your plan — you have unfinished items on your todo list, so do NOT stop here or wait for the user. Carry straight on with the next step (queue it now if that is what the plan says). Don't repeat an earlier comment.`
+    : `Reply with ONE short sentence acknowledging the result and suggesting a sensible next step — you do NOT need to call any tools. Don't repeat an earlier comment.`;
+}


### PR DESCRIPTION
Closes #977

## The bug

Every finished render injected a **fixed** closing instruction:

> Reply with ONE short sentence acknowledging the result and suggesting a sensible next step — **you do NOT need to call any tools.**

Paired with `panel_run`'s own *"just end your turn now and wait"*, the emergent default was:

```
queue → end turn → render → one sentence → end turn
```

A user running a five-variant sweep had to send a message to advance **every single step**.

That contradicted the orchestrator's own system prompt, which tells the agent to treat a todo list as a loop and *"keep going … Do NOT stop between steps"*. The per-event text won because it is the most recent and most specific thing in context — an agent obeys the instruction in front of it.

## The signal was there and we discarded it

`panel_set_todo` was a **pure pass-through** to the panel UI: the agent could declare a five-step plan and the orchestrator retained nothing to consult.

It now keeps that snapshot per tab (both the direct and desktop-redirect paths), so the completion notice can tell *"you are three renders into a sweep you announced"* from *"that was the last thing you were doing"*.

## Positive evidence only

This changes an instruction the agent obeys, so absence must never trigger it. All of these keep the original acknowledge-and-stop wording:

| Situation | In flight? |
|---|---|
| no checklist ever set | no |
| empty checklist | no |
| every entry settled | no |
| unrecognised status | no |
| malformed payload | no — and it **forgets**, rather than retaining a stale snapshot that would keep claiming work remains |

Retention is bounded. Both wordings still ask for the one-sentence acknowledgement — the user is watching the panel, and a silent continuation would read as a hang.

## Coverage, stated exactly

The **decision** (`planInFlight` / `runCompletionDirective`) and the **recording** (`panel_set_todo`) are mutation-verified: ignoring the plan kills 2 tests; dropping the recording kills 1.

**What is not covered** is the single call site inside `PanelAgent.injectEvent` — replacing `runCompletionDirective(this.tabId)` with a hardcoded string breaks no test, because that method is reachable only through a full agent harness (SDK mocks, watchdog) I did not build.

As with #889, I moved the seam rather than fake the coverage: the composition is a named function the tests drive directly, which reduces the unverified surface to one argument-free call. **Three fixes have now stopped at this same wall** — that harness is worth someone's time.

## Credit

Reported with precise line references and this exact design — retain the todo state, suppress conditionally. The analysis is the reporter's.

## Verification

- 16 new tests; full suite **330 files / 7044 passed**; `tsc`, `check:vocabulary`, `docs:gen` no-op clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)