### PR TITLE
release: v0.50.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.40] - 2026-08-08
+
+### MCP
+
+#### Fixed
+- a REFUSED Manager enqueue falls through to the direct git clone (#1143)
+
+
 ## [0.50.39] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.39",
+  "version": "0.50.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.39",
+      "version": "0.50.40",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.39",
+  "version": "0.50.40",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.40` tag.

**A refused ComfyUI-Manager enqueue falls through to the direct git clone** (#1129, via #1143).

A reporter on legacy Manager 3.x could not install a custom node from a git URL by any documented route, on a machine whose `custom_nodes` directory was sitting right there. The 3.x git-URL install is gated by `security_level` + `allow_git_url_install`, that gate answers on the POST, and the POST threw — so the direct-clone fallback twenty lines below, which needs no Manager at all, was unreachable in the one case it exists for.

A pre-queue refusal (403/404) now continues to the clone. The warrant is that the response describes the request, so nothing was queued and the clone cannot race a Manager task; 5xx and remote targets keep throwing, and 405 stays with the dialect self-heal that owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)