### PR TITLE
fix(health): recent_errors:0 returns none, and says the log was not checked

### DIFF
--- a/src/__tests__/services/health-check.test.ts
+++ b/src/__tests__/services/health-check.test.ts
@@ -88,3 +88,91 @@ describe("runHealthCheck", () => {
     ).rejects.toThrow(/ComfyUI unreachable/);
   });
 });
+
+// #1146 — recent_errors:0 means "show me none", and it returned EVERYTHING.
+//
+// `slice(-0)` is `slice(0)`: -0 === 0 in JS, so the negative-index reading never
+// happens and the whole array comes back. A reporter asking for zero got the
+// full historical ComfyUI log and a response truncated at ~12k tokens — the
+// opposite of the request, from the one argument value meant to suppress it.
+describe("recent_errors as a limit (#1146)", () => {
+  const LOG = [
+    "Traceback (most recent call last):",
+    "  File a.py, line 1",
+    "ERROR: node blew up",
+    "startup ok",
+    "Exception: boom",
+  ].join("\n");
+
+  // This block is a sibling of the suite above, so it needs its own stats stub —
+  // runHealthCheck reads system/devices before it ever reaches the log section.
+  beforeEach(() => {
+    fetchApi.mockReset();
+    getSystemStats.mockReset();
+    getQueue.mockReset();
+    getSystemStats.mockResolvedValue({
+      system: { python_version: "3.11.0", comfyui_version: "0.5.0", ram_free: 8 * 1024 ** 3 },
+      devices: [{ name: "GPU", vram_total: 24 * 1024 ** 3, vram_free: 22 * 1024 ** 3 }],
+    });
+    getQueue.mockResolvedValue({ queue_running: [], queue_pending: [] });
+  });
+
+  function serverWithLog() {
+    fetchApi.mockImplementation(async (path: string) =>
+      path === "/internal/logs"
+        ? new Response(LOG, { status: 200 })
+        : new Response(JSON.stringify([]), { status: 200 }),
+    );
+  }
+
+  it("0 returns NO error lines — not all of them", async () => {
+    serverWithLog();
+    const text = await runHealthCheck({ modelCategories: [], recentErrors: 0 });
+    expect(text).not.toMatch(/Traceback/);
+    expect(text).not.toMatch(/node blew up/);
+    expect(text).not.toMatch(/Recent errors\*\* \(last/);
+  });
+
+  it("0 says NOT REQUESTED — it must not claim the log is clean", async () => {
+    // The log was never read for content, so "none in /internal/logs" would
+    // assert an absence nobody observed: a caller shrinking a response would be
+    // told their server is healthy as a side effect.
+    serverWithLog();
+    const text = await runHealthCheck({ modelCategories: [], recentErrors: 0 });
+    expect(text).toMatch(/not requested \(recent_errors=0\)/);
+    expect(text).toMatch(/NOT checked/);
+    expect(text).not.toMatch(/none in \/internal\/logs/);
+  });
+
+  it("does not even fetch the log when none were asked for", async () => {
+    serverWithLog();
+    await runHealthCheck({ modelCategories: [], recentErrors: 0 });
+    expect(fetchApi.mock.calls.filter((c) => c[0] === "/internal/logs")).toHaveLength(0);
+  });
+
+  it("a positive limit still takes the LAST N matching lines", async () => {
+    serverWithLog();
+    const text = await runHealthCheck({ modelCategories: [], recentErrors: 1 });
+    expect(text).toMatch(/Recent errors\*\* \(last 1\)/);
+    // The most recent match, not the first.
+    expect(text).toMatch(/Exception: boom/);
+    expect(text).not.toMatch(/Traceback/);
+  });
+
+  it("a genuinely clean log still reports none — the honest empty is preserved", async () => {
+    fetchApi.mockImplementation(async (path: string) =>
+      path === "/internal/logs"
+        ? new Response("startup ok\nready\n", { status: 200 })
+        : new Response(JSON.stringify([]), { status: 200 }),
+    );
+    const text = await runHealthCheck({ modelCategories: [], recentErrors: 20 });
+    expect(text).toMatch(/none in \/internal\/logs/);
+  });
+
+  it("a negative limit is treated as zero, not as a slice from the end", async () => {
+    serverWithLog();
+    const text = await runHealthCheck({ modelCategories: [], recentErrors: -5 });
+    expect(text).toMatch(/not requested/);
+    expect(text).not.toMatch(/Traceback/);
+  });
+});

--- a/src/services/health-check.ts
+++ b/src/services/health-check.ts
@@ -150,23 +150,39 @@ export async function runHealthCheck(
 
   // Recent custom-node errors from /internal/logs (best-effort; older
   // ComfyUI versions and remote-only deployments may not expose it).
-  try {
-    const res = await client.fetchApi("/internal/logs");
-    if (res.ok) {
-      const text = await res.text();
-      const errLines = text
-        .split("\n")
-        .filter((l) => /traceback|error|exception/i.test(l))
-        .slice(-recentErrors);
-      if (errLines.length > 0) {
-        lines.push(`\n**Recent errors** (last ${errLines.length}):`);
-        for (const e of errLines) lines.push(`  ${e.trim()}`);
-      } else {
-        lines.push(`\n**Recent errors**: none in /internal/logs`);
+  // #1146 — recent_errors:0 means "show me none", and it returned EVERYTHING.
+  //
+  // `slice(-0)` is `slice(0)`: -0 === 0 in JS, so the negative-index reading
+  // never happens and the whole array comes back. A reporter asking for zero got
+  // the full historical ComfyUI log and a response truncated at ~12k tokens —
+  // the opposite of the request, from the one argument value meant to suppress
+  // it. Any non-positive limit takes the explicit branch instead.
+  //
+  // And it is reported as NOT REQUESTED, not as "none in /internal/logs". The
+  // log was never read for content, so claiming it is clean would assert an
+  // absence nobody observed — a caller trying to shrink a response would be told
+  // their server is healthy as a side effect of asking for a shorter answer.
+  if (recentErrors <= 0) {
+    lines.push(`\n**Recent errors**: not requested (recent_errors=${recentErrors}) — the log was NOT checked, which is not the same as it being clean.`);
+  } else {
+    try {
+      const res = await client.fetchApi("/internal/logs");
+      if (res.ok) {
+        const text = await res.text();
+        const errLines = text
+          .split("\n")
+          .filter((l) => /traceback|error|exception/i.test(l))
+          .slice(-recentErrors);
+        if (errLines.length > 0) {
+          lines.push(`\n**Recent errors** (last ${errLines.length}):`);
+          for (const e of errLines) lines.push(`  ${e.trim()}`);
+        } else {
+          lines.push(`\n**Recent errors**: none in /internal/logs`);
+        }
       }
+    } catch {
+      // Logs endpoint unavailable — silent.
     }
-  } catch {
-    // Logs endpoint unavailable — silent.
   }
 
   return lines.join("\n");


### PR DESCRIPTION
Fixes #1146.

`slice(-0)` is `slice(0)` — `-0 === 0` in JavaScript, so the negative-index reading never happens and the whole array comes back:

```js
[1,2,3].slice(-0).length  // 3
[1,2,3].slice(-1).length  // 1
```

A reporter calling `get_system_stats({action:"health", recent_errors:0})` got the full historical ComfyUI log and a response truncated at ~12k tokens — the exact opposite of the request, from the one argument value that exists to suppress it. They found and named the line themselves.

Any **non-positive** limit now takes an explicit branch, so a negative value cannot slip back into a slice-from-the-end either.

## The part that isn't the one-liner

The obvious fix produces `**Recent errors**: none in /internal/logs`, and that would be a new bug in the #796 family. On that path the log is **not read at all**, so reporting it clean asserts an absence nobody observed — a caller trying to shrink a response would be told their server is healthy as a side effect of asking for a shorter answer.

So it reports:

> **Recent errors**: not requested (recent_errors=0) — the log was NOT checked, which is not the same as it being clean.

and skips the fetch entirely.

The genuinely-clean case is untouched: a positive limit matching nothing still says `none in /internal/logs`, because there the log **was** read.

## Testing notes

Verified by mutation — each fails the suite:

| mutation | result |
|---|---|
| restore the `slice(-0)` path | ✗ killed (4 tests) |
| let negatives fall through to the slice | ✗ killed |
| swap "not requested" for "none in /internal/logs" | ✗ killed (2 tests) |

Also pinned: the log endpoint is not fetched at all when zero were asked for, and the last-N ordering (not first-N) for a positive limit.

Full suite: 373 files, 7702 passed. Lint and the vocabulary gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)