### PR TITLE
0.50.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.10] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- close the swap window — and fix the reproduction that hid it (#1031)
+
+
 ## [0.50.9] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.9",
+  "version": "0.50.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.9",
+      "version": "0.50.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.9",
+  "version": "0.50.10",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.10` tag (the tag publishes to npm; protected `main` needs this PR).

Shipping a single fix rather than waiting for a batch, because it is silent data loss.

### Fixed
- **#881** — close the credential store's swap window (#1031). A concurrent writer landing between our compare-and-swap check and our own rename was overwritten **silently**: the loss account compares against a sentinel captured before their write, so it saw only our own changes and reported the save clean. The store is now re-read at the last possible moment before the rename and the save retries against their content instead of replacing it.

The window is narrowed, not closed — a writer landing between that read and the rename is still unobservable without an OS-level atomic CAS — and `persisted` continues to report `"unknown"` rather than `"yes"` whenever contention was seen.

This also removes the last `it.fails` marker in the codebase: the suite now runs with **no expected-fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)