### PR TITLE
0.50.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.21] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- the generate_* family reports rejected output branches too (#1060)
+
+#### Changed
+- a remedy never names an action the tool does not have (#1059)
+
+
 ## [0.50.20] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.20",
+  "version": "0.50.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.20",
+      "version": "0.50.21",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.20",
+  "version": "0.50.21",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles `main` with the pushed `v0.50.21` tag (the tag publishes to npm; protected `main` needs this PR).

### Fixed
- **#1037** — the `generate_*` family reports rejected output branches too (#1060). 0.50.15 made a queued prompt disclose the output branches ComfyUI refused at validation, but only on the workflow-execution tools; the `generate_*` family routes through its own result types, so the disclosure was logged and then dropped before the caller saw it.

  `rejectedOutputs` is now threaded through all six result types and rendered by every tool that builds an enqueued result — **13 renderers, up from 5**. Absent when nothing was rejected, because a field that always appears would read as "we checked and it was fine".

This finishes the half deliberately scoped out of #1042 rather than leaving part of the surface reporting a clean success over a dropped output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)