### PR TITLE
fix(restart): the refusal names the origin the connected panel is actually on

### DIFF
--- a/src/__tests__/comfyui/target-drift-in-refusal.test.ts
+++ b/src/__tests__/comfyui/target-drift-in-refusal.test.ts
@@ -1,0 +1,76 @@
+// #1175 — the restart refusal asserted "could not be identified" while the
+// orchestrator was holding the evidence that would identify it.
+//
+// A reporter's ComfyUI was started by an external Windows launcher on a port
+// that is not 8188. Their panel was connected and live graph reads worked, so a
+// ComfyUI demonstrably existed — but the restart preflight probes only
+// config.resolvedPort, found nothing, and reported that, which reads as "ComfyUI
+// is not running" when it plainly was.
+//
+// describeTargetDrift is the comparison comfyuiFetch already makes on a
+// transport error. This pins that it says the three things it must, so wiring it
+// into the refusal turns "we found nothing" into "we looked at the wrong
+// address, and here is the right one".
+
+import { afterEach, describe, expect, it } from "vitest";
+import { describeTargetDrift, setConnectedPanelOrigins } from "../../comfyui/fetch.js";
+
+afterEach(() => setConnectedPanelOrigins(null));
+
+describe("describeTargetDrift", () => {
+  it("names the DIFFERENT origin a connected panel is actually on", () => {
+    // The reporter's shape exactly: panel alive elsewhere, probe on 8188.
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8000"]);
+    const text = describeTargetDrift("http://127.0.0.1:8188");
+    expect(text).toContain("http://127.0.0.1:8000");
+    expect(text).toMatch(/DIFFERENT address/);
+    expect(text).toMatch(/COMFYUI_URL/);
+  });
+
+  it("RULES OUT drift when the panel is on the same origin", () => {
+    // Worth stating: it stops the reader chasing an explanation that is excluded.
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8188"]);
+    const text = describeTargetDrift("http://127.0.0.1:8188");
+    expect(text).toMatch(/NOT a wrong-address problem/);
+    expect(text).toMatch(/firewall|container|interface/);
+  });
+
+  it("says NOTHING when no origin is known — an absent comparison is not a result", () => {
+    setConnectedPanelOrigins(() => []);
+    expect(describeTargetDrift("http://127.0.0.1:8188")).toBe("");
+    setConnectedPanelOrigins(null);
+    expect(describeTargetDrift("http://127.0.0.1:8188")).toBe("");
+  });
+
+  it("never lets a broken origin source replace the real error", () => {
+    setConnectedPanelOrigins(() => {
+      throw new Error("bridge exploded");
+    });
+    expect(describeTargetDrift("http://127.0.0.1:8188")).toBe("");
+  });
+
+  it("says nothing for an unparseable target rather than guessing", () => {
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8000"]);
+    expect(describeTargetDrift("not a url")).toBe("");
+  });
+});
+
+// THE WIRING. The helper cannot see whether the restart preflight appends it —
+// the call-site blindness this suite keeps getting caught by. Read the source,
+// the way the other prose gates in this repo do.
+describe("the restart preflight appends the drift comparison (#1175)", () => {
+  it("calls describeTargetDrift in the could-not-identify refusal", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      new URL("../../services/process-control.ts", import.meta.url),
+      "utf-8",
+    );
+    const start = src.indexOf("the ComfyUI this restart would stop could not be identified");
+    expect(start, "the refusal must still exist").toBeGreaterThan(-1);
+    const branch = src.slice(start, start + 2200);
+    expect(branch).toMatch(/describeTargetDrift\(/);
+    // And it must remain a REFUSAL — naming the right address does not make
+    // restarting an unidentified instance safe (#814).
+    expect(src.slice(start - 400, start)).toMatch(/ok: false/);
+  });
+});

--- a/src/__tests__/services/restart-instance-identity.test.ts
+++ b/src/__tests__/services/restart-instance-identity.test.ts
@@ -57,6 +57,9 @@ vi.mock("../../config.js", () => ({
 
 vi.mock("../../comfyui/fetch.js", () => ({
   comfyuiFetch: (url: string, init?: RequestInit) => hoisted.fetchMock(url, init),
+  // #1175 — the refusal now appends the panel-origin drift comparison. Stubbed
+  // empty here so these #914 assertions keep testing identification alone.
+  describeTargetDrift: () => "",
 }));
 
 vi.mock("../../comfyui/client.js", () => ({

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -65,7 +65,7 @@ function originOf(target: string): string | undefined {
  *                   handshake carried no usable Origin. Say nothing about drift;
  *                   an absent comparison is not a negative result.
  */
-function describeTargetDrift(target: string): string {
+export function describeTargetDrift(target: string): string {
   const origins = (() => {
     try {
       return connectedPanelOrigins?.() ?? [];

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -15,7 +15,7 @@ import {
   getComfyuiTargetGeneration,
   isRemoteMode,
 } from "../config.js";
-import { comfyuiFetch } from "../comfyui/fetch.js";
+import { comfyuiFetch, describeTargetDrift } from "../comfyui/fetch.js";
 import { errorText } from "../orchestrator/error-text.js";
 import {
   acquireInstanceWitness,
@@ -3989,7 +3989,29 @@ export async function preflightLocalRestart(): Promise<{
       reason:
         `the ComfyUI this restart would stop could not be identified from here` +
         (diagnostic ? ` (${diagnostic})` : ` (nothing was found listening on port ${config.resolvedPort})`) +
-        `, so it could not be established that stopping it is something we could undo.`,
+        `, so it could not be established that stopping it is something we could undo.` +
+        // #1175 — the refusal asserted "could not be identified" while the
+        // orchestrator was holding the evidence that would identify it.
+        //
+        // A reporter's ComfyUI was started by an external Windows launcher on a
+        // port that is not 8188. Their panel was connected and live graph reads
+        // worked, so a ComfyUI demonstrably existed — but this preflight probes
+        // only `config.resolvedPort` and reported nothing listening, which reads
+        // as "ComfyUI is not running" when it plainly was.
+        //
+        // describeTargetDrift is the comparison comfyuiFetch already makes for a
+        // transport error: it asks the bridge which origins the connected tabs
+        // actually front, and says DIFFERENT / SAME / unknown. Saying which of
+        // those holds turns "we found nothing" into "we looked at the wrong
+        // address, and here is the right one".
+        //
+        // Deliberately additive. This does NOT relax the refusal: an instance we
+        // cannot identify is still an instance whose relaunch we cannot prove
+        // (#814), and restarting a server this process cannot even see would be
+        // exactly the loss that gate exists to prevent. What changes is that the
+        // caller is told where to point COMFYUI_URL instead of being told their
+        // running ComfyUI does not exist.
+        describeTargetDrift(getComfyUIBaseUrl()),
     };
   }
   if (info.isDesktopApp) {


### PR DESCRIPTION
Refs #1175. Addresses the diagnosis half; the retarget half is discussed below and left open.

## The report

A reporter's ComfyUI was started by an external Windows launcher on a port that is **not** 8188. Their panel was connected and `panel_graph_outline` / `panel_query_graph` worked. `panel_restart_comfyui` still said:

> Refusing to restart ComfyUI: the ComfyUI this restart would stop could not be identified from here (**nothing was found listening on port 8188**) … restart it from whatever launches it.

A ComfyUI demonstrably existed — they were reading its canvas. The preflight probes only `config.resolvedPort`, found nothing there, and reported that, which reads as *"ComfyUI is not running"* when it plainly was.

And the orchestrator was **holding the evidence that would identify it**: the bridge knows the server-trusted handshake `Origin` of every connected tab.

## The change

`describeTargetDrift` is the comparison `comfyuiFetch` already makes on a transport error. It was module-private; it is now exported and appended to this refusal:

| state | what it says |
|---|---|
| panel on a **different** origin | names it, and says to point `COMFYUI_URL` there — *"which is why the panel works while this call does not"* |
| panel on the **same** origin | drift is **ruled out** — a firewall/container/interface boundary, not a wrong address |
| **no** known origin | says nothing; an absent comparison is not a negative result |

## Deliberately additive

This does **not** relax the refusal. An instance we cannot identify is still one whose relaunch we cannot prove (#814), and restarting a server this process cannot see would be exactly the loss that gate exists to prevent. What changes is that the caller is told **where to point `COMFYUI_URL`** instead of being told their running ComfyUI does not exist.

## Not done: deriving the reboot route from the bridge

The reporter's fuller ask — *"derive the active ComfyUI origin/port and reboot route from that bridge/session, or delegate the Manager reboot through the panel's same-origin API"* — is a real design change: it would move the restart's identification and its proof-of-relaunch onto a different transport, and the `#814` guarantees would have to be re-established there rather than assumed. Their proposed `externally_managed` status is worth having too. Left open on the issue.

## Testing notes

| mutation | result |
|---|---|
| **drop the call at the refusal site** | ✗ killed |
| let a broken origin source throw outward | ✗ killed |
| silence the same-origin case | ✗ killed |

The first row is the one that matters — the helper's own tests cannot see the preflight dropping it, so a source-level wiring check pins it (and also pins that the branch is still `ok: false`).

One existing test mocks `comfyui/fetch.js` and needed the new export stubbed; it is stubbed to `""` so those #914 assertions keep testing identification alone.

Full suite: 379 files, 7780 passed. Lint and the vocabulary gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)