### PR TITLE
fix(download): status must not report a LIVE download as missing

### DIFF
--- a/src/__tests__/services/download-status-decline.test.ts
+++ b/src/__tests__/services/download-status-decline.test.ts
@@ -88,9 +88,14 @@ describe("describeUnresolvedDownload (#1183)", () => {
     expect(mod.describeUnresolvedDownload("done1")).toBeUndefined();
   });
 
-  it("says nothing for a STALE in-flight record — the writer is gone", () => {
-    // Beyond the freshness window this is not evidence of a live transfer, and
-    // claiming it is would be the same defect in the other direction.
+  it("REPORTS a stale in-flight record, hedged — a missed heartbeat is not proof", () => {
+    // This assertion used to demand silence here, and that was the bug in my own
+    // first version: it used the same 60s window the lookup uses, so it went
+    // quiet in exactly the situation most likely to have produced the reporter's
+    // one-poll miss — a heartbeat delayed while the writer was busy at 90% of a
+    // 26GB file. The codebase already states the rule (#761): a missed heartbeat
+    // is a liveness HINT, not proof the transfer stopped, which is why in-flight
+    // records are retained for 6h rather than reaped at 60s.
     writeFileSync(
       join(dir, `${progress.CONTROL_PREFIX}job-stale1-ownerA.json`),
       JSON.stringify({
@@ -101,7 +106,14 @@ describe("describeUnresolvedDownload (#1183)", () => {
         updated: Date.now() - progress.PERSISTED_INFLIGHT_STALE_MS - 1000,
       }),
     );
-    expect(mod.describeUnresolvedDownload("stale1")).toBeUndefined();
+    const note = mod.describeUnresolvedDownload("stale1");
+    expect(note).toBeDefined();
+    expect(note).toMatch(/stopped reporting/);
+    expect(note).toMatch(/liveness HINT, not proof/);
+    expect(note).toMatch(/NOT the same as it being gone/);
+    // Hedged, not asserted: it must not claim the transfer IS running.
+    expect(note).not.toMatch(/IS still running/);
+    expect(note).toMatch(/BEFORE re-downloading/);
   });
 });
 

--- a/src/__tests__/services/download-status-decline.test.ts
+++ b/src/__tests__/services/download-status-decline.test.ts
@@ -1,0 +1,130 @@
+// #1183 — a DECLINE is not an ABSENCE.
+//
+// A reporter polled a live 26.5GB local download for ~30 minutes (20% → 67% →
+// 79% → 85% → 89% → 95%) and then, for ONE poll, got:
+//
+//   No download matching id `cb43b8c206bec9b1`. It has either finished long ago
+//   … or never started
+//
+// The file existed nowhere on disk and nothing had been cancelled. Re-issuing the
+// same URL immediately re-adopted the SAME id at 97% — the job had been alive in
+// process the whole time.
+//
+// getDownloadJob DECLINES rather than guessing when two live transfers share an
+// id, and that refusal is right: picking one arbitrarily is how you report the
+// wrong transfer's progress. What is wrong is rendering the refusal as an
+// absence. "I will not choose between two" and "there is nothing here" are
+// different facts, and only the second justifies telling someone their download
+// vanished — which is what invites a redundant multi-gigabyte re-download.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let dir: string;
+let mod: typeof import("../../services/download-jobs.js");
+let progress: typeof import("../../services/download-progress.js");
+
+beforeEach(async () => {
+  dir = mkdtempSync(join(tmpdir(), "cm-dl-decline-"));
+  vi.resetModules();
+  vi.stubEnv("COMFYUI_MCP_PROGRESS_DIR", dir);
+  progress = await import("../../services/download-progress.js");
+  mod = await import("../../services/download-jobs.js");
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** A persisted in-flight record, as a foreign session's heartbeat would write it. */
+function writeLive(id: string, trayId: string, owner: string) {
+  writeFileSync(
+    join(dir, `${progress.CONTROL_PREFIX}job-${id}-${owner}.json`),
+    JSON.stringify({
+      id,
+      trayId,
+      owner,
+      status: "downloading",
+      url: `https://huggingface.co/org/repo/resolve/main/${trayId}.safetensors`,
+      updated: Date.now(),
+    }),
+  );
+}
+
+describe("describeUnresolvedDownload (#1183)", () => {
+  it("says the transfer is STILL RUNNING when two live records share an id", () => {
+    // The ambiguity the lookup legitimately declines to resolve.
+    writeLive("cb43b8c206bec9b1", "tray-a", "ownerA");
+    writeLive("cb43b8c206bec9b1", "tray-b", "ownerB");
+
+    const note = mod.describeUnresolvedDownload("cb43b8c206bec9b1");
+    expect(note).toBeDefined();
+    expect(note).toMatch(/IS still running/);
+    expect(note).toMatch(/NOT the same as it being gone/);
+    // …and names the way to disambiguate, rather than leaving the caller stuck.
+    expect(note).toMatch(/tray_id/);
+    expect(note).toContain("tray-a");
+    expect(note).toContain("tray-b");
+  });
+
+  it("tells the caller NOT to re-download — the harm this prevents", () => {
+    writeLive("abc", "tray-a", "ownerA");
+    expect(mod.describeUnresolvedDownload("abc")).toMatch(/Do NOT re-download/);
+  });
+
+  it("says nothing when the id is genuinely absent", () => {
+    // A real "not found" must keep its existing wording, or this becomes a
+    // different false answer pointing the other way.
+    expect(mod.describeUnresolvedDownload("no-such-id")).toBeUndefined();
+  });
+
+  it("says nothing for a SETTLED record — done is not still running", () => {
+    writeFileSync(
+      join(dir, `${progress.CONTROL_PREFIX}job-done1-ownerA.json`),
+      JSON.stringify({ id: "done1", trayId: "t", owner: "ownerA", status: "done", updated: Date.now() }),
+    );
+    expect(mod.describeUnresolvedDownload("done1")).toBeUndefined();
+  });
+
+  it("says nothing for a STALE in-flight record — the writer is gone", () => {
+    // Beyond the freshness window this is not evidence of a live transfer, and
+    // claiming it is would be the same defect in the other direction.
+    writeFileSync(
+      join(dir, `${progress.CONTROL_PREFIX}job-stale1-ownerA.json`),
+      JSON.stringify({
+        id: "stale1",
+        trayId: "t",
+        owner: "ownerA",
+        status: "downloading",
+        updated: Date.now() - progress.PERSISTED_INFLIGHT_STALE_MS - 1000,
+      }),
+    );
+    expect(mod.describeUnresolvedDownload("stale1")).toBeUndefined();
+  });
+});
+
+// THE WIRING. The helper cannot see whether the status renderer consults it —
+// the call-site blindness this repo keeps getting caught by, and the mutation
+// that survived until this test existed.
+describe("the status renderer consults the explainer before saying 'no download' (#1183)", () => {
+  it("prefers the still-running explanation over the not-found text", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      new URL("../../tools/model-management.ts", import.meta.url),
+      "utf-8",
+    );
+
+    // It must be CALLED…
+    expect(src).toContain("describeUnresolvedDownload(args.id)");
+
+    // …and its result must take PRECEDENCE over the "No download matching" text,
+    // not merely be computed and dropped.
+    const notFound = src.indexOf("`No download matching ${selector}.");
+    expect(notFound, "the not-found text must still exist").toBeGreaterThan(-1);
+    const before = src.slice(Math.max(0, notFound - 700), notFound);
+    expect(before).toContain("unresolvedLive");
+    expect(before).toMatch(/text: unresolvedLive\s*\n?\s*\? unresolvedLive/);
+  });
+});

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -1111,6 +1111,62 @@ export function getDownloadJob(id: string, trayId?: string): DownloadJob | undef
   return terminal ? jobFromPersisted(terminal) : undefined;
 }
 
+/**
+ * Why a by-id lookup came back empty — when the answer is NOT "it is gone" (#1183).
+ *
+ * A reporter polled a live 26.5GB local download for ~30 minutes (20% → 95%) and
+ * then got, for ONE poll:
+ *
+ *   No download matching id `cb43b8c206bec9b1`. It has either finished long ago
+ *   … or never started
+ *
+ * The file existed nowhere on disk and nothing had been cancelled. Re-issuing the
+ * same URL immediately re-adopted the SAME id at 97% — the job was alive in
+ * process the entire time.
+ *
+ * getDownloadJob DECLINES in several places rather than guessing, and those
+ * declines are correct: two concurrent physical transfers sharing an id must not
+ * be resolved by picking one. What is not correct is rendering a decline as an
+ * ABSENCE. "I will not choose between two" and "there is nothing here" are
+ * different facts, and only the second justifies telling a user their download
+ * vanished — which is what invites a redundant multi-gigabyte re-download.
+ *
+ * So: when the lookup misses, ask the cheaper question it never asked — is there
+ * a LIVE record for this id at all? Returns undefined when there genuinely is
+ * not, so a real "not found" keeps its existing wording.
+ */
+export function describeUnresolvedDownload(id: string): string | undefined {
+  const now = Date.now();
+  const liveInMemory = jobs.get(id)?.job;
+  const livePersisted = listPersistedDownloadJobs().filter(
+    (r) =>
+      r.id === id &&
+      r.status === "downloading" &&
+      now - (r.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,
+  );
+  const inMemoryLive = liveInMemory?.status === "downloading";
+  if (!inMemoryLive && livePersisted.length === 0) return undefined;
+
+  const trays = [
+    ...new Set([
+      ...(inMemoryLive && liveInMemory ? [liveInMemory.trayId] : []),
+      ...livePersisted.map((r) => r.trayId).filter((t): t is string => typeof t === "string"),
+    ]),
+  ];
+  const several = trays.length > 1;
+  return (
+    `A download with id \`${id}\` IS still running — this lookup declined to answer for it, ` +
+    `which is NOT the same as it being gone. ` +
+    (several
+      ? `TWO OR MORE live transfers share that id (tray ids: ${trays.join(", ")}), so answering ` +
+        `by id alone would have picked one arbitrarily. Re-run with \`tray_id\` to select the one ` +
+        `you mean, or omit the selector to list them all.`
+      : `Its record could not be matched by id alone in this session. Re-run with no selector to ` +
+        `list every tracked download, or pass \`tray_id\`${trays[0] ? ` (\`${trays[0]}\`)` : ""}.`) +
+    ` Do NOT re-download: the transfer is in flight and a second one would duplicate it.`
+  );
+}
+
 /** Adopt an in-flight download by URL or destination after a reconnect (#529) —
  *  so a caller can confirm a download is still running (and not start a duplicate)
  *  even without the id. Prefers a LIVE in-memory job, then the persisted store.

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -1138,14 +1138,46 @@ export function getDownloadJob(id: string, trayId?: string): DownloadJob | undef
 export function describeUnresolvedDownload(id: string): string | undefined {
   const now = Date.now();
   const liveInMemory = jobs.get(id)?.job;
-  const livePersisted = listPersistedDownloadJobs().filter(
-    (r) =>
-      r.id === id &&
-      r.status === "downloading" &&
-      now - (r.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,
+  const inFlight = listPersistedDownloadJobs().filter(
+    (r) => r.id === id && r.status === "downloading",
+  );
+  const livePersisted = inFlight.filter(
+    (r) => now - (r.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,
+  );
+  // A STALE in-flight record counts here, hedged — and getting that wrong is
+  // what would have left the REPORTED case uncovered.
+  //
+  // This function first used the same freshness window the lookup uses, which
+  // means it went silent in exactly the situation most likely to have produced a
+  // one-poll miss during a 26GB transfer: a heartbeat delayed past 60s while the
+  // writer was busy. The codebase already states the right rule one file over
+  // (#761): "a missed heartbeat is only a liveness hint, not proof the transfer
+  // stopped" — which is why an in-flight record is retained for 6h rather than
+  // reaped at 60s. Declining to mention such a record would repeat the very fold
+  // this fix exists to remove, one level down.
+  const stalePersisted = inFlight.filter(
+    (r) => now - (r.updated ?? 0) >= PERSISTED_INFLIGHT_STALE_MS,
   );
   const inMemoryLive = liveInMemory?.status === "downloading";
-  if (!inMemoryLive && livePersisted.length === 0) return undefined;
+  if (!inMemoryLive && livePersisted.length === 0 && stalePersisted.length === 0) {
+    return undefined;
+  }
+
+  // Only a stale record to go on: say what is known and what is not, rather than
+  // asserting either "running" or "gone".
+  if (!inMemoryLive && livePersisted.length === 0) {
+    const newest = stalePersisted.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
+    const ageS = Math.round((now - (newest?.updated ?? now)) / 1000);
+    return (
+      `A download with id \`${id}\` has an IN-FLIGHT record that stopped reporting ` +
+      `${ageS}s ago — this lookup declined to answer for it, which is NOT the same as it ` +
+      `being gone. A missed heartbeat is a liveness HINT, not proof the transfer stopped: ` +
+      `the bytes may still be streaming while persistence was interrupted (a reconnect, or ` +
+      `a busy writer). Check the panel download tray, or re-run with no selector to list ` +
+      `every tracked download, BEFORE re-downloading — a second transfer would duplicate ` +
+      `a multi-gigabyte file.`
+    );
+  }
 
   const trays = [
     ...new Set([

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -17,6 +17,7 @@ import { isRemoteMode } from "../config.js";
 import {
   startDownloadJob,
   getDownloadJob,
+  describeUnresolvedDownload,
   findDownloadJob,
   listDownloadJobs,
   listDownloadJobCandidates,
@@ -881,11 +882,19 @@ async function statusAction(args: {
             : args.url
               ? `url \`${args.url}\``
               : "";
+          const unresolvedLive = args.id ? describeUnresolvedDownload(args.id) : undefined;
           return {
             content: [
               {
                 type: "text",
-                text: (args.id || args.url)
+                // #1183 — a DECLINE is not an ABSENCE. getDownloadJob refuses to
+                // choose between two live transfers sharing an id, which is
+                // right; rendering that refusal as "no download matching" told a
+                // reporter their live 26GB transfer had vanished. Ask the cheaper
+                // question first: is anything still running under this id?
+                text: unresolvedLive
+                  ? unresolvedLive
+                  : (args.id || args.url)
                   ? `No download matching ${selector}. Several causes reach this same message and it does not distinguish them — treat it as "not found", NOT as "finished": it may have finished long ago (settled records are pruned after a while), never started, been interrupted by an orchestrator restart with the carry-over that records that (#1148) not having run (it is best-effort by design), been given a valid \`id\` with a \`tray_id\` that does not match it, been looked up by a \`url\` that does not match BYTE FOR BYTE (matching includes the query, so a re-signed CDN link or a dropped query misses a record that is still there — retry by \`id\`), or named a \`url\` that TWO live downloads share, which declines rather than guessing: omit the selector to list them both. Check the panel download tray before re-downloading. Within the SAME session, re-issuing an identical in-flight download adopts it rather than duplicating; across a reconnect, confirm via the tray first.`
                   : "No downloads are being tracked.",
               },


### PR DESCRIPTION
Fixes #1183. **Draft — claiming the issue, work in progress.**

## The report

A local 26.5GB download polled normally for ~30 minutes — 20% → 67% → 79% → 85% → 89% → 95% — and then one poll of `action:"status"` with the same id returned:

> No download matching id `cb43b8c206bec9b1`. It has either finished long ago … or never started

The file did not exist anywhere on the filesystem, and nothing had been cancelled. Re-issuing `action:"download"` with the same URL **immediately re-adopted the same id and reported 97%** — so the job was alive in-process the whole time. Only the by-id lookup produced a false negative, for one poll.

## Why it matters

An agent that trusts it mid-download will report a false failure, or start a **redundant multi-GB download**. The anti-duplication safety net only holds if the caller re-issues with the exact same URL — which an agent reacting to "not found" has no reason to do.

## What the reporter already established

They traced it to `getDownloadJob(id)` in `download-jobs.js` and named the suspects — the `hasAmbiguousForeignSibling` / `foreignLive` trayId-set bail-outs firing for what is really a **single** physical transfer, most likely an owner/trayId divergence between the in-memory record and the persisted one for the same download.

They also explained why they did not patch it, and the reasoning is right: this area has been hardened repeatedly (#420, #467, #822, #529) and a shallow fix risks reintroducing one of those races.

## Plan

Reproduce first with a harness that drives the real registry, rather than reasoning from the code — the whole point of the ambiguity guards is that they are subtle, and I want to see which branch actually fires before touching any of them.

The fix must not weaken the guarantee those guards exist for: a genuinely ambiguous id (two concurrent physical transfers sharing an id) must still refuse rather than guess. The target is the case where ambiguity is *claimed* but only one live job exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)