### PR TITLE
fix(search): say "could not reach <host>", not "nothing found"

### DIFF
--- a/src/__tests__/utils/unreachable-not-empty.test.ts
+++ b/src/__tests__/utils/unreachable-not-empty.test.ts
@@ -1,0 +1,112 @@
+// #1136 — an unreachable host must not read as an empty result.
+//
+// A Chinese-speaking user was told to search ComfyUI Manager for the panel and
+// replied 我这边搜不到任何内容 — "I can't find anything when I search". Three
+// consecutive pieces of advice were spent before anyone suspected the door
+// itself could not open. Empty reads as "nothing matched", so the user
+// concludes their query was wrong, or that the thing does not exist, and goes
+// on trying variations of an action that can never succeed.
+//
+// The two search surfaces this repo owns are the ComfyUI Registry (custom-node
+// packs) and HuggingFace (models). Both are commonly filtered. Both previously
+// failed with a bare `fetch failed`, which names nothing.
+//
+// panel_civitai_results already gets this right, and its tool description says
+// so: a total:0 result is NOT automatically "no matches" because an error field
+// may be present. This applies the same rule to the paths that lacked it.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { unreachableHostMessage } from "../../utils/errors.js";
+
+/** The shape undici throws: an opaque TypeError whose detail is on `.cause`. */
+function fetchFailure(code: string, detail: string): Error {
+  const err = new TypeError("fetch failed");
+  (err as Error & { cause?: unknown }).cause = Object.assign(new Error(detail), { code });
+  return err;
+}
+
+describe("unreachableHostMessage", () => {
+  const dnsFail = () =>
+    unreachableHostMessage(
+      fetchFailure("ENOTFOUND", "getaddrinfo ENOTFOUND api.comfy.org"),
+      "https://api.comfy.org/nodes?page=1",
+      "the custom-node search",
+    );
+
+  it("names the host that could not be reached", () => {
+    // The whole point for a filtered user: recognising their own situation.
+    expect(dnsFail().message).toContain("api.comfy.org");
+  });
+
+  it("says explicitly that this is not an empty result", () => {
+    const { message } = dnsFail();
+    expect(message).toMatch(/NOT an empty result/);
+    expect(message).toMatch(/nothing was queried/i);
+  });
+
+  it("names a blocked network as a likely cause, since ENOTFOUND does not", () => {
+    expect(dnsFail().message).toMatch(/blocked by corporate, campus and national network filters/);
+  });
+
+  it("keeps the underlying detail and code", () => {
+    const { message, code } = dnsFail();
+    expect(code).toBe("ENOTFOUND");
+    expect(message).toContain("getaddrinfo ENOTFOUND api.comfy.org");
+  });
+
+  it("calls a TIMEOUT a timeout, and does not claim the network is filtered", () => {
+    // A slow host is not a blocked host. Telling someone their network is
+    // filtered when it is not is its own wrong answer — it sends them to a VPN
+    // for a problem a retry would have solved.
+    const err = Object.assign(new Error("The operation was aborted"), { name: "TimeoutError" });
+    const { message } = unreachableHostMessage(err, "https://huggingface.co/api/models", "the search");
+    expect(message).toMatch(/did not respond in time/);
+    expect(message).not.toMatch(/blocked by corporate/);
+    // Still not an empty result — that part holds for both causes.
+    expect(message).toMatch(/NOT an empty result/);
+  });
+
+  it("appends a host-specific remedy when one exists", () => {
+    const { message } = unreachableHostMessage(
+      fetchFailure("ECONNREFUSED", "connect ECONNREFUSED"),
+      "https://huggingface.co/api/models",
+      "the search",
+      { remedy: "Set HF_ENDPOINT to a mirror." },
+    );
+    expect(message).toContain("Set HF_ENDPOINT to a mirror.");
+  });
+
+  it("does not invent a host when the URL will not parse", () => {
+    const { message } = unreachableHostMessage(new Error("boom"), "not a url", "the search");
+    expect(message).toContain("the remote host");
+    expect(message).toMatch(/NOT an empty result/);
+  });
+});
+
+// THE WIRING. The helper cannot see whether either search actually calls it —
+// exactly the call-site blindness this suite keeps getting caught by. These
+// drive the real functions with a failing fetch.
+describe("the search surfaces use it", () => {
+  const origFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    vi.restoreAllMocks();
+  });
+  beforeEach(() => {
+    globalThis.fetch = vi.fn(async () => {
+      throw fetchFailure("ENOTFOUND", "getaddrinfo ENOTFOUND blocked.example");
+    }) as unknown as typeof fetch;
+  });
+
+  it("searchNodes reports the registry as unreachable, and does NOT return []", async () => {
+    const { searchNodes } = await import("../../services/registry-client.js");
+    await expect(searchNodes("impact pack")).rejects.toThrow(/NOT an empty result/);
+    await expect(searchNodes("impact pack")).rejects.toThrow(/api\.comfy\.org/);
+  });
+
+  it("searchHuggingFaceModels reports HuggingFace as unreachable, and does NOT return []", async () => {
+    const { searchHuggingFaceModels } = await import("../../services/model-resolver.js");
+    await expect(searchHuggingFaceModels("flux")).rejects.toThrow(/NOT an empty result/);
+    await expect(searchHuggingFaceModels("flux")).rejects.toThrow(/HF_ENDPOINT/);
+  });
+});

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -8,7 +8,7 @@ import { getClient, getSystemStats } from "../comfyui/client.js";
 import { getExtraModelRoots, getLiveExtraModelRoots } from "./extra-paths.js";
 import { resolveEffectiveComfyUIBase, resolveLiveServerRoot } from "./workspace-env.js";
 import { installModelViaManager } from "./node-management.js";
-import { ModelError, ValidationError } from "../utils/errors.js";
+import { ModelError, ValidationError, unreachableHostMessage } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { downloadWithCache, probeRemoteModelPayload } from "./download-cache.js";
 import { reportDownloadProgress } from "./download-progress.js";
@@ -224,7 +224,21 @@ export async function searchHuggingFaceModels(
   // Third-party API: bound the wait so a stalled response cannot wedge the
   // turn. Same class as #1026 — an unbounded metadata call has no limit at
   // all and hangs until the caller gives up.
-  const res = await fetch(url, { headers, signal: AbortSignal.timeout(20_000) });
+  //
+  // #1136: an unreachable HuggingFace is the failure most easily mistaken for
+  // "no such model" — this call backs model SEARCH, and its caller renders a
+  // zero-length array as "nothing found". Only errors thrown by fetch() itself
+  // take this path; an HTTP status is a real answer and keeps its own wording.
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(20_000) }).catch(
+    (err: unknown) => {
+      const { message, code } = unreachableHostMessage(err, url, "the HuggingFace model search", {
+        remedy:
+          "If huggingface.co is blocked in your region, set HF_ENDPOINT to a reachable mirror " +
+          "(e.g. https://hf-mirror.com) and retry.",
+      });
+      throw new ModelError(message, { url, code });
+    },
+  );
   if (!res.ok) {
     // unknown-ok: "" is interpolated into an ERROR MESSAGE and nothing else — the
     // HTTP status is reported either way, so an unreadable body costs detail in the

--- a/src/services/registry-client.ts
+++ b/src/services/registry-client.ts
@@ -1,4 +1,4 @@
-import { RegistryError } from "../utils/errors.js";
+import { RegistryError, unreachableHostMessage } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
 const REGISTRY_BASE = "https://api.comfy.org";
@@ -52,7 +52,17 @@ async function registryFetch<T>(path: string): Promise<T> {
   // Third-party API: bound the wait so a stalled response cannot wedge the
   // turn. Same class as #1026 — an unbounded metadata call has no limit at
   // all and hangs until the caller gives up.
-  const res = await fetch(url, { signal: AbortSignal.timeout(20_000) });
+  //
+  // #1136: a failure to REACH api.comfy.org is the one that misleads worst here,
+  // because this endpoint backs "search for the pack you need" — the surface a
+  // filtered user is most often sent to, and the one whose failure they read as
+  // "the pack does not exist". Only errors thrown by fetch() itself take this
+  // path; an HTTP status is a real answer from the host and keeps its own
+  // wording below.
+  const res = await fetch(url, { signal: AbortSignal.timeout(20_000) }).catch((err: unknown) => {
+    const { message, code } = unreachableHostMessage(err, url, "the ComfyUI Registry lookup");
+    throw new RegistryError(message, { url, code });
+  });
   if (!res.ok) {
     // unknown-ok: "" is interpolated into an ERROR MESSAGE and nothing else — the
     // HTTP status is reported either way, so an unreadable body costs detail in the

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -140,6 +140,74 @@ export function isBareFetchFailure(err: unknown): boolean {
   return err instanceof Error && /^fetch failed$/i.test(err.message.trim());
 }
 
+/** The host of `url`, or undefined if it will not parse. Never throws. */
+function hostOf(url: string): string | undefined {
+  try {
+    return new URL(url).host || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Say UNREACHABLE, and say which host (#1136).
+ *
+ * A `fetch()` that never completed is not a result. When the answer it would
+ * have carried is a LIST, the difference matters enormously: an empty list reads
+ * as "nothing matched", so the reader concludes the thing they are looking for
+ * does not exist and goes on trying variations of a query that can never
+ * succeed. That is what happened to a user behind a national filter, who was
+ * told to search ComfyUI Manager and reported 我这边搜不到任何内容 — "I can't
+ * find anything when I search". Three rounds of advice were spent before anyone
+ * suspected the door itself could not open.
+ *
+ * So the message states three things the bare error does not:
+ *   - the HOST, so someone behind a filter recognises their own situation;
+ *   - that NOTHING WAS SEARCHED, so absence was never established;
+ *   - that a blocked network is a common cause, since the user who most needs
+ *     this cannot be expected to infer it from `ENOTFOUND`.
+ *
+ * `what` names the operation as a noun phrase — "the custom-node search".
+ * `opts.remedy` adds a host-specific escape hatch where one exists (HuggingFace
+ * has HF_ENDPOINT; the ComfyUI Registry has none).
+ *
+ * A timeout is called a timeout: the host may well be reachable and merely slow,
+ * and telling a user their network is blocked when it is not is its own wrong
+ * answer. The underlying detail is kept at the end so nothing is lost.
+ */
+export function unreachableHostMessage(
+  err: unknown,
+  url: string,
+  what: string,
+  opts?: { remedy?: string },
+): { message: string; code?: string } {
+  const { message: detail, code } = describeFetchFailure(err);
+  const host = hostOf(url);
+  const named = host ?? "the remote host";
+  const timedOut =
+    code === "UND_ERR_CONNECT_TIMEOUT" ||
+    code === "UND_ERR_HEADERS_TIMEOUT" ||
+    code === "ETIMEDOUT" ||
+    (err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError"));
+
+  return {
+    code,
+    message:
+      (timedOut
+        ? `${named} did not respond in time, so ${what} did not complete. `
+        : `Could not reach ${named}, so ${what} did not run. `) +
+      `This is NOT an empty result — nothing was queried, so nothing follows about whether ` +
+      `what you asked for exists. ` +
+      (timedOut
+        ? `Retry; if it keeps timing out, the host may be throttled or filtered on this network.`
+        : `${named} is commonly blocked by corporate, campus and national network filters — ` +
+          `if other sites work but this one never does, that is the likely cause, and a VPN, ` +
+          `proxy or different network is what changes it.`) +
+      (opts?.remedy ? ` ${opts.remedy}` : "") +
+      ` (${detail})`,
+  };
+}
+
 export function errorToToolResult(err: unknown): CallToolResult {
   if (err instanceof ComfyUIError) return err.toToolResult();
   // A bare "fetch failed" reaching a tool result tells the reader nothing and


### PR DESCRIPTION
Refs #1136.

A Chinese-speaking user was told to search ComfyUI Manager for the panel and replied 我这边搜不到任何内容 — *"I can't find anything when I search"*. Three consecutive pieces of advice were spent before anyone suspected the door itself could not open.

Empty reads as "nothing matched". So the user concludes their query was wrong, or that the thing does not exist, and goes on trying variations of an action that can never succeed.

## What changed

The two search surfaces this repo owns both failed with a bare `fetch failed` — which names no host, offers no cause, and does not say that nothing was searched:

| surface | host | before | after |
|---|---|---|---|
| `search_custom_nodes` | `api.comfy.org` | `fetch failed` | names the host, says nothing was queried, names filtering as a likely cause |
| `download_model action:"search"` | `huggingface.co` (or your `HF_ENDPOINT` mirror) | `fetch failed` | same, plus the `HF_ENDPOINT` escape hatch |

`unreachableHostMessage` states the three things the bare error does not:

1. **the host** — so someone behind a filter recognises their own situation;
2. **that nothing was queried** — so absence was never established;
3. **that a blocked network is a likely cause** — a user who most needs this cannot be expected to infer it from `ENOTFOUND`.

A **timeout is called a timeout** and gets "retry", not "your network is filtered". The host may be reachable and merely slow, and sending someone to a VPN for a problem a retry would have solved is its own wrong answer.

Only errors thrown by `fetch()` itself take this path — an HTTP status is a real answer from the host and keeps its existing wording.

This is the pattern `panel_civitai_results` already documents (a `total:0` result is not automatically "no matches", because an `error` may be present), applied to the paths that lacked it.

## Already correct — checked, not changed

While scoping this I verified the other network-dependent paths the issue names, and these already distinguish unreachable from empty:

- `civitai-resolver` — throws `CivitAI is unreachable (network error: …)`
- `resolve_missing_models` — records `failedProviders` and renders *"the lookup FAILED …, so this is 'could not look', NOT 'nothing exists'"*
- `self-update` — `npm registry unreachable (offline or timed out)`
- `panel-sync` re-check — returns `null`, commented *"could not determine, never determined fine"*
- `skill-generator` — `describeSkillFetchTimeout` names the URL

**Ask 3 of the issue is not covered here.** "Anywhere we tell a user to search for X in Manager" refers to ComfyUI-Manager's own catalogue inside the panel UI, which is not this repo's fetch — that half belongs to the panel. Leaving #1136 open for it.

## Testing notes

Verified by mutation across the helper and both call sites — each fails the suite:

| mutation | result |
|---|---|
| drop the "not an empty result" clause | ✗ killed (5 tests) |
| stop naming the host | ✗ killed |
| force the timeout branch off (timeouts told "you are blocked") | ✗ killed |
| force the timeout branch on (blocked hosts told "just retry") | ✗ killed |
| drop the host-specific remedy | ✗ killed (2 tests) |
| revert the registry call site to a bare fetch | ✗ killed |
| revert the HuggingFace call site to a bare fetch | ✗ killed |

The two call-site tests drive the real `searchNodes` / `searchHuggingFaceModels` against a failing `fetch`, so they see a revert the helper tests cannot.

Full suite: 370 files, 7512 passed. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)