### PR TITLE
fix(#1204): typecheck the tests, so a fixture cannot claim a shape the writer never produces

### DIFF
--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -398,9 +398,26 @@ function makeDeps(opts: {
     },
     // #1204 — this guard used to be on `gitPullFfOnly`, which is NOT a member of
     // PanelInstallerDeps: nothing ever called it, so the assertion could not
-    // fire while the REAL pull path (gitFetch → gitMergeFfOnly) went unguarded.
-    // A safety net that cannot catch anything is worse than none, because it
-    // reads as coverage.
+    // fire at all.
+    //
+    // It is replaced by the deps the fallback ACTUALLY touches, in the order it
+    // touches them. To be accurate about what that buys: the entry point was
+    // already covered — `gitStatusPorcelain` (guarded above) runs at
+    // panel-installer.ts:2675, before `gitFetch` at :2704, and there is no route
+    // to the pull that skips it. So these are belt-and-braces on the only
+    // reachable path, not a hole being closed. `gitWorktreeRoot` is the genuinely
+    // new one: it is the FIRST dep the fallback calls (:2652), and its absence
+    // was also leaving this literal short of PanelInstallerDeps's required
+    // members — a TS2739 the excess `gitPullFfOnly` had been masking.
+    gitWorktreeRoot: () => {
+      throw new Error("git fallback must not run in this persona (not a git checkout)");
+    },
+    gitUpstreamRev: () => {
+      throw new Error("git fallback must not run in this persona (not a git checkout)");
+    },
+    gitIgnoredPullConflicts: () => {
+      throw new Error("git fallback must not run in this persona (not a git checkout)");
+    },
     gitFetch: () => {
       throw new Error("git fallback must not run in this persona (not a git checkout)");
     },

--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -396,7 +396,15 @@ function makeDeps(opts: {
     gitStatusPorcelain: () => {
       throw new Error("git fallback must not run in this persona (not a git checkout)");
     },
-    gitPullFfOnly: () => {
+    // #1204 — this guard used to be on `gitPullFfOnly`, which is NOT a member of
+    // PanelInstallerDeps: nothing ever called it, so the assertion could not
+    // fire while the REAL pull path (gitFetch → gitMergeFfOnly) went unguarded.
+    // A safety net that cannot catch anything is worse than none, because it
+    // reads as coverage.
+    gitFetch: () => {
+      throw new Error("git fallback must not run in this persona (not a git checkout)");
+    },
+    gitMergeFfOnly: () => {
       throw new Error("git fallback must not run in this persona (not a git checkout)");
     },
     readPin: () => opts.pin ?? UNPINNED,

--- a/src/__tests__/services/training-jobs.test.ts
+++ b/src/__tests__/services/training-jobs.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// #1204 — import the REAL progress type instead of restating a narrower one.
+// The local shape omitted `loss`, which `training-jobs.ts:1654` actually reads,
+// so six tests were passing a field their own annotation said could not exist.
+import type { TrainingProgress } from "../../services/ai-toolkit.js";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -377,7 +381,7 @@ describe("startTrainingJob", () => {
     vi.useFakeTimers();
     try {
       const d = deferred<{ code: number; tail: string }>();
-      let tick: ((p: { step?: number; totalSteps?: number; raw: string }) => void) | undefined;
+      let tick: ((p: TrainingProgress) => void) | undefined;
       const dataset = join(mod.datasetsRoot(), "dataset");
       mkdirSync(dataset, { recursive: true });
       makeImage(dataset, "img_00001.png");
@@ -449,7 +453,7 @@ describe("cancelJob", () => {
 
   it("ignores progress ticks that arrive after a cancel (no resurrection)", async () => {
     const d = deferred<{ code: number; tail: string }>();
-    let tick: ((p: { step?: number; totalSteps?: number; raw: string }) => void) | undefined;
+    let tick: ((p: TrainingProgress) => void) | undefined;
     const dataset = join(mod.datasetsRoot(), "dataset");
     mkdirSync(dataset, { recursive: true });
     makeImage(dataset, "img_00001.png");
@@ -480,7 +484,7 @@ describe("cancelJob", () => {
     vi.useFakeTimers();
     try {
       const d = deferred<{ code: number; tail: string }>();
-      let tick: ((p: { step?: number; totalSteps?: number; raw: string }) => void) | undefined;
+      let tick: ((p: TrainingProgress) => void) | undefined;
       const dataset = join(mod.datasetsRoot(), "dataset");
       mkdirSync(dataset, { recursive: true });
       makeImage(dataset, "img_00001.png");
@@ -523,7 +527,7 @@ describe("cancelJob", () => {
     vi.useFakeTimers();
     try {
       const d = deferred<{ code: number; tail: string }>();
-      let tick: ((p: { step?: number; totalSteps?: number; raw: string }) => void) | undefined;
+      let tick: ((p: TrainingProgress) => void) | undefined;
       const catalog = fakeCatalog();
       const lorasDir = join(root, "loras");
       const dataset = join(mod.datasetsRoot(), "dataset");
@@ -1145,7 +1149,7 @@ describe("independent review fixes (PR #237)", () => {
 
   it("progress during a pending cancel does NOT reconcile memory back to running", async () => {
     const d = deferred<{ code: number; tail: string }>();
-    let tick: ((p: { step?: number; totalSteps?: number; raw: string }) => void) | undefined;
+    let tick: ((p: TrainingProgress) => void) | undefined;
     const dataset = join(mod.datasetsRoot(), "dataset");
     mkdirSync(dataset, { recursive: true });
     makeImage(dataset, "img_00001.png");
@@ -1221,7 +1225,7 @@ describe("independent review fixes (PR #237)", () => {
 
   it("a live snapshot never overwrites a terminal disk record", async () => {
     const d = deferred<{ code: number; tail: string }>();
-    let tick: ((p: { step?: number; totalSteps?: number; raw: string }) => void) | undefined;
+    let tick: ((p: TrainingProgress) => void) | undefined;
     const dataset = join(mod.datasetsRoot(), "dataset");
     mkdirSync(dataset, { recursive: true });
     makeImage(dataset, "img_00001.png");

--- a/src/__tests__/tools/model-management.test.ts
+++ b/src/__tests__/tools/model-management.test.ts
@@ -4,9 +4,15 @@ const downloadModelMock = vi.fn();
 const listLocalModelsMock = vi.fn();
 /** #369 post-landing verification, controlled per test. Default: the honest
  *  "could not check" verdict, echoing the path back. */
-const verifyLandedModelMock = vi.fn(async (targetPath: string) => ({
+// #1204 — the RETURN type comes from the real verdict, not from whatever this
+// default happens to contain. Inferring it from the literal made the mock's
+// shape narrower than `verifyLandedModel`'s, so a test overriding it with
+// `verifiedAgainstRoot` (real: model-resolver.ts:1349, read at
+// download-jobs.ts:623) was rejected by an annotation the test itself invented.
+type LandedVerdict = Awaited<ReturnType<typeof import("../../services/model-resolver.js").verifyLandedModel>>;
+const verifyLandedModelMock = vi.fn(async (targetPath: string): Promise<LandedVerdict> => ({
   verifiedPath: targetPath,
-  liveVisible: "unknown" as string,
+  liveVisible: "unknown",
   note: "no live server in this test",
 }));
 /** The models root the connected server reads NOW (stubbed; see the mock). */


### PR DESCRIPTION
Fixes #1204. **Draft — claiming the issue.**

## The gap

`tsconfig.json` excludes `src/__tests__`, so `npx tsc --listFiles --noEmit | grep -c __tests__` returns **0**. No fixture is ever checked against the interface it claims to model.

## What it let through, today alone

Two wrong-key bugs in a single object literal in `migrateInFlightJobs`:

1. **`tray_id` vs `trayId`** — the record's one camelCase key, and the only key url lookup matches on. The migration copied nothing in production; the test passed because its fixture used the same wrong key.
2. **Five keys from the wrong interface** — `name`, `dest`, `target`, `total`, `received` belong to `DownloadProgress` (tray rows), not `PersistedDownloadJob`. They survived for months, and a test even asserted `received` was 700000000 on a field that is always `undefined`.

In both cases the fixture agreed with the mistake, so green meant nothing.

## Why only the type layer closes it

Worth stating because I got it wrong first: a runtime assertion **cannot** catch a dead key. It is always `undefined`, and `JSON.stringify` drops undefined before it reaches disk — I wrote a key-set assertion against the round-tripped record and restoring all five dead keys still passed. Annotating the literal turns it into `TS2353` immediately, and that annotation caught a latent bug on contact (three required fields the migration could emit as `undefined`).

## Plan

- [ ] Include `src/__tests__` in typechecking — either drop the exclude or add a `tsconfig.test.json` wired into `npm run lint` and CI
- [ ] Measure the backlog first: it IS the finding, since every error is a fixture currently unverified against its type
- [ ] Triage the backlog — real shape mismatches get fixed; deliberate partial doubles get an explicit, commented cast rather than a silent one
- [ ] Do NOT make it pass by loosening types or blanket-casting; that reproduces the gap with extra steps

Draft until the backlog is measured, since its size decides whether this lands in one pass or needs staging.