### PR TITLE
0.50.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.6] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- ask PowerShell for UTF-8 before reading a process command line (#1012)
+- the ACTION-level admission refusal owes the same explanation the name-level one got (#1008)
+- scan untracked files too, and say what was skipped (#1009)
+- dedupe the changelog against what it already says (#1007)
+
+
 ## [0.50.5] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.5",
+  "version": "0.50.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.5",
+      "version": "0.50.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.5",
+  "version": "0.50.6",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **0.50.6**, reconciling the release commit onto protected `main` (the tag `v0.50.6` is already pushed and publishing).

### Contents

| PR | Issue | Fix |
|---|---|---|
| #1012 | #1005 | ask PowerShell for UTF-8 before reading a process command line |
| #1008 | #908 | the ACTION-level admission refusal owes the same explanation the name-level one got |
| #1009 | #970 | scan untracked files too, and say what was skipped |
| #1007 | #988 | dedupe the changelog against what it already says |

### The changelog generated itself correctly

First release since #1007, and **this section is unedited**. The generator still reports a 32-commit range — the range was never the thing that could be safely narrowed — but it now filters against what the file already documents, so the output is the four entries that are actually new.

0.50.3, 0.50.4 and 0.50.5 each needed the section trimmed by hand before the tag went out. That is the check this release existed to run, and it passed.

### Two of these were self-inflicted process defects

#1007 and #1009 both fix gates that had been *reporting* correctness they could not establish:

- `gen-changelog` reached past three version tags because none of them is an ancestor of `main` (the flow tags a local commit, then squash-merges the bump).
- `check:vocabulary` could not see untracked files, so a brand-new file was invisible until its first commit — while printing `OK — N tracked files`, which reads as "checked everything". It had caught the gate out three separate times, twice recorded in its own comments.

Both now say what they actually covered.

### On #1005

Reproduced on a real Windows box before the one-line change: PowerShell encodes redirected stdout with the console's OEM codepage, so `Пример-café-日本` arrived as `??????-caf?-??`. That mangled command line then failed ownership corroboration, and `restart_comfyui` refused to control the very process it had just identified.

### Verification

Full suite **333 files / 7057 passed** on `main` at `c3418e5`, with `tsc`, `lint`, `build`, `check:vocabulary`, `vocab:export --check` and the `docs:gen` no-op gate all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)