### PR TITLE
0.50.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.19] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- make the character budget reachable (#1055)
+
+
 ## [0.50.18] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.18",
+  "version": "0.50.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.18",
+      "version": "0.50.19",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.18",
+  "version": "0.50.19",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.19` tag (the tag publishes to npm; protected `main` needs this PR).

### Fixed
- **panel_view_nodes_in_viewport** — the character budget is reachable (#1055, part of #845). The panel has enforced a char cap on this command since the 135k-character reply that motivated it, but the tool schema was `{}` and passed no arguments, so no caller could see or move it. Its sibling `panel_query_graph` always exposed the lever.

  `max_chars` is now a declared parameter with `.max(200000)`, matching the panel's actual clamp (`viewport-char-bound.js`: default 24000, clamped 2000–200000) — a stated ceiling the schema does not enforce is #809's defect in miniature. The floor stays undeclared on purpose so a small value clamps up rather than erroring. The truncation remedy no longer contradicts itself by sending callers to a sibling "which DOES take max_chars".

`node_ids` deliberately not added: `panel_query_graph {ids:[…], fields:'detail'}` already reads specific nodes, is token-bounded, and takes `limit`.

Verified before merging: the panel's clamp constants match the numbers this schema declares, and `docs:gen` stays a no-op (panel tools aren't in the generated 37-tool reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)