### PR TITLE
fix(history): getHistory names the endpoint instead of leaking a parser message

### DIFF
--- a/src/__tests__/comfyui/history-non-json.test.ts
+++ b/src/__tests__/comfyui/history-non-json.test.ts
@@ -1,0 +1,83 @@
+// #1149 — get_history and get_image both failed with `Unexpected end of JSON
+// input` after a COMPLETED video render on a remote H100, and get_image wrapped
+// it as HISTORY_UNREADABLE.
+//
+// getHistory was the last unguarded `res.json()` on the media read paths. Every
+// sibling already routes through readComfyJson (#918/#946/#952), which names the
+// URL, the status, the content type and a body prefix — so an empty body, an
+// auth gate's login page and a proxy's HTML are each said out loud instead of
+// collapsing into one parser message that names nothing.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const fetchApi = vi.hoisted(() => ({ impl: async (_p: string) => new Response("{}") }));
+vi.mock("@stable-canvas/comfyui-client", () => ({
+  Client: class {
+    async fetchApi(p: string) {
+      return fetchApi.impl(p);
+    }
+    close() {}
+  },
+}));
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: "" },
+  getComfyUIApiHost: () => "remote.example:8188",
+  getComfyUIBasePath: () => "",
+  getComfyUIBaseUrl: () => "http://remote.example:8188",
+  getComfyUIAuthHeaders: () => ({}),
+  isCloudMode: () => false,
+  isRemoteMode: () => true,
+}));
+
+import { getHistory } from "../../comfyui/client.js";
+import { isNonJsonResponseError } from "../../comfyui/json-guard.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchApi.impl = async () => new Response("{}", { status: 200 });
+});
+
+describe("getHistory does not leak a bare parser message (#1149)", () => {
+  it("classifies an EMPTY body instead of 'Unexpected end of JSON input'", async () => {
+    // The reporter's exact error. An empty body is the one case where the
+    // evidence is unambiguous — the server answered and sent zero bytes.
+    fetchApi.impl = async () => new Response("", { status: 200 });
+    const err = await getHistory().catch((e: unknown) => e);
+    expect(isNonJsonResponseError(err)).toBe(true);
+    expect((err as Error).message).not.toMatch(/^Unexpected end of JSON input$/);
+    expect((err as Error).message).toMatch(/\/history/);
+  });
+
+  it("names HTML as HTML — an auth gate or proxy, not a parse failure", async () => {
+    fetchApi.impl = async () =>
+      new Response("<!doctype html><html>login</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      });
+    const err = await getHistory().catch((e: unknown) => e);
+    expect(isNonJsonResponseError(err)).toBe(true);
+    expect((err as Error).message).toMatch(/HTML/i);
+    expect((err as Error).message).not.toMatch(/Unexpected token/);
+  });
+
+  it("names the PROMPT-scoped url when one was requested", async () => {
+    fetchApi.impl = async () => new Response("", { status: 200 });
+    const err = await getHistory("abc123").catch((e: unknown) => e);
+    expect((err as Error).message).toMatch(/\/history\/abc123/);
+  });
+
+  it("an EMPTY history ({}) is a valid answer, not a failure", async () => {
+    // The opposite defect, and the reason no expectShape is asserted: /history
+    // legitimately returns {} when nothing has run, and calling that a bad shape
+    // would fabricate a failure from a correct response.
+    fetchApi.impl = async () => new Response("{}", { status: 200 });
+    await expect(getHistory()).resolves.toEqual({});
+  });
+
+  it("passes a real history through unchanged", async () => {
+    const body = { "p-1": { prompt: [], outputs: {}, status: { completed: true } } };
+    fetchApi.impl = async () => new Response(JSON.stringify(body), { status: 200 });
+    await expect(getHistory()).resolves.toEqual(body);
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -862,7 +862,22 @@ export async function getHistory(
   const client = getClient();
   const path = promptId ? `/history/${promptId}` : "/history";
   const res = await client.fetchApi(path);
-  return res.json() as Promise<Record<string, HistoryEntry>>;
+  // #1149 — this was a bare res.json(), the last unguarded parse on the media
+  // read paths. A reporter on a remote H100 got `Unexpected end of JSON input`
+  // from get_history and get_image after a completed video render, which
+  // get_image then wrapped as HISTORY_UNREADABLE: a raw parser message standing
+  // in for a diagnosis, naming no endpoint and no status, for a render that had
+  // demonstrably succeeded.
+  //
+  // readComfyJson is what every sibling read already uses (#918/#946/#952): it
+  // names the URL, the status, the content type and a body prefix, so an empty
+  // body, an auth gate's login page and a proxy's HTML are each said out loud
+  // rather than collapsing into one parser error.
+  //
+  // No expectShape: /history's value is an object keyed by prompt id, and `{}`
+  // is a perfectly valid EMPTY history. Asserting a shape here would turn a
+  // legitimately empty answer into a fabricated failure — the opposite defect.
+  return readComfyJson<Record<string, HistoryEntry>>(res, { url: path });
 }
 
 /**


### PR DESCRIPTION
Refs #1149.

After a **completed** video render on a remote H100:

```
get_history(action:"list")        → Unexpected end of JSON input
get_image(action:"list_outputs")  → HISTORY_UNREADABLE / Unexpected end of JSON input
```

A raw parser message standing in for a diagnosis — no endpoint, no status, no content type — for a render that had demonstrably succeeded.

## Cause

`getHistory` was the last unguarded `res.json()` on the media read paths:

```ts
const res = await client.fetchApi(path);
return res.json() as Promise<Record<string, HistoryEntry>>;
```

Every sibling already routes through `readComfyJson` (#918/#946/#952), which names the URL, the status, the content type and a body prefix. So the three causes that produce this exact message are now each said out loud:

| body | before | after |
|---|---|---|
| empty | `Unexpected end of JSON input` | "answered HTTP 200 with an EMPTY body (0 bytes) — it reported nothing about this either way" |
| HTML login page | `Unexpected token '<'` | "returned HTML instead of JSON (a proxy, a login page, or a server still starting)" |
| other non-JSON | parser message | status + a bounded body excerpt |

`get_image`'s `HISTORY_UNREADABLE` wrapper inherits the classified text, so both surfaces the reporter hit improve from one change. I grepped the rest of `client.ts`: no unguarded parse remains.

## Deliberately no `expectShape`

`/history` returns an object keyed by prompt id, and `{}` is a legitimately **empty** history. Asserting a shape would turn a correct answer into a fabricated failure — the same defect pointing the other way. There is a mutation test for exactly this.

## Testing notes

| mutation | result |
|---|---|
| revert to the bare `res.json()` | ✗ killed (3 tests) |
| hardcode `"/history"` so a prompt-scoped lookup is misnamed | ✗ killed |
| add an `expectShape` that rejects an empty history | ✗ killed |

Full suite: 377 files, 7763 passed. Lint and the vocabulary gate clean.

This does not explain *why* that server returned an empty body — the reporter's remote may have an auth gate or proxy in front of it, which is the same open question as #1160's ask (a). What it fixes is that the message now says which endpoint, with what status, and what actually came back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)