### PR TITLE
fix(enqueue): a non-JSON /prompt reply states the delivery doubt instead of a parser message

### DIFF
--- a/src/__tests__/comfyui/enqueue-prompt-validation.test.ts
+++ b/src/__tests__/comfyui/enqueue-prompt-validation.test.ts
@@ -226,3 +226,58 @@ describe("#1037: a 200 can still carry rejected output branches", () => {
     expect(rejectedOutputs).toContain("node 2");
   });
 });
+
+// The same family as #1149/#1160/#828, at the worst possible place for it.
+//
+// A bare res.json() here sits AFTER a mutating POST that already succeeded at the
+// HTTP layer. If the body will not parse, the prompt may well be queued and
+// running — and `Unexpected end of JSON input` says nothing about that. A caller
+// reads it as "the run failed" and re-submits, queueing the render twice.
+describe("a 200 whose body is not the enqueue result", () => {
+  beforeEach(() => {
+    comfyuiFetch.mockReset();
+  });
+
+  it("does not leak a bare parser message for an empty body", async () => {
+    comfyuiFetch.mockResolvedValue(res(200, "", "OK"));
+    const err = (await enqueuePrompt({}, undefined).catch((e: unknown) => e)) as Error;
+    expect(err.message).not.toMatch(/^Unexpected end of JSON input/);
+    expect(err.message).toMatch(/\/prompt/);
+  });
+
+  it("states the DELIVERY DOUBT — the workflow may already be queued", async () => {
+    // The whole point. "It errored" must not read as "nothing happened" after a
+    // POST the server accepted.
+    comfyuiFetch.mockResolvedValue(res(200, "<!doctype html><html>login</html>", "OK"));
+    const err = (await enqueuePrompt({}, undefined).catch((e: unknown) => e)) as Error;
+    expect(err.message).toMatch(/OUTCOME UNDETERMINED/);
+    expect(err.message).toMatch(/MAY ALREADY BE QUEUED/);
+    expect(err.message).toMatch(/BEFORE re-submitting/);
+    expect(err.message).toMatch(/run the same workflow twice/i);
+  });
+
+  it("does NOT use the OUTCOME UNKNOWN sentinel, which other code matches on", async () => {
+    // rebootDropped()/isReconnectDrop() classify a POST-WRITE drop with
+    // /disconnected mid-command|OUTCOME UNKNOWN/i. Reusing that exact phrase here
+    // would silently reclassify a proxy's HTML answer as a reboot drop.
+    comfyuiFetch.mockResolvedValue(res(200, "", "OK"));
+    const err = (await enqueuePrompt({}, undefined).catch((e: unknown) => e)) as Error;
+    expect(err.message).not.toMatch(/OUTCOME UNKNOWN/);
+  });
+
+  it("rejects valid JSON that carries no prompt_id, instead of returning undefined", async () => {
+    // A gateway's own JSON error envelope parses fine. Reading prompt_id off it
+    // would hand back `undefined` as an id and send every downstream poll chasing
+    // a job that was never queued.
+    comfyuiFetch.mockResolvedValue(res(200, { error: "upstream unavailable" }, "OK"));
+    const err = (await enqueuePrompt({}, undefined).catch((e: unknown) => e)) as Error;
+    expect(err).toBeInstanceOf(ComfyUIError);
+    expect(err.message).toMatch(/OUTCOME UNDETERMINED/);
+  });
+
+  it("still returns the prompt_id on a normal success", async () => {
+    comfyuiFetch.mockResolvedValue(res(200, { prompt_id: "p-42", number: 3 }, "OK"));
+    const out = await enqueuePrompt({}, undefined);
+    expect(out.prompt_id).toBe("p-42");
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -461,11 +461,41 @@ export async function enqueuePrompt(
   if (!res.ok) {
     throw await buildEnqueueError(res);
   }
-  const data = (await res.json()) as {
-    prompt_id: string;
-    number?: number;
-    node_errors?: Record<string, unknown>;
-  };
+  // A bare res.json() here is the worst place in the codebase for one, and the
+  // same family as #1149/#1160/#828. This is a MUTATING POST that already
+  // succeeded at the HTTP layer: if the body will not parse, the prompt may well
+  // be queued and running, and `Unexpected end of JSON input` says nothing about
+  // that — a caller reads it as "the run failed" and re-submits, queueing the
+  // render twice.
+  //
+  // So: classify what actually answered (readComfyJson names the URL, status,
+  // content type and body prefix), and state the delivery doubt explicitly. The
+  // expectShape check is what catches the shape that matters — a gateway's own
+  // JSON error envelope is valid JSON with no prompt_id, and reading
+  // `data.prompt_id` off it would hand back `undefined` as a prompt id and let
+  // every downstream poll chase a job that was never queued.
+  let data: { prompt_id: string; number?: number; node_errors?: Record<string, unknown> };
+  try {
+    data = await readComfyJson<{
+      prompt_id: string;
+      number?: number;
+      node_errors?: Record<string, unknown>;
+    }>(res, {
+      url: "/prompt",
+      expectShape: (v: unknown) =>
+        !!v && typeof v === "object" && typeof (v as { prompt_id?: unknown }).prompt_id === "string",
+      shapeHint: "the enqueue result ({ prompt_id, … })",
+    });
+  } catch (err) {
+    throw new ComfyUIError(
+      `${err instanceof Error ? err.message : String(err)} ` +
+        `OUTCOME UNDETERMINED: the POST to /prompt was accepted (HTTP ${res.status}) and the ` +
+        `workflow MAY ALREADY BE QUEUED — this is not proof it failed. Check queue ` +
+        `(action:"status") or get_history BEFORE re-submitting; a blind retry can run the ` +
+        `same workflow twice.`,
+      "ENQUEUE_UNVERIFIED",
+    );
+  }
   // NB: `data.number` is ComfyUI's monotonic priority counter (and is NEGATIVE
   // for front-inserted jobs) — NOT the remaining queue depth. The old SDK path
   // returned exec_info.queue_remaining; to preserve an accurate count now that


### PR DESCRIPTION
Refs #828. **Not from a new report** — found by auditing the rest of the family behind #1149/#1160/#828 (every remaining raw `res.json()` on a read path) instead of waiting for the next one.

This is the worst place in the codebase for a bare parse.

## Why

`enqueuePrompt` POSTs `/prompt`, checks `res.ok`, then parsed the body bare:

```ts
if (!res.ok) throw await buildEnqueueError(res);
const data = (await res.json()) as { prompt_id: string; … };
```

A proxy, auth gate, or still-starting server that answers **200 with HTML or an empty body** therefore produced `Unexpected end of JSON input` **after a mutating request the server had already accepted**. A caller reads that as "the run failed" and re-submits — queueing the same render twice.

This is the delivery-doubt class the repo already handles for a POST timeout (`fetch.ts`) and for a bridge write (#334). It was missing on the one call that actually enqueues work.

## What it says now

> …classified diagnosis… **OUTCOME UNDETERMINED**: the POST to /prompt was accepted (HTTP 200) and the workflow **MAY ALREADY BE QUEUED** — this is not proof it failed. Check `queue (action:"status")` or `get_history` **BEFORE re-submitting**; a blind retry can run the same workflow twice.

The `expectShape` is the half that catches the subtler failure: **an API gateway's own JSON error envelope parses fine and has no `prompt_id`**, so the old code handed back `undefined` as a prompt id and sent every downstream poll chasing a job that was never queued.

## The sentinel

The wording is deliberately `OUTCOME UNDETERMINED`, **not** `OUTCOME UNKNOWN`. `rebootDropped()` / `isReconnectDrop()` classify a post-write drop with `/disconnected mid-command|OUTCOME UNKNOWN/i`, so reusing that exact phrase here would silently reclassify a proxy's HTML answer as a reboot drop. There is a test pinning the distinction.

## Deliberately left alone

The two other remaining raw parses — the `/object_info/<Type>` backfill and `queueRemainingCount` — are best-effort reads inside a `try/catch` that degrades. Neither can surface a parser message or fabricate a result, so guarding them would add noise without changing any outcome.

## Testing notes

| mutation | result |
|---|---|
| drop `expectShape` (gateway envelope → `prompt_id: undefined`) | ✗ killed |
| drop the delivery-doubt clause | ✗ killed |
| use `OUTCOME UNKNOWN` (sentinel collision) | ✗ killed (3 tests) |

Full suite: 378 files, 7774 passed. Lint and the vocabulary gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)