### PR TITLE
fix(pairing): defer the update-restart while a phone is connected over a tunnel

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -4714,3 +4714,48 @@ describe("UiBridge.connectedServerOrigins (#952)", () => {
     expect(bridge.connectedServerOrigins()).toEqual([]);
   });
 });
+
+// #875 — the liveness signal the self-restarter's tunnel gate depends on.
+//
+// isHeadless() is STICKY on purpose (a tab that ever connected headless stays so
+// while offline, so a render finishing during a disconnect is byte-inlined for
+// the mailbox). That is right for rendering and WRONG for liveness: using it
+// would report a phone that paired once and left as still connected, and the
+// restarter would defer updates forever instead of until the next disconnect.
+describe("#875: hasLiveHeadlessClient reports the LIVE set, not the sticky one", () => {
+  it("is false with no connections at all", async () => {
+    const { bridge: b } = await startBridgeOnFreePort();
+    expect(b.hasLiveHeadlessClient()).toBe(false);
+    await b.stop();
+  });
+
+  // The POSITIVE case, and the one that makes this suite non-vacuous: without it
+  // every assertion here would pass with the accessor hardcoded to false — a
+  // mutation to the STICKY isHeadless() killed nothing until this existed.
+  it("is TRUE while a headless client is connected, and false once it leaves", async () => {
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      sock.on("open", () => res());
+      sock.on("error", rej);
+    });
+    sock.send(JSON.stringify({ type: "hello", tab_id: "phone-live", title: "phone", headless: true }));
+    await new Promise((r) => setTimeout(r, 80));
+
+    expect(bridge.hasLiveHeadlessClient()).toBe(true);
+
+    sock.close();
+    await new Promise((r) => setTimeout(r, 150));
+    // The whole point of not using the sticky isHeadless(): once the phone is
+    // gone the restarter must be free to restart again.
+    expect(bridge.hasLiveHeadlessClient()).toBe(false);
+  });
+
+  it("is false for a connected NON-headless (canvas) tab", async () => {
+    const sock = await connectPanel("tab-desktop");
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(bridge.hasLiveHeadlessClient()).toBe(false);
+
+    sock.close();
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1059,6 +1059,20 @@ export async function runPanelOrchestrator(): Promise<void> {
   let pairToken: string | null = envPairToken;
   let pairListenerStarted = false;
   let pairTunnel: { url: string; stop: () => void } | null = null;
+  /**
+   * #875 — is a phone paired over a TUNNEL right now?
+   *
+   * Gates the self-restarter (see its allIdle below). A tunnel URL cannot survive
+   * a restart: cloudflared mints a fresh quick-tunnel hostname per run and there
+   * is no way to pin it, so restarting under a live tunnel breaks a phone that is
+   * connected at that moment. A LAN URL is fine — the token persists now — which
+   * is why this is narrowed to the tunnel rather than to pairing in general.
+   */
+  // Requires BOTH: a tunnel exists AND a client is connected through it right
+  // now. `pairTunnel` alone is not liveness — nothing stops the tunnel until the
+  // process exits, so gating on it would postpone every future update after a
+  // single pairing, rather than deferring to the next disconnect as intended.
+  const tunnelPairingLive = (): boolean => pairTunnel !== null && bridge.hasLiveHeadlessClient();
   // #875 — the token is PERSISTED, not per-session. It used to be minted fresh on
   // every run, so a self-restart (on by default, hourly npm check) invalidated the
   // URL the phone had saved. The reporter experienced that as "updating the npm
@@ -5876,7 +5890,20 @@ export async function runPanelOrchestrator(): Promise<void> {
       // …and the same for an ask answer the user actually gave that has not
       // reached the agent yet (#486). Restarting would destroy it silently.
       !AskAnswers.hasOutstanding() &&
-      !QueueMonitor.isBusy(),
+      !QueueMonitor.isBusy() &&
+      // #875 — a LIVE TUNNEL PAIRING SESSION defers the restart to the next
+      // disconnect. The token now persists, so a LAN URL survives a restart; a
+      // tunnel URL cannot, because cloudflared mints a fresh quick-tunnel
+      // hostname every run and there is no way to pin it. Restarting under a live
+      // tunnel therefore breaks a phone that is connected RIGHT NOW, to install
+      // an update nobody asked for at that moment — which is what the reporter
+      // experienced and (reasonably) blamed on the npm version.
+      //
+      // Deferral, not cancellation: the update check still runs and the restart
+      // stays armed, so it fires as soon as the tunnel goes away. The cost is
+      // that a tunnel left up indefinitely postpones updates indefinitely, which
+      // is why noteTunnelDeferral announces it rather than doing it silently.
+      !tunnelPairingLive(),
     announce: (text) => void bridge.push({ type: "say", text }),
     teardown: teardownCore,
   });

--- a/src/orchestrator/pair-durability.ts
+++ b/src/orchestrator/pair-durability.ts
@@ -95,8 +95,15 @@ export function pairUrlDurability(input: PairDurabilityInput): PairUrlDurability
   const remedy = rotates.includes("hostname")
     ? "There is no way to pin the tunnel hostname today — phone pairing always uses a cloudflared " +
       "quick tunnel, and COMFYUI_MCP_TUNNEL_BACKEND=relay does not apply to it. To keep a link " +
-      "that survives restarts, pair over LAN with COMFYUI_MCP_PAIR_TOKEN set; otherwise re-pair " +
-      "from the panel after a restart." +
+      "that survives restarts, pair over LAN (the token is persisted, so a LAN URL keeps " +
+      "working); otherwise re-pair from the panel after a restart. " +
+      // #875 — the reassurance that matters mid-session: an automatic restart
+      // will NOT yank this tunnel out from under a connected phone. Stated here
+      // because pair time is where the user is looking; the deferral itself is a
+      // gate on the self-restarter, and a log would not reach them.
+      "While a phone is connected over this tunnel, automatic update-restarts are DEFERRED until " +
+      "it disconnects, so an update cannot break the link mid-session (a tunnel left connected " +
+      "indefinitely therefore postpones updates indefinitely)." +
       (rotates.includes("token")
         ? " (Pinning COMFYUI_MCP_PAIR_TOKEN alone will not help here — the hostname still rotates.)"
         : "")

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2718,6 +2718,21 @@ export class UiBridge {
 
   /** True when the tab advertised itself as a canvas-less (mobile/remote) client
    *  in its `hello`. Unknown tabs → false. */
+  /**
+   * #875 — is any CURRENTLY-CONNECTED client headless (a paired phone / mirror)?
+   *
+   * Deliberately NOT `isHeadless()`, which is STICKY by design: a tab that ever
+   * connected headless stays "headless" while offline so a render finishing
+   * during a disconnect is byte-inlined for the mailbox. That is right for
+   * rendering decisions and wrong for a LIVENESS gate — using it would report a
+   * phone that paired once and left as still connected, and the self-restarter
+   * would defer updates forever.
+   */
+  hasLiveHeadlessClient(): boolean {
+    for (const c of this.conns.values()) if (c.headless === true) return true;
+    return false;
+  }
+
   isHeadless(tabId: string): boolean {
     // Sticky: a tab that EVER connected headless stays "headless" even while
     // offline, so a render finishing during a disconnect is byte-inlined (not a


### PR DESCRIPTION
Suggestion 3 from #875 — the half that persisting the token could not reach.

A LAN URL now survives a restart. A tunnel URL cannot: cloudflared mints a fresh quick-tunnel hostname every run and there's no way to pin it. So restarting under a live tunnel breaks a link that is in use **right now**, to install an update nobody asked for at that moment — which is exactly what the reporter experienced and reasonably blamed on the npm version.

As they predicted, this is *another gate rather than new machinery*: the self-restarter already composes `allIdle` from "nothing queued or held", and a live tunnel pairing session joins it.

**Deferral, not cancellation.** The update check still runs and the restart stays armed, so it fires as soon as the phone disconnects.

## The liveness signal is the load-bearing part

`pairTunnel` alone is **not** liveness — nothing stops the tunnel until the process exits, so gating on it would postpone every future update after a single pairing, rather than deferring to the next disconnect. The gate requires a tunnel **and** a currently-connected headless client.

That needed a new accessor. `isHeadless()` is **sticky** by design: a tab that ever connected headless stays so while offline, so a render finishing during a disconnect is byte-inlined for the mailbox. Right for rendering, wrong for liveness — it would report a phone that paired once and left as still connected. `hasLiveHeadlessClient()` reads only the live connection set.

The tradeoff — a tunnel left connected indefinitely postpones updates indefinitely — is disclosed at **pair time** rather than logged. That's where the user is looking, and #1077 showed a log isn't somewhere they can necessarily reach.

## Verification

| Mutation | Result |
|---|---|
| swap the live scan for the sticky accessor | the positive liveness test fails |

Two things worth stating about getting there:

**That positive test had to be added.** My first pass asserted only the *false* cases (no connections; a canvas tab), so the mutation killed **nothing** — the suite would have passed with the accessor hardcoded to `false`.

**I deleted four tests I'd written for the gate itself.** They defined the two-term conjunction locally and asserted that local definition, exercising nothing real. The gate is verified by inspection plus the accessor's tests; fake coverage is worse than none.

Full suite green — 366 files, 7474 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)