### PR TITLE
0.50.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.26] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- a config that could not be loaded is neither empty nor disposable (#796) (#1087)
+
+
 ## [0.50.25] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.25",
+  "version": "0.50.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.25",
+      "version": "0.50.26",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.25",
+  "version": "0.50.26",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.26**. Tag pushed; `release.yml` publishes from it; this PR reconciles protected `main`.

Released promptly because #1087 is a **data-loss** fix on a file the user hand-wrote.

## #1087 — an unloadable defaults config was silently ignored, then silently destroyed

A defaults config that exists and fails to load left `configValues` empty with only a `logger.warn`.

**Silently not applied.** The user wrote that file to change what gets generated. `get_defaults action:"get"` reported the built-in and env defaults as though nothing were wrong, and renders quietly used settings they never chose. The only signal went to a log — and #1077's reporter had just shown that a user may have no access to one.

**Silently destroyed.** `set(..., {persist:true})` merges into `state.configValues`, which after a failed load is `{}`. Persisting *one* new default overwrote the whole file with just that key. Same shape as the session-store bug in #1079, but on content a person typed, whose only problem may be a trailing comma.

Now the failure is recorded and surfaced in `get_defaults action:"get"` as a `config_not_applied` block, and persisting moves the unloadable file to `<path>.unreadable-<ts>` — refusing to write at all if it can't be moved aside.

A parse failure is preserved here but *not* in the session store: that file is machine-written, so unparseable really is worthless; this one is typed by a person. Same class, opposite ruling, deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)