### PR TITLE
fix(compact): a bare JSON parse error names the tool, the likely cause, and the delivery doubt

### DIFF
--- a/src/__tests__/tools/compact.test.ts
+++ b/src/__tests__/tools/compact.test.ts
@@ -4,7 +4,12 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { ToolCatalog } from "../../tools/catalog.js";
-import { buildManifest, registerCompactTools, summarize } from "../../tools/compact.js";
+import {
+  buildManifest,
+  contextualizeBareParseError,
+  registerCompactTools,
+  summarize,
+} from "../../tools/compact.js";
 import { collectToolCatalog, registerFullTools } from "../../tools/index.js";
 import { TOOL_NAMES } from "../../tools/vocabulary.js";
 
@@ -576,4 +581,122 @@ describe("collectToolCatalog (real tool surface)", () => {
     const manifest = buildManifest(catalog);
     expect(manifest.length).toBeLessThan(30_000);
   }, 30_000);
+});
+
+// #1160 — a bare JSON.parse message reaching a caller.
+//
+// On an AUTHENTICATED remote, upload_image AND get_image both returned the raw
+// `Unexpected end of JSON input` — identical text from two different endpoints,
+// with no endpoint, status, content type, or delivery state. Every request path
+// in this repo that the report named is already guarded (readComfyJson names all
+// four; /upload/image and /view report a non-OK status before parsing; the args
+// parser catches its own JSON.parse), so the message escapes from a layer below
+// those. This is the backstop at the choke point every compact call passes.
+describe("a bare JSON parse error is contextualized (#1160)", () => {
+  function messageOf(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
+  }
+
+  it("names the tool and says it is NOT an argument problem", () => {
+    const out = contextualizeBareParseError(
+      new SyntaxError("Unexpected end of JSON input"),
+      "upload_image",
+    );
+    const m = messageOf(out);
+    expect(m).toContain("upload_image");
+    expect(m).toMatch(/NOT a problem with your arguments/);
+  });
+
+  it("keeps the original text at the front so existing matchers still match", () => {
+    const m = messageOf(
+      contextualizeBareParseError(new SyntaxError("Unexpected end of JSON input"), "get_image"),
+    );
+    expect(m.startsWith("Unexpected end of JSON input")).toBe(true);
+  });
+
+  it("names the auth-gate reading, and that a working panel proves nothing about this server", () => {
+    // The reporter's exact situation: browser-authenticated panel fine, headless
+    // COMFYUI_URL 401. "The panel works" is the reasoning that hides it.
+    const m = messageOf(contextualizeBareParseError(new SyntaxError("Unexpected end of JSON input"), "upload_image"));
+    expect(m).toMatch(/auth gate or proxy/);
+    expect(m).toMatch(/WITHOUT a browser session/);
+    expect(m).toMatch(/get_system_stats/);
+  });
+
+  it("warns that an upload's delivery is UNDETERMINED", () => {
+    // A parse failure says nothing about whether the POST landed; "it errored"
+    // must not read as "nothing happened".
+    const m = messageOf(contextualizeBareParseError(new SyntaxError("Unexpected end of JSON input"), "upload_image"));
+    expect(m).toMatch(/may or may not have been delivered/);
+    expect(m).toMatch(/verify before retrying/);
+  });
+
+  it("covers the other V8 JSON-parse spellings", () => {
+    for (const msg of [
+      "Unexpected token '<', \"<!doctype \"... is not valid JSON",
+      "Unexpected non-whitespace character after JSON at position 4",
+    ]) {
+      expect(messageOf(contextualizeBareParseError(new SyntaxError(msg), "get_image"))).toMatch(
+        /NOT a problem with your arguments/,
+      );
+    }
+  });
+
+  it("does NOT rewrite a non-SyntaxError, however its message reads", () => {
+    // The instanceof check is a second guard on top of the message match: a
+    // library that reports a parse failure as a plain Error is not something we
+    // should be re-narrating as an auth-gate diagnosis.
+    const err = new Error("Unexpected end of JSON input");
+    expect(contextualizeBareParseError(err, "get_image")).toBe(err);
+  });
+
+  it("does NOT touch a SyntaxError that is not a JSON parse failure", () => {
+    const err = new SyntaxError("Invalid regular expression: missing /");
+    expect(contextualizeBareParseError(err, "get_image")).toBe(err);
+  });
+
+  it("does NOT paper over an error that is already diagnosed", () => {
+    // The guards that work must keep their own wording — this is a backstop, not
+    // a wrapper.
+    const err = new Error("/upload/image returned 401: <html>login</html>");
+    expect(contextualizeBareParseError(err, "upload_image")).toBe(err);
+  });
+});
+
+// THE WIRING. The unit tests above call contextualizeBareParseError directly, so
+// they cannot see the dispatcher dropping it — which is exactly the call-site
+// blindness this suite keeps getting caught by. Drive the real call_tool.
+describe("call_tool applies the parse backstop (#1160)", () => {
+  function catalogThatThrows(err: unknown): ToolCatalog {
+    const catalog = new ToolCatalog();
+    const registrar = catalog.asRegistrar();
+    catalog.setCategory("media");
+    registrar.tool("upload_image", "Upload a file.", {}, async () => {
+      throw err;
+    });
+    return catalog;
+  }
+
+  it("a handler throwing a bare JSON SyntaxError comes back contextualized", async () => {
+    const client = await compactPair(catalogThatThrows(new SyntaxError("Unexpected end of JSON input")));
+    const res = (await client.callTool({ name: "call_tool", arguments: { name: "upload_image" } })) as {
+      content?: Array<{ type: string; text?: string }>;
+    };
+    const t = textOf(res);
+    expect(t).toContain("Unexpected end of JSON input");
+    expect(t).toMatch(/NOT a problem with your arguments/);
+    expect(t).toMatch(/may or may not have been delivered/);
+  });
+
+  it("a handler throwing an already-diagnosed error keeps its own wording", async () => {
+    const client = await compactPair(
+      catalogThatThrows(new Error("/upload/image returned 401: <html>login</html>")),
+    );
+    const res = (await client.callTool({ name: "call_tool", arguments: { name: "upload_image" } })) as {
+      content?: Array<{ type: string; text?: string }>;
+    };
+    const t = textOf(res);
+    expect(t).toContain("returned 401");
+    expect(t).not.toMatch(/NOT a problem with your arguments/);
+  });
 });

--- a/src/tools/compact.ts
+++ b/src/tools/compact.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { errorToToolResult } from "../utils/errors.js";
+import { ComfyUIError, errorToToolResult } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import type { CatalogedTool, ToolCatalog } from "./catalog.js";
 import { retiredToolMessage } from "./vocabulary.js";
@@ -248,9 +248,59 @@ export function registerCompactTools(
       try {
         return await tool.handler(validated.data as Record<string, unknown>);
       } catch (err) {
-        return errorToToolResult(err);
+        return errorToToolResult(contextualizeBareParseError(err, name));
       }
     },
+  );
+}
+
+/**
+ * A BACKSTOP for a bare `JSON.parse` message reaching a caller (#1160).
+ *
+ * The repo's own request paths classify this properly: readComfyJson names the
+ * URL, status, content type and body prefix; `/upload/image` and `/view` both
+ * report a non-OK status before parsing; the argument parser above catches its
+ * own JSON.parse. Every one of those was checked against this report and none of
+ * them is the source.
+ *
+ * A reporter on an AUTHENTICATED remote still got `Unexpected end of JSON input`
+ * from `upload_image` AND `get_image` — identical text from two different
+ * endpoints, which points at a layer below all of that (the ComfyUI client
+ * library's own fetch, or an auth proxy answering somewhere the guards do not
+ * reach). Without their server I cannot say which.
+ *
+ * What I can say is that the message is useless wherever it comes from: it names
+ * no endpoint, no status, and — for an upload — does not say whether the POST was
+ * delivered. So this catches the shape at the one choke point every compact call
+ * passes through and attaches what IS known: the tool, and the fact that a POST's
+ * outcome is undetermined.
+ *
+ * Deliberately narrow. Only a bare `SyntaxError` whose message is one of V8's
+ * JSON-parse forms is rewritten, and the original text is kept at the front so
+ * anything matching on it still matches. A properly classified error (a
+ * NonJsonResponseError, a ComfyUIError) passes through untouched — this must not
+ * paper over the diagnostics that already work.
+ */
+export function contextualizeBareParseError(err: unknown, toolName: string): unknown {
+  if (!(err instanceof SyntaxError)) return err;
+  const msg = err.message ?? "";
+  const isJsonParse =
+    /^Unexpected end of JSON input$/.test(msg) ||
+    /^Unexpected (?:token|non-whitespace character).*JSON/i.test(msg) ||
+    /^JSON\.parse:/.test(msg);
+  if (!isJsonParse) return err;
+  return new ComfyUIError(
+    `${msg} — while running ${toolName}. A JSON response could not be parsed and the ` +
+      `failure escaped without naming the endpoint, so this is NOT a problem with your ` +
+      `arguments. The usual cause is something other than ComfyUI answering the request: ` +
+      `an auth gate or proxy returning an empty body, a login page, or a redirect. Check ` +
+      `that the configured COMFYUI_URL is reachable WITHOUT a browser session — a panel ` +
+      `that works proves the browser is authenticated, not that this server is. ` +
+      `get_system_stats (action:"health") exercises the same path and reports the status. ` +
+      `IMPORTANT: if ${toolName} sends data (an upload), the request may or may not have ` +
+      `been delivered — verify before retrying rather than assuming nothing happened.`,
+    "NON_JSON_RESPONSE",
+    { tool: toolName, original: msg },
   );
 }
 


### PR DESCRIPTION
Refs #1160 — the independent half the reporter asked for. Does **not** close it; see below.

## The report

On an **authenticated** remote ComfyUI, `upload_image` and `get_image` both returned the raw:

```
Unexpected end of JSON input
```

No endpoint, no status, no content type, and — for the upload — no statement about whether the POST was delivered. Their panel worked (the browser holds the session); a direct POST to the same `/upload/image` answered **401**.

## What I checked before writing anything

Every request path the report names is **already guarded**, and I verified each against this report rather than assuming:

| path | guard |
|---|---|
| `uploadImageHttp` | non-OK status reported first, then `readComfyJson` |
| `fetchImage` (`/view`) | non-OK status reported first; body is bytes, never parsed |
| `readComfyJson` | names url, status, content-type, body prefix (`NonJsonResponseError`) |
| compact `args` parsing | catches its own `JSON.parse` |

So the message escapes from a layer **below** all of them — the ComfyUI client library's own fetch, or an auth proxy answering somewhere the guards do not reach. Without the reporter's server I cannot say which, and I would rather say that plainly than guess.

## What this does

A **backstop** at the one choke point every compact call passes through. It attaches what *is* known:

- the **tool name**, and that this is not an argument problem;
- the **auth-gate / proxy reading** — including that a working panel proves the *browser* is authenticated, not this server, which is the reasoning that hides this;
- `get_system_stats (action:"health")`, which exercises the same path and reports a status;
- **delivery doubt**: a sending tool's request may or may not have landed — verify before retrying rather than assuming nothing happened.

Deliberately narrow. Only a bare `SyntaxError` whose message is one of V8's JSON-parse forms is rewritten, and the original text stays at the **front** so anything matching on it still matches. A `NonJsonResponseError` or `ComfyUIError` passes through untouched — a catch-all backstop that swallowed the working diagnostics would be worse than the bug.

## Not done: ask (a)

Routing remote media upload/fetch through the authenticated live-panel bridge is the real fix for the underlying problem and is a substantially larger change (the panel is browser JS; moving bytes through it is a new transport). Left open on the issue.

## Testing notes

Verified by mutation — each fails the suite:

| mutation | result |
|---|---|
| rewrite every error (papers over working diagnostics) | ✗ killed |
| drop the `instanceof SyntaxError` guard | ✗ killed |
| drop the delivery-doubt warning | ✗ killed |
| stop leading with the original text | ✗ killed |
| **unwire the backstop from the dispatcher** | ✗ killed |

The last two rows are the ones that matter: the first three mutations initially **survived** because the tests only exercised the helper. Two tests now drive the real `call_tool` with a throwing handler, which is what catches a dispatcher that drops the call.

Full suite: 375 files, 7739 passed. Lint and the vocabulary gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)