### PR TITLE
0.50.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.33] - 2026-08-08
+
+### MCP
+
+#### Added
+- declare destructive/openWorld hints on the money-spending tools (#1108)
+
+#### Fixed
+- a fence the panel repaired mid-call is no longer reported as failure (#1043) (#1111)
+
+
 ## [0.50.32] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.32",
+  "version": "0.50.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.32",
+      "version": "0.50.33",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.32",
+  "version": "0.50.33",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.33**. Tag pushed; `release.yml` publishes from it; this PR reconciles protected `main`.

## #1111 — a fence the panel repaired mid-call is no longer reported as failure

The panel answers a workflow-instance mismatch by re-advertising its identity, and the orchestrator's hello handler adopts it. That budget is per-identity and **resets when the live uuid changes** — so right after a `workflow_new`, the very refusal `rebindWorkflowFence` collects is what buys the re-hello that fixes the fence.

It lands asynchronously, and the rebind was reporting the reading it took *before* the call: "NOT recovered", plus a remedy, about a session that was by then fine. The unreadable returns now settle once and re-read, reporting `bound` when the stamp changed — with the provenance stated, since the repair came from the panel rather than from our read.

Claimed **only** when both reads are `known` and the uuid actually changed; an unreadable fence proves nothing.

Does not fix #1043's root cause, which still needs `workflow_uuid` on the panel's `workflow_new` reply (comfyui-mcp-panel#768). It removes a false negative on the path out.

## #1108 — money-spending tools now declare `destructiveHint` / `openWorldHint`

From another session, closing the gap I filed as #1106 out of #269's finding 5: a billed `runpod (action:"create")` was invocable with only prose warning the caller. The hints are machine-readable, so an MCP client can gate on them rather than relying on the model reading the description carefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)