### PR TITLE
feat(annotations): declare destructive/openWorld hints on the money-spending tools

### DIFF
--- a/src/__tests__/tools/install-environment.test.ts
+++ b/src/__tests__/tools/install-environment.test.ts
@@ -110,7 +110,11 @@ interface Registered {
 function registered(): Registered[] {
   const tools: Registered[] = [];
   const server = {
-    tool: (name: string, _desc: string, shape: z.ZodRawShape, handler: Handler) => {
+    // The SDK's `tool()` is overloaded: the callback is the LAST argument, and an
+    // optional annotations object (#1106) sits before it. Resolve by TYPE the way the
+    // real SDK does, so adding annotations to a tool cannot break this fake.
+    tool: (name: string, _desc: string, shape: z.ZodRawShape, ...rest: unknown[]) => {
+      const handler = rest.find((a) => typeof a === "function") as Handler;
       tools.push({ name, shape, handler });
     },
   };

--- a/src/__tests__/tools/model-management.test.ts
+++ b/src/__tests__/tools/model-management.test.ts
@@ -67,7 +67,11 @@ type ToolHandler = (args: Record<string, unknown>) => Promise<{
 function makeServer() {
   const handlers = new Map<string, ToolHandler>();
   const server = {
-    tool: (name: string, _desc: string, _schema: unknown, handler: ToolHandler) => {
+    // The SDK's `tool()` is overloaded: the callback is the LAST argument, and an
+    // optional annotations object (#1106) sits before it. Resolve by TYPE the way the
+    // real SDK does, so adding annotations to a tool cannot break this fake.
+    tool: (name: string, _desc: string, _schema: unknown, ...rest: unknown[]) => {
+      const handler = rest.find((a) => typeof a === "function") as ToolHandler;
       handlers.set(name, handler);
     },
   };

--- a/src/__tests__/tools/models-consolidated.test.ts
+++ b/src/__tests__/tools/models-consolidated.test.ts
@@ -159,7 +159,11 @@ interface Registered {
 function registered(): Registered[] {
   const tools: Registered[] = [];
   const server = {
-    tool: (name: string, _desc: string, shape: z.ZodRawShape, handler: Handler) => {
+    // The SDK's `tool()` is overloaded: the callback is the LAST argument, and an
+    // optional annotations object (#1106) sits before it. Resolve by TYPE the way the
+    // real SDK does, so adding annotations to a tool cannot break this fake.
+    tool: (name: string, _desc: string, shape: z.ZodRawShape, ...rest: unknown[]) => {
+      const handler = rest.find((a) => typeof a === "function") as Handler;
       tools.push({ name, shape, handler });
     },
   };

--- a/src/__tests__/tools/runpod.test.ts
+++ b/src/__tests__/tools/runpod.test.ts
@@ -82,7 +82,11 @@ interface Registered {
 function registered(): Registered[] {
   const tools: Registered[] = [];
   const server = {
-    tool: (name: string, _desc: string, shape: z.ZodRawShape, handler: Handler) => {
+    // The SDK's `tool()` is overloaded: the callback is the LAST argument, and an
+    // optional annotations object (#1106) sits before it. Resolve by TYPE the way the
+    // real SDK does, so adding annotations to a tool cannot break this fake.
+    tool: (name: string, _desc: string, shape: z.ZodRawShape, ...rest: unknown[]) => {
+      const handler = rest.find((a) => typeof a === "function") as Handler;
       tools.push({ name, shape, handler });
     },
   };

--- a/src/__tests__/tools/tool-annotations.test.ts
+++ b/src/__tests__/tools/tool-annotations.test.ts
@@ -1,0 +1,51 @@
+// #1106 — tools declared no MCP annotations, so a client could not gate a
+// money-spending or destructive call. Split out of #269's finding 5: `runpod
+// (action:"create")` is invocable without confirmation, and its "SPENDS MONEY"
+// warning lives only in prose a host cannot act on.
+//
+// This covers the FRICTION-ADDING slice only. See the assertion at the bottom for
+// why readOnlyHint is absent everywhere.
+
+import { describe, expect, it } from "vitest";
+import { listRegisteredTools } from "../../tools/introspect.js";
+
+type Tool = { name: string; annotations?: Record<string, unknown> };
+
+/** Tools whose effects are unambiguous: they spend money, reach the network, or
+ *  change an install. Over-marking these is harmless — the worst case is a
+ *  confirmation the user did not need. */
+const MUST_BE_MARKED = ["runpod", "install_comfyui", "download_model"];
+
+describe("#1106 money and destructive tools carry machine-readable annotations", () => {
+  let tools: Tool[];
+  it("loads the real registered surface", async () => {
+    tools = (await listRegisteredTools()) as Tool[];
+    expect(tools.length).toBeGreaterThan(20);
+  });
+
+  for (const name of MUST_BE_MARKED) {
+    it(`${name} is marked destructive and open-world`, async () => {
+      tools ??= (await listRegisteredTools()) as Tool[];
+      const t = tools.find((x) => x.name === name);
+      expect(t, `${name} is not registered`).toBeTruthy();
+      expect(t!.annotations, `${name} declares no annotations`).toBeTruthy();
+      expect(t!.annotations!.destructiveHint).toBe(true);
+      expect(t!.annotations!.openWorldHint).toBe(true);
+    });
+  }
+
+  it("NO tool claims readOnlyHint yet — absent is honest, wrong is dangerous", async () => {
+    // The asymmetry that shapes this whole issue: a missing destructiveHint leaves
+    // a host where it is today, but a readOnlyHint on something that mutates
+    // DISABLES a confirmation it would otherwise have shown. It also cannot be
+    // answered per-tool while the surface is action-parameterized — `list_packs`
+    // is read-only in every action, but a tool with mixed actions cannot carry one
+    // honest value. Until that is decided deliberately, nothing claims it.
+    tools ??= (await listRegisteredTools()) as Tool[];
+    const claiming = tools.filter((t) => t.annotations?.readOnlyHint === true).map((t) => t.name);
+    expect(
+      claiming,
+      `these claim readOnlyHint before the mixed-action question was settled: ${claiming.join(", ")}`,
+    ).toEqual([]);
+  });
+});

--- a/src/tools/install-comfyui.ts
+++ b/src/tools/install-comfyui.ts
@@ -168,6 +168,13 @@ export function registerInstallComfyUITools(server: McpServer): void {
             "(set_network_mode, set_security_level) apply only after a ComfyUI restart.",
         ),
     },
+    // #1106 — friction-ADDING hints only; see the note on `runpod`. readOnlyHint is
+    // deliberately never set: it removes a host confirmation rather than adding one.
+    {
+      destructiveHint: true,
+      openWorldHint: true,
+      idempotentHint: false,
+    },
     async (args) => {
       try {
         switch (args.action) {

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -336,6 +336,13 @@ export function registerModelManagementTools(server: McpServer): void {
           'REQUIRED for action:"resolve_missing" — the ComfyUI workflow in API format (JSON string or object).',
         ),
     },
+    // #1106 — friction-ADDING hints only; see the note on `runpod`. readOnlyHint is
+    // deliberately never set: it removes a host confirmation rather than adding one.
+    {
+      destructiveHint: true,
+      openWorldHint: true,
+      idempotentHint: false,
+    },
     async (args) => {
       try {
         requireLimitInRange("download_model", args.action, args.limit);

--- a/src/tools/runpod.ts
+++ b/src/tools/runpod.ts
@@ -195,6 +195,16 @@ export function registerRunpodTools(server: McpServer): void {
           'action:"create" — arm the pod-side dead-man watchdog (default true for OUR stock template): the pod STOPS ITSELF if comfyui-mcp\'s heartbeats stop (process crash/offline — boot grace ~45min, then ~20min without beats). Uses the pod-scoped API key RunPod auto-injects into every pod — your account key never leaves this machine. false deploys without the watchdog. With a custom template (RUNPOD_TEMPLATE_ID) the default is OFF — pass true only if that image ships our watchdog.',
         ),
     },
+    // #1106 — the machine-readable half of what this tool already says in prose.
+    // A host can gate on an annotation; it cannot gate on a sentence. DELIBERATELY
+    // only the FRICTION-ADDING hints: destructive/openWorld can be over-applied
+    // safely (worst case is a confirmation nobody needed), whereas readOnlyHint
+    // REMOVES a prompt the host would otherwise show — so it is not set here at all.
+    {
+      destructiveHint: true,
+      openWorldHint: true,
+      idempotentHint: false,
+    },
     async (args) => {
       try {
         // `pod_id` cannot be schema-required in a flat shape, so the handler


### PR DESCRIPTION
Closes #1106

`runpod (action:"create")` boots a GPU pod that bills by the second. The tool says so — in prose, in its description, which no client can act on. A host that wants to confirm before spending money has nothing structured to gate on, because not one tool on the surface declared MCP annotations.

This lands the half that cannot be wrong.

### The hints split by direction, and the halves have opposite risk

| | effect | cost of being wrong |
|---|---|---|
| `destructiveHint`, `openWorldHint` | **add** friction | a confirmation nobody needed |
| `readOnlyHint` | **removes** friction | suppresses a prompt on something that mutates |

So only the friction-adding half is set here, on the three tools whose effects are unambiguous in *every* action — `runpod`, `install_comfyui`, `download_model`. **No tool claims `readOnlyHint`, and a test asserts none does.**

### Why the rest of the surface is untouched

Not caution for its own sake — it is unanswerable in the current shape. Tools are action-parameterized, so `install_comfyui (action:"environment")` is a read-only probe living inside a tool whose other actions rewrite an install. One annotation object per tool cannot describe that honestly, and annotations are not per-action. That is #1106's remaining half, and it is a design decision rather than a patch.

### Why this touches four test files

The fake servers bound the handler to argument 4:

```ts
tool: (name, _desc, shape, handler) => …
```

The SDK's `tool()` is overloaded and takes optional annotations in exactly that slot, resolving the callback by **type**. Inserting an annotations object shifted the handler to argument 5, and the fakes captured the annotations object *as the handler* — 79 tests failed across `runpod`, `install-environment`, `models-consolidated` and `model-management`. In other words annotations were effectively unaddable without this.

The fakes now pick the last function argument, the way the SDK does, so annotating any further tool is free.

### Verification

Mutation-tested in both directions, each asserting an exact pre-count of 1 before rewriting so it could not silently hit unrelated code:

- delete `runpod`'s annotation → **1 failed** (presence assertion)
- add `readOnlyHint` to `download_model` → **1 failed** (absence assertion)

Full suite **7430 passed | 2 skipped**. `tsc`, `lint`, `check:vocabulary` all exit 0. Control-byte scan clean on all eight changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)