### PR TITLE
release: v0.50.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.56] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- redact the response body in the enqueue error builders (#1202)
+
+
 ## [0.50.55] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.55",
+  "version": "0.50.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.55",
+      "version": "0.50.56",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.55",
+  "version": "0.50.56",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.56` tag.

**Enqueue errors no longer echo a credential back** (#1191, via #1202).

Two enqueue error builders interpolated up to **500 raw response bytes** — and `statusText` unscrubbed — into a tool result the agent reads and users paste into bug reports. A gateway that reflects the request can echo the caller's own credential in that body, and `/prompt` is the worst endpoint to have it on: the one call every render makes, with the error path most likely to be hit and shared. The cloud site carried an API key on the same shape.

Both now use the redaction the repo already had (`bodyPrefixOf`, `describeStatus`), which redacts by shape as well as by known value and withholds entirely when it cannot substitute safely.

Adversarial review then found two leaks the first pass missed, both fixed here:

- **the cloud API key was never a known value** — the scrubber's known-value pass only knew the ComfyUI auth token and Cloudflare Access pair, so an unlabelled reflection of `COMFYUI_API_KEY` went straight out, on precisely the path the fix was written for. The HF/CivitAI tokens are included for the same reason.
- **the structured branch bypassed redaction entirely** — `buildEnqueueError` parses the body first and copied `error.message`, `class_type` and every node error verbatim, so a gateway answering with JSON *shaped* like a validation failure leaked while the redacted fallback never ran.

Fail-closed does not mean fail-noisy: a genuine ComfyUI validation error carries no credential and reads exactly as before (#485 diagnosis intact, with a test pinning it).

A third, pre-existing exposure the review surfaced — `getLogs()` returning raw `/internal/logs` lines — is filed as **#1206** rather than widened into this PR.

Verified live against the built artifact: a reflected `Authorization: Bearer …` and `X-API-Key` both come back `«redacted»`, while ordinary diagnostic text passes through untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)