### PR TITLE
test(smoke): verify the published PANEL surface builds too

### DIFF
--- a/scripts/smoke-install.mjs
+++ b/scripts/smoke-install.mjs
@@ -14,6 +14,7 @@ import { execSync, spawn, spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, existsSync, readdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 /**
  * Ask the installed server for its tool list over MCP stdio. Resolves to the
@@ -144,5 +145,34 @@ if (missingMeta.length) {
   process.exit(1);
 }
 console.log(`✅ installed surface registers ${core.length} core tools + ${META.length} compact-mode tools`);
+
+// 6. The PANEL surface too. Those 91 tools are the whole reason the panel can
+//    drive a live canvas, they ship in the same tarball, and until now nothing
+//    checked that the published build still builds them. buildPanelToolDefs is
+//    pure — no server, no socket — so this is a direct call into the INSTALLED
+//    dist rather than another stdio round trip.
+const PANEL_LEDGER = readFileSync(join(process.cwd(), "docs/design/panel-surface.txt"), "utf-8")
+  .split(/\r?\n/)
+  .map((l) => l.trim())
+  .filter((l) => l.startsWith("panel_"));
+let panelCount = null;
+try {
+  const mod = await import(pathToFileURL(join(pkg, "dist/orchestrator/panel-tools.js")).href);
+  panelCount = mod.buildPanelToolDefs?.().length ?? null;
+} catch (err) {
+  console.error(`❌ could not load the installed panel tools: ${err?.message ?? err}`);
+  process.exit(1);
+}
+if (panelCount === null) {
+  console.error("❌ the installed build exports no buildPanelToolDefs");
+  process.exit(1);
+}
+if (PANEL_LEDGER.length > 0 && panelCount !== PANEL_LEDGER.length) {
+  console.error(
+    `❌ installed build makes ${panelCount} panel tools, ledger declares ${PANEL_LEDGER.length}`,
+  );
+  process.exit(1);
+}
+console.log(`✅ installed build makes ${panelCount} panel tools (ledger: ${PANEL_LEDGER.length})`);
 
 console.log("✅ pack/install smoke passed — tarball installs cleanly, boots, and registers its tools");


### PR DESCRIPTION
Completes the surface verification started in #1064.

## The other half

That change proved the installed tarball registers its **37 core** tools. The ledger also tracks **91 panel** tools — the entire reason the panel can drive a live canvas — and nothing checked those at all.

They ship in the same tarball. A packaging or build regression that lost one would leave the core surface intact, the entrypoint booting, every existing gate green, and the panel quietly short a tool.

`buildPanelToolDefs` is pure — no server, no socket — so this is a direct call into the **installed** dist rather than another stdio round trip, compared against `docs/design/panel-surface.txt`.

## Not redundant with the existing hash

There's already a `PANEL_BASELINE_SHA256` integrity check. The difference is the whole point:

| check | catches |
|---|---|
| `PANEL_BASELINE_SHA256` | the **ledger** being edited |
| this | the **build** losing a tool while the ledger stays correct |

The second is the regression that would actually ship.

## Verified in the direction that matters

Appending a name to the ledger fails it — but that's what the hash already covers, so it proves little. My first attempt did exactly that and I nearly accepted it.

The real test is breaking the **source**: making `buildPanelToolDefs` return one fewer, letting `prepare: tsc` rebuild, and packing that:

```
✅ installed surface registers 37 core tools + 3 compact-mode tools
❌ installed build makes 90 panel tools, ledger declares 91
exit: 1
```

Note the core check above it still **passes** — that's how I know the two are independent rather than one masking the other.

## How it was found

By installing `comfyui-mcp@0.50.21` from npm and asking it. The answer was right (91, exactly matching the ledger) — that's the good outcome, but nothing was checking.

Full suite green: 348 files, 7227 passing. `lint` and `check:vocabulary` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)