### PR TITLE
fix(show-media): accept the video containers this codebase already recognizes (#811)

### DIFF
--- a/src/__tests__/orchestrator/panel-show-media-video-ext.test.ts
+++ b/src/__tests__/orchestrator/panel-show-media-video-ext.test.ts
@@ -1,0 +1,127 @@
+// #811 — panel_show_media rejected a valid local ProRes .mov output even though
+// this codebase already treats .mov as a video format everywhere else:
+// get_image's action:"list_outputs" documents ".mp4/.webm/.mov/.mkv/.m4v/.avi",
+// and upload_image's action:"video" accepts the identical set. panel_show_media's
+// own VIDEO_EXTS was narrower — just {.mp4, .webm} — for no stated reason, an
+// inconsistency verified against the source rather than assumed from the report.
+//
+// Widening the container-extension allowlist surfaced a SEPARATE, independent
+// bug: the MIME type was built by naive `"video/" + ext.slice(1)`, which only
+// ever worked for .mp4/.webm by coincidence (their extension equals their MIME
+// subtype). Extended to .mov it would have produced the invalid `video/mov`
+// instead of `video/quicktime` — and a wrong MIME can make a browser refuse to
+// even ATTEMPT playback before the codec is ever considered. Both are fixed
+// together and tested together, since testing the extension alone would have
+// missed the MIME regression.
+//
+// SCOPE, stated plainly: this widens which CONTAINERS are accepted and fixes
+// their MIME types. It does not and cannot guarantee every codec inside those
+// containers is browser-decodable (a ProRes stream may still not play natively
+// outside Safari) — that is a downstream browser limitation the panel's video
+// path already degrades gracefully around, not something this fix claims to
+// solve.
+//
+// The resolved item (with its dataUrl/mime) is never echoed back in the tool's
+// OWN reply — it is dispatched onward via `ctx.call({cmd:"show_media", items})`
+// to the panel. So verification captures the OUTBOUND call, mirroring
+// panel-show-media-oversized.test.ts's own makeCtx/calls convention exactly.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildPanelToolDefs, type PanelToolCtx, type ToolResult } from "../../orchestrator/panel-tools.js";
+
+type Forwarded = Record<string, unknown>;
+
+function makeCtx(): { ctx: PanelToolCtx; calls: Forwarded[] } {
+  const calls: Forwarded[] = [];
+  const ctx = {
+    call: async (cmd: Forwarded) => {
+      calls.push(cmd);
+      return { content: [{ type: "text", text: JSON.stringify(cmd) }] } as ToolResult;
+    },
+    confirm: async () => "yes" as const,
+    bridge: { isHeadless: () => false } as unknown as PanelToolCtx["bridge"],
+    tabId: "test-tab",
+  } as PanelToolCtx;
+  return { ctx, calls };
+}
+
+async function showMedia(items: Array<Record<string, unknown>>): Promise<{ res: ToolResult; calls: Forwarded[] }> {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_show_media");
+  if (!def) throw new Error("panel_show_media not found");
+  const { ctx, calls } = makeCtx();
+  const res = (await def.handler({ items }, ctx)) as ToolResult;
+  return { res, calls };
+}
+
+const textOf = (res: ToolResult): string => res.content.map((c) => ("text" in c ? c.text : "")).join("\n");
+
+let root: string;
+const paths: Record<string, string> = {};
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "cmcp-showmedia-videoext-"));
+  mkdirSync(root, { recursive: true });
+  for (const ext of [".mp4", ".webm", ".mov", ".mkv", ".m4v", ".avi", ".txt"]) {
+    const p = join(root, `clip${ext}`);
+    writeFileSync(p, Buffer.alloc(64)); // well under the inline cap
+    paths[ext] = p;
+  }
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("#811 previously-refused video containers are now accepted", () => {
+  it.each([".mov", ".mkv", ".m4v", ".avi"])("%s is no longer refused", async (ext) => {
+    const { res } = await showMedia([{ source: { path: paths[ext] }, caption: "c" }]);
+    expect(res.isError).toBeFalsy();
+    expect(textOf(res)).not.toMatch(/unsupported file type/);
+  });
+});
+
+describe("#811 each container gets its REAL MIME type, not a slice-of-the-extension guess", () => {
+  const cases: Array<[string, string]> = [
+    [".mp4", "video/mp4"],
+    [".webm", "video/webm"],
+    [".mov", "video/quicktime"],
+    [".mkv", "video/x-matroska"],
+    [".m4v", "video/x-m4v"],
+    [".avi", "video/x-msvideo"],
+  ];
+
+  it.each(cases)("%s -> %s", async (ext, mime) => {
+    const { res, calls } = await showMedia([{ source: { path: paths[ext] } }]);
+    expect(res.isError).toBeFalsy();
+
+    const dispatched = calls.find((c) => c.cmd === "show_media");
+    expect(dispatched, "no show_media command was dispatched to the panel").toBeTruthy();
+    const items = dispatched!.items as Array<{ kind?: string; dataUrl?: string }>;
+    expect(items).toHaveLength(1);
+    expect(items[0].kind).toBe("video");
+    expect(items[0].dataUrl).toBeTruthy();
+    expect(items[0].dataUrl!.startsWith(`data:${mime};base64,`)).toBe(true);
+
+    // Guard the OLD bug specifically: the naive form is only correct for
+    // .mp4/.webm by coincidence, and must never appear for .mov/.mkv/.m4v/.avi.
+    const naive = "data:video/" + ext.slice(1) + ";";
+    if (mime !== "video/" + ext.slice(1)) {
+      expect(items[0].dataUrl!.startsWith(naive)).toBe(false);
+    }
+  });
+});
+
+describe("#811 a genuinely unsupported type is still refused, and says so with the WIDER list", () => {
+  it("refuses .txt and names the current allowed set", async () => {
+    const { res } = await showMedia([{ source: { path: paths[".txt"] } }]);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toMatch(/unsupported file type ".txt"/);
+    expect(text).toContain(".mov");
+    expect(text).toContain(".mkv");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -10112,7 +10112,39 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         }>;
 
         const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
-        const VIDEO_EXTS = new Set([".mp4", ".webm"]);
+        // #811 — this used to be just {.mp4, .webm}, narrower than what this
+        // codebase ALREADY treats as video elsewhere: get_image's
+        // action:"list_outputs" documents ".mp4/.webm/.mov/.mkv/.m4v/.avi", and
+        // upload_image's action:"video" accepts the identical set. A ProRes
+        // .mov produced by VHS/standard ComfyUI video nodes was refused here
+        // even though every other tool in this codebase already calls it a
+        // valid video output. Aligned to the same set both of those already use.
+        //
+        // This widens the CONTAINER-extension gate only — it does not and
+        // cannot guarantee browser-side codec decode (a ProRes stream inside
+        // that .mov may still not play natively outside Safari). That is a
+        // downstream browser limitation, not a reason to refuse the file
+        // upfront: the panel's video path already degrades gracefully when a
+        // codec can't be decoded (falls back to a native <video> element,
+        // which surfaces the browser's own playback error, rather than
+        // silently failing) — an honest browser failure is a strictly better
+        // outcome than a blanket refusal at this gate for every .mov file,
+        // most of which (H.264/H.265-encoded) play back completely fine.
+        const VIDEO_EXTS = new Set([".mp4", ".webm", ".mov", ".mkv", ".m4v", ".avi"]);
+        // Real IANA subtypes. The old code built video MIME by naive
+        // `"video/" + ext.slice(1)`, which only ever worked for .mp4/.webm by
+        // COINCIDENCE (their extension equals their MIME subtype) — extended to
+        // .mov/.mkv/.avi it would have produced invalid types (`video/mov`
+        // instead of `video/quicktime`), and a wrong MIME can make a browser
+        // refuse to even ATTEMPT playback before the codec is ever considered.
+        const VIDEO_MIME: Record<string, string> = {
+          ".mp4": "video/mp4",
+          ".webm": "video/webm",
+          ".mov": "video/quicktime",
+          ".mkv": "video/x-matroska",
+          ".m4v": "video/x-m4v",
+          ".avi": "video/x-msvideo",
+        };
         const MAX_BYTES = 20 * 1024 * 1024; // 20 MB
 
         const resolved: Array<Record<string, unknown>> = [];
@@ -10167,7 +10199,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               mime = ext === ".jpg" ? "image/jpeg" : "image/" + ext.slice(1);
               kind = "image";
             } else if (VIDEO_EXTS.has(ext)) {
-              mime = "video/" + ext.slice(1);
+              mime = VIDEO_MIME[ext];
               kind = "video";
             } else {
               return fail(


### PR DESCRIPTION
```
Error: unsupported file type ".mov" (allowed: .png, .jpg, .jpeg, .gif, .webp, .mp4, .webm)
```

`VIDEO_EXTS` here was `{.mp4, .webm}` — narrower than what this **same codebase** already treats as video everywhere else, verified against the source rather than assumed from the report:

- `get_image`'s `action:"list_outputs"` documents `.mp4/.webm/.mov/.mkv/.m4v/.avi`
- `upload_image`'s `action:"video"` accepts the identical set

`panel_show_media`'s own allowlist had quietly drifted narrower than its siblings.

## A second bug, found while fixing the first

Widening the allowlist surfaced an independent bug in the same few lines: the MIME type was built by naive `"video/" + ext.slice(1)`, which only ever worked for `.mp4`/`.webm` by **coincidence** — their extension happens to equal their MIME subtype. Extended to `.mov` as-is it would have produced the invalid `video/mov` instead of `video/quicktime` (and `video/mkv`/`video/avi` instead of `video/x-matroska`/`video/x-msvideo`). A wrong MIME can make a browser refuse to even *attempt* playback before the codec is ever considered — fixing the allowlist alone would have traded an honest upfront refusal for a confusing silent failure downstream. Both fixed together, with an explicit real-MIME map.

## Scope, stated plainly

This widens which **containers** are accepted and fixes their MIME types. It does not and cannot guarantee every **codec** inside those containers is browser-decodable — a ProRes stream inside a `.mov` may still not play natively outside Safari, and that's a downstream browser limitation, not something this fix claims to solve. The panel's video path already degrades gracefully when a codec can't be decoded (falls back to a native `<video>` element, surfacing the browser's own playback error, rather than failing silently) — an honest browser-side failure for the minority of genuinely undecodable files is a strictly better outcome than refusing every `.mov` upfront, when most (H.264/H.265-encoded) play back fine.

## Verification

11 new tests: each newly-accepted extension is no longer refused, each gets its correct real-world MIME (captured from the item actually **dispatched** to the panel via `ctx.call`, since the resolved item is never echoed in the tool's own reply text — mirrors `panel-show-media-oversized.test.ts`'s own capture convention), the old naive-MIME bug is explicitly guarded per extension, and a genuinely unsupported type (`.txt`) is still refused with the error text reflecting the current (wider) allowed set.

Existing oversized-media suite: unchanged. **Full suite: 376 files / 7740 passed / 0 failures.**

Mutation-verified two ways, each application confirmed by occurrence-count before trusting the result: reverting the extension set fails 9/11; reverting the MIME map to the naive form fails 4/11 — exactly the four extensions where the naive form was never correct (`.mp4`/`.webm` coincidentally still pass, which is itself the point).

Refs #811