### PR TITLE
fix(download): a Manager listing is PLACEMENT, never validity — my 0.50.29 regression

### DIFF
--- a/src/__tests__/services/manager-visibility.test.ts
+++ b/src/__tests__/services/manager-visibility.test.ts
@@ -24,10 +24,11 @@
 // which is why three of its assertions "failed" with plausible-looking values.
 
 import { describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
 import { verifyManagerVisibility } from "../../services/model-resolver.js";
 
 describe("verifyManagerVisibility asks the live server", () => {
-  it("CONFIRMS when the server lists the file", async () => {
+  it("reports VISIBLE when the server lists the file", async () => {
     const probe = vi.fn().mockResolvedValue(true);
 
     const r = await verifyManagerVisibility("clip_vision", "clip_vision_h.safetensors", {
@@ -112,5 +113,67 @@ describe("verifyManagerVisibility asks the live server", () => {
 
     // A verification hiccup must not turn a transfer into an error.
     expect(r.visibility).toBe("unknown");
+  });
+});
+
+// #473 — LISTING IS NOT VALIDITY, and saying otherwise was my regression.
+//
+// A reporter on 0.50.34 got six byte-identical 10,038-byte CivitAI Login HTML
+// documents saved as models, and observed that `download_model` "sometimes
+// upgraded the filename-presence check to CONFIRMED". That upgrade was this
+// check, shipped in 0.50.29.
+//
+// Manager writes whatever the URL returned under the name you asked for, and it
+// cannot carry this MCP's credentials — so an auth-gated URL yields a login page
+// with a .safetensors name. It lists perfectly. It deserializes into
+// "SafetensorError: header too large" the moment a LoraLoader touches it.
+//
+// This is #473's original failure (the landing watcher treating presence as
+// success) reintroduced one layer up, which is why the wording is pinned here.
+describe("a visible verdict never implies the payload is a real model", () => {
+  it("says placement, and explicitly disclaims validity", async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+
+    const r = await verifyManagerVisibility("loras", "KNP_000003000.safetensors", {
+      attempts: 1,
+      probe,
+    });
+
+    expect(r.visibility).toBe("visible");
+    expect(r.note).toMatch(/PLACEMENT, not validity/i);
+    // The mechanism, so the reader can tell WHY a listing proves so little.
+    expect(r.note).toMatch(/whatever the URL returned under the name you asked for/i);
+    expect(r.note).toMatch(/cannot carry this MCP's credentials/i);
+    // The tell a caller can actually act on.
+    expect(r.note).toMatch(/login page is ~10KB/i);
+  });
+
+  it("does not use the word CONFIRMED for a Manager dispatch", async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+
+    const r = await verifyManagerVisibility("loras", "x.safetensors", { attempts: 1, probe });
+
+    // The label is the whole defect: "CONFIRMED" reads as "this worked".
+    expect(r.note).not.toMatch(/\bCONFIRMED\b/);
+  });
+});
+
+// THE WIRING. The label lives in the tool's Manager branch, so the helper tests
+// above cannot see a revert to "CONFIRMED:" there — the same call-site blindness
+// that has bitten this suite repeatedly. Read the source, the way the other
+// prose gates in this repo do.
+describe("the tool's Manager branch never labels a listing as confirmation", () => {
+  it("has no CONFIRMED label on the viaManager path", () => {
+    const src = readFileSync(
+      new URL("../../tools/model-management.ts", import.meta.url),
+      "utf-8",
+    );
+    const start = src.indexOf("const text = job.viaManager");
+    expect(start, "the viaManager branch must still exist").toBeGreaterThan(-1);
+    const branch = src.slice(start, start + 1400);
+
+    // The regression, stated exactly: `CONFIRMED: ${managerSeen.note}`.
+    expect(branch).not.toMatch(/`CONFIRMED[:\s]/);
+    expect(branch).toMatch(/LISTED \(placement only, NOT validity\)/);
   });
 });

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1304,7 +1304,13 @@ export async function verifyManagerVisibility(
         visibility: "visible",
         note:
           `The connected ComfyUI now lists ${targetSubfolder}/${filename}, so the dispatch ` +
-          `landed somewhere it reads.`,
+          `landed somewhere it reads. That is PLACEMENT, not validity: a listing proves a file ` +
+          `of that NAME exists, and Manager writes whatever the URL returned under the name you ` +
+          `asked for. #473 is exactly this — a CivitAI login page saved as a .safetensors, ` +
+          `listed happily, and only discovered when LoraLoader failed to deserialize it. ` +
+          `Manager cannot carry this MCP's credentials, so an auth-gated URL is the case to ` +
+          `distrust: if the file is implausibly small for its kind (a login page is ~10KB), ` +
+          `treat it as failed and re-fetch it locally with COMFYUI_PATH set.`,
       };
     }
     if (has === false) asked = true;

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -730,8 +730,20 @@ async function downloadAction(args: {
             : undefined;
           const text = job.viaManager
             ? `Download DISPATCHED to the remote ComfyUI via ComfyUI-Manager (server-side fetch):\n${job.path}\n\n` +
+              // #473 — "CONFIRMED" was WRONG here, and it was my regression in
+              // 0.50.29. A listing proves a file of that NAME exists; Manager
+              // writes whatever the URL returned under the name you asked for,
+              // and it cannot carry this MCP's credentials. A reporter on 0.50.34
+              // got six byte-identical 10,038-byte CivitAI login pages saved as
+              // models, and said this check "sometimes upgraded the
+              // filename-presence check to CONFIRMED" — which is precisely the
+              // fabricated success #473 has now been reported for three times.
+              //
+              // The word stays out of the Manager branch entirely. LISTED is the
+              // observation; validity is not established here and must not be
+              // implied by the label.
               (managerSeen?.visibility === "visible"
-                ? `CONFIRMED: ${managerSeen.note}`
+                ? `LISTED (placement only, NOT validity): ${managerSeen.note}`
                 : `NOTE: ${placement.warning}` +
                   (managerSeen ? `\n\n${managerSeen.note}` : ""))
             : placement.confirmed


### PR DESCRIPTION
#473 was reported a **third time**, against **0.50.34 — today's release** — and one half of that report is my own change.

The reporter got six byte-identical **10,038-byte CivitAI Login HTML documents saved as models**, and observed that `download_model` *"sometimes upgraded the filename-presence check to CONFIRMED"*.

That upgrade is `verifyManagerVisibility`, which I shipped in 0.50.29 for #1086. It asks the server whether it **lists** the file. A login page saved under a `.safetensors` name lists perfectly. So the check turned a poisoned artifact into "CONFIRMED" — which is **#473's original failure** (the landing watcher treating filename presence as success) reintroduced one layer up, by the person who had just read that issue.

Manager writes whatever the URL returned under the name you asked for, and it cannot carry this MCP's credentials — so an auth-gated URL is exactly the case where presence proves least.

## The change

- the tool's Manager branch no longer says `CONFIRMED` at all. **"LISTED (placement only, NOT validity)"** is the observation; validity isn't established here and must not be implied by the label.
- the note states the mechanism, and gives a tell the caller can act on: a login page is ~10KB, so an implausibly small model should be treated as failed and re-fetched locally with `COMFYUI_PATH` set — which the reporter confirms produces valid artifacts.

## What this does *not* do

It does not fix the root cause: the credential still cannot reach a Manager dispatch. That's the same constraint #511 hardened the **local** streaming path against (content-type + magic-byte gate before materializing), and that gate cannot run when we never see the bytes. This change stops us **certifying** the result.

## Verification

| Mutation | Result |
|---|---|
| restore `` `CONFIRMED: ${managerSeen.note}` `` | the wiring test fails |
| weaken the disclaimer in the note | the helper test fails |

The wiring test reads the **source** of the tool's Manager branch, because the helper tests cannot see a revert at the call site — the same blindness that has bitten this suite repeatedly today.

Full suite green — 367 files, 7481 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)