### PR TITLE
release: v0.50.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.40] - 2026-08-08
+
+### MCP
+
+#### Fixed
+- a REFUSED Manager enqueue falls through to the direct git clone (#1143)
+
+
 ## [0.50.39] - 2026-08-08
 
 ### MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.41] - 2026-08-08
+
+### MCP
+
+#### Added
+- attach UI workflow metadata to API-enqueued prompts (#1124)
+
+
 ## [0.50.40] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.40",
+  "version": "0.50.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.40",
+      "version": "0.50.41",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.39",
+  "version": "0.50.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.39",
+      "version": "0.50.40",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.39",
+  "version": "0.50.40",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.40",
+  "version": "0.50.41",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.41` tag.

**API-enqueued prompts now carry UI workflow metadata** — contributed by @kamekazu (#1124).

Prompts submitted through the ComfyUI API retained only the API graph, so ComfyUI History and Media Assets could not offer "Open as workflow" for anything comfyui-mcp generated. The shared enqueue service now derives a UI graph from the final post-seed-randomization API graph and nested-merges it into `extra_data.extra_pnginfo.workflow`.

Notable properties of the contribution:

- Generated from the **post-randomization** graph, so "Open as workflow" reproduces the seed that actually ran.
- A valid caller-provided canvas is authoritative and short-circuits the `/object_info` fetch entirely.
- Fails open — a conversion or `/object_info` failure logs and enqueues the original prompt exactly once.
- Reuses the existing `convertApiToUi` converter and the client's TTL cache / single-flight request.

Review follow-up on top: a non-object `extra_pnginfo` (an array, a string) was being discarded to make room for the workflow. Attaching metadata is an enhancement and must not buy itself room by dropping a field the caller set, so such a request now goes out untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)