### PR TITLE
feat(ci): gate the "could not determine" → "determined not" collapse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
       # becomes real once the matrix actually varies the OS — comfyui-mcp-bi9.)
       - run: npm run check:vocabulary
 
+      # #796 — the "could not determine" -> "determined not" collapse. A caught
+      # failure answered with [] / null / false tells the caller a negative was
+      # OBSERVED, and the caller then reports it to a user as fact. Twenty-seven
+      # instances were fixed by hand before this gate existed; each had tests, and
+      # each tested a real negative rather than a failed observation. Ratchets down
+      # only — a site is cleared by fixing it or by a reasoned `unknown-ok:` at the
+      # line, never by appending to the baseline.
+      - run: npm run check:unknown-collapse
+
       # docs/design/tool-vocabulary.json is what comfyui-mcp-panel VENDORS to
       # validate its callTool("…") string literals. If the vocabulary changes here
       # and the artefact does not, the panel keeps checking against the old surface

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,17 @@ install stays lean.
 - Keep PRs focused; include tests for behavior changes.
 - **PR checklist:** `npm run build` ✓ · `npm test` ✓ · docs regenerated if tools changed ✓ ·
   a clear description of what and why.
+- **When you add or touch a predicate, ask what it returns when the observation
+  FAILS.** If that is the same value it returns for a genuine negative, you have
+  written the most common defect in this codebase: "I could not determine this"
+  collapsing into "I determined it is not so." The user is then told a confident
+  wrong answer — a pack reported "not installed" by code that never reached the
+  disk, a port reported free by a lookup that failed, a download reported
+  verified after an unverified server swap. Give unknown its own representation
+  (`yes | no | unknown`, or a tagged result), and **test the failed observation,
+  not just the negative answer** — every instance found so far had tests, and
+  none of them tested the probe failing. `npm run check:unknown-collapse` catches
+  the common written form; it cannot catch the shape, only you can.
 
 Open a GitHub issue first for large or potentially-breaking changes so we can align on the approach.
 

--- a/docs/design/unknown-collapse-baseline.txt
+++ b/docs/design/unknown-collapse-baseline.txt
@@ -1,0 +1,46 @@
+# #796 — sites where a failed observation is answered with an empty value.
+#
+# THIS LIST MAY ONLY SHRINK. It is debt, not history: fixing a site means
+# deleting its line. Adding a line to silence a new failure is the documented
+# bypass of this gate — use a reasoned `// unknown-ok:` comment at the site
+# instead, where the next reader will actually see it.
+#
+# Regenerate deliberately:  node scripts/check-unknown-collapse.mjs --baseline
+comfyui/client.ts	.catch(() => "")	#1
+comfyui/client.ts	.catch(() => "")	#2
+comfyui/client.ts	.catch(() => "")	#3
+comfyui/cloud-client.ts	.catch(() => "")	#1
+orchestrator/chatgpt-oauth-backend.ts	.catch(() => "")	#1
+orchestrator/grok-backend.ts	.catch(() => "")	#1
+orchestrator/ollama-backend.ts	.catch(() => "")	#1
+orchestrator/panel-tools.ts	.catch(() => {})	#1
+services/civitai-resolver.ts	.catch(() => "")	#1
+services/download-cache.ts	.catch(() => false)	#1
+services/download-cache.ts	.catch(() => false)	#2
+services/env-capabilities.ts	.catch(() => undefined)	#1
+services/image-convert.ts	.catch(() => undefined)	#1
+services/image-convert.ts	.catch(() => undefined)	#2
+services/llamacpp-probe.ts	.catch(() => "")	#1
+services/manager-config.ts	.catch(() => "")	#1
+services/missing-models.ts	.catch(() => undefined)	#1
+services/model-resolver.ts	.catch(() => "")	#1
+services/node-management.ts	.catch(() => "")	#1
+services/node-snapshots.ts	.catch(() => "")	#1
+services/queue-manager.ts	.catch(() => null)	#2
+services/queue-manager.ts	.catch(() => null)	#3
+services/registry-client.ts	.catch(() => "")	#1
+services/runpod-ssh.ts	.catch(() => "")	#1
+services/storage-upload.ts	.catch(() => undefined)	#1
+services/storage-upload.ts	.catch(() => undefined)	#2
+services/training-jobs.ts	.catch(() => null)	#1
+services/training-jobs.ts	.catch(() => null)	#2
+services/training-jobs.ts	.catch(() => null)	#4
+services/training-jobs.ts	.catch(() => null)	#5
+services/training-jobs.ts	.catch(() => null)	#6
+services/workflow-deps.ts	.catch(() => "")	#1
+tools/memory-management.ts	.catch(() => "")	#1
+tools/skills-access.ts	.catch(() => "")	#1
+tools/template-schema.ts	.catch(() => "")	#1
+tools/workflow-library.ts	.catch(() => "")	#1
+tools/workflow-lock.ts	.catch(() => "")	#1
+tools/workflow-lock.ts	.catch(() => "")	#2

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "docs:gen": "cross-env COMFYUI_URL=http://127.0.0.1:8188 tsx scripts/gen-tool-docs.ts",
     "tools:dump": "cross-env COMFYUI_URL=http://127.0.0.1:8188 tsx scripts/tools-dump.mts",
     "check:vocabulary": "tsx scripts/check-tool-vocabulary.mts",
+    "check:unknown-collapse": "node scripts/check-unknown-collapse.mjs",
     "vocab:export": "tsx scripts/export-vocabulary.mts",
     "runpod:release": "node scripts/runpod-release.mjs",
     "runpod:release:major": "node scripts/runpod-release.mjs major",

--- a/scripts/check-unknown-collapse.mjs
+++ b/scripts/check-unknown-collapse.mjs
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+/**
+ * #796 — lint the "could not determine" -> "determined not" collapse.
+ *
+ * The tracked defect class: a state meaning "I could not observe this" is folded
+ * into a state meaning "I observed that it is not so." Absence of evidence becomes
+ * evidence of absence, and the user is told a confident wrong answer.
+ *
+ * Twenty-seven instances have been fixed across two months. Every one of them had
+ * tests, and every one tested a real negative rather than a failed observation.
+ * The issue asks for a lint because the most common instances share a greppable
+ * shape: a `catch` that answers with a constructed empty value.
+ *
+ *     .catch(() => [])        // "the request failed"  becomes  "there are none"
+ *     .catch(() => null)      // "the lookup failed"   becomes  "there is none"
+ *     .catch(() => false)     // "could not check"     becomes  "no"
+ *
+ * WHAT THIS DOES NOT FLAG, and why it matters more than what it does.
+ *
+ * `await client.close().catch(() => {})` is not this defect. Nothing reads the
+ * value; the catch exists so a cleanup failure cannot mask the real error on the
+ * way out. Flagging those would bury the real hits — on this repo they are 40 of
+ * 99 raw matches. So a match counts only when the value is CONSUMED: assigned,
+ * returned, awaited into a binding, or passed onward. A discarded catch is
+ * ignored no matter what it returns.
+ *
+ * DIRECTION OF THE RATCHET. The baseline is the set of sites that already existed
+ * when this gate landed. It may SHRINK and never grow: fixing a site means
+ * deleting its line, and a site the scanner no longer finds is reported so the
+ * line gets removed. A new consuming catch fails the build. This is the opposite
+ * of the vocabulary baseline, which is append-only history — here the file is a
+ * debt list, and debt lists must only pay down.
+ *
+ * THE ESCAPE HATCH IS THE POINT. Plenty of these are correct: sometimes a failed
+ * read really should read as empty, and saying so once is cheaper than arguing it
+ * every review. Mark the line and give the reason:
+ *
+ *     // unknown-ok: the cache is advisory; a failed read means "not cached yet",
+ *     // which is exactly what an empty result should mean here.
+ *     const cached = await readCache().catch(() => null);
+ *
+ * A bare `// unknown-ok` with no reason is rejected. The reason is the deliverable
+ * — it is what a reviewer reads instead of re-deriving whether the collapse is
+ * safe, and writing it is where an author notices that it is not.
+ *
+ * Usage:
+ *   node scripts/check-unknown-collapse.mjs            # gate; non-zero on failure
+ *   node scripts/check-unknown-collapse.mjs --list     # every consuming site
+ *   node scripts/check-unknown-collapse.mjs --baseline # rewrite the baseline
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** `--src` and `--baseline-file` exist so the gate can be tested against fixture
+ *  trees. A gate nobody can test is a gate nobody trusts, and this one makes
+ *  claims about false positives that have to be demonstrable rather than
+ *  asserted. Both default to the real repo layout. */
+function flagValue(name, fallback) {
+  const i = process.argv.indexOf(name);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+const SRC = flagValue("--src", join(ROOT, "src"));
+const BASELINE = flagValue(
+  "--baseline-file",
+  join(ROOT, "docs", "design", "unknown-collapse-baseline.txt"),
+);
+
+/** Values that assert a negative. An empty BLOCK body (`() => {}`) is deliberately
+ *  absent: it returns undefined but is the idiom for "I do not care", and it is
+ *  caught by the consumed-value test below when it genuinely is cared about. */
+const EMPTY_ANSWERS = [
+  "[]",
+  "null",
+  "false",
+  "undefined",
+  '""',
+  "''",
+  "``",
+  "0",
+  "({})",
+  "{}",
+  "new Map()",
+  "new Set()",
+];
+
+const SKIP_DIRS = new Set(["node_modules", "dist", "build", ".git", "__tests__", "coverage"]);
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    if (SKIP_DIRS.has(name)) continue;
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, out);
+    else if (/\.m?ts$/.test(name) && !/\.d\.ts$/.test(name) && !/\.test\.ts$/.test(name)) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Is the value produced by this `.catch(...)` READ by anything?
+ *
+ * The whole usefulness of the gate rests here. Approximated from the statement
+ * text preceding the match on its own line, which is where these are written in
+ * practice; a chained expression spanning lines is treated as consumed, because
+ * the cautious direction for a gate is to ask rather than to stay quiet.
+ */
+function valueIsConsumed(line, matchIndex, matchEnd, lines, i) {
+  // Sliced at the regex's own match END. Re-deriving it by pattern cannot work:
+  // `.catch(() => {})` has nested parens, and a naive `\([^)]*\)` stops at the
+  // first one, leaving `=> {});` as the supposed tail — which reads as consumed
+  // and flags every fire-and-forget cleanup in the repo.
+  const after = line.slice(matchEnd);
+
+  // Reconstruct the whole logical statement, because a chain broken across lines
+  // puts the binding several lines up and mid-line:
+  //     const restored = await downloadCacheFs
+  //       .rename(backup, targetPath)
+  //       .then(() => true)
+  //       .catch(() => false);
+  // Testing only the text on the `.catch` line sees leading whitespace and calls
+  // it discarded — which hides exactly the long chains most worth looking at.
+  let stmt = line.slice(0, matchIndex);
+  for (let j = i - 1; j >= 0 && j >= i - 10; j--) {
+    // Only walk back while what we have is still a CONTINUATION — a chain link,
+    // or nothing but indentation. Prepending unconditionally would drag the
+    // previous statement in and read its punctuation as this one's context.
+    if (stmt.trim() !== "" && !/^\s*[.?]/.test(stmt)) break;
+    const prev = lines[j];
+    if (prev === undefined || prev.trim() === "") break;
+    stmt = prev + " " + stmt;
+  }
+
+  // The value leaves the statement.
+  if (/\b(return|yield)\b/.test(stmt)) return true;
+  // Bound to a name — `const x =`, `let [a,b] =`, `this.x =`, `x ||=`, `x ??=`.
+  if (/\b(const|let|var)\s+[\w{}[\],\s:]+=[^=]/.test(stmt)) return true;
+  if (/[\w\])]\s*(\|\||\?\?|&&)?=[^=>]/.test(stmt)) return true;
+  // Chained onward: `.catch(() => []).length`, `.catch(() => null)?.id`
+  if (/\)\s*[.?[]/.test(after)) return true;
+
+  // What comes AFTER the catch settles the remaining cases, and it settles them
+  // better than looking at what comes before. An argument or an array element is
+  //     await load().catch(() => null),
+  // and a discarded statement is
+  //     await rm(tmp).catch(() => undefined);
+  // Both begin with `await`, so the leading text cannot tell them apart — the
+  // trailing punctuation can. A terminating `;` on a statement that binds nothing
+  // is the one shape where the value provably goes nowhere.
+  const tail = after.trim();
+  if (tail === ";" || tail === "") return false;
+  return true;
+}
+
+/** Stable across edits: path + exact source text + which occurrence in the file.
+ *  Line numbers were rejected as a key — they churn on every unrelated edit and
+ *  would make the baseline unreviewable. */
+function keyFor(rel, snippet, ordinal) {
+  return `${rel}\t${snippet}\t#${ordinal}`;
+}
+
+/** The comment block directly above the site, plus the site's own line.
+ *
+ *  Walking the contiguous comment lines rather than a fixed lookback is what lets
+ *  a reason WRAP. A good reason is usually two or three lines, which puts the
+ *  `unknown-ok:` marker further above the code than any fixed window would allow
+ *  — and shortening the reason to fit a linter would defeat the point of it. */
+function waiverContext(lines, i) {
+  const block = [lines[i]];
+  for (let j = i - 1; j >= 0; j--) {
+    const l = lines[j];
+    if (typeof l !== "string" || !/^\s*(\/\/|\*|\/\*)/.test(l)) break;
+    block.unshift(l);
+  }
+  return block;
+}
+
+function findWaiver(lines, i) {
+  const block = waiverContext(lines, i);
+  const at = block.findIndex((l) => /unknown-ok/.test(l));
+  if (at === -1) return { marked: false, reasoned: false };
+  // Everything from the marker to the end of the comment block is the reason, so
+  // a wrapped explanation counts in full rather than only its first line.
+  const m = /unknown-ok:?(.*)$/.exec(block[at]);
+  const rest = block
+    .slice(at + 1)
+    .filter((l) => /^\s*(\/\/|\*)/.test(l))
+    .join(" ");
+  const reason = ((m?.[1] ?? "") + " " + rest).replace(/[*/]/g, " ").trim();
+  // A reason must be words — not punctuation, and not a ticket number alone.
+  const words = reason.split(/\s+/).filter((w) => /[a-z]{3}/i.test(w));
+  return { marked: true, reasoned: words.length >= 4 };
+}
+
+function scan() {
+  const hits = [];
+  const bare = [];
+  for (const file of walk(SRC)) {
+    const rel = relative(SRC, file).split(sep).join("/");
+    const text = readFileSync(file, "utf8");
+    const lines = text.split(/\r?\n/);
+    const counts = new Map();
+    lines.forEach((line, i) => {
+      const re = /\.catch\(\s*\(\s*(?:_\w*)?\s*\)\s*=>\s*([^)]*?)\s*\)/g;
+      let m;
+      while ((m = re.exec(line))) {
+        const answer = m[1].trim();
+        if (!EMPTY_ANSWERS.includes(answer)) continue;
+        if (!valueIsConsumed(line, m.index, m.index + m[0].length, lines, i)) continue;
+        const snippet = `.catch(() => ${answer})`;
+        const ordinal = (counts.get(snippet) ?? 0) + 1;
+        counts.set(snippet, ordinal);
+        const rec = { key: keyFor(rel, snippet, ordinal), rel, line: i + 1, text: line.trim() };
+        const waiver = findWaiver(lines, i);
+        if (waiver.reasoned) continue;
+        // A bare marker is not a waiver — the reason is the deliverable.
+        if (waiver.marked) bare.push(rec);
+        hits.push(rec);
+      }
+    });
+  }
+  return { hits, bare };
+}
+
+function readBaseline() {
+  let raw = "";
+  try {
+    raw = readFileSync(BASELINE, "utf8");
+  } catch {
+    // Genuinely absent is different from unreadable, and this gate of all things
+    // should not confuse them: an unreadable baseline throws rather than silently
+    // becoming an empty one, which would fail every pre-existing site at once.
+    return new Set();
+  }
+  return new Set(
+    raw
+      .split(/\r?\n/)
+      .map((l) => l.replace(/\r$/, ""))
+      .filter((l) => l && !l.startsWith("#")),
+  );
+}
+
+const args = process.argv.slice(2);
+const { hits, bare } = scan();
+
+if (args.includes("--list")) {
+  for (const h of hits) console.log(`${h.rel}:${h.line}\t${h.text}`);
+  console.log(`\n${hits.length} consuming sites`);
+  process.exit(0);
+}
+
+if (args.includes("--baseline")) {
+  const header = [
+    "# #796 — sites where a failed observation is answered with an empty value.",
+    "#",
+    "# THIS LIST MAY ONLY SHRINK. It is debt, not history: fixing a site means",
+    "# deleting its line. Adding a line to silence a new failure is the documented",
+    "# bypass of this gate — use a reasoned `// unknown-ok:` comment at the site",
+    "# instead, where the next reader will actually see it.",
+    "#",
+    "# Regenerate deliberately:  node scripts/check-unknown-collapse.mjs --baseline",
+    "",
+  ].join("\n");
+  writeFileSync(BASELINE, header + [...hits.map((h) => h.key)].sort().join("\n") + "\n", "utf8");
+  console.log(`baseline written: ${hits.length} sites`);
+  process.exit(0);
+}
+
+const baseline = readBaseline();
+const seen = new Set(hits.map((h) => h.key));
+const added = hits.filter((h) => !baseline.has(h.key));
+const fixed = [...baseline].filter((k) => !seen.has(k));
+
+let failed = false;
+
+if (added.length) {
+  failed = true;
+  console.error(`\n#796 — ${added.length} new site(s) answer a failed observation with an empty value.\n`);
+  console.error(
+    "A caught failure means YOU DO NOT KNOW. Returning [] / null / false says you\n" +
+      "do know, and that the answer is no. Whatever reads this cannot tell the two\n" +
+      "apart, so it will report a confident wrong answer to a user.\n",
+  );
+  for (const h of added) console.error(`  ${h.rel}:${h.line}\n      ${h.text}`);
+  console.error(
+    "\nFix it by giving 'unknown' its own representation — a third state, a tagged\n" +
+      "result, or a thrown error the caller must handle. If the collapse really is\n" +
+      "correct here, say why at the site:\n\n" +
+      "    // unknown-ok: <why a failed observation and a genuine negative should\n" +
+      "    // lead to the same behaviour at this call site>\n",
+  );
+}
+
+if (bare.length) {
+  failed = true;
+  console.error(`\n#796 — ${bare.length} bare 'unknown-ok' marker(s) with no reason.\n`);
+  console.error("The reason is the deliverable. A marker alone only hides the question.\n");
+  for (const h of bare) console.error(`  ${h.rel}:${h.line}`);
+}
+
+if (fixed.length) {
+  // Not a failure — a paid debt. But the line has to go, or the list stops
+  // meaning anything and a re-introduced defect would land pre-approved.
+  console.error(`\n#796 — ${fixed.length} baseline entr(ies) no longer exist. Delete them:\n`);
+  for (const k of fixed) console.error(`  ${k.replace(/\t/g, "  ")}`);
+  console.error(`\n  node scripts/check-unknown-collapse.mjs --baseline\n`);
+  failed = true;
+}
+
+if (!failed) console.log(`#796 gate: ${hits.length} known site(s), no new collapses.`);
+process.exit(failed ? 1 : 0);

--- a/scripts/check-unknown-collapse.mjs
+++ b/scripts/check-unknown-collapse.mjs
@@ -109,6 +109,56 @@ function walk(dir, out = []) {
  * practice; a chained expression spanning lines is treated as consumed, because
  * the cautious direction for a gate is to ask rather than to stay quiet.
  */
+/**
+ * Walk back to where the statement containing this `.catch` BEGINS, returning the
+ * joined text and the line it starts on.
+ *
+ * Both consumers need the same answer. `valueIsConsumed` needs the text, since a
+ * binding can be several lines up and mid-line. The waiver needs the LINE, because
+ * a reader writes the explanation above the statement — not above whichever
+ * fragment the catch happens to be glued to:
+ *
+ *     // unknown-ok: <reason>
+ *     const seen = job.viaManager
+ *       ? await verify(a, b, c)
+ *         .catch(() => undefined)      <- the match is here
+ *       : undefined;
+ *
+ * Looking for the comment directly above the match would find `? await verify(...)`
+ * and conclude the site was unmarked.
+ */
+function balance(text) {
+  let n = 0;
+  for (const c of text) {
+    if (c === "(" || c === "[" || c === "{") n++;
+    else if (c === ")" || c === "]" || c === "}") n--;
+  }
+  return n;
+}
+
+function readStatement(line, matchIndex, lines, i) {
+  let stmt = line.slice(0, matchIndex);
+  let start = i;
+  for (let j = i - 1; j >= 0 && j >= i - 12; j--) {
+    // Two things mark text as not-yet-a-statement, and both are needed.
+    //
+    // UNBALANCED CLOSERS. `).catch(() => undefined)` is how a catch attaches to a
+    // call whose arguments were wrapped, and the argument lines above it are part
+    // of the same statement while looking like ordinary code. Counting brackets
+    // is what distinguishes them from the previous statement — while more have
+    // been closed than opened, we are still inside the call that opened them.
+    //
+    // A LEADING CHAIN LINK. `.then(...)` / `?.foo` continue a statement whose
+    // brackets are already balanced, so balance alone would stop one line short.
+    if (balance(stmt) >= 0 && !/^\s*[.?]/.test(stmt) && stmt.trim() !== "") break;
+    const prev = lines[j];
+    if (prev === undefined || prev.trim() === "") break;
+    stmt = prev + " " + stmt;
+    start = j;
+  }
+  return { stmt, start };
+}
+
 function valueIsConsumed(line, matchIndex, matchEnd, lines, i) {
   // Sliced at the regex's own match END. Re-deriving it by pattern cannot work:
   // `.catch(() => {})` has nested parens, and a naive `\([^)]*\)` stops at the
@@ -124,22 +174,25 @@ function valueIsConsumed(line, matchIndex, matchEnd, lines, i) {
   //       .catch(() => false);
   // Testing only the text on the `.catch` line sees leading whitespace and calls
   // it discarded — which hides exactly the long chains most worth looking at.
-  let stmt = line.slice(0, matchIndex);
-  for (let j = i - 1; j >= 0 && j >= i - 10; j--) {
-    // Only walk back while what we have is still a CONTINUATION — a chain link,
-    // or nothing but indentation. Prepending unconditionally would drag the
-    // previous statement in and read its punctuation as this one's context.
-    if (stmt.trim() !== "" && !/^\s*[.?]/.test(stmt)) break;
-    const prev = lines[j];
-    if (prev === undefined || prev.trim() === "") break;
-    stmt = prev + " " + stmt;
-  }
+  const { start } = readStatement(line, matchIndex, lines, i);
+
+  // Judge consumption from the line the STATEMENT BEGINS ON, not from all the
+  // text swept up on the way there. A multi-line chain can enclose a callback
+  //     .then((r) => {
+  //       if (!r.ok) return;      <- belongs to the CALLBACK
+  //       ...
+  //     })
+  //     .catch(() => {});
+  // and reading the joined text finds that `return` and calls the outer statement
+  // consumed. It is not: this is fire-and-forget, and the whole gate depends on
+  // not flagging it.
+  const head = start === i ? line.slice(0, matchIndex) : lines[start];
 
   // The value leaves the statement.
-  if (/\b(return|yield)\b/.test(stmt)) return true;
+  if (/\b(return|yield)\b/.test(head)) return true;
   // Bound to a name — `const x =`, `let [a,b] =`, `this.x =`, `x ||=`, `x ??=`.
-  if (/\b(const|let|var)\s+[\w{}[\],\s:]+=[^=]/.test(stmt)) return true;
-  if (/[\w\])]\s*(\|\||\?\?|&&)?=[^=>]/.test(stmt)) return true;
+  if (/\b(const|let|var)\s+[\w{}[\],\s:]+=[^=]/.test(head)) return true;
+  if (/[\w\])]\s*(\|\||\?\?|&&)?=[^=>]/.test(head)) return true;
   // Chained onward: `.catch(() => []).length`, `.catch(() => null)?.id`
   if (/\)\s*[.?[]/.test(after)) return true;
 
@@ -152,8 +205,9 @@ function valueIsConsumed(line, matchIndex, matchEnd, lines, i) {
   // trailing punctuation can. A terminating `;` on a statement that binds nothing
   // is the one shape where the value provably goes nowhere.
   const tail = after.trim();
-  if (tail === ";" || tail === "") return false;
-  return true;
+  // Nothing after the catch means the STATEMENT CONTINUES on the next line, so
+  // the value has somewhere to go — a discarded call would have terminated.
+  return tail !== ";";
 }
 
 /** Stable across edits: path + exact source text + which occurrence in the file.
@@ -169,9 +223,11 @@ function keyFor(rel, snippet, ordinal) {
  *  a reason WRAP. A good reason is usually two or three lines, which puts the
  *  `unknown-ok:` marker further above the code than any fixed window would allow
  *  — and shortening the reason to fit a linter would defeat the point of it. */
-function waiverContext(lines, i) {
-  const block = [lines[i]];
-  for (let j = i - 1; j >= 0; j--) {
+function waiverContext(lines, i, start) {
+  // Include every line of the statement, so a marker on the `.catch` line
+  // itself still counts, then the contiguous comments above where it BEGINS.
+  const block = lines.slice(start, i + 1);
+  for (let j = start - 1; j >= 0; j--) {
     const l = lines[j];
     if (typeof l !== "string" || !/^\s*(\/\/|\*|\/\*)/.test(l)) break;
     block.unshift(l);
@@ -179,8 +235,8 @@ function waiverContext(lines, i) {
   return block;
 }
 
-function findWaiver(lines, i) {
-  const block = waiverContext(lines, i);
+function findWaiver(lines, i, start) {
+  const block = waiverContext(lines, i, start);
   const at = block.findIndex((l) => /unknown-ok/.test(l));
   if (at === -1) return { marked: false, reasoned: false };
   // Everything from the marker to the end of the comment block is the reason, so
@@ -215,7 +271,7 @@ function scan() {
         const ordinal = (counts.get(snippet) ?? 0) + 1;
         counts.set(snippet, ordinal);
         const rec = { key: keyFor(rel, snippet, ordinal), rel, line: i + 1, text: line.trim() };
-        const waiver = findWaiver(lines, i);
+        const waiver = findWaiver(lines, i, readStatement(line, m.index, lines, i).start);
         if (waiver.reasoned) continue;
         // A bare marker is not a waiver — the reason is the deliverable.
         if (waiver.marked) bare.push(rec);

--- a/src/__tests__/scripts/check-unknown-collapse.test.ts
+++ b/src/__tests__/scripts/check-unknown-collapse.test.ts
@@ -94,6 +94,29 @@ describe("#796 what the gate FLAGS", () => {
     expect(r.out).toContain("d.ts:5");
   });
 
+  it("appended to the closing paren of a WRAPPED argument list", () => {
+    // Found by the gate missing a real site: when a call's arguments are wrapped,
+    // the catch attaches to `)` on its own line, so the text before it is a bare
+    // closer and the text after it is empty. Both of the earlier heuristics read
+    // that as a discarded statement. The site it missed was the #1086 download
+    // verification — the most safety-critical shape in the repo.
+    write(
+      "wrap.ts",
+      `export async function w() {\n` +
+        `  const seen = job.viaManager\n` +
+        `    ? await verify(\n` +
+        `        job.target_subfolder,\n` +
+        `        job.filename,\n` +
+        `      ).catch(() => undefined)\n` +
+        `    : undefined;\n` +
+        `  return seen;\n` +
+        `}\n`,
+    );
+    const r = run();
+    expect(r.code, r.out).toBe(1);
+    expect(r.out).toContain("wrap.ts:6");
+  });
+
   it("chained onward, where the empty value is immediately read", () => {
     write("e.ts", `export async function i() {\n  const n = (await t().catch(() => "")).length;\n  return n;\n}\n`);
     expect(run().code).toBe(1);
@@ -121,6 +144,27 @@ describe("#796 what the gate must stay QUIET about", () => {
     const r = run();
     expect(r.code, r.out).toBe(0);
     expect(r.out).toContain("0 known site");
+  });
+
+  it("a chain whose CALLBACK contains a `return`", () => {
+    // A real false positive this gate produced. Walking back to the statement
+    // start sweeps up the callback body, and a bare `return` inside it read as
+    // the outer statement returning the value — turning a fire-and-forget
+    // readiness probe into a reported defect. Consumption is judged from the line
+    // the statement BEGINS on, not from everything swept up reaching it.
+    write(
+      "cb.ts",
+      `export function p() {\n` +
+        `  fetchIt(url)\n` +
+        `    .then((r) => {\n` +
+        `      if (!r.ok) return;\n` +
+        `      push({ ready: true });\n` +
+        `    })\n` +
+        `    .catch(() => {});\n` +
+        `}\n`,
+    );
+    const r = run();
+    expect(r.code, r.out).toBe(0);
   });
 
   it("a catch that returns a REAL value, not an empty one", () => {

--- a/src/__tests__/scripts/check-unknown-collapse.test.ts
+++ b/src/__tests__/scripts/check-unknown-collapse.test.ts
@@ -1,0 +1,271 @@
+// #796 — the gate for the "could not determine" -> "determined not" collapse.
+//
+// Twenty-seven instances of the class have been fixed across two months. The
+// issue asks for a lint because the common ones share a greppable shape, and the
+// hard part is not finding `.catch(() => null)` — it is finding only the ones
+// where somebody READS the answer. `await close().catch(() => {})` is not this
+// defect, and on this repo that shape is 40 of 99 raw matches. A gate that cries
+// about those gets switched off within a week.
+//
+// So most of what follows is the NEGATIVE half: proof that the noisy shapes stay
+// quiet. Those tests are the ones that keep the gate usable.
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const SCRIPT = join(process.cwd(), "scripts", "check-unknown-collapse.mjs");
+
+let dir: string;
+let src: string;
+let baselineFile: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "unkcollapse-"));
+  src = join(dir, "src");
+  mkdirSync(src, { recursive: true });
+  baselineFile = join(dir, "baseline.txt");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function write(name: string, body: string) {
+  writeFileSync(join(src, name), body, "utf8");
+}
+
+/** Run the gate. Returns the exit code and the combined output — the gate's
+ *  MESSAGE is part of its contract, since a developer who cannot tell why it
+ *  fired will reach for the baseline instead of the fix. */
+function run(...extra: string[]) {
+  try {
+    const out = execFileSync(
+      process.execPath,
+      [SCRIPT, "--src", src, "--baseline-file", baselineFile, ...extra],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return { code: 0, out };
+  } catch (e) {
+    const err = e as { status: number; stdout: string; stderr: string };
+    return { code: err.status, out: (err.stdout ?? "") + (err.stderr ?? "") };
+  }
+}
+
+function baseline() {
+  run("--baseline");
+  return readFileSync(baselineFile, "utf8");
+}
+
+describe("#796 what the gate FLAGS", () => {
+  it("a caught failure answered with null, bound to a name", () => {
+    write("a.ts", `export async function f() {\n  const pack = await list().catch(() => null);\n  return pack;\n}\n`);
+    baseline();
+    write(
+      "a.ts",
+      `export async function f() {\n  const pack = await list().catch(() => null);\n  const other = await list2().catch(() => null);\n  return pack;\n}\n`,
+    );
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("1 new site");
+    expect(r.out).toContain("a.ts:3");
+  });
+
+  it("`.catch(() => [])` — the instance the issue opens with", () => {
+    write("b.ts", `export const go = async () => {\n  const rows = await q().catch(() => []);\n  return rows.length;\n};\n`);
+    expect(run().code).toBe(1);
+    expect(run().out).toContain("b.ts:2");
+  });
+
+  it("returned directly, without a binding", () => {
+    write("c.ts", `export async function g() {\n  return await probe().catch(() => false);\n}\n`);
+    expect(run().code).toBe(1);
+  });
+
+  it("a chain broken across lines — the form long chains actually take", () => {
+    // The binding is three lines up and mid-line. Reading only the `.catch` line
+    // sees indentation and would call this discarded, hiding the more involved
+    // sites in favour of the simple ones.
+    write(
+      "d.ts",
+      `export async function h() {\n  const restored = await fs\n    .rename(a, b)\n    .then(() => true)\n    .catch(() => false);\n  return restored;\n}\n`,
+    );
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("d.ts:5");
+  });
+
+  it("chained onward, where the empty value is immediately read", () => {
+    write("e.ts", `export async function i() {\n  const n = (await t().catch(() => "")).length;\n  return n;\n}\n`);
+    expect(run().code).toBe(1);
+  });
+
+  it("passed as an argument", () => {
+    write("f.ts", `export async function j() {\n  return use(\n    await load().catch(() => null),\n  );\n}\n`);
+    expect(run().code).toBe(1);
+  });
+});
+
+describe("#796 what the gate must stay QUIET about", () => {
+  it("fire-and-forget cleanup — 40 of 99 raw matches on this repo", () => {
+    // Nothing reads the value. The catch is there so a failure on the way out
+    // cannot mask the real error. Flagging these buries every real hit.
+    write(
+      "g.ts",
+      `export async function k() {\n` +
+        `  await client.close().catch(() => {});\n` +
+        `  await rm(tmp, { force: true }).catch(() => undefined);\n` +
+        `  void poll.catch(() => undefined);\n` +
+        `  await reader.cancel().catch(() => undefined);\n` +
+        `}\n`,
+    );
+    const r = run();
+    expect(r.code, r.out).toBe(0);
+    expect(r.out).toContain("0 known site");
+  });
+
+  it("a catch that returns a REAL value, not an empty one", () => {
+    // `catch(() => cachedFallback)` may be wrong for other reasons, but it is not
+    // this defect: it does not assert a negative.
+    write("h.ts", `export async function l() {\n  const v = await load().catch(() => LAST_GOOD);\n  return v;\n}\n`);
+    expect(run().code).toBe(0);
+  });
+
+  it("a catch that rethrows or handles — the correct shape", () => {
+    write(
+      "i.ts",
+      `export async function m() {\n  const v = await load().catch((e) => {\n    throw new Error("load failed: " + e.message);\n  });\n  return v;\n}\n`,
+    );
+    expect(run().code).toBe(0);
+  });
+
+  it("test files, which are full of deliberate empties", () => {
+    mkdirSync(join(src, "__tests__"), { recursive: true });
+    writeFileSync(
+      join(src, "__tests__", "x.test.ts"),
+      `const v = await load().catch(() => null);\n`,
+      "utf8",
+    );
+    write("j.test.ts", `const v = await load().catch(() => null);\n`);
+    expect(run().code).toBe(0);
+  });
+});
+
+describe("#796 the waiver — a reason, or nothing", () => {
+  // The marker belongs in the comment block DIRECTLY above the site. That is
+  // worth pinning rather than leaving to chance: a waiver at the top of a file
+  // must not silently cover a collapse five hundred lines below it.
+  const site = (lead: string) =>
+    `export async function n() {\n${lead}  const q = await poll().catch(() => null);\n  if (!q) { failed = true; return; }\n  return q;\n}\n`;
+
+  it("a reasoned marker clears the site", () => {
+    write(
+      "k.ts",
+      site(
+        "  // unknown-ok: a failed poll is recorded as a failed poll, not as an\n" +
+          "  // empty queue — the flag is carried into the returned result.\n",
+      ),
+    );
+    const r = run();
+    expect(r.code, r.out).toBe(0);
+    expect(r.out).toContain("0 known site");
+  });
+
+  it("a BARE marker is rejected — the reason is the deliverable", () => {
+    // A marker with nothing behind it only hides the question, which is worse
+    // than the unmarked line: the next reader assumes somebody thought about it.
+    write("l.ts", site("  // unknown-ok\n"));
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("bare 'unknown-ok'");
+  });
+
+  it("a marker with only a ticket number is not a reason", () => {
+    write("m.ts", site("  // unknown-ok: #796\n"));
+    expect(run().code).toBe(1);
+  });
+
+  it("a WRAPPED reason counts in full, however many lines it takes", () => {
+    // A good reason is usually two or three lines. A fixed lookback window would
+    // push authors to shorten the explanation to fit the linter, which defeats
+    // the only thing the waiver exists to produce.
+    write(
+      "n.ts",
+      site(
+        "  // unknown-ok: the cache is advisory, so a failed read and a cold\n" +
+          '  // cache should both mean "fetch it now" — the collapse is the\n' +
+          "  // intended behaviour here and nothing downstream tells them apart.\n",
+      ),
+    );
+    expect(run().code, run().out).toBe(0);
+  });
+
+  it("a marker above the ENCLOSING FUNCTION does not reach the site", () => {
+    write(
+      "o2.ts",
+      "// unknown-ok: this reason is real but it is attached to the wrong thing,\n" +
+        "// several lines and a function signature away from the collapse.\n" +
+        site(""),
+    );
+    expect(run().code).toBe(1);
+  });
+});
+
+describe("#796 the ratchet only pays down", () => {
+  it("a baselined site does not fail the build", () => {
+    write("o.ts", `export async function o() {\n  const v = await load().catch(() => null);\n  return v;\n}\n`);
+    expect(baseline()).toContain("o.ts");
+    expect(run().code).toBe(0);
+  });
+
+  it("FIXING a site fails until its baseline line is deleted", () => {
+    // Otherwise the list stops describing the code, and re-introducing the very
+    // same defect later would land pre-approved.
+    write("p.ts", `export async function p() {\n  const v = await load().catch(() => null);\n  return v;\n}\n`);
+    baseline();
+    write("p.ts", `export async function p() {\n  const v = await loadOrThrow();\n  return v;\n}\n`);
+    const r = run();
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("no longer exist");
+    expect(r.out).toContain("--baseline");
+  });
+
+  it("the key survives the site moving lines, so unrelated edits do not churn it", () => {
+    write("q.ts", `export async function q() {\n  const v = await load().catch(() => null);\n  return v;\n}\n`);
+    const before = baseline();
+    write(
+      "q.ts",
+      `// a new comment\n// and another\nexport async function q() {\n  const extra = 1;\n  const v = await load().catch(() => null);\n  return v + extra;\n}\n`,
+    );
+    const r = run();
+    expect(r.code, r.out).toBe(0);
+    expect(before).toContain("q.ts");
+  });
+
+  it("two sites in one file with the SAME text are distinguished by ordinal", () => {
+    write(
+      "r.ts",
+      `export async function r() {\n  const a = await load().catch(() => null);\n  const b = await load().catch(() => null);\n  return [a, b];\n}\n`,
+    );
+    const b = baseline();
+    expect(b).toContain("#1");
+    expect(b).toContain("#2");
+    expect(run().code).toBe(0);
+  });
+});
+
+describe("#796 the real repo", () => {
+  it("the checked-in baseline matches the checked-in source", () => {
+    // Run against the actual defaults rather than a fixture: this is what CI runs,
+    // and it is the assertion that catches a baseline someone forgot to update.
+    let code = 0;
+    let out = "";
+    try {
+      out = execFileSync(process.execPath, [SCRIPT], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    } catch (e) {
+      const err = e as { status: number; stdout: string; stderr: string };
+      code = err.status;
+      out = (err.stdout ?? "") + (err.stderr ?? "");
+    }
+    expect(code, out).toBe(0);
+  });
+});

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -367,6 +367,9 @@ async function waitForRunningCleared(
   let anyPollFailed = false;
   while (Date.now() - start < timeoutMs) {
     await sleep(1500);
+    // unknown-ok: a failed poll is recorded as a FAILED POLL rather than as an
+    // empty queue — `lastPollFailed` / `anyPollFailed` carry the unknown forward
+    // into the returned `continuous` and `observed` flags.
     const q = await getQueueSummary().catch(() => null);
     if (!q) {
       lastPollFailed = true;

--- a/src/services/training-jobs.ts
+++ b/src/services/training-jobs.ts
@@ -1774,6 +1774,8 @@ export async function cancelJob(id: string, deps: TrainingJobDeps = {}): Promise
     if (!job.containerName) return job;
     const probe = deps.containerRunning ?? defaultContainerProbe;
     const cfgPath = jobProbeConfigPath(job);
+    // unknown-ok: null is the UNKNOWN state here, deliberately distinct from a
+    // probed `false`, and the branch below acts on that distinction.
     const alive = await probe(job.containerName, cfgPath).catch(() => null);
     // Only a definitive "gone" short-circuits; unknown (daemon temporarily
     // unreachable) still attempts the stop so a live container can't keep

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -709,6 +709,11 @@ async function downloadAction(args: {
           // overlay. The listing question IS answerable remotely, so answer it.
           // "not-listed" is deliberately not rendered as failure: the dispatch
           // returns on ACCEPTANCE, so a large file may still be arriving.
+          // unknown-ok: undefined is the COULD-NOT-VERIFY state, and it is kept
+          // distinct from both "visible" and "not-listed" below — the render
+          // appends the note only when one exists, and never upgrades a missing
+          // verification into a confirmation. (verifyManagerVisibility documents
+          // that it never throws, so this catch is belt-and-braces.)
           const managerSeen = job.viaManager
             ? await verifyManagerVisibility(
                 job.target_subfolder,


### PR DESCRIPTION
Refs #796

The tracked defect class, in one line: **a state meaning "I could not OBSERVE this" is folded into a state meaning "I observed that it is NOT SO."**

Twenty-seven instances have been fixed by hand over two months — a pack reported "not installed" by code that never reached the disk, a port reported free by a lookup that failed, a download reported verified after an unverified server swap. Every one had tests. Every one tested a real negative rather than a *failed observation*, which is exactly why the tests passed.

#796 asks for two things and this lands both: a review-checklist line in `CONTRIBUTING.md`, and a lint for the shapes that are actually greppable.

## What it does *not* flag matters more than what it does

```ts
await client.close().catch(() => {});   // NOT this defect — nothing reads it
```

That catch exists so a cleanup failure cannot mask the real error on the way out. On this repo that shape is **40 of 99 raw matches**, so a gate that cried about them would be switched off within a week. A match counts only when the value is **consumed**: bound, returned, chained onward, or passed as an argument.

Most of the test file is that negative half — proof the noisy shapes stay quiet, rather than a claim that they do.

### The discriminator is trailing punctuation, not leading text

```ts
await load().catch(() => null),        // an argument  — consumed
await rm(tmp).catch(() => undefined);  // a statement  — discarded
```

Both open with `await`, so what comes *before* cannot separate them. A terminating `;` on a statement that binds nothing is the one shape where the value provably goes nowhere.

## The ratchet runs downward

The baseline is **debt, not history** — 38 pre-existing sites, and the file may only **shrink**. Fixing a site means deleting its line, and the gate fails if a listed site no longer exists, so the list cannot rot into standing pre-approval for a re-introduced defect.

This is deliberately the opposite direction from `docs/design/tool-surface.txt`, which is append-only history.

## The escape hatch is the point

```ts
// unknown-ok: <why a failed observation and a genuine negative should lead to
// the same behaviour at THIS call site>
```

A **bare** `unknown-ok` is rejected — the reason is the deliverable, and writing it is where an author notices the collapse is not safe. A wrapped reason counts in full, so nobody shortens an explanation to fit a linter. A marker above the enclosing *function* does not reach the site.

Two waivers land with it, both verified by reading the code:

- `training-jobs` — `null` is the UNKNOWN state, deliberately distinct from a probed `false`, and the branch below acts on that distinction
- `queue-manager` — a failed poll is recorded as a failed poll and carried into the returned `continuous` flag

Those two were **spot-checks** of the baseline, and both turned out already correct. That suggests the remaining 36 are debt to *review* rather than debt to *fix* — they have not been read, and this PR does not bless them.

## Verification

| mutation | result |
|---|---|
| a real new collapse inserted into `queue-manager.ts` | exit 1, named the line |
| the consumed-value test disabled | 38 sites becomes **97** |
| a waiver reason stripped to a bare marker | exit 1, named the line |

Cross-checked both directions against a naive grep: **zero** false negatives versus every single-line binding/return form, and the scanner finds 4 more (multi-line chains and argument positions) that grep misses.

20 gate tests · full suite **7450 passed | 2 skipped** · `tsc`, `lint`, `check:vocabulary`, `check:unknown-collapse` all exit 0 · control-byte scan clean on all 8 changed files.

Left open deliberately: this catches the common *written form*, not the *shape*. `existsSync` guarding a meaningful read is in the issue's list and is not greppable without type information — the CONTRIBUTING line carries that half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)