### PR TITLE
fix(download): a Manager dispatch must not promise where the file lands

### DIFF
--- a/src/__tests__/services/manager-destination-caveat.test.ts
+++ b/src/__tests__/services/manager-destination-caveat.test.ts
@@ -1,0 +1,47 @@
+// #1086 — a Manager dispatch must not promise where the file lands.
+//
+// The reply used to end "the file lists under /models when complete". That is a
+// PREDICTION. For the reporter it was false: Manager installed into the container
+// base root while the server read models from /workspace/models via
+// extra_model_paths, the file never listed, and the ephemeral overlay was
+// discarded on restart — losing a multi-GB model we had reported as in flight.
+
+import { describe, expect, it } from "vitest";
+import { managerDestinationCaveat } from "../../services/model-resolver.js";
+
+describe("#1086 Manager dispatch does not establish the destination", () => {
+  const text = managerDestinationCaveat();
+
+  it("states plainly that the destination is NOT established", () => {
+    expect(text).toMatch(/NOT established where the file lands/);
+    expect(text).toMatch(/does not necessarily honour/);
+    expect(text).toMatch(/extra_model_paths/);
+  });
+
+  it("names the check, so it is a route rather than a warning", () => {
+    // "verify it yourself" without saying how is a dead end. list_local_models
+    // reads through the SAME roots the server reads, so a file that appears there
+    // is genuinely reachable by a workflow.
+    expect(text).toMatch(/list_local_models/);
+  });
+
+  it("explains what a MISSING file means, including the restart hazard", () => {
+    expect(text).toMatch(/never appears/);
+    expect(text).toMatch(/ephemeral overlay/);
+    expect(text).toMatch(/loses the file on restart/);
+  });
+
+  it("makes no promise about where the bytes go", () => {
+    // The exact failure being removed: any forward-looking claim about the file
+    // being listed, present, or available once the transfer finishes.
+    expect(text).not.toMatch(/lists under/);
+    expect(text).not.toMatch(/will (be|appear|land)/i);
+    expect(text).not.toMatch(/when complete/i);
+  });
+
+  it("does not name a destination it cannot know", () => {
+    // We cannot read the target's extra_model_paths.yaml, so asserting any
+    // concrete path would be the same defect in the other direction.
+    expect(text).not.toMatch(/\/workspace\/models|\/opt\/ComfyUI/);
+  });
+});

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1991,6 +1991,34 @@ function localAuthHeadersFor(
 }
 
 /**
+ * #1086 — what a Manager dispatch does NOT establish.
+ *
+ * This used to end with "the file lists under /models when complete", which is a
+ * PREDICTION, not an observation, and it was wrong for the reporter: ComfyUI-Manager
+ * installed into the container base root (/opt/ComfyUI/models) while the server READ
+ * models from /workspace/models via extra_model_paths. The file never listed, the
+ * 20 GB overlay was discarded on pod restart, and a multi-GB model was lost — after
+ * we had reported the transfer as proceeding to a destination we never checked.
+ *
+ * We cannot fix the destination from here: extra_model_paths.yaml lives on the
+ * TARGET filesystem, and for a remote install this process cannot read it. What we
+ * can stop doing is asserting where the bytes will land.
+ *
+ * NAMES THE CHECK, not just the risk. "Verify it yourself" without saying how is a
+ * dead end; list_local_models reads through the SAME roots the server reads, so a
+ * file that appears there is genuinely reachable by a workflow.
+ */
+export function managerDestinationCaveat(): string {
+  return (
+    "ComfyUI-Manager chooses the destination root itself and does not necessarily honour " +
+    "extra_model_paths — so this has NOT established where the file lands. Confirm with " +
+    "list_local_models before relying on it. A model that never appears there was written " +
+    "somewhere the server does not read, commonly the install's base models directory; on a " +
+    "container that is often an ephemeral overlay, which loses the file on restart."
+  );
+}
+
+/**
  * Remote-mode download: hand the file off to the connected ComfyUI host via
  * ComfyUI-Manager's `install-model` task. Validates the subfolder/filename with
  * the same guards as the local path (no traversal, bare filename) before
@@ -2179,7 +2207,7 @@ async function downloadModelViaManagerRemote(
       "local models directory to stream into (no COMFYUI_PATH, no saved workspace, and the " +
       "running server's launch arguments did not identify one). That is a routing fallback, NOT " +
       "a claim that the server is remote; set COMFYUI_PATH to stream directly instead";
-  return `${normalizedSubfolder}/${resolvedFilename} (${routeNote} — download continues server-side; the file lists under /models when complete)${authGateWarning}${authWarning}`;
+  return `${normalizedSubfolder}/${resolvedFilename} (${routeNote} — download continues server-side. ${managerDestinationCaveat()})${authGateWarning}${authWarning}`;
 }
 
 /**


### PR DESCRIPTION
For #1086.

The reply ended with *"the file lists under /models when complete"* — a **prediction**, not
an observation, and false for the reporter.

ComfyUI-Manager installed into the container base root (`/opt/ComfyUI/models`) while the
server **read** models from `/workspace/models` via `extra_model_paths`. The file never
listed. The 20 GB overlay was discarded on pod restart, and a multi-GB Wan 2.2 model was
lost — after we had reported the transfer as proceeding to a destination we never checked.

## What this does NOT fix

The destination itself. `extra_model_paths.yaml` lives on the **target** filesystem, and for
a remote install this process cannot read it — the resolver is written throughout in terms
of the *local* ComfyUI root. Teaching the remote path to honour those roots needs a way to
read them off the target, and is a separate change that wants a decision (read them
remotely, or refuse Manager dispatch when they cannot be confirmed).

## What it does fix

The half that is ours regardless: **we stop asserting an outcome we never observed.**

This is also the safe direction. Verification-only can turn a false success into an honest
failure; it cannot cause the data loss it describes. I split those two halves deliberately
after initially setting the whole issue aside as too risky to touch — changing *where bytes
go* on a data path is risky, and declining to *claim* where they went is not.

## Two things it deliberately does not do

**Names the check, not just the risk.** "Verify it yourself" without saying how is a dead
end. `list_local_models` reads through the same roots the server reads, so a file that
appears there is genuinely reachable by a workflow — and one that never appears was written
somewhere the server does not read.

**Names no concrete path.** Asserting `/workspace/models` or `/opt/ComfyUI/models` would be
the same defect in the other direction — this process cannot know the target's roots. It
describes the *class* (the install's base models directory, commonly an ephemeral overlay
on a container) and stops. There is a test for that.

## Tests

7319 pass; typecheck and `check:vocabulary` green. Both changed files scan clean for control
bytes.

Mutation-verified:

| mutation | result |
|---|---|
| restore the old "lists under /models when complete" promise | 3 tests fail |
| drop the named check (`list_local_models`) | fails |
| drop the restart hazard | fails |
