### PR TITLE
fix(release): the GitHub Release body is this version's changelog, not every PR since forever

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,8 +132,37 @@ jobs:
       - name: Publish to npm
         run: npm publish --provenance --access public --tag "${{ steps.disttag.outputs.value }}"
 
+      # The release body is THIS VERSION's CHANGELOG section, not GitHub's
+      # synthesised "What's Changed".
+      #
+      # `generate_release_notes: true` alone asks GitHub to diff against a
+      # previous release IT chooses. With versions cut back-to-back (and
+      # prereleases interleaved) that base is routinely many versions old, so
+      # v0.50.31 — whose changelog entry is a single line — shipped ~13,600
+      # characters listing every PR across a dozen releases. A reader cannot
+      # tell what changed in the thing they just installed, which is the one
+      # question a release page exists to answer.
+      #
+      # CHANGELOG.md is already curated per version, in our words, so it is both
+      # shorter and more honest. Extraction failing is NOT fatal: we fall back to
+      # the generated notes rather than publishing an empty release body.
+      - name: Build release notes from CHANGELOG
+        id: relnotes
+        run: |
+          set -euo pipefail
+          if node scripts/changelog-section.mjs "${GITHUB_REF_NAME}" > RELEASE_NOTES.md; then
+            echo "from_changelog=true" >> "$GITHUB_OUTPUT"
+            echo "release notes for ${GITHUB_REF_NAME} ($(wc -c < RELEASE_NOTES.md) chars):"
+            cat RELEASE_NOTES.md
+          else
+            echo "from_changelog=false" >> "$GITHUB_OUTPUT"
+            rm -f RELEASE_NOTES.md
+            echo "::warning::No CHANGELOG section for ${GITHUB_REF_NAME}; falling back to generated notes."
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
-          generate_release_notes: true
+          body_path: ${{ steps.relnotes.outputs.from_changelog == 'true' && 'RELEASE_NOTES.md' || '' }}
+          generate_release_notes: ${{ steps.relnotes.outputs.from_changelog != 'true' }}
           prerelease: ${{ steps.disttag.outputs.prerelease == 'true' }}

--- a/scripts/changelog-section.mjs
+++ b/scripts/changelog-section.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * Print ONE version's section from CHANGELOG.md — the body for that version's
+ * GitHub Release.
+ *
+ * Why this exists: the release workflow used `generate_release_notes: true` and
+ * nothing else, which asks GitHub to synthesise "What's Changed" from a previous
+ * release IT picks. With releases cut back-to-back (and prereleases interleaved)
+ * that base is frequently far older than the previous version, so a release whose
+ * changelog entry is a single line shipped ~13,600 characters listing every PR
+ * across many versions. The reader cannot tell what actually changed in the thing
+ * they just installed, which is the only question a release page has to answer.
+ *
+ * CHANGELOG.md is already curated per version (Keep a Changelog), so it is the
+ * honest source: it says what changed, in our words, for exactly this version.
+ *
+ * Usage:  node scripts/changelog-section.mjs 0.50.31 [--file CHANGELOG.md]
+ * Exits non-zero (and prints nothing to stdout) when the section is absent, so a
+ * caller can fall back rather than publish an empty release body.
+ */
+import { readFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+const fileFlag = args.indexOf("--file");
+const file = fileFlag >= 0 ? args[fileFlag + 1] : "CHANGELOG.md";
+const raw = args.find((a) => !a.startsWith("--") && a !== file);
+if (!raw) {
+  console.error("usage: changelog-section.mjs <version> [--file CHANGELOG.md]");
+  process.exit(2);
+}
+// Accept `v0.50.31` and `0.50.31` alike — the workflow has the tag, humans have
+// the version, and getting this wrong publishes an empty release body.
+const version = raw.replace(/^v/, "");
+
+const md = readFileSync(file, "utf8");
+const lines = md.split(/\r?\n/);
+
+// Keep a Changelog heading: `## [0.50.31] - 2026-08-07`. Match the version
+// inside brackets exactly, so 0.50.3 never matches 0.50.31's heading.
+const isVersionHeading = (line) => /^##\s+\[/.test(line);
+const headingVersion = (line) => {
+  const m = line.match(/^##\s+\[([^\]]+)\]/);
+  return m ? m[1].trim() : null;
+};
+
+let start = -1;
+for (let i = 0; i < lines.length; i += 1) {
+  if (isVersionHeading(lines[i]) && headingVersion(lines[i]) === version) {
+    start = i;
+    break;
+  }
+}
+if (start === -1) {
+  console.error(`changelog-section: no section for ${version} in ${file}`);
+  process.exit(1);
+}
+
+let end = lines.length;
+for (let i = start + 1; i < lines.length; i += 1) {
+  if (isVersionHeading(lines[i])) {
+    end = i;
+    break;
+  }
+}
+
+// Drop the heading itself — the GitHub Release is already titled with the tag,
+// so repeating "## [0.50.31] - date" in the body is noise.
+const body = lines
+  .slice(start + 1, end)
+  .join("\n")
+  .replace(/^\s*\n+/, "")
+  .replace(/\s+$/, "");
+
+if (!body) {
+  console.error(`changelog-section: section for ${version} is empty in ${file}`);
+  process.exit(1);
+}
+
+process.stdout.write(body + "\n");


### PR DESCRIPTION
Reported by artokun:

> We need to fix the gh release change log, we dump the entire change log spanning the whole thing instead of just adding the new update

## The problem

The workflow's release step was:

```yaml
- name: Create GitHub Release
  uses: softprops/action-gh-release@…
  with:
    generate_release_notes: true
```

With no body of our own, GitHub synthesises "What's Changed" by diffing against a previous release **it** chooses. Versions here are cut back-to-back and prereleases interleave, so that base is routinely many versions old.

**v0.50.31's entire changelog entry is one line** — *"a 403 already says WHY — stop dropping it (#1099)"* — and its release body is **13,658 characters** listing every PR across a dozen releases.

That inverts the purpose of the page. Someone opening a release wants to know what changed in the thing they just installed; instead this version's single fix was indistinguishable from work that shipped days earlier.

## The fix

`CHANGELOG.md` is already curated per version, in our own words. It is both shorter and more truthful than a synthesised commit diff — so use it.

New `scripts/changelog-section.mjs` prints exactly one version's section. The workflow writes it to `RELEASE_NOTES.md` and passes `body_path`.

**v0.50.31: 74 characters instead of 13,658.**

```
### MCP

#### Fixed
- a 403 already says WHY — stop dropping it (#1099)
```

## Details that are deliberate

- **Accepts `v0.50.31` and `0.50.31`.** The workflow holds `GITHUB_REF_NAME` (tagged), humans hold the bare version. Getting this wrong publishes an empty body.
- **Exact bracketed match**, so `0.50.3` can never pick up `0.50.31`'s heading. Verified both directions against the real `CHANGELOG.md`.
- **Drops the `## [x.y.z] - date` heading** — the release is already titled with its tag.
- **Fails open.** A missing or empty section exits non-zero; the workflow then falls back to `generate_release_notes` and emits a `::warning::`. A release with verbose notes is recoverable; one with an empty body is not, and a release must never be blocked by its own notes.

## Verification

Ran against the real `CHANGELOG.md`:

| case | result |
|---|---|
| `v0.50.31` (single entry) | 74 chars, correct section |
| `0.50.22` (multi-section, Fixed + Changed) | correct, both subsections intact |
| `0.50.3` vs `0.50.31` | no cross-match in either direction |
| `99.99.99` (absent) | exits 1, prints nothing to stdout |

Workflow YAML re-parses; control-byte scan clean on both changed files.

Not merged or released here — the next tag pushed picks it up.
