### PR TITLE
release: v0.50.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.53] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- a 404 category is an ANSWER, not an unreadable one (#1196)
+
+
 ## [0.50.52] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.52",
+  "version": "0.50.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.52",
+      "version": "0.50.53",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.52",
+  "version": "0.50.53",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.53` tag.

**A 404 model category is an ANSWER, not an unreadable one** (#1015, via #1196).

A reporter's healthy ComfyUI 0.31 ended every inventory with `Partial listing — 2 categories could not be read (clip: …; unet: …)`. Modern ComfyUI renamed those folders — `clip` → `text_encoders`, `unet` → `diffusion_models` — so a current install 404s the old names, which are still in `MODEL_SUBDIRS` for older servers. The scan treated any non-OK status as unreadable, so every healthy modern install was permanently told its inventory was incomplete, naming aliases whose real contents were already listed under the new names.

A 404 is the server answering *definitively*. It is now a third state (`absent`), distinct from both "answered" and "could not read". A genuine failure — 502, HTML, transport — still degrades the listing exactly as before.

The opposite fabrication is guarded: if **every** category 404s and none answered, that is a server serving none of these routes (an old build, or a proxy), not an empty install — and it says so instead of claiming zero models.

Review before merge caught the all-404 branch answering a **filtered** call with the unfiltered diagnosis — telling someone asking for `clip` to go debug a working URL. A filtered 404 now names the rename and points at `text_encoders`.

Verified live on a real ComfyUI 0.31: 155 models across 58 categories, `clip`/`unet` recorded absent, and **zero** unanswered — the reporter's warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)