### PR TITLE
0.50.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.27] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- never overwrite a ~/.claude.json we could not read (#796) (#1091)
+- a Manager dispatch must not promise where the file lands (#1090)
+
+
 ## [0.50.26] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.26",
+  "version": "0.50.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.26",
+      "version": "0.50.27",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.26",
+  "version": "0.50.27",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.27**. Tag pushed; `release.yml` publishes from it; this PR reconciles protected `main`.

Released immediately: #1091 is **data loss on a file we don't own**.

## #1091 — `~/.claude.json` could be replaced wholesale

`readClaudeJson()` returned `{}` for both "no config" and "config exists and I could not read it", and every mutation is a read-modify-write. So one hand-edit with a trailing comma, or one transient read error, and adding a single MCP server **replaced the user's entire Claude Code configuration** — every server, their per-project history, and any credentials stored in a server's `headers`/`env` (including ones this very file writes there).

Three write paths were affected. All now refuse rather than write.

The remedy deliberately differs from #1079 (sessions) and #1087 (defaults), where we move the unreadable original aside and write a fresh one. That would be wrong here: this file isn't ours and another program expects it at that path, so moving it would break Claude Code itself. The write is refused, the file is left byte-identical, and the error says what would have been lost.

The query path stays lenient — an unreadable config still reads as "no servers", which is a wrong answer but not a destructive one, and throwing there would break agent spawn for anyone with a malformed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)