### PR TITLE
fix(#988): dedupe the changelog against what it already says

### DIFF
--- a/scripts/gen-changelog.mjs
+++ b/scripts/gen-changelog.mjs
@@ -23,7 +23,14 @@ import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+// The repo this operates on. Derived from the script's own location so it works
+// from any cwd — with an explicit override so the generator can be exercised
+// against a scratch repo. Without one it can only be tested by running it on the
+// real CHANGELOG, which is how a range bug survived three releases: the only way
+// to check its output was to generate a release and read it.
+const ROOT = process.env.COMFYUI_MCP_CHANGELOG_ROOT
+  ? process.env.COMFYUI_MCP_CHANGELOG_ROOT
+  : join(dirname(fileURLToPath(import.meta.url)), "..");
 const CHANGELOG = join(ROOT, "CHANGELOG.md");
 
 // ── Repo config ─────────────────────────────────────────────────────────────
@@ -210,10 +217,48 @@ const rawMd = readFileSync(CHANGELOG, "utf-8");
 const EOL = rawMd.includes("\r\n") ? "\r\n" : "\n";
 const writeChangelog = (s) => writeFileSync(CHANGELOG, EOL === "\r\n" ? s.replace(/\n/g, "\r\n") : s);
 
+/**
+ * Every PR number the CHANGELOG already documents (#988).
+ *
+ * Read from the file rather than from git, because the file is the record of
+ * what has actually been ANNOUNCED — which is the question being asked. Tags
+ * cannot answer it here: the release flow leaves them off the branch entirely.
+ *
+ * Deliberately scans the WHOLE file, not just the newest section. An
+ * over-reaching range can reach back several releases (v0.50.5's reached to
+ * v0.50.1, four sections back), and each of those releases already said its
+ * piece.
+ */
+function alreadyDocumentedPRs() {
+  return [...rawMd.matchAll(/\(#(\d+)\)/g)].map((m) => m[1]);
+}
+
 /** Build a dated entry string for `ver` from commits in `range`, folding in any
  *  hand-written highlights (deduped by PR). */
 function buildEntry(ver, range, highlights = "") {
-  const covered = new Set([...highlights.matchAll(/\(#(\d+)\)/g)].map((m) => m[1]));
+  // #988 — dedupe against EVERY PR the changelog already documents, not just the
+  // hand-written highlights for this release.
+  //
+  // The range this is given routinely reaches too far back. `describe --tags`
+  // returns the newest tag REACHABLE from HEAD, and the release flow pushes the
+  // tag from a local commit and then squash-merges the version bump onto
+  // protected main — which writes a different sha, so a version tag is never an
+  // ancestor of main. `describe` walks straight past it to the release before.
+  // 0.50.3, 0.50.4 and 0.50.5 each generated a section listing every commit back
+  // to v0.50.1, and each had to be trimmed by hand before the tag was pushed.
+  //
+  // A narrower RANGE was tried and rejected: bounding by the newest release
+  // COMMIT on the branch under-includes instead, silently dropping anything
+  // merged between the tag being cut and the reconcile PR landing (#976 fell in
+  // exactly that window). Dropping an entry is worse than repeating one — a
+  // duplicate is visible, a gap is not.
+  //
+  // Filtering by what is already WRITTEN has neither failure mode: an entry the
+  // changelog already carries is a duplicate by definition, and one it does not
+  // carry survives however wide the range was. The mechanism already existed
+  // for the highlights; it was simply never pointed at the rest of the file.
+  const documented = [...alreadyDocumentedPRs(), ...[...highlights.matchAll(/\(#(\d+)\)/g)].map((m) => m[1])];
+  const covered = new Set(documented);
   const commits = parseCommits(range);
   const auto = autoBody(commits, covered);
   const parts = [`## [${ver}] - ${today()}`, ""];

--- a/src/__tests__/gen-changelog-dedupe.test.ts
+++ b/src/__tests__/gen-changelog-dedupe.test.ts
@@ -1,0 +1,138 @@
+// #988 — the changelog range reaches too far back, every single release.
+//
+// `describe --tags --abbrev=0` returns the newest tag REACHABLE from HEAD. The
+// release flow pushes the tag from a LOCAL commit and then squash-merges the
+// version bump onto protected main, which writes a different sha — so a version
+// tag is NEVER an ancestor of main and `describe` walks straight past it.
+//
+// 0.50.3, 0.50.4 and 0.50.5 each generated a section listing every commit back
+// to v0.50.1 (28 entries for a 5-commit release), and each had to be trimmed by
+// hand before the tag was pushed. Three hand-corrections is how a wrong
+// changelog eventually ships.
+//
+// A narrower RANGE was tried and rejected: bounding by the newest release COMMIT
+// on the branch under-includes instead, silently dropping anything merged
+// between the tag being cut and the reconcile PR landing (#976 fell in exactly
+// that window). Dropping an entry is worse than repeating one — a duplicate is
+// visible, a gap is not. Both directions are covered below.
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const SCRIPT = join(ROOT, "scripts", "gen-changelog.mjs");
+
+let dir: string;
+let changelog: string;
+
+/** A repo with a real history, so the script's own git queries work. */
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+}
+
+function commit(subject: string): void {
+  writeFileSync(join(dir, "f.txt"), subject);
+  git(["add", "-A"], dir);
+  git(["commit", "-q", "-m", subject], dir);
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cl-"));
+  changelog = join(dir, "CHANGELOG.md");
+  git(["init", "-q", "-b", "main"], dir);
+  git(["config", "user.email", "t@example.com"], dir);
+  git(["config", "user.name", "t"], dir);
+  // The generator writes into an "## Unreleased" section; without one there is
+  // nowhere to put the entry and it refuses (correctly).
+  writeFileSync(changelog, "# Changelog\n\n## Unreleased\n\n");
+  git(["add", "-A"], dir);
+  git(["commit", "-q", "-m", "chore: init"], dir);
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/** Run the real script against the scratch repo. */
+function generate(version: string): string {
+  execFileSync(process.execPath, [SCRIPT, version], {
+    cwd: dir,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, COMFYUI_MCP_CHANGELOG_ROOT: dir },
+  });
+  return readFileSync(changelog, "utf-8");
+}
+
+describe("#988: an over-reaching range does not duplicate what is already written", () => {
+  it("omits entries a previous section already documents", () => {
+    commit("fix(a): first thing (#101)");
+    const first = generate("1.0.0");
+    expect(first).toContain("first thing (#101)");
+
+    // No new commits, but the range still reaches back past #101 (the tag this
+    // flow would have created is not an ancestor here either).
+    commit("fix(b): second thing (#102)");
+    const second = generate("1.0.1");
+
+    // The new one appears…
+    expect(second).toContain("second thing (#102)");
+    // …and the old one is NOT repeated in the new section.
+    const newSection = second.slice(second.indexOf("## [1.0.1]"), second.indexOf("## [1.0.0]"));
+    expect(newSection).not.toContain("(#101)");
+    // …while still being present in its own, earlier section.
+    expect(second.slice(second.indexOf("## [1.0.0]"))).toContain("(#101)");
+  });
+
+  it("says so plainly when everything in range is already documented", () => {
+    commit("fix(a): only thing (#101)");
+    generate("1.0.0");
+    const again = generate("1.0.1");
+    const section = again.slice(again.indexOf("## [1.0.1]"), again.indexOf("## [1.0.0]"));
+    expect(section).toContain("_No user-facing changes._");
+  });
+
+  it("dedupes across SEVERAL earlier sections, not just the newest", () => {
+    commit("fix(a): one (#101)");
+    generate("1.0.0");
+    commit("fix(b): two (#102)");
+    generate("1.0.1");
+    commit("fix(c): three (#103)");
+    const out = generate("1.0.2");
+    const section = out.slice(out.indexOf("## [1.0.2]"), out.indexOf("## [1.0.1]"));
+    expect(section).toContain("(#103)");
+    expect(section).not.toContain("(#101)");
+    expect(section).not.toContain("(#102)");
+  });
+});
+
+describe("#988: it must not UNDER-include — the failure the narrow range had", () => {
+  // The #976 shape: a commit lands after the previous tag was cut but before its
+  // reconcile PR merged, so it belongs to NO release yet. A range bounded by the
+  // release commit would skip it forever. Filtering by what is written cannot,
+  // because nothing has written it.
+  it("includes a commit that no section documents, however wide the range", () => {
+    commit("fix(a): released thing (#101)");
+    generate("1.0.0");
+    commit("fix(b): fell in the release window (#976)");
+    commit("fix(c): later thing (#102)");
+    const out = generate("1.0.1");
+    const section = out.slice(out.indexOf("## [1.0.1]"), out.indexOf("## [1.0.0]"));
+    expect(section).toContain("(#976)");
+    expect(section).toContain("(#102)");
+  });
+
+  // A commit with no PR number cannot be deduped by number. It must still be
+  // emitted rather than silently dropped — the conservative direction.
+  it("keeps an entry that carries no PR number to match on", () => {
+    commit("fix(a): numbered (#101)");
+    generate("1.0.0");
+    commit("fix(b): unnumbered local fix");
+    const out = generate("1.0.1");
+    const section = out.slice(out.indexOf("## [1.0.1]"), out.indexOf("## [1.0.0]"));
+    // Conventional-with-no-PR is housekeeping only when its TYPE is unmapped;
+    // a `fix:` is a real entry and must survive.
+    expect(section).toContain("unnumbered local fix");
+  });
+});


### PR DESCRIPTION
Closes #988

## The bug

`describe --tags --abbrev=0` returns the newest tag **reachable from HEAD**. The release flow pushes the tag from a *local* commit and then squash-merges the version bump onto protected `main`, which writes a different sha — so a version tag is **never** an ancestor of `main`, and `describe` walks straight past it.

0.50.3, 0.50.4 and 0.50.5 each generated a section listing every commit back to `v0.50.1` — **28 entries for a 5-commit release** — and each was trimmed by hand before the tag went out. Three hand-corrections is how a wrong changelog eventually ships.

## The fix I reverted first

Narrowing the **range** — bounding by the newest release *commit* on the branch — under-includes instead: it silently drops anything merged between the tag being cut and the reconcile PR landing. **#976 fell in exactly that window.**

Dropping an entry is worse than repeating one. A duplicate is visible noise someone notices; a gap is invisible.

## The fix that works

Filter by what is already **written**. An entry the changelog already carries is a duplicate by definition; one it does not carry survives however wide the range was. Neither failure mode is reachable.

The dedupe machinery already existed for the hand-written highlights — it was simply never pointed at the rest of the file.

Verified against the exact case: removing the `[0.50.5]` section and regenerating reproduces **precisely the five entries I trimmed to by hand**, and regenerating on a clean tree now says `_No user-facing changes._` instead of restating 28.

## Why this survived three releases

`ROOT` was derived from the script's own location, so it always wrote the **real** CHANGELOG regardless of cwd. The only way to see its output was to cut a release and read it.

`COMFYUI_MCP_CHANGELOG_ROOT` lets it run against a scratch repo. That hazard was not hypothetical — the first run of these tests, before the override existed, appended three junk sections to this repo's own changelog. The suite now asserts against a scratch dir, and I verified a full run leaves `CHANGELOG.md` untouched.

## Verification

- 5 new tests covering **both** directions — over-inclusion *and* the under-inclusion the narrow range would have caused; full suite **332 files / 7053 passed**; `tsc` and `check:vocabulary` clean.
- **Mutation-verified**: not consulting the existing file kills 3 tests, including the multi-section case.
- A second mutation aimed at the same property reported `applied: false` — the replacement never matched — so I **discarded it** rather than count a no-op as a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)