### PR TITLE
fix(cloud): getSystemStats must be able to fail, and fetchImage must be able to time out

### DIFF
--- a/src/__tests__/comfyui/cloud-system-stats-honesty.test.ts
+++ b/src/__tests__/comfyui/cloud-system-stats-honesty.test.ts
@@ -124,3 +124,42 @@ describe("the placeholder survives only for a genuinely absent endpoint", () => 
     expect(stats.devices[0]!.name).toMatch(/placeholders, not readings/);
   });
 });
+
+// fetchImage does NOT go through cloudFetch — it needs redirect-following and raw
+// bytes rather than the JSON envelope. That exemption is how it kept the bare,
+// signal-less `fetch` that #1069 removed from cloudFetch one call over: a download
+// from a wedged cloud hung the tool call with nothing for the caller to act on.
+describe("fetchImage cannot hang forever either", () => {
+  it("sends a timeout signal", async () => {
+    const spy = vi
+      .fn()
+      .mockResolvedValue(new Response(new Uint8Array([1, 2, 3]), { status: 200 }));
+    vi.stubGlobal("fetch", spy);
+
+    await cloud.fetchImage("a.png");
+
+    const init = spy.mock.calls.at(-1)![1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    // The exemption itself must survive: /api/view answers with a 302 to a signed URL.
+    expect(init.redirect).toBe("follow");
+  });
+
+  it("reports its ceiling honestly, and does not call a timeout a 'not found'", async () => {
+    const abort = new Error("The operation was aborted");
+    abort.name = "TimeoutError";
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(abort));
+
+    const msg = await cloud.fetchImage("a.png").catch((e: unknown) => (e as Error).message);
+    expect(msg).toMatch(/No reply from Comfy Cloud within \d+s while downloading "a\.png"/);
+    expect(msg).toMatch(/a timeout is not a "not found"/);
+  });
+
+  it("names the file and keeps the cause on a transport failure", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(undiciFailure("ECONNRESET", "read ECONNRESET")));
+
+    const err = await cloud.fetchImage("a.png").catch((e: unknown) => e);
+    expect((err as Error).message).toMatch(/Could not download "a\.png"/);
+    expect((err as Error).message).toMatch(/fetch failed/);
+    expect((err as { code?: string }).code).toBe("ECONNRESET");
+  });
+});

--- a/src/__tests__/comfyui/cloud-system-stats-honesty.test.ts
+++ b/src/__tests__/comfyui/cloud-system-stats-honesty.test.ts
@@ -1,0 +1,126 @@
+// #1070 — a health check that cannot fail.
+//
+// cloud-client's getSystemStats() caught EVERYTHING and returned an invented
+// device: a "Comfy Cloud GPU" with zeroed VRAM. An expired API key, a 402, a DNS
+// failure, a timeout, a network partition — all of them came back looking like a
+// successful health check.
+//
+// Two things made that worse than a mislabelled outcome usually is.
+//
+// `get_system_stats (action:"health")` is the remedy our own error messages send
+// people to: it is named in describeComfyFetchFailure, in the timeout text, and in
+// cloud-client's own messages. In cloud mode that remedy could not return a
+// negative result — someone told "confirm the server is up" would run it, see a
+// GPU, and conclude the problem was elsewhere. And health-check.ts /
+// local-models-fallback.ts both call it as a REACHABILITY PROBE, which the
+// placeholder answered "yes" to unconditionally.
+//
+// It also fabricated data rather than merely mislabelling it. `vram_total: 0` is
+// not a reading, and a caller sizing a job against it is reading an invention.
+//
+// Three states, not two: answered / endpoint absent / could not ask.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  getApiKey: () => "test-key",
+  getCloudUrl: () => "https://cloud.comfy.org",
+  getComfyUIAuthHeaders: () => ({}),
+}));
+
+const cloud = await import("../../comfyui/cloud-client.js");
+
+function undiciFailure(code: string, detail: string): Error {
+  const cause = new Error(detail);
+  (cause as { code?: string }).code = code;
+  return new TypeError("fetch failed", { cause });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("getSystemStats answers when the endpoint answers", () => {
+  it("returns what the cloud reported", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            system: { os: "linux", python_version: "3.12", embedded_python: false },
+            devices: [{ name: "H100", type: "cuda", index: 0, vram_total: 80, vram_free: 79, torch_vram_total: 80, torch_vram_free: 79 }],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const stats = await cloud.getSystemStats();
+    expect(stats.devices[0]!.name).toBe("H100");
+    expect(stats.devices[0]!.vram_total).toBe(80);
+  });
+});
+
+describe("it propagates a failure instead of inventing a GPU", () => {
+  // Each of these is a REAL failure the caller must see. Before #1070 every one
+  // returned a healthy-looking placeholder.
+  it("propagates an expired/invalid API key (401)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("bad key", { status: 401, statusText: "Unauthorized" })),
+    );
+    await expect(cloud.getSystemStats()).rejects.toThrow(/401/);
+  });
+
+  it("propagates a billing failure (402)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("pay up", { status: 402, statusText: "Payment Required" })),
+    );
+    await expect(cloud.getSystemStats()).rejects.toThrow(/402/);
+  });
+
+  it("propagates a server error (500)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("boom", { status: 500, statusText: "Internal Server Error" })),
+    );
+    await expect(cloud.getSystemStats()).rejects.toThrow(/500/);
+  });
+
+  it("propagates a transport failure", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(undiciFailure("ECONNRESET", "read ECONNRESET")));
+    await expect(cloud.getSystemStats()).rejects.toThrow(/fetch failed/);
+  });
+
+  it("propagates a timeout", async () => {
+    const abort = new Error("The operation was aborted");
+    abort.name = "TimeoutError";
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(abort));
+    await expect(cloud.getSystemStats()).rejects.toThrow(/No reply from Comfy Cloud/);
+  });
+
+  // The load-bearing consequence, stated directly: the probe must be able to say no.
+  it("lets a reachability probe actually fail", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(undiciFailure("ECONNREFUSED", "connect ECONNREFUSED")));
+    const reachable = await cloud
+      .getSystemStats()
+      .then(() => true)
+      .catch(() => false);
+    expect(reachable).toBe(false);
+  });
+});
+
+describe("the placeholder survives only for a genuinely absent endpoint", () => {
+  it.each([404, 405, 501])("still falls back on %i", async (status) => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("nope", { status })));
+
+    const stats = await cloud.getSystemStats();
+    expect(stats.devices).toHaveLength(1);
+    // Kept as a prefix so anything matching the old name still matches…
+    expect(stats.devices[0]!.name).toMatch(/^Comfy Cloud GPU/);
+    // …but a reader can now tell these are not measurements.
+    expect(stats.devices[0]!.name).toMatch(/placeholders, not readings/);
+  });
+});

--- a/src/comfyui/cloud-client.ts
+++ b/src/comfyui/cloud-client.ts
@@ -304,8 +304,35 @@ export async function fetchImage(
 ): Promise<{ base64: string; mimeType: string }> {
   const params = new URLSearchParams({ filename, type, subfolder });
   const url = cloudUrl(`/api/view?${params.toString()}`);
-  // /api/view returns either bytes or a 302 to a signed URL.
-  const res = await fetch(url, { headers: authHeaders(), redirect: "follow" });
+  // /api/view returns either bytes or a 302 to a signed URL, which is why this
+  // does NOT go through cloudFetch: it needs redirect-following and raw bytes
+  // rather than the JSON envelope. That exemption is also how it kept the bare,
+  // signal-less `fetch` that #1069 removed from cloudFetch one call over — a
+  // download from a wedged cloud hung the tool call with nothing to act on.
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: authHeaders(),
+      redirect: "follow",
+      signal: defaultComfyTimeoutSignal(),
+    });
+  } catch (err) {
+    if (isTimeoutAbort(err)) {
+      throw new ConnectionError(
+        `No reply from Comfy Cloud within ${comfyHttpTimeoutSeconds()}s while downloading ` +
+          `"${filename}" — ${url} (GET). Nothing was learned about the image from this: a ` +
+          `timeout is not a "not found". Raise COMFYUI_MCP_HTTP_TIMEOUT_S if the cloud is ` +
+          `simply slow.`,
+      );
+    }
+    // A read, so no delivery doubt applies — re-requesting an image is safe.
+    const { message, code } = describeFetchFailure(err);
+    const wrapped = new ConnectionError(
+      `Could not download "${filename}" from Comfy Cloud at ${url}: ${message}.`,
+    );
+    if (code) (wrapped as { code?: string }).code = code;
+    throw wrapped;
+  }
   if (!res.ok) {
     throw new ComfyUIError(
       `Cloud /api/view ${res.status} for "${filename}"`,

--- a/src/comfyui/cloud-client.ts
+++ b/src/comfyui/cloud-client.ts
@@ -134,12 +134,48 @@ export async function getHistory(
   return {};
 }
 
+/** HTTP statuses that mean "this cloud has no such endpoint" rather than "the
+ *  request failed". Only these may fall back to the placeholder. */
+const ENDPOINT_ABSENT_STATUSES = new Set([404, 405, 501]);
+
+/**
+ * #1070 — the catch here used to swallow EVERYTHING and return an invented
+ * device, so an expired API key, a 402, a DNS failure, a timeout and a network
+ * partition all came back looking like a successful health check.
+ *
+ * That mattered more than a mislabelled outcome usually does, for two reasons.
+ * `get_system_stats (action:"health")` is the remedy our own error messages send
+ * people to — it is named in describeComfyFetchFailure, in the timeout text, and
+ * in this file's messages — so in cloud mode the remedy could not return a
+ * negative result. And health-check.ts / local-models-fallback.ts both call this
+ * as a REACHABILITY PROBE, which the placeholder answered "yes" to unconditionally.
+ *
+ * It also fabricated data rather than merely mislabelling it: `vram_total: 0` is
+ * not a reading, and a caller sizing a job against it is reading an invention.
+ *
+ * Three states now, not two:
+ *   - answered              → return what the endpoint said
+ *   - endpoint ABSENT (404) → the placeholder, which is the case this was written
+ *                             for, but named so a reader can see it is not a reading
+ *   - could not ask         → propagate, because that is a real failure
+ */
 export async function getSystemStats(): Promise<SystemStats> {
   try {
     const res = await cloudFetch("/system_stats");
     return (await res.json()) as unknown as SystemStats;
-  } catch {
-    logger.info("Cloud: /system_stats unavailable, returning placeholder");
+  } catch (err) {
+    const status =
+      err instanceof ComfyUIError && err.details && typeof err.details === "object"
+        ? (err.details as { status?: unknown }).status
+        : undefined;
+    if (typeof status !== "number" || !ENDPOINT_ABSENT_STATUSES.has(status)) {
+      // Auth, billing, transport, timeout — a real failure. The caller asked
+      // whether the cloud is reachable; inventing a GPU is not an answer.
+      throw err;
+    }
+    logger.info("Cloud: /system_stats not implemented by this cloud, returning placeholder", {
+      status,
+    });
     return {
       system: {
         os: "cloud",
@@ -149,7 +185,9 @@ export async function getSystemStats(): Promise<SystemStats> {
       },
       devices: [
         {
-          name: "Comfy Cloud GPU",
+          // Named, not silent: these are placeholders, not measurements. The
+          // "Comfy Cloud GPU" prefix is kept so anything matching on it still does.
+          name: "Comfy Cloud GPU (no stats endpoint — values below are placeholders, not readings)",
           type: "cloud",
           index: 0,
           vram_total: 0,


### PR DESCRIPTION
Closes #1070. Two cloud-client defects with the same shape: a call that cannot report failure.

## 1. `getSystemStats` could not fail

The catch swallowed **everything** and returned an invented device — a `"Comfy Cloud GPU"` with zeroed VRAM. An expired API key, a 402, a DNS failure, a timeout, a network partition: all came back looking like a successful health check.

**`get_system_stats (action:"health")` is the remedy our own error messages send people to.** It's named in `describeComfyFetchFailure`, in the timeout text, and in cloud-client's own messages from #1069. In cloud mode that remedy *could not return a negative result* — someone told "confirm the server is up" runs it, sees a GPU, and concludes the problem is elsewhere.

**Two callers use it as a reachability probe** — `health-check.ts:33` and `local-models-fallback.ts:71` — and the placeholder answered "yes" to both, unconditionally.

**And it fabricated data rather than merely mislabelling it.** `vram_total: 0` is not a reading. A caller sizing a job against it is reading an invention.

| State | Behaviour |
|---|---|
| answered | return what the endpoint said |
| endpoint **absent** (404/405/501) | the placeholder — the case this was written for — now **named**: `Comfy Cloud GPU (no stats endpoint — values below are placeholders, not readings)` |
| could not ask (auth, billing, transport, timeout) | propagate |

The `"Comfy Cloud GPU"` prefix is preserved so anything matching on it still matches.

## 2. `fetchImage` kept the signal-less fetch #1069 removed one call over

`fetchImage` deliberately bypasses `cloudFetch` — `/api/view` returns either bytes or a 302 to a signed URL, so it needs redirect-following and raw bytes rather than the JSON envelope. That exemption is *also* how it kept a bare `fetch` with no signal: #1069 gave `cloudFetch` a ceiling and left this one call able to **hang the tool call forever**.

Found by sweeping every `await fetch(` in `src/` for a missing signal after shipping #1069 — which is to say, my own fix was incomplete and the sweep is what caught it, not review.

It also threw whatever undici threw. It now names the file, keeps the cause via `describeFetchFailure`, carries the syscall code, and its timeout says plainly that nothing was learned — a timeout is not a "not found". No delivery doubt: it's a read, and re-requesting an image is safe.

## Verification

| Check | Result |
|---|---|
| **mutation** — drop the propagating `throw err` | 6 of 10 tests fail |
| **mutation** — remove `fetchImage`'s signal | ceiling test fails |
| new tests | 13 — answered / 401 / 402 / 500 / transport / timeout / probe-can-fail / 404-405-501 fallback / signal sent / honest timeout / named download failure |
| full suite | green — 352 files, 7264 passed |

One test states the consequence rather than the mechanism: a reachability probe must be able to return `false`.

Completes #1067, #1068, #1069 — same defect class throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)