### PR TITLE
fix(#952): name the panel's ComfyUI origin instead of asking the reader to check

### DIFF
--- a/src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
+++ b/src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
@@ -24,7 +24,7 @@ vi.mock("../../config.js", () => ({
   getComfyUIAuthHeaders: () => ({}),
 }));
 
-const { comfyuiFetch } = await import("../../comfyui/fetch.js");
+const { comfyuiFetch, setConnectedPanelOrigins } = await import("../../comfyui/fetch.js");
 const { describeFetchFailure, isBareFetchFailure, errorToToolResult, ComfyUIError } =
   await import("../../utils/errors.js");
 
@@ -146,5 +146,97 @@ describe("comfyuiFetch names the target it could not reach", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("<html>", { status: 502 })));
     const res = await comfyuiFetch("http://127.0.0.1:8188/x");
     expect(res.status).toBe(502);
+  });
+});
+
+// #952 follow-on — naming the drift instead of asking the reader to check for it.
+//
+// The shipped message said a connected panel "does not imply this address is
+// reachable" and pointed at install_comfyui(action:"environment") to compare the
+// two by hand. The bridge already knows what each connected tab fronts, so the
+// comparison can just be done — and which of the three cases holds is worth much
+// more than the instruction to go and find out.
+describe("#952: a headless failure names the connected panel's origin", () => {
+  afterEach(() => setConnectedPanelOrigins(null));
+
+  /** Drive a real comfyuiFetch failure and return the wrapped message. */
+  async function failureText(target: string): Promise<string> {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      undiciFailure("ECONNREFUSED", "connect ECONNREFUSED 127.0.0.1:8188"),
+    );
+    try {
+      await comfyuiFetch(target);
+      throw new Error("expected comfyuiFetch to throw");
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  it("says DIFFERENT when the panel is on another origin — the likely answer", async () => {
+    setConnectedPanelOrigins(() => ["http://192.168.1.50:8188"]);
+    const text = await failureText("http://127.0.0.1:8188/object_info");
+    expect(text).toContain("http://192.168.1.50:8188");
+    expect(text).toContain("a DIFFERENT address");
+    expect(text).toContain("COMFYUI_URL");
+  });
+
+  // The valuable inverse: stating that drift is RULED OUT stops the reader
+  // chasing the explanation the surrounding text volunteers.
+  it("RULES OUT drift when the panel is on the same origin", async () => {
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8188"]);
+    const text = await failureText("http://127.0.0.1:8188/object_info");
+    expect(text).toContain("NOT a wrong-address problem");
+    expect(text).toContain("firewall");
+    expect(text).not.toContain("a DIFFERENT address");
+  });
+
+  it("ignores the path and compares ORIGINS only", async () => {
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8188"]);
+    expect(await failureText("http://127.0.0.1:8188/api/v2/deep/path?x=1")).toContain(
+      "NOT a wrong-address problem",
+    );
+  });
+
+  it("says nothing about drift when no panel is connected", async () => {
+    setConnectedPanelOrigins(() => []);
+    const text = await failureText("http://127.0.0.1:8188/object_info");
+    expect(text).not.toContain("a DIFFERENT address");
+    expect(text).not.toContain("NOT a wrong-address problem");
+  });
+
+  // An absent comparison is not a negative result. With no source installed at
+  // all (the plain MCP server), the message must read exactly as it did before.
+  it("says nothing about drift when no origin source is installed", async () => {
+    const text = await failureText("http://127.0.0.1:8188/object_info");
+    expect(text).not.toContain("a DIFFERENT address");
+    expect(text).not.toContain("NOT a wrong-address problem");
+    expect(text).toContain("does not imply this address is reachable");
+  });
+
+  it("lists every distinct origin, without repeating one", async () => {
+    setConnectedPanelOrigins(() => [
+      "http://192.168.1.50:8188",
+      "http://192.168.1.50:8188",
+      "http://10.0.0.9:8188",
+    ]);
+    const text = await failureText("http://127.0.0.1:8188/object_info");
+    expect(text).toContain("http://192.168.1.50:8188, http://10.0.0.9:8188");
+    expect(text.match(/192\.168\.1\.50/g)).toHaveLength(1);
+  });
+
+  // The comparison is a nicety; the network error is the point. A throwing
+  // source must never cost the caller the real diagnosis.
+  it("still reports the real failure when the origin source throws", async () => {
+    setConnectedPanelOrigins(() => {
+      throw new Error("bridge exploded");
+    });
+    const text = await failureText("http://127.0.0.1:8188/object_info");
+    expect(text).toContain("ECONNREFUSED");
+    expect(text).not.toContain("bridge exploded");
+  });
+
+  it("does not crash on an unparsable target", async () => {
+    setConnectedPanelOrigins(() => ["http://192.168.1.50:8188"]);
+    expect(await failureText("not-a-url")).toContain("ECONNREFUSED");
   });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -4653,3 +4653,64 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
     expect(bridge.takeLateAskReply("tab-plain")).toBeUndefined();
   });
 });
+
+// #952 — the headless tools failed with `fetch failed` while every panel tool
+// worked, and nothing in the error connected the two. They are separate targets
+// by design (the panel talks to whichever ComfyUI its browser tab is on; the
+// headless calls go to COMFYUI_URL), so the failure has to be able to say
+// whether the two actually differ. comfyui/fetch.ts asks the bridge, via a
+// callback the orchestrator installs, and this is what it asks for.
+describe("UiBridge.connectedServerOrigins (#952)", () => {
+  /** A panel socket carrying a SERVER-OBSERVED handshake Origin, like a browser. */
+  function connectWithOrigin(tabId: string, origin?: string): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+      const sock = new WebSocket(`ws://127.0.0.1:${port}`, origin ? { origin } : {});
+      sock.on("open", () => {
+        sock.send(JSON.stringify({ type: "hello", tab_id: tabId, title: tabId }));
+        resolve(sock);
+      });
+      sock.on("error", reject);
+    });
+  }
+
+  it("reports the origins connected tabs actually front", async () => {
+    const a = await connectWithOrigin("o-1", "http://192.168.1.50:8188");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "o-1")).toBe(true));
+    expect(bridge.connectedServerOrigins()).toEqual(["http://192.168.1.50:8188"]);
+    a.close();
+  });
+
+  it("de-duplicates two tabs on the SAME ComfyUI", async () => {
+    const a = await connectWithOrigin("o-1", "http://192.168.1.50:8188");
+    const b = await connectWithOrigin("o-2", "http://192.168.1.50:8188");
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(2));
+    expect(bridge.connectedServerOrigins()).toEqual(["http://192.168.1.50:8188"]);
+    a.close();
+    b.close();
+  });
+
+  it("reports BOTH when tabs front different ComfyUIs", async () => {
+    const a = await connectWithOrigin("o-1", "http://192.168.1.50:8188");
+    const b = await connectWithOrigin("o-2", "http://10.0.0.9:8188");
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(2));
+    expect(bridge.connectedServerOrigins().sort()).toEqual(
+      ["http://10.0.0.9:8188", "http://192.168.1.50:8188"].sort(),
+    );
+    a.close();
+    b.close();
+  });
+
+  // A relay/non-browser client sends no Origin. Omitting it is required: an
+  // invented origin would be compared against COMFYUI_URL and could report drift
+  // that does not exist, or rule out drift that does.
+  it("omits a tab that supplied no handshake Origin rather than guessing", async () => {
+    const a = await connectWithOrigin("o-1"); // no Origin header
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "o-1")).toBe(true));
+    expect(bridge.connectedServerOrigins()).toEqual([]);
+    a.close();
+  });
+
+  it("is empty with nothing connected, and never throws", () => {
+    expect(bridge.connectedServerOrigins()).toEqual([]);
+  });
+});

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -13,6 +13,79 @@ function targetOf(input: string | URL | Request): string {
 }
 
 /**
+ * What the CONNECTED panels front, for the drift comparison below (#952).
+ *
+ * Injected by the orchestrator at startup rather than imported: this module is
+ * the bottom of the stack and must not depend on the bridge. Unset (the plain
+ * MCP server, tests, any process with no bridge) simply means the comparison is
+ * skipped — never that there is no drift.
+ *
+ * Origins here must be the SERVER-OBSERVED handshake Origin (UiBridge's
+ * `tabServerOrigin`), not the client-supplied `hello.comfyui_url`: the browser
+ * sets the former and blocks page JS from forging it, so it is the trustworthy
+ * answer to "which ComfyUI is this tab actually on".
+ */
+let connectedPanelOrigins: (() => string[]) | null = null;
+
+/** Install the panel-origin source. Pass null to clear (tests, shutdown). */
+export function setConnectedPanelOrigins(fn: (() => string[]) | null): void {
+  connectedPanelOrigins = fn;
+}
+
+/** Origin (scheme://host:port) of a request target, or undefined if unparsable. */
+function originOf(target: string): string | undefined {
+  try {
+    return new URL(target).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Name the drift instead of asking the reader to go and check for it (#952).
+ *
+ * The shipped message told the user a connected panel "does not imply this
+ * address is reachable" and pointed them at install_comfyui(action:"environment")
+ * to compare the two by hand. We can usually just do the comparison — the bridge
+ * knows what each connected tab fronts — and saying which of the three cases
+ * holds is worth far more than the instruction to go and find out:
+ *
+ *   - DIFFERENT   → that is very likely the whole answer.
+ *   - THE SAME    → drift is RULED OUT. Worth stating plainly, because it stops
+ *                   the reader chasing the explanation the old text volunteered.
+ *                   The panel reaches it from the browser; this process does not
+ *                   (a firewall, a container boundary, a bound interface).
+ *   - UNKNOWN     → no panel connected, no origin source installed, or the
+ *                   handshake carried no usable Origin. Say nothing about drift;
+ *                   an absent comparison is not a negative result.
+ */
+function describeTargetDrift(target: string): string {
+  const origins = (() => {
+    try {
+      return connectedPanelOrigins?.() ?? [];
+    } catch {
+      return []; // a broken source must never replace the real network error
+    }
+  })();
+  if (origins.length === 0) return "";
+  const want = originOf(target);
+  if (!want) return "";
+  const distinct = [...new Set(origins)];
+  if (distinct.includes(want)) {
+    return (
+      ` A connected panel is on this same origin, so this is NOT a wrong-address problem: ` +
+      `the browser can reach ${want} and this process cannot (a firewall, a container ` +
+      `boundary, or a server bound to one interface).`
+    );
+  }
+  return (
+    ` A connected panel is on ${distinct.join(", ")} — a DIFFERENT address, which is why ` +
+    `the panel works while this call does not. Point COMFYUI_URL at that origin if it is the ` +
+    `server you meant.`
+  );
+}
+
+/**
  * Turn a network-layer throw into a diagnostic that says WHAT was attempted.
  *
  * `TypeError: fetch failed` was reaching tool results verbatim: #954 saw it from
@@ -24,15 +97,17 @@ function targetOf(input: string | URL | Request): string {
  *
  * The two ARE separate targets by design: the panel talks to whichever ComfyUI
  * the browser is on, while these calls go to the configured COMFYUI_URL. That is
- * not a bug, but it is invisible unless the failure names the address.
+ * not a bug, but it is invisible unless the failure names the address — and,
+ * where the bridge can tell us, says whether the two actually differ.
  */
 function describeComfyFetchFailure(err: unknown, target: string): Error {
   const { message, code } = describeFetchFailure(err);
   const wrapped = new Error(
     `${message} — while requesting ${target}. ` +
       `That is the headless ComfyUI target (COMFYUI_URL); a CONNECTED sidebar panel does not imply this address is reachable, ` +
-      `because the panel talks to whichever ComfyUI its browser tab is on. ` +
-      `Check the target with install_comfyui (action:"environment"), and confirm the server is up with get_system_stats (action:"health").`,
+      `because the panel talks to whichever ComfyUI its browser tab is on.` +
+      describeTargetDrift(target) +
+      ` Check the target with install_comfyui (action:"environment"), and confirm the server is up with get_system_stats (action:"health").`,
     { cause: err },
   );
   if (code) (wrapped as { code?: string }).code = code;

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -58,6 +58,7 @@ import {
 } from "./turn-origins.js";
 import { listSessions, loadTranscript } from "./history.js";
 import { uploadImageHttp, resetClient } from "../comfyui/client.js";
+import { setConnectedPanelOrigins } from "../comfyui/fetch.js";
 import { logger } from "../utils/logger.js";
 import {
   PanelAgentManager,
@@ -2695,6 +2696,12 @@ export async function runPanelOrchestrator(): Promise<void> {
   // `null` (ambiguous origin) makes the bridge refuse loudly; no entry lets
   // the bridge fall back to active-tab resolution (idle-time probes).
   bridge.setScopeTargetResolver(makeScopeTargetResolver({ tracker: turnOrigins, scopeAgentKeyOf }));
+  // #952 — let a headless `fetch failed` say whether the connected panel is on a
+  // DIFFERENT ComfyUI than COMFYUI_URL. The reporter's readonly tools failed
+  // while every panel tool worked, and nothing in the error connected the two.
+  // SERVER-OBSERVED origins only (tabServerOrigin): the browser sets the
+  // handshake Origin and page JS cannot forge it, unlike hello.comfyui_url.
+  setConnectedPanelOrigins(() => bridge.connectedServerOrigins());
   // #884 P1 (confirming gate 2) — EXPLICIT recovery from a DEAD or AMBIGUOUS
   // pin, and from those only. The bridge's refusal names
   // panel_set_workflow_target as the way out; this is the ONLY path that

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2565,6 +2565,20 @@ export class UiBridge {
     }
   }
 
+  /** #952 — the DISTINCT ComfyUI origins the connected tabs actually front, for
+   *  the headless-fetch drift comparison (see comfyui/fetch.ts). Trusted
+   *  handshake Origins only, so a tab that supplied none is simply absent rather
+   *  than guessed at: an incomplete list must never be read as "no drift". Order
+   *  follows connection order; never throws. */
+  connectedServerOrigins(): string[] {
+    const out: string[] = [];
+    for (const conn of this.conns.values()) {
+      const origin = conn.serverOrigin;
+      if (typeof origin === "string" && origin !== "" && !out.includes(origin)) out.push(origin);
+    }
+    return out;
+  }
+
   /** Fence a same-socket migration alias (#570 P0a): drop the `fromId → to` route and
    *  every other entry that points at the SAME target (fromId's path-compressed chain),
    *  so a RETIRED workflow's stale / in-flight panel_* calls addressed to fromId can no


### PR DESCRIPTION
Closes artokun/comfyui-mcp#952

## Where this stood

The readonly tools returned `fetch failed` while every panel tool reached the live canvas in the same session. Those **are** separate targets by design — the panel talks to whichever ComfyUI its browser tab is on, the headless calls go to `COMFYUI_URL`.

#968 made the failure name the address it used, shipped in **0.50.3** (the reporter was on 0.49.8). This finishes the other half of their ask.

## What was still missing

The message told the reader that a connected panel *"does not imply this address is reachable"* and pointed them at `install_comfyui(action:"environment")` to compare the two by hand. The bridge already knows what every connected tab fronts — so it can just do the comparison. Which of the three cases holds is worth far more than the instruction to go and find out:

| | message |
|---|---|
| **DIFFERENT** | `A connected panel is on http://192.168.1.50:8188 — a DIFFERENT address, which is why the panel works while this call does not.` |
| **SAME** | `A connected panel is on this same origin, so this is NOT a wrong-address problem: the browser can reach it and this process cannot (a firewall, a container boundary, or a server bound to one interface).` |
| **UNKNOWN** | nothing said |

The **SAME** branch is the one worth having. Stating that drift is ruled out is what stops the reader chasing the explanation the surrounding text volunteers — the same reason the reporter's own second hypothesis went where it did.

**UNKNOWN** stays silent deliberately: no panel connected, no source installed, or the handshake carried no `Origin`. An absent comparison is not a negative result, and silence must not read as "no drift".

## Wiring

`comfyui/fetch.ts` is the bottom of the stack and must not import the bridge, so it exposes `setConnectedPanelOrigins()` and the orchestrator installs `UiBridge.connectedServerOrigins()` at startup — the same shape as the existing `setScopeTargetResolver`. With no source installed (the plain MCP server, tests) the message is **byte-identical** to before, which a test pins.

**Server-observed handshake Origins only.** A tab that supplied none is *omitted*, never guessed — an invented origin would either report drift that doesn't exist or rule out drift that does. `hello.comfyui_url` is spoofable and is not used. A throwing origin source is swallowed: the comparison is a nicety and must never cost the caller the real network error.

## What I did not do

Their other suggestion was to bind the readonly tools to the panel's resolved target. I don't think that's right:

- it breaks the case where `COMFYUI_URL` is deliberately a *different* server, and
- the panel's origin isn't necessarily reachable from this process at all — which is exactly the **SAME origin** branch above, where the browser can reach an address the orchestrator cannot.

Silently retargeting would turn a visible, explicable failure into a call that quietly goes somewhere the user didn't ask for. Naming the drift lets them make that call.

## Tests

13 total. 8 drive real `comfyuiFetch` failures for the message; 5 drive a **real `UiBridge`** over real WebSocket handshakes with real `Origin` headers for the data — including two tabs on the same ComfyUI (deduped), two on different ones (both listed), and a relay client with no `Origin` (omitted).

Both halves mutation-verified. Full suite green: 334 files, 7081 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)