### PR TITLE
fix(panel-tools): reject unrecognized argument keys instead of silently dropping them (#754)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools-strict-schema.test.ts
+++ b/src/__tests__/orchestrator/panel-tools-strict-schema.test.ts
@@ -1,0 +1,137 @@
+// panel#754 — an unrecognized argument key was silently DROPPED, not rejected.
+// Measured: a real call and one carrying an extra `utterly_bogus_param` key
+// returned byte-identical replies. zod's default `z.object()` is "strip" mode,
+// so an unknown key vanishes before the handler ever sees it — a caller with a
+// misspelled or hallucinated field name gets no signal anything was wrong; the
+// call just quietly does less than asked.
+//
+// These tests exercise the REAL dispatch path, not just the schema object in
+// isolation: a genuine `@modelcontextprotocol/sdk` McpServer, registered via
+// `registerPanelTools` exactly as production does, connected to a real Client
+// over an in-memory transport. The unrecognized-key rejection has to survive
+// `normalizeObjectSchema` + `safeParseAsync` inside the SDK's own
+// `validateToolInput` — nothing here is mocked at the validation layer.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { buildPanelToolDefs, registerPanelTools, type PanelToolCtx } from "../../orchestrator/panel-tools.js";
+
+const BOGUS_KEY = "__e2e_bogus_marker_754__";
+
+function makeFakeCtx(): PanelToolCtx {
+  return {
+    call: async (cmd) => ({ content: [{ type: "text", text: JSON.stringify(cmd) }] }),
+    confirm: async () => "yes" as const,
+    bridge: {
+      send: async () => ({}),
+    } as unknown as PanelToolCtx["bridge"],
+    tabId: "test-tab",
+  } as PanelToolCtx;
+}
+
+describe("panel-tools #754: strict schemas reject unknown argument keys", () => {
+  let client: Client;
+  let server: McpServer;
+
+  beforeAll(async () => {
+    server = new McpServer({ name: "panel-tools-strict-test", version: "1.0.0" });
+    registerPanelTools(server, makeFakeCtx());
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: "panel-tools-strict-test-client", version: "1.0.0" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  const defs = buildPanelToolDefs();
+  const allOptional = defs.filter((d) => z.object(d.schema).safeParse({}).success);
+  const hasRequired = defs.filter((d) => !z.object(d.schema).safeParse({}).success);
+
+  it("the survey itself is meaningful — both groups are non-trivial", () => {
+    // If either group collapsed to 0 the tests below would pass vacuously.
+    expect(allOptional.length).toBeGreaterThan(10);
+    expect(hasRequired.length).toBeGreaterThan(10);
+    expect(allOptional.length + hasRequired.length).toBe(defs.length);
+  });
+
+  describe.each(allOptional.map((d) => d.name))("all-optional tool: %s", (name) => {
+    it("an empty call is NOT rejected for carrying an unknown key (there isn't one)", async () => {
+      const r = await client.callTool({ name, arguments: {} });
+      const text = (r.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+      // May still be isError for OPERATIONAL reasons against the fake ctx/bridge
+      // (e.g. "no connected tab") — that is fine and expected; what must NOT
+      // appear is the schema-validation rejection this test exists to check for.
+      expect(text).not.toMatch(/Unrecognized key|Input validation error/);
+    });
+
+    it("the SAME call plus one unknown key IS rejected, naming the key", async () => {
+      const r = await client.callTool({ name, arguments: { [BOGUS_KEY]: true } });
+      expect(r.isError).toBe(true);
+      const text = (r.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+      expect(text).toContain(BOGUS_KEY);
+      expect(text).toMatch(/Unrecognized key|unrecognized_keys/);
+    });
+  });
+
+  describe.each(hasRequired.map((d) => d.name))("required-field tool: %s", (name) => {
+    it("an unknown key is flagged even when required fields are also missing", async () => {
+      // Weaker than the all-optional case (this call was never going to validate
+      // cleanly), but it proves strictness reaches EVERY tool uniformly — the
+      // combined zod error still names the unknown key alongside the missing
+      // required ones, rather than being silently absorbed into "just missing
+      // fields".
+      const r = await client.callTool({ name, arguments: { [BOGUS_KEY]: true } });
+      expect(r.isError).toBe(true);
+      const text = (r.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+      expect(text).toContain(BOGUS_KEY);
+    });
+  });
+
+  it("SPOT CHECK — a VALID required-field call succeeds at the schema layer; the same call plus a bogus key does not", async () => {
+    // panel_add_node requires only class_type; a fresh /object_info refresh isn't
+    // needed for the fake ctx to accept the call — this isolates the schema-layer
+    // effect from anything the real handler would do against a live panel.
+    const valid = await client.callTool({ name: "panel_add_node", arguments: { class_type: "KSampler" } });
+    const validText = (valid.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+    expect(validText).not.toMatch(/Unrecognized key|Input validation error/);
+
+    const poisoned = await client.callTool({
+      name: "panel_add_node",
+      arguments: { class_type: "KSampler", [BOGUS_KEY]: true },
+    });
+    expect(poisoned.isError).toBe(true);
+    const poisonedText = (poisoned.content as Array<{ text?: string }>)?.[0]?.text ?? "";
+    expect(poisonedText).toContain(BOGUS_KEY);
+  });
+
+  it("WIRING: both registration call sites route through strictPanelSchema, not the raw shape", () => {
+    // A green protocol-dispatch test above proves the CURRENT registration works;
+    // it says nothing about whether a future edit reverts one of the two call
+    // sites back to the raw (non-strict) shape while leaving the other fixed.
+    // Read the source directly for both.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const src = readFileSync(join(here, "../../orchestrator/panel-tools.ts"), "utf8");
+
+    // registerPanelTools (MCP SDK / Codex HTTP transport).
+    const registerIdx = src.indexOf("export function registerPanelTools(");
+    expect(registerIdx).toBeGreaterThan(0);
+    const registerBlock = src.slice(registerIdx, registerIdx + 1200);
+    expect(registerBlock).toMatch(/inputSchema:\s*strictPanelSchema\(d\.schema\)/);
+    expect(registerBlock).not.toMatch(/inputSchema:\s*d\.schema[,\s]/);
+
+    // createPanelMcpServer (Anthropic Agent SDK / Claude in-process transport).
+    const createIdx = src.indexOf("export function createPanelMcpServer(");
+    expect(createIdx).toBeGreaterThan(0);
+    const createBlock = src.slice(createIdx, createIdx + 1800);
+    expect(createBlock).toMatch(/strictPanelSchema\(d\.schema\)/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5998,6 +5998,34 @@ export interface PanelToolDef {
   handler: (args: Record<string, unknown>, ctx: PanelToolCtx) => Promise<ToolResult>;
 }
 
+/**
+ * #754 — an unrecognized argument key was silently DROPPED, not rejected. Measured:
+ * a real call and one with an extra `utterly_bogus_param` key returned byte-identical
+ * replies. Zod's default `z.object()` is "strip" mode: unknown keys vanish before the
+ * handler ever sees them, so a caller with a misspelled or hallucinated field name gets
+ * no signal that anything was wrong — the call just quietly does less than asked.
+ *
+ * `.strict()` turns that into a validation error the caller can see and correct,
+ * which is the whole value for an LLM caller: a loud, specific failure ("Unrecognized
+ * key: X") is something a model can read and fix on the next attempt; a silent no-op
+ * is not distinguishable from "it worked but had no effect".
+ *
+ * BOTH transports' registration functions accept this directly in place of the raw
+ * shape (verified against each SDK's actual runtime behavior, not assumed from the
+ * TypeScript types — see the cast note at the Anthropic SDK call site):
+ *   - `@modelcontextprotocol/sdk`'s `registerTool({ inputSchema })` types `inputSchema`
+ *     as `AnySchema | ZodRawShapeCompat`, so a full ZodObject is accepted as-is by the
+ *     TYPE, and at runtime `normalizeObjectSchema` detects an already-built schema
+ *     (it carries `_def`/`_zod`) and passes it through unwrapped rather than
+ *     re-wrapping it — so the `.strict()` marker survives into validation.
+ *   - The Anthropic Agent SDK's `tool()` stores whatever is passed as `inputSchema`
+ *     verbatim; a `.safeParse()` probe against the returned tool definition confirmed
+ *     an unrecognized key is rejected with `Unrecognized key: "..."`.
+ */
+function strictPanelSchema(shape: z.ZodRawShape) {
+  return z.object(shape).strict();
+}
+
 const PANEL_EDIT_NODE_FIELDS = ["pos", "size", "title", "preset", "color", "bgcolor", "shape", "collapsed", "pinned", "mode"] as const;
 const NODE_COLOR_HEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
 
@@ -10268,7 +10296,21 @@ export function createPanelMcpServer(
   // to the SDK's tool-list element type so the heterogeneous array type-checks.
   type SdkTool = ReturnType<typeof tool>;
   const tools = defs.map((d) =>
-    tool(d.name, d.description, d.schema, (args: Record<string, unknown>) => d.handler(args, ctx)),
+    tool(
+      d.name,
+      d.description,
+      // #754 — strict() so an unrecognized arg key is a loud validation error,
+      // not a silent drop. tool()'s TS signature requires a bare ZodRawShape
+      // (`Schema extends AnyZodRawShape`), which a strict ZodObject instance does
+      // NOT structurally satisfy (it has methods like `.parse`, not just field
+      // schemas) — but at RUNTIME the SDK stores whatever is passed as
+      // `inputSchema` verbatim (confirmed by constructing a tool this way and
+      // calling `.safeParse` on the returned definition: unknown keys are
+      // rejected). The cast documents that the type is being widened past what
+      // TS can express here, not past what the SDK actually accepts.
+      strictPanelSchema(d.schema) as unknown as typeof d.schema,
+      (args: Record<string, unknown>) => d.handler(args, ctx),
+    ),
   ) as unknown as SdkTool[];
   const server = createSdkMcpServer({
     name: "comfyui-panel",
@@ -10296,9 +10338,12 @@ export function registerPanelTools(server: McpServer, ctx: PanelToolCtx): void {
       d.name,
       {
         description: d.description,
-        // The MCP SDK accepts a zod raw shape as inputSchema (same shape the
-        // Anthropic SDK tool() takes), so the shared schema drops straight in.
-        inputSchema: d.schema,
+        // #754 — strict() so an unrecognized arg key is a loud validation error,
+        // not silently stripped. The MCP SDK types `inputSchema` as a full zod
+        // schema OR a raw shape (`AnySchema | ZodRawShapeCompat`), so passing the
+        // already-built ZodObject needs no cast here — unlike the Anthropic SDK
+        // call site, which types inputSchema as a bare raw shape only.
+        inputSchema: strictPanelSchema(d.schema),
       },
       (async (args: Record<string, unknown>) => {
         const res = await d.handler(args ?? {}, ctx);


### PR DESCRIPTION
Owner-ratified (#754 / task queue): *"yes zod strictness allows the LLM to adjust appropriately"* — an unrecognized key should be a loud, correctable error, not a silent no-op.

## Measured

A real `panel_*` call and the same call with an extra `utterly_bogus_param` key returned **byte-identical replies**. zod's default `z.object()` is "strip" mode: an unknown key vanishes before the handler ever sees it. For an LLM caller that's the worst failure mode — a misspelled or hallucinated field name produces no signal, the call just quietly does less than asked, and there's nothing in the result to notice or correct.

## The change

`strictPanelSchema(shape)` — `z.object(shape).strict()` — wired into **both** registration call sites that consume the shared 91-tool `buildPanelToolDefs()` list:

- **`registerPanelTools`** (MCP SDK / Codex HTTP): types `inputSchema` as a full zod schema *or* a raw shape, so the built `ZodObject` drops in directly.
- **`createPanelMcpServer`** (Anthropic Agent SDK / Claude in-process): `tool()`'s TS signature requires a bare `ZodRawShape`, which a `ZodObject` instance doesn't structurally satisfy. Verified at **runtime**, not assumed from the types — constructing a tool this way and calling `.safeParse()` on the returned definition confirmed rejection with the same `Unrecognized key` message the other SDK produces. The cast documents that the type is being widened past what TS can express, not past what the SDK accepts.

## Verification

Against the **real dispatch path**, not the schema object in isolation: a genuine `McpServer` registered via `registerPanelTools` exactly as production does, connected to a real `Client` over `InMemoryTransport`. The rejection has to survive the SDK's own `normalizeObjectSchema` + `safeParseAsync` inside `validateToolInput` — nothing is mocked at the validation layer.

Swept all 91 tools (42 all-optional / 49 with required fields):
- **all-optional** — an empty call is unaffected; the same call plus one unknown key is rejected, naming the key
- **required-field** — an unknown key is flagged even when required fields are *also* missing
- **spot check** (`panel_add_node`) — a genuinely valid call is unaffected; the same call plus an unknown key is rejected

**Full existing suite: 373 files / 7678 tests / 0 failures.** Nothing currently relies on an unrecognized key being silently accepted.

**Mutation-verified both call sites independently**, with each mutation's *application* confirmed, not just its effect (a lesson from elsewhere this session — an unconfirmed mutation can silently hit the wrong line and "pass" for the wrong reason):
- reverting `registerPanelTools`'s call site → 93/136 new tests fail (the live protocol path breaks)
- reverting `createPanelMcpServer`'s call site → exactly 1 fails, the wiring test — that path has no live end-to-end dispatch test (constructing a fake `UiBridge` isn't something the existing suite does anywhere), so nothing else would have caught a regression there

Gates: `tsc --noEmit` clean, control-byte scan clean on both files.

Refs #754