### PR TITLE
fix(settings): an unreadable settings answer is not an empty one

### DIFF
--- a/src/__tests__/comfyui/settings-unreadable.test.ts
+++ b/src/__tests__/comfyui/settings-unreadable.test.ts
@@ -1,0 +1,119 @@
+// #796 again: an UNREADABLE settings answer is not an empty one.
+//
+// getSettings() fell through to `{}` on any non-JSON body, and getSetting() was
+// documented as folding "empty / null / 404 / PARSE-FAILURE" uniformly into
+// "unset (frontend default applies)".
+//
+// The first three are things a ComfyUI build actually SAYS to mean unset. A
+// non-empty body that is not JSON is something else answering — an auth proxy's
+// sign-in page, an API gateway's error envelope, a different service on the host.
+// This repo meets that responder constantly (#828/#952/#954), and the settings
+// path was the one place that read it as an answer.
+//
+// What the caller saw:
+//   get_defaults action:"get_ui"          → count: 0, "only explicitly-stored
+//                                            settings appear here" — i.e. "you
+//                                            have none", from a body nobody parsed
+//   get_defaults action:"get_ui" id:X     → value: null, "unset (frontend default
+//                                            applies)"
+//   get_defaults action:"set_ui"          → previous: null — so a user who then
+//                                            set a value was told the old one was
+//                                            unset, and could not restore it.
+//
+// The fix routes both through the guard the file already imported for every other
+// JSON endpoint (readComfyJson / classifyNonJson), which names the URL and the
+// responder and scrubs secret-shaped text.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
+  return { ...actual, isCloudMode: () => false, getComfyUIApiHost: () => "127.0.0.1:8188" };
+});
+
+const fetchApi = vi.fn();
+vi.mock("@stable-canvas/comfyui-client", () => ({
+  Client: class {
+    fetchApi = fetchApi;
+    close() {}
+  },
+}));
+
+const { getSettings, getSetting } = await import("../../comfyui/client.js");
+
+/** A Response-alike with just what the settings path reads. */
+function reply(body: string, opts: { status?: number; contentType?: string } = {}) {
+  return {
+    status: opts.status ?? 200,
+    ok: (opts.status ?? 200) < 400,
+    headers: { get: (h: string) => (h.toLowerCase() === "content-type" ? opts.contentType ?? "application/json" : null) },
+    text: async () => body,
+  };
+}
+
+/** The classic culprit: a proxy sign-in page served where JSON was promised. */
+const SIGN_IN_PAGE =
+  "<!DOCTYPE html><html><head><title>Sign in</title></head><body><form>Please sign in</form></body></html>";
+
+beforeEach(() => fetchApi.mockReset());
+afterEach(() => vi.clearAllMocks());
+
+describe("getSettings: an unparseable body is not 'no settings'", () => {
+  it("throws instead of returning {} when a sign-in page answers", async () => {
+    fetchApi.mockResolvedValue(reply(SIGN_IN_PAGE, { contentType: "text/html" }));
+
+    await expect(getSettings()).rejects.toThrow();
+    // The message must name the route and point at the responder, not the user's
+    // settings — that is the whole difference from silently answering "none".
+    await expect(getSettings()).rejects.toThrow(/\/settings/);
+  });
+
+  it("throws when the body parses but is not a settings map", async () => {
+    // An API gateway's own JSON error envelope: valid JSON, wrong document. The
+    // old truthiness check accepted ANY object, including an array.
+    fetchApi.mockResolvedValue(reply(JSON.stringify(["nope"])));
+
+    await expect(getSettings()).rejects.toThrow();
+  });
+
+  it("still returns the settings map on a normal answer", async () => {
+    fetchApi.mockResolvedValue(reply(JSON.stringify({ "Comfy.Validation.Workflows": false })));
+
+    await expect(getSettings()).resolves.toEqual({ "Comfy.Validation.Workflows": false });
+  });
+});
+
+describe("getSetting: unset and unreadable are different answers", () => {
+  // The three signals a real ComfyUI build uses for "unset" must still be unset —
+  // this is the noise guard. Turning these into errors would make the tool throw
+  // constantly on perfectly healthy installs.
+  it("still reports UNSET for an empty body", async () => {
+    fetchApi.mockResolvedValue(reply(""));
+    await expect(getSetting("Comfy.Foo")).resolves.toBeUndefined();
+  });
+
+  it("still reports UNSET for a null body", async () => {
+    fetchApi.mockResolvedValue(reply("null"));
+    await expect(getSetting("Comfy.Foo")).resolves.toBeUndefined();
+  });
+
+  it("still reports UNSET for a 404 route", async () => {
+    fetchApi.mockResolvedValue(reply("", { status: 404 }));
+    await expect(getSetting("Comfy.Foo")).resolves.toBeUndefined();
+  });
+
+  it("THROWS for a non-empty unparseable body instead of claiming unset", async () => {
+    fetchApi.mockResolvedValue(reply(SIGN_IN_PAGE, { contentType: "text/html" }));
+
+    await expect(getSetting("Comfy.Foo")).rejects.toThrow();
+  });
+
+  it("passes a stored value through verbatim, uncoerced", async () => {
+    // An older frontend stores booleans as strings; that must survive.
+    fetchApi.mockResolvedValue(reply(JSON.stringify("true")));
+    await expect(getSetting("Comfy.Foo")).resolves.toBe("true");
+
+    fetchApi.mockResolvedValue(reply(JSON.stringify(false)));
+    await expect(getSetting("Comfy.Foo")).resolves.toBe(false);
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -16,8 +16,10 @@ import {
 } from "../utils/errors.js";
 import { comfyuiFetch } from "./fetch.js";
 import {
+  classifyNonJson,
   fetchComfyJson,
   looksLikeHtmlParsedAsJson,
+  NonJsonResponseError,
   readComfyJson,
   redactErrorMessage,
   rethrowWithJsonDiagnosis,
@@ -741,36 +743,56 @@ function settingsVersionDriftError(): ComfyUIError {
   );
 }
 
-/** GET /settings — every stored frontend setting as a raw `id: value` object. */
+/**
+ * GET /settings — every stored frontend setting as a raw `id: value` object.
+ *
+ * An UNREADABLE answer is not an empty one (#796). This used to fall through to
+ * `{}` on any non-JSON body, and `get_defaults action:"get_ui"` renders that as
+ * `count: 0` beside a note saying only explicitly-stored settings appear — i.e.
+ * "you have no settings", asserted from a body nobody could parse. The realistic
+ * trigger is the one this repo keeps meeting: an auth proxy answering with a
+ * sign-in page, or a different service on the host.
+ *
+ * readComfyJson is the vetted path for exactly this — it names the URL and what
+ * actually answered, and scrubs secret-shaped text — and was already imported
+ * here; these two functions simply hand-rolled `res.text()` + `JSON.parse`
+ * instead. `expectShape` also rejects a 200 that parses as JSON but is not a map
+ * (an API gateway's own error envelope), which the old truthiness check accepted
+ * as long as it was any object — including an array.
+ */
 export async function getSettings(): Promise<Record<string, unknown>> {
   requireLocalMode("settings");
   const client = getClient();
   const res = await client.fetchApi("/settings");
   if (res.status === 404) throw settingsVersionDriftError();
-  const text = await res.text();
-  try {
-    const parsed = JSON.parse(text);
-    if (parsed && typeof parsed === "object") {
-      return parsed as Record<string, unknown>;
-    }
-  } catch {
-    // Non-JSON body — fall through to empty.
-  }
-  return {};
+  return await readComfyJson<Record<string, unknown>>(res, {
+    url: "/settings",
+    expectShape: (v) => typeof v === "object" && v !== null && !Array.isArray(v),
+    shapeHint: "the settings map",
+  });
 }
 
 /**
  * GET /settings/{id} — one setting's raw stored value. Returns `undefined` for
  * an unset key: ComfyUI returns an empty body or `null` for unset ids on
  * different versions, and some builds 404 the per-id route, so empty / `null` /
- * 404 / parse-failure are all treated uniformly as "unset (frontend default
- * applies)". Stored values are passed through verbatim — never coerced, so an
- * older frontend's `"true"` string surfaces as a string.
+ * 404 are treated uniformly as "unset (frontend default applies)". Stored values
+ * are passed through verbatim — never coerced, so an older frontend's `"true"`
+ * string surfaces as a string.
+ *
+ * PARSE FAILURE IS NOT IN THAT LIST ANY MORE (#796). Empty, `null` and 404 are
+ * things a ComfyUI build actually SAYS to mean "unset"; a non-empty body that is
+ * not JSON is something else answering — a proxy sign-in page, a gateway error
+ * envelope — and reporting it as unset is a claim nobody observed. It reached the
+ * caller as `value: null, note: "unset (frontend default applies)"`, and worse,
+ * `set_ui` reports `previous: null` from this same call, so a user who then set a
+ * value was told the old one was unset and could not restore it.
  */
 export async function getSetting(id: string): Promise<unknown> {
   requireLocalMode("settings");
   const client = getClient();
-  const res = await client.fetchApi(`/settings/${encodeURIComponent(id)}`);
+  const url = `/settings/${encodeURIComponent(id)}`;
+  const res = await client.fetchApi(url);
   if (res.status === 404) return undefined;
   const text = await res.text();
   if (text.trim() === "") return undefined;
@@ -778,7 +800,18 @@ export async function getSetting(id: string): Promise<unknown> {
     const parsed = JSON.parse(text);
     return parsed === null ? undefined : parsed;
   } catch {
-    return undefined;
+    // Classified rather than swallowed. Same machinery readComfyJson uses, so the
+    // message names the URL and the responder and is secret-scrubbed; it cannot
+    // use readComfyJson directly because an EMPTY body must stay "unset" here and
+    // that helper (correctly) treats an unparseable body as a failure.
+    throw new NonJsonResponseError(
+      classifyNonJson({
+        url,
+        status: res.status,
+        contentType: res.headers.get("content-type") ?? "",
+        body: text,
+      }),
+    );
   }
 }
 


### PR DESCRIPTION
Another #796 instance, in the one place this repo still read a proxy sign-in page as an answer.

`getSettings()` fell through to `{}` on any non-JSON body, and `getSetting()` was **documented** as folding `empty / null / 404 / parse-failure` uniformly into *"unset (frontend default applies)"*.

The first three are things a real ComfyUI build **says** to mean unset. A non-empty body that isn't JSON is something *else* answering — an auth proxy's sign-in page, an API gateway's error envelope, a different service on the host. This repo meets that responder constantly (#828 / #952 / #954); the settings path was where it got read as data.

## What the caller was told

| call | reported | actually |
|---|---|---|
| `get_defaults action:"get_ui"` | `count: 0`, beside *"only explicitly-stored settings appear here"* | nobody could parse the body |
| `get_defaults action:"get_ui" id:X` | `value: null`, *"unset (frontend default applies)"* | same |
| `get_defaults action:"set_ui"` | `previous: null` — from that same call | **a user who set a value was told the old one was unset, and could not restore it** |

## The fix

Both now route through the guard this file **already imported** for every other JSON endpoint — `readComfyJson` / `classifyNonJson` — which names the URL and what actually answered, and scrubs secret-shaped text. `getSetting` can't call `readComfyJson` directly (an empty body must stay "unset" there, and that helper correctly treats an unparseable body as a failure), so it classifies with the same machinery.

`expectShape` additionally rejects a 200 that parses as JSON but isn't a map — a gateway error envelope, or an array — which the old `parsed && typeof parsed === "object"` truthiness check accepted.

**Empty / `null` / 404 still mean unset.** That's the noise guard, and it's tested: turning those into errors would make the tool throw on perfectly healthy installs.

## Verification

| Check | Result |
|---|---|
| **mutation** — swallow the throw, return `undefined` | the unreadable test fails |
| **mutation** — `expectShape: () => true` | the wrong-document test fails |
| tests | 8, driven through the real client with a stubbed `fetchApi` |
| full suite | green — 354 files, 7294 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)