### PR TITLE
0.50.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.24] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- a store that could not be READ is never overwritten (#796) (#1079)
+- a log that could not be read is not a clean restart (#796) (#1078)
+
+
 ## [0.50.23] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.23",
+  "version": "0.50.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.23",
+      "version": "0.50.24",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.23",
+  "version": "0.50.24",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.24**. Tag pushed; `release.yml` publishes from it; this PR reconciles protected `main`.

Two fixes, both the same defect class (#796) — **a failed observation reported as a negative result** — found by sweeping for the greppable shape I'd just recorded on that issue: *a `catch` whose body returns a constructed literal rather than propagating*.

## #1079 — a session store that could not be READ is no longer overwritten

`read()` had one catch covering both `readFileSync` throwing and `parse` throwing, returning `{ sessions: {} }` for both.

- `parse` threw → the bytes really are unusable.
- `readFileSync` threw (`EACCES`/`EBUSY`/`EMFILE`) → the sessions are **intact**, we just couldn't open the file this instant.

Starting empty on the second is **silent data loss**: `flush()` renames over the path unconditionally, so the first new session — or even a `touch()` — replaces an intact store with a one-entry one, and every prior resume id is gone. The agent forgets every conversation across every backend, with nothing to explain why.

The file already argued, about a failed *write*, that "failing to persist is strictly better than destroying what's there". That reasoning had never covered a failed **load**. Now an unread store is moved to `<path>.unreadable-<ts>` before anything overwrites it, and if it can't even be moved, the persist is refused.

## #1078 — a crash log that could not be read is not a clean restart

`fatal: boolean` carried three states: crash found, no crash found, and *nothing was looked at*. The third rendered as the second — and `formatCrashNote` returns `null` for `!fatal`, so a log that couldn't be opened told the agent its restart was **clean**.

That's the worst direction for this feature specifically: it exists so the agent doesn't re-run the graph that just killed the server, and silence reads as "safe to proceed". The note now says the outcome is unknown, names the file and reason, and states that no crash signature was ruled out because nothing was scanned. It also needed its own fingerprint — the injection site drops any note without one, which would have suppressed the warning entirely.

## Verification

Both mutation-verified in both directions, and both driven against **real I/O** rather than a mocked fs (a directory where the file goes: `existsSync` passes, `readFileSync` throws `EISDIR`, on every platform). Without those, every assertion would still pass if the field were never set.

Full suite green — 353 files, 7286 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)