### PR TITLE
fix(download): an EMPTY live listing is not evidence of a different install

### DIFF
--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -190,6 +190,34 @@ describe("pre-write: a destination the LIVE server does not read from is refused
     expect(msg).toMatch(/127\.0\.0\.1:8188/);
   });
 
+  // #1147 — an EMPTY live listing is not disagreement.
+  //
+  // A reporter's portable install held models/birefnet/BiRefNet_lite/model.safetensors
+  // (a HuggingFace repo dump) while the running server's /models/birefnet answered
+  // empty. Their loras/ agreed with the live server perfectly and argv pointed at
+  // that very tree — and the download was refused into the correct install.
+  //
+  // The #369 signature this guard exists for is a POPULATED listing describing a
+  // DIFFERENT tree (3 on disk, 24 unrelated live). "0 live entries" cannot tell
+  // "wrong install" from "a category this server does not enumerate the way a
+  // filesystem walk does", so it is not positive evidence and must not refuse.
+  it("#1147: PROCEEDS when the live listing for a populated category is EMPTY", async () => {
+    h.onDisk = { birefnet: ["BiRefNet_lite/model.safetensors"] };
+    h.liveListings["birefnet"] = []; // registered, answers, names nothing
+    h.liveListings["loras"] = ["agreed.safetensors"];
+
+    await expect(resolveModelSubfolderPreferServer("loras")).resolves.toBeTruthy();
+  });
+
+  it("#1147: still REFUSES when that same category lists OTHER files", async () => {
+    // The guard must not be blunted: a populated listing that omits the on-disk
+    // files is the real #369 signature and still fails closed.
+    h.onDisk = { birefnet: ["BiRefNet_lite/model.safetensors"] };
+    h.liveListings["birefnet"] = ["someone-elses.safetensors"];
+
+    await expect(resolveModelSubfolderPreferServer("birefnet")).rejects.toThrow(ModelError);
+  });
+
   it("REFUSES on a POPULATED SIBLING when the target category is empty (codex gate)", async () => {
     // The stale install has never held a diffusion model, so the target folder is
     // empty and says nothing — but its checkpoints/ betrays the wrong install.

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1050,6 +1050,26 @@ async function assertDestinationVisibleToLiveServer(
     if (onDisk.length === 0) continue; // nothing here to contradict anything
     const listing = await liveCategoryListing(category);
     if (listing === undefined) continue; // the server can't speak for it — no evidence
+    // #1147 — AN EMPTY LISTING IS NOT DISAGREEMENT.
+    //
+    // The #369 signature this guard exists for is a POPULATED listing that
+    // describes a different tree: 3 files on disk, 24 unrelated files live. That
+    // is positive evidence — the server demonstrably scans SOMETHING ELSE for
+    // this category.
+    //
+    // An empty listing says only that the server named nothing here, and that is
+    // equally explained by a server that reads this very directory but does not
+    // enumerate it the way a filesystem walk does. A reporter's portable install
+    // held models/birefnet/BiRefNet_lite/model.safetensors — a HuggingFace repo
+    // dump — while /models/birefnet answered empty, and the download was refused
+    // into the correct, running install, with their loras/ agreeing perfectly.
+    //
+    // So "0 live entries" cannot distinguish "wrong install" from "a category
+    // this server does not scan like we do", and this guard refuses only on
+    // positive evidence. The same reasoning the surrounding code already applies
+    // to `diffusers` (#844), whose listing contractually names no files —
+    // generalized from one hardcoded category to the condition underneath it.
+    if (listing.length === 0) continue;
     probed += 1;
     // CONTAINMENT, not overlap. If this directory really is one the server reads, it
     // SCANS it — so EVERY core-extension file in it must appear in the listing. A


### PR DESCRIPTION
Refs #1147.

A reporter's `download_civitai` was refused into the **correct, running** install:

```
Refusing to download into ...\models: the connected ComfyUI does not read from it.
Its "birefnet" folder holds 1 model file(s), 1 of which the running server does NOT
list (e.g. BiRefNet_lite/model.safetensors)
```

Their `loras/` agreed with the live server perfectly, and the server's own argv (`ComfyUI\main.py --windows-standalone-build`) pointed at that very tree. What tripped the guard was a HuggingFace repo dump at `models/birefnet/BiRefNet_lite/model.safetensors` while `/models/birefnet` answered with an **empty array**.

## Why empty is not disagreement

The #369 signature this guard exists for is a **populated** listing describing a **different** tree — 3 files on disk, 24 unrelated files live. That is positive evidence: the server demonstrably scans something else for this category.

An empty listing says only that the server named nothing here. That is equally explained by a server reading this exact directory but not enumerating it the way a filesystem walk does — an unregistered category, a custom node's own folder, a nested layout. **"0 live entries" cannot distinguish "wrong install" from "a category this server does not scan like we do"**, and this guard refuses only on positive evidence.

The surrounding code already applies exactly this reasoning to `diffusers` (#844), whose listing contractually names no files. This generalizes it from one hardcoded category to the condition underneath it.

| on disk | live listing | verdict |
|---|---|---|
| 1 file | `[]` | **proceed** (was: refuse) |
| 1 file | 1+ *other* files | refuse — the real #369 case, unchanged |
| 1 file | contains it | proceed, unchanged |
| any | endpoint unreadable | proceed, unchanged |

## On the reporter's other suggestions

They proposed four fixes; this takes (3), which is the principled one. (1) and (2) — filtering nested/HF-style layouts — would be guessing at ComfyUI's scan semantics, and ComfyUI *does* scan nested directories for many categories, so excluding them would create a different false answer. (4), preferring argv, is real but belongs to root resolution rather than this disproof check.

## Testing notes

Verified by mutation:

| mutation | result |
|---|---|
| remove the empty-listing check (false refusal returns) | ✗ killed |
| widen it to skip every listing (guard never refuses) | ✗ killed (6 existing tests) |

The second row is the one that matters — it proves the guard still does its #369 job.

Full suite: 376 files, 7752 passed. Lint and the vocabulary gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)