### PR TITLE
fix(models): a 404 category is an ANSWER, not an unreadable one

### DIFF
--- a/src/__tests__/services/model-listing-coverage.test.ts
+++ b/src/__tests__/services/model-listing-coverage.test.ts
@@ -477,3 +477,46 @@ describe("#1015: all-404 is NOT a verified empty install", () => {
     expect(text).toMatch(/vae/);
   });
 });
+
+// Adversarial review of PR #1196 (my own, before merge) — the all-404 branch
+// answered a FILTERED call with the UNFILTERED diagnosis.
+//
+// list_local_models({model_type:"clip"}) on a healthy modern server returned
+// "usually an older ComfyUI, or a proxy answering in front of it. Check the
+// ComfyUI URL…" — sending someone to debug a URL that works perfectly, when the
+// real answer is that the folder was renamed. A wrong remedy is worse than a
+// vague one: it costs time and teaches distrust of a working setup.
+describe("#1015: a filtered 404 names the RENAME, not a broken server", () => {
+  const base = { answered: [], unanswered: [], usedFilesystem: false };
+
+  it("points clip → text_encoders", () => {
+    const text = describeEmptyModelListing("clip", { ...base, absent: ["clip"] });
+    expect(text).toMatch(/LEGACY name/);
+    expect(text).toContain("text_encoders");
+    // The wrong remedy must be gone.
+    expect(text).not.toMatch(/older\s+ComfyUI, or a proxy/);
+    expect(text).not.toMatch(/Check the ComfyUI URL/);
+  });
+
+  it("points unet → diffusion_models", () => {
+    const text = describeEmptyModelListing("unet", { ...base, absent: ["unet"] });
+    expect(text).toContain("diffusion_models");
+    expect(text).toMatch(/LEGACY name/);
+  });
+
+  it("a NON-legacy 404 category says what to do without inventing a rename", () => {
+    const text = describeEmptyModelListing("gligen", { ...base, absent: ["gligen"] });
+    expect(text).toMatch(/does not serve a "gligen" model category/);
+    expect(text).toMatch(/NO model_type/);
+    expect(text).not.toMatch(/LEGACY name/);
+  });
+
+  it("the UNFILTERED all-404 case keeps the old-server\/proxy diagnosis", () => {
+    // That message is right there and must not be lost to the filtered branch.
+    const text = describeEmptyModelListing(undefined, {
+      ...base,
+      absent: ["checkpoints", "loras"],
+    });
+    expect(text).toMatch(/older\s+ComfyUI, or a proxy/);
+  });
+});

--- a/src/__tests__/services/model-listing-coverage.test.ts
+++ b/src/__tests__/services/model-listing-coverage.test.ts
@@ -386,3 +386,94 @@ describe("#962: the message names the other categories instead of claiming none"
     expect(text).not.toMatch(/fact about ONE folder/);
   });
 });
+
+// #1015 — a 404 category is an ANSWER, not an unreadable one.
+//
+// A reporter's healthy ComfyUI 0.31 kept saying:
+//
+//   Partial listing — 2 categories could not be read
+//   (clip: Unexpected end of JSON input; unet: Unexpected end of JSON input).
+//
+// Their follow-up gave the precise shape: /models/clip and /models/unet each
+// answer HTTP 404 with an empty body. Reproduced on a live 0.31 server here —
+// clip and unet 404 with 0 bytes while text_encoders and diffusion_models answer
+// 200. Modern ComfyUI renamed those folders (clip → text_encoders, unet →
+// diffusion_models), so a current install does not register the old names at all.
+//
+// A 404 is the server answering DEFINITIVELY. Counting it as unread put a
+// permanent "your inventory is incomplete" on every healthy modern install — and
+// named aliases whose real contents were already listed under the new names. The
+// house defect, pointing the other way.
+describe("#1015: a 404 category does not degrade the listing", () => {
+  function serverWith(byCat: Record<string, { status: number; body?: string }>) {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockImplementation(async (path: string) => {
+      if (path === "/models") return new Response("[]", { status: 200 });
+      const cat = path.replace(/^\/models\//, "");
+      const spec = byCat[cat] ?? { status: 200, body: "[]" };
+      return new Response(spec.body ?? "", { status: spec.status });
+    });
+    readdir.mockRejectedValue(new Error("ENOENT"));
+  }
+
+  it("records a 404 as ABSENT, never as unanswered", async () => {
+    serverWith({ clip: { status: 404 }, unet: { status: 404 } });
+    const { coverage } = await listLocalModelsWithCoverage();
+    expect(coverage.absent).toEqual(expect.arrayContaining(["clip", "unet"]));
+    // The line the reporter kept seeing.
+    expect(coverage.unanswered.map((u) => u.dir)).not.toContain("clip");
+    expect(coverage.unanswered.map((u) => u.dir)).not.toContain("unet");
+  });
+
+  it("a REAL read failure still degrades the listing", async () => {
+    // The guard must not be blunted: a 502 or a proxy page is genuinely unread.
+    serverWith({ clip: { status: 404 }, vae: { status: 502, body: "bad gateway" } });
+    const { coverage } = await listLocalModelsWithCoverage();
+    expect(coverage.unanswered.map((u) => u.dir)).toContain("vae");
+    expect(coverage.absent).toContain("clip");
+  });
+
+  it("a 404 on a FILTERED call is not a coverage gap either", async () => {
+    serverWith({ clip: { status: 404 } });
+    const { coverage } = await listLocalModelsWithCoverage("clip");
+    expect(coverage.unanswered).toEqual([]);
+    expect(coverage.absent).toEqual(["clip"]);
+  });
+});
+
+describe("#1015: all-404 is NOT a verified empty install", () => {
+  const base = { answered: [], unanswered: [], usedFilesystem: false };
+
+  it("refuses to say 'none' when every category 404'd", async () => {
+    // A server serving no /models route at all is an old build or a proxy — not
+    // an install with no models. Claiming the latter would be the same fabricated
+    // negative this change exists to remove, pointing the other way.
+    const text = describeEmptyModelListing(undefined, {
+      ...base,
+      absent: ["checkpoints", "loras", "vae"],
+    });
+    expect(text).toMatch(/Could not determine/);
+    expect(text).toMatch(/NOT\s+the same as having no models/);
+    expect(text).toMatch(/older\s+ComfyUI, or a proxy/);
+  });
+
+  it("still says 'none' when the server ANSWERED and was genuinely empty", async () => {
+    const text = describeEmptyModelListing(undefined, {
+      ...base,
+      answered: ["checkpoints"],
+      absent: ["clip"],
+    });
+    expect(text).toBe("No local models found.");
+  });
+
+  it("an UNANSWERED category still wins over the all-404 branch", async () => {
+    // "Could not read" says more than "did not serve", so it keeps precedence.
+    const text = describeEmptyModelListing(undefined, {
+      ...base,
+      unanswered: [{ dir: "vae", reason: "HTTP 502" }],
+      absent: ["clip"],
+    });
+    expect(text).toMatch(/could not be read|Could not determine which/);
+    expect(text).toMatch(/vae/);
+  });
+});

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -436,6 +436,13 @@ export type ModelListingCoverage = {
   /** Categories whose read failed or returned an unusable body, with why. Their
    *  emptiness is UNKNOWN, not zero. */
   unanswered: { dir: string; reason: string }[];
+  /** Categories the server answered 404 for — it does NOT register them (#1015).
+   *  A definite answer, not a gap: modern ComfyUI renamed `clip` → `text_encoders`
+   *  and `unet` → `diffusion_models`, so the old names 404 on every current
+   *  install. Kept distinct from `unanswered` so they never degrade a complete
+   *  listing to "partial", and distinct from `answered` because the server holds
+   *  no such folder at all rather than an empty one. */
+  absent?: string[];
   /** Set when HTTP listing was unavailable as a whole (no client, cloud mode,
    *  category discovery threw) — every category is then unanswered. */
   httpUnavailable?: string;
@@ -520,6 +527,7 @@ export async function listLocalModelsWithCoverage(
   const coverage: ModelListingCoverage = {
     answered: [],
     unanswered: [],
+    absent: [],
     usedFilesystem: false,
   };
   const models = await collectLocalModels(modelType, coverage);
@@ -605,6 +613,30 @@ async function collectLocalModels(
         // A non-OK status or a non-array body means we did NOT learn what this
         // category holds. Recording the reason is the whole point: continuing
         // silently is what let a warming-up server look like an empty install.
+        //
+        // …with ONE exception, and it is the opposite fold (#1015). A 404 is the
+        // server answering DEFINITIVELY that it does not serve this category —
+        // "determined not present", not "could not determine". Modern ComfyUI
+        // renamed two of the folders in MODEL_SUBDIRS (clip → text_encoders,
+        // unet → diffusion_models), so a current install 404s the old names.
+        // Reproduced on a live 0.31 server:
+        //
+        //   clip             HTTP 404 bytes=0
+        //   unet             HTTP 404 bytes=0
+        //   text_encoders    HTTP 200 bytes=297
+        //   diffusion_models HTTP 200 bytes=360
+        //
+        // Counting those as unread put a permanent "Partial listing — 2
+        // categories could not be read" on every healthy modern install, telling
+        // a user their inventory was incomplete when it was complete — and naming
+        // aliases whose real contents were already listed under the new names.
+        //
+        // Recorded as ABSENT rather than dropped silently, so an unfiltered
+        // listing can still say which categories this server does not register.
+        if (res.status === 404) {
+          (coverage.absent ??= []).push(dir);
+          continue;
+        }
         if (!res.ok) {
           coverage.unanswered.push({ dir, reason: `HTTP ${res.status}` });
           continue;
@@ -674,7 +706,13 @@ async function collectLocalModels(
     // The outer throw (no client / cloud mode / GGUF discovery) aborts before any
     // per-category read, so nothing below it was answered either.
     for (const dir of dirsToScan) {
-      if (!coverage.answered.includes(dir) && !coverage.unanswered.some((u) => u.dir === dir)) {
+      if (
+        !coverage.answered.includes(dir) &&
+        // A category already answered 404 was ANSWERED — the later outer failure
+        // does not un-answer it (#1015).
+        !(coverage.absent ?? []).includes(dir) &&
+        !coverage.unanswered.some((u) => u.dir === dir)
+      ) {
         coverage.unanswered.push({ dir, reason: coverage.httpUnavailable });
       }
     }

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -1148,6 +1148,30 @@ export function describeEmptyModelListing(
   coverage: ModelListingCoverage,
 ): string {
   const scope = modelType ? `${modelType} models` : "local models";
+  // #1015 — a 404 is a definite "this server does not register that category",
+  // and treating it as one is the whole fix. But if EVERY category came back 404
+  // and none was ever answered, the definite thing established is not "you have
+  // no models" — it is that this server serves none of these routes at all (an
+  // old build, or something in front of it). Saying "No local models found" there
+  // would be a fabricated negative, which is the same defect this change exists
+  // to remove, pointing the other way.
+  //
+  // Scoped tightly: only when NOTHING was answered, NOTHING was unreadable, and
+  // at least one 404 came back. An unreadable category still belongs to the
+  // "could not determine" path below, which says more.
+  const absent = coverage.absent ?? [];
+  if (coverage.answered.length === 0 && coverage.unanswered.length === 0 && absent.length > 0) {
+    return (
+      `Could not determine which ${scope} are installed. The connected ComfyUI answered ` +
+      `404 for every category asked about (${absent.slice(0, 8).join(", ")}` +
+      `${absent.length > 8 ? `, …and ${absent.length - 8} more` : ""}) ` +
+      `and served none of them, so NOTHING was learned about the install — this is NOT ` +
+      `the same as having no models.\n\n` +
+      `A server that serves no /models/<category> route at all is usually an older ` +
+      `ComfyUI, or a proxy answering in front of it. Check the ComfyUI URL with ` +
+      `get_system_stats (action:"health") before concluding anything about the install.`
+    );
+  }
   if (coverage.unanswered.length === 0) {
     // Verified: the server was asked and said zero. For a FILTERED call that is
     // a true statement about ONE folder, and #962 is what it costs when it is

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -1143,6 +1143,20 @@ async function cancelAction(args: { id: string; tray_id?: string }): Promise<Cal
  *
  * Exported for tests: the distinction is the fix, so it is pinned directly.
  */
+/**
+ * ComfyUI folder names that were RENAMED, and what they became (#1015).
+ *
+ * These are still in MODEL_SUBDIRS so an OLDER server that serves them keeps
+ * working. On a current server they 404 — which is the definite answer this
+ * change teaches the scan to read, and the reason a caller asking for the old
+ * name deserves to be pointed at the new one rather than told their server
+ * might be broken.
+ */
+const LEGACY_CATEGORY_RENAMES: Record<string, string> = {
+  clip: "text_encoders",
+  unet: "diffusion_models",
+};
+
 export function describeEmptyModelListing(
   modelType: string | undefined,
   coverage: ModelListingCoverage,
@@ -1161,6 +1175,25 @@ export function describeEmptyModelListing(
   // "could not determine" path below, which says more.
   const absent = coverage.absent ?? [];
   if (coverage.answered.length === 0 && coverage.unanswered.length === 0 && absent.length > 0) {
+    // A FILTERED call is a different question with a different answer, and
+    // bucketing them hands the caller a remedy they cannot act on. Asking for
+    // ONE category and getting a 404 means THAT category is not registered here
+    // — most often because it was RENAMED, which is the whole origin of #1015.
+    // Blaming "an older ComfyUI or a proxy" would send someone to check a URL
+    // that is working perfectly.
+    if (modelType) {
+      const modern = LEGACY_CATEGORY_RENAMES[modelType];
+      return (
+        `The connected ComfyUI does not serve a "${modelType}" model category — it ` +
+        `answered 404 for that route, which is a definite answer, not a failed read.\n\n` +
+        (modern
+          ? `"${modelType}" is the LEGACY name for this folder; current ComfyUI calls it ` +
+            `"${modern}". Ask for "${modern}" instead — the models you are looking for are ` +
+            `almost certainly listed there.`
+          : `Run list_local_models with NO model_type to see every category this server ` +
+            `does register.`)
+      );
+    }
     return (
       `Could not determine which ${scope} are installed. The connected ComfyUI answered ` +
       `404 for every category asked about (${absent.slice(0, 8).join(", ")}` +


### PR DESCRIPTION
Fixes #1015. **Draft — claiming the issue, work in progress.**

## What the reporter sees

```
Partial listing — 2 categories could not be read
(clip: Unexpected end of JSON input; unet: Unexpected end of JSON input).
```

and on their follow-up, the precise shape: `/models/clip` and `/models/unet` each return **HTTP 404 with an empty body**, while `/system_stats`, `checkpoints`, `vae`, `diffusion_models` and `text_encoders` all answer normally.

## Reproduced on the rig

```
clip               HTTP 404 bytes=0
unet               HTTP 404 bytes=0
text_encoders      HTTP 200 bytes=297
diffusion_models   HTTP 200 bytes=360
```

## The cause

`MODEL_SUBDIRS` still carries `clip` and `unet`. Modern ComfyUI renamed those folders — `clip` → `text_encoders`, `unet` → `diffusion_models` — so a current server does not register them at all and answers 404.

The scan treats **any** non-OK status as "could not be read", which is right for a 502 or a proxy page and wrong for a 404: a 404 is the server answering **definitively** that it does not serve that category. Folding the two produces a permanent "partial listing" warning on every healthy modern install, telling the user their inventory is incomplete when it is complete — and the categories named are aliases whose real contents are already listed under their modern names.

That is the house defect pointing the other way: "determined not present" reported as "could not determine".

## Plan

Distinguish a 404 from an unreadable answer, and stop counting a legacy alias whose modern equivalent answered as a coverage gap. The listing must stay honest for a genuine read failure — a 502, HTML, or a transport error still degrades to partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)