### PR TITLE
fix(#1011): an explicit retry is not a blind re-issue

### DIFF
--- a/src/__tests__/orchestrator/panel-run-backpressure.test.ts
+++ b/src/__tests__/orchestrator/panel-run-backpressure.test.ts
@@ -415,3 +415,67 @@ describe("#889: runErrorNotice picks its wording from real attribution", () => {
     expect(t).not.toMatch(/You did NOT queue this run/);
   });
 });
+
+// #1011 — the duplicate fence made the retry token inert.
+//
+// After a reconnect, panel_run timed out waiting for graph_run and returned a
+// retry_of rid. Re-issuing with that token hit the fence FIRST, so the panel's
+// dedupe — the only thing that can settle whether the timed-out dispatch created
+// the pending job — was never reached. The caller was left holding a token for
+// exactly this situation with no way to spend it.
+//
+// The fence's own comment claims it "composes with #694's retry_of". In the order
+// they actually ran, it did not: refusing before dispatch means the token cannot
+// travel.
+describe("#1011: an explicit retry is not a blind re-issue", () => {
+  beforeEach(() => {
+    qm.selfQueuedIds.clear();
+    qm.lastSelfQueueTs = null;
+    qm.state.connected = true;
+    qm.state.runningPromptId = "p-unaccountable";
+    qm.state.pendingPromptIds = [];
+    qm.state.queueRemaining = 1;
+  });
+
+  it("still REFUSES a blind re-issue — the fence is unchanged without the token", async () => {
+    const ctx = makeCtx({ queued: true, prompt_id: "p-new" });
+    const res = await defByName("panel_run").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    expect(firstText(res)).toMatch(/refused to queue: a render is already in flight/);
+  });
+
+  it("lets a retry_of THROUGH so the panel can reconcile it", async () => {
+    const ctx = makeCtx({ queued: true, prompt_id: "p-reconciled" });
+    const res = await defByName("panel_run").handler({ retry_of: "rid-abc" }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(firstText(res)).not.toMatch(/refused to queue/);
+  });
+
+  // Riding past a duplicate guard silently would hide the one risk the caller
+  // took. The note says what was skipped and how to check it actually deduped.
+  it("DISCLOSES that the fence was skipped, and how to verify", async () => {
+    const ctx = makeCtx({ queued: true, prompt_id: "p-reconciled" });
+    const t = firstText(await defByName("panel_run").handler({ retry_of: "rid-abc" }, ctx));
+    expect(t).toMatch(/\[RETRY\]/);
+    expect(t).toMatch(/duplicate fence was SKIPPED/);
+    expect(t).toContain("p-unaccountable");
+    // Expected, not guaranteed — the token might not match.
+    expect(t).toMatch(/VERIFY that before assuming/);
+    expect(t).toMatch(/one MORE job than you intended/);
+  });
+
+  it("says nothing when there was no fence to skip", async () => {
+    qm.state.runningPromptId = null;
+    qm.state.queueRemaining = 0;
+    const ctx = makeCtx({ queued: true, prompt_id: "p-quiet" });
+    const t = firstText(await defByName("panel_run").handler({ retry_of: "rid-abc" }, ctx));
+    expect(t).not.toMatch(/\[RETRY\]/);
+  });
+
+  it("an empty retry_of is not an assertion and does not bypass", async () => {
+    const ctx = makeCtx({ queued: true, prompt_id: "p-new" });
+    const res = await defByName("panel_run").handler({ retry_of: "" }, ctx);
+    expect(res.isError).toBe(true);
+    expect(firstText(res)).toMatch(/refused to queue/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6784,8 +6784,28 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // rather than duplicating it: that token dedupes an EXPLICIT retry of an
         // outcome-unknown dispatch at the panel; this fence stops a BLIND
         // re-issue before any dispatch.
+        // #1011 — an EXPLICIT retry is not a blind re-issue, and this fence was
+        // stopping the one mechanism that can settle it.
+        //
+        // The comment above says this "composes with #694's retry_of". It does
+        // not, in the order they actually run: the fence refuses BEFORE dispatch,
+        // so a caller who was handed a retry_of rid by an outcome-unknown timeout
+        // can never get that token to the panel, where the dedupe lives. After a
+        // reconnect the in-flight render is exactly the one they are unsure
+        // about, `selfAttributedProven` is false (the ledger is in-memory and did
+        // not survive), and the fence fires every time — leaving them unable to
+        // discover whether their timed-out dispatch created the pending job, with
+        // the token that exists for that purpose inert in their hand.
+        //
+        // A supplied retry_of is a caller ASSERTION of the same weight as
+        // allow_duplicate: "this is a retry of that dispatch, dedupe it." It is
+        // only ever obtained FROM an outcome-unknown failure of this identical
+        // call, so it is not a blanket bypass. Honour it, and let the panel do
+        // the reconciliation it is designed for.
+        const explicitRetry = typeof args.retry_of === "string" && args.retry_of !== "";
         if (
           args.allow_duplicate !== true &&
+          !explicitRetry &&
           pre.connected &&
           (pre.running || pre.queueDepth > 0) &&
           !pre.selfAttributedProven
@@ -6889,6 +6909,22 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // (a minted prompt id outranks the rejection signals). Say which outputs
         // were dropped, or the caller waits for files that will never be written.
         const droppedNote = describeDroppedOutputs(runReply);
+        // #1011 — a retry that rode PAST the duplicate fence must say so. The
+        // fence exists to stop a second render stacking behind an unaccountable
+        // one; skipping it on the caller's assertion is right, but silently
+        // skipping it would hide the one risk the caller took. The panel dedupes
+        // on the token, so the expected outcome is reconciliation rather than a
+        // new render — expected, not guaranteed, which is exactly why it is said.
+        const retryBypassNote =
+          explicitRetry && pre.connected && (pre.running || pre.queueDepth > 0) && !pre.selfAttributedProven
+            ? `\n\n[RETRY] You passed retry_of, so the duplicate fence was SKIPPED — a render this session ` +
+              `could not account for was already in flight` +
+              (pre.runningPromptId ? ` (running prompt ${pre.runningPromptId})` : "") +
+              `. The panel dedupes on that token, so a matching earlier dispatch should have been ` +
+              `reconciled rather than re-queued. VERIFY that before assuming: check queue (action:"list") ` +
+              `and get_history — if you now see one MORE job than you intended, the token did not match ` +
+              `and this dispatch stacked a duplicate.`
+            : "";
         // markSelfQueued with NO id still stamps the recent-self-queue timestamp,
         // so the id-less case must still call it exactly once (#559).
         if (queuedIds.length === 0) QueueMonitor.markSelfQueued(null);
@@ -6972,7 +7008,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               // droppedNote sits FIRST among the appendices: "some outputs were
               // dropped" changes what the caller should expect from this run, so
               // it must not trail behind the anti-poll boilerplate (#944).
-              { type: "text", text: res.content[0].text + droppedNote + retryNote + warn + note },
+              { type: "text", text: res.content[0].text + droppedNote + retryBypassNote + retryNote + warn + note },
               ...res.content.slice(1),
             ],
           };


### PR DESCRIPTION
Closes #1011

## The bug

After a reconnect, `panel_run` timed out waiting for `graph_run` and handed back a `retry_of` rid. Re-issuing with that token hit the **#862 duplicate fence first**, so the panel's dedupe — the only thing that can settle whether the timed-out dispatch created the pending job — was never reached.

The caller was left holding a token minted for exactly this situation with no way to spend it.

## Why it fired every time

The fence's own comment claims it *"composes with #694's retry_of"*. In the order they actually ran, it did not: refusing **before dispatch** means the token cannot travel.

And after a reconnect the fence fires *unconditionally* — the in-flight render is precisely the one the caller is unsure about, and `selfAttributedProven` is false by construction because the self-queue ledger is in-memory and did not survive the restart.

## The fix

A supplied `retry_of` is a caller **assertion** of the same weight as `allow_duplicate`: *"this is a retry of that dispatch, dedupe it."* It is only ever obtained **from** an outcome-unknown failure of this identical call, so it is not a blanket bypass — which is why honouring it is safe, and why an **empty** `retry_of` still refuses.

Riding past a duplicate guard **silently** would hide the one risk the caller took, so the success path now carries a `[RETRY]` note: what was skipped, which prompt was in flight, and how to check the dedupe actually happened.

It says the reconciliation is **expected, not guaranteed** — a token that doesn't match at the panel would stack a real duplicate, and that's the caller's cue to check `queue`/`get_history` rather than assume.

The blind re-issue path is untouched: no token, same refusal, same wording.

## Verification

- 5 new tests; full suite **333 files / 7062 passed**; `tsc`, `check:vocabulary`, `docs:gen` no-op clean.
- **Mutation-verified**: removing the retry exemption kills 2 tests; silencing the disclosure kills 1.
- Both mutations reported a **false result** on the first attempt — one never applied (CRLF anchors), the other applied without failing. Re-run with the resulting file inspected rather than the replacement's return value. **Fifth time today** that check has caught a bogus verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)