### PR TITLE
fix(#1018): accept the todo status spellings agents actually produce

### DIFF
--- a/src/__tests__/orchestrator/todo-status-aliases.test.ts
+++ b/src/__tests__/orchestrator/todo-status-aliases.test.ts
@@ -1,0 +1,199 @@
+// #1018 — an agent's FIRST panel_set_todo was rejected over a spelling.
+//
+// It submitted `in_progress` and `completed`; the schema accepted only
+// `pending` | `active` | `done`, so the call died at the protocol layer with
+//
+//     MCP error -32602: Input validation error; expected one of `pending`|`active`|`done`
+//
+// Those are not typos. They are the near-universal todo vocabulary in agent
+// tooling, so an agent that has not read this tool's enum reaches for them by
+// default — and pays a full round trip at plan setup, the first thing the user
+// sees. Nothing about the request was ambiguous: the intent of `in_progress` is
+// not in question.
+//
+// The schema now admits the synonyms and the handler canonicalizes them, so
+// everything downstream — the panel, recordTodo's snapshot (#977), the
+// completion-directive logic that reads it — still sees only the canonical
+// three. The tool description deliberately still teaches one vocabulary.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  TODO_STATUSES,
+  TODO_STATUS_INPUTS,
+  normalizeTodoItems,
+  normalizeTodoStatus,
+  planInFlight,
+  todoFor,
+  __resetTodoState,
+} from "../../orchestrator/todo-state.js";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+} from "../../orchestrator/panel-tools.js";
+
+describe("#1018: the status vocabulary a caller actually brings", () => {
+  it("maps the two spellings from the report", () => {
+    expect(normalizeTodoStatus("in_progress")).toBe("active");
+    expect(normalizeTodoStatus("completed")).toBe("done");
+  });
+
+  it("maps the other spellings agents produce", () => {
+    for (const [given, want] of [
+      ["in-progress", "active"],
+      ["inprogress", "active"],
+      ["running", "active"],
+      ["current", "active"],
+      ["complete", "done"],
+      ["finished", "done"],
+      ["todo", "pending"],
+      ["not_started", "pending"],
+      ["not-started", "pending"],
+      ["queued", "pending"],
+    ] as const) {
+      expect(normalizeTodoStatus(given), given).toBe(want);
+    }
+  });
+
+  it("leaves the canonical values exactly as they are", () => {
+    for (const s of TODO_STATUSES) expect(normalizeTodoStatus(s)).toBe(s);
+  });
+
+  it("is case- and whitespace-tolerant on an alias", () => {
+    expect(normalizeTodoStatus(" In_Progress ")).toBe("active");
+  });
+
+  // Guessing at an unrecognised status would put a wrong state in front of the
+  // user. Unknown input passes through and is rejected by validation instead.
+  it("does NOT invent a mapping for an unknown status", () => {
+    expect(normalizeTodoStatus("blocked")).toBe("blocked");
+    expect(TODO_STATUS_INPUTS).not.toContain("blocked");
+  });
+
+  it("normalizes a list without disturbing items that carry no status", () => {
+    const out = normalizeTodoItems([
+      { text: "a", status: "in_progress" },
+      { text: "b" },
+      { text: "c", status: "done" },
+    ]);
+    expect(out).toEqual([
+      { text: "a", status: "active" },
+      { text: "b" },
+      { text: "c", status: "done" },
+    ]);
+  });
+
+  it("does not mutate the caller's array", () => {
+    const input = [{ text: "a", status: "completed" }];
+    normalizeTodoItems(input);
+    expect(input[0].status).toBe("completed");
+  });
+
+  it("every admitted spelling normalizes INTO the canonical set", () => {
+    for (const s of TODO_STATUS_INPUTS) {
+      expect(TODO_STATUSES as readonly string[], s).toContain(normalizeTodoStatus(s));
+    }
+  });
+});
+
+// The helper being right proves nothing about the tool using it. These drive the
+// REAL panel_set_todo handler and assert on what reached the wire.
+describe("#1018: the tool accepts the aliases and sends only canonical values", () => {
+  let sent: Array<Record<string, unknown>>;
+  let ctx: PanelToolCtx;
+
+  beforeEach(() => {
+    __resetTodoState();
+    sent = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        sent.push(cmd);
+        return { ok: true };
+      },
+      push: () => 1,
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: "tab-1", title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => "tab-1",
+    } as unknown as PanelToolCtx["bridge"];
+    ctx = makePanelToolCtx(bridge, "tab-1");
+  });
+
+  const setTodo = () => buildPanelToolDefs().find((d) => d.name === "panel_set_todo")!;
+
+  it("accepts the exact payload from the report instead of failing validation", async () => {
+    const res = await setTodo().handler(
+      {
+        items: [
+          { text: "read the code", status: "completed" },
+          { text: "write the fix", status: "in_progress" },
+          { text: "run the tests", status: "pending" },
+        ],
+      },
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    expect(sent).toHaveLength(1);
+    expect(sent[0].items).toEqual([
+      { text: "read the code", status: "done" },
+      { text: "write the fix", status: "active" },
+      { text: "run the tests", status: "pending" },
+    ]);
+  });
+
+  // The panel renders these; a raw `in_progress` would either not match its
+  // styling or be shown verbatim. Canonical-only on the wire is the contract.
+  it("never puts an alias on the wire", async () => {
+    await setTodo().handler({ items: [{ text: "a", status: "in-progress" }] }, ctx);
+    expect(JSON.stringify(sent[0].items)).not.toContain("in-progress");
+  });
+
+  // #977's snapshot feeds the completion-directive logic, which compares against
+  // the canonical names. An alias stored here would silently break that — and
+  // `planInFlight` alone cannot catch it, since an unrecognised status counts as
+  // not-done either way. Assert the stored values themselves.
+  it("records the canonical form in the orchestrator's own snapshot", async () => {
+    await setTodo().handler(
+      {
+        items: [
+          { text: "a", status: "completed" },
+          { text: "b", status: "in_progress" },
+        ],
+      },
+      ctx,
+    );
+    expect(todoFor("tab-1")?.items).toEqual([
+      { text: "a", status: "done" },
+      { text: "b", status: "active" },
+    ]);
+    // …and the derived signal still reads correctly: one step is still active.
+    expect(planInFlight("tab-1")).toBe(true);
+  });
+
+  // The inverse: an all-done list must NOT read as a plan in flight. If an alias
+  // reached the snapshot, "completed" would not match "done" and this would
+  // wrongly say a sweep is still running.
+  it("an all-done list written with aliases is not reported as in flight", async () => {
+    await setTodo().handler(
+      {
+        items: [
+          { text: "a", status: "completed" },
+          { text: "b", status: "finished" },
+        ],
+      },
+      ctx,
+    );
+    expect(planInFlight("tab-1")).toBe(false);
+  });
+
+  it("still works for a caller that used the canonical values all along", async () => {
+    await setTodo().handler({ items: [{ text: "a", status: "active" }] }, ctx);
+    expect(sent[0].items).toEqual([{ text: "a", status: "active" }]);
+  });
+
+  it("still clears the tray on an empty array", async () => {
+    await setTodo().handler({ items: [] }, ctx);
+    expect(sent[0].items).toEqual([]);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -102,7 +102,7 @@ import {
 } from "../services/panel-secrets.js";
 import { flattenUiWorkflow } from "../services/flatten-workflow.js";
 import { describeUnappliedFilters } from "./civitai-filter-guard.js";
-import { recordTodo } from "./todo-state.js";
+import { recordTodo, normalizeTodoItems, TODO_STATUS_INPUTS } from "./todo-state.js";
 import { applyCapturedWidgetValues } from "../services/live-widget-overlay.js";
 import { listWorkflowLibraryKeys, userdataFetch } from "../services/userdata-library.js";
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
@@ -7503,8 +7503,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .array(
             z.object({
               text: z.string().describe("Short step description (a few words)."),
+              // #1018 — accept the synonyms agents actually produce (in_progress,
+              // completed, …) and normalize them in the handler. The DESCRIPTION
+              // still teaches only the canonical trio: one vocabulary to learn,
+              // and no round trip lost to a rejected first call over a spelling
+              // whose intent was never in doubt.
               status: z
-                .enum(["pending", "active", "done"])
+                .enum(TODO_STATUS_INPUTS as [string, ...string[]])
                 .optional()
                 .describe("Step state (default 'pending'). Mark the one you're on 'active'."),
             }),
@@ -7520,17 +7525,21 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // bound tab is a headless (mobile/remote) client, resolve the live desktop
         // canvas tab instead of dispatching at the headless client — which would
         // reject with the misleading "mobile client has no open canvas".
+        // #1018 — canonicalize ONCE, here, before anything reads the list. The
+        // panel, recordTodo's snapshot (#977) and the completion-directive logic
+        // all keep seeing only pending/active/done.
+        const items = normalizeTodoItems(args.items as Array<{ text?: unknown; status?: unknown }>);
         const redirect = desktopCanvasRedirect(ctx, "panel_set_todo");
         if (redirect?.error) return fail(redirect.error);
         if (redirect?.tabId) {
           // #977 — the desktop redirect writes the checklist to ANOTHER tab, so
           // record it against that one. Keying it on ctx.tabId would leave the
           // tab that actually holds the plan looking planless.
-          recordTodo(redirect.tabId, args.items);
+          recordTodo(redirect.tabId, items);
           return dispatchToTab(
             ctx,
             redirect.tabId,
-            { cmd: "set_todo", items: args.items },
+            { cmd: "set_todo", items },
             15000,
             () => reResolveDesktopTab(ctx, "panel_set_todo"),
           );
@@ -7538,8 +7547,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // #977 — retain what the agent DECLARED, so a later render completion can
         // tell "you are mid-sweep" from "that was the last thing you were doing".
         // The panel keeps the UI copy; this is the orchestrator's own record.
-        recordTodo(ctx.tabId, args.items);
-        return ctx.call({ cmd: "set_todo", items: args.items }, 15000);
+        recordTodo(ctx.tabId, items);
+        return ctx.call({ cmd: "set_todo", items }, 15000);
       },
     ),
     def(

--- a/src/orchestrator/todo-state.ts
+++ b/src/orchestrator/todo-state.ts
@@ -103,3 +103,72 @@ export function runCompletionDirective(tabId: string | undefined): string {
     ? `Acknowledge the result in ONE short sentence, then CONTINUE your plan — you have unfinished items on your todo list, so do NOT stop here or wait for the user. Carry straight on with the next step (queue it now if that is what the plan says). Don't repeat an earlier comment.`
     : `Reply with ONE short sentence acknowledging the result and suggesting a sensible next step — you do NOT need to call any tools. Don't repeat an earlier comment.`;
 }
+
+// ---------------------------------------------------------------------------
+// #1018 — the status vocabulary the caller brings.
+//
+// The schema accepted exactly `pending` | `active` | `done`, and an agent's FIRST
+// panel_set_todo submitted `in_progress` and `completed`. Those are not a typo:
+// they are the near-universal todo vocabulary in agent tooling, so an agent that
+// has never read this particular tool's enum reaches for them by default. The
+// call was rejected at the protocol layer with a bare
+//
+//     MCP error -32602: Input validation error; expected one of `pending`|`active`|`done`
+//
+// which costs a full round trip at exactly the worst moment — plan setup, the
+// first thing the user sees. Nothing about the request was ambiguous: the intent
+// of `in_progress` is not in question.
+//
+// So the schema accepts the aliases and normalizes them here, at the boundary.
+// Everything downstream — the panel UI, recordTodo's snapshot (#977), the
+// completion-directive logic that reads it — continues to see ONLY the canonical
+// three. This adds no new state and changes no behaviour for a caller that
+// already used the canonical values.
+//
+// The tool DESCRIPTION still teaches `pending → active → done`, deliberately.
+// The aliases are a compatibility shim, not a second vocabulary to document: an
+// agent should be told one set of names, and simply not be punished for the
+// obvious synonyms.
+
+/** Canonical checklist states, in progress order. */
+export const TODO_STATUSES = ["pending", "active", "done"] as const;
+export type TodoStatus = (typeof TODO_STATUSES)[number];
+
+/**
+ * Accepted synonyms → canonical. Kept deliberately small: these are the spellings
+ * agents actually produce, not an open thesaurus. An unknown value is NOT mapped
+ * — it still fails validation, because guessing at a status nobody recognises
+ * would put a wrong state in front of the user.
+ */
+const TODO_STATUS_ALIASES: Record<string, TodoStatus> = {
+  in_progress: "active",
+  "in-progress": "active",
+  inprogress: "active",
+  running: "active",
+  current: "active",
+  completed: "done",
+  complete: "done",
+  finished: "done",
+  todo: "pending",
+  not_started: "pending",
+  "not-started": "pending",
+  queued: "pending",
+};
+
+/** Every spelling the schema admits (canonical first, for the error message). */
+export const TODO_STATUS_INPUTS: string[] = [...TODO_STATUSES, ...Object.keys(TODO_STATUS_ALIASES)];
+
+/** Map an accepted spelling to its canonical form. Unknown input is returned
+ *  unchanged — validation, not this function, is what rejects it. */
+export function normalizeTodoStatus(status: string): string {
+  if ((TODO_STATUSES as readonly string[]).includes(status)) return status;
+  return TODO_STATUS_ALIASES[status.trim().toLowerCase()] ?? status;
+}
+
+/** Normalize a checklist's statuses in place-safe fashion (returns a new array).
+ *  Items without a status are left alone — the default is applied downstream. */
+export function normalizeTodoItems<T extends { status?: unknown }>(items: T[]): T[] {
+  return items.map((item) =>
+    typeof item?.status === "string" ? { ...item, status: normalizeTodoStatus(item.status) } : item,
+  );
+}


### PR DESCRIPTION
Closes artokun/comfyui-mcp#1018

## What happened

An agent's **first** `panel_set_todo` was rejected because it wrote `in_progress` and `completed`:

```
MCP error -32602: Input validation error; expected one of `pending`|`active`|`done`
```

Those aren't typos — they're the near-universal todo vocabulary in agent tooling. An agent that hasn't read this tool's enum reaches for them by default, and pays a full round trip at plan setup, the first thing the user sees. Nothing about the request was ambiguous: the intent of `in_progress` is not in question, and rejecting it taught the caller nothing that accepting it wouldn't have.

The reporter filed it as *"probably caller-side, not a confirmed product defect."* I disagree — a schema that rejects the most likely spelling of an unambiguous intent, on the first call, is our defect.

## Fix

The schema admits a small set of synonyms; the handler canonicalizes at the boundary:

| accepted | canonical |
|---|---|
| `in_progress`, `in-progress`, `inprogress`, `running`, `current` | `active` |
| `completed`, `complete`, `finished` | `done` |
| `todo`, `not_started`, `not-started`, `queued` | `pending` |

Everything downstream keeps seeing **only** the canonical three — the panel UI, `recordTodo`'s snapshot (#977), and the completion-directive logic that compares against those names.

That last one is the subtle part. An alias reaching the snapshot would silently break the "is a plan in flight" reading, so normalization happens **once, before any consumer**, and the test asserts the *stored values* rather than only the derived signal — `planInFlight` passes either way, so it could not have caught it. I only noticed because the first version of that test survived the mutation.

## Deliberately closed, not an open thesaurus

An unrecognised status is **not** mapped — it still fails validation. Guessing at a state nobody recognises would put a wrong one in front of the user. `blocked` stays rejected on purpose, and a test pins that.

The tool **description** still teaches `pending → active → done` and nothing else, so `docs:gen` is a no-op. The aliases are a compatibility shim, not a second vocabulary to document: an agent should be told one set of names and simply not punished for the obvious synonyms.

## Tests

14, of which 5 drive the **real** `panel_set_todo` handler and assert on what reached the wire — the helper being correct proves nothing about the tool using it. Mutation-verified: removing the normalize call fails 3.

Full suite green: 336 files, 7115 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)