### PR TITLE
release: v0.50.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.45] - 2026-08-08
+
+### MCP
+
+#### Fixed
+- an interrupted download leaves a findable record instead of vanishing (#1170)
+
+
 ## [0.50.44] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.44",
+  "version": "0.50.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.44",
+      "version": "0.50.45",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.44",
+  "version": "0.50.45",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.45` tag.

**An interrupted download leaves a findable record instead of vanishing** (#1148, via #1170).

A reporter's 12GB transfer was reported STARTED and progressing, then silently ceased to exist across a session reconnect — `No download matching id`, `No downloads are being tracked`, no file, no partial, no error event. The tool's own status text promises an in-flight download stays resolvable by id across a reconnect, so an agent following that contract waits forever.

Two mechanisms were written against each other: the persisted job store keeps records for 6h so a reconnecting session can adopt them (#529), while the orchestrator nonces its progress dir per start and reaps every earlier dir for the port — deleting that store on any restart.

In-flight records are now carried forward as terminal *interrupted* records, findable by the id the caller already holds, stating plainly that the transfer is not running and will not resume on its own. It does not resurrect the transfer — that streamed inside the exited process — and the larger half (making downloads outlive the orchestrator, and the description that over-promises) stays open on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)