### PR TITLE
0.50.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.5] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- a render completion is a STEP when a plan is still running (#1002)
+- name our own User-Agent, and stop pushing Windows onto Python (#1000)
+- the Manager route is a routing fallback, not a remote server (#999)
+- say WHY the caller is holding a tool that does not exist (#998)
+
+#### Changed
+- reach the injection call sites three fixes could not (#1004)
+
+
 ## [0.50.4] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.4",
+  "version": "0.50.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.4",
+      "version": "0.50.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.4",
+  "version": "0.50.5",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **0.50.5**, reconciling the release commit onto protected `main` (the tag `v0.50.5` is already pushed and publishing).

### Contents

| PR | Issue | Change |
|---|---|---|
| #1002 | #977 | a render completion is a STEP when a plan is still running |
| #1000 | #937 | name our own User-Agent, and stop pushing Windows onto Python |
| #999 | #947 | the Manager route is a routing fallback, not a remote server |
| #998 | #996 | say WHY the caller is holding a tool that does not exist |
| #1004 | — | *(test)* reach the injection call sites three fixes could not |

### The theme

Four of the five are the same class this whole line of work has been about — **a message asserting something the code never established**:

- #947 — a loopback server described as "the remote ComfyUI", when the decision was actually "no local models directory was resolvable". The classification was right; the sentence was wrong.
- #996 — a retired tool name answered with "call X instead" and no explanation of *why* the caller was holding it, leaving "the server is inconsistent" as the only reading. It was a cached client tool list.
- #977 — a fixed "you do NOT need to call any tools" after every render, sent to an agent three steps into a sweep it had announced.
- #937 — a `/login` remedy that is correct at the `pi` prompt and unusable in the chat box where it was printed.

#1004 is the one that isn't a fix: it removes a test seam that had blocked three separate PRs from verifying their own call sites.

### Changelog hand-corrected again (#988)

`gen-changelog` produced **28** entries — every commit since `v0.50.1`, walking past the 0.50.2/0.50.3/0.50.4 tags because none of them is an ancestor of `main`. Trimmed to the 5 that are real.

Third release in a row. The structural cause and two possible fixes are written up in #988; it is worth doing before the next one rather than after.

### Verification

Full suite **331 files / 7048 passed** on `main` at `f27902f`, with `tsc`, `lint`, `build`, `check:vocabulary`, `vocab:export --check` and the `docs:gen` no-op gate all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)