### PR TITLE
0.50.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.14] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- settle the linked-nested placeholder ambiguity by counting the row (#1040)
+
+
 ## [0.50.13] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.13",
+  "version": "0.50.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.13",
+      "version": "0.50.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.13",
+  "version": "0.50.14",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.14` tag (the tag publishes to npm; protected `main` needs this PR).

### Fixed
- **#1037** — settle the linked-nested placeholder ambiguity by counting the row (#1040). Two packs **we bundle** (`ltx-2.3-txt2vid`, `ltx-2.3-img2vid`) queued a prompt missing a required input; ComfyUI rejected the output node, logged `Output will be ignored`, and finished — so the run reported **success** with no video produced.

  The converter refused to map the tail after a converted-to-input nested leaf, because a placeholder slot may or may not be present. It now counts the whole row: where exactly one reading adds up, the value is read instead of dropped; where it doesn't, the refusal stands unchanged. Verified against the shipped pack files, not just a fixture.

  Also corrects the warning, which said the tail was "left to their defaults" — true for a top-level widget, but a nested `<combo>.<leaf>` key has no fallback and is omitted entirely, which is what made this report so hard to spot.

Notably this also recovers a user's seed that the old refusal silently replaced with `0`, while keeping the #517 guard that a retained placeholder must never become the seed.

Two parts of #1037 remain open there: nested override keys are still rejected, and a validation-rejected output node still reads as a clean success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)