### PR TITLE
0.50.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.34] - 2026-08-08
+
+### MCP
+
+#### Added
+- gate the "could not determine" → "determined not" collapse (#1110)
+
+#### Fixed
+- persist the phone pair token so a restart stops killing the link (#875) (#1113)
+
+
 ## [0.50.33] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.33",
+  "version": "0.50.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.33",
+      "version": "0.50.34",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.33",
+  "version": "0.50.34",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.34**. Tag pushed; `release.yml` publishes from it; this PR reconciles protected `main`.

## #1113 — the phone pairing token survives a restart (#875)

A user asked to pin the orchestrator version because *"updating the npm version bricks my communication with the agent"*. The version was never the cause: the self-restarter is on by default and a restart minted a fresh pairing token, so the URL their phone had saved was dead.

The token is now generated once and reused — removing that rotation for everyone with no configuration. It's stored `0600` beside the session store, written tmp-then-rename, and only a valid 48-hex value is accepted so a truncated file is replaced rather than trusted. If it can't be persisted at all, it falls back to the old per-session behaviour and reports that honestly, so the pair-time durability note never claims a stability the URL lacks.

Deliberately half the fix: a tunnel URL also carries a cloudflared quick-tunnel hostname that cannot be pinned, so a stable token makes the **LAN** URL durable while a tunnel URL still rotates — which `pair-durability` continues to say at pair time.

Picked up by following the *triage oldest first* rule: #875 is the oldest open `bug`, and the rest of the oldest items are enhancements parked under the freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)