### PR TITLE
fix(#881): close the swap window — and fix the reproduction that hid it

### DIFF
--- a/src/__tests__/services/env-store-atomic-write.test.ts
+++ b/src/__tests__/services/env-store-atomic-write.test.ts
@@ -17,7 +17,15 @@
 // verification that REPORTS a loss instead of confirming a save over it.
 
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import { existsSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -432,7 +440,7 @@ describe("the credential store is written ATOMICALLY", () => {
     expect(r.uncertainty).toMatch(/two adjacent operations/);
   });
 
-  it("REPORTS the key of a writer that lands AFTER the compare-and-swap re-read", () => {
+  it("PRESERVES the key of a writer that lands AFTER the compare-and-swap re-read", () => {
     // THE window the compare-and-swap cannot close, and the case the receipt used
     // to narrate as a clean save: writer B lands between our `current !== raw`
     // check (read 2) and our rename, so our rename replaces B's file. Computing
@@ -450,14 +458,20 @@ describe("the credential store is written ATOMICALLY", () => {
       },
     };
     const r = setComfyuiSecret("CIVITAI_API_TOKEN", "civ-new");
-    // Our key landed, and B's really is gone — that is the damage.
+    // #881 — this window is now CLOSED, so there is no damage left to report.
+    // The store is re-read at the last possible moment before the rename, so B's
+    // arrival is SEEN and the save retries against their content instead of
+    // replacing it. Both keys survive, which is strictly better than the
+    // accurate loss report this test used to assert.
     expect(parseEnvFile()!.CIVITAI_API_TOKEN).toBe("civ-new");
-    expect(parseEnvFile()!.RUNPOD_API_KEY).toBeUndefined();
-    // ...and it is REPORTED, not narrated away.
-    expect(r.lostKeys).toContain("RUNPOD_API_KEY");
-    // The verdict itself is what stops any caller rendering this as a save:
-    // every success test in the codebase is `persisted === "yes"`.
-    expect(r.persisted).toBe("damaged");
+    expect(parseEnvFile()!.RUNPOD_API_KEY).toBe("rp-from-other-process");
+    expect(r.lostKeys ?? []).toEqual([]);
+    // NOT "yes", and that is deliberate. The collision was real, and the guard
+    // NARROWS the window rather than closing it — a writer landing between that
+    // last read and the rename is still unobservable, and no portable API can
+    // see it. The verdict has to keep saying so.
+    expect(r.persisted).toBe("unknown");
+    expect(r.uncertainty).toMatch(/another process was writing/);
   });
 
   it("preserves comments and unrelated keys through a normal save", () => {
@@ -530,7 +544,7 @@ describe("a save is never CONFIRMED over lost credentials", () => {
     expect(fsState.links).toContain(envPath);
   });
 
-  it("REPORTS a writer that CREATES the store before the snapshot is taken", () => {
+  it("PRESERVES a writer that CREATES the store before the snapshot is taken", () => {
     rmSync(envPath, { force: true }); // start with NO store at all
     // existsSync #1 is the writer's own "does it exist?"; #2 is the
     // compare-and-swap's. The other process creates the file right after #2 —
@@ -542,10 +556,16 @@ describe("a save is never CONFIRMED over lost credentials", () => {
       },
     };
     const r = setComfyuiSecret("CIVITAI_API_TOKEN", "civ-new");
+    // #881 — also closed. The store did not exist when we read it, so `raw` is
+    // "", and the last-moment re-read before the rename finds their file there
+    // instead. That difference is the collision, and the retry recomputes from
+    // what they wrote rather than replacing it.
     expect(parseEnvFile()!.CIVITAI_API_TOKEN).toBe("civ-new");
-    expect(parseEnvFile()!.RUNPOD_API_KEY).toBeUndefined(); // theirs really is gone
-    expect(r.lostKeys).toContain("RUNPOD_API_KEY"); // ...and it is REPORTED
-    expect(r.persisted).toBe("damaged");
+    expect(parseEnvFile()!.RUNPOD_API_KEY).toBe("rp-from-other-process");
+    expect(r.lostKeys ?? []).toEqual([]);
+    // Still not a confirmed save, for the same reason as the sibling test above:
+    // the residual read→rename window cannot be observed from in-process.
+    expect(r.persisted).toBe("unknown");
   });
 
   it("still reports a clean save on a genuinely FIRST write (no prior store)", () => {
@@ -1107,17 +1127,20 @@ function readdirSyncSafe(d: string): string[] {
 // sentinel, saw only our own intended changes and reported the save clean.
 
 describe("a save that would clobber a writer who landed in the swap window", () => {
-  // KNOWN DEFECT, REPRODUCED — see issue #881. `it.fails` because the assertion below
-  // genuinely does not hold today: the other writer's credential is silently
-  // overwritten and the save still reports itself clean. Kept executing rather
-  // than skipped so the reproduction cannot rot, and marked `.fails` so that
-  // whoever fixes it is told immediately (this test starts FAILING once the bug
-  // is gone, which is the prompt to flip it back to `it`).
+  // FIXED — see issue #881. This ran as `it.fails` for a while, and the reason it
+  // could not be fixed is worth keeping: the harness was broken, not the store.
   //
-  // I tried two guards before the rename and neither ever executed — the
-  // sentinel is not taken on this path, and I did not establish why. That is the
-  // next thing to find out, not another guess.
-  it.fails("REFUSES rather than overwriting, and the other writer's value survives", () => {
+  // The hook below calls `renameSync`, which this file did not import. So it threw
+  // ReferenceError on every run, the concurrent write NEVER happened, and the
+  // throw propagated out of the mocked linkSync — which production caught as a
+  // link failure and answered with the copyFile fallback. Every guard tried
+  // against it "never executed" because there was no collision to see, and the
+  // earlier note here concluded the sentinel was not taken on this path. It was;
+  // the ReferenceError just looked exactly like a link that failed.
+  //
+  // The lesson: when a reproduction proves nothing, instrument the REPRODUCTION
+  // before instrumenting the code under test.
+  it("REFUSES rather than overwriting, and the other writer's value survives", () => {
     // Ours is already on disk and readable, so the CAS passes cleanly.
     setComfyuiSecret("CIVITAI_API_TOKEN", "mine-first");
 

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -1141,6 +1141,47 @@ function rewriteEnvFile(
           }
         }
       }
+      // #881 — THE SWAP WINDOW. The compare-and-swap above closes the gap
+      // between our first read and our decision. It cannot close the gap between
+      // that check and this rename, and a writer landing in THAT window was
+      // overwritten silently: the loss account compares the store against the
+      // sentinel, which was captured before their write, so it saw only our own
+      // intended changes and reported the save clean. Losing another process's
+      // credential is bad; reporting it as a clean save is what made it
+      // undiagnosable.
+      //
+      // Re-read at the LAST possible moment and retry if the file moved under
+      // us. Retrying (rather than refusing) is what preserves their key: the
+      // next pass recomputes `next` from their content, so both writes survive.
+      //
+      // Compared by CONTENT, not by inode. st_ino is the more precise signal —
+      // the sentinel is a hard link, so a replacement gives `p` a new inode
+      // while the sentinel keeps the old one — but Node reports an unstable or
+      // zero `ino` on Windows, which is the platform this store is most used on.
+      // A content comparison is exact everywhere and costs one small read.
+      //
+      // HONEST LIMIT: this NARROWS the window, it does not close it. A writer
+      // landing between this read and the rename below is still unobservable
+      // without an OS-level atomic compare-and-swap, which no portable API
+      // offers. What it removes is the SILENT part — after this, a collision we
+      // can see is retried instead of clobbered.
+      if (sentinelTaken) {
+        // readFileSync + catch, NOT existsSync-then-read: this is a
+        // check-then-act pair otherwise, and the read is the observation anyway.
+        let atSwap = "";
+        try {
+          atSwap = readFileSync(p, "utf-8");
+        } catch {
+          atSwap = ""; // gone entirely — also a change
+        }
+        if (atSwap !== raw) {
+          rmSync(tmp, { force: true });
+          rmSync(sentinel, { force: true });
+          sentinelTaken = false;
+          sawConcurrentWriter = true;
+          continue;
+        }
+      }
       renameSync(tmp, p);
     } catch (err) {
       if (fd !== undefined) {
@@ -1276,8 +1317,9 @@ function rewriteEnvFile(
             `or between it and the rename, is not covered by the account above`
           : sawConcurrentWriter
           ? `another process was writing ${p} during this save (a compare-and-swap conflict was hit and retried). ` +
-            `The snapshot of the replaced state and the rename are two adjacent operations, so a write landing exactly between them ` +
-            `is replaced by this one without appearing in any read — this save cannot rule that out`
+            `The store is re-read immediately before the rename, so a write that landed up to that point was seen and retried ` +
+            `against rather than replaced (#881); but that read and the rename are still two adjacent operations, and a write ` +
+            `landing in the gap between them is replaced by this one without appearing in any read — this save cannot rule that out`
           : null;
     return {
       changed: afterRaw !== raw,


### PR DESCRIPTION
Closes artokun/comfyui-mcp#881

## The defect

The credential store's compare-and-swap closes the gap between our first read and our decision. It could **not** close the gap between that check and our own rename — and a writer landing there was overwritten **silently**: the loss account compares the store against a sentinel captured *before* their write, so it saw only our own intended changes and reported the save clean.

Losing another process's credential is bad. Reporting it as a clean save is what made it undiagnosable.

## Why this sat parked — the reproduction never reproduced anything

The injected writer calls `renameSync`, which the test file **did not import**. So it threw `ReferenceError` on every run, and the throw propagated out of the *mocked* `linkSync` — which production caught as a link failure and answered with the `copyFile` fallback.

That is why every guard tried against it "never executed": there was no collision to see. The note left in the test concluded the sentinel was not taken on this path. **It was.** The `ReferenceError` just looked exactly like a link that failed.

I reverted a working fix once because of this. The lesson is narrow and worth keeping: **when a reproduction proves nothing, instrument the reproduction before instrumenting the code under test.** Establishing it took four instrumented runs and no guesses — the decisive one printed `hook THREW: ReferenceError: renameSync is not defined`.

## The fix

Re-read the store at the last possible moment before the rename; retry if it moved under us. **Retrying rather than refusing** is what preserves their key — the next pass recomputes from their content, so both writes survive.

Compared by **content, not inode**. `st_ino` is the more precise signal (the sentinel is a hard link, so a replacement gives the store a new inode while the sentinel keeps the old one), but Node reports an unstable or zero `ino` on **Windows**, which is the platform this store is most used on. Content comparison is exact everywhere and costs one small read. Read via `readFileSync` + catch, not `existsSync`-then-read — that pair is the same check-then-act shape this area exists to remove.

## Honest limit

The window is **narrowed, not closed**. A writer landing between that last read and the rename is still unobservable without an OS-level atomic compare-and-swap, which no portable API offers. What is gone is the *silent* part, and `persisted` still returns `"unknown"` rather than `"yes"` whenever contention was observed. The uncertainty text now says exactly this instead of implying nothing could be done.

## Two existing tests changed, deliberately

Both pinned a window that is now closed — asserting the other writer's key was gone and the loss *reported*. It now survives, which is strictly better than an accurate report of destroying it. Renamed `REPORTS` → `PRESERVES`, asserting the stronger property while keeping `persisted: "unknown"` so the residual window stays disclosed.

The loss-reporting machinery is **untouched** — it still covers the residual window and every non-snapshotted case (copy fallback, unsnapshottable target, post-rename race).

## Result

The full suite now runs with **no expected-fail** — the last known-defect marker in the codebase is gone. 340 files, 7152 passing. All three collision tests mutation-verified: disabling the guard fails exactly those three.

`lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)