### PR TITLE
fix(codex): hold a turn's temp images past the turn, so a deferred read still finds them

### DIFF
--- a/src/__tests__/orchestrator/codex-temp-image-grace.test.ts
+++ b/src/__tests__/orchestrator/codex-temp-image-grace.test.ts
@@ -1,0 +1,130 @@
+// #1152 — the temp localImage was deleted before Codex read it.
+//
+// A reporter saw the panel render a storyboard while the SAME turn reported:
+//
+//   Codex could not read the local image at …\comfyui-codex-<pid>-…png:
+//   The system cannot find the file specified. (os error 2)
+//
+// The turn's finally block deleted the file immediately, on a comment asserting
+// "the bytes were read at turn/start". The app-server can defer that read, so
+// the delete raced it. Reproduced on two storyboards and a PreviewImage result.
+//
+// There is no "image consumed" signal in the protocol, so the fix is a grace
+// window rather than a handshake — and the invariant that matters is that the
+// window is a DELAY, never the only thing preventing a leak: close() still
+// sweeps every tracked file.
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { writeFileSync, existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+type BackendModule = typeof import("../../orchestrator/codex-backend.js");
+let CodexBackend: BackendModule["CodexBackend"];
+
+beforeAll(async () => {
+  vi.resetModules();
+  ({ CodexBackend } = await import("../../orchestrator/codex-backend.js"));
+});
+
+let dir: string;
+
+/** Advance past the grace window AND let the real fs.unlink I/O settle — fake
+ *  timers fire the callback but do not await the promise it starts. */
+async function elapseGraceWindow(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(5 * 60_000 + 10);
+  vi.useRealTimers();
+  for (let i = 0; i < 20; i++) await new Promise((r) => setTimeout(r, 5));
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A backend with two tracked temp files on disk, reaching the private members
+ *  the way the turn loop does. */
+function backendWithTempFiles(): { be: any; files: string[] } {
+  dir = mkdtempSync(join(tmpdir(), "codex-temp-"));
+  const files = ["a.png", "b.png"].map((n) => join(dir, n));
+  for (const f of files) writeFileSync(f, "x");
+  const be = new CodexBackend({} as never) as any;
+  for (const f of files) be.tempImageFiles.add(f);
+  return { be, files };
+}
+
+describe("temp localImage files survive the turn (#1152)", () => {
+  it("does NOT delete them when the turn ends", async () => {
+    // REAL timers on purpose. Under fake timers this passes even with a ZERO
+    // grace window, because nothing advances the clock — the test would claim to
+    // pin the fix while a reverted constant sailed through it. Caught by
+    // mutating TEMP_IMAGE_GRACE_MS to 0 and watching this go green.
+    const { be, files } = backendWithTempFiles();
+
+    be.scheduleTempImageCleanup(files);
+    // Long enough that a 0ms timer would have fired AND its unlink completed.
+    await new Promise((r) => setTimeout(r, 120));
+
+    // The race the reporter hit: at this instant Codex may not have read them.
+    for (const f of files) expect(existsSync(f)).toBe(true);
+  });
+
+  it("uses a grace window measured in minutes, not milliseconds", () => {
+    // The duration is the fix. A window short enough to still race a deferred
+    // read is the bug wearing the fix's shape.
+    const be = new CodexBackend({} as never) as any;
+    const grace = (be.constructor as { TEMP_IMAGE_GRACE_MS: number }).TEMP_IMAGE_GRACE_MS;
+    expect(grace).toBeGreaterThanOrEqual(60_000);
+  });
+
+  it("deletes them once the grace window elapses", async () => {
+    vi.useFakeTimers();
+    const { be, files } = backendWithTempFiles();
+
+    be.scheduleTempImageCleanup(files);
+    await elapseGraceWindow();
+
+    for (const f of files) expect(existsSync(f)).toBe(false);
+    // And they leave tracking, so close() has nothing stale to re-sweep.
+    expect(be.tempImageFiles.size).toBe(0);
+  });
+
+  it("keeps them TRACKED while the window is open, so close() still sweeps", async () => {
+    // The invariant: the grace window is a delay, not the sole guard against a
+    // leak. A process that exits mid-window must not strand files.
+    vi.useFakeTimers();
+    const { be, files } = backendWithTempFiles();
+
+    be.scheduleTempImageCleanup(files);
+    expect(be.tempImageFiles.size).toBe(2);
+
+    await be.cleanupTempImages([...be.tempImageFiles]);
+    for (const f of files) expect(existsSync(f)).toBe(false);
+  });
+
+  it("unrefs the timer so a pending window cannot hold the process open", () => {
+    vi.useFakeTimers();
+    const { be, files } = backendWithTempFiles();
+    be.scheduleTempImageCleanup(files);
+    const [timer] = [...be.tempImageTimers];
+    expect(timer).toBeDefined();
+    // vitest's fake timer objects expose hasRef() like Node's.
+    if (typeof timer.hasRef === "function") expect(timer.hasRef()).toBe(false);
+  });
+
+  it("survives a file that is already gone", async () => {
+    vi.useFakeTimers();
+    const { be, files } = backendWithTempFiles();
+    rmSync(files[0], { force: true });
+
+    be.scheduleTempImageCleanup(files);
+    await elapseGraceWindow();
+
+    expect(existsSync(files[1])).toBe(false);
+    expect(be.tempImageFiles.size).toBe(0);
+  });
+});

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -778,6 +778,33 @@ export class CodexBackend implements AgentBackend {
     }
   }
 
+  /**
+   * How long a turn's localImage files survive after the turn ends (#1152).
+   *
+   * The app-server may read a localImage well after turn/start returns, so the
+   * delete has to wait for a read whose timing we do not control. There is no
+   * signal for "the image was consumed" in the protocol, so this is a grace
+   * window rather than a handshake — chosen long enough to cover a deferred read
+   * on a busy machine, and bounded so the files do not accumulate for a session's
+   * whole lifetime.
+   */
+  private static readonly TEMP_IMAGE_GRACE_MS = 5 * 60_000;
+
+  /** Pending grace timers, so close() can clear them rather than leave them armed. */
+  private tempImageTimers = new Set<NodeJS.Timeout>();
+
+  /** Delete this turn's temp images after the grace window (#1152). */
+  private scheduleTempImageCleanup(files: string[]): void {
+    const timer = setTimeout(() => {
+      this.tempImageTimers.delete(timer);
+      void this.cleanupTempImages(files);
+    }, CodexBackend.TEMP_IMAGE_GRACE_MS);
+    // Must never keep the process alive: an orchestrator that has finished its
+    // work should exit, and close() sweeps the files regardless.
+    timer.unref?.();
+    this.tempImageTimers.add(timer);
+  }
+
   /** Delete the given temp image files (best-effort) and drop them from tracking. */
   private async cleanupTempImages(files: Iterable<string>): Promise<void> {
     for (const f of files) {
@@ -1355,10 +1382,24 @@ export class CodexBackend implements AgentBackend {
       // it during shutdown — don't resurrect a stale handler onto a dead client).
       if (client.notificationHandler && !client.exitError) client.notificationHandler = prev ?? null;
       this.turnId = null;
-      // Sweep this turn's temp image files now that the app-server has consumed
-      // them (the bytes were read at turn/start). Best-effort + non-blocking on the
-      // generator's teardown.
-      if (turnTempFiles.length) void this.cleanupTempImages(turnTempFiles);
+      // #1152 — the app-server does NOT necessarily read a localImage at
+      // turn/start, which is what this used to assume ("the bytes were read at
+      // turn/start"). A reporter saw the panel render a storyboard while the
+      // Codex turn reported the file gone:
+      //
+      //   Codex could not read the local image at …\comfyui-codex-<pid>-…png:
+      //   The system cannot find the file specified. (os error 2)
+      //
+      // Deleting at turn teardown therefore races a read that has not happened
+      // yet. Hold the files for a grace period instead: the cost of keeping a few
+      // PNGs in the OS temp dir for minutes is nothing next to an image the agent
+      // cannot see.
+      //
+      // The files stay in `tempImageFiles`, so close() still sweeps them — a
+      // pending timer is a delay, never the only thing standing between us and a
+      // leak. The timer is unref'd (it must not hold the process open) and
+      // tracked so close() can clear it.
+      if (turnTempFiles.length) this.scheduleTempImageCleanup(turnTempFiles);
     }
   }
 
@@ -1557,8 +1598,13 @@ export class CodexBackend implements AgentBackend {
         this.beginClientClose(candidate, "backend close teardown failed"),
       ),
     );
+    // #1152 — cancel the grace timers first. Their files are swept right below,
+    // so leaving them armed would only re-unlink paths that are already gone.
+    for (const t of this.tempImageTimers) clearTimeout(t);
+    this.tempImageTimers.clear();
     // Sweep any temp image files a turn didn't get to clean up (e.g. close() raced
-    // an in-flight turn). Snapshot first — cleanupTempImages mutates the set.
+    // an in-flight turn, or a grace window was still open). Snapshot first —
+    // cleanupTempImages mutates the set.
     if (this.tempImageFiles.size) {
       await this.cleanupTempImages([...this.tempImageFiles]).catch(() => {});
     }


### PR DESCRIPTION
Fixes #1152.

A reporter saw the panel render a storyboard while the **same** Codex turn reported:

```
Codex could not read the local image at …\comfyui-codex-<pid>-<timestamp>-<id>.png:
The system cannot find the file specified. (os error 2)
```

Reproduced on two final-video storyboards and a PreviewImage result.

## Cause

The turn's `finally` block deleted the files immediately, on an assumption stated in its own comment:

> Sweep this turn's temp image files now that the app-server has consumed them (**the bytes were read at turn/start**).

They are not necessarily. The app-server can defer reading a `localImage`, so the delete raced a read that had not happened yet.

There is no "image consumed" signal in the protocol to wait on, so this is a grace window rather than a handshake — the shape the reporter proposed.

## The invariant

The window is a **delay, never the only thing preventing a leak**:

- files stay in `tempImageFiles`, so `close()` still sweeps them;
- `close()` now also **clears** the pending timers instead of leaving them armed to re-unlink paths that are already gone;
- the timer is `unref`'d, so a pending window cannot hold the process open.

## Testing notes — two test bugs found by mutation, not by the green run

The first test used **fake timers**, so it passed with a **zero** grace window: nothing advances the clock, so the file survives either way. It claimed to pin the fix while a reverted constant would sail straight through. It now uses real timers and waits past what a 0 ms window would take.

A sibling then asserts the **duration** is minutes rather than milliseconds — because a window short enough to still race a deferred read is the bug wearing the fix's shape, and only a discriminating test tells those apart.

| mutation | result |
|---|---|
| 0 ms window (immediate cleanup — the reported race) | ✗ killed (2 tests) |
| **1-second window** (still races a deferred read) | ✗ killed |
| drop files from tracking so `close()` cannot sweep | ✗ killed |
| remove the `unref` | ✗ killed |

Full suite: 378 files, 7769 passed. Lint and the vocabulary gate clean.

Thanks to the reporter for the working patch and for saying which comment's assumption was wrong — that is what made this a read-and-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)