### PR TITLE
fix(panel): a RESERVED Manager update is staged, not failed

### DIFF
--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -658,6 +658,78 @@ describe("runPanelAction", () => {
     );
   });
 
+  // #1133 — THE WIRING for the staged-update reading. readManagerReservation is
+  // unit-tested next door; only driving the real update path can show that this
+  // branch consults it at all, and that it sits AHEAD of the no-op cascade.
+  //
+  // Same persona as the #639 test above — the stale-3.x signature, nothing moved
+  // on disk — plus the one thing that changes its meaning: ComfyUI-Manager's own
+  // install-scripts.txt naming this pack for a next-boot switch.
+  it("#1133: Manager RESERVED the switch → reports STAGED + restart, never 'did NOT apply'", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const reserveFile = join(
+      COMFY,
+      "user",
+      "__manager",
+      "startup-scripts",
+      "install-scripts.txt",
+    );
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: {
+        [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.9.8"),
+        [reserveFile]:
+          `['${PANEL_REGISTRY_ID}', '#LAZY-CNR-SWITCH-SCRIPT', 'https://x/y.zip', ` +
+          `'/from', '/to', False, '/cn', 'python']\n`,
+      },
+      revs: { [dir]: "dddddddddddddddddddddddddddddddddddddddd" },
+      updateDetails: {
+        total_count: 0,
+        done_count: 2,
+        in_progress_count: 0,
+        pending_count: 0,
+        is_processing: false,
+      },
+      // No onUpdate: the pack has NOT moved on disk — which is correct here, and
+      // is exactly what made this read as a failure before.
+    });
+
+    const r = await runPanelAction("update", h.deps);
+
+    expect(r.message).toMatch(/STAGED, not failed/);
+    expect(r.message).toMatch(/RESTART ComfyUI/);
+    expect(r.restartRequired).toBe(true);
+    // The misreport that cost the reporter four attempts and a reinstall path.
+    expect(r.message).not.toMatch(/did NOT apply/);
+    expect(r.message).not.toMatch(/silent no-op/);
+    // It must not invent movement either — the pack IS still the old version.
+    expect(r.installedVersion).toBe("0.9.8");
+  });
+
+  it("#1133: no reservation for OUR pack → the no-op verdict is unchanged", async () => {
+    // The guard against over-reach: a reserve file naming somebody else must not
+    // convert a genuine failure into a pending success.
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: {
+        [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.9.8"),
+        [join(COMFY, "user", "__manager", "startup-scripts", "install-scripts.txt")]:
+          `['comfyui-impact-pack', '#LAZY-CNR-SWITCH-SCRIPT', 'https://x/y.zip', ` +
+          `'/from', '/to', False, '/cn', 'python']\n`,
+      },
+      revs: { [dir]: "dddddddddddddddddddddddddddddddddddddddd" },
+      updateDetails: {
+        total_count: 0,
+        done_count: 2,
+        in_progress_count: 0,
+        pending_count: 0,
+        is_processing: false,
+      },
+    });
+    await expect(runPanelAction("update", h.deps)).rejects.toBeInstanceOf(PanelInstallError);
+  });
+
   it("#639: unchanged version AND unchanged git-HEAD + coherent counts → fails closed (not success)", async () => {
     // An unchanged LOCAL git-HEAD is NOT proof of being at the upstream tip — it
     // only proves nothing was pulled, which is exactly the no-op. So even a git

--- a/src/__tests__/services/panel-update-reserved.test.ts
+++ b/src/__tests__/services/panel-update-reserved.test.ts
@@ -1,0 +1,124 @@
+// #1133 — "staged" is not "failed".
+//
+// ComfyUI-Manager cannot swap a directory the running server is serving, and it
+// is always serving the panel. So instead of no-op'ing it RESERVES the switch:
+// it appends a `#LAZY-CNR-SWITCH-SCRIPT` line naming the pack to
+// `<user>/__manager/startup-scripts/install-scripts.txt`, prints "Installation
+// reserved: <pack>", and returns success. Its prestartup script applies the line
+// on the next boot.
+//
+// From the outside that is indistinguishable from the stale-3.x silent no-op:
+// the queue drains and the pack has not moved. A reporter on ComfyUI Desktop hit
+// it four times in a row, was told each time the update "did NOT apply", and was
+// steered toward reinstall-from-source — for something a restart finishes. On
+// Desktop the reinstall fallback refuses and restart_comfyui declines to act, so
+// the misreport left no route at all.
+//
+// install-scripts.txt is the file Manager itself writes, so reading it is direct
+// evidence of the staging rather than an inference from absence of movement.
+
+import { describe, expect, it } from "vitest";
+import { dirname, join } from "node:path";
+import { readManagerReservation } from "../../services/panel-installer.js";
+
+const PACK = "comfyui-agent-panel";
+// Built with join(), like the code under test — a hard-coded "/" path silently
+// misses on Windows, where this reporter was.
+const ROOT = join("/comfy");
+const NEW = join(ROOT, "user", "__manager", "startup-scripts", "install-scripts.txt");
+const LEGACY = join(
+  ROOT,
+  "user",
+  "default",
+  "ComfyUI-Manager",
+  "startup-scripts",
+  "install-scripts.txt",
+);
+
+/** Manager writes a repr'd Python list, one per line. */
+const reservedLine = (pack: string) =>
+  `['${pack}', '#LAZY-CNR-SWITCH-SCRIPT', 'https://x/y.zip', '/from', '/to', False, '/cn', 'python']`;
+
+function fsWith(files: Record<string, string | Error>) {
+  const dirs = new Set(Object.keys(files).map((f) => dirname(f)));
+  return {
+    existsSync: (p: string) => p in files || dirs.has(p),
+    readFile: (p: string) => {
+      const v = files[p];
+      if (v instanceof Error) throw v;
+      if (v === undefined) throw new Error(`ENOENT ${p}`);
+      return v;
+    },
+  };
+}
+
+describe("readManagerReservation", () => {
+  it("reports RESERVED when Manager staged this pack (current layout)", () => {
+    const deps = fsWith({ [NEW]: reservedLine(PACK) });
+    expect(readManagerReservation(ROOT, PACK, deps)).toBe("reserved");
+  });
+
+  it("reads the LEGACY user/default/ComfyUI-Manager layout too", () => {
+    // manager_migration.get_manager_path moved this; hosts that have not
+    // migrated must not read as "nothing staged".
+    const deps = fsWith({ [LEGACY]: reservedLine(PACK) });
+    expect(readManagerReservation(ROOT, PACK, deps)).toBe("reserved");
+  });
+
+  it("reports ABSENT when the dir exists but nothing is staged", () => {
+    // Manager creates startup-scripts/ at boot and writes the txt only when
+    // something is reserved — so dir-without-file IS proof of no staging.
+    const deps = {
+      existsSync: (p: string) => p === join(ROOT, "user", "__manager", "startup-scripts"),
+      readFile: () => {
+        throw new Error("should not be read");
+      },
+    };
+    expect(readManagerReservation(ROOT, PACK, deps)).toBe("absent");
+  });
+
+  it("reports ABSENT when another pack is staged, not ours", () => {
+    const deps = fsWith({ [NEW]: reservedLine("comfyui-impact-pack") });
+    expect(readManagerReservation(ROOT, PACK, deps)).toBe("absent");
+  });
+
+  it("does not match a pack whose name merely STARTS with ours", () => {
+    // `comfyui-agent-panel-extras` must not be read as `comfyui-agent-panel`,
+    // or an unrelated staging would suppress a real failure report.
+    const deps = fsWith({ [NEW]: reservedLine("comfyui-agent-panel-extras") });
+    expect(readManagerReservation(ROOT, PACK, deps)).toBe("absent");
+  });
+
+  it("ignores a line for our pack that is NOT a CNR switch", () => {
+    const deps = fsWith({ [NEW]: `['${PACK}', '#LAZY-INSTALL-SCRIPT', 'python']` });
+    expect(readManagerReservation(ROOT, PACK, deps)).toBe("absent");
+  });
+
+  it("reports UNKNOWN when no user directory is visible at all", () => {
+    // Remote mode, a relocated user dir, a permissions failure. Saying "absent"
+    // here would be the same fold this fix exists to undo, pointing the other
+    // way: a failure re-labelled as a pending success.
+    const deps = { existsSync: () => false, readFile: () => "" };
+    expect(readManagerReservation(ROOT, PACK, deps)).toBe("unknown");
+  });
+
+  it("reports UNKNOWN when there is no ComfyUI path", () => {
+    expect(readManagerReservation(undefined, PACK, fsWith({}))).toBe("unknown");
+  });
+
+  it("reports UNKNOWN when the file is present but unreadable", () => {
+    const deps = fsWith({ [NEW]: new Error("EACCES") });
+    expect(readManagerReservation(ROOT, PACK, deps)).toBe("unknown");
+  });
+
+  it("finds the reservation among unrelated lines", () => {
+    const deps = fsWith({
+      [NEW]: [
+        `['other-pack', '#LAZY-INSTALL-SCRIPT', 'python']`,
+        reservedLine(PACK),
+        "",
+      ].join("\r\n"), // Manager runs on Windows too
+    });
+    expect(readManagerReservation(ROOT, PACK, deps)).toBe("reserved");
+  });
+});

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -299,6 +299,84 @@ export interface PanelInstallerDeps {
 }
 
 /**
+ * Did ComfyUI-Manager STAGE this pack's update for the next startup? (#1133)
+ *
+ * When a pack's files are in use — which they always are for the panel, since
+ * the running ComfyUI is serving it — Manager does not swap the directory. It
+ * appends a `#LAZY-CNR-SWITCH-SCRIPT` line naming the pack to
+ * `<user>/__manager/startup-scripts/install-scripts.txt`, prints
+ * "Installation reserved: <pack>", and returns SUCCESS. Its prestartup script
+ * applies the line on the next boot.
+ *
+ * From the outside that is indistinguishable from the stale-3.x silent no-op:
+ * the queue drains, and the pack has not moved on disk. A reporter on ComfyUI
+ * Desktop hit this four times in a row, was told each time that the update "did
+ * NOT apply", and was steered toward reinstall-from-source for something a
+ * plain restart would have finished.
+ *
+ * This is the file Manager itself writes, so its presence is direct evidence of
+ * the staging rather than an inference from the absence of movement. Both
+ * `manager_files_path` layouts are checked (`manager_migration.get_manager_path`
+ * moved it from `user/default/ComfyUI-Manager` to `user/__manager`).
+ *
+ * TRI-STATE, deliberately. "reserved" is proof of staging; "absent" is proof of
+ * none; "unknown" means no candidate file could be read — remote mode, a
+ * relocated user dir, a permissions failure — and must never be reported as
+ * "not staged", which is the very fold this fix exists to undo.
+ */
+export type ManagerReservation = "reserved" | "absent" | "unknown";
+
+export function readManagerReservation(
+  comfyuiPath: string | undefined,
+  packName: string,
+  deps: { existsSync: (p: string) => boolean; readFile: (p: string) => string },
+): ManagerReservation {
+  if (!comfyuiPath) return "unknown";
+  const candidates = [
+    join(comfyuiPath, "user", "__manager", "startup-scripts", "install-scripts.txt"),
+    join(
+      comfyuiPath,
+      "user",
+      "default",
+      "ComfyUI-Manager",
+      "startup-scripts",
+      "install-scripts.txt",
+    ),
+  ];
+
+  let sawDir = false;
+  for (const file of candidates) {
+    // The DIRECTORY existing is what makes an absent file meaningful: Manager
+    // creates startup-scripts/ at boot and only writes the txt when something
+    // is actually reserved, so "dir there, file not" IS proof of no staging.
+    // Without that distinction an install whose user dir we cannot see would
+    // read as "nothing staged" — the wrong half of the tri-state.
+    if (deps.existsSync(dirname(file))) sawDir = true;
+    let contents: string;
+    try {
+      if (!deps.existsSync(file)) continue;
+      contents = deps.readFile(file);
+    } catch {
+      // The file is there and unreadable: strictly "could not determine".
+      return "unknown";
+    }
+    for (const line of contents.split(/\r?\n/)) {
+      if (!line.includes("#LAZY-CNR-SWITCH-SCRIPT")) continue;
+      // Manager writes a repr'd Python list: ['<pack>', '#LAZY-CNR-SWITCH-SCRIPT', …].
+      // Match the pack as a whole quoted token so `comfyui-agent-panel` is not
+      // matched by `comfyui-agent-panel-extras`.
+      if (new RegExp(`['"]${escapeForRegExp(packName)}['"]`).test(line)) return "reserved";
+    }
+  }
+  return sawDir ? "absent" : "unknown";
+}
+
+/** Escape a literal for embedding in a RegExp. */
+function escapeForRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
  * Resolve the current commit sha of a git checkout at `dir` by reading its
  * `.git` metadata directly (no subprocess). Handles a normal `.git/` dir, a
  * `.git` FILE pointer (worktrees/submodules: `gitdir: <path>`), a symbolic HEAD
@@ -5620,6 +5698,50 @@ async function runPanelActionCore(
       assertSameTarget("before reporting the update verdict");
       return finalizeUpdate(verdict, post, result); // throws, honestly
     }
+    // #1133 — STAGED IS NOT FAILED, and it short-circuits every fallback below.
+    //
+    // Manager cannot swap a directory the running server is serving, so for the
+    // panel specifically it reserves the switch for the next startup and returns
+    // success. The pack legitimately has not moved, which is exactly the shape
+    // the no-op/unverified branches read as failure. Reporting that sends the
+    // agent to reinstall-from-source — a destructive path — for something a
+    // restart finishes, and on ComfyUI Desktop (where the reinstall fallback
+    // refuses and restart_comfyui declines to act) it leaves no route at all.
+    //
+    // Only a POSITIVE "reserved" reading diverts here. "absent" and "unknown"
+    // both fall through to the existing verdicts unchanged: an install whose
+    // user directory we cannot read must not have its failure re-labelled as a
+    // pending success, which would be this same defect pointing the other way.
+    //
+    // And only where NOTHING MOVED. install-scripts.txt is append-only until the
+    // next boot consumes it, so on an outcome where the pack demonstrably did
+    // change on disk a leftover line would describe some earlier reservation,
+    // not this update — "moved-unknown-direction" keeps its own verdict.
+    if (verdict.outcome === "no-op" || verdict.outcome === "unverified") {
+      const reservation = readManagerReservation(comfyPath, PANEL_REGISTRY_ID, deps);
+      if (reservation === "reserved") {
+        assertSameTarget("before reporting a staged panel update");
+        const message =
+          `Panel update is STAGED, not failed: ComfyUI-Manager could not swap ` +
+          `${PANEL_REGISTRY_ID} while the running ComfyUI is serving it, so it reserved the ` +
+          `switch for the next startup ("Installation reserved" in the ComfyUI log) and ` +
+          `recorded it in startup-scripts/install-scripts.txt. The pack on disk is still ` +
+          `${post.version ?? "unreadable"} and WILL NOT change until ComfyUI restarts — this ` +
+          `is expected, not a no-op. RESTART ComfyUI to apply it, then confirm with ` +
+          `${describeInstallPanelAction("status", "a re-check on the ComfyUI host")}. ` +
+          `Do NOT reinstall from source and do NOT re-run the update — each retry only ` +
+          `reserves it again.`;
+        return {
+          action: "update",
+          result: { ...result, message },
+          restartRequired: true,
+          message,
+          previousVersion,
+          installedVersion: post.version,
+        };
+      }
+    }
+
     // #724/#824 — the Manager produced no usable verdict (the proven stale
     // legacy-3.x no-op, OR an incoherent-but-provably-idle drained queue), and
     // the panel dir is a real git checkout (a pre-op HEAD resolved; a registry


### PR DESCRIPTION
Refs #1133 — the first of the three compounding failures in that report.

ComfyUI-Manager cannot swap a directory the running server is serving, and it is **always** serving the panel. So instead of no-op'ing, it *reserves* the switch: it appends a `#LAZY-CNR-SWITCH-SCRIPT` line naming the pack to `<user>/__manager/startup-scripts/install-scripts.txt`, prints `Installation reserved: <pack>`, and returns success. Its prestartup script applies the line on the next boot.

From the outside that is indistinguishable from the stale-3.x silent no-op — the queue drains, and the pack has not moved on disk. So the tool said:

> Panel update did NOT apply (ComfyUI-Manager reported the queue drained without moving the pack on disk), and the reinstall-from-source fallback is REFUSED …

while the host's log showed `Installation reserved: comfyui-agent-panel` **four times over seven minutes**. Four attempts, each correctly staged by Manager, each reported as a failure, each re-reserving. Nothing ever applied.

The cost is not just a confusing message: it steers an agent toward reinstall-from-source — a destructive path — for something a plain restart finishes. And on ComfyUI Desktop, where that fallback refuses and `restart_comfyui` declines to act, the misreport leaves **no route at all**.

## The fix

`readManagerReservation` reads the file Manager itself writes, so the staging is *observed*, not inferred from the absence of movement. Both `manager_files_path` layouts are checked (`manager_migration.get_manager_path` moved it from `user/default/ComfyUI-Manager` to `user/__manager`).

Verified against the ComfyUI-Manager source on a live install — `manager_core.reserve_cnr_switch` writes the line, `prestartup_script.py` consumes `#LAZY-CNR-SWITCH-SCRIPT` at boot.

The reading is **tri-state** and only a positive `reserved` diverts:

| reading | meaning | behaviour |
|---|---|---|
| `reserved` | Manager staged this pack | report STAGED + restart required |
| `absent` | startup-scripts/ exists, no line for us | unchanged — existing verdict |
| `unknown` | no candidate readable (remote, relocated user dir, EACCES) | unchanged — existing verdict |

`unknown` must not become `absent`: an install whose user directory we cannot read must not have its **failure** re-labelled as a **pending success**, which is this same defect pointing the other way. It also applies only where nothing moved on disk — `install-scripts.txt` is append-only until the next boot consumes it, so on an outcome where the pack demonstrably *did* change, a leftover line would describe some earlier reservation.

## Not covered here

The report names two more failures, both left open on the issue:

2. **Root corroboration refuses on a Desktop argv.** The reporter's suggestion is sound — `--input-directory`/`--output-directory` relocate media, not `custom_nodes`, and only `--base-directory` creates the split the guard defends against — but relaxing a corroboration gate that protects a destructive swap deserves its own change and its own review.
3. **`restart_comfyui` declining on an unverifiable Desktop supervisor** is correct as written; with (1) fixed it is no longer the *only* door, since the update now says plainly that a restart is what finishes it.

## Testing notes

`readManagerReservation` is unit-tested (10 cases), and **two tests drive the real `runPanelAction("update")`** — the helper tests cannot see whether the update path consults it at all, or that the check sits ahead of the no-op cascade.

Verified by mutation, in both directions — each fails the suite:

| mutation | result |
|---|---|
| fold `unknown` into `absent` | ✗ killed |
| match the pack name as a substring (`…-panel-extras` counts) | ✗ killed |
| ignore the `#LAZY-CNR-SWITCH-SCRIPT` marker | ✗ killed |
| drop the legacy `user/default/ComfyUI-Manager` layout | ✗ killed |
| never consult the check | ✗ killed |
| invert it — everything reads as staged | ✗ killed (4 tests, incl. the #639 guards) |

Full suite: 370 files, 7515 passed. Lint and the vocabulary gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)