### PR TITLE
fix(download): stop telling users to move a model into the folder it is already in

### DIFF
--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -416,13 +416,31 @@ describe("post-write: the reported path is VERIFIED, not intended (#369)", () =>
     expect(res.verifiedPath).toBe(real);
   });
 
-  it("reports NOT-VISIBLE (naming the server's real models dir) when the file is invisible", async () => {
+  // This test's own fixture writes INTO /live/ComfyUI/models — the very root the
+  // running server reported — so its original assertion ("move the file into the
+  // running server's models tree") was pinning #1131: an instruction naming the
+  // directory the file was already in. The verdict is unchanged; the remedy is
+  // the stale-listing one, and the outside-the-root case is covered below.
+  it("reports NOT-VISIBLE and blames the stale listing when the file is inside the live root", async () => {
     h.liveListings["loras"] = ["something-else.safetensors"];
     const res = await verifyLandedModel(target, "loras", { attempts: 2, retryMs: 0 });
     expect(res.liveVisible).toBe("not-visible");
     expect(res.verifiedPath).toBe(target);
+    expect(res.note).toMatch(/does not list "new\.safetensors" under "loras" YET/);
+    expect(res.note).toMatch(/Do NOT move the file/);
+    expect(res.note).not.toMatch(/Move the file into the running server's models tree/);
+    expect(res.note).toContain(resolve("/live/ComfyUI/models"));
+  });
+
+  it("still says MOVE IT when the file is outside the live models root", async () => {
+    const stray = resolve("/somewhere/else/new.safetensors");
+    realpathMock.mockImplementation(async () => stray);
+    h.liveListings["loras"] = ["something-else.safetensors"];
+    const res = await verifyLandedModel(target, "loras", { attempts: 2, retryMs: 0 });
+    expect(res.liveVisible).toBe("not-visible");
     expect(res.note).toMatch(/does NOT list "new\.safetensors"/);
     expect(res.note).toMatch(/will not be usable/);
+    expect(res.note).toMatch(/Move the file into the running server's models tree/);
     expect(res.note).toContain(resolve("/live/ComfyUI/models"));
   });
 

--- a/src/__tests__/services/placement-stale-listing.test.ts
+++ b/src/__tests__/services/placement-stale-listing.test.ts
@@ -1,0 +1,113 @@
+// #1131 — "not listed" has TWO causes, and they take OPPOSITE remedies.
+//
+// A user downloaded a LoRA into the connected ComfyUI's exact models root. The
+// placement check asked the server's loader option list immediately, the list had
+// not been re-read yet, and the tool reported NOT VISIBLE — then told them to
+// "move the file into the running server's models tree", naming a directory the
+// file was already in. Their own words: the written path and the server models
+// path were identical.
+//
+// That is a remedy that cannot be followed — the same family as #1043's fence
+// advice, where the verdict was defensible and the instruction was not.
+//
+// ComfyUI caches loader options and invalidates them on the directory's mtime, so
+// a check this soon after a write routinely races it. Inside the root ⇒ stale
+// listing, refresh. Outside ⇒ genuinely misplaced, move.
+
+import { describe, expect, it } from "vitest";
+import { isUnderRoot, notVisibleVerdict } from "../../services/model-resolver.js";
+
+const BASE = { wanted: "example.safetensors", category: "loras", baseUrl: "http://127.0.0.1:8188" };
+
+describe("a file inside the server's own models root is not called misplaced", () => {
+  // The reporter's exact shape: one path, spelled two ways.
+  const reported = notVisibleVerdict({
+    ...BASE,
+    verifiedPath: "C:\\ComfyUI\\models\\loras\\example.safetensors",
+    liveModelsDir: "C:/ComfyUI/models",
+  });
+
+  it("never prints the impossible instruction", () => {
+    expect(reported.note).not.toMatch(/Move the file into the running server's models tree/);
+    expect(reported.note).not.toMatch(/point COMFYUI_PATH/);
+  });
+
+  it("says the placement is right, and says so explicitly", () => {
+    expect(reported.note).toMatch(/it is in the right place/);
+    expect(reported.note).toMatch(/Do NOT move the file/);
+  });
+
+  it("names the actual cause and a remedy that can be followed", () => {
+    expect(reported.note).toMatch(/cached loader options/);
+    expect(reported.note).toMatch(/refresh_nodes/);
+  });
+
+  it("still reports not-visible — the verdict did not weaken", () => {
+    // #369 exists because an unobserved placement must not render as confirmed.
+    // A kinder explanation is not evidence that the server can read the file.
+    expect(reported.liveVisible).toBe("not-visible");
+  });
+});
+
+describe("a file outside that root keeps the move remedy", () => {
+  const misplaced = notVisibleVerdict({
+    ...BASE,
+    verifiedPath: "/home/u/Downloads/example.safetensors",
+    liveModelsDir: "/opt/ComfyUI/models",
+  });
+
+  it("still tells the user to move it, and where", () => {
+    expect(misplaced.note).toMatch(/Move the file into the running server's models tree/);
+    expect(misplaced.note).toMatch(/\/opt\/ComfyUI\/models/);
+  });
+
+  it("does not tell them a refresh will fix it", () => {
+    // The dangerous inversion: a genuinely misplaced file that the user refreshes
+    // forever instead of moving.
+    expect(misplaced.note).not.toMatch(/Do NOT move the file/);
+  });
+
+  it("keeps the move remedy when the live root is unknown", () => {
+    const unknownRoot = notVisibleVerdict({
+      ...BASE,
+      verifiedPath: "/home/u/Downloads/example.safetensors",
+      liveModelsDir: undefined,
+    });
+    // Cannot prove it is in the right place ⇒ must not claim it is.
+    expect(unknownRoot.note).toMatch(/Move the file/);
+    expect(unknownRoot.note).not.toMatch(/models directory that server reads/);
+  });
+});
+
+describe("isUnderRoot", () => {
+  // The platform is a PARAMETER, not read from the host, so the Windows case is
+  // genuinely exercised on ubuntu CI rather than quietly passing there for the
+  // wrong reason — a local green run is single-platform evidence only.
+  it("treats mixed separators and case as the same directory on Windows", () => {
+    expect(
+      isUnderRoot("C:\\ComfyUI\\models\\loras\\example.safetensors", "c:/comfyui/models", "win32"),
+    ).toBe(true);
+  });
+
+  it("does NOT fold case on POSIX, where Models and models differ", () => {
+    expect(isUnderRoot("/comfy/Models/loras/x.safetensors", "/comfy/models", "linux")).toBe(false);
+  });
+
+  it("does not treat a SIBLING directory as inside", () => {
+    // …/models2 must never count as inside …/models, or a genuinely misplaced
+    // file gets the "just refresh" advice and is never found.
+    expect(isUnderRoot("/comfy/models2/loras/x.safetensors", "/comfy/models", "linux")).toBe(false);
+  });
+
+  it("counts the root itself as inside", () => {
+    expect(isUnderRoot("/comfy/models", "/comfy/models", "linux")).toBe(true);
+  });
+
+  it("ignores a trailing separator on the root", () => {
+    expect(isUnderRoot("/comfy/models/loras/x.safetensors", "/comfy/models/", "linux")).toBe(true);
+  });
+
+  it("keeps a genuinely outside path outside", () => {
+    expect(isUnderRoot("/somewhere/else/x.safetensors", "/comfy/models", "linux")).toBe(false);
+  });
+});

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1551,14 +1551,83 @@ export async function verifyLandedModel(
   }
   return {
     verifiedPath,
-    liveVisible: "not-visible",
-    note:
-      `The file IS on disk at ${verifiedPath}, but the connected ComfyUI ` +
-      `(${getComfyUIBaseUrl()}) does NOT list "${wanted}" under "${category}" — it will not be ` +
-      `usable in a workflow from there.` +
-      (liveModelsDir ? ` The models directory that server reads is ${liveModelsDir}.` : "") +
-      " Move the file into the running server's models tree (or point COMFYUI_PATH at that install and re-download).",
+    ...notVisibleVerdict({
+      verifiedPath,
+      liveModelsDir,
+      wanted,
+      category,
+      baseUrl: getComfyUIBaseUrl(),
+    }),
   };
+}
+
+/**
+ * The verdict for a file that is on disk but absent from the live listing (#1131).
+ *
+ * "Not listed" has TWO causes and they take OPPOSITE remedies. If the file sits
+ * UNDER the very models root the server reads, it is not misplaced: the server
+ * simply has not re-read that folder yet. ComfyUI caches its loader option lists
+ * and invalidates them on the directory's mtime, so a check this soon after the
+ * write routinely races it. Telling that user to "move the file into the running
+ * server's models tree" names a directory the file is ALREADY in — a remedy that
+ * cannot be followed, which is what the reporter received. Only a file OUTSIDE
+ * that root is genuinely in the wrong place.
+ *
+ * The DECISION lives here rather than at the call site so it is covered by the
+ * same tests as the wording; a branch chosen upstream and passed in as a boolean
+ * would be exactly the untested wiring this repo keeps getting caught by.
+ */
+export function notVisibleVerdict(args: {
+  verifiedPath: string;
+  liveModelsDir: string | undefined;
+  wanted: string;
+  category: string;
+  baseUrl: string;
+}): { liveVisible: "not-visible"; note: string } {
+  const { verifiedPath, liveModelsDir, wanted, category, baseUrl } = args;
+  const insideLiveRoot = liveModelsDir !== undefined && isUnderRoot(verifiedPath, liveModelsDir);
+  return {
+    // Still not VISIBLE — we did not observe it in the listing, and #369 exists
+    // because an unobserved placement must not render as confirmed. The verdict
+    // is unchanged; what changes is the explanation and the remedy.
+    liveVisible: "not-visible",
+    note: insideLiveRoot
+      ? `The file IS on disk at ${verifiedPath}, which is INSIDE the models directory the ` +
+        `connected ComfyUI reads (${liveModelsDir}) — so it is in the right place. That server ` +
+        `does not list "${wanted}" under "${category}" YET, which almost always means its ` +
+        `cached loader options have not been re-read since the write (ComfyUI invalidates them ` +
+        `on the directory's mtime). Do NOT move the file. Refresh the node/model definitions ` +
+        `— install_comfyui (action:"refresh_nodes"), or the panel's refresh — or restart ` +
+        `ComfyUI, then check list_local_models again.`
+      : `The file IS on disk at ${verifiedPath}, but the connected ComfyUI ` +
+        `(${baseUrl}) does NOT list "${wanted}" under "${category}" — it will not be ` +
+        `usable in a workflow from there.` +
+        (liveModelsDir ? ` The models directory that server reads is ${liveModelsDir}.` : "") +
+        " Move the file into the running server's models tree (or point COMFYUI_PATH at that install and re-download).",
+  };
+}
+
+/**
+ * Is `file` inside `root`? Compared on NORMALIZED paths (#1131).
+ *
+ * Windows mixes separators and is case-insensitive, so `C:\ComfyUI\models` and
+ * `c:/comfyui/models` name the same directory — comparing raw strings would call
+ * a correctly-placed file misplaced and print the "move it there" remedy for a
+ * file already there. The boundary check requires a separator so `…/models2`
+ * never counts as inside `…/models`.
+ */
+export function isUnderRoot(
+  file: string,
+  root: string,
+  platform: string = process.platform,
+): boolean {
+  const norm = (s: string): string => {
+    const slashed = s.replace(/\\/g, "/").replace(/\/+$/, "");
+    return platform === "win32" ? slashed.toLowerCase() : slashed;
+  };
+  const f = norm(file);
+  const r = norm(root);
+  return f === r || f.startsWith(`${r}/`);
 }
 
 /**


### PR DESCRIPTION
Fixes #1131.

A reporter downloaded a LoRA into their connected ComfyUI's exact models root, and `download_model` told them to move it there. Their evidence was two identical paths:

```
Written path:       <COMFYUI_PATH>\models\loras\example.safetensors
Server models path: <COMFYUI_PATH>\models
Message:            Move the file into the running server's models tree.
```

An instruction that cannot be followed — the same family as #1043's fence advice, where the verdict was defensible and the instruction was not.

## Cause

"Not listed" has **two** causes and the tool collapsed them into one. ComfyUI caches loader option lists and invalidates them on the directory's mtime, so a placement check this soon after a write routinely races the re-read. A file **inside** the root the server reads is not misplaced — the server just hasn't re-read that folder yet. Only a file **outside** that root is genuinely in the wrong place, and the two take opposite remedies.

## What changed

- Inside the live models root → say it is in the right place, name the stale-listing cause, say **do not move it**, and point at `install_comfyui(action:"refresh_nodes")` / the panel refresh / a restart.
- Outside it → the existing move remedy, unchanged.
- The verdict stays `not-visible` in **both** cases. We did not observe the file in the listing, and #369 exists because an unobserved placement must not render as confirmed; a kinder explanation is not evidence the server can read the file. Only the cause and the remedy differ.

`isUnderRoot` normalizes separators and folds case on Windows only (`C:\ComfyUI\models` and `c:/comfyui/models` name the same directory), with a separator boundary so `…/models2` never counts as inside `…/models`.

## Testing notes

The decision lives inside the tested unit (`notVisibleVerdict`) rather than at the call site, so the branch and its wording are covered by the same tests — a boolean chosen upstream and passed in would be exactly the untested wiring this repo keeps getting caught by. `isUnderRoot` takes the platform as a parameter so the Windows case is genuinely exercised on ubuntu CI instead of passing there for the wrong reason.

**One existing test was pinning the defect** — its own fixture wrote into the root the running server had reported, so it asserted the impossible instruction. It now asserts the stale-listing remedy, and a sibling test keeps the move remedy covered for a file that really is outside the root.

Verified by mutation — each of these fails the suite:

| mutation | result |
|---|---|
| drop the separator boundary (`…/models2` reads as inside) | ✗ killed |
| fold case on POSIX too | ✗ killed |
| invert the branch | ✗ killed (6 tests) |
| weaken the verdict to `visible` | ✗ killed |
| disable the inside-check entirely | ✗ killed (3 tests) |

Full suite: 370 files, 7517 passed. Lint and the vocabulary gate are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)