### PR TITLE
fix(models): a filtered empty listing says where else to look

### DIFF
--- a/src/__tests__/services/model-listing-coverage.test.ts
+++ b/src/__tests__/services/model-listing-coverage.test.ts
@@ -279,3 +279,105 @@ describe("#1015: an unparsable category body is described from what was observed
     expect(coverage.unanswered[0].reason).not.toMatch(/Unexpected end of JSON input/);
   });
 });
+
+// #962 — a filtered empty is a true statement about the WRONG folder.
+//
+// A reporter called list_local_models({model_type:"diffusion_models"}) and
+// {"unet"} against a remote server whose UNETLoader was loading
+// krastBf16_v3.safetensors at that moment. Both answered 200 with [], honestly:
+// the weights are registered under neither name. The unfiltered path discovers
+// every registered category; a filtered one skips discovery precisely because it
+// "already names its exact category" — which is what makes the answer misleading.
+describe("#962: a filtered empty says where else to look", () => {
+  /** `/models` lists categories; `/models/<dir>` lists that category's files. */
+  function serverWith(categories: string[], filesByCat: Record<string, string[]> = {}) {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockImplementation(async (path: string) => {
+      if (path === "/models") return new Response(JSON.stringify(categories), { status: 200 });
+      const cat = path.replace(/^\/models\//, "");
+      return new Response(JSON.stringify(filesByCat[cat] ?? []), { status: 200 });
+    });
+    readdir.mockRejectedValue(new Error("ENOENT"));
+  }
+
+  it("collects the OTHER registered categories when the asked-for one is empty", async () => {
+    serverWith(["diffusion_models", "unet_gguf", "checkpoints"]);
+    const { models, coverage } = await listLocalModelsWithCoverage("diffusion_models");
+    expect(models).toEqual([]);
+    // The asked-for category is excluded — repeating it back is not a lead.
+    expect(coverage.otherRegisteredCategories).toEqual(["unet_gguf", "checkpoints"]);
+  });
+
+  it("does NOT pay for the extra call when the listing found something", async () => {
+    serverWith(["diffusion_models", "checkpoints"], { diffusion_models: ["a.safetensors"] });
+    const { models, coverage } = await listLocalModelsWithCoverage("diffusion_models");
+    expect(models.length).toBe(1);
+    expect(coverage.otherRegisteredCategories).toBeUndefined();
+    expect(fetchApi.mock.calls.filter((c) => c[0] === "/models")).toHaveLength(0);
+  });
+
+  it("leaves it UNDEFINED when the category list cannot be read", async () => {
+    // "Could not ask" must not render as "there is nowhere else to look" — the
+    // same fold this coverage type exists to prevent.
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockImplementation(async (path: string) =>
+      path === "/models"
+        ? new Response("nope", { status: 503 })
+        : new Response("[]", { status: 200 }),
+    );
+    readdir.mockRejectedValue(new Error("ENOENT"));
+    const { coverage } = await listLocalModelsWithCoverage("diffusion_models");
+    expect(coverage.otherRegisteredCategories).toBeUndefined();
+  });
+
+  it("does not ask at all for an UNFILTERED call — it already discovers them", async () => {
+    serverWith(["diffusion_models", "unet_gguf"]);
+    const { coverage } = await listLocalModelsWithCoverage();
+    expect(coverage.otherRegisteredCategories).toBeUndefined();
+  });
+});
+
+describe("#962: the message names the other categories instead of claiming none", () => {
+  const base = { answered: ["diffusion_models"], unanswered: [], usedFilesystem: false };
+
+  it("stops asserting an empty install, and points at the real folders", () => {
+    const text = describeEmptyModelListing("diffusion_models", {
+      ...base,
+      otherRegisteredCategories: ["unet_gguf", "checkpoints"],
+    });
+    // The sentence the reporter acted on.
+    expect(text).not.toMatch(/^No diffusion_models models found\.$/);
+    expect(text).toMatch(/fact about ONE folder, not about this install/);
+    expect(text).toMatch(/unet_gguf/);
+    expect(text).toMatch(/checkpoints/);
+    // And the two ways out.
+    expect(text).toMatch(/NO model_type/);
+  });
+
+  it("keeps the plain sentence when the server registers nothing else", () => {
+    // Genuinely the only category: "none" is then the whole truth and extra
+    // hedging would be noise.
+    const text = describeEmptyModelListing("diffusion_models", {
+      ...base,
+      otherRegisteredCategories: [],
+    });
+    expect(text).toBe("No diffusion_models models found.");
+  });
+
+  it("keeps the plain sentence when the category list could not be read", () => {
+    expect(describeEmptyModelListing("diffusion_models", base)).toBe(
+      "No diffusion_models models found.",
+    );
+  });
+
+  it("an UNANSWERED category still wins — that path says 'could not determine'", () => {
+    const text = describeEmptyModelListing("diffusion_models", {
+      answered: [],
+      unanswered: [{ dir: "diffusion_models", reason: "HTTP 503" }],
+      usedFilesystem: false,
+      otherRegisteredCategories: ["checkpoints"],
+    });
+    expect(text).toMatch(/Could not determine/);
+    expect(text).not.toMatch(/fact about ONE folder/);
+  });
+});

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -444,6 +444,28 @@ export type ModelListingCoverage = {
   /** Set when neither path could run: no HTTP answer AND no local install path
    *  to scan, which is the exact shape that produced the false "no models". */
   noSourceAvailable?: boolean;
+  /**
+   * Other categories THIS server registers, collected only when a FILTERED call
+   * came back empty (#962).
+   *
+   * The unfiltered path already discovers every registered category, and its own
+   * comment says why a filtered one skips discovery: "a FILTERED call already
+   * names its exact category". True for the lookup — and it is exactly what makes
+   * the answer misleading. The reporter called
+   * `list_local_models({model_type:"diffusion_models"})` and `{"unet"}` on a
+   * server whose UNETLoader was loading `krastBf16_v3.safetensors` at that
+   * moment. Both names answered 200 with `[]`, honestly, because the weights are
+   * registered under neither of them.
+   *
+   * So a filtered empty is a true statement about the wrong folder, and it is
+   * dressed as a fact about the install. Only when we would otherwise report
+   * "none" do we spend one `/models` call to say where else to look.
+   *
+   * Undefined means the question was never asked (a non-empty result, or the
+   * category list could not be read) — never "there are no other categories",
+   * which is what an empty array means.
+   */
+  otherRegisteredCategories?: string[];
 };
 
 /**
@@ -501,7 +523,40 @@ export async function listLocalModelsWithCoverage(
     usedFilesystem: false,
   };
   const models = await collectLocalModels(modelType, coverage);
+  // #962 — a filtered call that found nothing is about to say "none". Before it
+  // does, ask the server what it actually registers. Bounded to this one case,
+  // so the common paths pay nothing.
+  if (models.length === 0 && modelType !== undefined && coverage.answered.includes(modelType)) {
+    coverage.otherRegisteredCategories = await otherRegisteredCategories(modelType);
+  }
   return { models, coverage };
+}
+
+/**
+ * Categories this ComfyUI registers, minus the one already asked about (#962).
+ *
+ * Undefined on any failure: "we could not ask" must not render as "there is
+ * nowhere else to look", which is the same fold the coverage type exists for.
+ */
+async function otherRegisteredCategories(asked: string): Promise<string[] | undefined> {
+  try {
+    const res = await getClient().fetchApi("/models");
+    if (!res.ok) return undefined;
+    const json = (await res.json()) as unknown;
+    if (!Array.isArray(json)) return undefined;
+    return [
+      ...new Set(
+        json.filter(
+          (c): c is string => typeof c === "string" && c.trim() !== "" && c !== asked,
+        ),
+      ),
+    ];
+  } catch (err) {
+    logger.debug("could not read the registered category list for an empty filtered listing", {
+      err,
+    });
+    return undefined;
+  }
 }
 
 export async function listLocalModels(

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -1110,7 +1110,29 @@ export function describeEmptyModelListing(
 ): string {
   const scope = modelType ? `${modelType} models` : "local models";
   if (coverage.unanswered.length === 0) {
-    // Verified: the server was asked and said zero.
+    // Verified: the server was asked and said zero. For a FILTERED call that is
+    // a true statement about ONE folder, and #962 is what it costs when it is
+    // read as a fact about the install: a reporter's UNETLoader was loading
+    // krastBf16_v3.safetensors while "diffusion_models" and "unet" both
+    // answered 200 with []. The weights were registered under neither name.
+    //
+    // The unfiltered path discovers every registered category; a filtered one
+    // skips discovery precisely because it "already names its exact category".
+    // So say which other folders this server actually has.
+    const others = coverage.otherRegisteredCategories;
+    if (modelType && others !== undefined && others.length > 0) {
+      const shown = others.slice(0, 20).join(", ");
+      const more = others.length > 20 ? `, …and ${others.length - 20} more` : "";
+      return (
+        `No models in "${modelType}" — ComfyUI answered for that category and it is empty.\n\n` +
+        `That is a fact about ONE folder, not about this install. This server also registers: ` +
+        `${shown}${more}.\n\n` +
+        `Weights a custom node, a fork, or an extra_model_paths entry registered under another ` +
+        `key are loadable in a workflow while being absent from "${modelType}" — so if a loader ` +
+        `on the canvas is offering a file, it is coming from one of those. Run list_local_models ` +
+        `with NO model_type to list every registered category, or name one of the above.`
+      );
+    }
     return modelType ? `No ${modelType} models found.` : "No local models found.";
   }
 


### PR DESCRIPTION
Refs #962 — the half the earlier fix explicitly does not reach.

## The report

`list_local_models({model_type:"diffusion_models"})` and `{"unet"}` against a remote ComfyUI whose `UNETLoader` was listing and loading `krastBf16_v3.safetensors` at that moment — and rendering with it successfully. Both calls answered `No … models found.`

**Both answers were true.** The server answered `200` with `[]` for each, honestly. The weights are registered under neither name.

## Why the existing coverage work doesn't cover it

#918 taught this listing to distinguish *"the server said zero"* from *"the server said nothing"*, and this is a verified zero — so it takes the confident branch. That's correct as far as it goes.

The earlier #962 work made the **unfiltered** path discover every registered category rather than a hardcoded 15. A **filtered** call skips discovery, and the code says why:

> A FILTERED call already names its exact category, so it needs no discovery.

True of the lookup — and precisely what makes the answer misleading. The caller named a folder; the answer reads as a fact about the install. Weights that a custom node, a fork, or an `extra_model_paths` entry registered under another key are loadable in a workflow while being absent from the folder you asked about.

## The change

When a filtered listing is about to report none, ask `/models` what this server actually registers and name the other categories:

```
No models in "diffusion_models" — ComfyUI answered for that category and it is empty.

That is a fact about ONE folder, not about this install. This server also
registers: unet_gguf, checkpoints, loras, …

Weights a custom node, a fork, or an extra_model_paths entry registered under
another key are loadable in a workflow while being absent from
"diffusion_models" — so if a loader on the canvas is offering a file, it is
coming from one of those. Run list_local_models with NO model_type to list every
registered category, or name one of the above.
```

One extra call, on the path that would otherwise assert an empty install. A listing that found something pays nothing.

Three-state, deliberately:

| `otherRegisteredCategories` | meaning | message |
|---|---|---|
| a non-empty array | other folders exist | name them |
| `[]` | genuinely the only category | plain "none" — extra hedging would be noise |
| `undefined` | `/models` could not be read | plain "none" — never "there is nowhere else to look" |

An **unanswered** category still takes precedence: "could not determine" outranks a lead about neighbours.

## Testing notes

Verified by mutation — each fails the suite:

| mutation | result |
|---|---|
| fold could-not-read into nowhere-else | ✗ killed |
| don't exclude the asked-for category (points back at itself) | ✗ killed |
| renderer ignores the categories (back to the bare sentence) | ✗ killed |
| pay for the extra call on every filtered listing | ✗ killed |

Full suite: 373 files, 7696 passed. Lint and the vocabulary gate clean.

This does not close #962 — reading the loader's own combo values (`UNETLoader.unet_name`) would name the exact files rather than the folders to look in. That is the reporter's original ask and a larger change; this removes the false "you have none" that made the tool actively misleading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)