### PR TITLE
release: v0.50.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.43] - 2026-08-08
+
+### MCP
+
+#### Fixed
+- stop reporting a live download as FAILED, and stop claiming bytes moved for a 404 (#1163)
+- Save-As and new-workflow trust their OWN reply's proven uuid (#1161)
+- recent_errors:0 returns none, and says the log was not checked (#1162)
+- reopening a tab's OWN tmp: routing_key refreshes the fence (#1157)
+
+
 ## [0.50.42] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.42",
+  "version": "0.50.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.42",
+      "version": "0.50.43",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.42",
+  "version": "0.50.43",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.43` tag.

**A live download is no longer reported as FAILED** (#1150, via #1163). An agent was woken with "Model download FAILED" for two files that `download_model action:"status"` showed streaming at 20% and 13% seconds later. Two 404s had been retried with corrected URLs and the same filenames; a corrected URL is a new id, so the `(id, target)` supersession key could not see the retry. And "The bytes finished transferring" was unconditional, so a failed-only batch asserted that bytes moved — for a 404, zero did, and that sentence argued against the correct reading.

**`recent_errors: 0` returns none** (#1146, via #1162). `slice(-0)` is `slice(0)`, so the one argument value meant to suppress the log returned all of it — a response truncated at ~12k tokens. It now reports "not requested … the log was NOT checked", rather than claiming the log is clean when it was never read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)