### PR TITLE
0.50.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.13] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- bound the four process probes that can wedge startup (#1038)
+
+
 ## [0.50.12] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.12",
+  "version": "0.50.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.12",
+      "version": "0.50.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.12",
+  "version": "0.50.13",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.13` tag (the tag publishes to npm; protected `main` needs this PR).

### Fixed
- **orchestrator** — bound the four process probes that can wedge startup (#1038). `pidListeningOnPort` and `processNameOf` ran `netstat`, `lsof`, `tasklist` and `ps` **synchronously with no timeout**, on the startup/takeover path. A hang there blocks the entire event loop — no bridge traffic, no agent turns — and `lsof` is a known staller on unreachable network mounts. The codebase already bounds these exact commands at 5s in `port-owner.ts` and `process-control.ts`; `index.ts` grew its own copies without it.

  Ships with a source-level gate so the next ad-hoc copy fails CI instead of a user's startup. Process **kills** are deliberately left unbounded — that's a consistent posture across the codebase, not an oversight.

This completes the unbounded-wait audit that ran through 0.50.11 (every ComfyUI HTTP call) and 0.50.12 (third-party metadata calls, plus the wrong-target bug that audit uncovered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)