### PR TITLE
fix(install): name the tool that CAN install an unregistered pack

### DIFF
--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -2179,6 +2179,31 @@ describe("node-management service", () => {
       expect(out.id).toBeUndefined();
     });
 
+    // #789 RECURRENCE — the reroute cannot fix an UNREGISTERED pack.
+    //
+    // The original report was a registered pack with the wrong version spec, which
+    // "nightly" fixes. The recurrence was ComfyUI-MiniMaxH3-FirstBlockCache, which
+    // is in no registry: Manager v4's do_install resolves by pack ID and never by
+    // URL (3.x's files:[url] clone path does not exist there), so a v4 host has NO
+    // Manager route for it by any spelling, and the panel cannot clone — it is
+    // browser JS. The reporter was left at "not found" and had to find the working
+    // tool themselves.
+    it("names install_custom_node, the tool that CAN finish an unregistered pack", () => {
+      const out = normalizeGitUrlInstallArgs({ id: URL });
+      expect(out.note).toMatch(/install_custom_node/);
+      expect(out.note).toMatch(/source:"git"/);
+      // The trigger the caller will actually see from the Manager.
+      expect(out.note).toMatch(/not found.*not available node|not available node/);
+      // And its precondition — the clone writes to the server's filesystem.
+      expect(out.note).toMatch(/LOCAL ComfyUI/);
+    });
+
+    it("does not offer the escape hatch when the caller pinned a version", () => {
+      // No reroute happened, so there is no note at all — a pinned version is the
+      // caller's own choice and gets no advice it did not ask for.
+      expect(normalizeGitUrlInstallArgs({ id: URL, version: "8.28.3" }).note).toBeUndefined();
+    });
+
     it("translates an explicit 'latest' on a git URL to 'nightly' (the #789 failure shape)", () => {
       const out = normalizeGitUrlInstallArgs({ id: URL, version: "latest" });
       expect(out.version).toBe("nightly");

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -3824,6 +3824,41 @@ export interface NormalizedGitUrlInstallArgs extends GitUrlInstallArgs {
  * `id` AND `repository` together name TWO targets (the schema presents them as
  * alternatives); that is a conflict to refuse, not a precedence to pick.
  */
+/**
+ * The route that still works when the Manager has no route at all (#789, recurrence).
+ *
+ * Rerouting a git URL to a from-source "nightly" install fixed the ORIGINAL report,
+ * where the pack was registered and only the version spec was wrong. It cannot fix
+ * the recurrence, because that pack is not in the registry:
+ *
+ *   Node 'ComfyUI-MiniMaxH3-FirstBlockCache@nightly' not found
+ *     — ManagerChannel.dev, ManagerDatabaseSource.remote
+ *
+ * Manager v4's do_install resolves a pack by its registry ID, never by URL (the
+ * 3.x `files:[url]` clone path does not exist there), so on a v4 host an
+ * unregistered repository has NO Manager route by any spelling. The panel cannot
+ * clone either — it is browser JS.
+ *
+ * `install_custom_node` can: it tries the Manager first and then clones the URL
+ * directly into custom_nodes, verifying the result is a real pack. That is the
+ * one tool that finishes this job, and the reporter had to find it by hand after
+ * being left at "not found". Naming it here costs a sentence.
+ *
+ * Stated up front rather than on the failure: the failure text comes back from
+ * the panel and matching on it would be brittle, and an agent that reads this
+ * when the install is queued needs one fewer round trip than one that reads it
+ * after the queue drains.
+ */
+function unregisteredPackEscapeHatch(): string {
+  return (
+    `If this comes back "not found" / "not available node", the pack is not in the ` +
+    `Manager's registry at all — on Manager v4 that leaves NO Manager route for a ` +
+    `repository URL, by any spelling. Use install_custom_node (source:"git") instead: ` +
+    `it clones the URL directly into custom_nodes and verifies a real pack landed. ` +
+    `Requires a LOCAL ComfyUI, since the clone writes to its filesystem.`
+  );
+}
+
 export function normalizeGitUrlInstallArgs(
   args: GitUrlInstallArgs,
 ): NormalizedGitUrlInstallArgs {
@@ -3854,7 +3889,8 @@ export function normalizeGitUrlInstallArgs(
       `"${gitTarget}" is a git repository URL, so this was queued as a from-source ` +
       `install with version "nightly" (git HEAD): ComfyUI-Manager cannot resolve a ` +
       `registry "latest" for a repository-style entry and rejects it ("not available ` +
-      `node: <repo>@<version>"). Pass an explicit version/ref to override.`;
+      `node: <repo>@<version>"). Pass an explicit version/ref to override. ` +
+      unregisteredPackEscapeHatch();
   } else {
     out.version = args.version;
   }


### PR DESCRIPTION
Refs #789 — addresses the recurrence reported on 0.50.36 / panel 0.11.44 / Manager v4.

## Why the existing #789 fix doesn't cover this

The reroute (a git URL → from-source `"nightly"`) fixed the **original** report, where ComfyUI-Impact-Pack *was* registered and only the version spec was wrong. The recurrence is different:

```
Node 'ComfyUI-MiniMaxH3-FirstBlockCache@nightly' not found
  — ManagerChannel.dev, ManagerDatabaseSource.remote
```

Note the `@nightly` — the reroute **did** apply and produced exactly the right request. The pack simply is not in any registry.

Manager v4's `do_install` resolves a pack by its registry ID and **never by URL**; 3.x's `files:[url]` clone path does not exist there. So on a v4 host an unregistered repository has **no Manager route by any spelling**, and no amount of argument normalization changes that. The panel cannot clone either — it is browser JS.

## What does work

`install_custom_node` tries the Manager first, then clones the URL directly into `custom_nodes` and verifies a real pack landed (not just a directory — #900). It is the one tool that finishes this job, and the reporter found it by hand after being left at "not found".

The reroute note now names it, with the trigger to watch for and the one precondition (a local ComfyUI, since the clone writes to its filesystem).

Stated **up front** rather than on the failure: the failure text comes back from the panel and matching on it would be brittle, and an agent reading this when the install is queued needs one fewer round trip than one reading it after the queue drains. It rides only on the reroute note, so a caller who pinned their own version gets no advice they did not ask for.

## Testing notes

Verified by mutation — each fails the suite:

| mutation | result |
|---|---|
| drop the sentence from the note | ✗ killed |
| rot the tool name (`install_custom_node` → a dead name) | ✗ killed |
| offer it on a pinned version too | ✗ killed (2 tests) |

The named remedy was checked to exist rather than assumed: `install_custom_node`'s `source` enum is `["registry", "git", "auto"]`, and the vocabulary gate would reject a retired tool name.

This does not close #789 — a nicer outcome would be routing the fallback automatically instead of telling the caller which tool to call. That is a larger change to the panel/orchestrator split and deserves its own review.

Full suite: 372 files, 7552 passed. Lint and the vocabulary gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)