### PR TITLE
fix(restart): a REMOTE no-reboot-endpoint failure now names what will work

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
@@ -271,3 +271,71 @@ describe("panel_restart_comfyui — legacy no-endpoint fallback", () => {
     expect(res.content[0].text).toContain("in progress");
   });
 });
+
+// #425 RECURRENCE, reported by the owner against 0.50.27 on a remote RunPod H100:
+// "server-scoped restart_comfyui received HTTP 405 from the Manager reboot routes.
+// The newly installed lee-rife nodes remained unavailable until a provider/host
+// restart."
+//
+// The v0.48.20 fallback is LOCAL-ONLY and correctly does nothing on a remote
+// target — there is no process on this machine to cycle. But the fall-through
+// returned the bare "no reboot endpoint … was NOT restarted", so nothing told
+// them a HOST restart was the actual requirement, or that the nodes they had just
+// installed were not loaded. That silence is what closed my earlier triage of this
+// issue too early.
+describe("#425 remote: the refusal must name what will actually work", () => {
+  beforeEach(() => {
+    hoisted.remoteMode.value = true;
+  });
+
+  it("says the managed local restart does not apply, and why", async () => {
+    const { ctx } = makeCtx(NO_ENDPOINT_REPLY);
+    const text = ((await restartTool().handler({}, ctx)) as ToolResult).content[0].text;
+
+    expect(text).toContain("was NOT restarted"); // the original refusal survives
+    expect(text).toMatch(/REMOTE/);
+    expect(text).toMatch(/no process on this machine to cycle/i);
+  });
+
+  it("explains the 405 as a missing route, not an auth failure", async () => {
+    // The frontend catchall answers every unregistered POST with 405, so a 405 from
+    // a Manager route means the dialect has no reboot API — chasing credentials is
+    // the wrong direction.
+    const { ctx } = makeCtx(NO_ENDPOINT_REPLY);
+    const text = ((await restartTool().handler({}, ctx)) as ToolResult).content[0].text;
+
+    expect(text).toMatch(/not registered on the running Manager/i);
+    expect(text).toMatch(/rather than an auth failure/i);
+  });
+
+  it("names the host restart, including the RunPod cycle, and warns about billing", async () => {
+    const { ctx } = makeCtx(NO_ENDPOINT_REPLY);
+    const text = ((await restartTool().handler({}, ctx)) as ToolResult).content[0].text;
+
+    expect(text).toMatch(/restart the HOST/i);
+    // The note travels inside a JSON envelope, so its quotes arrive ESCAPED —
+    // a regex written around bare quotes never matches (it did not, first try).
+    expect(text).toMatch(/runpod \(action:\\?"stop\\?"\)/);
+    expect(text).toMatch(/runpod \(action:\\?"start\\?"\)/);
+    expect(text).toMatch(/billing/i);
+  });
+
+  it("tells the caller not to report the new nodes as ready", async () => {
+    // The reporter's actual loss: they believed the install had taken effect.
+    const { ctx } = makeCtx(NO_ENDPOINT_REPLY);
+    const text = ((await restartTool().handler({}, ctx)) as ToolResult).content[0].text;
+
+    expect(text).toMatch(/stays unavailable until the ComfyUI process itself restarts/i);
+    expect(text).toMatch(/Do NOT report the newly installed nodes as ready/);
+  });
+
+  it("still does NOT cycle the pod itself", async () => {
+    // stop/resume bills, interrupts everything else on the box, and on a spot
+    // instance may not come back. That is the user's call, not a side effect of
+    // asking to restart ComfyUI.
+    const { ctx } = makeCtx(NO_ENDPOINT_REPLY);
+    await restartTool().handler({}, ctx);
+
+    expect(hoisted.restart).not.toHaveBeenCalled();
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -9516,6 +9516,39 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // 3.x — #425, panel #253/#266) AND the target is a LOCAL, process-controllable
           // ComfyUI, fall back to the headless managed restart (kill + relaunch). A
           // busy-guard / security refusal is NOT eligible (rebootNoEndpoint excludes them).
+          // #425 RECURRENCE (remote RunPod, 0.50.27). The managed fallback below is
+          // LOCAL-ONLY and correctly does nothing here — there is no process on this
+          // machine to restart. But falling through returned the bare "no reboot
+          // endpoint … was NOT restarted", which is where the owner's report ended:
+          // freshly installed custom nodes stayed unavailable "until a provider/host
+          // restart", and nothing had told them a host restart was the requirement.
+          //
+          // Say what this target actually needs. We do NOT cycle the pod ourselves:
+          // stop/resume bills, interrupts everything else on the box, and on a spot
+          // instance may not come back — that is the user's call, not a side effect
+          // of asking to restart ComfyUI.
+          if (isRemoteMode() && rebootNoEndpoint(res)) {
+            return ok({
+              rebooting: false,
+              ready: false,
+              confirmed_cycle: false,
+              note:
+                `${toolResultText(res)}\n\n` +
+                `This ComfyUI is REMOTE, so the managed restart that covers a local install ` +
+                `does not apply — there is no process on this machine to cycle. A 405 from a ` +
+                `Manager reboot route means that route is not registered on the running ` +
+                `Manager (the frontend catchall answers every unregistered POST with 405), so ` +
+                `it is a Manager version/dialect that exposes no reboot API rather than an ` +
+                `auth failure.\n\n` +
+                `WHAT WILL WORK: restart the HOST. Anything you just installed — custom nodes ` +
+                `especially — stays unavailable until the ComfyUI process itself restarts, and ` +
+                `nothing this MCP can reach will load it. On RunPod, runpod (action:"stop") ` +
+                `then runpod (action:"start") with the pod_id cycles the box (stop ends ` +
+                `billing; start bills again). Otherwise restart the container or provider ` +
+                `however you normally would.\n\n` +
+                `Do NOT report the newly installed nodes as ready: they are not loaded.`,
+            });
+          }
           if (
             !isRemoteMode() &&
             rebootNoEndpoint(res) &&


### PR DESCRIPTION
Addresses the #425 **recurrence** you reported on 0.50.27 (remote RunPod H100): server-scoped restart got HTTP 405 from the Manager reboot routes, and *"the newly installed lee-rife nodes remained unavailable until a provider/host restart."*

## What was wrong

The v0.48.20 managed fallback is **local-only**, and correctly does nothing on a remote target — there's no process on this machine to cycle. But the fall-through returned the bare *"no reboot endpoint … was NOT restarted"*, so nothing told you that a **host** restart was the requirement, or that the nodes you'd just installed weren't loaded. You worked that out by inference.

That silence is also what made my earlier triage close this issue too early: I verified the local path, found it shipped in v0.48.20, and treated the issue as resolved — when the remote half had no recovery *and* no guidance.

## What it says now

- this target is **remote**, so the managed local restart doesn't apply, and why;
- a **405** from a Manager reboot route means the route is *not registered* on the running Manager — ComfyUI's frontend catchall answers every unregistered POST with 405 — so it's a dialect without a reboot API, **not** an auth failure. Chasing credentials is the wrong direction;
- **restart the host**, naming the RunPod cycle explicitly (`runpod action:"stop"` then `action:"start"` with the pod_id) and that stop ends billing / start bills again;
- **do not report the newly installed nodes as ready** — they aren't loaded until that happens.

## What it deliberately doesn't do

Cycle the pod itself. `stop`/`resume` bills, interrupts everything else on the box, and on a spot instance may not come back. That's your call, not a side effect of asking to restart ComfyUI.

## Verification

| Check | Result |
|---|---|
| **mutation** — remove the remote branch | 4 of the new tests fail |
| new tests | 5 |
| existing tests | 15, still passing — the remote case still refuses and still never calls the managed restart; it just carries guidance now |
| full suite | green — 360 files, 7351 passed |

One test needed the JSON-envelope escaping: the note travels inside a JSON payload, so `action:"stop"` arrives with escaped quotes and a regex around bare ones never matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)