### PR TITLE
fix(turn-origins): a save's tmp:→wf: rename is one origin, not a mixed batch

### DIFF
--- a/src/__tests__/orchestrator/turn-origins.test.ts
+++ b/src/__tests__/orchestrator/turn-origins.test.ts
@@ -70,6 +70,75 @@ describe("TurnOriginTracker — pins and stamps land at dequeue (#884)", () => {
     expect(warnings.join("\n")).toMatch(/mixed\/unknown-origin/);
   });
 
+  // A SAVE renames the tab (tmp:<uuid> → wf:<path>), so two messages issued from
+  // ONE tab either side of it carry different ids. Counting the minted ids made
+  // tabs.size === 2 and refused a single-tab turn as "issued from multiple
+  // workflows at once" — naming two entries that are the same workflow.
+  // Observed live on mcp 0.50.14 / panel 0.11.44: two origin banners, both
+  // titled "Untitled 2026-08-07 14-21-08", one tmp: and one wf:.
+  it("a tmp:→wf: SAVE migration is ONE origin, not a mixed batch", async () => {
+    const { tracker, tabAliases } = makeTracker();
+    // The save rewrote tmp:a onto wf:a; the instance uuid is carried across the
+    // swap (the tab is the same instance, only its id changed).
+    tabAliases.set("tmp:a", "wf:a");
+    tracker.recordForMid("m1", "uuid-a", "tmp:a"); // issued before the save
+    tracker.recordForMid("m2", "uuid-a", "wf:a"); //  issued after it
+    tracker.onSeen(KEY, "m1");
+    tracker.onSeen(KEY, "m2");
+    await flushMicrotasks();
+    // Not null — that is the whole point: routing resolves instead of refusing.
+    // The pin keeps the RECORDED identity (the bridge resolves it onward through
+    // the alias), so this asserts the contract gate 4 established, not the live id.
+    expect(tracker.pinOf(KEY)).toBe("tmp:a");
+    // …and the stamp survives, so graph mutations are not fenced out either.
+    expect(tracker.stampOf(KEY)).toBe("uuid-a");
+  });
+
+  it("the migration collapse holds whichever ORDER the two halves dequeue in", async () => {
+    // The post-save message can dequeue first (a re-queue, or simply the order
+    // the manager drains). Ambiguity must not depend on arrival order.
+    const { tracker, tabAliases } = makeTracker();
+    tabAliases.set("tmp:a", "wf:a");
+    tracker.recordForMid("m2", "uuid-a", "wf:a");
+    tracker.recordForMid("m1", "uuid-a", "tmp:a");
+    tracker.onSeen(KEY, "m2"); // post-save half dequeues first
+    tracker.onSeen(KEY, "m1");
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY)).toBe("wf:a"); // whichever was recorded into the set first
+    expect(tracker.stampOf(KEY)).toBe("uuid-a");
+  });
+
+  it("the collapse is by ROUTING, so two genuinely distinct tabs still fail closed", async () => {
+    // Guards the obvious over-fix: if aliasing collapsed anything it touched,
+    // a real mixed batch would be laundered onto one tab — the P0 this whole
+    // gate exists to prevent. Neither id is aliased, so each routes to itself.
+    const { tracker, warnings } = makeTracker();
+    tracker.recordForMid("m1", "uuid-a", "tab-a");
+    tracker.recordForMid("m2", "uuid-b", "tab-b");
+    tracker.onSeen(KEY, "m1");
+    tracker.onSeen(KEY, "m2");
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY)).toBeNull();
+    expect(tracker.stampOf(KEY)).toBeUndefined();
+    expect(warnings.join("\n")).toMatch(/mixed\/unknown-origin/);
+  });
+
+  it("a migration whose halves carry DIFFERENT uuids pins the tab but withholds the stamp", async () => {
+    // One tab, so routing is honest and resolves. But the two halves disagree
+    // about which workflow instance they were issued for, and no single stamp is
+    // honest for that — mutations stay fenced while reads/routing recover.
+    // Pinning the tab must NOT be read as vouching for a workflow.
+    const { tracker, tabAliases } = makeTracker();
+    tabAliases.set("tmp:a", "wf:a");
+    tracker.recordForMid("m1", "uuid-before", "tmp:a");
+    tracker.recordForMid("m2", "uuid-after", "wf:a");
+    tracker.onSeen(KEY, "m1");
+    tracker.onSeen(KEY, "m2");
+    await flushMicrotasks();
+    expect(tracker.pinOf(KEY)).toBe("tmp:a"); // recorded identity, resolved onward
+    expect(tracker.stampOf(KEY)).toBeUndefined();
+  });
+
   it("an unknown (evicted/foreign) mid fails the batch closed rather than inheriting", async () => {
     const { tracker } = makeTracker();
     tracker.recordForMid("known", "uuid-a", "tab-a");

--- a/src/orchestrator/turn-origins.ts
+++ b/src/orchestrator/turn-origins.ts
@@ -57,7 +57,13 @@ interface MidOrigin {
 
 interface PendingBatch {
   known: Array<string | undefined>;
+  /** Origin tab ids AS RECORDED — the pin keeps this identity, and the bridge
+   *  resolves it onward through any migration alias. */
   tabs: Set<string>;
+  /** The same origins resolved to the tab they ROUTE TO today. Ambiguity is
+   *  judged on THIS set, so a save's tmp:→wf: rename does not read as two
+   *  workflows (see onSeen). */
+  routes: Set<string>;
   unknown: boolean;
 }
 
@@ -190,7 +196,7 @@ export class TurnOriginTracker {
     let batch = this.pendingBatchStamp.get(key);
     const opensBatch = !batch;
     if (!batch) {
-      batch = { known: [], tabs: new Set<string>(), unknown: false };
+      batch = { known: [], tabs: new Set<string>(), routes: new Set<string>(), unknown: false };
       this.pendingBatchStamp.set(key, batch);
     }
     // A mid's origin comes from the LIVE record (first dequeue) or the APPLIED
@@ -236,7 +242,29 @@ export class TurnOriginTracker {
         );
       } else {
         batch.known.push(rec.uuid);
+        // TWO sets, because the pin and the ambiguity test want different things.
+        //
+        // The PIN keeps the id as RECORDED — the bridge resolves it onward through
+        // any migration alias, which is the existing contract (gate 4, P1).
+        //
+        // AMBIGUITY is judged on where the origins ROUTE, via the same `liveOrigin`
+        // the ownership check above already uses, and for the same reason. A
+        // same-socket migration (a workflow switch, a save, tmp:→wf:) rewrites the
+        // tab's id, so two messages issued from ONE tab either side of a save
+        // arrive carrying DIFFERENT ids. Counting those made the set size 2 and
+        // declared a single-tab turn a mixed-origin batch — routing and mutations
+        // then failed closed with "issued from multiple workflows at once", naming
+        // two entries that are the same workflow (observed live on mcp 0.50.14 /
+        // panel 0.11.44: one tmp: and one wf: banner, both titled "Untitled
+        // 2026-08-07 14-21-08").
+        //
+        // That is the FALSE REFUSAL the block above fixed for backend ownership and
+        // left in place for the tab count, a few lines apart. liveTabIdFor path-
+        // compresses every historical alias onto the newest live id, so genuinely
+        // distinct tabs still resolve distinctly and a real mixed batch still fails
+        // closed — only the aliases of ONE tab collapse.
         batch.tabs.add(rec.tab);
+        batch.routes.add(liveOrigin);
         this.turnUuidByMid.delete(mid);
         this.noteAppliedTurnMid(mid, rec); // keeps its origin for a re-queue
       }
@@ -252,7 +280,7 @@ export class TurnOriginTracker {
       queueMicrotask(() => {
         this.pendingBatchStamp.delete(key);
         const distinct = new Set(closed.known);
-        if (closed.unknown || closed.tabs.size > 1) {
+        if (closed.unknown || closed.routes.size > 1) {
           // Mixed/unknown-TAB batch: no single stamp or target is honest for
           // it — fail BOTH closed (the bridge refuses routing; the panel fence
           // refuses mutations) until an explicit target or the next
@@ -262,7 +290,7 @@ export class TurnOriginTracker {
           this.deps.warn(
             `[panel-orchestrator] ${key} dispatched a mixed/unknown-origin batch — no single workflow stamp/target is honest for it, so scope routing and graph mutations FAIL CLOSED until the agent opens/pins a workflow or the next single-origin message (#884)`,
           );
-        } else if (closed.tabs.size === 1) {
+        } else if (closed.routes.size === 1) {
           // TURN-TARGET PIN (confirming gate P0): this turn's tool calls route
           // to the tab the turn was ISSUED from — never re-resolved mid-turn —
           // and its mutations are fenced to that tab's issue-time workflow.


### PR DESCRIPTION
## What happens

A save renames the tab (`tmp:<uuid>` → `wf:<path>`). Two messages issued from **one**
tab either side of that rename therefore arrive carrying **different ids**. The batch
aggregator counted them as minted, got `tabs.size === 2`, and declared a single-tab turn
mixed-origin — so routing and graph mutations failed closed with:

```
no connected tab can be chosen for "orchestrator::claude": the current turn was
issued from multiple workflows at once, so its target is ambiguous.
```

…naming two entries that are the same workflow.

## Observed live

On released builds — `mcp=0.50.14`, `panel=0.11.44` — a turn opened with two origin
banners:

```
1) "Untitled 2026-08-07 14-21-08"   tmp:95b5c183-…
2) "Untitled 2026-08-07 14-21-08"   wf:1927d99c-…:workflows/Untitled 2026-08-07 14-21-08.json
```

Same title, same workflow, two ids. Four consecutive `panel_*` calls were refused, each
self-reporting `was not dispatched — nothing was applied`.

## The same bug, a few lines up, already fixed

The backend-ownership check immediately above judges on `liveOrigin` — `liveTabIdFor`,
which path-compresses every historical alias onto the newest live id — and its comment
says exactly why:

> A same-socket migration (A→B: a workflow switch, a save, tmp:→wf:) moves the backend
> mapping to B and deletes A, so asking `backendForTab(A)` returns the DEFAULT backend and
> a perfectly healthy Codex turn requeued after such a migration was judged foreign and
> wedged until explicit recovery — **a false refusal, not a leak**.

The tab **count** was left judging on the minted id. Same migration, same false refusal,
one consumer over.

## The fix

Ambiguity is judged on a new `routes` set built from that same `liveOrigin`. The **pin**
still carries the id as recorded, so gate 4's contract is untouched — the bridge resolves
it onward through the alias.

Two sets rather than one, because the two consumers genuinely want different things.
Conflating them broke the existing gate-4 test, which is what surfaced the distinction —
that test is left exactly as it was.

## What stays refused

- **Genuinely distinct tabs** still resolve distinctly, so a real mixed batch still fails
  closed. This is the P0 the gate exists for and it has its own test.
- **Halves that disagree about the workflow uuid**: the tab pins (routing recovers) but the
  stamp is still withheld (mutations stay fenced). Pinning a tab is not a vouch for a
  workflow.

## Tests

35 in the file, **7193 in the full suite**, typecheck and `check:vocabulary` green — the
vocabulary gate is not part of `vitest`, so it is run separately.

Mutation-verified: reverting either size test to the minted-id set fails 3 tests, with
marker counts asserted before and after.

## Relationship to the panel-side fix

Independent, and both are needed. This one stops a false *ambiguity* refusal before
dispatch. artokun/comfyui-mcp-panel#759 stops the *fence* refusing the recovery probe once
a command does reach the panel. The live session hit both in sequence.

Does not close the reports on its own: they close when someone confirms on a released build.
