### PR TITLE
0.50.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.25] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- a refused adoption now says WHICH gate refused it (#1077) (#1084)
+- an unreadable settings answer is not an empty one (#796) (#1082)
+- say that `name` is dropped when the slot is reused (#1081)
+
+#### Changed
+- record the first measured arm, and what is still unmeasured (#1083)
+
+
 ## [0.50.24] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.24",
+  "version": "0.50.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.24",
+      "version": "0.50.25",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.24",
+  "version": "0.50.25",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.25**. Tag pushed; `release.yml` publishes from it; this PR reconciles protected `main`.

## #1084 — a refused fence adoption now says which gate refused it

The fence-adoption validator has three independent gates and all of them returned a bare `false`, so a wedged session was told only *"The adoption was REFUSED"*, given two possible causes, and pointed at one remedy: refresh the tab.

One of those gates is **structurally unsatisfiable**. Workflow identity is bound to the connection's server-observed Origin, and a relay-backend connection has none — `attachRelayConnection` has no origin to pass, and the relay protocol doesn't forward the browser's handshake Origin. So the fence can never be adopted, and we were telling the user to refresh. The reporter refreshed repeatedly, closed and reopened the tab, and only got an answer by reading `dist/` source — they had no orchestrator log, which is why the reason now travels to the tool result rather than to stderr.

Each gate now names itself, the reason is recorded per-tab and cleared on the next success, and for the structural case the remedy changes: refreshing will not help, here is the backend to avoid, and reads/non-graph tools still work.

## #1082 — an unreadable settings answer is not an empty one

`getSettings()` fell through to `{}` on any non-JSON body, and `getSetting()` folded parse-failure in with `empty`/`null`/`404` as "unset (frontend default applies)". The first three are things a real ComfyUI build says; a non-empty non-JSON body is something *else* answering — a proxy sign-in page, a gateway envelope. Worst consequence: `set_ui` reported `previous: null`, so a user who set a value was told the old one was unset and couldn't restore it. Both now use the JSON guard the file already imported for every other endpoint.

## Also

- **#1081** — `expose_subgraph_*` now says `name` is dropped when the slot is reused (from another session).
- **#1083** — benchmark docs record the first measured arm and what remains unmeasured.

## Housekeeping

Two issues closed against evidence rather than left to age:
- **#425** (P1, open since July) was already fixed in **v0.48.20** — the reporter was on 0.48.7. The Manager 3.x/v4 reboot deadlock now falls back to a managed local restart, with guards so a busy-guard or security refusal never escalates to a kill+relaunch.
- **#845** — this repo's half is complete (`max_chars` exposed, `nodeId()` coercion, ignored-arg reporting); the three panel-side defects continue at panel#754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)