### PR TITLE
0.50.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.7] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- say at pair time whether the phone URL survives a restart (#1020)
+- name the panel's ComfyUI origin instead of asking the reader to check (#1019)
+- describe an unparsable category body from what was observed (#1017)
+- an ambiguous routing pin is not a reconnecting panel (#1016)
+- an explicit retry is not a blind re-issue (#1014)
+
+
 ## [0.50.6] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.6",
+  "version": "0.50.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.6",
+      "version": "0.50.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.6",
+  "version": "0.50.7",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.7` tag (the tag publishes to npm; protected `main` needs this PR).

### Fixed
- **#1011** — an explicit retry is not a blind re-issue (#1014). The #862 duplicate fence ran *before* `retry_of` reconciliation, so a caller handed a retry token by an outcome-unknown timeout could never spend it: after a reconnect the fence fires unconditionally, because `selfAttributedProven` is false by construction.
- **#1001** — an ambiguous routing pin is not a reconnecting panel (#1016). A turn issued from several workflows at once was reported as *"still reconnecting after a restart/reload"* while every tab was connected — the refusal opens with the literal words "no connected tab", and the transient classifier was matching on that substring.
- **#1015** — describe an unparsable category body from what was observed (#1017). An empty `/models/<category>` body was reported as *"a non-JSON body (a proxy, login page, or a server still starting)"*; none of those sends zero bytes. The status is now carried on every parse-failure branch.
- **#952** — name the panel's ComfyUI origin instead of asking the reader to check (#1019). A headless `fetch failed` now says whether the connected panel is on a *different* ComfyUI, or on the same one (which rules drift out).
- **#875** — say at pair time whether the phone URL survives a restart (#1020). The self-restarter rotates the pair token and, in tunnel mode, the quick-tunnel hostname — so one default-on feature silently invalidated another. Orchestrator half; panel render filed as artokun/comfyui-mcp-panel#749.

The changelog section generated correctly with no hand-editing — first release since the #988 dedupe fix landed, and the over-range that had to be trimmed by hand for 0.50.3, 0.50.4 and 0.50.5 is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)