### PR TITLE
0.50.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.9] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- retry a mid-workflow-switch refusal instead of surfacing it (#1029)
+- bound the skill-generator's network calls (#1028)
+
+
 ## [0.50.8] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.8",
+  "version": "0.50.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.8",
+      "version": "0.50.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.8",
+  "version": "0.50.9",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.9` tag (the tag publishes to npm; protected `main` needs this PR).

### Fixed
- **#1027** — retry a mid-workflow-switch refusal instead of surfacing it (#1029). The panel refuses commands during a workflow switch, states that nothing was applied, and asks for a retry in a moment — but none of that text matched the transient classifier, so reads issued right after `panel_open_workflow` surfaced the raw refusal. The retry's own fallback would also have called a healthy, connected panel "reconnecting"; it now names the real state.
- **#1026** — bound the skill-generator's network calls (#1028). `list_packs action:"generate_skill"` reached GitHub and api.comfy.org through three bare `fetch` calls with no `AbortSignal`, so a host that accepts a connection and never answers left the call pending indefinitely — a reporter's sat past 180s and had to be killed client-side.

Both are cases where the caller got no usable answer at all, which is why they're going out promptly rather than waiting for a fuller batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)