### PR TITLE
release: v0.50.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.51] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- make the endpoint-specific !res.ok branches reachable (#1187)
+
+
 ## [0.50.50] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.50",
+  "version": "0.50.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.50",
+      "version": "0.50.51",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.50",
+  "version": "0.50.51",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the `v0.50.51` tag into protected main (version bump + changelog).

Contents: **#1187** — `Client.fetchApi` throws for every status outside [200, 400), so every `if (!res.ok)` / `if (res.status === 404)` written after it was dead code. 20 such branches across 8 files, including `fetchImage`'s `IMAGE_NOT_FOUND` — added by #435 *for* #385 and never once executed. Closes #385.

Gates run locally before tagging: build, full suite (383 files / 7843 passed), `check:vocabulary` (clean on the tracked tree), `vocab:export --check`, `asset-counts --check`, `docs:gen` freshness. Verified against live ComfyUI 0.31.1 and through a panel bridge round-trip.