### PR TITLE
fix(fence): a fence the panel repaired mid-call is no longer reported as failure

### DIFF
--- a/src/__tests__/orchestrator/open-workflow-fence-unreadable.test.ts
+++ b/src/__tests__/orchestrator/open-workflow-fence-unreadable.test.ts
@@ -340,3 +340,109 @@ describe("the reopen advice names the case it does not cover", () => {
     expect(text).toMatch(/would abandon it/);
   });
 });
+
+// #1043/#932 — the refused read may have REPAIRED the fence on its way out.
+//
+// The panel answers a workflow-instance mismatch by re-advertising its identity
+// (noteWorkflowInstanceMismatch → sendHello), and the orchestrator's hello
+// handler adopts a validated identity into the tab's stamp. That budget is
+// per-identity and RESETS when the live uuid changes — so right after a
+// workflow_new, the very refusal we just collected is what buys the re-hello
+// that fixes the fence.
+//
+// It lands asynchronously, so reporting the reading taken BEFORE the call
+// described a state that no longer existed by the time the caller read it:
+// "NOT recovered" about a session that was, by then, fine.
+describe("a fence repaired by the panel mid-call is not reported as a failure", () => {
+  const setTarget = () => buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target")!;
+  const HEALED = "33333333-4444-4555-8666-777777777777";
+
+  /** Every read is refused; `fenceNow` models the stamp the hello handler wrote
+   *  while the refusal was in flight. */
+  function wedgedBridge(fenceNow: () => { known: boolean; uuid?: string }) {
+    return {
+      send: async () => {
+        throw new Error("workflow instance mismatch: this command targets a different workflow");
+      },
+      push: () => 1,
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: "tab-1", title: "A", connected_at: 0 }],
+      resolveActiveTabId: () => "tab-1",
+      workflowUuidFor: () => fenceNow(),
+      refreshWorkflowUuid: () => false,
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+    } as unknown as PanelToolCtx["bridge"];
+  }
+
+  const textOf = (res: { content: Array<{ text?: string }> }): string => res.content[0]!.text ?? "";
+
+  it("reports BOUND when the stamp changed while the read was refused", async () => {
+    let calls = 0;
+    // First read (before): the stale fence. Later reads: the panel's new one.
+    const bridge = wedgedBridge(() => (++calls <= 1 ? { known: true, uuid: PRIOR_UUID } : { known: true, uuid: HEALED }));
+
+    const res = await setTarget().handler(
+      { mode: "current" },
+      makePanelToolCtx(bridge, "tab-1", new WorkflowTargetStore()),
+    );
+    const text = textOf(res);
+
+    expect(text).toMatch(/fence CHANGED while it ran/);
+    expect(text).toContain(HEALED);
+    // It must NOT keep telling the user they are wedged.
+    expect(text).not.toMatch(/Could NOT read the live canvas identity/);
+    // …and it says where the repair came from, so the claim is not overstated.
+    expect(text).toMatch(/repair came from the panel, not from this call/);
+  });
+
+  it("still reports UNREADABLE when the stamp did not change", async () => {
+    const bridge = wedgedBridge(() => ({ known: true, uuid: PRIOR_UUID }));
+
+    const text = textOf(
+      await setTarget().handler(
+        { mode: "current" },
+        makePanelToolCtx(bridge, "tab-1", new WorkflowTargetStore()),
+      ),
+    );
+
+    expect(text).toMatch(/Could NOT read the live canvas identity/);
+    expect(text).not.toMatch(/fence CHANGED while it ran/);
+  });
+
+  // The guard that keeps this honest: an UNREADABLE fence is not evidence of a
+  // repair. #770/#803 exist because a failed read used to render as a definite
+  // answer, and claiming "healed" from one would be the same fold.
+  it("never claims a repair from an unreadable fence", async () => {
+    const bridge = wedgedBridge(() => ({ known: false }));
+
+    const text = textOf(
+      await setTarget().handler(
+        { mode: "current" },
+        makePanelToolCtx(bridge, "tab-1", new WorkflowTargetStore()),
+      ),
+    );
+
+    expect(text).not.toMatch(/fence CHANGED while it ran/);
+  });
+
+  // The case that actually EXERCISES the `known` guards. The one above passes
+  // even without them (both reads are undefined, so the comparison is false
+  // either way) — a mutation dropping the guards killed nothing until this
+  // existed. Here the BEFORE read failed and the AFTER read succeeds: the uuids
+  // differ, so a bare comparison would announce a repair from a transition
+  // nobody observed.
+  it("never claims a repair when the BEFORE read failed but the after one worked", async () => {
+    let calls = 0;
+    const bridge = wedgedBridge(() => (++calls <= 1 ? { known: false } : { known: true, uuid: HEALED }));
+
+    const text = textOf(
+      await setTarget().handler(
+        { mode: "current" },
+        makePanelToolCtx(bridge, "tab-1", new WorkflowTargetStore()),
+      ),
+    );
+
+    expect(text).not.toMatch(/fence CHANGED while it ran/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2580,6 +2580,10 @@ export type WorkflowFenceRebind =
    *  validator's three gates tripped when the bridge can tell us (#1077); absent
    *  on an older bridge, which is why the remedy below must still stand alone. */
   | { status: "rejected"; uuid: string; before: FenceRead; refusalReason?: string }
+  /** Our read was refused, but the fence CHANGED underneath us while we asked —
+   *  the panel's mismatch re-hello re-advertised its identity and the hello
+   *  handler adopted it (#1043/#932). The session is bound again, just not by us. */
+  | { status: "healed_by_panel"; uuid: string; before: FenceRead }
   /** The adoption itself THREW. Distinct from `rejected` (codex gate): a refusal
    *  proves the old fence is untouched, whereas a throw can land on either side
    *  of the write, so whether the fence changed is UNKNOWN and must not be
@@ -2670,6 +2674,38 @@ function corroborateActiveForFence(
  * NEVER throws and NEVER fabricates: every failure mode gets its own status, and
  * the caller — not this function — decides what that means for its own report.
  */
+/**
+ * A refused read may have REPAIRED the fence on its way out (#1043/#932).
+ *
+ * The panel answers a workflow-instance mismatch by re-advertising its current
+ * identity (noteWorkflowInstanceMismatch → sendHello), and the orchestrator's
+ * hello handler adopts a validated identity into the tab's command stamp. That
+ * budget is per-identity and RESETS when the live uuid changes — so right after a
+ * workflow_new, the very refusal we just collected is what buys the re-hello that
+ * fixes the fence.
+ *
+ * It lands asynchronously, though, so reporting the reading we took BEFORE the
+ * call describes a state that may no longer exist by the time the caller sees it:
+ * "NOT recovered" about a session that is, by then, fine. Wait one settle and
+ * re-read before saying so.
+ *
+ * Only claims a repair when BOTH reads are known and the uuid actually CHANGED —
+ * an unreadable fence proves nothing, and #770/#803 exist precisely because a
+ * failed read used to render as a definite answer.
+ */
+async function unreadableOrHealed(
+  ctx: PanelToolCtx,
+  before: FenceRead,
+  detail: string,
+): Promise<WorkflowFenceRebind> {
+  await sleep(retrySettleMs());
+  const now = currentWorkflowFence(ctx);
+  if (before.known && now.known && now.uuid && now.uuid !== before.uuid) {
+    return { status: "healed_by_panel", uuid: now.uuid, before };
+  }
+  return { status: "unreadable", before, detail };
+}
+
 async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebind> {
   const tabAtStart = ctx.tabId;
   let before = currentWorkflowFence(ctx);
@@ -2687,23 +2723,19 @@ async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebi
     const res = await ctx.call({ cmd: "workflow_list" }, 6000);
     syncFenceToCurrentTab();
     if (res?.isError) {
-      return { status: "unreadable", before, detail: toolResultText(res) };
+      return await unreadableOrHealed(ctx, before, toolResultText(res));
     }
     parsed = parseToolResultJson(res);
   } catch (err) {
     syncFenceToCurrentTab();
-    return {
-      status: "unreadable",
+    return await unreadableOrHealed(
+      ctx,
       before,
-      detail: err instanceof Error ? err.message : String(err ?? "unknown error"),
-    };
+      err instanceof Error ? err.message : String(err ?? "unknown error"),
+    );
   }
   if (!parsed) {
-    return {
-      status: "unreadable",
-      before,
-      detail: "the panel's workflow_list reply was not readable as JSON",
-    };
+    return await unreadableOrHealed(ctx, before, "the panel's workflow_list reply was not readable as JSON");
   }
   // CORROBORATE before adopting. The uuid must come from a record the panel's own
   // open-workflow list agrees is the live canvas — otherwise a stale or mixed
@@ -2901,6 +2933,21 @@ function describeFenceRebind(
             : `\n\nWHAT TO DO if graph tools are still failing: call this once more. If the ` +
               `mismatch SURVIVES that repeat, this session and the panel agree on the target ` +
               `and the disagreement is inside the panel — ${RELOAD_TAB_REMEDY}`),
+      };
+    case "healed_by_panel":
+      // Reported as BOUND, and the provenance said out loud: the stamp came from
+      // the panel's own re-advertised identity through the hello handler's
+      // validator — the same path that sets it normally — not from a reading we
+      // took. Calling this "not recovered" because OUR read failed would report a
+      // wedge that no longer exists.
+      return {
+        binding: "bound",
+        note:
+          ` The read was refused, but this session's fence CHANGED while it ran: the panel ` +
+          `re-advertised its live identity (${r.uuid}) and it was adopted, replacing ` +
+          `${r.before.known && r.before.uuid ? r.before.uuid : "the previous stamp"}. Graph tools ` +
+          `should work now — the repair came from the panel, not from this call, so treat the ` +
+          `next graph command as the confirmation.`,
       };
     case "rejected":
       return {


### PR DESCRIPTION
Addresses a false negative on the way out of #1043/#932 — not their root cause.

## The mechanism

The panel answers a workflow-instance mismatch by **re-advertising its identity** (`noteWorkflowInstanceMismatch` → `sendHello`), and the orchestrator's hello handler adopts a validated identity into the tab's command stamp.

That budget is **per-identity and resets when the live uuid changes**. So right after a `workflow_new`, the very refusal `rebindWorkflowFence` collects is what buys the re-hello that fixes the fence.

It lands asynchronously. `rebindWorkflowFence` reported the reading it took *before* the call — so it described a state that no longer existed by the time the caller saw it: **"NOT recovered", plus a remedy, about a session that was by then fine.**

That's the same could-not-determine/therefore-not fold as the rest of this cluster, aimed at a state that repaired itself.

## The change

The three `unreadable` returns now settle once and re-read. When the stamp **changed**, the result is `healed_by_panel` and reports `binding: "bound"` — with the provenance stated, because the repair came from the panel's own re-advertised identity through the hello handler's validator, not from a reading we took. The caller is told to treat the next graph command as the confirmation.

It claims this **only** when both reads are `known` and the uuid actually changed. An unreadable fence proves nothing — #770/#803 exist because a failed read used to render as a definite answer, and announcing a repair from one would be the same defect wearing the opposite sign.

## Verification

| Mutation | Result |
|---|---|
| disable the heal | the healed test fails |
| drop the `known` guards, keep the uuid comparison | **killed zero at first** |

That second one is worth spelling out. My "never claims a repair from an unreadable fence" test passed for the wrong reason: both reads were `undefined`, so the comparison was false with or without the guards. I added the case that actually exercises them — *before* unreadable, *after* readable, uuids differing, where a bare comparison announces a transition nobody observed. The mutation now fails it.

Full suite green — 363 files, 7434 passed.

## Scope

Does **not** fix #1043's underlying cause, which still needs `workflow_uuid` on the panel's `workflow_new` reply (comfyui-mcp-panel#768). It removes a false negative on the path out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)