### PR TITLE
0.50.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.36] - 2026-08-08
+
+### MCP
+
+#### Fixed
+- a Manager listing is PLACEMENT, never validity — my 0.50.29 regression (#473) (#1120)
+
+#### Changed
+- the shipped build's data-loss guards must actually guard (#1119)
+- pin the env var our errors tell people to set (#1118)
+- the tunnel-deferral comment named a function that does not exist (#1117)
+
+
 ## [0.50.35] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.35",
+  "version": "0.50.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.35",
+      "version": "0.50.36",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.35",
+  "version": "0.50.36",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.36**. Tag pushed; `release.yml` publishes from it; this PR reconciles protected `main`.

Released promptly: #1120 corrects a **regression I introduced in 0.50.29** that made a P1 data-corruption bug harder to notice.

## #1120 — a Manager listing is placement, never validity (#473)

#473 was reported a third time, against 0.50.34. The reporter got six byte-identical 10,038-byte CivitAI Login HTML documents saved as models, and noted that `download_model` *"sometimes upgraded the filename-presence check to CONFIRMED"*.

That upgrade was `verifyManagerVisibility` (shipped 0.50.29 for #1086): it asks whether the server **lists** the file, and a login page saved under a `.safetensors` name lists perfectly. So it turned a poisoned artifact into "CONFIRMED" — #473's original failure, reintroduced one layer up.

The Manager branch no longer uses the word at all: **"LISTED (placement only, NOT validity)"**, plus the mechanism (Manager writes whatever the URL returned and cannot carry this MCP's credentials) and an actionable tell (a login page is ~10KB; treat an implausibly small model as failed and re-fetch locally with `COMFYUI_PATH` set).

The root cause — the credential not reaching a Manager dispatch — is unchanged, and is the same constraint #511's magic-byte gate cannot cover when we never see the bytes.

## Also shipping (already on main)

- **#1119** — the smoke gate now verifies the shipped build's data-loss guards (pair token, defaults config, `~/.claude.json`) actually guard, before `npm publish`.
- **#1117** — a comment that named a function which does not exist.
- **#1118** — pins the env var our errors tell people to set (another session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)