### PR TITLE
0.50.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.16] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- a Save-As re-anchors the session fence too (#1046)
+
+
 ## [0.50.15] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.15",
+  "version": "0.50.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.15",
+      "version": "0.50.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.15",
+  "version": "0.50.16",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.16` tag (the tag publishes to npm; protected `main` needs this PR).

### Fixed
- **#1045** — a Save-As re-anchors the session fence too (#1046). A reporter built ~40 nodes, saved successfully, and the very next `panel_run` failed with `workflow instance mismatch`. A Save-As re-points the active workflow (the canvas is now the new file, with its own identity) while the session's fence still names the old one.

  This is #932's defect at a path I closed for `panel_new_workflow` and missed here — both commands re-point the active workflow, so both have to re-anchor. In-place saves are covered too, where the refresh is normally a no-op.

Still open on #1043: when the canvas-identity read doesn't answer at all, the recovery depends on that same read and the session stays deadlocked. That needs the panel to return the post-save `workflow_uuid` on the receipt (artokun/comfyui-mcp-panel#755, now extended to cover save as well as new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)