### PR TITLE
fix(#1001): an ambiguous routing pin is not a reconnecting panel

### DIFF
--- a/src/__tests__/orchestrator/ambiguous-pin-is-not-reconnecting.test.ts
+++ b/src/__tests__/orchestrator/ambiguous-pin-is-not-reconnecting.test.ts
@@ -1,0 +1,159 @@
+// #1001 — a turn issued from several workflows at once was reported as a panel
+// that is "still reconnecting after a restart/reload".
+//
+// The two conditions are opposites. The ambiguity refusal fires when every tab
+// is connected and healthy but no single one is honestly "the" target (#884);
+// the reconnect wording is for the post-restart window when NO tab is reachable.
+// They were conflated because the refusal's message opens with the literal
+// phrase "no connected tab can be chosen for …", and the transient classifier
+// was a substring match on /no connected tab/.
+//
+// Two consequences, both visible in the report:
+//   1. A retry-safe read (graph_outline, workflow_list) took the post-reconnect
+//      retry branch: sleep, rebind, re-dispatch — guaranteed to fail
+//      identically, because the pin is decided once per batch and does not heal
+//      on a clock.
+//   2. The final message asserted the panel was still reconnecting. It was not.
+//      The reporter believed it and filed "reconnect readiness is reported
+//      before the graph tool route is usable" as a second, independent root
+//      cause — citing that sentence as their evidence. There was no second bug;
+//      there was one speculative sentence presented as an observation.
+//
+// The fix is a typed marker, mirroring the capability-refusal precedent (#709)
+// which solved the same shape: an error whose own text already names its cause
+// and its recovery must not be wrapped in a guess.
+//
+// The ctx under test is the REAL makePanelToolCtx — the classifier and the
+// wrapper are both module-private, and testing them directly would not prove
+// they are wired to the path the reporter actually hit.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { markDispatched, markRoutingAmbiguity } from "../../services/ui-bridge.js";
+
+const textOf = (res: ToolResult): string => (res.content[0] as { text: string }).text;
+
+/**
+ * The refusal the bridge really produces: resolveTarget throws it, and send()'s
+ * catch tags the SAME object dispatched:false. Both markers therefore ride along
+ * together, exactly as in production.
+ */
+function ambiguityRefusal(scope = "orchestrator::codex"): Error {
+  return markDispatched(
+    markRoutingAmbiguity(
+      new Error(
+        `no connected tab can be chosen for "${scope}": the current turn was issued from ` +
+          `multiple workflows at once, so its target is ambiguous. Target a workflow ` +
+          `explicitly (panel_set_workflow_target / panel_open_workflow) or wait for the ` +
+          `next single-origin message.`,
+      ),
+    ),
+    false,
+  );
+}
+
+/** The genuine post-restart window — same opening phrase, opposite cause. */
+function connectedNone(): Error {
+  return markDispatched(
+    new Error(`no connected tab with id "tab-1". Connected: none — refresh the ComfyUI browser tab`),
+    false,
+  );
+}
+
+/**
+ * A bridge that counts send attempts, so "was it retried?" is observable rather
+ * than inferred from wording. Two tabs are reported connected: the ambiguity
+ * case is defined by tabs being healthy, and a single-tab bridge would let the
+ * strict-single auto-heal muddy what is being measured.
+ */
+function countingBridge(fail: () => Error) {
+  const calls: string[] = [];
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push(String(cmd.cmd));
+      throw fail();
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [
+      { tab_id: "tab-1", title: "video_minimax_h3_t2v", connected_at: 0 },
+      { tab_id: "tab-2", title: "other_workflow", connected_at: 0 },
+    ],
+    resolveActiveTabId: () => "tab-1",
+  } as unknown as PanelToolCtx["bridge"];
+  return { bridge, calls };
+}
+
+describe("#1001: an ambiguous pin is not a reconnecting panel", () => {
+  it("does not retry a read whose pin is ambiguous — waiting cannot clear it", async () => {
+    const { bridge, calls } = countingBridge(ambiguityRefusal);
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    const res = await ctx.call({ cmd: "graph_outline" });
+
+    expect(res.isError).toBe(true);
+    // ONE attempt. The old behaviour slept ~400ms, rebound, and dispatched a
+    // second time — an identical failure by construction.
+    expect(calls).toEqual(["graph_outline"]);
+  });
+
+  it("never claims the panel is reconnecting when every tab is connected", async () => {
+    const { bridge } = countingBridge(ambiguityRefusal);
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    const text = textOf(await ctx.call({ cmd: "graph_outline" }));
+
+    // The fabricated diagnosis the reporter filed as a second root cause.
+    expect(text).not.toContain("still reconnecting");
+    expect(text).not.toContain("restart/reload");
+    // …nor the other two speculative causes from the generic differential.
+    expect(text).not.toContain("may be disconnected");
+    expect(text).not.toContain("Retry in a moment");
+  });
+
+  it("surfaces the real cause and both real recoveries verbatim", async () => {
+    const { bridge } = countingBridge(ambiguityRefusal);
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    const text = textOf(await ctx.call({ cmd: "graph_outline" }));
+
+    expect(text).toContain("issued from multiple workflows at once");
+    expect(text).toContain("panel_set_workflow_target");
+    expect(text).toContain("next single-origin message");
+    // dispatched:false is authoritative — resolveTarget throws before any write.
+    expect(text).toContain("nothing was applied");
+  });
+
+  it("holds for the other tool the reporter called (workflow_list)", async () => {
+    const { bridge, calls } = countingBridge(ambiguityRefusal);
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    const text = textOf(await ctx.call({ cmd: "workflow_list" }));
+
+    expect(calls).toEqual(["workflow_list"]);
+    expect(text).not.toContain("still reconnecting");
+  });
+});
+
+describe("#1001: narrowing must not cost the genuine reconnect handling", () => {
+  // The post-restart window uses the SAME opening phrase deliberately — it is
+  // the machine-readable marker the retry machinery keys on. If this regresses,
+  // every real reconnect stops being retried, which is far worse than the bug
+  // being fixed.
+  it("still retries a read during the real Connected:none window", async () => {
+    const { bridge, calls } = countingBridge(connectedNone);
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    const res = await ctx.call({ cmd: "graph_outline" });
+
+    expect(res.isError).toBe(true);
+    expect(calls).toEqual(["graph_outline", "graph_outline"]);
+  });
+
+  it("still names the reconnect when that is genuinely the cause", async () => {
+    const { bridge } = countingBridge(connectedNone);
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    expect(textOf(await ctx.call({ cmd: "graph_outline" }))).toContain("still reconnecting");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -78,6 +78,7 @@ import {
   isCapabilityRefusal,
   isPanelCmdUnsupportedError,
   isReplyTimeoutTagged,
+  isRoutingAmbiguity,
   requiresWorkflowStampEnforcement,
 } from "../services/ui-bridge.js";
 import {
@@ -764,6 +765,15 @@ function isMutatingGraphCmd(cmd: Record<string, unknown>): boolean {
  *  frozen tab — retrying just double-waits, #334) and "OUTCOME UNKNOWN" (a
  *  mutating command that may already have applied). */
 function isTransientReconnectError(err: unknown): boolean {
+  // #1001 — the TYPED marker wins over the text. A routing-ambiguity refusal
+  // (the turn was issued from several workflows at once) opens with the literal
+  // words "no connected tab", so the regex below matched it and called a fully
+  // connected panel "transient". Nothing about it is: the pin is settled for the
+  // whole batch, so the retry is guaranteed to fail identically, and the caller
+  // then reported "still reconnecting after a restart/reload" about a panel that
+  // never disconnected. Waiting cannot clear this; only an explicit target or the
+  // next single-origin message can.
+  if (isRoutingAmbiguity(err)) return false;
   const msg = err instanceof Error ? err.message : String(err ?? "");
   return /no connected tab|genuinely gone|is not open|Failed to fetch|Panel not reachable|ECONNRESET|socket hang up|premature close|other side closed|ECONNABORTED|EPIPE/i.test(
     msg,
@@ -4673,6 +4683,22 @@ export function makePanelToolCtx(
       // already names the real recovery (update + restart + browser hard-refresh).
       if (isCapabilityRefusal(err)) {
         return fail(err instanceof Error ? err.message : String(err));
+      }
+      // #1001 — same shape, opposite cause: a ROUTING-AMBIGUITY refusal already
+      // knows exactly why it refused AND names both recoveries in its own text
+      // (target a workflow explicitly, or wait for the next single-origin
+      // message). The generic wrapper below would bury that under a differential
+      // — "disconnected, still reconnecting, or the binding is stale" — of which
+      // all three are FALSE here, plus a "retry in a moment" that can never
+      // work. That speculation reads as observation: the reporter of #1001 filed
+      // "reconnect readiness is reported before the route is usable" as a second
+      // root cause, citing this wrapper's guess as their evidence. Surface the
+      // cause verbatim; add only the fact the flag actually proves.
+      if (isRoutingAmbiguity(err)) {
+        return fail(
+          `${typeof cmd.cmd === "string" ? cmd.cmd : "panel command"} was not dispatched — ` +
+            `nothing was applied. ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
       if (dispatchOutcomeOf(err) === false) {
         const name = typeof cmd.cmd === "string" ? cmd.cmd : "panel command";

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1133,6 +1133,35 @@ export function isCapabilityRefusal(err: unknown): boolean {
   return (err as Record<symbol, unknown>)[CAPABILITY_REFUSAL] === true;
 }
 
+/** Marks an error as a ROUTING-AMBIGUITY refusal: every tab is healthy and reachable,
+ *  but the turn was issued from SEVERAL of them at once, so no single one is honestly
+ *  "the" target (#884). Like a capability refusal this is pre-dispatch and settled —
+ *  the pin is decided once per batch and does not heal on its own clock — but it is
+ *  the OPPOSITE of a connectivity problem, and callers had no way to tell the two
+ *  apart: the refusal opens with the literal phrase "no connected tab", which is also
+ *  the machine-readable marker of the genuine post-restart "Connected: none" window.
+ *  A substring classifier therefore read this as a transient reconnect, retried it
+ *  pointlessly, and then reported "the panel is still reconnecting after a
+ *  restart/reload" — a fabricated diagnosis of a panel that was never disconnected
+ *  (#1001). Key on THIS marker, never on the text. */
+const ROUTING_AMBIGUITY = Symbol.for("comfyui-mcp.bridge.routing-ambiguity");
+
+/** Tag an error as a routing-ambiguity refusal and return it (for throw/reject). */
+export function markRoutingAmbiguity<E extends Error>(err: E): E {
+  Object.defineProperty(err, ROUTING_AMBIGUITY, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+  return err;
+}
+
+/** True when `err` carries the typed routing-ambiguity marker set by the bridge. */
+export function isRoutingAmbiguity(err: unknown): boolean {
+  if (err == null || (typeof err !== "object" && typeof err !== "function")) return false;
+  return (err as Record<symbol, unknown>)[ROUTING_AMBIGUITY] === true;
+}
+
 /** Tag an error as a reply-timeout and return it (for throw/reject). */
 /**
  * Key for a pending "is this tab gone?" clock (#486).
@@ -2920,11 +2949,16 @@ export class UiBridge {
     if (isScopeAddress(tabId)) {
       const pin = this.scopeTargetResolver?.(tabId);
       if (pin === null) {
-        throw new Error(
-          `no connected tab can be chosen for "${tabId}": the current turn was issued from ` +
-            `multiple workflows at once, so its target is ambiguous. Target a workflow ` +
-            `explicitly (panel_set_workflow_target / panel_open_workflow) or wait for the ` +
-            `next single-origin message.`,
+        // TYPED, not text-matched (#1001): this refusal's own opening words are
+        // "no connected tab", which is exactly what the transient-reconnect
+        // classifier keys on — yet the tabs here are all connected and fine.
+        throw markRoutingAmbiguity(
+          new Error(
+            `no connected tab can be chosen for "${tabId}": the current turn was issued from ` +
+              `multiple workflows at once, so its target is ambiguous. Target a workflow ` +
+              `explicitly (panel_set_workflow_target / panel_open_workflow) or wait for the ` +
+              `next single-origin message.`,
+          ),
         );
       }
       if (typeof pin === "string" && pin.length > 0) {


### PR DESCRIPTION
Closes artokun/comfyui-mcp#1001

## The report

A turn issued from several workflows at once came back as:

> `graph_outline could not reach the ComfyUI panel — it is still reconnecting after a restart/reload.` (`no connected tab can be chosen for orchestrator::codex: the current turn was issued from multiple workflows at once, so its target is ambiguous…`)

Every tab was connected the whole time. Nothing was reconnecting.

## Root cause

The two conditions are **opposites**:

| | ambiguity refusal (#884) | reconnect window |
|---|---|---|
| tabs | all healthy | none reachable |
| clears by waiting | **no** — the pin is decided once per batch | yes |
| recovery | explicit target, or next single-origin message | wait / rebind |

They were conflated because the refusal's message opens with the literal phrase **"no connected tab** can be chosen for…", and `isTransientReconnectError` was a substring match on `/no connected tab/` — a phrase the genuine `Connected: none` error deliberately shares as its machine-readable marker.

So a retry-safe read (`graph_outline`, `workflow_list`) took the post-reconnect retry branch: sleep ~400 ms, rebind, re-dispatch. That retry **cannot** succeed, and its failure then produced the reconnect sentence.

## Why this mattered more than a wasted round trip

The reporter read that sentence as an observation and filed a **second, independent root cause** — *"reconnect readiness is reported before the graph tool route is usable"* — citing it as their evidence. There was no second bug. There was one guess presented as a fact, and it sent a careful reporter chasing it.

This is the house defect class: *could not determine which tab* reported as *the panel is disconnected*.

## Fix

Mirrors the #709 capability-refusal precedent, which solved exactly this shape — an error whose own text already names its cause **and** its recovery must not be wrapped in a differential.

- **`ui-bridge`**: a `ROUTING_AMBIGUITY` symbol marker set on the `pin === null` throw. `send()`'s catch tags that same object `dispatched:false`, so both markers ride along together. Typed, never text-matched.
- **`isTransientReconnectError`** returns `false` for it before consulting the regex — the read fails once, immediately.
- **the `dispatched:false` wrapper** surfaces the cause verbatim instead of *"disconnected, still reconnecting, or the binding is stale"* (all three false here) plus a *"Retry in a moment"* that can never work. The refusal already names both real recoveries.

The refusal itself is **unchanged and still refuses**. Guessing a tab for a multi-origin turn is the navigate-then-mutate-on-the-wrong-tab P0 the pin exists to prevent. This only changes how the refusal is described.

On the reporter's suggestion to *"allow explicit workflow-origin context to disambiguate automatically"* — deliberately **not** done. When a turn genuinely carries several origins, picking one is guessing, and reading the wrong graph while reporting it as the current one is worse than refusing. Their working recovery (`panel_set_workflow_target`) is the sanctioned path, and it is now the first thing the message says instead of the fourth.

## Tests

Six tests drive the **real** `makePanelToolCtx` — the classifier and the wrapper are both module-private, and testing them directly would not prove they are wired to the path the reporter hit. A counting bridge makes *"was it retried?"* observable rather than inferred from wording.

Two tests pin the **other** direction: a genuine `Connected: none` read is still retried (`["graph_outline", "graph_outline"]`) and still named a reconnect. Narrowing this classifier too far would stop every real reconnect from being retried — far worse than the bug being fixed.

Both halves mutation-verified independently: reverting the classifier fix fails 4 tests (visible as the ~411 ms retry sleep reappearing); reverting the wrapper fails 2.

Full suite green: 334 files, 7068 passing. `lint`, `check:vocabulary`, and `docs:gen` (no-op) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)