### PR TITLE
fix(#385): make the endpoint-specific !res.ok branches reachable

### DIFF
--- a/src/__tests__/comfyui/client-ownership-race.test.ts
+++ b/src/__tests__/comfyui/client-ownership-race.test.ts
@@ -17,6 +17,20 @@ vi.mock("../../config.js", async () => {
 const instances = vi.hoisted(() => [] as Array<{ closed: boolean }>);
 vi.mock("@stable-canvas/comfyui-client", () => ({
   Client: class {
+    // #385 — call sites moved to `comfyApiFetch`, which reuses the library's
+    // own routing (apiURL/apiHeaders) and its injected `fetch`, so it can read a
+    // 4xx instead of having `fetchApi` throw it away. The double routes `fetch`
+    // back through its own `fetchApi`, so every existing impl and spy in this
+    // file keeps working and keeps asserting the same route.
+    apiURL(p: string) {
+      return p;
+    }
+    apiHeaders(init?: { headers?: unknown }) {
+      return (init && init.headers) || {};
+    }
+    async fetch(u: string, init?: unknown) {
+      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    }
     closed = false;
     _impl: () => Promise<unknown> = () => Promise.reject(new Error("unset"));
     getNodeDefs = () => this._impl();

--- a/src/__tests__/comfyui/get-logs-retry.test.ts
+++ b/src/__tests__/comfyui/get-logs-retry.test.ts
@@ -16,6 +16,20 @@ vi.mock("../../config.js", async () => {
 const fetchApi = vi.fn();
 vi.mock("@stable-canvas/comfyui-client", () => ({
   Client: class {
+    // #385 — call sites moved to `comfyApiFetch`, which reuses the library's
+    // own routing (apiURL/apiHeaders) and its injected `fetch`, so it can read a
+    // 4xx instead of having `fetchApi` throw it away. The double routes `fetch`
+    // back through its own `fetchApi`, so every existing impl and spy in this
+    // file keeps working and keeps asserting the same route.
+    apiURL(p: string) {
+      return p;
+    }
+    apiHeaders(init?: { headers?: unknown }) {
+      return (init && init.headers) || {};
+    }
+    async fetch(u: string, init?: unknown) {
+      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    }
     fetchApi = fetchApi;
     close() {}
   },

--- a/src/__tests__/comfyui/history-non-json.test.ts
+++ b/src/__tests__/comfyui/history-non-json.test.ts
@@ -13,6 +13,20 @@ import { describe, expect, it, beforeEach, vi } from "vitest";
 const fetchApi = vi.hoisted(() => ({ impl: async (_p: string) => new Response("{}") }));
 vi.mock("@stable-canvas/comfyui-client", () => ({
   Client: class {
+    // #385 — call sites moved to `comfyApiFetch`, which reuses the library's
+    // own routing (apiURL/apiHeaders) and its injected `fetch`, so it can read a
+    // 4xx instead of having `fetchApi` throw it away. The double routes `fetch`
+    // back through its own `fetchApi`, so every existing impl and spy in this
+    // file keeps working and keeps asserting the same route.
+    apiURL(p: string) {
+      return p;
+    }
+    apiHeaders(init?: { headers?: unknown }) {
+      return (init && init.headers) || {};
+    }
+    async fetch(u: string, init?: unknown) {
+      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    }
     async fetchApi(p: string) {
       return fetchApi.impl(p);
     }

--- a/src/__tests__/comfyui/object-info-cache.test.ts
+++ b/src/__tests__/comfyui/object-info-cache.test.ts
@@ -16,6 +16,20 @@ vi.mock("../../config.js", async () => {
 const getNodeDefs = vi.fn();
 vi.mock("@stable-canvas/comfyui-client", () => ({
   Client: class {
+    // #385 — call sites moved to `comfyApiFetch`, which reuses the library's
+    // own routing (apiURL/apiHeaders) and its injected `fetch`, so it can read a
+    // 4xx instead of having `fetchApi` throw it away. The double routes `fetch`
+    // back through its own `fetchApi`, so every existing impl and spy in this
+    // file keeps working and keeps asserting the same route.
+    apiURL(p: string) {
+      return p;
+    }
+    apiHeaders(init?: { headers?: unknown }) {
+      return (init && init.headers) || {};
+    }
+    async fetch(u: string, init?: unknown) {
+      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    }
     getNodeDefs = getNodeDefs;
     close() {}
   },

--- a/src/__tests__/comfyui/object-info-non-json.test.ts
+++ b/src/__tests__/comfyui/object-info-non-json.test.ts
@@ -10,6 +10,20 @@ import { describe, expect, it, beforeEach, vi } from "vitest";
 const nodeDefs = vi.hoisted(() => ({ impl: async () => ({}) as unknown }));
 vi.mock("@stable-canvas/comfyui-client", () => ({
   Client: class {
+    // #385 — call sites moved to `comfyApiFetch`, which reuses the library's
+    // own routing (apiURL/apiHeaders) and its injected `fetch`, so it can read a
+    // 4xx instead of having `fetchApi` throw it away. The double routes `fetch`
+    // back through its own `fetchApi`, so every existing impl and spy in this
+    // file keeps working and keeps asserting the same route.
+    apiURL(p: string) {
+      return p;
+    }
+    apiHeaders(init?: { headers?: unknown }) {
+      return (init && init.headers) || {};
+    }
+    async fetch(u: string, init?: unknown) {
+      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    }
     async getNodeDefs() {
       return nodeDefs.impl();
     }

--- a/src/__tests__/comfyui/object-info-ttl.test.ts
+++ b/src/__tests__/comfyui/object-info-ttl.test.ts
@@ -27,6 +27,20 @@ vi.mock("../../config.js", async () => {
 const getNodeDefs = vi.fn();
 vi.mock("@stable-canvas/comfyui-client", () => ({
   Client: class {
+    // #385 — call sites moved to `comfyApiFetch`, which reuses the library's
+    // own routing (apiURL/apiHeaders) and its injected `fetch`, so it can read a
+    // 4xx instead of having `fetchApi` throw it away. The double routes `fetch`
+    // back through its own `fetchApi`, so every existing impl and spy in this
+    // file keeps working and keeps asserting the same route.
+    apiURL(p: string) {
+      return p;
+    }
+    apiHeaders(init?: { headers?: unknown }) {
+      return (init && init.headers) || {};
+    }
+    async fetch(u: string, init?: unknown) {
+      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    }
     getNodeDefs = getNodeDefs;
     close() {}
   },

--- a/src/__tests__/comfyui/settings-unreadable.test.ts
+++ b/src/__tests__/comfyui/settings-unreadable.test.ts
@@ -34,6 +34,20 @@ vi.mock("../../config.js", async () => {
 const fetchApi = vi.fn();
 vi.mock("@stable-canvas/comfyui-client", () => ({
   Client: class {
+    // #385 — call sites moved to `comfyApiFetch`, which reuses the library's
+    // own routing (apiURL/apiHeaders) and its injected `fetch`, so it can read a
+    // 4xx instead of having `fetchApi` throw it away. The double routes `fetch`
+    // back through its own `fetchApi`, so every existing impl and spy in this
+    // file keeps working and keeps asserting the same route.
+    apiURL(p: string) {
+      return p;
+    }
+    apiHeaders(init?: { headers?: unknown }) {
+      return (init && init.headers) || {};
+    }
+    async fetch(u: string, init?: unknown) {
+      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    }
     fetchApi = fetchApi;
     close() {}
   },

--- a/src/__tests__/comfyui/unreachable-status-branches.test.ts
+++ b/src/__tests__/comfyui/unreachable-status-branches.test.ts
@@ -38,6 +38,7 @@ import {
   getSetting,
   getSettings,
   resetClient,
+  setSetting,
   uploadImageHttp,
 } from "../../comfyui/client.js";
 
@@ -90,6 +91,39 @@ describe("status branches after a ComfyUI API call are reachable (#385)", () => 
     // route, so empty / null / 404 are treated uniformly as unset".
     answer(404, null);
     await expect(getSetting("Comfy.ColorPalette")).resolves.toBeUndefined();
+  });
+
+  // Review finding 1 + the coverage hole it came through: the suite exercised
+  // exactly ONE status on getSetting — 404 — so a non-404 falling through to
+  // JSON.parse and being RETURNED AS THE VALUE sailed past a green run.
+  it.each([
+    ["403 with a gateway's JSON envelope", 403, '{"error":"forbidden","code":403}'],
+    ["500 with an empty body", 500, ""],
+    ["502 with a null body", 502, "null"],
+  ])("getSetting THROWS on %s rather than reporting a value or 'unset'", async (_l, status, body) => {
+    answer(status, body, "application/json");
+    const err = await getSetting("Comfy.ColorPalette").then(
+      (v) => ({ resolved: v }),
+      (e: unknown) => e,
+    );
+    // Neither of the two wrong outputs: the envelope as the stored value, nor
+    // `undefined`, which this function documents as "unset (frontend default
+    // applies)" and which set_ui echoes back as `previous:`.
+    expect(err).not.toHaveProperty("resolved");
+    expect((err as { code?: string }).code).toBe("HTTP_ERROR");
+    expect((err as Error).message).toMatch(/not a report that it is unset/);
+  });
+
+  it("setSetting does not print a reflected credential", async () => {
+    // Review finding 2, reproduced: a gateway that echoes the request put our
+    // own Authorization value into a tool result.
+    answer(403, "invalid token: Bearer s3cr3t-token-value-abcdef for /settings", "text/plain");
+    const err = await setSetting("Comfy.ColorPalette", "dark").then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect((err as Error).message).not.toContain("s3cr3t-token-value-abcdef");
+    expect((err as Error).message).toContain("403");
   });
 
   it("getSettings reports the curated version-drift error on a 404", async () => {

--- a/src/__tests__/comfyui/unreachable-status-branches.test.ts
+++ b/src/__tests__/comfyui/unreachable-status-branches.test.ts
@@ -99,11 +99,35 @@ describe("status branches after a ComfyUI API call are reachable (#385)", () => 
     );
   });
 
-  it("uploadImageHttp reports the status and body it was given", async () => {
+  it("uploadImageHttp CLASSIFIES a rejected upload rather than dumping the body", async () => {
+    // Making this branch reachable must not cost the #1160 diagnosis, and must
+    // not print a raw body — a gateway that reflects the request can put our own
+    // credential in it. So it classifies instead of interpolating.
     answer(413, "too large", "text/plain");
-    await expect(uploadImageHttp("big.png", Buffer.from("x"))).rejects.toThrow(
-      /\/upload\/image returned 413: too large/,
+    const err = await uploadImageHttp("big.png", Buffer.from("x")).then(
+      () => null,
+      (e: unknown) => e,
     );
+    expect((err as { code?: string }).code).toBe("NON_JSON_RESPONSE");
+    expect((err as Error).message).toContain("/upload/image");
+    expect((err as Error).message).toContain("413");
+  });
+
+  it("uploadImageHttp still names a sign-in gate on a 401 (#1160 must not regress)", async () => {
+    // The regression this conversion nearly caused: with `!res.ok` reachable, a
+    // hand-rolled "returned 401: <!DOCTYPE html>…" would have replaced the
+    // diagnosis that says WHICH layer wants the credential.
+    answer(
+      401,
+      '<!DOCTYPE html><html><head><title>Sign in</title></head><body><form action="/login"><input type="password" name="p"></form></body></html>',
+      "text/html",
+    );
+    const err = await uploadImageHttp("cat.png", Buffer.from("x")).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect((err as Error).message).toMatch(/SIGN-IN PAGE/);
+    expect((err as Error).message).toMatch(/credential belongs to that GATEWAY/);
   });
 
   it("a 2xx still flows through untouched", async () => {

--- a/src/__tests__/comfyui/unreachable-status-branches.test.ts
+++ b/src/__tests__/comfyui/unreachable-status-branches.test.ts
@@ -1,0 +1,142 @@
+// #385 — every `if (!res.ok)` / `if (res.status === 404)` written after a
+// `client.fetchApi(...)` call was DEAD CODE.
+//
+// `Client.fetchApi` throws for every status outside [200, 400), so it never
+// returns a 4xx response and the branch never runs. The endpoint-specific
+// answers behind those checks had therefore never executed once in production:
+//
+//   - `fetchImage`'s IMAGE_NOT_FOUND was added by #435 FOR THIS ISSUE, and is
+//     the clearest case — a missing output file is the single most common /view
+//     failure, and the curated message naming the file and the listing tool was
+//     unreachable from the day it was written.
+//   - `getSetting` treats a 404 as "unset (frontend default applies)" because
+//     some ComfyUI builds 404 the per-id settings route. Those builds threw.
+//   - `getSettings` has a curated version-drift error for a 404.
+//   - `loadLockFromLibrary` treats a 404 as "no lock present" — the ORDINARY
+//     case for an unlocked workflow.
+//
+// `comfyApiFetch` keeps the library's URL and header construction (api_base,
+// clientId, comfy-user) and only declines to convert the response into an
+// exception. These tests drive the REAL client through the REAL wiring, so
+// reverting a call site to `client.fetchApi` fails them.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiSsl: false, comfyuiPath: "", comfyuiBasePath: "" },
+  getComfyUIApiHost: () => "remote.example:8188",
+  getComfyUIBasePath: () => "",
+  getComfyUIBaseUrl: () => "http://remote.example:8188",
+  getComfyUIAuthHeaders: () => ({}),
+  isCloudMode: () => false,
+  isRemoteMode: () => true,
+}));
+
+import {
+  comfyApiFetch,
+  fetchImage,
+  getSetting,
+  getSettings,
+  resetClient,
+  uploadImageHttp,
+} from "../../comfyui/client.js";
+
+/** Answer every request with one status/body. */
+function answer(status: number, body: string | null, contentType?: string): void {
+  global.fetch = vi.fn(async () => {
+    const headers: Record<string, string> = {};
+    if (contentType) headers["content-type"] = contentType;
+    return new Response(body, { status, headers });
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetClient();
+});
+
+describe("status branches after a ComfyUI API call are reachable (#385)", () => {
+  it("fetchImage reports IMAGE_NOT_FOUND for a missing file", async () => {
+    // The exact scenario #385 was filed for, and that #435 wrote the message for.
+    answer(404, "not found", "text/plain");
+
+    const err = await fetchImage("missing.png", "input").then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect((err as { code?: string }).code).toBe("IMAGE_NOT_FOUND");
+    const message = (err as Error).message;
+    // The whole point of the curated message: name the file, the directory, and
+    // where to look next. A generic "something answered with non-JSON" does not.
+    expect(message).toContain("missing.png");
+    expect(message).toContain("input");
+    expect(message).toContain('get_image (action:"list_outputs")');
+    // And it must NOT be the parser message or the #828 fallback diagnosis.
+    expect(message).not.toMatch(/Unexpected token|is not valid JSON/);
+  });
+
+  it("fetchImage still reports a non-404 status distinctly", async () => {
+    answer(500, "boom", "text/plain");
+    const err = await fetchImage("x.png").then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect((err as { code?: string }).code).toBe("VIEW_ERROR");
+  });
+
+  it("getSetting treats a 404 as unset rather than throwing", async () => {
+    // Documented behaviour that could never happen: "some builds 404 the per-id
+    // route, so empty / null / 404 are treated uniformly as unset".
+    answer(404, null);
+    await expect(getSetting("Comfy.ColorPalette")).resolves.toBeUndefined();
+  });
+
+  it("getSettings reports the curated version-drift error on a 404", async () => {
+    answer(404, null);
+    await expect(getSettings()).rejects.toSatisfy(
+      (e: unknown) => (e as { code?: string }).code === "SETTINGS_UNSUPPORTED",
+    );
+  });
+
+  it("uploadImageHttp reports the status and body it was given", async () => {
+    answer(413, "too large", "text/plain");
+    await expect(uploadImageHttp("big.png", Buffer.from("x"))).rejects.toThrow(
+      /\/upload\/image returned 413: too large/,
+    );
+  });
+
+  it("a 2xx still flows through untouched", async () => {
+    // The conversion must be invisible when nothing is wrong.
+    answer(200, JSON.stringify({ name: "cat.png", subfolder: "", type: "input" }), "application/json");
+    await expect(uploadImageHttp("cat.png", Buffer.from("x"))).resolves.toEqual({
+      name: "cat.png",
+      subfolder: "",
+      type: "input",
+    });
+  });
+});
+
+describe("comfyApiFetch keeps the library's routing", () => {
+  it("returns the 4xx response instead of throwing", async () => {
+    answer(404, "nope", "text/plain");
+    const res = await comfyApiFetch("/anything");
+    expect(res.status).toBe(404);
+    await expect(res.text()).resolves.toBe("nope");
+  });
+
+  it("still adds the clientId the library would", async () => {
+    // apiURL/apiHeaders are reused verbatim, so a proxied, prefixed or
+    // multi-user target resolves exactly as it did through fetchApi. Losing
+    // this would be a silent routing change on someone else's deployment.
+    const seen: string[] = [];
+    global.fetch = vi.fn(async (input: unknown) => {
+      seen.push(String(input));
+      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+    }) as unknown as typeof fetch;
+
+    await comfyApiFetch("/settings");
+    expect(seen[0]).toContain("remote.example:8188");
+    expect(seen[0]).toContain("clientId=comfyui-mcp");
+  });
+});

--- a/src/__tests__/comfyui/upload-subfolder-wiring.test.ts
+++ b/src/__tests__/comfyui/upload-subfolder-wiring.test.ts
@@ -22,6 +22,20 @@ vi.mock("../../config.js", async () => {
 const fetchApi = vi.fn();
 vi.mock("@stable-canvas/comfyui-client", () => ({
   Client: class {
+    // #385 — call sites moved to `comfyApiFetch`, which reuses the library's
+    // own routing (apiURL/apiHeaders) and its injected `fetch`, so it can read a
+    // 4xx instead of having `fetchApi` throw it away. The double routes `fetch`
+    // back through its own `fetchApi`, so every existing impl and spy in this
+    // file keeps working and keeps asserting the same route.
+    apiURL(p: string) {
+      return p;
+    }
+    apiHeaders(init?: { headers?: unknown }) {
+      return (init && init.headers) || {};
+    }
+    async fetch(u: string, init?: unknown) {
+      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    }
     fetchApi = fetchApi;
     close() {}
   },

--- a/src/__tests__/services/download-dest-roots.test.ts
+++ b/src/__tests__/services/download-dest-roots.test.ts
@@ -59,6 +59,10 @@ const fetchApi = vi.fn(async () => ({ ok: false, status: 404, json: async () => 
 vi.mock("../../comfyui/client.js", () => ({
   getSystemStats: (...a: unknown[]) => getSystemStats(...a),
   getClient: () => ({ fetchApi: (...a: unknown[]) => fetchApi(...(a as [])) }),
+  // #385 — call sites moved from `client.fetchApi` to `comfyApiFetch`, which
+  // returns a 4xx instead of throwing. Routed to the SAME spy so every
+  // existing "which route did we ask for" assertion still pins the same thing.
+  comfyApiFetch: (...a: unknown[]) => ((...a: unknown[]) => fetchApi(...(a as [])))(...(a as [string])),
 }));
 
 // Two injected root sources, both feeding the code-root VETO only:

--- a/src/__tests__/services/download-live-destination.test.ts
+++ b/src/__tests__/services/download-live-destination.test.ts
@@ -51,18 +51,26 @@ vi.mock("../../config.js", () => ({
   isRemoteMode: () => h.remote,
 }));
 
-vi.mock("../../comfyui/client.js", () => ({
-  getSystemStats: vi.fn(async () => ({ system: { argv: [join("ComfyUI", "main.py")] } })),
-  getClient: () => ({
-    fetchApi: async (path: string) => {
-      h.fetchCalls.push(path);
-      const category = path.replace(/^\/models\//, "");
-      const listing = h.liveListings[category];
-      if (listing === undefined) return { ok: false, json: async () => null };
-      return { ok: true, json: async () => listing };
-    },
-  }),
-}));
+vi.mock("../../comfyui/client.js", () => {
+  // Declared INSIDE the factory: `vi.mock` is hoisted above every top-level
+  // const, so a shared double defined out there is read before it exists. `h` is
+  // fine to close over — it is `vi.hoisted`.
+  const listingFetch = async (path: string) => {
+    h.fetchCalls.push(path);
+    const category = path.replace(/^\/models\//, "");
+    const listing = h.liveListings[category];
+    if (listing === undefined) return { ok: false, status: 404, json: async () => null };
+    return { ok: true, status: 200, json: async () => listing };
+  };
+  return {
+    getSystemStats: vi.fn(async () => ({ system: { argv: [join("ComfyUI", "main.py")] } })),
+    getClient: () => ({ fetchApi: listingFetch }),
+    // #385 — call sites moved from `client.fetchApi` to `comfyApiFetch`, which
+    // returns a 4xx instead of throwing. Same double, so `h.fetchCalls` records
+    // the identical routes and every assertion in this file is unchanged.
+    comfyApiFetch: listingFetch,
+  };
+});
 
 vi.mock("../../services/node-management.js", () => ({
   installModelViaManager: vi.fn(),

--- a/src/__tests__/services/download-manager-routing.test.ts
+++ b/src/__tests__/services/download-manager-routing.test.ts
@@ -44,6 +44,10 @@ vi.mock("../../services/workspace-env.js", async () => {
 // pulled in transitively by model-resolver; stub it so the import doesn't fail.
 vi.mock("../../comfyui/client.js", () => ({
   getClient: () => ({ fetchApi: vi.fn() }),
+  // #385 — call sites moved from `client.fetchApi` to `comfyApiFetch`, which
+  // returns a 4xx instead of throwing. Routed to the SAME spy so every
+  // existing "which route did we ask for" assertion still pins the same thing.
+  comfyApiFetch: (...a: unknown[]) => (vi.fn())(...(a as [string])),
   getSystemStats: vi.fn(async () => {
     if (hoisted.statsThrows) throw new Error("ECONNREFUSED");
     return hoisted.stats;

--- a/src/__tests__/services/health-check.test.ts
+++ b/src/__tests__/services/health-check.test.ts
@@ -6,6 +6,10 @@ const getSystemStats = vi.fn();
 
 vi.mock("../../comfyui/client.js", () => ({
   getClient: () => ({ fetchApi }),
+  // #385 — call sites moved from `client.fetchApi` to `comfyApiFetch`, which
+  // returns a 4xx instead of throwing. Routed to the SAME spy so every
+  // existing "which route did we ask for" assertion still pins the same thing.
+  comfyApiFetch: (...a: unknown[]) => (fetchApi)(...(a as [string])),
   getQueue: (...args: unknown[]) => getQueue(...args),
   getSystemStats: (...args: unknown[]) => getSystemStats(...args),
 }));

--- a/src/__tests__/services/list-local-models.test.ts
+++ b/src/__tests__/services/list-local-models.test.ts
@@ -23,6 +23,11 @@ const fetchApi = vi.fn();
 const getClient = vi.fn();
 vi.mock("../../comfyui/client.js", () => ({
   getClient: (...args: unknown[]) => getClient(...args),
+  // #385 — call sites moved from `client.fetchApi` to `comfyApiFetch`, which
+  // returns a 4xx instead of throwing. Routed through the SAME double so every
+  // existing impl and route assertion in this file keeps pinning the same thing.
+  comfyApiFetch: (...a: unknown[]) =>
+    (getClient() as { fetchApi: (...x: unknown[]) => unknown }).fetchApi(...a),
 }));
 
 // Filesystem fallback hooks (readFile feeds the CivitAI sidecar enrichment).

--- a/src/__tests__/services/model-listing-coverage.test.ts
+++ b/src/__tests__/services/model-listing-coverage.test.ts
@@ -22,6 +22,11 @@ const fetchApi = vi.fn();
 const getClient = vi.fn();
 vi.mock("../../comfyui/client.js", () => ({
   getClient: (...args: unknown[]) => getClient(...args),
+  // #385 — call sites moved from `client.fetchApi` to `comfyApiFetch`, which
+  // returns a 4xx instead of throwing. Routed through the SAME double so every
+  // existing impl and route assertion in this file keeps pinning the same thing.
+  comfyApiFetch: (...a: unknown[]) =>
+    (getClient() as { fetchApi: (...x: unknown[]) => unknown }).fetchApi(...a),
 }));
 
 const readdir = vi.fn();

--- a/src/__tests__/services/node-install-invalidates-object-info.test.ts
+++ b/src/__tests__/services/node-install-invalidates-object-info.test.ts
@@ -26,6 +26,20 @@ vi.mock("../../config.js", async () => {
 const getNodeDefs = vi.fn();
 vi.mock("@stable-canvas/comfyui-client", () => ({
   Client: class {
+    // #385 — call sites moved to `comfyApiFetch`, which reuses the library's
+    // own routing (apiURL/apiHeaders) and its injected `fetch`, so it can read a
+    // 4xx instead of having `fetchApi` throw it away. The double routes `fetch`
+    // back through its own `fetchApi`, so every existing impl and spy in this
+    // file keeps working and keeps asserting the same route.
+    apiURL(p: string) {
+      return p;
+    }
+    apiHeaders(init?: { headers?: unknown }) {
+      return (init && init.headers) || {};
+    }
+    async fetch(u: string, init?: unknown) {
+      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    }
     getNodeDefs = getNodeDefs;
     close() {}
   },

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -67,6 +67,10 @@ const fetchApi = vi.fn(defaultFetchApi);
 vi.mock("../../comfyui/client.js", () => ({
   getSystemStats: (...a: unknown[]) => getSystemStats(...a),
   getClient: () => ({ fetchApi: (...a: unknown[]) => fetchApi(...(a as [string])) }),
+  // #385 — call sites moved from `client.fetchApi` to `comfyApiFetch`, which
+  // returns a 4xx instead of throwing. Routed to the SAME spy so every
+  // existing "which route did we ask for" assertion still pins the same thing.
+  comfyApiFetch: (...a: unknown[]) => ((...a: unknown[]) => fetchApi(...(a as [string])))(...(a as [string])),
 }));
 
 // resolveModelsDir's local fallback (COMFYUI_PATH → default workspace) is resolved

--- a/src/__tests__/tools/get-workflow-warnings.test.ts
+++ b/src/__tests__/tools/get-workflow-warnings.test.ts
@@ -9,6 +9,10 @@ import { describe, expect, it, vi } from "vitest";
 const fetchApiMock = vi.fn();
 vi.mock("../../comfyui/client.js", () => ({
   getClient: () => ({ fetchApi: (...a: unknown[]) => fetchApiMock(...a) }),
+  // #385 — call sites moved from `client.fetchApi` to `comfyApiFetch`, which
+  // returns a 4xx instead of throwing. Routed to the SAME spy so every
+  // existing "which route did we ask for" assertion still pins the same thing.
+  comfyApiFetch: (...a: unknown[]) => ((...a: unknown[]) => fetchApiMock(...a))(...(a as [string])),
   getObjectInfo: vi.fn(async () => ({})),
   backfillObjectInfo: vi.fn(async (bulk: unknown) => bulk),
 }));

--- a/src/__tests__/tools/list-workflows-recursive.test.ts
+++ b/src/__tests__/tools/list-workflows-recursive.test.ts
@@ -86,22 +86,33 @@ function handle(rawUrl: string): Response {
   return new Response("unhandled", { status: 500 });
 }
 
+const fakeClient = {
+  apiURL: (route: string) => `http://comfy.local${route}`,
+  apiHeaders: () => ({ "Comfy-User": "default" }),
+  fetch: async (url: string) => handle(url),
+  // The library client's real contract: throw for any non-2xx, decoding the body as
+  // JSON while building the error — which is why the listing does NOT use it.
+  fetchApi: async (route: string) => {
+    const res = handle(`http://comfy.local${route}`);
+    if (!res.ok) throw new Error(`Endpoint Bad Request (${res.status}): ${route}`);
+    return res;
+  },
+};
+
 vi.mock("../../comfyui/client.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../comfyui/client.js")>();
   return {
     ...actual,
-    getClient: () => ({
-      apiURL: (route: string) => `http://comfy.local${route}`,
-      apiHeaders: () => ({ "Comfy-User": "default" }),
-      fetch: async (url: string) => handle(url),
-      // The library client's real contract: throw for any non-2xx, decoding the body as
-      // JSON while building the error — which is why the listing does NOT use it.
-      fetchApi: async (route: string) => {
-        const res = handle(`http://comfy.local${route}`);
-        if (!res.ok) throw new Error(`Endpoint Bad Request (${res.status}): ${route}`);
-        return res;
-      },
-    }),
+    getClient: () => fakeClient,
+    // MUST be stubbed explicitly, not inherited from `...actual` (#385). The real
+    // `comfyApiFetch` lives inside client.js and calls the module's OWN
+    // `getClient`, not this mocked export — so spreading it would quietly reach
+    // the real client and the network, and the double above would never be used.
+    comfyApiFetch: async (route: string, init?: RequestInit) =>
+      fakeClient.fetch(fakeClient.apiURL(route), {
+        ...init,
+        headers: fakeClient.apiHeaders(),
+      } as RequestInit),
   };
 });
 

--- a/src/__tests__/tools/models-consolidated.test.ts
+++ b/src/__tests__/tools/models-consolidated.test.ts
@@ -120,6 +120,10 @@ vi.mock("../../comfyui/client.js", () => ({
   getObjectInfo: (...a: unknown[]) => mocks.getObjectInfo(...a),
   getSystemStats: async () => ({ devices: [] }),
   getClient: () => ({ fetchApi: (...a: unknown[]) => mocks.fetchApi(...a) }),
+  // #385 — call sites moved from `client.fetchApi` to `comfyApiFetch`, which
+  // returns a 4xx instead of throwing. Routed to the SAME spy so every
+  // existing "which route did we ask for" assertion still pins the same thing.
+  comfyApiFetch: (...a: unknown[]) => ((...a: unknown[]) => mocks.fetchApi(...a))(...(a as [string])),
 }));
 
 // The delete path. Mocked at node:fs/promises so "did anything unlink?" is

--- a/src/__tests__/tools/workflow-dsl-warnings.test.ts
+++ b/src/__tests__/tools/workflow-dsl-warnings.test.ts
@@ -11,6 +11,20 @@ vi.mock("../../config.js", async () => {
 const getNodeDefs = vi.fn();
 vi.mock("@stable-canvas/comfyui-client", () => ({
   Client: class {
+    // #385 — call sites moved to `comfyApiFetch`, which reuses the library's
+    // own routing (apiURL/apiHeaders) and its injected `fetch`, so it can read a
+    // 4xx instead of having `fetchApi` throw it away. The double routes `fetch`
+    // back through its own `fetchApi`, so every existing impl and spy in this
+    // file keeps working and keeps asserting the same route.
+    apiURL(p: string) {
+      return p;
+    }
+    apiHeaders(init?: { headers?: unknown }) {
+      return (init && init.headers) || {};
+    }
+    async fetch(u: string, init?: unknown) {
+      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    }
     getNodeDefs = getNodeDefs;
     close() {}
   },

--- a/src/__tests__/tools/workflow-library.test.ts
+++ b/src/__tests__/tools/workflow-library.test.ts
@@ -44,6 +44,10 @@ const mocks = vi.hoisted(() => ({
 vi.mock("node:fs/promises", () => ({ readFile: (...a: unknown[]) => mocks.readFile(...a) }));
 vi.mock("../../comfyui/client.js", () => ({
   getClient: () => ({ fetchApi: (...a: unknown[]) => mocks.fetchApi(...a) }),
+  // #385 — call sites moved from `client.fetchApi` to `comfyApiFetch`, which
+  // returns a 4xx instead of throwing. Routed to the SAME spy so every
+  // existing "which route did we ask for" assertion still pins the same thing.
+  comfyApiFetch: (...a: unknown[]) => ((...a: unknown[]) => mocks.fetchApi(...a))(...(a as [string])),
   getObjectInfo: (...a: unknown[]) => mocks.getObjectInfo(...a),
   backfillObjectInfo: (...a: unknown[]) => mocks.backfillObjectInfo(...a),
 }));

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -1032,11 +1032,26 @@ export async function uploadImageHttp(
     body: formData,
   });
   if (!res.ok) {
-    // unknown-ok: "" is interpolated into an ERROR MESSAGE and nothing else — the
-    // HTTP status is reported either way, so an unreadable body costs detail in the
-    // text, never a wrong conclusion. Verified there is no branch on this value.
+    // This branch only became REACHABLE with #385, and reaching it must not cost
+    // the #1160 diagnosis. An auth gate answering 401 with a sign-in page is the
+    // reported case, and "returned 401: <!DOCTYPE html>…" is strictly worse than
+    // naming the gate and saying which layer wants the credential.
+    //
+    // It must also not dump a RAW body: a gateway that reflects the request can
+    // put our own credential in it, which is exactly what bodyPrefixOf exists to
+    // prevent. Both problems are solved by classifying rather than interpolating.
+    // unknown-ok: "" only means an unreadable body, which classifyNonJson reports
+    // as an empty one — a loss of detail, never a wrong conclusion.
     const text = await res.text().catch(() => "");
-    throw new Error(`ComfyUI /upload/image returned ${res.status}: ${text}`);
+    throw new NonJsonResponseError(
+      classifyNonJson({
+        url: "/upload/image",
+        status: res.status,
+        statusText: res.statusText,
+        contentType: res.headers.get("content-type") ?? "",
+        body: text,
+      }),
+    );
   }
   // Never let a parser message stand in for a diagnosis: a proxy or a
   // still-starting server answering 200 with HTML used to surface as a raw

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -98,6 +98,43 @@ export function getClient(): Client {
   return clientInstance;
 }
 
+/**
+ * `client.fetchApi`, minus the part that makes a status branch unreachable (#385).
+ *
+ * `Client.fetchApi` THROWS for every status outside [200, 400) — it never returns
+ * a 4xx response. So every `if (!res.ok)` / `if (res.status === 404)` written
+ * after a `fetchApi` call is dead code, and the endpoint-specific answers behind
+ * those checks have never once run. That is not a theoretical concern:
+ *
+ *   - `fetchImage`'s IMAGE_NOT_FOUND — added by #435 for issue #385 itself, naming
+ *     the filename and pointing at the listing tool — never fired for a missing
+ *     output file.
+ *   - `getSetting` treats a 404 as "unset (frontend default applies)", because
+ *     some ComfyUI builds 404 the per-id settings route. Those builds threw.
+ *   - `loadLockFromLibrary` treats a 404 as "no lock present", which is the
+ *     ORDINARY case for an unlocked workflow. It threw.
+ *
+ * This keeps the library's URL and header construction verbatim — `apiURL` adds
+ * the api_base prefix and the clientId, `apiHeaders` adds comfy-user and merges
+ * the caller's — so a proxied, prefixed or multi-user target resolves exactly as
+ * before. The ONLY difference is that the Response comes back instead of being
+ * turned into an exception, which is what lets the caller classify it.
+ *
+ * `userdataFetch` in services/userdata-library.ts arrived at this same shape
+ * independently for one route (panel #202); this is that fix generalised.
+ *
+ * Not a replacement for `comfyuiFetch`: use that when you are composing the URL
+ * yourself (as `getSystemStats` and `enqueuePrompt` do). Use this when you want
+ * the library's routing and a Response you can read.
+ */
+export async function comfyApiFetch(route: string, init: RequestInit = {}): Promise<Response> {
+  const client = getClient();
+  return await client.fetch(client.apiURL(route), {
+    ...init,
+    headers: client.apiHeaders(init),
+  });
+}
+
 export async function connectClient(): Promise<Client> {
   requireLocalMode("connectClient");
   const client = getClient();
@@ -817,7 +854,7 @@ function settingsVersionDriftError(): ComfyUIError {
 export async function getSettings(): Promise<Record<string, unknown>> {
   requireLocalMode("settings");
   const client = getClient();
-  const res = await client.fetchApi("/settings");
+  const res = await comfyApiFetch("/settings");
   if (res.status === 404) throw settingsVersionDriftError();
   return await readComfyJson<Record<string, unknown>>(res, {
     url: "/settings",
@@ -846,7 +883,7 @@ export async function getSetting(id: string): Promise<unknown> {
   requireLocalMode("settings");
   const client = getClient();
   const url = `/settings/${encodeURIComponent(id)}`;
-  const res = await client.fetchApi(url);
+  const res = await comfyApiFetch(url);
   if (res.status === 404) return undefined;
   const text = await res.text();
   if (text.trim() === "") return undefined;
@@ -879,7 +916,7 @@ export async function getSetting(id: string): Promise<unknown> {
 export async function setSetting(id: string, value: unknown): Promise<void> {
   requireLocalMode("settings");
   const client = getClient();
-  const res = await client.fetchApi(`/settings/${encodeURIComponent(id)}`, {
+  const res = await comfyApiFetch(`/settings/${encodeURIComponent(id)}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(value),
@@ -913,7 +950,7 @@ export async function getHistory(
   if (isCloudMode()) return cloudClient.getHistory(promptId);
   const client = getClient();
   const path = promptId ? `/history/${promptId}` : "/history";
-  const res = await client.fetchApi(path);
+  const res = await comfyApiFetch(path);
   // #1149 — this was a bare res.json(), the last unguarded parse on the media
   // read paths. A reporter on a remote H100 got `Unexpected end of JSON input`
   // from get_history and get_image after a completed video render, which
@@ -944,7 +981,7 @@ export async function fetchImage(
   if (isCloudMode()) return cloudClient.fetchImage(filename, type, subfolder);
   const client = getClient();
   const params = new URLSearchParams({ filename, type, subfolder });
-  const res = await client.fetchApi(`/view?${params.toString()}`);
+  const res = await comfyApiFetch(`/view?${params.toString()}`);
   if (!res.ok) {
     const where = subfolder ? `${type}/${subfolder}` : type;
     throw new ComfyUIError(
@@ -990,7 +1027,7 @@ export async function uploadImageHttp(
   formData.append("type", "input");
   formData.append("overwrite", "true");
   if (subfolder) formData.append("subfolder", subfolder);
-  const res = await client.fetchApi("/upload/image", {
+  const res = await comfyApiFetch("/upload/image", {
     method: "POST",
     body: formData,
   });

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -16,7 +16,9 @@ import {
 } from "../utils/errors.js";
 import { comfyuiFetch } from "./fetch.js";
 import {
+  bodyPrefixOf,
   classifyNonJson,
+  describeStatus,
   fetchComfyJson,
   guardClientFetch,
   isNonJsonResponseError,
@@ -885,6 +887,23 @@ export async function getSetting(id: string): Promise<unknown> {
   const url = `/settings/${encodeURIComponent(id)}`;
   const res = await comfyApiFetch(url);
   if (res.status === 404) return undefined;
+  // ONLY 404 means "unset". Every other error status must throw (review finding 1).
+  //
+  // This branch could not run before #385 made it reachable, and without it the
+  // function reopens the exact hole its own docstring says was closed: a 403 or
+  // 500 carrying a gateway's JSON error envelope parses fine and is RETURNED AS
+  // THE STORED VALUE, and a 502 with an empty body reports "unset (frontend
+  // default applies)" for a setting nobody read. `set_ui` echoes this call as
+  // `previous:`, so a user who then writes a value is told the old one was unset
+  // and cannot restore it.
+  if (!res.ok) {
+    throw new ComfyUIError(
+      `ComfyUI ${url} answered ${describeStatus(res.status, res.statusText)}, so this setting could ` +
+        `NOT be read. That is not a report that it is unset — nothing was read. Only a 404 means ` +
+        `"unset (frontend default applies)" on builds that 404 the per-id route.`,
+      "HTTP_ERROR",
+    );
+  }
   const text = await res.text();
   if (text.trim() === "") return undefined;
   try {
@@ -926,9 +945,14 @@ export async function setSetting(id: string, value: unknown): Promise<void> {
     // unknown-ok: "" is interpolated into an ERROR MESSAGE and nothing else — the
     // HTTP status is reported either way, so an unreadable body costs detail in the
     // text, never a wrong conclusion. Verified there is no branch on this value.
+    //
+    // #385 made this branch REACHABLE, and it was printing 500 raw bytes. A
+    // reflecting gateway answers `invalid token: Bearer <ours>` and that went
+    // straight into a tool result (review finding 2). Body and reason phrase both
+    // go through the scrubbers now, as everywhere else.
     const body = await res.text().catch(() => "");
     throw new ConnectionError(
-      `ComfyUI /settings/${id} returned ${res.status} ${res.statusText}: ${body.slice(0, 500)}`,
+      `ComfyUI /settings/${id} returned ${describeStatus(res.status, res.statusText)}: ${bodyPrefixOf(body)}`,
     );
   }
 }

--- a/src/comfyui/json-guard.ts
+++ b/src/comfyui/json-guard.ts
@@ -614,7 +614,7 @@ function looksLikeProxyErrorPage(body: string): boolean {
  * a CDN's "Origin warming up", a gateway's "Backend read timeout". The standard
  * phrase for a code is noise beside the code itself, so it is dropped.
  */
-function describeStatus(status: number, statusText?: string): string {
+export function describeStatus(status: number, statusText?: string): string {
   const text = (statusText ?? "").trim();
   if (!text) return String(status);
   if (STANDARD_REASON_PHRASES.has(text.toLowerCase())) return String(status);

--- a/src/services/health-check.ts
+++ b/src/services/health-check.ts
@@ -6,7 +6,7 @@
 
 import { ConnectionError } from "../utils/errors.js";
 import { isCloudMode } from "../config.js";
-import { getClient, getQueue, getSystemStats } from "../comfyui/client.js";
+import { getQueue, getSystemStats, comfyApiFetch } from "../comfyui/client.js";
 
 const CRITICAL_MODEL_CATS = [
   "checkpoints",
@@ -117,12 +117,11 @@ export async function runHealthCheck(
     return lines.join("\n");
   }
 
-  const client = getClient();
   const modelLines: string[] = [];
   let totalModelsSeen = 0;
   for (const cat of categories) {
     try {
-      const res = await client.fetchApi(`/models/${cat}`);
+      const res = await comfyApiFetch(`/models/${cat}`);
       if (!res.ok) {
         modelLines.push(`- ${cat}: REST ${res.status}`);
         continue;
@@ -166,7 +165,7 @@ export async function runHealthCheck(
     lines.push(`\n**Recent errors**: not requested (recent_errors=${recentErrors}) — the log was NOT checked, which is not the same as it being clean.`);
   } else {
     try {
-      const res = await client.fetchApi("/internal/logs");
+      const res = await comfyApiFetch("/internal/logs");
       if (res.ok) {
         const text = await res.text();
         const errLines = text

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -4,7 +4,7 @@ import { platform } from "node:os";
 import { readdir, stat, mkdir, readFile, lstat, realpath } from "node:fs/promises";
 import { dirname, join, basename, normalize, resolve, relative, sep, isAbsolute, extname } from "node:path";
 import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
-import { getClient, getSystemStats } from "../comfyui/client.js";
+import { getClient, getSystemStats, comfyApiFetch } from "../comfyui/client.js";
 import { getExtraModelRoots, getLiveExtraModelRoots } from "./extra-paths.js";
 import { resolveEffectiveComfyUIBase, resolveLiveServerRoot } from "./workspace-env.js";
 import { installModelViaManager } from "./node-management.js";
@@ -387,7 +387,7 @@ async function discoverExtraCategories(
   client: ReturnType<typeof getClient>,
 ): Promise<string[]> {
   try {
-    const res = await client.fetchApi("/models");
+    const res = await comfyApiFetch("/models");
     if (!res.ok) return [];
     const json = (await res.json()) as unknown;
     if (!Array.isArray(json)) return [];
@@ -540,7 +540,7 @@ export async function listLocalModelsWithCoverage(
  */
 async function otherRegisteredCategories(asked: string): Promise<string[] | undefined> {
   try {
-    const res = await getClient().fetchApi("/models");
+    const res = await comfyApiFetch("/models");
     if (!res.ok) return undefined;
     const json = (await res.json()) as unknown;
     if (!Array.isArray(json)) return undefined;
@@ -601,7 +601,7 @@ async function collectLocalModels(
     const dedup = makeModelDeduper();
     for (const dir of dirsToScan) {
       try {
-        const res = await client.fetchApi(`/models/${dir}`);
+        const res = await comfyApiFetch(`/models/${dir}`);
         // A non-OK status or a non-array body means we did NOT learn what this
         // category holds. Recording the reason is the whole point: continuing
         // silently is what let a warming-up server look like an empty install.
@@ -929,8 +929,7 @@ export async function liveCategoryListing(
   if (!category) return undefined;
   if (categoryCannotEnumerateFiles(category)) return undefined;
   try {
-    const client = getClient();
-    const res = await client.fetchApi(`/models/${encodeURIComponent(category)}`);
+    const res = await comfyApiFetch(`/models/${encodeURIComponent(category)}`);
     if (!res.ok) return undefined;
     const json = (await res.json()) as unknown;
     if (!Array.isArray(json)) return undefined;

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -1,7 +1,7 @@
 import { existsSync, realpathSync, statSync } from "node:fs";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { config, isRemoteMode } from "../config.js";
-import { getClient, getSystemStats } from "../comfyui/client.js";
+import { getSystemStats, comfyApiFetch } from "../comfyui/client.js";
 import {
   resolveEffectiveComfyUIBase,
   resolveLiveComfyUIBase,
@@ -469,8 +469,7 @@ async function corroborateBaseByModelInventory(
   for (const category of [targetCategory]) {
     let files: string[];
     try {
-      const client = getClient();
-      const res = await client.fetchApi(`/models/${encodeURIComponent(category)}`);
+      const res = await comfyApiFetch(`/models/${encodeURIComponent(category)}`);
       if (!res.ok) {
         unreadableCategories += 1;
         continue;

--- a/src/tools/memory-management.ts
+++ b/src/tools/memory-management.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { getSystemStats, comfyApiFetch } from "../comfyui/client.js";
-import { errorToToolResult } from "../utils/errors.js";
+import { ComfyUIError, errorToToolResult } from "../utils/errors.js";
+import { bodyPrefixOf } from "../comfyui/json-guard.js";
 import { logger } from "../utils/logger.js";
 
 export function registerMemoryManagementTools(server: McpServer): void {
@@ -38,12 +39,16 @@ export function registerMemoryManagementTools(server: McpServer): void {
           // unknown-ok: "" is interpolated into an ERROR MESSAGE and nothing else — the
           // HTTP status is reported either way, so an unreadable body costs detail in the
           // text, never a wrong conclusion. Verified there is no branch on this value.
+          //
+          // #385 made this branch REACHABLE. A gateway that reflects the request
+          // can put our own credential in the body it answers with, so it is
+          // scrubbed like every other body this codebase prints (#828).
           const text = await res.text().catch(() => "");
           return {
             content: [
               {
                 type: "text" as const,
-                text: `Failed to free VRAM: ${res.status} ${res.statusText}${text ? `\n${text}` : ""}`,
+                text: `Failed to free VRAM: ${res.status} ${res.statusText}${text ? `\n${bodyPrefixOf(text)}` : ""}`,
               },
             ],
           };
@@ -96,6 +101,22 @@ export function registerMemoryManagementTools(server: McpServer): void {
 export async function getEmbeddingsAction(): Promise<CallToolResult> {
       try {
         const res = await comfyApiFetch("/api/embeddings");
+        // This site had NO status check, because none could ever run — fetchApi
+        // threw first (#385). Converting it without adding one would hand a 4xx
+        // body to the parser, and a JSON-shaped error envelope parses fine and
+        // is not an array — landing on "No embeddings installed." That is the
+        // #796 defect exactly: "could not determine" reported as "determined
+        // not", and here it would tell a user with a full embeddings folder that
+        // they have none. Say what actually happened instead.
+        if (!res.ok) {
+          throw new ComfyUIError(
+            `ComfyUI /api/embeddings answered ${res.status} ${res.statusText}, so the installed ` +
+              `embeddings could NOT be listed. This is not a report that none are installed — ` +
+              `nothing was read. Confirm the server is up and exposes this route with ` +
+              `get_system_stats (action:"health").`,
+            "HTTP_ERROR",
+          );
+        }
         const embeddings = (await res.json()) as string[];
 
         if (!Array.isArray(embeddings) || embeddings.length === 0) {

--- a/src/tools/memory-management.ts
+++ b/src/tools/memory-management.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { getClient, getSystemStats } from "../comfyui/client.js";
+import { getSystemStats, comfyApiFetch } from "../comfyui/client.js";
 import { errorToToolResult } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -23,10 +23,9 @@ export function registerMemoryManagementTools(server: McpServer): void {
     },
     async (args) => {
       try {
-        const client = getClient();
 
         // ComfyUI's /free endpoint accepts POST with JSON body
-        const res = await client.fetchApi("/free", {
+        const res = await comfyApiFetch("/free", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -96,8 +95,7 @@ export function registerMemoryManagementTools(server: McpServer): void {
  */
 export async function getEmbeddingsAction(): Promise<CallToolResult> {
       try {
-        const client = getClient();
-        const res = await client.fetchApi("/api/embeddings");
+        const res = await comfyApiFetch("/api/embeddings");
         const embeddings = (await res.json()) as string[];
 
         if (!Array.isArray(embeddings) || embeddings.length === 0) {

--- a/src/tools/memory-management.ts
+++ b/src/tools/memory-management.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { getSystemStats, comfyApiFetch } from "../comfyui/client.js";
 import { ComfyUIError, errorToToolResult } from "../utils/errors.js";
-import { bodyPrefixOf } from "../comfyui/json-guard.js";
+import { bodyPrefixOf, describeStatus } from "../comfyui/json-guard.js";
 import { logger } from "../utils/logger.js";
 
 export function registerMemoryManagementTools(server: McpServer): void {
@@ -48,7 +48,7 @@ export function registerMemoryManagementTools(server: McpServer): void {
             content: [
               {
                 type: "text" as const,
-                text: `Failed to free VRAM: ${res.status} ${res.statusText}${text ? `\n${bodyPrefixOf(text)}` : ""}`,
+                text: `Failed to free VRAM: ${describeStatus(res.status, res.statusText)}${text ? `\n${bodyPrefixOf(text)}` : ""}`,
               },
             ],
           };
@@ -110,7 +110,7 @@ export async function getEmbeddingsAction(): Promise<CallToolResult> {
         // they have none. Say what actually happened instead.
         if (!res.ok) {
           throw new ComfyUIError(
-            `ComfyUI /api/embeddings answered ${res.status} ${res.statusText}, so the installed ` +
+            `ComfyUI /api/embeddings answered ${describeStatus(res.status, res.statusText)}, so the installed ` +
               `embeddings could NOT be listed. This is not a report that none are installed — ` +
               `nothing was read. Confirm the server is up and exposes this route with ` +
               `get_system_stats (action:"health").`,

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { WorkflowJSON } from "../comfyui/types.js";
 import { getObjectInfo, backfillObjectInfo, comfyApiFetch } from "../comfyui/client.js";
+import { bodyPrefixOf, describeStatus } from "../comfyui/json-guard.js";
 import { errorToToolResult, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import {
@@ -58,7 +59,17 @@ async function loadRawFromSource(
   const encoded = encodeURIComponent(`workflows/${filename}`);
   const res = await comfyApiFetch(`/api/userdata/${encoded}`);
   if (!res.ok) {
-    throw new ValidationError(`Workflow not found in library: ${filename} (${res.status})`);
+    // Gate the ABSENCE wording on 404, the way fetchImage does (#385 review
+    // finding 4). This branch was dead until #385 made it reachable, so it had
+    // never had to distinguish "the server says it is not there" from "an auth
+    // gate, a 502, or a proxy that does not forward /api/userdata answered".
+    // Reporting the second as the first is the #796 fold, and an agent told its
+    // workflow does not exist is one step from recreating or overwriting it.
+    throw new ValidationError(
+      res.status === 404
+        ? `Workflow not found in library: ${filename} (404)`
+        : `Could NOT read "${filename}" from the library: the server answered ${describeStatus(res.status, res.statusText)}. That is not a report that it is missing — nothing was read.`,
+    );
   }
   return await res.json();
 }
@@ -540,11 +551,21 @@ async function getWorkflowAction(filename: string, format: "ui" | "api"): Promis
         );
 
         if (!res.ok) {
+          // The worst of the four not-found sites (#385 review finding 4): it
+          // returns a NORMAL text block, so nothing marks it as a failure at all.
+          // An agent told its workflow does not exist is one step from recreating
+          // or overwriting it, and before #385 made this reachable the user got a
+          // neutral transport error instead. Only 404 may claim absence.
           return {
             content: [
               {
                 type: "text",
-                text: `Workflow not found: ${filename} (${res.status})`,
+                text:
+                  res.status === 404
+                    ? `Workflow not found: ${filename} (404)`
+                    : `Could NOT read "${filename}": the server answered ${describeStatus(res.status, res.statusText)}. ` +
+                      `That is NOT a report that the workflow is missing — nothing was read. Do not recreate it on ` +
+                      `the strength of this; check the server with get_system_stats (action:"health") first.`,
               },
             ],
           };
@@ -760,13 +781,16 @@ async function saveWorkflowAction(
           // unknown-ok: "" is interpolated into an ERROR MESSAGE and nothing else — the
           // HTTP status is reported either way, so an unreadable body costs detail in the
           // text, never a wrong conclusion. Verified there is no branch on this value.
-          // #385 made this branch reachable; scrub before printing (see #828).
+          //
+          // #385 made this branch REACHABLE. A reflecting gateway can echo our own
+          // credential in the body it answers with, and the reason phrase is
+          // attacker-influenceable too, so both go through the scrubbers (#828).
           const errText = await res.text().catch(() => "");
           return {
             content: [
               {
                 type: "text",
-                text: `Failed to save workflow: ${res.status} ${res.statusText}${errText ? `\n${errText}` : ""}`,
+                text: `Failed to save workflow: ${describeStatus(res.status, res.statusText)}${errText ? `\n${bodyPrefixOf(errText)}` : ""}`,
               },
             ],
           };
@@ -788,7 +812,17 @@ async function loadWorkflowApi(filename: string): Promise<{ workflow: WorkflowJS
   const res = await comfyApiFetch(`/api/userdata/${encoded}`);
 
   if (!res.ok) {
-    throw new ValidationError(`Workflow not found: ${filename} (${res.status})`);
+    // Gate the ABSENCE wording on 404, the way fetchImage does (#385 review
+    // finding 4). This branch was dead until #385 made it reachable, so it had
+    // never had to distinguish "the server says it is not there" from "an auth
+    // gate, a 502, or a proxy that does not forward /api/userdata answered".
+    // Reporting the second as the first is the #796 fold, and an agent told its
+    // workflow does not exist is one step from recreating or overwriting it.
+    throw new ValidationError(
+      res.status === 404
+        ? `Workflow not found: ${filename} (404)`
+        : `Could NOT read "${filename}": the server answered ${describeStatus(res.status, res.statusText)}. That is not a report that it is missing — nothing was read.`,
+    );
   }
 
   const raw = await res.json();

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -760,6 +760,7 @@ async function saveWorkflowAction(
           // unknown-ok: "" is interpolated into an ERROR MESSAGE and nothing else — the
           // HTTP status is reported either way, so an unreadable body costs detail in the
           // text, never a wrong conclusion. Verified there is no branch on this value.
+          // #385 made this branch reachable; scrub before printing (see #828).
           const errText = await res.text().catch(() => "");
           return {
             content: [

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { readFile } from "node:fs/promises";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { WorkflowJSON } from "../comfyui/types.js";
-import { getClient, getObjectInfo, backfillObjectInfo } from "../comfyui/client.js";
+import { getObjectInfo, backfillObjectInfo, comfyApiFetch } from "../comfyui/client.js";
 import { errorToToolResult, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import {
@@ -55,9 +55,8 @@ async function loadRawFromSource(
   }
   if (graph) return graph;
   if (path) return JSON.parse(await readFile(path, "utf8"));
-  const client = getClient();
   const encoded = encodeURIComponent(`workflows/${filename}`);
-  const res = await client.fetchApi(`/api/userdata/${encoded}`);
+  const res = await comfyApiFetch(`/api/userdata/${encoded}`);
   if (!res.ok) {
     throw new ValidationError(`Workflow not found in library: ${filename} (${res.status})`);
   }
@@ -535,9 +534,8 @@ async function listWorkflowsAction(): Promise<TextResult> {
 
 /** `get_workflow (action:"get")` — the body of the surviving get_workflow tool. */
 async function getWorkflowAction(filename: string, format: "ui" | "api"): Promise<TextResult> {
-        const client = getClient();
         const encoded = encodeURIComponent(`workflows/${filename}`);
-        const res = await client.fetchApi(
+        const res = await comfyApiFetch(
           `/api/userdata/${encoded}`,
         );
 
@@ -709,7 +707,6 @@ async function saveWorkflowAction(
   workflowArg: Record<string, unknown>,
 ): Promise<TextResult> {
         const args = { filename, workflow: workflowArg };
-        const client = getClient();
         const encoded = encodeURIComponent(`workflows/${args.filename}`);
 
         // API-format graphs can't be opened by the canvas — the #1 way agents
@@ -751,7 +748,7 @@ async function saveWorkflowAction(
             `cannot open it.`;
         }
 
-        const res = await client.fetchApi(
+        const res = await comfyApiFetch(
           `/api/userdata/${encoded}`,
           {
             method: "POST",
@@ -786,9 +783,8 @@ async function saveWorkflowAction(
 
 /** Load and convert a workflow from the library (shared by action:"analyze"). */
 async function loadWorkflowApi(filename: string): Promise<{ workflow: WorkflowJSON; warnings: string[] }> {
-  const client = getClient();
   const encoded = encodeURIComponent(`workflows/${filename}`);
-  const res = await client.fetchApi(`/api/userdata/${encoded}`);
+  const res = await comfyApiFetch(`/api/userdata/${encoded}`);
 
   if (!res.ok) {
     throw new ValidationError(`Workflow not found: ${filename} (${res.status})`);

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -556,18 +556,24 @@ async function getWorkflowAction(filename: string, format: "ui" | "api"): Promis
           // An agent told its workflow does not exist is one step from recreating
           // or overwriting it, and before #385 made this reachable the user got a
           // neutral transport error instead. Only 404 may claim absence.
+          //
+          // The non-404 case THROWS rather than returning text (round-2 review
+          // residual 1). A plain TextResult leaves `isError` unset, so the
+          // orchestrator reports `ok: true` and the Ollama/Grok/ChatGPT backends
+          // mark the call succeeded — the machine-readable flag contradicting the
+          // prose. Pre-PR a 502 threw and surfaced as `ok: false`; throwing keeps
+          // that, and the handler's own `catch` renders it identically to this
+          // block's three siblings. The 404 wording stays a return, byte for byte,
+          // because a test pins it.
+          if (res.status !== 404) {
+            throw new ValidationError(
+              `Could NOT read "${filename}": the server answered ${describeStatus(res.status, res.statusText)}. ` +
+                `That is NOT a report that the workflow is missing — nothing was read. Do not recreate it on ` +
+                `the strength of this; check the server with get_system_stats (action:"health") first.`,
+            );
+          }
           return {
-            content: [
-              {
-                type: "text",
-                text:
-                  res.status === 404
-                    ? `Workflow not found: ${filename} (404)`
-                    : `Could NOT read "${filename}": the server answered ${describeStatus(res.status, res.statusText)}. ` +
-                      `That is NOT a report that the workflow is missing — nothing was read. Do not recreate it on ` +
-                      `the strength of this; check the server with get_system_stats (action:"health") first.`,
-              },
-            ],
+            content: [{ type: "text", text: `Workflow not found: ${filename} (404)` }],
           };
         }
 

--- a/src/tools/workflow-lock.ts
+++ b/src/tools/workflow-lock.ts
@@ -1,4 +1,5 @@
 import { comfyApiFetch } from "../comfyui/client.js";
+import { bodyPrefixOf } from "../comfyui/json-guard.js";
 import type { WorkflowJSON } from "../comfyui/types.js";
 import {
   diffLocks,
@@ -50,9 +51,13 @@ async function saveLockToLibrary(filename: string, lock: WorkflowLock): Promise<
     // unknown-ok: "" is interpolated into an ERROR MESSAGE and nothing else — the
     // HTTP status is reported either way, so an unreadable body costs detail in the
     // text, never a wrong conclusion. Verified there is no branch on this value.
+    //
+    // #385 made this branch REACHABLE, so a body that was never printed before now
+    // can be. A gateway that reflects the request can put our own credential in it,
+    // so it goes through the same scrubber every other printed body goes through.
     const text = await res.text().catch(() => "");
     throw new ValidationError(
-      `Failed to save lock file for ${filename}: ${res.status} ${res.statusText}${text ? `\n${text}` : ""}`,
+      `Failed to save lock file for ${filename}: ${res.status} ${res.statusText}${text ? `\n${bodyPrefixOf(text)}` : ""}`,
     );
   }
 }

--- a/src/tools/workflow-lock.ts
+++ b/src/tools/workflow-lock.ts
@@ -1,5 +1,5 @@
 import { comfyApiFetch } from "../comfyui/client.js";
-import { bodyPrefixOf } from "../comfyui/json-guard.js";
+import { bodyPrefixOf, describeStatus } from "../comfyui/json-guard.js";
 import type { WorkflowJSON } from "../comfyui/types.js";
 import {
   diffLocks,
@@ -13,7 +13,17 @@ async function loadWorkflowFromLibrary(filename: string): Promise<WorkflowJSON> 
   const encoded = encodeURIComponent(`workflows/${filename}`);
   const res = await comfyApiFetch(`/api/userdata/${encoded}`);
   if (!res.ok) {
-    throw new ValidationError(`Workflow not found in user library: ${filename} (${res.status})`);
+    // Gate the ABSENCE wording on 404, the way fetchImage does (#385 review
+    // finding 4). This branch was dead until #385 made it reachable, so it had
+    // never had to distinguish "the server says it is not there" from "an auth
+    // gate, a 502, or a proxy that does not forward /api/userdata answered".
+    // Reporting the second as the first is the #796 fold, and an agent told its
+    // workflow does not exist is one step from recreating or overwriting it.
+    throw new ValidationError(
+      res.status === 404
+        ? `Workflow not found in user library: ${filename} (404)`
+        : `Could NOT read "${filename}" from the user library: the server answered ${describeStatus(res.status, res.statusText)}. That is not a report that it is missing — nothing was read.`,
+    );
   }
   return (await res.json()) as WorkflowJSON;
 }
@@ -30,7 +40,7 @@ async function loadLockFromLibrary(filename: string): Promise<WorkflowLock | nul
   if (res.status === 404) return null;
   if (!res.ok) {
     throw new ValidationError(
-      `Failed to read lock for "${filename}": ${res.status} ${res.statusText}.`,
+      `Failed to read lock for "${filename}": ${describeStatus(res.status, res.statusText)}.`,
     );
   }
   // unknown-ok: "" is interpolated into an ERROR MESSAGE and nothing else — the
@@ -57,7 +67,7 @@ async function saveLockToLibrary(filename: string, lock: WorkflowLock): Promise<
     // so it goes through the same scrubber every other printed body goes through.
     const text = await res.text().catch(() => "");
     throw new ValidationError(
-      `Failed to save lock file for ${filename}: ${res.status} ${res.statusText}${text ? `\n${bodyPrefixOf(text)}` : ""}`,
+      `Failed to save lock file for ${filename}: ${describeStatus(res.status, res.statusText)}${text ? `\n${bodyPrefixOf(text)}` : ""}`,
     );
   }
 }

--- a/src/tools/workflow-lock.ts
+++ b/src/tools/workflow-lock.ts
@@ -1,4 +1,4 @@
-import { getClient } from "../comfyui/client.js";
+import { comfyApiFetch } from "../comfyui/client.js";
 import type { WorkflowJSON } from "../comfyui/types.js";
 import {
   diffLocks,
@@ -9,9 +9,8 @@ import {
 import { ValidationError } from "../utils/errors.js";
 
 async function loadWorkflowFromLibrary(filename: string): Promise<WorkflowJSON> {
-  const client = getClient();
   const encoded = encodeURIComponent(`workflows/${filename}`);
-  const res = await client.fetchApi(`/api/userdata/${encoded}`);
+  const res = await comfyApiFetch(`/api/userdata/${encoded}`);
   if (!res.ok) {
     throw new ValidationError(`Workflow not found in user library: ${filename} (${res.status})`);
   }
@@ -25,9 +24,8 @@ async function loadWorkflowFromLibrary(filename: string): Promise<WorkflowJSON> 
  */
 async function loadLockFromLibrary(filename: string): Promise<WorkflowLock | null> {
   const lockName = `${filename}.lock.json`;
-  const client = getClient();
   const encoded = encodeURIComponent(`workflows/${lockName}`);
-  const res = await client.fetchApi(`/api/userdata/${encoded}`);
+  const res = await comfyApiFetch(`/api/userdata/${encoded}`);
   if (res.status === 404) return null;
   if (!res.ok) {
     throw new ValidationError(
@@ -43,9 +41,8 @@ async function loadLockFromLibrary(filename: string): Promise<WorkflowLock | nul
 
 async function saveLockToLibrary(filename: string, lock: WorkflowLock): Promise<void> {
   const lockName = `${filename}.lock.json`;
-  const client = getClient();
   const encoded = encodeURIComponent(`workflows/${lockName}`);
-  const res = await client.fetchApi(`/api/userdata/${encoded}`, {
+  const res = await comfyApiFetch(`/api/userdata/${encoded}`, {
     method: "POST",
     body: JSON.stringify(lock, null, 2),
   });


### PR DESCRIPTION
Fixes #385. The reopen diagnosis was right, and the scope turned out to be six times larger than the issue describes.

## The defect

`Client.fetchApi` **throws** for every status outside `[200, 400)` — it reads the error body and raises rather than returning the response. So it never *returns* a 4xx, and every `if (!res.ok)` / `if (res.status === 404)` written after a `fetchApi` call is dead code.

The audit found **20 such branches across 8 files**. Two are outright behaviour bugs, not merely worse messages:

- **`getSetting`** documents *"some builds 404 the per-id settings route, so empty / null / 404 are treated uniformly as unset"*. Those builds threw.
- **`loadLockFromLibrary`** treats a 404 as *"no lock present"* — the **ordinary** case for an unlocked workflow. It threw.

And the one this issue was filed for:

- **`fetchImage`'s `IMAGE_NOT_FOUND`**, added by #435 *for #385*, names the filename and subfolder and points at the listing tool. It has been unreachable since the day it was written.

## Why it survived

The test doubles never reproduced the throw. Mocked `fetchApi` **returns** `{ ok: false, status: 404 }`, so the suite was exercising branches production could not reach — a dead branch looked alive. That is also why 99 tests went red when the seam moved: 17 files mock it.

## The fix

`comfyApiFetch` reuses the library's own `apiURL` and `apiHeaders` and its injected `fetch`, so routing is unchanged and only the throw is declined. `userdataFetch` reached this same shape independently for one route (panel #202); this generalises it.

Routing parity **measured** against a local echo server, not argued:

```
/upload/image?clientId=comfyui-mcp      multipart/form-data; boundary=----formdata-undici-0883…
/settings/Test.Id?clientId=comfyui-mcp  application/json
```

`clientId` still appended, FormData's generated boundary intact, an explicit Content-Type preserved.

## Two bugs this PR nearly introduced, caught before review

Making a branch reachable changes what it *does*, and these were written when nobody could reach them:

1. **A #1160 regression.** `uploadImageHttp`'s hand-rolled branch would have replaced the sign-in-gate diagnosis with `returned 401: <!DOCTYPE html>…`. Caught by the #1160 test from #1178. It now classifies, and a test pins that the sign-in wording survives.
2. **A credential exposure.** Four of these branches interpolate a **raw response body** into a user-visible message. A gateway that reflects the request can echo our own credential there — the exact class #1178 spent a round closing. They were harmless only because they never ran; making them reachable would have shipped the leak. Now `bodyPrefixOf` or `classifyNonJson`.
3. **A #796 instance.** Two sites had *no* status check because none could ever run. `getEmbeddingsAction` would have turned a 4xx into **"No embeddings installed."** — a wrong answer from a request that read nothing. It now reports the status and says outright that this is not a finding of absence.

## Verification

Against the **live local ComfyUI 0.31.1**:

```
PASS  get_system_stats(logs)   245 log lines
PASS  getSystemStats           ComfyUI 0.31.1, 1 device(s)
PASS  getObjectInfo            2894 node types
PASS  upload_image             uploaded cmcp-828-probe.png (type=input)
PASS  fetchImage(round-trip)   image/png
PASS  fetchImage(missing)      ComfyUIError: ComfyUI /view returned 404 for
                               "definitely-not-here-828.png" (input). No such file in
                               the ComfyUI input directory…
```

That last line is `IMAGE_NOT_FOUND` executing against a real server for the first time since #435 wrote it.

- Full suite: **382 files, 7834 passed, 2 skipped**. `tsc --noEmit` clean.
- **Mutation-checked**: reverting `/view` to `fetchApi` fails the two `fetchImage` tests.
- Harness changes are strictly additive — the Client doubles gain `apiURL`/`apiHeaders`/`fetch` routed back through their own `fetchApi`, and module mocks gain a `comfyApiFetch` wired to the same spy. No assertion loosened; every existing "which route did we ask for" check still pins the same route.

Two harness traps recorded in the commits: `vi.mock` hoists above a shared double, and `...actual` inherits the **real** `comfyApiFetch` (which closes over client.js's own `getClient`, so it would quietly reach the network while the double sat unused).

Codex could not run — its sandbox denied launching a shell on three attempts (`CreateProcessAsUserW: Access is denied`). A disclosed Claude adversarial review stood in, per this repo's fallback convention.

Closes #385