### PR TITLE
0.50.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.23] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- the fence repair was gated behind the one call the wedge blocks (#1075)
+
+
 ## [0.50.22] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.22",
+  "version": "0.50.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.22",
+      "version": "0.50.23",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.22",
+  "version": "0.50.23",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.23**. Tag is pushed and `release.yml` publishes from it; this PR reconciles protected `main`.

Single fix, released promptly because it is a **session-wedging** bug that three open reports are about (#1071, and the same root cause behind #932 / #1043).

## #1075 — the fence repair was gated behind the one call the wedge blocks

A session fenced to a workflow instance that is no longer active has every `panel_*` call refused with `workflow instance mismatch`. The documented recovery, `panel_set_workflow_target({mode:"current"})`, re-derives the fence by reading `workflow_list` — and `workflow_list` is **not exempt** from the panel's fence. So the recovery probe is refused by the very fence it exists to repair, structurally and every time. The reporter called it five times over twenty minutes and lost the canvas for the rest of the task.

The panel already publishes a `workflow_uuid` on the `workflow_open` reply, after its own final synchronous active-workflow check (#716) — expressly so the MCP can stamp with it. We were ignoring it unless the fenced read *also* succeeded.

Now: three outcomes for that read instead of two — confirms → prefer the fresher read; **contradicts** → adopt nothing (another tab won the active slot); **could not ask** → adopt the reply's proven uuid. So `panel_open_workflow(<path>)` clears the wedge, and the failure message says so rather than sending people to a browser refresh.

The remedy also branches on cause: a fence refusal leads with reopening, a dead tab still leads with retry, and the unsaved-canvas case is called out — a blank workflow has no path to reopen, and opening anything else would abandon it.

## Known remaining half

`workflow_new` has the same gap and cannot be fixed here: its reply carries no uuid, so there is nothing to fall back to. Filed upstream as artokun/comfyui-mcp-panel#768; #932 and #1043 stay open pending it, and both now carry an explanation of exactly what is and isn't fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)