### PR TITLE
fix(panel-tools): reopening a tab's OWN tmp: routing_key refreshes the fence (#812)

### DIFF
--- a/src/__tests__/orchestrator/open-workflow-unsaved-refresh.test.ts
+++ b/src/__tests__/orchestrator/open-workflow-unsaved-refresh.test.ts
@@ -1,0 +1,207 @@
+// #812 — panel_new_workflow leaves the session permanently fenced whenever the
+// created tab is UNSAVED: there is no real disk path, so the documented recovery
+// (panel_open_workflow(<path>)) has nothing to open. The tool's own error text
+// acknowledges this — "that case needs the tab refresh, not a reopen" — which
+// made panel_new_workflow "effectively unusable whenever this fires."
+//
+// The reporter found the narrowest fix themselves: panel_open_workflow on the
+// tab's OWN tmp:<uuid> routing_key already resolves to the right tab and returns
+// opened:true — it just never re-derived the fence from that reply the way a
+// saved-path open does.
+//
+// Root cause: refreshOpenWorkflowUuid's ENTIRE corroboration path is built around
+// canonicalRequestedSavedIdentity, which returns null for every unsaved token by
+// construction (canonicalSavedWorkflowPath explicitly excludes tmp:/wf: prefixes —
+// they are routing tokens, not path syntax). So an unsaved open always took the
+// early return, before ever looking at the reply's own workflow_uuid — a field
+// that has existed since #716 and is proven the SAME way for saved and unsaved
+// targets: "only after a FINAL SYNCHRONOUS check that target is still the active
+// workflow… omitting it otherwise, expressly so the MCP keeps its existing fence
+// fail-closed."
+//
+// The fix adds a PARALLEL identity check for the unsaved case: exact string
+// equality between the caller's literal tmp:<uuid> token and the panel's own
+// routing_key for the tab it just opened. This is not alias resolution (the
+// #716 P1 concern for the saved case) — a tmp: token is not a lookup key, it IS
+// the per-tab identity, unique by construction. No workflow_list round trip is
+// attempted (mirroring the trust level of the EXISTING "could not ask" fallback):
+// that read is refused by the exact wedge #812 exists to escape (#1071).
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { buildPanelToolDefs, makePanelToolCtx, type PanelToolCtx, type ToolResult } from "../../orchestrator/panel-tools.js";
+
+// RFC-shaped: WORKFLOW_UUID_RE requires a [1-5] version and an [89ab] variant
+// nibble. A placeholder that does not match this is silently rejected, which
+// would make a positive test pass for the wrong reason (see open-workflow-
+// fence-unreadable.test.ts's own warning on this exact trap).
+const OPENED_UUID = "11111111-2222-4333-8444-555555555555";
+const PRIOR_UUID = "99999999-8888-4777-a666-555555555555";
+const TAB_TOKEN = "tmp:12345678-1234-4234-8234-123456789012";
+const OTHER_TAB_TOKEN = "tmp:87654321-4321-4321-8321-210987654321";
+
+let fence: string | undefined;
+let sent: Array<Record<string, unknown>>;
+let stamps: string[];
+
+const textOf = (res: ToolResult): string => (res.content[0] as { text: string }).text;
+
+function openReply(opts: { routingKey: string; withUuid: boolean }): Record<string, unknown> {
+  return {
+    // An UNSAVED workflow has no real path — the panel's own reply shape, per
+    // web/js/comfyui-mcp-panel.js: `opened: { path: target.path, filename }`
+    // with `target.path` undefined for a tmp: tab.
+    opened: { path: null, filename: null },
+    routing_key: opts.routingKey,
+    ...(opts.withUuid ? { workflow_uuid: OPENED_UUID } : {}),
+    modified: false,
+    open_seq: 3,
+  };
+}
+
+function bridgeFor(reply: Record<string, unknown>) {
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      sent.push(cmd);
+      if (cmd.cmd === "workflow_open") return reply;
+      // #812's own reported sequence: workflow_list is unreadable right after
+      // creation. The fix must not depend on this call succeeding, or ever
+      // being made at all for the unsaved path — asserted explicitly below.
+      if (cmd.cmd === "workflow_list") {
+        throw new Error(
+          "workflow instance mismatch: this command targets a different workflow than the active canvas",
+        );
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: "tab-1", title: "Unsaved Workflow", connected_at: 0 }],
+    resolveActiveTabId: () => "tab-1",
+    workflowUuidFor: () => ({ known: true, uuid: fence }),
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      fence = uuid;
+      stamps.push(uuid);
+      return true;
+    },
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+const ctxWith = (b: ReturnType<typeof bridgeFor>): PanelToolCtx => makePanelToolCtx(b, "tab-1");
+const openWorkflow = () => buildPanelToolDefs().find((d) => d.name === "panel_open_workflow")!;
+
+beforeEach(() => {
+  sent = [];
+  stamps = [];
+  fence = PRIOR_UUID; // the wedge: fenced to the instance we are no longer on
+});
+
+describe("#812 opening the tab's OWN tmp: routing_key refreshes the fence", () => {
+  it("adopts the reply's proven uuid when the caller's token matches the opened tab exactly", async () => {
+    const res = await openWorkflow().handler(
+      { path: TAB_TOKEN },
+      ctxWith(bridgeFor(openReply({ routingKey: TAB_TOKEN, withUuid: true }))),
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(fence).toBe(OPENED_UUID);
+    expect(fence).not.toBe(PRIOR_UUID);
+  });
+
+  it("never attempts the workflow_list round trip for this path — it is refused by the exact wedge being escaped", async () => {
+    await openWorkflow().handler(
+      { path: TAB_TOKEN },
+      ctxWith(bridgeFor(openReply({ routingKey: TAB_TOKEN, withUuid: true }))),
+    );
+
+    expect(sent.map((c) => c.cmd)).not.toContain("workflow_list");
+  });
+
+  it("adopts nothing when the reply carries no uuid — fail-closed is preserved", async () => {
+    await openWorkflow().handler(
+      { path: TAB_TOKEN },
+      ctxWith(bridgeFor(openReply({ routingKey: TAB_TOKEN, withUuid: false }))),
+    );
+
+    expect(stamps).toEqual([]);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it("does not turn a wedged corroboration path into a failed open", async () => {
+    const res = await openWorkflow().handler(
+      { path: TAB_TOKEN },
+      ctxWith(bridgeFor(openReply({ routingKey: TAB_TOKEN, withUuid: true }))),
+    );
+
+    expect(res.isError).toBeFalsy();
+  });
+});
+
+describe("#812 safety — a mismatched or malformed token adopts nothing", () => {
+  it("adopts nothing when the reply names a DIFFERENT unsaved tab (another tab raced in)", async () => {
+    const res = await openWorkflow().handler(
+      { path: TAB_TOKEN },
+      ctxWith(bridgeFor(openReply({ routingKey: OTHER_TAB_TOKEN, withUuid: true }))),
+    );
+
+    expect(res.isError).toBeFalsy(); // the open itself still succeeded and is reported as such
+    expect(stamps).toEqual([]);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it("rejects a malformed uuid suffix even if it literal-string-matches the reply", async () => {
+    const bogus = "tmp:not-a-real-uuid";
+    await openWorkflow().handler(
+      { path: bogus },
+      ctxWith(bridgeFor(openReply({ routingKey: bogus, withUuid: true }))),
+    );
+
+    expect(stamps).toEqual([]);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it("does not treat a bare 'tmp:' prefix with no suffix as a match", async () => {
+    await openWorkflow().handler(
+      { path: "tmp:" },
+      ctxWith(bridgeFor(openReply({ routingKey: "tmp:", withUuid: true }))),
+    );
+
+    expect(stamps).toEqual([]);
+  });
+
+  it("still refuses a caller-typed BASENAME or non-canonical string (#716 P1 territory, untouched)", async () => {
+    // Not a tmp: token and not a slash-containing saved path — the pre-existing
+    // saved-path gate already rejects this; confirms the new branch does not
+    // accidentally widen it.
+    await openWorkflow().handler(
+      { path: "foo.json" },
+      ctxWith(bridgeFor(openReply({ routingKey: TAB_TOKEN, withUuid: true }))),
+    );
+
+    expect(stamps).toEqual([]);
+  });
+});
+
+describe("#812 end to end — the reporter's exact sequence", () => {
+  it("panel_new_workflow leaves the session wedged, then opening its OWN routing_key recovers it", async () => {
+    // Step 1: workflow_new (not exercised here directly — its own #932 refresh
+    // path is covered elsewhere) leaves the session fenced to the prior instance,
+    // exactly as #812 reports: "still fenced to the previous workflow instance."
+    expect(fence).toBe(PRIOR_UUID);
+
+    // Step 2: the reporter's own diagnosed recovery — reopen the tab by its
+    // returned routing_key.
+    const res = await openWorkflow().handler(
+      { path: TAB_TOKEN },
+      ctxWith(bridgeFor(openReply({ routingKey: TAB_TOKEN, withUuid: true }))),
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(textOf(res)).toBeTruthy();
+    // The fence is now the NEW tab's instance — every subsequent panel_* call
+    // this session sends will carry the correct stamp.
+    expect(fence).toBe(OPENED_UUID);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3158,7 +3158,25 @@ async function refreshOpenWorkflowUuid(
   const openedIdentity = openedPath
     ? canonicalSavedRecordIdentity({ path: openedPath, routing_key: parsedOpen?.routing_key })
     : null;
-  if (!requestedIdentity || requestedIdentity !== openedIdentity) return;
+  if (!requestedIdentity || requestedIdentity !== openedIdentity) {
+    // #812 — the SAVED corroboration above can never succeed for an unsaved
+    // target (there is no path), so try the parallel UNSAVED identity: the
+    // caller's literal token against the panel's own proven routing_key for
+    // the tab it just opened. Exact equality only — see
+    // canonicalUnsavedWorkflowIdentity for why that carries no alias risk.
+    //
+    // Trust level matches the EXISTING "could not ask" fallback below exactly:
+    // adopt the reply's own workflow_uuid directly, which the panel published
+    // only after its own final synchronous check that this target was still
+    // the active workflow (#716). No extra workflow_list round trip — that
+    // read is itself refused by the exact wedge this exists to repair
+    // (#1071), which is the same trap `panel_new_workflow`'s recovery hit.
+    const requestedUnsaved = canonicalUnsavedWorkflowIdentity(requestedPath);
+    if (requestedUnsaved && requestedUnsaved === parsedOpen?.routing_key) {
+      refreshWorkflowUuid(ctx, parsedOpen);
+    }
+    return;
+  }
 
   // THREE outcomes for this corroborating read, not two — and conflating the last
   // two is #1071 (also #932/#1043).
@@ -3648,6 +3666,28 @@ function canonicalSavedWorkflowRoutingIdentity(value: unknown): string | null {
   if (typeof value !== "string" || !value.startsWith("wf:")) return null;
   const path = canonicalSavedWorkflowPath(value.slice(3));
   return path ? `wf:${path}` : null;
+}
+
+/**
+ * #812 — an UNSAVED workflow has no saved path, so `canonicalRequestedSavedIdentity`
+ * always returns null for it, and `refreshOpenWorkflowUuid` bails out before ever
+ * consulting the reply. `panel_open_workflow(tmp:<uuid>)` on the panel's OWN
+ * routing_key succeeded (`opened:true`) but never refreshed the fence — the ONLY
+ * documented recovery for a just-created blank tab, reported as leaving the tool
+ * "effectively unusable whenever this fires."
+ *
+ * A `tmp:<uuid>` token is not an alias needing corroboration the way a saved path's
+ * basename is (#716 P1's concern) — it is the per-tab routing id itself, unique by
+ * construction. So the identity check here is a single exact-string equality, not a
+ * lookup: does the caller's literal request match the panel's own proven routing_key
+ * for the tab it just opened? No resolution happens on either side.
+ *
+ * Strict RFC-uuid suffix (same `WORKFLOW_UUID_RE` the command-fence stamp itself is
+ * validated against) so a malformed or truncated token is never treated as a match.
+ */
+function canonicalUnsavedWorkflowIdentity(value: unknown): string | null {
+  if (typeof value !== "string" || !value.startsWith("tmp:")) return null;
+  return WORKFLOW_UUID_RE.test(value.slice(4)) ? value : null;
 }
 
 /** Stable-identity match (positive only) — used to prefer the active record among matches. */


### PR DESCRIPTION
`panel_new_workflow` creates a blank unsaved tab and cannot re-derive this session's workflow-instance fence, so every subsequent `panel_*` call is refused with `workflow instance mismatch`. Because the tab is unsaved it has no real path, and the documented recovery (`panel_open_workflow(<path>)`) had nothing to open. The tool's own error text acknowledges the case is unrecoverable in-band — reported as making `panel_new_workflow` **"effectively unusable whenever this fires"** (#812).

The reporter diagnosed the narrowest fix themselves: `panel_open_workflow` on the tab's **own** `tmp:<uuid>` routing_key already resolves to the right tab and returns `opened:true` — it just never re-derives the fence from that reply the way a saved-path open does.

## Root cause

`refreshOpenWorkflowUuid`'s entire corroboration path runs through `canonicalRequestedSavedIdentity`, which returns `null` for **every** unsaved token by construction — `canonicalSavedWorkflowPath` explicitly excludes `tmp:`/`wf:` prefixes ("routing tokens, not path syntax"). So an unsaved open always hit the early return before ever consulting the reply.

The reply's own `workflow_uuid` field has existed since `#716` and is proven the **same way** for saved and unsaved targets:

> only after a FINAL SYNCHRONOUS check that target is still the active workflow… omitting it otherwise, expressly so the MCP keeps its existing fence fail-closed

The corroboration gate was simply never extended to recognize the unsaved shape of that same proof.

## The fix

A parallel identity check for the unsaved case: `canonicalUnsavedWorkflowIdentity` validates a strict `tmp:<RFC-uuid>` token (the same `WORKFLOW_UUID_RE` the command-fence stamp itself is validated against), compared by **exact string equality** against the panel's own `routing_key` for the tab it just opened.

This is not alias resolution — the `#716 P1` concern for the saved case, where a caller string could resolve via loose lookup to an unrelated real workflow. A `tmp:` token *is* the per-tab identity, unique by construction; no lookup happens on either side.

No extra `workflow_list` round trip for this path (unlike the saved-path branch's "prefer freshness" step): that read is refused by the exact wedge this exists to escape (`#1071`) — the same trap the caller already hit via `panel_new_workflow`'s own recovery attempt. Trust level matches the **existing** "could not ask" fallback exactly; no new trust introduced.

## Verification

9 new tests: positive adoption, no-round-trip, fail-closed on a missing uuid, mismatched-tab safety (another tab raced in), malformed-suffix rejection, bare-prefix rejection, saved-path-gate-untouched regression, and the reporter's full end-to-end sequence.

Existing `#716`/`#1071` suite (340 tests): unchanged, zero regression to the saved-path branch. **Full suite: 373 files / 0 failures.**

Mutation-verified three ways, each application confirmed by occurrence-count before trusting the result (an earlier attempt this session silently failed to apply and would have read as false reassurance): dropping the uuid-suffix validation, removing the whole new branch, and neutralizing the refresh call while keeping the identity match — each fails 2 of the 9 new tests.

Refs #812