### PR TITLE
0.50.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.20] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- settle before re-issuing a scoped run that lost the stamp race (#1057)
+
+
 ## [0.50.19] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.19",
+  "version": "0.50.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.19",
+      "version": "0.50.20",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.19",
+  "version": "0.50.20",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.20` tag (the tag publishes to npm; protected `main` needs this PR).

### Fixed
- **#1050** — settle before re-issuing a scoped run that lost the stamp race (#1057). `panel_run(to_node_id)` was refused twice back-to-back with nothing queued: the panel correctly refuses when the graph changed between dispatch and apply (rather than rendering a modified workflow as the scoped one, #556), but the single re-issue fired in the *same tick* and landed in the very window that had just refused it.

  There is now a settle pause before the second dispatch — the same one the reconnect retry takes. It's a settle, not the mutation-quiescence barrier the report asked for: the panel exposes no graph-is-quiet signal, so this buys pending edits a moment to land and claims nothing more. A graph still moving after it races again and is surfaced, never re-raced — still exactly one re-issue.

The disclosure now says a *second* race means the graph is still changing under the run, which is the one thing the caller can act on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)