### PR TITLE
fix(panel-tools): Save-As and new-workflow trust their OWN reply's proven uuid (#814)

### DIFF
--- a/src/__tests__/orchestrator/fence-trusts-own-reply.test.ts
+++ b/src/__tests__/orchestrator/fence-trusts-own-reply.test.ts
@@ -1,0 +1,192 @@
+// #814 — Save-As left a stale workflow identity, and the very next graph command
+// failed with root-workflow-uuid-mismatch.
+//
+// panel_save_workflow and panel_new_workflow both re-point the active workflow,
+// and both repair the session's command fence by calling rebindWorkflowFence(ctx)
+// UNCONDITIONALLY — a generic re-derivation that makes its OWN independent
+// workflow_list round trip and never sees the command's own reply. That read is
+// refused by the exact fence this whole flow exists to repair (#1071), and the
+// only remaining recovery (the panel's async hello re-advertise, checked by
+// unreadableOrHealed) is timing-dependent.
+//
+// Both replies ALREADY carry workflow_uuid directly — #762 for workflow_new,
+// #800 for workflow_save/save_as — published only after the panel's own FINAL
+// SYNCHRONOUS check that the target is still the active workflow. Nothing
+// downstream ever read it. refreshFenceFromOwnReply trusts it FIRST, before ever
+// attempting the round trip that can be refused, and falls back to the EXISTING
+// rebindWorkflowFence(ctx) unchanged when the reply carries none.
+//
+// One stale comment corrected along the way: panel_new_workflow's handler
+// claimed "it is simply not carried on the workflow_new reply" — verified false
+// against the current panel source (workflow_new DOES carry workflow_uuid, #762).
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { buildPanelToolDefs, makePanelToolCtx, type PanelToolCtx, type ToolResult } from "../../orchestrator/panel-tools.js";
+
+// RFC-shaped: WORKFLOW_UUID_RE requires a [1-5] version and an [89ab] variant
+// nibble — an arbitrary placeholder is silently rejected, which would make a
+// positive test pass for the wrong reason.
+const NEW_UUID = "11111111-2222-4333-8444-555555555555";
+const PRIOR_UUID = "99999999-8888-4777-a666-555555555555";
+
+let fence: string | undefined;
+let sent: Array<Record<string, unknown>>;
+let stamps: string[];
+
+const textOf = (res: ToolResult): string => (res.content[0] as { text: string }).text;
+
+const REFUSED = "workflow instance mismatch: this command targets a different workflow than the active canvas";
+
+/** A bridge whose workflow_list is ALWAYS refused — the exact wedge #814/#1071
+ *  exist to escape. `reply` is what the triggering command (workflow_save /
+ *  workflow_save_as / workflow_new) answers with. */
+function bridgeFor(cmd: string, reply: Record<string, unknown>) {
+  return {
+    send: async (c: Record<string, unknown>) => {
+      sent.push(c);
+      if (c.cmd === cmd) return reply;
+      if (c.cmd === "workflow_list") throw new Error(REFUSED);
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: "tab-1", title: "A", connected_at: 0 }],
+    resolveActiveTabId: () => "tab-1",
+    workflowUuidFor: () => ({ known: true, uuid: fence }),
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      fence = uuid;
+      stamps.push(uuid);
+      return true;
+    },
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+const ctxWith = (b: ReturnType<typeof bridgeFor>): PanelToolCtx => makePanelToolCtx(b, "tab-1");
+const toolNamed = (name: string) => buildPanelToolDefs().find((d) => d.name === name)!;
+
+beforeEach(() => {
+  sent = [];
+  stamps = [];
+  fence = PRIOR_UUID; // the pre-existing fence, about to go stale
+});
+
+describe("#814 panel_save_workflow trusts its OWN reply before the round trip", () => {
+  it("adopts the Save-As reply's proven uuid without ever attempting workflow_list", async () => {
+    const reply = {
+      saved: true,
+      workflow: "renamed",
+      workflow_uuid: NEW_UUID,
+      routing_key: "wf:workflows/renamed.json",
+      workflow_instance_changed: true,
+    };
+    const res = await toolNamed("panel_save_workflow").handler(
+      { name: "renamed" },
+      ctxWith(bridgeFor("workflow_save_as", reply)),
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(fence).toBe(NEW_UUID);
+    expect(fence).not.toBe(PRIOR_UUID);
+    expect(sent.map((c) => c.cmd)).not.toContain("workflow_list");
+  });
+
+  it("adopts an in-place save's proven uuid too — the reply carries it unconditionally", async () => {
+    const reply = { saved: true, workflow: "same", workflow_uuid: NEW_UUID, routing_key: "wf:workflows/same.json" };
+    await toolNamed("panel_save_workflow").handler({}, ctxWith(bridgeFor("workflow_save", reply)));
+
+    expect(fence).toBe(NEW_UUID);
+    expect(sent.map((c) => c.cmd)).not.toContain("workflow_list");
+  });
+
+  it("falls back to the EXISTING rebindWorkflowFence round trip when the reply carries no uuid", async () => {
+    // An older panel build, or the panel's own final check could not prove it
+    // (#716's fail-closed omission) — behaviour here must be UNCHANGED from
+    // before this fix: it still tries workflow_list (and here, still refused).
+    const reply = { saved: true, workflow: "renamed" }; // no workflow_uuid
+    const res = await toolNamed("panel_save_workflow").handler(
+      { name: "renamed" },
+      ctxWith(bridgeFor("workflow_save_as", reply)),
+    );
+
+    expect(res.isError).toBeFalsy(); // the save itself is still reported honestly
+    expect(sent.map((c) => c.cmd)).toContain("workflow_list"); // fallback WAS attempted
+    expect(stamps).toEqual([]); // and it was refused, so nothing was adopted
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it("never turns a wedged fallback into a failed save", async () => {
+    const res = await toolNamed("panel_save_workflow").handler(
+      {},
+      ctxWith(bridgeFor("workflow_save", { saved: true, workflow: "x" })),
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(textOf(res)).toBeTruthy();
+  });
+});
+
+describe("#814/#812 panel_new_workflow trusts its OWN reply before the round trip", () => {
+  it("adopts the reply's proven uuid without ever attempting workflow_list", async () => {
+    const reply = { created: true, empty: true, key: "tmp:abc", routing_key: "tmp:abc", workflow_uuid: NEW_UUID };
+    const res = await toolNamed("panel_new_workflow").handler({}, ctxWith(bridgeFor("workflow_new", reply)));
+
+    expect(res.isError).toBeFalsy();
+    expect(fence).toBe(NEW_UUID);
+    expect(sent.map((c) => c.cmd)).not.toContain("workflow_list");
+  });
+
+  it("falls back to the EXISTING round trip when the reply carries no uuid", async () => {
+    const reply = { created: true, empty: true, key: "tmp:abc", routing_key: "tmp:abc" }; // no workflow_uuid
+    await toolNamed("panel_new_workflow").handler({}, ctxWith(bridgeFor("workflow_new", reply)));
+
+    expect(sent.map((c) => c.cmd)).toContain("workflow_list");
+    expect(stamps).toEqual([]);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+});
+
+describe("#814 the reporter's exact sequence", () => {
+  it("Save-As, then the VERY NEXT command, no longer sees a stale identity", async () => {
+    const reply = {
+      saved: true,
+      workflow: "renamed",
+      workflow_uuid: NEW_UUID,
+      workflow_instance_changed: true,
+    };
+    await toolNamed("panel_save_workflow").handler(
+      { name: "renamed" },
+      ctxWith(bridgeFor("workflow_save_as", reply)),
+    );
+
+    // The next fenced command (panel_screenshot in the report) reads the fence
+    // via workflowUuidFor — simulated here directly, since the point of this
+    // fix is that the STAMP itself is correct by the time anything else runs.
+    expect(fence).toBe(NEW_UUID);
+  });
+});
+
+describe("#814 WIRING: both call sites route through refreshFenceFromOwnReply first", () => {
+  it("panel_save_workflow and panel_new_workflow both try the direct path before the round trip", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { fileURLToPath } = await import("node:url");
+    const { dirname, join } = await import("node:path");
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "../../orchestrator/panel-tools.ts"),
+      "utf8",
+    );
+
+    const saveIdx = src.indexOf('"panel_save_workflow"');
+    const newIdx = src.indexOf('"panel_new_workflow"');
+    expect(saveIdx).toBeGreaterThan(0);
+    expect(newIdx).toBeGreaterThan(0);
+
+    const saveBlock = src.slice(saveIdx, saveIdx + 5000);
+    const newBlock = src.slice(newIdx, newIdx + 5000);
+    const wired = /const fenceRebind = refreshFenceFromOwnReply\(ctx, res\) \?\? \(await rebindWorkflowFence\(ctx\)\);/;
+    expect(saveBlock).toMatch(wired);
+    expect(newBlock).toMatch(wired);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2476,6 +2476,48 @@ function refreshWorkflowUuid(ctx: PanelToolCtx, value: unknown): boolean {
 }
 
 /**
+ * #814 — workflow_new and workflow_save/workflow_save_as all re-point the active
+ * workflow, and each of their handlers repairs the session's command fence by
+ * calling `rebindWorkflowFence(ctx)` unconditionally — a GENERIC re-derivation
+ * that makes its OWN independent `workflow_list` round trip and has no access to
+ * the command's own reply. That read is refused by the exact fence this whole
+ * flow exists to repair (#1071), and the only remaining recovery
+ * (`unreadableOrHealed`'s check for the panel's async hello re-advertise) is
+ * timing-dependent — a reporter hit exactly this: the save reply already proved
+ * the new uuid, and the very next command still failed with
+ * root-workflow-uuid-mismatch.
+ *
+ * Each of these replies ALREADY carries `workflow_uuid` directly (#762 for
+ * workflow_new, #800 for workflow_save/save_as), published only after the
+ * panel's own FINAL SYNCHRONOUS check that this target is still the active
+ * workflow — the identical proof `workflow_open`'s reply carries, which
+ * `refreshOpenWorkflowUuid` already trusts as a fallback. Trust it FIRST here
+ * too, before ever attempting the round trip that can be refused.
+ *
+ * No corroboration gate is needed (unlike workflow_open, which must verify the
+ * reply's identity against a caller-supplied path): there is no caller target to
+ * corroborate against — this session's own tab just performed the operation that
+ * produced this exact reply.
+ *
+ * Returns null when the reply carries no adoptable uuid (an older panel build,
+ * or the panel's own check could not prove it — #716's fail-closed omission), so
+ * the caller falls back to the EXISTING rebindWorkflowFence(ctx) round trip
+ * completely unchanged.
+ */
+function refreshFenceFromOwnReply(ctx: PanelToolCtx, reply: ToolResult): WorkflowFenceRebind | null {
+  const before = currentWorkflowFence(ctx);
+  const parsed = parseToolResultJson(reply);
+  if (!parsed) return null;
+  const uuid = responseWorkflowUuid(parsed);
+  if (!uuid) return null;
+  try {
+    return refreshWorkflowUuid(ctx, parsed) ? { status: "refreshed", uuid, before } : null;
+  } catch {
+    return null; // never surface a throw here as worse than the existing fallback
+  }
+}
+
+/**
  * The stamp currently fencing this session's tab — TRI-STATE, because reading it
  * is itself an operation that can fail (codex gate).
  *
@@ -8320,7 +8362,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // NEVER fails the call: the file WAS written. Retracting a completed save
         // would be the worse lie, so a fence that could not be re-established is
         // DISCLOSED instead.
-        const fenceRebind = await rebindWorkflowFence(ctx);
+        //
+        // #814 — trust THIS reply's own proven uuid first (#800), before ever
+        // attempting rebindWorkflowFence's independent workflow_list round trip,
+        // which can be refused by the exact fence this repairs.
+        const fenceRebind = refreshFenceFromOwnReply(ctx, res) ?? (await rebindWorkflowFence(ctx));
         let canMutateNow: boolean | undefined;
         let refusalCause: "unroutable" | "disconnected" | "no_identity" | "capability" | undefined;
         try {
@@ -8623,15 +8669,20 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         //
         // Refresh from the panel's own live active record, the same way the open
         // path does. The panel mints the new canvas's identity EAGERLY at
-        // creation ("so the key exists BEFORE the first edit"), so it is readable
-        // by the time this runs — it is simply not carried on the workflow_new
-        // reply, which returns key/routing_key but no workflow_uuid.
+        // creation ("so the key exists BEFORE the first edit").
+        //
+        // #814/#812 — this reply DOES carry workflow_uuid directly (#762), and the
+        // stale comment that used to stand here said otherwise. Trust it first,
+        // before ever attempting rebindWorkflowFence's independent workflow_list
+        // round trip, which can be refused by the exact fence being repaired
+        // (#1071) — the same trap a reporter hit via panel_new_workflow's own
+        // recovery attempt.
         //
         // NEVER fails the call on a rebind miss: the workflow WAS created, and
         // retracting that would be the worse lie. Disclose instead, so the agent
         // learns the graph tools are not yet usable here rather than discovering
         // it one confusing mismatch at a time.
-        const fenceRebind = await rebindWorkflowFence(ctx);
+        const fenceRebind = refreshFenceFromOwnReply(ctx, res) ?? (await rebindWorkflowFence(ctx));
         let canMutateNow: boolean | undefined;
         let refusalCause: "unroutable" | "disconnected" | "no_identity" | "capability" | undefined;
         try {


### PR DESCRIPTION
```
[root-workflow-uuid-mismatch] The live canvas carries a different workflow's
identity tag than the active workflow.
```

reported right after a successful Save-As, on the very next graph command (`#814`).

`panel_save_workflow` already calls `rebindWorkflowFence(ctx)` after a successful save (`#1045`/`#1046`), and that call already survives a **refused** `workflow_list` read via the panel's async hello-heal check (`#1071`/`#1075`). Both of those fixes are in the reporter's exact `comfyui-mcp` version (`0.50.41`) — confirmed against the actual release tag, not commit-message grepping (my first pass got this wrong by checking against the wrong commit). It still reproduced, because neither touches the actual gap: `rebindWorkflowFence` is a **generic** re-derivation that makes its own independent `workflow_list` round trip and has no access to the save command's own reply — so it can never use the uuid `#800` already added there.

`panel_new_workflow` has the identical shape (`#812`/`#932`): a call to the same generic `rebindWorkflowFence`, never consulting `workflow_new`'s own reply.

## The fix

Both replies **already** carry `workflow_uuid` directly — `#762` for `workflow_new`, `#800` for `workflow_save`/`workflow_save_as` — published only after the panel's own final synchronous check that the target is still the active workflow. That's the identical proof `workflow_open`'s reply carries, which `refreshOpenWorkflowUuid` already trusts as a fallback. Nothing on the orchestrator side ever read it for these two commands.

`refreshFenceFromOwnReply(ctx, reply)` trusts it first: parse the reply, check for a valid `workflow_uuid`, adopt it directly, and return the same `{status:"refreshed", uuid, before}` shape `rebindWorkflowFence`'s own success path already produces — `describeFenceRebind` treats it identically, no changes needed there. Falls back to the **existing** `rebindWorkflowFence(ctx)` round trip, completely unchanged, when the reply carries no adoptable uuid.

One stale comment corrected in passing: `panel_new_workflow`'s handler claimed *"it is simply not carried on the workflow_new reply"* — verified false against the current panel source (line 11219, `workflow_uuid` is present, per `#762`). The comment predates that fix and was never updated.

## Verification

8 new tests covering both commands: direct adoption with the `workflow_list` round trip explicitly asserted **absent**, fallback preserved unchanged when no uuid is present (still attempts + can still be refused, matching pre-fix behavior exactly), the reporter's own end-to-end sequence, and a source-level wiring check on both call sites.

Existing `#716`/`#1071` suite (348 tests together): zero regression. **Full suite: 374 files / 7704 passed / 0 failures.**

Mutation-verified two ways, each application confirmed by occurrence-count before trusting the result: reverting both call sites to the plain `rebindWorkflowFence` call fails 5/8; neutralizing the helper's return value (refresh still fires, but the round-trip-avoidance guarantee breaks) fails 3/8.

Refs #814, #812, #932