### PR TITLE
fix(comfyui-fetch): a ComfyUI call with no budget of its own had no time limit

### DIFF
--- a/src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
+++ b/src/__tests__/comfyui/fetch-failure-diagnostics.test.ts
@@ -18,7 +18,7 @@
 // original message survives at the FRONT of the expansion: transient-error
 // matchers elsewhere test for /fetch failed/.
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../config.js", () => ({
   getComfyUIAuthHeaders: () => ({}),
@@ -238,5 +238,100 @@ describe("#952: a headless failure names the connected panel's origin", () => {
   it("does not crash on an unparsable target", async () => {
     setConnectedPanelOrigins(() => ["http://192.168.1.50:8188"]);
     expect(await failureText("not-a-url")).toContain("ECONNREFUSED");
+  });
+});
+
+// A ComfyUI call that brought no budget of its own had NO time limit at all:
+// comfyuiFetch passed `init` straight to fetch, so a host that accepts the
+// connection and never answers left the request pending forever. Thirteen of
+// twenty-five call sites were in that state, including /prompt, /queue,
+// /object_info and the Manager API — the same defect #1026 hit in the skill
+// generator, which bounded three calls and left these.
+describe("comfyuiFetch bounds a call that brought no budget", () => {
+  afterEach(() => {
+    delete process.env.COMFYUI_MCP_HTTP_TIMEOUT_S;
+  });
+
+  it("supplies a signal when the caller passed none", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+    await comfyuiFetch("http://127.0.0.1:8188/queue");
+    expect((spy.mock.calls.at(-1)![1] as RequestInit).signal).toBeInstanceOf(AbortSignal);
+  });
+
+  // The caller's own budget is the informed one — 8s for the template listing,
+  // and so on. Ours must never shorten or replace it.
+  it("NEVER overrides a caller's own signal", async () => {
+    const mine = AbortSignal.timeout(5_000);
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+    await comfyuiFetch("http://127.0.0.1:8188/queue", { signal: mine });
+    expect((spy.mock.calls.at(-1)![1] as RequestInit).signal).toBe(mine);
+  });
+
+  it("keeps auth headers while adding the signal", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+    await comfyuiFetch("http://127.0.0.1:8188/queue", { headers: { "X-Mine": "1" } });
+    const init = spy.mock.calls.at(-1)![1] as RequestInit;
+    expect(new Headers(init.headers).get("X-Mine")).toBe("1");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("a nonsense env value does not disable the ceiling", async () => {
+    for (const bad of ["0", "-1", "abc", ""]) {
+      process.env.COMFYUI_MCP_HTTP_TIMEOUT_S = bad;
+      const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+      await comfyuiFetch("http://127.0.0.1:8188/queue");
+      expect((spy.mock.calls.at(-1)![1] as RequestInit).signal, bad).toBeInstanceOf(AbortSignal);
+      vi.restoreAllMocks();
+    }
+  });
+});
+
+describe("a ComfyUI timeout says what it did NOT establish", () => {
+  beforeEach(() => vi.unstubAllGlobals());
+  function timeoutError(): Error {
+    const err = new Error("The operation was aborted due to timeout");
+    err.name = "TimeoutError";
+    return err;
+  }
+
+  it("does not read a GET timeout as a refusal or a missing resource", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(timeoutError());
+    const err = await comfyuiFetch("http://127.0.0.1:8188/queue").catch((e) => e);
+    const text = String((err as Error).message);
+    expect(text).toContain("Nothing was learned about the server");
+    expect(text).toContain("not a refusal");
+    expect((err as { code?: string }).code).toBe("COMFYUI_HTTP_TIMEOUT");
+  });
+
+  // THE case that matters. /prompt may have queued the render before the reply
+  // was lost, so calling this a failure would invite a retry that queues twice.
+  it("calls a MUTATING timeout OUTCOME UNKNOWN, not a failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(timeoutError());
+    const err = await comfyuiFetch("http://127.0.0.1:8188/prompt", { method: "POST" }).catch(
+      (e) => e,
+    );
+    const text = String((err as Error).message);
+    expect(text).toContain("OUTCOME UNKNOWN");
+    expect(text).toContain("do NOT");
+    expect(text).toContain("queue (action:\"list\")");
+    expect(text).not.toContain("Nothing was learned");
+  });
+
+  it("names the target and the method", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(timeoutError());
+    const err = await comfyuiFetch("http://gpu.local:8188/object_info").catch((e) => e);
+    expect(String((err as Error).message)).toContain("http://gpu.local:8188/object_info");
+    expect(String((err as Error).message)).toContain("(GET)");
+  });
+
+  // A caller who set their OWN deadline gets their own abort back untouched —
+  // rewriting it as our ceiling would misattribute whose budget expired.
+  it("leaves a CALLER's abort exactly as it was", async () => {
+    const original = timeoutError();
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(original);
+    const err = await comfyuiFetch("http://127.0.0.1:8188/queue", {
+      signal: AbortSignal.timeout(5_000),
+    }).catch((e) => e);
+    expect(err).toBe(original);
   });
 });

--- a/src/__tests__/comfyui/fetch.test.ts
+++ b/src/__tests__/comfyui/fetch.test.ts
@@ -21,10 +21,17 @@ describe("comfyuiFetch", () => {
     vi.unstubAllGlobals();
   });
 
-  it("is a passthrough when no auth is configured", async () => {
+  // Passthrough for everything the caller supplied — plus a timeout ceiling the
+  // caller did not. A call with no signal previously had NO limit at all and
+  // could hang forever against a host that accepts the connection and never
+  // answers; `init.signal` still always wins (see fetch-failure-diagnostics).
+  it("passes the caller's init through when no auth is configured", async () => {
     authHeaders.mockReturnValue({});
     await comfyuiFetch("http://comfy/prompt", { method: "POST" });
-    expect(fetchMock).toHaveBeenCalledWith("http://comfy/prompt", { method: "POST" });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://comfy/prompt");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
   });
 
   it("injects the configured auth header", async () => {

--- a/src/__tests__/tools/prompt-director.test.ts
+++ b/src/__tests__/tools/prompt-director.test.ts
@@ -24,12 +24,13 @@ describe('get_workflow (action:"prompt_director") inspection', () => {
 
     const result = await promptDirectorInspectAction("42");
 
-    // Routed through comfyuiFetch now (so CF Access / COMFYUI_AUTH_* headers reach
-    // this endpoint too); with no auth configured it calls fetch(url, {}).
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:8188/prompt_director/inspection?node_id=42",
-      {},
-    );
+    // Routed through comfyuiFetch (so CF Access / COMFYUI_AUTH_* headers reach
+    // this endpoint too). With no auth configured the only thing added is the
+    // timeout ceiling: this call passes no signal of its own, and before that
+    // ceiling existed it could wait forever on a host that never answers.
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:8188/prompt_director/inspection?node_id=42");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
     expect(result.content[0].text).toContain('"node_id": "42"');
     expect(result.content[0].text).toContain("prompt_director_auto");
   });

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -115,6 +115,78 @@ function describeComfyFetchFailure(err: unknown, target: string): Error {
 }
 
 /**
+ * A last-resort ceiling on a ComfyUI HTTP call that brought no budget of its own.
+ *
+ * `comfyuiFetch` passed `init` straight to `fetch`, so a call with no signal had
+ * NO time limit at all: a host that accepts the connection and then never
+ * answers — a stalled reverse proxy, a black-holed route, a ComfyUI wedged
+ * mid-request — left it pending forever. Thirteen of the twenty-five call sites
+ * were in that state, including `/prompt`, `/queue`, `/object_info` and the
+ * Manager API. This is the same defect #1026 hit in the skill generator; that
+ * fix bounded three calls, and this bounds the rest.
+ *
+ * DELIBERATELY GENEROUS. Every caller that knows its own budget already passes a
+ * signal (8s for the template listing, and so on) and keeps it — `init.signal`
+ * always wins. This value only has to be shorter than "forever" and longer than
+ * any healthy request: `/object_info` on a large custom-node install is
+ * legitimately slow, and a ceiling that fires on a working server would be a
+ * worse bug than the one being fixed.
+ *
+ * SAFE TO APPLY BROADLY because of what does NOT come through here: uploads and
+ * `/view` go through the client library's own `fetchApi`, and model downloads
+ * have their own streaming path. Every comfyuiFetch site is a small JSON API
+ * request.
+ */
+const DEFAULT_COMFY_HTTP_TIMEOUT_S = 120;
+
+function comfyHttpTimeoutSeconds(): number {
+  const raw = Number(process.env.COMFYUI_MCP_HTTP_TIMEOUT_S);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_COMFY_HTTP_TIMEOUT_S;
+}
+
+function defaultComfyTimeoutSignal(): AbortSignal {
+  return AbortSignal.timeout(Math.round(comfyHttpTimeoutSeconds() * 1000));
+}
+
+/** True for an abort raised by AbortSignal.timeout (not a caller's own abort). */
+function isTimeoutAbort(err: unknown): boolean {
+  return err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError");
+}
+
+/**
+ * Say what the ceiling did and did NOT establish.
+ *
+ * The critical distinction is the METHOD. A GET that times out learned nothing
+ * about the server's state. A POST that times out is OUTCOME UNKNOWN — `/prompt`
+ * may well have queued the render before the reply was lost — and reporting that
+ * as a failure would invite a retry that queues it twice. Neither may be
+ * described as "the server is down".
+ */
+function describeComfyTimeout(input: string | URL | Request, init: RequestInit): Error {
+  const target = targetOf(input);
+  const method = String(
+    init.method ?? (input instanceof Request ? input.method : "GET"),
+  ).toUpperCase();
+  const seconds = comfyHttpTimeoutSeconds();
+  const mutating = method !== "GET" && method !== "HEAD";
+  const err = new Error(
+    `No reply from ComfyUI within ${seconds}s — while requesting ${target} (${method}). ` +
+      (mutating
+        ? `OUTCOME UNKNOWN: this request may already have been received and acted on, so do NOT ` +
+          `blindly re-issue it — check the server's state first (for a queued prompt, queue ` +
+          `(action:"list") and get_history (action:"list")). `
+        : `Nothing was learned about the server from this — a timeout is not a refusal and not a ` +
+          `"not found". `) +
+      `The connection was accepted but no answer arrived in time, which points at the server or ` +
+      `something between it and here rather than at the request. Confirm it is up with ` +
+      `get_system_stats (action:"health"), and raise COMFYUI_MCP_HTTP_TIMEOUT_S if this server is ` +
+      `simply slow.`,
+  );
+  (err as { code?: string }).code = "COMFYUI_HTTP_TIMEOUT";
+  return err;
+}
+
+/**
  * `fetch` wrapper for ComfyUI HTTP requests that injects the configured generic
  * auth header(s) (COMFYUI_AUTH_* — for self-hosted ComfyUI behind a reverse
  * proxy / API gateway). A no-op when no auth is configured. Explicit headers on
@@ -129,19 +201,28 @@ export async function comfyuiFetch(
   init: RequestInit = {},
 ): Promise<Response> {
   const auth = getComfyUIAuthHeaders();
+  // A CEILING, not a policy. Callers that know their own budget pass a signal
+  // and it always wins — this only covers the ones that passed none, which
+  // otherwise wait forever.
+  const signal = init.signal ?? defaultComfyTimeoutSignal();
   let request: Promise<Response>;
   if (Object.keys(auth).length === 0) {
-    request = fetch(input, init);
+    request = fetch(input, { ...init, signal });
   } else {
     const headers = new Headers(init.headers);
     for (const [name, value] of Object.entries(auth)) {
       if (!headers.has(name)) headers.set(name, value);
     }
-    request = fetch(input, { ...init, headers });
+    request = fetch(input, { ...init, headers, signal });
   }
   try {
     return await request;
   } catch (err) {
+    // Our own ceiling firing is not the same event as a caller's abort, and it
+    // must not be reported as one. Only rewrite when WE supplied the signal.
+    if (init.signal === undefined && isTimeoutAbort(err)) {
+      throw describeComfyTimeout(input, init);
+    }
     // ONLY the opaque undici failure is rewritten. An AbortError, a timeout with
     // its own message, or anything else already says what happened, and
     // replacing that text would be a downgrade.


### PR DESCRIPTION
Follow-on from #1026, found while fixing it and deliberately deferred at the time.

## The defect

`comfyuiFetch` passed `init` straight to `fetch`, so a call that supplied no `AbortSignal` had **no limit at all**. A host that accepts the connection and then never answers — a stalled reverse proxy, a black-holed route, a ComfyUI wedged mid-request — left it pending forever: no error, no result, nothing for the caller to act on, and an agent turn that cannot end.

**13 of the 25 call sites** were in that state, including `/prompt`, `/queue`, `/object_info` and the whole ComfyUI-Manager API. #1026 was this same defect in the skill generator; that fix bounded three calls and left these.

## A ceiling, not a policy

Callers that know their own budget already pass a signal (8s for the template listing, and so on) and **keep it** — `init.signal` always wins. The default only has to be shorter than *forever* and longer than any healthy request, so it is deliberately generous at **120s** (`COMFYUI_MCP_HTTP_TIMEOUT_S`): `/object_info` on a large custom-node install is legitimately slow, and a ceiling that fires on a working server would be a worse bug than the one being fixed. A nonsense env value falls back to the default rather than disabling the bound.

## Why it is safe to apply this broadly

I checked what does **not** come through here before touching it: uploads and `/view` go through the client library's own `fetchApi`, and model downloads have their own streaming path. Every `comfyuiFetch` site is a small JSON API request — there is no large-transfer caller to starve.

## The method is the distinction that matters

| | message |
|---|---|
| **GET** | *Nothing was learned about the server from this — a timeout is not a refusal and not a "not found".* |
| **POST** | *OUTCOME UNKNOWN: this request may already have been received and acted on, so do NOT blindly re-issue it* — with `queue (action:"list")` / `get_history` named as the way to check |

That second row is the one that earns its keep: `/prompt` may well have queued the render before the reply was lost, and calling that a failure invites a retry that queues it **twice**.

Only *our* ceiling is rewritten. A caller's own abort is re-thrown by identity — misattributing whose budget expired would be the same defect one level up.

## Two existing tests updated

Both asserted the old exact-`init` contract: the passthrough test now checks the caller's init survives *and* a ceiling was added, and prompt-director's asserted `fetch(url, {})` and now reads the call. Neither weakened — both got more specific.

Worth flagging for anyone adding tests to `fetch-failure-diagnostics.test.ts`: earlier tests there use `vi.stubGlobal("fetch", …)`, which `restoreAllMocks()` does **not** undo, so a later `vi.spyOn` inherits the leftover mock's recorded calls and `calls[0]` is someone else's. Cost me two confusing failures; the new tests `unstubAllGlobals()` and read `calls.at(-1)`.

9 tests, both halves mutation-verified (3 each). Full suite green: 341 files, 7165 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)