### PR TITLE
fix(enqueue): redact the response body in the enqueue error builders

### DIFF
--- a/src/__tests__/comfyui/cloud-client-hardening.test.ts
+++ b/src/__tests__/comfyui/cloud-client-hardening.test.ts
@@ -20,6 +20,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../config.js", () => ({
+  // #1191 — the scrubber now redacts the CLOUD API KEY by known value, so it
+  // reads `config` directly. Stubbed empty: this test is about the error's
+  // delivery-doubt wording, not about redaction.
+  config: {},
   getApiKey: () => "test-key",
   getCloudUrl: () => "https://cloud.comfy.org",
   getComfyUIAuthHeaders: () => ({}),

--- a/src/__tests__/comfyui/cloud-key-redaction.test.ts
+++ b/src/__tests__/comfyui/cloud-key-redaction.test.ts
@@ -1,0 +1,49 @@
+// #1191 (codex review) — the CLOUD API KEY was not among the known values the
+// scrubber redacts.
+//
+// `getComfyUIAuthHeaders()` carries the ComfyUI auth token and the Cloudflare
+// Access pair. It does NOT carry COMFYUI_API_KEY, which cloud-client sends as
+// `X-API-Key` — so the cloud enqueue error path, whose body is the one most
+// likely to reflect that key back, had no known-value pass for it at all.
+//
+// The by-name pass catches a LABELLED reflection ("api-key: …"). An UNLABELLED
+// echo of a short key has neither a recognized label nor the 24-character
+// opaque-run shape, and went straight out. That is the case pinned here.
+
+import { describe, expect, it, vi } from "vitest";
+
+const CLOUD_KEY = "cmfy-7Q2w9Z";      // short + unlabelled: no other pass catches it
+const HF_TOKEN = "hf_aBcD3fGh1jK";
+
+vi.mock("../../config.js", () => ({
+  getComfyUIAuthHeaders: () => ({}),   // deliberately EMPTY: the old known-value source
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  config: { comfyuiApiKey: CLOUD_KEY, huggingfaceToken: HF_TOKEN, civitaiApiToken: undefined },
+}));
+
+const { scrubSecretShapedText, bodyPrefixOf } = await import("../../comfyui/json-guard.js");
+
+describe("the scrubber knows every configured credential (#1191)", () => {
+  it("redacts an UNLABELLED reflected cloud API key", () => {
+    const out = scrubSecretShapedText(`upstream rejected ${CLOUD_KEY} at edge`);
+    // null = withheld entirely (also acceptable); a returned string must not
+    // carry the key.
+    expect(out === null || !out.includes(CLOUD_KEY)).toBe(true);
+  });
+
+  it("redacts a reflected HuggingFace token", () => {
+    const out = scrubSecretShapedText(`fetch failed for ${HF_TOKEN}`);
+    expect(out === null || !out.includes(HF_TOKEN)).toBe(true);
+  });
+
+  it("bodyPrefixOf never returns the cloud key", () => {
+    const body = JSON.stringify({ echo: { headers: { "X-API-Key": CLOUD_KEY } } });
+    expect(bodyPrefixOf(body)).not.toContain(CLOUD_KEY);
+  });
+
+  it("leaves ordinary text alone", () => {
+    // Fail-closed must not mean fail-always: an unrelated body still reads.
+    const out = scrubSecretShapedText("upstream gateway exploded");
+    expect(out).toBe("upstream gateway exploded");
+  });
+});

--- a/src/__tests__/comfyui/cloud-system-stats-honesty.test.ts
+++ b/src/__tests__/comfyui/cloud-system-stats-honesty.test.ts
@@ -23,6 +23,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../config.js", () => ({
+  // #1191 — the scrubber now also redacts the CLOUD API KEY and the download
+  // tokens by known value, so it reads `config` directly. Stubbed empty here:
+  // these tests are about the non-JSON diagnosis, not about redaction.
+  config: {},
   getApiKey: () => "test-key",
   getCloudUrl: () => "https://cloud.comfy.org",
   getComfyUIAuthHeaders: () => ({}),

--- a/src/__tests__/comfyui/enqueue-error-redaction.test.ts
+++ b/src/__tests__/comfyui/enqueue-error-redaction.test.ts
@@ -98,3 +98,49 @@ describe("an enqueue error never hands back the credential (#1191)", () => {
     expect(err.message.length).toBeLessThan(400);
   });
 });
+
+// Codex adversarial review of PR #1202 found two real leaks the first fix missed.
+// Both are the same shape as the original: a credential reaching a tool result.
+describe("review findings (PR #1202)", () => {
+  // DEFECT 5 — the STRUCTURED branch runs FIRST and bypassed redaction entirely.
+  // A hostile or reflecting gateway can answer with JSON shaped exactly like a
+  // ComfyUI validation failure, so the "redacted" fallback never ran.
+  it("scrubs a credential reflected in a JSON error.message", async () => {
+    const body = JSON.stringify({ error: { message: `rejected for Bearer ${TOKEN}` } });
+    comfyuiFetch.mockResolvedValueOnce(res(400, body));
+    const err = (await enqueuePrompt({}).catch((e: unknown) => e)) as Error;
+    expect(err.message).not.toContain(TOKEN);
+  });
+
+  it("scrubs a credential reflected in node_errors messages and details", async () => {
+    const body = JSON.stringify({
+      node_errors: {
+        "5": {
+          class_type: "LoadImage",
+          errors: [{ message: `upstream said ${TOKEN}`, details: `header was ${TOKEN}` }],
+        },
+      },
+    });
+    comfyuiFetch.mockResolvedValueOnce(res(400, body));
+    const err = (await enqueuePrompt({}).catch((e: unknown) => e)) as Error;
+    expect(err.message).not.toContain(TOKEN);
+    // …and the useful half of the diagnosis survives.
+    expect(err.message).toContain("LoadImage");
+  });
+
+  it("a genuine validation message is returned UNCHANGED", async () => {
+    // Fail-closed must not mean fail-noisy: a real ComfyUI error carries no
+    // credential and must read exactly as before.
+    const body = JSON.stringify({
+      error: { message: "Prompt outputs failed validation" },
+      node_errors: {
+        "7": { class_type: "KSampler", errors: [{ message: "steps must be >= 1" }] },
+      },
+    });
+    comfyuiFetch.mockResolvedValueOnce(res(400, body));
+    const err = (await enqueuePrompt({}).catch((e: unknown) => e)) as Error;
+    expect(err.message).toContain("Prompt outputs failed validation");
+    expect(err.message).toContain("KSampler");
+    expect(err.message).toContain("steps must be >= 1");
+  });
+});

--- a/src/__tests__/comfyui/enqueue-error-redaction.test.ts
+++ b/src/__tests__/comfyui/enqueue-error-redaction.test.ts
@@ -1,0 +1,100 @@
+// #1191 — the enqueue error builders printed up to 500 RAW response bytes.
+//
+// A gateway that reflects the request can echo OUR OWN CREDENTIAL in the body it
+// answers with, and that string goes straight into a tool result the agent reads
+// and users paste into bug reports. `/prompt` is the worst endpoint to have this
+// on: it is the one call that enqueues work, so it runs on every render, and its
+// error path is the one most likely to be hit and shared.
+//
+// Same class as #828 (the diagnosis path) and #1187 (the branches it made
+// reachable); genuinely pre-existing on both sites, which is why it was filed
+// separately rather than folded into that PR.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const TOKEN = "sk-live-9f2b7c41aa6e4d0e8b3f5a1c2d7e9f04";
+
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
+  return {
+    ...actual,
+    isCloudMode: () => false,
+    getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+    config: { ...actual.config, comfyuiAuthToken: TOKEN, comfyuiAuthHeader: "Authorization" },
+  };
+});
+
+const comfyuiFetch = vi.fn();
+vi.mock("../../comfyui/fetch.js", () => ({
+  comfyuiFetch: (...a: unknown[]) => comfyuiFetch(...a),
+}));
+
+const { enqueuePrompt } = await import("../../comfyui/client.js");
+
+function res(status: number, body: string, statusText = "Bad Request"): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    text: async () => body,
+    json: async () => JSON.parse(body),
+    headers: new Map(),
+  } as unknown as Response;
+}
+
+beforeEach(() => comfyuiFetch.mockReset());
+afterEach(() => vi.clearAllMocks());
+
+describe("an enqueue error never hands back the credential (#1191)", () => {
+  it("does not echo a reflected token from the body", async () => {
+    // The shape that matters: a gateway echoing the request it received.
+    const reflected = JSON.stringify({
+      message: "unauthorized",
+      request: { headers: { Authorization: `Bearer ${TOKEN}` } },
+    });
+    comfyuiFetch.mockResolvedValueOnce(res(401, reflected, "Unauthorized"));
+
+    const err = (await enqueuePrompt({}).catch((e: unknown) => e)) as Error;
+    expect(err.message).not.toContain(TOKEN);
+  });
+
+  it("does not echo a token reflected in the STATUS phrase either", async () => {
+    comfyuiFetch.mockResolvedValueOnce(res(403, "", `denied for ${TOKEN}`));
+    const err = (await enqueuePrompt({}).catch((e: unknown) => e)) as Error;
+    expect(err.message).not.toContain(TOKEN);
+  });
+
+  it("still says WHAT happened — redaction must not eat the diagnosis", async () => {
+    // A redaction that withholds everything trades one defect for another.
+    comfyuiFetch.mockResolvedValueOnce(res(502, "upstream gateway exploded", "Bad Gateway"));
+    const err = (await enqueuePrompt({}).catch((e: unknown) => e)) as Error;
+    expect(err.message).toContain("502");
+    expect(err.message).toContain("upstream gateway exploded");
+  });
+
+  it("keeps ComfyUI's own node_errors diagnosis intact (#485)", async () => {
+    // The validation path is the whole reason /prompt errors are read at all, and
+    // it must survive: it does not go through the raw-body fallback.
+    const body = JSON.stringify({
+      error: { message: "Prompt outputs failed validation" },
+      node_errors: {
+        "5": {
+          class_type: "LoadImage",
+          errors: [{ message: "Custom validation failed", details: "Invalid image file" }],
+        },
+      },
+    });
+    comfyuiFetch.mockResolvedValueOnce(res(400, body));
+    const err = (await enqueuePrompt({}).catch((e: unknown) => e)) as Error;
+    expect(err.message).toContain("Prompt outputs failed validation");
+    expect(err.message).toContain("LoadImage");
+    expect(err.message).toContain("Invalid image file");
+  });
+
+  it("bounds the body — a huge page cannot flood the tool result", async () => {
+    comfyuiFetch.mockResolvedValueOnce(res(500, "x".repeat(5000), "Internal Server Error"));
+    const err = (await enqueuePrompt({}).catch((e: unknown) => e)) as Error;
+    // The old code allowed 500 bytes; bodyPrefixOf clips far tighter.
+    expect(err.message.length).toBeLessThan(400);
+  });
+});

--- a/src/__tests__/comfyui/enqueue-prompt-validation.test.ts
+++ b/src/__tests__/comfyui/enqueue-prompt-validation.test.ts
@@ -88,7 +88,20 @@ describe("enqueuePrompt — surfaces ComfyUI 400 validation details (#485)", () 
     const err = await enqueuePrompt({}).catch((e) => e);
     expect(err).toBeInstanceOf(ComfyUIError);
     expect((err as Error).message).toContain("400");
-    expect((err as Error).message).toContain("Bad Request");
+    // #1191 — the STATUS is what this test is about, and it is still named.
+    // describeStatus deliberately drops a STANDARD reason phrase ("Bad Request"
+    // adds nothing over 400) and scrubs a non-standard one, because a reason
+    // phrase is attacker-influenceable on a hostile proxy and lands in a message
+    // the agent reads. A NON-standard phrase still comes through, which is the
+    // half that carries information — asserted below.
+    expect((err as Error).message).toContain("ComfyUI /prompt returned 400");
+  });
+
+  it("#1191: keeps a NON-standard reason phrase, which is the informative one", async () => {
+    comfyuiFetch.mockResolvedValueOnce(res(503, "", "Upstream model host unavailable"));
+    const err = await enqueuePrompt({}).catch((e) => e);
+    expect((err as Error).message).toContain("503");
+    expect((err as Error).message).toContain("Upstream model host unavailable");
   });
 
   it("returns prompt_id + the authoritative /queue depth on success", async () => {

--- a/src/__tests__/tools/html-instead-of-json.test.ts
+++ b/src/__tests__/tools/html-instead-of-json.test.ts
@@ -17,6 +17,10 @@ import { describe, expect, it, beforeEach, vi } from "vitest";
 
 const authHeaders = vi.hoisted(() => ({ value: {} as Record<string, string> }));
 vi.mock("../../config.js", () => ({
+  // #1191 — the scrubber now also redacts the CLOUD API KEY and the download
+  // tokens by known value, so it reads `config` directly. Stubbed empty here:
+  // these tests are about the non-JSON diagnosis, not about redaction.
+  config: {},
   getComfyUIBaseUrl: () => "http://remote.example:8188",
   getComfyUIAuthHeaders: () => authHeaders.value,
 }));

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -621,7 +621,11 @@ async function buildEnqueueError(res: Response): Promise<ComfyUIError> {
   // HTTP status and claims nothing about node errors. An unread body and an empty
   // body get the same honest fallback rather than a fabricated validation result.
   const bodyText = await res.text().catch(() => "");
-  const generic = `ComfyUI /prompt returned ${res.status} ${res.statusText}`;
+  // #1191 — statusText is attacker-influenceable on a hostile proxy and lands in
+  // a message the agent reads, so it gets the same scrub the body does.
+  // describeStatus drops a standard reason phrase entirely (it adds nothing),
+  // clips a long one, and falls back to the bare status if it cannot scrub.
+  const generic = `ComfyUI /prompt returned ${describeStatus(res.status, res.statusText)}`;
 
   let parsed: unknown;
   try {
@@ -668,10 +672,18 @@ async function buildEnqueueError(res: Response): Promise<ComfyUIError> {
     }
   }
 
-  // Empty or unexpected body: fall back to the generic HTTP status, but keep
-  // any raw text so nothing is silently dropped.
+  // Empty or unexpected body: fall back to the generic HTTP status, but keep a
+  // REDACTED prefix of the text so nothing is silently dropped.
+  //
+  // #1191 — this used to interpolate 500 RAW bytes. A gateway that reflects the
+  // request can echo our own credential in the body it answers with, and this
+  // string goes straight into a tool result the agent reads and users paste into
+  // bug reports. /prompt is the worst endpoint to have that on: it is the call
+  // every render makes, so this is the error path most likely to be hit and
+  // shared. bodyPrefixOf redacts by SHAPE as well as by known value, and
+  // withholds the prefix entirely when it cannot substitute safely.
   return new ConnectionError(
-    bodyText ? `${generic}: ${bodyText.slice(0, 500)}` : generic,
+    bodyText ? `${generic}: ${bodyPrefixOf(bodyText)}` : generic,
   );
 }
 

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -28,6 +28,7 @@ import {
   readComfyJson,
   redactErrorMessage,
   rethrowWithJsonDiagnosis,
+  scrubSecretShapedText,
 } from "./json-guard.js";
 import * as cloudClient from "./cloud-client.js";
 import type { ObjectInfo, SystemStats, QueueStatus } from "./types.js";
@@ -616,6 +617,28 @@ async function queueRemainingCount(): Promise<number | undefined> {
  * Falls back to the generic HTTP status only when the body is empty or is not
  * the expected validation JSON (#485).
  */
+/**
+ * One field of a STRUCTURED /prompt error, made safe to interpolate (#1191,
+ * codex review).
+ *
+ * The fix for #1191 redacted the raw-body FALLBACK and stopped there — but the
+ * structured branch runs FIRST and copied `error.message`, each node's
+ * `class_type`, and every `errors[].message` / `.details` verbatim into the
+ * result. A hostile or reflecting gateway can answer with JSON shaped exactly
+ * like a ComfyUI validation failure, so a credential echoed in any of those
+ * fields reached the agent while the "redacted" path never ran.
+ *
+ * scrubSecretShapedText returns null when it cannot substitute safely; that is a
+ * FAIL-CLOSED signal, so the field is withheld rather than passed through. The
+ * #485 diagnosis survives because a genuine ComfyUI validation message contains
+ * no credential and is returned unchanged.
+ */
+function safeField(v: unknown): string {
+  if (typeof v !== "string" || v === "") return "";
+  const scrubbed = scrubSecretShapedText(v);
+  return scrubbed === null ? "(withheld: contains a configured credential)" : scrubbed;
+}
+
 async function buildEnqueueError(res: Response): Promise<ComfyUIError> {
   // unknown-ok: "" only routes to the GENERIC status message, which reports the
   // HTTP status and claims nothing about node errors. An unread body and an empty
@@ -648,17 +671,20 @@ async function buildEnqueueError(res: Response): Promise<ComfyUIError> {
       const cls = info?.class_type ?? "node";
       const errs = Array.isArray(info?.errors) ? info.errors : [];
       if (errs.length === 0) {
-        lines.push(`- ${cls} (node ${nodeId}): validation failed`);
+        lines.push(`- ${safeField(cls)} (node ${safeField(nodeId)}): validation failed`);
         continue;
       }
       for (const e of errs) {
-        const detail = e?.details ? ` (${e.details})` : "";
-        lines.push(`- ${cls} (node ${nodeId}): ${e?.message ?? "validation failed"}${detail}`);
+        const detail = e?.details ? ` (${safeField(e.details)})` : "";
+        lines.push(
+          `- ${safeField(cls)} (node ${safeField(nodeId)}): ` +
+            `${safeField(e?.message) || "validation failed"}${detail}`,
+        );
       }
     }
 
     const headline = payload.error?.message
-      ? `ComfyUI rejected the workflow (${res.status}): ${payload.error.message}`
+      ? `ComfyUI rejected the workflow (${res.status}): ${safeField(payload.error.message)}`
       : `ComfyUI rejected the workflow (${res.status})`;
 
     if (lines.length > 0 || payload.error?.message) {

--- a/src/comfyui/cloud-client.ts
+++ b/src/comfyui/cloud-client.ts
@@ -22,6 +22,7 @@ import {
   deliveryDoubt,
   isTimeoutAbort,
 } from "./fetch.js";
+import { bodyPrefixOf, describeStatus } from "./json-guard.js";
 import { ComfyUIError, ConnectionError, describeFetchFailure } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import type { HistoryEntry } from "./client.js";
@@ -62,8 +63,14 @@ async function cloudFetch(
       // HTTP status is reported either way, so an unreadable body costs detail in the
       // text, never a wrong conclusion. Verified there is no branch on this value.
       const body = await res.text().catch(() => "");
+      // #1191 — same raw-500-byte exposure as the local /prompt builder, on the
+      // path that carries a CLOUD API KEY. A gateway that reflects the request
+      // can echo it in the body it answers with, and this string lands in a tool
+      // result users paste into bug reports. bodyPrefixOf redacts by shape as
+      // well as by known value and withholds entirely when it cannot substitute
+      // safely; describeStatus does the same for the reason phrase.
       throw new ComfyUIError(
-        `Cloud API error: ${res.status} ${res.statusText} — ${body.slice(0, 500)}`,
+        `Cloud API error: ${describeStatus(res.status, res.statusText)} — ${bodyPrefixOf(body)}`,
         "CLOUD_API_ERROR",
         { url, status: res.status },
       );

--- a/src/comfyui/json-guard.ts
+++ b/src/comfyui/json-guard.ts
@@ -19,7 +19,7 @@
 // diagnosis costs more than an honest "the body is HTML; here is its first line".
 
 import { ComfyUIError } from "../utils/errors.js";
-import { getComfyUIAuthHeaders, getComfyUIBaseUrl } from "../config.js";
+import { config, getComfyUIAuthHeaders, getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch, targetOf } from "./fetch.js";
 
 /** What answered instead of the ComfyUI JSON API. */
@@ -246,11 +246,41 @@ function reflectionPatterns(value: string): { pattern: RegExp; length: number }[
  * Passes 2 and 3 run whether or not a credential is configured: a reflected
  * body can carry someone else's secret too, and this text goes to an agent.
  */
+/**
+ * Every credential this process is configured with, as raw values (#1191).
+ *
+ * Deliberately broader than `getComfyUIAuthHeaders()`, which is about what to
+ * SEND: this is about what must never come BACK. A reflected body can echo any
+ * of them, and the scrubber should not have to know which endpoint it is looking
+ * at to redact the right one.
+ *
+ * Empty values are dropped by the caller's own guard; nothing here is logged.
+ */
+function knownCredentialValues(): string[] {
+  const out = Object.values(getComfyUIAuthHeaders());
+  for (const v of [config.comfyuiApiKey, config.huggingfaceToken, config.civitaiApiToken]) {
+    if (typeof v === "string" && v.trim()) out.push(v.trim());
+  }
+  return out;
+}
+
 export function scrubSecretShapedText(text: string): string | null {
   let out = text;
 
   // 1. Known configured values, in every encoding we can anticipate.
-  for (const headerValue of Object.values(getComfyUIAuthHeaders())) {
+  //
+  // #1191 (codex review) — getComfyUIAuthHeaders() carries ONLY the ComfyUI auth
+  // token and the Cloudflare Access pair. It does NOT carry the Comfy Cloud API
+  // key, which cloud-client sends as `X-API-Key` — so the cloud enqueue error
+  // path, the one whose body is most likely to reflect that key back, had no
+  // known-value pass for it at all. The by-name pass below catches a LABELLED
+  // reflection, but an unlabelled echo of a short key has neither a recognized
+  // label nor the 24-char opaque-run shape, and would have gone straight out.
+  //
+  // The download tokens are here for the same reason: a reflected body on any of
+  // these paths reaches the agent, and which credential leaked is not something
+  // to decide per call site.
+  for (const headerValue of knownCredentialValues()) {
     if (!headerValue) continue;
     // The header value may be "Bearer <token>"; handle the whole thing and the
     // bare token, so neither form survives.


### PR DESCRIPTION
Fixes #1191. **Draft — claiming the issue, work in progress.**

## What

Two enqueue error builders interpolate the response body verbatim, and print `statusText` unscrubbed:

- `src/comfyui/client.ts` — `buildEnqueueError`: `` `${generic}: ${bodyText.slice(0, 500)}` ``
- `src/comfyui/cloud-client.ts` — the identical raw-500-byte shape on the cloud path

## Why it matters

A gateway that reflects the request can echo **our own credential** in the body it answers with, and that body goes straight into a tool result the agent reads and users paste into bug reports. `/prompt` is the worst endpoint to have this on: it is the one call that enqueues work, so it runs on every render, and its error path is the one users are most likely to hit and share.

This is the same class #828 closed for the diagnosis path and #1187 closed for the branches it made reachable — genuinely pre-existing on both sites, which is why it was filed separately rather than folded into that PR.

## Plan

The repo already has the right tools:

- `bodyPrefixOf` (`src/comfyui/json-guard.ts`) — redacts by shape as well as by known value, and fails closed when it cannot substitute safely;
- `describeStatus` — the matching one for the reason phrase, which is attacker-influenceable on a hostile proxy.

Use both at each site. The change is small; the care is in verifying the redaction genuinely fires for a credential-bearing body, and that a legitimate ComfyUI validation error (the `node_errors` diagnosis #485 exists to surface) is still readable afterwards — a redaction that eats the useful half would trade one defect for another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)