### PR TITLE
fix(#1050): settle before re-issuing a scoped run that lost the stamp race

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -6011,6 +6011,72 @@ describe("panel-tools: panel_run scoped-run stamp-race retry (#772)", () => {
     expect(runText(res)).toMatch(/queued once, not twice/);
   });
 
+  // #1050 — the re-issue used to fire in the SAME tick as the refusal, so it
+  // landed in the very window the panel had just refused for. A reporter's
+  // retry raced identically and instantly: the one re-issue was spent for
+  // nothing and the run was refused twice with nothing queued.
+  //
+  // The pause is a SETTLE, not the mutation-quiescence barrier the report asked
+  // for — the panel exposes no such signal, and inventing a graph-is-quiet
+  // reading from out here would be guessing at the frontend's state. What it
+  // buys is a moment for pending edits to land, exactly as the reconnect retry
+  // already does for a dropped socket.
+  describe("#1050: the re-issue settles first", () => {
+    it("waits before re-dispatching instead of racing in the same tick", async () => {
+      __panelToolsTestHooks.setRetrySettleMs(40);
+      try {
+        const { ctx, runs } = runCtx([{ error: RACE }, { queued: true, prompt_id: "p1" }]);
+        const started = Date.now();
+        const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+        const elapsed = Date.now() - started;
+
+        expect(res.isError).toBeFalsy();
+        expect(runs).toHaveLength(2);
+        // The gap is the whole fix: without it the second dispatch is issued
+        // synchronously into the window that just refused the first.
+        expect(elapsed).toBeGreaterThanOrEqual(35);
+      } finally {
+        __panelToolsTestHooks.setRetrySettleMs(0);
+      }
+    });
+
+    it("still re-issues EXACTLY once when the pause does not save it", async () => {
+      const { ctx, runs } = runCtx([{ error: RACE }, { error: RACE }]);
+      const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+
+      expect(res.isError).toBe(true);
+      expect(runs).toHaveLength(2); // never a third — a second race is surfaced
+    });
+
+    // A graph still moving after the pause means the canvas is being edited, and
+    // that is the one thing the caller can act on.
+    it("says a second race means the graph is still changing", async () => {
+      const { ctx } = runCtx([{ error: RACE }, { error: RACE }]);
+      const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+      const text = runText(res);
+      expect(text).toMatch(/after a short pause to let pending graph edits land/);
+      expect(text).toMatch(/still changing under the run/);
+      // …and the certified fact is unchanged.
+      expect(text).toMatch(/first dispatch definitely queued nothing/);
+    });
+
+    // The pause must not apply to rejections that are NOT the certified race —
+    // those are terminal and must stay instant.
+    it("does not pause a rejection it will not retry", async () => {
+      __panelToolsTestHooks.setRetrySettleMs(300);
+      try {
+        const { ctx, runs } = runCtx([{ error: "ComfyUI refused: node 3 has no input 'x'" }]);
+        const started = Date.now();
+        const res = await defByName("panel_run").handler({ to_node_id: 650 }, ctx);
+        expect(res.isError).toBe(true);
+        expect(runs).toHaveLength(1);
+        expect(Date.now() - started).toBeLessThan(250);
+      } finally {
+        __panelToolsTestHooks.setRetrySettleMs(0);
+      }
+    });
+  });
+
   it("does NOT retry a rejection that is not the certified race (validation failure)", async () => {
     const { ctx, runs } = runCtx([
       { node_errors: { 5: { class_type: "KSampler", errors: [{ message: "bad seed" }] } } },

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -7066,6 +7066,20 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         ) {
           scopeRebuilt = true;
           try {
+            // #1050 — SETTLE before re-issuing. The panel refuses this race when the
+            // graph changed between dispatch and apply, and re-dispatching in the
+            // same tick lands in the SAME window: a reporter's retry raced
+            // identically and instantly, so the one re-issue was spent for nothing
+            // and the run was refused twice with nothing queued.
+            //
+            // This is a SETTLE PAUSE, not the mutation-quiescence barrier the report
+            // asked for. The panel exposes no such signal, and inventing a
+            // graph-is-quiet reading from out here would be guessing at the
+            // frontend's state. It buys pending edits a moment to land — exactly
+            // what the reconnect retry already does for a dropped socket — and
+            // nothing more. A graph still moving after it (a user actively editing)
+            // races again and is SURFACED, never re-raced.
+            await sleep(retrySettleMs());
             res = await ctx.call(runCmd, 20000);
             rejection = detectRunRejection(res);
           } catch (err) {
@@ -7095,9 +7109,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             rejection,
             `\n\n(Dispatch history: the first graph_run was refused by the panel's run-to-node ` +
               `graph-stamp race, which CERTIFIED that nothing was queued, so the scoped run was ` +
-              `re-issued exactly once. The failure above is that SECOND dispatch; it was not ` +
-              `retried again. Judge whether anything was queued from that message alone — the ` +
-              `first dispatch definitely queued nothing.)`,
+              `re-issued exactly once — after a short pause to let pending graph edits land ` +
+              `(#1050). The failure above is that SECOND dispatch; it was not retried again. ` +
+              `Judge whether anything was queued from that message alone — the first dispatch ` +
+              `definitely queued nothing. Racing AGAIN after the pause means the graph is still ` +
+              `changing under the run: let the canvas settle, then re-run.)`,
           );
         }
         // Attribute this genuine queue to ourselves so a later panel_run in the


### PR DESCRIPTION
Closes artokun/comfyui-mcp#1050

## What happened

`panel_run(to_node_id)` was refused **twice, back to back**, with nothing queued.

The panel refuses a run-to-node dispatch when the graph changed between dispatch and apply — correctly, because falling through would render a *modified* workflow as if it were the scoped one (#556). It certifies nothing was queued, which is what makes the single re-issue safe (#772).

But the re-issue fired **in the same tick** as the refusal, so it landed in the very window that had just refused the first. The reporter's retry raced identically and instantly, and the one re-issue was spent for nothing.

## Fix

A settle pause before the second dispatch — the same one the reconnect retry already takes for a dropped socket.

**It is a settle, not a barrier.** The report asked for a "frontend mutation-quiescence barrier"; the panel exposes no graph-is-quiet signal, and inventing one from out here would be guessing at the frontend's state. This buys pending edits a moment to land and claims nothing more. A graph still moving after it — a user actively editing — races again and is **surfaced, never re-raced**: still exactly one re-issue, never a third dispatch.

The disclosure now says the pause happened, and what a *second* race means: the graph is still changing under the run, which is the one thing the caller can act on. Everything it certified before is unchanged — the first dispatch queued nothing.

## Tests

4, and the last one is the one I'd review hardest:

- the gap is real (timing-verified against an overridden settle)
- a doomed retry still re-issues **exactly once**, never a third time
- the second-race text names the cause
- **a rejection that is NOT the certified race stays terminal *and* instant** — the pause must never delay a failure it will not retry, which would turn one bug into a slower one

Mutation-verified: removing the pause fails the timing test.

Full suite green: 345 files, 7217 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)