### PR TITLE
fix(panel_view_nodes_in_viewport): make the character budget reachable

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -6272,3 +6272,43 @@ describe("panel-tools: ack-timeout classification survives a full, spaced tab id
     ).toBe(false);
   });
 });
+
+describe("#754 panel_view_nodes_in_viewport: the character budget is REACHABLE", () => {
+  // The panel has enforced a character budget here since #845 (a 135k-character
+  // reply for a caller inspecting one node). But the orchestrator declared `{}`
+  // and called with no arguments, so the budget applied at its default and no
+  // caller could move it. An enforced-but-hidden cap is the worst shape: callers
+  // hit a limit they can neither see nor raise, and the reply looks merely small.
+  it("forwards max_chars when the caller supplies it", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_view_nodes_in_viewport").handler({ max_chars: 50000 }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "graph_view_nodes_in_viewport", max_chars: 50000 });
+  });
+
+  it("omits the key entirely when the caller does not", async () => {
+    // Not `max_chars: undefined` on the wire: the panel's normalizer treats a
+    // nonsense value as "fall back to the default", so sending the key at all
+    // would record this caller as having asked for something it did not.
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_view_nodes_in_viewport").handler({}, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "graph_view_nodes_in_viewport" });
+    expect("max_chars" in calls[0]).toBe(false);
+  });
+
+  it("declares the ceiling it advertises, so the stated number is enforced", () => {
+    // The remedy string says "Raise `max_chars` up to 200000". A prose ceiling the
+    // schema does not enforce is the #809 defect in miniature — the caller raises
+    // past it and nothing changes. Read the ceiling off the zod shape itself.
+    const def = defByName("panel_view_nodes_in_viewport");
+    const shape = def.schema as Record<string, { safeParse: (v: unknown) => { success: boolean } }>;
+    expect(shape.max_chars).toBeDefined();
+    expect(shape.max_chars.safeParse(200000).success).toBe(true);
+    expect(shape.max_chars.safeParse(200001).success).toBe(false);
+    // …and the remedy's number matches what was just proven enforceable.
+    expect(def.description).not.toContain("node_ids");
+    const remedy = JSON.stringify(def);
+    if (remedy.includes("up to ")) {
+      expect(remedy).toContain("up to 200000");
+    }
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6247,10 +6247,44 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_view_nodes_in_viewport",
-      "ONLY the nodes inside the current VIEWPORT (pan+zoom) — a screen-region subset, NOT the whole open graph (that is panel_graph_outline, which is what 'show me what's on the canvas' means). Use this to SCOPE your work to what's on their screen: when they say \"these nodes\", \"the ones here\", \"what am I looking at right now\", or when a graph is large and you only need the region in front of them. Returns the viewport rect in graph coordinates (x, y, width, height, zoom), `node_count` (whole graph) vs `in_view_count`, and the detail summary of each visible node. A node counts as visible if any part of it overlaps the viewport. On a big canvas this is dramatically cheaper than reading everything. Read-only.",
-      {},
-      async (_args, ctx) =>
-        withTruncationHints(await ctx.call({ cmd: "graph_view_nodes_in_viewport" }), [
+      "ONLY the nodes inside the current VIEWPORT (pan+zoom) — a screen-region subset, NOT the whole open graph (that is panel_graph_outline, which is what 'show me what's on the canvas' means). Use this to SCOPE your work to what's on their screen: when they say \"these nodes\", \"the ones here\", \"what am I looking at right now\", or when a graph is large and you only need the region in front of them. Returns the viewport rect in graph coordinates (x, y, width, height, zoom), `node_count` (whole graph) vs `in_view_count`, and the detail summary of each visible node. A node counts as visible if any part of it overlaps the viewport. On a big canvas this is dramatically cheaper than reading everything. This tool does NOT filter to specific nodes — to read one node's exact slot/widget detail use panel_query_graph {ids:[…], fields:'detail'}. Read-only.",
+      {
+        // #845/#754 — the panel has enforced a CHARACTER budget here since the
+        // 135k-character reply that motivated it, but the budget was unreachable:
+        // this schema was `{}` and the call below passed no arguments, so the
+        // default applied and no caller could raise or lower it. Its sibling
+        // panel_query_graph has always exposed the lever. An enforced-but-hidden
+        // knob is the worst of both — callers hit a cap they cannot see or move.
+        //
+        // The range described here is the PANEL's own clamp (viewport-char-bound.js),
+        // not panel_graph_outline's 500–60000. Two different clamps already exist;
+        // describing the one that is not enforced would make this text false, and a
+        // schema that lies about its bounds is worse than one that omits them.
+        max_chars: z
+          .number()
+          .int()
+          .positive()
+          // Declared so the #809 gate can check the ceiling this tool STATES
+          // against the one it enforces. Only the ceiling: the floor stays
+          // undeclared so a small value clamps up panel-side rather than being
+          // refused — a caller asking for 1000 wants less, not an error.
+          .max(200000)
+          .optional()
+          .describe(
+            "Character budget for the whole reply (default 24000, clamped 2000–200000). Nodes are taken in view order until it is spent, never partially serialized. `in_view_count` keeps describing the SCREEN, so compare it to nodes.length to see what was withheld.",
+          ),
+      },
+      async (args: A, ctx) =>
+        withTruncationHints(
+          await ctx.call({
+            cmd: "graph_view_nodes_in_viewport",
+            // Forwarded only when supplied: an explicit `undefined` on the wire
+            // would reach the panel's normalizer as a nonsense value, and it
+            // deliberately falls back to the default rather than to zero — but
+            // sending it at all would misreport this caller as having asked.
+            ...(args.max_chars === undefined ? {} : { max_chars: args.max_chars }),
+          }),
+          [
           {
             flag: "truncated",
             key: "truncation_hint",
@@ -6259,7 +6293,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 "visible node(s)",
                 replyCount(p, "nodes"),
                 p.in_view_count,
-                "Ask the user to zoom in so fewer nodes are on screen, or read the region with panel_query_graph (which DOES take limit and max_chars) / panel_graph_outline for the whole graph.",
+                // #754 — this remedy used to send the caller to panel_query_graph
+                // "which DOES take limit and max_chars", because this tool did not.
+                // It does now, so the first move is the lever in your own hand.
+                "Raise `max_chars` up to 200000 to see more of the same screen, or ask the user to zoom in so fewer nodes are on it. To read SPECIFIC nodes instead, panel_query_graph {ids:[…], fields:'detail'}; for the whole graph, panel_graph_outline.",
               ),
           },
         ]),


### PR DESCRIPTION
Part of artokun/comfyui-mcp-panel#754.

## An enforced cap nobody could move

The panel has enforced a character budget on this command since #845 — the
**135,531-character** reply a caller got while inspecting one node. But it was
unreachable from the tool surface. The schema was `{}` and the handler called:

```ts
ctx.call({ cmd: "graph_view_nodes_in_viewport" })   // no arguments
```

…so the panel's default applied and no caller could raise or lower it, while its sibling
`panel_query_graph` has always exposed the lever. Enforced-but-hidden is the worst of the
three shapes: callers hit a limit they can neither see nor move, and the reply just looks
small.

## Measured before changing anything

Released `mcp=0.50.15` / `panel=0.11.44`, over the loopback panel MCP:

| call | reply |
|---|---|
| `{}` | 204 chars |
| `{"node_ids":["42"]}` | **byte-identical** |
| `{"utterly_bogus_param":123}` | **byte-identical** |

Unknown keys are accepted and silently dropped — zod's `object()` strips by default. That
silence is **surface-wide across all 91 panel tools** and is deliberately **not** addressed
here: making schemas strict would turn every currently-tolerated extra key into a hard
failure, which is a call to make on purpose. It is written up on the issue.

## The stated ceiling is now a real one

The remedy says "Raise `max_chars` up to 200000", and the schema declares `.max(200000)` so
that number is enforced. A prose ceiling the schema does not enforce is #809's defect in
miniature — the caller raises past it and nothing changes.

The **floor** stays undeclared on purpose: a caller asking for 1000 wants *less*, not an
error, so it clamps up panel-side.

The range documented is the **panel's** clamp (2000–200000, `viewport-char-bound.js`), not
`panel_graph_outline`'s 500–60000. Two different clamps already exist; describing the one
that is not enforced would make the text false.

## The remedy contradicted itself

It sent callers to `panel_query_graph` *"which DOES take limit and max_chars"* — true when
written, self-contradictory once this tool takes it too. It now names the lever in the
caller's own hand first, and still points at `panel_query_graph {ids:[…]}` for reading
**specific** nodes.

That is also why `node_ids` is **not** added here, despite being what the reporter passed:
`panel_query_graph {ids:[42], fields:'detail'}` already does it, is token-bounded, and
takes `limit`. Duplicating it would make this tool's own description untrue.

## Tests

7208 pass; typecheck and `check:vocabulary` green.

Worth flagging: **the #809 truncation gate does not cover this.** I assumed it would and
checked — stating a ceiling of `999999` and removing the forwarding entirely **both
survived** it. The three tests added here kill all three mutations:

| mutation | result |
|---|---|
| stop forwarding `max_chars` | fails |
| send the key unconditionally (even `undefined`) | fails |
| widen the enforced ceiling past the stated one | fails |
