### PR TITLE
fix(#1037): settle the linked-nested placeholder ambiguity by counting the row

### DIFF
--- a/src/__tests__/services/nested-linked-widget-arity.test.ts
+++ b/src/__tests__/services/nested-linked-widget-arity.test.ts
@@ -1,0 +1,190 @@
+// #1037 — the UI→API converter dropped a nested DYNAMICCOMBO's non-linked
+// siblings whenever one sibling was converted-to-input, and the resulting prompt
+// was missing a REQUIRED input. ComfyUI then rejected that output node and
+// carried on:
+//
+//   [ERROR] Failed to validate prompt for output 75:
+//   [ERROR]   - Required input is missing: crop
+//   [ERROR] Output will be ignored
+//   [INFO]  Prompt executed in 1.12 seconds
+//
+// ...so `queue(action:"status")` reported `success` and no video was produced.
+// Two packs we BUNDLE hit this (ltx-2.3-txt2vid, ltx-2.3-img2vid), both via the
+// same ResizeImageMaskNode.
+//
+// The refusal it came from is sound in general: a converted-to-input nested leaf
+// may or may not keep a placeholder slot in widgets_values (frontend versions
+// differ), and consuming the wrong number shifts a later widget — a seed
+// silently becoming a stray `4`. What was missing is that the whole ROW usually
+// settles which reading is true:
+//
+//   ["scale dimensions", 1920, 1088, "center", "lanczos"]     5 slots
+//   parent(1) + nested width/height/crop(3) + scale_method(1) = 5  -> retained
+//   parent(1) + nested crop(1)             + scale_method(1) = 3  -> omitted ✗
+//
+// Only one adds up, so `crop` can be read rather than dropped. Where the count
+// does NOT settle it, the refusal must survive exactly as it was — that half is
+// pinned here just as hard as the fix.
+
+import { describe, expect, it } from "vitest";
+
+import { convertUiToApi } from "../../services/workflow-converter.js";
+
+/** The reporter's node, reduced to the parts that drive the mapping. */
+function resizeNodeDef(): Record<string, unknown> {
+  return {
+    input: {
+      required: {
+        input: ["IMAGE"],
+        resize_type: [
+          "COMFY_DYNAMICCOMBO_V3",
+          {
+            options: [
+              {
+                key: "scale dimensions",
+                inputs: {
+                  required: {
+                    width: ["INT", { default: 512 }],
+                    height: ["INT", { default: 512 }],
+                    crop: [["center", "disabled"], { default: "center" }],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        scale_method: [["nearest-exact", "lanczos"], { default: "nearest-exact" }],
+      },
+    },
+  };
+}
+
+/** UI graph: width+height converted-to-input (linked), crop still a widget. */
+function graphWithLinkedNested(widgetsValues: unknown[]) {
+  return {
+    nodes: [
+      {
+        id: 1,
+        type: "PrimitiveInt",
+        widgets_values: [1920],
+        outputs: [{ name: "INT", links: [558] }],
+      },
+      {
+        id: 2,
+        type: "PrimitiveInt",
+        widgets_values: [1088],
+        outputs: [{ name: "INT", links: [559] }],
+      },
+      {
+        id: 343,
+        type: "ResizeImageMaskNode",
+        widgets_values: widgetsValues,
+        inputs: [
+          { name: "input", link: null },
+          { name: "resize_type.width", link: 558, widget: { name: "resize_type.width" } },
+          { name: "resize_type.height", link: 559, widget: { name: "resize_type.height" } },
+        ],
+      },
+    ],
+    links: [
+      [558, 1, 0, 343, 1, "INT"],
+      [559, 2, 0, 343, 2, "INT"],
+    ],
+  };
+}
+
+const OBJECT_INFO = {
+  ResizeImageMaskNode: resizeNodeDef(),
+  PrimitiveInt: { input: { required: { value: ["INT", { default: 0 }] } } },
+} as unknown as Parameters<typeof convertUiToApi>[1];
+
+function convert(widgetsValues: unknown[]) {
+  const { workflow, warnings } = convertUiToApi(
+    graphWithLinkedNested(widgetsValues) as never,
+    OBJECT_INFO,
+  );
+  return { prompt: workflow as Record<string, { inputs: Record<string, unknown> }>, warnings };
+}
+
+describe("#1037: a linked nested sibling no longer drops the rest", () => {
+  // THE reported case: placeholders retained, so 5 slots.
+  it("emits resize_type.crop instead of omitting it", () => {
+    const { prompt } = convert(["scale dimensions", 1920, 1088, "center", "lanczos"]);
+    const node = prompt["343"];
+    expect(node.inputs["resize_type.crop"]).toBe("center");
+  });
+
+  it("still maps the widget that FOLLOWS the combo", () => {
+    const { prompt } = convert(["scale dimensions", 1920, 1088, "center", "lanczos"]);
+    const node = prompt["343"];
+    // The bug dropped this too — everything after the linked leaf was refused.
+    expect(node.inputs.scale_method).toBe("lanczos");
+  });
+
+  it("does not invent values for the LINKED leaves — the link supplies those", () => {
+    const { prompt } = convert(["scale dimensions", 1920, 1088, "center", "lanczos"]);
+    const node = prompt["343"];
+    // Linked inputs are wired as [nodeId, slot] pairs, never taken from the
+    // saved array — a placeholder is stepped over, not read.
+    expect(Array.isArray(node.inputs["resize_type.width"])).toBe(true);
+    expect(Array.isArray(node.inputs["resize_type.height"])).toBe(true);
+  });
+
+  it("stops warning about values it no longer drops", () => {
+    const { warnings } = convert(["scale dimensions", 1920, 1088, "center", "lanczos"]);
+    expect(warnings.join("\n")).not.toMatch(/can't be positionally resolved/);
+  });
+
+  // The OTHER reading: a frontend that omits placeholders serializes 3 slots.
+  // Counting settles this one too, in the opposite direction.
+  it("handles a frontend that omits the placeholder slots", () => {
+    const { prompt } = convert(["scale dimensions", "center", "lanczos"]);
+    const node = prompt["343"];
+    expect(node.inputs["resize_type.crop"]).toBe("center");
+    expect(node.inputs.scale_method).toBe("lanczos");
+  });
+});
+
+describe("#1037: where counting does NOT settle it, the refusal stands", () => {
+  // A row that matches NEITHER reading (4 slots: retained needs 5, omitted 3).
+  // Guessing here is exactly how a seed gets a stray value.
+  it("refuses an ambiguous row rather than guessing", () => {
+    const { prompt, warnings } = convert(["scale dimensions", 1920, 1088, "center"]);
+    const node = prompt["343"];
+    expect(warnings.join("\n")).toMatch(/can't be positionally resolved/);
+    // The saved "center"/"lanczos" are NOT read — that is the refusal working.
+    expect(node.inputs.scale_method).not.toBe("lanczos");
+  });
+
+  // The asymmetry that made #1037 so hard to spot, pinned so it stays visible.
+  //
+  // On a refusal a TOP-LEVEL widget falls back to its schema default, which is
+  // what the warning's "left to their defaults" describes and is harmless. A
+  // NESTED key has no such fallback — nothing fills `resize_type.crop`, so it is
+  // simply ABSENT from the prompt, and ComfyUI rejects the node for a missing
+  // required input. Same refusal, two very different outcomes.
+  it("defaults the top-level widget but leaves the NESTED key absent", () => {
+    const { prompt } = convert(["scale dimensions", 1920, 1088, "center"]);
+    const node = prompt["343"];
+    expect(node.inputs.scale_method).toBe("nearest-exact"); // defaulted: benign
+    expect("resize_type.crop" in node.inputs).toBe(false); // absent: fatal
+  });
+
+  // The warning is the only signal a user gets on a refusal, and it previously
+  // described the benign half of the outcome only.
+  it("the warning names the OMITTED nested key, not just 'defaults'", () => {
+    const { warnings } = convert(["scale dimensions", 1920, 1088, "center"]);
+    const text = warnings.join("\n");
+    expect(text).toMatch(/OMITTED from the prompt/);
+    expect(text).toMatch(/reject this node and ignore its output/);
+    expect(text).toMatch(/report success with nothing produced/);
+    // And it no longer claims the whole tail is merely defaulted.
+    expect(text).not.toMatch(/are left to their defaults/);
+  });
+
+  it("keeps the parent selection even when it refuses the tail", () => {
+    const { prompt } = convert(["scale dimensions", 1920, 1088, "center"]);
+    const node = prompt["343"];
+    expect(node.inputs.resize_type).toBe("scale dimensions");
+  });
+});

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -1696,22 +1696,25 @@ describe("convertUiToApi — linked PrimitiveNode combo validation (P1-A, #504)"
       ],
       links: [[10, 2, 0, 1, 0, "FLOAT"]],
     } as never;
-    const { workflow, warnings } = convertUiToApi(ui, info);
-    // The retained placeholder must NEVER become the seed.
+    const { workflow } = convertUiToApi(ui, info);
+    // THE P0, unchanged and non-negotiable: the retained placeholder must NEVER
+    // become the seed.
     expect(workflow["1"].inputs.seed).not.toBe(4);
-    // seed falls to its schema default, not a shifted placeholder value.
-    expect(workflow["1"].inputs.seed).toBe(0);
+    // #1037 — this row is now RESOLVED rather than refused, and the seed the user
+    // actually saved survives. Counting settles it: 3 slots remain after the
+    // parent; "placeholders retained" consumes 1 and leaves 2 for seed + its
+    // control_after_generate phantom, while "omitted" would leave 3. Only one
+    // adds up, so the placeholder is stepped over and 424242 lands on seed.
+    //
+    // This assertion used to read `toBe(0)`. That was the refusal's outcome and
+    // the best answer available while the ambiguity was unresolvable — but it
+    // meant the user's seed was silently REPLACED BY ZERO, which is its own
+    // quiet data loss. Recovering 424242 is strictly better, and the guard that
+    // matters (never 4) is untouched.
+    expect(workflow["1"].inputs.seed).toBe(424242);
     // The linked nested leaf is supplied by its (PrimitiveNode) source, not the
     // retained placeholder 4.
     expect(workflow["1"].inputs["mode.multiplier"]).toBe(8);
-    expect(
-      warnings.some(
-        (w) =>
-          w.includes("1") &&
-          w.includes("mode.multiplier") &&
-          /default/.test(w),
-      ),
-    ).toBe(true);
   });
 
   it("re-anchors nested leaves when a PrimitiveNode overrides the dynamic PARENT (A -> B)", () => {

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -92,6 +92,70 @@ function isWidgetInput(
  * (a string type carrying an `options` list), and the standard scalar widget
  * types all qualify; link/list types (IMAGE, COMFY_AUTOGROW_V3, …) do not.
  */
+/**
+ * #1037 — can the linked-nested placeholder ambiguity be settled by COUNTING?
+ *
+ * When a dynamic combo's nested leaf is converted-to-input, the saved array may
+ * or may not still carry a placeholder slot for it — frontend versions differ,
+ * and the two readings are indistinguishable from the leaf alone. The converter
+ * therefore refuses the tail rather than risk shifting a later widget (a seed
+ * silently becoming a stray `4`). That refusal is right in general.
+ *
+ * But it is often over-broad, because the WHOLE row usually settles it. Given
+ * the slots still unread and the widgets still to map, exactly one reading
+ * normally adds up:
+ *
+ *   widgets_values: ["scale dimensions", 1920, 1088, "center", "lanczos"]
+ *   nested(width, height, crop) with width+height linked, then scale_method
+ *     retained  -> consumes 3, leaves 1 for scale_method   ✓
+ *     omitted   -> consumes 1, leaves 3 for scale_method   ✗
+ *
+ * So the placeholders ARE present, and `crop` can be read from its slot instead
+ * of being dropped — which is what left ltx-2.3-txt2vid queueing a prompt with
+ * no `resize_type.crop`, getting its output node ignored by ComfyUI, and still
+ * reporting success.
+ *
+ * Returns the number of nested slots to consume, or undefined when the count
+ * does NOT settle it — in which case the caller refuses exactly as before.
+ * Deliberately conservative: it answers only when the remaining top-level
+ * widgets have a KNOWABLE width, and bails out entirely if any of them is
+ * itself a dynamic combo (whose own nested arity is unknown from here) or is a
+ * non-positional input. Ambiguity must stay a refusal, never a guess.
+ */
+function resolveLinkedNestedArity(opts: {
+  /** Slots not yet read, i.e. widgetValues.length - widgetIdx. */
+  remainingSlots: number;
+  /** Positional nested leaves of the selected option, in order. */
+  nestedPositional: string[];
+  /** Which of those are converted-to-input. */
+  isLinked: (leaf: string) => boolean;
+  /** Top-level widget names still to map AFTER this combo. */
+  laterWidgets: string[];
+  /** Slots a later top-level widget consumes, or undefined if unknowable. */
+  slotsForLaterWidget: (name: string) => number | undefined;
+}): number | undefined {
+  const total = opts.nestedPositional.length;
+  const linked = opts.nestedPositional.filter(opts.isLinked).length;
+  if (linked === 0) return undefined; // not the ambiguous case
+
+  let tail = 0;
+  for (const w of opts.laterWidgets) {
+    const n = opts.slotsForLaterWidget(w);
+    if (n === undefined) return undefined; // unknowable width — refuse, as before
+    tail += n;
+  }
+
+  const retained = total; // every nested leaf kept a slot
+  const omitted = total - linked; // linked leaves serialized nothing
+  const fitsRetained = opts.remainingSlots - retained === tail;
+  const fitsOmitted = opts.remainingSlots - omitted === tail;
+  // Exactly one reading may account for the row. Both (possible when linked
+  // leaves and later widgets happen to cancel out) or neither is still
+  // ambiguous, and stays a refusal.
+  if (fitsRetained === fitsOmitted) return undefined;
+  return fitsRetained ? retained : omitted;
+}
+
 function isPositionalWidgetSpec(spec: unknown): boolean {
   if (!Array.isArray(spec)) return false;
   const type = spec[0];
@@ -2716,6 +2780,35 @@ export function convertUiToApi(
         // non-widget nested inputs (AUTOGROW lists like Nano Banana 2's
         // "images", or IMAGE/link types) have no saved widget value, so skipping
         // them keeps the positional mapping aligned.
+        // #1037 — settle the placeholder ambiguity by COUNTING the row before
+        // falling back to a refusal. Computed once for the whole nested block so
+        // every leaf reads the same way; undefined means it did NOT settle, and
+        // the per-leaf refusal below then behaves exactly as it always did.
+        const nestedPositional = Object.entries(nested)
+          .filter(([, nSpec]) => isPositionalWidgetSpec(nSpec))
+          .map(([nName]) => nName);
+        const slotsForLaterWidget = (wName: string): number | undefined => {
+          const wSpec =
+            (def.input?.required as Record<string, unknown>)?.[wName] ??
+            (def.input?.optional as Record<string, unknown>)?.[wName];
+          // A later DYNAMIC COMBO carries its own unknown nested arity, so the
+          // row cannot be counted past it. Same for a non-positional input.
+          const wType = Array.isArray(wSpec) ? wSpec[0] : undefined;
+          if (wType === "COMFY_DYNAMICCOMBO_V3") return undefined;
+          if (!isPositionalWidgetSpec(wSpec)) return undefined;
+          return 1 + (hasControlAfterGenerate(wName, def) ? 1 : 0);
+        };
+        const settledArity = resolveLinkedNestedArity({
+          remainingSlots: widgetValues.length - widgetIdx,
+          nestedPositional,
+          isLinked: (leaf) => linkedInputNames.has(`${name}.${leaf}`),
+          laterWidgets: widgetNames.slice(nameIdx + 1),
+          slotsForLaterWidget,
+        });
+        // "retained" is the only reading under which a linked leaf still occupies
+        // a slot that must be stepped over.
+        const linkedLeavesHoldSlots =
+          settledArity !== undefined && settledArity === nestedPositional.length;
         let refuseTail = false;
         for (const [nName, nSpec] of Object.entries(nested)) {
           if (!isPositionalWidgetSpec(nSpec)) continue;
@@ -2734,11 +2827,25 @@ export function convertUiToApi(
           // (If NO trailing values remain there is nothing to misassign, so the
           // link simply supplies the leaf and the loop ends.)
           if (linkedInputNames.has(`${name}.${nName}`)) {
+            // #1037 — the row settled the ambiguity: step over the placeholder
+            // (or don't) and keep mapping, instead of dropping the rest. The
+            // leaf's own value still arrives via the link loop either way.
+            if (settledArity !== undefined) {
+              if (linkedLeavesHoldSlots && widgetIdx < widgetValues.length) widgetIdx++;
+              continue;
+            }
             if (widgetIdx < widgetValues.length) {
               warnings.push(
-                `Node ${nodeId} (${classType}): widget "${name}" has a converted-to-input (linked) nested widget "${name}.${nName}" whose widgets_values slot can't be positionally resolved (frontend versions differ on whether a converted widget keeps a placeholder slot), so the remaining ${
+                // #1037 — "left to their defaults" was only half true, and the
+                // harmless half. A TOP-LEVEL widget does fall back to its schema
+                // default. A NESTED "<combo>.<leaf>" key has NO such fallback: it
+                // is omitted from the prompt entirely, and if it is required
+                // ComfyUI rejects the node ("Required input is missing: crop") and
+                // IGNORES that output — which reads downstream as a successful run
+                // that produced nothing. Say which of the two this is.
+                `Node ${nodeId} (${classType}): widget "${name}" has a converted-to-input (linked) nested widget "${name}.${nName}" whose widgets_values slot can't be positionally resolved (frontend versions differ on whether a converted widget keeps a placeholder slot, and the saved row's length settles neither reading), so the remaining ${
                   widgetValues.length - widgetIdx
-                } saved widget value(s) are left to their defaults rather than risk silently assigning a stale value to a later widget (such as a seed).`,
+                } saved widget value(s) are not read — rather than risk silently assigning a stale value to a later widget (such as a seed). Top-level widgets fall back to their defaults; any NESTED "${name}.<leaf>" key is OMITTED from the prompt instead, so if one of them is required ComfyUI will reject this node and ignore its output branch (the run can then report success with nothing produced). Set the missing nested value explicitly, or reconnect the linked nested input as a widget.`,
               );
               refuseTail = true;
               break;


### PR DESCRIPTION
Refs artokun/comfyui-mcp#1037 — the converter half. Two remaining parts tracked there (see Scope).

## What was happening

Two packs **we bundle** (`ltx-2.3-txt2vid`, `ltx-2.3-img2vid`) queued a prompt with a required input missing. ComfyUI rejected that output node, logged `Output will be ignored`, and finished — so `queue(action:"status")` reported **success**, `diagnose` reported **"validates clean"**, and no video existed.

## Cause, and why the old behaviour was defensible

When a dynamic combo's nested leaf is converted-to-input, the saved array may or may not still carry a placeholder slot for it — frontend versions differ, and the two readings are indistinguishable from the leaf alone. The converter refused the tail rather than risk shifting a later widget: a seed silently becoming a stray `4` (#517 P0-A). **That refusal is right in general, and it stays.**

What was missing is that the whole **row** usually settles it:

```
["scale dimensions", 1920, 1088, "center", "lanczos"]        5 slots
parent(1) + nested width/height/crop(3) + scale_method(1)  =  5   retained ✓
parent(1) + nested crop(1)              + scale_method(1)  =  3   omitted  ✗
```

Only one reading adds up, so `crop` can be **read** instead of dropped.

`resolveLinkedNestedArity` returns the number of nested slots to consume, or `undefined` when counting does not settle it — and `undefined` refuses exactly as before. It bails out entirely when a later top-level widget is itself a dynamic combo (unknown nested arity) or non-positional, because the row cannot be counted past those. **Ambiguity stays a refusal; it never becomes a guess.**

## Verified against the shipped packs

Not just a fixture — converting `packs/ltx-2.3-txt2vid/workflow.json` and `-img2vid` now emits `resize_type.crop="center"` and `scale_method="lanczos"` on **node 343**, the exact node and id the reporter named.

## The #517 seed test changed — this is the part worth reviewing closely

That row is now *resolved* rather than refused, and the seed the user saved (`424242`) survives. The assertion used to be `toBe(0)`.

`0` was the refusal's outcome and the best answer available while the ambiguity was unresolvable — but it meant the user's seed was **silently replaced by zero**, which is its own quiet data loss. The guard that actually matters is untouched and still asserted: the placeholder `4` must never become the seed.

## The warning was half-true, and the harmless half

*"Left to their defaults"* is accurate for a **top-level** widget. A **nested** `<combo>.<leaf>` key has no such fallback — it is omitted from the prompt entirely. Same refusal, two very different outcomes, and the benign wording is part of why a run could report success with nothing produced. It now names the omission, the rejected output branch, and the remedy. A test pins that asymmetry directly (`scale_method` defaults; `"resize_type.crop" in inputs` is `false`).

## Scope

Still open on #1037, deliberately not bundled here:

- nested override keys (`"343.resize_type.crop"`) are rejected, blocking the obvious workaround
- a validation-rejected output node still reads as a clean success — I'd treat that as its own detection gap, independent of what caused it

## Tests

9 added. Both directions mutation-verified: disabling the disambiguation fails 4 (the fix), making it guess when ambiguous fails 3 (the safety).

Full suite green: 344 files, 7182 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)