### PR TITLE
release: v0.50.38 — a release page that describes its own release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.38] - 2026-08-08
+
+### MCP
+
+#### Fixed
+- the GitHub Release body is THIS version's changelog, not every PR since forever (#1138)
+- stop telling users to move a model into the folder it is already in (#1137)
+
+
 ## [0.50.37] - 2026-08-08
 
 ### RunPod image

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.37",
+  "version": "0.50.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.37",
+      "version": "0.50.38",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.37",
+  "version": "0.50.38",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Two fixes since 0.50.37.

**#1138 — the GitHub Release body is this version's changelog.** The workflow used `generate_release_notes: true` with no body of ours, so GitHub synthesised "What's Changed" against a previous release it picked. With versions cut back-to-back and prereleases interleaved that base was routinely many versions old — v0.50.31, whose entire changelog entry is one line, shipped a **13,658 character** body listing every PR across a dozen releases.

This is the first release to use the curated `CHANGELOG.md` section as its body, so **this release is the test of its own fix**. Expected body:

```
### MCP

#### Fixed
- the GitHub Release body is THIS version's changelog, not every PR since forever (#1138)
- stop telling users to move a model into the folder it is already in (#1137)
```

**#1137 — stop telling users to move a model into the folder it is already in.** Same honest-message class as the rest of this week.

## Release mechanics

Merge this with a **merge commit**, then tag the resulting `origin/main` SHA — not local HEAD. Tagging local HEAD after a version bump is what published a broken release once before; the tag push is what triggers `release.yml` → npm publish.

Staged deliberately: only `package.json`, `package-lock.json`, `CHANGELOG.md`. The working tree carries untracked scratch files that `git add -A` would sweep in.

Control-byte scan clean on all three.