### PR TITLE
release: v0.50.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.57] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- download status must not promise survival across an orchestrator restart (#1194)
+
+
 ## [0.50.56] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.56",
+  "version": "0.50.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.56",
+      "version": "0.50.57",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.56",
+  "version": "0.50.57",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the `v0.50.57` tag into protected main (version bump + changelog).

Contents: **#1194** — `download_model action:"status"` claimed "Survives a sidebar/tool-session reconnect", folding an agent reconnect (transfer alive) and an orchestrator restart (transfer dead, or — for a Manager dispatch — running on the host) into one answer. Now defers to the record, which since #1197 says the true thing per route. Refs #1148, which stays open for item 1 (making downloads outlive the orchestrator).

Gates run locally before tagging: build, full suite (389 files / 7911 passed), `check:vocabulary`, `vocab:export --check`, `asset-counts --check`, `docs:gen` freshness. Description verified on the merged build.