### PR TITLE
0.50.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.32] - 2026-08-08
+
+### MCP
+
+#### Fixed
+- an AMBIGUOUS turn is not a dead tab, and not a missing Origin (#1077) (#1107)
+- refuse API/prompt format instead of crashing or lying (#1103)
+
+#### Changed
+- pin that every pack ships a UI workflow, not API/prompt (#1105)
+
+
 ## [0.50.31] - 2026-08-07
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.31",
+  "version": "0.50.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.31",
+      "version": "0.50.32",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.31",
+  "version": "0.50.32",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.32**. Tag pushed; `release.yml` publishes from it; this PR reconciles protected `main`.

## #1107 — an ambiguous turn is no longer diagnosed as a structural relay failure

A defect in the diagnostic added for #1077 one release earlier.

`canReach()` and `tabServerOrigin()` both swallow whatever `resolveTarget` throws, so a turn issued from several workflows at once (routing ambiguity, #1001) reached the fence validator looking identical to a dead tab *and* to a connection carrying no server-observed Origin.

The second is the damaging one: its remedy says the failure is **structural**, that refreshing cannot help, and that the relay backend is the cause. For an ambiguous turn all three are wrong — the tabs are connected, the Origin exists, and it clears on the next single-origin message. So the message added to stop a wedged session chasing a useless remedy would itself have told an ambiguous turn to disable its tunnel backend.

The cause was typed the whole time (#1001 marks the ambiguity refusal); the boolean-returning callers were discarding it. `UiBridge.resolveFailure()` now reports it, and both gates consult it — with ambiguity checked **before** the structural case, since it also yields no origin.

The reason strings moved to `fence-refusal.ts` so they are testable without standing up the orchestrator. While inline, the only way to assert them was a fake bridge echoing its own configuration — a tautology that would pass with the logic deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)