### PR TITLE
release: v0.50.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.50] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- a BACKGROUNDED phone is not a departed phone (#1185)
+
+
 ## [0.50.49] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.49",
+  "version": "0.50.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.49",
+      "version": "0.50.50",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.49",
+  "version": "0.50.50",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.50` tag.

**A backgrounded phone no longer loses its tunnel to a self-restart** (#1176, via #1185).

#875 defers a self-restart while a paired phone is present, because restarting mints a new cloudflared quick-tunnel hostname. The gate read currently-open sockets only — and a phone at work with its screen off has had its socket suspended by the mobile OS. So the gate opened, the orchestrator self-updated 0.50.39 → 0.50.41, and the reporter picked up their phone to `Failed host lookup … errno = 7`: a DNS failure, because the hostname no longer existed.

The sticky alternative was correctly rejected — it would defer updates forever after one pairing — but "socket open right now" and "ever paired" are not the only options, and the state between them is the *normal* one for a phone. A 30-minute recency window covers a pocketed phone while keeping the property that matters: a phone that genuinely left stops deferring on its own, with no unpairing step and no user action.

Codex review of the PR found one real defect, fixed before merge: the window measures elapsed time, so it must not use the wall clock — an NTP step could skip it and rotate the hostname anyway. Now on `performance.now()`, with reader, writer and test seam moved together so a clock-domain mismatch also fails.

Verified live against the built artifact: a real WebSocket paired as headless, closed the way a backgrounded phone closes, still defers; past the window it does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)