### PR TITLE
fix(fence): an AMBIGUOUS turn is not a dead tab, and not a missing Origin

### DIFF
--- a/src/__tests__/orchestrator/fence-refusal-reason.test.ts
+++ b/src/__tests__/orchestrator/fence-refusal-reason.test.ts
@@ -18,6 +18,7 @@
 
 import { describe, expect, it } from "vitest";
 import { UiBridge } from "../../services/ui-bridge.js";
+import { unreachableReason, identityReason } from "../../orchestrator/fence-refusal.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 import {
   buildPanelToolDefs,
@@ -185,5 +186,68 @@ describe("the refusal message names the gate and matches the remedy to it", () =
 
     expect(text).toMatch(/this bridge could not say which/);
     expect(text).toMatch(/Ask the user to manually refresh/);
+  });
+});
+
+// #1077 follow-up — a defect in the diagnostic added for #1077 itself.
+//
+// `canReach()` and `tabServerOrigin()` BOTH swallow whatever resolveTarget
+// throws, so a turn issued from several workflows at once (routing ambiguity,
+// #1001) reaches the validator looking identical to (a) a dead tab and (b) a
+// connection carrying no server-observed Origin.
+//
+// (b) is the damaging one: its remedy says the failure is STRUCTURAL, that
+// refreshing cannot help, and that the relay backend is the known cause. For an
+// ambiguous turn all three are wrong — the tabs are connected, the Origin
+// exists, and it clears on the next single-origin message.
+//
+// These drive the REAL reason builders. An earlier version of this block built a
+// fake bridge and asserted it returned what the fake was told to return, which
+// would have passed with the logic deleted.
+describe("the refusal reasons distinguish an AMBIGUOUS turn", () => {
+  const TAB = "orchestrator::claude";
+  const UUID = "621187be-2fa9-49cd-b6af-7402895c89b9";
+
+  it("gate 1: names the ambiguity instead of claiming the tab is gone", () => {
+    const r = unreachableReason(TAB, "ambiguous");
+
+    expect(r).toMatch(/SEVERAL workflows at once/);
+    expect(r).toMatch(/tabs are connected and fine/);
+    expect(r).toMatch(/Do NOT reconnect or refresh/);
+    expect(r).not.toMatch(/no longer reachable/);
+  });
+
+  it("gate 1: still reports a genuinely dead tab as unreachable", () => {
+    const r = unreachableReason(TAB, "unresolved");
+
+    expect(r).toMatch(/no longer reachable/);
+    expect(r).not.toMatch(/SEVERAL workflows/);
+  });
+
+  // THE ONE THAT MATTERS. Ambiguity also yields no origin, so order decides
+  // whether it inherits the relay story.
+  it("gate 3: an ambiguous turn does NOT borrow the structural relay remedy", () => {
+    const r = identityReason(TAB, undefined, UUID, "ambiguous");
+
+    expect(r).toMatch(/SEVERAL workflows at once/);
+    expect(r).not.toMatch(/structural/);
+    expect(r).not.toMatch(/relay/i);
+    expect(r).not.toMatch(/refreshing the tab will not change it/);
+  });
+
+  it("gate 3: a genuine no-Origin connection KEEPS the structural remedy", () => {
+    const r = identityReason(TAB, undefined, UUID, undefined);
+
+    expect(r).toMatch(/no server-observed Origin/);
+    expect(r).toMatch(/structural, not transient/);
+    expect(r).toMatch(/COMFYUI_MCP_TUNNEL_BACKEND=relay/);
+  });
+
+  it("gate 3: an origin that IS present reports a validation failure, not absence", () => {
+    const r = identityReason(TAB, "https://x.trycloudflare.com", "not-a-uuid", undefined);
+
+    expect(r).toMatch(/did not validate/);
+    expect(r).toMatch(/not-a-uuid/);
+    expect(r).not.toMatch(/no server-observed Origin/);
   });
 });

--- a/src/orchestrator/fence-refusal.ts
+++ b/src/orchestrator/fence-refusal.ts
@@ -1,0 +1,76 @@
+// WHY the fence-adoption validator refused, in words the caller can act on.
+//
+// Extracted from the validator callback in index.ts so it is reachable by tests:
+// while it lived inline, the only way to assert the wording was to build a fake
+// bridge and check that it returned what the fake was told to return — a
+// tautology that would have passed with the logic deleted.
+//
+// #1077 — the validator has three gates and all of them used to return a bare
+// `false`, so a permanently-wedged session was told only "the adoption was
+// REFUSED". Naming the gate is the fix; naming it WRONGLY is worse than not
+// naming it, which is what the first version of this did.
+//
+// `canReach()` and `tabServerOrigin()` both swallow whatever `resolveTarget`
+// throws, so a turn issued from SEVERAL workflows at once (routing ambiguity,
+// #1001) is indistinguishable at those call sites from a dead tab and from a
+// connection carrying no Origin. It therefore inherited the structural
+// no-Origin story: "refreshing will not help, stop using the relay backend".
+// For an ambiguous turn that is wrong on every count — the tabs are connected,
+// the Origin exists, nothing is structural, and it clears on the next
+// single-origin message. The cause is typed and was simply being discarded.
+
+/** What `UiBridge.resolveFailure()` reports: why a tab id does not resolve, or
+ *  undefined when it does. */
+export type ResolveFailure = "ambiguous" | "unresolved" | undefined;
+
+/** The turn's target is ambiguous — say so, and say it is self-clearing. */
+function ambiguousTurn(tabId: string, what: string): string {
+  return (
+    `this turn was issued from SEVERAL workflows at once, so ${what} for "${tabId}" — the tabs ` +
+    `are connected and fine. This clears itself: target a workflow explicitly ` +
+    `(panel_set_workflow_target with a path, or panel_open_workflow), or let the next ` +
+    `single-origin message settle it. Do NOT reconnect or refresh.`
+  );
+}
+
+/** Gate 1: the routed tab did not resolve at all. */
+export function unreachableReason(tabId: string, failure: ResolveFailure): string {
+  if (failure === "ambiguous") return ambiguousTurn(tabId, "there is no single target to fence");
+  return `the routed tab (${tabId}) is no longer reachable, so there is nothing to fence`;
+}
+
+/** Gate 2: it resolved, but not to a live panel tab. */
+export function noPanelTabReason(tabId: string): string {
+  return `${tabId} does not resolve to a live panel tab (a scope address whose tab has gone away)`;
+}
+
+/**
+ * Gate 3: the workflow identity did not validate.
+ *
+ * ORDER MATTERS. An ambiguous turn also yields no origin, so it must be checked
+ * BEFORE the structural no-Origin case, or it borrows a remedy that cannot help
+ * it and is told its problem is permanent.
+ */
+export function identityReason(
+  tabId: string,
+  origin: string | undefined,
+  workflowUuid: unknown,
+  failure: ResolveFailure,
+): string {
+  if (!origin && failure === "ambiguous") {
+    return ambiguousTurn(tabId, "no single tab's identity could be read");
+  }
+  if (!origin) {
+    return (
+      `this tab's connection carries no server-observed Origin, and the workflow identity is ` +
+      `bound to one — so the fence can never be adopted for it. This is structural, not ` +
+      `transient: refreshing the tab will not change it. Relay-backend connections ` +
+      `(COMFYUI_MCP_TUNNEL_BACKEND=relay) are the known case, because the relay protocol does ` +
+      `not forward the browser's handshake Origin.`
+    );
+  }
+  return (
+    `the workflow identity did not validate (uuid ${String(workflowUuid)} against origin ` +
+    `${origin}) — a malformed uuid, or one bound to a different origin.`
+  );
+}

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -43,6 +43,7 @@ import { isPanelAutoInstallDisabled } from "../services/panel-installer.js";
 import { SelfRestarter, canSelfRestart } from "../services/self-restart.js";
 import { pairUrlDurability } from "./pair-durability.js";
 import { SessionStore, workflowIdentityParts } from "./session-store.js";
+import { unreachableReason, noPanelTabReason, identityReason } from "./fence-refusal.js";
 import {
   SHARED_SESSION_SCOPE,
   isScopeAddress,
@@ -2774,11 +2775,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       // log to fall back on. One of these is structurally unsatisfiable for a
       // relay-backend session, and that is invisible without this.
       try {
+        // #1077 — an AMBIGUOUS turn is not a dead tab. Both fail canReach, and
+        // calling the first the second sent the caller to reconnect a panel that
+        // was never disconnected. The wording lives in fence-refusal.ts so it is
+        // testable without standing up the orchestrator.
         if (!bridge.canReach(tabId))
-          return {
-            ok: false,
-            reason: `the routed tab (${tabId}) is no longer reachable, so there is nothing to fence`,
-          };
+          return { ok: false, reason: unreachableReason(tabId, bridge.resolveFailure?.(tabId)) };
       } catch (err) {
         return {
           ok: false,
@@ -2786,26 +2788,13 @@ export async function runPanelOrchestrator(): Promise<void> {
         };
       }
       const panelTab = scopeToRealTab(tabId);
-      if (!panelTab)
-        return {
-          ok: false,
-          reason: `${tabId} does not resolve to a live panel tab (a scope address whose tab has gone away)`,
-        };
+      if (!panelTab) return { ok: false, reason: noPanelTabReason(tabId) };
       const origin = bridge.tabServerOrigin(tabId);
       const identity = workflowIdentityParts({ workflowUuid, origin });
       if (!identity)
         return {
           ok: false,
-          reason: !origin
-            ? // The relay case, and the one worth naming precisely: this is not
-              // transient and no amount of refreshing fixes it.
-              `this tab's connection carries no server-observed Origin, and the workflow ` +
-              `identity is bound to one — so the fence can never be adopted for it. This is ` +
-              `structural, not transient: refreshing the tab will not change it. Relay-backend ` +
-              `connections (COMFYUI_MCP_TUNNEL_BACKEND=relay) are the known case, because the ` +
-              `relay protocol does not forward the browser's handshake Origin`
-            : `the workflow identity did not validate (uuid ${String(workflowUuid)} against ` +
-              `origin ${origin}) — a malformed uuid, or one bound to a different origin`,
+          reason: identityReason(tabId, origin, workflowUuid, bridge.resolveFailure?.(tabId)),
         };
       tabCommandWorkflowUuid.set(panelTab, identity.uuid);
       // #716/#884 — an explicit, VALIDATED open/re-pin from the shared agent is

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2384,6 +2384,31 @@ export class UiBridge {
     }
   }
 
+  /**
+   * WHY `tabId` does not resolve, or undefined when it does (#1077).
+   *
+   * `canReach()` and `tabServerOrigin()` both swallow the throw, so a turn whose
+   * target is AMBIGUOUS (issued from several workflows at once, #1001) is
+   * indistinguishable from a dead tab or a connection with no Origin. The fence
+   * validator reads exactly those two signals, so an ambiguous turn was reported
+   * as "the routed tab is no longer reachable" — or, worse, as the structural
+   * no-Origin case, whose remedy tells the user that refreshing cannot help and
+   * to stop using the relay backend. Every part of that is wrong here: the tabs
+   * are connected, nothing is structural, and it clears on the next
+   * single-origin message.
+   *
+   * The distinction is available and typed — resolveTarget marks the ambiguity
+   * refusal — it was simply being discarded by the boolean-returning callers.
+   */
+  resolveFailure(tabId: string): "ambiguous" | "unresolved" | undefined {
+    try {
+      this.resolveTarget(tabId);
+      return undefined;
+    } catch (err) {
+      return isRoutingAmbiguity(err) ? "ambiguous" : "unresolved";
+    }
+  }
+
   /** The LIVE tab id `tabId` currently resolves to (exact id, unambiguous
    *  prefix, or the same-socket migration-alias chain — the SAME acceptance
    *  {@link canReach}/resolveTarget use), or undefined when nothing resolves.


### PR DESCRIPTION
A defect in the diagnostic I added for #1077 itself.

`canReach()` and `tabServerOrigin()` **both** swallow whatever `resolveTarget` throws. So a turn issued from several workflows at once — routing ambiguity, #1001 — reaches the fence validator looking identical to:

1. a dead tab, and
2. a connection carrying no server-observed Origin.

**(2) is the damaging one.** Its remedy states the failure is *structural*, that refreshing cannot help, and that the relay backend is the known cause. For an ambiguous turn every one of those is wrong: the tabs are connected, the Origin exists, nothing is structural, and it clears on the next single-origin message.

So the message I added to stop a wedged session chasing the wrong remedy would itself have told an ambiguous turn to disable its tunnel backend.

## The cause was already typed

`resolveTarget` marks the ambiguity refusal (#1001) — the boolean-returning callers were just discarding it. `UiBridge.resolveFailure()` now reports `"ambiguous" | "unresolved" | undefined`, and both gates consult it.

**Order matters in gate 3:** ambiguity *also* yields no origin, so it must be checked **before** the structural case, or it inherits a remedy that cannot help it.

## On the tests

The wording moved to `fence-refusal.ts`. While it lived inline in the validator callback, the only way to assert it was to build a fake bridge and check the fake returned what it was told to — a tautology that would pass with the logic deleted. That is exactly what my first attempt at these tests did, so they were thrown away and rewritten against the real reason builders.

| Mutation | Result |
|---|---|
| drop the ambiguity branch in gate 3 | "does NOT borrow the structural relay remedy" fails |
| drop it in gate 1 | "names the ambiguity" fails |

6 tests, including that a *genuine* no-Origin connection keeps the structural remedy, and that a present-but-invalid origin reports a validation failure rather than absence. Full suite green — 361 files, 7366 passed.

## How it was found

Not from a new report. By re-reading #1077's environment — cloudflared, `COMFYUI_MCP_FORCE_REMOTE=1`, `COMFYUI_MCP_TAB=orchestrator::claude` — and asking what a scope-addressed session would actually hit in those gates. Their Finding 2 is still unconfirmed, but this removes one way the new diagnostic could have pointed them somewhere useless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)