### PR TITLE
fix(cloud): give the cloud client the timeout ceiling and delivery doubt its twin already had

### DIFF
--- a/src/__tests__/comfyui/cloud-client-hardening.test.ts
+++ b/src/__tests__/comfyui/cloud-client-hardening.test.ts
@@ -1,0 +1,145 @@
+// The cloud client is a PARALLEL implementation of the headless one, and the last
+// two rounds of hardening reached only its twin. That is how a parallel
+// implementation rots: nothing fails, it simply stops keeping up.
+//
+// 1. NO TIMEOUT AT ALL. comfyuiFetch got a default ceiling in 0.50.11 because a
+//    request that never answers otherwise waits forever. cloudFetch called bare
+//    `fetch` with no signal anywhere in the file, so a hung cloud request hung the
+//    whole tool call — no timeout, no error, nothing for the caller to act on.
+//
+// 2. "Failed to reach Comfy Cloud at <url>" was a CLAIM, not an observation. It
+//    was produced for every transport error, including an ECONNRESET on the POST
+//    to /api/prompt — which does not establish that the submission never landed.
+//    A caller reading "failed to reach" retries, and the retry bills a SECOND
+//    cloud render. Of every instance of this defect class in the repo, this is the
+//    one that costs the user actual money.
+//
+// Both fixes reuse the headless client's helpers rather than re-deriving them, so
+// there is one ceiling and one delivery-doubt rule.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  getApiKey: () => "test-key",
+  getCloudUrl: () => "https://cloud.comfy.org",
+  getComfyUIAuthHeaders: () => ({}),
+}));
+
+const cloud = await import("../../comfyui/cloud-client.js");
+
+/** The exact shape undici throws: an opaque top-level, detail on `.cause`. */
+function undiciFailure(code: string | undefined, detail: string): Error {
+  const cause = new Error(detail);
+  if (code !== undefined) (cause as { code?: string }).code = code;
+  return new TypeError("fetch failed", { cause });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  delete process.env.COMFYUI_MCP_HTTP_TIMEOUT_S;
+});
+
+describe("cloudFetch applies a timeout ceiling", () => {
+  it("passes a signal even when the caller supplies none", async () => {
+    const spy = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", spy);
+
+    await cloud.getJobStatus("p1");
+
+    const init = spy.mock.calls.at(-1)![1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("reports its own ceiling as a timeout, not as a caller abort", async () => {
+    const abort = new Error("The operation was aborted");
+    abort.name = "TimeoutError";
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(abort));
+
+    const err = await cloud.getJobStatus("p1").catch((e: unknown) => e);
+    const msg = (err as Error).message;
+
+    expect(msg).toMatch(/No reply from Comfy Cloud within \d+s/);
+    expect(msg).toMatch(/COMFYUI_MCP_HTTP_TIMEOUT_S/);
+  });
+
+  // NOT TESTED, deliberately, and said out loud rather than faked: no exported
+  // cloud function accepts a signal today (fetchImage takes filename/type/
+  // subfolder, enqueuePrompt takes workflow/extraData, and so on), so the
+  // `init?.signal === undefined` guard has no reachable caller from the public
+  // surface. It exists for symmetry with comfyuiFetch, where callers DO pass their
+  // own budgets, so that the day a cloud caller gains one the ceiling does not
+  // silently overrule it.
+  //
+  // An earlier draft of this file "covered" that guard by passing an object where
+  // `filename` goes and asserting `used.signal === own || used.signal instanceof
+  // AbortSignal` — a tautology, green forever, testing nothing.
+  it("applies the configured ceiling, not a hardcoded one", async () => {
+    process.env.COMFYUI_MCP_HTTP_TIMEOUT_S = "7";
+    const abort = new Error("The operation was aborted");
+    abort.name = "TimeoutError";
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(abort));
+
+    const err = await cloud.getJobStatus("p1").catch((e: unknown) => e);
+    expect((err as Error).message).toMatch(/within 7s/);
+  });
+});
+
+describe("a transport failure no longer claims the request never arrived", () => {
+  it("warns that a POST /api/prompt may already have been billed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(undiciFailure("ECONNRESET", "read ECONNRESET")),
+    );
+
+    const err = await cloud.enqueuePrompt({ "1": {} }).catch((e: unknown) => e);
+    const msg = (err as Error).message;
+
+    expect(msg).toMatch(/may already have been received and acted on/i);
+    expect(msg).toMatch(/do NOT blindly re-issue/i);
+    // It must say what was attempted, which "Failed to reach" never did.
+    expect(msg).toMatch(/POST/);
+    expect(msg).toMatch(/cloud\.comfy\.org\/api\/prompt/);
+    // The underlying cause survives — matchers elsewhere look for it.
+    expect(msg).toMatch(/fetch failed/);
+    expect((err as { code?: string }).code).toBe("ECONNRESET");
+  });
+
+  it("stays silent when the connection was refused — nothing could have arrived", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(undiciFailure("ECONNREFUSED", "connect ECONNREFUSED")),
+    );
+
+    const err = await cloud.enqueuePrompt({ "1": {} }).catch((e: unknown) => e);
+    const msg = (err as Error).message;
+
+    expect(msg).not.toMatch(/may already have been received/i);
+    expect(msg).toMatch(/fetch failed/);
+  });
+
+  it("stays silent for a READ, which cannot double-bill", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(undiciFailure("ECONNRESET", "read ECONNRESET")),
+    );
+
+    const err = await cloud.getJobStatus("p1").catch((e: unknown) => e);
+    expect((err as Error).message).not.toMatch(/may already have been received/i);
+  });
+
+  // A genuine API error (4xx/5xx with a body) is an ANSWER, not a transport
+  // failure. It must keep its own text and never acquire delivery doubt.
+  it("leaves a real Cloud API error alone", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("nope", { status: 402, statusText: "Payment Required" })),
+    );
+
+    const err = await cloud.enqueuePrompt({ "1": {} }).catch((e: unknown) => e);
+    const msg = (err as Error).message;
+
+    expect(msg).toMatch(/Cloud API error: 402/);
+    expect(msg).not.toMatch(/may already have been received/i);
+  });
+});

--- a/src/comfyui/cloud-client.ts
+++ b/src/comfyui/cloud-client.ts
@@ -12,7 +12,17 @@
 // keep working in cloud mode.
 
 import { getApiKey, getCloudUrl } from "../config.js";
-import { ComfyUIError, ConnectionError } from "../utils/errors.js";
+// Shared with the headless client on purpose: one ceiling, one delivery-doubt
+// rule. The cloud client is a parallel implementation, and the last two rounds of
+// hardening (the 0.50.11 timeout ceiling, the delivery-doubt disclosure) reached
+// only its twin — which is exactly how a parallel implementation rots.
+import {
+  comfyHttpTimeoutSeconds,
+  defaultComfyTimeoutSignal,
+  deliveryDoubt,
+  isTimeoutAbort,
+} from "./fetch.js";
+import { ComfyUIError, ConnectionError, describeFetchFailure } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import type { HistoryEntry } from "./client.js";
 import type { ObjectInfo, QueueStatus, SystemStats } from "./types.js";
@@ -39,8 +49,14 @@ async function cloudFetch(
     ...authHeaders(baseHeaders),
     ...((init?.headers as Record<string, string> | undefined) ?? {}),
   };
+  const method = String(init?.method ?? "GET").toUpperCase();
+  // A CEILING, not a policy — the same one comfyuiFetch got in 0.50.11, which this
+  // client never inherited. Without it a cloud request that never answers hangs the
+  // tool call forever: no timeout, no error, nothing for the caller to act on. A
+  // caller's own signal always wins.
+  const signal = init?.signal ?? defaultComfyTimeoutSignal();
   try {
-    const res = await fetch(url, { ...init, headers });
+    const res = await fetch(url, { ...init, headers, signal });
     if (!res.ok) {
       const body = await res.text().catch(() => "");
       throw new ComfyUIError(
@@ -52,9 +68,27 @@ async function cloudFetch(
     return res;
   } catch (err) {
     if (err instanceof ComfyUIError) throw err;
-    throw new ConnectionError(
-      `Failed to reach Comfy Cloud at ${url}: ${err instanceof Error ? err.message : err}`,
+    // Our own ceiling firing is not the same event as a caller's abort, and must
+    // not be reported as one. Only rewrite when WE supplied the signal.
+    if (init?.signal === undefined && isTimeoutAbort(err)) {
+      throw new ConnectionError(
+        `No reply from Comfy Cloud within ${comfyHttpTimeoutSeconds()}s — while requesting ` +
+          `${url} (${method}).` +
+          deliveryDoubt(undefined, method) +
+          ` Raise COMFYUI_MCP_HTTP_TIMEOUT_S if the cloud is simply slow.`,
+      );
+    }
+    // "Failed to reach" was a claim, not an observation. A transport error on a
+    // POST to /api/prompt does not establish that the submission never landed —
+    // and a blind retry there bills a SECOND cloud render. Same three states as
+    // the headless client: delivered, definitely not delivered, unknown.
+    const { message, code } = describeFetchFailure(err);
+    const wrapped = new ConnectionError(
+      `Could not complete the ${method} to Comfy Cloud at ${url}: ${message}.` +
+        deliveryDoubt(code, method),
     );
+    if (code) (wrapped as { code?: string }).code = code;
+    throw wrapped;
   }
 }
 

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -151,7 +151,7 @@ const NEVER_DELIVERED_CODES: ReadonlySet<string> = new Set([
  * Only suppressed when the code POSITIVELY proves non-delivery, or the method is
  * a read. See NEVER_DELIVERED_CODES for why the default runs the other way.
  */
-function deliveryDoubt(code: string | undefined, method: string): string {
+export function deliveryDoubt(code: string | undefined, method: string): string {
   if (method === "GET" || method === "HEAD") return "";
   if (code !== undefined && NEVER_DELIVERED_CODES.has(code)) return "";
   // Says only what is known. Claiming "the connection was established" would be an
@@ -206,17 +206,17 @@ function describeComfyFetchFailure(err: unknown, target: string, method: string)
  */
 const DEFAULT_COMFY_HTTP_TIMEOUT_S = 120;
 
-function comfyHttpTimeoutSeconds(): number {
+export function comfyHttpTimeoutSeconds(): number {
   const raw = Number(process.env.COMFYUI_MCP_HTTP_TIMEOUT_S);
   return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_COMFY_HTTP_TIMEOUT_S;
 }
 
-function defaultComfyTimeoutSignal(): AbortSignal {
+export function defaultComfyTimeoutSignal(): AbortSignal {
   return AbortSignal.timeout(Math.round(comfyHttpTimeoutSeconds() * 1000));
 }
 
 /** True for an abort raised by AbortSignal.timeout (not a caller's own abort). */
-function isTimeoutAbort(err: unknown): boolean {
+export function isTimeoutAbort(err: unknown): boolean {
   return err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError");
 }
 


### PR DESCRIPTION
`cloud-client.ts` is a **parallel implementation** of `client.ts`, and the last two rounds of hardening reached only its twin. That's how a parallel implementation rots — nothing fails, it just stops keeping up.

## 1. No timeout at all

`comfyuiFetch` got a default ceiling in 0.50.11 because a request that never answers otherwise waits forever. `cloudFetch` called bare `fetch` with no signal — the string `signal` did not appear anywhere in the file — so a hung cloud request **hung the entire tool call**: no timeout, no error, nothing for the caller to act on.

## 2. "Failed to reach Comfy Cloud" was a claim, not an observation

That message was produced for *every* transport error, including an `ECONNRESET` on the `POST /api/prompt` — which does not establish that the submission never landed.

A caller reading "failed to reach" retries. The retry **bills a second cloud render**. Of every instance of this defect class in the repo, this is the one that costs the user actual money.

Now:

> `Could not complete the POST to Comfy Cloud at https://cloud.comfy.org/api/prompt: fetch failed: read ECONNRESET (ECONNRESET). This POST may already have been received and acted on: a transport failure does not establish that the request never arrived. Do NOT blindly re-issue it; check the server's state first…`

## One rule, not two

Both fixes reuse the headless client's helpers — `deliveryDoubt`, `defaultComfyTimeoutSignal`, `comfyHttpTimeoutSeconds`, `isTimeoutAbort` — rather than re-deriving them, so there is one ceiling and one delivery-doubt rule instead of two that can drift apart again. The message also names the method, preserves the underlying cause via `describeFetchFailure` (so `/fetch failed/` matchers elsewhere still work), and carries the syscall code on the wrapper.

A real Cloud API error (4xx/5xx with a body) is an **answer**, not a transport failure — it keeps its own text and never acquires delivery doubt.

## Verification

| Check | Result |
|---|---|
| **mutation** — drop the signal from the fetch call | ceiling test fails |
| **mutation** — replace the appended doubt with `""` | POST-billing test fails |
| new tests | 7 |
| existing cloud tests | 16, unchanged, passing |
| full suite | green — 350 files, 7246 passed |

One test was deliberately **not** written, and the file says so: no exported cloud function accepts a signal today, so the caller-signal guard has no reachable caller from the public surface. An earlier draft "covered" it by passing an object where `filename` goes and asserting `used.signal === own || used.signal instanceof AbortSignal` — a tautology, green forever, testing nothing.

Completes the sweep started in #1067 (panel bridge) and #1068 (headless HTTP).

### Noticed while here, not fixed here

`getSystemStats()` in this file catches **every** error and returns a fabricated placeholder — a "Comfy Cloud GPU" device with zeroed VRAM. That is the same folding one level up, and it matters because `get_system_stats (action:"health")` is the exact remedy these error messages send people to: in cloud mode a health check can't currently fail. Left alone because "degrade gracefully" appears to be deliberate there and changing it is a behaviour change, not a message change — filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)