### PR TITLE
fix(secure-bridge): the advertise retry loop could not retry

### DIFF
--- a/src/__tests__/services/secure-bridge-auth.test.ts
+++ b/src/__tests__/services/secure-bridge-auth.test.ts
@@ -80,3 +80,55 @@ describe("advertiseBridge auth headers", () => {
     expect(init.headers).toEqual({ "Content-Type": "application/json" });
   });
 });
+
+// The retry loop could not retry. A pod behind a proxy that accepts the
+// connection and then answers nothing — the characteristic RunPod-route failure
+// the function's own comment calls "not warm yet" — left attempt 1 awaiting
+// forever on a signal-less fetch, so attempts 2 and 3 never ran and bridge
+// exposure hung with no error at all.
+describe("advertiseBridge cannot hang on attempt 1", () => {
+  const OLD = process.env;
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...OLD, COMFYUI_URL: "http://127.0.0.1:8188" };
+  });
+  afterEach(() => {
+    process.env = OLD;
+    vi.unstubAllGlobals();
+  });
+
+  it("bounds each attempt so the loop can reach attempts 2 and 3", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { advertiseBridge } = await import("../../services/secure-bridge.js");
+    await advertiseBridge("https://podid-3000.proxy.runpod.net", "wss://relay/?token=t");
+
+    const [, init] = advertiseCall(fetchMock);
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  // Split deliberately from the assertion above, and NOT written as "wait for the
+  // real ceiling to fire". AbortSignal.timeout is backed by a platform timer that
+  // vitest's fake timers do not drive, so a version of this test using
+  // advanceTimersByTimeAsync sat for the full real 10s and then failed — it was
+  // measuring Node's timer, not our code.
+  //
+  // What is OURS is that an aborted attempt is caught and the loop proceeds. That
+  // is the half the hang broke, and it is what this pins.
+  it("an aborted attempt is caught and the NEXT attempt still runs", async () => {
+    const abortErr = new Error("This operation was aborted");
+    abortErr.name = "TimeoutError";
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(abortErr)
+      .mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { advertiseBridge } = await import("../../services/secure-bridge.js");
+    const ok = await advertiseBridge("https://podid-3000.proxy.runpod.net", "wss://relay/?token=t");
+
+    expect(ok).toBe(true);
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+  });
+});

--- a/src/services/secure-bridge.ts
+++ b/src/services/secure-bridge.ts
@@ -53,6 +53,11 @@ function maskToken(url: string): string {
   return url.replace(/token=[^&]+/, "token=…");
 }
 
+/** Per-attempt ceiling for the advertise POST. Deliberately well under the retry
+ *  budget: three attempts plus backoff must still finish in a bounded time, and a
+ *  pod route that has not answered in ten seconds is not about to. */
+const ADVERTISE_TIMEOUT_MS = 10_000;
+
 /**
  * POST the bridge URL to the pod's panel pack so its browser panel can fetch it.
  * Retries a few times — the orchestrator may advertise before the pod route is
@@ -74,6 +79,13 @@ export async function advertiseBridge(comfyuiUrl: string, wssUrl: string, should
         method: "POST",
         headers: { "Content-Type": "application/json", ...getComfyUIAuthHeaders() },
         body: JSON.stringify({ url: wssUrl }),
+        // Without this the retry loop could not retry: a pod behind a proxy that
+        // accepts the connection and then answers nothing (the characteristic
+        // RunPod-route failure this function's own comment describes as "not warm
+        // yet") left attempt 1 awaiting forever, so attempts 2 and 3 never ran and
+        // bridge exposure hung with no error. A ceiling turns that hang into the
+        // retry the loop was written to perform.
+        signal: AbortSignal.timeout(ADVERTISE_TIMEOUT_MS),
       });
       if (res.ok) return true;
       logger.warn(`[secure-bridge] advertise got HTTP ${res.status} from the pod panel`);


### PR DESCRIPTION
`advertiseBridge` POSTs the bridge URL to the pod's panel pack, retrying three times because — in its own words — *"the orchestrator may advertise before the pod route is warm"*.

The fetch carried **no signal**. So the characteristic failure of an unwarm RunPod route — the connection is accepted and then nothing comes back — left attempt 1 awaiting forever. Attempts 2 and 3 never ran, and bridge exposure hung with no error at all.

The retry loop existed but could not reach its own retries.

## The fix

A 10s per-attempt ceiling turns the hang into the retry the loop was written to perform. Deliberately well under the retry budget: three attempts plus backoff must still finish in a bounded time, and a pod route that hasn't answered in ten seconds isn't about to.

## How it was found

By sweeping every `await fetch(` in `src/` for a missing signal after shipping #1069 — the same sweep that caught cloud `fetchImage` in #1072. Two of the sweep's other hits were false positives (`llamacpp-probe`, `lmstudio-lifecycle` both carry `AbortSignal.timeout(120000)` further down than my matcher looked), and one was correctly left alone: `storage/http.ts` streams a large PUT, where a fixed ceiling would be actively wrong.

## Verification

| Check | Result |
|---|---|
| **mutation** — remove the signal | ceiling test fails |
| abort-then-retry test | an aborted attempt is caught and the loop proceeds to a successful attempt 2 |
| existing secure-bridge tests | 3, unchanged, passing |

One test was **not** written as "wait for the real ceiling to fire". `AbortSignal.timeout` is backed by a platform timer that vitest's fake timers do not drive, so that version sat for the full real 10 seconds and then failed — it was measuring Node's timer, not our code. What's ours is that an aborted attempt is caught and the loop continues, and that's what's pinned.

Adjacent to #875 (mobile tunnel), which lives in this same advertise path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)