### PR TITLE
fix(download): stop reporting a live download as FAILED, and stop claiming bytes moved for a 404

### DIFF
--- a/src/__tests__/orchestrator/download-done-event.test.ts
+++ b/src/__tests__/orchestrator/download-done-event.test.ts
@@ -128,3 +128,105 @@ describe("download-completion agent event (#547)", () => {
     expect(delivered).toBe(false);
   });
 });
+
+// #1150 — the event told a user two downloads had FAILED while they were
+// actively streaming at 20% and 13%.
+//
+// Two 404s were retried with corrected URLs and the same target filenames. The
+// panel#489 supersession key is (id, target), and a corrected retry has a
+// DIFFERENT id, so the eviction never fired and both filenames flushed as
+// failures. The event text carried no id, URL, or error — only the name — so
+// nothing distinguished the dead attempt from the live one.
+//
+// And "The bytes finished transferring" was unconditional, so a FAILED-only
+// batch asserted that bytes moved. For a 404, zero did — and that sentence
+// actively argued against the correct reading.
+describe("a failed attempt superseded by a live retry (#1150)", () => {
+  it("does NOT present a name that is currently downloading as a plain failure", async () => {
+    const backend = new TurnRecordingBackend();
+    const manager = makeManager(backend);
+    manager.send("tab-retry", "hi");
+    await waitFor(() => backend.turns.length >= 1);
+
+    manager.injectEvent("tab-retry", {
+      kind: "download_done",
+      downloads: [
+        { name: "MiniMax-H3.safetensors", status: "error", supersededByLive: true },
+      ],
+    });
+
+    await waitFor(() => backend.turns.length >= 2);
+    const t = backend.turns[1];
+    expect(t).toContain("MiniMax-H3.safetensors");
+    // The instruction that keeps an agent from reporting the false failure.
+    expect(t).toMatch(/do NOT report these as failed/);
+    expect(t).toMatch(/IN FLIGHT right now/);
+    // It must not read as a settled failure.
+    expect(t).not.toMatch(/FAILED: MiniMax-H3\.safetensors/);
+  });
+
+  it("claims NOTHING transferred when the whole batch failed", async () => {
+    const backend = new TurnRecordingBackend();
+    const manager = makeManager(backend);
+    manager.send("tab-404", "hi");
+    await waitFor(() => backend.turns.length >= 1);
+
+    manager.injectEvent("tab-404", {
+      kind: "download_done",
+      downloads: [{ name: "gone.safetensors", status: "error" }],
+    });
+
+    await waitFor(() => backend.turns.length >= 2);
+    const t = backend.turns[1];
+    expect(t).toContain("FAILED: gone.safetensors");
+    // The sentence that was false for a 404.
+    expect(t).not.toMatch(/bytes finished transferring/);
+    expect(t).toMatch(/NOTHING is claimed to have transferred/);
+  });
+
+  it("still claims the transfer for the entries that ACTUALLY completed", async () => {
+    const backend = new TurnRecordingBackend();
+    const manager = makeManager(backend);
+    manager.send("tab-mixed", "hi");
+    await waitFor(() => backend.turns.length >= 1);
+
+    manager.injectEvent("tab-mixed", {
+      kind: "download_done",
+      downloads: [
+        { name: "ok.safetensors", status: "done" },
+        { name: "bad.safetensors", status: "error" },
+      ],
+    });
+
+    await waitFor(() => backend.turns.length >= 2);
+    const t = backend.turns[1];
+    // Scoped to the completed ones — not withdrawn, and not over-claimed.
+    expect(t).toMatch(/bytes finished transferring for the completed one/);
+    expect(t).toContain("transfer completed: ok.safetensors");
+    expect(t).toContain("FAILED: bad.safetensors");
+  });
+
+  it("separates a genuinely dead failure from a retried one in the same batch", async () => {
+    const backend = new TurnRecordingBackend();
+    const manager = makeManager(backend);
+    manager.send("tab-both", "hi");
+    await waitFor(() => backend.turns.length >= 1);
+
+    manager.injectEvent("tab-both", {
+      kind: "download_done",
+      downloads: [
+        { name: "dead.safetensors", status: "error" },
+        { name: "retried.safetensors", status: "error", supersededByLive: true },
+      ],
+    });
+
+    await waitFor(() => backend.turns.length >= 2);
+    const t = backend.turns[1];
+    // The FAILED list itself runs to the next "; " separator — the retried name
+    // must not be inside it, however the rest of the sentence reads.
+    const failedList = /FAILED: ([^;]*)/.exec(t)?.[1] ?? "";
+    expect(failedList).toContain("dead.safetensors");
+    expect(failedList).not.toContain("retried.safetensors");
+    expect(t).toMatch(/EARLIER attempt failed for retried\.safetensors/);
+  });
+});

--- a/src/__tests__/services/download-progress.test.ts
+++ b/src/__tests__/services/download-progress.test.ts
@@ -276,3 +276,61 @@ describe("attempt-supersession (panel#489)", () => {
     expect(emitted.some((r) => r.status === "error")).toBe(false);
   });
 });
+
+// #1150 — the (id, target) supersession key cannot see a corrected retry.
+//
+// Two 404s were re-issued with corrected URLs and the same target filenames.
+// A new URL is a new id, so the eviction never fired and both filenames flushed
+// as failures — while download_model action:"status" showed them streaming at
+// 20% and 13%. This asks the narrower question the event text actually needs:
+// is the thing I am about to call failed currently arriving?
+describe("markSupersededByLive (#1150)", () => {
+  const live = (name: string) => ({ name, status: "downloading" });
+
+  it("flags a failure whose filename is downloading RIGHT NOW", () => {
+    const settled = [{ name: "big.safetensors", status: "error" }];
+    mod.markSupersededByLive(settled, [live("big.safetensors")]);
+    expect(settled[0]).toMatchObject({ supersededByLive: true });
+  });
+
+  it("leaves a genuinely dead failure alone", () => {
+    const settled = [{ name: "gone.safetensors", status: "error" }];
+    mod.markSupersededByLive(settled, [live("other.safetensors")]);
+    expect(settled[0].supersededByLive).toBeUndefined();
+  });
+
+  it("never flags a SUCCESS — 'done' is settled regardless of what else is live", () => {
+    // A second copy of the same name streaming elsewhere does not un-complete a
+    // transfer that finished.
+    const settled = [{ name: "big.safetensors", status: "done" }];
+    mod.markSupersededByLive(settled, [live("big.safetensors")]);
+    expect(settled[0].supersededByLive).toBeUndefined();
+  });
+
+  it("ignores live rows that are not actually downloading", () => {
+    const settled = [{ name: "big.safetensors", status: "error" }];
+    mod.markSupersededByLive(settled, [
+      { name: "big.safetensors", status: "done" },
+      { name: "big.safetensors", status: "error" },
+    ]);
+    expect(settled[0].supersededByLive).toBeUndefined();
+  });
+
+  it("ignores nameless rows rather than matching them to each other", () => {
+    const settled = [{ name: "", status: "error" }];
+    mod.markSupersededByLive(settled, [{ name: undefined, status: "downloading" }]);
+    expect(settled[0].supersededByLive).toBeUndefined();
+  });
+
+  it("handles the reporter's shape: two failures, both retried", () => {
+    const settled = [
+      { name: "MiniMax-H3_FL2VA-NVFP4-HQ.safetensors", status: "error" },
+      { name: "MiniMax-H3_FL2VA-NVFP4-LQ.safetensors", status: "error" },
+    ];
+    mod.markSupersededByLive(settled, [
+      live("MiniMax-H3_FL2VA-NVFP4-HQ.safetensors"),
+      live("MiniMax-H3_FL2VA-NVFP4-LQ.safetensors"),
+    ]);
+    expect(settled.every((s) => s.supersededByLive === true)).toBe(true);
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -146,7 +146,7 @@ import {
 import { AskAnswers, preview as previewQuestion } from "./ask-answer-journal.js";
 import { initRunpodWatcher, getRunpodWatcher, type RunpodStatusFrame, type RunpodAlertFrame } from "../services/runpod-watch.js";
 import { getPod } from "../services/runpod-client.js";
-import { listTargetChangeRequests, consumeTargetChange, ackTargetChange, setProgressDir, CONTROL_PREFIX, newestAttemptEpochs, isSupersededAttempt, downloadAttemptKey } from "../services/download-progress.js";
+import { listTargetChangeRequests, consumeTargetChange, ackTargetChange, setProgressDir, CONTROL_PREFIX, newestAttemptEpochs, isSupersededAttempt, downloadAttemptKey, markSupersededByLive } from "../services/download-progress.js";
 import { hasActiveTrainingJob, reconcileStaleTrainingJobs } from "../services/training-jobs.js";
 import {
   buildQueueStatusFrame,
@@ -5297,6 +5297,10 @@ export async function runPanelOrchestrator(): Promise<void> {
       // a queued terminal cancelled by a newer live attempt. Don't fire an empty
       // "download_done" turn in that case.
       if (settled.length === 0) continue;
+      // #1150 — a corrected retry of a 404 is a DIFFERENT id writing the SAME
+      // filename, so the (id, target) eviction above cannot see it. The live rows
+      // are already in hand this tick; markSupersededByLive asks them by name.
+      markSupersededByLive(settled, downloads);
       // #884 — a download has no originating TAB (its row names the owning
       // conversation), so its turn INHERITS the conversation's LAST
       // ESTABLISHED origin — never the active tab (confirming gate 2, P0 rule:

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -623,7 +623,7 @@ export class PanelAgent {
       images?: ImageRef[];
       error?: string;
       note?: string;
-      downloads?: Array<{ name: string; status: string }>;
+      downloads?: Array<{ name: string; status: string; supersededByLive?: boolean }>;
       /** #468 — run identity + how it correlates to a run this session queued. */
       prompt_id?: string;
       run_correlation?: "matched" | "foreign" | "unidentified";
@@ -768,7 +768,16 @@ export class PanelAgent {
       const dl = (ev.downloads ?? []).filter((d) => d && d.name);
       if (dl.length === 0) return false;
       const done = dl.filter((d) => d.status === "done").map((d) => d.name);
-      const failed = dl.filter((d) => d.status !== "done").map((d) => d.name);
+      // #1150 — a FAILED attempt whose filename is being downloaded RIGHT NOW by
+      // a newer attempt. The two share a name but not an id, so the panel#489
+      // supersession key never matched and the eviction never fired: a reporter
+      // was woken with "Model download FAILED: <name>" for two files that
+      // download_model action:"status" showed streaming at 20% and 13% seconds
+      // later. Naming them the same way as a real failure is what made the agent
+      // report a false failure to the user.
+      const failedDead = dl.filter((d) => d.status !== "done" && !d.supersededByLive);
+      const failedRetried = dl.filter((d) => d.status !== "done" && d.supersededByLive);
+      const failed = [...failedDead, ...failedRetried].map((d) => d.name);
       const parts: string[] = [];
       // This event is raised by the TRANSFER, which finishes BEFORE the placement
       // check against the connected ComfyUI does. Saying "finished" here would be a
@@ -776,15 +785,32 @@ export class PanelAgent {
       // install the running server never reads — so the wording says only what the
       // event actually proves and points at download_model action:"status" for the verdict.
       if (done.length) parts.push(`transfer completed: ${done.join(", ")}`);
-      if (failed.length) parts.push(`FAILED: ${failed.join(", ")}`);
+      if (failedDead.length) parts.push(`FAILED: ${failedDead.map((d) => d.name).join(", ")}`);
+      if (failedRetried.length) {
+        parts.push(
+          `an EARLIER attempt failed for ${failedRetried.map((d) => d.name).join(", ")}, but a ` +
+            `NEWER download of that name is IN FLIGHT right now — do NOT report these as failed`,
+        );
+      }
       const plural = dl.length > 1 ? "these downloads" : "it";
       text =
         `[panel event] Model download ${parts.join("; ")}. ` +
-        `The bytes finished transferring; whether the connected ComfyUI can actually LOAD ` +
-        `${plural} is confirmed separately. If you were waiting on ${plural} to continue a task, ` +
+        // The claim was UNCONDITIONAL, so a FAILED-only batch asserted that bytes
+        // transferred — for a 404, zero bytes moved. Worse, it argued against the
+        // correct reading: the reporter's agent had a sentence insisting the
+        // transfer completed while the file was still streaming (#1150). It is
+        // only ever a statement about the `done` entries.
+        (done.length
+          ? `The bytes finished transferring for the completed one${done.length > 1 ? "s" : ""}; ` +
+            `whether the connected ComfyUI can actually LOAD ${plural} is confirmed separately. `
+          : `NOTHING is claimed to have transferred here. `) +
+        `If you were waiting on ${plural} to continue a task, ` +
         `call download_model action:"status" FIRST for the verified path and placement verdict${failed.length ? " or the error detail" : ""} — ` +
-        `do not tell the user a model is ready until download_model action:"status" confirms it. ` +
-        `Otherwise reply with ONE short sentence acknowledging it and no tool calls.`;
+        `do not tell the user a model is ready until download_model action:"status" confirms it` +
+        (failedRetried.length
+          ? `, and do not tell them one failed until status shows no live attempt for that name`
+          : "") +
+        `. Otherwise reply with ONE short sentence acknowledging it and no tool calls.`;
     }
     if (!text) return false;
     this.busy = true;
@@ -2282,7 +2308,7 @@ export class PanelAgentManager {
       images?: ImageRef[];
       error?: string;
       note?: string;
-      downloads?: Array<{ name: string; status: string }>;
+      downloads?: Array<{ name: string; status: string; supersededByLive?: boolean }>;
       prompt_id?: string;
       run_correlation?: "matched" | "foreign" | "unidentified";
       replayed?: boolean;

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -246,6 +246,40 @@ export function downloadAttemptKey(row: AttemptRowLike): string | null {
   return `${id}\n${target}`;
 }
 
+/**
+ * Flag each settled FAILURE whose FILENAME is being downloaded right now (#1150).
+ *
+ * The supersession key above is (id, target), and it is right to be: it answers
+ * "is this the same transfer?", where a filename cannot. But a 404 retried with a
+ * CORRECTED URL is a different id writing the same filename, so the eviction
+ * cannot see it — and a reporter was woken with "Model download FAILED" for two
+ * files that `download_model action:"status"` showed streaming at 20% and 13%
+ * seconds later.
+ *
+ * This asks a different, narrower question: "is the thing I am about to call
+ * failed currently arriving?" For the human or agent reading that sentence, the
+ * NAME is the identity, so the name is the right key here even though it is the
+ * wrong key there. A false positive costs a hedge on a genuinely dead download; a
+ * false negative is the reported bug.
+ *
+ * Mutates and returns `settled` — the caller passes rows it just built.
+ */
+export function markSupersededByLive<T extends { name: string; status: string; supersededByLive?: boolean }>(
+  settled: T[],
+  liveRows: ReadonlyArray<{ name?: unknown; status?: unknown }>,
+): T[] {
+  const liveNames = new Set(
+    liveRows
+      .filter((r) => r?.status === "downloading")
+      .map((r) => (typeof r?.name === "string" ? r.name : ""))
+      .filter((n) => n !== ""),
+  );
+  for (const s of settled) {
+    if (s.status !== "done" && liveNames.has(s.name)) s.supersededByLive = true;
+  }
+  return settled;
+}
+
 /** Newest attempt epoch per (id, target) across the given rows (ANY status — a
  *  superseding newer attempt may itself be downloading OR already terminal). Rows
  *  missing an `attempt` epoch (pre-fix writer / non-model reporter) are ignored —


### PR DESCRIPTION
Fixes #1150. Both defects, both located exactly by the reporter — including the file and line numbers.

```
[panel event] Model download FAILED: MiniMax-H3_FL2VA-NVFP4-HQ.safetensors.
The bytes finished transferring; ...
```

…for two files that `download_model action:"status"` reported seconds later as:

```
574d64d9d3654193  downloading  2.73/13.60 GB (20%)  still streaming
258980784ce920e5  downloading  1.84/13.60 GB (13%)  still streaming
```

## 1. The settled row was identified by filename only

Two downloads 404'd and were re-issued with corrected URLs and the **same target filenames**. The panel#489 supersession key is `(id, target)`, and a corrected URL is a **new id** — so the eviction could not see the retry, and the event named a file that was at that moment downloading normally, with no id, URL, or error to tell the dead attempt from the live one.

The key is *right* to be `(id, target)`: it answers **"is this the same transfer?"**, and a filename cannot. `markSupersededByLive` asks the narrower question the event text actually needs — **"is the thing I am about to call failed currently arriving?"** — and for the reader of that sentence, the name *is* the identity.

A false positive costs a hedge on a genuinely dead download. A false negative is this bug. A `done` row is never flagged: a second copy streaming elsewhere does not un-complete a finished transfer.

## 2. "The bytes finished transferring" was unconditional

So a FAILED-only batch asserted that bytes moved. For a 404, zero moved — and the sentence actively argued against the correct interpretation. The reporter caught the false failure only because a *different* sentence in the same event told them to check `status` first.

| batch | before | after |
|---|---|---|
| all failed | "The bytes finished transferring" | "NOTHING is claimed to have transferred here." |
| mixed | same claim, unscoped | "…finished transferring for the completed ones" |
| retried failure | `FAILED: <name>` | "an EARLIER attempt failed for `<name>`, but a NEWER download of that name is IN FLIGHT right now — do NOT report these as failed" |

## Testing notes

The annotation lives in `download-progress.ts` rather than inline in the tick loop specifically so it is reachable from tests — inline, deleting it would have failed nothing, and the consumer tests pass the flag directly.

Verified by mutation on **both** sides:

| side | mutation | result |
|---|---|---|
| consumer | fold retried failures back into the plain FAILED list | ✗ killed (2 tests) |
| consumer | restore the unconditional transfer claim | ✗ killed |
| producer | flag a `done` row too | ✗ killed |
| producer | count non-downloading rows as live | ✗ killed |
| producer | collapse nameless rows together | ✗ killed |

Full suite: 374 files, 7721 passed. Lint and the vocabulary gate clean.

Thanks to the reporter for the verbatim event, the verbatim `status` output, and the two file:line locations — this was a read-and-fix rather than a hunt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)