### PR TITLE
feat: attach UI workflow metadata to API-enqueued prompts

### DIFF
--- a/src/__tests__/services/workflow-executor.test.ts
+++ b/src/__tests__/services/workflow-executor.test.ts
@@ -357,3 +357,31 @@ describe("enqueueWorkflow UI metadata", () => {
     );
   });
 });
+
+// A non-object extra_pnginfo cannot be merged into, and spreading it would
+// DISCARD whatever the caller put there. Attaching UI metadata is an
+// enhancement; dropping a field the caller set would be a regression.
+describe("enqueueWorkflow UI metadata — a field we cannot merge into is left alone", () => {
+  it("does not drop an ARRAY extra_pnginfo to make room for the workflow", async () => {
+    const extraData = { extra_pnginfo: ["caller", "data"], client_id: "c1" };
+
+    await enqueueWorkflow(
+      { "1": { class_type: "ClaudeNode", inputs: { prompt: "hi", seed: 7 } } },
+      { disable_random_seed: true, extra_data: extraData },
+    );
+
+    expect(enqueuedExtraData()).toEqual(extraData);
+    expect(enqueuedExtraData()!.extra_pnginfo).toEqual(["caller", "data"]);
+  });
+
+  it("does not drop a STRING extra_pnginfo either", async () => {
+    const extraData = { extra_pnginfo: "opaque" };
+
+    await enqueueWorkflow(
+      { "1": { class_type: "ClaudeNode", inputs: { prompt: "hi", seed: 7 } } },
+      { disable_random_seed: true, extra_data: extraData },
+    );
+
+    expect(enqueuedExtraData()).toEqual(extraData);
+  });
+});

--- a/src/__tests__/services/workflow-executor.test.ts
+++ b/src/__tests__/services/workflow-executor.test.ts
@@ -23,6 +23,7 @@ import {
   seedInputRange,
 } from "../../services/workflow-executor.js";
 import type { ObjectInfo, WorkflowJSON } from "../../comfyui/types.js";
+import { logger } from "../../utils/logger.js";
 
 const INT32_MAX = 2147483647;
 
@@ -65,6 +66,10 @@ const OBJECT_INFO: ObjectInfo = {
 
 function enqueuedWorkflow(): WorkflowJSON {
   return enqueuePromptMock.mock.calls[0][0] as WorkflowJSON;
+}
+
+function enqueuedExtraData(): Record<string, unknown> | undefined {
+  return enqueuePromptMock.mock.calls[0][1] as Record<string, unknown> | undefined;
 }
 
 beforeEach(() => {
@@ -244,5 +249,111 @@ describe("enqueueWorkflow seed randomization (#865)", () => {
     expect(watchMock).toHaveBeenCalledTimes(1);
     expect(watchMock.mock.calls[0][0]).toBe("pid-1");
     expect(watchMock.mock.calls[0][1]).toEqual(enqueuedWorkflow());
+  });
+});
+
+describe("enqueueWorkflow UI metadata", () => {
+  it("attaches UI metadata generated from the post-randomization workflow", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    await enqueueWorkflow({
+      "3": { class_type: "KSampler", inputs: { seed: 1 } },
+    });
+
+    const randomizedSeed = enqueuedWorkflow()["3"].inputs.seed;
+    const extraPngInfo = enqueuedExtraData()?.extra_pnginfo as Record<string, unknown>;
+    const ui = extraPngInfo.workflow as {
+      nodes: Array<{ type: string; widgets_values?: unknown[] }>;
+    };
+    const sampler = ui.nodes.find((node) => node.type === "KSampler");
+    expect(randomizedSeed).toBe(0.5 * (Number.MAX_SAFE_INTEGER + 1));
+    expect(sampler?.widgets_values).toContain(randomizedSeed);
+  });
+
+  it("nested-merges generated metadata with existing request data", async () => {
+    const extraData = {
+      api_key_comfy_org: "credential",
+      client_id: "client-123",
+      partial_execution: { targets: ["9"] },
+      extra_pnginfo: { source: "caller" },
+    };
+
+    await enqueueWorkflow(
+      { "1": { class_type: "ClaudeNode", inputs: { prompt: "hi", seed: 7 } } },
+      { disable_random_seed: true, extra_data: extraData },
+    );
+
+    const sent = enqueuedExtraData()!;
+    expect(sent).toMatchObject({
+      api_key_comfy_org: "credential",
+      client_id: "client-123",
+      partial_execution: { targets: ["9"] },
+      extra_pnginfo: { source: "caller" },
+    });
+    const extraPngInfo = sent.extra_pnginfo as Record<string, unknown>;
+    expect((extraPngInfo.workflow as { nodes: unknown[] }).nodes).toHaveLength(1);
+    expect(extraData).toEqual({
+      api_key_comfy_org: "credential",
+      client_id: "client-123",
+      partial_execution: { targets: ["9"] },
+      extra_pnginfo: { source: "caller" },
+    });
+  });
+
+  it("nested-merges metadata without replacing a valid caller workflow", async () => {
+    const callerWorkflow = { nodes: [], links: [], version: 0.4 };
+    const extraData = {
+      api_key_comfy_org: "credential",
+      client_id: "client-123",
+      partial_execution: { targets: ["9"] },
+      extra_pnginfo: {
+        workflow: callerWorkflow,
+        source: "caller",
+      },
+    };
+
+    await enqueueWorkflow(
+      { "1": { class_type: "ClaudeNode", inputs: { prompt: "hi", seed: 7 } } },
+      { disable_random_seed: true, extra_data: extraData },
+    );
+
+    expect(enqueuedExtraData()).toEqual(extraData);
+    expect(extraData.extra_pnginfo.workflow).toBe(callerWorkflow);
+    expect(getObjectInfoMock).not.toHaveBeenCalled();
+  });
+
+  it("logs converter warnings and still attaches the generated UI metadata", async () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+
+    await enqueueWorkflow(
+      { custom: { class_type: "ClaudeNode", inputs: { prompt: "hi", seed: 7 } } },
+      { disable_random_seed: true },
+    );
+
+    const extraPngInfo = enqueuedExtraData()?.extra_pnginfo as Record<string, unknown>;
+    expect((extraPngInfo.workflow as { nodes: unknown[] }).nodes).toHaveLength(1);
+    expect(warn).toHaveBeenCalledWith(
+      "Workflow UI metadata conversion completed with warnings",
+      expect.objectContaining({ warnings: expect.arrayContaining([expect.stringContaining("remapped")]) }),
+    );
+  });
+
+  it("fails open and enqueues the original prompt exactly once when conversion throws", async () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    const malformed = { "1": null } as unknown as WorkflowJSON;
+    const extraData = { client_id: "client-123" };
+
+    const result = await enqueueWorkflow(malformed, {
+      disable_random_seed: true,
+      extra_data: extraData,
+    });
+
+    expect(result.prompt_id).toBe("pid-1");
+    expect(enqueuePromptMock).toHaveBeenCalledTimes(1);
+    expect(enqueuePromptMock).toHaveBeenCalledWith(malformed, extraData);
+    expect(warn).toHaveBeenCalledWith(
+      "Workflow UI metadata conversion failed; enqueueing without it",
+      expect.objectContaining({ error: expect.any(String) }),
+    );
   });
 });

--- a/src/services/workflow-executor.ts
+++ b/src/services/workflow-executor.ts
@@ -138,6 +138,17 @@ async function withWorkflowMetadata(
   workflow: WorkflowJSON,
   extraData?: Record<string, unknown>,
 ): Promise<Record<string, unknown> | undefined> {
+  // Present but not an object (an array, a string) — we cannot merge into it,
+  // and spreading it would DISCARD whatever the caller put there. Attaching this
+  // metadata is an enhancement; silently dropping a field the caller set would be
+  // a regression, so leave the request exactly as it came.
+  if (extraData?.extra_pnginfo !== undefined && !isRecord(extraData.extra_pnginfo)) {
+    logger.debug("extra_pnginfo is not an object; leaving it untouched (no UI metadata attached)", {
+      type: Array.isArray(extraData.extra_pnginfo) ? "array" : typeof extraData.extra_pnginfo,
+    });
+    return extraData;
+  }
+
   const extraPngInfo = isRecord(extraData?.extra_pnginfo)
     ? extraData.extra_pnginfo
     : {};

--- a/src/services/workflow-executor.ts
+++ b/src/services/workflow-executor.ts
@@ -10,6 +10,7 @@ import type {
 } from "../comfyui/types.js";
 import { logger } from "../utils/logger.js";
 import { JobWatcher } from "./job-watcher.js";
+import { convertApiToUi, isUiFormat } from "./workflow-converter.js";
 
 export interface EnqueueWorkflowOptions {
   disable_random_seed?: boolean;
@@ -129,6 +130,47 @@ async function randomizeSeeds(
   return copy;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function withWorkflowMetadata(
+  workflow: WorkflowJSON,
+  extraData?: Record<string, unknown>,
+): Promise<Record<string, unknown> | undefined> {
+  const extraPngInfo = isRecord(extraData?.extra_pnginfo)
+    ? extraData.extra_pnginfo
+    : {};
+
+  // A valid caller-provided canvas is authoritative. Do not spend time fetching
+  // object_info or replace layout/provenance the caller already supplied.
+  if (isUiFormat(extraPngInfo.workflow)) return extraData;
+
+  try {
+    // Reuse the client's existing TTL cache and single-flight request. Seed
+    // randomization may already have warmed this exact snapshot.
+    const objectInfo = await clientGetObjectInfo();
+    const { workflow: uiWorkflow, warnings } = convertApiToUi(workflow, objectInfo);
+    if (warnings.length > 0) {
+      logger.warn("Workflow UI metadata conversion completed with warnings", {
+        warnings,
+      });
+    }
+    return {
+      ...(extraData ?? {}),
+      extra_pnginfo: {
+        ...extraPngInfo,
+        workflow: uiWorkflow,
+      },
+    };
+  } catch (err) {
+    logger.warn("Workflow UI metadata conversion failed; enqueueing without it", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return extraData;
+  }
+}
+
 /**
  * Fire-and-forget workflow enqueue. Returns prompt_id immediately
  * without waiting for execution to complete.
@@ -144,10 +186,12 @@ export async function enqueueWorkflow(
         new Set(options?.preserve_seed_inputs ?? []),
       );
 
+  const extraData = await withWorkflowMetadata(workflow, options?.extra_data);
+
   logger.info("Enqueueing workflow (fire-and-forget)");
   const result = await clientEnqueuePrompt(
     workflow as Record<string, unknown>,
-    options?.extra_data,
+    extraData,
   );
   logger.info("Workflow enqueued", {
     prompt_id: result.prompt_id,


### PR DESCRIPTION
## Why

Prompts submitted through the ComfyUI API currently retain only the API graph.
As a result, ComfyUI History and Media Assets cannot use “Open as workflow” for
generations created by comfyui-mcp.

## What changed

- Generate a UI graph from the final post-seed-randomization API graph in the
  shared enqueue service.
- Nested-merge it into `extra_data.extra_pnginfo.workflow`.
- Preserve a valid caller-provided workflow and all existing `extra_data`.
- Reuse the existing `/object_info` TTL cache and single-flight request.
- Log conversion warnings and failures, then fail open so metadata generation
  can never block or duplicate the original enqueue.

All generation paths continue to use the same shared enqueue service. No
tool-specific changes were added.

## Validation

- 7,483 tests passed (2 skipped)
- TypeScript typecheck and build passed
- Representative rerun, template, URL, image, and video paths passed
- Live ComfyUI smoke retained existing `extra_data` and stored a valid
  2-node / 1-link UI graph in History
- H3 8-node conversion timing:
  - cold: 839.30 ms
  - warm median: 0.08 ms
  - warm max: 0.19 ms