### PR TITLE
release: v0.50.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.58] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- scrub /internal/logs before it reaches a tool result (#1209)
+
+
 ## [0.50.57] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.57",
+  "version": "0.50.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.57",
+      "version": "0.50.58",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.57",
+  "version": "0.50.58",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.58` tag.

**Log lines are scrubbed before they reach a tool result** (#1206, via #1209).

`getLogs()` returned raw `/internal/logs` lines straight into a diagnostic tool result, and the health report emitted matching error lines the same way. A ComfyUI log is a plausible place for a credential — a custom node logging the URL it fetched (CivitAI and HuggingFace download URLs carry a token in the query string), Manager logging an install URL, a node logging a request header on failure. Both consumers are diagnostics, so they are called exactly when something is wrong and pasted straight into bug reports.

The part that took the work: scrubbing a whole line **destroys** it — the shape pass matches 24+ chars of an alphabet including `/`, `.` and `-`, so an ordinary URL collapses to `https:«redacted»` and the line loses the one fact it exists to report. The repo had already solved that a layer over, so a line is now split: URLs through `redactUrlForDiagnosis` (which keeps origin, route and parameter names), the text between them through the shape scrubber, and neither pass sees text the other owns.

```
[INFO] fetching https://huggingface.co/org/repo/resolve/main/model.safetensors?token=«redacted»
RuntimeError: CUDA out of memory
```

Fail-closed is visible and per line: a line that cannot be scrubbed safely is replaced by a marker, never emptied or dropped, so the log keeps its line count.

Verified live against the built artifact and this machine's real ComfyUI — 243 log lines read, token redacted, model path and error text intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)