### PR TITLE
fix(install): a REFUSED Manager enqueue falls through to the direct git clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.39] - 2026-08-08
+
+### MCP
+
+#### Fixed
+- a RESERVED Manager update is staged, not failed (#1141)
+
+
 ## [0.50.38] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.38",
+  "version": "0.50.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.38",
+      "version": "0.50.39",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.38",
+  "version": "0.50.39",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -192,6 +192,12 @@ function stubFetch(opts: {
   statusSequence?: unknown[];
   /** Fires when a queue op is submitted — lets a test make the install REAL. */
   onQueue?: () => void;
+  /**
+   * #1129 — status the queue op ITSELF answers with (403 = the 3.x
+   * security_level / allow_git_url_install gate, 404 = route not served here).
+   * The response describes the REQUEST, so nothing was queued.
+   */
+  queueOpStatus?: number;
 } = {}) {
   const calls: Call[] = [];
   let statusIdx = 0;
@@ -216,7 +222,21 @@ function stubFetch(opts: {
         return jsonResponse(s);
       }
       // queue ops + start return empty bodies
-      if (path.includes("/queue/")) opts.onQueue?.();
+      if (path.includes("/queue/")) {
+        // The install lands on /queue/install (3.x) or the /queue/task envelope
+        // with kind:"install" (v4) — match the OPERATION, not one route.
+        const isInstallOp =
+          path.includes("/queue/install") ||
+          (path.includes("/queue/task") &&
+            (body as { kind?: string } | undefined)?.kind === "install");
+        if (opts.queueOpStatus !== undefined && isInstallOp) {
+          return new Response(
+            "A security error has occurred. Please check the terminal logs",
+            { status: opts.queueOpStatus },
+          );
+        }
+        opts.onQueue?.();
+      }
       return new Response("", { status: 200 });
     },
   );
@@ -564,6 +584,106 @@ describe("node-management service", () => {
       const cloneEnv = (cloneCall![2] as { env?: Record<string, string> })?.env;
       expect(cloneEnv?.GIT_TERMINAL_PROMPT).toBe("0");
       expect(cloneEnv?.GIT_ASKPASS).toBe("echo");
+    });
+
+    // #1129 — a REFUSED enqueue is not the end of the road.
+    //
+    // The 3.x git-URL install is gated by security_level + allow_git_url_install,
+    // and a host that does not serve the route answers the same way. Both come
+    // back as a status on the POST, which throws — so the direct-clone fallback,
+    // which needs no Manager at all and is exactly what the user would do by
+    // hand, was unreachable in the one case it exists for. A reporter on legacy
+    // 3.x got "not reachable", then a 404 with "A security error has occurred",
+    // and was left with no install path on a machine whose custom_nodes
+    // directory was sitting right there.
+    // 405 is excluded on purpose: on this API it is the dialect-mismatch signal
+    // that the #646 self-heal retry owns, and the "no dialect self-heal" case
+    // below pins that.
+    for (const status of [403, 404]) {
+      it(`#1129: Manager REFUSES the git enqueue with ${status} → clones directly and says why`, async () => {
+        stubFetch({ installedBody: {}, queueOpStatus: status });
+        let cloned = false;
+        mockedExists.mockImplementation((p: unknown) => {
+          const s = String(p);
+          if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+          if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+          if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) return cloned;
+          return false;
+        });
+        mockedExec.mockImplementation(((bin: string, args: string[]) => {
+          if (bin === "git" && args[0] === "clone") cloned = true;
+          return "";
+        }) as never);
+
+        const res = await installCustomNode({
+          id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        });
+
+        expect(res.mechanism).toBe("git-clone");
+        // The reason must be the REFUSAL, not "not in the registry" — that would
+        // be a wrong explanation for a correct action, and it is what a reader
+        // would go on to act on.
+        expect(res.message).toMatch(new RegExp(`REFUSED the git-URL install \\(HTTP ${status}\\)`));
+        expect(res.message).toMatch(/security_level \/ allow_git_url_install/);
+        expect(res.message).toMatch(/Nothing was queued there/);
+        expect(res.message).not.toMatch(/not in the ComfyUI-Manager registry/);
+        // And it actually cloned.
+        expect(
+          mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+        ).toBeDefined();
+      });
+    }
+
+    it("#1129: a 405 never produces a policy-refusal message", async () => {
+      // 405 is ComfyUI's frontend catchall answering a route registered under
+      // the other API generation. Cloning on it would pre-empt a Manager install
+      // that is about to succeed on the right route.
+      //
+      // Honest scope note: this pins the user-visible outcome, NOT the classifier
+      // branch. Re-admitting 405 to managerEnqueueRefusal does not change this
+      // test, because a 405 is consumed upstream — the POST-then-GET retry and
+      // then the dialect self-heal both act on it first, so it never reaches the
+      // classifier by this route. That is precisely why excluding it there is the
+      // conservative choice rather than a load-bearing one.
+      const { calls } = stubFetch({ installedBody: {}, queueOpStatus: 405 });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        if (s.includes(NODE_DIR_UTILS) || s.endsWith("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+      });
+
+      // It may still end up cloning (unregistered pack) — what must NOT happen is
+      // the refusal shortcut claiming a policy gate the server never asserted.
+      expect(res.message).not.toMatch(/REFUSED the git-URL install/);
+      // And the self-heal must have re-tried rather than giving up at the 405.
+      expect(calls.filter((c) => c.url.includes("/queue/")).length).toBeGreaterThan(1);
+    });
+
+    it("#1129: a 500 from the queue still THROWS — the task may have been accepted", async () => {
+      // The warrant for cloning is that nothing was queued. A 5xx says the
+      // handler fell over, which does not establish that — cloning underneath a
+      // Manager install writing to the same directory is the race this avoids.
+      stubFetch({ installedBody: {}, queueOpStatus: 500 });
+      mockedExists.mockImplementation(() => false);
+      mockedExec.mockImplementation((() => "") as never);
+
+      await expect(
+        installCustomNode({ id: "https://github.com/teskor-hub/comfyui-teskors-utils" }),
+      ).rejects.toThrow(/500/);
+      expect(
+        mockedExec.mock.calls.find((c) => c[0] === "git" && (c[1] as string[])[0] === "clone"),
+      ).toBeUndefined();
     });
 
     it("clones an unregistered git pack into opts.comfyuiPath when global COMFYUI_PATH is unset (#463)", async () => {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2021,13 +2021,54 @@ function discardFailedClone(nodeDir: string, alreadyPresent: boolean): string {
   }
 }
 
+/**
+ * Did ComfyUI-Manager REFUSE the enqueue outright, before queueing anything? (#1129)
+ *
+ * A git-URL install is gated server-side by `security_level` and
+ * `allow_git_url_install`, and a legacy 3.x host that does not serve the route at
+ * all answers the same way. All three arrive as a status on the POST itself:
+ *
+ *   403 — "A security error has occurred" (the policy gate)
+ *   404 — the route is not registered on this build
+ *
+ * 405 is deliberately NOT here. On this API it is the DIALECT-MISMATCH signal
+ * (ComfyUI's frontend catchall answering a route registered under the other
+ * generation), and the self-heal retry in #646 already owns it — diverting to a
+ * clone would pre-empt a Manager install that is about to succeed on the right
+ * route.
+ *
+ * What matters is not which one, but that the response describes the REQUEST
+ * rather than a task: nothing was queued, so nothing is running, so a direct
+ * clone afterwards cannot race a Manager install writing to the same directory.
+ * That is the whole warrant for continuing — and it is why 5xx is excluded, where
+ * a task may well have been accepted before the handler fell over.
+ *
+ * Returns the status, or undefined when the failure is anything else (a transport
+ * error, a timeout, a 500) and must keep propagating.
+ */
+function managerEnqueueRefusal(err: unknown): number | undefined {
+  if (!(err instanceof NodeManagementError)) return undefined;
+  const status = (err.details as { status?: unknown } | undefined)?.status;
+  if (typeof status !== "number") return undefined;
+  return status === 403 || status === 404 ? status : undefined;
+}
+
 async function cloneCustomNodeFallback(
   gitId: string,
   repoName: string,
   gitRef: string | undefined,
   managerStatus: unknown,
   basePath?: string,
+  /**
+   * #1129 — why we are here, when it was NOT "the pack is unregistered". The
+   * refusal messages below name that reason by default, and stating it for a
+   * policy refusal would be a wrong explanation for a correct action; the caller
+   * that knows better passes its own.
+   */
+  opts?: { managerRefusalNote?: string },
 ): Promise<NodeOpResult> {
+  const because =
+    opts?.managerRefusalNote ?? `"${repoName}" is not in the ComfyUI-Manager registry`;
   // basePath is the CALL-SCOPED local ComfyUI root (apply_manifest threads an
   // adopted saved-default/live root here WITHOUT mutating global config, so a
   // panel-connected local session with no COMFYUI_PATH can still clone an
@@ -2039,7 +2080,7 @@ async function cloneCustomNodeFallback(
   // connected server will never see.
   if (isRemoteMode()) {
     throw new ProcessControlError(
-      `"${repoName}" is not in the ComfyUI-Manager registry, and cloning it would write to a ` +
+      `${because}. Cloning it would write to a ` +
         `LOCAL install` +
         (comfyuiBase ? ` (${comfyuiBase})` : "") +
         ` — but this session targets a REMOTE ComfyUI (--comfyui-url), so that is not the ` +
@@ -2049,7 +2090,7 @@ async function cloneCustomNodeFallback(
   }
   if (!comfyuiBase) {
     throw new ProcessControlError(
-      `"${repoName}" is not in the ComfyUI-Manager registry and cloning it ` +
+      `${because}, and cloning it ` +
         `requires a local ComfyUI install, but no ComfyUI path is set. ` +
         `Install it on the ComfyUI host, or pass a registered pack id.`,
     );
@@ -2186,7 +2227,7 @@ async function cloneCustomNodeFallback(
 
   const base = alreadyPresent
     ? `"${repoName}" already exists in custom_nodes (${repoName}) — left it in place.`
-    : `"${repoName}" is not in the ComfyUI-Manager registry — cloned it directly into custom_nodes (${repoName}).`;
+    : `${because} — cloned it directly into custom_nodes (${repoName}).`;
   const warn = warnings.length ? ` ${warnings.join(" ")}` : "";
   return {
     mechanism: "git-clone",
@@ -2381,7 +2422,23 @@ async function installCustomNodeImpl(
     // them from the cached dialect would let a self-heal retry (#646) resend
     // 3.x-shaped params to a v4 server (or the reverse) and install the wrong
     // thing — the retry has to rebuild the body, not just re-route it.
-    const status = await queueManagerTask(
+    // #1129 — A REFUSED ENQUEUE IS NOT THE END OF THE ROAD.
+    //
+    // The 3.x git-URL install is gated by security_level + allow_git_url_install,
+    // and a host that does not serve the route answers the same way. Both come
+    // back as a status on the POST, which throws — so the direct-clone fallback
+    // twenty lines below, which needs no Manager at all and is exactly what the
+    // user would do by hand, was unreachable in the one case it exists for. A
+    // reporter on legacy 3.x got "ComfyUI-Manager not reachable", then a 404 with
+    // "A security error has occurred", and was left with no install path on a
+    // machine whose custom_nodes directory was sitting right there.
+    //
+    // Only a PRE-QUEUE refusal diverts (see managerEnqueueRefusal): the response
+    // describes the request, so nothing is running and the clone cannot race a
+    // Manager task writing to the same directory. Everything else rethrows.
+    let refusedBy: number | undefined;
+    const enqueue = async (): Promise<unknown> =>
+      await queueManagerTask(
       "install",
       (api) =>
         api !== "v2"
@@ -2415,6 +2472,29 @@ async function installCustomNodeImpl(
           },
       managerBase,
     );
+
+    let status: unknown;
+    try {
+      status = await enqueue();
+    } catch (err) {
+      refusedBy = managerEnqueueRefusal(err);
+      // A remote target keeps the original error: the clone would write to a
+      // LOCAL tree that is not the server we are connected to, so "the Manager
+      // refused" is the honest and complete answer there.
+      if (refusedBy === undefined || isRemoteMode()) throw err;
+      logger.info("Manager refused the git install enqueue — cloning directly", {
+        status: refusedBy,
+        gitId,
+      });
+      return withCliNote(
+        await cloneCustomNodeFallback(gitId, repoName, gitRef, { manager_refused: refusedBy }, cliWorkspace, {
+          managerRefusalNote:
+            `ComfyUI-Manager REFUSED the git-URL install (HTTP ${refusedBy}) — on a legacy 3.x ` +
+            `host that is its security_level / allow_git_url_install gate, or a build that does ` +
+            `not serve the route. Nothing was queued there.`,
+        }),
+      );
+    }
 
     // VERIFY: /v2/customnode/installed reflects on-disk custom_nodes, so a
     // freshly-cloned pack shows up even before a reboot. If the Manager actually


### PR DESCRIPTION
Fixes #1129.

A reporter on legacy ComfyUI-Manager 3.x could not install a custom node from a git URL by any documented route:

```
panel_install_node          → ComfyUI-Manager not reachable
install_custom_node(git,    → NODE_MANAGEMENT_ERROR: ComfyUI-Manager API 404
  useCmCli:true)              for /manager/queue/install … A security error has occurred.
```

Their ComfyUI was **local**. The `custom_nodes` directory was sitting right there, and `git clone` into it is exactly what they would have done by hand.

## The fallback already existed — twenty lines below the enqueue

The 3.x git-URL install is gated server-side by `security_level` + `allow_git_url_install`. That gate answers on the POST, and the POST throws — so `cloneCustomNodeFallback`, which needs no Manager at all, was unreachable in the one case it exists for. The code even names the gate in a comment:

> (Gated server-side by security_level + allow_git_url_install config — a rejection surfaces as a 403/404 from the queue route.)

It knew the rejection shape and did not act on it.

## What licenses continuing

`managerEnqueueRefusal` recognises a **pre-queue** refusal — 403 or 404 — and falls through to the clone. The warrant is not the status but what it describes: the response is about the **request**, so nothing was queued, so nothing is running, so a clone afterwards cannot race a Manager task writing to the same directory.

| status | behaviour | why |
|---|---|---|
| 403 | clone | the security_level / allow_git_url_install gate; nothing queued |
| 404 | clone | route not served on this build; nothing queued |
| 405 | unchanged | the dialect-mismatch signal the #646 self-heal owns — diverting would pre-empt an install about to succeed on the right route |
| 5xx | unchanged (throws) | the handler fell over, which does **not** establish that the task was never accepted |
| remote target | unchanged (throws) | the clone would write to a LOCAL tree that is not the server we are connected to, so "the Manager refused" is the whole honest answer |

The clone's messages now take the **real** reason. They hard-coded `"<pack>" is not in the ComfyUI-Manager registry`, which on this path is a wrong explanation for a correct action — and it is the sentence a reader goes on to act on.

## Not changed: `useCmCli`

The report also flags `useCmCli:true` "still falling through to the Manager queue". That is #808's deliberate behaviour — an unusable comfy-cli is a fallback, not a fatal error, and the switch is disclosed in the result rather than silent. The reporter most likely did not have comfy-cli installed. What was genuinely missing was a working path *after* the Manager refused, which is what this fixes.

## Testing notes

Verified by mutation:

| mutation | result |
|---|---|
| widen the refusal set to every status (a 500 would clone under a running task) | ✗ killed |
| never recognise a refusal (back to throwing) | ✗ killed (2 tests) |
| drop the reason note (wrong explanation restored) | ✗ killed (2 tests) |
| re-admit 405 | **survives** — see below |

**The 405 mutation survives, and the test says so.** A 405 is consumed upstream — the POST-then-GET retry and then the dialect self-heal both act on it before it reaches the classifier — so it never arrives there by this route. That is why excluding it is the conservative choice rather than a load-bearing one, and the test comment states that scope instead of implying coverage it does not have.

Full suite: 372 files, 7542 passed. Lint and the vocabulary gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)