### PR TITLE
fix(#875): say at pair time whether the phone URL survives a restart

### DIFF
--- a/src/__tests__/orchestrator/pair-url-durability.test.ts
+++ b/src/__tests__/orchestrator/pair-url-durability.test.ts
@@ -1,0 +1,114 @@
+// #875 — a user asked to pin the orchestrator version because "updating the npm
+// version bricks my communication with the agent".
+//
+// The version was never the cause. The self-restarter is on by default, checks
+// npm hourly, and restarts into new code whenever the agent is idle — and a
+// restart rotates up to two independent parts of the URL the phone saved: the
+// pair token (per session unless COMFYUI_MCP_PAIR_TOKEN is pinned) and, in
+// tunnel mode, the cloudflared quick-tunnel hostname (always).
+//
+// So one default-on feature silently invalidated another, and nothing at pair
+// time said so. That is why the report arrived as "let me pin the version"
+// instead of "my pairing URL expired" — the user could only infer a cause from a
+// phone that stopped working.
+
+import { describe, expect, it } from "vitest";
+
+import { pairUrlDurability } from "../../orchestrator/pair-durability.js";
+import { canSelfRestart } from "../../services/self-restart.js";
+
+describe("#875: what the pairing URL actually promises", () => {
+  it("LAN + pinned token is the ONE durable combination", () => {
+    const d = pairUrlDurability({ mode: "lan", pinnedToken: true, autoRestart: true });
+    expect(d.survivesRestart).toBe(true);
+    expect(d.rotates).toEqual([]);
+    expect(d.note).toMatch(/survives an orchestrator restart/);
+  });
+
+  it("LAN without a pinned token rotates the token, and names the fix", () => {
+    const d = pairUrlDurability({ mode: "lan", pinnedToken: false, autoRestart: true });
+    expect(d.survivesRestart).toBe(false);
+    expect(d.rotates).toEqual(["token"]);
+    expect(d.note).toMatch(/COMFYUI_MCP_PAIR_TOKEN/);
+    expect(d.note).toMatch(/reconnects/);
+  });
+
+  it("tunnel rotates the hostname EVEN WITH a pinned token", () => {
+    const d = pairUrlDurability({ mode: "tunnel", pinnedToken: true, autoRestart: true });
+    expect(d.survivesRestart).toBe(false);
+    expect(d.rotates).toEqual(["hostname"]);
+  });
+
+  it("tunnel without a pinned token rotates both", () => {
+    const d = pairUrlDurability({ mode: "tunnel", pinnedToken: false, autoRestart: true });
+    expect(d.rotates).toEqual(["hostname", "token"]);
+    expect(d.note).toMatch(/both its hostname and its token/);
+  });
+
+  // The correction that matters most. The issue proposed deploying a relay as
+  // the workaround for a stable tunnel URL. COMFYUI_MCP_TUNNEL_BACKEND is read
+  // ONLY by services/secure-bridge.ts, for the `connect` path's remote-pod
+  // bridge; the pairing path calls startQuickTunnel() directly. Telling a user
+  // to stand up a Cloudflare Worker that cannot fix their problem is worse than
+  // telling them nothing.
+  it("does not offer the relay backend as a tunnel remedy — it does not apply", () => {
+    const d = pairUrlDurability({ mode: "tunnel", pinnedToken: false, autoRestart: true });
+    expect(d.note).toMatch(/COMFYUI_MCP_TUNNEL_BACKEND=relay does not apply/);
+    expect(d.note).toMatch(/no way to pin the tunnel hostname/);
+  });
+
+  it("does not tell a tunnel user that pinning the token will save them", () => {
+    const d = pairUrlDurability({ mode: "tunnel", pinnedToken: false, autoRestart: true });
+    expect(d.note).toMatch(/will not help here/);
+  });
+
+  // A warning about spontaneous restarts is false when they are switched off.
+  it("only blames automatic restarts when they are actually armed", () => {
+    const on = pairUrlDurability({ mode: "lan", pinnedToken: false, autoRestart: true });
+    expect(on.note).toMatch(/restarts on its own/);
+
+    const off = pairUrlDurability({ mode: "lan", pinnedToken: false, autoRestart: false });
+    expect(off.note).toMatch(/Automatic restarts are disabled/);
+    expect(off.note).not.toMatch(/restarts on its own/);
+    // Still not durable — a deliberate restart breaks it just the same.
+    expect(off.survivesRestart).toBe(false);
+  });
+
+  it("rotates is empty exactly when survivesRestart", () => {
+    for (const mode of ["lan", "tunnel"] as const) {
+      for (const pinnedToken of [true, false]) {
+        for (const autoRestart of [true, false]) {
+          const d = pairUrlDurability({ mode, pinnedToken, autoRestart });
+          expect(d.rotates.length === 0).toBe(d.survivesRestart);
+        }
+      }
+    }
+  });
+});
+
+// The note's restart clause is only honest if it matches what the restarter
+// really does. Deriving it from the env vars separately is how the two drift, so
+// the pairing site calls this exported predicate rather than re-reading them.
+describe("#875: canSelfRestart matches both documented switches", () => {
+  it("is on by default", () => {
+    expect(canSelfRestart({})).toBe(true);
+  });
+
+  it("is off under the master switch", () => {
+    expect(canSelfRestart({ COMFYUI_MCP_AUTO_UPDATE_DISABLE: "1" })).toBe(false);
+  });
+
+  it("is off under the restart-only opt-out", () => {
+    expect(canSelfRestart({ COMFYUI_MCP_AUTORESTART: "0" })).toBe(false);
+  });
+
+  it("accepts the documented falsey spellings of the opt-out", () => {
+    for (const v of ["0", "false", "no", "off", "OFF", " No "]) {
+      expect(canSelfRestart({ COMFYUI_MCP_AUTORESTART: v }), v).toBe(false);
+    }
+  });
+
+  it("does not treat an unrelated value as off", () => {
+    expect(canSelfRestart({ COMFYUI_MCP_AUTORESTART: "1" })).toBe(true);
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -40,7 +40,8 @@ import { performPanelSync, reassessPanelAfterSyncFailure } from "../services/pan
 import { clearPanelDiskObservation } from "../services/panel-workspace.js";
 import { panelRecoveryContext } from "../services/panel-recovery.js";
 import { isPanelAutoInstallDisabled } from "../services/panel-installer.js";
-import { SelfRestarter } from "../services/self-restart.js";
+import { SelfRestarter, canSelfRestart } from "../services/self-restart.js";
+import { pairUrlDurability } from "./pair-durability.js";
 import { SessionStore, workflowIdentityParts } from "./session-store.js";
 import {
   SHARED_SESSION_SCOPE,
@@ -4186,8 +4187,24 @@ export async function runPanelOrchestrator(): Promise<void> {
           }
           url = `ws://${ip}:${pairPort}/?token=${token}`;
         }
-        logger.info(`[panel-orchestrator] pairing URL minted (${mode})`);
-        bridge.push({ type: "pair_url", mode, url }, tabId);
+        // #875 — say at pair time whether this URL survives a restart. The
+        // self-restarter is on by default and rotates the token (always, unless
+        // pinned) and the tunnel hostname (always, quick tunnels cannot be
+        // pinned). A user hit exactly this and reported it as "updating the npm
+        // version bricks my communication with the agent" — the restart was the
+        // cause, and nothing here had told them.
+        const durability = pairUrlDurability({
+          mode,
+          pinnedToken: envPairToken !== null,
+          autoRestart: canSelfRestart(),
+        });
+        logger.info(
+          `[panel-orchestrator] pairing URL minted (${mode}) — ` +
+            (durability.survivesRestart
+              ? "survives restart"
+              : `rotates on restart: ${durability.rotates.join(", ")}`),
+        );
+        bridge.push({ type: "pair_url", mode, url, durability }, tabId);
       })().catch((err) => {
         bridge.push(
           { type: "pair_error", mode, error: err instanceof Error ? err.message : String(err) },

--- a/src/orchestrator/pair-durability.ts
+++ b/src/orchestrator/pair-durability.ts
@@ -1,0 +1,109 @@
+/**
+ * #875 — will this pairing URL still work after the orchestrator restarts?
+ *
+ * A user asked to pin the orchestrator version because "updating the npm version
+ * bricks my communication with the agent". The version is not the cause. The
+ * self-restarter is on by default, checks npm hourly, and restarts into new code
+ * whenever the agent is idle — and a restart rotates up to two independent parts
+ * of the URL the phone saved:
+ *
+ *   1. THE TOKEN. Generated per session unless COMFYUI_MCP_PAIR_TOKEN is pinned.
+ *   2. THE HOSTNAME, tunnel mode only. Phone pairing opens a cloudflared QUICK
+ *      tunnel, which mints a fresh random `<rand>.trycloudflare.com` every run.
+ *
+ * So a default-on feature silently invalidates another default-on feature, and
+ * nothing at pair time says so. The user is left to infer it from a phone that
+ * stopped working, which is how this arrived as "pin the version" rather than as
+ * "my pairing URL expired".
+ *
+ * IMPORTANT, and the reason this file states the tunnel case unconditionally:
+ * COMFYUI_MCP_TUNNEL_BACKEND=relay does NOT give a stable phone-pairing URL. That
+ * setting is read only by services/secure-bridge.ts, for the `connect` path's
+ * remote-pod bridge. The pairing path calls startQuickTunnel() directly and never
+ * consults it. A relay operator therefore gets exactly the same rotating
+ * trycloudflare hostname as everyone else, and advice to "deploy a relay" would
+ * send them to build a Cloudflare Worker that cannot fix this. Whoever changes
+ * pairing to honour a backend selection must revisit `hostRotates` here.
+ *
+ * This module only DESCRIBES. It does not defer restarts or persist a token —
+ * both change behaviour the user did not ask for (persisting a
+ * password-equivalent token removes the auto-expiry that a per-run token gives
+ * you today), and neither is mine to decide silently.
+ */
+
+/** How a minted pairing URL fares across an orchestrator restart. */
+export interface PairUrlDurability {
+  /** True only when NOTHING in the URL is known to rotate on a restart. */
+  survivesRestart: boolean;
+  /** The parts that rotate, named. Empty exactly when `survivesRestart`. */
+  rotates: ("token" | "hostname")[];
+  /** One human sentence: what happens, and what to do about it. */
+  note: string;
+}
+
+export interface PairDurabilityInput {
+  /** "lan" → ws://<lan-ip>:<port>; "tunnel" → a cloudflared quick tunnel. */
+  mode: "lan" | "tunnel";
+  /** Whether COMFYUI_MCP_PAIR_TOKEN is pinned (a stable token across restarts). */
+  pinnedToken: boolean;
+  /** Whether the self-restarter can restart this process (default on). When it
+   *  cannot, a rotating URL is far less likely to bite — say so rather than
+   *  warning about a restart that will not happen on its own. */
+  autoRestart: boolean;
+}
+
+/**
+ * Describe the URL's durability from configuration alone — no probing, no
+ * guessing. Every branch below is a fact about how the URL was constructed.
+ */
+export function pairUrlDurability(input: PairDurabilityInput): PairUrlDurability {
+  const rotates: ("token" | "hostname")[] = [];
+  // Tunnel pairing is ALWAYS a quick tunnel (see the note above): the hostname
+  // is regenerated per run with no way to pin it.
+  if (input.mode === "tunnel") rotates.push("hostname");
+  if (!input.pinnedToken) rotates.push("token");
+
+  if (rotates.length === 0) {
+    return {
+      survivesRestart: true,
+      rotates: [],
+      note:
+        "This URL survives an orchestrator restart: COMFYUI_MCP_PAIR_TOKEN is pinned and the " +
+        "LAN address does not change per run. (If your router reassigns this machine a different " +
+        "IP, the address changes for that reason, not because of a restart.)",
+    };
+  }
+
+  // Name the parts, then the cause, then the remedy that exists for each. The
+  // restarter clause is stated only when it is actually armed.
+  const what =
+    rotates.length === 2
+      ? "both its hostname and its token are regenerated"
+      : rotates[0] === "hostname"
+        ? "its hostname is regenerated"
+        : "its token is regenerated";
+
+  const cause = input.autoRestart
+    ? "The orchestrator restarts on its own to apply updates (hourly check, when idle), so this " +
+      "can happen without you doing anything."
+    : "Automatic restarts are disabled here, so this only happens when the orchestrator is " +
+      "restarted deliberately.";
+
+  const remedy = rotates.includes("hostname")
+    ? "There is no way to pin the tunnel hostname today — phone pairing always uses a cloudflared " +
+      "quick tunnel, and COMFYUI_MCP_TUNNEL_BACKEND=relay does not apply to it. To keep a link " +
+      "that survives restarts, pair over LAN with COMFYUI_MCP_PAIR_TOKEN set; otherwise re-pair " +
+      "from the panel after a restart." +
+      (rotates.includes("token")
+        ? " (Pinning COMFYUI_MCP_PAIR_TOKEN alone will not help here — the hostname still rotates.)"
+        : "")
+    : "Set COMFYUI_MCP_PAIR_TOKEN to a fixed secret to keep this URL working across restarts; " +
+      "the pairing listener then also starts automatically at boot, so the phone reconnects " +
+      "without opening the panel.";
+
+  return {
+    survivesRestart: false,
+    rotates,
+    note: `This URL stops working when the orchestrator restarts — ${what}. ${cause} ${remedy}`,
+  };
+}

--- a/src/services/self-restart.ts
+++ b/src/services/self-restart.ts
@@ -143,6 +143,19 @@ function isRestartDisabled(env: NodeJS.ProcessEnv): boolean {
   return v === "0" || v === "false" || v === "no" || v === "off";
 }
 
+/**
+ * Can this process restart itself to apply an update? Both switches, in one
+ * place (#875): the master off (COMFYUI_MCP_AUTO_UPDATE_DISABLE) and the
+ * restart-only opt-out (COMFYUI_MCP_AUTORESTART=0).
+ *
+ * Exported so the phone-pairing disclosure can say whether a rotating pair URL
+ * is likely to be invalidated on its own, without re-deriving the rule from the
+ * env vars and drifting from what the restarter actually does.
+ */
+export function canSelfRestart(env: NodeJS.ProcessEnv = process.env): boolean {
+  return !isAutoUpdateDisabled(env) && !isRestartDisabled(env);
+}
+
 export class SelfRestarter {
   private deps: SelfRestartDeps;
   private info: InstallInfo;


### PR DESCRIPTION
Refs artokun/comfyui-mcp#875 (orchestrator half — see Scope)

## The actual cause

The user asked to pin the orchestrator version because *"updating the npm version bricks my communication with the agent"*. The version was never the cause. The self-restarter is **on by default**, checks npm hourly, and restarts into new code whenever the agent is idle — and a restart rotates up to two independent parts of the URL the phone saved:

1. **The token** — generated per session unless `COMFYUI_MCP_PAIR_TOKEN` is pinned.
2. **The hostname**, tunnel mode — phone pairing opens a cloudflared **quick** tunnel, a fresh random `trycloudflare.com` host every run.

One default-on feature silently invalidates another, and nothing at pair time said so. That's why this arrived as *"let me pin the version"* rather than *"my pairing URL expired"* — a phone that stopped working was the only evidence available.

## What the URL now promises

`pairUrlDurability()` computes it from configuration alone, no probing:

| mode | token | result |
|---|---|---|
| lan | pinned | **survives a restart** — the only durable combination |
| lan | random | token rotates; names `COMFYUI_MCP_PAIR_TOKEN` as the fix |
| tunnel | either | hostname rotates, **always** |

The pair path logs it and ships it on the `pair_url` frame.

## Correction to the issue's own advice

**`COMFYUI_MCP_TUNNEL_BACKEND=relay` does not give a stable phone-pairing URL.**

That variable is read only by `services/secure-bridge.ts`, for the `connect` path's remote-pod bridge. The pairing path calls `startQuickTunnel()` directly (`index.ts:4172`) and never consults it. A relay operator gets exactly the same rotating hostname as everyone else.

The issue listed deploying a relay as the primary workaround — following it means standing up a Cloudflare Worker that cannot fix this. (Our docs are fine; `self-hosted-relay.mdx` correctly scopes itself to `connect`. The wrong claim is in the issue body.) A test pins that we never offer it, and another pins that we don't tell a tunnel user a pinned token will save them either.

## Honesty of the restart clause

Warning about spontaneous restarts is false when they're switched off, so `canSelfRestart()` is now exported from `self-restart.ts` — both switches in one place — rather than the message re-deriving the rule from env vars and drifting from what the restarter does. With restarts off, the note says a *deliberate* restart still breaks the URL, not that nothing will.

## Describes only — deliberately

The issue also proposed persisting the pair token by default and deferring restarts while a pairing is live. I did neither:

- **Persisting the token** removes the auto-expiry a per-run token gives you today. That's a real security property, and turning it off by default isn't mine to decide silently. `COMFYUI_MCP_PAIR_TOKEN` is the existing opt-in.
- **Deferring restarts** while a pairing is live could park updates indefinitely — a long-lived phone link would mean never updating.

Both are the user's call. Describing the tradeoff at the moment they choose is what was actually missing.

## Scope

This is the **orchestrator half**. `durability` rides on the `pair_url` frame, but **the panel does not render it yet** — today it's visible in the orchestrator log and to any client reading the frame, *not* in the QR modal. Panel issue filed separately; I'm leaving #875 open until that lands.

The one-line call at the pair site is **not** covered by a test — nothing boots `runPanelOrchestrator`. The computation and the predicate are (13 tests), including an exhaustive check that `rotates` is empty exactly when `survivesRestart`.

Full suite green: 335 files, 7088 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)