### PR TITLE
test(smoke): verify the published surface REGISTERS, not just that it boots

### DIFF
--- a/scripts/smoke-install.mjs
+++ b/scripts/smoke-install.mjs
@@ -10,10 +10,49 @@
  * crashed on a missing file. Unit tests (`npm test`) never exercise the packed
  * tarball, so this is the gap. Run in CI and as a pre-publish gate.
  */
-import { execSync, spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { execSync, spawn, spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, existsSync, readdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+/**
+ * Ask the installed server for its tool list over MCP stdio. Resolves to the
+ * names, or null if it never answers within the budget — a silence this script
+ * reports rather than reading as "no tools".
+ */
+function listTools(entry) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [entry], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, COMFYUI_URL: "http://127.0.0.1:59999" },
+    });
+    const send = (o) => child.stdin.write(JSON.stringify(o) + "\n");
+    let buf = "";
+    const done = (v) => { try { child.kill(); } catch { /* already gone */ } resolve(v); };
+    const timer = setTimeout(() => done(null), 60_000);
+    child.stdout.on("data", (d) => {
+      buf += d.toString();
+      let i;
+      while ((i = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, i);
+        buf = buf.slice(i + 1);
+        if (!line.trim()) continue;
+        let msg;
+        try { msg = JSON.parse(line); } catch { continue; }
+        if (msg.id === 1) send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+        if (msg.id === 2) {
+          clearTimeout(timer);
+          done((msg.result?.tools ?? []).map((t) => t.name));
+        }
+      }
+    });
+    child.on("error", () => { clearTimeout(timer); done(null); });
+    send({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "smoke", version: "1" } },
+    });
+  });
+}
 
 const run = (cmd, opts = {}) => {
   console.log(`$ ${cmd}${opts.cwd ? `  (cwd: ${opts.cwd})` : ""}`);
@@ -67,4 +106,43 @@ if (boot.signal === "SIGTERM" || boot.status === 0) {
   process.exit(1);
 }
 
-console.log("✅ pack/install smoke passed — tarball installs cleanly and boots");
+// 5. The published surface actually REGISTERS. Booting proves the process starts;
+//    it does not prove the tools are there. A packaging or registration
+//    regression that leaves the server up but short a tool would pass step 4 and
+//    ship — the user finds out when the tool they wanted is simply absent.
+//
+//    Driven over real MCP stdio against the INSTALLED tarball, so this is the
+//    surface a user gets, not the one the repo builds. COMFYUI_URL points at a
+//    dead port on purpose: registration must not depend on a reachable ComfyUI.
+// The ledger IS the list, not a ceiling: TOOL_NAMES holds every core tool, and
+// MAX_TOOLS beside it is a budget target that merely happens to match today.
+// Counting the list keeps this honest if the two ever diverge.
+const LEDGER = readFileSync(join(process.cwd(), "src/tools/vocabulary.ts"), "utf-8");
+const EXPECTED_CORE = (
+  LEDGER.match(/TOOL_NAMES\s*=\s*\[[\s\S]*?\n\]/)?.[0].match(/"[a-z][a-z0-9_]*"/g) ?? []
+).length;
+const surface = await listTools(join(pkg, "dist/index.js"));
+if (surface === null) {
+  console.error("❌ the installed server never answered tools/list");
+  process.exit(1);
+}
+// The three compact-mode meta tools (list_tools / describe_tool / call_tool) are
+// registered ALONGSIDE the core surface and are deliberately absent from the
+// ledger, so they are counted out rather than expected in it.
+const META = ["list_tools", "describe_tool", "call_tool"];
+const core = surface.filter((n) => !META.includes(n));
+const missingMeta = META.filter((n) => !surface.includes(n));
+if (EXPECTED_CORE > 0 && core.length !== EXPECTED_CORE) {
+  console.error(
+    `❌ installed surface has ${core.length} core tools, ledger declares ${EXPECTED_CORE}` +
+      `\n   registered: ${core.join(", ")}`,
+  );
+  process.exit(1);
+}
+if (missingMeta.length) {
+  console.error(`❌ compact-mode tools missing from the installed surface: ${missingMeta.join(", ")}`);
+  process.exit(1);
+}
+console.log(`✅ installed surface registers ${core.length} core tools + ${META.length} compact-mode tools`);
+
+console.log("✅ pack/install smoke passed — tarball installs cleanly, boots, and registers its tools");


### PR DESCRIPTION
## The gap

The release smoke test packed the tarball, installed it, and confirmed the entrypoint came up. **Booting proves the process starts. It does not prove the tools are there.** A packaging or registration regression that leaves the server running but short a tool passed every step and shipped — the user finds out when the tool they wanted is simply absent.

That gap was invisible from the repo side: `vocab:export --check` verifies the surface against the ledger, but it reads the **working tree**. Nothing checked the artefact a user actually installs.

## What it does now

Drives the **installed tarball** over real MCP stdio and compares what registers against the ledger.

- `COMFYUI_URL` points at a dead port **on purpose** — registration must not depend on a reachable ComfyUI, and this proves it.
- Counted against `TOOL_NAMES`, the actual list — **not** `MAX_TOOLS`, the budget target that merely happens to equal it today. If those diverge, this stays correct.
- The three compact-mode tools (`list_tools` / `describe_tool` / `call_tool`) register *alongside* the core surface and are deliberately absent from the ledger, so they're counted out and asserted separately rather than silently tolerated in the total.

## How I found it

By installing `comfyui-mcp@0.50.21` from npm and asking it — after **eleven releases this session in which I verified the repo every time and the published artefact never once.**

It was correct (37 core + 3 meta, exactly matching the ledger). That's the good outcome. But nothing was checking.

## Verified both directions

Adding a name to the ledger the build doesn't register fails the script with the mismatch and the full registered list:

```
❌ installed surface has 37 core tools, ledger declares 38
   registered: comfy_cli, enqueue_workflow, get_system_stats, …
```

And — the part I nearly missed — `echo $?` confirms it exits **1**, not 0. My first check ran it through `| tail -3`, which masked the exit code and showed `exit=0`. A gate that prints a failure and exits clean is worse than no gate, because CI goes green while displaying the error.

Full suite green: 346 files, 7227 passing. `lint` and `check:vocabulary` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)