### PR TITLE
0.50.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.17] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- a save's tmp:→wf: rename is one origin, not a mixed batch (#1047)
+
+
 ## [0.50.16] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.16",
+  "version": "0.50.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.16",
+      "version": "0.50.17",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.16",
+  "version": "0.50.17",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.17` tag (the tag publishes to npm; protected `main` needs this PR).

### Fixed
- **turn-origins** — a save's `tmp:`→`wf:` rename is one origin, not a mixed batch (#1047). A save renames the tab, so messages issued either side of it carry different ids and the batch aggregator counted them as **two** workflows — a single-tab turn was declared mixed-origin and routing failed closed with *"issued from multiple workflows at once"*, naming two entries that were the same workflow.

  Ambiguity is now judged on where origins **route** (the same `liveOrigin` resolution the ownership check already used a few lines above), while the pin keeps the id as recorded. Genuinely distinct tabs still fail closed, and a migration whose halves carry different uuids pins the tab but withholds the stamp.

This is the second half of the #932 live repro. The first half — the recovery probe being refused by the very fence it repairs — is panel-side (artokun/comfyui-mcp-panel#759).

Verified on merged `main` before release: 345 files, 7202 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)