### PR TITLE
fix(model-explorer): talk to the SAME ComfyUI as every other tool

### DIFF
--- a/src/__tests__/tools/model-explorer-comfy-target.test.ts
+++ b/src/__tests__/tools/model-explorer-comfy-target.test.ts
@@ -1,0 +1,111 @@
+// model_metadata talked to a DIFFERENT ComfyUI than every other tool.
+//
+// `comfyBase()` re-derived the address from raw env — `COMFYUI_URL`, else
+// `COMFYUI_PORT` on loopback, else 127.0.0.1:8188 — while the rest of the
+// codebase resolves it through `getComfyUIBaseUrl()`. Those disagree on three
+// counts, each of which breaks a real deployment:
+//
+//   - PROTOCOL: an https ComfyUI (config.comfyuiSsl) was addressed as http.
+//   - HOST:     the config-resolved host was ignored in favour of raw env.
+//   - BASE PATH: a reverse-proxied install (`/comfyapi`) had its prefix dropped,
+//                so every request 404'd against the proxy.
+//
+// And because the calls used bare `fetch`, they carried no COMFYUI_AUTH_*
+// headers either — so an authenticated ComfyUI rejected them outright. That is
+// exactly the class of deployment #952 and #954 were about, and this tool was
+// never migrated with the others.
+//
+// They also inherited no timeout, which #1033's ceiling now supplies.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const cfg = vi.hoisted(() => ({
+  comfyuiBasePath: "",
+  comfyuiSsl: false,
+  comfyuiHost: "127.0.0.1",
+  comfyuiPort: 8188,
+}));
+
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return {
+    ...actual,
+    isRemoteMode: () => false,
+    getComfyUIBaseUrl: () =>
+      `${cfg.comfyuiSsl ? "https" : "http"}://${cfg.comfyuiHost}:${cfg.comfyuiPort}${cfg.comfyuiBasePath}`,
+    getComfyUIAuthHeaders: () => ({ Authorization: "Bearer test-token" }),
+    config: { ...actual.config, huggingfaceToken: undefined },
+  };
+});
+
+const { registerModelExplorerTools } = await import("../../tools/model-explorer.js");
+
+/** Capture the tool handlers the server registers. */
+function collect(): Map<string, (args: Record<string, unknown>) => Promise<unknown>> {
+  const tools = new Map<string, (args: Record<string, unknown>) => Promise<unknown>>();
+  const server = {
+    tool: (name: string, _d: unknown, _s: unknown, handler: (a: Record<string, unknown>) => Promise<unknown>) => {
+      tools.set(name, handler);
+    },
+  } as unknown as Parameters<typeof registerModelExplorerTools>[0];
+  registerModelExplorerTools(server);
+  return tools;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  cfg.comfyuiBasePath = "";
+  cfg.comfyuiSsl = false;
+  cfg.comfyuiHost = "127.0.0.1";
+  cfg.comfyuiPort = 8188;
+  fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ classify: {}, namespaces: {} }), { status: 200 }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function readOnce(): Promise<void> {
+  const read = collect().get("model_metadata")!;
+  await read({ action: "read", category: "loras", name: "x.safetensors" });
+}
+
+describe("model_metadata addresses the SAME ComfyUI as every other tool", () => {
+  it("honours the reverse-proxy base path", async () => {
+    cfg.comfyuiBasePath = "/comfyapi";
+    await readOnce();
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/comfyapi/model_explorer/detail");
+  });
+
+  it("honours https", async () => {
+    cfg.comfyuiSsl = true;
+    await readOnce();
+    expect(String(fetchMock.mock.calls[0][0])).toMatch(/^https:\/\//);
+  });
+
+  it("honours the configured host and port", async () => {
+    cfg.comfyuiHost = "gpu.local";
+    cfg.comfyuiPort = 9999;
+    await readOnce();
+    expect(String(fetchMock.mock.calls[0][0])).toContain("http://gpu.local:9999/");
+  });
+
+  // The auth gap. Going through comfyuiFetch is what injects COMFYUI_AUTH_*;
+  // a bare fetch reached an authenticated ComfyUI with no credentials at all.
+  it("sends the configured auth header", async () => {
+    await readOnce();
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(new Headers(init.headers).get("Authorization")).toBe("Bearer test-token");
+  });
+
+  // #1033's ceiling rides along, so these can no longer wait forever.
+  it("carries a timeout", async () => {
+    await readOnce();
+    expect((fetchMock.mock.calls[0][1] as RequestInit).signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -221,7 +221,10 @@ export async function searchHuggingFaceModels(
   const url = applyHfEndpoint(`https://huggingface.co/api/models?${params}`);
   logger.debug("HuggingFace API request", { url });
 
-  const res = await fetch(url, { headers });
+  // Third-party API: bound the wait so a stalled response cannot wedge the
+  // turn. Same class as #1026 — an unbounded metadata call has no limit at
+  // all and hangs until the caller gives up.
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(20_000) });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new ModelError(

--- a/src/services/registry-client.ts
+++ b/src/services/registry-client.ts
@@ -49,7 +49,10 @@ async function registryFetch<T>(path: string): Promise<T> {
   const url = `${REGISTRY_BASE}${path}`;
   logger.debug("Registry API request", { url });
 
-  const res = await fetch(url);
+  // Third-party API: bound the wait so a stalled response cannot wedge the
+  // turn. Same class as #1026 — an unbounded metadata call has no limit at
+  // all and hangs until the caller gives up.
+  const res = await fetch(url, { signal: AbortSignal.timeout(20_000) });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new RegistryError(

--- a/src/tools/missing-models.ts
+++ b/src/tools/missing-models.ts
@@ -58,6 +58,8 @@ async function hfRepoFiles(repoId: string): Promise<Array<{ filename: string; si
     // reading process.env.HF_TOKEN directly made a token saved after this
     // process started invisible here, while the save reported live pickup.
     headers: hfToken ? { authorization: `Bearer ${hfToken}` } : undefined,
+    // Third-party API: bound the wait (same class as #1026).
+    signal: AbortSignal.timeout(20_000),
   });
   if (!res.ok) return [];
   const body = (await res.json()) as Array<{ type?: string; path?: string; size?: number }>;

--- a/src/tools/model-explorer.ts
+++ b/src/tools/model-explorer.ts
@@ -8,14 +8,22 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { open, readFile } from "node:fs/promises";
 import { errorToToolResult } from "../utils/errors.js";
-import { isRemoteMode } from "../config.js";
+import { getComfyUIBaseUrl, isRemoteMode } from "../config.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 import { resolveExistingModelFile } from "../services/model-resolver.js";
 
+/**
+ * The connected ComfyUI's base URL.
+ *
+ * This used to re-derive the address from raw env (`COMFYUI_URL` / `COMFYUI_PORT`,
+ * else loopback:8188), which silently disagreed with the resolver every other
+ * caller uses on three counts: it ignored the configured PROTOCOL (an https
+ * ComfyUI got http), the config-resolved HOST, and the BASE PATH that a
+ * reverse-proxied install needs (`/comfyapi`). So model_metadata pointed at the
+ * wrong address on exactly the deployments #952 and #954 were about.
+ */
 function comfyBase(): string {
-  return (
-    process.env.COMFYUI_URL ||
-    (process.env.COMFYUI_PORT ? `http://127.0.0.1:${process.env.COMFYUI_PORT}` : "http://127.0.0.1:8188")
-  ).replace(/\/$/, "");
+  return getComfyUIBaseUrl().replace(/\/$/, "");
 }
 
 const okText = (value: unknown) => ({
@@ -54,7 +62,11 @@ export async function fetchCivitaiVersionDirect(
   versionId: number,
 ): Promise<Record<string, unknown> | null> {
   try {
-    const res = await fetch(`https://civitai.com/api/v1/model-versions/${versionId}`);
+    const res = await fetch(`https://civitai.com/api/v1/model-versions/${versionId}`, {
+      // CivitAI is a third party: bound the wait so a stalled response cannot
+      // wedge the turn (same class as #1026).
+      signal: AbortSignal.timeout(15_000),
+    });
     if (!res || !res.ok) return null;
     const v = (await res.json()) as any;
     const modelId = v?.modelId ?? null;
@@ -342,7 +354,7 @@ export function registerModelExplorerTools(server: McpServer): void {
             const { category, name } = requireCategoryName("read");
             const COMFY = comfyBase();
             const q = `category=${encodeURIComponent(category)}&name=${encodeURIComponent(name)}`;
-            const dr = await fetch(`${COMFY}/model_explorer/detail?${q}`);
+            const dr = await comfyuiFetch(`${COMFY}/model_explorer/detail?${q}`);
             if (!dr.ok) {
               const body = await readBodyText(dr);
               // #363: make an absent optional route a structured unavailable
@@ -368,7 +380,7 @@ export function registerModelExplorerTools(server: McpServer): void {
             const detail = (await dr.json()) as any;
             let tags = null;
             try {
-              const tr = await fetch(`${COMFY}/model_explorer/suggest_triggers?${q}`);
+              const tr = await comfyuiFetch(`${COMFY}/model_explorer/suggest_triggers?${q}`);
               if (tr.ok) tags = ((await tr.json()) as any).candidates;
             } catch { /* optional */ }
             return okText({
@@ -390,7 +402,7 @@ export function registerModelExplorerTools(server: McpServer): void {
               );
             }
             const COMFY = comfyBase();
-            const r = await fetch(`${COMFY}/model_explorer/proposal`, {
+            const r = await comfyuiFetch(`${COMFY}/model_explorer/proposal`, {
               method: "POST",
               headers: { "content-type": "application/json" },
               body: JSON.stringify({ category, name, fields: args.fields, note: args.note }),
@@ -413,7 +425,7 @@ export function registerModelExplorerTools(server: McpServer): void {
             const q =
               `category=${encodeURIComponent(category)}&name=${encodeURIComponent(name)}` +
               (hasVersionId ? `&version_id=${args.version_id}` : "");
-            const r = await fetch(`${COMFY}/model_explorer/civitai?${q}`);
+            const r = await comfyuiFetch(`${COMFY}/model_explorer/civitai?${q}`);
             if (r.ok) return okText(await r.json());
             const body = await readBodyText(r);
             // #541: the node route is unavailable. Degrade instead of hard-failing.


### PR DESCRIPTION
Found by auditing the remaining unbounded network calls after #1033. The timeout is what I went looking for; **the wrong-target and missing-auth bugs are what the audit actually turned up**, and they're the more serious half.

## model_metadata was addressing a different server

It resolved ComfyUI itself:

```ts
process.env.COMFYUI_URL
  || (COMFYUI_PORT ? `http://127.0.0.1:${COMFYUI_PORT}` : "http://127.0.0.1:8188")
```

while every other caller goes through `getComfyUIBaseUrl()`. They disagree on three counts, each breaking a real deployment:

| | env-derived | `getComfyUIBaseUrl()` |
|---|---|---|
| **protocol** | always `http` | honours `config.comfyuiSsl` |
| **host** | raw env only | config-resolved |
| **base path** | dropped | `/comfyapi` for a reverse-proxied install |

And because the four calls used bare `fetch` rather than `comfyuiFetch`, they carried **no `COMFYUI_AUTH_*` headers** — an authenticated ComfyUI rejected them outright.

This is exactly the class of deployment #952 and #954 were about. This tool was simply never migrated with the others.

**A timeout wastes a turn; a wrong address returns a confident 404 about a server that was answering fine all along.** That's why this matters more than the thing I was looking for.

## Also bounded

Three third-party metadata calls that had no limit at all — same class as #1026:

- the ComfyUI Registry lookup (`registry-client`)
- the HuggingFace model search (`model-resolver`)
- the HuggingFace tree listing behind `missing-models`

**Left alone deliberately:** model downloads and storage uploads. Those are legitimately long-running and have their own streaming paths — putting a ceiling on them would be the bug, not the fix.

## Tests

5, driving the real registered `model_metadata` handler against a mocked config: reverse-proxy base path, https, configured host/port, the auth header, and the timeout. Both halves mutation-verified — reverting the resolver fails 3, reverting to bare `fetch` fails 2.

Full suite green: 342 files, 7170 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)