### PR TITLE
fix(crash-log): a log that could not be read is not a clean restart

### DIFF
--- a/src/__tests__/crash-log.test.ts
+++ b/src/__tests__/crash-log.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   parseCrashBlock,
   formatCrashNote,
   comfyuiLogCandidates,
+  readComfyuiCrashLog,
 } from "../services/crash-log.js";
 
 // The MOTIVATING CASE: a Wan2.2 build crashed ComfyUI with a native access
@@ -185,5 +189,107 @@ describe("comfyuiLogCandidates", () => {
     const c = comfyuiLogCandidates("/comfy");
     expect(c[0]).toMatch(/logs[\\/]+comfyui\.log$/);
     expect(c[1]).toMatch(/user[\\/]+comfyui\.log$/);
+  });
+});
+
+// #796's class, in the place it costs most.
+//
+// `fatal: boolean` is a two-valued field carrying THREE states: a crash was
+// found, no crash was found, and NOTHING WAS LOOKED AT. The third rendered as the
+// second — and formatCrashNote returns null for !fatal, so a log that could not be
+// opened (locked mid-write on Windows, permissions, a truncated read) told the
+// agent its restart was CLEAN.
+//
+// That is the worst available direction. The whole feature exists so the agent
+// does not re-run the graph that just killed the server, and silence reads as
+// "safe to proceed".
+describe("an unreadable log is not a clean restart", () => {
+  it("says the outcome is UNKNOWN, and that nothing was scanned", () => {
+    const note = formatCrashNote({
+      fatal: false,
+      block: "",
+      unreadable: { path: "C:/comfy/user/comfyui.log", reason: "EBUSY: resource busy or locked" },
+    });
+
+    expect(note).not.toBeNull();
+    expect(note!).toMatch(/could NOT be read/);
+    expect(note!).toMatch(/UNKNOWN/);
+    // It must not merely hedge — it has to say WHY the silence is uninformative.
+    expect(note!).toMatch(/no crash signature was ruled out, because nothing was scanned/);
+    // And name what it tried, so the user can go and look.
+    expect(note!).toContain("C:/comfy/user/comfyui.log");
+    expect(note!).toContain("EBUSY");
+  });
+
+  it("still stays silent for a genuinely clean restart", () => {
+    // The noise guard: no `unreadable`, no note. A permanent unknown-banner on
+    // every resume is how a real warning stops being read.
+    expect(formatCrashNote({ fatal: false, block: "" })).toBeNull();
+  });
+
+  it("does not displace a REAL crash note", () => {
+    const note = formatCrashNote({
+      fatal: true,
+      block: "Windows fatal exception: access violation",
+      culpritNode: "ComfyUI-WanVideoWrapper",
+      unreadable: { path: "x", reason: "y" },
+    });
+
+    expect(note!).toMatch(/ComfyUI crashed/);
+    expect(note!).not.toMatch(/could NOT be read/);
+  });
+});
+
+// THE WIRING, not just the helper. The tests above hand formatCrashNote a
+// constructed result; they would all still pass if readComfyuiCrashLog never set
+// `unreadable` at all. This drives the real function against a real unreadable
+// path — and pins the fingerprint, because the injection site skips any note
+// without one, so a missing fingerprint would silently suppress the warning.
+describe("readComfyuiCrashLog reports an existing-but-unreadable log", () => {
+  it("sets unreadable + a fingerprint when the log cannot be read", () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-crashlog-"));
+    // A DIRECTORY where the log file goes: existsSync passes, statSync succeeds,
+    // readFileSync throws EISDIR. That is the read-catch branch, cross-platform.
+    mkdirSync(join(root, "user", "comfyui.log"), { recursive: true });
+
+    const r = readComfyuiCrashLog(root);
+
+    expect(r.fatal).toBe(false);
+    expect(r.unreadable, "an existing log that cannot be read must be reported").toBeTruthy();
+    expect(r.unreadable!.path).toContain("comfyui.log");
+    expect(r.unreadable!.reason).toBeTruthy();
+    // Without this the note is built and then dropped by the injection site.
+    expect(r.fingerprint, "no fingerprint means the note is never injected").toBeTruthy();
+    expect(r.fingerprint!).toMatch(/^unreadable:/);
+    // End to end: the agent actually gets told.
+    expect(formatCrashNote(r)).toMatch(/could NOT be read/);
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("stays silent when there is no log at all — nothing to report, not an unknown", () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-crashlog-empty-"));
+
+    const r = readComfyuiCrashLog(root);
+
+    expect(r.fatal).toBe(false);
+    expect(r.unreadable).toBeUndefined();
+    expect(formatCrashNote(r)).toBeNull();
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("is unchanged for a readable log with no crash", () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-crashlog-clean-"));
+    mkdirSync(join(root, "user"), { recursive: true });
+    writeFileSync(join(root, "user", "comfyui.log"), "[INFO] Prompt executed in 3.2 seconds\n");
+
+    const r = readComfyuiCrashLog(root);
+
+    expect(r.fatal).toBe(false);
+    expect(r.unreadable).toBeUndefined();
+    expect(formatCrashNote(r)).toBeNull();
+
+    rmSync(root, { recursive: true, force: true });
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -4835,7 +4835,9 @@ export async function runPanelOrchestrator(): Promise<void> {
           injectedCrashes.add(key);
           outText = `${note}\n\n${event.text}`;
           logger.warn(
-            `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} crash-dump injected on resume — culprit=${crash.culpritNode ?? "?"} frame=${crash.culpritFrame ?? "?"} (log=${crash.logPath ?? "?"})`,
+            crash.unreadable
+              ? `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} crash-log UNREADABLE note injected on resume — whether ComfyUI crashed is unknown (log=${crash.unreadable.path}: ${crash.unreadable.reason})`
+              : `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} crash-dump injected on resume — culprit=${crash.culpritNode ?? "?"} frame=${crash.culpritFrame ?? "?"} (log=${crash.logPath ?? "?"})`,
           );
         }
       } catch (err) {

--- a/src/services/crash-log.ts
+++ b/src/services/crash-log.ts
@@ -30,8 +30,27 @@ export interface CrashParseResult {
   culpritFrame?: string;
   /** A stable identifier for THIS crash (signature head + culprit), so the caller
    *  can inject a given crash at most once and not re-surface it on every later
-   *  resume. Absent when !fatal. */
+   *  resume. Also set for the `unreadable` case below — the injection site skips
+   *  any note without one — and otherwise absent. */
   fingerprint?: string;
+  /**
+   * A log candidate EXISTED and could not be read (#796's class).
+   *
+   * `fatal` is a two-valued field carrying three states: a crash was found, no
+   * crash was found, and NOTHING WAS LOOKED AT. The third used to render as the
+   * second, and formatCrashNote returns null for `!fatal` — so a log we could not
+   * open (locked mid-write on Windows, permissions, a truncated read) told the
+   * agent that its restart was CLEAN. That is the worst possible direction here:
+   * the whole feature exists so the agent does not re-run the graph that just
+   * killed the server, and silence is read as "safe to proceed".
+   *
+   * Set ONLY when a candidate file exists and reading or stat-ing it failed.
+   * Deliberately NOT set when there are no candidates at all: that is "no source
+   * to consult", it is the normal state for anyone whose logs live elsewhere, and
+   * a permanent unknown-banner on every resume would be noise — which is how a
+   * real warning stops being read.
+   */
+  unreadable?: { path: string; reason: string };
 }
 
 /** What readComfyuiCrashLog returns: the parse plus where it read from. */
@@ -50,6 +69,21 @@ const CRASH_SIGNATURES = [
 
 /** Hard caps so an enormous log can't blow up memory or the agent's context. */
 const MAX_TAIL_BYTES = 256 * 1024; // read at most the last 256 KiB of the log
+
+/**
+ * The dedupe key for an UNREADABLE log, in the same namespace as a crash
+ * fingerprint (the injection site skips any note without one, and keys on it to
+ * inject at most once per tab).
+ *
+ * Keyed on path + reason so a persistent condition — a permissions problem, say —
+ * is surfaced ONCE rather than on every resume for the rest of the session, while
+ * a genuinely different failure later still gets through. The reason is truncated
+ * so an error string carrying a varying detail (an offset, a handle id) cannot
+ * defeat the dedupe by minting a fresh key each time.
+ */
+function unreadableFingerprint(u: { path: string; reason: string }): string {
+  return `unreadable:${u.path}:${u.reason.slice(0, 60)}`;
+}
 const MAX_BLOCK_CHARS = 4000; // the injected fatal block is capped to this
 
 /**
@@ -227,6 +261,7 @@ export function readComfyuiCrashLog(comfyPath: string | undefined): CrashLogRead
   // Most-recently-modified candidate (the live log after a crash+restart).
   let chosen: string | undefined;
   let chosenMtime = -Infinity;
+  let statFailure: { path: string; reason: string } | undefined;
   for (const p of candidates) {
     try {
       const m = statSync(p).mtimeMs;
@@ -234,11 +269,18 @@ export function readComfyuiCrashLog(comfyPath: string | undefined): CrashLogRead
         chosenMtime = m;
         chosen = p;
       }
-    } catch {
-      // unreadable stat — skip this candidate
+    } catch (err) {
+      // Remember WHY, rather than only skipping. If no candidate survives, this
+      // is the difference between "no crash" and "could not look" (#796).
+      statFailure ??= { path: p, reason: err instanceof Error ? err.message : String(err) };
     }
   }
-  if (!chosen) return { fatal: false, block: "" };
+  // Candidates existed (they passed existsSync) and every one failed to stat.
+  if (!chosen) {
+    return statFailure
+      ? { fatal: false, block: "", unreadable: statFailure, fingerprint: unreadableFingerprint(statFailure) }
+      : { fatal: false, block: "" };
+  }
 
   let text: string;
   try {
@@ -248,8 +290,15 @@ export function readComfyuiCrashLog(comfyPath: string | undefined): CrashLogRead
       size > MAX_TAIL_BYTES
         ? buf.subarray(size - MAX_TAIL_BYTES).toString("utf8")
         : buf.toString("utf8");
-  } catch {
-    return { fatal: false, block: "", logPath: chosen };
+  } catch (err) {
+    const unreadable = { path: chosen, reason: err instanceof Error ? err.message : String(err) };
+    return {
+      fatal: false,
+      block: "",
+      logPath: chosen,
+      unreadable,
+      fingerprint: unreadableFingerprint(unreadable),
+    };
   }
   return { ...parseCrashBlock(text), logPath: chosen };
 }
@@ -259,6 +308,21 @@ export function readComfyuiCrashLog(comfyPath: string | undefined): CrashLogRead
  * null when there's nothing to inject (clean restart). Kept small + capped.
  */
 export function formatCrashNote(result: CrashParseResult): string | null {
+  // A log we could not open is NOT a clean restart (#796). Say so plainly, and
+  // say what it does and does not establish — the agent's next move after a
+  // resume is usually to re-run what it was doing, which is the one thing a
+  // genuine crash makes dangerous.
+  if (!result.fatal && result.unreadable) {
+    return (
+      "⚠️ ComfyUI restarted, and its log could NOT be read — so whether it crashed is UNKNOWN. " +
+      `Tried: ${result.unreadable.path} (${result.unreadable.reason}). ` +
+      "This is not a clean restart, it is an unread one: no crash signature was ruled out, because " +
+      "nothing was scanned. Before re-running the last action, consider whether it was heavy " +
+      "(large model load, a custom node doing native work) — a repeat of a native fault will look " +
+      "identical from here. Reading that file yourself, or checking ComfyUI's console, is the " +
+      "quickest way to settle it."
+    );
+  }
   if (!result.fatal) return null;
   const culprit = result.culpritNode
     ? `Most likely culprit custom node: ${result.culpritNode}${


### PR DESCRIPTION
Another #796 instance, in the place it costs most.

`fatal: boolean` is a two-valued field carrying **three** states: a crash was found, no crash was found, and *nothing was looked at*. The third rendered as the second.

Two paths returned `{ fatal: false }` after a **failed observation** — every candidate's `statSync` throwing, and `readFileSync` throwing on the chosen file. And `formatCrashNote` returns `null` for `!fatal`, so a log that could not be opened (locked mid-write on Windows, a permissions problem, a truncated read) told the agent its restart was **clean**.

That is the worst available direction *for this feature specifically*. The entire reason it exists is so the agent does not blindly re-run the graph that just killed the server. Silence reads as "safe to proceed" — so an unreadable log actively encourages the repeat.

## The fix

`unreadable: { path, reason }`, set **only** when a candidate file exists and reading or stat-ing it failed. The note now says the outcome is UNKNOWN, names the file and the reason, and states what the silence does *not* establish:

> ⚠️ ComfyUI restarted, and its log could NOT be read — so whether it crashed is UNKNOWN. Tried: `…/comfyui.log` (EBUSY: resource busy or locked). This is not a clean restart, it is an unread one: **no crash signature was ruled out, because nothing was scanned.** …

**Deliberately not set when there are no candidates at all.** That's "no source to consult" — the normal state for anyone whose logs live elsewhere — and a permanent unknown-banner on every resume is how a real warning stops being read. #796's own point 4: decide which way unknown should fail, per site.

## It also needed a fingerprint

The injection site skips any note without one:

```ts
const key = crash.fingerprint ? `${event.tab_id}:${crash.fingerprint}` : null;
if (note && key && !injectedCrashes.has(key)) { … }
```

Without it the warning would have been built and then silently dropped — the fix defeated by the caller, which is #796's "beware the guard in front of the fix" one more time. Keyed on path + truncated reason, so a persistent condition surfaces once per tab rather than every resume, while a genuinely different failure later still gets through.

The orchestrator's log line no longer claims "crash-dump injected" for a note that isn't a crash dump.

## Verification

| Check | Result |
|---|---|
| **mutation** — drop `unreadable` + `fingerprint` from the read result | wiring test fails |
| **mutation** — disable the formatter branch | 2 tests fail |
| full suite | green — 353 files, 7283 passed |

The wiring is tested against **real I/O**, not just the formatter with a hand-built result: a directory at the log path makes `existsSync`/`statSync` succeed and `readFileSync` throw `EISDIR`, cross-platform. Without that test, every assertion here would still pass if `readComfyuiCrashLog` never set the field at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)