### PR TITLE
0.50.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.22] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- the advertise retry loop could not retry (#1073)
+- getSystemStats must be able to fail, and fetchImage must be able to time out (#1072)
+- give the cloud client the timeout ceiling and delivery doubt its twin already had (#1069)
+- a transport failure on a POST no longer implies the POST never arrived (#1068)
+- a reply-timeout on a mutating command no longer reads as "nothing happened" (#1067)
+- two release gates anchored to a frozen retirement baseline instead of the live surface (#1066)
+
+#### Changed
+- verify the published PANEL surface builds too (#1065)
+- verify the published surface REGISTERS, not just that it boots (#1064)
+- the startup probe budget is 60, not 20 — and gate the drift (#1063)
+- COMFYUI_MCP_NO_AUTOSPAWN does not exist — name the control that does (#1062)
+
+
 ## [0.50.21] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.21",
+  "version": "0.50.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.21",
+      "version": "0.50.22",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.21",
+  "version": "0.50.22",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.22**. The tag is pushed and `release.yml` publishes from it; this PR reconciles protected `main` with the release commit.

## What's in it

Six fixes, all one defect class: **a failure reported as a fact it never established.**

| PR | Fix |
|---|---|
| #1067 | A bridge reply-timeout on a **mutating** command read as "nothing happened" — the caller supplied the retry the bridge deliberately refused, and the node/workflow landed twice |
| #1068 | A transport failure on a `POST` no longer implies the POST never arrived — an `ECONNRESET` after `/prompt` queued the render is indistinguishable from one before it |
| #1069 | The cloud client had **no timeout at all** (a hung request hung the whole tool call) and reported every transport error as "Failed to reach Comfy Cloud" — on requests that bill real renders |
| #1072 | Cloud `getSystemStats` could not fail: every error returned a fabricated healthy GPU, and it's the exact remedy our error messages point people to. Plus `fetchImage`, which kept the signal-less fetch #1069 removed one call over |
| #1073 | `advertiseBridge`'s three-attempt retry loop **could not reach its own retries** — attempt 1 awaited forever on an unwarm pod route |
| #1066 | Two release gates anchored to a frozen *retirement baseline* instead of the live surface. One would have failed a release on the first legitimate panel-tool retirement; the other's printed remedy would have disarmed the dead-name ratchet for 158 names |

Plus the docs/gate work already on main: #1062, #1063, #1064, #1065.

## Notes

- Every fix is mutation-verified in both directions (call-site *and* helper), and three of them found the bug in code a **previous fix in this same series** had just touched — #1072's `fetchImage` and #1073 both came from sweeping `await fetch(` for a missing signal *after* shipping #1069.
- No behaviour change for reads anywhere: re-running a read cannot double-apply, so none of them gained a disclosure.
- The cloud and headless clients now share one ceiling and one delivery-doubt rule rather than two that drift apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)