### PR TITLE
0.50.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.11] - 2026-08-07
+
+### MCP
+
+#### Added
+- tool-reach corpus for the consolidated 37-tool surface (#1003)
+
+#### Fixed
+- a ComfyUI call with no budget of its own had no time limit (#1033)
+
+
 ## [0.50.10] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.10",
+  "version": "0.50.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.10",
+      "version": "0.50.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.10",
+  "version": "0.50.11",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.11` tag (the tag publishes to npm; protected `main` needs this PR).

### Fixed
- **comfyui-fetch** — a ComfyUI call with no budget of its own had no time limit (#1033). `comfyuiFetch` passed `init` straight to `fetch`, so 13 of 25 call sites — including `/prompt`, `/queue`, `/object_info` and the Manager API — could wait **forever** against a host that accepts the connection and never answers. There is now a generous 120s ceiling (`COMFYUI_MCP_HTTP_TIMEOUT_S`) that applies only when the caller supplied no signal of its own, and a timeout on a mutating request is reported as **outcome unknown** rather than a failure, since `/prompt` may have queued the render before the reply was lost.

### Added
- **benchmarks** — tool-reach corpus for the consolidated 37-tool surface (#1003).

Found while fixing #1026, which was the same defect in the skill generator: that release bounded three calls, this one bounds the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)