### PR TITLE
fix(#828): stop the client library's error path eating non-JSON responses

### DIFF
--- a/src/__tests__/comfyui/client-fetch-json-guard.test.ts
+++ b/src/__tests__/comfyui/client-fetch-json-guard.test.ts
@@ -1,0 +1,218 @@
+// #828 / #1160 — the client library's OWN error path was eating the response.
+//
+// `Client.fetchApi` calls `res.json()` on the ERROR body for any status outside
+// [200, 400), so it can attach the parsed body to the error it is about to
+// throw. When that body is not JSON — empty, an HTML login page, a proxy error
+// document — `res.json()` rejects FIRST and its bare SyntaxError propagates in
+// place of the library's error, taking the status, the statusText and the URL
+// with it.
+//
+// That is one defect upstream of every `client.fetchApi` call site, which is why
+// guarding the call sites one at a time kept missing it: `uploadImageHttp`
+// already ran `readComfyJson` on its success path and STILL reported a bare
+// "Unexpected end of JSON input" (#1160), because the library threw before that
+// code ever saw the response.
+//
+// These tests drive the REAL library through the REAL wiring in getClient(), so
+// reverting `fetch: guardClientFetch(comfyuiFetch)` to `fetch: comfyuiFetch`
+// fails them.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: "" },
+  getComfyUIApiHost: () => "remote.example:8188",
+  getComfyUIBasePath: () => "",
+  getComfyUIBaseUrl: () => "http://remote.example:8188",
+  getComfyUIAuthHeaders: () => ({}),
+  isCloudMode: () => false,
+  isRemoteMode: () => true,
+}));
+
+import { getLogs, resetClient, uploadImageHttp } from "../../comfyui/client.js";
+import {
+  classifyNonJson,
+  guardClientFetch,
+  isNonJsonResponseError,
+} from "../../comfyui/json-guard.js";
+
+/** Every response the fake server will give, in order. */
+function serve(...responses: Array<() => Response>): void {
+  let i = 0;
+  global.fetch = vi.fn(async () => {
+    const make = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return make();
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // getClient() memoises, and these tests each want a client built from the
+  // wiring under test rather than one another's leftovers.
+  resetClient();
+});
+
+describe("the library's non-2xx path can no longer eat the response (#828)", () => {
+  it("diagnoses an EMPTY error body instead of 'Unexpected end of JSON input'", async () => {
+    // The reported shape: remote ComfyUI, post-reconnect, /internal/logs answers
+    // a bodiless 404. getLogs retries once, so both attempts get it.
+    serve(() => new Response(null, { status: 404, statusText: "Not Found" }));
+
+    const err = await getLogs().then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+    // The regression itself: the parser message must not be the whole answer.
+    expect(message).not.toMatch(/^Unexpected end of JSON input$/);
+    expect(message).not.toMatch(/Failed to fetch ComfyUI logs after reconnect retry: Unexpected end of JSON input/);
+    expect(isNonJsonResponseError(err)).toBe(true);
+    // What the reader actually needed: which endpoint, what status, what came back.
+    expect(message).toContain("/internal/logs");
+    expect(message).toContain("404");
+    expect(message).toContain("EMPTY body");
+  });
+
+  it("does not recast a diagnosed server answer as a connection failure", async () => {
+    // getLogs used to wrap EVERY second-attempt error in a ConnectionError
+    // headed "Failed to fetch", which contradicted a diagnosis that had just
+    // established the server answered.
+    serve(() => new Response(null, { status: 404, statusText: "Not Found" }));
+
+    const err = await getLogs().then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect((err as Error).message).not.toContain("Failed to fetch ComfyUI logs");
+    expect((err as { code?: string }).code).toBe("NON_JSON_RESPONSE");
+  });
+
+  it("names the sign-in gate on an authenticated remote upload (#1160)", async () => {
+    // uploadImageHttp's success path was already guarded; the 401 made the
+    // library throw first, so that guard never ran.
+    serve(
+      () =>
+        new Response(
+          "<!DOCTYPE html><html><head><title>Sign in</title></head>" +
+            '<body><form action="/login"><input type="password" name="p"></form></body></html>',
+          { status: 401, statusText: "Unauthorized", headers: { "content-type": "text/html" } },
+        ),
+    );
+
+    const err = await uploadImageHttp("cat.png", Buffer.from("x")).then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(isNonJsonResponseError(err)).toBe(true);
+    const message = (err as Error).message;
+    expect(message).not.toMatch(/^Unexpected/);
+    expect(message).toContain("/upload/image");
+    expect(message).toContain("401");
+    expect(message).toMatch(/SIGN-IN PAGE/);
+  });
+
+  it("still succeeds on a normal 2xx JSON response", async () => {
+    // The guard must be invisible when nothing is wrong — a false positive here
+    // would break every upload.
+    serve(
+      () =>
+        new Response(JSON.stringify({ name: "cat.png", subfolder: "", type: "input" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    await expect(uploadImageHttp("cat.png", Buffer.from("x"))).resolves.toEqual({
+      name: "cat.png",
+      subfolder: "",
+      type: "input",
+    });
+  });
+
+  it("passes a plain-text 200 log body through untouched", async () => {
+    // /internal/logs legitimately answers raw text on some versions, and getLogs
+    // reads it with text(). The override must not disturb that path.
+    serve(
+      () =>
+        new Response("line one\nline two\n", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+    );
+
+    await expect(getLogs()).resolves.toEqual(["line one", "line two"]);
+  });
+});
+
+describe("guardClientFetch", () => {
+  it("leaves text() and a valid json() alone", async () => {
+    const wrapped = guardClientFetch(
+      async () =>
+        new Response('{"ok":true}', { status: 200, headers: { "content-type": "application/json" } }),
+    );
+
+    await expect((await wrapped("http://x/y")).json()).resolves.toEqual({ ok: true });
+    await expect((await wrapped("http://x/y")).text()).resolves.toBe('{"ok":true}');
+  });
+
+  it("reports the request target when the response carries no url of its own", async () => {
+    // A synthesised Response (a test double, a mock server shim) has url === "".
+    const wrapped = guardClientFetch(async () => new Response("<html></html>", { status: 502 }));
+
+    await expect(wrapped("http://remote.example:8188/prompt").then((r) => r.json())).rejects.toThrow(
+      /http:\/\/remote\.example:8188\/prompt/,
+    );
+  });
+
+  it("does not consume the body until json() is called", async () => {
+    // Reading the body up front would break every caller that uses text() — the
+    // guard has to be lazy, not eager.
+    const wrapped = guardClientFetch(async () => new Response("not json", { status: 200 }));
+    const res = await wrapped("http://x/y");
+    expect(res.bodyUsed).toBe(false);
+    await expect(res.text()).resolves.toBe("not json");
+  });
+});
+
+describe("classifyNonJson on an empty body", () => {
+  it("says the body was empty rather than that it failed to parse", () => {
+    const d = classifyNonJson({
+      url: "http://remote.example:8188/internal/logs",
+      status: 404,
+      contentType: "",
+      body: "",
+    });
+    expect(d.kind).toBe("not-found");
+    expect(d.message).toContain("EMPTY body");
+    expect(d.message).toContain("NOTHING was sent back");
+  });
+
+  it("flags an empty 2xx as the stranger case that it is", () => {
+    const d = classifyNonJson({
+      url: "http://remote.example:8188/system_stats",
+      status: 200,
+      contentType: "application/json",
+      body: "   \n ",
+    });
+    expect(d.kind).toBe("not-json");
+    expect(d.message).toContain("EMPTY body");
+    expect(d.message).toContain("SUCCESS one");
+  });
+
+  it("still prefers the gateway diagnosis for an empty 502", () => {
+    // The status IS the evidence here, and "a proxy could not reach ComfyUI" is
+    // more use than "the body was empty".
+    const d = classifyNonJson({
+      url: "http://remote.example:8188/prompt",
+      status: 502,
+      contentType: "",
+      body: "",
+    });
+    expect(d.kind).toBe("proxy-error");
+  });
+});

--- a/src/__tests__/comfyui/client-fetch-json-guard.test.ts
+++ b/src/__tests__/comfyui/client-fetch-json-guard.test.ts
@@ -29,11 +29,18 @@ vi.mock("../../config.js", () => ({
   isRemoteMode: () => true,
 }));
 
-import { getLogs, resetClient, uploadImageHttp } from "../../comfyui/client.js";
+import {
+  getLogs,
+  getObjectInfo,
+  resetClient,
+  resetObjectInfoCache,
+  uploadImageHttp,
+} from "../../comfyui/client.js";
 import {
   classifyNonJson,
   guardClientFetch,
   isNonJsonResponseError,
+  redactUrlForDiagnosis,
 } from "../../comfyui/json-guard.js";
 
 /** Every response the fake server will give, in order. */
@@ -51,6 +58,7 @@ beforeEach(() => {
   // getClient() memoises, and these tests each want a client built from the
   // wiring under test rather than one another's leftovers.
   resetClient();
+  resetObjectInfoCache();
 });
 
 describe("the library's non-2xx path can no longer eat the response (#828)", () => {
@@ -214,5 +222,157 @@ describe("classifyNonJson on an empty body", () => {
       body: "",
     });
     expect(d.kind).toBe("proxy-error");
+  });
+
+  // Pins the empty branch's POSITION, not just its existence. Moving it above
+  // the auth branch would turn "an auth gate rejected this" into a generic
+  // "nothing came back", which sends the reader to the wrong layer entirely —
+  // and the 404/200/502 cases above would all still pass (codex gate, finding 7).
+  it.each([401, 403])("still prefers the auth diagnosis for an empty %i", (status) => {
+    const d = classifyNonJson({
+      url: "http://remote.example:8188/upload/image",
+      status,
+      contentType: "",
+      body: "",
+    });
+    expect(d.kind).toBe("login");
+    expect(d.message).toMatch(/needs the credential/);
+  });
+});
+
+// The guard changes the SHAPE of the error the library throws, from a raw
+// SyntaxError to a NonJsonResponseError. Any predicate written against the old
+// shape silently answers "no" for the strongest evidence available — and
+// getObjectInfo has one, picking which of two failed attempts to report.
+describe("a first-hand diagnosis still wins over a retry blip", () => {
+  it("reports attempt 1's HTML diagnosis, not the retry's transport failure", async () => {
+    // Round 8 of the original #828 gate established this rule: when the first
+    // request PROVED a non-JSON answer and the retry merely hit a blip,
+    // surfacing the retry downgrades a known diagnosis to "server unavailable"
+    // and sends the user to check whether ComfyUI is running. The guard broke
+    // the predicate that enforced it.
+    let call = 0;
+    global.fetch = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return new Response("<!DOCTYPE html><html><body>gateway</body></html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+      }
+      throw Object.assign(new TypeError("fetch failed"), { code: "ECONNREFUSED" });
+    }) as unknown as typeof fetch;
+
+    const err = await getObjectInfo().then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(isNonJsonResponseError(err)).toBe(true);
+    expect((err as Error).message).toContain("HTML page");
+    expect((err as Error).message).not.toContain("fetch failed");
+  });
+});
+
+describe("the diagnosis URL is redacted (codex gate, finding 6)", () => {
+  it("redacts an OAuth redirect target without mangling the route", () => {
+    // Response.url is the url AFTER redirects, so an identity proxy that bounces
+    // the request to its SSO endpoint puts a live authorization code in it.
+    const out = redactUrlForDiagnosis(
+      "https://sso.example.com/callback?code=4/0AY0e-g7xQ&state=abc123&redirect_uri=/api",
+    );
+    expect(out).not.toContain("4/0AY0e-g7xQ");
+    expect(out).not.toContain("abc123");
+    // The part that identifies the route must survive — that is the whole point
+    // of the message.
+    expect(out).toContain("sso.example.com/callback");
+    expect(out).toContain("redirect_uri");
+  });
+
+  it("redacts a presigned-URL signature and userinfo", () => {
+    const signed = redactUrlForDiagnosis(
+      "https://s3.example.com/bucket/model.safetensors?X-Amz-Signature=deadbeefcafe&X-Amz-Expires=60",
+    );
+    expect(signed).not.toContain("deadbeefcafe");
+    expect(signed).toContain("X-Amz-Expires=60");
+
+    expect(redactUrlForDiagnosis("http://bob:hunter2@comfy.example.com/prompt")).not.toContain(
+      "hunter2",
+    );
+  });
+
+  it("redacts a token that rides in the PATH, per segment", () => {
+    const out = redactUrlForDiagnosis(
+      "https://gw.example.com/t/AbCdEf0123456789AbCdEf0123456789/internal/logs",
+    );
+    expect(out).not.toContain("AbCdEf0123456789AbCdEf0123456789");
+    expect(out).toContain("/internal/logs");
+  });
+
+  it("leaves an ordinary URL byte-identical", () => {
+    // The body scrubber's opaque-run pass would collapse this whole URL to
+    // "https:«redacted»" — a host+path IS a long run of the credential
+    // alphabet. Structural redaction is what makes the diagnosis survivable.
+    for (const clean of [
+      "https://comfy.example.com/api/v1/internal/logs",
+      "http://127.0.0.1:8188/internal/logs?clientId=comfyui-mcp",
+      "http://remote.example:8188/system_stats",
+    ]) {
+      expect(redactUrlForDiagnosis(clean)).toBe(clean);
+    }
+  });
+
+  it("withholds the query of an unparsable target rather than printing it", () => {
+    expect(redactUrlForDiagnosis("/internal/logs?token=secretvalue")).not.toContain("secretvalue");
+  });
+
+  it("reaches the message built by the live guard", () => {
+    // Wiring: the redaction must be applied where the diagnosis is BUILT, not
+    // only when a caller remembers to ask for it.
+    const d = classifyNonJson({
+      url: "https://gw.example.com/internal/logs?access_token=sk-live-abcdef123456",
+      status: 500,
+      contentType: "text/plain",
+      body: "boom",
+    });
+    expect(d.message).not.toContain("sk-live-abcdef123456");
+    expect(d.url).not.toContain("sk-live-abcdef123456");
+    expect(d.message).toContain("gw.example.com/internal/logs");
+  });
+});
+
+describe("the status reason phrase is carried (codex gate, finding 1)", () => {
+  it("keeps a CUSTOM phrase, which is often the most useful token present", () => {
+    const d = classifyNonJson({
+      url: "http://remote.example:8188/system_stats",
+      status: 503,
+      statusText: "Origin warming up",
+      contentType: "text/html",
+      body: "<html><body>please wait</body></html>",
+    });
+    expect(d.message).toContain("503 Origin warming up");
+  });
+
+  it("drops a STANDARD phrase, which only restates the code", () => {
+    const d = classifyNonJson({
+      url: "http://remote.example:8188/internal/logs",
+      status: 404,
+      statusText: "Not Found",
+      contentType: "",
+      body: "",
+    });
+    expect(d.message).toContain("answered 404 with");
+    expect(d.message).not.toContain("404 Not Found");
+  });
+
+  it("scrubs a credential a hostile proxy put in the reason phrase", () => {
+    const d = classifyNonJson({
+      url: "http://remote.example:8188/prompt",
+      status: 400,
+      statusText: "rejected token=sk-live-abcdef123456",
+      contentType: "",
+      body: "x",
+    });
+    expect(d.message).not.toContain("sk-live-abcdef123456");
   });
 });

--- a/src/__tests__/comfyui/client-fetch-json-guard.test.ts
+++ b/src/__tests__/comfyui/client-fetch-json-guard.test.ts
@@ -299,7 +299,52 @@ describe("the diagnosis URL is redacted (codex gate, finding 6)", () => {
     // The route and the parameter NAME still print — that is what identifies
     // the responder, and redacting them would defeat the diagnosis.
     expect(out).toContain("gw.example.com/internal/logs");
-    expect(out).toContain(param);
+    // Anchored: a bare toContain("t") is satisfied by "internal" and asserts
+    // nothing (review finding, test integrity).
+    expect(out).toContain(`?${param}=`);
+  });
+
+  // Review finding 2: dropping the value length-check for the WHOLE allowlist
+  // was wider than the long-filename evidence justified. Generic single words
+  // like `id`/`ref`/`name` are as likely to be a gateway's choice as ComfyUI's.
+  it.each([
+    ["id", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.sig"],
+    ["ref", "Zm9vYmFyYmF6cXV4MTIzNDU2Nzg5MA"],
+    ["name", "AKIAIOSFODNN7EXAMPLEwJalrXUtnFEMI"],
+  ])("still length-checks the generic allowlisted name %s", (param, secret) => {
+    expect(redactUrlForDiagnosis(`https://gw.example.com/l?${param}=${secret}`)).not.toContain(
+      secret,
+    );
+  });
+
+  it("redacts a secret nested inside a redirect_uri", () => {
+    // An arbitrary URL as a value: `:` and `?` are outside the opaque alphabet,
+    // so no length rule can see the nested credential. The name was dropped
+    // from the allowlist entirely instead.
+    const nested = encodeURIComponent("https://app.example/cb?session=s3cr3t-live");
+    expect(redactUrlForDiagnosis(`https://gw.example.com/l?redirect_uri=${nested}`)).not.toContain(
+      "s3cr3t-live",
+    );
+  });
+
+  // Review finding 4: a RELATIVE target reaches this too — client.ts passes
+  // "/settings", `/settings/${id}` and "/history" straight into readComfyJson.
+  it("gives a relative target the same path scrub as an absolute one", () => {
+    expect(redactUrlForDiagnosis("/t/AbCdEf0123456789AbCdEf0123456789/logs")).not.toContain(
+      "AbCdEf0123456789AbCdEf0123456789",
+    );
+    expect(redactUrlForDiagnosis("/logs;jsessionid=s3cr3t-live")).not.toContain("s3cr3t-live");
+    // …without disturbing the ordinary case.
+    expect(redactUrlForDiagnosis("/internal/logs")).toBe("/internal/logs");
+  });
+
+  // Review finding 5: `data:`/`blob:` PARSE, but their pathname setter is a
+  // spec'd no-op, so the path scrub silently did nothing while reporting that
+  // it had — the one fail-OPEN path in a fail-closed helper.
+  it("does not fail open on a non-http scheme", () => {
+    expect(
+      redactUrlForDiagnosis("data:text/plain;base64,QUJDREVGR0hJSktMTU5PUFFSU1RVVldY"),
+    ).not.toContain("QUJDREVGR0hJSktMTU5PUFFSU1RVVldY");
   });
 
   it("redacts userinfo and a fragment token", () => {

--- a/src/__tests__/comfyui/client-fetch-json-guard.test.ts
+++ b/src/__tests__/comfyui/client-fetch-json-guard.test.ts
@@ -275,30 +275,40 @@ describe("a first-hand diagnosis still wins over a retry blip", () => {
 });
 
 describe("the diagnosis URL is redacted (codex gate, finding 6)", () => {
-  it("redacts an OAuth redirect target without mangling the route", () => {
-    // Response.url is the url AFTER redirects, so an identity proxy that bounces
-    // the request to its SSO endpoint puts a live authorization code in it.
-    const out = redactUrlForDiagnosis(
-      "https://sso.example.com/callback?code=4/0AY0e-g7xQ&state=abc123&redirect_uri=/api",
-    );
-    expect(out).not.toContain("4/0AY0e-g7xQ");
-    expect(out).not.toContain("abc123");
-    // The part that identifies the route must survive — that is the whole point
-    // of the message.
-    expect(out).toContain("sso.example.com/callback");
-    expect(out).toContain("redirect_uri");
+  // The first version of the redactor used a list of credential-ish parameter
+  // NAMES. Probing it with credential-carrying URLs leaked NINE of sixteen,
+  // because the set of names a gateway can pick is open. Each name below is one
+  // that actually leaked; they are kept as the regression set for the inversion
+  // to a fail-closed allowlist.
+  it.each([
+    ["oauth code", "code"],
+    ["a one-letter name", "t"],
+    ["jwt", "jwt"],
+    ["ticket", "ticket"],
+    ["nonce", "nonce"],
+    ["otp", "otp"],
+    ["hmac", "hmac"],
+    ["bearer", "bearer"],
+    ["SAMLResponse", "SAMLResponse"],
+    ["X-Amz-Credential", "X-Amz-Credential"],
+    ["a capitalised Signature", "Signature"],
+    ["an unfamiliar name entirely", "wibble"],
+  ])("redacts a credential in %s", (_label, param) => {
+    const out = redactUrlForDiagnosis(`https://gw.example.com/internal/logs?${param}=s3cr3t-live`);
+    expect(out).not.toContain("s3cr3t-live");
+    // The route and the parameter NAME still print — that is what identifies
+    // the responder, and redacting them would defeat the diagnosis.
+    expect(out).toContain("gw.example.com/internal/logs");
+    expect(out).toContain(param);
   });
 
-  it("redacts a presigned-URL signature and userinfo", () => {
-    const signed = redactUrlForDiagnosis(
-      "https://s3.example.com/bucket/model.safetensors?X-Amz-Signature=deadbeefcafe&X-Amz-Expires=60",
-    );
-    expect(signed).not.toContain("deadbeefcafe");
-    expect(signed).toContain("X-Amz-Expires=60");
-
+  it("redacts userinfo and a fragment token", () => {
     expect(redactUrlForDiagnosis("http://bob:hunter2@comfy.example.com/prompt")).not.toContain(
       "hunter2",
     );
+    expect(
+      redactUrlForDiagnosis("https://gw.example.com/cb#access_token=s3cr3t-live"),
+    ).not.toContain("s3cr3t-live");
   });
 
   it("redacts a token that rides in the PATH, per segment", () => {
@@ -307,6 +317,33 @@ describe("the diagnosis URL is redacted (codex gate, finding 6)", () => {
     );
     expect(out).not.toContain("AbCdEf0123456789AbCdEf0123456789");
     expect(out).toContain("/internal/logs");
+  });
+
+  it("redacts a matrix parameter, which is under the opaque-run threshold", () => {
+    // `;jsessionid=…` is part of the PATH, not the query, and short enough to
+    // slip past a length rule. It was one of the nine leaks.
+    const out = redactUrlForDiagnosis("https://gw.example.com/logs;jsessionid=s3cr3t-live/x");
+    expect(out).not.toContain("s3cr3t-live");
+    expect(out).toContain("/logs;");
+  });
+
+  it("does not lose a repeated query key while redacting", () => {
+    // `searchParams.set` collapses repeats onto the first occurrence, which
+    // would silently drop a value while claiming only to redact one.
+    const out = redactUrlForDiagnosis("https://gw.example.com/l?a=1&code=s3cr3t-live&a=2");
+    expect(out).not.toContain("s3cr3t-live");
+    expect(out.match(/(^|[?&])a=/g)).toHaveLength(2);
+  });
+
+  it("keeps the parameters this codebase actually sends", () => {
+    // Fail-closed must not cost the diagnosis its usefulness on OUR OWN urls —
+    // these are the ones that appear in real messages.
+    for (const clean of [
+      "http://127.0.0.1:8188/view?filename=cat.png&type=output&subfolder=&clientId=comfyui-mcp",
+      "http://127.0.0.1:8188/api/userdata?dir=workflows&recurse=true&split=false",
+    ]) {
+      expect(redactUrlForDiagnosis(clean)).toBe(clean);
+    }
   });
 
   it("leaves an ordinary URL byte-identical", () => {

--- a/src/__tests__/comfyui/client-fetch-json-guard.test.ts
+++ b/src/__tests__/comfyui/client-fetch-json-guard.test.ts
@@ -346,6 +346,17 @@ describe("the diagnosis URL is redacted (codex gate, finding 6)", () => {
     }
   });
 
+  it("keeps a LONG filename, which a length rule would have eaten", () => {
+    // Caught by live-testing a missing /view: `definitely-not-here-828.png` is
+    // 27 characters of the credential alphabet, so an opaque-run check on the
+    // VALUE redacted the one fact the message exists to report. The name is on
+    // the allowlist because we know it carries a path, so its length says
+    // nothing.
+    const url =
+      "http://127.0.0.1:8188/view?filename=a-really-quite-long-output-filename-00042.png&type=input&subfolder=";
+    expect(redactUrlForDiagnosis(url)).toBe(url);
+  });
+
   it("leaves an ordinary URL byte-identical", () => {
     // The body scrubber's opaque-run pass would collapse this whole URL to
     // "https:«redacted»" — a host+path IS a long run of the credential

--- a/src/__tests__/comfyui/json-guard-base-url-redaction.test.ts
+++ b/src/__tests__/comfyui/json-guard-base-url-redaction.test.ts
@@ -1,0 +1,52 @@
+// Review finding 1 — the diagnosis redacted the FAILING url and then, three
+// clauses later, printed the CONFIGURED BASE url verbatim in its own advice:
+//
+//   http://host:8188/«redacted»/system_stats answered 500 with …
+//   … The check is that http://host:8188/AbCdEf0123456789AbCdEf0123456789/system_stats returns JSON …
+//
+// Same string, redacted and then printed, inside one sentence.
+//
+// `parseComfyUIUrl` keeps only hostname and pathname, so the base can never
+// carry userinfo or a query — but a PATH PREFIX is exactly the tunnel/gateway
+// shape the path scrub was added for (a quick-tunnel or gateway route can be an
+// opaque token), so the leak was real and bounded rather than theoretical.
+//
+// This lives in its OWN file because the assertion needs a base URL that
+// actually carries a token, and the sibling suite's module mock returns a clean
+// one — under which the test would pass whether or not the fix is present.
+
+import { describe, expect, it, vi } from "vitest";
+
+// `vi.mock` is hoisted above every const, so the token has to be hoisted too.
+const { TOKEN } = vi.hoisted(() => ({ TOKEN: "AbCdEf0123456789AbCdEf0123456789" }));
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: `/${TOKEN}` },
+  getComfyUIApiHost: () => "gateway.example",
+  getComfyUIBasePath: () => `/${TOKEN}`,
+  // A tunnel/gateway whose route prefix IS the credential.
+  getComfyUIBaseUrl: () => `https://gateway.example/${TOKEN}`,
+  getComfyUIAuthHeaders: () => ({}),
+  isCloudMode: () => false,
+  isRemoteMode: () => true,
+}));
+
+import { classifyNonJson } from "../../comfyui/json-guard.js";
+
+describe("the diagnosis does not print the configured base URL raw", () => {
+  it("redacts the token in its own 'the check is that …' advice", () => {
+    const d = classifyNonJson({
+      url: `https://gateway.example/${TOKEN}/internal/logs`,
+      status: 500,
+      contentType: "text/plain",
+      body: "boom",
+    });
+
+    // The whole message, not just the url field: the advice clause is the part
+    // that regressed, and it sits well after the url.
+    expect(d.message).not.toContain(TOKEN);
+    // …while still saying the thing it exists to say.
+    expect(d.message).toContain("/system_stats returns JSON");
+    expect(d.message).toContain("gateway.example");
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -22,6 +22,7 @@ import {
   isNonJsonResponseError,
   looksLikeHtmlParsedAsJson,
   NonJsonResponseError,
+  provesNonJsonAnswer,
   readComfyJson,
   redactErrorMessage,
   rethrowWithJsonDiagnosis,
@@ -273,7 +274,14 @@ export async function getObjectInfo(): Promise<ObjectInfo> {
         // only the retry would downgrade a known #828 diagnosis to "server
         // unavailable" and send the user to check whether ComfyUI is running
         // (codex gate, round 8, finding 2).
-        const toReport = looksLikeHtmlParsedAsJson(retryErr) ? retryErr : looksLikeHtmlParsedAsJson(err) ? err : retryErr;
+        //
+        // `provesNonJsonAnswer`, not `looksLikeHtmlParsedAsJson`: since
+        // guardClientFetch the library's parse failure arrives as a
+        // NonJsonResponseError carrying no parser text, so the old predicate
+        // answered "no" for the strongest evidence available and this picker
+        // fell through to `retryErr` every time — reintroducing the very
+        // downgrade round 8 fixed.
+        const toReport = provesNonJsonAnswer(retryErr) ? retryErr : provesNonJsonAnswer(err) ? err : retryErr;
         return await rethrowWithJsonDiagnosis(toReport, `${getComfyUIBaseUrl()}/object_info`);
       }
     }

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -18,6 +18,8 @@ import { comfyuiFetch } from "./fetch.js";
 import {
   classifyNonJson,
   fetchComfyJson,
+  guardClientFetch,
+  isNonJsonResponseError,
   looksLikeHtmlParsedAsJson,
   NonJsonResponseError,
   readComfyJson,
@@ -81,7 +83,12 @@ export function getClient(): Client {
       clientId: "comfyui-mcp",
       // Inject generic auth headers (COMFYUI_AUTH_*) on the library's own HTTP
       // calls; a no-op when unset. Node 22+ provides global WebSocket.
-      fetch: comfyuiFetch,
+      //
+      // Wrapped so the library's non-2xx path — which calls `res.json()` on the
+      // ERROR body and lets a bare SyntaxError replace its own error, losing the
+      // status and the URL with it — reports what actually answered instead
+      // (#828, #1160). See guardClientFetch.
+      fetch: guardClientFetch(comfyuiFetch),
     });
     logger.info("ComfyUI client created", {
       host: getComfyUIApiHost(),
@@ -700,6 +707,12 @@ export async function getLogs(): Promise<string[]> {
     try {
       text = await getClient().fetchApi("/internal/logs").then((r) => r.text());
     } catch (err2) {
+      // A DIAGNOSED non-JSON answer is not a connection failure — the server (or
+      // whatever is in front of it) replied, and the diagnosis already names the
+      // endpoint, the status and what answered. Wrapping it in a ConnectionError
+      // titled "Failed to fetch" contradicted its own contents and sent readers
+      // to check whether ComfyUI was up when it demonstrably was (#828).
+      if (isNonJsonResponseError(err2)) throw err2;
       const detail = err2 instanceof Error ? err2.message : String(err2);
       throw new ConnectionError(
         `Failed to fetch ComfyUI logs after reconnect retry: ${detail}`,

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -862,6 +862,7 @@ export async function getSetting(id: string): Promise<unknown> {
       classifyNonJson({
         url,
         status: res.status,
+        statusText: res.statusText,
         contentType: res.headers.get("content-type") ?? "",
         body: text,
       }),

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -2,7 +2,7 @@ import { getComfyUIAuthHeaders } from "../config.js";
 import { describeFetchFailure, isBareFetchFailure } from "../utils/errors.js";
 
 /** The request target, for the diagnostic. Never throws on an odd input. */
-function targetOf(input: string | URL | Request): string {
+export function targetOf(input: string | URL | Request): string {
   try {
     if (typeof input === "string") return input;
     if (input instanceof URL) return input.href;

--- a/src/comfyui/json-guard.ts
+++ b/src/comfyui/json-guard.ts
@@ -295,6 +295,108 @@ export function scrubSecretShapedText(text: string): string | null {
   return out;
 }
 
+/**
+ * Parameter names whose VALUE is a credential often enough that printing it is
+ * not worth the diagnosis. Matched as a SUBSTRING of the name, because gateways
+ * prefix and suffix freely — `x-amz-signature`, `access_token`,
+ * `cf_authorization`, `id_token` are all the same idea wearing different names,
+ * and an exact-match list would have to anticipate every one of them.
+ */
+const CREDENTIAL_PARAM_WORDS = [
+  "token",
+  "secret",
+  "password",
+  "passwd",
+  "pwd",
+  "signature",
+  "sig",
+  "credential",
+  "auth",
+  "session",
+  "apikey",
+  "api_key",
+  "key",
+  "code",
+  "state",
+  "assertion",
+  "refresh",
+];
+
+/** A single opaque run long enough to be a credential and nothing else. Reused
+ *  from the body scrubber's pass 3, but applied PER COMPONENT so an ordinary
+ *  host+path — which is one long run of exactly this alphabet — survives. */
+const OPAQUE_RUN = /^[A-Za-z0-9\-._~+/=%]{24,}$/;
+
+function isCredentialish(name: string, value: string): boolean {
+  const n = name.toLowerCase();
+  return CREDENTIAL_PARAM_WORDS.some((w) => n.includes(w)) || OPAQUE_RUN.test(value);
+}
+
+/**
+ * A URL that is safe to put in an error message (codex gate, finding 6).
+ *
+ * `bodyPrefixOf` scrubs the BODY, and until now nothing scrubbed the URL —
+ * which was fine while every diagnosis was built from a base URL we composed
+ * ourselves, and stopped being fine once `guardClientFetch` started reporting
+ * `Response.url`. That is the url AFTER redirects, so an identity proxy that
+ * bounces the request to an SSO endpoint (`?code=…&state=…`), or a gateway that
+ * hands back a presigned object URL (`?X-Amz-Signature=…`), puts a live
+ * credential in it. The diagnosis is shown to the agent and routinely pasted
+ * into bug reports.
+ *
+ * `scrubSecretShapedText` cannot be used for this: its opaque-run pass matches
+ * 24+ characters of an alphabet that includes `/`, `.` and `-`, so an ordinary
+ * `https://comfy.example.com/api/v1/internal/logs` collapses to `https:«redacted»`
+ * and the diagnosis loses the one fact it exists to report. This redacts by
+ * URL STRUCTURE instead — userinfo, credential-shaped query/fragment values,
+ * and credential-shaped path segments — and leaves origin and route intact.
+ *
+ * Returns the ORIGINAL string when nothing needed redacting, so a clean URL is
+ * never reformatted by a round-trip through the URL parser.
+ */
+export function redactUrlForDiagnosis(raw: string): string {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    // Not absolute (a relative path from a test double, or a malformed target).
+    // There is no structure to reason about, so keep everything up to the first
+    // query/fragment and say plainly that the rest was dropped rather than
+    // printing an unexamined credential.
+    const cut = raw.search(/[?#]/);
+    return cut === -1 ? raw : `${raw.slice(0, cut)} (query withheld: unparsable URL)`;
+  }
+
+  let changed = false;
+  if (u.username || u.password) {
+    u.username = REDACTED;
+    u.password = "";
+    changed = true;
+  }
+  for (const [name, value] of [...u.searchParams]) {
+    if (value && isCredentialish(name, value)) {
+      u.searchParams.set(name, REDACTED);
+      changed = true;
+    }
+  }
+  // The FRAGMENT is where an OAuth implicit flow puts its access token, and it
+  // is never needed to identify a route. Any fragment carrying `=` goes.
+  if (u.hash.includes("=")) {
+    u.hash = REDACTED;
+    changed = true;
+  }
+  // A token can also ride in the path (`/api/v1/<opaque>/logs`). Judge each
+  // segment on its own so a long ROUTE is not mistaken for a long secret.
+  const segments = u.pathname.split("/");
+  const scrubbed = segments.map((s) => (OPAQUE_RUN.test(s) ? REDACTED : s));
+  if (scrubbed.some((s, i) => s !== segments[i])) {
+    u.pathname = scrubbed.join("/");
+    changed = true;
+  }
+
+  return changed ? u.href : raw;
+}
+
 /** Back-compat alias: the known-value redaction is now one pass of the
  *  shape-based scrubber. Callers that only want "is this safe to print" should
  *  use `scrubSecretShapedText`/`bodyPrefixOf`. */
@@ -370,16 +472,69 @@ function looksLikeProxyErrorPage(body: string): boolean {
 }
 
 /**
+ * `503` or `503 Origin warming up` — the code, plus the reason phrase when the
+ * responder wrote one worth reading.
+ *
+ * A CUSTOM phrase is often the single most useful token in the whole response:
+ * a CDN's "Origin warming up", a gateway's "Backend read timeout". The standard
+ * phrase for a code is noise beside the code itself, so it is dropped.
+ */
+function describeStatus(status: number, statusText?: string): string {
+  const text = (statusText ?? "").trim();
+  if (!text) return String(status);
+  if (STANDARD_REASON_PHRASES.has(text.toLowerCase())) return String(status);
+  // A phrase is a short label, not a document. Anything longer is a body that
+  // escaped into the status line and is not worth the room.
+  const clipped = text.length > 80 ? `${text.slice(0, 80)}…` : text;
+  // Reason phrases are attacker-influenceable on a hostile proxy, and this one
+  // is interpolated into a message the agent reads. Same scrub the body gets.
+  const safe = scrubSecretShapedText(clipped);
+  return safe === null ? String(status) : `${status} ${safe}`;
+}
+
+/** Reason phrases that merely restate their code. Lowercased for comparison. */
+const STANDARD_REASON_PHRASES: ReadonlySet<string> = new Set([
+  "ok",
+  "no content",
+  "moved permanently",
+  "found",
+  "not modified",
+  "bad request",
+  "unauthorized",
+  "forbidden",
+  "not found",
+  "method not allowed",
+  "request timeout",
+  "conflict",
+  "payload too large",
+  "unprocessable entity",
+  "too many requests",
+  "internal server error",
+  "not implemented",
+  "bad gateway",
+  "service unavailable",
+  "gateway timeout",
+]);
+
+/**
  * Classify a non-JSON response body. Pure (no I/O) so the classification rules
  * are unit-testable without a server.
  */
 export function classifyNonJson(args: {
   url: string;
   status: number;
+  /** The reason phrase, when the responder sent a meaningful one. `503 Origin
+   *  warming up` says more than `503`, and it was being dropped. Standard
+   *  phrases add nothing next to the code and are omitted. */
+  statusText?: string;
   contentType: string;
   body: string;
 }): NonJsonDiagnosis {
-  const { url, status, contentType, body } = args;
+  const { status, contentType, body } = args;
+  // Redacted HERE rather than at the call sites, so no future caller can
+  // reintroduce the leak by composing a url that carries a credential.
+  const url = redactUrlForDiagnosis(args.url);
+  const reason = describeStatus(status, args.statusText);
   const bodyPrefix = bodyPrefixOf(body);
   // EVIDENCE, not the header's claim. `claimsHtml` is reported as a claim; only
   // `html` (the body really is markup) may drive a diagnosis.
@@ -481,7 +636,7 @@ export function classifyNonJson(args: {
           ? `a ${contentType} body that did not parse as JSON`
           : "a body that did not parse as JSON";
   const message =
-    `${url} answered ${status} with ${what} where JSON was expected. This means ${cause}. ` +
+    `${url} answered ${reason} with ${what} where JSON was expected. This means ${cause}. ` +
     `Content-Type: ${contentType || "(none)"}. Body starts: ${bodyPrefix || "(empty)"}. ` +
     `Confirm the configured ComfyUI base URL really is a ComfyUI API root — a URL that loads the ComfyUI UI in a browser is not proof, because the UI is served by the same catch-all that produced this page. ` +
     `The check is that ${getComfyUIBaseUrl()}/system_stats returns JSON with a "system"/"devices" shape; if it returns HTML too, the base URL, its path prefix, or the proxy's route map is wrong` +
@@ -523,26 +678,35 @@ export async function readComfyJson<T = unknown>(
     parsed = JSON.parse(body);
   } catch {
     throw new NonJsonResponseError(
-      classifyNonJson({ url: opts.url, status: res.status, contentType, body }),
+      classifyNonJson({
+        url: opts.url,
+        status: res.status,
+        statusText: res.statusText,
+        contentType,
+        body,
+      }),
     );
   }
+  // Every url that reaches a MESSAGE goes through the same redaction as the one
+  // in classifyNonJson — these two paths build their text by hand.
+  const safeUrl = redactUrlForDiagnosis(opts.url);
   if (!res.ok) {
     // Valid JSON, but an error status — surface it verbatim rather than as a
     // shape failure; the server told us something specific.
     throw new ComfyUIError(
-      `${opts.url} returned ${res.status}: ${bodyPrefixOf(body)}`,
+      `${safeUrl} returned ${describeStatus(res.status, res.statusText)}: ${bodyPrefixOf(body)}`,
       "HTTP_ERROR",
     );
   }
   if (opts.expectShape && !opts.expectShape(parsed)) {
     throw new NonJsonResponseError({
       kind: "not-json",
-      url: opts.url,
+      url: safeUrl,
       status: res.status,
       contentType,
       bodyPrefix: bodyPrefixOf(body),
       message:
-        `${opts.url} answered ${res.status} with valid JSON that is not ${opts.shapeHint ?? "the expected document"}. ` +
+        `${safeUrl} answered ${res.status} with valid JSON that is not ${opts.shapeHint ?? "the expected document"}. ` +
         `Something other than ComfyUI is very likely answering this route (an API gateway's own JSON error envelope, or a different service on this host). ` +
         `Body starts: ${bodyPrefixOf(body)}.` +
         (jsonish ? "" : ` (Content-Type was ${contentType || "(none)"}.)`),
@@ -612,6 +776,7 @@ export function guardClientFetch(
             classifyNonJson({
               url,
               status: res.status,
+              statusText: res.statusText,
               contentType: res.headers.get("content-type") ?? "",
               body,
             }),
@@ -688,6 +853,20 @@ export function redactedError(err: unknown): unknown {
  * signature of a client library that called `res.json()` itself and so gave us
  * no URL, status, or content type to report.
  */
+/**
+ * Did this error PROVE the response was not JSON?
+ *
+ * Two shapes prove it now, and code that picks between competing errors has to
+ * accept both. `looksLikeHtmlParsedAsJson` recognises a raw parser message, which
+ * was the only shape available while the client library did the parsing. Since
+ * `guardClientFetch`, that same failure arrives as a NonJsonResponseError whose
+ * message contains no parser text at all — so a predicate written against the
+ * old shape silently answers "no" for the strongest evidence we have.
+ */
+export function provesNonJsonAnswer(err: unknown): boolean {
+  return isNonJsonResponseError(err) || looksLikeHtmlParsedAsJson(err);
+}
+
 export function looksLikeHtmlParsedAsJson(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   // Require a MARKUP indicator, not merely "is not valid JSON" (codex gate,
@@ -735,6 +914,12 @@ export async function diagnoseComfyEndpoint(url: string): Promise<NonJsonDiagnos
  * happened to be conclusive).
  */
 export async function rethrowWithJsonDiagnosis(err: unknown, url: string): Promise<never> {
+  // Already a FIRST-HAND diagnosis of the response that actually failed — since
+  // guardClientFetch, the library's own parse throws one of these. Re-probing
+  // would replace evidence from the failing response with a guess from a
+  // different, later one, which is the exact trade this function's own comment
+  // warns against.
+  if (isNonJsonResponseError(err)) throw err;
   if (looksLikeHtmlParsedAsJson(err)) {
     const diagnosis = await diagnoseComfyEndpoint(url);
     if (diagnosis) {
@@ -752,7 +937,7 @@ export async function rethrowWithJsonDiagnosis(err: unknown, url: string): Promi
         ...diagnosis,
         message:
           `The request failed while parsing the response as JSON: ${original} ` +
-          `A follow-up probe of ${url} — a separate request, so not necessarily the same response — found: ${diagnosis.message}`,
+          `A follow-up probe of ${redactUrlForDiagnosis(url)} — a separate request, so not necessarily the same response — found: ${diagnosis.message}`,
       });
     }
   }

--- a/src/comfyui/json-guard.ts
+++ b/src/comfyui/json-guard.ts
@@ -64,6 +64,17 @@ export function isNonJsonResponseError(err: unknown): err is NonJsonResponseErro
 const REDACTED = "«redacted»";
 
 /**
+ * The same marker, spelled for a URL component.
+ *
+ * `«redacted»` is non-ASCII, so putting it in a query value, a path segment or
+ * userinfo gets it percent-encoded to `%C2%ABredacted%C2%BB` on the way out.
+ * That leaves one message carrying two spellings of the same word, and — the
+ * part that actually costs something — a triage grep for `«redacted»` silently
+ * misses every URL occurrence. ASCII here keeps one greppable spelling.
+ */
+const URL_REDACTED = "REDACTED";
+
+/**
  * Collapse a body to a short single-line prefix for the message.
  *
  * The prefix is diagnostic — it is what lets a user recognise the page that
@@ -343,9 +354,35 @@ const SHOWABLE_PARAMS: ReadonlySet<string> = new Set([
   "input",
   "response_type",
   "scope",
-  "redirect_uri",
   "code_challenge_method",
 ]);
+
+/**
+ * The subset of SHOWABLE_PARAMS whose values are legitimately LONG free text —
+ * user-supplied paths and titles — and so must not be length-checked.
+ *
+ * Everything else on the allowlist keeps the opaque-run check on its value. The
+ * names there are generic enough (`id`, `ref`, `type`, `mode`, `input`, `raw`,
+ * `channel`) that a third-party gateway is as likely to pick one as ComfyUI is,
+ * and a JWT under `?id=` or an access key under `?ref=` should not print merely
+ * because ComfyUI also happens to use that word. Dropping the check for ALL 31
+ * names — which is what the long-filename fix did — was wider than the evidence
+ * justified (review finding 2).
+ *
+ * `redirect_uri` was removed from the allowlist entirely rather than added here:
+ * its value is an arbitrary URL, so a nested `?session=…` prints whole and no
+ * length rule can see it, `:` and `?` being outside the opaque alphabet.
+ */
+const LONG_TEXT_PARAMS: ReadonlySet<string> = new Set([
+  "filename",
+  "subfolder",
+  "dir",
+  "template",
+]);
+// `name` is deliberately NOT here, though it was in the review's suggested set:
+// probing found `?name=AKIAIOSFODNN7EXAMPLEwJalrXUtnFEMI` printing in full. A
+// pack or model name long enough to trip the length check is rare and costs
+// only a redacted word in a diagnostic; an access key printing costs more.
 
 /** A single opaque run long enough to be a credential and nothing else. Reused
  *  from the body scrubber's pass 3, but applied PER COMPONENT so an ordinary
@@ -353,24 +390,23 @@ const SHOWABLE_PARAMS: ReadonlySet<string> = new Set([
 const OPAQUE_RUN = /^[A-Za-z0-9\-._~+/=%]{24,}$/;
 
 /**
- * A parameter value may be printed only if we recognise the NAME.
+ * A parameter value may be printed only if we recognise the NAME, and — unless
+ * the name is one that legitimately carries long free text — only if the value
+ * is not itself credential-shaped.
  *
- * The value is deliberately NOT length-checked. An earlier version also required
- * it not to match the opaque-run pattern, on the reasoning that a known-good name
- * carrying a 40-character blob is still not worth printing — but the pattern's
- * alphabet includes letters, digits, `-`, `.` and `_`, so an ordinary filename of
- * 24 characters or more matches it. Live-testing a missing `/view` produced:
+ * The long-text exemption exists because live-testing a missing `/view` produced
  *
  *     /view?filename=«redacted»&type=input&subfolder=
  *
- * which redacts the single most useful fact in the message. These names are on
- * the list precisely because we know what they carry — user-supplied paths and
- * identifiers, never credentials — so the length of the value says nothing. Any
- * name NOT on the list is still redacted whatever its value looks like, which is
- * where the fail-closed protection actually lives.
+ * — the opaque-run alphabet is letters, digits, `-`, `.` and `_`, so any
+ * filename of 24 characters or more matched it, and the message threw away the
+ * single most useful fact it had. The exemption is scoped to LONG_TEXT_PARAMS
+ * rather than applied to the whole allowlist: a JWT under `?id=` is still a JWT.
  */
-function isShowableParam(name: string): boolean {
-  return SHOWABLE_PARAMS.has(name.toLowerCase());
+function isShowableParam(name: string, value: string): boolean {
+  const n = name.toLowerCase();
+  if (!SHOWABLE_PARAMS.has(n)) return false;
+  return LONG_TEXT_PARAMS.has(n) || !OPAQUE_RUN.test(value);
 }
 
 /**
@@ -383,12 +419,12 @@ function isShowableParam(name: string): boolean {
  * way, because that is the route and the route is the diagnosis.
  */
 function scrubPathSegment(segment: string): string {
-  if (OPAQUE_RUN.test(segment)) return REDACTED;
+  if (OPAQUE_RUN.test(segment)) return URL_REDACTED;
   if (!segment.includes(";") && !segment.includes("=")) return segment;
   const [head, ...matrix] = segment.split(";");
   const eq = head.indexOf("=");
-  const safeHead = eq === -1 ? head : `${head.slice(0, eq)}=${REDACTED}`;
-  return matrix.length > 0 ? `${safeHead};${REDACTED}` : safeHead;
+  const safeHead = eq === -1 ? head : `${head.slice(0, eq)}=${URL_REDACTED}`;
+  return matrix.length > 0 ? `${safeHead};${URL_REDACTED}` : safeHead;
 }
 
 /**
@@ -411,10 +447,13 @@ function scrubPathSegment(segment: string): string {
  *
  *   - userinfo                → always redacted
  *   - query/fragment values   → redacted unless the NAME is one this codebase
- *                               sends (see SHOWABLE_PARAMS) and the value is not
- *                               itself credential-shaped
+ *                               sends (SHOWABLE_PARAMS); for those, the value is
+ *                               additionally length-checked unless the name is
+ *                               one that carries long free text (LONG_TEXT_PARAMS)
  *   - path segments           → redacted when opaque, or when carrying a matrix
- *                               parameter (`;jsessionid=…`)
+ *                               parameter (`;jsessionid=…`); applied to a
+ *                               RELATIVE target too, not only an absolute one
+ *   - non-http(s) schemes     → refused outright rather than parsed
  *   - origin, route, param NAMES → always kept; they are the diagnosis
  *
  * Residual, stated rather than papered over: a SHORT secret sitting in a bare
@@ -426,21 +465,34 @@ function scrubPathSegment(segment: string): string {
  * never reformatted by a round-trip through the URL parser.
  */
 export function redactUrlForDiagnosis(raw: string): string {
-  let u: URL;
+  let u: URL | null = null;
   try {
-    u = new URL(raw);
+    const parsed = new URL(raw);
+    // `data:`, `blob:` and `about:` DO parse, but they are "cannot-be-a-base"
+    // URLs whose `pathname` setter is a spec'd silent no-op — so the path scrub
+    // below would report success and change nothing, the sole fail-OPEN path in
+    // a function documented as fail-closed (review finding 5). A ComfyUI target
+    // is always http(s); anything else is refused rather than trusted.
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") u = parsed;
   } catch {
-    // Not absolute (a relative path from a test double, or a malformed target).
-    // There is no structure to reason about, so keep everything up to the first
-    // query/fragment and say plainly that the rest was dropped rather than
-    // printing an unexamined credential.
+    u = null;
+  }
+  if (!u) {
+    // Relative (`/settings/<id>`, a test double's target), malformed, or an
+    // opaque scheme. There is no origin to reason about, but a relative path can
+    // still carry an opaque segment or a matrix parameter, so it gets the SAME
+    // per-segment scrub as an absolute one (review finding 4) — an asymmetry
+    // here is a trap for the next caller. The query/fragment cannot be parsed
+    // safely, so it is withheld rather than printed unexamined.
     const cut = raw.search(/[?#]/);
-    return cut === -1 ? raw : `${raw.slice(0, cut)} (query withheld: unparsable URL)`;
+    const path = cut === -1 ? raw : raw.slice(0, cut);
+    const scrubbedPath = path.split("/").map(scrubPathSegment).join("/");
+    return cut === -1 ? scrubbedPath : `${scrubbedPath} (query withheld: unparsable URL)`;
   }
 
   let changed = false;
   if (u.username || u.password) {
-    u.username = REDACTED;
+    u.username = URL_REDACTED;
     u.password = "";
     changed = true;
   }
@@ -450,8 +502,8 @@ export function redactUrlForDiagnosis(raw: string): string {
   const rebuilt = new URLSearchParams();
   let paramsChanged = false;
   for (const [name, value] of u.searchParams) {
-    if (value && !isShowableParam(name)) {
-      rebuilt.append(name, REDACTED);
+    if (value && !isShowableParam(name, value)) {
+      rebuilt.append(name, URL_REDACTED);
       paramsChanged = true;
     } else {
       rebuilt.append(name, value);
@@ -464,7 +516,7 @@ export function redactUrlForDiagnosis(raw: string): string {
   // The FRAGMENT is where an OAuth implicit flow puts its access token, and it
   // is never needed to identify a route. Any fragment carrying `=` goes.
   if (u.hash.includes("=")) {
-    u.hash = REDACTED;
+    u.hash = URL_REDACTED;
     changed = true;
   }
   // A token can also ride in the path (`/api/v1/<opaque>/logs`, or a
@@ -722,7 +774,7 @@ export function classifyNonJson(args: {
     `${url} answered ${reason} with ${what} where JSON was expected. This means ${cause}. ` +
     `Content-Type: ${contentType || "(none)"}. Body starts: ${bodyPrefix || "(empty)"}. ` +
     `Confirm the configured ComfyUI base URL really is a ComfyUI API root — a URL that loads the ComfyUI UI in a browser is not proof, because the UI is served by the same catch-all that produced this page. ` +
-    `The check is that ${getComfyUIBaseUrl()}/system_stats returns JSON with a "system"/"devices" shape; if it returns HTML too, the base URL, its path prefix, or the proxy's route map is wrong` +
+    `The check is that ${redactUrlForDiagnosis(getComfyUIBaseUrl())}/system_stats returns JSON with a "system"/"devices" shape; if it returns HTML too, the base URL, its path prefix, or the proxy's route map is wrong` +
     // The credential instruction must follow the same evidence rule as the
     // diagnosis above. Only a body-confirmed sign-in page justifies "give it to
     // the gateway"; a bare 401/403 could equally be ComfyUI's own auth layer, and
@@ -829,6 +881,13 @@ export async function readComfyJson<T = unknown>(
  * original `json()` would have, so `text()`, `body` and `bodyUsed` are unchanged
  * for every caller that does not call `json()` — including `readComfyJson`,
  * which reads `text()` and keeps its own richer shape checking.
+ *
+ * KNOWN GAP, written down because the override is otherwise invisible: it is an
+ * OWN property of this Response, so it does NOT survive `res.clone()` or
+ * `new Response(res.body)` — a clone's `json()` is the prototype's again and
+ * throws a bare SyntaxError. Nothing in src/ clones a guarded response today
+ * (checked), so this is latent rather than live; anything that starts to should
+ * read `text()` and classify it directly instead.
  *
  * Applied to ALL statuses, not just the ones the library throws on: a 200 that
  * carries an HTML catch-all is the same defect one layer over, and the override
@@ -981,7 +1040,13 @@ export async function diagnoseComfyEndpoint(url: string): Promise<NonJsonDiagnos
       JSON.parse(body);
       return null; // it parses now — we cannot claim the earlier body was HTML
     } catch {
-      return classifyNonJson({ url, status: res.status, contentType, body });
+      return classifyNonJson({
+        url,
+        status: res.status,
+        statusText: res.statusText,
+        contentType,
+        body,
+      });
     }
   } catch {
     return null; // probe failed; we learned nothing and must not invent a cause

--- a/src/comfyui/json-guard.ts
+++ b/src/comfyui/json-guard.ts
@@ -296,40 +296,85 @@ export function scrubSecretShapedText(text: string): string | null {
 }
 
 /**
- * Parameter names whose VALUE is a credential often enough that printing it is
- * not worth the diagnosis. Matched as a SUBSTRING of the name, because gateways
- * prefix and suffix freely — `x-amz-signature`, `access_token`,
- * `cf_authorization`, `id_token` are all the same idea wearing different names,
- * and an exact-match list would have to anticipate every one of them.
+ * Query parameters worth PRINTING, which is the only list that can be complete.
+ *
+ * The first version of this went the other way — a list of credential-ish NAMES
+ * (`token`, `secret`, `signature`, …) to redact. Probing it with sixteen
+ * credential-carrying URLs leaked nine of them: `?t=`, `?jwt=`, `?ticket=`,
+ * `?nonce=`, `?otp=`, `?hmac=`, `?bearer=`, `?SAMLResponse=` and a
+ * `;jsessionid=` matrix parameter all sailed through, because the set of names
+ * a gateway might use for a credential is open and the set I can think of is
+ * not. That is the same failure the credential-encoding list in
+ * `reflectionVariants` documents above: enumerate a family by hand and you miss
+ * a member.
+ *
+ * So this is inverted and FAILS CLOSED. Only parameters this codebase itself
+ * sends to ComfyUI are shown; every other value is redacted whatever it is
+ * called. The cost is bounded and small — the origin, the path and every
+ * parameter NAME still print, which is what identifies the responder — while
+ * the benefit is that an unfamiliar parameter cannot leak by default.
  */
-const CREDENTIAL_PARAM_WORDS = [
-  "token",
-  "secret",
-  "password",
-  "passwd",
-  "pwd",
-  "signature",
-  "sig",
-  "credential",
-  "auth",
-  "session",
-  "apikey",
-  "api_key",
-  "key",
-  "code",
-  "state",
-  "assertion",
-  "refresh",
-];
+const SHOWABLE_PARAMS: ReadonlySet<string> = new Set([
+  "clientid",
+  "client_id",
+  "filename",
+  "subfolder",
+  "type",
+  "types",
+  "dir",
+  "recurse",
+  "split",
+  "node_id",
+  "ref",
+  "name",
+  "mode",
+  "raw",
+  "template",
+  "max_items",
+  "version_id",
+  "id",
+  "ui_id",
+  "format",
+  "channel",
+  "preview",
+  "overwrite",
+  "skip_update",
+  "blobs",
+  "input",
+  "response_type",
+  "scope",
+  "redirect_uri",
+  "code_challenge_method",
+]);
 
 /** A single opaque run long enough to be a credential and nothing else. Reused
  *  from the body scrubber's pass 3, but applied PER COMPONENT so an ordinary
  *  host+path — which is one long run of exactly this alphabet — survives. */
 const OPAQUE_RUN = /^[A-Za-z0-9\-._~+/=%]{24,}$/;
 
-function isCredentialish(name: string, value: string): boolean {
-  const n = name.toLowerCase();
-  return CREDENTIAL_PARAM_WORDS.some((w) => n.includes(w)) || OPAQUE_RUN.test(value);
+/** A parameter value may be printed only if we recognise the name AND the value
+ *  is not itself credential-shaped — a known-good name carrying a 40-char opaque
+ *  blob is still not something to put in an error message. */
+function isShowableParam(name: string, value: string): boolean {
+  return SHOWABLE_PARAMS.has(name.toLowerCase()) && !OPAQUE_RUN.test(value);
+}
+
+/**
+ * One path segment, with the parts that can carry a credential removed.
+ *
+ * Two shapes hide in a path. A whole segment can BE a token (`/t/<40 chars>/x`),
+ * and a MATRIX PARAMETER can append one to an ordinary segment
+ * (`/logs;jsessionid=…`) — the latter is under the opaque-run threshold and was
+ * missed entirely by the first version. The head of the segment is kept either
+ * way, because that is the route and the route is the diagnosis.
+ */
+function scrubPathSegment(segment: string): string {
+  if (OPAQUE_RUN.test(segment)) return REDACTED;
+  if (!segment.includes(";") && !segment.includes("=")) return segment;
+  const [head, ...matrix] = segment.split(";");
+  const eq = head.indexOf("=");
+  const safeHead = eq === -1 ? head : `${head.slice(0, eq)}=${REDACTED}`;
+  return matrix.length > 0 ? `${safeHead};${REDACTED}` : safeHead;
 }
 
 /**
@@ -347,9 +392,21 @@ function isCredentialish(name: string, value: string): boolean {
  * `scrubSecretShapedText` cannot be used for this: its opaque-run pass matches
  * 24+ characters of an alphabet that includes `/`, `.` and `-`, so an ordinary
  * `https://comfy.example.com/api/v1/internal/logs` collapses to `https:«redacted»`
- * and the diagnosis loses the one fact it exists to report. This redacts by
- * URL STRUCTURE instead — userinfo, credential-shaped query/fragment values,
- * and credential-shaped path segments — and leaves origin and route intact.
+ * and the diagnosis loses the one fact it exists to report. This redacts by URL
+ * STRUCTURE instead, and FAILS CLOSED on the parts that can carry a secret:
+ *
+ *   - userinfo                → always redacted
+ *   - query/fragment values   → redacted unless the NAME is one this codebase
+ *                               sends (see SHOWABLE_PARAMS) and the value is not
+ *                               itself credential-shaped
+ *   - path segments           → redacted when opaque, or when carrying a matrix
+ *                               parameter (`;jsessionid=…`)
+ *   - origin, route, param NAMES → always kept; they are the diagnosis
+ *
+ * Residual, stated rather than papered over: a SHORT secret sitting in a bare
+ * path segment (`/t/abc123/logs`) is indistinguishable from a route and is not
+ * redacted. Redacting it would mean redacting every path, which would leave the
+ * message unable to say what was requested.
  *
  * Returns the ORIGINAL string when nothing needed redacting, so a clean URL is
  * never reformatted by a round-trip through the URL parser.
@@ -373,11 +430,22 @@ export function redactUrlForDiagnosis(raw: string): string {
     u.password = "";
     changed = true;
   }
-  for (const [name, value] of [...u.searchParams]) {
-    if (value && isCredentialish(name, value)) {
-      u.searchParams.set(name, REDACTED);
-      changed = true;
+  // Rebuilt rather than mutated in place: `searchParams.set` COLLAPSES repeated
+  // keys onto the first occurrence, so `?a=1&code=…&a=2` would silently lose a
+  // value while claiming only to redact one.
+  const rebuilt = new URLSearchParams();
+  let paramsChanged = false;
+  for (const [name, value] of u.searchParams) {
+    if (value && !isShowableParam(name, value)) {
+      rebuilt.append(name, REDACTED);
+      paramsChanged = true;
+    } else {
+      rebuilt.append(name, value);
     }
+  }
+  if (paramsChanged) {
+    u.search = rebuilt.toString();
+    changed = true;
   }
   // The FRAGMENT is where an OAuth implicit flow puts its access token, and it
   // is never needed to identify a route. Any fragment carrying `=` goes.
@@ -385,10 +453,11 @@ export function redactUrlForDiagnosis(raw: string): string {
     u.hash = REDACTED;
     changed = true;
   }
-  // A token can also ride in the path (`/api/v1/<opaque>/logs`). Judge each
-  // segment on its own so a long ROUTE is not mistaken for a long secret.
+  // A token can also ride in the path (`/api/v1/<opaque>/logs`, or a
+  // `;jsessionid=` matrix parameter). Judge each segment on its own so a long
+  // ROUTE is not mistaken for a long secret.
   const segments = u.pathname.split("/");
-  const scrubbed = segments.map((s) => (OPAQUE_RUN.test(s) ? REDACTED : s));
+  const scrubbed = segments.map(scrubPathSegment);
   if (scrubbed.some((s, i) => s !== segments[i])) {
     u.pathname = scrubbed.join("/");
     changed = true;

--- a/src/comfyui/json-guard.ts
+++ b/src/comfyui/json-guard.ts
@@ -352,11 +352,25 @@ const SHOWABLE_PARAMS: ReadonlySet<string> = new Set([
  *  host+path — which is one long run of exactly this alphabet — survives. */
 const OPAQUE_RUN = /^[A-Za-z0-9\-._~+/=%]{24,}$/;
 
-/** A parameter value may be printed only if we recognise the name AND the value
- *  is not itself credential-shaped — a known-good name carrying a 40-char opaque
- *  blob is still not something to put in an error message. */
-function isShowableParam(name: string, value: string): boolean {
-  return SHOWABLE_PARAMS.has(name.toLowerCase()) && !OPAQUE_RUN.test(value);
+/**
+ * A parameter value may be printed only if we recognise the NAME.
+ *
+ * The value is deliberately NOT length-checked. An earlier version also required
+ * it not to match the opaque-run pattern, on the reasoning that a known-good name
+ * carrying a 40-character blob is still not worth printing — but the pattern's
+ * alphabet includes letters, digits, `-`, `.` and `_`, so an ordinary filename of
+ * 24 characters or more matches it. Live-testing a missing `/view` produced:
+ *
+ *     /view?filename=«redacted»&type=input&subfolder=
+ *
+ * which redacts the single most useful fact in the message. These names are on
+ * the list precisely because we know what they carry — user-supplied paths and
+ * identifiers, never credentials — so the length of the value says nothing. Any
+ * name NOT on the list is still redacted whatever its value looks like, which is
+ * where the fail-closed protection actually lives.
+ */
+function isShowableParam(name: string): boolean {
+  return SHOWABLE_PARAMS.has(name.toLowerCase());
 }
 
 /**
@@ -436,7 +450,7 @@ export function redactUrlForDiagnosis(raw: string): string {
   const rebuilt = new URLSearchParams();
   let paramsChanged = false;
   for (const [name, value] of u.searchParams) {
-    if (value && !isShowableParam(name, value)) {
+    if (value && !isShowableParam(name)) {
       rebuilt.append(name, REDACTED);
       paramsChanged = true;
     } else {

--- a/src/comfyui/json-guard.ts
+++ b/src/comfyui/json-guard.ts
@@ -20,7 +20,7 @@
 
 import { ComfyUIError } from "../utils/errors.js";
 import { getComfyUIAuthHeaders, getComfyUIBaseUrl } from "../config.js";
-import { comfyuiFetch } from "./fetch.js";
+import { comfyuiFetch, targetOf } from "./fetch.js";
 
 /** What answered instead of the ComfyUI JSON API. */
 export type NonJsonKind =
@@ -401,6 +401,12 @@ export function classifyNonJson(args: {
   const loginPage = html && looksLikeLoginPage(body);
   const gatewayStatus = status === 502 || status === 503 || status === 504;
   const authStatus = status === 401 || status === 403;
+  // An EMPTY body is its own observation and deserves its own sentence. It is
+  // what a parser reports as "Unexpected end of JSON input" — the message #828
+  // and #1160 were reported as — and the generic "did not parse as JSON and is
+  // not markup either" reads as though there WAS a body to inspect, sending the
+  // reader to look at a body prefix that says "(empty)".
+  const empty = body.trim() === "";
 
   let kind: NonJsonKind;
   let cause: string;
@@ -428,6 +434,20 @@ export function classifyNonJson(args: {
     cause = looksLikeComfyFrontend(body)
       ? "the ComfyUI web FRONTEND answered this path (its markers are in the body) instead of the ComfyUI HTTP API — typically a reverse proxy that forwards the UI but not the API routes, or a base URL pointing at the frontend's catch-all"
       : "some HTTP responder other than the ComfyUI JSON API answered this path; this body alone does not identify which. The usual candidates are the ComfyUI frontend's SPA catch-all, a reverse proxy that forwards the UI but not the API routes, a maintenance/WAF page, or an unrelated web app on this host";
+  } else if (empty) {
+    // A 404 with nothing in it is still "that route is not served here", and
+    // saying so is more use than a generic parse complaint.
+    kind = status === 404 ? "not-found" : "not-json";
+    cause =
+      `NOTHING was sent back — the response carried no body at all, so the ${status} status is the entire message ` +
+      `and this response does not identify what produced it. That is what a JSON parser reports as ` +
+      `"Unexpected end of JSON input", and it is equally consistent with ComfyUI itself answering the status ` +
+      `without an error document, with a proxy or gateway ending the exchange after the headers, and with a route ` +
+      `that is not served here at all. Nothing in this response distinguishes them` +
+      (status >= 200 && status < 300
+        ? `, and note the status is a SUCCESS one — an empty 2xx where a JSON document was promised points at ` +
+          `something answering on ComfyUI's behalf rather than at ComfyUI`
+        : ``);
   } else if (malformedJson) {
     kind = "not-json";
     // OBSERVED: the body starts with `{` or `[` and JSON.parse rejects it. That
@@ -453,11 +473,13 @@ export function classifyNonJson(args: {
 
   const what = html
     ? "an HTML page"
-    : malformedJson
-      ? "a body that begins like JSON but does not parse"
-      : contentType
-        ? `a ${contentType} body that did not parse as JSON`
-        : "a body that did not parse as JSON";
+    : empty
+      ? "an EMPTY body"
+      : malformedJson
+        ? "a body that begins like JSON but does not parse"
+        : contentType
+          ? `a ${contentType} body that did not parse as JSON`
+          : "a body that did not parse as JSON";
   const message =
     `${url} answered ${status} with ${what} where JSON was expected. This means ${cause}. ` +
     `Content-Type: ${contentType || "(none)"}. Body starts: ${bodyPrefix || "(empty)"}. ` +
@@ -527,6 +549,78 @@ export async function readComfyJson<T = unknown>(
     });
   }
   return parsed as T;
+}
+
+/**
+ * Wrap the `fetch` handed to the ComfyUI client library so the library's own
+ * error path cannot EAT the response (#828, #1160).
+ *
+ * `Client.fetchApi` does this on every status outside [200, 400):
+ *
+ *     if (status < 200 || status >= 400)
+ *       return res.json().then(body => { throw new Error(`Endpoint Bad Request (${status} ${statusText}): ${url}`) })
+ *
+ * — it reads the ERROR body as JSON in order to attach it to the error it is
+ * about to throw. When that body is not JSON, `res.json()` rejects FIRST, and
+ * its bare SyntaxError propagates in place of the library's error, so the
+ * status, the statusText and the URL are all lost. The failure is upstream of
+ * every `client.fetchApi` call site, which is why guarding them one at a time
+ * kept missing it:
+ *
+ *   - #828: a remote `/internal/logs` answered non-2xx with an empty body after
+ *     a reconnect, and surfaced as
+ *     `Failed to fetch ComfyUI logs after reconnect retry: Unexpected end of JSON input`.
+ *   - #1160: `upload_image` on an authenticated remote surfaced as a bare
+ *     `Unexpected end of JSON input` even though `uploadImageHttp`'s SUCCESS
+ *     path already runs `readComfyJson` — the auth gate's 401/403 made the
+ *     library throw before that code ever saw the response, so its own
+ *     `if (!res.ok)` branch was unreachable.
+ *
+ * The wrapper overrides `json()` on the returned Response so a parse failure
+ * throws the diagnosis instead of a SyntaxError. It deliberately does NOT read
+ * the body up front: the override consumes the stream at exactly the moment the
+ * original `json()` would have, so `text()`, `body` and `bodyUsed` are unchanged
+ * for every caller that does not call `json()` — including `readComfyJson`,
+ * which reads `text()` and keeps its own richer shape checking.
+ *
+ * Applied to ALL statuses, not just the ones the library throws on: a 200 that
+ * carries an HTML catch-all is the same defect one layer over, and the override
+ * costs nothing on a response nobody parses.
+ */
+export function guardClientFetch(
+  base: (input: string | URL | Request, init?: RequestInit) => Promise<Response>,
+): (input: string | URL | Request, init?: RequestInit) => Promise<Response> {
+  return async (input, init) => {
+    const res = await base(input, init);
+    // Bind before overriding: the override must reach the REAL reader, and
+    // `res.text` would otherwise still resolve through the prototype anyway —
+    // binding makes that independent of anything else patching the instance.
+    const readText = res.text.bind(res);
+    // `url` on a real fetch Response is the FINAL url after redirects, which is
+    // the more useful one to name. Falling back to the request target keeps the
+    // message honest for a synthesised response (a test double, a mock).
+    const url = res.url || targetOf(input);
+    Object.defineProperty(res, "json", {
+      configurable: true,
+      writable: true,
+      value: async (): Promise<unknown> => {
+        const body = await readText();
+        try {
+          return JSON.parse(body);
+        } catch {
+          throw new NonJsonResponseError(
+            classifyNonJson({
+              url,
+              status: res.status,
+              contentType: res.headers.get("content-type") ?? "",
+              body,
+            }),
+          );
+        }
+      },
+    });
+    return res;
+  };
 }
 
 /** Fetch a ComfyUI endpoint and parse it as JSON with the guard above. */


### PR DESCRIPTION
Fixes the residual half of #828. #1160 falls out of the same root cause, and this also answers the open question recorded in `contextualizeBareParseError`'s comment about which layer was producing it.

## The actual defect

The close comment on #828 asked to hear about any endpoint still producing a bare parse error, on the theory it would be *"a path that doesn't yet route through the guard"*. It is not a coverage gap. It is one defect **upstream of every `client.fetchApi` call site**.

`@stable-canvas/comfyui-client`'s `Client.fetchApi` does this on any status outside `[200, 400)`:

```js
if (status < 200 || status >= 400)
  return Promise.resolve(res.json()).then(function (body) {
    throw new A("Endpoint Bad Request (" + status + " " + statusText + "): " + url, status, body)
  })
```

It reads the **error** body as JSON so it can attach it to the error it is about to throw. When that body is not JSON — empty, an HTML login page, a proxy error document — `res.json()` rejects **first**, and its bare `SyntaxError` propagates in place of the library's error. The status, the statusText and the URL all go with it.

That explains both reports exactly:

- **#828**: a remote `/internal/logs` answered non-2xx with an empty body after a reconnect. `JSON.parse("")` is *"Unexpected end of JSON input"* — verbatim what was reported.
- **#1160**: `upload_image` on an authenticated remote reported the same bare message **even though `uploadImageHttp`'s success path already runs `readComfyJson`** — the auth gate's 401 made the library throw before that code saw the response, so its own `if (!res.ok)` branch was dead code for exactly the case it was written for.

This is independently corroborated in-tree: `userdataFetch` (`src/services/userdata-library.ts`) already bypasses `fetchApi` for one route, and its comment names the same mechanism — *"`fetchApi` throws for every non-2xx AND calls `response.json()` while building that error"*. That fix was route-local; this one is at the choke point.

`contextualizeBareParseError` (`src/tools/compact.ts`) is the backstop added for #1160, whose comment says *"points at a layer below all of that (the ComfyUI client library's own fetch...). Without their server I cannot say which."* It was the client library's own fetch. The backstop is unchanged and correctly steps aside now that a classified error arrives instead.

## The fix

`guardClientFetch` wraps the `fetch` handed to the library at the single `new Client({...})` site and overrides `json()` on the returned Response, so a parse failure throws the existing `NonJsonResponseError` diagnosis instead of a `SyntaxError`.

It is **lazy** — the body is consumed at exactly the moment the original `json()` would have. `text()`, `body` and `bodyUsed` are untouched for every caller that does not parse, including `readComfyJson` and `/view`'s `arrayBuffer()`.

Plus, in the same area:

- **`classifyNonJson` gains an EMPTY-body branch** — the shape both reports hit. A gateway status still outranks it.
- **The status reason phrase is carried**: `503 Origin warming up` instead of `503`. Standard phrases are dropped; custom ones are scrubbed and clipped.
- **`getLogs` no longer recasts a diagnosed answer as a `ConnectionError`** headed "Failed to fetch", which contradicted its own contents.
- **`provesNonJsonAnswer`** — see the review section; the shape change silently broke a predicate.

## Before / after

```
Failed to fetch ComfyUI logs after reconnect retry: Unexpected end of JSON input
```

```
http://remote.example:8188/internal/logs answered 404 with an EMPTY body where JSON
was expected. This means NOTHING was sent back — the response carried no body at all,
so the 404 status is the entire message and this response does not identify what
produced it. … Content-Type: (none). Body starts: (empty). …
```

## Review — codex found a Major, and fixing it found more

**Codex round 1: NO-SHIP.** Three findings, all real, all fixed:

1. **Major — credential leak.** `bodyPrefixOf` scrubs the body; nothing scrubbed the URL. Survivable while diagnoses were built from a base URL we compose, and not survivable once `Response.url` (post-redirect) started being reported.
2. Minor — `statusText` dropped.
3. Minor — the tests did not pin the EMPTY branch's position relative to the auth branch.

**A regression the review missed.** Changing the error's SHAPE from `SyntaxError` to `NonJsonResponseError` silently falsified a predicate written against the old one: `getObjectInfo`'s picker used `looksLikeHtmlParsedAsJson` to choose which of two failed attempts to report, and a `NonJsonResponseError` message contains no parser text. It fell through to `retryErr` every time — reintroducing exactly the downgrade round 8 of the original #828 gate fixed. Added `provesNonJsonAnswer`, and `rethrowWithJsonDiagnosis` now short-circuits on a first-hand diagnosis rather than re-probing a later response. Mutation-checked.

**Then the first redaction fix turned out to be wrong.** I probed it with sixteen credential-carrying URLs and it leaked **nine**: `?t=`, `?jwt=`, `?ticket=`, `?nonce=`, `?otp=`, `?hmac=`, `?bearer=`, `?SAMLResponse=`, and a `;jsessionid=` matrix parameter in the path. A blocklist of credential-ish names cannot be complete — the same trap this file already documents for credential *encodings*. Inverted to an allowlist of the parameters this codebase itself sends; everything else is redacted whatever it is called. Re-probed: **0 bypasses**. Two further bugs fell out: `searchParams.set` was silently dropping a repeated key, and matrix parameters sit under any length threshold.

**Codex round 2 could not run** — its sandbox denied launching a shell (`CreateProcessAsUserW: Access is denied`) on two attempts. Substituted a disclosed Claude adversarial review, per this repo's fallback convention.

## Verification

- Tests drive the **real** library through the **real** `getClient()` wiring.
- **Mutation-checked twice**: reverting `fetch: guardClientFetch(comfyuiFetch)` fails 3 tests; restoring the old `looksLikeHtmlParsedAsJson` picker fails the regression test.
- **Live repro** against a real HTTP server (not a mock) for both reported endpoints, before and after.
- Redactor probes: 16 credential URLs → 0 bypasses; 12 edge cases → no crashes, no unwanted rewrites; our own URLs byte-identical.
- Full suite green, `tsc --noEmit` clean, CI green on ubuntu/windows/macos + pack-install smoke.

## Adjacent defect filed, not fixed here

`if (!res.ok)` after `client.fetchApi` is **unreachable** — the library throws first — so the hand-written `IMAGE_NOT_FOUND` message for `/view` has never been shown to anyone. Verified before and after this PR (it was already dead; this PR neither causes nor fixes it). Filed as #385.

Closes #828
Closes #1160