### PR TITLE
fix(manager): a 403 already says WHY — stop dropping it

### DIFF
--- a/src/__tests__/services/manager-403-reason.test.ts
+++ b/src/__tests__/services/manager-403-reason.test.ts
@@ -1,6 +1,6 @@
 // #1089 — a Manager 403 already says WHY; we were dropping it.
 //
-// Reported against a remote ComfyUI 0.30.1: install_comfyui(action:'update_all')
+// Reported against a remote ComfyUI 0.30.1: install_comfyui (action:"update_all")
 // got 403 and the tool returned a bare NODE_MANAGEMENT_ERROR, so the reporter had
 // to ask which permission was even involved.
 

--- a/src/__tests__/services/manager-403-reason.test.ts
+++ b/src/__tests__/services/manager-403-reason.test.ts
@@ -1,0 +1,73 @@
+// #1089 — a Manager 403 already says WHY; we were dropping it.
+//
+// Reported against a remote ComfyUI 0.30.1: install_comfyui(action:'update_all')
+// got 403 and the tool returned a bare NODE_MANAGEMENT_ERROR, so the reporter had
+// to ask which permission was even involved.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { explainManagerForbidden } from "../../services/node-management.js";
+
+const j = (o: unknown) => JSON.stringify(o);
+
+describe("#1089 Manager 403 names its own reason", () => {
+  it("security_level: names the setting, its allowed values, and the tradeoff", () => {
+    const t = explainManagerForbidden(403, j({ error: "security_level" }));
+    expect(t).toMatch(/security level/i);
+    expect(t).toMatch(/weak, normal or normal-/);
+    expect(t).toMatch(/restart ComfyUI/);
+    // It is a real decision about exposure, not a step to rubber-stamp.
+    expect(t).toMatch(/deliberate choice/);
+    expect(t).toMatch(/shell on the machine itself/);
+    // And it corrects the two things a reader would otherwise assume.
+    expect(t).toMatch(/not on credentials/);
+    expect(t).toMatch(/not\s+because the server is remote/);
+  });
+
+  it("comfyui_outdated: sends the reader to the right fix, not to settings", () => {
+    const t = explainManagerForbidden(403, j({ error: "comfyui_outdated" }));
+    expect(t).toMatch(/too OLD/);
+    expect(t).toMatch(/Update ComfyUI itself/);
+    expect(t).toMatch(/changing Manager settings will not clear this/);
+    expect(t).not.toMatch(/weak, normal or normal-/);
+  });
+
+  it("an unrecognised flag token is REPORTED, never explained away", () => {
+    // Manager names a specific install flag. Inventing a remedy for a flag we do
+    // not know would be the same defect as a userdata 400 blaming the filename.
+    const t = explainManagerForbidden(403, j({ error: "some_install_flag" }));
+    expect(t).toMatch(/"some_install_flag"/);
+    expect(t).toMatch(/consult\s+ComfyUI-Manager/);
+    expect(t).not.toMatch(/security_level to be weak/);
+  });
+
+  it("says NOTHING for a non-403", () => {
+    for (const s of [200, 401, 404, 409, 500]) {
+      expect(explainManagerForbidden(s, j({ error: "security_level" }))).toBe("");
+    }
+  });
+
+  it("says NOTHING when the body is not Manager's JSON", () => {
+    // An unparseable body means something else answered — a proxy, an auth gate.
+    // Attributing a Manager reason to it would be a fabricated diagnosis.
+    for (const b of ["", "Forbidden", "<html>nginx</html>", "{oops"]) {
+      expect(explainManagerForbidden(403, b)).toBe("");
+    }
+    // Valid JSON with no usable error field is the same case.
+    expect(explainManagerForbidden(403, j({}))).toBe("");
+    expect(explainManagerForbidden(403, j({ error: "   " }))).toBe("");
+    expect(explainManagerForbidden(403, j({ error: 7 }))).toBe("");
+  });
+  it("WIRING: managerFetch appends it to the thrown message", () => {
+    // The helper being right proves nothing if the throw site does not call it.
+    // A mutation that removed exactly this call SURVIVED the helper-only tests.
+    const src = readFileSync(new URL("../../services/node-management.ts", import.meta.url), "utf8");
+    const i = src.indexOf("ComfyUI-Manager API ${res.status} ${res.statusText} for ${path}");
+    expect(i).toBeGreaterThan(-1);
+    const window = src.slice(i, i + 240);
+    expect(window).toMatch(/explainManagerForbidden\(res\.status, text\)/);
+    // …and the raw body is still carried in details, so nothing is LOST by
+    // summarising it in the message.
+    expect(window).toMatch(/body: text/);
+  });
+});

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -188,7 +188,7 @@ interface ManagerFetchOptions {
  * "ComfyUI-Manager API 403 Forbidden for /v2/manager/queue/update_all". The
  * reporter had to ask which permission was even involved.
  *
- * update_all specifically needs is_allowed_security_level("middle"), which passes
+ * install_comfyui (action:"update_all") specifically needs is_allowed_security_level("middle"), which passes
  * only for security_level in weak / normal / normal-. That is a Manager SETTING,
  * not a credential and not a consequence of being remote.
  *
@@ -213,7 +213,8 @@ export function explainManagerForbidden(status: number, body: string): string {
   if (reason === "security_level") {
     return (
       " — ComfyUI-Manager REFUSED this on its own security level, not on credentials and not" +
-      " because the server is remote. Privileged routes (update_all, install, snapshot removal)" +
+      " because the server is remote. Privileged Manager routes (its update-all, install and" +
+      " snapshot-removal endpoints)" +
       " require Manager config security_level to be weak, normal or normal-; anything stricter" +
       " refuses. Change it in ComfyUI-Manager settings (or its config.ini) and restart ComfyUI." +
       " Loosening it decides who may reach that server, so it is a deliberate choice: the" +

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -171,6 +171,72 @@ interface ManagerFetchOptions {
   soft?: boolean;
 }
 
+/**
+ * #1089 — a Manager 403 already SAYS why; we were dropping it.
+ *
+ * ComfyUI-Manager gates privileged routes behind its own security level and
+ * answers with a machine-readable body (glob/manager_server.py):
+ *
+ *     def security_403_response(flag_token=None):
+ *         if not manager_migration.has_system_user_api():
+ *             return web.json_response({"error": "comfyui_outdated"}, status=403)
+ *         if flag_token is not None:
+ *             return web.json_response({"error": flag_token}, status=403)
+ *         return web.json_response({"error": "security_level"}, status=403)
+ *
+ * Three causes, three different remedies — and the caller saw only
+ * "ComfyUI-Manager API 403 Forbidden for /v2/manager/queue/update_all". The
+ * reporter had to ask which permission was even involved.
+ *
+ * update_all specifically needs is_allowed_security_level("middle"), which passes
+ * only for security_level in weak / normal / normal-. That is a Manager SETTING,
+ * not a credential and not a consequence of being remote.
+ *
+ * NAMES NO REMEDY IT CANNOT SUPPORT. An unrecognised token is reported as the
+ * flag Manager named, with no invented advice — a specific install flag denied it
+ * and only that flag can say more. Guessing here would be the same defect as the
+ * status blaming the filename in a userdata 400.
+ */
+export function explainManagerForbidden(status: number, body: string): string {
+  if (status !== 403) return "";
+  let reason: string | null = null;
+  try {
+    const parsed: unknown = JSON.parse(body);
+    const e = (parsed as { error?: unknown } | null)?.error;
+    if (typeof e === "string" && e.trim()) reason = e.trim();
+  } catch {
+    // Not JSON — Manager always sends JSON here, so an unparseable body means
+    // something else answered (a proxy, an auth gate). Say nothing rather than
+    // attribute a Manager reason to a response Manager may not have sent.
+    return "";
+  }
+  if (reason === "security_level") {
+    return (
+      " — ComfyUI-Manager REFUSED this on its own security level, not on credentials and not" +
+      " because the server is remote. Privileged routes (update_all, install, snapshot removal)" +
+      " require Manager config security_level to be weak, normal or normal-; anything stricter" +
+      " refuses. Change it in ComfyUI-Manager settings (or its config.ini) and restart ComfyUI." +
+      " Loosening it decides who may reach that server, so it is a deliberate choice: the" +
+      " alternative is to run the update from a shell on the machine itself."
+    );
+  }
+  if (reason === "comfyui_outdated") {
+    return (
+      " — ComfyUI-Manager reports this ComfyUI as too OLD for the route: it predates the" +
+      " system-user API that Manager checks first, before it ever consults security_level." +
+      " Update ComfyUI itself; changing Manager settings will not clear this."
+    );
+  }
+  if (reason) {
+    return (
+      ` — ComfyUI-Manager denied this via a specific install flag it names as "${reason}".` +
+      " That flag, not the general security level, is what governs this route; consult" +
+      " ComfyUI-Manager for what it controls."
+    );
+  }
+  return "";
+}
+
 async function managerFetch<T>(
   path: string,
   options: ManagerFetchOptions = {},
@@ -202,7 +268,8 @@ async function managerFetch<T>(
     if (soft) return undefined;
     const text = await res.text().catch(() => "");
     throw new NodeManagementError(
-      `ComfyUI-Manager API ${res.status} ${res.statusText} for ${path}`,
+      `ComfyUI-Manager API ${res.status} ${res.statusText} for ${path}` +
+        explainManagerForbidden(res.status, text),
       { url, status: res.status, body: text },
     );
   }


### PR DESCRIPTION
Closes #1089.

ComfyUI-Manager gates privileged routes behind its own security level and answers with a
**machine-readable** body:

```python
def security_403_response(flag_token=None):
    if not manager_migration.has_system_user_api():
        return web.json_response({"error": "comfyui_outdated"}, status=403)
    if flag_token is not None:
        return web.json_response({"error": flag_token}, status=403)
    return web.json_response({"error": "security_level"}, status=403)
```

Three causes, three different remedies. The caller saw only `ComfyUI-Manager API 403
Forbidden for /v2/manager/queue/update_all` and had to ask which permission was even
involved. `managerFetch` was already **capturing** that body into `details` — it just never
reached the message anyone reads.

## What each branch now says

**`security_level`** — `update_all` needs `is_allowed_security_level("middle")`, which
passes only for `weak` / `normal` / `normal-`. It names the setting, the allowed values,
and the restart, and corrects the two things a reader would otherwise assume: this is *not*
about credentials, and *not* a consequence of being remote.

It also says loosening that level is a **deliberate decision about who can reach the
server**, and names the alternative (run the update from a shell on the box). "Reduce your
security setting" should not be presented as a routine step.

**`comfyui_outdated`** — sends the reader to a ComfyUI update and states that changing
Manager settings will *not* clear it. That branch is checked first upstream, so settings
are irrelevant to it.

**An unrecognised flag token** — reported as the flag Manager named, with no invented
advice. And a **non-JSON body says nothing at all**: Manager always sends JSON here, so an
unparseable one means something else answered (a proxy, an auth gate), and attributing a
Manager reason to it would be a fabricated diagnosis.

## The wiring test earned its place

A mutation removing the call from the throw site **survived** the helper-only tests — the
exact "test the wiring, not just the helper" failure. Added, and now five mutations fail:

| mutation | result |
|---|---|
| drop the call from the throw site | fails |
| explain an unknown flag with the `security_level` remedy | fails |
| fabricate a reason for a non-JSON body | fails |
| drop the 403 guard (explain every status) | fails |
| (helper branches) | fail |

7356 tests pass; typecheck and `check:vocabulary` green; both files clean of control bytes.
