### PR TITLE
fix(download): an interrupted download leaves a findable record instead of vanishing

### DIFF
--- a/src/__tests__/services/download-progress.test.ts
+++ b/src/__tests__/services/download-progress.test.ts
@@ -334,3 +334,90 @@ describe("markSupersededByLive (#1150)", () => {
     expect(settled.every((s) => s.supersededByLive === true)).toBe(true);
   });
 });
+
+// #1148 — a tracked download vanished silently across an orchestrator restart.
+//
+// The persisted store exists so a reconnecting session can still resolve an
+// in-flight download by id (#529), and download_model's own status text promises
+// exactly that. But the orchestrator nonces its progress dir per start and reaps
+// every earlier dir for the port, deleting the store that promise rests on. A
+// reporter's 12GB transfer answered "No download matching id" and "No downloads
+// are being tracked" — no file, no partial, no error event. 40 minutes lost
+// invisibly, while the documented contract told their agent to keep waiting.
+//
+// The transfer really is dead (it streamed inside the exited process), so this
+// resurrects nothing. It replaces the SILENCE with a findable terminal record.
+describe("migrateInFlightJobs (#1148)", () => {
+  let oldDir: string;
+
+  beforeEach(() => {
+    oldDir = mkdtempSync(join(tmpdir(), "cm-old-"));
+  });
+  afterEach(() => {
+    rmSync(oldDir, { recursive: true, force: true });
+  });
+
+  // Built from the module's OWN prefix, not a hard-coded "job-": the real files
+  // are `control-job-…`, and a literal here would have silently written fixtures
+  // the scanner ignores — a test that passes by matching nothing.
+  const writeJob = (d: string, rec: Record<string, unknown>) =>
+    writeFileSync(
+      join(d, `${mod.CONTROL_PREFIX}job-${rec.id}-owner.json`),
+      JSON.stringify(rec),
+    );
+
+  it("carries an IN-FLIGHT record forward as a findable terminal record", () => {
+    writeJob(oldDir, {
+      id: "53012d3181fd46b6",
+      status: "downloading",
+      name: "krea2_turbo_fp8.safetensors",
+      received: 700000000,
+      total: 12010000000,
+      updated: Date.now(),
+    });
+
+    expect(mod.migrateInFlightJobs(oldDir, dir)).toBe(1);
+
+    const found = mod.readPersistedDownloadJob("53012d3181fd46b6");
+    expect(found).not.toBeNull();
+    expect(found!.status).toBe("error");
+    expect(found!.interrupted_by_restart).toBe(true);
+    // The bytes it had, so a reader can see what was lost.
+    expect(found!.received).toBe(700000000);
+  });
+
+  it("says the transfer is NOT running and will not resume itself", () => {
+    // The whole harm was an agent waiting forever on the documented contract.
+    writeJob(oldDir, { id: "abc", status: "downloading", updated: Date.now() });
+    mod.migrateInFlightJobs(oldDir, dir);
+    const msg = mod.readPersistedDownloadJob("abc")!.error ?? "";
+    expect(msg).toMatch(/INTERRUPTED/);
+    expect(msg).toMatch(/NOT running/);
+    expect(msg).toMatch(/will not resume on its own/);
+    expect(msg).toMatch(/Re-issue the download/);
+  });
+
+  it("does NOT migrate a TERMINAL record — its outcome was already delivered", () => {
+    // Re-landing a settled record would replay an event the caller already saw.
+    for (const status of ["done", "error", "cancelled"]) {
+      writeJob(oldDir, { id: `t-${status}`, status, updated: Date.now() });
+    }
+    expect(mod.migrateInFlightJobs(oldDir, dir)).toBe(0);
+  });
+
+  it("survives an unreadable record without dropping the others", () => {
+    writeFileSync(join(oldDir, `${mod.CONTROL_PREFIX}job-corrupt-owner.json`), "{not json");
+    writeJob(oldDir, { id: "good", status: "downloading", updated: Date.now() });
+    expect(mod.migrateInFlightJobs(oldDir, dir)).toBe(1);
+    expect(mod.readPersistedDownloadJob("good")).not.toBeNull();
+  });
+
+  it("returns 0 for a directory that does not exist", () => {
+    expect(mod.migrateInFlightJobs(join(oldDir, "nope"), dir)).toBe(0);
+  });
+
+  it("ignores non-job files in the old directory", () => {
+    writeFileSync(join(oldDir, `${mod.CONTROL_PREFIX}something.json`), JSON.stringify({ id: "x" }));
+    expect(mod.migrateInFlightJobs(oldDir, dir)).toBe(0);
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -146,7 +146,7 @@ import {
 import { AskAnswers, preview as previewQuestion } from "./ask-answer-journal.js";
 import { initRunpodWatcher, getRunpodWatcher, type RunpodStatusFrame, type RunpodAlertFrame } from "../services/runpod-watch.js";
 import { getPod } from "../services/runpod-client.js";
-import { listTargetChangeRequests, consumeTargetChange, ackTargetChange, setProgressDir, CONTROL_PREFIX, newestAttemptEpochs, isSupersededAttempt, downloadAttemptKey, markSupersededByLive } from "../services/download-progress.js";
+import { listTargetChangeRequests, consumeTargetChange, ackTargetChange, setProgressDir, CONTROL_PREFIX, newestAttemptEpochs, isSupersededAttempt, downloadAttemptKey, markSupersededByLive, migrateInFlightJobs } from "../services/download-progress.js";
 import { hasActiveTrainingJob, reconcileStaleTrainingJobs } from "../services/training-jobs.js";
 import {
   buildQueueStatusFrame,
@@ -1327,6 +1327,28 @@ export async function runPanelOrchestrator(): Promise<void> {
   try {
     for (const d of readdirSync(tmpdir())) {
       if (d.startsWith(`comfyui-mcp-progress-${bridgePort}-`) && join(tmpdir(), d) !== progressDir) {
+        // #1148 — carry any IN-FLIGHT download records forward before deleting.
+        //
+        // The persisted store exists so a reconnecting session can still resolve
+        // an in-flight download by id (#529), and download_model's status text
+        // promises exactly that. This reap deleted the store that promise rests
+        // on: a reporter's 12GB transfer answered "No download matching id" and
+        // "No downloads are being tracked", with no file, no partial, and no
+        // error event — 40 minutes lost invisibly while the documented contract
+        // told their agent to wait rather than re-issue.
+        //
+        // The transfer IS dead (it streamed inside the exited process), so this
+        // resurrects nothing. It replaces the silence with a terminal record
+        // saying the download was interrupted, which status can find by the id
+        // the caller already holds. Runs BEFORE the delete, and its failure is
+        // never allowed to skip the delete.
+        try {
+          mkdirSync(progressDir, { recursive: true, mode: 0o700 });
+          const n = migrateInFlightJobs(join(tmpdir(), d), progressDir);
+          if (n > 0) logger.info(`Carried ${n} interrupted download record(s) forward`);
+        } catch {
+          /* best-effort */
+        }
         rmSync(join(tmpdir(), d), { recursive: true, force: true });
       }
     }

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -134,6 +134,10 @@ export interface DownloadJob {
    *  in-flight record whose writer was PROVEN dead (#858) — no live transfer was
    *  aborted, so no renderer may claim a resumable partial was deliberately left. */
   reclaimedDead?: boolean;
+  /** #1148 — this terminal record was carried forward from a dead orchestrator's
+   *  channel dir. The transfer stopped because its PROCESS exited, not because the
+   *  server or URL failed. */
+  interruptedByRestart?: boolean;
 }
 
 interface Entry {
@@ -836,6 +840,7 @@ function jobFromPersisted(rec: PersistedDownloadJob): DownloadJob {
     staleInflight: rec.staleInflight,
     staleForMs: rec.staleForMs,
     reclaimedDead: rec.reclaimed_dead,
+    interruptedByRestart: rec.interrupted_by_restart,
   };
 }
 

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -78,6 +78,80 @@ function channelDir(): string {
 }
 const lastWriteAt = new Map<string, number>();
 
+/**
+ * Carry a dead orchestrator's IN-FLIGHT job records into the new channel dir as
+ * terminal "interrupted" records, instead of deleting them (#1148).
+ *
+ * The persisted store exists so a session that reconnects can still resolve an
+ * in-flight download by id (#529), and download_model's own status text promises
+ * exactly that. But the orchestrator nonces its progress dir per start and reaps
+ * every earlier dir for the port — so an orchestrator restart deleted the store
+ * that promise depends on. A reporter's 12GB transfer answered "No download
+ * matching id" and "No downloads are being tracked", with no file and no partial
+ * on disk and no error event: 40 minutes gone, invisibly, while the documented
+ * contract told their agent to keep waiting rather than re-issue.
+ *
+ * The transfer really is dead — it streamed inside a process that no longer
+ * exists — so this does NOT resurrect it, and pretending otherwise would be the
+ * worse bug. What it fixes is the SILENCE: a record that says the download was
+ * interrupted, which `status` can find by the id the caller was handed.
+ *
+ * Only `downloading` records migrate. A terminal record's outcome was already
+ * delivered, and re-landing it would replay a settled event. Fields are copied
+ * INDIVIDUALLY rather than spread: this reads a file written by a process that
+ * is gone, and the new record must be a record we constructed.
+ *
+ * Best-effort throughout — a failure here must never block startup.
+ */
+export function migrateInFlightJobs(fromDir: string, toDir: string): number {
+  let migrated = 0;
+  let files: string[];
+  try {
+    files = readdirSync(fromDir).filter((f) => f.startsWith(JOB_PREFIX) && f.endsWith(".json"));
+  } catch {
+    return 0;
+  }
+  for (const f of files) {
+    try {
+      const raw = JSON.parse(readFileSync(join(fromDir, f), "utf8")) as Record<string, unknown>;
+      if (!raw || typeof raw !== "object") continue;
+      if (typeof raw.id !== "string" || raw.status !== "downloading") continue;
+      const str = (k: string): string | undefined =>
+        typeof raw[k] === "string" ? (raw[k] as string) : undefined;
+      const num = (k: string): number | undefined =>
+        typeof raw[k] === "number" ? (raw[k] as number) : undefined;
+      const rec = {
+        id: raw.id,
+        status: "error" as const,
+        name: str("name"),
+        url: str("url"),
+        dest: str("dest"),
+        target: str("target"),
+        dest_key: str("dest_key"),
+        req_key: str("req_key"),
+        total: num("total"),
+        received: num("received"),
+        updated: Date.now(),
+        interrupted_by_restart: true,
+        error:
+          `This download was INTERRUPTED: the orchestrator process it was streaming ` +
+          `inside exited (a restart or a session drop), so the transfer stopped. It is ` +
+          `NOT running and will not resume on its own — nothing is waiting to finish. ` +
+          `Any partial file may also have been discarded. Re-issue the download.`,
+      };
+      writeFileSync(
+        join(toDir, `${JOB_PREFIX}${sanitizeIdPart(raw.id)}-${PERSIST_OWNER}.json`),
+        JSON.stringify(rec),
+        { mode: 0o600 },
+      );
+      migrated += 1;
+    } catch {
+      /* one unreadable record must not stop the rest */
+    }
+  }
+  return migrated;
+}
+
 /** True when running under the panel orchestrator (progress channel is active). */
 export function progressEnabled(): boolean {
   return !!PROGRESS_DIR;
@@ -577,6 +651,11 @@ export interface PersistedDownloadJob {
   verified_root?: string;
   /** Epoch ms of this snapshot (set on write). */
   updated: number;
+  /** Set on a terminal record MIGRATED from a dead orchestrator's channel dir
+   *  (#1148). The transfer stopped because the process it streamed inside exited,
+   *  not because the server or the URL failed — so renderers say that, and never
+   *  imply a resumable partial was deliberately left behind. */
+  interrupted_by_restart?: boolean;
   /**
    * Read-only diagnostics added when an in-flight record missed the liveness
    * heartbeat. These are never persisted: a stale heartbeat is not proof that

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -899,7 +899,13 @@ async function statusAction(args: {
                   ? `\n    ${placement.pathLabel}${placement.pathQualifier}: ${j.path}`
                   : `\n    ${placement.pathLabel}${placement.pathQualifier}: ${j.path}\n    ${placement.wrongPlace ? "WARNING" : "NOTE"}: ${placement.warning}`
               : j.status === "error"
-                ? `\n    failed: ${j.error}`
+                ? j.interruptedByRestart
+                  ? // #1148 — NOT a transfer failure. The process it streamed
+                    // inside exited, which the previous behaviour rendered as
+                    // "No download matching id": the job silently ceased to exist
+                    // while the contract told the caller to keep waiting.
+                    `\n    INTERRUPTED — ${j.error}`
+                  : `\n    failed: ${j.error}`
                 : j.status === "cancelled"
                   ? (j.reclaimedDead
                       ? // #858: NO live transfer was aborted — the writer was already


### PR DESCRIPTION
Refs #1148. Does not close it — see "What this does not fix".

## The report

A 12GB download reported STARTED and progressing, then silently ceased to exist across a session reconnect:

```
download_model action:"status" id:53012d3181fd46b6  → No download matching id
download_model action:"status"                      → No downloads are being tracked.
ls <ComfyUI>/models/diffusion_models                → no file, no .part
```

No error event either — the channel was alive, since unrelated 401s had fired events minutes earlier.

And `download_model`'s own status text promises the opposite:

> Survives a sidebar/tool-session reconnect: an in-flight download started in a previous session is still resolvable by its `id` (or by `url`), so you can confirm it's still running instead of starting a duplicate.

So an agent following the documented contract (*"do NOT call action:download again for this URL"*) waits forever. It cost the reporter ~40 minutes, twice.

## Cause

Two mechanisms written against each other:

- `download-progress.ts` persists job records for **6 hours** so a reconnecting session can adopt them (#529). That is what the promise above rests on.
- `orchestrator/index.ts` nonces its progress dir per start and **reaps every earlier dir for the port** — deleting that store wholesale on any orchestrator restart.

## What this fixes

The **silence**, not the loss. The transfer really is dead — it streamed inside the process that exited — and resurrecting it is not on the table here; claiming otherwise would be the worse bug.

In-flight records are now carried into the new dir as terminal *interrupted* records, findable by the id the caller already holds:

```
- `53012d3181fd46b6` (tray `…`) **error**  0.67 GB so far
    INTERRUPTED — This download was INTERRUPTED: the orchestrator process it was
    streaming inside exited (a restart or a session drop), so the transfer stopped.
    It is NOT running and will not resume on its own — nothing is waiting to finish.
    Any partial file may also have been discarded. Re-issue the download.
```

Design notes:

- **Only in-flight records migrate.** A terminal record's outcome was already delivered; re-landing it would replay a settled event.
- **Fields are copied individually, not spread.** This reads a file written by a process that is gone, so the record that lands is one we constructed.
- **The reap still happens**, and a migration failure can neither skip it nor block startup.

## What this does not fix

The download still dies with the orchestrator. Making transfers outlive the process that started them is a much larger change (a detached writer, or resumable adoption of a `.part` by a later session), and the tool description's "survives a reconnect" promise is still stronger than what the code delivers. Both stay open on the issue.

## Testing notes

Verified by mutation — each fails the suite:

| mutation | result |
|---|---|
| remove the migration (silent vanish returns) | ✗ killed (3 tests) |
| migrate terminal records too (replays settled outcomes) | ✗ killed |
| drop the interrupted flag (renders as a plain failure) | ✗ killed |
| let one corrupt record abort the rest | ✗ killed |

**A caught test bug worth naming:** the fixtures first wrote `job-…` filenames while the real prefix is `control-job-…`, so they passed by matching nothing. They now build the name from the module's own exported constant.

Full suite: 376 files, 7758 passed. Lint and the vocabulary gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)