### PR TITLE
fix(ci): finish the #796 review — baseline reaches zero, and a comment could switch the gate off

### DIFF
--- a/docs/design/unknown-collapse-baseline.txt
+++ b/docs/design/unknown-collapse-baseline.txt
@@ -1,17 +1,14 @@
 # #796 — sites where a failed observation is answered with an empty value.
 #
-# THIS LIST MAY ONLY SHRINK. It is debt, not history: fixing a site means
-# deleting its line. Adding a line to silence a new failure is the documented
-# bypass of this gate — use a reasoned `// unknown-ok:` comment at the site
-# instead, where the next reader will actually see it.
+# THIS LIST IS EMPTY, AND A TEST ASSERTS IT STAYS EMPTY. All 38 original
+# entries have been read: one was a real defect (runpod-ssh reported a sha256
+# MISMATCH when hashing had FAILED), one was a false positive in this gate
+# itself, and the other 36 were already correct and now carry a reasoned
+# `// unknown-ok:` at the site explaining why.
+#
+# So there is no debt left to grandfather, and adding a line here is no longer
+# a slow bypass — it is the only bypass. Clear a new site by fixing it, or by
+# writing the reason at the site where the next reader will actually see it.
 #
 # Regenerate deliberately:  node scripts/check-unknown-collapse.mjs --baseline
-services/download-cache.ts	.catch(() => false)	#1
-services/download-cache.ts	.catch(() => false)	#2
-services/queue-manager.ts	.catch(() => null)	#2
-services/queue-manager.ts	.catch(() => null)	#3
-services/training-jobs.ts	.catch(() => null)	#1
-services/training-jobs.ts	.catch(() => null)	#2
-services/training-jobs.ts	.catch(() => null)	#4
-services/training-jobs.ts	.catch(() => null)	#5
-services/training-jobs.ts	.catch(() => null)	#6
+

--- a/scripts/check-unknown-collapse.mjs
+++ b/scripts/check-unknown-collapse.mjs
@@ -153,6 +153,16 @@ function readStatement(line, matchIndex, lines, i) {
     if (balance(stmt) >= 0 && !/^\s*[.?]/.test(stmt) && stmt.trim() !== "") break;
     const prev = lines[j];
     if (prev === undefined || prev.trim() === "") break;
+    // A comment line inside a chain is not where the statement begins. Including
+    // it made `stmt` start with `//`, which ends the walk and leaves `head` as a
+    // comment — no binding, no return, so the site vanished from the scan
+    // ENTIRELY. That is worse than a missed waiver: any comment placed inside a
+    // chain silently switched the gate off for that site. Found by mutating a
+    // waiver down to a bare marker and getting 0 sites instead of a failure.
+    if (/^\s*(\/\/|\*|\/\*)/.test(prev)) {
+      start = j;
+      continue;
+    }
     stmt = prev + " " + stmt;
     start = j;
   }
@@ -318,10 +328,15 @@ if (args.includes("--baseline")) {
   const header = [
     "# #796 — sites where a failed observation is answered with an empty value.",
     "#",
-    "# THIS LIST MAY ONLY SHRINK. It is debt, not history: fixing a site means",
-    "# deleting its line. Adding a line to silence a new failure is the documented",
-    "# bypass of this gate — use a reasoned `// unknown-ok:` comment at the site",
-    "# instead, where the next reader will actually see it.",
+    "# THIS LIST IS EMPTY, AND A TEST ASSERTS IT STAYS EMPTY. All 38 original",
+    "# entries have been read: one was a real defect (runpod-ssh reported a sha256",
+    "# MISMATCH when hashing had FAILED), one was a false positive in this gate",
+    "# itself, and the other 36 were already correct and now carry a reasoned",
+    "# `// unknown-ok:` at the site explaining why.",
+    "#",
+    "# So there is no debt left to grandfather, and adding a line here is no longer",
+    "# a slow bypass — it is the only bypass. Clear a new site by fixing it, or by",
+    "# writing the reason at the site where the next reader will actually see it.",
     "#",
     "# Regenerate deliberately:  node scripts/check-unknown-collapse.mjs --baseline",
     "",

--- a/src/__tests__/scripts/check-unknown-collapse.test.ts
+++ b/src/__tests__/scripts/check-unknown-collapse.test.ts
@@ -343,3 +343,88 @@ describe("#796 a trailing comment does not make a discarded call look consumed",
     }
   });
 });
+
+describe("#796 the baseline is EMPTY, and stays that way", () => {
+  it("grandfathers nothing", () => {
+    // The whole 38-entry list has been read: 1 real defect, 1 gate false
+    // positive, 36 already correct and now carrying a reasoned `unknown-ok:` at
+    // the site. With no debt left to grandfather, a line here is no longer a slow
+    // bypass — it is the ONLY bypass, so it is worth failing loudly on.
+    const raw = readFileSync(
+      join(process.cwd(), "docs", "design", "unknown-collapse-baseline.txt"),
+      "utf8",
+    );
+    const entries = raw
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith("#"));
+    expect(
+      entries,
+      `the baseline must stay empty — clear a new site by FIXING it, or with a\n` +
+        `reasoned // unknown-ok: at the site. Entries found:\n${entries.join("\n")}`,
+    ).toEqual([]);
+  });
+});
+
+describe("#796 a comment inside a chain must not switch the gate off", () => {
+  const CHAIN = (comment: string) =>
+    `export async function r() {\n` +
+    `  const restored = await fs\n` +
+    `${comment}` +
+    `    .rename(a, b)\n` +
+    `    .then(() => true)\n` +
+    `    .catch(() => false);\n` +
+    `  return restored;\n` +
+    `}\n`;
+
+  function scan(body: string) {
+    const dir = mkdtempSync(join(tmpdir(), "unkcollapse-chain-"));
+    try {
+      const s = join(dir, "src");
+      mkdirSync(s, { recursive: true });
+      writeFileSync(join(s, "x.ts"), body, "utf8");
+      try {
+        return {
+          code: 0,
+          out: execFileSync(
+            process.execPath,
+            [SCRIPT, "--src", s, "--baseline-file", join(dir, "b.txt")],
+            { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+          ),
+        };
+      } catch (e) {
+        const err = e as { status: number; stdout: string; stderr: string };
+        return { code: err.status, out: (err.stdout ?? "") + (err.stderr ?? "") };
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("still FINDS the site when an ordinary comment sits mid-chain", () => {
+    // The walk-back used to stop on the comment and treat it as the statement
+    // start, leaving `head` as a comment — no binding, no return — so the site
+    // disappeared from the scan entirely. Any comment placed inside a chain
+    // silently switched the gate off for that site. Found by mutating a waiver
+    // down to a bare marker and getting a PASS instead of a failure.
+    const r = scan(CHAIN("    // a note about the rename\n"));
+    expect(r.code, r.out).toBe(1);
+    expect(r.out).toContain("x.ts:6");
+  });
+
+  it("a BARE marker mid-chain is rejected, not honoured", () => {
+    const r = scan(CHAIN("    // unknown-ok\n"));
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("bare 'unknown-ok'");
+  });
+
+  it("a REASONED marker mid-chain still clears it", () => {
+    const r = scan(
+      CHAIN(
+        "    // unknown-ok: a rename either completed or it did not, so false is the\n" +
+          "    // only honest answer and the caller preserves the backup either way.\n",
+      ),
+    );
+    expect(r.code, r.out).toBe(0);
+  });
+});

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -2983,6 +2983,9 @@ async function renameTempOverDestination(
       await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
       if (backedUp) {
         const restored = await downloadCacheFs
+          // unknown-ok: there is no third state for a rename — it either completed or it
+          // did not, and `.then(() => true)` runs only on completion. false therefore means
+          // "not restored", and the throw below preserves the backup and says where it is.
           .rename(backup, targetPath)
           .then(() => true)
           .catch(() => false);
@@ -3007,6 +3010,9 @@ async function renameTempOverDestination(
       await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
       if (backedUp) {
         const restored = await downloadCacheFs
+          // unknown-ok: there is no third state for a rename — it either completed or it
+          // did not, and `.then(() => true)` runs only on completion. false therefore means
+          // "not restored", and the throw below preserves the backup and says where it is.
           .rename(backup, targetPath)
           .then(() => true)
           .catch(() => false);

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -450,6 +450,9 @@ export async function cancelRunningJobEscalating(opts: {
   let pending_cleared: number | undefined;
   let clearPendingFailed = false;
   if (opts.clear_pending) {
+    // unknown-ok: null suppresses the COUNT rather than reporting a wrong one — see
+    // pending_cleared below, which stays undefined so the message says "cleared"
+    // without a number it never observed.
     const before = await getQueueSummary().catch(() => null);
     await clearAllQueued().catch((err) => {
       clearPendingFailed = true;
@@ -469,6 +472,9 @@ export async function cancelRunningJobEscalating(opts: {
         : `Pending jobs were cleared.`;
 
   // Identify the job we're trying to stop so we can verify it actually clears.
+  // unknown-ok: null makes targetSeenRunning false, and "interrupted" is only
+  // claimed about a job we OBSERVED running (see the comment below). A failed
+  // summary therefore withholds the claim instead of fabricating it.
   const pre = await getQueueSummary().catch(() => null);
   const runningId = opts.prompt_id ?? pre?.running_jobs?.[0]?.prompt_id;
   // "Interrupted" is only a claim we may make about a job we OBSERVED running.

--- a/src/services/training-jobs.ts
+++ b/src/services/training-jobs.ts
@@ -734,6 +734,9 @@ async function refreshRegistry(deps: TrainingJobDeps = {}): Promise<void> {
     if (handles.has(job.id)) { jobs.set(job.id, jobs.get(job.id) ?? job); continue; } // live here — memory wins
     if ((job.status === "running" || job.status === "queued") && job.containerName) {
       const probe = deps.containerRunning ?? defaultContainerProbe;
+      // unknown-ok: only a probed `false` acts. null is UNKNOWN and takes no action —
+      // the guard below tests `=== false` / `!== false` precisely so an unreachable
+      // daemon can never be read as "the container is gone".
       const running = await probe(job.containerName, jobProbeConfigPath(job)).catch(() => null);
       if (running === false && (!ownerAlive(job) || ownerLeaseStale(job))) {
         // Container gone AND (owner provably dead OR its liveness lease
@@ -943,6 +946,9 @@ export async function reconcileStaleTrainingJobs(deps: TrainingJobDeps = {}): Pr
     if (handles.has(job.id)) continue; // live in THIS process — the owner is us
     if (ownerAlive(job) && !ownerLeaseStale(job)) continue; // healthy owner — not ours to touch
     const probe = deps.containerRunning ?? defaultContainerProbe;
+    // unknown-ok: only a probed `false` acts. null is UNKNOWN and takes no action —
+    // the guard below tests `=== false` / `!== false` precisely so an unreachable
+    // daemon can never be read as "the container is gone".
     const running = await probe(job.containerName, jobProbeConfigPath(job)).catch(() => null);
     if (running !== false) continue; // alive or unknown → err toward "busy" (never stop a live run)
     await recoverOrphanedJob(job.id, deps);
@@ -1787,6 +1793,9 @@ export async function cancelJob(id: string, deps: TrainingJobDeps = {}): Promise
     // daemon honored the stop (codex finding). Only when liveness is unknown
     // do we fall back to the stop command's own result. The probe is scoped to
     // THIS job's config path so an unrelated run.py can't fake still-running.
+    // unknown-ok: null is UNKNOWN and falls through to the stop command's own result
+    // (`probed ?? res.ok === false`), which is the documented intent above — a probe
+    // that could not answer must not overrule what the stop reported.
     const probed = await probe(job.containerName, cfgPath).catch(() => null);
     const stillRunning = probed ?? res.ok === false;
     if (stillRunning === true) {
@@ -1867,6 +1876,9 @@ async function cancelJobBody(id: string, job: TrainingJob, deps: TrainingJobDeps
     const probe = deps.containerRunning ?? defaultContainerProbe;
     // Probe after the stop regardless of its exit status (see above), scoped to
     // THIS job's config path so an unrelated run.py can't fake still-running.
+    // unknown-ok: null is UNKNOWN and falls through to the stop command's own result
+    // (`probed ?? res.ok === false`), which is the documented intent above — a probe
+    // that could not answer must not overrule what the stop reported.
     const probed = await probe(job.containerName, cfgPath).catch(() => null);
     const stillRunning = probed ?? res.ok === false;
     if (stillRunning === true) {
@@ -1912,6 +1924,9 @@ export async function deleteJob(
   }
   if (job.status === "cancelled" && job.containerName) {
     const probe = deps.containerRunning ?? defaultContainerProbe;
+    // unknown-ok: only a probed `false` acts. null is UNKNOWN and takes no action —
+    // the guard below tests `=== false` / `!== false` precisely so an unreachable
+    // daemon can never be read as "the container is gone".
     const alive = await probe(job.containerName, jobProbeConfigPath(job)).catch(() => null);
     if (alive !== false) {
       throw new Error(


### PR DESCRIPTION
Refs #796

The last **9** baseline entries are read, so the whole 38 have been. All 9 were already correct, each now carrying its own reason at the site:

- **queue-manager ×2** — `null` suppresses the *count* rather than reporting a wrong one, and blocks the "interrupted" claim, which is only made about a job actually **observed** running.
- **training-jobs ×5** — only a probed `false` acts. The guards test `=== false` / `!== false` precisely so an unreachable daemon is never read as "the container is gone" (*"alive or unknown → err toward busy"*), and two fall through to the stop command's own result on unknown, as documented.
- **download-cache ×2** — a rename has no third state: `.then(() => true)` runs only on completion, so `false` means "not restored", and the throw preserves the backup and says where it is.

## The baseline is now empty, and a test keeps it there

With no debt left to grandfather, a line in that file is no longer a slow bypass — **it is the only bypass** — so it fails loudly.

## And the gate had a hole

Found by mutating a waiver down to a bare marker and getting a **pass** instead of a failure. A comment line *inside* a chain:

```js
const restored = await fs
  // any comment at all
  .rename(a, b)
  .then(() => true)
  .catch(() => false);
```

ended the statement walk-back, so `head` became the comment — no binding, no return — and **the site vanished from the scan entirely**. Not a missed waiver: any comment placed mid-chain silently switched the gate off for that site, and a `// unknown-ok` with no reason at all was "honoured" the same way.

**That also indicts the download-cache waivers this PR adds.** They sit mid-chain, so before this fix they were passing by making the site *invisible* rather than by being reasoned. They are now genuinely evaluated — the site is detected and cleared **by its reason**, which is what a waiver is supposed to mean.

## Verification

| mutation | result |
|---|---|
| add a baseline entry | 2 failed |
| re-introduce a real collapse in source | gate exit 1 |
| remove a whole waiver block | site flagged |
| bare marker mid-chain | now rejected as bare *(passed silently before)* |
| ordinary comment mid-chain | site still found *(hidden before)* |

Full suite **7489 passed | 2 skipped** · `tsc`, `lint`, `check:vocabulary`, `check:unknown-collapse` all exit 0 · control-byte scan clean.

**Final tally on the original 38:** 1 real defect (fixed in #1123), 1 gate false positive (trailing comments), 1 gate hole (this), **35 already correct**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)