### PR TITLE
0.50.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.15] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- a queued prompt can still have had output branches rejected (#1042)
+
+
 ## [0.50.14] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.14",
+  "version": "0.50.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.14",
+      "version": "0.50.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.14",
+  "version": "0.50.15",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.15` tag (the tag publishes to npm; protected `main` needs this PR).

### Fixed
- **#1037** — a queued prompt can still have had output branches rejected (#1042). ComfyUI validates each output branch independently: when some validate it queues those and answers **200 with a prompt_id and non-empty `node_errors`** for the ones it refused. Those branches never run, the prompt still completes, and the run reported `success` with `diagnose` saying "validates clean" while producing nothing.

  We were discarding that. `enqueuePrompt` goes direct to `/prompt` precisely so `node_errors` can be read (#485) — but only the 400 path read them. The 200 path now reports which branches were refused, with the node, class_type, message and offending input, plus the fact that the run can report success while producing nothing from them.

  Surfaced as `rejected_outputs` on `run_template`, `enqueue_workflow`, `workflow_execute`, `workflow_url` and `workflow_autoload`, and logged unconditionally at the enqueue chokepoint so it survives callers that render only `prompt_id`.

This is the detection gap behind 0.50.14's converter fix — independent of what causes a rejection, and the part that made #1037 cost a real investigation. The `generate_*` family logs it but does not yet render it; tracked as follow-up on #1037.

🤖 Generated with [Claude Code](https://claude.com/claude-code)