### PR TITLE
docs(report): ask for the ComfyUI FRONTEND version, and say why

### DIFF
--- a/docs/tools/install-environment.mdx
+++ b/docs/tools/install-environment.mdx
@@ -234,7 +234,7 @@ File or triage a GitHub issue for a bug/problem you hit (ComfyUI, a workflow, a 
   Short, specific issue title.
 </ParamField>
 <ParamField path="body" type="string" required>
-  Issue body: what happened, steps to reproduce, the exact error text, and environment (GPU/VRAM, ComfyUI version, OS) if known. Scrub secrets first.
+  Issue body: what happened, steps to reproduce, the exact error text, and environment (GPU/VRAM, ComfyUI version, ComfyUI FRONTEND version, OS) if known. The FRONTEND version is a SEPARATE package from ComfyUI and they move independently — get_system_stats (action:"health") prints both, and for any panel/UI bug it is often the deciding variable. Scrub secrets first.
 </ParamField>
 <ParamField path="repo" type="string">
   owner/repo (default 'artokun/comfyui-mcp'; use 'artokun/comfyui-mcp-panel' for the sidebar panel).

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -116,7 +116,17 @@ so we can reproduce and merge:
 <applied locally: yes/no>  <upstream-only: yes/no>
 <the diff / patch, or the precise change needed if upstream-only>
 ### Environment
-OS / ComfyUI version / GPU+VRAM / **comfyui-mcp version** / **panel version**.
+OS / ComfyUI version / **ComfyUI FRONTEND version** / GPU+VRAM / **comfyui-mcp
+version** / **panel version**.
+
+The FRONTEND version is a separate package from ComfyUI itself and they move
+independently — `get_system_stats (action:"health")` prints both on the ComfyUI
+line. Include it for ANY panel/UI bug. It is not a formality: comfyui-mcp-panel#779
+was a blank agent panel on a fresh install where ComfyUI was 0.30.0 on the broken
+machine and 0.30.2 on a working one — indistinguishable, and not the cause. The
+frontend was 1.50.3 vs 1.47.12, which was the whole answer, and it took an hour of
+eliminating the install, two browsers, the cache and the orchestrator to get to a
+number that one line of output already had.
 Always include BOTH our versions — a bug is only actionable if we know which mcp +
 panel build it came from. They're already in your **ENVIRONMENT line** (the
 `mcp <ver> · panel <ver>` segment), so just copy them from there. Fallbacks if the

--- a/src/__tests__/tools/report-asks-for-frontend-version.test.ts
+++ b/src/__tests__/tools/report-asks-for-frontend-version.test.ts
@@ -1,0 +1,70 @@
+// panel#779 — a report that omits the ComfyUI FRONTEND version cannot be
+// diagnosed, and both places that tell an agent what to include asked for the
+// wrong field.
+//
+// The reporter's environment block said `comfyui: 0.30.0`. A working machine was
+// 0.30.2 — indistinguishable, and not the cause. The frontend package was 1.50.3
+// vs 1.47.12 and that was the whole answer. It took an hour of eliminating the
+// install, two browsers, the cache and the orchestrator to reach a number one
+// line of output already had.
+//
+// mcp#1126 made the number visible. This pins the two places that ASK for it, so
+// the request cannot quietly revert to "ComfyUI version" alone.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(__dirname, "..", "..", "..");
+const TOOL = readFileSync(join(ROOT, "src", "tools", "report-issue.ts"), "utf8");
+const SKILL = readFileSync(
+  join(ROOT, "plugin", "skills", "report-bug", "SKILL.md"),
+  "utf8",
+);
+
+describe("#779 reports must ask for the FRONTEND version", () => {
+  it("the report_issue tool asks for it in the body description", () => {
+    expect(TOOL).toMatch(/ComfyUI FRONTEND version/);
+  });
+
+  it("…and says WHY, because 'another version field' reads as optional", () => {
+    // The failure mode is not that people refuse; it is that they reasonably
+    // think "ComfyUI version" already covers it. It does not.
+    expect(TOOL).toMatch(/SEPARATE package from ComfyUI/);
+    expect(TOOL).toMatch(/move independently/);
+  });
+
+  it("…and names where to GET it", () => {
+    // An ask with no source is an ask that gets skipped. This is the tool that
+    // prints both versions on one line.
+    // The TS source escapes the inner quotes, so the raw file holds a backslash
+    // before each one. Strip backslashes and assert on the sentence a reader
+    // actually sees — writing the escape into the regex tests the escaping
+    // rather than the instruction, and two attempts at it collapsed to a pattern
+    // that matched nothing.
+    const readable = TOOL.split("\\").join("");
+    expect(readable).toContain('get_system_stats (action:"health")');
+  });
+
+  it("the report-bug skill asks for it too", () => {
+    // Two independent paths tell an agent what to collect. Fixing one and
+    // leaving the other is how the field keeps going missing.
+    expect(SKILL).toMatch(/ComfyUI FRONTEND version/);
+    expect(SKILL).toMatch(/get_system_stats \(action:"health"\)/);
+  });
+
+  it("the skill carries the evidence, not just the instruction", () => {
+    // A rule with its story attached survives editing; a bare "also include X"
+    // gets trimmed by the next person tightening the doc.
+    expect(SKILL).toMatch(/779/);
+    expect(SKILL).toMatch(/1\.50\.3/);
+    expect(SKILL).toMatch(/1\.47\.12/);
+  });
+
+  it("neither place asks ONLY for the ComfyUI version any more", () => {
+    // The exact string that shipped for months, which is what produced a report
+    // missing the deciding variable.
+    expect(TOOL).not.toMatch(/\(GPU\/VRAM, ComfyUI version, OS\)/);
+    expect(SKILL).not.toMatch(/^OS \/ ComfyUI version \/ GPU\+VRAM/m);
+  });
+});

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -476,7 +476,7 @@ export function registerReportIssueTools(server: McpServer): void {
         .string()
         .min(1)
         .describe(
-          "Issue body: what happened, steps to reproduce, the exact error text, and environment (GPU/VRAM, ComfyUI version, OS) if known. Scrub secrets first.",
+          "Issue body: what happened, steps to reproduce, the exact error text, and environment (GPU/VRAM, ComfyUI version, ComfyUI FRONTEND version, OS) if known. The FRONTEND version is a SEPARATE package from ComfyUI and they move independently — get_system_stats (action:\"health\") prints both, and for any panel/UI bug it is often the deciding variable. Scrub secrets first.",
         ),
       repo: z
         .string()


### PR DESCRIPTION
Refs artokun/comfyui-mcp-panel#779

Both places that tell an agent what to put in a bug report asked for the wrong field:

```
report_issue   "environment (GPU/VRAM, ComfyUI version, OS)"
report-bug     "OS / ComfyUI version / GPU+VRAM / mcp / panel"
```

Neither mentions the ComfyUI **frontend** package, which is a separate release that moves independently.

#779's report duly said `comfyui: 0.30.0`. A working machine was **0.30.2** — indistinguishable, and not the cause. The frontend was **1.50.3 vs 1.47.12**, which was the entire answer. Getting that number took an hour of eliminating the install, two browsers, the cache and the orchestrator.

mcp#1126 made it **visible** (the health check now prints it). This makes it **asked for**, in both paths — fixing one and leaving the other is how a field keeps going missing.

## Each ask carries why and where

The failure mode isn't refusal; it's that *"ComfyUI version"* reasonably reads as already covering it. So both say the frontend is a separate package, and both name `get_system_stats (action:"health")`, which prints the two on one line.

The skill entry keeps the **evidence** attached rather than a bare "also include X" — a rule with its story survives editing; a bare instruction gets trimmed by the next person tightening the doc.

## Verification

| mutation | result |
|---|---|
| revert the tool description | 4 failed |
| revert the skill guidance | 3 failed |

6 new tests · full suite **7502 passed | 2 skipped** · `tsc`, `lint`, `check:vocabulary`, `check:unknown-collapse` all exit 0.

**One test-authoring note:** the tool description escapes its inner quotes, so the raw file holds `action:\"health\"`. Two attempts to write that escape into a regex collapsed to a pattern matching nothing — the assertion now strips backslashes and checks the sentence a reader actually sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)