### PR TITLE
0.50.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.30] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- a REMOTE no-reboot-endpoint failure now names what will work (#425) (#1100)
+- name the tunnelled-remote case in the panel-restart refusal (#1098)
+
+
 ## [0.50.29] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.29",
+  "version": "0.50.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.29",
+      "version": "0.50.30",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.29",
+  "version": "0.50.30",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.30**. Tag pushed; `release.yml` publishes from it; this PR reconciles protected `main`.

## #1100 — a remote no-reboot-endpoint failure now names the host restart it needs

Addresses the #425 **recurrence** on a remote RunPod H100: server-scoped restart got HTTP 405 from the Manager reboot routes and newly installed custom nodes stayed unavailable until a provider/host restart — with nothing saying that was the requirement.

The v0.48.20 managed fallback is local-only and correctly does nothing remotely, but the fall-through was a bare "was NOT restarted". It now explains that the target is remote, that a 405 means the reboot route isn't registered on the running Manager (not an auth failure), names the RunPod stop/start cycle with its billing implication, and warns not to report the newly installed nodes as ready.

It deliberately does **not** cycle the pod itself — that bills, interrupts everything else on the box, and on a spot instance may not come back.

This also corrects my own earlier triage: I closed #425 on the strength of the local fix and missed that the remote half had neither recovery nor guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)