### PR TITLE
0.50.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.18] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- I/O dirs follow the CONNECTED ComfyUI, not a second install (#1053)
+
+#### Changed
+- pin that nested "<node>.<combo>.<leaf>" override keys work (#1051)
+
+
 ## [0.50.17] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.17",
+  "version": "0.50.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.17",
+      "version": "0.50.18",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.17",
+  "version": "0.50.18",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.18` tag (the tag publishes to npm; protected `main` needs this PR).

### Fixed
- **#1052** — I/O dirs follow the connected ComfyUI, not a second install (#1053). With ComfyUI Desktop installed alongside the git checkout they were connected to, a reporter's `train_prepare_dataset` refs failed `image not found` against the Desktop path while the files sat in the connected server's output dir.

  `resolveOutputDir`/`resolveInputDir` were live-first but only one rung deep: they honoured an explicit `--output-directory` from the running server's argv, then fell straight through to the configured install. The running server's own argv (`main.py` + `cwd`) identifies its root, so that becomes a middle rung — explicit flags still win above it, the configured install still catches below.

Same family as 0.50.12's `model_metadata` fix: a tool resolving the install itself instead of asking which one is actually running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)