### PR TITLE
fix(gates): two release gates anchored to a frozen retirement baseline instead of the live surface

### DIFF
--- a/scripts/export-vocabulary.mts
+++ b/scripts/export-vocabulary.mts
@@ -29,10 +29,18 @@
  *
  * `core` is the LEDGER (src/tools/vocabulary.ts), not a live probe: this file is
  * about what the vocabulary is DECLARED to be, and registry-surface.test.ts is
- * what proves the running server matches. `panel` has no ledger yet — it is read
- * live from buildPanelToolDefs() until the canvas_* consolidation gives it one,
- * which means an accidental panel rename or duplicate regenerates cleanly here and
- * is NOT caught.
+ * what proves the running server matches. `panel` has no ledger of its own — it is
+ * read live from buildPanelToolDefs() until the canvas_* consolidation gives it one,
+ * so an accidental panel rename regenerates cleanly HERE and this script will never
+ * flag it.
+ *
+ * That is a statement about THIS script, not about the repo. check-tool-vocabulary.mts
+ * closes it from both sides against the frozen docs/design/panel-surface.txt:
+ * `panelRetiredNotDeclared` (baseline \ live ⊆ DEAD_NAMES) catches the old name
+ * vanishing without a DEAD_NAMES entry, and `panelMissingFromBaseline` (live ⊆
+ * baseline) catches the new name appearing without joining the ratchet. A rename
+ * trips both. Said plainly because the older wording here read as "panel renames are
+ * unguarded" and cost a later reader a re-implementation of a ratchet that exists.
  *
  * What `--check` proves is narrow, and worth stating so it is not over-trusted: the
  * committed artefact matches this repo's ledger. It says nothing about whether the

--- a/scripts/smoke-install.mjs
+++ b/scripts/smoke-install.mjs
@@ -147,32 +147,55 @@ if (missingMeta.length) {
 console.log(`✅ installed surface registers ${core.length} core tools + ${META.length} compact-mode tools`);
 
 // 6. The PANEL surface too. Those 91 tools are the whole reason the panel can
-//    drive a live canvas, they ship in the same tarball, and until now nothing
-//    checked that the published build still builds them. buildPanelToolDefs is
+//    drive a live canvas, they ship in the same tarball, and nothing else here
+//    checks that the published build still builds them. buildPanelToolDefs is
 //    pure — no server, no socket — so this is a direct call into the INSTALLED
 //    dist rather than another stdio round trip.
-const PANEL_LEDGER = readFileSync(join(process.cwd(), "docs/design/panel-surface.txt"), "utf-8")
-  .split(/\r?\n/)
-  .map((l) => l.trim())
-  .filter((l) => l.startsWith("panel_"));
-let panelCount = null;
-try {
-  const mod = await import(pathToFileURL(join(pkg, "dist/orchestrator/panel-tools.js")).href);
-  panelCount = mod.buildPanelToolDefs?.().length ?? null;
-} catch (err) {
-  console.error(`❌ could not load the installed panel tools: ${err?.message ?? err}`);
+//
+//    Compared against THIS REPO'S build, not against docs/design/panel-surface.txt.
+//    That baseline is frozen HISTORY, not the current surface: check-tool-vocabulary
+//    requires live ⊆ baseline, so the baseline only ever grows, and a retired panel
+//    tool keeps its line there forever. Counting against it passes today only
+//    because nothing has been retired yet — the first legitimate retirement would
+//    read as "installed build makes 90, ledger declares 92" and fail a RELEASE, the
+//    one gate a false alarm is most expensive in. The ledger relationship is already
+//    enforced on every PR by check:vocabulary, from both sides; what only this script
+//    can see is whether the TARBALL carries the same surface the repo builds, which
+//    is a packaging question and is what it now asks.
+//
+//    `prepare: tsc` runs during npm pack in step 1, so ./dist is a fresh build of
+//    this source. Two separate module instances, same process and env.
+async function panelNames(root, label) {
+  try {
+    const mod = await import(pathToFileURL(join(root, "dist/orchestrator/panel-tools.js")).href);
+    if (typeof mod.buildPanelToolDefs !== "function") {
+      console.error(`❌ the ${label} build exports no buildPanelToolDefs`);
+      process.exit(1);
+    }
+    return mod.buildPanelToolDefs().map((d) => d.name);
+  } catch (err) {
+    console.error(`❌ could not load the ${label} panel tools: ${err?.message ?? err}`);
+    process.exit(1);
+  }
+}
+const installedPanel = await panelNames(pkg, "installed");
+const repoPanel = await panelNames(process.cwd(), "repo");
+// A comparison of two empty lists is equal and proves nothing — the vacuous pass
+// that the sibling gate tests each carry a floor assertion against.
+if (repoPanel.length < 50) {
+  console.error(`❌ the repo build makes only ${repoPanel.length} panel tools — check is not looking at a real surface`);
   process.exit(1);
 }
-if (panelCount === null) {
-  console.error("❌ the installed build exports no buildPanelToolDefs");
-  process.exit(1);
-}
-if (PANEL_LEDGER.length > 0 && panelCount !== PANEL_LEDGER.length) {
+const onlyInstalled = installedPanel.filter((n) => !repoPanel.includes(n));
+const onlyRepo = repoPanel.filter((n) => !installedPanel.includes(n));
+if (onlyInstalled.length || onlyRepo.length) {
   console.error(
-    `❌ installed build makes ${panelCount} panel tools, ledger declares ${PANEL_LEDGER.length}`,
+    `❌ the tarball's panel surface differs from this repo's build` +
+      (onlyRepo.length ? `\n   in the repo but NOT in the tarball: ${onlyRepo.join(", ")}` : "") +
+      (onlyInstalled.length ? `\n   in the tarball but NOT in the repo: ${onlyInstalled.join(", ")}` : ""),
   );
   process.exit(1);
 }
-console.log(`✅ installed build makes ${panelCount} panel tools (ledger: ${PANEL_LEDGER.length})`);
+console.log(`✅ tarball's ${installedPanel.length} panel tools match this repo's build`);
 
 console.log("✅ pack/install smoke passed — tarball installs cleanly, boots, and registers its tools");

--- a/scripts/tools-dump.mts
+++ b/scripts/tools-dump.mts
@@ -9,9 +9,13 @@
  *   npx tsx scripts/tools-dump.mts                 # JSON: {count, tools:[…]}
  *   npx tsx scripts/tools-dump.mts --names         # one name per line, registration order
  *   npx tsx scripts/tools-dump.mts --max 30        # exit 1 if count > 30
- *   npx tsx scripts/tools-dump.mts --golden docs/design/tool-surface.txt
+ *   npx tsx scripts/tools-dump.mts --golden path/to/expected.txt
  *                                                  # diff names vs a committed golden
- *   npx tsx scripts/tools-dump.mts --write-golden docs/design/tool-surface.txt
+ *   npx tsx scripts/tools-dump.mts --write-golden path/to/expected.txt
+ *
+ * The golden is a snapshot of the LIVE surface. It is NOT docs/design/tool-surface.txt
+ * or docs/design/panel-surface.txt — those are hash-pinned retirement baselines and
+ * both invocations are refused against them; see RETIREMENT_BASELINES below.
  *
  * COMFYUI_URL is set so src/config.ts skips its network port-probe at import
  * time (same reason npm run docs:gen sets it).
@@ -113,6 +117,48 @@ if (max !== undefined) {
     failed = true;
   } else {
     console.error(`OK: ${tools.length}/${limit} tools.`);
+  }
+}
+
+/**
+ * The two hash-pinned RETIREMENT BASELINES. Neither is a live-surface golden, and
+ * pointing this script at either is a footgun in both directions.
+ *
+ * They are history, not state: docs/design/tool-surface.txt holds every core name
+ * that has EVER existed (195), against which check-tool-vocabulary enforces
+ * `BASELINE \ TOOL_NAMES ⊆ DEAD_NAMES`. The live surface is 37 after the 0.50.0
+ * consolidation and will never equal it again.
+ *
+ * So `--golden docs/design/tool-surface.txt` — an invocation this script's own
+ * usage text used to advertise — reports 158 removals and exits 1 on a perfectly
+ * healthy repo. That alone is only noise. The danger is the remedy printed
+ * underneath it: "re-run with --write-golden", which would overwrite the baseline
+ * with the 37 live names and DELETE the other 158. Deleting a line from a
+ * retirement baseline is exactly how the ratchet is disarmed for that name — every
+ * stale reference to it stops being an error. One typo-free, instruction-following
+ * run would have silently disarmed the repo's main vocabulary gate for 158 names,
+ * leaving only the SHA pin, whose own error text invites updating the hash.
+ *
+ * Refused rather than warned: there is no correct reading of either invocation.
+ * The baseline is maintained by APPENDING a newly shipped name and updating its
+ * SHA deliberately, which is a reviewed edit, not a regenerate.
+ */
+const RETIREMENT_BASELINES = ["tool-surface.txt", "panel-surface.txt"];
+const isRetirementBaseline = (p: string): boolean =>
+  RETIREMENT_BASELINES.some((b) => p.replace(/\\/g, "/").endsWith(`docs/design/${b}`));
+
+for (const opt of ["--golden", "--write-golden"] as const) {
+  const p = value(opt);
+  if (p !== undefined && isRetirementBaseline(p)) {
+    usage(
+      `${p} is a hash-pinned RETIREMENT BASELINE (every name that has ever existed), ` +
+        `not a golden of the live surface — ${opt} would ` +
+        (opt === "--write-golden"
+          ? `overwrite it with today's ${names.length} live names and delete the rest, disarming the dead-name ratchet for every name dropped.`
+          : `report every retired name as a removal and exit 1 on a healthy repo.`) +
+        `\n  What enforces it: npm run check:vocabulary (BASELINE \\ TOOL_NAMES ⊆ DEAD_NAMES).` +
+        `\n  To add a newly shipped tool: append the name, then update BASELINE_SHA256 in src/tools/vocabulary.ts.`,
+    );
   }
 }
 

--- a/scripts/tools-dump.mts
+++ b/scripts/tools-dump.mts
@@ -141,7 +141,7 @@ if (max !== undefined) {
  *
  * Refused rather than warned: there is no correct reading of either invocation.
  * The baseline is maintained by APPENDING a newly shipped name and updating its
- * SHA deliberately, which is a reviewed edit, not a regenerate.
+ * SHA deliberately, which is a reviewed edit rather than a bulk rewrite.
  */
 const RETIREMENT_BASELINES = ["tool-surface.txt", "panel-surface.txt"];
 const isRetirementBaseline = (p: string): boolean =>


### PR DESCRIPTION
Two gates compare the **live surface** against `docs/design/*-surface.txt`. Those files are hash-pinned **retirement baselines** — every name that has ever existed, history rather than state. `check-tool-vocabulary` enforces `live ⊆ baseline`, so a baseline only ever grows and can never equal the live surface again.

One gate is noisy. The other is destructive.

## 1. `smoke-install.mjs` — would fail a release over a correct change

The panel check I added in #1065 compares `buildPanelToolDefs().length` from the installed tarball against the line count of `docs/design/panel-surface.txt`. The two are equal today (91/91) only because no panel tool has ever been retired.

The first legitimate retirement — tool removed, `DEAD_NAMES` entry added, baseline correctly left alone — prints:

```
❌ installed build makes 90 panel tools, ledger declares 92
```

`npm run smoke` is the **pre-publish** gate, so that blocks a release over a correct change, with a message pointing at the wrong thing. A gate that cries wolf gets deleted.

**Fix:** compare the tarball against *this repo's own build* — the question only this script can answer, and one that cannot false-alarm on a legitimate surface change. `prepare: tsc` runs during `npm pack` in step 1, so `./dist` is a fresh build of the same source. The ledger relationship is already enforced on every PR by `check:vocabulary` from both sides (`panelRetiredNotDeclared`, `panelMissingFromBaseline`).

## 2. `tools-dump.mts` — its own remedy disarms the ratchet

`--golden docs/design/tool-surface.txt`, an invocation the script's usage text advertised, reports **158 removals and exits 1 on a healthy repo** (195 historical names vs 37 live after the 0.50.0 consolidation).

The noise isn't the problem. The remedy printed underneath it is:

```
If this change is intended, re-run with --write-golden docs/design/tool-surface.txt
```

Following that overwrites the baseline with today's 37 names and **deletes the other 158**. Deleting a line from a retirement baseline is precisely how the dead-name ratchet is disarmed for that name — the scanner only hunts names that are *in* the baseline, so every stale reference to a dropped name silently stops being an error. One instruction-following run, no typo required, would have disarmed the repo's main vocabulary gate for 158 names, leaving only the SHA pin — whose own error text invites updating the hash.

**Fix:** both directions refused with exit 2 (invocation wrong, distinct from `1` = check failed), naming what enforces the baseline and how to legitimately extend it. Refused rather than warned because neither invocation has a correct reading. Usage text no longer names either baseline.

## 3. A comment that caused all of this

`export-vocabulary.mts` said an accidental panel rename "regenerates cleanly here and is **NOT caught**". True of that script, false of the repo — `check-tool-vocabulary` catches it from both sides and a rename trips both. It reads as a claim about the system, and it sent me to build a panel ratchet that already exists. Now says what it means and points at the gate that does the catching.

## Verification

| Path | Result |
|---|---|
| `smoke` mutation: tarball one tool short of repo | `in the repo but NOT in the tarball: panel_query_graph`, exit 1 |
| `smoke` restored | green, `tarball's 91 panel tools match this repo's build` |
| `--golden` / `--write-golden` at a baseline | exit 2, file **byte-identical** (sha256 before/after) |
| real golden: write / check / doctored | rc 0 / rc 0 / rc 1 |
| `check:vocabulary`, `vocab:export --check`, `lint` | green |

A floor assertion was added to the smoke check so two empty lists cannot pass vacuously — the same guard the sibling gate tests each carry.

Note for reviewers: `check:vocabulary` caught my own comment prose using `regenerate` (a name retired in 0.50.0) as an English verb. Fixed by rewording, not by an `allowedIn` exemption — the gate was right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)