### PR TITLE
fix(bridge): stop abandoning a WRITE sooner than a read

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -3326,7 +3326,28 @@ describe("defaultBridgeTimeoutMs — tolerant read timeout (#357)", () => {
     // Preview3D loaded a large FBX on a busy-but-alive main thread.
     expect(defaultBridgeTimeoutMs("graph_query")).toBe(20_000);
     expect(defaultBridgeTimeoutMs("graph_query")).toBeGreaterThan(6000);
-    expect(defaultBridgeTimeoutMs("graph_query")).toBeGreaterThan(defaultBridgeTimeoutMs("graph_run"));
+  });
+
+  it("a WRITE is never abandoned sooner than a read (#694)", () => {
+    // This inverts what #574 left in place, and the inversion is the point.
+    //
+    // A read abandoned too early costs a retry. A write abandoned too early is
+    // unrecoverable ambiguity: it was already delivered so it may have applied,
+    // the bridge refuses to auto-retry it (#334), and the caller must go verify by
+    // hand. The cheap failure had the patience and the expensive one had the hair
+    // trigger — a reporter's panel_set_node_mode timed out at 6s on a live tab
+    // that had already applied it.
+    //
+    // Asserted as an INVARIANT rather than a number so re-tightening writes fails
+    // here no matter which constant someone edits.
+    for (const write of ["graph_run", "graph_add_node", "graph_set_node_mode", "workflow_save"]) {
+      expect(BRIDGE_READONLY_CMDS.has(write)).toBe(false);
+      expect(defaultBridgeTimeoutMs(write)).toBeGreaterThanOrEqual(
+        defaultBridgeTimeoutMs("graph_query"),
+      );
+      // And still past the old flat cutoff that produced the false unknowns.
+      expect(defaultBridgeTimeoutMs(write)).toBeGreaterThan(6000);
+    }
   });
 
   it("a no-timeout READ stays alive PAST the old 6s cutoff (end-to-end) (#357)", async () => {

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1035,9 +1035,35 @@ export function requiresWorkflowStampEnforcement(cmd: { cmd?: unknown }): boolea
   return ACTIVE_WORKFLOW_MUTATORS.has(name);
 }
 
-/** Tight default reply timeout for a MUTATING command with no explicit timeout —
- *  fail fast so the agent isn't blocked on a stuck write. */
-export const BRIDGE_DEFAULT_TIMEOUT_MS = 6000;
+/**
+ * Default reply timeout for a MUTATING command with no explicit timeout.
+ *
+ * This was 6000 ms — the flat pre-#574 default, kept when reads were raised to
+ * 20 s, on the rationale "fail fast so the agent isn't blocked on a stuck write".
+ * That rationale had the asymmetry backwards, and #694's recurrence is what it
+ * costs: `panel_set_node_mode` timed out at 6 s on a live tab, and an immediate
+ * `panel_query_graph` showed the mode HAD been set.
+ *
+ * The reason reads got 20 s applies to writes with more force, not less. It is the
+ * same busy-but-alive main thread — a write does strictly more of that work, since
+ * it mutates, re-renders, and answers the workflow-stamp check — and the two
+ * failures are not equally expensive:
+ *
+ *   - A read abandoned too early costs a retry. Nothing is ambiguous.
+ *   - A write abandoned too early is UNRECOVERABLE ambiguity. The command was
+ *     already delivered, so it may have applied; the bridge deliberately refuses
+ *     to auto-retry it (#334), and the caller is left to verify by hand before it
+ *     can safely do anything. Which is exactly the manual step the reporter
+ *     performed.
+ *
+ * So the cheap failure got the patience and the expensive one got the hair
+ * trigger. Writes now wait as long as reads. This lowers how OFTEN a live tab is
+ * declared unknown; it does not make an unknown recoverable — that needs the
+ * caller-supplied retry identity #694 is actually about.
+ *
+ * Never below the read bound: see the invariant test.
+ */
+export const BRIDGE_DEFAULT_TIMEOUT_MS = 20_000;
 /** More tolerant default for a READ (idempotent) command with no explicit timeout.
  *  A legitimately busy-but-alive panel main thread — e.g. Preview3D parsing a large
  *  FBX — can take many seconds to service a graph_query; failing it at the tight


### PR DESCRIPTION
Refs #694 — addresses the recurrence reported on 0.50.36 / panel 0.11.44, not the retry-identity design the issue is about. #694 stays open.

## The report

`panel_set_node_mode({node_id:126, mode:"active"})` timed out after 6000 ms with an outcome-unknown warning. An immediate `panel_query_graph` showed node 126 was **already active**, and every later graph operation worked normally.

The tab was alive. The write had landed. The caller was told it could not be sure.

## The asymmetry was backwards

6000 ms is the flat pre-#574 default. When #574 raised **reads** to 20 s — because a busy-but-alive main thread (Preview3D parsing a large FBX) was being cut off — writes kept the old number on the rationale *"fail fast so the agent isn't blocked on a stuck write"*.

That reasoning applies to writes with **more** force, not less:

- It is the **same** busy main thread, and a write does strictly more of that work — it mutates, re-renders, and answers the workflow-stamp check.
- The failures are not equally expensive:

| | abandoned too early | cost |
|---|---|---|
| read | retry it | nothing is ambiguous |
| write | **cannot** retry it | already delivered, so it may have applied; the bridge refuses to auto-retry (#334); the caller must verify by hand |

So the cheap failure got the patience and the expensive one got the hair trigger. Writes now wait as long as reads.

## What this does and does not do

It lowers how **often** a live tab is declared unknown. It does **not** make an unknown recoverable — an unlucky 20 s timeout lands in the same place. That needs the caller-supplied retry identity #694 is actually about (`retry_of` / idempotency key + the panel dedupe ledger from #521), which is unchanged and still open.

## Testing notes

The old test asserted `graph_query > graph_run` — the inversion itself. It is replaced by the invariant:

> a write is never abandoned sooner than a read

asserted as a **comparison rather than a number**, so re-tightening fails no matter which constant someone edits.

Verified by mutation:

| mutation | result |
|---|---|
| writes back to 6000 | ✗ killed |
| writes to 19_000 — just under reads, a subtle re-inversion | ✗ killed |

Full suite: 372 files, 7550 passed. Lint and the vocabulary gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)