### PR TITLE
release: v0.50.54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.54] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- a rebind that fails on an OLD panel says so, and names the version (#1199)
+
+
 ## [0.50.53] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.53",
+  "version": "0.50.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.53",
+      "version": "0.50.54",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.53",
+  "version": "0.50.54",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.54` tag.

**A fence deadlock caused by an old panel now names the version that fixes it** (#1043, via #1199).

Three reports — #1043, #1077, #1174 — end in the same dead end: a command re-points the active workflow, the session fence is not re-derived, every later `panel_*` call is refused with `workflow instance mismatch`, and the documented recovery fails because it needs a read the fence blocks.

The repair already exists — `refreshFenceFromOwnReply` (#1161) trusts the `workflow_uuid` on the command's own reply and never makes that read. It needs the panel to *publish* that uuid, which first shipped in **panel 0.11.45**, and every reporter was below it (0.11.43, 0.11.44). So the fix was present and inert while the message said only "could not be read" — a mystery instead of one action.

Tri-state throughout: only a **freshly advertised**, parseable version below the minimum is narrated as too old. An unknown, unparseable, or *inherited* version stays silent rather than telling someone to update a panel that may already be current.

Codex review caught two real defects before merge, both wrong-remedy: the note was also being attached to `panel_set_workflow_target`, where the claim is false (that command has no own-reply uuid to gain); and the version could be a stale inherited value from a re-hello that omitted it.

Verified live against the built artifact using the reporters' actual panel versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)