### PR TITLE
fix(logs): scrub /internal/logs before it reaches a tool result

### DIFF
--- a/src/__tests__/comfyui/log-scrub-withhold.test.ts
+++ b/src/__tests__/comfyui/log-scrub-withhold.test.ts
@@ -1,0 +1,40 @@
+// #1206 — the FAIL-CLOSED half of the log scrub, in its own file because it
+// needs a different configured credential than the redaction tests.
+//
+// `scrubSecretShapedText` returns null when it cannot substitute a configured
+// credential without mangling unrelated text — documented trigger: a credential
+// shorter than 8 characters. That must REPLACE the line with a marker, never
+// delete it: a shorter log with no explanation is a worse diagnostic than one
+// that says what it withheld, and a caller counting lines would be misled.
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  // Deliberately SHORT — this is the documented "too short to replace safely"
+  // case, and it is the only reliable way to reach the null branch.
+  getComfyUIAuthHeaders: () => ({ Authorization: "abc" }),
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  config: {},
+}));
+
+const { scrubLogLines } = await import("../../comfyui/json-guard.js");
+
+describe("a line that cannot be scrubbed is withheld VISIBLY (#1206)", () => {
+  it("replaces the line with a marker rather than emptying it", () => {
+    const out = scrubLogLines(["[INFO] header was abc"]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatch(/withheld/);
+    // An empty string would satisfy "no credential" while silently deleting the
+    // entry — the failure mode this wording exists to prevent.
+    expect(out[0].length).toBeGreaterThan(0);
+    expect(out[0]).not.toContain("header was abc");
+  });
+
+  it("withholds only the affected line, never the whole log", () => {
+    const out = scrubLogLines(["fine one", "[INFO] header was abc", "fine two"]);
+    expect(out).toHaveLength(3);
+    expect(out[0]).toBe("fine one");
+    expect(out[2]).toBe("fine two");
+    expect(out[1]).toMatch(/withheld/);
+  });
+});

--- a/src/__tests__/comfyui/log-scrub.test.ts
+++ b/src/__tests__/comfyui/log-scrub.test.ts
@@ -1,0 +1,93 @@
+// #1206 — /internal/logs reached a tool result with no credential scrub.
+//
+// A ComfyUI log is a plausible place for one to appear: a custom node logging
+// the URL it fetched (CivitAI and HuggingFace download URLs routinely carry a
+// token in the query string), ComfyUI-Manager logging an install URL, or any
+// node logging a request header on failure.
+//
+// Both consumers are DIAGNOSTICS — get_system_stats action:"logs" and the health
+// report — so they are called exactly when something is wrong, and their output
+// is what a user pastes into a bug report. Found during the review of #1191.
+
+import { describe, expect, it, vi } from "vitest";
+
+const HF = "hf_aBcD3fGh1jKlMnOpQrStUvWxYz";
+const CIVITAI = "civitai-9f2b7c41aa6e4d0e8b3f5a1c";
+
+vi.mock("../../config.js", () => ({
+  getComfyUIAuthHeaders: () => ({}),
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  config: { huggingfaceToken: HF, civitaiApiToken: CIVITAI, comfyuiApiKey: undefined },
+}));
+
+const { scrubLogLines } = await import("../../comfyui/json-guard.js");
+
+describe("scrubLogLines (#1206)", () => {
+  it("redacts a token in a logged download URL", () => {
+    const out = scrubLogLines([
+      `[INFO] fetching https://huggingface.co/org/repo/resolve/main/m.safetensors?token=${HF}`,
+    ]);
+    expect(out[0]).not.toContain(HF);
+    // The line is still a line — the URL and the action survive.
+    expect(out[0]).toContain("huggingface.co/org/repo");
+    expect(out[0]).toContain("fetching");
+  });
+
+  it("redacts a CivitAI token too", () => {
+    const out = scrubLogLines([`[INFO] GET https://civitai.com/api/download/1?token=${CIVITAI}`]);
+    expect(out[0]).not.toContain(CIVITAI);
+  });
+
+  it("keeps ordinary log lines EXACTLY as they were", () => {
+    // The whole value of a log is its fidelity. A scrub that rewrites innocent
+    // lines makes the diagnostic untrustworthy.
+    const lines = [
+      "[INFO] Starting server",
+      "Traceback (most recent call last):",
+      '  File "/x/nodes.py", line 42, in load',
+      "RuntimeError: CUDA out of memory",
+    ];
+    expect(scrubLogLines(lines)).toEqual(lines);
+  });
+
+  it("preserves the LINE COUNT — nothing is silently dropped", () => {
+    const lines = ["a", `token=${HF}`, "c"];
+    expect(scrubLogLines(lines)).toHaveLength(3);
+  });
+
+  // The FAIL-CLOSED half lives in log-scrub-withhold.test.ts: it needs a SHORT
+  // configured credential (the documented "too short to replace safely" trigger)
+  // and therefore a different config mock than the redaction cases here.
+  //
+  // Worth recording why: my first attempt tested it in this file with a
+  // zero-width space, which `\s` does not match — so it never reached the null
+  // branch and passed for the wrong reason.
+
+
+  it("is a no-op on an empty log", () => {
+    expect(scrubLogLines([])).toEqual([]);
+  });
+});
+
+// THE WIRING. The helper cannot see whether its two consumers call it — the
+// call-site blindness this repo keeps getting caught by. Both emit into a tool
+// result, so both must.
+describe("both log consumers scrub (#1206)", () => {
+  it("getLogs and the health report both route through scrubLogLines", async () => {
+    const { readFileSync } = await import("node:fs");
+    const client = readFileSync(new URL("../../comfyui/client.ts", import.meta.url), "utf-8");
+    const health = readFileSync(
+      new URL("../../services/health-check.ts", import.meta.url),
+      "utf-8",
+    );
+
+    // getLogs has TWO return paths — JSON-encoded and raw text — and both carry
+    // the same exposure.
+    const start = client.indexOf("export async function getLogs");
+    const body = client.slice(start, client.indexOf("\n}", start));
+    expect(body.split("scrubLogLines(").length - 1).toBe(2);
+
+    // The health report emits matching error lines into its own text.
+    expect(health).toContain("scrubLogLines(");
+  });
+});

--- a/src/__tests__/comfyui/log-scrub.test.ts
+++ b/src/__tests__/comfyui/log-scrub.test.ts
@@ -67,6 +67,31 @@ describe("scrubLogLines (#1206)", () => {
   it("is a no-op on an empty log", () => {
     expect(scrubLogLines([])).toEqual([]);
   });
+
+  // AWKWARD URL SHAPES. The split sends anything matching /https?:\/\/[^\s"'<>]+/
+  // to the URL redactor and everything else to the shape scrubber, so the cases
+  // worth pinning are the ones that sit awkwardly across that line: trailing
+  // punctuation swallowed into the match, a non-http scheme the URL redactor
+  // refuses, a scheme-relative URL the regex never matches at all, and a bare
+  // token with no URL. Each must be safe by SOME pass — that is the property,
+  // not which pass caught it.
+  it("leaks nothing across awkward URL shapes", () => {
+    const cases: Record<string, string> = {
+      parens: `see (https://hf.co/a/b?token=${HF}) for details`,
+      trailingDot: `url: https://hf.co/a/b?token=${HF}.`,
+      backticks: "url: `https://hf.co/a/b?token=" + HF + "`",
+      wsScheme: `ws://host/ws?token=${HF}`,
+      schemeRelative: `//hf.co/a/b?token=${HF}`,
+      bareToken: `bare token ${HF} with no url`,
+      userinfo: `https://user:${HF}@hf.co/a/b`,
+      fragment: `https://hf.co/a/b#access_token=${HF}`,
+    };
+    const leaked = Object.entries(cases)
+      .map(([name, line]) => [name, scrubLogLines([line])[0]] as const)
+      .filter(([, out]) => out.includes(HF))
+      .map(([name, out]) => `${name}: ${out}`);
+    expect(leaked, `these shapes leaked: ${leaked.join(" | ")}`).toEqual([]);
+  });
 });
 
 // THE WIRING. The helper cannot see whether its two consumers call it — the

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -28,6 +28,7 @@ import {
   readComfyJson,
   redactErrorMessage,
   rethrowWithJsonDiagnosis,
+  scrubLogLines,
   scrubSecretShapedText,
 } from "./json-guard.js";
 import * as cloudClient from "./cloud-client.js";
@@ -840,13 +841,14 @@ export async function getLogs(): Promise<string[]> {
   try {
     const parsed = JSON.parse(text);
     if (typeof parsed === "string") {
-      return parsed.split("\n").filter(Boolean);
+      return scrubLogLines(parsed.split("\n").filter(Boolean));
     }
   } catch {
     // Not JSON — treat as raw text
   }
-  return text.split("\n").filter(Boolean);
+  return scrubLogLines(text.split("\n").filter(Boolean));
 }
+
 
 /**
  * ComfyUI frontend per-user settings, served by the frontend user manager:

--- a/src/comfyui/json-guard.ts
+++ b/src/comfyui/json-guard.ts
@@ -89,6 +89,62 @@ const URL_REDACTED = "REDACTED";
  * value: anything credential-shaped goes, whether or not we can prove it is
  * ours. A diagnostic that can print a secret is not worth the diagnosis.
  */
+/**
+ * Redact credentials from log lines before they reach a tool result (#1206).
+ *
+ * A ComfyUI log is a plausible place for one to appear: a custom node logging
+ * the URL it fetched (CivitAI and HuggingFace download URLs routinely carry a
+ * token in the query string), ComfyUI-Manager logging an install URL, or any
+ * node logging a request header on failure. `get_system_stats action:"logs"` is
+ * a DIAGNOSTIC tool, so it is called exactly when something is wrong — and its
+ * output is what a user pastes into a bug report.
+ *
+ * PER LINE, deliberately. The log line is the thing being asked for, so this
+ * keeps the line and redacts the match. Scrubbing the whole blob as one string
+ * would let a single unscrubbable line withhold the ENTIRE log, and a diagnostic
+ * that refuses to diagnose is not an improvement.
+ *
+ * Fail-closed is VISIBLE: a line that cannot be scrubbed safely (the credential
+ * is too short to substitute without mangling unrelated text, or it arrived
+ * line-wrapped) is REPLACED by a marker rather than dropped — so the log keeps
+ * its line count and the reader can see that something was withheld, instead of
+ * silently receiving a shorter log.
+ */
+export function scrubLogLines(lines: string[]): string[] {
+  const URL_RE = /https?:\/\/[^\s"'<>]+/g;
+  return lines.map((line) => {
+    // URLs and the rest of the line need DIFFERENT redactors, and running one
+    // over the other is what destroys the diagnostic.
+    //
+    //  - scrubSecretShapedText's opaque-run pass matches 24+ chars of an
+    //    alphabet including `/`, `.` and `-`, so an ordinary log URL collapses to
+    //    `https:«redacted»` — and a log line whose URL is gone has lost the fact
+    //    it exists to report ("which model was it fetching?").
+    //  - redactUrlForDiagnosis was built for exactly that: it keeps origin,
+    //    route and parameter NAMES and fails closed on userinfo, opaque path
+    //    segments and unknown query values — which is where a token lives.
+    //
+    // So: URLs go through the URL redactor, everything BETWEEN them through the
+    // shape/known-value scrubber, and the pieces are rejoined. Neither pass ever
+    // sees text the other owns.
+    const urls = line.match(URL_RE) ?? [];
+    const gaps = line.split(URL_RE);
+    const safeGaps: string[] = [];
+    for (const gap of gaps) {
+      const safe = scrubSecretShapedText(gap);
+      // Fail closed for the whole LINE, not the gap: a half-redacted line is
+      // harder to reason about than one that says it was withheld.
+      if (safe === null) return "(log line withheld: it contains a configured credential)";
+      safeGaps.push(safe);
+    }
+    let out = safeGaps[0] ?? "";
+    for (let i = 0; i < urls.length; i++) {
+      out += redactUrlForDiagnosis(urls[i]) + (safeGaps[i + 1] ?? "");
+    }
+    return out;
+  });
+}
+
 export function bodyPrefixOf(body: string): string {
   const redacted = scrubSecretShapedText(body);
   if (redacted === null) {

--- a/src/services/health-check.ts
+++ b/src/services/health-check.ts
@@ -7,6 +7,7 @@
 import { ConnectionError } from "../utils/errors.js";
 import { isCloudMode } from "../config.js";
 import { getQueue, getSystemStats, comfyApiFetch } from "../comfyui/client.js";
+import { scrubLogLines } from "../comfyui/json-guard.js";
 
 const CRITICAL_MODEL_CATS = [
   "checkpoints",
@@ -168,10 +169,16 @@ export async function runHealthCheck(
       const res = await comfyApiFetch("/internal/logs");
       if (res.ok) {
         const text = await res.text();
-        const errLines = text
-          .split("\n")
-          .filter((l) => /traceback|error|exception/i.test(l))
-          .slice(-recentErrors);
+        // #1206 — these lines go straight into the health report, which is a
+        // DIAGNOSTIC users paste into bug reports. A custom node logging the URL
+        // it fetched can put a CivitAI/HF token in one, so scrub before emitting.
+        // Per line, and fail-closed VISIBLY, for the same reasons as getLogs.
+        const errLines = scrubLogLines(
+          text
+            .split("\n")
+            .filter((l) => /traceback|error|exception/i.test(l))
+            .slice(-recentErrors),
+        );
         if (errLines.length > 0) {
           lines.push(`\n**Recent errors** (last ${errLines.length}):`);
           for (const e of errLines) lines.push(`  ${e.trim()}`);


### PR DESCRIPTION
Fixes #1206. **Draft — claiming the issue, work in progress.**

## What

`getLogs()` reads `/internal/logs` with `r.text()` and returns the split raw lines; its tool caller turns those directly into a text tool result. Nothing on that path goes through `bodyPrefixOf` or `scrubSecretShapedText`.

## Why it matters

A ComfyUI log is a plausible place for a credential to appear:

- a custom node logging the URL it fetched, query string included — CivitAI and HuggingFace download URLs routinely carry a token;
- ComfyUI-Manager logging an install URL;
- any node that logs a request header on failure.

`get_system_stats action:"logs"` is a **diagnostic** tool, so it is called precisely when something is wrong — and its output is exactly what a user pastes into a bug report.

Found during the adversarial review of #1191; genuinely pre-existing, which is why it was filed separately rather than widened into that PR.

## Plan

Per-line scrubbing. The log line **is** the thing being asked for, so the fix must keep the line and redact the match — withholding the whole log would trade one defect for another, and a diagnostic that refuses to diagnose is not an improvement.

`scrubSecretShapedText` already redacts by shape as well as by configured value and fails closed when it cannot substitute safely; #1191 additionally taught it the cloud API key and the download tokens, so a token echoed from a CivitAI/HF URL is now a known value.

The care is in the fail-closed case: a line it cannot scrub safely must be replaced rather than dropped silently, so the log stays readable and the reader knows something was withheld.

🤖 Generated with [Claude Code](https://claude.com/claude-code)