### PR TITLE
fix(expose_subgraph_*): say that `name` is dropped when the slot is reused

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -6378,3 +6378,35 @@ describe("#754 panel_view_nodes_in_viewport: the character budget is REACHABLE",
     }
   });
 });
+
+describe("#690(3) expose_subgraph_* disclose that `name` is dropped on reuse", () => {
+  // The executor is idempotent-ish: if the slot is ALREADY exposed it returns the
+  // existing boundary slot with `reused:true` and its ORIGINAL name. The tool
+  // descriptions promised `name` "titles the new boundary output" with no mention
+  // of that, so a caller passing a name got a differently-named slot and a success.
+  // Both twins behave identically; the reporter only hit the output one.
+  for (const tool of ["panel_expose_subgraph_output", "panel_expose_subgraph_input"]) {
+    it(`${tool} says the name is IGNORED on reuse`, () => {
+      const def = defByName(tool);
+      expect(def.description).toMatch(/IGNORED when this slot is ALREADY exposed/);
+      expect(def.description).toMatch(/reused:true/);
+      // …and the parameter's own describe() must not contradict the prose.
+      const shape = def.schema as Record<string, { description?: string }>;
+      expect(shape.name?.description ?? "").toMatch(/IGNORED when the slot is already exposed/);
+    });
+  }
+
+  it("cites no tool that does not exist", () => {
+    // An earlier draft of this text pointed at a `panel_rename_subgraph_slot` that
+    // was never built — the #809 "names the wrong lever" defect, in a description
+    // rather than a truncation remedy. There is no boundary-slot rename tool, and
+    // saying so is more useful than inventing one.
+    const names = new Set(buildPanelToolDefs().map((d) => d.name));
+    for (const tool of ["panel_expose_subgraph_output", "panel_expose_subgraph_input"]) {
+      const text = defByName(tool).description;
+      for (const m of text.match(/panel_[a-z_]+/g) ?? []) {
+        expect(names.has(m), `${tool} description cites ${m}, which is not a registered tool`).toBe(true);
+      }
+    }
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -8826,11 +8826,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_expose_subgraph_output",
-      "Wire an interior node's OUTPUT to the subgraph's OUTPUT RAIL — i.e. expose it as a SUBGRAPH OUTPUT on the boundary so the PARENT graph can connect to the subgraph node's new output slot. You MUST be INSIDE the subgraph first (panel_enter_subgraph). This is the correct way to \"wire an internal output to the subgraph's output rail\": do NOT panel_connect to a guessed rail node id — call this with the interior node + the output you want exposed. Read panel_query_graph's `rails` to see the resulting boundary slots. `from_output` is an output slot NAME ('IMAGE', 'LATENT') or numeric index. Optional `name` titles the new boundary output (defaults from the source slot). Undoable with Ctrl+Z.",
+      "Wire an interior node's OUTPUT to the subgraph's OUTPUT RAIL — i.e. expose it as a SUBGRAPH OUTPUT on the boundary so the PARENT graph can connect to the subgraph node's new output slot. You MUST be INSIDE the subgraph first (panel_enter_subgraph). This is the correct way to \"wire an internal output to the subgraph's output rail\": do NOT panel_connect to a guessed rail node id — call this with the interior node + the output you want exposed. Read panel_query_graph's `rails` to see the resulting boundary slots. `from_output` is an output slot NAME ('IMAGE', 'LATENT') or numeric index. Optional `name` titles the new boundary output (defaults from the source slot) — but it is IGNORED when this slot is ALREADY exposed: the call then returns the existing boundary output unchanged, with `reused:true` and its ORIGINAL `name`. Check `reused` before relying on the name you asked for — there is currently NO tool that renames an existing boundary slot, so a name is only applied on FIRST exposure. Undoable with Ctrl+Z.",
       {
         from_node_id: nodeId().describe("Interior (inner) node id whose output to expose (from panel_query_graph while inside the subgraph)."),
         from_output: slotRef.describe("Output slot name (e.g. 'IMAGE', 'LATENT') or numeric index on that node."),
-        name: z.string().optional().describe("Optional name for the new subgraph output (boundary slot). Defaults from the source slot."),
+        name: z.string().optional().describe("Optional name for the new subgraph output (boundary slot). Defaults from the source slot. IGNORED when the slot is already exposed — the reply carries reused:true and the existing name."),
       },
       async (args: A, ctx) =>
         ctx.call(
@@ -8845,11 +8845,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_expose_subgraph_input",
-      "Wire an interior node's INPUT to the subgraph's INPUT RAIL — i.e. expose it as a SUBGRAPH INPUT on the boundary so the PARENT graph can feed the subgraph node's new input slot. You MUST be INSIDE the subgraph first (panel_enter_subgraph). This is the correct way to wire an internal input to the subgraph's input rail: do NOT panel_connect to a guessed rail node id — call this with the interior node + the input you want exposed. Read panel_query_graph's `rails` to see the resulting boundary slots. `to_input` is an input slot NAME ('model', 'pixels') or numeric index. Optional `name` titles the new boundary input (defaults from the target slot). Undoable with Ctrl+Z.",
+      "Wire an interior node's INPUT to the subgraph's INPUT RAIL — i.e. expose it as a SUBGRAPH INPUT on the boundary so the PARENT graph can feed the subgraph node's new input slot. You MUST be INSIDE the subgraph first (panel_enter_subgraph). This is the correct way to wire an internal input to the subgraph's input rail: do NOT panel_connect to a guessed rail node id — call this with the interior node + the input you want exposed. Read panel_query_graph's `rails` to see the resulting boundary slots. `to_input` is an input slot NAME ('model', 'pixels') or numeric index. Optional `name` titles the new boundary input (defaults from the target slot) — but it is IGNORED when this slot is ALREADY exposed: the call then returns the existing boundary input unchanged, with `reused:true` and its ORIGINAL `name`. Check `reused` before relying on the name you asked for — there is currently NO tool that renames an existing boundary slot, so a name is only applied on FIRST exposure. Undoable with Ctrl+Z.",
       {
         to_node_id: nodeId().describe("Interior (inner) node id whose input to expose (from panel_query_graph while inside the subgraph)."),
         to_input: slotRef.describe("Input slot name (e.g. 'model', 'pixels') or numeric index on that node."),
-        name: z.string().optional().describe("Optional name for the new subgraph input (boundary slot). Defaults from the target slot."),
+        name: z.string().optional().describe("Optional name for the new subgraph input (boundary slot). Defaults from the target slot. IGNORED when the slot is already exposed — the reply carries reused:true and the existing name."),
       },
       async (args: A, ctx) =>
         ctx.call(


### PR DESCRIPTION
Closes artokun/comfyui-mcp-panel#690 (3).

## The docs promised something the tool does not do

Both executors are idempotent-ish: if the slot is **already exposed** they return the
existing boundary slot with `reused:true` and its **original** name, ignoring `name`. The
descriptions said only that `name` *"titles the new boundary output (defaults from the
source slot)"*.

The reporter's exact call: `{name:"neg_dup"}` → `{name:"CONDITIONING_1", reused:true}`.

`reused:true` was already honest. The **description** was not — and a caller who believes
the docs has no reason to read the flag.

## Both twins

The report only hit `expose_subgraph_output`. `expose_subgraph_input` has the identical
reuse branch and the identical wording, so it is fixed here rather than left to be
re-reported later.

Fixed in the prose **and** in the parameter's own `describe()`, since a schema description
still promising the name was applied would contradict the tool text one field away.

## A fabricated tool name, caught before it shipped

An earlier draft of this text pointed callers at `panel_rename_subgraph_slot` for renaming
an existing boundary slot. **No such tool exists — I invented it.** There is no
boundary-slot rename anywhere in the surface.

That is #809's "names the wrong lever" defect living in a *description* rather than a
truncation remedy, and it is worse there: a description is read **before** the caller has
any error to make them suspicious. The text now states the true situation — no rename
exists, so a name only applies on first exposure — which is also more useful, because it
stops an agent hunting for a tool that was never built.

A test now asserts that **every `panel_*` token in these two descriptions resolves to a
registered tool**, so the next invented name fails instead of shipping.

## Tests

7289 pass; typecheck and `check:vocabulary` green.

Mutation-verified — each fails a test:

| mutation | result |
|---|---|
| revert one twin's prose disclosure | fails |
| revert one twin's parameter `describe()` | fails |
| re-introduce the fabricated tool name | fails |
