### PR TITLE
fix(fetch): a transport failure on a POST no longer implies the POST never arrived

### DIFF
--- a/src/__tests__/comfyui/fetch-delivery-doubt.test.ts
+++ b/src/__tests__/comfyui/fetch-delivery-doubt.test.ts
@@ -1,0 +1,148 @@
+// A transport failure on a POST does not prove the POST never arrived.
+//
+// describeComfyTimeout already draws this distinction for the CEILING: a POST
+// that times out is "OUTCOME UNKNOWN: this request may already have been received
+// and acted on, so do NOT blindly re-issue it". A CONNECTION ERROR on that same
+// POST carries the identical risk — an ECONNRESET after ComfyUI accepted and
+// enqueued the prompt is indistinguishable, at this layer, from one before it —
+// and yet the message said only "confirm the server is up with get_system_stats",
+// which reads as "it never got there".
+//
+// The caller retries, and the render is queued twice. That is the most expensive
+// duplicate this client can produce.
+//
+// #796's class again: "could not determine whether it was delivered" folded into
+// "it was not delivered". Three states, not two — delivered, definitely not
+// delivered, and unknown.
+//
+// THE DIRECTION OF THE DEFAULT is the whole design. Only a code that POSITIVELY
+// proves non-delivery (refused, DNS, TLS, bad URL — all of which fire before a
+// byte can reach the application) suppresses the warning. Anything unrecognised
+// keeps it, because the two errors are not symmetric: a spurious "verify first"
+// costs one extra read, while a spurious "it never arrived" costs a duplicate
+// render.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  getComfyUIAuthHeaders: () => ({}),
+}));
+
+const { comfyuiFetch } = await import("../../comfyui/fetch.js");
+
+/** The exact shape undici throws: an opaque top-level, detail on `.cause`. */
+function undiciFailure(code: string | undefined, detail: string): Error {
+  const cause = new Error(detail);
+  if (code !== undefined) (cause as { code?: string }).code = code;
+  return new TypeError("fetch failed", { cause });
+}
+
+/** The message comfyuiFetch produces for `err` on `method`. */
+async function messageFor(err: Error, method: string | undefined): Promise<string> {
+  vi.stubGlobal("fetch", vi.fn().mockRejectedValue(err));
+  const thrown = await comfyuiFetch(
+    "http://127.0.0.1:8188/prompt",
+    method === undefined ? {} : { method },
+  ).catch((e: unknown) => e);
+  return thrown instanceof Error ? thrown.message : String(thrown);
+}
+
+// vi.stubGlobal is NOT undone by restoreAllMocks — a leftover stub leaks into the
+// next test's fetch and makes its assertions describe the previous case.
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("a mutating request warns that it may already have been delivered", () => {
+  it("warns on ECONNRESET, which fires on an ESTABLISHED connection", async () => {
+    const msg = await messageFor(undiciFailure("ECONNRESET", "read ECONNRESET"), "POST");
+
+    expect(msg).toMatch(/may already have been received and acted on/i);
+    expect(msg).toMatch(/does not establish that the request never arrived/i);
+    expect(msg).toMatch(/do NOT blindly re-issue/i);
+    // The remedy has to be callable, not a suggestion to "check". These two names
+    // are kept live by the vocabulary gate.
+    expect(msg).toMatch(/queue \(action:"list"\)/);
+    expect(msg).toMatch(/get_history \(action:"list"\)/);
+  });
+
+  it("warns on socket-level failures generally (EPIPE, UND_ERR_SOCKET)", async () => {
+    for (const code of ["EPIPE", "UND_ERR_SOCKET"]) {
+      const msg = await messageFor(undiciFailure(code, `socket ${code}`), "POST");
+      expect(msg, code).toMatch(/may already have been received and acted on/i);
+    }
+  });
+
+  // The conservative default, stated as a test so a later "tidy-up" that inverts
+  // it fails here rather than in someone's queue.
+  it("warns on an UNRECOGNISED code, and on no code at all", async () => {
+    const unknown = await messageFor(undiciFailure("ESOMETHINGNEW", "novel failure"), "POST");
+    expect(unknown).toMatch(/may already have been received and acted on/i);
+
+    const none = await messageFor(undiciFailure(undefined, "no code at all"), "POST");
+    expect(none).toMatch(/may already have been received and acted on/i);
+  });
+
+  it("covers the other mutating verbs, not just POST", async () => {
+    for (const method of ["PUT", "PATCH", "DELETE"]) {
+      const msg = await messageFor(undiciFailure("ECONNRESET", "read ECONNRESET"), method);
+      expect(msg, method).toMatch(/may already have been received and acted on/i);
+      expect(msg, method).toMatch(new RegExp(`This ${method} may already`));
+    }
+  });
+});
+
+describe("it stays silent when nothing could have been delivered", () => {
+  // Each of these fires before any byte can reach the application, so the
+  // warning would be noise — and noise in an error message is how a real warning
+  // stops being read.
+  it.each([
+    ["ECONNREFUSED", "connect ECONNREFUSED 127.0.0.1:8188"],
+    ["ENOTFOUND", "getaddrinfo ENOTFOUND gpu.local"],
+    ["EAI_AGAIN", "getaddrinfo EAI_AGAIN gpu.local"],
+    ["CERT_HAS_EXPIRED", "certificate has expired"],
+    ["ERR_INVALID_URL", "Invalid URL"],
+  ])("says nothing for %s", async (code, detail) => {
+    const msg = await messageFor(undiciFailure(code, detail), "POST");
+
+    expect(msg).not.toMatch(/may already have been received/i);
+    expect(msg).not.toMatch(/do NOT blindly re-issue/i);
+    // …while still being the full diagnostic it was before.
+    expect(msg).toMatch(/fetch failed/);
+    expect(msg).toMatch(/127\.0\.0\.1:8188\/prompt/);
+  });
+
+  it("says nothing for a READ, which cannot double-apply", async () => {
+    // Explicit GET, and the default (no method) — both are reads.
+    for (const method of ["GET", "HEAD", undefined]) {
+      const msg = await messageFor(undiciFailure("ECONNRESET", "read ECONNRESET"), method);
+      expect(msg, String(method)).not.toMatch(/may already have been received/i);
+    }
+  });
+});
+
+describe("the existing diagnostic is preserved", () => {
+  // Load-bearing: transient-error matchers elsewhere test for /fetch failed/, and
+  // the #952 drift explanation must survive the insertion.
+  it("keeps the original message, the target, the method and the remedies", async () => {
+    const msg = await messageFor(undiciFailure("ECONNRESET", "read ECONNRESET"), "POST");
+
+    expect(msg.startsWith("fetch failed")).toBe(true);
+    expect(msg).toMatch(/http:\/\/127\.0\.0\.1:8188\/prompt \(POST\)/);
+    expect(msg).toMatch(/CONNECTED sidebar panel does not imply/);
+    expect(msg).toMatch(/install_comfyui \(action:"environment"\)/);
+    expect(msg).toMatch(/get_system_stats \(action:"health"\)/);
+  });
+
+  it("still carries the syscall code on the wrapped error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(undiciFailure("ECONNRESET", "read ECONNRESET")),
+    );
+    const err = await comfyuiFetch("http://127.0.0.1:8188/prompt", { method: "POST" }).catch(
+      (e: unknown) => e,
+    );
+    expect((err as { code?: string }).code).toBe("ECONNRESET");
+  });
+});

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -12,6 +12,12 @@ function targetOf(input: string | URL | Request): string {
   }
 }
 
+/** The request's HTTP method, uppercased. `init.method` wins over a Request's own,
+ *  matching what fetch itself does when both are supplied. */
+function methodOf(input: string | URL | Request, init: RequestInit): string {
+  return String(init.method ?? (input instanceof Request ? input.method : "GET")).toUpperCase();
+}
+
 /**
  * What the CONNECTED panels front, for the drift comparison below (#952).
  *
@@ -99,11 +105,72 @@ function describeTargetDrift(target: string): string {
  * the browser is on, while these calls go to the configured COMFYUI_URL. That is
  * not a bug, but it is invisible unless the failure names the address — and,
  * where the bridge can tell us, says whether the two actually differ.
+ *
+ * Header for the three pieces below: the never-delivered code set, the delivery
+ * doubt it gates, and describeComfyFetchFailure itself.
  */
-function describeComfyFetchFailure(err: unknown, target: string): Error {
+/**
+ * Failure codes that prove the request was NEVER DELIVERED.
+ *
+ * Each one fires before any byte of the request could reach the application: the
+ * connection was refused, the name never resolved, the TLS handshake failed, or
+ * the URL was rejected locally. On these the server cannot have acted, so saying
+ * so is accurate and a retry is safe.
+ *
+ * Everything else is deliberately NOT listed. ECONNRESET, EPIPE, "socket hang up"
+ * and UND_ERR_SOCKET all fire on an ESTABLISHED connection, which is precisely the
+ * case where ComfyUI may have received and acted on the request before the socket
+ * died. The default for an unrecognised code is therefore "may have been
+ * delivered": a spurious "verify first" costs one extra read, while a spurious
+ * "it never arrived" costs a duplicate render.
+ */
+const NEVER_DELIVERED_CODES: ReadonlySet<string> = new Set([
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ERR_INVALID_URL",
+  "ERR_UNSUPPORTED_PROTOCOL",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "CERT_HAS_EXPIRED",
+  "ERR_TLS_CERT_ALTNAME_INVALID",
+]);
+
+/**
+ * The transport-failure twin of describeComfyTimeout's OUTCOME UNKNOWN.
+ *
+ * A timeout on a POST already warned that /prompt may have queued the render
+ * before the reply was lost. A CONNECTION ERROR on that same POST carries the
+ * identical risk — an ECONNRESET after the server accepted and enqueued the
+ * prompt is indistinguishable, at this layer, from one before it — yet the
+ * message said only "confirm the server is up", which reads as "it never got
+ * there". The caller retries and the render is queued twice, on the single most
+ * expensive operation this client makes.
+ *
+ * Only suppressed when the code POSITIVELY proves non-delivery, or the method is
+ * a read. See NEVER_DELIVERED_CODES for why the default runs the other way.
+ */
+function deliveryDoubt(code: string | undefined, method: string): string {
+  if (method === "GET" || method === "HEAD") return "";
+  if (code !== undefined && NEVER_DELIVERED_CODES.has(code)) return "";
+  // Says only what is known. Claiming "the connection was established" would be an
+  // overclaim for an unrecognised code — the same folding this function exists to
+  // undo, merely pointed the other way.
+  return (
+    ` This ${method} may already have been received and acted on: a transport failure ` +
+    `does not establish that the request never arrived. Do NOT blindly re-issue it; ` +
+    `check the server's state first (for a queued prompt, queue (action:"list") and ` +
+    `get_history (action:"list")).`
+  );
+}
+
+function describeComfyFetchFailure(err: unknown, target: string, method: string): Error {
   const { message, code } = describeFetchFailure(err);
   const wrapped = new Error(
-    `${message} — while requesting ${target}. ` +
+    `${message} — while requesting ${target} (${method}).` +
+      deliveryDoubt(code, method) +
+      ` ` +
       `That is the headless ComfyUI target (COMFYUI_URL); a CONNECTED sidebar panel does not imply this address is reachable, ` +
       `because the panel talks to whichever ComfyUI its browser tab is on.` +
       describeTargetDrift(target) +
@@ -164,9 +231,7 @@ function isTimeoutAbort(err: unknown): boolean {
  */
 function describeComfyTimeout(input: string | URL | Request, init: RequestInit): Error {
   const target = targetOf(input);
-  const method = String(
-    init.method ?? (input instanceof Request ? input.method : "GET"),
-  ).toUpperCase();
+  const method = methodOf(input, init);
   const seconds = comfyHttpTimeoutSeconds();
   const mutating = method !== "GET" && method !== "HEAD";
   const err = new Error(
@@ -227,6 +292,6 @@ export async function comfyuiFetch(
     // its own message, or anything else already says what happened, and
     // replacing that text would be a downgrade.
     if (!isBareFetchFailure(err)) throw err;
-    throw describeComfyFetchFailure(err, targetOf(input));
+    throw describeComfyFetchFailure(err, targetOf(input), methodOf(input, init));
   }
 }


### PR DESCRIPTION
## The defect

`describeComfyTimeout` already draws this distinction for the **ceiling**:

> `OUTCOME UNKNOWN: this request may already have been received and acted on, so do NOT blindly re-issue it — check the server's state first…`

A **connection error** on that same POST carries the identical risk. An `ECONNRESET` that fires *after* ComfyUI accepted and enqueued the prompt is indistinguishable, at this layer, from one that fires before. But that path said only:

> `fetch failed: read ECONNRESET (ECONNRESET) — while requesting http://…/prompt. … Check the target with install_comfyui (action:"environment"), and confirm the server is up with get_system_stats (action:"health").`

Which reads as *it never got there*. The caller retries, and the render is queued twice — the most expensive duplicate this client can produce, on the request most likely to be in flight when a socket dies.

[#796](https://github.com/artokun/comfyui-mcp/issues/796)'s class again: "could not determine whether it was delivered" folded into "it was not delivered". Three states, not two.

## The direction of the default is the design

Only a code that **positively proves non-delivery** suppresses the warning — refused, DNS, TLS, bad URL, each of which fires before a byte can reach the application. Anything unrecognised *keeps* it, because the two errors are not symmetric:

- a spurious "verify first" costs one extra read
- a spurious "it never arrived" costs a duplicate render

`ECONNRESET`, `EPIPE`, `UND_ERR_SOCKET` are deliberately **not** on the never-delivered list: they fire on an established connection, which is exactly the ambiguous case.

The warning also states only what is *known*. It does not claim "the connection was established" — that would be an overclaim for an unrecognised code, i.e. the same folding this change undoes, pointed the other way.

The method now appears in every failure message (it was already in the timeout's), so a reader can see which half applies.

## Verification

| Check | Result |
|---|---|
| **call-site mutation** — replace the appended call with `""` | 4 tests fail |
| **direction mutation** — list `ECONNRESET` as never-delivered | 2 tests fail |
| warns: `ECONNRESET`, `EPIPE`, `UND_ERR_SOCKET`, unrecognised, no code; `PUT`/`PATCH`/`DELETE` | ✅ |
| silent: `ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN`, `CERT_HAS_EXPIRED`, `ERR_INVALID_URL`; `GET`/`HEAD`/default | ✅ |
| `fetch failed` prefix, #952 drift explanation, both remedies, syscall `code` on the wrapper | all preserved |
| full suite | green — 350 files, 7244 passed |

A note on the first mutation: my initial attempt used a `perl` pattern ending in `+\n`, which silently no-opped on this CRLF file and reported 12/12 green. The ref count is what caught it — the mutation is only evidence once you confirm it applied.

Companion to #1067, which fixes the same inversion one layer up in the panel bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)