### PR TITLE
release: v0.50.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.46] - 2026-08-08
+
+### MCP
+
+#### Fixed
+- getHistory names the endpoint instead of leaking a parser message (#1172)
+
+
 ## [0.50.45] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.45",
+  "version": "0.50.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.45",
+      "version": "0.50.46",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.45",
+  "version": "0.50.46",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.46` tag.

**`getHistory` names the endpoint instead of leaking a parser message** (#1149, via #1172).

After a completed video render on a remote H100, `get_history` and `get_image` both returned the bare `Unexpected end of JSON input` — the latter wrapped as `HISTORY_UNREADABLE`. `getHistory` was the last unguarded `res.json()` on the media read paths; every sibling already routes through the classifier that names the URL, status, content type and body prefix. An empty body, an auth gate's login page and a proxy's HTML are now each said out loud.

No shape assertion was added: `/history` legitimately returns `{}` when nothing has run, and rejecting that would fabricate a failure from a correct answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)