### PR TITLE
fix(download): report the destination ComfyUI-Manager actually chose

### DIFF
--- a/src/__tests__/services/manager-destination.test.ts
+++ b/src/__tests__/services/manager-destination.test.ts
@@ -63,9 +63,16 @@ describe("describeManagerDestination", () => {
 
   it("WARNS when the destination is outside the root the server reads", async () => {
     // The reported case, and the one that costs a multi-GB file.
+    //
+    // extraRoots is INJECTED, and must be: without it this falls through to the
+    // live read, which on a developer machine reaches the real ComfyUI and on CI
+    // reaches nothing. That difference is exactly what made this pass locally and
+    // fail on CI — the same "a test silently queried the real server" trap this
+    // suite has hit before. A hermetic test states its own world.
     const note = await describeManagerDestination("clip_vision_h.safetensors", {
       readLog: readLog(LOG("/opt/ComfyUI/models/clip_vision/clip_vision_h.safetensors")),
       liveModelsDir: "/workspace/models",
+      extraRoots: async () => [],
     });
     expect(note).toMatch(/OUTSIDE the models directory/);
     expect(note).toContain("/opt/ComfyUI/models");
@@ -77,6 +84,7 @@ describe("describeManagerDestination", () => {
   it("confirms a destination INSIDE the live root", async () => {
     const note = await describeManagerDestination("clip_vision_h.safetensors", {
       readLog: readLog(LOG("/workspace/models/clip_vision/clip_vision_h.safetensors")),
+      extraRoots: async () => [],
       liveModelsDir: "/workspace/models",
     });
     expect(note).toMatch(/INSIDE the models directory/);
@@ -88,6 +96,7 @@ describe("describeManagerDestination", () => {
     // half is what decides usability. Say the first without implying the second.
     const note = await describeManagerDestination("clip_vision_h.safetensors", {
       readLog: readLog(LOG("/opt/ComfyUI/models/clip_vision/clip_vision_h.safetensors")),
+      extraRoots: async () => [],
       liveModelsDir: undefined,
     });
     expect(note).toContain("/opt/ComfyUI/models");
@@ -101,6 +110,7 @@ describe("describeManagerDestination", () => {
     expect(
       await describeManagerDestination("x.safetensors", {
         readLog: readLog("[INFO] nothing relevant"),
+        extraRoots: async () => [],
         liveModelsDir: "/workspace/models",
       }),
     ).toBeUndefined();
@@ -114,6 +124,7 @@ describe("describeManagerDestination", () => {
         readLog: async () => {
           throw new Error("logs unavailable");
         },
+        extraRoots: async () => [],
         liveModelsDir: "/workspace/models",
       }),
     ).resolves.toBeUndefined();
@@ -174,6 +185,7 @@ describe("review fixes (PR #1190)", () => {
   it("refuses to judge INSIDE/OUTSIDE across path syntaxes", async () => {
     const note = await describeManagerDestination("x.safetensors", {
       readLog: readLog(LINE("/workspace/models/x.safetensors")),
+      extraRoots: async () => [],
       liveModelsDir: "C:\workspace\models",
     });
     expect(note).toContain("/workspace/models/x.safetensors");
@@ -219,5 +231,24 @@ describe("review fixes (PR #1190)", () => {
     });
     expect(note).toMatch(/OUTSIDE the models directory/);
     expect(note).toMatch(/EPHEMERAL OVERLAY/);
+  });
+});
+
+// A test that reaches the developer's real ComfyUI passes locally and fails on
+// CI — which is exactly what happened here: the outside-root case omitted
+// `extraRoots`, fell through to the live read, and was green on this machine and
+// red on ubuntu. Green-because-it-found-a-server is not green.
+//
+// Pin it structurally: every call in this file states its own world.
+describe("this file never reaches a live server", () => {
+  it("injects extraRoots wherever a live models root is given", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(new URL(import.meta.url), "utf-8");
+    const calls = src.split("describeManagerDestination(").slice(1);
+    const leaky = calls.filter((c) => {
+      const body = c.slice(0, c.indexOf("});") + 3);
+      return body.includes("liveModelsDir:") && !body.includes("extraRoots:");
+    });
+    expect(leaky, "every call must stub extraRoots or it hits the network").toEqual([]);
   });
 });

--- a/src/__tests__/services/manager-destination.test.ts
+++ b/src/__tests__/services/manager-destination.test.ts
@@ -1,0 +1,144 @@
+// #1086 — the destination is unknowable only until we LOOK.
+//
+// A remote RunPod ComfyUI read models from /workspace/models (the 100GB volume)
+// via extra_model_paths, while / was a 20GB overlay. download_model dispatched to
+// ComfyUI-Manager, which wrote into /opt/ComfyUI/models instead. A multi-GB Wan
+// 2.2 file and a required clip-vision file were gone after a pod restart.
+//
+// The standing caveat says we cannot know where a Manager dispatch lands, because
+// extra_model_paths.yaml lives on the target filesystem. That is true of the
+// CONFIG. It is not true of the OUTCOME — Manager announces the absolute path it
+// picked, in both generations:
+//
+//   glob/manager_server.py:1063   f"Install model '{name}' from '{url}' into '{path}'"
+//   legacy/manager_server.py:634  (identical)
+//
+// which is exactly how the reporter found their file. /internal/logs is readable.
+
+import { describe, expect, it } from "vitest";
+import {
+  describeManagerDestination,
+  parseManagerInstallDestination,
+} from "../../services/model-resolver.js";
+
+/** The reporter's own log line, verbatim in shape. */
+const LOG = (dest: string, name = "clip_vision_h.safetensors") =>
+  `[INFO] Install model '${name}' from 'https://example/x' into '${dest}'`;
+
+describe("parseManagerInstallDestination", () => {
+  it("reads the absolute path Manager logged", () => {
+    const dest = parseManagerInstallDestination(
+      LOG("/opt/ComfyUI/models/clip_vision/clip_vision_h.safetensors"),
+      "clip_vision_h.safetensors",
+    );
+    expect(dest).toBe("/opt/ComfyUI/models/clip_vision/clip_vision_h.safetensors");
+  });
+
+  it("takes the LAST line for a name installed more than once", () => {
+    const text = [LOG("/opt/ComfyUI/models/a.safetensors", "a.safetensors"),
+                  LOG("/workspace/models/a.safetensors", "a.safetensors")].join("\n");
+    expect(parseManagerInstallDestination(text, "a.safetensors")).toBe(
+      "/workspace/models/a.safetensors",
+    );
+  });
+
+  it("does not match a DIFFERENT file whose name merely contains ours", () => {
+    // `x.safetensors` must not be answered by a line about `x.safetensors.part`.
+    const text = LOG("/opt/models/x.safetensors.part", "x.safetensors.part");
+    expect(parseManagerInstallDestination(text, "x.safetensors")).toBeUndefined();
+  });
+
+  it("returns undefined for a log with no such line", () => {
+    expect(parseManagerInstallDestination("[INFO] starting up\n", "x.safetensors")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty log or empty filename", () => {
+    expect(parseManagerInstallDestination("", "x.safetensors")).toBeUndefined();
+    expect(parseManagerInstallDestination(LOG("/a/b.safetensors"), "")).toBeUndefined();
+  });
+});
+
+describe("describeManagerDestination", () => {
+  const readLog = (text: string) => async () => text;
+
+  it("WARNS when the destination is outside the root the server reads", async () => {
+    // The reported case, and the one that costs a multi-GB file.
+    const note = await describeManagerDestination("clip_vision_h.safetensors", {
+      readLog: readLog(LOG("/opt/ComfyUI/models/clip_vision/clip_vision_h.safetensors")),
+      liveModelsDir: "/workspace/models",
+    });
+    expect(note).toMatch(/OUTSIDE the models directory/);
+    expect(note).toContain("/opt/ComfyUI/models");
+    expect(note).toContain("/workspace/models");
+    expect(note).toMatch(/EPHEMERAL OVERLAY/);
+    expect(note).toMatch(/will NOT see it/);
+  });
+
+  it("confirms a destination INSIDE the live root", async () => {
+    const note = await describeManagerDestination("clip_vision_h.safetensors", {
+      readLog: readLog(LOG("/workspace/models/clip_vision/clip_vision_h.safetensors")),
+      liveModelsDir: "/workspace/models",
+    });
+    expect(note).toMatch(/INSIDE the models directory/);
+    expect(note).not.toMatch(/OUTSIDE/);
+  });
+
+  it("locates the file WITHOUT claiming usability when the live root is unknown", async () => {
+    // Knowing WHERE is not knowing whether the server reads there, and the second
+    // half is what decides usability. Say the first without implying the second.
+    const note = await describeManagerDestination("clip_vision_h.safetensors", {
+      readLog: readLog(LOG("/opt/ComfyUI/models/clip_vision/clip_vision_h.safetensors")),
+      liveModelsDir: undefined,
+    });
+    expect(note).toContain("/opt/ComfyUI/models");
+    expect(note).toMatch(/could not be established/);
+    expect(note).not.toMatch(/INSIDE|OUTSIDE/);
+  });
+
+  it("says NOTHING when the log carries no destination line", async () => {
+    // Silence leaves the standing caveat as the answer, which is already the
+    // honest unknown. Inventing a second one would be noise.
+    expect(
+      await describeManagerDestination("x.safetensors", {
+        readLog: readLog("[INFO] nothing relevant"),
+        liveModelsDir: "/workspace/models",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("never throws when the log cannot be read", async () => {
+    // This runs AFTER a transfer: a diagnostic that cannot be gathered must not
+    // turn a completed dispatch into an error.
+    await expect(
+      describeManagerDestination("x.safetensors", {
+        readLog: async () => {
+          throw new Error("logs unavailable");
+        },
+        liveModelsDir: "/workspace/models",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+// THE WIRING. The helper cannot see whether download_model appends its answer —
+// the call-site blindness this suite keeps getting caught by. Read the source,
+// the way the other prose gates in this repo do.
+describe("the Manager branch reports the destination (#1086)", () => {
+  it("calls describeManagerDestination and appends it to BOTH arms", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      new URL("../../tools/model-management.ts", import.meta.url),
+      "utf-8",
+    );
+    const start = src.indexOf("const managerDest = job.viaManager");
+    expect(start, "the destination read must exist").toBeGreaterThan(-1);
+    expect(src).toMatch(/describeManagerDestination\(/);
+
+    // Appended OUTSIDE the visible/not-listed ternary, so a LISTED file whose
+    // destination is outside the live root still gets the warning — that pairing
+    // is exactly the #1086 shape.
+    const branch = src.slice(start, start + 2600);
+    expect(branch).toContain('(managerDest ? `');
+    expect(branch).toContain('${managerDest}');
+  });
+});

--- a/src/__tests__/services/manager-destination.test.ts
+++ b/src/__tests__/services/manager-destination.test.ts
@@ -142,3 +142,82 @@ describe("the Manager branch reports the destination (#1086)", () => {
     expect(branch).toContain('${managerDest}');
   });
 });
+
+// Codex adversarial review of PR #1190 found three real defects. Each is pinned
+// here, because each was a case where the fix said something CONFIDENT and WRONG
+// — and for two of them, wrong in the dangerous direction: a false OUTSIDE cries
+// wolf about a file that is fine, and contradicts a LISTED verdict in the very
+// same message.
+describe("review fixes (PR #1190)", () => {
+  const readLog = (text: string) => async () => text;
+  const LINE = (dest: string, name = "x.safetensors") =>
+    `Install model '${name}' from 'https://e/x' into '${dest}'`;
+
+  // DEFECT 2, and a PRE-EXISTING bug it exposed: job.filename is optional, and
+  // for a Manager dispatch job.path is a DESCRIPTOR, not a path.
+  it("recovers the filename from a Manager job DESCRIPTOR", async () => {
+    const { managerJobFilename } = await import("../../services/model-resolver.js");
+    expect(
+      managerJobFilename({
+        path: "checkpoints/foo.safetensors (dispatched to the remote ComfyUI via ComfyUI-Manager — download continues server-side. …)",
+      }),
+    ).toBe("foo.safetensors");
+    // An explicit filename still wins.
+    expect(managerJobFilename({ filename: "given.safetensors", path: "a/b (x)" })).toBe(
+      "given.safetensors",
+    );
+  });
+
+  // DEFECT 3: a remote POSIX destination vs a root that node's resolve() turned
+  // into "C:\workspace\models" on a Windows orchestrator. Comparing those always
+  // says OUTSIDE — for a destination that is exactly right.
+  it("refuses to judge INSIDE/OUTSIDE across path syntaxes", async () => {
+    const note = await describeManagerDestination("x.safetensors", {
+      readLog: readLog(LINE("/workspace/models/x.safetensors")),
+      liveModelsDir: "C:\workspace\models",
+    });
+    expect(note).toContain("/workspace/models/x.safetensors");
+    expect(note).toMatch(/different path syntaxes/);
+    // Assert the CLAIM, not the word: the message legitimately contains
+    // "INSIDE/OUTSIDE" while declining to make that call.
+    expect(note).toMatch(/no INSIDE\/OUTSIDE verdict is claimed/);
+    expect(note).not.toMatch(/is OUTSIDE the models directory/);
+    expect(note).not.toMatch(/will NOT see it/);
+  });
+
+  // DEFECT 5: a server reads more than one tree. A destination under a registered
+  // extra root is reachable, and calling it unusable would contradict the LISTED
+  // verdict rendered beside it.
+  it("does not call a destination unusable when an EXTRA root covers it", async () => {
+    const note = await describeManagerDestination("x.safetensors", {
+      readLog: readLog(LINE("/opt/ComfyUI/models/x.safetensors")),
+      liveModelsDir: "/workspace/models",
+      extraRoots: async () => ["/opt/ComfyUI/models"],
+    });
+    expect(note).toMatch(/INSIDE an extra_model_paths root/);
+    expect(note).not.toMatch(/will NOT see it/);
+  });
+
+  it("withholds the verdict when the extra roots could NOT be read", async () => {
+    // "We could not check" must not render as "there are none" — that is the
+    // #796 fold, and here it would produce a false unusable.
+    const note = await describeManagerDestination("x.safetensors", {
+      readLog: readLog(LINE("/opt/ComfyUI/models/x.safetensors")),
+      liveModelsDir: "/workspace/models",
+      extraRoots: async () => undefined,
+    });
+    expect(note).toMatch(/could NOT be checked/);
+    expect(note).toMatch(/not being called unusable/);
+  });
+
+  it("STILL warns for the reported case — outside, with extra roots known and clear", async () => {
+    // The guard rails must not have blunted the actual fix.
+    const note = await describeManagerDestination("x.safetensors", {
+      readLog: readLog(LINE("/opt/ComfyUI/models/x.safetensors")),
+      liveModelsDir: "/workspace/models",
+      extraRoots: async () => [],
+    });
+    expect(note).toMatch(/OUTSIDE the models directory/);
+    expect(note).toMatch(/EPHEMERAL OVERLAY/);
+  });
+});

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -2302,6 +2302,79 @@ function localAuthHeadersFor(
  * Matches the LAST occurrence: a filename can be installed more than once in a
  * session, and the newest line is the dispatch we just made.
  */
+/**
+ * Are these two absolute paths written in the SAME path syntax? (#1086, codex review)
+ *
+ * A destination read from the REMOTE server's log is in that host's syntax, while
+ * a root resolved here has been through node's `resolve()` — which on Windows
+ * turns "/workspace/models" into "C:\workspace\models". Comparing across that
+ * boundary always answers OUTSIDE, for a destination that may be exactly right,
+ * and a false OUTSIDE is the dangerous direction: it cries wolf about a good file
+ * and contradicts a LISTED verdict in the same message.
+ *
+ * Deliberately crude — POSIX-absolute vs drive-letter is the only distinction that
+ * matters here, and anything it cannot classify is treated as incomparable rather
+ * than guessed.
+ */
+/**
+ * The extra_model_paths directories the LIVE server reads, or undefined when that
+ * could not be established (#1086, codex review).
+ *
+ * Undefined is load-bearing: "we could not read the extra roots" must not render
+ * as "there are none", which would let a destination under a perfectly good extra
+ * root be reported as unusable.
+ */
+async function liveExtraRootDirs(): Promise<string[] | undefined> {
+  try {
+    const snapshot = await resolveModelsDirWithBases();
+    const live = await getLiveExtraModelRoots(snapshot.snapshot);
+    if (!live.authoritative) return undefined;
+    return live.roots.map((r) => r.dir).filter((d): d is string => typeof d === "string");
+  } catch {
+    return undefined;
+  }
+}
+
+function samePathDomain(a: string, b: string): boolean {
+  const kind = (p: string): "posix" | "win32" | "unknown" => {
+    if (/^[A-Za-z]:[\/]/.test(p)) return "win32";
+    if (p.startsWith("\\\\")) return "win32"; // UNC
+    if (p.startsWith("/")) return "posix";
+    return "unknown";
+  };
+  const ka = kind(a);
+  const kb = kind(b);
+  return ka !== "unknown" && ka === kb;
+}
+
+/**
+ * The FILENAME a Manager dispatch actually used, from a finished job (#1086,
+ * codex review).
+ *
+ * `job.filename` is OPTIONAL — a URL-only download never sets it — and the
+ * fallback in use was `job.path.split(/[\/]/).pop()`. For a Manager dispatch
+ * `job.path` is not a path at all; it is
+ *
+ *     "checkpoints/foo.safetensors (dispatched to the remote ComfyUI via …)"
+ *
+ * so that fallback returned the whole descriptive tail. Every consumer then
+ * searched for a filename that cannot match anything: the destination read below
+ * misses, and `verifyManagerVisibility` — which used the identical fallback long
+ * before this change — probed a name the server could never list, quietly turning
+ * every URL-only Manager download into an unverifiable one.
+ *
+ * Take the leading "<subfolder>/<filename>" that descriptor is built from,
+ * stopping at the " (" the note begins with.
+ */
+export function managerJobFilename(job: {
+  filename?: string;
+  path?: string;
+}): string {
+  if (job.filename) return job.filename;
+  const head = (job.path ?? "").split(" (")[0];
+  return head.split(/[\/]/).pop() ?? "";
+}
+
 export function parseManagerInstallDestination(
   logText: string,
   filename: string,
@@ -2330,6 +2403,9 @@ export async function describeManagerDestination(
     /** Injectable so this is testable without a live server. */
     readLog?: () => Promise<string | undefined>;
     liveModelsDir?: string | undefined;
+    /** The server's extra_model_paths roots, or undefined when they could not be
+     *  established. Injectable for tests; defaults to the live read. */
+    extraRoots?: () => Promise<string[] | undefined>;
   },
 ): Promise<string | undefined> {
   let text: string | undefined;
@@ -2348,6 +2424,32 @@ export async function describeManagerDestination(
   if (!dest) return undefined;
 
   const root = opts?.liveModelsDir;
+  // #1086 (codex review, PR #1190) — ONLY compare when the comparison is
+  // trustworthy, and the two ways it is not are both dangerous in the SAME
+  // direction: a false OUTSIDE cries wolf about a file that is fine, and
+  // contradicts a LISTED verdict sitting in the same message.
+  //
+  //  - PATH DOMAIN. `dest` comes from the REMOTE server's log, so it is that
+  //    host's path syntax. `currentLiveModelsRoot()` runs its value through
+  //    node's `resolve()`, which on a WINDOWS orchestrator turns the remote
+  //    "/workspace/models" into "C:\workspace\models". Comparing those two
+  //    always says OUTSIDE — for a destination that is exactly right.
+  //  - EXTRA ROOTS. This compares one PRIMARY root, while a server can read
+  //    several. A destination under a legitimately-registered extra root would
+  //    be reported as unusable while `verifyManagerVisibility` lists it.
+  //
+  // So the INSIDE/OUTSIDE verdict is asserted only when the domains agree, and
+  // an OUTSIDE reading also has to survive the extra roots. Anything else falls
+  // back to locating the file WITHOUT judging it — which is still far more than
+  // the old "we cannot know where this lands".
+  if (root !== undefined && !samePathDomain(dest, root)) {
+    return (
+      `ComfyUI-Manager reported writing it to ${dest}. That path is on the ComfyUI ` +
+      `host and could not be compared with the models directory known here ` +
+      `(${root}) — they are written in different path syntaxes, so no INSIDE/OUTSIDE ` +
+      `verdict is claimed. Check list_local_models to confirm the server can read it.`
+    );
+  }
   if (root === undefined) {
     // We know WHERE, but not whether that is a place the server reads — and the
     // second half is the one that decides whether the file is usable. Say the
@@ -2362,6 +2464,29 @@ export async function describeManagerDestination(
     return (
       `ComfyUI-Manager reported writing it to ${dest}, which is INSIDE the models ` +
       `directory that server reads (${root}).`
+    );
+  }
+  // An OUTSIDE reading has to survive the EXTRA roots before it is asserted: a
+  // server reads more than one tree, and a destination under a registered extra
+  // root is fine. Unreadable extra roots mean we cannot rule that out, so the
+  // verdict is withheld rather than guessed — the same three-state discipline as
+  // everywhere else here.
+  const extra = await (opts?.extraRoots !== undefined
+    ? opts.extraRoots()
+    : liveExtraRootDirs());
+  if (extra === undefined) {
+    return (
+      `ComfyUI-Manager reported writing it to ${dest}, which is not under the primary ` +
+      `models directory the connected server reads (${root}). Whether that server also ` +
+      `reads it through an extra_model_paths entry could NOT be checked from here, so ` +
+      `this is not being called unusable — confirm with list_local_models.`
+    );
+  }
+  if (extra.some((r) => typeof r === "string" && isUnderRoot(dest, r))) {
+    return (
+      `ComfyUI-Manager reported writing it to ${dest}, which is outside the primary ` +
+      `models directory (${root}) but INSIDE an extra_model_paths root that server ` +
+      `reads — so it is reachable.`
     );
   }
   return (

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -4,7 +4,7 @@ import { platform } from "node:os";
 import { readdir, stat, mkdir, readFile, lstat, realpath } from "node:fs/promises";
 import { dirname, join, basename, normalize, resolve, relative, sep, isAbsolute, extname } from "node:path";
 import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
-import { getClient, getSystemStats } from "../comfyui/client.js";
+import { getClient, getLogs, getSystemStats } from "../comfyui/client.js";
 import { getExtraModelRoots, getLiveExtraModelRoots } from "./extra-paths.js";
 import { resolveEffectiveComfyUIBase, resolveLiveServerRoot } from "./workspace-env.js";
 import { installModelViaManager } from "./node-management.js";
@@ -2275,6 +2275,106 @@ function localAuthHeadersFor(
  * dead end; list_local_models reads through the SAME roots the server reads, so a
  * file that appears there is genuinely reachable by a workflow.
  */
+/**
+ * The destination ComfyUI-Manager LOGGED for `filename`, read back from
+ * `/internal/logs` (#1086).
+ *
+ * The standing caveat says we cannot know where a Manager dispatch lands, because
+ * `extra_model_paths.yaml` lives on the target filesystem. That is true of the
+ * CONFIG — and the reporter's own evidence shows it is not true of the OUTCOME.
+ * Manager announces the absolute path it picked, in both generations:
+ *
+ *   glob/manager_server.py:1063  f"Install model '{name}' from '{url}' into '{path}'"
+ *   legacy/manager_server.py:634 (identical)
+ *
+ * which is how they discovered their Wan 2.2 file had gone to
+ * `/opt/ComfyUI/models` while the server read `/workspace/models` — a 20GB overlay
+ * that discarded it on the next pod restart.
+ *
+ * So the destination is unknowable only until we look. This looks.
+ *
+ * Returns undefined when the log could not be read OR carried no such line —
+ * DELIBERATELY not distinguished here, because the caller's remedy is identical
+ * (fall back to the caveat) and inventing a distinction the caller cannot act on
+ * would be noise. What must never happen is an unread log rendering as a
+ * destination, which is why undefined is the only other answer.
+ *
+ * Matches the LAST occurrence: a filename can be installed more than once in a
+ * session, and the newest line is the dispatch we just made.
+ */
+export function parseManagerInstallDestination(
+  logText: string,
+  filename: string,
+): string | undefined {
+  if (!logText || !filename) return undefined;
+  // The name is interpolated into the line inside single quotes, so match it as a
+  // whole quoted token — a bare substring would let `clip_vision_h.safetensors`
+  // be matched by a line about `clip_vision_h.safetensors.part`.
+  const esc = filename.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`Install model '${esc}' from '[^']*' into '([^']+)'`, "g");
+  let last: string | undefined;
+  for (const m of logText.matchAll(re)) last = m[1];
+  return last;
+}
+
+/**
+ * Read the live server's log and report where Manager said it put `filename`,
+ * plus whether that is inside the models root the server actually reads (#1086).
+ *
+ * Never throws: this runs after a transfer, and a diagnostic that cannot be
+ * gathered must not turn a completed dispatch into an error.
+ */
+export async function describeManagerDestination(
+  filename: string,
+  opts?: {
+    /** Injectable so this is testable without a live server. */
+    readLog?: () => Promise<string | undefined>;
+    liveModelsDir?: string | undefined;
+  },
+): Promise<string | undefined> {
+  let text: string | undefined;
+  try {
+    // getLogs() already carries the reconnect-and-retry a Manager reboot needs
+    // (#399) — a restart is exactly what precedes many of these reads.
+    text =
+      opts?.readLog !== undefined
+        ? await opts.readLog()
+        : (await getLogs()).join("\n");
+  } catch {
+    return undefined;
+  }
+  if (!text) return undefined;
+  const dest = parseManagerInstallDestination(text, filename);
+  if (!dest) return undefined;
+
+  const root = opts?.liveModelsDir;
+  if (root === undefined) {
+    // We know WHERE, but not whether that is a place the server reads — and the
+    // second half is the one that decides whether the file is usable. Say the
+    // first without implying the second.
+    return (
+      `ComfyUI-Manager reported writing it to ${dest}. Whether that path is one the ` +
+      `connected server reads could not be established from here, so this locates the ` +
+      `file without confirming it is usable — check list_local_models.`
+    );
+  }
+  if (isUnderRoot(dest, root)) {
+    return (
+      `ComfyUI-Manager reported writing it to ${dest}, which is INSIDE the models ` +
+      `directory that server reads (${root}).`
+    );
+  }
+  return (
+    `⚠ ComfyUI-Manager reported writing it to ${dest}, which is OUTSIDE the models ` +
+    `directory the connected server reads (${root}) — so a workflow there will NOT see ` +
+    `it. This is the extra_model_paths case: Manager picks its own destination root ` +
+    `and does not necessarily honour that config. On a container the base models ` +
+    `directory is commonly an EPHEMERAL OVERLAY, which discards the file on the next ` +
+    `restart — move it into ${root} now, or re-download with COMFYUI_PATH set so this ` +
+    `MCP streams it to a destination it controls.`
+  );
+}
+
 export function managerDestinationCaveat(): string {
   return (
     "ComfyUI-Manager chooses the destination root itself and does not necessarily honour " +

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -6,6 +6,7 @@ import {
   listLocalModels,
   listLocalModelsWithCoverage,
   describeManagerDestination,
+  managerJobFilename,
   currentLiveModelsRoot,
   verifyManagerVisibility,
   MODEL_SUBDIRS,
@@ -724,7 +725,11 @@ async function downloadAction(args: {
           const managerSeen = job.viaManager
             ? await verifyManagerVisibility(
                 job.target_subfolder,
-                job.filename ?? (job.path ?? "").split(/[\\/]/).pop() ?? "",
+                // #1086 (codex review) — was `job.filename ?? path.split(…).pop()`.
+                // For a Manager dispatch `job.path` is a DESCRIPTOR, not a path, so
+                // that returned the whole trailing note and made every URL-only
+                // download unverifiable. Pre-existing; exposed by the review.
+                managerJobFilename(job),
                 { attempts: 1 },
               ).catch(() => undefined)
             : undefined;
@@ -748,10 +753,9 @@ async function downloadAction(args: {
           // string, never undefined. Verified there is no branch on this value
           // beyond "append it if present".
           const managerDest = job.viaManager
-            ? await describeManagerDestination(
-                job.filename ?? (job.path ?? "").split(/[\\/]/).pop() ?? "",
-                { liveModelsDir: liveRoot },
-              ).catch(() => undefined)
+            ? await describeManagerDestination(managerJobFilename(job), {
+                liveModelsDir: liveRoot,
+              }).catch(() => undefined)
             : undefined;
           const text = job.viaManager
             ? `Download DISPATCHED to the remote ComfyUI via ComfyUI-Manager (server-side fetch):\n${job.path}\n\n` +

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -5,6 +5,7 @@ import {
   searchHuggingFaceModels,
   listLocalModels,
   listLocalModelsWithCoverage,
+  describeManagerDestination,
   currentLiveModelsRoot,
   verifyManagerVisibility,
   MODEL_SUBDIRS,
@@ -707,9 +708,8 @@ async function downloadAction(args: {
           // ONE placement policy for every consumer (#369): only a file the running
           // ComfyUI actually lists may be called a success. A Manager dispatch, a
           // still-pending check and an inconclusive check are all unconfirmed.
-          const placement = describePlacement(job, {
-            liveModelsDir: await currentLiveModelsRoot(),
-          });
+          const liveRoot = await currentLiveModelsRoot();
+          const placement = describePlacement(job, { liveModelsDir: liveRoot });
           // #1086 — ASK the server instead of telling the caller to. The Manager
           // branch could only ever say "confirm with list_local_models yourself",
           // and a reporter who did not lost a multi-GB model to an ephemeral
@@ -726,6 +726,31 @@ async function downloadAction(args: {
                 job.target_subfolder,
                 job.filename ?? (job.path ?? "").split(/[\\/]/).pop() ?? "",
                 { attempts: 1 },
+              ).catch(() => undefined)
+            : undefined;
+          // #1086 — the destination is unknowable only until we LOOK.
+          //
+          // The standing caveat says we cannot know where a Manager dispatch
+          // lands, because extra_model_paths.yaml lives on the target filesystem.
+          // True of the CONFIG; not true of the OUTCOME — Manager logs the
+          // absolute path it chose, which is how a reporter found their Wan 2.2
+          // file in /opt/ComfyUI/models while the server read /workspace/models,
+          // a 20GB overlay that discarded it on the next pod restart.
+          //
+          // unknown-ok: undefined here means "no destination line was read" —
+          // from an unreadable log, a Manager build that logs differently, or a
+          // throw — and every one of those leads to the SAME correct behaviour:
+          // append nothing, and leave managerDestinationCaveat()'s standing "this
+          // has NOT established where the file lands" as the answer. That caveat
+          // is already the honest unknown; a second one saying the same thing
+          // would be noise. The state that must never collapse is the opposite
+          // one — a destination we DID read must never be dropped — and that is a
+          // string, never undefined. Verified there is no branch on this value
+          // beyond "append it if present".
+          const managerDest = job.viaManager
+            ? await describeManagerDestination(
+                job.filename ?? (job.path ?? "").split(/[\\/]/).pop() ?? "",
+                { liveModelsDir: liveRoot },
               ).catch(() => undefined)
             : undefined;
           const text = job.viaManager
@@ -745,7 +770,11 @@ async function downloadAction(args: {
               (managerSeen?.visibility === "visible"
                 ? `LISTED (placement only, NOT validity): ${managerSeen.note}`
                 : `NOTE: ${placement.warning}` +
-                  (managerSeen ? `\n\n${managerSeen.note}` : ""))
+                  (managerSeen ? `\n\n${managerSeen.note}` : "")) +
+              // Appended to BOTH Manager arms: a listed file whose destination is
+              // outside the live root is exactly the #1086 shape, so the "LISTED"
+              // arm needs this every bit as much as the unverified one.
+              (managerDest ? `\n\n${managerDest}` : "")
             : placement.confirmed
               ? `Model downloaded successfully to${placement.pathQualifier}:\n${job.path}`
               : placement.wrongPlace


### PR DESCRIPTION
Fixes #1086. **Draft — claiming the issue, work in progress.**

## The report

A remote RunPod ComfyUI read models from `/workspace/models` (the 100GB volume) via `extra_model_paths`, while `/` was a 20GB overlay. `download_model` dispatched to ComfyUI-Manager, which wrote into `/opt/ComfyUI/models` instead. A multi-GB Wan 2.2 file and a required clip-vision file were gone after a pod restart.

## What we say today, and why it is not enough

`managerDestinationCaveat()` already tells the caller we have **not** established where the file lands, and `verifyManagerVisibility` asks the server afterwards whether it lists the file. Both were the right calls at the time — the reasoning being that `extra_model_paths.yaml` lives on the target filesystem, which this process cannot read.

But the reporter's own evidence shows the destination **is** observable:

```
get_system_stats action:"logs" →
  Install model 'clip_vision_h.safetensors' ... into '/opt/ComfyUI/models/clip_vision/clip_vision_h.safetensors'
```

Verified against the installed Manager source — both generations log it:

- `comfyui_manager/glob/manager_server.py:1063`
- `comfyui_manager/legacy/manager_server.py:634`

```py
f"Install model '{json_data['name']}' from '{model_url}' into '{model_path}'"
```

So "we cannot know where it lands" is true only before we look. `/internal/logs` is already read by the health check.

## Plan

After a Manager dispatch, read back the destination Manager logged and report it — and where the live models root is known, say whether that destination is inside it. Turns a permanent caveat into a specific, checkable answer, without pretending we controlled the destination.

Three-state, as ever: a destination we read, a destination the log did not carry, and a log we could not read are different facts and must not render alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)