### PR TITLE
fix(prompt-overrides): an unreadable overrides file is preserved, not erased

### DIFF
--- a/src/__tests__/services/prompt-overrides-unreadable.test.ts
+++ b/src/__tests__/services/prompt-overrides-unreadable.test.ts
@@ -1,0 +1,142 @@
+// #796, on a file whose contents are the user's own WRITING.
+//
+// readOverrides() returned `{}` for both "no overrides file" and "there is one
+// and I could not read it", and setPromptOverride is a read-modify-write:
+//
+//     const o = readOverrides();   // {} after a failed parse
+//     o[id] = value;
+//     writeOverrides(o);           // …now the file holds ONLY this one override
+//
+// Every other prompt the user had customised was erased by setting one. This
+// file's own write guard already calls its contents "user-authored prompt text"
+// and refuses to touch the real one from tests — the same care was missing at the
+// read.
+//
+// The remedy matches the file's OWNERSHIP, which is the distinction this cluster
+// keeps turning on: this is our file, so the unreadable original is moved aside
+// and replaced. ~/.claude.json is another program's file, so it is refused
+// instead of moved.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  setPromptOverride,
+  clearPromptOverride,
+  resolvePrompt,
+  panelPromptsPath,
+} from "../../services/prompt-overrides.js";
+
+let dir: string;
+let file: string;
+const OLD = process.env.COMFYUI_MCP_PANEL_PROMPTS;
+
+/** What the user typed, in a file with one typo. */
+const USER_TEXT = '{ "planner": "Always think step by step.", "critic": "Be harsh.", }';
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cmcp-prompts-"));
+  file = join(dir, "panel-prompts.json");
+  process.env.COMFYUI_MCP_PANEL_PROMPTS = file;
+});
+
+afterEach(() => {
+  if (OLD === undefined) delete process.env.COMFYUI_MCP_PANEL_PROMPTS;
+  else process.env.COMFYUI_MCP_PANEL_PROMPTS = OLD;
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe("an unreadable overrides file is preserved, not erased", () => {
+  it("moves the user's text aside instead of overwriting it", () => {
+    writeFileSync(file, USER_TEXT);
+
+    setPromptOverride("newone", "hello");
+
+    const preserved = readdirSync(dir).filter((f) => f.includes(".unreadable-"));
+    expect(preserved, "the user's prompt text must be kept").toHaveLength(1);
+    expect(readFileSync(join(dir, preserved[0]!), "utf-8")).toBe(USER_TEXT);
+
+    // …and the new override really was written in its place.
+    expect(JSON.parse(readFileSync(file, "utf-8"))).toEqual({ newone: "hello" });
+  });
+
+  it("preserves once — the next set merges normally", () => {
+    writeFileSync(file, "{ broken");
+
+    setPromptOverride("a", "1");
+    setPromptOverride("b", "2");
+
+    expect(readdirSync(dir).filter((f) => f.includes(".unreadable-"))).toHaveLength(1);
+    expect(JSON.parse(readFileSync(file, "utf-8"))).toEqual({ a: "1", b: "2" });
+  });
+
+  it("preserves valid JSON that is not an object", () => {
+    writeFileSync(file, JSON.stringify(["not", "a", "map"]));
+
+    setPromptOverride("a", "1");
+
+    expect(readdirSync(dir).filter((f) => f.includes(".unreadable-"))).toHaveLength(1);
+  });
+});
+
+describe("the healthy paths are unchanged", () => {
+  it("merges into a readable file, keeping the other overrides", () => {
+    writeFileSync(file, JSON.stringify({ planner: "keep me", critic: "me too" }));
+
+    setPromptOverride("planner", "changed");
+
+    expect(JSON.parse(readFileSync(file, "utf-8"))).toEqual({
+      planner: "changed",
+      critic: "me too",
+    });
+    expect(readdirSync(dir).filter((f) => f.includes(".unreadable-"))).toHaveLength(0);
+  });
+
+  it("writes into a MISSING file — absent is not unreadable", () => {
+    setPromptOverride("planner", "hello");
+
+    expect(JSON.parse(readFileSync(file, "utf-8"))).toEqual({ planner: "hello" });
+    expect(readdirSync(dir).filter((f) => f.includes(".unreadable-"))).toHaveLength(0);
+  });
+
+  it("an empty value still clears an override", () => {
+    writeFileSync(file, JSON.stringify({ planner: "old", critic: "keep" }));
+
+    setPromptOverride("planner", "   ");
+
+    expect(JSON.parse(readFileSync(file, "utf-8"))).toEqual({ critic: "keep" });
+  });
+
+  // The QUERY path stays lenient: an unreadable file means built-in defaults
+  // apply. A wrong answer, but not a destructive one — and throwing here would
+  // break every prompt lookup in the process.
+  it("resolvePrompt falls back to the default rather than throwing", () => {
+    writeFileSync(file, "{ broken");
+
+    expect(() => resolvePrompt("planner", "BUILT-IN")).not.toThrow();
+    expect(resolvePrompt("planner", "BUILT-IN")).toBe("BUILT-IN");
+    // …and merely READING must not have touched the file.
+    expect(readFileSync(file, "utf-8")).toBe("{ broken");
+  });
+
+  // clearPromptOverride was already safe by accident: it only writes when the id
+  // is present, and an unreadable file yields `{}`, so `id in o` is false. Pinned
+  // so a later refactor cannot quietly turn it into a destructive write.
+  it("clearing against an unreadable file writes nothing at all", () => {
+    writeFileSync(file, "{ broken");
+
+    clearPromptOverride("planner");
+
+    expect(readFileSync(file, "utf-8")).toBe("{ broken");
+    expect(readdirSync(dir).filter((f) => f.includes(".unreadable-"))).toHaveLength(0);
+  });
+
+  it("honours the env override for its path", () => {
+    expect(panelPromptsPath()).toBe(file);
+  });
+});

--- a/src/services/prompt-overrides.ts
+++ b/src/services/prompt-overrides.ts
@@ -13,7 +13,7 @@
 // registered centrally at startup (see registerBuiltinPrompts in index.ts).
 
 import { EventEmitter } from "node:events";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { logger } from "../utils/logger.js";
@@ -48,21 +48,39 @@ export function panelPromptsPath(): string {
   );
 }
 
-function readOverrides(): Record<string, string> {
+/**
+ * Load the overrides, distinguishing ABSENT from UNREADABLE (#796).
+ *
+ * `{}` is right for a file that is not there and WRONG for one that exists and
+ * could not be read, because setPromptOverride is a read-modify-write:
+ * `{}` + one new override, written back, erases every other prompt the user has
+ * written. This file holds USER-AUTHORED PROMPT TEXT — as the write guard below
+ * already says — so that is lost writing, not a lost setting.
+ */
+function readOverridesState(): { values: Record<string, string>; unreadable?: string } {
   const p = panelPromptsPath();
-  if (!existsSync(p)) return {};
+  if (!existsSync(p)) return { values: {} };
   try {
     const parsed = JSON.parse(readFileSync(p, "utf-8")) as unknown;
-    if (!parsed || typeof parsed !== "object") return {};
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { values: {}, unreadable: "it is valid JSON but not an object" };
+    }
     const out: Record<string, string> = {};
     for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
       if (typeof v === "string") out[k] = v;
     }
-    return out;
+    return { values: out };
   } catch (err) {
     logger.warn(`[prompt-overrides] could not parse ${p}: ${err instanceof Error ? err.message : String(err)}`);
-    return {};
+    return { values: {}, unreadable: err instanceof Error ? err.message : String(err) };
   }
+}
+
+/** The lenient read, for QUERIES (which prompt text applies right now). An
+ *  unreadable file means the built-in defaults apply — a wrong answer, but not a
+ *  destructive one, and throwing here would break every prompt lookup. */
+function readOverrides(): Record<string, string> {
+  return readOverridesState().values;
 }
 
 function writeOverrides(o: Record<string, string>): void {
@@ -92,11 +110,42 @@ export function resolvePrompt(id: string, fallback: string): string {
 
 /** Persist an override. Empty/whitespace clears it (→ back to default). Emits change. */
 export function setPromptOverride(id: string, value: string): void {
-  const o = readOverrides();
+  const { values: o, unreadable } = readOverridesState();
+  // The file exists and we could not read it, so `o` is EMPTY — not because the
+  // user has no overrides, but because we could not read the ones they wrote.
+  // Writing now would replace all of their prompt text with this single entry.
+  // This IS our file, so it is preserved and replaced (the ruling for
+  // ~/.claude.json is different — that one belongs to another program and is
+  // refused instead of moved).
+  if (unreadable !== undefined) preserveUnreadableOverrides(unreadable);
   if (!value || !value.trim()) delete o[id];
   else o[id] = value;
   writeOverrides(o);
   emitter.emit("change", id);
+}
+
+/**
+ * Move an unreadable overrides file aside so the write that follows cannot
+ * destroy it. Throws if it cannot be moved — refusing to persist is better than
+ * overwriting prompt text the user typed, which is the same ruling the session
+ * store and defaults manager make.
+ */
+function preserveUnreadableOverrides(reason: string): void {
+  const p = panelPromptsPath();
+  const aside = `${p}.unreadable-${Date.now()}`;
+  try {
+    renameSync(p, aside);
+    logger.warn(
+      `[prompt-overrides] preserved the unreadable overrides as ${aside} before writing a fresh ` +
+        `file (it could not be read: ${reason}). Any prompt text you had customised is in there.`,
+    );
+  } catch (err) {
+    throw new Error(
+      `Refusing to overwrite ${p}: it could not be read (${reason}) and could not be moved aside ` +
+        `either (${err instanceof Error ? err.message : String(err)}), so writing would destroy ` +
+        `prompt text that is probably still there. Fix or move that file, then set the prompt again.`,
+    );
+  }
 }
 
 /** Remove an override → back to the built-in default. Emits change. */


### PR DESCRIPTION
The last of the read-modify-write family, on a file whose contents are the user's own **writing**.

`readOverrides()` returned `{}` for both "no overrides file" and "there is one and I could not read it", and `setPromptOverride` is a read-modify-write:

```ts
const o = readOverrides();   // {} after a failed parse
o[id] = value;
writeOverrides(o);           // …the file now holds ONLY this one override
```

Every other prompt the user had customised was erased by setting one. This file's own write guard already calls its contents *"user-authored prompt text"* and refuses to touch the real one from tests — the same care was simply missing at the read.

## The remedy follows ownership

This is **our** file, so the unreadable original is moved to `<path>.unreadable-<ts>` and replaced, with a log saying where the text went. `~/.claude.json` (#1091) is another program's file, so that one is refused instead of moved. Same class, different ruling, decided by who owns the path.

`clearPromptOverride` was already safe by accident — it only writes when the id is present, and an unreadable file yields `{}` — and there's now a test pinning that, so a later refactor can't quietly turn it into a destructive write.

The **query** path stays lenient: `resolvePrompt` falls back to the built-in default rather than throwing, since throwing there would break every prompt lookup in the process.

## Verification

| Check | Result |
|---|---|
| **mutation** — drop the preserve call | 3 tests fail; the user's text is erased, which is the bug |
| tests | 9, against real files |
| full suite | green — 359 files, 7337 passed |

Tests assert the preserved copy is byte-identical to what the user wrote, that a healthy file merges normally, that a *missing* file still writes, that clearing touches nothing, and that a read never modifies the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)