### PR TITLE
feat(health): report the ComfyUI FRONTEND version — the field #779 turned on

### DIFF
--- a/src/__tests__/services/health-frontend-version.test.ts
+++ b/src/__tests__/services/health-frontend-version.test.ts
@@ -1,0 +1,89 @@
+// panel#779 — the health check reported the ComfyUI version and not the FRONTEND
+// version, and the frontend version was the whole answer.
+//
+// A blank agent panel on a fresh install. ComfyUI 0.30.0 on the broken machine,
+// 0.30.2 on the working one — near-identical, and not the variable. The frontend
+// package was 1.50.3 vs 1.47.12, and pinning it fixed the machine. The reporter
+// had to be asked for that number after an hour of eliminating everything else,
+// because nothing we ship surfaced it.
+//
+// /system_stats reports it. Nothing in src read it. The fixtures below are the
+// REAL shape, captured from a live ComfyUI 0.30.2.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = readFileSync(
+  join(__dirname, "..", "..", "services", "health-check.ts"),
+  "utf8",
+);
+
+/** Load describeFrontendVersion out of the module under test. */
+async function load() {
+  const mod: any = await import("../../services/health-check.js");
+  // Not exported (it is an implementation detail of one line of output), so the
+  // behaviour is asserted through the source plus the shape checks below.
+  return mod;
+}
+
+/** The real /system_stats shape — note both fields live under `system`. */
+const LIVE = {
+  system: {
+    os: "nt",
+    comfyui_version: "0.30.2",
+    required_frontend_version: "1.47.12",
+    comfy_package_versions: [
+      { name: "comfyui-frontend-package", installed: "1.47.12", required: "1.47.12" },
+      { name: "comfyui-workflow-templates", installed: "0.11.31", required: "0.11.31" },
+    ],
+    python_version: "3.12.9 (main)",
+    pytorch_version: "2.9.1",
+  },
+  devices: [{ name: "cuda:0", vram_total: 1, vram_free: 1 }],
+};
+
+describe("#779 the health check surfaces the FRONTEND version", () => {
+  it("reads both fields from under `system`, where they actually are", () => {
+    // The first draft read them off the top level and silently produced "?" on a
+    // server that reports them perfectly well. Caught by querying a live ComfyUI
+    // rather than trusting the shape.
+    expect(SRC).toMatch(/stats\?\.system\?\.comfy_package_versions/);
+    expect(SRC).toMatch(/stats\?\.system\?\.required_frontend_version/);
+  });
+
+  it("prints the frontend version on the ComfyUI line", () => {
+    expect(SRC).toMatch(/frontend \$\{describeFrontendVersion\(stats\)\}/);
+  });
+
+  it("names comfyui-frontend-package, not some other package", () => {
+    expect(SRC).toMatch(/"comfyui-frontend-package"/);
+  });
+
+  it("DISCLOSES a pin: installed differing from required is the #779 situation", () => {
+    // `--front-end-version …@1.47.12` was the fix on the reporter's machine. A
+    // health check that hid the override would hide the remedy.
+    expect(SRC).toMatch(/pinned or overridden/);
+    expect(SRC).toMatch(/installed && required && installed !== required/);
+  });
+
+  it('answers "?" rather than inventing a version', () => {
+    // An unknown version must not read as an absent problem — that collapse is
+    // the tracked defect class (#796).
+    expect(SRC).toMatch(/installed \?\? required \?\? "\?"/);
+  });
+
+  it("the live fixture proves the shape this depends on", () => {
+    const pkgs = LIVE.system.comfy_package_versions;
+    const fe = pkgs.find((p) => p.name === "comfyui-frontend-package");
+    expect(fe?.installed).toBe("1.47.12");
+    expect(LIVE.system.required_frontend_version).toBe("1.47.12");
+    // and NOT at the top level, which is what the first draft assumed
+    expect((LIVE as any).comfy_package_versions).toBeUndefined();
+  });
+
+  it("the module still loads", async () => {
+    const mod = await load();
+    expect(typeof mod.runHealthCheck).toBe("function");
+  });
+});

--- a/src/services/health-check.ts
+++ b/src/services/health-check.ts
@@ -22,6 +22,42 @@ export interface HealthCheckOptions {
   recentErrors?: number;
 }
 
+/**
+ * The ComfyUI FRONTEND package version, as reported by /system_stats.
+ *
+ * ComfyUI gives this two ways and they can disagree, which is itself worth
+ * seeing: `comfy_package_versions[comfyui-frontend-package].installed` is what is
+ * actually loaded, and `required_frontend_version` is what this ComfyUI asked
+ * for. A mismatch means someone pinned or overrode the frontend — exactly the
+ * situation in panel#779, where `--front-end-version …@1.47.12` was the fix.
+ *
+ * Returns "?" when neither is present rather than inventing one. An unknown
+ * version must not read as an absent problem.
+ */
+function describeFrontendVersion(stats: Record<string, any>): string {
+  // Both fields live under `system`, verified against a live ComfyUI 0.30.2 —
+  // the first draft read them off the top level and silently produced "?" on a
+  // server that reports them perfectly well. Top-level is still accepted in case
+  // another build puts them there, but `system` is where they actually are.
+  const pkgs = Array.isArray(stats?.system?.comfy_package_versions)
+    ? stats.system.comfy_package_versions
+    : Array.isArray(stats?.comfy_package_versions)
+      ? stats.comfy_package_versions
+      : [];
+  const fe = pkgs.find((p: any) => p?.name === "comfyui-frontend-package");
+  const installed = typeof fe?.installed === "string" ? fe.installed : undefined;
+  const required =
+    typeof stats?.system?.required_frontend_version === "string"
+      ? stats.system.required_frontend_version
+      : typeof stats?.required_frontend_version === "string"
+        ? stats.required_frontend_version
+        : undefined;
+  if (installed && required && installed !== required) {
+    return `${installed} (this ComfyUI expects ${required} — pinned or overridden)`;
+  }
+  return installed ?? required ?? "?";
+}
+
 export async function runHealthCheck(
   options: HealthCheckOptions = {},
 ): Promise<string> {
@@ -44,6 +80,13 @@ export async function runHealthCheck(
       : "?";
     lines.push(
       `**ComfyUI**: ${sys.comfyui_version ?? "?"} | ` +
+        // panel#779 — the FRONTEND package version, which /system_stats reports and
+        // nothing here read. That outage (a blank agent panel on a fresh install)
+        // turned entirely on it: ComfyUI 0.30.0 was identical between the broken
+        // and working machines, and the frontend was 1.50.3 vs 1.47.12. A reporter
+        // had to be asked for it after an hour of eliminating everything else, and
+        // "ComfyUI version" alone will keep hiding this class of skew.
+        `frontend ${describeFrontendVersion(stats)} | ` +
         `Python ${(sys.python_version ?? "").split(" ")[0] || "?"} | ` +
         `PyTorch ${sys.pytorch_version ?? "?"}`,
     );


### PR DESCRIPTION
Refs artokun/comfyui-mcp-panel#779

A blank agent panel on a fresh install. ComfyUI **0.30.0** on the broken machine, **0.30.2** on the working one — near-identical, and not the variable. The **frontend package** was 1.50.3 vs 1.47.12, and pinning it fixed the machine outright.

The reporter had to be *asked* for that number, after an hour of eliminating the install, both browsers, the cache and the orchestrator — because nothing we ship surfaced it. `/system_stats` reports it. `comfy_package_versions` and `required_frontend_version` appear **nowhere in `src`**.

`get_system_stats (action:"health")` — the pre-flight an agent actually runs, and the output that ends up pasted into reports — said `ComfyUI 0.30.0 | Python … | PyTorch …` and stopped. It now includes the frontend version.

## It discloses a pin

ComfyUI reports the version twice and they can disagree:

- `comfy_package_versions[comfyui-frontend-package].installed` — what's loaded
- `required_frontend_version` — what this ComfyUI asked for

A mismatch means someone **overrode** the frontend, which is precisely the #779 remedy (`--front-end-version …@1.47.12`). A health check that hid the override would hide the remedy, so it prints:

> `1.47.12 (this ComfyUI expects 1.50.3 — pinned or overridden)`

Unknown answers `"?"` rather than inventing a version — an unknown version must not read as an absent problem (#796).

## Caught by the rig, not by review

My first draft read both fields off the **top level** of `/system_stats`. They live under `system` — verified against a live ComfyUI 0.30.2, which reports them perfectly well and would have silently produced `"?"` forever.

The test fixture is that captured shape, and a mutation back to the top-level read fails it.

| mutation | result |
|---|---|
| read from the top level (the bug I made) | 1 failed |
| stop printing it on the ComfyUI line | 1 failed |
| drop the pin disclosure | 1 failed |
| invent a version instead of `"?"` | 1 failed |

7 new tests · full suite **7496 passed | 2 skipped** · `tsc`, `lint`, `check:vocabulary`, `check:unknown-collapse` all exit 0.

**Not in this PR:** `report_issue`'s environment guidance still asks for "ComfyUI version" and not the frontend version. Worth a follow-up, but this is the half that makes the number *visible* in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)