### PR TITLE
fix(#845): accept the node ids we print, and say which canvas args were ignored

### DIFF
--- a/src/__tests__/orchestrator/node-id-and-canvas-args.test.ts
+++ b/src/__tests__/orchestrator/node-id-and-canvas-args.test.ts
@@ -1,0 +1,168 @@
+// #845 — two defects a reporter hit while inspecting ONE node.
+//
+// (4) Node ids the tools PRINT could not be passed back in. Every graph reader
+//     returns ids as strings (`"id": "42"`), while every input schema demanded
+//     `z.number().int()`. So the obvious move — copy an id out of
+//     panel_query_graph, paste it into panel_select_nodes — failed on the first
+//     attempt, every time, with a raw zod `expected number, received string`.
+//
+// (3) panel_canvas used two names for one concept and dropped the other in
+//     silence: `action:"zoom"` requires `scale`, while a `zoom` argument was not
+//     in the schema at all. Passing `zoom: 0.55` with `center_on_node` returned
+//     `scale: 0.067` — which reads as "applied, then overridden", when it was
+//     never applied. The panel's center_on_node sets the offset and does not
+//     touch the scale.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  buildPanelToolDefs,
+  ignoredCanvasArgs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const textOf = (res: ToolResult): string => (res.content[0] as { text: string }).text;
+
+let sent: Array<Record<string, unknown>>;
+let ctx: PanelToolCtx;
+
+beforeEach(() => {
+  sent = [];
+  const bridge = {
+    send: async (cmd: Record<string, unknown>) => {
+      sent.push(cmd);
+      // Mirror the panel: report the canvas's ACTUAL resulting state.
+      return { ok: true, scale: cmd.action === "zoom" ? cmd.scale : 0.067 };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: "tab-1", title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => "tab-1",
+  } as unknown as PanelToolCtx["bridge"];
+  ctx = makePanelToolCtx(bridge, "tab-1");
+});
+
+const tool = (name: string) => buildPanelToolDefs().find((d) => d.name === name)!;
+
+/**
+ * Call a tool the way the MCP server does: PARSE the args through the tool's own
+ * schema first, then hand the parsed value to the handler. Calling `handler`
+ * directly skips zod entirely — which is exactly where the coercion lives, so a
+ * direct call would test nothing about it.
+ *
+ * Returns the zod error as a failed ToolResult, mirroring the -32602 the caller
+ * would receive.
+ */
+async function callTool(name: string, args: Record<string, unknown>): Promise<ToolResult> {
+  const def = tool(name);
+  const parsed = z.object(def.schema).safeParse(args);
+  if (!parsed.success) {
+    return { isError: true, content: [{ type: "text", text: parsed.error.message }] } as ToolResult;
+  }
+  return def.handler(parsed.data as Record<string, unknown>, ctx);
+}
+
+describe("#845(4): an id the tools printed is accepted back", () => {
+  it("panel_select_nodes takes the string form from panel_query_graph", async () => {
+    const res = await callTool("panel_select_nodes", { node_ids: ["42"] });
+    expect(res.isError).toBeFalsy();
+    // …and the wire still carries the number it always did.
+    expect(sent[0].node_ids).toEqual([42]);
+  });
+
+  it("still takes the numeric form", async () => {
+    await callTool("panel_select_nodes", { node_ids: [42] });
+    expect(sent[0].node_ids).toEqual([42]);
+  });
+
+  it("accepts a mixed list", async () => {
+    await callTool("panel_select_nodes", { node_ids: ["42", 7] });
+    expect(sent[0].node_ids).toEqual([42, 7]);
+  });
+
+  it("applies to scalar node_id args too", async () => {
+    await callTool("panel_canvas", { action: "center_on_node", node_id: "42" });
+    expect(sent[0].node_id).toBe(42);
+  });
+
+  // A subgraph-qualified id is a REAL shape in newer ComfyUI. Coercing "5:12" to
+  // 5 would target the WRONG node — worse than refusing. Supporting it is a
+  // deliberate wire-contract change, not something to fall out of a parse.
+  it("refuses a subgraph-qualified id rather than truncating it", async () => {
+    const res = await callTool("panel_select_nodes", { node_ids: ["5:12"] });
+    expect(res.isError).toBe(true);
+    expect(sent).toHaveLength(0);
+  });
+
+  it("refuses other non-integer strings", async () => {
+    for (const bad of ["42px", "4.5", "", "abc"]) {
+      sent = [];
+      const res = await callTool("panel_select_nodes", { node_ids: [bad] });
+      expect(res.isError, bad).toBe(true);
+    }
+  });
+});
+
+describe("#845(3): panel_canvas says what it ignored", () => {
+  it("accepts `zoom` as the alias it obviously is", async () => {
+    await callTool("panel_canvas", { action: "zoom", zoom: 0.55 });
+    expect(sent[0].scale).toBe(0.55);
+  });
+
+  it("prefers an explicit `scale` when both are given", async () => {
+    await callTool("panel_canvas", { action: "zoom", scale: 0.8, zoom: 0.55 });
+    expect(sent[0].scale).toBe(0.8);
+  });
+
+  // The reported case, exactly.
+  it("says the zoom was ignored rather than letting it vanish", async () => {
+    const res = await callTool("panel_canvas", 
+      { action: "center_on_node", node_id: 42, zoom: 0.55 },
+    );
+    expect(res.isError).toBeFalsy(); // a harmless extra arg must not fail the move
+    const text = textOf(res);
+    expect(text).toContain("does not use scale/zoom");
+    expect(text).toContain("ignored, not applied");
+    expect(text).toContain('action:"zoom"'); // the call that would work
+  });
+
+  it("stays quiet when every supplied argument is used", async () => {
+    const res = await callTool("panel_canvas", { action: "pan", dx: 10, dy: 20 });
+    expect(textOf(res)).not.toContain("ignored");
+  });
+
+  it("stays quiet for a bare action", async () => {
+    const res = await callTool("panel_canvas", { action: "fit" });
+    expect(textOf(res)).not.toContain("ignored");
+  });
+});
+
+describe("#845(3): which args each action consumes", () => {
+  it("names only the supplied-but-unused ones", () => {
+    expect(ignoredCanvasArgs("center_on_node", { node_id: 42, scale: 0.5 })).toEqual(["scale/zoom"]);
+    expect(ignoredCanvasArgs("zoom", { scale: 0.5 })).toEqual([]);
+    expect(ignoredCanvasArgs("pan", { dx: 1, dy: 2 })).toEqual([]);
+    expect(ignoredCanvasArgs("pan", { dx: 1, node_id: 42 })).toEqual(["node_id"]);
+    expect(ignoredCanvasArgs("fit", { node_id: 42, dx: 1, dy: 2, scale: 0.5 })).toEqual([
+      "node_id",
+      "dx",
+      "dy",
+      "scale/zoom",
+    ]);
+  });
+
+  it("ignores absent arguments — undefined is not 'supplied'", () => {
+    expect(ignoredCanvasArgs("fit", {})).toEqual([]);
+    expect(ignoredCanvasArgs("fit", { node_id: undefined })).toEqual([]);
+  });
+
+  // An unknown action is the enum's job to reject. Guessing a consumed-arg set
+  // here would invent a claim about behaviour nobody defined.
+  it("claims nothing about an action it does not know", () => {
+    expect(ignoredCanvasArgs("teleport", { node_id: 42, scale: 1 })).toEqual([]);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5808,6 +5808,74 @@ function validatePanelEditNodeArgs(args: Record<string, unknown>): string | null
  * forwarded to the wire UNTOUCHED (contrast workflow_uuid, which is bridge-owned
  * and always overwritten). Optional everywhere; never required.
  */
+/**
+ * #845 — a node id the tools THEMSELVES printed must be accepted back.
+ *
+ * Every panel tool took `z.number().int()` for a node id, while the graph
+ * readers return ids as STRINGS (`"id": "42"`). So the obvious move — copy an id
+ * out of panel_query_graph, paste it into panel_select_nodes — failed on the
+ * first attempt, every time, with a raw zod `expected number, received string`.
+ * The reporter hit it doing exactly that.
+ *
+ * Nothing about `"42"` is ambiguous. Accept both spellings and normalize to the
+ * number the wire has always carried, so the round trip closes.
+ *
+ * DELIBERATELY STRICT about what counts as a node id: only an integer, or a
+ * string that is exactly an integer. `"42px"`, `"4.5"`, `""` and `"5:12"` are
+ * still rejected. The last one matters — a subgraph-qualified id is a real
+ * shape in newer ComfyUI, and silently truncating it to `5` would target the
+ * WRONG node rather than fail. If those need supporting, that is a separate,
+ * deliberate change to the wire contract, not something to fall out of a coerce.
+ */
+const nodeId = () =>
+  z.union([z.number().int(), z.string().regex(/^-?\d+$/, "a node id must be an integer")]).transform(
+    (v) => (typeof v === "number" ? v : Number.parseInt(v, 10)),
+  );
+
+/**
+ * #845 — which `panel_canvas` arguments the chosen action actually consumes.
+ *
+ * The tool accepted node_id/dx/dy/scale for every action and forwarded them all,
+ * so an argument the action ignores vanished without a word. The reporter passed
+ * `zoom: 0.55` alongside `center_on_node` and got `scale: 0.067` back — which
+ * reads as "your zoom was applied and then overridden", when in truth it was
+ * never applied at all. The panel's center_on_node case sets the offset and
+ * touches the scale not at all.
+ *
+ * Naming what an action ignores is the whole fix. It is NOT an error — passing a
+ * harmless extra argument should not fail a viewport move — but it must not be
+ * silent either.
+ */
+const CANVAS_ACTION_ARGS: Record<string, string[]> = {
+  fit: [], // computes its own framing from the graph bounds
+  center_on_node: ["node_id"],
+  pan: ["dx", "dy"],
+  zoom: ["scale"],
+};
+
+/** Supplied-but-unused argument names for `action`, in a caller-facing spelling. */
+export function ignoredCanvasArgs(
+  action: string,
+  supplied: { node_id?: unknown; dx?: unknown; dy?: unknown; scale?: unknown },
+): string[] {
+  const used = CANVAS_ACTION_ARGS[action];
+  if (!used) return []; // unknown action — the enum rejects it; never guess here
+  const label: Record<string, string> = { scale: "scale/zoom" };
+  return (["node_id", "dx", "dy", "scale"] as const)
+    .filter((k) => supplied[k] !== undefined && !used.includes(k))
+    .map((k) => label[k] ?? k);
+}
+
+/** Append a disclosure line to a successful text result, leaving errors alone. */
+function appendNote(res: ToolResult, note: string): ToolResult {
+  const first = res.content[0];
+  if (!first || first.type !== "text") return res;
+  return {
+    ...res,
+    content: [{ ...first, text: `${first.text}\n\n${note}` }, ...res.content.slice(1)],
+  };
+}
+
 const RETRY_OF_ARG = {
   retry_of: z
     .string()
@@ -6157,7 +6225,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     def(
       "panel_get_subgraph",
       "Read INSIDE a subgraph node on the user's open graph: ids, types, widget values, and connections of its inner nodes. Use after panel_graph_outline / panel_query_graph shows a node with is_subgraph=true. Read-only.",
-      { node_id: z.number().int().describe("Subgraph node id (is_subgraph=true).") },
+      { node_id: nodeId().describe("Subgraph node id (is_subgraph=true).") },
       async (args: A, ctx) =>
         withTruncationHints(await ctx.call({ cmd: "graph_get_subgraph", node_id: args.node_id }), [
           {
@@ -6294,7 +6362,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     def(
       "panel_remove_node",
       "Remove a node (and its connections) from the user's open graph by id. Undoable with Ctrl+Z.",
-      { node_id: z.number().int().describe("Node id from panel_graph_outline / panel_query_graph.") },
+      { node_id: nodeId().describe("Node id from panel_graph_outline / panel_query_graph.") },
       async (args: A, ctx) => ctx.call({ cmd: "graph_remove_node", node_id: args.node_id }),
     ),
     def(
@@ -6561,11 +6629,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "panel_connect",
       "Connect an output slot of one node to an input slot of another in the user's open graph. Slots accept a name ('MODEL', 'samples') or numeric index. If both slot args are omitted the panel picks the first type-compatible pairing. On failure the error lists every slot with its type and [connected] flag — re-check with panel_query_graph ({ids:[node_id], fields:'detail'}). Undoable.",
       {
-        from_node_id: z.number().int().describe("Source node id."),
+        from_node_id: nodeId().describe("Source node id."),
         from_output: slotRef
           .optional()
           .describe("Source output slot name or index; omit to auto-match by type (prefers an unconnected, exact-type input; `*` wildcards match last)."),
-        to_node_id: z.number().int().describe("Target node id."),
+        to_node_id: nodeId().describe("Target node id."),
         to_input: slotRef
           .optional()
           .describe("Target input slot name or index; omit to auto-match by type (prefers an unconnected, exact-type input; `*` wildcards match last)."),
@@ -6598,7 +6666,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "panel_disconnect",
       "Disconnect an input slot of a node in the user's open graph. Undoable with Ctrl+Z.",
       {
-        node_id: z.number().int().describe("Node id whose input to disconnect."),
+        node_id: nodeId().describe("Node id whose input to disconnect."),
         input: slotRef.optional().describe("Input slot name or index (default 0)."),
       },
       async (args: A, ctx) => ctx.call({ cmd: "graph_disconnect", node_id: args.node_id, input: args.input }),
@@ -6607,7 +6675,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "panel_set_widget",
       "Set a widget value on a node in the user's open graph (steps, cfg, seed, ckpt_name, text prompts, …). Returns the previous and new value. Undoable with Ctrl+Z. To CLEAR a text widget to an empty string, pass `clear: true` (some MCP clients drop an empty-string `value` from the serialized payload, so `value: \"\"` may not arrive — `clear: true` always works). For the LTXDirector timeline node (WhatDreamsCost CSGlide), set `timeline_data` with the FULL timeline JSON (segments + global_prompt) to drive its custom timeline UI — this re-syncs the editor and regenerates its derived `local_prompts`/`segment_lengths`/`guide_strength` widgets; setting those derived widgets directly is refused (they are silently reverted).",
       {
-        node_id: z.number().int().describe("Node id from panel_graph_outline / panel_query_graph."),
+        node_id: nodeId().describe("Node id from panel_graph_outline / panel_query_graph."),
         widget: z.string().describe("Widget name (e.g. 'steps', 'cfg', 'text')."),
         value: z
           .union([z.string(), z.number(), z.boolean()])
@@ -6643,7 +6711,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "panel_set_property",
       "Set a node's LiteGraph PROPERTY (the right-click → Properties panel), NOT a widget — the counterpart to panel_set_widget, which only reaches `widgets`. Many custom nodes are configured entirely through node properties: e.g. the rgthree Fast Groups Bypasser's filters `matchTitle`, `matchColors`, `sort`, and `toggleRestriction` are node properties, and without `matchTitle` the node enumerates EVERY group in the workflow (a footgun). Sets node.properties[name] and, when the node defines an onPropertyChanged callback (rgthree and many LiteGraph nodes do), invokes it so the change takes effect LIVE (e.g. rgthree re-filters its group list). Returns the previous and new value. Undoable with Ctrl+Z.",
       {
-        node_id: z.number().int().describe("Node id from panel_graph_outline / panel_query_graph."),
+        node_id: nodeId().describe("Node id from panel_graph_outline / panel_query_graph."),
         name: z
           .string()
           .describe("Property name from the node's right-click → Properties panel (e.g. 'matchTitle', 'matchColors', 'sort', 'toggleRestriction')."),
@@ -6658,8 +6726,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "panel_edit_node",
       "Atomically edit one node, or apply the same edit to several nodes. Pass exactly one of node_id or node_ids, plus at least one field. In one Ctrl+Z step you can move (pos), resize (size — including Note/MarkdownNote), retitle, recolor, change shape, collapse, pin, or set execution mode. Widget values, LiteGraph properties, links, and slot order stay on their dedicated tools. For a multi-node call, position/size/title/mode apply the same value to every target. Color fields accept #RGB, #RGBA, #RRGGBB, or #RRGGBBAA; null clears a color. Bypassing a subgraph retains panel_set_node_mode's unsafe-boundary guard; force:true is required to override it. Undoable with Ctrl+Z.",
       {
-        node_id: z.number().int().optional().describe("One node id from panel_graph_outline / panel_query_graph. Provide this OR node_ids, not both."),
-        node_ids: z.array(z.number().int()).min(1).optional().describe("Several node ids that receive the same presentation edit. Provide this OR node_id, not both."),
+        node_id: nodeId().optional().describe("One node id from panel_graph_outline / panel_query_graph. Provide this OR node_ids, not both."),
+        node_ids: z.array(nodeId()).min(1).optional().describe("Several node ids that receive the same presentation edit. Provide this OR node_id, not both."),
         pos: xy().optional().describe("New canvas [x, y]."),
         size: nodeSize().optional().describe("New [width, height] in canvas px. Uses the node's setSize so DOM-widget nodes reflow and minimum sizes are honored."),
         title: z.string().optional().describe("New header title."),
@@ -6696,8 +6764,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     // Keep legacy bridge commands behind compatibility tool names. graph_edit_node
     // is newer than several installed panels, while current panels adapt these
     // commands into the same atomic implementation.
-    def("panel_move_node", "Compatibility wrapper for panel_edit_node(pos).", { node_id: z.number().int(), pos: xy() }, async (args: A, ctx) => ctx.call({ cmd: "graph_move_node", node_id: args.node_id, pos: args.pos })),
-    def("panel_resize_node", "Compatibility wrapper for panel_edit_node(size).", { node_id: z.number().int(), size: nodeSize() }, async (args: A, ctx) => ctx.call({ cmd: "graph_resize_node", node_id: args.node_id, size: args.size })),
+    def("panel_move_node", "Compatibility wrapper for panel_edit_node(pos).", { node_id: nodeId(), pos: xy() }, async (args: A, ctx) => ctx.call({ cmd: "graph_move_node", node_id: args.node_id, pos: args.pos })),
+    def("panel_resize_node", "Compatibility wrapper for panel_edit_node(size).", { node_id: nodeId(), size: nodeSize() }, async (args: A, ctx) => ctx.call({ cmd: "graph_resize_node", node_id: args.node_id, size: args.size })),
     def(
       "panel_auto_layout",
       "Automatically arrange the user's open graph (or a subset of nodes) into a clean left-to-right / top-to-bottom / grid layout based on the real link topology. Group boxes move with their members and are re-fit. Use dry_run:true to preview proposed positions without touching the canvas. Undoable (one Ctrl+Z).",
@@ -6740,20 +6808,48 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "MOVE the user's viewport: 'fit' frames the whole graph, 'center_on_node' jumps to a node (give node_id), 'pan' shifts by dx/dy, 'zoom' sets an absolute scale. It changes what they are looking AT and returns nothing about the graph — to find out what is ON the canvas, use panel_graph_outline. View-only.",
       {
         action: z.enum(["fit", "center_on_node", "pan", "zoom"]),
-        node_id: z.number().int().optional().describe("Required for center_on_node."),
+        node_id: nodeId().optional().describe("Required for center_on_node."),
         dx: z.number().optional().describe("Pan delta x."),
         dy: z.number().optional().describe("Pan delta y."),
         scale: z.number().optional().describe("Absolute zoom for 'zoom' (0.05–4, 1 = 100%)."),
+        // #845 — the tool used two names for one concept: `action:"zoom"` requires
+        // `scale`, and a `zoom` argument was simply not in the schema, so passing
+        // it was dropped without a word. Accept it as the alias it obviously is.
+        zoom: z.number().optional().describe("Alias for `scale`."),
       },
-      async (args: A, ctx) =>
-        ctx.call({
+      async (args: A, ctx) => {
+        const scale = args.scale ?? args.zoom;
+        const res = await ctx.call({
           cmd: "graph_canvas",
           action: args.action,
           node_id: args.node_id,
           dx: args.dx,
           dy: args.dy,
-          scale: args.scale,
-        }),
+          scale,
+        });
+        // #845 — an argument this action does not consume was SILENTLY dropped.
+        // The reporter passed zoom:0.55 to center_on_node, got scale 0.067 back,
+        // and had no way to tell the zoom had been ignored rather than applied
+        // and overridden. Only `zoom` applies a scale — the panel's
+        // center_on_node sets the offset alone — so say which arguments this
+        // action actually used.
+        const ignored = ignoredCanvasArgs(String(args.action), {
+          node_id: args.node_id,
+          dx: args.dx,
+          dy: args.dy,
+          scale,
+        });
+        if (!ignored.length || res.isError) return res;
+        return appendNote(
+          res,
+          `Note: action:"${args.action}" does not use ${ignored.join(", ")} — ` +
+            `${ignored.length === 1 ? "it was" : "they were"} ignored, not applied. ` +
+            (ignored.includes("scale/zoom")
+              ? `To change the zoom, call panel_canvas again with action:"zoom" and scale. `
+              : "") +
+            `Any values in this result are the canvas's actual state.`,
+        );
+      },
     ),
     def(
       "panel_run",
@@ -8207,13 +8303,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     def(
       "panel_select_nodes",
       "Select nodes on the user's canvas by id (highlights them, sets the multi-selection). Useful before panel_create_subgraph.",
-      { node_ids: z.array(z.number().int()).describe("Node ids to select.") },
+      { node_ids: z.array(nodeId()).describe("Node ids to select.") },
       async (args: A, ctx) => ctx.call({ cmd: "graph_select_nodes", node_ids: args.node_ids }),
     ),
     def(
       "panel_create_subgraph",
       "Group the given nodes into a SUBGRAPH (ComfyUI 'Convert to Subgraph') on the user's canvas — collapses them into one subgraph node. Returns the new subgraph node id. Undoable with Ctrl+Z. To wrap an existing GROUP, prefer panel_subgraph_group (you don't have to list the node_ids yourself).",
-      { node_ids: z.array(z.number().int()).describe("Node ids to group into a subgraph.") },
+      { node_ids: z.array(nodeId()).describe("Node ids to group into a subgraph.") },
       async (args: A, ctx) => ctx.call({ cmd: "graph_create_subgraph", node_ids: args.node_ids }, 15000),
     ),
     def(
@@ -8256,7 +8352,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "panel_save_subgraph",
       "Save a SUBGRAPH node to the user's reusable blueprint LIBRARY (publish), so it can be dropped into any workflow later. Pass node_id to pick the subgraph node (else a single selected subgraph node is used) and name to title the blueprint (defaults to the node's title). Runs programmatically — NO save dialog pops. The blueprint becomes the addable type 'SubgraphBlueprint.<name>' (use panel_add_subgraph or panel_list_subgraphs). Returns {saved: {name, type}}.",
       {
-        node_id: z.number().int().optional().describe("Subgraph node id to publish (is_subgraph=true). Omit to use the selected subgraph node."),
+        node_id: nodeId().optional().describe("Subgraph node id to publish (is_subgraph=true). Omit to use the selected subgraph node."),
         name: z.string().optional().describe("Blueprint name. Defaults to the subgraph node's title."),
       },
       async (args: A, ctx) =>
@@ -8364,13 +8460,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     def(
       "panel_set_node_title",
       "Compatibility wrapper for panel_edit_node(title).",
-      { node_id: z.number().int(), title: z.string() },
+      { node_id: nodeId(), title: z.string() },
       async (args: A, ctx) => ctx.call({ cmd: "graph_set_title", node_id: args.node_id, title: args.title }, 15000),
     ),
     def(
       "panel_set_node_collapsed",
       "Compatibility wrapper for panel_edit_node(collapsed).",
-      { node_id: z.number().int(), collapsed: z.boolean().optional() },
+      { node_id: nodeId(), collapsed: z.boolean().optional() },
       async (args: A, ctx) => ctx.call({ cmd: "graph_set_node_collapsed", node_id: args.node_id, collapsed: args.collapsed ?? true }),
     ),
     def(
@@ -8381,7 +8477,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         "• 'mute' — the node AND everything DOWNSTREAM of it do NOT execute (no pass-through). Use to fully switch off a branch/output.\n" +
         "CRITICAL — modes silently change what a render produces, so they are a top cause of 'wrong output'. A BYPASSED node contributes nothing of its own and a MUTED node kills its branch. Use this tool to ENABLE the path you actually want and DISABLE the one you don't — e.g. to drive a workflow from its Ideogram/JSON prompt builder you must set the manual-prompt node to 'bypass' and the JSON-builder path to 'active' (or vice-versa); likewise to pick one branch of an rgthree 'Fast Groups Bypasser'/Muter or a prompt-source switch. ALWAYS read modes first (panel_graph_outline marks [bypass]/[mute]; panel_query_graph detail rows carry mode): if the intended path is bypassed/muted, fix it HERE before running, and never assume a switch/route is already active. UNSAFE-BYPASS GUARD: bypassing a SUBGRAPH node whose boundary inputs are ordered differently from its outputs is REJECTED — ComfyUI forwards each output from the input at the SAME index, so e.g. an IMAGE output backed by a BBOX_DETECTOR input would silently feed the wrong type downstream. Re-order the boundary inputs or add an explicit ImpactSwitch to choose the passthrough; pass force:true only if you truly intend the positional forward. Undoable with Ctrl+Z.",
       {
-        node_id: z.number().int().describe("Node id from panel_graph_outline / panel_query_graph."),
+        node_id: nodeId().describe("Node id from panel_graph_outline / panel_query_graph."),
         mode: z
           .enum(["active", "bypass", "mute"])
           .describe(
@@ -8401,7 +8497,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "panel_set_node_color",
       "Legacy color compatibility wrapper. Unlike panel_edit_node, color and bgcolor accept any CSS color string; when preset is supplied it wins over explicit colors, preserving the historical bridge behavior.",
       {
-        node_id: z.number().int(),
+        node_id: nodeId(),
         preset: z.enum(["red", "brown", "green", "blue", "pale_blue", "cyan", "purple", "yellow", "black"]).nullable().optional(),
         color: z.string().nullable().optional(),
         bgcolor: z.string().nullable().optional(),
@@ -8453,7 +8549,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     def(
       "panel_enter_subgraph",
       "Navigate INTO a subgraph node so you can read and EDIT its inner nodes — after this, panel_query_graph / panel_graph_outline and all panel_* edit tools target the subgraph's inner graph (the user sees the canvas drill in). This is how you edit inside a subgraph (e.g. tweak a widget on an inner node). Call panel_exit_subgraph when done. Returns the new viewing scope.",
-      { node_id: z.number().int().describe("Subgraph node id (is_subgraph=true).") },
+      { node_id: nodeId().describe("Subgraph node id (is_subgraph=true).") },
       async (args: A, ctx) => ctx.call({ cmd: "graph_enter_subgraph", node_id: args.node_id }, 15000),
     ),
     def(
@@ -8475,7 +8571,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "panel_promote_widget",
       "Expose (promote) an INNER subgraph widget on the PARENT subgraph node, so it can be set from outside without opening the subgraph — e.g. surface an inner KSampler's `seed`/`steps` on the subgraph node. You MUST be inside the subgraph first (call panel_enter_subgraph): `node_id` is an inner node (from panel_query_graph while inside) and `widget` is one of its widget names. Pass demote:true to un-promote. Undoable with Ctrl+Z.",
       {
-        node_id: z.number().int().describe("Inner node id (from panel_query_graph while inside the subgraph)."),
+        node_id: nodeId().describe("Inner node id (from panel_query_graph while inside the subgraph)."),
         widget: z.string().describe("Name of the widget on that node to promote (e.g. 'seed', 'steps', 'text')."),
         demote: z.boolean().optional().describe("Set true to UN-promote (remove the widget from the parent node)."),
       },
@@ -8486,7 +8582,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "panel_expose_subgraph_output",
       "Wire an interior node's OUTPUT to the subgraph's OUTPUT RAIL — i.e. expose it as a SUBGRAPH OUTPUT on the boundary so the PARENT graph can connect to the subgraph node's new output slot. You MUST be INSIDE the subgraph first (panel_enter_subgraph). This is the correct way to \"wire an internal output to the subgraph's output rail\": do NOT panel_connect to a guessed rail node id — call this with the interior node + the output you want exposed. Read panel_query_graph's `rails` to see the resulting boundary slots. `from_output` is an output slot NAME ('IMAGE', 'LATENT') or numeric index. Optional `name` titles the new boundary output (defaults from the source slot). Undoable with Ctrl+Z.",
       {
-        from_node_id: z.number().int().describe("Interior (inner) node id whose output to expose (from panel_query_graph while inside the subgraph)."),
+        from_node_id: nodeId().describe("Interior (inner) node id whose output to expose (from panel_query_graph while inside the subgraph)."),
         from_output: slotRef.describe("Output slot name (e.g. 'IMAGE', 'LATENT') or numeric index on that node."),
         name: z.string().optional().describe("Optional name for the new subgraph output (boundary slot). Defaults from the source slot."),
       },
@@ -8505,7 +8601,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "panel_expose_subgraph_input",
       "Wire an interior node's INPUT to the subgraph's INPUT RAIL — i.e. expose it as a SUBGRAPH INPUT on the boundary so the PARENT graph can feed the subgraph node's new input slot. You MUST be INSIDE the subgraph first (panel_enter_subgraph). This is the correct way to wire an internal input to the subgraph's input rail: do NOT panel_connect to a guessed rail node id — call this with the interior node + the input you want exposed. Read panel_query_graph's `rails` to see the resulting boundary slots. `to_input` is an input slot NAME ('model', 'pixels') or numeric index. Optional `name` titles the new boundary input (defaults from the target slot). Undoable with Ctrl+Z.",
       {
-        to_node_id: z.number().int().describe("Interior (inner) node id whose input to expose (from panel_query_graph while inside the subgraph)."),
+        to_node_id: nodeId().describe("Interior (inner) node id whose input to expose (from panel_query_graph while inside the subgraph)."),
         to_input: slotRef.describe("Input slot name (e.g. 'model', 'pixels') or numeric index on that node."),
         name: z.string().optional().describe("Optional name for the new subgraph input (boundary slot). Defaults from the target slot."),
       },
@@ -8523,7 +8619,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     def(
       "panel_unpack_subgraph",
       "EXPAND / DISSOLVE a subgraph node on the user's open graph — inline its interior nodes back into the PARENT graph, rewire all external links to those now-inlined nodes, and remove the subgraph wrapper. This is the frontend's \"Unpack Subgraph\" (litegraph LGraph.unpackSubgraph) and the exact INVERSE of panel_create_subgraph. Use it to flatten a stage that was over-nested, or to edit interior nodes directly at the parent level. The interior nodes reappear on the parent canvas with their connections preserved. Undoable with Ctrl+Z.",
-      { node_id: z.number().int().describe("Subgraph node id to unpack/dissolve (is_subgraph=true, from panel_graph_outline / panel_query_graph).") },
+      { node_id: nodeId().describe("Subgraph node id to unpack/dissolve (is_subgraph=true, from panel_graph_outline / panel_query_graph).") },
       async (args: A, ctx) => ctx.call({ cmd: "graph_unpack_subgraph", node_id: args.node_id }, 15000),
     ),
     def(


### PR DESCRIPTION
Refs artokun/comfyui-mcp#845 — defects (3) and (4). See Scope.

Both are the same shape: the tool knew exactly what the caller meant, and either refused or silently dropped it.

## (4) A node id we printed could not be passed back in

Every graph reader returns ids as **strings** (`"id": "42"`); all 24 node-id inputs demanded `z.number().int()`. So copying an id out of `panel_query_graph` into `panel_select_nodes` failed on the **first** attempt, every time, with a raw zod `expected number, received string`.

A shared `nodeId()` accepts either spelling and normalizes to the number the wire has always carried. **All 24 sites converted, not some** — a partial conversion would leave some tools taking strings and others not, which is the reported inconsistency made worse.

Deliberately strict about what counts as an id:

| input | result |
|---|---|
| `42`, `"42"` | → `42` |
| `"42px"`, `"4.5"`, `""` | rejected |
| `"5:12"` | **rejected** |

That last row matters. A subgraph-qualified id is a real shape in newer ComfyUI, and quietly truncating it to `5` would target the **wrong node** rather than fail. Supporting those is a deliberate wire-contract change, not something that should fall out of a coerce.

## (3) panel_canvas had two names for one concept, and dropped the other in silence

`action:"zoom"` requires `scale`; a `zoom` argument was not in the schema at all, so passing it vanished. The reporter sent `zoom: 0.55` with `center_on_node` and got `scale: 0.067` back — which reads as *applied, then overridden*, when it was never applied.

- `zoom` is accepted as the alias it obviously is (an explicit `scale` wins).
- An argument the action does not consume is **named** in the result, with the call that would work. Not an error — a harmless extra argument must not fail a viewport move — but not silent either.

**I checked the panel before letting `zoom` through to `center_on_node`.** Its `graph_canvas` `center_on_node` case sets the offset and never touches the scale. Forwarding a scale there and reporting success would have reproduced the exact defect being fixed, so it is disclosed as ignored instead. Making `center_on_node` honour a scale is a panel change, filed separately.

## Scope

Defects **(1)** `panel_view_nodes_in_viewport` returning 135k chars for a single `node_ids: ["42"]`, and **(2)** `panel_screenshot` ignoring canvas viewport state, are panel-side. Filed there; **#845 stays open** until they land.

## A note on the tests

They call each tool through its **own zod schema** before the handler, because `def.handler(args)` skips validation entirely — which is precisely where the coercion lives. My first draft called the handler directly and passed against *unconverted* code. That's the "helper tested, wiring not" trap in a new costume, and worth flagging for anyone writing panel-tool tests.

14 tests; both halves mutation-verified (3 and 1 respectively).

Full suite green: 337 files, 7129 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)