### PR TITLE
fix(restart): name the tunnelled-remote case in the panel-restart refusal

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -7,6 +7,7 @@
 // panel JS executors implement), and that the McpServer HTTP path registers the
 // identical set.
 
+import { readFileSync } from "node:fs";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -6443,5 +6444,49 @@ describe("#767 panel_add_node warns against parallel bursts", () => {
     // now safe to parallelise or that the timeout was raised.
     const d = defByName("panel_add_node");
     expect(d.description).not.toMatch(/now safe|no longer times out|timeout (has been )?raised/i);
+  });
+});
+
+describe("panel#769 restart refusal names the tunnelled-remote case", () => {
+  // remoteUrlActive = forceRemote || !isLoopbackHost(host). A REMOTE ComfyUI
+  // reached over a tunnel or port-forward has a LOOPBACK host, so it classifies
+  // as local, this refusal fires, and it correctly reports that it cannot find a
+  // local process to account for — because there is none. The refusal was right
+  // about what it observed and useless about what to do: the reader goes looking
+  // for a local install that does not exist.
+  const refusal = () => {
+    const src = readFileSync(
+      new URL("../../orchestrator/panel-tools.ts", import.meta.url),
+      "utf8",
+    );
+    const i = src.indexOf("Refusing to restart ComfyUI: I could not confirm");
+    expect(i).toBeGreaterThan(-1);
+    return src.slice(i, i + 3000);
+  };
+
+  it("names the classification as HOST-based, not instance-based", () => {
+    const t = refusal();
+    expect(t).toMatch(/reached through a tunnel/);
+    expect(t).toMatch(/proves the route is local, not the instance/);
+  });
+
+  it("names the exact setting that re-classifies it", () => {
+    // A lever that does not exist is worse than no lever (#809's defect in a
+    // description). Both spellings are real: resolveForceRemote() reads
+    // COMFYUI_MCP_FORCE_REMOTE and argv --force-remote.
+    const t = refusal();
+    expect(t).toMatch(/COMFYUI_MCP_FORCE_REMOTE=1/);
+    expect(t).toMatch(/--force-remote/);
+  });
+
+  it("says what the remote path then does, so it is not a blind flag", () => {
+    expect(refusal()).toMatch(/restarts through ComfyUI-Manager/);
+  });
+
+  it("keeps the original alternative — this is additive", () => {
+    // restart_comfyui remains the answer for a genuinely local install that
+    // simply could not be identified; the tunnel note must not displace it.
+    const t = refusal();
+    expect(t).toMatch(/USE restart_comfyui/);
   });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -9261,7 +9261,23 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               "INSTEAD: unlike this panel-scoped restart, it is not tied to a browser tab " +
               "— it acts on the ComfyUI this server is configured for, which it CAN " +
               "identify and check before stopping. Or restart ComfyUI from whatever " +
-              "launches it (its own launcher, the Desktop app, or your terminal).",
+              "launches it (its own launcher, the Desktop app, or your terminal)." +
+              // artokun/comfyui-mcp-panel#769 — a REMOTE ComfyUI reached over a
+              // tunnel or port-forward has a LOOPBACK host, and remoteUrlActive is
+              // derived from exactly that (`forceRemote || !isLoopbackHost(host)`).
+              // So a cloud pod fronted at 127.0.0.1:<port> classifies as LOCAL, this
+              // branch runs, and it correctly reports it cannot find a local process
+              // to account for — because there isn't one. The refusal is right about
+              // what it observed and useless about what to do, since the reader is
+              // looking for a local install that does not exist. Name the one setting
+              // that re-classifies it; it is a config fix, not a workaround.
+              " NOTE: if this ComfyUI is actually REMOTE but reached through a tunnel " +
+              "or port-forward (a 127.0.0.1 address that is not this machine), it is " +
+              "being classified as local because that classification reads the HOST — " +
+              "which proves the route is local, not the instance. Set " +
+              "COMFYUI_MCP_FORCE_REMOTE=1 (or pass --force-remote) and this tool takes " +
+              "the remote path, which restarts through ComfyUI-Manager and does not " +
+              "need a local process to account for.",
           });
         }
         if (preflightBound) {


### PR DESCRIPTION
For artokun/comfyui-mcp-panel#769 — the **guidance half**. Whether the classifier should
stop deciding local-vs-remote from the host string is a separate change with #814 in its
history (a user's server was stopped and never came back), and is not touched here.

## The mechanism

```ts
remoteUrlActive = forceRemote || !isLoopbackHost(t.host)
```

A genuinely **remote** ComfyUI reached over a tunnel or port-forward has a **loopback**
host, so it classifies as local, this refusal fires, and it correctly reports that it
cannot find a local process to account for — because there is none.

The refusal was right about what it **observed** and useless about what to **do**: the
reader goes hunting for a local install that does not exist. The reporter reached
`restart_comfyui` (which works — it drives the Manager reboot against the configured URL
and reaches the box through the same tunnel) and filed asking why the panel-scoped one
could not.

## What it says now

That the classification reads the **host**, which proves the *route* is local rather than
the *instance* — and the one setting that re-classifies it.

`COMFYUI_MCP_FORCE_REMOTE=1` and `--force-remote` are **both real**; `resolveForceRemote()`
reads exactly those. I checked both spellings against `config.ts` before naming them —
citing a lever that does not exist is #809's defect, and I shipped one of those earlier
tonight (an invented `panel_rename_subgraph_slot`), so it is now a step I do not skip.

It also says what the remote path then *does* (restarts through ComfyUI-Manager), so it is
not a blind flag, and it is strictly **additive**: `restart_comfyui` remains the answer for
a genuinely local install that merely could not be identified. There is a test for that.

## Tests

7344 pass; typecheck and `check:vocabulary` green.

| mutation | result |
|---|---|
| drop the tunnel note | fails |
| name a non-existent env var | fails |
| drop the route-vs-instance distinction | fails |
