### PR TITLE
0.50.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.35] - 2026-08-08
+
+### MCP
+
+#### Fixed
+- defer the update-restart while a phone is connected over a tunnel (#875) (#1115)
+
+
 ## [0.50.34] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.34",
+  "version": "0.50.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.34",
+      "version": "0.50.35",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.34",
+  "version": "0.50.35",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.35**. Tag pushed; `release.yml` publishes from it; this PR reconciles protected `main`.

## #1115 — an update-restart no longer breaks a live phone tunnel (#875)

Completes the pair with 0.50.34's persisted token. That made a **LAN** URL survive a restart; a tunnel URL cannot, because cloudflared mints a fresh quick-tunnel hostname per run with no way to pin it. So a background auto-update could still yank the link out from under a phone that was connected at that moment.

The self-restarter now treats a live tunnel pairing session as "not idle" — deferral, not cancellation: the update check still runs, the restart stays armed, and it fires as soon as the phone disconnects.

The liveness signal required care. `pairTunnel` alone isn't liveness (nothing stops the tunnel until process exit, so gating on it would postpone updates forever after one pairing), and `isHeadless()` is sticky by design. A new `hasLiveHeadlessClient()` reads only the live connection set.

The tradeoff — a tunnel left connected indefinitely postpones updates indefinitely — is disclosed at pair time, where the user is actually looking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)