### PR TITLE
fix(orchestrator): bound the four process probes that can wedge startup

### DIFF
--- a/src/__tests__/services/process-probe-timeouts.test.ts
+++ b/src/__tests__/services/process-probe-timeouts.test.ts
@@ -1,0 +1,99 @@
+// A SYNCHRONOUS subprocess that hangs blocks the whole event loop — no bridge
+// traffic, no agent turns, nothing. That is strictly worse than a hung fetch,
+// which at least only wedges its own caller.
+//
+// The codebase already knows this: port-owner.ts times out its `lsof` and
+// `netstat`, and process-control.ts its `tasklist`. But orchestrator/index.ts
+// grew its own copies of all four inspections (netstat / lsof / tasklist / ps)
+// with no timeout at all, on the startup-and-takeover path — precisely where
+// being stuck is indistinguishable from being broken. `lsof` is the known
+// offender, stalling on unreachable network mounts.
+//
+// Those four are fixed. This test exists so the NEXT ad-hoc copy is caught by
+// CI rather than by a user whose orchestrator will not start: the functions in
+// question are private to a 5,000-line module that no test boots, so a
+// source-level gate is the only thing that can hold this line.
+//
+// DELIBERATELY NOT COVERED: process KILLS (taskkill /T /F, pkill, kill). Not one
+// of them carries a timeout anywhere in the codebase, and that is a consistent
+// posture rather than an oversight — a kill is fire-and-forget cleanup, and
+// there is no useful thing to do if it stalls. Requiring a timeout there would
+// be inventing a convention, not enforcing one.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { globSync } from "node:fs";
+
+/** This file lives at src/__tests__/services, so two levels up IS src/. */
+const SRC = join(import.meta.dirname, "..", "..");
+
+/** Commands that INSPECT the machine: they answer a question and can block. */
+const INSPECTION = ["netstat", "lsof", "tasklist", "wmic", "Get-NetTCPConnection"];
+
+/** Balanced-paren argument text for a call starting at `from`. */
+function argsOf(text: string, from: number): string {
+  let depth = 0;
+  for (let i = from; i < Math.min(text.length, from + 4000); i++) {
+    const ch = text[i];
+    if (ch === "(") depth++;
+    else if (ch === ")") {
+      if (depth === 0) return text.slice(from, i);
+      depth--;
+    }
+  }
+  return "";
+}
+
+function sourceFiles(): string[] {
+  return globSync("**/*.ts", { cwd: SRC })
+    .filter((p) => !p.includes("__tests__") && !p.endsWith(".test.ts"))
+    .map((p) => join(SRC, p));
+}
+
+describe("every synchronous process INSPECTION carries a timeout", () => {
+  it("finds no unbounded netstat/lsof/tasklist/wmic call", () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      const text = readFileSync(file, "utf-8");
+      for (const m of text.matchAll(/\b(execSync|execFileSync|spawnSync)\(/g)) {
+        const args = argsOf(text, m.index! + m[0].length);
+        // `ps` is excluded from the name list on purpose: it appears inside far
+        // too many identifiers to match on safely. It is covered by the
+        // dedicated assertion below.
+        if (!INSPECTION.some((cmd) => args.includes(cmd))) continue;
+        if (/\btimeout\s*:/.test(args)) continue;
+        const line = text.slice(0, m.index!).split("\n").length;
+        offenders.push(`${file.slice(SRC.length + 1)}:${line}`);
+      }
+    }
+    expect(offenders, `unbounded process inspection(s):\n  ${offenders.join("\n  ")}`).toEqual([]);
+  });
+
+  // The POSIX sibling of the tasklist probe, matched precisely so the loop above
+  // does not have to guess at the two-letter name.
+  it("finds no unbounded `ps` process-name lookup", () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      const text = readFileSync(file, "utf-8");
+      for (const m of text.matchAll(/\b(execSync|execFileSync|spawnSync)\(\s*["'`]ps["'`]/g)) {
+        const args = argsOf(text, text.indexOf("(", m.index!) + 1);
+        if (/\btimeout\s*:/.test(args)) continue;
+        offenders.push(`${file.slice(SRC.length + 1)}:${text.slice(0, m.index!).split("\n").length}`);
+      }
+    }
+    expect(offenders, `unbounded ps lookup(s):\n  ${offenders.join("\n  ")}`).toEqual([]);
+  });
+
+  // The gate is only worth having if it can actually fail — a scanner that
+  // matches nothing would pass forever and protect nothing.
+  it("actually inspects the files it claims to", () => {
+    const files = sourceFiles();
+    expect(files.length).toBeGreaterThan(100);
+    const withInspection = files.filter((f) => {
+      const t = readFileSync(f, "utf-8");
+      return INSPECTION.some((cmd) => t.includes(cmd));
+    });
+    expect(withInspection.length).toBeGreaterThan(0);
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -551,11 +551,32 @@ function portKillHint(port: number): string {
     : `To free the port manually:\n  bash/zsh:    ${sh}\n  PowerShell:  ${ps}`;
 }
 
+
+/**
+ * PROBE TIMEOUT. These four inspections run SYNCHRONOUSLY, so a command that
+ * hangs blocks the whole event loop — no bridge traffic, no agent turns,
+ * nothing — and they run on the startup/takeover path where being stuck is
+ * indistinguishable from being broken. `lsof` is the known offender (it stalls
+ * on unreachable network mounts), and `netstat` is slow on a busy host.
+ *
+ * 5s matches what the rest of the codebase already uses for these EXACT
+ * commands — port-owner.ts times out its `lsof`/`netstat` and process-control.ts
+ * its `tasklist`. These copies simply never got it.
+ *
+ * Timing out costs nothing in correctness: both callers already fail closed on
+ * a throw (null / "unknown"), and both READ that as "could not determine" —
+ * pidListeningOnPort's null makes the caller decline to claim a takeover rather
+ * than assert the port is free.
+ */
+const PORT_PROBE_TIMEOUT_MS = 5000;
 /** Resolve which pid is LISTENING on a local TCP port (null if none/unknown). */
 function pidListeningOnPort(port: number): number | null {
   try {
     if (process.platform === "win32") {
-      const out = execFileSync("netstat", ["-ano", "-p", "tcp"], { encoding: "utf8" });
+      const out = execFileSync("netstat", ["-ano", "-p", "tcp"], {
+        encoding: "utf8",
+        timeout: PORT_PROBE_TIMEOUT_MS,
+      });
       for (const line of out.split(/\r?\n/)) {
         const m = line.match(/TCP\s+\S+:(\d+)\s+\S+\s+LISTENING\s+(\d+)\s*$/i);
         if (m && Number(m[1]) === port) return Number(m[2]);
@@ -564,6 +585,7 @@ function pidListeningOnPort(port: number): number | null {
     }
     const out = execFileSync("lsof", ["-ti", `tcp:${port}`, "-s", "tcp:LISTEN"], {
       encoding: "utf8",
+      timeout: PORT_PROBE_TIMEOUT_MS,
     });
     const pid = Number(out.trim().split(/\s+/)[0]);
     return Number.isInteger(pid) && pid > 0 ? pid : null;
@@ -578,11 +600,15 @@ function processNameOf(pid: number): string {
     if (process.platform === "win32") {
       const out = execFileSync("tasklist", ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"], {
         encoding: "utf8",
+        timeout: PORT_PROBE_TIMEOUT_MS,
       });
       return /^"([^"]+)"/m.exec(out)?.[1] ?? "unknown";
     }
     return (
-      execFileSync("ps", ["-p", String(pid), "-o", "comm="], { encoding: "utf8" }).trim() ||
+      execFileSync("ps", ["-p", String(pid), "-o", "comm="], {
+        encoding: "utf8",
+        timeout: PORT_PROBE_TIMEOUT_MS,
+      }).trim() ||
       "unknown"
     );
   } catch {


### PR DESCRIPTION
Completes the unbounded-wait audit (after #1033 and #1035) with the worst class: a **synchronous** subprocess that hangs blocks the entire event loop, not just its own caller.

## The defect

`pidListeningOnPort` and `processNameOf` run `netstat`, `lsof`, `tasklist` and `ps` with **no timeout**, on the startup/takeover path — precisely where being stuck is indistinguishable from being broken. `lsof` is the known offender (stalls on unreachable network mounts); `netstat` is slow on a busy host.

## This is a gap, not a judgement call

The codebase already times out these **exact commands** elsewhere:

| where | command | timeout |
|---|---|---|
| `port-owner.ts` | `lsof`, `netstat` | 5s |
| `process-control.ts` | `tasklist` (identical query) | 5s |
| `orchestrator/index.ts` | all four | **none** |

`index.ts` grew its own copies without it. All four now use the same 5s.

## Correctness is unchanged

Both functions already fail closed on a throw (`null` / `"unknown"`), and both **callers** read that as *could not determine* rather than as a negative — `pidListeningOnPort`'s `null` makes the caller decline to claim a takeover, never assert the port is free. A timeout is just one more way to not know, landing on a path that already handles not knowing. (I checked that before touching it; had `null` rendered as "nothing is listening", this would have been a bigger fix.)

## What I deliberately did NOT change

**Process kills** — `taskkill /T /F`, `pkill`. Not one carries a timeout anywhere in this codebase, and that is a *consistent posture*, not an oversight: a kill is fire-and-forget cleanup and there is nothing useful to do if it stalls. Requiring one there would be inventing a convention rather than enforcing one.

That check is what kept this small. 11 of 52 synchronous subprocess calls lack a timeout; only these 4 are defects.

## The guard

These functions are private to a 5,000-line module that no test boots, so the test is a **source-level convention gate**: it scans `src/` for synchronous inspection calls missing a timeout and names the file and line.

Two things make it worth having:

- **It can fail.** Removing one timeout fails it with `orchestrator\index.ts:576`.
- **It inspects what it claims.** An earlier draft resolved its own root wrongly, globbed `src/src`, scanned **zero** files and passed cleanly. Its own self-check caught that — which is the entire reason that third assertion exists, and worth copying into any future scanner-style test.

Full suite green: 343 files, 7173 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)