### PR TITLE
fix(user-mcp): never overwrite a ~/.claude.json we could not read

### DIFF
--- a/src/__tests__/services/claude-json-not-clobbered.test.ts
+++ b/src/__tests__/services/claude-json-not-clobbered.test.ts
@@ -1,0 +1,151 @@
+// #796's class where it costs the most: a file we do not own.
+//
+// `readClaudeJson()` returned `{}` for BOTH "there is no config" and "there is a
+// config and I could not read it". Every mutation here is a read-modify-WRITE:
+//
+//     const cfg = readClaudeJson();                    // {} after a failed parse
+//     cfg.mcpServers = servers;
+//     writeFileSync(claudeJsonPath(), JSON.stringify(cfg, null, 2));
+//
+// So one hand-edit with a trailing comma, or one transient read error, and adding
+// a single MCP server REPLACED the user's entire ~/.claude.json — every server
+// they had configured, plus any credentials other tools (and this very file) had
+// written into a server's `headers`/`env`.
+//
+// The remedy differs from our own configs on purpose. We do not move this file
+// aside, because it is not ours and another program expects it at that exact
+// path. Refusing to write is the only safe move, and the values the caller was
+// trying to set are simply not persisted.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  addUserMcpServer,
+  removeUserMcpServer,
+  setUserMcpServerSecret,
+  readUserMcpServers,
+} from "../../services/user-mcp-config.js";
+
+let dir: string;
+let cfgPath: string;
+const OLD_ENV = process.env.COMFYUI_MCP_CLAUDE_JSON;
+
+/** A real-looking config: other tools' servers, and a stored credential. */
+const HEALTHY = JSON.stringify(
+  {
+    numStartups: 42,
+    mcpServers: {
+      civitai: { type: "http", url: "https://example.invalid/mcp", headers: { Authorization: "Bearer KEEP-ME" } },
+      other: { command: "node", args: ["x.js"] },
+    },
+    projects: { "/some/project": { history: ["a", "b"] } },
+  },
+  null,
+  2,
+);
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cmcp-claudejson-"));
+  cfgPath = join(dir, ".claude.json");
+  process.env.COMFYUI_MCP_CLAUDE_JSON = cfgPath;
+});
+
+afterEach(() => {
+  if (OLD_ENV === undefined) delete process.env.COMFYUI_MCP_CLAUDE_JSON;
+  else process.env.COMFYUI_MCP_CLAUDE_JSON = OLD_ENV;
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe("an unreadable ~/.claude.json is never overwritten", () => {
+  // The exact reported shape: a config that is ALMOST valid.
+  const TRAILING_COMMA = '{ "mcpServers": { "civitai": { "type": "http" } }, }';
+
+  it("refuses to add a server rather than replacing the whole config", () => {
+    writeFileSync(cfgPath, TRAILING_COMMA);
+
+    expect(() => addUserMcpServer("newthing", { command: "node" })).toThrow(/Refusing to modify/);
+    // The user's file is byte-identical — nothing was written.
+    expect(readFileSync(cfgPath, "utf-8")).toBe(TRAILING_COMMA);
+  });
+
+  it("refuses to write a secret rather than replacing the whole config", () => {
+    writeFileSync(cfgPath, TRAILING_COMMA);
+
+    expect(() =>
+      setUserMcpServerSecret({ kind: "header", server: "civitai", key: "Authorization" }, "s3cret"),
+    ).toThrow(/Refusing to modify/);
+    expect(readFileSync(cfgPath, "utf-8")).toBe(TRAILING_COMMA);
+    // And the value never reaches the file (nor this assertion's failure output).
+    expect(readFileSync(cfgPath, "utf-8")).not.toContain("s3cret");
+  });
+
+  it("refuses to remove a server rather than replacing the whole config", () => {
+    writeFileSync(cfgPath, TRAILING_COMMA);
+
+    expect(() => removeUserMcpServer("civitai")).toThrow(/Refusing to modify/);
+    expect(readFileSync(cfgPath, "utf-8")).toBe(TRAILING_COMMA);
+  });
+
+  it("explains what would have been lost, so the refusal is actionable", () => {
+    writeFileSync(cfgPath, TRAILING_COMMA);
+
+    expect(() => addUserMcpServer("x", { command: "node" })).toThrow(/whole Claude configuration/);
+    expect(() => addUserMcpServer("x", { command: "node" })).toThrow(/nothing has been changed/);
+  });
+
+  it("refuses on valid JSON that is not an object", () => {
+    writeFileSync(cfgPath, JSON.stringify(["not", "a", "config"]));
+
+    expect(() => addUserMcpServer("x", { command: "node" })).toThrow(/Refusing to modify/);
+  });
+});
+
+describe("the healthy paths are untouched", () => {
+  it("still adds a server, preserving everything else in the file", () => {
+    writeFileSync(cfgPath, HEALTHY);
+
+    addUserMcpServer("newthing", { command: "node", args: ["y.js"] });
+
+    const after = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    expect(after.mcpServers.newthing).toEqual({ command: "node", args: ["y.js"] });
+    // The parts we must not disturb.
+    expect(after.numStartups).toBe(42);
+    expect(after.projects["/some/project"].history).toEqual(["a", "b"]);
+    expect(after.mcpServers.civitai.headers.Authorization).toBe("Bearer KEEP-ME");
+  });
+
+  it("still writes into a MISSING config — absent is not unreadable", () => {
+    addUserMcpServer("newthing", { command: "node" });
+
+    expect(JSON.parse(readFileSync(cfgPath, "utf-8")).mcpServers.newthing).toEqual({
+      command: "node",
+    });
+  });
+
+  it("still removes a server, and reports absence without writing", () => {
+    writeFileSync(cfgPath, HEALTHY);
+
+    expect(removeUserMcpServer("nope")).toBe(false);
+    expect(removeUserMcpServer("other")).toBe(true);
+
+    const after = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    expect(after.mcpServers.other).toBeUndefined();
+    expect(after.mcpServers.civitai).toBeTruthy();
+  });
+
+  // The QUERY path stays lenient on purpose: an unreadable config reads as "no
+  // servers", which is a wrong answer but not a destructive one, and throwing
+  // here would break agent spawn for anyone with a malformed file.
+  it("reading servers from an unreadable config yields none rather than throwing", () => {
+    writeFileSync(cfgPath, "{ broken");
+
+    expect(() => readUserMcpServers()).not.toThrow();
+    expect(readUserMcpServers()).toEqual({});
+  });
+});

--- a/src/services/user-mcp-config.ts
+++ b/src/services/user-mcp-config.ts
@@ -22,18 +22,64 @@ export function claudeJsonPath(): string {
   return process.env.COMFYUI_MCP_CLAUDE_JSON || join(homedir(), ".claude.json");
 }
 
-function readClaudeJson(): Record<string, unknown> {
+/**
+ * Load the user's Claude config, distinguishing ABSENT from UNREADABLE (#796).
+ *
+ * `{}` is the right answer for a file that is not there. It is the WRONG answer
+ * for one that exists and could not be read — and here that difference destroys
+ * data, because every mutation below is a read-modify-WRITE:
+ *
+ *     const cfg = readClaudeJson();   // {} after a failed parse — the OLD shape
+ *     cfg.mcpServers = servers;
+ *     writeFileSync(claudeJsonPath(), JSON.stringify(cfg, null, 2));
+ *
+ * `~/.claude.json` is the user's entire Claude Code configuration — every MCP
+ * server, plus whatever secrets other tools have written into `headers`/`env`
+ * (this file writes them there itself). One hand-edit with a trailing comma, or
+ * one transient read error, and adding a single MCP server replaced all of it.
+ *
+ * It is also NOT OUR FILE, which decides the remedy: unlike our own configs we do
+ * not move it aside, because another program expects it at that exact path.
+ * Refusing to write is the only safe move.
+ */
+function loadClaudeJson(): { cfg: Record<string, unknown>; unreadable?: string } {
   const p = claudeJsonPath();
-  if (!existsSync(p)) return {};
+  if (!existsSync(p)) return { cfg: {} };
   try {
     const parsed = JSON.parse(readFileSync(p, "utf-8")) as unknown;
-    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return { cfg: parsed as Record<string, unknown> };
+    }
+    return { cfg: {}, unreadable: "it is valid JSON but not an object" };
   } catch (err) {
     logger.warn(
       `[user-mcp] could not parse ${p}: ${err instanceof Error ? err.message : String(err)}`,
     );
-    return {};
+    return { cfg: {}, unreadable: err instanceof Error ? err.message : String(err) };
   }
+}
+
+/** The lenient read, for QUERIES. An unreadable config reads as "no servers",
+ *  which is a wrong answer but not a destructive one — see readUserMcpServers. */
+function readClaudeJson(): Record<string, unknown> {
+  return loadClaudeJson().cfg;
+}
+
+/**
+ * The read that precedes a WRITE. Refuses rather than handing back an empty
+ * object that the caller would then persist over the user's real config.
+ */
+function readClaudeJsonForMutation(): Record<string, unknown> {
+  const { cfg, unreadable } = loadClaudeJson();
+  if (unreadable !== undefined) {
+    throw new Error(
+      `Refusing to modify ${claudeJsonPath()}: it exists but could not be read (${unreadable}). ` +
+        `Writing would replace your whole Claude configuration — every MCP server, and any ` +
+        `credentials stored in a server's headers/env — with just this change. Fix that file ` +
+        `(a trailing comma is the usual cause) and try again; nothing has been changed.`,
+    );
+  }
+  return cfg;
 }
 
 function serversObject(cfg: Record<string, unknown>): Record<string, McpServerConfig> {
@@ -79,7 +125,7 @@ export function addUserMcpServer(name: string, config: McpServerConfig): void {
   if (isConflictingServer(name, config)) {
     throw new Error(`Refusing to add "${name}" — it conflicts with the panel's own comfyui server.`);
   }
-  const cfg = readClaudeJson();
+  const cfg = readClaudeJsonForMutation();
   const servers = serversObject(cfg);
   servers[name] = config;
   cfg.mcpServers = servers;
@@ -104,7 +150,7 @@ export interface McpSecretTarget {
  * straight from the secure input; it is never logged or returned anywhere.
  */
 export function setUserMcpServerSecret(target: McpSecretTarget, value: string): void {
-  const cfg = readClaudeJson();
+  const cfg = readClaudeJsonForMutation();
   const servers = serversObject(cfg);
   const server = servers[target.server];
   if (!server || typeof server !== "object") {
@@ -122,7 +168,7 @@ export function setUserMcpServerSecret(target: McpSecretTarget, value: string): 
 
 /** Remove an MCP server from the user's config. Returns false if absent. */
 export function removeUserMcpServer(name: string): boolean {
-  const cfg = readClaudeJson();
+  const cfg = readClaudeJsonForMutation();
   const servers = serversObject(cfg);
   if (!(name in servers)) return false;
   delete servers[name];


### PR DESCRIPTION
The worst instance of #796's class found so far, because the file isn't ours.

`readClaudeJson()` returned `{}` for **both** "there is no config" and "there is a config and I could not read it". Every mutation in this file is a read-modify-**write**:

```ts
const cfg = readClaudeJson();                    // {} after a failed parse
cfg.mcpServers = servers;
writeFileSync(claudeJsonPath(), JSON.stringify(cfg, null, 2));
```

So one hand-edit with a trailing comma, or one transient read error, and adding a single MCP server **replaced the user's entire `~/.claude.json`** — every server they had configured, their per-project history, and any credentials other tools (and this very file, via `setUserMcpServerSecret`) had written into a server's `headers`/`env`.

Three write paths were affected: `addUserMcpServer`, `setUserMcpServerSecret`, `removeUserMcpServer`.

## The remedy differs from our own configs, deliberately

For files we own — #1079 (sessions), #1087 (defaults) — the unreadable original is moved aside and a fresh one written. That would be **wrong here**: `~/.claude.json` is not ours, and another program expects it at that exact path. Moving it would break Claude Code itself.

So the write is **refused**, the file is left untouched, and the error says what would have been lost and how to fix it.

The **query** path stays lenient on purpose: `readUserMcpServers()` still reports "no servers" for an unreadable config — a wrong answer, but not a destructive one, and throwing there would break agent spawn for anyone with a malformed file.

## Verification

| Check | Result |
|---|---|
| **mutation** — disable the refusal | all 5 refusal tests fail; the config *is* destroyed, which is the bug |
| tests | 9, against real files |
| full suite | green — 357 files, 7323 passed |

The tests assert the file is **byte-identical** after each refusal, that a stored credential survives an ordinary add, and that a *missing* config still writes (absent is not unreadable).

## On the lint suggested in #796

I tried to build it and it isn't viable in the broad form: `catch` returning a constructed literal matches **155** sites, overwhelmingly legitimate (fail-closed booleans, cleanup, already-three-state results). A gate needing a ~20-entry allowlist would cry wolf and get deleted.

The **narrow** form is useful as an audit query rather than a gate: a failed *read of an external source* (`readFile`/`JSON.parse`/`.text()`/`statSync`) returning a literal — 31 sites, most already three-state (`{ state: "unreadable" }`, `{ kind: "undecodable" }`, ENOENT-guarded). This was the most serious of the remainder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)