### PR TITLE
fix(#1037): the generate_* family reports rejected output branches too

### DIFF
--- a/src/__tests__/services/upscale-image.test.ts
+++ b/src/__tests__/services/upscale-image.test.ts
@@ -82,3 +82,40 @@ describe("upscaleImage", () => {
     await expect(upscaleImage({ image: "" }, deps)).rejects.toThrow(/image is required/i);
   });
 });
+
+// #1037 — a 200 from /prompt does not mean every output was accepted. ComfyUI
+// validates each branch independently, queues the ones that pass, and reports
+// `node_errors` for the ones it refused; those never run while the prompt still
+// completes, so the run reads as a clean success that produced nothing.
+//
+// 0.50.15 surfaced that on the workflow-execution tools, but the generate_*
+// family routes through its own result types and only LOGGED it. This pins that
+// the disclosure now reaches the caller here too.
+describe("#1037: a rejected output branch reaches the caller", () => {
+  const REJECTED =
+    'The prompt was QUEUED, but ComfyUI REJECTED 1 output branch at validation and will not run it ' +
+    '— node 9 (SaveImage): Required input is missing (images).';
+
+  it("carries rejectedOutputs through to the result", async () => {
+    const { deps } = makeDeps({
+      enqueue: async () => ({
+        prompt_id: "pid-upscale",
+        queue_remaining: 0,
+        rejectedOutputs: REJECTED,
+      }),
+    });
+    const res = await upscaleImage({ image: "in.png" }, deps);
+    expect(res.rejectedOutputs).toBe(REJECTED);
+    // …and the run is still reported as queued, because it was.
+    expect(res.prompt_id).toBe("pid-upscale");
+  });
+
+  // Absent when nothing was rejected — the field must never appear as an empty
+  // reassurance, which would read as "we checked and it was fine".
+  it("is absent when every output was accepted", async () => {
+    const { deps } = makeDeps();
+    const res = await upscaleImage({ image: "in.png" }, deps);
+    expect(res.rejectedOutputs).toBeUndefined();
+    expect("rejectedOutputs" in res && res.rejectedOutputs !== undefined).toBe(false);
+  });
+});

--- a/src/services/api-nodes.ts
+++ b/src/services/api-nodes.ts
@@ -44,7 +44,7 @@ export interface ApiNodesDeps {
       disable_random_seed?: boolean;
       extra_data?: Record<string, unknown>;
     },
-  ) => Promise<{ prompt_id: string; queue_remaining?: number }>;
+  ) => Promise<{ prompt_id: string; queue_remaining?: number; rejectedOutputs?: string }>;
 }
 
 const defaultDeps: ApiNodesDeps = {
@@ -518,6 +518,10 @@ export interface GenerateWithApiNodeArgs {
 export interface GenerateWithApiNodeResult {
   prompt_id: string;
   queue_remaining?: number;
+  /** #1037 — output branches ComfyUI REFUSED while accepting the prompt. Present
+   *  only when some were: the run WAS queued, and the accepted branches still
+   *  produce output, so this is a disclosure attached to a success. */
+  rejectedOutputs?: string;
   /** The minimal single-node workflow that was enqueued. */
   workflow: WorkflowJSON;
   /** Non-fatal guidance (e.g. unknown inputs, auth reminder). */
@@ -656,6 +660,7 @@ export async function generateWithApiNode(
   return {
     prompt_id: result.prompt_id,
     queue_remaining: result.queue_remaining,
+    rejectedOutputs: result.rejectedOutputs,
     workflow,
     notes,
   };

--- a/src/services/generate-audio.ts
+++ b/src/services/generate-audio.ts
@@ -43,12 +43,18 @@ export interface GenerateAudioArgs {
 
 export interface GenerateAudioDeps {
   resolveFirstModel: (type: string) => Promise<string | undefined>;
-  enqueue: (workflow: WorkflowJSON) => Promise<{ prompt_id: string; queue_remaining?: number }>;
+  enqueue: (
+    workflow: WorkflowJSON,
+  ) => Promise<{ prompt_id: string; queue_remaining?: number; rejectedOutputs?: string }>;
 }
 
 export interface GenerateAudioResult {
   prompt_id: string;
   queue_remaining?: number;
+  /** #1037 — output branches ComfyUI REFUSED while accepting the prompt. Present
+   *  only when some were: the run WAS queued, and the accepted branches still
+   *  produce output, so this is a disclosure attached to a success. */
+  rejectedOutputs?: string;
   model_family: string;
 }
 
@@ -147,8 +153,8 @@ export async function generateAudio(
       filename_prefix: resolved.filename_prefix as string | undefined,
     });
 
-    const { prompt_id, queue_remaining } = await deps.enqueue(workflow);
-    return { prompt_id, queue_remaining, model_family: "ace_step_1.5" };
+    const { prompt_id, queue_remaining, rejectedOutputs } = await deps.enqueue(workflow);
+    return { prompt_id, queue_remaining, rejectedOutputs, model_family: "ace_step_1.5" };
   }
 
   // Stable Audio 3
@@ -178,6 +184,6 @@ export async function generateAudio(
     filename_prefix: resolved.filename_prefix as string | undefined,
   });
 
-  const { prompt_id, queue_remaining } = await deps.enqueue(workflow);
-  return { prompt_id, queue_remaining, model_family: "stable_audio_3" };
+  const { prompt_id, queue_remaining, rejectedOutputs } = await deps.enqueue(workflow);
+  return { prompt_id, queue_remaining, rejectedOutputs, model_family: "stable_audio_3" };
 }

--- a/src/services/generate-image.ts
+++ b/src/services/generate-image.ts
@@ -21,12 +21,18 @@ export interface GenerateImageDeps {
   /** Resolve a checkpoint filename when none is given or defaulted. */
   resolveCheckpoint: () => Promise<string | undefined>;
   /** Submit the constructed workflow; returns the prompt id. */
-  enqueue: (workflow: WorkflowJSON) => Promise<{ prompt_id: string; queue_remaining?: number }>;
+  enqueue: (
+    workflow: WorkflowJSON,
+  ) => Promise<{ prompt_id: string; queue_remaining?: number; rejectedOutputs?: string }>;
 }
 
 export interface GenerateImageResult {
   prompt_id: string;
   queue_remaining?: number;
+  /** #1037 — output branches ComfyUI REFUSED while accepting the prompt. Present
+   *  only when some were: the run WAS queued, and the accepted branches still
+   *  produce output, so this is a disclosure attached to a success. */
+  rejectedOutputs?: string;
   checkpoint: string;
 }
 
@@ -95,6 +101,6 @@ export async function generateImage(
     }
   }
 
-  const { prompt_id, queue_remaining } = await deps.enqueue(workflow);
-  return { prompt_id, queue_remaining, checkpoint };
+  const { prompt_id, queue_remaining, rejectedOutputs } = await deps.enqueue(workflow);
+  return { prompt_id, queue_remaining, rejectedOutputs, checkpoint };
 }

--- a/src/services/generate-video.ts
+++ b/src/services/generate-video.ts
@@ -31,12 +31,18 @@ export interface GenerateVideoDeps {
   /** List local model filenames for a category (may be empty; throws when the
    *  listing can't be obtained, e.g. no running server). */
   listModels: (type: string) => Promise<string[]>;
-  enqueue: (workflow: WorkflowJSON) => Promise<{ prompt_id: string; queue_remaining?: number }>;
+  enqueue: (
+    workflow: WorkflowJSON,
+  ) => Promise<{ prompt_id: string; queue_remaining?: number; rejectedOutputs?: string }>;
 }
 
 export interface GenerateVideoResult {
   prompt_id: string;
   queue_remaining?: number;
+  /** #1037 — output branches ComfyUI REFUSED while accepting the prompt. Present
+   *  only when some were: the run WAS queued, and the accepted branches still
+   *  produce output, so this is a disclosure attached to a success. */
+  rejectedOutputs?: string;
   mode: "t2v" | "i2v";
   checkpoint: string;
   width: number;
@@ -244,10 +250,11 @@ export async function generateVideo(
     filename_prefix: filenamePrefix,
   });
 
-  const { prompt_id, queue_remaining } = await deps.enqueue(workflow);
+  const { prompt_id, queue_remaining, rejectedOutputs } = await deps.enqueue(workflow);
   return {
     prompt_id,
     queue_remaining,
+    rejectedOutputs,
     mode,
     checkpoint,
     width: res.width,

--- a/src/services/remove-background.ts
+++ b/src/services/remove-background.ts
@@ -21,12 +21,18 @@ export interface RemoveBackgroundDeps {
    *  it can't be determined (no running server) — in which case we proceed and
    *  let execution surface any problem. */
   isNodeInstalled?: (classType: string) => Promise<boolean | undefined>;
-  enqueue: (workflow: WorkflowJSON) => Promise<{ prompt_id: string; queue_remaining?: number }>;
+  enqueue: (
+    workflow: WorkflowJSON,
+  ) => Promise<{ prompt_id: string; queue_remaining?: number; rejectedOutputs?: string }>;
 }
 
 export interface RemoveBackgroundResult {
   prompt_id: string;
   queue_remaining?: number;
+  /** #1037 — output branches ComfyUI REFUSED while accepting the prompt. Present
+   *  only when some were: the run WAS queued, and the accepted branches still
+   *  produce output, so this is a disclosure attached to a success. */
+  rejectedOutputs?: string;
   model: string;
 }
 
@@ -88,6 +94,6 @@ export async function removeBackground(
   const model =
     (workflow["2"]?.inputs.model as string | undefined) ?? "BiRefNet_toonout";
 
-  const { prompt_id, queue_remaining } = await deps.enqueue(workflow);
-  return { prompt_id, queue_remaining, model };
+  const { prompt_id, queue_remaining, rejectedOutputs } = await deps.enqueue(workflow);
+  return { prompt_id, queue_remaining, rejectedOutputs, model };
 }

--- a/src/services/upscale-image.ts
+++ b/src/services/upscale-image.ts
@@ -17,12 +17,18 @@ export interface UpscaleImageArgs {
 export interface UpscaleImageDeps {
   /** Resolve a local upscale model filename when none is given/defaulted. */
   resolveUpscaleModel: () => Promise<string | undefined>;
-  enqueue: (workflow: WorkflowJSON) => Promise<{ prompt_id: string; queue_remaining?: number }>;
+  enqueue: (
+    workflow: WorkflowJSON,
+  ) => Promise<{ prompt_id: string; queue_remaining?: number; rejectedOutputs?: string }>;
 }
 
 export interface UpscaleImageResult {
   prompt_id: string;
   queue_remaining?: number;
+  /** #1037 — output branches ComfyUI REFUSED while accepting the prompt. Present
+   *  only when some were: the run WAS queued, and the accepted branches still
+   *  produce output, so this is a disclosure attached to a success. */
+  rejectedOutputs?: string;
   model: string;
   scale: 2 | 4;
 }
@@ -74,6 +80,6 @@ export async function upscaleImage(
     scale,
   });
 
-  const { prompt_id, queue_remaining } = await deps.enqueue(workflow);
-  return { prompt_id, queue_remaining, model, scale };
+  const { prompt_id, queue_remaining, rejectedOutputs } = await deps.enqueue(workflow);
+  return { prompt_id, queue_remaining, rejectedOutputs, model, scale };
 }

--- a/src/tools/api-nodes.ts
+++ b/src/tools/api-nodes.ts
@@ -129,6 +129,11 @@ export function registerApiNodesTools(server: McpServer): void {
                       status: "enqueued",
                       prompt_id: result.prompt_id,
                       queue_remaining: result.queue_remaining,
+                      // #1037 — a 200 from /prompt does not mean every output was accepted;
+                      // ComfyUI queues the branches that validate and reports the rest.
+                      ...(result.rejectedOutputs
+                        ? { rejected_outputs: result.rejectedOutputs }
+                        : {}),
                       notes: result.notes,
                       workflow: result.workflow,
                     },

--- a/src/tools/generate-3d.ts
+++ b/src/tools/generate-3d.ts
@@ -24,6 +24,11 @@ export async function generate3dAction(
             status: "enqueued",
             prompt_id: result.prompt_id,
             queue_remaining: result.queue_remaining,
+            // #1037 — a 200 from /prompt does not mean every output was accepted;
+            // ComfyUI queues the branches that validate and reports the rest.
+            ...(result.rejectedOutputs
+              ? { rejected_outputs: result.rejectedOutputs }
+              : {}),
             node: result.class_type,
             display_name: result.display_name,
             category: result.category,

--- a/src/tools/generate-audio.ts
+++ b/src/tools/generate-audio.ts
@@ -47,6 +47,11 @@ export async function generateAudioAction(
             model_family: result.model_family,
             prompt_id: result.prompt_id,
             queue_remaining: result.queue_remaining,
+            // #1037 — a 200 from /prompt does not mean every output was accepted;
+            // ComfyUI queues the branches that validate and reports the rest.
+            ...(result.rejectedOutputs
+              ? { rejected_outputs: result.rejectedOutputs }
+              : {}),
             note: "asset_id will be available in the completion notification; the SaveAudioMP3 node writes the output file to ComfyUI's output directory.",
           },
           null,

--- a/src/tools/generate-conditioned.ts
+++ b/src/tools/generate-conditioned.ts
@@ -24,7 +24,16 @@ const deps: ConditionedDeps = {
 };
 
 
-function enqueuedResult(result: { prompt_id: string; queue_remaining?: number; checkpoint: string }, tool: string) {
+function enqueuedResult(
+  result: {
+    prompt_id: string;
+    queue_remaining?: number;
+    checkpoint: string;
+    /** #1037 — output branches ComfyUI refused while accepting the prompt. */
+    rejectedOutputs?: string;
+  },
+  tool: string,
+) {
   return {
     content: [
       {
@@ -35,6 +44,11 @@ function enqueuedResult(result: { prompt_id: string; queue_remaining?: number; c
             tool,
             prompt_id: result.prompt_id,
             queue_remaining: result.queue_remaining,
+            // #1037 — a 200 from /prompt does not mean every output was accepted;
+            // ComfyUI queues the branches that validate and reports the rest.
+            ...(result.rejectedOutputs
+              ? { rejected_outputs: result.rejectedOutputs }
+              : {}),
             checkpoint: result.checkpoint,
             note: 'asset_id will be available in the completion notification; use get_image (action:"view") or generate_image (action:"regenerate") with it.',
           },

--- a/src/tools/generate-image.ts
+++ b/src/tools/generate-image.ts
@@ -469,6 +469,11 @@ export function registerGenerateImageTool(server: McpServer): void {
                       status: "enqueued",
                       prompt_id: result.prompt_id,
                       queue_remaining: result.queue_remaining,
+                      // #1037 — a 200 from /prompt does not mean every output was accepted;
+                      // ComfyUI queues the branches that validate and reports the rest.
+                      ...(result.rejectedOutputs
+                        ? { rejected_outputs: result.rejectedOutputs }
+                        : {}),
                       checkpoint: result.checkpoint,
                       note: 'asset_id will be available in the completion notification; use get_image (action:"view") or generate_image (action:"regenerate") with it.',
                     },

--- a/src/tools/generate-video.ts
+++ b/src/tools/generate-video.ts
@@ -49,6 +49,11 @@ export async function generateVideoAction(
             mode: result.mode,
             prompt_id: result.prompt_id,
             queue_remaining: result.queue_remaining,
+            // #1037 — a 200 from /prompt does not mean every output was accepted;
+            // ComfyUI queues the branches that validate and reports the rest.
+            ...(result.rejectedOutputs
+              ? { rejected_outputs: result.rejectedOutputs }
+              : {}),
             checkpoint: result.checkpoint,
             width: result.width,
             height: result.height,

--- a/src/tools/remove-background.ts
+++ b/src/tools/remove-background.ts
@@ -47,6 +47,11 @@ export async function removeBackgroundAction(args: {
             tool: 'generate_image (action:"remove_background")',
             prompt_id: result.prompt_id,
             queue_remaining: result.queue_remaining,
+            // #1037 — a 200 from /prompt does not mean every output was accepted;
+            // ComfyUI queues the branches that validate and reports the rest.
+            ...(result.rejectedOutputs
+              ? { rejected_outputs: result.rejectedOutputs }
+              : {}),
             model: result.model,
             note: 'Transparent cutout asset_id arrives in the completion notification; use get_image (action:"view") with it.',
           },

--- a/src/tools/upscale-image.ts
+++ b/src/tools/upscale-image.ts
@@ -41,6 +41,11 @@ export async function upscaleImageAction(args: {
             tool: 'generate_image (action:"upscale")',
             prompt_id: result.prompt_id,
             queue_remaining: result.queue_remaining,
+            // #1037 — a 200 from /prompt does not mean every output was accepted;
+            // ComfyUI queues the branches that validate and reports the rest.
+            ...(result.rejectedOutputs
+              ? { rejected_outputs: result.rejectedOutputs }
+              : {}),
             model: result.model,
             scale: result.scale,
             note: 'Upscaled asset_id arrives in the completion notification; use get_image (action:"view") with it.',


### PR DESCRIPTION
Finishes the half I deliberately scoped out of #1042 (shipped as 0.50.15).

## What was left undone

0.50.15 made a queued prompt disclose the output branches ComfyUI **refused** at validation — the case where `/prompt` answers 200 with a `prompt_id` *and* non-empty `node_errors`, those branches never run, and the run still reports success while producing nothing from them.

It reached the workflow-execution tools. The `generate_*` family did **not**: those route through their own result types, so the disclosure was logged and then dropped before the caller saw it. I said so on that PR rather than quietly shipping a partial fix — this is the other half.

## What changed

`rejectedOutputs` threaded through all six result types and their injected `enqueue` deps — `generate-image` / `-video` / `-audio` / `-3d`, `upscale-image`, `remove-background`, and the `api-nodes` base they extend — and rendered as `rejected_outputs` by every tool that builds an enqueued result.

**13 renderers carry it now, up from 5.**

Mechanical, and uniform because the shape was: every one of these takes an injected `enqueue` returning `{ prompt_id, queue_remaining? }` and returns the same two fields. Widening the dep, the interface and the construction site was the same three edits five times over — which is why this is one change rather than six.

## Absent when nothing was rejected

The field must never appear as an empty reassurance. *"We checked and it was fine"* is a claim; the only honest signal here is its presence. A test pins the absence directly.

Mutation-verified: dropping the propagation fails the service test.

Full suite green: 346 files, 7222 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)