### PR TITLE
0.50.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.28] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- an unreadable overrides file is preserved, not erased (#796) (#1093)
+
+
 ## [0.50.27] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.27",
+  "version": "0.50.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.27",
+      "version": "0.50.28",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.27",
+  "version": "0.50.28",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.28**. Tag pushed; `release.yml` publishes from it; this PR reconciles protected `main`.

## #1093 — an unreadable prompt-overrides file is preserved, not erased

The last of the read-modify-write family. `readOverrides()` returned `{}` for both "no file" and "there is one and I could not read it", and `setPromptOverride` reads-modifies-writes — so setting **one** prompt erased every other prompt the user had customised.

This file's own write guard already calls its contents *"user-authored prompt text"* and refuses to touch the real one from tests. The same care was missing at the read.

The unreadable original is now moved to `<path>.unreadable-<ts>` and replaced, with a log saying where the text went.

## The pattern across four files

The same defect appeared four times this week, and the *remedy* differs by who owns the file and who wrote the contents:

| file | on an unreadable original |
|---|---|
| session store (#1079) | machine-written → preserve on **I/O** failure only; a parse failure really is worthless bytes |
| defaults config (#1087) | user-typed → preserve on **parse** failure too; unparseable usually means a trailing comma in content they care about |
| prompt overrides (#1093) | user-*written* → same, and the contents are prose |
| `~/.claude.json` (#1091) | **another program's file** → never move it; refuse the write entirely |

Getting the class right was not enough on its own — each site needed its own ruling about what to do with the thing it could not read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)