### PR TITLE
release: v0.50.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.42] - 2026-08-08
+
+### MCP
+
+#### Fixed
+- a filtered empty listing says where else to look (#1158)
+- name the tool that CAN install an unregistered pack (#1156)
+- reject unrecognized argument keys instead of silently dropping them (#1153)
+- stop abandoning a WRITE sooner than a read (#1154)
+
+
 ## [0.50.41] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.41",
+  "version": "0.50.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.41",
+      "version": "0.50.42",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.41",
+  "version": "0.50.42",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.42` tag.

Four fixes, all from reporter evidence on current releases.

**A write is no longer abandoned sooner than a read** (#694 recurrence, via #1154). `panel_set_node_mode` timed out at 6000 ms on a live tab that had already applied it. That 6 s was the flat pre-#574 default, kept when reads were raised to 20 s on the rationale "fail fast so the agent isn't blocked on a stuck write" — which has the asymmetry backwards. A read abandoned early costs a retry; a write abandoned early is unrecoverable ambiguity the bridge deliberately refuses to auto-retry. Pinned as an invariant (`write >= read`) rather than a number.

**A refused Manager enqueue falls through to the direct git clone** (#1129, via #1143). The 3.x git-URL install is gated by `security_level` + `allow_git_url_install`; that gate answers on the POST, so the clone fallback twenty lines below was unreachable in the one case it exists for.

**An unregistered pack names the tool that can install it** (#789 recurrence, via #1156). Manager v4 resolves a pack by registry ID and never by URL, so an unregistered repository has no Manager route by any spelling — and the panel cannot clone. `install_custom_node` can.

**A filtered empty model listing says where else to look** (#962, via #1158). `list_local_models({model_type:"diffusion_models"})` answered "none" while the live `UNETLoader` was loading a file — truthfully, because the weights are registered under another key. A filtered call skips category discovery, so its true statement about one folder read as a fact about the install.

Also included: strict argument-key rejection on panel tools (#1153).

🤖 Generated with [Claude Code](https://claude.com/claude-code)