### PR TITLE
fix(fence): a refused adoption now says WHICH gate refused it

### DIFF
--- a/src/__tests__/orchestrator/fence-refusal-reason.test.ts
+++ b/src/__tests__/orchestrator/fence-refusal-reason.test.ts
@@ -1,0 +1,189 @@
+// #1077 — a refused fence adoption that cannot say which gate refused it.
+//
+// The orchestrator's validator has THREE independent gates: the routed tab is
+// unreachable, it does not resolve to a live panel tab, or the workflow identity
+// did not validate. Every one returned a bare `false`, so the tool could only
+// report "The adoption was REFUSED" and offer one remedy — refresh the tab.
+//
+// That is unactionable in general and WRONG in one specific case. Identity is
+// bound to the connection's server-observed Origin, and a relay-backend
+// connection has none: `attachRelayConnection(sock)` calls `handleConnection(sock)`
+// with no origin argument, and the relay protocol does not forward the browser's
+// handshake Origin. So `workflowIdentityParts()` can never validate, the fence can
+// NEVER be adopted, and no amount of refreshing changes it. The reporter refreshed
+// repeatedly and closed and reopened the tab before tracing it to source.
+//
+// They also had no orchestrator log to read, which is why the reason has to reach
+// the TOOL RESULT and not just stderr.
+
+import { describe, expect, it } from "vitest";
+import { UiBridge } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+} from "../../orchestrator/panel-tools.js";
+
+/** The bridge is the seam: the orchestrator injects the validator, and the tool
+ *  layer reads back the reason. Driving it here keeps the test on the contract
+ *  rather than on either side's internals. */
+function bridgeWithValidator(
+  refresh: (tabId: string, uuid: string) => boolean | { ok: true } | { ok: false; reason: string },
+): UiBridge {
+  const b = new UiBridge(0);
+  b.setTabWorkflowUuidResolver(() => undefined, refresh);
+  return b;
+}
+
+const UUID = "11111111-2222-4333-8444-555555555555";
+
+describe("a refused adoption records WHY", () => {
+  it("exposes the validator's reason to the caller", () => {
+    const b = bridgeWithValidator(() => ({
+      ok: false,
+      reason: "the routed tab (wf:x) is no longer reachable, so there is nothing to fence",
+    }));
+
+    expect(b.refreshWorkflowUuid("wf:x", UUID)).toBe(false);
+    expect(b.lastFenceRefusal("wf:x")).toMatch(/no longer reachable/);
+  });
+
+  it("keeps reasons per-tab, so one wedged tab cannot explain another", () => {
+    const b = bridgeWithValidator((tabId) =>
+      tabId === "wf:a" ? { ok: false, reason: "reason for A" } : { ok: true },
+    );
+
+    b.refreshWorkflowUuid("wf:a", UUID);
+    b.refreshWorkflowUuid("wf:b", UUID);
+
+    expect(b.lastFenceRefusal("wf:a")).toBe("reason for A");
+    expect(b.lastFenceRefusal("wf:b")).toBeUndefined();
+  });
+
+  it("clears the reason once an adoption succeeds — it must not outlive its state", () => {
+    let refuse = true;
+    const b = bridgeWithValidator(() => (refuse ? { ok: false, reason: "temporarily wedged" } : { ok: true }));
+
+    b.refreshWorkflowUuid("wf:x", UUID);
+    expect(b.lastFenceRefusal("wf:x")).toBe("temporarily wedged");
+
+    refuse = false;
+    expect(b.refreshWorkflowUuid("wf:x", UUID)).toBe(true);
+    expect(b.lastFenceRefusal("wf:x")).toBeUndefined();
+  });
+
+  // Backward compatibility: the resolver may be a plain boolean (tests register
+  // one, and an older injection would too). It must keep working, just without a
+  // reason to report.
+  it("still accepts a plain boolean validator", () => {
+    const b = bridgeWithValidator(() => false);
+
+    expect(b.refreshWorkflowUuid("wf:x", UUID)).toBe(false);
+    expect(b.lastFenceRefusal("wf:x")).toBeUndefined();
+
+    const ok = bridgeWithValidator(() => true);
+    expect(ok.refreshWorkflowUuid("wf:x", UUID)).toBe(true);
+  });
+
+  it("reports false when no validator is registered at all", () => {
+    const b = new UiBridge(0);
+    expect(b.refreshWorkflowUuid("wf:x", UUID)).toBe(false);
+  });
+});
+
+// The half that matters to the person reading the tool result.
+describe("the refusal message names the gate and matches the remedy to it", () => {
+  const setTarget = () =>
+    buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target")!;
+
+  /** A panel that answers workflow_list with a corroborated live identity, so the
+   *  rebind reaches the ADOPT step — which is the step being refused. */
+  function ctxRefusing(reason: string): PanelToolCtx {
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        if (cmd.cmd === "workflow_list") {
+          return {
+            active: {
+              path: "workflows/a.json",
+              filename: "a.json",
+              key: "wf:workflows/a.json",
+              routing_key: "wf:workflows/a.json",
+              workflow_uuid: UUID,
+            },
+            active_confirmed: true,
+            workflows: [
+              {
+                path: "workflows/a.json",
+                filename: "a.json",
+                key: "wf:workflows/a.json",
+                routing_key: "wf:workflows/a.json",
+                active: true,
+                persisted: true,
+              },
+            ],
+          };
+        }
+        return { ok: true };
+      },
+      push: () => 1,
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: "tab-1", title: "A", connected_at: 0 }],
+      resolveActiveTabId: () => "tab-1",
+      workflowUuidFor: () => ({ known: true, uuid: "99999999-8888-4777-a666-555555555555" }),
+      refreshWorkflowUuid: () => false, // the adoption is refused…
+      lastFenceRefusal: () => reason, // …and this is why
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    } as unknown as PanelToolCtx["bridge"];
+    return makePanelToolCtx(bridge, "tab-1", new WorkflowTargetStore());
+  }
+
+  const textOf = (res: { content: Array<{ text?: string }> }): string => res.content[0]!.text ?? "";
+
+  it("quotes the reason instead of listing two causes and shrugging", async () => {
+    const text = textOf(
+      await setTarget().handler({ mode: "current" }, ctxRefusing("the routed tab (wf:x) is no longer reachable")),
+    );
+
+    expect(text).toMatch(/refused it because the routed tab \(wf:x\) is no longer reachable/);
+    // The old text offered both causes and let the reader pick.
+    expect(text).not.toMatch(/this bridge could not say which/);
+  });
+
+  // THE ONE THAT COST THE REPORTER THE SESSION. A structural refusal must not be
+  // answered with "refresh the tab" — they did that, repeatedly, and closed and
+  // reopened the tab too.
+  it("does NOT tell the user to refresh when the gate is structural", async () => {
+    const text = textOf(
+      await setTarget().handler(
+        { mode: "current" },
+        ctxRefusing(
+          "this tab's connection carries no server-observed Origin, and the workflow identity is bound to one",
+        ),
+      ),
+    );
+
+    expect(text).toMatch(/Refreshing the tab will NOT help/);
+    expect(text).toMatch(/COMFYUI_MCP_TUNNEL_BACKEND=relay/);
+    // The generic remedy must be suppressed, not merely preceded.
+    expect(text).not.toMatch(/Ask the user to manually refresh/);
+  });
+
+  it("falls back to the generic remedy when the bridge cannot say why", async () => {
+    const bridge = {
+      ...(ctxRefusing("x").bridge as unknown as Record<string, unknown>),
+      lastFenceRefusal: undefined, // an older bridge
+    } as unknown as PanelToolCtx["bridge"];
+
+    const text = textOf(
+      await setTarget().handler(
+        { mode: "current" },
+        makePanelToolCtx(bridge, "tab-1", new WorkflowTargetStore()),
+      ),
+    );
+
+    expect(text).toMatch(/this bridge could not say which/);
+    expect(text).toMatch(/Ask the user to manually refresh/);
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2768,18 +2768,45 @@ export async function runPanelOrchestrator(): Promise<void> {
       // only when its UUID has the same strict shape/origin binding as hello.
       // Invalid/missing panel data leaves the old stamp in place, causing the
       // existing fail-closed fence to reject a subsequent mutation.
+      // #1077 — each gate now says WHICH one refused. All three used to return a
+      // bare `false`, so a permanently-wedged session could only be told "the
+      // adoption was REFUSED", and the reporter who traced it had no orchestrator
+      // log to fall back on. One of these is structurally unsatisfiable for a
+      // relay-backend session, and that is invisible without this.
       try {
-        if (!bridge.canReach(tabId)) return false;
-      } catch {
-        return false;
+        if (!bridge.canReach(tabId))
+          return {
+            ok: false,
+            reason: `the routed tab (${tabId}) is no longer reachable, so there is nothing to fence`,
+          };
+      } catch (err) {
+        return {
+          ok: false,
+          reason: `checking whether the routed tab (${tabId}) is reachable threw: ${err instanceof Error ? err.message : String(err)}`,
+        };
       }
       const panelTab = scopeToRealTab(tabId);
-      if (!panelTab) return false;
-      const identity = workflowIdentityParts({
-        workflowUuid,
-        origin: bridge.tabServerOrigin(tabId),
-      });
-      if (!identity) return false;
+      if (!panelTab)
+        return {
+          ok: false,
+          reason: `${tabId} does not resolve to a live panel tab (a scope address whose tab has gone away)`,
+        };
+      const origin = bridge.tabServerOrigin(tabId);
+      const identity = workflowIdentityParts({ workflowUuid, origin });
+      if (!identity)
+        return {
+          ok: false,
+          reason: !origin
+            ? // The relay case, and the one worth naming precisely: this is not
+              // transient and no amount of refreshing fixes it.
+              `this tab's connection carries no server-observed Origin, and the workflow ` +
+              `identity is bound to one — so the fence can never be adopted for it. This is ` +
+              `structural, not transient: refreshing the tab will not change it. Relay-backend ` +
+              `connections (COMFYUI_MCP_TUNNEL_BACKEND=relay) are the known case, because the ` +
+              `relay protocol does not forward the browser's handshake Origin`
+            : `the workflow identity did not validate (uuid ${String(workflowUuid)} against ` +
+              `origin ${origin}) — a malformed uuid, or one bound to a different origin`,
+        };
       tabCommandWorkflowUuid.set(panelTab, identity.uuid);
       // #716/#884 — an explicit, VALIDATED open/re-pin from the shared agent is
       // the agent deliberately moving its turn to another workflow: refresh

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2576,8 +2576,10 @@ export type WorkflowFenceRebind =
     }
   /** A live identity was read, but the bridge declined to adopt it (the tab stopped
    *  being reachable, or the uuid failed the orchestrator's shape/origin check).
-   *  A clean `false` — nothing was written. */
-  | { status: "rejected"; uuid: string; before: FenceRead }
+   *  A clean `false` — nothing was written. `refusalReason` names WHICH of the
+   *  validator's three gates tripped when the bridge can tell us (#1077); absent
+   *  on an older bridge, which is why the remedy below must still stand alone. */
+  | { status: "rejected"; uuid: string; before: FenceRead; refusalReason?: string }
   /** The adoption itself THREW. Distinct from `rejected` (codex gate): a refusal
    *  proves the old fence is untouched, whereas a throw can land on either side
    *  of the write, so whether the fence changed is UNKNOWN and must not be
@@ -2738,9 +2740,23 @@ async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebi
   // write, so `rejected`'s "the previous fence is unchanged" would be a state
   // nobody observed.
   try {
-    return refreshWorkflowUuid(ctx, active)
-      ? { status: "refreshed", uuid, before }
-      : { status: "rejected", uuid, before };
+    if (refreshWorkflowUuid(ctx, active)) return { status: "refreshed", uuid, before };
+    // #1077 — carry WHY. The validator has three independent gates and all of
+    // them used to surface as the same bare "REFUSED", which left a wedged
+    // session with nothing to act on. One of them (no server-observed Origin on
+    // a relay connection) is structurally unsatisfiable, so a caller told only
+    // "refused" will keep refreshing a tab that can never recover.
+    const why = ((): string | undefined => {
+      try {
+        const read = (ctx.bridge as unknown as { lastFenceRefusal?: unknown }).lastFenceRefusal;
+        return typeof read === "function"
+          ? (read.call(ctx.bridge, ctx.tabId) as string | undefined)
+          : undefined;
+      } catch {
+        return undefined; // a diagnostic must never replace the outcome
+      }
+    })();
+    return { status: "rejected", uuid, before, refusalReason: why };
   } catch (err) {
     return {
       status: "adopt_error",
@@ -2891,10 +2907,29 @@ function describeFenceRebind(
         binding: "not_recovered",
         note:
           ` Read the live canvas identity (${r.uuid}) but could NOT adopt it as this session's ` +
-          `graph command fence — the bound tab stopped being reachable, or the panel reported an ` +
-          `identity this orchestrator does not trust. The adoption was REFUSED, so the previous ` +
-          `fence is unchanged and graph tools will keep failing.` +
-          `\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY}`,
+          `graph command fence.` +
+          // #1077 — name the gate when we can. "the bound tab stopped being
+          // reachable, OR the panel reported an identity this orchestrator does
+          // not trust" listed two causes with different remedies and left the
+          // caller to guess which; one of them cannot be fixed by retrying at all.
+          (r.refusalReason
+            ? ` The orchestrator's validator refused it because ${r.refusalReason}.`
+            : ` Either the bound tab stopped being reachable, or the panel reported an identity ` +
+              `this orchestrator does not trust — this bridge could not say which.`) +
+          ` The adoption was REFUSED, so the previous fence is unchanged and graph tools will ` +
+          `keep failing.` +
+          `\n\nWHAT TO DO: ${
+            // A structurally-unsatisfiable gate must not be answered with "refresh
+            // the tab" — the reporter did that repeatedly, including closing and
+            // reopening it, and it could never have worked.
+            r.refusalReason && /no server-observed Origin/i.test(r.refusalReason)
+              ? `Refreshing the tab will NOT help — this one is structural. Reconnect over a ` +
+                `direct/loopback or cloudflared link rather than the relay backend (unset ` +
+                `COMFYUI_MCP_TUNNEL_BACKEND=relay), or continue with reads and non-graph tools, ` +
+                `which do not need the fence. Please also report it: the relay protocol has to ` +
+                `forward the browser's handshake Origin for this path to work at all.`
+              : RELOAD_TAB_REMEDY
+          }`,
       };
     case "adopt_error":
       return {

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -795,6 +795,16 @@ export type TabWorkflowUuidRead =
   | { known: true; uuid?: string }
   | { known: false; reason: string };
 
+/**
+ * What the orchestrator's fence-adoption validator answers (#1077).
+ *
+ * `boolean` is still accepted so the injected resolver can stay simple (and so
+ * every existing test that registers only the read half keeps compiling); the
+ * object form carries the REASON a refusal happened, which is the difference
+ * between "the adoption was refused" and an actionable message.
+ */
+export type FenceAdoptOutcome = boolean | { ok: true } | { ok: false; reason: string };
+
 export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   "graph_serialize",
   "graph_outline",
@@ -1334,7 +1344,12 @@ export class UiBridge {
    * validates it against the server-observed origin; the bridge merely gives a
    * successful tab-bound command a narrow way to ask for that refresh.
    */
-  private refreshTabWorkflowUuid: ((tabId: string, workflowUuid: string) => boolean) | null = null;
+  private refreshTabWorkflowUuid:
+    | ((tabId: string, workflowUuid: string) => FenceAdoptOutcome)
+    | null = null;
+  /** Per-tab reason for the most recent REFUSED fence adoption (#1077). Cleared
+   *  on the next successful adoption, so it never outlives the state it explains. */
+  private readonly fenceRefusals = new Map<string, string>();
   /** #570 P0a — records the mirror subscribers/viewers a same-socket re-hello OPTIMISTICALLY
    *  moved from the retiring id to the new id, keyed by the RETIRING (from) id. The move
    *  happens BEFORE the orchestrator can classify the switch as proven/unproven; if it turns
@@ -3742,10 +3757,31 @@ export class UiBridge {
    *  the orchestrator). Enables the per-command workflow-instance stamp/fence. */
   setTabWorkflowUuidResolver(
     fn: (tabId: string) => string | undefined,
-    refresh?: (tabId: string, workflowUuid: string) => boolean,
+    refresh?: (tabId: string, workflowUuid: string) => FenceAdoptOutcome,
   ): void {
     this.resolveTabWorkflowUuid = fn;
     this.refreshTabWorkflowUuid = refresh ?? null;
+  }
+
+  /**
+   * #1077 — WHY the last adoption for this tab was refused, if it was.
+   *
+   * The validator has three independent gates (the tab is unreachable, it does
+   * not resolve to a real panel tab, or the identity did not validate) and every
+   * one of them returned a bare `false`. The caller could only say "the adoption
+   * was REFUSED", so a permanently-wedged session gave the user no way to tell
+   * which gate tripped — and the reporter who traced this had NO orchestrator log
+   * to fall back on, which is why the reason has to travel to the tool result
+   * rather than only to stderr.
+   *
+   * It matters here more than a diagnostic usually would, because one of those
+   * gates can be structurally unsatisfiable: a relay-backend connection carries
+   * no server Origin (attachRelayConnection has none to pass), so
+   * workflowIdentityParts can NEVER validate and the fence can never be adopted,
+   * no matter how many times the user refreshes the tab.
+   */
+  lastFenceRefusal(tabId: string): string | undefined {
+    return this.fenceRefusals.get(tabId);
   }
 
   /**
@@ -3755,7 +3791,19 @@ export class UiBridge {
    * stamp in place.
    */
   refreshWorkflowUuid(tabId: string, workflowUuid: string): boolean {
-    return this.refreshTabWorkflowUuid?.(tabId, workflowUuid) ?? false;
+    const outcome = this.refreshTabWorkflowUuid?.(tabId, workflowUuid) ?? false;
+    // Accepts the plain boolean too: the resolver is injected by the orchestrator
+    // and by tests, and a bare `false` simply carries no reason to record.
+    if (typeof outcome === "boolean") {
+      if (outcome) this.fenceRefusals.delete(tabId);
+      return outcome;
+    }
+    if (outcome.ok) {
+      this.fenceRefusals.delete(tabId);
+      return true;
+    }
+    this.fenceRefusals.set(tabId, outcome.reason);
+    return false;
   }
 
   /**


### PR DESCRIPTION
Addresses #1077 — specifically its **Finding 1**, and makes its (unconfirmed) Finding 2 diagnosable rather than requiring another expensive RunPod session to reproduce.

## The problem

The fence-adoption validator has **three independent gates**:

```ts
if (!bridge.canReach(tabId)) return false;
const panelTab = scopeToRealTab(tabId);
if (!panelTab) return false;
const identity = workflowIdentityParts({ workflowUuid, origin: bridge.tabServerOrigin(tabId) });
if (!identity) return false;
```

All three returned a bare `false`. The tool could only say *"The adoption was REFUSED"*, list two possible causes, and offer one remedy — refresh the tab.

That's unactionable in general and **wrong** in one case. Workflow identity is bound to the connection's server-observed Origin, and a relay-backend connection has none: `attachRelayConnection(sock)` calls `handleConnection(sock)` with no origin argument, and the relay protocol doesn't forward the browser's handshake Origin at all. So `workflowIdentityParts()` can never validate, the fence can **never** be adopted — and we told the user to refresh the tab. The reporter refreshed repeatedly, closed and reopened the tab, and only got an answer by reading `dist/` source.

They also had **no orchestrator log** to read. That's why the reason has to reach the tool result, not just stderr — a log line alone would not have helped them.

## The change

- the validator returns `{ ok: false, reason }` naming the gate; the bridge records it per-tab and **clears it on the next successful adoption**, so a reason never outlives the state it explains;
- a plain `boolean` validator is still accepted (tests register one, and so would an older injection) — it simply carries no reason;
- the refusal message quotes the reason instead of listing two causes and leaving the reader to guess;
- for the structural gate the **remedy changes**: refreshing will not help, it names the relay backend, and points at reads and non-graph tools, which don't need the fence.

## Scope

The reporter's own session was **cloudflared, not relay**, so the relay gate wasn't their cause and their Finding 2 stays unconfirmed. That's precisely the point of this change: whichever gate trips next time names itself, which is what they asked for after finding they couldn't tell.

The relay half needs a protocol change in the separate `comfyui-mcp-relay` repo to carry the Origin through. Not fixable here — and the message now says so rather than implying a retry will work.

## Verification

| Mutation | Result |
|---|---|
| drop the structural remedy branch | the "does NOT tell the user to refresh" test fails |
| never record the reason | 3 tests fail |

8 new tests, including per-tab isolation (one wedged tab must not explain another), clearing on success, `boolean` back-compat, and the older-bridge fallback. Full suite green — 355 files, 7305 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)