### PR TITLE
release: v0.50.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.55] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- a live ComfyUI-Manager download must not be reported INTERRUPTED (#1200)
+
+
 ## [0.50.54] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.54",
+  "version": "0.50.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.54",
+      "version": "0.50.55",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.54",
+  "version": "0.50.55",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the `v0.50.55` tag into protected main (version bump + changelog).

Contents: **#1200** — a ComfyUI-Manager download stays `downloading` for the whole server-side transfer (without an aria2 sidecar), so an orchestrator restart migrated it as INTERRUPTED, stripped `via_manager`, and told the caller to re-issue — a second dispatch to the same destination, which corrupts the model. Closes #1197.

Gates run locally before tagging: build, full suite (386 files / 7889 passed), `check:vocabulary` (clean on the tracked tree), `vocab:export --check`, `asset-counts --check`, `docs:gen` freshness. Rendered output verified end-to-end on the merged build.