### PR TITLE
fix(defaults): a config that could not be loaded is neither empty nor disposable

### DIFF
--- a/src/__tests__/services/defaults-config-unloadable.test.ts
+++ b/src/__tests__/services/defaults-config-unloadable.test.ts
@@ -1,0 +1,152 @@
+// #796, on a file the USER typed.
+//
+// A defaults config that exists and fails to load left `configValues` empty with
+// only a `logger.warn` to show for it. Two harms followed, and the second is the
+// one that loses work.
+//
+// 1. SILENTLY NOT APPLIED. The user wrote that file to change what gets
+//    generated. `get_defaults action:"get"` reported the built-in and env
+//    defaults as though nothing were wrong, and renders quietly used settings
+//    the user had not chosen. The only signal went to a log they may have no
+//    access to.
+//
+// 2. SILENTLY DESTROYED. `set({...}, {persist:true})` does
+//    `{ ...state.configValues, ...updates }` — and after a failed load that is
+//    `{ ...{}, ...updates }`. Persisting ONE new default therefore overwrote the
+//    whole file with just that key.
+//
+// Unlike the session store (machine-written, so unparseable really is worthless),
+// this file is typed by a person: "unparseable" usually means a trailing comma in
+// content they care about. So a PARSE failure is preserved here too, not just an
+// I/O failure.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DefaultsManager } from "../../services/defaults-manager.js";
+
+let dir: string;
+let configPath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cmcp-defaults-"));
+  configPath = join(dir, "config.json");
+  // Empty env so nothing leaks in from the real process (COMFYUI_DEFAULT_*).
+  DefaultsManager.configure({ configPath, env: {} });
+});
+
+afterEach(() => {
+  DefaultsManager.reset();
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe("a config that could not be loaded says so", () => {
+  it("reports the reason instead of looking like an empty config", async () => {
+    writeFileSync(configPath, '{ "width": 1024, }'); // trailing comma — the usual cause
+    await DefaultsManager.load();
+
+    expect(DefaultsManager.configLoadError()).toBeTruthy();
+    // …and none of its values are in effect, which is exactly why saying so matters.
+    expect(DefaultsManager.getAll().width).toBeUndefined();
+  });
+
+  it("says nothing when the file loads fine", async () => {
+    writeFileSync(configPath, JSON.stringify({ width: 1024 }));
+    await DefaultsManager.load();
+
+    expect(DefaultsManager.configLoadError()).toBeUndefined();
+    expect(DefaultsManager.getAll().width).toEqual({ value: 1024, source: "config" });
+  });
+
+  it("says nothing when there is no file at all — absence is not a failure", async () => {
+    await DefaultsManager.load();
+    expect(DefaultsManager.configLoadError()).toBeUndefined();
+  });
+
+  it("flags valid JSON that is not an object", async () => {
+    writeFileSync(configPath, JSON.stringify(["width", 1024]));
+    await DefaultsManager.load();
+
+    expect(DefaultsManager.configLoadError()).toMatch(/not an object/);
+  });
+
+  it("clears once the file is fixed and reloaded", async () => {
+    writeFileSync(configPath, "{ broken");
+    await DefaultsManager.load();
+    expect(DefaultsManager.configLoadError()).toBeTruthy();
+
+    writeFileSync(configPath, JSON.stringify({ steps: 30 }));
+    await DefaultsManager.load();
+    expect(DefaultsManager.configLoadError()).toBeUndefined();
+  });
+});
+
+describe("persisting never destroys a config it could not read", () => {
+  it("moves the unloadable file aside instead of overwriting it", async () => {
+    const original = '{ "width": 1024, "steps": 30, }'; // the user's real settings
+    writeFileSync(configPath, original);
+    await DefaultsManager.load();
+
+    await DefaultsManager.set({ height: 512 }, { persist: true });
+
+    const preserved = readdirSync(dir).filter((f) => f.includes(".unreadable-"));
+    expect(preserved, "the user's file must be kept, not overwritten").toHaveLength(1);
+    expect(readFileSync(join(dir, preserved[0]!), "utf-8")).toBe(original);
+
+    // …and the new config really was written in its place.
+    expect(JSON.parse(readFileSync(configPath, "utf-8"))).toEqual({ height: 512 });
+  });
+
+  it("preserves only once — later writes are ordinary", async () => {
+    writeFileSync(configPath, "{ broken");
+    await DefaultsManager.load();
+
+    await DefaultsManager.set({ a: 1 }, { persist: true });
+    await DefaultsManager.set({ b: 2 }, { persist: true });
+
+    expect(readdirSync(dir).filter((f) => f.includes(".unreadable-"))).toHaveLength(1);
+    // The second write merged normally rather than clobbering the first.
+    expect(JSON.parse(readFileSync(configPath, "utf-8"))).toEqual({ a: 1, b: 2 });
+  });
+
+  // A DIRECTORY at the config path is the other way loading fails (EISDIR), and
+  // it must be preserved the same way — nothing about the guard should depend on
+  // the obstacle being a file.
+  it("preserves a directory at the config path too", async () => {
+    mkdirSync(configPath, { recursive: true });
+    writeFileSync(join(configPath, "marker.txt"), "the user's stuff");
+    await DefaultsManager.load();
+    expect(DefaultsManager.configLoadError()).toBeTruthy();
+
+    await DefaultsManager.set({ height: 512 }, { persist: true });
+
+    const preserved = readdirSync(dir).filter((f) => f.includes(".unreadable-"));
+    expect(preserved).toHaveLength(1);
+    expect(readFileSync(join(dir, preserved[0]!, "marker.txt"), "utf-8")).toBe("the user's stuff");
+    expect(JSON.parse(readFileSync(configPath, "utf-8"))).toEqual({ height: 512 });
+  });
+
+  // NOT TESTED, and said out loud rather than faked: the branch where the file
+  // can be neither loaded NOR moved aside, which throws rather than overwriting.
+  // Forcing `rename` to fail needs a read-only parent directory (not portable —
+  // it does not stop root, and Windows ACLs differ) or an injectable fs, which
+  // this module does not take. An earlier draft of this file "covered" it by
+  // asserting a runtime value applied after a persist:false call, which exercises
+  // neither the rename nor the throw.
+  it("keeps runtime values applying regardless of what the file is doing", async () => {
+    writeFileSync(configPath, "{ broken");
+    await DefaultsManager.load();
+
+    await DefaultsManager.set({ height: 512 }, { persist: false });
+
+    expect(DefaultsManager.getAll().height).toEqual({ value: 512, source: "runtime" });
+    // persist:false must not touch the file at all — no preservation, no write.
+    expect(readdirSync(dir).filter((f) => f.includes(".unreadable-"))).toHaveLength(0);
+    expect(readFileSync(configPath, "utf-8")).toBe("{ broken");
+  });
+});

--- a/src/services/defaults-manager.ts
+++ b/src/services/defaults-manager.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
@@ -32,6 +32,9 @@ const state = {
   cfg: { configPath: defaultConfigPath(), env: defaultEnv() } as ManagerConfig,
   configValues: {} as Record<string, unknown>,
   runtimeValues: {} as Record<string, unknown>,
+  /** Why the on-disk config is not being applied, when it EXISTS and failed to
+   *  load. Undefined = loaded fine, or there is no file. See configLoadError(). */
+  configError: undefined as string | undefined,
 };
 
 function parseEnvValue(raw: string): unknown {
@@ -63,6 +66,7 @@ export const DefaultsManager = {
     state.cfg = { configPath: defaultConfigPath(), env: defaultEnv() };
     state.configValues = {};
     state.runtimeValues = {};
+    state.configError = undefined;
   },
 
   getConfigPath(): string {
@@ -71,6 +75,7 @@ export const DefaultsManager = {
 
   async load(): Promise<void> {
     state.runtimeValues = {};
+    state.configError = undefined;
     if (!existsSync(state.cfg.configPath)) {
       state.configValues = {};
       return;
@@ -85,6 +90,7 @@ export const DefaultsManager = {
           path: state.cfg.configPath,
         });
         state.configValues = {};
+        state.configError = "it is valid JSON but not an object (an array or a bare value)";
       }
     } catch (err) {
       logger.warn("Failed to parse defaults config file, ignoring", {
@@ -92,7 +98,24 @@ export const DefaultsManager = {
         error: err instanceof Error ? err.message : err,
       });
       state.configValues = {};
+      state.configError = err instanceof Error ? err.message : String(err);
     }
+  },
+
+  /**
+   * Why the config file on disk is NOT being applied, if it is not (#796).
+   *
+   * A file that EXISTS and could not be loaded left `configValues` empty with
+   * only a `logger.warn` to show for it. The user wrote that file to change what
+   * gets generated, and the only signal that it stopped applying went to a log
+   * they may have no access to — so their renders quietly used different
+   * settings and `get_defaults action:"get"` reported the built-ins as though
+   * nothing were wrong.
+   *
+   * Undefined means the file was loaded, or there is no file — both fine.
+   */
+  configLoadError(): string | undefined {
+    return state.configError;
   },
 
   /**
@@ -125,6 +148,34 @@ export const DefaultsManager = {
       state.runtimeValues[k] = v;
     }
     if (opts?.persist) {
+      // The file exists and we could not load it, so `state.configValues` is
+      // EMPTY — not because the user has no defaults, but because we could not
+      // read the ones they wrote. Merging into `{}` and writing would replace
+      // their file with just this update, destroying hand-written content whose
+      // only problem may be a trailing comma (#796).
+      //
+      // Unlike the session store, a PARSE failure is preserved here too: that
+      // file is machine-written, this one is typed by a person, so unparseable
+      // means "has a typo in content they care about", not "worthless bytes".
+      if (state.configError !== undefined) {
+        const aside = `${state.cfg.configPath}.unreadable-${Date.now()}`;
+        try {
+          await rename(state.cfg.configPath, aside);
+          logger.warn(
+            `Preserved the unloadable defaults config as ${aside} before writing a fresh one ` +
+              `(it could not be loaded: ${state.configError}). Your previous settings are in that file.`,
+          );
+          state.configError = undefined; // preserved — later writes are ordinary
+        } catch (err) {
+          throw new Error(
+            `Refusing to overwrite ${state.cfg.configPath}: it could not be loaded ` +
+              `(${state.configError}) and could not be moved aside either ` +
+              `(${err instanceof Error ? err.message : String(err)}), so writing would destroy ` +
+              `settings that are probably still there. The values you just set are active for ` +
+              `this session; fix or move that file to persist them.`,
+          );
+        }
+      }
       const merged = { ...state.configValues, ...updates };
       state.configValues = merged;
       const dir = dirname(state.cfg.configPath);

--- a/src/tools/defaults.ts
+++ b/src/tools/defaults.ts
@@ -104,11 +104,30 @@ export function registerDefaultsTools(server: McpServer): void {
         //     the single most common real write this tool performs. A `!value`
         //     guard would refuse exactly that call.
         switch (args.action) {
-          case "get":
+          case "get": {
+            // #796 — a config file that exists and failed to load left this
+            // reporting the built-in/env defaults as though nothing were wrong,
+            // while the user's file sat on disk being ignored. Their renders were
+            // already using different settings; the only signal went to a log.
+            const configError = DefaultsManager.configLoadError?.();
             return json({
               config_path: DefaultsManager.getConfigPath(),
               defaults: DefaultsManager.getAll(),
+              ...(configError
+                ? {
+                    config_not_applied: {
+                      reason: configError,
+                      note:
+                        `The config file at the path above EXISTS but could not be loaded, so NONE of ` +
+                        `its values are in effect — the defaults listed here are the built-in and ` +
+                        `environment ones only. Fix that file (a trailing comma is the usual cause) ` +
+                        `and reload. Until then, persisting a new default moves the unloadable file ` +
+                        `aside rather than overwriting it.`,
+                    },
+                  }
+                : {}),
             });
+          }
           case "set": {
             if (args.values === undefined) {
               throw new Error(


### PR DESCRIPTION
#796's class again — this time on a file the **user typed**, with two harms.

A defaults config that exists and fails to load left `configValues` empty with only a `logger.warn` to show for it.

## 1. Silently not applied

The user wrote that file to change what gets generated. `get_defaults action:"get"` reported the built-in and env defaults as though nothing were wrong, and renders quietly used settings they never chose. The only signal went to a log — and #1077's reporter had just demonstrated that a user may have no access to one.

## 2. Silently destroyed

```ts
const merged = { ...state.configValues, ...updates };   // after a failed load: { ...{}, ...updates }
await writeFile(state.cfg.configPath, JSON.stringify(merged, null, 2));
```

Persisting **one** new default overwrote the whole file with just that key. Same shape as the session-store bug in #1079 — but on hand-written content whose only problem may be a trailing comma.

## The fix

- the load failure is recorded and exposed (`configLoadError()`);
- `get_defaults action:"get"` carries a `config_not_applied` block naming the reason and stating that **none** of the file's values are in effect, so the listed defaults aren't mistaken for the user's;
- persisting moves the unloadable file to `<path>.unreadable-<ts>` and says where it went, and **refuses to write at all** if it can't be moved aside.

### Why a parse failure is preserved here but not in the session store

The session store is machine-written, so unparseable really does mean worthless bytes. This file is typed by a person, where unparseable usually means a typo in content they care about. Same class, opposite ruling, deliberately.

## Verification

| Check | Result |
|---|---|
| **mutation** — disable the preserve guard | 3 tests fail; the user's file is overwritten, which is the bug |
| **mutation** — never record the load error | 5 tests fail |
| tests | 9, against real files: trailing comma, non-object JSON, missing file, clearing on a fixed reload, preserve-once, a directory at the config path, and `persist:false` touching nothing |
| full suite | green — 356 files, 7314 passed |

One test was deliberately **not** written, and the file says so: the branch where the file can be neither loaded nor moved aside. Forcing `rename` to fail needs a read-only parent (not portable — it doesn't stop root, and Windows ACLs differ) or an injectable fs this module doesn't take. An earlier draft "covered" it with a `persist:false` assertion that exercises neither the rename nor the throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)