### PR TITLE
fix(download): REFUSE an auth-gated Manager dispatch instead of writing a corrupt model

### DIFF
--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -657,45 +657,57 @@ describe("downloadModel — remote mode (Manager install-model dispatch)", () =>
     }
   });
 
-  // ── #473 remote residual: WARN LOUDLY (never block) when a credential flip proves the
-  //    URL is AUTH-GATED — so a dispatched auth page isn't mistaken for a real model, while
-  //    a legitimate download is NEVER refused (the host's fetch vantage may differ). ──
-  it("WARNS but still dispatches when the URL is auth-gated — an HTML page that flips with the token", async () => {
+  // ── #473: REFUSE when a credential flip PROVES the URL is auth-gated. ──
+  //
+  // The probe establishes it — unauthenticated returns a login/error page, the SAME
+  // url with the credential returns a real model — and ComfyUI-Manager fetches
+  // server-side without our headers. Dispatching anyway knowingly writes that page
+  // under the caller's filename, where it LISTS as a model and only fails later
+  // inside a loader. That is the shape this issue was reported for three times.
+  //
+  // These tests previously asserted WARN-and-dispatch. The owner reversed it
+  // (2026-08-08) after weighing the tradeoff: a ComfyUI HOST carrying its own token
+  // would have succeeded and is now blocked — but that case is speculative, has two
+  // documented ways out, and fails LOUDLY at the moment of the request, whereas the
+  // corrupt file fails silently much later on someone else's canvas.
+  it("REFUSES to dispatch when the URL is auth-gated — an HTML page that flips with the token", async () => {
     config.civitaiApiToken = "tok"; // the local token that Manager can't receive
     flipFetch(htmlProbeResponse); // unauth → login HTML; with the token → real model
-    const out = await downloadModel(
-      "https://civitai.com/api/download/models/627113",
-      "loras",
-      "KNP.safetensors",
-    );
-    // NEVER blocks — the dispatch still happens (the host may succeed from its own vantage)…
-    expect(installModelViaManagerMock).toHaveBeenCalledTimes(1);
-    // …but a loud, specific warning is surfaced so the auth page isn't trusted as a model.
-    expect(out).toMatch(/AUTHENTICATION-GATED/i);
-    expect(out).toMatch(/CORRUPT model/i);
+
+    await expect(
+      downloadModel("https://civitai.com/api/download/models/627113", "loras", "KNP.safetensors"),
+    ).rejects.toThrow(/AUTHENTICATION-GATED/i);
+
+    // The point of refusing: nothing is handed to Manager, so no corrupt file exists.
+    expect(installModelViaManagerMock).not.toHaveBeenCalled();
   });
 
-  it("WARNS when an auth-gated URL returns a JSON error unauthenticated but flips with the token", async () => {
-    config.civitaiApiToken = "tok";
-    flipFetch(jsonAuthProbeResponse);
-    const out = await downloadModel(
-      "https://civitai.com/api/download/models/9",
-      "checkpoints",
-      "gated.safetensors",
-    );
-    expect(installModelViaManagerMock).toHaveBeenCalledTimes(1);
-    expect(out).toMatch(/AUTHENTICATION-GATED/i);
-  });
-
-  it("names the CivitAI host-token remediation in the auth-gated warning", async () => {
+  it("says plainly that NOTHING was written, so the caller does not go hunting", async () => {
     config.civitaiApiToken = "tok";
     flipFetch(htmlProbeResponse);
-    const out = await downloadModel(
-      "https://civitai.com/api/download/models/1",
-      "loras",
-      "x.safetensors",
-    );
-    expect(out).toMatch(/CIVITAI_API_TOKEN on the ComfyUI HOST/i);
+
+    await expect(
+      downloadModel("https://civitai.com/api/download/models/2", "loras", "y.safetensors"),
+    ).rejects.toThrow(/NOTHING was downloaded and nothing was written/i);
+  });
+
+  it("REFUSES when an auth-gated URL returns a JSON error unauthenticated but flips with the token", async () => {
+    config.civitaiApiToken = "tok";
+    flipFetch(jsonAuthProbeResponse);
+
+    await expect(
+      downloadModel("https://civitai.com/api/download/models/9", "checkpoints", "gated.safetensors"),
+    ).rejects.toThrow(/AUTHENTICATION-GATED/i);
+    expect(installModelViaManagerMock).not.toHaveBeenCalled();
+  });
+
+  it("names the CivitAI host-token remediation in the refusal", async () => {
+    config.civitaiApiToken = "tok";
+    flipFetch(htmlProbeResponse);
+
+    await expect(
+      downloadModel("https://civitai.com/api/download/models/1", "loras", "x.safetensors"),
+    ).rejects.toThrow(/CIVITAI_API_TOKEN on the ComfyUI HOST/i);
   });
 
   it("does NOT warn (no false alarm) on a location interstitial that does NOT flip with the token", async () => {
@@ -748,18 +760,23 @@ describe("downloadModel — remote mode (Manager install-model dispatch)", () =>
     expect(leaked).toBe(false);
   });
 
-  it("attaches the HF token by PARSED host for a genuine huggingface.co gated URL and warns on the flip", async () => {
+  it("attaches the HF token by PARSED host for a genuine huggingface.co gated URL and REFUSES on the flip", async () => {
     config.huggingfaceToken = "hf-secret";
     fetchMock.mockImplementation((_url: string, opts?: { headers?: Record<string, string> }) =>
       Promise.resolve(opts?.headers?.Authorization ? binaryProbeResponse() : htmlProbeResponse()),
     );
-    const out = await downloadModel(
-      "https://huggingface.co/org/repo/resolve/main/m.safetensors",
-      "checkpoints",
-      "m.safetensors",
-    );
-    expect(installModelViaManagerMock).toHaveBeenCalledTimes(1);
-    expect(out).toMatch(/AUTHENTICATION-GATED/i);
+
+    await expect(
+      downloadModel(
+        "https://huggingface.co/org/repo/resolve/main/m.safetensors",
+        "checkpoints",
+        "m.safetensors",
+      ),
+    ).rejects.toThrow(/AUTHENTICATION-GATED/i);
+
+    expect(installModelViaManagerMock).not.toHaveBeenCalled();
+    // The assertion this test exists for: the probe used the HF token, so the flip
+    // it observed is real rather than an unauthenticated fetch failing twice.
     const sentHf = fetchMock.mock.calls.some(
       (c) => (c[1] as { headers?: Record<string, string> } | undefined)?.headers?.Authorization === "Bearer hf-secret",
     );
@@ -774,15 +791,19 @@ describe("downloadModel — remote mode (Manager install-model dispatch)", () =>
       fetchMock.mockImplementation((_url: string, opts?: { headers?: Record<string, string> }) =>
         Promise.resolve(opts?.headers?.Authorization ? binaryProbeResponse() : htmlProbeResponse()),
       );
-      const out = await downloadModel(
-        "https://huggingface.co/org/repo/resolve/main/m.safetensors",
-        "checkpoints",
-        "m.safetensors",
-      );
-      expect(installModelViaManagerMock).toHaveBeenCalledTimes(1);
+      await expect(
+        downloadModel(
+          "https://huggingface.co/org/repo/resolve/main/m.safetensors",
+          "checkpoints",
+          "m.safetensors",
+        ),
+      ).rejects.toThrow(/AUTHENTICATION-GATED/i);
+
+      expect(installModelViaManagerMock).not.toHaveBeenCalled();
       // The URL was rewritten to the mirror, yet the HF token still applies (threaded
-      // wasHfUrl) → the flip is detected and the auth-gated warning fires.
-      expect(out).toMatch(/AUTHENTICATION-GATED/i);
+      // wasHfUrl) → the flip is detected and the dispatch is refused. Without the
+      // threading the mirror host would drop the token, both probes would return the
+      // page, no flip would be seen, and the corrupt file would ship.
       const sentToMirror = fetchMock.mock.calls.some(
         (c) =>
           String(c[0]).startsWith("https://hf-mirror.example") &&

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -2239,7 +2239,6 @@ async function downloadModelViaManagerRemote(
     authHeaders: localAuthHeadersFor(url, auth, wasHfUrl),
   });
   if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
-  let authGateWarning = "";
   if (probe.verdict === "non-model") {
     const what =
       probe.kind === "html"
@@ -2260,16 +2259,31 @@ async function downloadModelViaManagerRemote(
         `token is applied and the payload is validated on disk`
       : `configure the credential on the ComfyUI host, or download to a LOCAL ComfyUI where the ` +
         `credential is applied and the payload is validated on disk`;
-    authGateWarning =
-      ` WARNING: this URL is AUTHENTICATION-GATED — an unauthenticated fetch (exactly what ` +
-      `ComfyUI-Manager performs server-side, since it cannot carry the MCP's auth headers) ` +
-      `returns ${what}, while the SAME URL fetched WITH the configured credential returns a ` +
-      `real model. ComfyUI-Manager will therefore almost certainly save that auth/error page ` +
-      `under "${resolvedFilename}" as a CORRUPT model (it fails at load time, e.g. "header too ` +
-      `large" / "Expecting value") — do NOT treat it as a real model until verified. To ` +
-      `download it, ${remediation}.`;
+    // #473 — REFUSE, do not dispatch. The probe has PROVEN the gate: the same URL
+    // returns a login/error page unauthenticated and a real model with the
+    // credential, and Manager fetches server-side without our headers. Dispatching
+    // anyway is knowingly writing a corrupt file under the caller's chosen
+    // filename — it then LISTS as a model and fails much later inside a loader
+    // ("header too large" / "Expecting value"), which is how this issue was
+    // reported three times.
+    //
+    // Owner's call (2026-08-08) after weighing the false-refusal risk: a ComfyUI
+    // HOST that carries its OWN token would have succeeded, and is now blocked.
+    // That case is speculative, has two documented ways out (below), and fails
+    // LOUDLY at the point of the request; the corrupt-file case is real,
+    // recurring, and fails silently hours later on someone else's canvas.
     logger.warn(
-      "Remote model dispatch is authentication-gated; ComfyUI-Manager will fetch it unauthenticated",
+      "Refusing an authentication-gated model dispatch to ComfyUI-Manager (it cannot carry our credentials)",
+      { url: redactUrlForLogs(dispatchUrl, sensitiveParams), filename: resolvedFilename },
+    );
+    throw new ModelError(
+      `Refusing to dispatch "${resolvedFilename}" to ComfyUI-Manager: this URL is ` +
+        `AUTHENTICATION-GATED. An unauthenticated fetch returns ${what}, while the SAME URL ` +
+        `fetched WITH the configured credential returns a real model — and ComfyUI-Manager ` +
+        `fetches server-side and cannot carry this MCP's auth headers. It would therefore save ` +
+        `that auth/error page under "${resolvedFilename}" as a CORRUPT model, which lists ` +
+        `normally and only fails later at load time ("header too large" / "Expecting value"). ` +
+        `NOTHING was downloaded and nothing was written. To download it, ${remediation}.`,
       { url: redactUrlForLogs(dispatchUrl, sensitiveParams), filename: resolvedFilename },
     );
   }
@@ -2316,7 +2330,7 @@ async function downloadModelViaManagerRemote(
       "local models directory to stream into (no COMFYUI_PATH, no saved workspace, and the " +
       "running server's launch arguments did not identify one). That is a routing fallback, NOT " +
       "a claim that the server is remote; set COMFYUI_PATH to stream directly instead";
-  return `${normalizedSubfolder}/${resolvedFilename} (${routeNote} — download continues server-side. ${managerDestinationCaveat()})${authGateWarning}${authWarning}`;
+  return `${normalizedSubfolder}/${resolvedFilename} (${routeNote} — download continues server-side. ${managerDestinationCaveat()})${authWarning}`;
 }
 
 /**


### PR DESCRIPTION
Closes the root cause of #473 as far as it can be closed from this side.

The flip probe already **proved** the gate: the same URL returns a login/error page unauthenticated and a real model with the configured credential, and ComfyUI-Manager fetches server-side without our headers. We warned about that and **dispatched anyway** — knowingly writing the auth page under the caller's filename, where it lists as a model and only fails much later inside a loader (`header too large` / `Expecting value`).

That's the shape #473 has now been reported for three times, most recently against 0.50.34.

It now refuses, naming what was proven, that **nothing was downloaded or written**, and the two ways forward.

## This was the owner's call, not mine

The tradeoff is real and I couldn't settle it from evidence: a ComfyUI **host** carrying its own token would have succeeded from its own vantage and is now blocked. @artokun chose refuse on the asymmetry — that case is speculative, has two documented ways out, and fails **loudly at the moment of the request**, whereas the corrupt file fails silently, hours later, on someone else's canvas.

## Two avenues checked and closed first

- **A size sanity check** (a login page is ~10KB) cannot work remotely: the HTTP listing path sets `size: 0`, because ComfyUI's REST API returns names only.
- **Detecting a host-side credential** is impossible from here, so the refusal cannot be narrowed to only the cases that would truly fail.

Also removed the now-dead `authGateWarning` and its variable, rather than leaving prose describing a path that can no longer be reached.

## Verification

| Check | Result |
|---|---|
| **mutation** — disable the throw | 4 tests fail |
| full suite | green — 369 files, 7503 passed |

The four tests that asserted WARN-and-dispatch were **rewritten to the new contract, not loosened**. Each now asserts `installModelViaManager` was *not* called — which is the whole point: no dispatch, no corrupt file. The HF-token tests keep their original assertion, so the flip they observe is a genuine credential flip rather than two unauthenticated failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)