### PR TITLE
0.50.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.37] - 2026-08-08
+
+### RunPod image
+
+#### Fixed
+- a hash that could not be COMPUTED is not a hash that DIFFERED (#1123)
+
+### MCP
+
+#### Added
+- report the ComfyUI FRONTEND version — the field #779 turned on (#1126)
+
+#### Fixed
+- REFUSE an auth-gated Manager dispatch instead of writing a corrupt model (#473) (#1134)
+- finish the #796 review — baseline reaches zero, and a comment could switch the gate off (#1125)
+
+#### Changed
+- ask for the ComfyUI FRONTEND version, and say why (#1127)
+
+
 ## [0.50.36] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.36",
+  "version": "0.50.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.36",
+      "version": "0.50.37",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.36",
+  "version": "0.50.37",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for **v0.50.37**. Tag pushed; `release.yml` publishes from it; this PR reconciles protected `main`.

## #1134 — an auth-gated Manager dispatch is refused, not written as a corrupt model (#473)

The flip probe already proved the gate — the same URL returns a login page unauthenticated and a real model with the credential, and ComfyUI-Manager fetches server-side without our headers. We warned and dispatched anyway, writing the auth page under the caller's filename where it lists as a model and fails much later inside a loader. #473 has been reported three times with that shape, most recently against 0.50.34.

It now refuses, naming what was proven, that nothing was written, and the two ways forward (credential on the ComfyUI host, or `COMFYUI_PATH` so this MCP streams locally where the payload is validated on disk).

**Owner's decision** on a tradeoff I couldn't settle from evidence: a host carrying its own token would have succeeded and is now blocked, but that case is speculative with documented workarounds and fails loudly at the request — whereas the corrupt file fails silently, hours later, on someone else's canvas.

A size sanity check was investigated first and doesn't work remotely: ComfyUI's REST listing returns names only, so `size` is 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)