### PR TITLE
release: v0.50.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.48] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- the refusal names the origin the connected panel is actually on (#1181)
+
+
 ## [0.50.47] - 2026-08-08
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.47",
+  "version": "0.50.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.47",
+      "version": "0.50.48",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.47",
+  "version": "0.50.48",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.48` tag.

**A restart refusal names the origin the connected panel is actually on** (#1175, via #1181).

A reporter's ComfyUI was launched by an external Windows launcher on a port that is not 8188. Their panel was connected and live graph reads worked, yet `panel_restart_comfyui` refused with "nothing was found listening on port 8188" — which reads as "ComfyUI is not running" when it demonstrably was. The orchestrator was holding the evidence that identifies it: the bridge knows the server-trusted handshake Origin of every connected tab, and a helper already compares it against the configured target for exactly this purpose.

That comparison is now appended to the refusal: it names a different origin, rules drift out when the panel is on the same one, and says nothing when no origin is known. It stays a refusal — an instance this process cannot identify is one whose relaunch it cannot prove (#814) — but the caller is now pointed at the fix instead of being told their server does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)