### PR TITLE
0.50.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.29] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- ask the server whether a Manager dispatch landed (#1086) (#1096)
+
+#### Changed
+- tell callers to add sequentially, and why (#1095)
+
+
 ## [0.50.28] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.28",
+  "version": "0.50.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.28",
+      "version": "0.50.29",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.28",
+  "version": "0.50.29",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.29**. Tag pushed; `release.yml` publishes from it; this PR reconciles protected `main`.

## #1096 — a Manager dispatch now asks the server whether it landed

The actionable half of the #1086 P1. A Manager dispatch could only ever say *"confirm with `list_local_models` before relying on it"*, and the reporter who didn't lost a multi-GB model to an ephemeral 20GB overlay while their ComfyUI read from a 100GB volume.

`verifyLandedModel` couldn't answer — it stats the local filesystem first and returns `unknown` in remote mode, which is exactly what a Manager dispatch creates. But the *listing* question is answerable remotely, so we now ask the server: `visible` / `not-listed` / `unknown`.

`not-listed` is deliberately **not** rendered as failure: a dispatch returns on acceptance, so a large file may still be arriving, and claiming otherwise would be a fabricated failure mirroring the fabricated success. What it establishes is the difference between "still arriving / landed somewhere unreadable" and a confirmed presence.

Fixing the *destination* remains upstream: for a remote target this MCP cannot learn the real model root (`getLiveExtraModelRoots` skips the auto-loaded config in remote mode because it lives on the remote host), and Manager's task takes no destination root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)