### PR TITLE
0.50.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.12] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- talk to the SAME ComfyUI as every other tool (#1035)
+
+
 ## [0.50.11] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.11",
+  "version": "0.50.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.11",
+      "version": "0.50.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.11",
+  "version": "0.50.12",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.12` tag (the tag publishes to npm; protected `main` needs this PR).

### Fixed
- **model-explorer** — talk to the same ComfyUI as every other tool (#1035). `model_metadata` re-derived the server address from raw env instead of `getComfyUIBaseUrl()`, so it ignored the configured protocol (an https ComfyUI was addressed as http), the config-resolved host, and the reverse-proxy base path — and, using bare `fetch`, sent no `COMFYUI_AUTH_*` headers, so an authenticated ComfyUI rejected it outright. Same class of deployment as #952/#954; this tool was never migrated with the others.

  Also bounds three third-party metadata calls that had no timeout at all (ComfyUI Registry, HuggingFace search, HuggingFace tree). Model downloads and storage uploads are deliberately untouched — they're legitimately long-running.

Found by auditing what remained unbounded after 0.50.11. The timeout was the thing I went looking for; the wrong-target and missing-auth bugs are what the audit turned up, and they matter more — a timeout wastes a turn, a wrong address returns a confident 404 about a server that was answering fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)