### PR TITLE
fix(pairing): persist the phone pair token so a restart stops killing the link

### DIFF
--- a/src/__tests__/orchestrator/pair-token-store.test.ts
+++ b/src/__tests__/orchestrator/pair-token-store.test.ts
@@ -1,0 +1,116 @@
+// #875 — the pairing token stops rotating per run.
+//
+// A user asked to pin the orchestrator version because "updating the npm version
+// bricks my communication with the agent". The version was never the cause: the
+// self-restarter is on by default (hourly npm check, restarts when idle), and a
+// restart minted a fresh pairing token — so the URL their phone had saved was
+// dead. The documented answer was to set COMFYUI_MCP_PAIR_TOKEN, which works but
+// requires knowing that the thing that broke was a token at all.
+//
+// Persisting it removes that rotation for everyone with no configuration.
+//
+// HALF the fix, deliberately: a tunnel URL also carries a cloudflared quick-tunnel
+// hostname, minted fresh every run with no way to pin it. A stable token makes the
+// LAN URL durable; a tunnel URL still rotates, and pair-durability must keep
+// saying so.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadOrCreatePairToken, pairTokenPath } from "../../orchestrator/pair-token-store.js";
+
+let dir: string;
+let file: string;
+const OLD = process.env.COMFYUI_MCP_PAIR_TOKEN_FILE;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cmcp-pairtok-"));
+  file = join(dir, "pair-token");
+  process.env.COMFYUI_MCP_PAIR_TOKEN_FILE = file;
+});
+
+afterEach(() => {
+  if (OLD === undefined) delete process.env.COMFYUI_MCP_PAIR_TOKEN_FILE;
+  else process.env.COMFYUI_MCP_PAIR_TOKEN_FILE = OLD;
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe("the pairing token survives a restart", () => {
+  it("mints one on first use and persists it", () => {
+    const first = loadOrCreatePairToken();
+
+    expect(first.persisted).toBe(true);
+    expect(first.token).toMatch(/^[0-9a-f]{48}$/);
+    expect(readFileSync(file, "utf-8").trim()).toBe(first.token);
+  });
+
+  it("returns the SAME token on the next run — this is the whole fix", () => {
+    const first = loadOrCreatePairToken();
+    const second = loadOrCreatePairToken(); // a fresh process would do exactly this
+
+    expect(second.token).toBe(first.token);
+    expect(second.persisted).toBe(true);
+  });
+
+  it("honours the configured path", () => {
+    expect(pairTokenPath()).toBe(file);
+  });
+});
+
+describe("a damaged token file is replaced, never trusted", () => {
+  // An interrupted write is the realistic way this goes wrong, and a truncated
+  // value must not become the credential a phone is told to trust.
+  it.each([
+    ["truncated", "abc123"],
+    ["empty", ""],
+    ["not hex", "z".repeat(48)],
+    ["hand-edited prose", "my-token"],
+  ])("replaces a %s file with a fresh valid token", (_label, content) => {
+    writeFileSync(file, content);
+
+    const got = loadOrCreatePairToken();
+
+    expect(got.token).toMatch(/^[0-9a-f]{48}$/);
+    expect(got.token).not.toBe(content);
+    expect(got.persisted).toBe(true);
+    // …and the bad value is gone, so the next boot does not repeat the warning.
+    expect(readFileSync(file, "utf-8").trim()).toBe(got.token);
+  });
+
+  it("tolerates surrounding whitespace rather than discarding a good token", () => {
+    const good = "a".repeat(48);
+    writeFileSync(file, `\n${good}\n`);
+
+    expect(loadOrCreatePairToken().token).toBe(good);
+  });
+});
+
+describe("it degrades instead of failing", () => {
+  // A read-only home or a permissions problem must not break pairing outright.
+  // The old behaviour — a per-session token — is the correct fallback, and the
+  // caller is told which it got so pair-durability can report honestly rather
+  // than claiming a stability the URL does not have.
+  it("falls back to a per-session token when the path cannot be written", () => {
+    // A directory where the file goes: mkdir succeeds, the write cannot.
+    process.env.COMFYUI_MCP_PAIR_TOKEN_FILE = dir; // dir itself, not a file in it
+
+    const got = loadOrCreatePairToken();
+
+    expect(got.token).toMatch(/^[0-9a-f]{48}$/);
+    expect(got.persisted).toBe(false); // the honest half
+  });
+});
+
+describe("the file is not world-readable", () => {
+  it("writes the token 0600 on POSIX", () => {
+    if (process.platform === "win32") return; // POSIX modes are meaningless here
+    loadOrCreatePairToken();
+
+    expect(statSync(file).mode & 0o077).toBe(0);
+  });
+});

--- a/src/__tests__/orchestrator/pair-url-durability.test.ts
+++ b/src/__tests__/orchestrator/pair-url-durability.test.ts
@@ -19,14 +19,14 @@ import { canSelfRestart } from "../../services/self-restart.js";
 
 describe("#875: what the pairing URL actually promises", () => {
   it("LAN + pinned token is the ONE durable combination", () => {
-    const d = pairUrlDurability({ mode: "lan", pinnedToken: true, autoRestart: true });
+    const d = pairUrlDurability({ mode: "lan", stableToken: true, autoRestart: true });
     expect(d.survivesRestart).toBe(true);
     expect(d.rotates).toEqual([]);
     expect(d.note).toMatch(/survives an orchestrator restart/);
   });
 
   it("LAN without a pinned token rotates the token, and names the fix", () => {
-    const d = pairUrlDurability({ mode: "lan", pinnedToken: false, autoRestart: true });
+    const d = pairUrlDurability({ mode: "lan", stableToken: false, autoRestart: true });
     expect(d.survivesRestart).toBe(false);
     expect(d.rotates).toEqual(["token"]);
     expect(d.note).toMatch(/COMFYUI_MCP_PAIR_TOKEN/);
@@ -34,13 +34,13 @@ describe("#875: what the pairing URL actually promises", () => {
   });
 
   it("tunnel rotates the hostname EVEN WITH a pinned token", () => {
-    const d = pairUrlDurability({ mode: "tunnel", pinnedToken: true, autoRestart: true });
+    const d = pairUrlDurability({ mode: "tunnel", stableToken: true, autoRestart: true });
     expect(d.survivesRestart).toBe(false);
     expect(d.rotates).toEqual(["hostname"]);
   });
 
   it("tunnel without a pinned token rotates both", () => {
-    const d = pairUrlDurability({ mode: "tunnel", pinnedToken: false, autoRestart: true });
+    const d = pairUrlDurability({ mode: "tunnel", stableToken: false, autoRestart: true });
     expect(d.rotates).toEqual(["hostname", "token"]);
     expect(d.note).toMatch(/both its hostname and its token/);
   });
@@ -52,22 +52,22 @@ describe("#875: what the pairing URL actually promises", () => {
   // to stand up a Cloudflare Worker that cannot fix their problem is worse than
   // telling them nothing.
   it("does not offer the relay backend as a tunnel remedy — it does not apply", () => {
-    const d = pairUrlDurability({ mode: "tunnel", pinnedToken: false, autoRestart: true });
+    const d = pairUrlDurability({ mode: "tunnel", stableToken: false, autoRestart: true });
     expect(d.note).toMatch(/COMFYUI_MCP_TUNNEL_BACKEND=relay does not apply/);
     expect(d.note).toMatch(/no way to pin the tunnel hostname/);
   });
 
   it("does not tell a tunnel user that pinning the token will save them", () => {
-    const d = pairUrlDurability({ mode: "tunnel", pinnedToken: false, autoRestart: true });
+    const d = pairUrlDurability({ mode: "tunnel", stableToken: false, autoRestart: true });
     expect(d.note).toMatch(/will not help here/);
   });
 
   // A warning about spontaneous restarts is false when they are switched off.
   it("only blames automatic restarts when they are actually armed", () => {
-    const on = pairUrlDurability({ mode: "lan", pinnedToken: false, autoRestart: true });
+    const on = pairUrlDurability({ mode: "lan", stableToken: false, autoRestart: true });
     expect(on.note).toMatch(/restarts on its own/);
 
-    const off = pairUrlDurability({ mode: "lan", pinnedToken: false, autoRestart: false });
+    const off = pairUrlDurability({ mode: "lan", stableToken: false, autoRestart: false });
     expect(off.note).toMatch(/Automatic restarts are disabled/);
     expect(off.note).not.toMatch(/restarts on its own/);
     // Still not durable — a deliberate restart breaks it just the same.
@@ -76,9 +76,9 @@ describe("#875: what the pairing URL actually promises", () => {
 
   it("rotates is empty exactly when survivesRestart", () => {
     for (const mode of ["lan", "tunnel"] as const) {
-      for (const pinnedToken of [true, false]) {
+      for (const stableToken of [true, false]) {
         for (const autoRestart of [true, false]) {
-          const d = pairUrlDurability({ mode, pinnedToken, autoRestart });
+          const d = pairUrlDurability({ mode, stableToken, autoRestart });
           expect(d.rotates.length === 0).toBe(d.survivesRestart);
         }
       }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -42,6 +42,7 @@ import { panelRecoveryContext } from "../services/panel-recovery.js";
 import { isPanelAutoInstallDisabled } from "../services/panel-installer.js";
 import { SelfRestarter, canSelfRestart } from "../services/self-restart.js";
 import { pairUrlDurability } from "./pair-durability.js";
+import { loadOrCreatePairToken } from "./pair-token-store.js";
 import { SessionStore, workflowIdentityParts } from "./session-store.js";
 import { unreachableReason, noPanelTabReason, identityReason } from "./fence-refusal.js";
 import {
@@ -1058,8 +1059,18 @@ export async function runPanelOrchestrator(): Promise<void> {
   let pairToken: string | null = envPairToken;
   let pairListenerStarted = false;
   let pairTunnel: { url: string; stop: () => void } | null = null;
+  // #875 — the token is PERSISTED, not per-session. It used to be minted fresh on
+  // every run, so a self-restart (on by default, hourly npm check) invalidated the
+  // URL the phone had saved. The reporter experienced that as "updating the npm
+  // version bricks my communication with the agent" and asked to pin the version;
+  // the version was never the cause. An explicit COMFYUI_MCP_PAIR_TOKEN still wins.
+  let pairTokenPersisted = envPairToken !== null;
   const ensurePairListener = async (): Promise<string> => {
-    if (!pairToken) pairToken = randomBytes(24).toString("hex");
+    if (!pairToken) {
+      const loaded = loadOrCreatePairToken();
+      pairToken = loaded.token;
+      pairTokenPersisted = loaded.persisted;
+    }
     if (!pairListenerStarted) {
       await bridge.addListener("0.0.0.0", pairPort, pairToken);
       pairListenerStarted = true;
@@ -4244,7 +4255,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         // cause, and nothing here had told them.
         const durability = pairUrlDurability({
           mode,
-          pinnedToken: envPairToken !== null,
+          stableToken: envPairToken !== null || pairTokenPersisted,
           autoRestart: canSelfRestart(),
         });
         logger.info(

--- a/src/orchestrator/pair-durability.ts
+++ b/src/orchestrator/pair-durability.ts
@@ -44,8 +44,11 @@ export interface PairUrlDurability {
 export interface PairDurabilityInput {
   /** "lan" → ws://<lan-ip>:<port>; "tunnel" → a cloudflared quick tunnel. */
   mode: "lan" | "tunnel";
-  /** Whether COMFYUI_MCP_PAIR_TOKEN is pinned (a stable token across restarts). */
-  pinnedToken: boolean;
+  /** Whether the token is STABLE across restarts — persisted to disk by default,
+   *  or pinned via COMFYUI_MCP_PAIR_TOKEN. Either way the phone's saved token
+   *  keeps working; the note below must not name one mechanism as if it were the
+   *  only one (#875). */
+  stableToken: boolean;
   /** Whether the self-restarter can restart this process (default on). When it
    *  cannot, a rotating URL is far less likely to bite — say so rather than
    *  warning about a restart that will not happen on its own. */
@@ -61,15 +64,15 @@ export function pairUrlDurability(input: PairDurabilityInput): PairUrlDurability
   // Tunnel pairing is ALWAYS a quick tunnel (see the note above): the hostname
   // is regenerated per run with no way to pin it.
   if (input.mode === "tunnel") rotates.push("hostname");
-  if (!input.pinnedToken) rotates.push("token");
+  if (!input.stableToken) rotates.push("token");
 
   if (rotates.length === 0) {
     return {
       survivesRestart: true,
       rotates: [],
       note:
-        "This URL survives an orchestrator restart: COMFYUI_MCP_PAIR_TOKEN is pinned and the " +
-        "LAN address does not change per run. (If your router reassigns this machine a different " +
+        "This URL survives an orchestrator restart: the pairing token is stable (persisted, or " +
+        "pinned via COMFYUI_MCP_PAIR_TOKEN) and the LAN address does not change per run. (If your router reassigns this machine a different " +
         "IP, the address changes for that reason, not because of a restart.)",
     };
   }

--- a/src/orchestrator/pair-token-store.ts
+++ b/src/orchestrator/pair-token-store.ts
@@ -1,0 +1,104 @@
+// #875 — the phone pairing token, persisted so it stops rotating per run.
+//
+// A user asked to pin the orchestrator version because "updating the npm version
+// bricks my communication with the agent". The version was never the cause: the
+// self-restarter is on by default, and a restart rotated the pairing token, so
+// the URL their phone had saved was dead. They were told to set
+// COMFYUI_MCP_PAIR_TOKEN — which works, but requires knowing that the thing that
+// broke was a token at all.
+//
+// Generating it once and reusing it removes that rotation for everyone with no
+// configuration. The reporter's own note on the trust model is the right one:
+// the token is already password-equivalent and already handed to a phone over a
+// QR/URL, so writing it to the user's own config dir does not change who can
+// reach what. It lives beside the session store and panel secrets, which are the
+// same class of local-only material.
+//
+// This is HALF the fix. A tunnel URL also carries a cloudflared quick-tunnel
+// hostname, which is minted fresh every run and cannot be pinned — so a stable
+// token makes the LAN URL durable and a tunnel URL still rotates. pair-durability
+// reports exactly that at pair time; nothing here may imply otherwise.
+
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { logger } from "../utils/logger.js";
+
+/** Where the token lives. Overridable for tests — this must NEVER be written
+ *  under a real home directory from a test run. */
+export function pairTokenPath(): string {
+  return (
+    process.env.COMFYUI_MCP_PAIR_TOKEN_FILE ||
+    join(homedir(), ".comfyui-mcp", "pair-token")
+  );
+}
+
+/** A token we minted: 24 random bytes, hex — the same shape the per-session path
+ *  used, so nothing downstream sees a different kind of value. */
+function mint(): string {
+  return randomBytes(24).toString("hex");
+}
+
+/**
+ * Accept only what we would have minted. A file that has been truncated,
+ * half-written, or filled with something else must not become the credential a
+ * phone is told to trust — and a short/empty read is exactly what an interrupted
+ * write leaves behind.
+ */
+function usable(raw: string): string | null {
+  const t = raw.trim();
+  return /^[0-9a-f]{48}$/.test(t) ? t : null;
+}
+
+/**
+ * The stable pairing token: the one on disk, or a freshly minted one persisted
+ * for next time.
+ *
+ * NEVER throws and never returns an empty string. If the file cannot be read or
+ * written — a read-only home, a permissions problem — this falls back to a
+ * per-session token, which is exactly the behaviour that existed before. Pairing
+ * degrades to "works now, dies on restart" rather than failing outright, and the
+ * caller is told which it got so pair-durability can say so.
+ */
+export function loadOrCreatePairToken(): { token: string; persisted: boolean } {
+  const path = pairTokenPath();
+  try {
+    if (existsSync(path)) {
+      const existing = usable(readFileSync(path, "utf-8"));
+      if (existing) return { token: existing, persisted: true };
+      // Present but unusable. Do NOT reuse it, and do not silently keep a file
+      // that will fail the same way every boot — replace it with a good one.
+      logger.warn(
+        `[pair-token] ${path} did not contain a usable token (truncated or edited); minting a new one`,
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      `[pair-token] could not read ${path}: ${err instanceof Error ? err.message : String(err)} — using a per-session token`,
+    );
+    return { token: mint(), persisted: false };
+  }
+
+  const token = mint();
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    // Write-then-rename so an interrupted write cannot leave a half-token that
+    // the next boot would read as the credential.
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, token, { mode: 0o600 });
+    renameSync(tmp, path);
+    try {
+      chmodSync(path, 0o600); // no-op on Windows; belt-and-braces on POSIX
+    } catch {
+      /* best-effort — the rename already carried the mode on POSIX */
+    }
+    return { token, persisted: true };
+  } catch (err) {
+    logger.warn(
+      `[pair-token] could not persist a stable token to ${path}: ${err instanceof Error ? err.message : String(err)} — ` +
+        `pairing still works, but the URL your phone saves will stop working after a restart`,
+    );
+    return { token, persisted: false };
+  }
+}


### PR DESCRIPTION
Suggestion 2 from #875 — the one that removes a rotation for everyone with no configuration.

## What was happening

A user asked to pin the orchestrator version because *"updating the npm version bricks my communication with the agent"*. The version was never the cause. The self-restarter is on by default (hourly npm check, restarts when idle), and a restart minted a **fresh pairing token** — so the URL their phone had saved was dead.

The documented answer was to set `COMFYUI_MCP_PAIR_TOKEN`. That works, but it requires knowing that the thing that broke was a token at all — which is why this arrived as "pin the version" rather than "my pairing URL expired".

## The change

The token is generated once and reused. The reporter's own note on the trust model is the right one: it's already password-equivalent and already handed to a phone over a QR/URL, so writing it to the user's own config dir doesn't change who can reach what. It sits beside the session store and panel secrets — the same class of local-only material — at `0600`, written tmp-then-rename so an interrupted write can't leave a half-token the next boot reads as the credential.

**Degrades, never fails.** A read-only home or a permissions problem falls back to a per-session token — exactly the old behaviour — and reports `persisted: false`, so the pair-time durability note keeps telling the truth rather than claiming a stability the URL doesn't have.

**A damaged file is replaced, never trusted.** Only a 48-hex value is accepted, so a truncated or hand-edited file mints a fresh token and overwrites the bad one instead of warning identically on every boot.

## A rename that had to happen

`PairDurabilityInput.pinnedToken` → `stableToken`. The field *meant* "the token survives a restart", but was documented as — and its success note literally said — *"COMFYUI_MCP_PAIR_TOKEN is pinned"*. That's now false for a persisted token, and leaving it would have made the note lie about the mechanism: the exact defect class that file exists to fix.

## Deliberately half the fix

A tunnel URL also carries a cloudflared **quick-tunnel hostname**, minted fresh per run with no way to pin it. So a stable token makes the LAN URL durable while a tunnel URL still rotates — and `pair-durability` continues to say exactly that. Suggestion 3 (defer the self-*restart* while a tunnel pairing session is live) is untouched.

## Verification

| Mutation | Result |
|---|---|
| never reuse the stored token | the "SAME token on the next run" test fails — that test *is* the fix |
| accept any non-empty file as a token | 3 damaged-file tests fail |

10 new tests, including degrade-to-per-session and `0600` on POSIX. Full suite green — 365 files, 7449 passed.

Worth noting: the rename's blast radius was caught by the existing durability suite, but one shorthand `{ mode, pinnedToken, autoRestart }` survived my colon-anchored replace. It compiled, and would have passed **vacuously** against an unknown property. Fixed, and there are now zero `pinnedToken` references left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)