### PR TITLE
fix(session-store): a store that could not be READ is never overwritten

### DIFF
--- a/src/__tests__/orchestrator/session-store.test.ts
+++ b/src/__tests__/orchestrator/session-store.test.ts
@@ -17,7 +17,7 @@
 //    v2 file's stable entries are dropped on load.
 
 import { describe, expect, it, afterEach } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SessionStore, workflowIdentityParts } from "../../orchestrator/session-store.js";
@@ -439,5 +439,75 @@ describe("SessionStore", () => {
         }),
       ).toEqual({ origin: "http://host:8188", uuid: UUID_A });
     });
+  });
+});
+
+// #796's class, with DATA LOSS as the consequence.
+//
+// read() had ONE catch covering both `readFileSync` throwing and `parse` throwing,
+// and returned `{ sessions: {} }` for both. Those are different states:
+//
+//   parse threw        → the bytes really are unusable; nothing recoverable is lost.
+//   readFileSync threw → EACCES / EBUSY / EMFILE. The sessions are INTACT and
+//                        readable later; we just could not open the file this
+//                        instant (antivirus, backup software, another orchestrator
+//                        mid-write — all routine on Windows).
+//
+// Starting empty on the second is silent data loss, because flush() renames over
+// this.path unconditionally: the first new session — or even a touch() — replaces
+// an intact store with a one-entry one, and every prior resume id is gone. The
+// agent forgets every conversation, and nothing says why.
+//
+// This file already argues "failing to persist is strictly better than destroying
+// what's there". That reasoning simply never covered a failed LOAD.
+describe("a store that could not be READ is never overwritten", () => {
+  /** A path that exists and cannot be read: a directory where the file goes.
+   *  existsSync passes, readFileSync throws EISDIR — on every platform. */
+  function unreadableStore(): { dir: string; storePath: string } {
+    const dir = scratchDir();
+    const storePath = join(dir, `panel-sessions-${PORT}.json`);
+    mkdirSync(storePath, { recursive: true });
+    return { dir, storePath };
+  }
+
+  it("starts empty but PRESERVES the file instead of clobbering it", () => {
+    const { dir, storePath } = unreadableStore();
+
+    const store = new SessionStore(PORT, { dir });
+    // It could not read anything, so it has nothing.
+    expect(store.get(sharedAgentKey("claude"))).toBeUndefined();
+
+    // The first persist must move the unreadable original aside, not destroy it.
+    expect(store.set(sharedAgentKey("claude"), "sess-new")).toBe(true);
+
+    const preserved = readdirSync(dir).filter((f) => f.includes(".unreadable-"));
+    expect(preserved, "the unreadable store must be kept, not overwritten").toHaveLength(1);
+    // …and the new store really was written in its place.
+    expect(existsSync(storePath)).toBe(true);
+    expect(readFileSync(storePath, "utf8")).toContain("sess-new");
+  });
+
+  it("preserves only once — later writes are ordinary", () => {
+    const { dir } = unreadableStore();
+    const store = new SessionStore(PORT, { dir });
+
+    store.set(sharedAgentKey("claude"), "sess-1");
+    store.set(sharedAgentKey("claude"), "sess-2");
+    store.set(sharedAgentKey("codex"), "sess-3");
+
+    expect(readdirSync(dir).filter((f) => f.includes(".unreadable-"))).toHaveLength(1);
+  });
+
+  // The other half: a genuinely CORRUPT file is still discarded. Preserving every
+  // parse failure would litter the directory and imply the data was salvageable.
+  it("still starts empty for a corrupt (readable) store, with no preservation copy", () => {
+    const dir = scratchDir();
+    writeFileSync(join(dir, `panel-sessions-${PORT}.json`), "{ this is not json");
+
+    const store = new SessionStore(PORT, { dir });
+    expect(store.get(sharedAgentKey("claude"))).toBeUndefined();
+    store.set(sharedAgentKey("claude"), "sess-1");
+
+    expect(readdirSync(dir).filter((f) => f.includes(".unreadable-"))).toHaveLength(0);
   });
 });

--- a/src/orchestrator/session-store.ts
+++ b/src/orchestrator/session-store.ts
@@ -99,6 +99,11 @@ export class SessionStore {
    *  would otherwise take an in-memory shortcut and answer `true` consults this
    *  first, so a durability claim always describes the DISK, never just RAM. */
   private undurable = false;
+  /** Set when the on-disk store EXISTED but could not be READ (an I/O error, not
+   *  a parse error). Its contents are unknown and presumed good, so flush() must
+   *  move it aside before overwriting — see read() and flush(). Cleared once it
+   *  has been preserved. */
+  private loadUnreadable: string | undefined;
   /** #884 P1 (confirming gate 3) — the (size, mtime) of the store file as last
    *  READ or WRITTEN by this instance. `undurable === false` alone proved only
    *  that the LAST write succeeded, not that the file is still there: deleted
@@ -226,8 +231,38 @@ export class SessionStore {
       // tmp unreadable/corrupt (a crash mid-tmp-write) — fall through to main.
     }
     if (existsSync(this.path)) {
+      // COULD NOT READ IT and IT IS CORRUPT are different states (#796), and this
+      // catch used to serve both. The difference decides whether the file on disk
+      // is worthless or precious:
+      //
+      //   parse threw     → the bytes really are unusable; starting empty loses
+      //                     nothing that was recoverable.
+      //   readFileSync threw → EACCES / EBUSY / EMFILE. The sessions are INTACT
+      //                     and readable later; we simply could not open the file
+      //                     this instant (antivirus, a backup process, another
+      //                     orchestrator mid-write — all routine on Windows).
+      //
+      // Starting empty on the second one is silent data loss, because flush()
+      // renames over this.path unconditionally: the first new session — or even a
+      // touch() — replaces an intact store with a one-entry one, and every prior
+      // resume id is gone. This file already argues "failing to persist is
+      // strictly better than destroying what's there"; that reasoning simply never
+      // covered a failed LOAD.
+      let text: string | undefined;
       try {
-        const parsed = this.parse(readFileSync(this.path, "utf8"));
+        text = readFileSync(this.path, "utf8");
+      } catch (err) {
+        // Do NOT let the next flush() overwrite a file we never managed to read.
+        this.loadUnreadable = String(err);
+        logger.warn(
+          `[session-store] ${this.path} could NOT be READ (it is not known to be corrupt) — ` +
+            `starting empty for now, and the next persist will move it aside rather than ` +
+            `overwrite it, so nothing in it is lost: ${String(err)}`,
+        );
+        return { sessions: {}, dirty: false };
+      }
+      try {
+        const parsed = this.parse(text);
         // The in-memory state now equals this on-disk file — fingerprint it so
         // a later durability shortcut can verify the file is still in place.
         this.captureDiskFingerprint();
@@ -266,6 +301,33 @@ export class SessionStore {
   private flush(): boolean {
     const payload = JSON.stringify({ v: 2, sessions: this.sessions } satisfies StoreFileV2);
     const tmp = `${this.path}.tmp`;
+    // The store we are about to replace was never read (an I/O failure at load,
+    // not a parse failure), so its contents are unknown and presumed GOOD. Move it
+    // aside before the rename below destroys it. If it cannot even be moved,
+    // REFUSE to persist — the same ruling this method already makes for a failed
+    // write: failing to persist is strictly better than destroying what's there.
+    if (this.loadUnreadable !== undefined) {
+      const aside = `${this.path}.unreadable-${this.now()}`;
+      try {
+        if (existsSync(this.path)) {
+          renameSync(this.path, aside);
+          logger.warn(
+            `[session-store] preserved the unreadable store as ${aside} before writing a fresh one ` +
+              `(it could not be read at startup: ${this.loadUnreadable}). If sessions went missing, ` +
+              `that file holds them.`,
+          );
+        }
+        this.loadUnreadable = undefined; // preserved (or already gone) — safe from here
+      } catch (err) {
+        this.undurable = true;
+        logger.warn(
+          `[session-store] REFUSING to persist: ${this.path} could not be read at startup and cannot ` +
+            `be moved aside either, so overwriting it would destroy sessions that are probably intact ` +
+            `(${String(err)}). State is kept in memory for this run.`,
+        );
+        return false;
+      }
+    }
     try {
       writeFileSync(tmp, payload);
       renameSync(tmp, this.path);


### PR DESCRIPTION
Another #796 instance — this one loses data.

`read()` had **one** catch covering both `readFileSync` throwing and `parse` throwing, and returned `{ sessions: {} }` for both. Those are different states, and the difference decides whether the file on disk is worthless or precious:

| failure | what it means |
|---|---|
| `parse` threw | the bytes really are unusable; nothing recoverable is lost |
| `readFileSync` threw | `EACCES` / `EBUSY` / `EMFILE` — the sessions are **intact** and readable later; we just couldn't open the file this instant (antivirus, backup software, another orchestrator mid-write — all routine on Windows) |

Starting empty on the second is **silent data loss**, because `flush()` renames over `this.path` unconditionally. The first new session — or even a `touch()` — replaces an intact store with a one-entry one, and every prior resume id is gone. The agent forgets every conversation across every backend, and nothing says why.

This file already argues, about a failed *write*:

> *there is deliberately NO truncate-in-place fallback … failing to persist is strictly better than destroying what's there*

That reasoning simply never covered a failed **load**.

## The fix

- an I/O failure at load sets `loadUnreadable` instead of masquerading as empty;
- before the first overwrite, `flush()` moves the unreadable file to `<path>.unreadable-<ts>` and logs where it went, so nothing in it is lost;
- if it can't even be moved, `flush()` **refuses to persist** and keeps state in memory — the same ruling the write path already makes;
- a genuinely **corrupt** (readable) store still starts empty with no preservation copy, because preserving every parse failure would litter the directory and imply the data was salvageable.

## Verification

| Check | Result |
|---|---|
| **mutation** — disable the preservation guard | 2 tests fail; the unreadable store is destroyed, which is the bug |
| **mutation** — never set the flag | the same 2 fail |
| full suite | green — 353 files, 7286 passed |

Driven against **real I/O**, not a mocked fs: a directory where the store file goes makes `existsSync` pass and `readFileSync` throw `EISDIR` on every platform.

Companion to #1078 (crash log) — same class, found by the greppable shape I noted on #796: a `catch` whose body returns a constructed literal rather than propagating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)