### PR TITLE
release: v0.50.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.39] - 2026-08-08
+
+### MCP
+
+#### Fixed
+- a RESERVED Manager update is staged, not failed (#1141)
+
+
 ## [0.50.38] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.38",
+  "version": "0.50.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.38",
+      "version": "0.50.39",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.38",
+  "version": "0.50.39",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.39` tag.

**A reserved ComfyUI-Manager update is staged, not failed** (#1133, via #1141).

Manager cannot swap a directory the running server is serving, and it is always serving the panel — so it reserves the switch for the next startup and returns success. The pack legitimately has not moved on disk, which is exactly the shape the no-op branch read as failure. A reporter on ComfyUI Desktop saw `Installation reserved` four times over seven minutes, was told each time the update "did NOT apply", and was steered toward reinstall-from-source for something a restart finishes.

The update now reads the file Manager itself writes and reports STAGED + restart required. The reading is tri-state: only a positive `reserved` diverts, so an install whose user directory cannot be read keeps its existing verdict rather than having a failure re-labelled as a pending success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)