### PR TITLE
release: v0.50.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.49] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- stop the client library's error path eating non-JSON responses (#1178)
+
+
 ## [0.50.48] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.48",
+  "version": "0.50.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.48",
+      "version": "0.50.49",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.48",
+  "version": "0.50.49",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the `v0.50.49` tag into protected main (version bump + changelog).

Contents: **#1178** — the ComfyUI client library's own error path was eating non-JSON responses, so a proxy/auth-gate/empty body reached the user as a bare `Unexpected end of JSON input` with the status, statusText and URL all lost. Closes #828 and #1160.

Release gates run locally before tagging: build, full suite (380 files / 7819 passed), `check:vocabulary` (clean on the tracked tree — the only hits were untracked scratch files in my working copy), `vocab:export --check`, `asset-counts --check`, and `docs:gen` freshness.