### PR TITLE
release: v0.50.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.52] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- report the destination ComfyUI-Manager actually chose (#1190)
+
+
 ## [0.50.51] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.51",
+  "version": "0.50.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.51",
+      "version": "0.50.52",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.51",
+  "version": "0.50.52",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.52` tag.

**`download_model` reports the destination ComfyUI-Manager actually chose** (#1086, via #1190).

A remote RunPod ComfyUI read models from `/workspace/models` (a 100GB volume) via `extra_model_paths`, while `/` was a 20GB ephemeral overlay. The dispatch went to ComfyUI-Manager, which wrote into `/opt/ComfyUI/models` instead — and a multi-GB Wan 2.2 file plus a required clip-vision file were gone after a pod restart. All the tool could say was "we cannot know where this lands; verify it yourself".

But the reporter's own evidence showed the destination **is** observable: Manager logs the absolute path it picked, in both generations (`glob/manager_server.py:1063`, `legacy/manager_server.py:634`), and `/internal/logs` is readable. So the destination is unknowable only until we look. It now reads that back and, where it can, says whether the path is inside a tree the server reads.

Codex review found three real defects, all fixed before merge — two wrong in the dangerous direction, since a false OUTSIDE both cries wolf about a good file and contradicts the LISTED verdict beside it:

- a Windows orchestrator's `resolve()` turns a remote `/workspace/models` into `C:\workspace\models`, so the comparison always said OUTSIDE — the verdict is now withheld across path syntaxes;
- only the primary root was consulted, so a destination under a registered extra root read as unusable — extra roots are now checked, and an unreadable list withholds rather than assumes;
- **a pre-existing bug**: `job.filename` is optional and `job.path` is a descriptor, so the old fallback returned the whole trailing note — which has been making every URL-only Manager download unverifiable since #1086's first half.

CI then caught a test that passed locally only because it reached the developer's real ComfyUI. Every call in that file is now hermetic, with a structural test enforcing it.

Verified live against the built artifact using the reporter's verbatim log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)