### PR TITLE
fix(#1037): a queued prompt can still have had output branches rejected

### DIFF
--- a/src/__tests__/comfyui/enqueue-prompt-validation.test.ts
+++ b/src/__tests__/comfyui/enqueue-prompt-validation.test.ts
@@ -118,3 +118,111 @@ describe("enqueuePrompt — surfaces ComfyUI 400 validation details (#485)", () 
     expect(out).toEqual({ prompt_id: "abc", queue_remaining: undefined });
   });
 });
+
+// #1037 — the OTHER half of the same body, and the one that was discarded.
+//
+// ComfyUI validates each output branch independently. When SOME validate it
+// queues those and answers **200** with a prompt_id, carrying `node_errors` for
+// the branches it REJECTED (execution.py returns (True, None, good_outputs,
+// node_errors); it only 400s when NO output is good). Those branches never run
+// — ComfyUI logs "Output will be ignored" — and the prompt still completes.
+//
+// So the run reported `success`, `diagnose` said "validates clean", and no video
+// existed. This function already goes direct to /prompt SO THAT node_errors can
+// be read (#485 above) — but only the 400 path ever read them.
+describe("#1037: a 200 can still carry rejected output branches", () => {
+  const partial = {
+    prompt_id: "abc-123",
+    number: 1,
+    node_errors: {
+      "343": {
+        class_type: "ResizeImageMaskNode",
+        errors: [
+          {
+            type: "required_input_missing",
+            message: "Required input is missing",
+            details: "crop",
+            extra_info: { input_name: "resize_type.crop" },
+          },
+        ],
+      },
+    },
+  };
+
+  beforeEach(() => {
+    comfyuiFetch.mockReset();
+    comfyuiFetch.mockImplementation(async (url: string) =>
+      String(url).endsWith("/queue")
+        ? res(200, { queue_running: [], queue_pending: [] }, "OK")
+        : res(200, partial, "OK"),
+    );
+  });
+
+  it("still reports the prompt as queued — it genuinely was", async () => {
+    const out = await enqueuePrompt({} as never);
+    expect(out.prompt_id).toBe("abc-123");
+  });
+
+  it("names the rejected branch instead of discarding it", async () => {
+    const { rejectedOutputs } = await enqueuePrompt({} as never);
+    expect(rejectedOutputs).toBeDefined();
+    expect(rejectedOutputs).toContain("node 343");
+    expect(rejectedOutputs).toContain("ResizeImageMaskNode");
+    expect(rejectedOutputs).toContain("Required input is missing");
+    expect(rejectedOutputs).toContain("resize_type.crop");
+  });
+
+  // The sentence that would have saved the reporter an investigation.
+  it("warns that the run can report success while producing nothing", async () => {
+    const { rejectedOutputs } = await enqueuePrompt({} as never);
+    expect(rejectedOutputs).toMatch(/QUEUED, but ComfyUI REJECTED/);
+    expect(rejectedOutputs).toMatch(/report success while producing nothing/);
+  });
+
+  it("says nothing when every output was accepted", async () => {
+    comfyuiFetch.mockImplementation(async (url: string) =>
+      String(url).endsWith("/queue")
+        ? res(200, { queue_running: [], queue_pending: [] }, "OK")
+        : res(200, { prompt_id: "ok-1", number: 1, node_errors: {} }, "OK"),
+    );
+    const out = await enqueuePrompt({} as never);
+    expect(out.rejectedOutputs).toBeUndefined();
+  });
+
+  it("says nothing when node_errors is absent entirely", async () => {
+    comfyuiFetch.mockImplementation(async (url: string) =>
+      String(url).endsWith("/queue")
+        ? res(200, { queue_running: [], queue_pending: [] }, "OK")
+        : res(200, { prompt_id: "ok-2", number: 1 }, "OK"),
+    );
+    expect((await enqueuePrompt({} as never)).rejectedOutputs).toBeUndefined();
+  });
+
+  // A node we cannot parse a reason for must still be NAMED — "this branch will
+  // not run" is the load-bearing fact and does not depend on our parsing.
+  it("names a rejected node even when its error detail is unreadable", async () => {
+    comfyuiFetch.mockImplementation(async (url: string) =>
+      String(url).endsWith("/queue")
+        ? res(200, { queue_running: [], queue_pending: [] }, "OK")
+        : res(200, { prompt_id: "x", number: 1, node_errors: { "9": {} } }, "OK"),
+    );
+    const { rejectedOutputs } = await enqueuePrompt({} as never);
+    expect(rejectedOutputs).toContain("node 9");
+  });
+
+  it("counts multiple rejected branches", async () => {
+    comfyuiFetch.mockImplementation(async (url: string) =>
+      String(url).endsWith("/queue")
+        ? res(200, { queue_running: [], queue_pending: [] }, "OK")
+        : res(200, {
+            prompt_id: "x",
+            number: 1,
+            node_errors: { "1": { class_type: "A" }, "2": { class_type: "B" } },
+          }, "OK"),
+    );
+    const { rejectedOutputs } = await enqueuePrompt({} as never);
+    expect(rejectedOutputs).toContain("2 output branches");
+    expect(rejectedOutputs).toContain("node 1");
+    expect(rejectedOutputs).toContain("node 2");
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -385,11 +385,56 @@ export async function freeMemory(opts: { unload_models?: boolean; free_memory?: 
  * Fire-and-forget: enqueue a prompt via HTTP POST (no WebSocket needed).
  * Returns prompt_id and queue position immediately.
  */
+/**
+ * Human-readable account of output branches ComfyUI REFUSED while accepting the
+ * prompt, or undefined when it accepted everything.
+ *
+ * Shape from ComfyUI: { "<nodeId>": { class_type, errors: [{ type, message,
+ * details, extra_info: { input_name } }] } }. Only what is actually present is
+ * stated — a node that carries no readable error still gets named, because "this
+ * branch will not run" is the load-bearing fact and it does not depend on our
+ * being able to parse the reason.
+ */
+function describeRejectedOutputs(nodeErrors: unknown): string | undefined {
+  if (!nodeErrors || typeof nodeErrors !== "object") return undefined;
+  const entries = Object.entries(nodeErrors as Record<string, unknown>);
+  if (entries.length === 0) return undefined;
+  const parts = entries.map(([nodeId, raw]) => {
+    const rec = (raw ?? {}) as { class_type?: unknown; errors?: unknown };
+    const cls = typeof rec.class_type === "string" ? ` (${rec.class_type})` : "";
+    const errs = Array.isArray(rec.errors) ? rec.errors : [];
+    const reasons = errs
+      .map((e) => {
+        const er = (e ?? {}) as { message?: unknown; extra_info?: { input_name?: unknown } };
+        const msg = typeof er.message === "string" ? er.message : null;
+        const input =
+          er.extra_info && typeof er.extra_info.input_name === "string"
+            ? er.extra_info.input_name
+            : null;
+        if (msg && input) return `${msg} (${input})`;
+        return msg ?? (input ? `problem with input "${input}"` : null);
+      })
+      .filter((r): r is string => !!r);
+    return `node ${nodeId}${cls}${reasons.length ? `: ${reasons.join("; ")}` : ""}`;
+  });
+  return (
+    `The prompt was QUEUED, but ComfyUI REJECTED ${parts.length} output branch` +
+    `${parts.length === 1 ? "" : "es"} at validation and will not run ${
+      parts.length === 1 ? "it" : "them"
+    } — ${parts.join(" | ")}. Everything upstream of the ACCEPTED outputs still ` +
+    `runs, so this prompt can complete and report success while producing nothing ` +
+    `from the rejected branch${parts.length === 1 ? "" : "es"}. Fix the named ` +
+    `input(s) and re-queue if you expected output from ${
+      parts.length === 1 ? "it" : "them"
+    }.`
+  );
+}
+
 export async function enqueuePrompt(
   workflow: Record<string, unknown>,
   extraData?: Record<string, unknown>,
   opts?: { front?: boolean },
-): Promise<{ prompt_id: string; queue_remaining?: number }> {
+): Promise<{ prompt_id: string; queue_remaining?: number; rejectedOutputs?: string }> {
   if (isCloudMode()) return cloudClient.enqueuePrompt(workflow, extraData);
 
   // POST /prompt directly (rather than the SDK's _enqueue_prompt) for two
@@ -414,13 +459,38 @@ export async function enqueuePrompt(
   if (!res.ok) {
     throw await buildEnqueueError(res);
   }
-  const data = (await res.json()) as { prompt_id: string; number?: number };
+  const data = (await res.json()) as {
+    prompt_id: string;
+    number?: number;
+    node_errors?: Record<string, unknown>;
+  };
   // NB: `data.number` is ComfyUI's monotonic priority counter (and is NEGATIVE
   // for front-inserted jobs) — NOT the remaining queue depth. The old SDK path
   // returned exec_info.queue_remaining; to preserve an accurate count now that
   // we POST directly, read /queue for the authoritative running+pending total.
   // Fall back to undefined (never the misleading counter) if that read fails.
-  return { prompt_id: data.prompt_id, queue_remaining: await queueRemainingCount() };
+  // A 200 does NOT mean every output was accepted. ComfyUI validates each output
+  // branch independently: if SOME validate it queues those and returns 200 with a
+  // prompt_id, carrying `node_errors` for the ones it REJECTED (execution.py
+  // returns (True, None, good_outputs, node_errors); it only 400s when NO output
+  // is good). Those branches then never run — ComfyUI logs "Output will be
+  // ignored" — and the prompt still completes, so the run reports success while
+  // producing nothing from them.
+  //
+  // That is exactly how #1037 reached a user: a required nested input was missing
+  // on one node, its output branch was dropped, and queue(action:"status") said
+  // success with no video. This function already goes direct to /prompt SO THAT
+  // node_errors can be read (#485) — but only the 400 path read them.
+  //
+  // Reported, never swallowed and never fatal: the run WAS queued and the
+  // accepted branches will produce output, so this is a disclosure attached to a
+  // success, not a failure.
+  const rejectedOutputs = describeRejectedOutputs(data.node_errors);
+  return {
+    prompt_id: data.prompt_id,
+    queue_remaining: await queueRemainingCount(),
+    ...(rejectedOutputs ? { rejectedOutputs } : {}),
+  };
 }
 
 /**

--- a/src/services/workflow-executor.ts
+++ b/src/services/workflow-executor.ts
@@ -136,7 +136,7 @@ async function randomizeSeeds(
 export async function enqueueWorkflow(
   workflowJson: WorkflowJSON,
   options?: EnqueueWorkflowOptions,
-): Promise<{ prompt_id: string; queue_remaining?: number }> {
+): Promise<{ prompt_id: string; queue_remaining?: number; rejectedOutputs?: string }> {
   const workflow = options?.disable_random_seed
     ? workflowJson
     : await randomizeSeeds(
@@ -153,6 +153,13 @@ export async function enqueueWorkflow(
     prompt_id: result.prompt_id,
     queue_remaining: result.queue_remaining,
   });
+  // A 200 from /prompt does not mean every output was accepted: ComfyUI queues
+  // the branches that validate and reports the rejected ones in node_errors. Log
+  // it unconditionally so the fact survives even if a caller renders only
+  // prompt_id — a rejected branch produces nothing while the run still completes.
+  if (result.rejectedOutputs) {
+    logger.warn(`[enqueue] ${result.rejectedOutputs}`, { prompt_id: result.prompt_id });
+  }
 
   // Start background watcher for completion detection. Capture the workflow
   // that was actually sent (post-seed-randomization) so the AssetRegistry can

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -50,6 +50,11 @@ export async function regenerateAction(args: {
             status: "enqueued",
             prompt_id: result.prompt_id,
             queue_remaining: result.queue_remaining,
+            // #1037 — a 200 from /prompt does not mean every output was accepted;
+            // ComfyUI queues the branches that validate and reports the rest.
+            ...(result.rejectedOutputs
+              ? { rejected_outputs: result.rejectedOutputs }
+              : {}),
             source_asset_id: asset_id,
             overrides_applied: overrides ?? {},
           },

--- a/src/tools/run-template.ts
+++ b/src/tools/run-template.ts
@@ -170,6 +170,11 @@ export async function runTemplateAction(args: {
     template: args.template,
     prompt_id: result.prompt_id,
     queue_remaining: result.queue_remaining,
+    // #1037 — a 200 from /prompt does not mean every output was accepted;
+    // ComfyUI queues the branches that validate and reports the rest.
+    ...(result.rejectedOutputs
+      ? { rejected_outputs: result.rejectedOutputs }
+      : {}),
     overrides_applied: Object.keys(overrides),
   };
 

--- a/src/tools/workflow-autoload.ts
+++ b/src/tools/workflow-autoload.ts
@@ -92,6 +92,11 @@ export async function registerAutoloadedWorkflows(server: McpServer): Promise<vo
                   tool: wf.toolName,
                   prompt_id: result.prompt_id,
                   queue_remaining: result.queue_remaining,
+                  // #1037 — a 200 from /prompt does not mean every output was accepted;
+                  // ComfyUI queues the branches that validate and reports the rest.
+                  ...(result.rejectedOutputs
+                    ? { rejected_outputs: result.rejectedOutputs }
+                    : {}),
                 },
                 null,
                 2,

--- a/src/tools/workflow-execute.ts
+++ b/src/tools/workflow-execute.ts
@@ -194,6 +194,11 @@ export function registerWorkflowExecuteTools(server: McpServer): void {
                       status: "enqueued",
                       prompt_id: result.prompt_id,
                       queue_remaining: result.queue_remaining,
+                      // #1037 — a 200 from /prompt does not mean every output was accepted;
+                      // ComfyUI queues the branches that validate and reports the rest.
+                      ...(result.rejectedOutputs
+                        ? { rejected_outputs: result.rejectedOutputs }
+                        : {}),
                     },
                     null,
                     2,
@@ -238,6 +243,11 @@ export function registerWorkflowExecuteTools(server: McpServer): void {
                       status: "enqueued",
                       prompt_id: result.prompt_id,
                       queue_remaining: result.queue_remaining,
+                      // #1037 — a 200 from /prompt does not mean every output was accepted;
+                      // ComfyUI queues the branches that validate and reports the rest.
+                      ...(result.rejectedOutputs
+                        ? { rejected_outputs: result.rejectedOutputs }
+                        : {}),
                       source_prompt_id: sourcePromptId,
                       overrides_applied: args.inputs ?? {},
                     },

--- a/src/tools/workflow-url.ts
+++ b/src/tools/workflow-url.ts
@@ -161,6 +161,11 @@ export async function runWorkflowUrlAction(args: {
             status: "enqueued",
             prompt_id: result.prompt_id,
             queue_remaining: result.queue_remaining,
+            // #1037 — a 200 from /prompt does not mean every output was accepted;
+            // ComfyUI queues the branches that validate and reports the rest.
+            ...(result.rejectedOutputs
+              ? { rejected_outputs: result.rejectedOutputs }
+              : {}),
             source_url: finalUrl,
             overrides_applied: inputs ?? {},
             conversion_warnings: warnings,


### PR DESCRIPTION
Refs artokun/comfyui-mcp#1037 — the **detection gap**, which is independent of what caused the rejection and is the part that actually cost the reporter an investigation.

## What ComfyUI tells us, and what we did with it

ComfyUI validates each output branch independently:

```python
# execution.py
if len(good_outputs) == 0:
    return (False, error, list(good_outputs), node_errors)   # -> 400
return (True, None, list(good_outputs), node_errors)          # -> 200, errors ride along

# server.py
response = {"prompt_id": prompt_id, "number": number, "node_errors": valid[3]}
```

So when **some** outputs validate, it queues those and answers **200 with a prompt_id and non-empty `node_errors`**. The rejected branches never run — ComfyUI logs `Output will be ignored` — and the prompt still completes.

Result: `queue(action:"status")` says `success`, `diagnose` says *"the recorded graph validates clean"*, and no video exists.

**We were discarding the answer.** `enqueuePrompt` goes direct to `/prompt` for precisely this reason — the SDK swallows the validation body, so #485 made us read `node_errors` ourselves — but only the **400** path ever read them. The 200 path took `prompt_id` and `number` and dropped the rest.

## What it says now

> The prompt was QUEUED, but ComfyUI REJECTED 1 output branch at validation and will not run it — node 343 (ResizeImageMaskNode): Required input is missing (resize_type.crop). Everything upstream of the ACCEPTED outputs still runs, so this prompt can complete and report success while producing nothing from the rejected branch. Fix the named input(s) and re-queue if you expected output from it.

**Never fatal.** The prompt *was* queued and the accepted branches will produce output — this is a disclosure attached to a success, not a failure. A node whose error detail is unparseable is still **named**, because "this branch will not run" is the load-bearing fact and doesn't depend on our parsing.

## Surfaced two ways

- **Logged unconditionally** at the enqueue chokepoint, so the fact survives even where a caller renders only `prompt_id`.
- **Returned as `rejected_outputs`** from the workflow-execution tools: `run_template` (the reporter's exact path), `enqueue_workflow`, `workflow_execute`, `workflow_url`, `workflow_autoload`.

## Scope

The `generate_*` family (image/video/audio/3d/api-nodes/upscale/remove-background) routes through **six intermediate result types** that would each need widening plus their construction sites. Those tools **log** the disclosure but do not yet render it in their result. I reverted that half after tsc showed the plumbing required — better as a follow-up than smuggled into this PR.

## Tests

7 on the 200 path, sitting beside the existing #485 tests on the 400 path — including an all-accepted prompt (says nothing), an absent `node_errors` (says nothing), an unreadable error detail (still names the node), and a multi-branch count.

Mutation-verified: discarding `node_errors` again fails 4.

Full suite green: 344 files, 7189 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)