### PR TITLE
fix(#1005): ask PowerShell for UTF-8 before reading a process command line

### DIFF
--- a/src/__tests__/services/process-identity-encoding.test.ts
+++ b/src/__tests__/services/process-identity-encoding.test.ts
@@ -1,0 +1,84 @@
+// #1005 — a ComfyUI under a non-ASCII path could not be restarted.
+//
+// PowerShell encodes REDIRECTED stdout with the console's legacy OEM codepage,
+// not UTF-8, while this output is decoded as UTF-8. Any character the codepage
+// cannot represent arrives as `?` or U+FFFD, so a Cyrillic Windows profile (or
+// an accented folder, or CJK) yields a MANGLED command line.
+//
+// That is not cosmetic. `commandLineMatchesArgv` compares this against
+// /system_stats argv to corroborate ownership before a restart, so a mangled
+// path never matches and restart_comfyui refuses to control the very process it
+// just identified — telling the user it "is not running the ComfyUI that
+// answered /system_stats" about the one that is.
+//
+// Measured on Windows 11 before the fix:
+//   without the preamble:  "CMD=??????-caf?-??"
+//   with it:               "CMD=Пример-café-日本"
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const execFileSync = vi.fn();
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  execFileSync: (...a: unknown[]) => execFileSync(...a),
+}));
+
+// The module reads platform() ONCE at load, so it must be pinned before import
+// or this suite passes vacuously on Linux/macOS CI (the IS_WIN branch never runs).
+vi.mock("node:os", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:os")>()),
+  platform: () => "win32",
+}));
+
+const { readProcessIdentity } = await import("../../services/live-interpreter.js");
+
+/** A path with characters no single OEM codepage covers. */
+const CYRILLIC_PATH = "C:\Users\Пример\ComfyUI\main.py";
+
+beforeEach(() => execFileSync.mockReset());
+
+describe("#1005: the identity probe asks PowerShell for UTF-8", () => {
+  it("sets OutputEncoding before anything that can emit a path", () => {
+    execFileSync.mockReturnValue("START=1\nPPID=2\nEXE=x\nCMD=y\n");
+    readProcessIdentity(1234);
+
+    const [exe, args] = execFileSync.mock.calls[0] as [string, string[]];
+    expect(exe).toMatch(/powershell/);
+    const command = args[args.indexOf("-Command") + 1];
+    expect(command).toContain("[Console]::OutputEncoding");
+    expect(command).toContain("UTF8Encoding");
+    // Order is load-bearing: the encoding must be set BEFORE the query that
+    // produces the path, or the first line is already mangled.
+    expect(command.indexOf("OutputEncoding")).toBeLessThan(command.indexOf("Get-CimInstance"));
+  });
+
+  // A BOM would land at the head of stdout and corrupt the first field parsed.
+  it("asks for UTF-8 WITHOUT a BOM", () => {
+    execFileSync.mockReturnValue("START=1\nCMD=y\n");
+    readProcessIdentity(1234);
+    const [, args] = execFileSync.mock.calls[0] as [string, string[]];
+    expect(args[args.indexOf("-Command") + 1]).toContain("UTF8Encoding]::new($false)");
+  });
+
+  it("carries a non-ASCII command line through intact", () => {
+    execFileSync.mockReturnValue(
+      `START=133000000000000000\nPPID=42\nEXE=C:\Python\python.exe\nCMD=${CYRILLIC_PATH}\n`,
+    );
+    const id = readProcessIdentity(1234);
+    expect(id?.commandLine).toBe(CYRILLIC_PATH);
+    // …and the tokenised argv keeps it too, since that is what ownership
+    // corroboration actually compares.
+    expect(id?.argv?.[0]).toContain("Пример");
+    expect(id?.argvFidelity).toBe("exact");
+  });
+
+  // The failure this produced: a replacement char makes the OS command line
+  // differ from the argv the server reported, so ownership never corroborates.
+  it("a MANGLED line does not match the argv it should have matched", async () => {
+    const { commandLineMatchesArgv } = await import("../../services/live-interpreter.js");
+    const argv = [CYRILLIC_PATH, "--listen"];
+    expect(commandLineMatchesArgv(`${CYRILLIC_PATH} --listen`, argv)).toBe(true);
+    // What the OEM codepage produced before the fix.
+    expect(commandLineMatchesArgv("C:\Users\??????\ComfyUI\main.py --listen", argv)).toBe(false);
+  });
+});

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -278,6 +278,21 @@ export function readProcessIdentity(pid: number): ProcessIdentity | undefined {
         [
           "-NoProfile",
           "-Command",
+          // #1005 — PowerShell encodes REDIRECTED stdout with the console's
+          // legacy OEM codepage, not UTF-8, and this output is decoded as UTF-8.
+          // Any character the codepage cannot represent arrives as `?` or U+FFFD,
+          // so a ComfyUI under a non-ASCII path (a Cyrillic Windows profile, an
+          // accented folder, CJK) reports a MANGLED command line.
+          //
+          // That is not cosmetic here: commandLineMatchesArgv compares this
+          // against /system_stats argv to corroborate ownership before a restart.
+          // A mangled path never matches, so restart_comfyui refuses to control
+          // the very process it just identified — reporting "is not running the
+          // ComfyUI that answered /system_stats" about the one that is.
+          //
+          // Verified on Windows 11: without this line `Пример-café-日本` comes back
+          // as `??????-caf?-??`; with it, intact.
+          `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); ` +
           `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; ` +
             `if ($p) { "START=" + $p.CreationDate.ToFileTimeUtc(); "PPID=" + $p.ParentProcessId; "EXE=" + $p.ExecutablePath; "CMD=" + $p.CommandLine }`,
         ],


### PR DESCRIPTION
Closes #1005

## The bug

PowerShell encodes **redirected** stdout with the console's legacy OEM codepage, not UTF-8, while `readProcessIdentity` decodes it as UTF-8. Any character the codepage cannot represent arrives as `?` or U+FFFD — so a ComfyUI under a non-ASCII path (a Cyrillic Windows profile, an accented folder, CJK) reports a **mangled** command line.

That is not cosmetic. `commandLineMatchesArgv` compares this against `/system_stats` argv to corroborate ownership before a restart, so a mangled path never matches:

> The process listening on port 8189 … is **not running the ComfyUI that answered /system_stats** — the OS reports its command line as `"C:\Users\�\..."` …

`restart_comfyui` refuses to control the very process it just identified.

## Reproduced before changing anything

The fix is one line, so the claim is the whole value. On this Windows 11 box:

```
without the preamble:  "CMD=??????-caf?-??"
with it:               "CMD=Пример-café-日本"
```

The reporter had already found and verified this — the diff is theirs.

## Two details the tests pin

- **Order is load-bearing.** Setting the encoding *after* the CIM query is too late: that query's own output is already on its way out.
- **`::new($false)`** — no BOM, for the same reason. A BOM would land at the head of stdout and corrupt the first field parsed.

## The sibling readers are safe, for a reason

I checked rather than assumed. `ai-toolkit`'s two readers emit a `ProcessId` and a `.Count`; `port-owner` emits an address and a pid; `self-update` spawns with `stdio: "ignore"` and never reads stdout at all. `live-interpreter` is the only one whose **output** can carry a user path.

## Verification

- 4 new tests; full suite **333 files / 7057 passed**; `tsc` and `check:vocabulary` clean.
- The test **pins `platform()` before importing** the module — `IS_WIN` is read once at load, so without that this suite would pass vacuously on Linux/macOS CI with the Windows branch never executing.
- **Mutation-verified**: dropping the preamble kills 2 tests; moving it after the query kills the ordering one.
- Both mutations first reported a **false result** — one never applied, the other applied without failing. Re-run inspecting the resulting file rather than trusting the replacement's return value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)