### PR TITLE
release: v0.50.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.47] - 2026-08-08
+
+### MCP
+
+#### Fixed
+- a non-JSON /prompt reply states the delivery doubt instead of a parser message (#1179)
+- hold a turn's temp images past the turn, so a deferred read still finds them (#1177)
+
+
 ## [0.50.46] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.46",
+  "version": "0.50.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.46",
+      "version": "0.50.47",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.46",
+  "version": "0.50.47",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.47` tag.

**Codex temp images survive a deferred read** (#1152, via #1177). A reporter saw the panel render a storyboard while the same Codex turn reported `The system cannot find the file specified. (os error 2)` for the image it was handed. The turn's teardown deleted the file on an assumption its own comment stated — "the bytes were read at turn/start" — which the app-server does not guarantee. The files now survive a grace window; `close()` still sweeps them, so the window is a delay rather than the only guard against a leak.

**A non-JSON `/prompt` reply states the delivery doubt** (refs #828, via #1179). Found by auditing the rest of the family behind #1149/#1160 rather than waiting for the report. `enqueuePrompt` parsed the response bare, so a proxy or auth gate answering 200 with HTML produced `Unexpected end of JSON input` after a mutating request the server had already accepted — which reads as "the run failed" and invites a re-submit that queues the render twice. It now classifies what answered and says the workflow may already be queued. A shape check also stops a gateway's JSON error envelope from yielding `undefined` as a prompt id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)