### PR TITLE
fix(fence): a rebind that fails on an OLD panel says so, and names the version

### DIFF
--- a/src/__tests__/services/panel-version-gap.test.ts
+++ b/src/__tests__/services/panel-version-gap.test.ts
@@ -18,12 +18,14 @@
 import { describe, expect, it } from "vitest";
 import { UiBridge, PANEL_MIN_VERSION_REPLY_UUID } from "../../services/ui-bridge.js";
 
-/** A bridge whose resolveTarget reports the given advertised panel version. */
-function bridgeWithPanel(version: string | undefined): UiBridge {
+/** A bridge whose resolveTarget reports the given panel version. `advertised`
+ *  models whether THIS connection's hello carried it (vs inheriting it from a
+ *  previous one) — the distinction codex review showed is load-bearing. */
+function bridgeWithPanel(version: string | undefined, advertised = true): UiBridge {
   const b = new UiBridge(0) as UiBridge & {
-    resolveTarget: (id: string) => { panelVersion?: string };
+    resolveTarget: (id: string) => { panelVersion?: string; panelVersionAdvertised?: boolean };
   };
-  b.resolveTarget = () => ({ panelVersion: version });
+  b.resolveTarget = () => ({ panelVersion: version, panelVersionAdvertised: advertised });
   return b;
 }
 
@@ -49,6 +51,15 @@ describe("panelTooOldForReplyUuid (#1043)", () => {
     for (const v of [undefined, "", "dev", "nightly", "not-a-version"]) {
       expect(bridgeWithPanel(v).panelTooOldForReplyUuid("t").tooOld, String(v)).toBe(false);
     }
+  });
+
+  it("an INHERITED version is not narrated as too old (codex review)", () => {
+    // A re-hello that omits panel_version inherits the previous value, so a panel
+    // that was updated and reloaded without re-advertising would still read as
+    // old — and we would tell someone to update a panel they just updated.
+    expect(bridgeWithPanel("0.11.43", false).panelTooOldForReplyUuid("t").tooOld).toBe(false);
+    // …while a freshly advertised old version still is.
+    expect(bridgeWithPanel("0.11.43", true).panelTooOldForReplyUuid("t").tooOld).toBe(true);
   });
 
   it("never throws when the tab cannot be resolved", () => {
@@ -85,18 +96,13 @@ describe("the rebind failure message carries the version gap (#1043)", () => {
     expect(start, "the failure message must still exist").toBeGreaterThan(-1);
     expect(src.slice(start, start + 1400)).toContain("panelGapNote");
 
-    // …and EVERY caller supplies it. A renderer defaulting to "" is silent when a
-    // call site forgets, which is exactly how this would rot.
-    const calls = src.split("describeFenceRebind(").slice(1);
-    const rendererDecl = calls.filter((c) => c.trimStart().startsWith("\n"));
-    const callSites = calls.length - rendererDecl.length;
-    expect(callSites, "expected the known call sites").toBeGreaterThanOrEqual(3);
-    for (const c of calls) {
-      const head = c.slice(0, c.indexOf(")") + 1);
-      // Skip the declaration itself (its "call" text is the parameter list).
-      if (head.includes("r: WorkflowFenceRebind")) continue;
-      expect(head).toContain("panelTooOldNote(ctx)");
-    }
+    // Exactly TWO call sites pass it — panel_save_workflow and panel_new_workflow,
+    // the commands whose replies actually carry a workflow_uuid. Codex review
+    // caught panel_set_workflow_target getting it too, where the claim "updating
+    // removes this failure" is false: that command has no own-reply uuid to gain,
+    // so an updated panel would still make this read.
+    const withNote = src.split("panelTooOldNote(ctx)").length - 1;
+    expect(withNote, "save + new only").toBe(2);
   });
 
   it("the note names the version they have, the one they need, and how to get it", async () => {

--- a/src/__tests__/services/panel-version-gap.test.ts
+++ b/src/__tests__/services/panel-version-gap.test.ts
@@ -1,0 +1,116 @@
+// #1043 — a fence deadlock that is really a VERSION GAP should say so.
+//
+// Three reports end the same way: a command re-points the active workflow
+// (panel_new_workflow, a Save-As), the session's fence is not re-derived, and
+// every later panel_* call is refused with `workflow instance mismatch`. The
+// documented recovery then fails because it needs a read the fence blocks.
+//
+// The orchestrator already has the repair — refreshFenceFromOwnReply (#1161)
+// trusts the workflow_uuid the command's OWN reply carries, and never makes that
+// read. It depends on the panel PUBLISHING that uuid, which is panel #800, first
+// shipped in panel 0.11.45 (verified against the panel repo: #800 landed after
+// the 0.11.44 release commit).
+//
+// Every reporter was below it — #1043 on 0.11.43, #1174 on 0.11.44 — so the fix
+// was present and inert, and the message said only that the identity "could not
+// be read". That reads as a mystery instead of "update the panel".
+
+import { describe, expect, it } from "vitest";
+import { UiBridge, PANEL_MIN_VERSION_REPLY_UUID } from "../../services/ui-bridge.js";
+
+/** A bridge whose resolveTarget reports the given advertised panel version. */
+function bridgeWithPanel(version: string | undefined): UiBridge {
+  const b = new UiBridge(0) as UiBridge & {
+    resolveTarget: (id: string) => { panelVersion?: string };
+  };
+  b.resolveTarget = () => ({ panelVersion: version });
+  return b;
+}
+
+describe("panelTooOldForReplyUuid (#1043)", () => {
+  it("says TOO OLD for the versions the reporters were actually on", () => {
+    for (const v of ["0.11.43", "0.11.44"]) {
+      const r = bridgeWithPanel(v).panelTooOldForReplyUuid("t");
+      expect(r.tooOld, `${v} should be too old`).toBe(true);
+      expect(r.version).toBe(v);
+      expect(r.needed).toBe(PANEL_MIN_VERSION_REPLY_UUID);
+    }
+  });
+
+  it("says NOT too old at the exact minimum and above", () => {
+    for (const v of ["0.11.45", "0.11.51", "0.12.0"]) {
+      expect(bridgeWithPanel(v).panelTooOldForReplyUuid("t").tooOld, v).toBe(false);
+    }
+  });
+
+  it("an UNKNOWN version is never called too old", () => {
+    // Telling someone to update a panel that may already be current is a wrong
+    // remedy, and the whole point of this file is not handing out those.
+    for (const v of [undefined, "", "dev", "nightly", "not-a-version"]) {
+      expect(bridgeWithPanel(v).panelTooOldForReplyUuid("t").tooOld, String(v)).toBe(false);
+    }
+  });
+
+  it("never throws when the tab cannot be resolved", () => {
+    const b = new UiBridge(0) as UiBridge & { resolveTarget: () => never };
+    b.resolveTarget = () => {
+      throw new Error("no such tab");
+    };
+    expect(() => b.panelTooOldForReplyUuid("ghost")).not.toThrow();
+    expect(b.panelTooOldForReplyUuid("ghost").tooOld).toBe(false);
+  });
+
+  it("pins the minimum to the release that actually publishes the uuid", () => {
+    // Verified against the panel repo rather than assumed: panel #800 landed
+    // after the 0.11.44 release commit and first shipped in 0.11.45. A wrong
+    // constant here would either miss the reporters or slander a good panel.
+    expect(PANEL_MIN_VERSION_REPLY_UUID).toBe("0.11.45");
+  });
+});
+
+// THE WIRING, at two levels. The accessor above cannot see whether the failure
+// message carries its answer, and describeFenceRebind is pure — so it cannot see
+// whether its callers pass one. Both are the call-site blindness this repo keeps
+// getting caught by.
+describe("the rebind failure message carries the version gap (#1043)", () => {
+  it("threads the note into describeFenceRebind and prints it", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      new URL("../../orchestrator/panel-tools.ts", import.meta.url),
+      "utf-8",
+    );
+
+    // The renderer prints whatever it is given, in the not_recovered branch.
+    const start = src.indexOf("Could NOT read the live canvas identity");
+    expect(start, "the failure message must still exist").toBeGreaterThan(-1);
+    expect(src.slice(start, start + 1400)).toContain("panelGapNote");
+
+    // …and EVERY caller supplies it. A renderer defaulting to "" is silent when a
+    // call site forgets, which is exactly how this would rot.
+    const calls = src.split("describeFenceRebind(").slice(1);
+    const rendererDecl = calls.filter((c) => c.trimStart().startsWith("\n"));
+    const callSites = calls.length - rendererDecl.length;
+    expect(callSites, "expected the known call sites").toBeGreaterThanOrEqual(3);
+    for (const c of calls) {
+      const head = c.slice(0, c.indexOf(")") + 1);
+      // Skip the declaration itself (its "call" text is the parameter list).
+      if (head.includes("r: WorkflowFenceRebind")) continue;
+      expect(head).toContain("panelTooOldNote(ctx)");
+    }
+  });
+
+  it("the note names the version they have, the one they need, and how to get it", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      new URL("../../orchestrator/panel-tools.ts", import.meta.url),
+      "utf-8",
+    );
+    const start = src.indexOf("function panelTooOldNote");
+    const body = src.slice(start, start + 1200);
+    expect(body).toContain("${v.version}");
+    expect(body).toContain("${v.needed}");
+    expect(body).toMatch(/panel_action:"sync"/);
+    // And it stays silent unless PROVEN too old.
+    expect(body).toMatch(/if \(!v\?\.tooOld\) return ""/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2748,6 +2748,37 @@ async function unreadableOrHealed(
   return { status: "unreadable", before, detail };
 }
 
+/**
+ * The version-gap sentence for a fence rebind that failed on an OLD panel (#1043).
+ *
+ * Empty string when the panel is new enough, or when its version is unknown —
+ * an unproven version must never be narrated as "yours is too old", which would
+ * send someone to update a panel that is already current. That is the same
+ * three-state discipline the rest of this file runs on.
+ *
+ * Never throws: this decorates an error path, and a decoration that fails must
+ * not replace the diagnosis it was meant to improve.
+ */
+function panelTooOldNote(ctx: PanelToolCtx): string {
+  try {
+    const v = ctx.bridge?.panelTooOldForReplyUuid?.(ctx.tabId);
+    if (!v?.tooOld) return "";
+    return (
+      `
+
+WHY THIS READ WAS NEEDED AT ALL: this session's panel is ${v.version}, and a ` +
+      `panel only reports the new workflow's identity ON THE REPLY from ${v.needed} ` +
+      `onwards. On ${v.needed}+ the command that re-pointed the canvas repairs the ` +
+      `fence from its own reply and never makes this read — so UPDATING THE PANEL ` +
+      `to ${v.needed} or later removes this failure rather than working around it. ` +
+      `Update it with install_comfyui (action:"panel", panel_action:"sync"), then ` +
+      `restart ComfyUI.`
+    );
+  } catch {
+    return "";
+  }
+}
+
 async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebind> {
   const tabAtStart = ctx.tabId;
   let before = currentWorkflowFence(ctx);
@@ -2891,6 +2922,13 @@ function describeFenceRebind(
    * first as the second is a bucket standing in for a cause (codex gate P1).
    */
   refusalCause?: "unroutable" | "disconnected" | "no_identity" | "capability",
+  /**
+   * #1043 — the version-gap sentence, when the connected panel is PROVABLY too
+   * old to publish the reply uuid this rebind exists to avoid needing. Passed in
+   * rather than looked up: this renderer is pure, and keeping it that way is what
+   * makes its wording testable without a bridge.
+   */
+  panelGapNote = "",
 ): {
   binding: "bound" | "reads_only" | "unverified" | "not_recovered";
   note: string;
@@ -3052,6 +3090,19 @@ function describeFenceRebind(
         note:
           ` Could NOT read the live canvas identity — the panel did not answer, so NOTHING ` +
           `about this session's graph binding was observed.` +
+          // #1043 — NAME THE VERSION GAP when that is what this is.
+          //
+          // The repair that would have avoided this read entirely
+          // (refreshFenceFromOwnReply, #1161) trusts a workflow_uuid the panel
+          // only publishes from 0.11.45. Three reports — #1043, #1077, #1174 —
+          // deadlocked here on OLDER panels: the fix is present and inert, and
+          // the message said only "could not be read", which reads as a mystery
+          // rather than as "update the panel".
+          //
+          // Only a PARSEABLE version below the minimum says this; an unknown
+          // version stays quiet rather than telling someone to update a panel
+          // that may already be current.
+          panelGapNote +
           // THREE states, not two (codex gate). "We could not read the existing
           // fence either" must not render as "it has no fence" — that absence was
           // never observed, and it is the same fold one level down.
@@ -8421,7 +8472,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           canMutateNow = undefined;
           refusalCause = undefined;
         }
-        const fence = describeFenceRebind(fenceRebind, canMutateNow, refusalCause);
+        const fence = describeFenceRebind(fenceRebind, canMutateNow, refusalCause, panelTooOldNote(ctx));
         if (!fence || fence.binding === "bound") return res;
         return appendNote(res, `The workflow WAS saved.${fence.note}`);
       },
@@ -8672,7 +8723,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           refusalCause = undefined;
         }
         const fence = fenceRebind
-          ? describeFenceRebind(fenceRebind, canMutateNow, refusalCause)
+          ? describeFenceRebind(fenceRebind, canMutateNow, refusalCause, panelTooOldNote(ctx))
           : undefined;
         if (fence && fence.binding === "not_recovered") {
           return fail(
@@ -8737,7 +8788,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           canMutateNow = undefined; // a guard that can throw is not a guard
           refusalCause = undefined;
         }
-        const fence = describeFenceRebind(fenceRebind, canMutateNow, refusalCause);
+        const fence = describeFenceRebind(fenceRebind, canMutateNow, refusalCause, panelTooOldNote(ctx));
         if (!fence || fence.binding === "bound") return res;
         return appendNote(
           res,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -8722,8 +8722,21 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           canMutateNow = undefined; // a guard that can throw is not a guard
           refusalCause = undefined;
         }
+        // #1043 (codex review) — NO version note on THIS path, deliberately.
+        //
+        // The note claims that on 0.11.45+ "the command that re-pointed the canvas
+        // repairs the fence from its own reply and never makes this read". That is
+        // true of panel_save_workflow and panel_new_workflow, which DO carry a
+        // workflow_uuid on their reply. panel_set_workflow_target does not — it has
+        // no own-reply uuid to gain, so updating the panel would NOT remove this
+        // failure, and saying it would is a confident wrong remedy.
+        //
+        // A user may well have arrived here recovering from a save/new that hit the
+        // gap — but arriving here does not establish that, and guessing which of
+        // the two it was is exactly the kind of unearned claim this file exists to
+        // avoid. The save/new paths say it at the moment it is provable.
         const fence = fenceRebind
-          ? describeFenceRebind(fenceRebind, canMutateNow, refusalCause, panelTooOldNote(ctx))
+          ? describeFenceRebind(fenceRebind, canMutateNow, refusalCause)
           : undefined;
         if (fence && fence.binding === "not_recovered") {
           return fail(

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2538,11 +2538,21 @@ export class UiBridge {
   } {
     const needed = PANEL_MIN_VERSION_REPLY_UUID;
     let version: string | undefined;
+    let advertised = false;
     try {
-      version = this.resolveTarget(tabId).panelVersion;
+      const t = this.resolveTarget(tabId);
+      version = t.panelVersion;
+      // #1043 (codex review) — the version must come from THIS connection's own
+      // hello. A re-hello that omits `panel_version` INHERITS the previous value,
+      // so a panel that was updated and reloaded without re-advertising would
+      // still show its old version — and we would tell someone to update a panel
+      // they just updated. `panelVersionAdvertised` exists for exactly this, and
+      // the proactive command gate already refuses to act on an inherited value.
+      advertised = t.panelVersionAdvertised === true;
     } catch {
       version = undefined;
     }
+    if (!advertised) return { tooOld: false, needed };
     if (!version || !SEMVER_RE.test(version.trim())) return { tooOld: false, needed };
     return { tooOld: compareSemver(version, needed) < 0, version, needed };
   }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1086,6 +1086,16 @@ export const BRIDGE_DEFAULT_TIMEOUT_MS = 20_000;
  * sticky `isHeadless()` unacceptable for this gate.
  */
 export const HEADLESS_RECENCY_MS = 30 * 60_000;
+
+/**
+ * The first panel version whose save / new-workflow replies carry `workflow_uuid`
+ * (panel #800) — the value `refreshFenceFromOwnReply` (#1161) needs to repair a
+ * session fence without the round trip the fence itself refuses.
+ *
+ * Verified against the panel repo rather than assumed: #800 landed after the
+ * 0.11.44 release commit and first shipped in 0.11.45.
+ */
+export const PANEL_MIN_VERSION_REPLY_UUID = "0.11.45";
 /** More tolerant default for a READ (idempotent) command with no explicit timeout.
  *  A legitimately busy-but-alive panel main thread — e.g. Preview3D parsing a large
  *  FBX — can take many seconds to service a graph_query; failing it at the tight
@@ -2500,6 +2510,41 @@ export class UiBridge {
     // state to a human should use tabGraphMutationCapability instead — see below.
     const r = this.tabGraphMutationCapability(tabId);
     return r.known ? r.canMutate : false;
+  }
+
+  /**
+   * Is the connected panel PROVABLY too old to publish a workflow_uuid on the
+   * replies the fence recovery trusts? (#1043)
+   *
+   * `refreshFenceFromOwnReply` (#1161) repairs the session fence from the
+   * command's OWN reply, before attempting the round trip the fence refuses.
+   * That depends on the panel putting `workflow_uuid` on a save / new-workflow
+   * reply, which is panel #800 — first shipped in panel 0.11.45.
+   *
+   * Three reports (#1043, #1077, #1174) hit the same deadlock on panels BELOW
+   * that: the recovery finds nothing to adopt, falls back to the fenced read, and
+   * the user is told only that the identity "could not be read". The fix is
+   * present and inert, and the message names none of that.
+   *
+   * TRI-STATE, and the distinction is load-bearing: an UNKNOWN version must not
+   * render as "your panel is too old", which would send someone to update a panel
+   * that is already current. Only a parseable version below the minimum returns
+   * `{ tooOld: true }`.
+   */
+  panelTooOldForReplyUuid(tabId: string): {
+    tooOld: boolean;
+    version?: string;
+    needed: string;
+  } {
+    const needed = PANEL_MIN_VERSION_REPLY_UUID;
+    let version: string | undefined;
+    try {
+      version = this.resolveTarget(tabId).panelVersion;
+    } catch {
+      version = undefined;
+    }
+    if (!version || !SEMVER_RE.test(version.trim())) return { tooOld: false, needed };
+    return { tooOld: compareSemver(version, needed) < 0, version, needed };
   }
 
   /**


### PR DESCRIPTION
Fixes #1043. **Draft — claiming the issue, work in progress.**

## The pattern across three reports

#1043, #1077 and #1174 all end in the same deadlock: a command that re-points the active workflow (`panel_new_workflow`, a Save-As) succeeds, the session's fence is not re-derived, and every later `panel_*` call is refused with `workflow instance mismatch`. The documented recovery, `panel_set_workflow_target({mode:"current"})`, then fails because it needs a read the fence itself blocks.

The orchestrator already has the fix for this: `refreshFenceFromOwnReply` (#1161, shipped in mcp 0.50.43) trusts the `workflow_uuid` the command's **own reply** carries, before ever attempting the round trip that gets refused.

**It depends on the panel publishing that uuid — which is panel #800, first shipped in panel 0.11.45.** And every one of these reporters is below it:

| issue | panel |
|---|---|
| #1043 | 0.11.43 |
| #1174 | 0.11.44 |
| #1077 | (checking) |

So the fix is present and inert, and the user is told only that the identity "could not be read" — an unexplained unknown, when the actual answer is "your panel is too old to answer this, update it".

## Plan

The orchestrator knows the panel's version from its `hello` (`panelVersion`), and there is already a semver gate for exactly this class of judgement. When the reply-trust path finds no uuid **and** the connected panel is below the version that publishes one, say that — with the version they have, the version they need, and how to update — instead of reporting a bare unknown.

Strictly additive: a panel new enough to publish the uuid is unaffected, and a panel of unknown version keeps the existing wording rather than guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)