### PR TITLE
docs(panel): COMFYUI_MCP_NO_AUTOSPAWN does not exist — name the control that does

### DIFF
--- a/docs/panel.mdx
+++ b/docs/panel.mdx
@@ -79,9 +79,11 @@ JavaScript).
 No `claude mcp add`, no API key. The orchestrator is started **only when you click
 Connect** — never silently on load — and the panel auto-connects if a bridge is
 already running. Prerequisites are Node.js/`npx` on your PATH and the provider login
-above. To run an orchestrator yourself, set `COMFYUI_MCP_NO_AUTOSPAWN=1` and launch
-`npx -y comfyui-mcp@latest connect`, then click Connect; change the bridge
-port with `COMFYUI_MCP_BRIDGE_PORT`.
+above. To run an orchestrator yourself, turn on **Settings → General → "Use
+external/local orchestrator (advanced)"**, launch `npx -y comfyui-mcp@latest
+connect`, then click Connect — the panel links to the bridge that is already
+running instead of starting its own. Change the bridge port with
+`COMFYUI_MCP_BRIDGE_PORT`.
 
 <Note>
 **Driving a remote ComfyUI** (a cloud GPU pod, another box on your LAN)? The setup

--- a/src/__tests__/tools/documented-env-vars-exist.test.ts
+++ b/src/__tests__/tools/documented-env-vars-exist.test.ts
@@ -1,0 +1,95 @@
+// A documented env var that nothing reads is a knob that does nothing.
+//
+// `docs/panel.mdx` told users to set `COMFYUI_MCP_NO_AUTOSPAWN=1` to run their
+// own orchestrator. That name appears NOWHERE — not in this repo, not in the
+// panel's Python, not in its browser JS. It could not have worked even in
+// principle: the spawn decision is made in the BROWSER, which cannot read
+// process env at all, and the panel's Python passes no such value through.
+//
+// A user following that instruction would launch their own orchestrator, click
+// Connect, and get a second one spawned anyway — with nothing to indicate the
+// setting they were told to use had no effect. The real control was a Settings
+// toggle, documented eleven lines further down for the adjacent remote-ComfyUI
+// case.
+//
+// This is the inverse of #1055's enforced-but-hidden cap: documented but inert.
+// Both leave the caller acting on a lever that is not connected to anything.
+//
+// SCOPE, and why this is narrow on purpose. It checks only that a documented
+// name appears SOMEWHERE in the source — not that it is read correctly, and not
+// that undocumented vars get documented (196 are read; documenting every
+// internal tuning knob is not the goal). Presence is the cheap half, and it is
+// the half that would have caught this.
+
+import { readFileSync } from "node:fs";
+import { globSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+
+/** Env-var-shaped names our docs hand to users. */
+const DOCUMENTED = /\b(COMFYUI_[A-Z0-9_]{2,}|HF_[A-Z0-9_]{2,}|HUGGINGFACE_[A-Z0-9_]{2,}|CIVITAI_[A-Z0-9_]{2,})\b/g;
+
+/**
+ * Names that are PREFIXES, expanded at runtime rather than read literally —
+ * `COMFYUI_DEFAULT_CHECKPOINT` is served by `ENV_PREFIX = "COMFYUI_DEFAULT_"`,
+ * and `COMFYUI_AUTH_*` likewise. Matching them literally would report a working
+ * knob as broken, which is the same false-negative this test exists to prevent.
+ */
+const PREFIXES = ["COMFYUI_DEFAULT_", "COMFYUI_AUTH_"];
+
+/**
+ * Read by the PANEL (a separate repo): its Python serves these. Listed
+ * explicitly rather than skipped silently, so the exemption is visible and has
+ * to be justified when it grows.
+ */
+const READ_BY_PANEL = new Set(["COMFYUI_MCP_APPS_DIR", "COMFYUI_MCP_DATA_DIR", "COMFYUI_MCP_TRAINING_DIR"]);
+
+function sourceText(): string {
+  return globSync("src/**/*.ts", { cwd: ROOT })
+    .filter((p) => !p.includes("__tests__") && !p.endsWith(".test.ts"))
+    .map((p) => readFileSync(join(ROOT, p), "utf-8"))
+    .join("\n");
+}
+
+function documentedNames(): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const rel of globSync("docs/**/*.mdx", { cwd: ROOT })) {
+    const text = readFileSync(join(ROOT, rel), "utf-8");
+    for (const m of text.matchAll(DOCUMENTED)) {
+      if (!out.has(m[1])) out.set(m[1], `${rel}:${text.slice(0, m.index!).split("\n").length}`);
+    }
+  }
+  return out;
+}
+
+describe("a documented env var is read by something", () => {
+  it("every env var our docs name appears in the source", () => {
+    const src = sourceText();
+    const inert: string[] = [];
+    for (const [name, where] of documentedNames()) {
+      if (READ_BY_PANEL.has(name)) continue;
+      if (PREFIXES.some((p) => name.startsWith(p))) continue;
+      // Property access OR a bare string literal — many are passed by NAME to a
+      // helper (`parsePositiveNumberEnv("COMFYUI_…", 0.4)`), which a property
+      // scan alone misses. That omission made 8 working vars look inert on the
+      // first pass of this audit.
+      if (src.includes(name)) continue;
+      inert.push(`${name}   documented at ${where}`);
+    }
+    expect(inert, `documented but read by nothing:\n  ${inert.join("\n  ")}`).toEqual([]);
+  });
+
+  it("actually reads the docs it claims to", () => {
+    const names = documentedNames();
+    expect(names.size).toBeGreaterThan(40);
+    expect(sourceText().length).toBeGreaterThan(100_000);
+  });
+
+  // A gate that cannot fail protects nothing.
+  it("would flag a name nothing reads", () => {
+    const src = sourceText();
+    expect(src.includes("COMFYUI_MCP_DEFINITELY_NOT_READ")).toBe(false);
+  });
+});


### PR DESCRIPTION
## A documented knob attached to nothing

`docs/panel.mdx` told users to set `COMFYUI_MCP_NO_AUTOSPAWN=1` to run their own orchestrator. **That name appears nowhere** — not in this repo, not in the panel's Python, not in its browser JS.

It could not have worked even in principle: the spawn decision is made in the **browser**, which cannot read process env at all, and the panel's Python passes no such value through (it reads exactly three env vars, none about spawning).

So a user following that instruction would launch their own orchestrator, click Connect, and get a second one spawned anyway — with nothing to indicate the setting they were told to use was inert.

## The real control was already in the same file

Eleven lines further down, for the adjacent remote-ComfyUI case: **Settings → General → "Use external/local orchestrator (advanced)"**. And the paragraph's own preceding sentence already stated the mechanism — *"the panel auto-connects if a bridge is already running"* — so the env var was both inert **and** superfluous.

`COMFYUI_MCP_BRIDGE_PORT` in the same sentence is real (`src/index.ts:372`) and is kept.

This is the inverse of #1055's enforced-but-hidden cap: **documented but inert**. Both hand the reader a lever attached to nothing.

## Ships with a gate

Every env var our docs name must appear somewhere in the source. Verified it catches this exact defect — re-introducing the name fails it with `COMFYUI_MCP_NO_AUTOSPAWN documented at docs\panel.mdx:82`.

Deliberately narrow: it checks **presence**, not that a var is read correctly, and it does **not** require the 196 vars the code reads to be documented — documenting every internal tuning knob isn't the goal. Two exemptions are listed explicitly rather than skipped silently: runtime-expanded prefixes (`COMFYUI_DEFAULT_*`, `COMFYUI_AUTH_*`) and the three vars the panel's Python serves.

## How I got to exactly one defect

The first pass flagged **11** names. Checking each:

- **8** were passed by *name* to a helper (`parsePositiveNumberEnv("COMFYUI_…", 0.4)`) — my property-access scan couldn't see them.
- **`COMFYUI_MCP_APPS_DIR`** is read by the panel's `py/apps_routes.py`.
- **`COMFYUI_DEFAULT_CHECKPOINT`** is served by a runtime prefix (`ENV_PREFIX = "COMFYUI_DEFAULT_"`).

That left one. The gate carries both lessons — the string-literal scan and the two exemption lists — so the next run doesn't re-learn them by flagging 10 working knobs.

Full suite green: 346 files, 7225 passing. `lint`, `check:vocabulary`, `docs:gen` (no-op) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)