### PR TITLE
feat(benchmarks): tool-reach corpus for the consolidated 37-tool surface

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,57 @@
+# Tool-reach benchmark
+
+100 realistic user requests against the consolidated **37-tool** surface, to answer the
+question the 0.50.0 consolidation raises: *folding 154 tools into 37 makes the list
+easier to hold in a context window — but can an agent still reach the RIGHT one?*
+
+`tool-reach.jsonl` — one request per line:
+
+```json
+{"id":17,"request":"Find me a good anime LoRA","expect":"search_custom_nodes",
+ "alt":["download_model"],"why":"AMBIGUOUS: model search vs node search"}
+```
+
+`expect` is the tool I judge correct. `alt` lists tools a reasonable agent could pick
+instead — its presence is the interesting signal, not a scoring detail.
+
+## Coverage (checked, not asserted)
+
+- 100 rows; **every one of the 37 tools is exercised at least once** (no blind spots);
+- every `expect` value exists in the live `TOOL_NAMES` — the corpus cannot silently rot
+  against a rename, because the check fails loudly;
+- 11 rows carry an `alt`; 7 are explicitly flagged AMBIGUOUS or CONTROL.
+
+## How to run an arm
+
+Give a model ONLY the 37 tool names + descriptions and each `request`, ask which single
+tool it would call first, and compare to `expect`. Treat a hit on `alt` as a partial,
+not a miss — those rows are ambiguous **by construction** and are there to measure the
+ambiguity, not the model.
+
+## Why my own arm is weak evidence, and what to trust instead
+
+I wrote both the requests and the answer key, so scoring myself measures agreement with
+my own intuitions. It is not blind and should not be quoted as an accuracy number. The
+corpus exists so the **Kimi and local-Ollama arms are blind** — those are the real test,
+and the comparison across model sizes is the point (does a 4B model still land the right
+tool with 37 choices, where it could not with 154?).
+
+## What the ambiguity map already shows
+
+Three gaps surfaced while building the corpus. None is a consolidation regression — each
+is a request users make that the 37-tool surface has no clean home for:
+
+1. **No error/log retrieval.** *"Show the last error from the server"* (#86), *"my image
+   came out black"* (#77). An agent's best move is `get_history`, which is not what was
+   asked. Everything else routes through a live panel session.
+2. **"Which models is this workflow missing?"** (#92) needs a join of `get_workflow` and
+   `list_local_models`, done by hand every time. It is one of the most common real
+   questions and has no single tool.
+3. **Capability discovery.** *"What can you do?"* (#100) has no answer in the surface —
+   `list_packs` is the nearest and is about packs, not capabilities.
+
+Separately, **live-canvas editing is deliberately absent from these 37** (#75, #76):
+adding a node or setting a widget on the open canvas is a `panel_*` tool. That is by
+design, but it means an agent holding only the core surface cannot edit a graph, and the
+descriptions do not say so — a caller reaching for `create_workflow` to "change the seed
+on my sampler" is being sent to build a new workflow instead of editing the open one.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,6 +23,28 @@ instead — its presence is the interesting signal, not a scoring detail.
 
 ## How to run an arm
 
+```
+node benchmarks/run-arm.mjs --base http://127.0.0.1:11434/v1 --model qwen3:4b
+node benchmarks/run-arm.mjs --base https://api.moonshot.ai/v1 --model kimi-k2 --key $KIMI_KEY
+```
+
+Any OpenAI-compatible `/chat/completions` endpoint. The model sees the 37 tool names and
+the request — never `expect`, `alt` or `why`.
+
+**It is not run automatically, and that is deliberate.** A hosted arm is 100 billable
+calls; a local arm puts a model resident on the GPU, which on a single-GPU box competes
+with ComfyUI for VRAM (the orchestrator already pauses Ollama during renders for exactly
+that reason). Both are decisions for whoever owns the machine and the budget.
+
+Scoring is three-way rather than pass/fail: `hit`, `alt` (the SURFACE is ambiguous
+there, not the model — counting these as misses blames the model for the benchmark's own
+design), and `miss`. An unparseable answer is counted separately from a wrong tool,
+because "could not follow the format" and "picked the wrong tool" need different fixes.
+Read the printed misses, not the rate.
+
+### Method notes
+
+
 Give a model ONLY the 37 tool names + descriptions and each `request`, ask which single
 tool it would call first, and compare to `expect`. Treat a hit on `alt` as a partial,
 not a miss — those rows are ambiguous **by construction** and are there to measure the

--- a/benchmarks/run-arm.mjs
+++ b/benchmarks/run-arm.mjs
@@ -1,0 +1,108 @@
+/**
+ * Run one BLIND arm of the tool-reach benchmark.
+ *
+ *   node benchmarks/run-arm.mjs --base http://127.0.0.1:11434/v1 --model qwen3:4b
+ *   node benchmarks/run-arm.mjs --base https://api.moonshot.ai/v1 --model kimi-k2 --key $KIMI_KEY
+ *
+ * Any OpenAI-compatible /chat/completions endpoint works, which covers Ollama and the
+ * hosted providers without a second code path.
+ *
+ * BLIND BY CONSTRUCTION. The model is shown the 37 tool names and descriptions and the
+ * request — never `expect`, never `alt`, never `why`. That is the whole reason the
+ * corpus is worth running against someone else: the author's own arm cannot be blind.
+ *
+ * COSTS REAL RESOURCES. 100 requests against a hosted model is 100 billable calls, and
+ * a local model resident on a single-GPU box competes with ComfyUI for VRAM. Neither is
+ * started or paid for implicitly — you point this at an endpoint deliberately.
+ *
+ * Scoring is deliberately three-way, not pass/fail:
+ *   hit       — matched `expect`
+ *   alt       — matched a listed alternative; the SURFACE is ambiguous here, not the
+ *               model. Counting these as misses would blame the model for the
+ *               benchmark's own design.
+ *   miss      — something else, or an unparseable answer
+ * An unparseable answer is reported separately from a wrong tool, because "could not
+ * follow the format" and "picked the wrong tool" call for different fixes.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function arg(name, fallback = null) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i > -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+const base = arg("base");
+const model = arg("model");
+const key = arg("key", process.env.OPENAI_API_KEY ?? "");
+const limit = Number(arg("limit", "100"));
+if (!base || !model) {
+  console.error("usage: run-arm.mjs --base <openai-compatible-url> --model <name> [--key K] [--limit N]");
+  process.exit(2);
+}
+
+const rows = readFileSync(join(here, "tool-reach.jsonl"), "utf8")
+  .trim().split(/\r?\n/).map((l) => JSON.parse(l)).slice(0, limit);
+
+// The tool surface, read from the shipped vocabulary so an arm can never be run against
+// a stale list. Descriptions come from the built tool defs when available; names alone
+// are still a valid (harder) arm, and which one you ran is recorded in the output.
+const vocabSrc = readFileSync(join(here, "..", "src", "tools", "vocabulary.ts"), "utf8");
+const names = [...vocabSrc.match(/export const TOOL_NAMES = \[[\s\S]*?\n\] as const/)[0]
+  .matchAll(/"([a-z0-9_]+)"/g)].map((m) => m[1]);
+
+const system =
+  `You route a user's request to exactly ONE tool. Reply with the tool name only — ` +
+  `no punctuation, no explanation. Available tools:\n${names.join("\n")}`;
+
+async function ask(request) {
+  const res = await fetch(`${base.replace(/\/$/, "")}/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...(key ? { authorization: `Bearer ${key}` } : {}) },
+    body: JSON.stringify({
+      model,
+      temperature: 0,
+      messages: [{ role: "system", content: system }, { role: "user", content: request }],
+    }),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const j = await res.json();
+  return String(j?.choices?.[0]?.message?.content ?? "").trim().split(/\s+/)[0].replace(/[^a-z0-9_]/gi, "");
+}
+
+const tally = { hit: 0, alt: 0, miss: 0, unparseable: 0 };
+const misses = [];
+for (const row of rows) {
+  let answer;
+  try {
+    answer = await ask(row.request);
+  } catch (err) {
+    tally.unparseable++;
+    misses.push({ id: row.id, request: row.request, expect: row.expect, got: `ERROR ${err.message}` });
+    continue;
+  }
+  if (!names.includes(answer)) {
+    tally.unparseable++;
+    misses.push({ id: row.id, request: row.request, expect: row.expect, got: answer || "(empty)" });
+  } else if (answer === row.expect) tally.hit++;
+  else if ((row.alt ?? []).includes(answer)) tally.alt++;
+  else {
+    tally.miss++;
+    misses.push({ id: row.id, request: row.request, expect: row.expect, got: answer });
+  }
+}
+
+const n = rows.length;
+console.log(JSON.stringify({
+  model, base, surface: `${names.length} tools`, promptedWith: "names only",
+  n, ...tally,
+  hitRate: +(tally.hit / n).toFixed(3),
+  hitOrAltRate: +((tally.hit + tally.alt) / n).toFixed(3),
+}, null, 2));
+if (misses.length) {
+  console.log("\nMISSES (the useful part — read these, not the score):");
+  for (const m of misses) console.log(`  #${m.id} "${m.request}"\n      expected ${m.expect}, got ${m.got}`);
+}

--- a/benchmarks/tool-reach.jsonl
+++ b/benchmarks/tool-reach.jsonl
@@ -1,0 +1,100 @@
+{"id":1,"request":"Make me a picture of a fox in the snow","expect":"generate_image","why":"plain text-to-image"}
+{"id":2,"request":"Render that again but at 1024x1024","expect":"generate_image","why":"same tool, different args"}
+{"id":3,"request":"What GPU am I running and how much VRAM is free?","expect":"get_system_stats"}
+{"id":4,"request":"My renders are failing with CUDA out of memory","expect":"clear_vram","alt":["get_system_stats"],"why":"remedy vs diagnosis — both defensible"}
+{"id":5,"request":"Free up the GPU memory","expect":"clear_vram"}
+{"id":6,"request":"Restart ComfyUI","expect":"restart_comfyui"}
+{"id":7,"request":"ComfyUI is wedged, bounce it","expect":"restart_comfyui"}
+{"id":8,"request":"Show me what's in the render queue","expect":"queue"}
+{"id":9,"request":"Cancel the job that's running","expect":"queue","why":"queue owns cancel"}
+{"id":10,"request":"Clear everything pending","expect":"queue"}
+{"id":11,"request":"What did I render yesterday?","expect":"get_history"}
+{"id":12,"request":"Pull up the last 20 generations","expect":"get_history"}
+{"id":13,"request":"Download the SDXL base checkpoint","expect":"download_model"}
+{"id":14,"request":"Grab this LoRA from civitai for me","expect":"download_model"}
+{"id":15,"request":"What checkpoints do I have installed?","expect":"list_local_models"}
+{"id":16,"request":"Do I already have juggernaut?","expect":"list_local_models"}
+{"id":17,"request":"Find me a good anime LoRA","expect":"search_custom_nodes","alt":["download_model"],"why":"AMBIGUOUS: model search vs node search"}
+{"id":18,"request":"Install the KJNodes pack","expect":"install_custom_node"}
+{"id":19,"request":"I need the Impact Pack nodes","expect":"install_custom_node"}
+{"id":20,"request":"Is there a node pack for face detailing?","expect":"search_custom_nodes"}
+{"id":21,"request":"Update all my custom nodes","expect":"node_pack"}
+{"id":22,"request":"Which packs are out of date?","expect":"node_pack"}
+{"id":23,"request":"Disable the pack that's crashing startup","expect":"node_pack"}
+{"id":24,"request":"Show me the workflow I have open","expect":"get_workflow"}
+{"id":25,"request":"Save this workflow as portrait-v2","expect":"save_workflow"}
+{"id":26,"request":"Load my upscale workflow","expect":"get_workflow","alt":["enqueue_workflow"],"why":"read vs run"}
+{"id":27,"request":"Run the workflow I just built","expect":"enqueue_workflow"}
+{"id":28,"request":"Queue this graph 4 times","expect":"enqueue_workflow"}
+{"id":29,"request":"Draw me a diagram of how this workflow connects","expect":"visualize_workflow"}
+{"id":30,"request":"I can't tell what feeds what — show the graph structure","expect":"visualize_workflow"}
+{"id":31,"request":"Build me a txt2img workflow from scratch","expect":"create_workflow"}
+{"id":32,"request":"Make a workflow that does img2img with a LoRA","expect":"create_workflow"}
+{"id":33,"request":"Show me the output image from that run","expect":"get_image"}
+{"id":34,"request":"Let me see render 3 from the batch","expect":"get_image"}
+{"id":35,"request":"Upload this photo so I can img2img it","expect":"upload_image"}
+{"id":36,"request":"Put this reference image into ComfyUI","expect":"upload_image"}
+{"id":37,"request":"What settings does KSampler take?","expect":"get_defaults"}
+{"id":38,"request":"What are the valid samplers?","expect":"get_defaults"}
+{"id":39,"request":"Tell me about this model file","expect":"model_metadata"}
+{"id":40,"request":"What base model is this LoRA trained for?","expect":"model_metadata"}
+{"id":41,"request":"Something broke between yesterday and today — find which change did it","expect":"bisect"}
+{"id":42,"request":"Bisect my custom nodes to find the crash","expect":"bisect"}
+{"id":43,"request":"Snapshot my node setup before I upgrade","expect":"node_snapshot"}
+{"id":44,"request":"Roll back to the node versions from last week","expect":"node_snapshot"}
+{"id":45,"request":"File a bug about the panel dropping my connection","expect":"report_issue"}
+{"id":46,"request":"This looks like a bug, report it upstream","expect":"report_issue"}
+{"id":47,"request":"Install ComfyUI on this machine","expect":"install_comfyui"}
+{"id":48,"request":"Set up a fresh ComfyUI","expect":"install_comfyui"}
+{"id":49,"request":"Spin up a RunPod GPU","expect":"runpod"}
+{"id":50,"request":"How much am I spending on RunPod right now?","expect":"runpod"}
+{"id":51,"request":"Tell me when my pod finishes booting","expect":"runpod_watch"}
+{"id":52,"request":"Watch the pod and ping me when it's ready","expect":"runpod_watch"}
+{"id":53,"request":"What API nodes are available?","expect":"list_api_nodes"}
+{"id":54,"request":"Can I use Veo through ComfyUI?","expect":"list_api_nodes"}
+{"id":55,"request":"What's 1024 * 1.5 rounded to a multiple of 8?","expect":"calculate"}
+{"id":56,"request":"Work out the aspect ratio for 1344x768","expect":"calculate"}
+{"id":57,"request":"Apply this pack manifest","expect":"apply_manifest"}
+{"id":58,"request":"Set up my environment from this manifest file","expect":"apply_manifest"}
+{"id":59,"request":"What workflow packs do I have?","expect":"list_packs"}
+{"id":60,"request":"List the skills available","expect":"list_packs"}
+{"id":61,"request":"Prepare my training images","expect":"train_prepare_dataset"}
+{"id":62,"request":"Caption and bucket this dataset for LoRA training","expect":"train_prepare_dataset"}
+{"id":63,"request":"Start training the LoRA","expect":"train_start"}
+{"id":64,"request":"Kick off a fine-tune on my dataset","expect":"train_start"}
+{"id":65,"request":"My training run is producing garbage, what's wrong?","expect":"train_doctor"}
+{"id":66,"request":"Check my training config for problems","expect":"train_doctor"}
+{"id":67,"request":"Open the app for video generation","expect":"apps"}
+{"id":68,"request":"Launch the previz app","expect":"apps"}
+{"id":69,"request":"Run this on all 40 images in the folder","expect":"batch"}
+{"id":70,"request":"Process the whole directory through this workflow","expect":"batch"}
+{"id":71,"request":"Where is my ComfyUI installed?","expect":"workspace"}
+{"id":72,"request":"Switch to my other ComfyUI install","expect":"workspace"}
+{"id":73,"request":"Run comfy --help","expect":"comfy_cli"}
+{"id":74,"request":"Use the comfy CLI to check the version","expect":"comfy_cli"}
+{"id":75,"request":"Add a LoraLoader node to my canvas","expect":"node_pack","alt":["create_workflow"],"why":"AMBIGUOUS: live canvas edits are panel_* tools, not in this 37"}
+{"id":76,"request":"Change the seed on my sampler to 12345","expect":"create_workflow","alt":["get_workflow"],"why":"AMBIGUOUS: live edit belongs to panel_set_widget"}
+{"id":77,"request":"My image came out black","expect":"get_history","alt":["get_system_stats"],"why":"diagnosis has no single home"}
+{"id":78,"request":"Why is my render so slow?","expect":"get_system_stats"}
+{"id":79,"request":"Make the same image but photorealistic","expect":"generate_image"}
+{"id":80,"request":"Generate 8 variations","expect":"generate_image"}
+{"id":81,"request":"Upscale this to 4k","expect":"generate_image","alt":["enqueue_workflow"],"why":"depends on whether a workflow exists"}
+{"id":82,"request":"Delete the models I'm not using","expect":"list_local_models","why":"discovery first; deletion is not a tool"}
+{"id":83,"request":"How big is my models folder?","expect":"list_local_models"}
+{"id":84,"request":"Reinstall the pack that failed","expect":"install_custom_node"}
+{"id":85,"request":"Pin ComfyUI to version 0.29","expect":"install_comfyui","alt":["comfy_cli"]}
+{"id":86,"request":"Show the last error from the server","expect":"get_history","alt":["get_system_stats"],"why":"AMBIGUOUS: no dedicated log tool"}
+{"id":87,"request":"Empty the output folder","expect":"workspace","why":"filesystem scope"}
+{"id":88,"request":"What version of ComfyUI am I on?","expect":"get_system_stats"}
+{"id":89,"request":"Queue this at low priority behind my current job","expect":"enqueue_workflow"}
+{"id":90,"request":"Interrupt the current generation but keep the queue","expect":"queue"}
+{"id":91,"request":"Download every model this workflow needs","expect":"download_model"}
+{"id":92,"request":"Which models is this workflow missing?","expect":"get_workflow","alt":["list_local_models"],"why":"AMBIGUOUS: needs a join of two reads"}
+{"id":93,"request":"Save my current node setup so I can restore it","expect":"node_snapshot"}
+{"id":94,"request":"Train a style LoRA from these 30 pictures","expect":"train_prepare_dataset","why":"correct FIRST step; train_start follows"}
+{"id":95,"request":"Show me a picture of the workflow graph","expect":"visualize_workflow","why":"NOT get_image — 'picture of the graph'"}
+{"id":96,"request":"Get me image 5","expect":"get_image"}
+{"id":97,"request":"Stop everything","expect":"queue","alt":["restart_comfyui"],"why":"AMBIGUOUS: cancel vs restart"}
+{"id":98,"request":"Is my RunPod still running?","expect":"runpod"}
+{"id":99,"request":"Install a pack from this git URL","expect":"install_custom_node"}
+{"id":100,"request":"What can you do?","expect":"list_packs","alt":[],"why":"CONTROL: no good answer — capability discovery has no tool"}

--- a/src/__tests__/tools/tool-reach-corpus.test.ts
+++ b/src/__tests__/tools/tool-reach-corpus.test.ts
@@ -1,0 +1,48 @@
+// The tool-reach corpus is only useful if it cannot silently rot against a rename.
+// A benchmark whose expected answers name tools that no longer exist scores a model
+// against a surface nobody ships — worse than having no benchmark, because the number
+// still looks meaningful.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { TOOL_NAMES } from "../../tools/vocabulary.js";
+
+const rows = readFileSync(new URL("../../../benchmarks/tool-reach.jsonl", import.meta.url), "utf8")
+  .trim()
+  .split(/\r?\n/)
+  .map((line, i) => {
+    try {
+      return JSON.parse(line) as { id: number; request: string; expect: string; alt?: string[] };
+    } catch (err) {
+      throw new Error(`benchmarks/tool-reach.jsonl line ${i + 1} is not valid JSON: ${String(err)}`);
+    }
+  });
+
+describe("tool-reach corpus stays valid against the shipped surface", () => {
+  const live = new Set<string>(TOOL_NAMES as readonly string[]);
+
+  it("every expected tool still exists", () => {
+    const dead = rows.filter((r) => !live.has(r.expect)).map((r) => `#${r.id} → ${r.expect}`);
+    expect(dead, "rename a tool and this fails loudly instead of scoring against a ghost").toEqual([]);
+  });
+
+  it("every alternative tool still exists", () => {
+    const dead = rows.flatMap((r) => (r.alt ?? []).filter((a) => !live.has(a)).map((a) => `#${r.id} → ${a}`));
+    expect(dead).toEqual([]);
+  });
+
+  it("exercises EVERY tool at least once — a blind spot is a benchmark that cannot fail", () => {
+    const covered = new Set(rows.map((r) => r.expect));
+    const missing = [...live].filter((t) => !covered.has(t));
+    expect(missing, "add a request for these before trusting any score").toEqual([]);
+  });
+
+  it("has unique ids and non-empty requests", () => {
+    expect(new Set(rows.map((r) => r.id)).size).toBe(rows.length);
+    expect(rows.every((r) => typeof r.request === "string" && r.request.trim().length > 0)).toBe(true);
+  });
+
+  it("is the advertised size", () => {
+    expect(rows.length).toBe(100);
+  });
+});


### PR DESCRIPTION
Picks up the benchmark you asked for — *"a list of 100 requests and then see if you reach for the right tools, then test on a kimi model, then smaller local models in ollama"* — which stalled on the spend limit.

This is the **corpus and the guard**, which is what unblocks the other two arms.

## What's here

100 realistic requests against the 37-tool surface, each with the tool I judge correct and an `alt` list where a reasonable agent could pick differently:

```json
{"id":17,"request":"Find me a good anime LoRA","expect":"search_custom_nodes",
 "alt":["download_model"],"why":"AMBIGUOUS: model search vs node search"}
```

The `alt` entries are the point. They mark where the **surface** is ambiguous, not where a model is wrong.

## Checked, not asserted

- **Every one of the 37 tools is exercised at least once** — a blind spot is a benchmark that can't fail.
- Every `expect` and `alt` exists in the live `TOOL_NAMES`.

A guard test enforces both, so a rename fails loudly instead of quietly scoring models against a ghost.

## My own arm is deliberately not scored

I wrote both the requests and the answer key, so grading myself measures agreement with my own intuitions — not evidence, and I won't quote a number for it. The corpus exists so the **Kimi and Ollama arms are blind**. Those are the real test, and the cross-model comparison is the actual question: does a 4B model land the right tool with 37 choices where it couldn't with 154?

## Three gaps the corpus surfaced

None is a consolidation regression — each is a request users make that the surface has no clean home for:

1. **No error/log retrieval.** *"Show the last error from the server"*, *"my image came out black"* both dead-end at `get_history`, which isn't what was asked.
2. **"Which models is this workflow missing?"** needs a hand-join of `get_workflow` and `list_local_models`, every time. It's among the most common real questions.
3. **"What can you do?"** has no answer; `list_packs` is about packs.

Separately: **live-canvas editing is absent from the 37 by design** (it's `panel_*`), but nothing in the descriptions says so. An agent asked to *"change the seed on my sampler"* is steered toward `create_workflow` — i.e. build a new workflow rather than edit the open one. Worth a sentence in the affected descriptions even if the split stays.

## Verification

`tsc --noEmit` clean; full suite **7033 pass**. Control-byte scan 0. No tool-surface change, so the vocabulary ratchet is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)