### PR TITLE
fix(download): ask the server whether a Manager dispatch landed

### DIFF
--- a/src/__tests__/services/manager-visibility.test.ts
+++ b/src/__tests__/services/manager-visibility.test.ts
@@ -1,0 +1,116 @@
+// #1086 — ask the server, instead of telling the caller to ask it.
+//
+// A Manager dispatch could only ever say "confirm with list_local_models before
+// relying on it". A reporter who did not confirm lost a multi-GB model: ComfyUI-
+// Manager picks its own destination root and does not necessarily honour
+// extra_model_paths, so their file landed in the install's base models directory
+// — an ephemeral 20GB overlay — while their ComfyUI read from a 100GB volume.
+// Nothing contradicted "download complete" until a pod restart made it absent.
+//
+// verifyLandedModel cannot answer this. It stats the local filesystem first and
+// returns `unknown` outright in remote mode — exactly the case a Manager dispatch
+// creates, since there is no local file. But the LISTING question is answerable
+// remotely, because it asks the server.
+//
+// THE TRAP THIS FILE PINS. A Manager dispatch returns when the task is ACCEPTED,
+// so a large file is still arriving for minutes afterwards. "not-listed" must
+// therefore NEVER be rendered as failure — "not there yet" and "landed somewhere
+// the server cannot read" are indistinguishable from here, and claiming the
+// second would be a fabricated failure mirroring the fabricated success.
+//
+// The probe is INJECTED. Mocking the module does not work: the function resolves
+// `liveListingHasEntry` through a module-local binding, not the namespace object,
+// so a first draft of this file silently queried the developer's real ComfyUI —
+// which is why three of its assertions "failed" with plausible-looking values.
+
+import { describe, expect, it, vi } from "vitest";
+import { verifyManagerVisibility } from "../../services/model-resolver.js";
+
+describe("verifyManagerVisibility asks the live server", () => {
+  it("CONFIRMS when the server lists the file", async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+
+    const r = await verifyManagerVisibility("clip_vision", "clip_vision_h.safetensors", {
+      attempts: 1,
+      probe,
+    });
+
+    expect(r.visibility).toBe("visible");
+    expect(r.note).toMatch(/now lists clip_vision\/clip_vision_h\.safetensors/);
+  });
+
+  it("reports NOT-LISTED without calling it a failure", async () => {
+    const probe = vi.fn().mockResolvedValue(false);
+
+    const r = await verifyManagerVisibility("clip_vision", "clip_vision_h.safetensors", {
+      attempts: 1,
+      retryMs: 0,
+      probe,
+    });
+
+    expect(r.visibility).toBe("not-listed");
+    // The load-bearing hedge: a dispatch returns on ACCEPTANCE.
+    expect(r.note).toMatch(/not proof of failure/i);
+    expect(r.note).toMatch(/still be arriving/i);
+    // …and the actionable half, which is what the reporter needed.
+    expect(r.note).toMatch(/does not necessarily honour/);
+    expect(r.note).toMatch(/ephemeral overlay/);
+  });
+
+  it("says UNKNOWN when the server could not be asked — not 'not-listed'", async () => {
+    const probe = vi.fn().mockResolvedValue(undefined);
+
+    const r = await verifyManagerVisibility("loras", "x.safetensors", {
+      attempts: 2,
+      retryMs: 0,
+      probe,
+    });
+
+    expect(r.visibility).toBe("unknown");
+    expect(r.note).toMatch(/could not be asked/);
+    // An unanswerable probe must not masquerade as a negative observation.
+    expect(r.note).not.toMatch(/does NOT list/);
+  });
+
+  it("says UNKNOWN when the file was ALREADY listed before the dispatch", async () => {
+    // A pre-existing file of the same name would otherwise read as a successful
+    // landing — the same trap the local path's `listedBefore` guards.
+    const probe = vi.fn();
+
+    const r = await verifyManagerVisibility("checkpoints", "sdxl.safetensors", {
+      listedBefore: true,
+      attempts: 1,
+      probe,
+    });
+
+    expect(r.visibility).toBe("unknown");
+    expect(r.note).toMatch(/already listed .* BEFORE this dispatch/);
+    expect(probe).not.toHaveBeenCalled(); // no point asking
+  });
+
+  it("retries before concluding not-listed, and stops early once seen", async () => {
+    const probe = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    const r = await verifyManagerVisibility("loras", "x.safetensors", {
+      attempts: 3,
+      retryMs: 0,
+      probe,
+    });
+
+    expect(r.visibility).toBe("visible");
+    expect(probe).toHaveBeenCalledTimes(2); // stopped at the hit
+  });
+
+  it("never throws outward when the probe explodes", async () => {
+    const probe = vi.fn().mockRejectedValue(new Error("connection reset"));
+
+    const r = await verifyManagerVisibility("loras", "x.safetensors", {
+      attempts: 1,
+      retryMs: 0,
+      probe,
+    });
+
+    // A verification hiccup must not turn a transfer into an error.
+    expect(r.visibility).toBe("unknown");
+  });
+});

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1231,6 +1231,106 @@ export interface LandedModelVerification {
 const LIVE_VISIBILITY_ATTEMPTS = 3;
 const LIVE_VISIBILITY_RETRY_MS = 1000;
 
+/** What asking the LIVE server whether it can see a Manager-dispatched model
+ *  established. Three states, because "the server did not list it" and "the
+ *  server could not be asked" are different facts (#796). */
+export type ManagerVisibility = "visible" | "not-listed" | "unknown";
+
+/**
+ * Ask the CONNECTED server whether it now lists a model a Manager dispatch was
+ * supposed to fetch (#1086).
+ *
+ * `verifyLandedModel` cannot answer this: it stats the local filesystem first and
+ * returns `unknown` outright in remote mode, because there is no local file to
+ * stat — which is exactly the case a Manager dispatch creates. But the LISTING
+ * question is answerable remotely, since `liveListingHasEntry` asks the server.
+ *
+ * A reporter lost a multi-GB model to this. ComfyUI-Manager picks its own
+ * destination root and does not necessarily honour `extra_model_paths`, so their
+ * file landed in the install's base models directory — an ephemeral 20GB overlay
+ * — while their ComfyUI read from a 100GB volume. Nothing contradicted the
+ * "download complete" until a pod restart made the file simply absent.
+ *
+ * "not-listed" IS NOT FAILURE, and callers must not render it as one. A Manager
+ * dispatch returns when the task is ACCEPTED, so a large file is still arriving
+ * for minutes afterwards, and "not there yet" and "landed somewhere the server
+ * cannot read" are indistinguishable from here. What this does establish is the
+ * difference between those two and a CONFIRMED presence, which is the thing the
+ * caller previously had no way to learn except by asking by hand.
+ *
+ * Never throws: a verification hiccup must not turn a transfer into an error.
+ */
+export async function verifyManagerVisibility(
+  targetSubfolder: string,
+  filename: string,
+  opts?: {
+    attempts?: number;
+    retryMs?: number;
+    listedBefore?: boolean;
+    /** The listing probe, injectable so this is testable without a live server.
+     *  Defaults to liveListingHasEntry — which a test CANNOT intercept by mocking
+     *  the module, because the call below resolves a module-local binding rather
+     *  than going through the namespace object. A first draft of the tests for
+     *  this function silently queried the developer's real ComfyUI instead. */
+    probe?: (subfolder: string, name: string) => Promise<boolean | undefined>;
+  },
+): Promise<{ visibility: ManagerVisibility; note: string }> {
+  const probe = opts?.probe ?? liveListingHasEntry;
+  // It was ALREADY listed before the download, so the listing cannot attribute
+  // what it sees to this dispatch — a pre-existing file of the same name would
+  // read as a successful landing (the same trap verifyLandedModel's `listedBefore`
+  // guards on the local path).
+  if (opts?.listedBefore === true) {
+    return {
+      visibility: "unknown",
+      note:
+        `The connected ComfyUI already listed "${filename}" in ${targetSubfolder} BEFORE this ` +
+        `dispatch, so its presence now does not establish that this download landed — it may ` +
+        `still be the older file. Compare the file size or hash on the server if that matters.`,
+    };
+  }
+  const attempts = Math.max(1, opts?.attempts ?? LIVE_VISIBILITY_ATTEMPTS);
+  const retryMs = opts?.retryMs ?? LIVE_VISIBILITY_RETRY_MS;
+  let asked = false;
+  for (let i = 0; i < attempts; i++) {
+    let has: boolean | undefined;
+    try {
+      has = await probe(targetSubfolder, filename);
+    } catch {
+      has = undefined; // never throws outward — see the docblock
+    }
+    if (has === true) {
+      return {
+        visibility: "visible",
+        note:
+          `The connected ComfyUI now lists ${targetSubfolder}/${filename}, so the dispatch ` +
+          `landed somewhere it reads.`,
+      };
+    }
+    if (has === false) asked = true;
+    if (i < attempts - 1) await new Promise((r) => setTimeout(r, retryMs));
+  }
+  if (!asked) {
+    return {
+      visibility: "unknown",
+      note:
+        `The connected ComfyUI could not be asked whether it lists ${targetSubfolder}/${filename}, ` +
+        `so nothing about this dispatch's destination was established.`,
+    };
+  }
+  return {
+    visibility: "not-listed",
+    note:
+      `The connected ComfyUI does NOT list ${targetSubfolder}/${filename}. That is not proof of ` +
+      `failure — a Manager dispatch returns when the task is ACCEPTED, so a large file may still ` +
+      `be arriving. But if it does not appear shortly, the file landed somewhere this server does ` +
+      `not read: ComfyUI-Manager picks its own destination root and does not necessarily honour ` +
+      `extra_model_paths, which on a container is commonly an ephemeral overlay that loses the ` +
+      `file on restart. Re-check with list_local_models, and check free space on the install's ` +
+      `own models directory rather than your configured model root.`,
+  };
+}
+
 /**
  * Confirm, AFTER a download lands, that the bytes are (a) really on disk and
  * (b) somewhere the LIVE server reads from — then report the path we actually

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -6,6 +6,7 @@ import {
   listLocalModels,
   listLocalModelsWithCoverage,
   currentLiveModelsRoot,
+  verifyManagerVisibility,
   MODEL_SUBDIRS,
 } from "../services/model-resolver.js";
 import type { ModelListingCoverage } from "../services/model-resolver.js";
@@ -702,9 +703,25 @@ async function downloadAction(args: {
           const placement = describePlacement(job, {
             liveModelsDir: await currentLiveModelsRoot(),
           });
+          // #1086 — ASK the server instead of telling the caller to. The Manager
+          // branch could only ever say "confirm with list_local_models yourself",
+          // and a reporter who did not lost a multi-GB model to an ephemeral
+          // overlay. The listing question IS answerable remotely, so answer it.
+          // "not-listed" is deliberately not rendered as failure: the dispatch
+          // returns on ACCEPTANCE, so a large file may still be arriving.
+          const managerSeen = job.viaManager
+            ? await verifyManagerVisibility(
+                job.target_subfolder,
+                job.filename ?? (job.path ?? "").split(/[\\/]/).pop() ?? "",
+                { attempts: 1 },
+              ).catch(() => undefined)
+            : undefined;
           const text = job.viaManager
             ? `Download DISPATCHED to the remote ComfyUI via ComfyUI-Manager (server-side fetch):\n${job.path}\n\n` +
-              `NOTE: ${placement.warning}`
+              (managerSeen?.visibility === "visible"
+                ? `CONFIRMED: ${managerSeen.note}`
+                : `NOTE: ${placement.warning}` +
+                  (managerSeen ? `\n\n${managerSeen.note}` : ""))
             : placement.confirmed
               ? `Model downloaded successfully to${placement.pathQualifier}:\n${job.path}`
               : placement.wrongPlace


### PR DESCRIPTION
The actionable half of #1086 — the part I said on that issue we could still do.

A Manager dispatch could only ever say *"confirm with `list_local_models` before relying on it"*. The reporter who didn't confirm lost a multi-GB model: Manager picks its own destination root and doesn't necessarily honour `extra_model_paths`, so their file landed in the install's base models directory — an **ephemeral 20GB overlay** — while their ComfyUI read from a 100GB volume. Nothing contradicted "download complete" until a pod restart made it absent.

## Why the existing verifier couldn't answer

`verifyLandedModel` stats the local filesystem first and returns `unknown` outright in remote mode — which is exactly what a Manager dispatch creates, since there's no local file to stat. But the **listing** question is answerable remotely, because `liveListingHasEntry` asks the server. So ask it.

## Three states

| result | meaning |
|---|---|
| `visible` | the connected ComfyUI now lists it — the dispatch landed somewhere it reads |
| `not-listed` | it doesn't, **with the reason that matters** |
| `unknown` | the server couldn't be asked, or the file was **already listed before** the dispatch (a pre-existing file of the same name would otherwise read as a successful landing — the same trap the local path's `listedBefore` guards) |

**`not-listed` is not failure, and isn't rendered as one.** A dispatch returns when the task is *accepted*, so a large file is still arriving for minutes afterwards; "not there yet" and "landed where the server can't read" are indistinguishable from here. Claiming the second would be a fabricated failure mirroring the fabricated success this whole cluster is about. What it *does* establish is the difference between those two and a confirmed presence — which the caller previously could only learn by hand.

## Not attempted: fixing the destination

For a remote target this MCP cannot learn the real model root. `getLiveExtraModelRoots` deliberately skips the auto-loaded `extra_model_paths.yaml` in remote mode because that file lives on the remote host, and Manager's `install-model` task takes no destination root. That half is upstream, as the reporter concluded.

## Verification

| Check | Result |
|---|---|
| **mutation** — never record that the server answered "no" | the unknown-vs-not-listed test fails |
| **mutation** — drop the `listedBefore` guard | that test fails |
| tests | 6, hermetic |
| full suite | green — 360 files, 7343 passed |

The probe is **injectable**, and that isn't decoration: the function resolves `liveListingHasEntry` through a module-local binding, so `vi.mock` on the module does *not* intercept it. The first draft of these tests silently queried my real ComfyUI and "failed" with plausible-looking values — worth stating, because that failure mode looks like a bug in the code under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)