### PR TITLE
fix(workflow-input): refuse API/prompt format instead of crashing or lying

### DIFF
--- a/src/__tests__/orchestrator/workflow-input-ui-guard.test.ts
+++ b/src/__tests__/orchestrator/workflow-input-ui-guard.test.ts
@@ -1,0 +1,83 @@
+// panel#775 — a pack shipping API/prompt format reached three tools unvalidated.
+//
+// packs/ltx23-distill-3stage/workflow.json is API format (numeric keys →
+// {class_type, inputs}, no nodes[]). panel_load_workflow refused it correctly;
+// panel_strip_workflow crashed on ".map of undefined"; panel_flatten_workflow
+// (apply:true) reported SUCCESS and loaded a 0-node graph.
+
+import { describe, expect, it, vi } from "vitest";
+import { buildPanelToolDefs } from "../../orchestrator/panel-tools.js";
+import type { PanelToolCtx } from "../../orchestrator/panel-tools.js";
+
+/** The real LTX pack shape, reduced: API/prompt format. */
+const API_GRAPH = {
+  "1": { class_type: "KSamplerSelect", inputs: { sampler_name: "euler" }, _meta: { title: "K" } },
+  "2": { class_type: "ManualSigmas", inputs: { sigmas: "0.8, 0.0" }, _meta: { title: "S" } },
+};
+const UI_GRAPH = { nodes: [{ id: 1, type: "KSamplerSelect" }], links: [] };
+
+function ctx(): PanelToolCtx {
+  return {
+    call: vi.fn(async () => ({ content: [{ type: "text", text: "{}" }] })),
+    confirm: vi.fn(async () => "yes" as const),
+    bridge: { send: vi.fn(async () => ({})) } as unknown as PanelToolCtx["bridge"],
+    tabId: "t",
+  } as unknown as PanelToolCtx;
+}
+const def = (n: string) => {
+  const d = buildPanelToolDefs().find((x) => x.name === n);
+  if (!d) throw new Error(`${n} not registered`);
+  return d;
+};
+
+describe("#775 caller-supplied API-format input is refused, not crashed or silently applied", () => {
+  for (const tool of ["panel_flatten_workflow", "panel_strip_workflow", "panel_slice_workflow"]) {
+    it(`${tool} refuses an API/prompt graph with an actionable message`, async () => {
+      await expect(def(tool).handler({ graph: API_GRAPH }, ctx())).rejects.toThrow(
+        /not a UI workflow \(missing a top-level `nodes` array\)/,
+      );
+    });
+
+    it(`${tool} names the SOURCE so the caller knows which input was wrong`, async () => {
+      await expect(def(tool).handler({ graph: API_GRAPH }, ctx())).rejects.toThrow(
+        /The supplied `graph`/,
+      );
+    });
+  }
+
+  it("a UI graph still gets through — the guard is a shape check, not a gate", async () => {
+    // Guarding must not turn a working call into a refusal; only the wrong SHAPE
+    // is rejected. (The handler may fail later for unrelated reasons; what matters
+    // is that it is NOT the format refusal.)
+    for (const tool of ["panel_flatten_workflow", "panel_strip_workflow"]) {
+      let msg = "";
+      try {
+        await def(tool).handler({ graph: UI_GRAPH }, ctx());
+      } catch (e) {
+        msg = e instanceof Error ? e.message : String(e);
+      }
+      expect(msg).not.toMatch(/not a UI workflow/);
+    }
+  });
+
+  it("a JSON STRING carrying API format is refused too", async () => {
+    // resolveWorkflowInput parses strings; the guard must sit after the parse,
+    // not before it, or the string form would slip past.
+    await expect(
+      def("panel_flatten_workflow").handler({ graph: JSON.stringify(API_GRAPH) }, ctx()),
+    ).rejects.toThrow(/not a UI workflow/);
+  });
+
+  it("a pack source is named as the pack, not as `graph`", async () => {
+    // The reporter's case came from a PACK; the message has to point at the pack
+    // so the fix (ship UI format) is obvious from the error alone.
+    let msg = "";
+    try {
+      await def("panel_flatten_workflow").handler({ pack: "ltx23-distill-3stage" }, ctx());
+    } catch (e) {
+      msg = e instanceof Error ? e.message : String(e);
+    }
+    // Either the pack is missing locally or it is API format — both name the pack.
+    expect(msg).toMatch(/ltx23-distill-3stage/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5219,12 +5219,38 @@ async function resolveWorkflowInput(
   // unverified widget mapping is never presented as a verified one.
   notes?: string[],
 ): Promise<Record<string, unknown>> {
-  if (args.pack) return readPackWorkflow(args.pack as string);
-  if (args.path) return await readWorkflowFromPath(args.path as string);
+  // panel#775 — every caller here (strip / flatten / slice) needs a UI
+  // /litegraph graph, and NONE of them validated the shape. A pack or file
+  // holding API/prompt format therefore reached them raw:
+  //   • panel_strip_workflow CRASHED on ".map of undefined" (no `nodes`);
+  //   • panel_flatten_workflow(apply:true) reported SUCCESS and loaded a
+  //     0-node graph — a false success on a canvas-replacing operation;
+  //   • panel_slice_workflow shares the path and had the same latent bug.
+  // panel_load_workflow already refused this correctly via assertUiWorkflow;
+  // routing the other three through the SAME check makes all four agree
+  // instead of one refusing, one crashing and one lying.
+  //
+  // The LIVE-CANVAS path below is deliberately NOT validated here: it is
+  // built by graph_serialize/graph_get_state and already carries its own
+  // shape handling plus the #384 lossy-fallback notes. Only CALLER-SUPPLIED
+  // sources — which are the ones that can be the wrong format — are checked.
+  if (args.pack) {
+    return assertUiWorkflow(
+      readPackWorkflow(args.pack as string),
+      `Pack "${String(args.pack)}" workflow.json`,
+    );
+  }
+  if (args.path) {
+    return assertUiWorkflow(
+      await readWorkflowFromPath(args.path as string),
+      `Workflow file "${String(args.path)}"`,
+    );
+  }
   if (args.graph != null) {
-    return (typeof args.graph === "string"
-      ? JSON.parse(args.graph as string)
-      : args.graph) as Record<string, unknown>;
+    return assertUiWorkflow(
+      typeof args.graph === "string" ? JSON.parse(args.graph as string) : args.graph,
+      "The supplied `graph`",
+    );
   }
   let reply: unknown;
   try {


### PR DESCRIPTION
For artokun/comfyui-mcp-panel#775 (1)(2)(3) — **one root cause, three different behaviours.**

`packs/ltx23-distill-3stage/workflow.json` is in **API/prompt format** (59 numeric keys,
each `{class_type, inputs}`, no `nodes[]`) despite the pack advertising UI format.
`resolveWorkflowInput` returned it raw, and its three callers each did something different:

| tool | behaviour |
|---|---|
| `panel_load_workflow` | **refused correctly** — it has `assertUiWorkflow` |
| `panel_strip_workflow` | **crashed** — `.map` on the missing `nodes` |
| `panel_flatten_workflow` | **reported success and loaded a 0-node graph**, on a canvas-replacing `apply:true` |

The third is the serious one, and it is the usual defect class: reporting the request
rather than the observed effect — here on an operation that replaces the user's canvas.

`panel_slice_workflow` shares the same resolver and had the identical latent bug. The
reporter never exercised it; it is fixed here rather than left to be re-reported.

## The fix

All three now route through the **same** `assertUiWorkflow` that `panel_load_workflow`
already used, so four tools agree instead of one refusing, one crashing and one lying.

Each source is **labelled** — the pack by name, the path by name, an inline graph as
`graph`. That matters here: the reporter's came from a *pack*, and naming it makes the real
fix (ship UI format) obvious from the error alone.

The **live-canvas** path is deliberately not guarded — it is built by
`graph_serialize`/`graph_get_state` and carries its own shape handling plus the #384
lossy-fallback notes. Only caller-supplied sources, the ones that can be the wrong format,
are checked.

## Not fixed here

The pack should ship UI format. API→UI **cannot be converted faithfully** — positions and
link routing are already discarded — so that is a pack-data change, not a conversion.

## Tests

9 new, **7370** in the suite; typecheck and `check:vocabulary` green (both exit codes
checked, after a `tail -1` hid a gate failure earlier tonight).

| mutation | result |
|---|---|
| remove the guard from the inline-graph path | 4 tests fail |
| remove the guard from the pack path | fails |
