### PR TITLE
fix(#1197): a live ComfyUI-Manager download must not be reported INTERRUPTED

### DIFF
--- a/src/__tests__/services/download-progress.test.ts
+++ b/src/__tests__/services/download-progress.test.ts
@@ -376,7 +376,7 @@ describe("migrateInFlightJobs (#1148)", () => {
       status: "downloading",
       via_manager: true,
       name: "wan22.safetensors",
-      tray_id: "tray-abc",
+      trayId: "tray-abc",
       filename: "wan22.safetensors",
       target_subfolder: "diffusion_models",
       started_at: 1_700_000_000_000,
@@ -424,7 +424,10 @@ describe("migrateInFlightJobs (#1148)", () => {
       writeJob(oldDir, managerJob);
       mod.migrateInFlightJobs(oldDir, dir);
       const rec = mod.readPersistedDownloadJob("mgr-12gb")!;
-      expect(rec.tray_id).toBe("tray-abc");
+      // Asserted against the REAL persisted key. The first version of this
+      // test used `tray_id` in both the fixture and the assertion, so it
+      // passed while the migration copied nothing.
+      expect(rec.trayId).toBe("tray-abc");
       expect(rec.filename).toBe("wan22.safetensors");
       expect(rec.target_subfolder).toBe("diffusion_models");
       expect(rec.started_at).toBe(1_700_000_000_000);

--- a/src/__tests__/services/download-progress.test.ts
+++ b/src/__tests__/services/download-progress.test.ts
@@ -366,6 +366,50 @@ describe("migrateInFlightJobs (#1148)", () => {
       JSON.stringify(rec),
     );
 
+  // The structural hole that produced BOTH key bugs in this function: every
+  // fixture here is hand-built, so a key the WRITER never emits still reads as
+  // "carried" and the test agrees with the mistake. `tray_id` vs `trayId` was
+  // caught by hand; `name`/`dest`/`target`/`total`/`received` — five keys that
+  // belong to the tray-row interface, not this record — survived for months and
+  // even had an assertion claiming bytes that are always undefined.
+  //
+  // This closes it by ROUND-TRIPPING a record the real writer produced.
+  it("round-trips a REAL persisted record, not a hand-built fixture", async () => {
+    const src = mkdtempSync(join(tmpdir(), "cm-rt-"));
+    const writer = await (async () => {
+      vi.resetModules();
+      process.env.COMFYUI_MCP_PROGRESS_DIR = src;
+      return import("../../services/download-progress.js");
+    })();
+
+    writer.persistDownloadJob({
+      id: "rt-1",
+      trayId: "tray-rt",
+      url: "https://example.invalid/m.safetensors",
+      target_subfolder: "checkpoints",
+      filename: "m.safetensors",
+      status: "downloading",
+      started_at: 1_700_000_000_000,
+      via_manager: true,
+    } as never);
+
+    // Migrate with the module under test (its own dir), reading what the WRITER
+    // actually wrote.
+    mod.migrateInFlightJobs(src, dir);
+    const rec = mod.readPersistedDownloadJob("rt-1");
+    rmSync(src, { recursive: true, force: true });
+
+    expect(rec, "a genuinely-written record must migrate").not.toBeNull();
+    // Every field the migration claims to carry, verified against the writer's
+    // own output rather than a fixture that could share my typo.
+    expect(rec!.trayId).toBe("tray-rt");
+    expect(rec!.filename).toBe("m.safetensors");
+    expect(rec!.target_subfolder).toBe("checkpoints");
+    expect(rec!.started_at).toBe(1_700_000_000_000);
+    expect(rec!.via_manager).toBe(true);
+    expect(rec!.url).toBeTruthy();
+  });
+
   // #1197 — the word "manager" appeared NOWHERE in this file, which is why a
   // live host-side transfer could be reported stopped for months. A Manager
   // dispatch is a server-side fetch: the ComfyUI HOST does the work, and a
@@ -440,19 +484,25 @@ describe("migrateInFlightJobs (#1148)", () => {
       writeJob(oldDir, { id: "local-1", status: "downloading", updated: Date.now() });
       mod.migrateInFlightJobs(oldDir, dir);
       const msg = mod.readPersistedDownloadJob("local-1")!.error ?? "";
-      expect(msg).toMatch(/Re-issue the download — it resumes from any surviving/);
+      expect(msg).toMatch(/picks up a resumable \.partial where one survives, and otherwise restarts/);
       expect(msg).not.toMatch(/STILL RUNNING/);
       expect(mod.readPersistedDownloadJob("local-1")!.via_manager).toBe(false);
     });
   });
 
   it("carries an IN-FLIGHT record forward as a findable terminal record", () => {
+    // Fields are the ones `persistDownloadJob` ACTUALLY writes. The previous
+    // fixture used `name`/`received`/`total`, which belong to the tray-row
+    // interface (`DownloadProgress`), not to this record — so the migration
+    // "carried" them from a hand-built fixture while copying nothing in
+    // production, and the assertion below claimed bytes that are always
+    // undefined. A fixture is not evidence; only the writer's schema is.
     writeJob(oldDir, {
       id: "53012d3181fd46b6",
       status: "downloading",
-      name: "krea2_turbo_fp8.safetensors",
-      received: 700000000,
-      total: 12010000000,
+      filename: "krea2_turbo_fp8.safetensors",
+      url: "https://example.invalid/krea2.safetensors",
+      started_at: 1_700_000_000_000,
       updated: Date.now(),
     });
 
@@ -462,8 +512,7 @@ describe("migrateInFlightJobs (#1148)", () => {
     expect(found).not.toBeNull();
     expect(found!.status).toBe("error");
     expect(found!.interrupted_by_restart).toBe(true);
-    // The bytes it had, so a reader can see what was lost.
-    expect(found!.received).toBe(700000000);
+    expect(found!.filename).toBe("krea2_turbo_fp8.safetensors");
   });
 
   it("ends the wait for a LOCAL stream without asserting a death it did not check", () => {
@@ -483,7 +532,7 @@ describe("migrateInFlightJobs (#1148)", () => {
     const msg = mod.readPersistedDownloadJob("abc")!.error ?? "";
     expect(msg).toMatch(/no longer being WATCHED/);
     expect(msg).toMatch(/nothing here is writing those bytes/);
-    expect(msg).toMatch(/Re-issue the download — it resumes from any surviving/);
+    expect(msg).toMatch(/picks up a resumable \.partial where one survives, and otherwise restarts/);
     expect(msg).not.toMatch(/will not resume on its own/);
   });
 

--- a/src/__tests__/services/download-progress.test.ts
+++ b/src/__tests__/services/download-progress.test.ts
@@ -366,6 +366,83 @@ describe("migrateInFlightJobs (#1148)", () => {
       JSON.stringify(rec),
     );
 
+  // #1197 — the word "manager" appeared NOWHERE in this file, which is why a
+  // live host-side transfer could be reported stopped for months. A Manager
+  // dispatch is a server-side fetch: the ComfyUI HOST does the work, and a
+  // restart of THIS process does not touch it.
+  describe("a ComfyUI-Manager dispatch (#1197)", () => {
+    const managerJob = {
+      id: "mgr-12gb",
+      status: "downloading",
+      via_manager: true,
+      name: "wan22.safetensors",
+      tray_id: "tray-abc",
+      filename: "wan22.safetensors",
+      target_subfolder: "diffusion_models",
+      started_at: 1_700_000_000_000,
+      pid: 4242,
+      updated: Date.now(),
+    };
+
+    it("never tells the caller it stopped, or to re-issue it", () => {
+      // The corrupt-model path: a second dispatch writes another copy to the
+      // same destination (node-management.ts:971-979).
+      writeJob(oldDir, managerJob);
+      mod.migrateInFlightJobs(oldDir, dir);
+      const msg = mod.readPersistedDownloadJob("mgr-12gb")!.error ?? "";
+      expect(msg).toMatch(/STILL RUNNING/);
+      expect(msg).toMatch(/Do NOT re-issue/);
+      expect(msg).toMatch(/CORRUPTS the model/);
+      // The old text said all three of these, and every one was false here.
+      expect(msg).not.toMatch(/the transfer stopped/i);
+      expect(msg).not.toMatch(/will not resume on its own/i);
+      expect(msg).not.toMatch(/Re-issue the download/);
+    });
+
+    it("does not offer a timer or an empty-listing check as proof", () => {
+      // An in-progress file is not listed until it COMPLETES, so "wait N
+      // minutes then decide" fires on a healthy multi-hour transfer.
+      writeJob(oldDir, managerJob);
+      mod.migrateInFlightJobs(oldDir, dir);
+      const msg = mod.readPersistedDownloadJob("mgr-12gb")!.error ?? "";
+      expect(msg).toMatch(/a timer is not a test/);
+      expect(msg).not.toMatch(/couple of minutes|within \d+ ?(?:min|second)/i);
+    });
+
+    it("CARRIES the route flag, so the caller can tell the two apart", () => {
+      // Dropping it is what made the old message render as a plain local
+      // interruption with no way to distinguish them.
+      writeJob(oldDir, managerJob);
+      mod.migrateInFlightJobs(oldDir, dir);
+      expect(mod.readPersistedDownloadJob("mgr-12gb")!.via_manager).toBe(true);
+    });
+
+    it("carries the fields the record needs to stay USABLE", () => {
+      // Without these a caller passing the tray_id they were handed gets
+      // "not found" on a record that exists, the row renders `(tray
+      // undefined)`, and the listing prints `NaN s ago`.
+      writeJob(oldDir, managerJob);
+      mod.migrateInFlightJobs(oldDir, dir);
+      const rec = mod.readPersistedDownloadJob("mgr-12gb")!;
+      expect(rec.tray_id).toBe("tray-abc");
+      expect(rec.filename).toBe("wan22.safetensors");
+      expect(rec.target_subfolder).toBe("diffusion_models");
+      expect(rec.started_at).toBe(1_700_000_000_000);
+      expect(rec.pid).toBe(4242);
+    });
+
+    it("a LOCAL record still gets its affirmative next step", () => {
+      // The other half must not regress: #1148's original harm was an agent
+      // that would not act, so the local case keeps a clear instruction.
+      writeJob(oldDir, { id: "local-1", status: "downloading", updated: Date.now() });
+      mod.migrateInFlightJobs(oldDir, dir);
+      const msg = mod.readPersistedDownloadJob("local-1")!.error ?? "";
+      expect(msg).toMatch(/Re-issue the download — it resumes from any surviving/);
+      expect(msg).not.toMatch(/STILL RUNNING/);
+      expect(mod.readPersistedDownloadJob("local-1")!.via_manager).toBe(false);
+    });
+  });
+
   it("carries an IN-FLIGHT record forward as a findable terminal record", () => {
     writeJob(oldDir, {
       id: "53012d3181fd46b6",
@@ -386,15 +463,25 @@ describe("migrateInFlightJobs (#1148)", () => {
     expect(found!.received).toBe(700000000);
   });
 
-  it("says the transfer is NOT running and will not resume itself", () => {
-    // The whole harm was an agent waiting forever on the documented contract.
+  it("ends the wait for a LOCAL stream without asserting a death it did not check", () => {
+    // The original harm was an agent waiting forever on the documented
+    // contract, so this must still end the wait and still give a next step.
+    //
+    // But this test used to REQUIRE "NOT running", "will not resume on its own"
+    // and a blanket "Re-issue the download" — claims this code cannot make. It
+    // reads neither the `pid` nor the `owner` it persists, `writerProcessGone()`
+    // exists to answer exactly that, and the cancel path refuses to close a
+    // stale record until that probe returns ESRCH (#761/#858). For a Manager
+    // dispatch those claims were not merely unproven but false, and following
+    // them corrupted the model (#1197) — so the test was holding the defect in
+    // place.
     writeJob(oldDir, { id: "abc", status: "downloading", updated: Date.now() });
     mod.migrateInFlightJobs(oldDir, dir);
     const msg = mod.readPersistedDownloadJob("abc")!.error ?? "";
-    expect(msg).toMatch(/INTERRUPTED/);
-    expect(msg).toMatch(/NOT running/);
-    expect(msg).toMatch(/will not resume on its own/);
-    expect(msg).toMatch(/Re-issue the download/);
+    expect(msg).toMatch(/no longer being WATCHED/);
+    expect(msg).toMatch(/nothing here is writing those bytes/);
+    expect(msg).toMatch(/Re-issue the download — it resumes from any surviving/);
+    expect(msg).not.toMatch(/will not resume on its own/);
   });
 
   it("does NOT migrate a TERMINAL record — its outcome was already delivered", () => {

--- a/src/__tests__/services/download-progress.test.ts
+++ b/src/__tests__/services/download-progress.test.ts
@@ -391,10 +391,19 @@ describe("migrateInFlightJobs (#1148)", () => {
       status: "downloading",
       started_at: 1_700_000_000_000,
       via_manager: true,
+      progressId: "prog-rt",
+      resume: { etag: 'W/"abc"' },
     } as never);
 
     // Migrate with the module under test (its own dir), reading what the WRITER
     // actually wrote.
+    // Capture the WRITER's own key set before the source dir goes away — that
+    // set, not a fixture, is the schema this migration must not invent keys on.
+    const writerKeys = new Set(
+      Object.keys(
+        JSON.parse(readFileSync(join(src, readdirSync(src).find((f) => f.includes("rt-1"))!), "utf8")),
+      ),
+    );
     mod.migrateInFlightJobs(src, dir);
     const rec = mod.readPersistedDownloadJob("rt-1");
     rmSync(src, { recursive: true, force: true });
@@ -408,6 +417,19 @@ describe("migrateInFlightJobs (#1148)", () => {
     expect(rec!.started_at).toBe(1_700_000_000_000);
     expect(rec!.via_manager).toBe(true);
     expect(rec!.url).toBeTruthy();
+    expect(rec!.progressId).toBe("prog-rt");
+    expect(rec!.resume).toEqual({ etag: "W/\"abc\"" });
+
+    // ...and the half that actually closes the class: NO key may appear that the
+    // writer does not emit. Asserting presence alone is what let five dead keys
+    // (`name`/`dest`/`target`/`total`/`received`, from the tray-row interface)
+    // survive for months — restoring them passed every test AND tsc, because
+    // `persistDownloadJob` spreads a variable (no excess-property check) and
+    // tsconfig EXCLUDES src/__tests__, so no fixture is ever typechecked.
+    // Keys the migration legitimately ADDS rather than carries.
+    for (const added of ["status", "error", "updated", "interrupted_by_restart"]) writerKeys.add(added);
+    const unknown = Object.keys(rec!).filter((k) => !writerKeys.has(k));
+    expect(unknown, "migrated record carries keys the writer never emits").toEqual([]);
   });
 
   // #1197 — the word "manager" appeared NOWHERE in this file, which is why a

--- a/src/__tests__/tools/manager-interrupted-render.test.ts
+++ b/src/__tests__/tools/manager-interrupted-render.test.ts
@@ -1,0 +1,148 @@
+// #1197 — the RENDERED output for a ComfyUI-Manager download carried across an
+// orchestrator restart.
+//
+// This file exists because of how the fix kept failing. Three separate rounds
+// produced a correct change that never reached the reader:
+//
+//   1. the tool DESCRIPTION was overridden by the record's own error text;
+//   2. the record's error text was overridden by the status TOKEN, which still
+//      said `**error**` beside "very likely STILL RUNNING";
+//   3. `action:"cancel"` said "already error — nothing to cancel", which reads
+//      as confirmation the transfer is over.
+//
+// A reviewer neutered all three user-visible sites at once and the FULL SUITE
+// stayed byte-identical — 385 files, 7884 passed. Nothing guarded the layer the
+// user actually reads, which is exactly the layer that kept being wrong.
+//
+// The stakes: a Manager fetch runs on the ComfyUI HOST, which a restart here
+// does not touch. Telling that caller the transfer stopped, or that cancelling
+// found nothing to cancel, invites a re-issue — and a second dispatch to the
+// same destination corrupts the model (node-management.ts:971-979).
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const listDownloadJobsMock = vi.fn();
+const getDownloadJobMock = vi.fn();
+const cancelDownloadJobMock = vi.fn();
+
+vi.mock("../../services/download-jobs.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/download-jobs.js")>();
+  return {
+    ...actual,
+    listDownloadJobs: (...a: unknown[]) => listDownloadJobsMock(...a),
+    getDownloadJob: (...a: unknown[]) => getDownloadJobMock(...a),
+    cancelDownloadJob: (...a: unknown[]) => cancelDownloadJobMock(...a),
+  };
+});
+
+const { registerModelManagementTools } = await import("../../tools/model-management.js");
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function tools() {
+  const handlers = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, _d: string, _s: unknown, ...rest: unknown[]) => {
+      handlers.set(name, rest.find((a) => typeof a === "function") as ToolHandler);
+    },
+  };
+  registerModelManagementTools(server as never);
+  const download = handlers.get("download_model")!;
+  return {
+    status: (args: Record<string, unknown> = {}) => download({ ...args, action: "status" }),
+    cancel: (args: Record<string, unknown>) => download({ ...args, action: "cancel" }),
+  };
+}
+
+/** A Manager dispatch that an orchestrator restart carried across. */
+const migratedManagerJob = {
+  id: "mgr-12gb",
+  trayId: "tray-mgr",
+  status: "error" as const,
+  interruptedByRestart: true,
+  viaManager: true,
+  error: "This download is no longer being WATCHED … very likely STILL RUNNING …",
+  url: "https://example.invalid/wan22.safetensors",
+  targetSubfolder: "diffusion_models",
+  startedAt: Date.now() - 600_000,
+};
+
+beforeEach(() => {
+  listDownloadJobsMock.mockReset();
+  getDownloadJobMock.mockReset();
+  cancelDownloadJobMock.mockReset();
+});
+
+describe("the rendered status for an interrupted Manager dispatch (#1197)", () => {
+  it("does NOT lead with the word error", async () => {
+    // The token is read first, so `**error**` beside "still running" is a
+    // contradiction the reader resolves by position — which is why fixing only
+    // the message body changed nothing for the caller.
+    listDownloadJobsMock.mockReturnValue([migratedManagerJob]);
+    const out = await tools().status();
+    const text = out.content[0].text;
+
+    expect(text).not.toMatch(/\*\*error\*\*/);
+    expect(text).toMatch(/host may still be fetching/);
+  });
+
+  it("labels it NO LONGER WATCHED, not INTERRUPTED", async () => {
+    // "INTERRUPTED" asserts the transfer stopped. For the Manager route that is
+    // the one thing this code cannot know and the host most likely contradicts.
+    listDownloadJobsMock.mockReturnValue([migratedManagerJob]);
+    const text = (await tools().status()).content[0].text;
+
+    expect(text).toMatch(/NO LONGER WATCHED/);
+    expect(text).not.toMatch(/INTERRUPTED —/);
+  });
+
+  it("keeps INTERRUPTED for a LOCAL interrupted download", async () => {
+    // The narrowing must not cost the local case its accurate label.
+    listDownloadJobsMock.mockReturnValue([
+      { ...migratedManagerJob, id: "local-1", viaManager: false, error: "local stopped" },
+    ]);
+    const text = (await tools().status()).content[0].text;
+
+    expect(text).toMatch(/INTERRUPTED —/);
+    expect(text).not.toMatch(/host may still be fetching/);
+  });
+
+  it("cancel does not report it as already finished", async () => {
+    // "already **error** — nothing to cancel" reads as confirmation the
+    // transfer is over. It is not, and a cancel could not have stopped it
+    // either — there is no Manager recall API.
+    getDownloadJobMock.mockReturnValue(migratedManagerJob);
+    cancelDownloadJobMock.mockReturnValue({
+      found: true,
+      owned: false,
+      aborted: false,
+      status: "error",
+      job: migratedManagerJob,
+    });
+
+    const text = (await tools().cancel({ id: "mgr-12gb" })).content[0].text;
+
+    expect(text).not.toMatch(/nothing to cancel/);
+    expect(text).toMatch(/NOT the same as stopped/);
+    expect(text).toMatch(/corrupts the model/);
+  });
+
+  it("cancel still reports a genuinely settled download plainly", async () => {
+    // The narrowing is scoped to the interrupted-Manager case; an ordinary
+    // finished download must keep its short answer.
+    const done = { ...migratedManagerJob, status: "done" as const, interruptedByRestart: false };
+    getDownloadJobMock.mockReturnValue(done);
+    cancelDownloadJobMock.mockReturnValue({
+      found: true,
+      owned: false,
+      aborted: false,
+      status: "done",
+      job: done,
+    });
+
+    const text = (await tools().cancel({ id: "mgr-12gb" })).content[0].text;
+    expect(text).toMatch(/already \*\*done\*\* — nothing to cancel/);
+  });
+});

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -91,10 +91,18 @@ const lastWriteAt = new Map<string, number>();
  * on disk and no error event: 40 minutes gone, invisibly, while the documented
  * contract told their agent to keep waiting rather than re-issue.
  *
- * The transfer really is dead — it streamed inside a process that no longer
- * exists — so this does NOT resurrect it, and pretending otherwise would be the
- * worse bug. What it fixes is the SILENCE: a record that says the download was
- * interrupted, which `status` can find by the id the caller was handed.
+ * What this does NOT do is decide whether the transfer is dead — the original
+ * framing, and WRONG for the case that matters. A download DISPATCHED to
+ * ComfyUI-Manager is a server-side fetch: the ComfyUI HOST is doing the work and
+ * a restart here does not touch it, so it is very likely still running, and
+ * telling that caller to re-issue writes a second copy to the same destination —
+ * a corrupt model (#1197). This function reads neither the `pid` nor the `owner`
+ * it persists, and `writerProcessGone()` exists to answer exactly the question it
+ * skips, so it is in no position to assert death for EITHER route.
+ *
+ * What it fixes is the SILENCE: a record saying we stopped WATCHING, which
+ * `status` can find by the id the caller was handed — worded per route, which is
+ * why `via_manager` has to survive the copy.
  *
  * Only `downloading` records migrate. A terminal record's outcome was already
  * delivered, and re-landing it would replay a settled event. Fields are copied
@@ -141,7 +149,11 @@ export function migrateInFlightJobs(fromDir: string, toDir: string): number {
         // caller passing the tray_id they were handed gets "not found" on a record
         // that exists, the row renders `(tray undefined)`, and an absent
         // started_at prints `NaN s ago` in the candidate listing.
-        tray_id: str("tray_id"),
+        // `trayId`, NOT `tray_id` — this record's one camelCase key (line ~631),
+        // and the ONLY one url lookup matches on. Getting it wrong yields a
+        // silent `undefined` that a fixture using the same wrong key would not
+        // catch, which is precisely how a test passes for the wrong reason.
+        trayId: str("trayId"),
         filename: str("filename"),
         target_subfolder: str("target_subfolder"),
         started_at: num("started_at"),

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -136,10 +136,17 @@ export function migrateInFlightJobs(fromDir: string, toDir: string): number {
       // stopped and the caller was told to re-issue, which writes a SECOND copy to
       // the same destination and corrupts the model (node-management.ts:971-979).
       const viaManager = raw.via_manager === true;
-      const rec = {
+      // TYPED, not inferred: an annotated object literal gets excess-property
+      // checking, so a key that is not on PersistedDownloadJob is a COMPILE
+      // error. That is the only thing that catches this class — the five dead
+      // keys here for months were always `undefined`, and JSON.stringify drops
+      // undefined, so they never reached disk and no runtime assertion could
+      // see them. (`persistDownloadJob` cannot help: it spreads a variable,
+      // which defeats the check.)
+      const rec: PersistedDownloadJob = {
         id: raw.id,
         status: "error" as const,
-        url: str("url"),
+        url: str("url") ?? "",
         dest_key: str("dest_key"),
         req_key: str("req_key"),
         // Carried so the record stays USABLE, not just readable: without trayId a
@@ -150,11 +157,14 @@ export function migrateInFlightJobs(fromDir: string, toDir: string): number {
         // and the ONLY one url lookup matches on. Getting it wrong yields a
         // silent `undefined` that a fixture using the same wrong key would not
         // catch, which is precisely how a test passes for the wrong reason.
-        
-        trayId: str("trayId"),
+
+        // Required by the interface. A source record missing one is already
+        // unusable for lookup; an empty string keeps the record VALID and
+        // findable by id rather than emitting a malformed one.
+        trayId: str("trayId") ?? "",
         filename: str("filename"),
-        target_subfolder: str("target_subfolder"),
-        started_at: num("started_at"),
+        target_subfolder: str("target_subfolder") ?? "",
+        started_at: num("started_at") ?? Date.now(),
         pid: num("pid"),
         via_manager: viaManager,
         // Real keys that were also being dropped. `resume` is what a re-issue

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -120,6 +120,14 @@ export function migrateInFlightJobs(fromDir: string, toDir: string): number {
         typeof raw[k] === "string" ? (raw[k] as string) : undefined;
       const num = (k: string): number | undefined =>
         typeof raw[k] === "number" ? (raw[k] as number) : undefined;
+      // WHO was transferring decides what this record may say, so the flag has to
+      // survive the migration (#1197). A Manager dispatch is a server-side fetch:
+      // the ComfyUI HOST is doing the work and a restart here does not touch it.
+      // Dropping `via_manager` is what made the old text dangerous — it rendered
+      // as a plain local interruption, so a live 12 GB host transfer was reported
+      // stopped and the caller was told to re-issue, which writes a SECOND copy to
+      // the same destination and corrupts the model (node-management.ts:971-979).
+      const viaManager = raw.via_manager === true;
       const rec = {
         id: raw.id,
         status: "error" as const,
@@ -129,15 +137,39 @@ export function migrateInFlightJobs(fromDir: string, toDir: string): number {
         target: str("target"),
         dest_key: str("dest_key"),
         req_key: str("req_key"),
+        // Carried so the record stays USABLE, not just readable: without trayId a
+        // caller passing the tray_id they were handed gets "not found" on a record
+        // that exists, the row renders `(tray undefined)`, and an absent
+        // started_at prints `NaN s ago` in the candidate listing.
+        tray_id: str("tray_id"),
+        filename: str("filename"),
+        target_subfolder: str("target_subfolder"),
+        started_at: num("started_at"),
+        pid: num("pid"),
+        via_manager: viaManager,
         total: num("total"),
         received: num("received"),
         updated: Date.now(),
         interrupted_by_restart: true,
-        error:
-          `This download was INTERRUPTED: the orchestrator process it was streaming ` +
-          `inside exited (a restart or a session drop), so the transfer stopped. It is ` +
-          `NOT running and will not resume on its own — nothing is waiting to finish. ` +
-          `Any partial file may also have been discarded. Re-issue the download.`,
+        // NEITHER branch asserts the transfer died. This function reads neither
+        // the `pid` nor the `owner` it persists, and `writerProcessGone()` exists
+        // to answer exactly that question — the cancel path refuses to close a
+        // stale record until that probe returns ESRCH (#761/#858). What is
+        // observed is only that we stopped watching.
+        error: viaManager
+          ? `This download is no longer being WATCHED, and it was DISPATCHED to ` +
+            `ComfyUI-Manager — the fetch runs on the ComfyUI host, which the restart ` +
+            `here did not touch, so it is very likely STILL RUNNING. Do NOT re-issue ` +
+            `it: a second dispatch writes another copy to the same destination and ` +
+            `CORRUPTS the model. The file is not listed until it COMPLETES (which can ` +
+            `be hours for a multi-GB model), so an empty list_local_models proves ` +
+            `nothing and a timer is not a test — check the ComfyUI host's own logs or ` +
+            `disk if you need to know where it is.`
+          : `This download is no longer being WATCHED: the orchestrator process that ` +
+            `was streaming it exited, so nothing here is writing those bytes and no ` +
+            `further progress will be reported. Any partial file may have been ` +
+            `discarded. Re-issue the download — it resumes from any surviving ` +
+            `.partial.`,
       };
       writeFileSync(
         join(toDir, `${JOB_PREFIX}${sanitizeIdPart(raw.id)}-${PERSIST_OWNER}.json`),

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -137,12 +137,22 @@ export function migrateInFlightJobs(fromDir: string, toDir: string): number {
       // the same destination and corrupts the model (node-management.ts:971-979).
       const viaManager = raw.via_manager === true;
       // TYPED, not inferred: an annotated object literal gets excess-property
-      // checking, so a key that is not on PersistedDownloadJob is a COMPILE
-      // error. That is the only thing that catches this class — the five dead
-      // keys here for months were always `undefined`, and JSON.stringify drops
-      // undefined, so they never reached disk and no runtime assertion could
-      // see them. (`persistDownloadJob` cannot help: it spreads a variable,
-      // which defeats the check.)
+      // checking, so a key that is NOT on PersistedDownloadJob is a COMPILE
+      // error. The five dead keys that lived here for months (`name`, `dest`,
+      // `target`, `total`, `received` — from the tray-row interface) are caught
+      // this way. `persistDownloadJob` cannot help: it spreads a variable, which
+      // defeats the check.
+      //
+      // The type gate and the round-trip test's key-set assertion are
+      // COMPLEMENTARY, and an earlier version of this comment wrongly said the
+      // type was "the only thing that catches this class":
+      //   - the TYPE catches a key that is not on the interface at all;
+      //   - the TEST catches a key that IS on the interface but that the writer
+      //     never emits (e.g. `notes`), which the type cannot see.
+      // What is true, and worth stating precisely, is that no assertion on the
+      // PERSISTED record can see a dead key: it is always `undefined` and
+      // JSON.stringify drops it before it reaches disk. An assertion on the
+      // literal itself would see it.
       const rec: PersistedDownloadJob = {
         id: raw.id,
         status: "error" as const,

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -139,10 +139,7 @@ export function migrateInFlightJobs(fromDir: string, toDir: string): number {
       const rec = {
         id: raw.id,
         status: "error" as const,
-        name: str("name"),
         url: str("url"),
-        dest: str("dest"),
-        target: str("target"),
         dest_key: str("dest_key"),
         req_key: str("req_key"),
         // Carried so the record stays USABLE, not just readable: without trayId a
@@ -153,14 +150,18 @@ export function migrateInFlightJobs(fromDir: string, toDir: string): number {
         // and the ONLY one url lookup matches on. Getting it wrong yields a
         // silent `undefined` that a fixture using the same wrong key would not
         // catch, which is precisely how a test passes for the wrong reason.
+        
         trayId: str("trayId"),
         filename: str("filename"),
         target_subfolder: str("target_subfolder"),
         started_at: num("started_at"),
         pid: num("pid"),
         via_manager: viaManager,
-        total: num("total"),
-        received: num("received"),
+        // Real keys that were also being dropped. `resume` is what a re-issue
+        // needs to continue a partial rather than restart it, and `progressId`
+        // links the record back to its tray row.
+        progressId: str("progressId"),
+        resume: raw.resume,
         updated: Date.now(),
         interrupted_by_restart: true,
         // NEITHER branch asserts the transfer died. This function reads neither
@@ -180,8 +181,8 @@ export function migrateInFlightJobs(fromDir: string, toDir: string): number {
           : `This download is no longer being WATCHED: the orchestrator process that ` +
             `was streaming it exited, so nothing here is writing those bytes and no ` +
             `further progress will be reported. Any partial file may have been ` +
-            `discarded. Re-issue the download — it resumes from any surviving ` +
-            `.partial.`,
+            `discarded. Re-issue the download — it picks up a resumable .partial where ` +
+            `one survives, and otherwise restarts from zero.`,
       };
       writeFileSync(
         join(toDir, `${JOB_PREFIX}${sanitizeIdPart(raw.id)}-${PERSIST_OWNER}.json`),

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -1098,19 +1098,29 @@ async function cancelAction(args: { id: string; tray_id?: string }): Promise<Cal
           // refusal — "can't be aborted" about a download that already finished
           // would report failure for work that succeeded.
           if (res.status && res.status !== "downloading") {
-            // #1197 — REMAINING: a caller who cancels to be safe is told
-            // "already error — nothing to cancel", which reads as confirmation
-            // the transfer is over. For a Manager dispatch the host may still be
-            // fetching, and this MCP cannot recall a server-side task, so the
-            // honest answer is "not tracked here, and not stopped either".
-            // Not done: this result object carries neither `interruptedByRestart`
-            // nor `viaManager`, so it needs them threaded through
-            // `cancelDownload` — a real change, not a wording one.
+            // #1197 — the third place this had to be fixed, and the one a worried
+            // caller reaches. "already error — nothing to cancel" reads as
+            // confirmation the transfer is over; for a Manager dispatch carried
+            // across a restart the ComfyUI host may still be fetching, and this
+            // MCP has no Manager recall API — so a cancel would not have stopped
+            // it either. Both halves have to be said, or the reply is heard as
+            // "it is finished".
+            //
+            // The flags come off `res.job` (`cancelDownloadJob`'s persisted
+            // fallback builds it with `jobFromPersisted`, so both survive) — the
+            // same `res.job?.viaManager` this handler already reads a few lines
+            // above. An earlier attempt read them off `res` itself, which does
+            // NOT carry them, and I wrongly concluded from the type error that
+            // the data was unavailable.
+            const unwatchedManager =
+              res.status === "error" && res.job?.interruptedByRestart && res.job?.viaManager;
             return {
               content: [
                 {
                   type: "text",
-                  text: `Download \`${args.id}\` is already **${res.status}** — nothing to cancel.`,
+                  text: unwatchedManager
+                    ? `Download \`${args.id}\` is no longer TRACKED here, so there is nothing for this MCP to cancel — but that is NOT the same as stopped. It was dispatched to ComfyUI-Manager, so the ComfyUI HOST may still be fetching it, and there is no Manager recall API, so cancelling could not have stopped it either. Do not read this as a cancellation, and do not re-issue on the strength of it: a second dispatch writes another copy to the same destination and corrupts the model.`
+                    : `Download \`${args.id}\` is already **${res.status}** — nothing to cancel.`,
                 },
               ],
             };

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -912,7 +912,17 @@ async function statusAction(args: {
               : p && p.downloaded > 0
                 ? `  ${(p.downloaded / 1024 ** 3).toFixed(2)} GB so far`
                 : "";
-          const head = `- \`${j.id}\` (tray \`${j.trayId}\`) **${j.status}**${bytes}`;
+          // #1197 — the STATUS TOKEN is the first thing read, and for a Manager
+          // dispatch carried across a restart `error` is the wrong word: the
+          // ComfyUI host may still be fetching. Printing "error" here and "very
+          // likely STILL RUNNING" two lines down is a contradiction the caller
+          // resolves by position, so the token has to change too. A fix confined
+          // to the message body never reaches them.
+          const statusToken =
+            j.status === "error" && j.interruptedByRestart && j.viaManager
+              ? "unwatched (host may still be fetching)"
+              : j.status;
+          const head = `- \`${j.id}\` (tray \`${j.trayId}\`) **${statusToken}**${bytes}`;
           const collisionNote = idCounts.get(j.id)! > 1
             ? `\n    AMBIGUOUS id: another row in this listing shares \`${j.id}\` — these are DIFFERENT source URLs writing the SAME destination file, so the last writer wins and the result may be a mix. Select this one with \`tray_id\`: \`${j.trayId}\`. Pass that same tray_id to \`action:"cancel"\` to stop THIS one specifically.`
             : "";
@@ -933,11 +943,17 @@ async function statusAction(args: {
                   : `\n    ${placement.pathLabel}${placement.pathQualifier}: ${j.path}\n    ${placement.wrongPlace ? "WARNING" : "NOTE"}: ${placement.warning}`
               : j.status === "error"
                 ? j.interruptedByRestart
-                  ? // #1148 — NOT a transfer failure. The process it streamed
-                    // inside exited, which the previous behaviour rendered as
-                    // "No download matching id": the job silently ceased to exist
-                    // while the contract told the caller to keep waiting.
-                    `\n    INTERRUPTED — ${j.error}`
+                  ? // #1148 — NOT a transfer failure. The process that was
+                    // TRACKING it exited, which the previous behaviour rendered
+                    // as "No download matching id": the job silently ceased to
+                    // exist while the contract told the caller to keep waiting.
+                    //
+                    // #1197 — and for a Manager dispatch the transfer itself is
+                    // very likely still going, on the ComfyUI host. "INTERRUPTED"
+                    // asserts the opposite, so that label is local-route only.
+                    j.viaManager
+                      ? `\n    NO LONGER WATCHED — ${j.error}`
+                      : `\n    INTERRUPTED — ${j.error}`
                   : `\n    failed: ${j.error}`
                 : j.status === "cancelled"
                   ? (j.reclaimedDead
@@ -1082,6 +1098,14 @@ async function cancelAction(args: { id: string; tray_id?: string }): Promise<Cal
           // refusal — "can't be aborted" about a download that already finished
           // would report failure for work that succeeded.
           if (res.status && res.status !== "downloading") {
+            // #1197 — REMAINING: a caller who cancels to be safe is told
+            // "already error — nothing to cancel", which reads as confirmation
+            // the transfer is over. For a Manager dispatch the host may still be
+            // fetching, and this MCP cannot recall a server-side task, so the
+            // honest answer is "not tracked here, and not stopped either".
+            // Not done: this result object carries neither `interruptedByRestart`
+            // nor `viaManager`, so it needs them threaded through
+            // `cancelDownload` — a real change, not a wording one.
             return {
               content: [
                 {


### PR DESCRIPTION
Fixes #1197. **Draft — claiming the issue.**

## The path

A Manager dispatch's record stays `downloading` for the whole server-side transfer (without an aria2 sidecar, where `runManagerQueue` drains only on completion). An orchestrator restart then runs `migrateInFlightJobs`, which:

1. migrates **every** `downloading` record with **no `via_manager` check**, writing a record that says the transfer stopped — for a fetch running on the ComfyUI **host**, which a restart here does not touch;
2. **drops `via_manager`**, so the record renders as a plain LOCAL interruption and nobody can tell the difference.

Re-issuing then writes a second copy to the same destination. `node-management.ts:971-979` says what that produces: **a corrupt model**.

## Why the fix is a field, not wording

#1194 spent five review rounds trying to word around this, and each attempt produced a new false claim — because the record cannot say the right thing for a route it has thrown away. Carry `via_manager` and the text splits cleanly:

- **local** → nothing is writing it; re-issue, it resumes from any surviving `.partial`. Short, correct, terminating.
- **Manager** → the host may still be fetching; the file is not listed until it COMPLETES, so absence proves nothing and a timer is not a test.

## Plan

- [ ] Carry `via_manager` (plus `trayId`, `pid`, `started_at` — dropped today, and load-bearing: the row renders `(tray undefined)` and the listing prints `NaN s ago`)
- [ ] Split the migrated record's text on that flag
- [ ] Do NOT claim death for either route — the migration reads neither `pid` nor `owner`, while `writerProcessGone()` exists to answer exactly that and the cancel path refuses to act without it (#761/#858)
- [ ] Tests: the word "manager" currently appears **nowhere** in `download-progress.test.ts`, which is why this shipped

## Config note

Reproduces **without** an aria2 sidecar. With one — and `docker/runpod/post_start.sh` exports `COMFYUI_MANAGER_ARIA2_SERVER`, so this project's own RunPod image has it — the queue drains at handoff, the record goes terminal `done`, and nothing migrates. A repro needs that variable unset, or the bug looks unreal.

Unblocks #1194, which is parked in draft pending this.