### PR TITLE
release: v0.50.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.44] - 2026-08-08
+
+### MCP
+
+#### Fixed
+- an EMPTY live listing is not evidence of a different install (#1168)
+- a bare JSON parse error names the tool, the likely cause, and the delivery doubt (#1166)
+- accept the video containers this codebase already recognizes (#1165)
+
+
 ## [0.50.43] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.43",
+  "version": "0.50.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.43",
+      "version": "0.50.44",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.43",
+  "version": "0.50.44",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.44` tag.

**An empty live listing is no longer evidence of a different install** (#1147, via #1168). A `download_civitai` was refused into the correct, running install because a HuggingFace repo dump sat under `models/birefnet/` while `/models/birefnet` answered with an empty array. The #369 guard exists for a *populated* listing describing a different tree; an empty one cannot distinguish "wrong install" from "a category this server does not scan like we do".

**A bare JSON parse error now says what is known** (#1160, via #1166). On an authenticated remote, `upload_image` and `get_image` both returned the raw `Unexpected end of JSON input` — no endpoint, no status, and no statement about whether the upload was delivered. A narrow backstop attaches the tool name, the auth-gate reading, and the delivery doubt, while leaving properly classified errors untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)