### PR TITLE
0.50.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.8] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- a new canvas gets a new fence (#1024)
+- accept the node ids we print, and say which canvas args were ignored (#1023)
+- accept the todo status spellings agents actually produce (#1022)
+
+
 ## [0.50.7] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.7",
+  "version": "0.50.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.7",
+      "version": "0.50.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.7",
+  "version": "0.50.8",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.8` tag (the tag publishes to npm; protected `main` needs this PR).

### Fixed
- **#932** — a new canvas gets a new fence (#1024). Reported *again* on 0.50.6: `panel_new_workflow` created a workflow and then every `panel_add_node` failed with `workflow instance mismatch`. `workflow_new` re-points the active workflow exactly as `workflow_open` does, but only the open path re-derived the command fence — so the session stayed stamped with the *previous* workflow while the user looked at a brand-new canvas.
- **#845** — accept the node ids we print, and say which canvas args were ignored (#1023). Every graph reader returns ids as strings while all 24 node-id inputs demanded numbers, so copying an id from `panel_query_graph` into `panel_select_nodes` failed on the first attempt, every time. Plus `panel_canvas` now names an argument the chosen action doesn't consume instead of dropping it silently.
- **#1018** — accept the todo status spellings agents actually produce (#1022). An agent's first `panel_set_todo` was rejected for writing `in_progress`/`completed` — the near-universal todo vocabulary — costing a round trip at plan setup.

Second release running where the changelog generated correctly with no hand-editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)