### PR TITLE
docs(pairing): the tunnel-deferral comment named a function that does not exist

### DIFF
--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -5901,8 +5901,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       //
       // Deferral, not cancellation: the update check still runs and the restart
       // stays armed, so it fires as soon as the tunnel goes away. The cost is
-      // that a tunnel left up indefinitely postpones updates indefinitely, which
-      // is why noteTunnelDeferral announces it rather than doing it silently.
+      // that a tunnel left up indefinitely postpones updates indefinitely, so it
+      // is DISCLOSED — in pair-durability's tunnel note, which the panel shows at
+      // pair time. Deliberately not announced from here: this is a predicate the
+      // restarter polls, and emitting from it would either fire repeatedly or
+      // need its own state to suppress itself. Pair time is also where the user
+      // is actually looking (#1077: an orchestrator log may be unreachable).
       !tunnelPairingLive(),
     announce: (text) => void bridge.push({ type: "say", text }),
     teardown: teardownCore,


### PR DESCRIPTION
Shipped in 0.50.35 an hour ago. The comment on the self-restarter's tunnel gate said the deferral's cost:

> …is why **noteTunnelDeferral** announces it rather than doing it silently.

There is no `noteTunnelDeferral`. I moved the disclosure to pair time (`pair-durability`'s tunnel note) mid-implementation and left prose describing a function I never wrote.

That's the same class this session has been clearing all day — prose asserting behaviour the code doesn't have. A reader greps the name, finds nothing, and has to reconstruct which half is true.

The comment now states where the disclosure actually lives, and **why** it isn't announced from the gate: that's a predicate the restarter polls, so emitting from it would either fire repeatedly or need its own suppression state. Pair time is also where the user is looking — #1077 was a good reminder that an orchestrator log may be somewhere they can't reach.

## How it was found

By verifying the **shipped artifact** rather than the source. I was confirming that `!tunnelPairingLive()` really sits inside the restarter's `allIdle` in `dist/orchestrator/index.js` — the call-site check that keeps catching gaps — and the surrounding comment was simply in front of me.

Comment only, no behaviour change, so it rides the next release rather than warranting its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)