### PR TITLE
0.50.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.31] - 2026-08-07
+
+### MCP
+
+#### Fixed
+- a 403 already says WHY — stop dropping it (#1099)
+
+
 ## [0.50.30] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.30",
+  "version": "0.50.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.30",
+      "version": "0.50.31",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.30",
+  "version": "0.50.31",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.31**. Tag pushed; `release.yml` publishes from it; this PR reconciles protected `main`.

## #1099 — a Manager 403 now says which of its gates refused

Ships the fix for #1089 (remote `update_all` → bare 403 → `NODE_MANAGEMENT_ERROR`, and a reporter asking what permission they were missing — the answer being none).

`explainManagerForbidden()` reads ComfyUI-Manager's machine-readable 403 body and distinguishes the three real causes rather than guessing:

- **`security_level`** — Manager's own gate, naming the levels that permit the route and that loosening it is a deliberate exposure decision;
- **`comfyui_outdated`** — ComfyUI predates the system-user API Manager checks *before* it ever consults `security_level`; changing Manager settings will not clear it;
- **a named install flag** — that flag, not the general security level, governs the route.

It also stays silent when the body isn't Manager's JSON, rather than attributing a Manager reason to whatever else answered.

## Note

I independently started the same fix this session and closed it (#1102) in favour of this one, which is better: mine inferred the cause from the request path, which would have given actively wrong advice for `comfyui_outdated` — telling the user to lower a setting that does not affect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)