### PR TITLE
fix(#1052): I/O dirs follow the CONNECTED ComfyUI, not a second install

### DIFF
--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -94,6 +94,16 @@ vi.mock("../../services/workspace-env.js", async () => {
   >("../../services/workspace-env.js");
   return {
     resolveEffectiveComfyUIBase: () => config.comfyuiPath ?? savedDefaultWorkspace,
+    // #1052 — backed by the REAL argv parsing, like the resolvers above, so the
+    // live-root rung is exercised end to end rather than stubbed away.
+    resolveLiveComfyUIBase: async () => {
+      try {
+        const stats = await getSystemStats();
+        return actual.liveRootFromArgv(stats?.system?.argv, stats?.system?.cwd);
+      } catch {
+        return undefined;
+      }
+    },
     liveRootFromArgv: actual.liveRootFromArgv,
     hasComfyUIEntrypoint: (dir: string) =>
       hasEntrypointFor ? hasEntrypointFor(dir) : baseHasEntrypoint,
@@ -1094,5 +1104,76 @@ describe("models dir — corroborating a data-dir base by the server's own inven
     const res = await resolveModelsDirWithBases({ targetCategory: "diffusion_models" });
     expect(res.source).toBe("live-root");
     expect(fetchApi).not.toHaveBeenCalled();
+  });
+});
+
+// #1052 — with TWO ComfyUI installs on one machine, refs resolved against the
+// wrong one.
+//
+// A reporter had ComfyUI Desktop installed alongside the git checkout they were
+// actually connected to. `train_prepare_dataset` refs
+// ({filename, subfolder, type:"output"}) pointing at images that server had just
+// produced failed "image not found" against the DESKTOP path, while the files
+// sat in the connected server's output dir the whole time.
+//
+// The argv rung only answers when ComfyUI was launched with an explicit
+// --output-directory. Without one, resolution fell straight through to the
+// configured/auto-detected install — a different tree from the running one. The
+// running server's own argv (main.py + cwd) identifies its root perfectly well,
+// which is the live-first move #463 already made for models.
+//
+// The tool's description promises refs resolve "against the connected ComfyUI's
+// output/input dirs", so the contract was right and the resolution was not.
+describe("#1052: I/O dirs follow the CONNECTED server, not a second install", () => {
+  const CONNECTED = resolve("/home/u/Documents/comfy/ComfyUI");
+  const DESKTOP = resolve("/home/u/AppData/Local/Programs/ComfyUI/resources/ComfyUI");
+
+  beforeEach(() => {
+    (config as { comfyuiPath?: string }).comfyuiPath = DESKTOP;
+    liveRootExists = true;
+  });
+
+  /** The connected server, launched WITHOUT an explicit --output/--input-directory. */
+  function connectedServerNoExplicitDirs(): void {
+    getSystemStats.mockResolvedValue({
+      system: { argv: ["python", join(CONNECTED, "main.py")], cwd: CONNECTED },
+    });
+  }
+
+  it("resolves the OUTPUT dir under the connected install, not the configured one", async () => {
+    connectedServerNoExplicitDirs();
+    const got = await resolveOutputDir();
+    expect(got).toBe(join(CONNECTED, "output"));
+    expect(got).not.toBe(resolve(DESKTOP, "output")); // the reported failure
+  });
+
+  it("resolves the INPUT dir the same way", async () => {
+    connectedServerNoExplicitDirs();
+    expect(await resolveInputDir()).toBe(join(CONNECTED, "input"));
+  });
+
+  // An EXPLICIT --output-directory is the server telling us outright; it must
+  // keep winning over an install root inferred from main.py.
+  it("still lets an explicit --output-directory win", async () => {
+    const redirected = resolve("/mnt/big/outputs");
+    getSystemStats.mockResolvedValue({
+      system: {
+        argv: ["python", join(CONNECTED, "main.py"), "--output-directory", redirected],
+        cwd: CONNECTED,
+      },
+    });
+    expect(await resolveOutputDir()).toBe(redirected);
+  });
+
+  // And when nothing about the live server can be read, the configured install
+  // is still the right answer — this rung adds a source, it does not remove one.
+  it("falls back to the configured install when the server cannot be read", async () => {
+    getSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+    expect(await resolveOutputDir()).toBe(resolve(DESKTOP, "output"));
+  });
+
+  it("falls back when the live argv identifies no root", async () => {
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    expect(await resolveOutputDir()).toBe(resolve(DESKTOP, "output"));
   });
 });

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -4,6 +4,7 @@ import { config, isRemoteMode } from "../config.js";
 import { getClient, getSystemStats } from "../comfyui/client.js";
 import {
   resolveEffectiveComfyUIBase,
+  resolveLiveComfyUIBase,
   liveRootFromArgv,
   resolveLiveServerRoot,
   hasComfyUIEntrypoint,
@@ -943,6 +944,36 @@ export function localInputDirFallback(): string {
  * Resolve the directory ComfyUI actually reads inputs from. Asks the running
  * ComfyUI (/system_stats argv) first; falls back to <COMFYUI_PATH>/input.
  */
+/**
+ * `<live install root>/<kind>` when the CONNECTED server's own argv identifies
+ * it, else undefined (#1052).
+ *
+ * The argv parse above only answers when ComfyUI was launched with an EXPLICIT
+ * --input-directory / --output-directory. Without one, resolution fell straight
+ * through to the configured/auto-detected install — and on a machine with more
+ * than one ComfyUI that is a different tree from the one actually running.
+ *
+ * A reporter with ComfyUI Desktop installed alongside the git checkout they were
+ * connected to had `train_prepare_dataset` refs resolve against Desktop and fail
+ * "image not found", while the files sat in the connected server's output dir
+ * the whole time. The tool's own description promises refs resolve "against the
+ * connected ComfyUI's output/input dirs", so the contract was right and the
+ * resolution was not.
+ *
+ * `resolveLiveComfyUIBase` derives the root from the running server's argv
+ * main.py + cwd, which is the same live-first move #463 made for models. It is
+ * only a middle rung: an explicit --output-directory still wins above, and the
+ * configured install still catches everything below.
+ */
+async function liveIoDirFallback(kind: "input" | "output"): Promise<string | undefined> {
+  try {
+    const base = await resolveLiveComfyUIBase();
+    return base ? join(base, kind) : undefined;
+  } catch {
+    return undefined; // never let a probe failure outrank the configured install
+  }
+}
+
 export async function resolveInputDir(): Promise<string> {
   try {
     const stats = await getSystemStats();
@@ -958,6 +989,16 @@ export async function resolveInputDir(): Promise<string> {
       "Could not resolve input dir from /system_stats; using COMFYUI_PATH/input",
       { error: err instanceof Error ? err.message : String(err) },
     );
+  }
+  // #1052 — before the CONFIGURED install, try the one that is actually
+  // running. With two ComfyUIs on a machine these differ, and the connected
+  // server is the one whose files the caller means.
+  const live = await liveIoDirFallback("input");
+  if (live) {
+    logger.debug("Resolved ComfyUI input directory from the LIVE server's install root", {
+      dir: live,
+    });
+    return live;
   }
   return localInputDirFallback();
 }
@@ -981,6 +1022,16 @@ export async function resolveOutputDir(): Promise<string> {
       "Could not resolve output dir from /system_stats; using COMFYUI_PATH/output",
       { error: err instanceof Error ? err.message : String(err) },
     );
+  }
+  // #1052 — before the CONFIGURED install, try the one that is actually
+  // running. With two ComfyUIs on a machine these differ, and the connected
+  // server is the one whose files the caller means.
+  const live = await liveIoDirFallback("output");
+  if (live) {
+    logger.debug("Resolved ComfyUI output directory from the LIVE server's install root", {
+      dir: live,
+    });
+    return live;
   }
   return localOutputDirFallback();
 }


### PR DESCRIPTION
Closes artokun/comfyui-mcp#1052

## What happened

With **ComfyUI Desktop** installed alongside the git checkout they were actually connected to, a reporter's `train_prepare_dataset` refs — `{filename, subfolder, type:"output"}` naming images that server had *just produced* — failed `image not found` against the **Desktop** path. The files sat in the connected server's output dir the whole time.

## Cause

`resolveOutputDir`/`resolveInputDir` were already live-first, but only **one rung deep**: they read an explicit `--output-directory` / `--input-directory` from the running server's argv, and with none present fell straight through to the configured/auto-detected install.

On a one-install machine those are the same tree. On this reporter's they were not.

## Fix

The running server's own argv identifies its root perfectly well (`main.py` + `cwd`) — the live-first move #463 already made for models. That becomes a **middle rung**:

| rung | source |
|---|---|
| 1 | explicit `--output-directory` from live argv — unchanged, still wins |
| 2 | **`<live install root>/output`, derived from the running server's argv** |
| 3 | the configured/saved install — unchanged, still catches everything below |

So this **adds** a source rather than removing one, and a probe failure never outranks the configured install.

Same family as #1035 (`model_metadata` addressing a different ComfyUI than every other tool): a tool resolving the install itself instead of asking which one is actually running. The tool's description already promised refs resolve *"against the connected ComfyUI's output/input dirs"* — the contract was right and the resolution was not.

## Tests

5 modelling the reporter's two-install machine, plus the two directions that must not regress: an explicit `--output-directory` still wins, and an unreadable server still falls back to the configured install. Mutation-verified — removing the rung fails the reported case specifically.

One note for whoever touches this suite next: the `workspace-env` mock had to grow `resolveLiveComfyUIBase`, backed by the **real** argv parsing like the resolvers beside it. Stubbing it would have left the new rung untested while the suite went green — the mock omitting a function is indistinguishable from the code not calling it.

Full suite green: 345 files, 7210 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)