### PR TITLE
fix(#1015): describe an unparsable category body from what was observed

### DIFF
--- a/src/__tests__/services/model-listing-coverage.test.ts
+++ b/src/__tests__/services/model-listing-coverage.test.ts
@@ -40,7 +40,9 @@ vi.mock("node:fs/promises", () => ({
 }));
 
 const { config } = await import("../../config.js");
-const { listLocalModelsWithCoverage } = await import("../../services/model-resolver.js");
+const { listLocalModelsWithCoverage, describeUnparsableBody } = await import(
+  "../../services/model-resolver.js"
+);
 const { describeEmptyModelListing } = await import("../../tools/model-management.js");
 
 beforeEach(() => {
@@ -203,5 +205,77 @@ describe("#918: what an empty listing is allowed to say", () => {
       unanswered: Array.from({ length: 15 }, (_, i) => ({ dir: `d${i}`, reason: "fetch failed" })),
     });
     expect(text).toMatch(/…and 7 more/);
+  });
+});
+
+// #1015 — the follow-on. Coverage correctly refused to call these categories
+// empty, but described WHY in the vaguest available terms: an EMPTY body was
+// reported as "a non-JSON body (a proxy, login page, or a server still starting
+// answers this way)". None of those three produces zero bytes, and the status
+// — which the reporter explicitly asked for, to tell an empty category apart
+// from a transport failure — was dropped on every parse-failure branch.
+//
+// What must NOT change: an unparsable answer still leaves the category
+// UNANSWERED. This is about the accuracy of the reason, not the verdict.
+describe("#1015: an unparsable category body is described from what was observed", () => {
+  it("names an EMPTY body as empty, and does not offer proxy/login/starting guesses", () => {
+    const reason = describeUnparsableBody(200, "");
+    expect(reason).toMatch(/EMPTY body/);
+    expect(reason).toMatch(/0 bytes/);
+    expect(reason).toMatch(/HTTP 200/);
+    // The three causes that cannot produce an empty body.
+    expect(reason).not.toMatch(/proxy/);
+    expect(reason).not.toMatch(/login/);
+    expect(reason).not.toMatch(/still starting/);
+    // And never the raw parser message the reporter saw on 0.50.2.
+    expect(reason).not.toMatch(/Unexpected end of JSON input/);
+  });
+
+  it("treats a whitespace-only body as empty too", () => {
+    expect(describeUnparsableBody(200, "\r\n  \n")).toMatch(/EMPTY body/);
+  });
+
+  it("keeps the HTML reading, and now carries the status with it", () => {
+    const reason = describeUnparsableBody(200, "<!doctype html><html><body>Sign in</body></html>");
+    expect(reason).toMatch(/returned HTML instead of JSON/);
+    expect(reason).toMatch(/still starting/);
+    expect(reason).toMatch(/HTTP 200/);
+  });
+
+  it("quotes a bounded excerpt for a body that is neither empty nor markup", () => {
+    const reason = describeUnparsableBody(200, "not json at all");
+    expect(reason).toMatch(/not JSON/);
+    expect(reason).toMatch(/15 bytes/);
+    expect(reason).toMatch(/not json at all/);
+  });
+
+  it("bounds the excerpt so a large body cannot flood the tool result", () => {
+    const reason = describeUnparsableBody(500, "x".repeat(50_000));
+    expect(reason.length).toBeLessThan(200);
+    expect(reason).toMatch(/50000 bytes/);
+    expect(reason).toMatch(/HTTP 500/);
+  });
+
+  it("collapses a multi-line body onto one line", () => {
+    expect(describeUnparsableBody(200, "line one\nline two")).not.toMatch(/\n/);
+  });
+
+  // The end-to-end shape the reporter hit: two categories answer 200 with an
+  // empty body while the rest answer normally.
+  it("leaves an empty-bodied category UNANSWERED, never empty", async () => {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockImplementation(async (url: string) =>
+      url.endsWith("/models/clip")
+        ? new Response("", { status: 200 })
+        : new Response(JSON.stringify(["m.safetensors"]), { status: 200 }),
+    );
+    readdir.mockRejectedValue(new Error("ENOENT"));
+
+    const { coverage } = await listLocalModelsWithCoverage("clip");
+    expect(coverage.answered).toEqual([]);
+    expect(coverage.unanswered).toHaveLength(1);
+    expect(coverage.unanswered[0].dir).toBe("clip");
+    expect(coverage.unanswered[0].reason).toMatch(/EMPTY body/);
+    expect(coverage.unanswered[0].reason).not.toMatch(/Unexpected end of JSON input/);
   });
 });

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -426,6 +426,51 @@ export type ModelListingCoverage = {
   noSourceAvailable?: boolean;
 };
 
+/**
+ * Why a category's body would not parse — stated from what was OBSERVED (#1015).
+ *
+ * The previous wording covered every parse failure with one sentence: "returned
+ * a non-JSON body instead of JSON (a proxy, login page, or a server still
+ * starting answers this way)". For an HTML body that is a fair reading. For an
+ * EMPTY body it is three guesses stacked on a fact we already hold exactly — the
+ * server answered, the status was fine, and it sent zero bytes. None of the
+ * three offered causes produces an empty body, so the one case where the
+ * evidence is unambiguous got the vaguest description.
+ *
+ * The reporter's ask was precisely this: "return the raw endpoint/status so
+ * callers can distinguish an empty category from a transport/parse failure."
+ * The status is now carried in every branch, because a parse failure at 200 and
+ * a parse failure at 502 are different problems.
+ *
+ * Note what this does NOT claim. An empty body is not read as "the category is
+ * empty" — that is the #918 conflation this whole coverage type exists to
+ * prevent. An unparsable answer leaves the category UNANSWERED regardless of
+ * why; this only makes the why accurate.
+ */
+export function describeUnparsableBody(status: number, body: string): string {
+  const at = `HTTP ${status}`;
+  if (body.trim() === "") {
+    return (
+      `ComfyUI answered ${at} with an EMPTY body (${body.length} byte${body.length === 1 ? "" : "s"}) — ` +
+      `it reported nothing about this category either way`
+    );
+  }
+  if (/^\s*</.test(body)) {
+    return (
+      `ComfyUI returned HTML instead of JSON ` +
+      `(${at} — a proxy, a login page, or a server still starting answers this way)`
+    );
+  }
+  // Neither empty nor markup: quote a bounded excerpt so the cause is
+  // diagnosable without dumping a large body into the tool result. Collapse
+  // whitespace so a multi-line payload stays on one line.
+  const excerpt = body.trim().replace(/\s+/g, " ").slice(0, 80);
+  return (
+    `ComfyUI answered ${at} with a body that is not JSON ` +
+    `(${body.length} bytes, starts: ${JSON.stringify(excerpt)})`
+  );
+}
+
 /** Model listing plus the provenance needed to describe it honestly. */
 export async function listLocalModelsWithCoverage(
   modelType?: string,
@@ -499,12 +544,7 @@ async function collectLocalModels(
         try {
           files = JSON.parse(body);
         } catch {
-          coverage.unanswered.push({
-            dir,
-            reason:
-              `ComfyUI returned ${/^\s*</.test(body) ? "HTML" : "a non-JSON body"} instead of JSON ` +
-              `(a proxy, login page, or a server still starting answers this way)`,
-          });
+          coverage.unanswered.push({ dir, reason: describeUnparsableBody(res.status, body) });
           continue;
         }
         if (!Array.isArray(files)) {


### PR DESCRIPTION
Closes artokun/comfyui-mcp#1015

## What the reporter saw

```
Partial listing — 2 categories could not be read
(clip: Unexpected end of JSON input; unet: Unexpected end of JSON input).
Models in those categories are NOT absent, they are unlisted — retry if something you expect is missing.
```

The verdict here is **correct** — that is the #918 coverage type doing exactly its job, declining to report an unread category as an empty one. Two things were still wrong with the *reason*.

## 1. The raw parser message (already fixed, after their version)

`Unexpected end of JSON input` was classified in **0.50.3** (`ff39d92`, #967). The reporter is on **0.50.2**. No action needed — but it exposed the second problem.

## 2. The replacement description guesses where we hold the fact

`Unexpected end of JSON input` is what `JSON.parse("")` throws. **The body was empty.** But every parse failure got one sentence:

> ComfyUI returned a non-JSON body instead of JSON (a proxy, login page, or a server still starting answers this way)

None of a proxy, a login page, or a warming-up server sends **zero bytes**. So the one case where the evidence is unambiguous received the vaguest available description, with three causes attached that are all wrong for it.

The status was also dropped on every parse-failure branch — the reporter's explicit second ask:

> return the raw endpoint/status so callers can distinguish an empty category from a transport/parse failure

A parse failure at 200 and one at 502 are different problems.

## Fix

`describeUnparsableBody(status, body)` splits three **observed** cases and carries the status through all of them:

| body | reason |
|---|---|
| empty / whitespace-only | `ComfyUI answered HTTP 200 with an EMPTY body (0 bytes) — it reported nothing about this category either way` |
| starts with `<` | the existing HTML reading, wording unchanged, plus the status |
| anything else | byte count + a bounded 80-char single-line excerpt |

The excerpt is bounded and whitespace-collapsed so a large or multi-line payload can't flood the tool result — a 50 KB body yields a reason under 200 chars.

## What deliberately does not change

**An unparsable answer still leaves the category UNANSWERED.** Reading an empty body as "this category is empty" is precisely the #918 conflation the coverage type exists to prevent — an empty body is not evidence of absence. This changes the accuracy of the reason, never the verdict, and a test pins `coverage.answered` staying `[]` for the reporter's exact shape.

I also did not chase their first hypothesis (that the aggregation path mishandles the response). The other categories in the same call parsed normally through the identical code path, so the empty body came from the server; what we control is describing it correctly.

## Tests

Seven added to the existing `#918` coverage file, including the reporter's end-to-end shape (`/models/clip` answers 200 with `""` while the rest answer normally). The empty-body branch is mutation-verified — 3 tests fail without it.

Existing `#918` assertions are untouched: the HTML branch keeps its exact wording deliberately, so no passing test needed churning.

Full suite green: 333 files, 7069 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)