### PR TITLE
fix(#1027): retry a mid-workflow-switch refusal instead of surfacing it

### DIFF
--- a/src/__tests__/orchestrator/switch-guard-retry.test.ts
+++ b/src/__tests__/orchestrator/switch-guard-retry.test.ts
@@ -1,0 +1,134 @@
+// #1027 — rapid read-only inspection across several workflow tabs produced a
+// run of confusing errors: "canvas IS bound, but graph does not match loaded
+// state", "workflow instance mismatch", "panel is switching/refreshing", and a
+// 15s open timeout. The reporter read it as a wedge.
+//
+// It is a race, and the panel already handles its half correctly. While a
+// workflow switch/reload is in flight it refuses every graph and workflow
+// executor rather than queueing — refusing cannot reorder or double-apply — and
+// says so explicitly:
+//
+//   the panel is switching/refreshing "<key>" right now, so "<cmd>" was NOT
+//   applied — nothing changed. Retry in a moment.
+//
+// Nothing was applied, and the section lasts a fraction of a second. But that
+// text matched none of the orchestrator's transient patterns, so a read issued
+// right after panel_open_workflow surfaced the raw refusal instead of waiting
+// the ~400ms the panel asked for.
+//
+// The second half matters as much: when the retry ALSO lands mid-switch, saying
+// "still reconnecting after a restart/reload" would repeat #1001 exactly — the
+// tab is connected and healthy, it is simply mid-switch.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  makePanelToolCtx,
+  __panelToolsTestHooks,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const textOf = (res: ToolResult): string => (res.content[0] as { text: string }).text;
+
+/** Verbatim from the panel's activeWorkflowReloadGuard branch. */
+function switchGuardError(cmd = "graph_outline"): Error {
+  return new Error(
+    `the panel is switching/refreshing "wf:workflows/a.json" right now, so "${cmd}" ` +
+      `was NOT applied — nothing changed. Retry in a moment.`,
+  );
+}
+
+let attempts: number;
+
+/** Fails the first `failures` sends with the switch guard, then succeeds. */
+function bridgeFailing(failures: number, err: () => Error = switchGuardError) {
+  attempts = 0;
+  return {
+    send: async () => {
+      attempts += 1;
+      if (attempts <= failures) throw err();
+      return { ok: true, nodes: [] };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: "tab-1", title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => "tab-1",
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+beforeEach(() => {
+  __panelToolsTestHooks.setRetrySettleMs(0); // the real wait is ~400ms
+});
+
+describe("#1027: a mid-switch refusal is retried, not surfaced", () => {
+  it("retries a read that landed during the switch, and succeeds", async () => {
+    const ctx = makePanelToolCtx(bridgeFailing(1), "tab-1");
+    const res = await ctx.call({ cmd: "graph_outline" });
+    expect(res.isError).toBeFalsy();
+    expect(attempts).toBe(2); // refused once, then applied
+  });
+
+  it("does not re-issue a MUTATING command on its own initiative", async () => {
+    const ctx = makePanelToolCtx(bridgeFailing(1), "tab-1");
+    const res = await ctx.call({ cmd: "graph_add_node", class_type: "KSampler" });
+    expect(res.isError).toBe(true);
+    expect(attempts).toBe(1); // never retried — that is the double-apply rule
+  });
+});
+
+describe("#1027: when the retry ALSO lands mid-switch", () => {
+  it("does not call a connected panel 'reconnecting' — the #1001 mistake", async () => {
+    const ctx = makePanelToolCtx(bridgeFailing(99), "tab-1");
+    const text = textOf(await ctx.call({ cmd: "graph_outline" }));
+    expect(text).not.toContain("still reconnecting");
+    expect(text).not.toContain("restart/reload");
+  });
+
+  it("names the actual state, and that nothing was applied", async () => {
+    const ctx = makePanelToolCtx(bridgeFailing(99), "tab-1");
+    const text = textOf(await ctx.call({ cmd: "graph_outline" }));
+    expect(text).toContain("was NOT applied");
+    expect(text).toContain("switching or reloading");
+    expect(text).toContain("this is not a");
+    // The one thing that would genuinely explain a stuck switch.
+    expect(text).toContain("unsaved-changes");
+  });
+
+  it("preserves the panel's own words for the reader", async () => {
+    const ctx = makePanelToolCtx(bridgeFailing(99), "tab-1");
+    expect(textOf(await ctx.call({ cmd: "graph_outline" }))).toContain(
+      "panel is switching/refreshing",
+    );
+  });
+});
+
+describe("#1027: the other refusals keep their own handling", () => {
+  it("a genuine reconnect still reports as a reconnect", async () => {
+    const ctx = makePanelToolCtx(
+      bridgeFailing(99, () => new Error('no connected tab with id "tab-1". Connected: none')),
+      "tab-1",
+    );
+    const text = textOf(await ctx.call({ cmd: "graph_outline" }));
+    expect(text).toContain("still reconnecting");
+    expect(text).not.toContain("switching or reloading");
+  });
+
+  // An instance mismatch is NOT retryable: the stamp names a workflow that is no
+  // longer active, and waiting cannot change that. Retrying it would burn a round
+  // trip and then report the same thing.
+  it("an instance mismatch is not retried", async () => {
+    const ctx = makePanelToolCtx(
+      bridgeFailing(99, () =>
+        new Error(
+          "workflow instance mismatch: this command targets a different workflow than the active canvas",
+        ),
+      ),
+      "tab-1",
+    );
+    const res = await ctx.call({ cmd: "graph_outline" });
+    expect(res.isError).toBe(true);
+    expect(attempts).toBe(1);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -780,6 +780,34 @@ function isTransientReconnectError(err: unknown): boolean {
   );
 }
 
+/**
+ * #1027 — the panel's WORKFLOW-SWITCH critical section, which is retryable by
+ * construction and was not being retried.
+ *
+ * While a workflow switch/reload is in flight the panel refuses every graph and
+ * workflow executor rather than queueing it, because refusing cannot reorder or
+ * double-apply. Its own words:
+ *
+ *   the panel is switching/refreshing "<key>" right now, so "<cmd>" was NOT
+ *   applied — nothing changed. Retry in a moment.
+ *
+ * Two facts make this the safest retry in the file: the panel STATES nothing was
+ * applied, and the section lasts a fraction of a second. Yet none of that text
+ * matched the transient classifier, so a read issued right after
+ * panel_open_workflow surfaced the refusal to the agent instead of waiting the
+ * ~400ms the panel asked for. A reporter driving several tabs read-only hit it
+ * repeatedly, and read the resulting instance-mismatch errors as a wedge.
+ *
+ * TEXT-matched, deliberately, unlike #1001's typed marker: this error is minted
+ * in the browser and arrives over the wire, so there is no object identity to
+ * carry a symbol across. The phrasing is distinctive enough to key on, and the
+ * retry it enables is bounded to RETRY-SAFE commands either way.
+ */
+function isWorkflowSwitchGuardRefusal(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  return /panel is switching\/refreshing|panel is switching or reloading/i.test(msg);
+}
+
 let retrySettleMsOverride: number | null = null;
 /** Short pause before the single post-drop retry, letting the replacement tab
  *  finish its reconnect hello so ensureReachable can resolve it. Test-overridable. */
@@ -4641,12 +4669,32 @@ export function makePanelToolCtx(
       // For idempotent commands, settle briefly, rebind onto the now-live tab, and
       // retry ONE time before surfacing an error (#278/#310/#332/#481). Mutating
       // edits are excluded from RETRY_SAFE_CMDS, so they never double-apply.
-      if (isRetrySafeCmd(cmd) && isTransientReconnectError(err)) {
+      // #1027 — the workflow-switch critical section is retried on the same path.
+      // The panel refuses during it, states that nothing was applied, and asks
+      // for a retry in a moment; the section lasts a fraction of a second, which
+      // is what retrySettleMs already waits. Still gated on RETRY-SAFE commands,
+      // so a mutation is never re-issued on our own initiative.
+      if (isRetrySafeCmd(cmd) && (isTransientReconnectError(err) || isWorkflowSwitchGuardRefusal(err))) {
         try {
           await sleep(retrySettleMs());
           ensureReachable(); // rebinds a current-mode session onto the reconnected tab
           return ok(await sendRouted(cmd, timeoutMs, observeRid));
         } catch (err2) {
+          // #1027 — a switch STILL in progress is not a reconnect, and saying so
+          // would be the #1001 mistake again: the tab is connected and healthy,
+          // it is simply mid-switch. Name the actual state and the actual wait.
+          if (isWorkflowSwitchGuardRefusal(err2)) {
+            const name = typeof cmd.cmd === "string" ? cmd.cmd : "panel command";
+            return fail(
+              `${name} was NOT applied — nothing changed. The panel is still switching or ` +
+                `reloading the workflow on the canvas, which it refuses commands during so a ` +
+                `command cannot land on the wrong graph. The tab is connected and this is not a ` +
+                `reconnect: it normally clears in well under a second, so simply retry. If a ` +
+                `switch appears stuck, check the canvas — a load dialog or an unsaved-changes ` +
+                `prompt can hold it open awaiting the user. ` +
+                `(${err2 instanceof Error ? err2.message : String(err2)})`,
+            );
+          }
           // The retry also failed — surface an actionable reconnecting status rather
           // than a bare transport error (#332), while still failing honestly.
           if (isTransientReconnectError(err2)) {


### PR DESCRIPTION
Closes artokun/comfyui-mcp#1027

## What happened

Rapid read-only inspection across several workflow tabs produced a run of confusing errors — *"canvas IS bound, but graph does not match loaded state"*, *"workflow instance mismatch"*, *"panel is switching/refreshing"*, a 15s open timeout — and the reporter read it as a wedge.

It's a race, and **the panel already handles its half correctly.** While a workflow switch/reload is in flight it refuses every graph and workflow executor rather than queueing (refusing cannot reorder or double-apply) and says so:

```
the panel is switching/refreshing "<key>" right now, so "<cmd>" was NOT applied
— nothing changed. Retry in a moment.
```

## The gap

None of that text matched `isTransientReconnectError`, so a read issued right after `panel_open_workflow` surfaced the raw refusal instead of waiting the ~400ms the panel explicitly asked for.

Two facts make this the safest retry in the file: the panel **states** nothing was applied, and it **names the wait**. Still gated on `RETRY_SAFE_CMDS`, so a mutation is never re-issued on our own initiative — pinned by a test.

## The second half

When the retry *also* lands mid-switch, the existing fallback would have said *"still reconnecting after a restart/reload"* — **#1001 exactly**, on the same code path I changed for it this morning. The tab is connected and healthy; it is simply mid-switch.

That case now names the real state, repeats that nothing was applied, and points at the one thing that genuinely explains a switch that won't finish: a load dialog or an unsaved-changes prompt on the canvas awaiting the user.

Text-matched, deliberately, unlike #1001's typed marker — this error is minted in the browser and arrives over the wire, so there's no object identity to carry a symbol across.

## What is deliberately NOT retried

An **instance mismatch**. The stamp names a workflow that is no longer active, and waiting cannot change that — retrying would burn a round trip and report the same thing. Pinned by a test, alongside one confirming a genuine reconnect still reports as a reconnect.

## On the reporter's other suggestions

They asked to *"serialize workflow switching (or expose an awaitable switch receipt)"*. The panel already serializes — the critical section is exactly that — and it deliberately refuses rather than queues, which is the safer half of the choice. What was missing was the caller honouring the retry it was being offered. An awaitable receipt would be a larger contract change for a window that closes in well under a second; worth revisiting if this recurs after the retry lands.

7 tests, both halves mutation-verified. Full suite green: 340 files, 7151 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)