### PR TITLE
fix(restart): a BACKGROUNDED phone is not a departed phone

### DIFF
--- a/src/__tests__/services/headless-recency-window.test.ts
+++ b/src/__tests__/services/headless-recency-window.test.ts
@@ -24,7 +24,9 @@ function bridgeWithHeadlessGoneFor(ms: number | null): UiBridge {
   const b = new UiBridge() as UiBridge & {
     markHeadlessDisconnectForTests(at: number): void;
   };
-  if (ms !== null) b.markHeadlessDisconnectForTests(Date.now() - ms);
+  // Monotonic, matching the field — the recency window measures ELAPSED time,
+  // which the wall clock does not (codex review: an NTP step could skip it).
+  if (ms !== null) b.markHeadlessDisconnectForTests(performance.now() - ms);
   return b;
 }
 

--- a/src/__tests__/services/headless-recency-window.test.ts
+++ b/src/__tests__/services/headless-recency-window.test.ts
@@ -1,0 +1,61 @@
+// #1176 — a BACKGROUNDED phone is not a departed phone.
+//
+// #875 defers a self-restart while a paired phone is present, because a restart
+// mints a NEW cloudflared quick-tunnel hostname and the old one stops resolving.
+// The gate asked `hasLiveHeadlessClient()`, which reads currently-OPEN sockets —
+// and a phone at work with its screen off has had its socket suspended or closed
+// by the mobile OS. So the gate opened, the orchestrator self-updated
+// 0.50.39 → 0.50.41, and the reporter picked up their phone to:
+//
+//   Failed host lookup: 'cameron-timing-face-spies.trycloudflare.com'
+//   (No address associated with hostname, errno = 7)
+//
+// A DNS failure, not a timeout or a refusal: the hostname no longer existed.
+//
+// The sticky isHeadless() was rejected for this gate and that was right — a phone
+// that paired once and left would defer updates forever. But those are not the
+// only two options, and the state between them is the NORMAL one for a phone.
+
+import { describe, expect, it } from "vitest";
+import { UiBridge, HEADLESS_RECENCY_MS } from "../../services/ui-bridge.js";
+
+/** A bridge with its headless-disconnect clock placed at a chosen age. */
+function bridgeWithHeadlessGoneFor(ms: number | null): UiBridge {
+  const b = new UiBridge() as UiBridge & {
+    markHeadlessDisconnectForTests(at: number): void;
+  };
+  if (ms !== null) b.markHeadlessDisconnectForTests(Date.now() - ms);
+  return b;
+}
+
+describe("the restart-deferral gate covers a pocketed phone (#1176)", () => {
+  it("still defers seconds after the socket closed — the reported case", () => {
+    // The mobile OS suspends a backgrounded socket within seconds.
+    expect(bridgeWithHeadlessGoneFor(5_000).hasLiveHeadlessClient()).toBe(true);
+  });
+
+  it("still defers across a meeting", () => {
+    expect(bridgeWithHeadlessGoneFor(20 * 60_000).hasLiveHeadlessClient()).toBe(true);
+  });
+
+  it("stops deferring once the phone has genuinely been gone", () => {
+    // The property that killed the sticky option: this happens on its own, with
+    // no unpairing step and no user action, so an install that lost its phone
+    // still gets its updates.
+    expect(bridgeWithHeadlessGoneFor(HEADLESS_RECENCY_MS + 1).hasLiveHeadlessClient()).toBe(false);
+  });
+
+  it("never defers on an install that has never seen a headless client", () => {
+    // The clock is undefined until a headless socket actually disconnects, so a
+    // desktop-only install can never be held back by this.
+    expect(bridgeWithHeadlessGoneFor(null).hasLiveHeadlessClient()).toBe(false);
+  });
+
+  it("uses a window measured in minutes, not seconds", () => {
+    // The duration IS the fix. A window short enough to still lapse while a
+    // phone is in a pocket is the bug wearing the fix's shape — and the cost of
+    // being generous is only a delayed update, while the cost of being stingy is
+    // a phone that cannot get back in.
+    expect(HEADLESS_RECENCY_MS).toBeGreaterThanOrEqual(5 * 60_000);
+  });
+});

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -4777,7 +4777,7 @@ describe("#875: hasLiveHeadlessClient reports the LIVE set, not the sticky one",
     // The property that killed the sticky isHeadless() is still intact: a phone
     // that has genuinely been gone longer than the window stops deferring, on
     // its own, with no unpairing step and no user action.
-    bridge.markHeadlessDisconnectForTests(Date.now() - HEADLESS_RECENCY_MS - 1);
+    bridge.markHeadlessDisconnectForTests(performance.now() - HEADLESS_RECENCY_MS - 1);
     expect(bridge.hasLiveHeadlessClient()).toBe(false);
   });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -13,6 +13,7 @@ import {
   isCapabilityRefusal,
   defaultBridgeTimeoutMs,
   BRIDGE_DEFAULT_TIMEOUT_MS,
+  HEADLESS_RECENCY_MS,
   BRIDGE_READ_DEFAULT_TIMEOUT_MS,
   BRIDGE_READONLY_CMDS,
   isMutatingGraphCommand,
@@ -4766,8 +4767,17 @@ describe("#875: hasLiveHeadlessClient reports the LIVE set, not the sticky one",
 
     sock.close();
     await new Promise((r) => setTimeout(r, 150));
-    // The whole point of not using the sticky isHeadless(): once the phone is
-    // gone the restarter must be free to restart again.
+    // #1176 — 150ms after the socket closed is NOT "the phone is gone". It is
+    // exactly the backgrounded case: the mobile OS suspends the socket within
+    // seconds of the screen going off. This assertion used to demand `false`
+    // here, and that is the bug — a reporter's restart rotated the cloudflared
+    // hostname during a pocket interval and their phone came back to a dead URL.
+    expect(bridge.hasLiveHeadlessClient()).toBe(true);
+
+    // The property that killed the sticky isHeadless() is still intact: a phone
+    // that has genuinely been gone longer than the window stops deferring, on
+    // its own, with no unpairing step and no user action.
+    bridge.markHeadlessDisconnectForTests(Date.now() - HEADLESS_RECENCY_MS - 1);
     expect(bridge.hasLiveHeadlessClient()).toBe(false);
   });
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2371,7 +2371,7 @@ export class UiBridge {
         // `headless` flag is still readable. This is the only place that knows a
         // headless socket just closed; after the delete the information is gone.
         if (this.conns.get(tabId)?.headless === true) {
-          this.lastHeadlessDisconnectAt = Date.now();
+          this.lastHeadlessDisconnectAt = performance.now();
         }
         this.conns.delete(tabId);
         if (this.lastActiveTabId === tabId) this.setLastActiveTab(null);
@@ -2813,16 +2813,32 @@ export class UiBridge {
    *  false for one that has genuinely been gone longer than the window. */
   private recentHeadlessWithin(ms: number): boolean {
     if (this.lastHeadlessDisconnectAt === undefined) return false;
-    return Date.now() - this.lastHeadlessDisconnectAt < ms;
+    return performance.now() - this.lastHeadlessDisconnectAt < ms;
   }
 
-  /** When a headless client last held an open socket (#1176). Undefined until one
-   *  disconnects — never set on a client that has not paired, so an install that
-   *  has never seen a phone can never defer. */
+  /**
+   * When a headless client last held an open socket (#1176), on the MONOTONIC
+   * clock — `performance.now()`, not `Date.now()`.
+   *
+   * This measures ELAPSED TIME, and the wall clock is not a measure of elapsed
+   * time: an NTP correction can move it. On Windows a step of more than the
+   * window would make a phone that disconnected seconds ago look long gone, and
+   * the restart would rotate the tunnel hostname — the exact bug this window
+   * exists to prevent, reintroduced by the clock rather than by the logic. A
+   * backward step would defer far longer than intended. (codex review, PR #1185)
+   *
+   * `performance.now()` is monotonic from process start, which is the right
+   * lifetime here: the value is only ever compared against another reading from
+   * the same process, and a restart clears it — after which there is no phone
+   * this process has seen, which is the correct answer anyway.
+   *
+   * Undefined until a headless client actually disconnects, so an install that
+   * has never seen a phone can never defer.
+   */
   private lastHeadlessDisconnectAt: number | undefined;
 
-  /** Test seam: the recency clock, so a test can place a disconnect in the past
-   *  without sleeping. */
+  /** Test seam: place the recency clock in the past without sleeping. Takes a
+   *  `performance.now()`-based reading, matching the field. */
   markHeadlessDisconnectForTests(at: number): void {
     this.lastHeadlessDisconnectAt = at;
   }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1064,6 +1064,28 @@ export function requiresWorkflowStampEnforcement(cmd: { cmd?: unknown }): boolea
  * Never below the read bound: see the invariant test.
  */
 export const BRIDGE_DEFAULT_TIMEOUT_MS = 20_000;
+
+/**
+ * How long after a headless client's socket closes it still counts as present
+ * for the #875 restart-deferral gate (#1176).
+ *
+ * Chosen from what the window has to cover and what it costs if it is wrong.
+ *
+ * It must cover: a phone whose screen went off, which the mobile OS suspends
+ * within seconds and which reconnects when the user next picks it up. That is a
+ * pocket interval — minutes to hours, unbounded in principle.
+ *
+ * It costs: a deferred auto-update, for this long, after a phone genuinely
+ * leaves. Nothing is lost — the update applies at the next check — so the price
+ * of being generous is a delay, while the price of being stingy is the reported
+ * bug: a rotated tunnel hostname and a phone that cannot get back in.
+ *
+ * Asymmetric, so lean generous. Thirty minutes covers a meeting or a commute and
+ * still lets an install that has truly lost its phone update within the hour,
+ * with no unpairing step and no user action — which is the property that made the
+ * sticky `isHeadless()` unacceptable for this gate.
+ */
+export const HEADLESS_RECENCY_MS = 30 * 60_000;
 /** More tolerant default for a READ (idempotent) command with no explicit timeout.
  *  A legitimately busy-but-alive panel main thread — e.g. Preview3D parsing a large
  *  FBX — can take many seconds to service a graph_query; failing it at the tight
@@ -2345,6 +2367,12 @@ export class UiBridge {
       let wasPrimary = false;
       if (tabId && this.conns.get(tabId)?.sock === sock) {
         wasPrimary = true;
+        // #1176 — start the recency clock BEFORE the conn is dropped, while its
+        // `headless` flag is still readable. This is the only place that knows a
+        // headless socket just closed; after the delete the information is gone.
+        if (this.conns.get(tabId)?.headless === true) {
+          this.lastHeadlessDisconnectAt = Date.now();
+        }
         this.conns.delete(tabId);
         if (this.lastActiveTabId === tabId) this.setLastActiveTab(null);
         // The mirrored desktop tab is gone — detach its viewers so their input
@@ -2756,7 +2784,47 @@ export class UiBridge {
    */
   hasLiveHeadlessClient(): boolean {
     for (const c of this.conns.values()) if (c.headless === true) return true;
-    return false;
+    // #1176 — A BACKGROUNDED PHONE IS NOT A DEPARTED PHONE.
+    //
+    // `conns` holds currently-OPEN sockets. A phone at work with its screen off
+    // has had its WebSocket suspended or closed by the mobile OS, so the loop
+    // above answers false and the restart gate opens — and the restart mints a
+    // NEW cloudflared hostname. A reporter picked their phone up to:
+    //
+    //   Failed host lookup: 'cameron-timing-face-spies.trycloudflare.com'
+    //   (No address associated with hostname, errno = 7)
+    //
+    // Not a timeout and not a refusal: the hostname no longer existed.
+    //
+    // The sticky `isHeadless()` was rejected for this gate, correctly — a phone
+    // that paired once and left would defer updates forever. But "socket open
+    // right now" and "ever paired" are not the only options, and the state
+    // between them is not an edge case: a phone in a pocket is the EXPECTED
+    // condition for someone who paired it to use at work.
+    //
+    // So: a bounded recency window. It keeps the property that killed the sticky
+    // option — a phone that genuinely left stops deferring, on its own, without
+    // anyone unpairing anything — while covering the normal mobile case.
+    return this.recentHeadlessWithin(HEADLESS_RECENCY_MS);
+  }
+
+  /** Was a headless client connected within `ms`? (#1176) Reads the disconnect
+   *  clock, so it answers true for a phone whose socket the OS suspended and
+   *  false for one that has genuinely been gone longer than the window. */
+  private recentHeadlessWithin(ms: number): boolean {
+    if (this.lastHeadlessDisconnectAt === undefined) return false;
+    return Date.now() - this.lastHeadlessDisconnectAt < ms;
+  }
+
+  /** When a headless client last held an open socket (#1176). Undefined until one
+   *  disconnects — never set on a client that has not paired, so an install that
+   *  has never seen a phone can never defer. */
+  private lastHeadlessDisconnectAt: number | undefined;
+
+  /** Test seam: the recency clock, so a test can place a disconnect in the past
+   *  without sleeping. */
+  markHeadlessDisconnectForTests(at: number): void {
+    this.lastHeadlessDisconnectAt = at;
   }
 
   isHeadless(tabId: string): boolean {


### PR DESCRIPTION
Fixes #1176. **Draft — claiming the issue, work in progress.**

## The gap

`#875`'s deferral gate asks `hasLiveHeadlessClient()`, which reads `conns` — currently-open sockets only. A phone at work with its screen off has had its WebSocket suspended or closed by the mobile OS, so the gate correctly reads "no headless client", opens, and the restart mints a new cloudflared hostname. The user picks up their phone and finds a dead URL:

```
WebSocketChannelException: SocketException: Failed host lookup:
'cameron-timing-face-spies.trycloudflare.com' (errno = 7)
```

Nothing misbehaves by its own contract — and the accessor's doc comment shows the sticky alternative was rejected for a good reason (it would defer updates forever after a single pairing). The hole is between the two:

| signal | behavior | problem |
|---|---|---|
| `isHeadless()` (sticky) | true once a phone ever paired | defers forever — correctly rejected |
| `hasLiveHeadlessClient()` (live) | true only while a socket is open | a backgrounded phone reads as gone — **this bug** |

The missing concept is *paired and in use, but not holding a socket right now* — which is the **normal** state of a mobile client, not an edge case.

## Plan

Bounded recency window: defer while a headless client was connected within the last N minutes. Keeps the "don't defer forever" property that killed the sticky option, while covering a pocketed phone. N chosen deliberately and stated in the code.

Not attempting #1151's structural fix here (decoupling the tunnel lifecycle so the hostname survives a restart) — that is the better long-term answer and this report is evidence for it, but it is a different change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)