### PR TITLE
fix(bridge): surface a late reply to a timed-out mutation instead of dropping it (#694)

### DIFF
--- a/src/__tests__/orchestrator/late-mutation-e2e.test.ts
+++ b/src/__tests__/orchestrator/late-mutation-e2e.test.ts
@@ -1,0 +1,314 @@
+// #694 — the late-mutation notice, END TO END over a REAL bridge.
+//
+// WHY THIS FILE EXISTS, when both halves already have coverage.
+//
+// ui-bridge.test.ts drives the real bridge but reads the outcome by calling
+// `bridge.takeLateMutation(rid)` with a rid harvested off the wire.
+// panel-retry-identity.test.ts drives the real tool defs and the real
+// makePanelToolCtx, but against a bridge whose `takeLateMutation` is a stub fed
+// from a scripted map. Both pass if the two halves disagree about WHICH rid.
+//
+// And they could disagree, silently. The caller is handed a token by
+// panel-tools (`retry_of:"<dispatchedRid>"`, from the onDispatchedRid observer);
+// retention is keyed by a rid minted inside UiBridge.dispatch. Nothing in the
+// suite asserts those are the same string. If they ever diverge — a re-dispatch
+// that mints a fresh rid, an observer moved before the mint, a rebind — the
+// feature is inert in production while every existing test still passes,
+// because every existing test supplies the rid itself.
+//
+// So this file hands NOTHING to the drain. It reads the rid out of the retry
+// hint the way an agent would (regex over the error text), and asserts that
+// string is the one the bridge saw on the wire and keyed retention by. That
+// identity is the feature's single point of failure.
+//
+// DELIBERATELY SHORT TIMEOUTS. The production default for a write is 20 s
+// (BRIDGE_DEFAULT_TIMEOUT_MS), and an earlier throwaway version of this probe
+// used it: first attempt times out at 20 s, panel replies at 21.5 s, retry
+// succeeds. It passes, and it costs 25 s of CI for no extra proof — the rid is
+// minted, observed, retained and drained by the same code paths regardless of
+// the number. The deadline is not what is under test, so `fastCtx` below shrinks
+// it and everything else stays real.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "node:net";
+import { readFileSync } from "node:fs";
+import WebSocket from "ws";
+import { UiBridge } from "../../services/ui-bridge.js";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  RETRY_TOKEN_CMDS,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const textOf = (res: ToolResult): string => (res.content[0] as { text: string }).text;
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+/** Same shape as ui-bridge.test.ts's harness: retry past the close→rebind race
+ *  so a bind flake is never reported as a feature failure. */
+async function startBridgeOnFreePort(): Promise<{ bridge: UiBridge; port: number }> {
+  let lastErr = "no attempt made";
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const p = await freePort();
+    const b = new UiBridge(p);
+    b.start();
+    if (await b.whenReady()) return { bridge: b, port: p };
+    lastErr = `bind to ${p} lost a close→rebind race`;
+    await b.stop();
+  }
+  throw new Error(`could not bind a free bridge port after 6 attempts: ${lastErr}`);
+}
+
+let bridge: UiBridge;
+let port: number;
+const sockets: WebSocket[] = [];
+
+beforeEach(async () => {
+  ({ bridge, port } = await startBridgeOnFreePort());
+  // A trusted workflow identity, so a `targeted` graph command clears the #570
+  // write fence and actually reaches the socket. Without it the dispatch is
+  // refused pre-write (dispatched:false), no rid is minted, and this file would
+  // be testing the fence instead of the feature.
+  bridge.setTabWorkflowUuidResolver(() => "11111111-1111-4111-8111-111111111111");
+  // EXACTLY what orchestrator/index.ts installs. Retention is fail-closed, so
+  // without this the bridge keeps nothing — see the fail-closed case below, and
+  // the SOURCE assertion that production really does install this same filter.
+  bridge.setLateMutationFilter((cmdName) => RETRY_TOKEN_CMDS.has(cmdName));
+});
+
+afterEach(async () => {
+  for (const s of sockets.splice(0)) s.close();
+  await bridge.stop();
+});
+
+function connectPanel(tabId: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    sockets.push(sock);
+    sock.on("open", () => {
+      sock.send(
+        JSON.stringify({
+          type: "hello",
+          tab_id: tabId,
+          title: "workflow-a",
+          enforces_workflow_stamp: true,
+          enforces_workflow_stamp_at_write: true,
+        }),
+      );
+      resolve(sock);
+    });
+    sock.on("error", reject);
+  });
+}
+
+/**
+ * A panel that answers `graph_set_node_mode`: the FIRST attempt only after
+ * `firstReplyDelayMs` (i.e. after its reply timer has already fired), every
+ * later attempt immediately — the panel #521 ledger recognising the retry.
+ * Records every rid it saw on the wire.
+ */
+function scriptPanel(
+  sock: WebSocket,
+  firstReplyDelayMs: number,
+): { rids: string[]; lateReplySent: Promise<void> } {
+  const rids: string[] = [];
+  // Resolved the instant the late reply is actually written, so the test waits
+  // on the EVENT rather than on a sleep long enough to probably cover it.
+  let markSent: () => void;
+  const lateReplySent = new Promise<void>((r) => (markSent = r));
+  sock.on("message", (buf) => {
+    const msg = JSON.parse(buf.toString()) as { rid?: string; cmd?: string };
+    if (typeof msg.rid !== "string" || msg.cmd !== "graph_set_node_mode") return;
+    const rid = msg.rid;
+    rids.push(rid);
+    const reply = JSON.stringify({ rid, ok: true, result: { node_id: 126, mode: "active" } });
+    if (rids.length === 1) {
+      setTimeout(() => {
+        sock.send(reply);
+        markSent();
+      }, firstReplyDelayMs);
+    } else {
+      sock.send(reply);
+    }
+  });
+  return { rids, lateReplySent };
+}
+
+/** The reply is written asynchronously; give the bridge's message loop the tick
+ *  it needs to receive and record it. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 5; i++) await new Promise((r) => setTimeout(r, 10));
+}
+
+/**
+ * The REAL ctx, with one property shortened: `call` supplies a tight default
+ * deadline when the handler passes none (panel_set_node_mode passes none, so it
+ * would otherwise wait the full 20 s production default). Everything the test
+ * asserts on — the onDispatchedRid observer, the retry-token mint, the retry_of
+ * attachment, the drain — is the untouched production implementation, reached
+ * through this one delegation.
+ */
+function fastCtx(tabId: string, timeoutMs = 60): PanelToolCtx {
+  const real = makePanelToolCtx(bridge, tabId);
+  const ctx = Object.create(real) as PanelToolCtx;
+  ctx.call = (cmd, t, onDispatchedRid) => real.call(cmd, t ?? timeoutMs, onDispatchedRid);
+  return ctx;
+}
+
+const setNodeMode = () => buildPanelToolDefs().find((d) => d.name === "panel_set_node_mode")!;
+
+/** The rid an agent would copy out of the failure text, exactly as told to. */
+function ridFromHint(text: string): string | undefined {
+  return /retry_of:"([^"]+)"/.exec(text)?.[1];
+}
+
+const indexSrc = (): string =>
+  readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf8");
+
+describe("late-mutation notice, end to end over a real bridge (#694)", () => {
+  it("the rid quoted in the retry hint IS the rid the bridge keyed retention by", async () => {
+    const sock = await connectPanel("tab-e2e");
+    const panel = scriptPanel(sock, 200);
+    const ctx = fastCtx("tab-e2e");
+
+    // 1. The reported failure: a write that is dispatched and then not answered
+    //    in time. The caller is handed a retry token.
+    const first = await setNodeMode().handler({ node_id: 126, mode: "active" }, ctx);
+    expect(first.isError, "the first attempt should have timed out").toBe(true);
+    const hintRid = ridFromHint(textOf(first));
+    expect(hintRid, `no retry token in: ${textOf(first)}`).toBeTruthy();
+
+    // 2. THE ASSERTION THIS FILE EXISTS FOR. Nothing else in the suite pins it:
+    //    the token an agent is told to quote must be the rid the bridge minted,
+    //    dispatched under, and keyed `timedOutMutations` by.
+    expect(panel.rids).toHaveLength(1);
+    expect(hintRid, "the retry hint quotes a rid the bridge never dispatched").toBe(panel.rids[0]);
+
+    // 3. The write lands late. The reply carries that same rid and is retained.
+    await panel.lateReplySent;
+    await settle();
+
+    // 4. The agent retries as instructed — and is told the earlier attempt had
+    //    already applied, without ever handing the drain a rid of our choosing.
+    const retry = await setNodeMode().handler(
+      { node_id: 126, mode: "active", retry_of: hintRid },
+      ctx,
+    );
+    expect(retry.isError).toBeFalsy();
+    expect(textOf(retry)).toMatch(/DID complete/);
+    expect(textOf(retry)).toContain("graph_set_node_mode");
+    expect(textOf(retry)).toContain("tab-e2e");
+    // The retry's own result survives underneath the notice.
+    expect(retry.content.length).toBeGreaterThan(1);
+    // Not a short-circuit: the retry really was dispatched (#683/#687).
+    expect(panel.rids).toHaveLength(2);
+    expect(panel.rids[1]).not.toBe(panel.rids[0]);
+  });
+
+  it("catches a reply that lands WHILE the retry is in flight", async () => {
+    // The drain runs after the handler precisely so this case is covered. When
+    // it ran first, a panel that unblocked a moment after the agent retried
+    // stranded its outcome in the map until TTL — and since a successful retry
+    // mints no new token, nobody could ever have drained it.
+    const sock = await connectPanel("tab-inflight");
+    const rids: string[] = [];
+    let firstRid = "";
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString()) as { rid?: string; cmd?: string };
+      if (typeof msg.rid !== "string" || msg.cmd !== "graph_set_node_mode") return;
+      rids.push(msg.rid);
+      if (rids.length === 1) {
+        firstRid = msg.rid;
+        return; // answered below, only once the retry is already under way
+      }
+      // The retry arrives: release the FIRST attempt's late reply first, then
+      // answer the retry, so the late outcome lands mid-flight.
+      sock.send(JSON.stringify({ rid: firstRid, ok: true, result: { mode: "active" } }));
+      const retryRid = msg.rid;
+      setTimeout(
+        () => sock.send(JSON.stringify({ rid: retryRid, ok: true, result: { mode: "active" } })),
+        40,
+      );
+    });
+    const ctx = fastCtx("tab-inflight");
+    const first = await setNodeMode().handler({ node_id: 126, mode: "active" }, ctx);
+    const hintRid = ridFromHint(textOf(first));
+    expect(hintRid).toBe(firstRid);
+
+    const retry = await setNodeMode().handler(
+      { node_id: 126, mode: "active", retry_of: hintRid },
+      ctx,
+    );
+    expect(textOf(retry)).toMatch(/DID complete/);
+  });
+
+  it("says nothing when the write never landed — the ordinary retry", async () => {
+    // The same flow with a panel that simply never answers the first attempt.
+    // Guards the over-fire: a retry must not claim a completion that never came.
+    const sock = await connectPanel("tab-never");
+    const rids: string[] = [];
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString()) as { rid?: string; cmd?: string };
+      if (typeof msg.rid !== "string" || msg.cmd !== "graph_set_node_mode") return;
+      rids.push(msg.rid);
+      if (rids.length > 1) sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: {} }));
+    });
+    const ctx = fastCtx("tab-never");
+    const first = await setNodeMode().handler({ node_id: 126, mode: "active" }, ctx);
+    const hintRid = ridFromHint(textOf(first));
+    expect(hintRid).toBeTruthy();
+    await settle();
+    const retry = await setNodeMode().handler(
+      { node_id: 126, mode: "active", retry_of: hintRid },
+      ctx,
+    );
+    expect(retry.isError).toBeFalsy();
+    expect(textOf(retry)).not.toMatch(/DID complete/);
+  });
+
+  it("FAIL CLOSED end to end — no filter installed, no notice", async () => {
+    // Retention is opt-in from the retry-token layer. This is the whole-stack
+    // statement of it: with the filter uninstalled the identical scenario, up to
+    // and including a correctly-quoted retry token, reports nothing. If this
+    // test ever passes the notice, retention is happening on some path the
+    // filter does not gate.
+    bridge.setLateMutationFilter(null);
+    const sock = await connectPanel("tab-nofilter");
+    const panel = scriptPanel(sock, 200);
+    const ctx = fastCtx("tab-nofilter");
+    const first = await setNodeMode().handler({ node_id: 126, mode: "active" }, ctx);
+    const hintRid = ridFromHint(textOf(first));
+    expect(hintRid, "the retry token is minted regardless of retention").toBe(panel.rids[0]);
+    await panel.lateReplySent;
+    await settle();
+    const retry = await setNodeMode().handler(
+      { node_id: 126, mode: "active", retry_of: hintRid },
+      ctx,
+    );
+    expect(textOf(retry)).not.toMatch(/DID complete/);
+  });
+
+  it("SOURCE: the orchestrator installs that filter from RETRY_TOKEN_CMDS", () => {
+    // The test above installs the filter itself, which is only honest if
+    // production installs the same one. It is wired inside
+    // runPanelOrchestrator(), which a unit test cannot boot — so assert the
+    // wiring at the source, the way the shared-session and hello-stamp
+    // invariants do. Without this, deleting the production install leaves every
+    // test in this file green and the feature dead.
+    expect(indexSrc()).toMatch(
+      /setLateMutationFilter\(\s*\(\s*\w+\s*\)\s*=>\s*RETRY_TOKEN_CMDS\.has\(\s*\w+\s*\)\s*\)/,
+    );
+  });
+});

--- a/src/__tests__/orchestrator/panel-retry-identity.test.ts
+++ b/src/__tests__/orchestrator/panel-retry-identity.test.ts
@@ -458,7 +458,7 @@ describe("late-mutation notice reaches the caller (#694)", () => {
 
   it("prepends 'DID complete' when the retried rid had landed late", async () => {
     const { bridge, taken } = bridgeWithLate({
-      "rid-late": { cmd: "graph_set_node_mode", tabId: "tab-1", lateByMs: 2400 },
+      "rid-late": { cmd: "graph_add_node", tabId: "tab-1", lateByMs: 2400 },
     });
     const ctx = makePanelToolCtx(bridge, "tab-1");
     const res = await addNode().handler(
@@ -468,7 +468,7 @@ describe("late-mutation notice reaches the caller (#694)", () => {
     expect(taken).toContain("rid-late");
     const first = textOf(res);
     expect(first).toMatch(/DID complete/);
-    expect(first).toMatch(/graph_set_node_mode/);
+    expect(first).toMatch(/graph_add_node/);
     expect(first).toMatch(/2\.4s after its reply timeout/);
     // The retry's own result must still be there, not replaced by the notice.
     expect(res.content.length).toBeGreaterThan(1);
@@ -489,13 +489,42 @@ describe("late-mutation notice reaches the caller (#694)", () => {
     // The drain is destructive, so an unconditional probe would consume a notice
     // meant for a caller who has not retried yet.
     const { bridge, taken } = bridgeWithLate({
-      "rid-late": { cmd: "graph_set_node_mode", tabId: "tab-1", lateByMs: 1000 },
+      "rid-late": { cmd: "graph_add_node", tabId: "tab-1", lateByMs: 1000 },
     });
     const ctx = makePanelToolCtx(bridge, "tab-1");
     await addNode().handler({ node_type: "KSampler" }, ctx);
     expect(taken).toEqual([]);
   });
 
+
+  it("stays silent when the token names a DIFFERENT command than this tool sends", async () => {
+    // A token names an attempt. "The attempt you are retrying DID complete" is
+    // only true if the retained completion is for the command this tool
+    // dispatches; pasting a stale token onto another tool must not print a
+    // confident notice about an unrelated write.
+    const { bridge } = bridgeWithLate({
+      "rid-other": { cmd: "graph_set_node_mode", tabId: "tab-1", lateByMs: 1500 },
+    });
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    const res = await addNode().handler({ node_type: "KSampler", retry_of: "rid-other" }, ctx);
+    expect(textOf(res)).not.toMatch(/DID complete/);
+  });
+
+  it("does not consume the notice when the retry itself throws", async () => {
+    // The drain is destructive and now runs AFTER the handler: a failed retry
+    // must leave the notice for the next attempt, not eat it.
+    const late = { "rid-late": { cmd: "graph_add_node", tabId: "tab-1", lateByMs: 700 } };
+    const { bridge, taken } = bridgeWithLate(late);
+    (bridge as unknown as { send: () => Promise<unknown> }).send = async () => {
+      throw new Error("panel gone");
+    };
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    await addNode()
+      .handler({ node_type: "KSampler", retry_of: "rid-late" }, ctx)
+      .catch(() => undefined);
+    expect(taken, "a throwing retry must not have drained").toEqual([]);
+    expect(late["rid-late"], "the notice must survive for the next attempt").toBeTruthy();
+  });
   it("does NOT skip the dispatch — the retry still runs (#687 stays reverted)", async () => {
     // Suppressing the write on the strength of a rid would be #683's inference
     // with the arrow reversed: the bridge stores no fingerprint, so a stale or

--- a/src/__tests__/orchestrator/panel-retry-identity.test.ts
+++ b/src/__tests__/orchestrator/panel-retry-identity.test.ts
@@ -425,3 +425,94 @@ describe("#694 session epoch on the models push frame", () => {
     ]);
   });
 });
+
+// ── #694 second half: retention is only worth anything if a caller is TOLD.
+//
+// The bridge now keeps a mutation that completed AFTER its reply timeout. These
+// assert the WIRING — that the retained outcome reaches the tool result a caller
+// actually reads — rather than re-testing the bridge helper, which has its own
+// coverage in ui-bridge.test.ts. A retention map nobody drains would satisfy
+// every bridge-level test and still leave #694 exactly as reported.
+describe("late-mutation notice reaches the caller (#694)", () => {
+  /** A bridge whose mutations succeed, carrying a scripted late-completion map. */
+  function bridgeWithLate(late: Record<string, { cmd: string; tabId: string; lateByMs: number }>) {
+    const taken: string[] = [];
+    return {
+      taken,
+      bridge: {
+        send: async () => ({ ok: true }),
+        push: () => 1,
+        tabs: () => [{ tab_id: "tab-1" }],
+        takeLateMutation: (rid: string) => {
+          taken.push(rid);
+          const hit = late[rid];
+          if (!hit) return undefined;
+          delete late[rid];
+          return { ok: true as const, ...hit };
+        },
+      } as unknown as PanelToolCtx["bridge"],
+    };
+  }
+
+  const addNode = () => buildPanelToolDefs().find((d) => d.name === "panel_add_node")!;
+
+  it("prepends 'DID complete' when the retried rid had landed late", async () => {
+    const { bridge, taken } = bridgeWithLate({
+      "rid-late": { cmd: "graph_set_node_mode", tabId: "tab-1", lateByMs: 2400 },
+    });
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    const res = await addNode().handler(
+      { node_type: "KSampler", retry_of: "rid-late" },
+      ctx,
+    );
+    expect(taken).toContain("rid-late");
+    const first = textOf(res);
+    expect(first).toMatch(/DID complete/);
+    expect(first).toMatch(/graph_set_node_mode/);
+    expect(first).toMatch(/2\.4s after its reply timeout/);
+    // The retry's own result must still be there, not replaced by the notice.
+    expect(res.content.length).toBeGreaterThan(1);
+  });
+
+  it("says nothing when the retried rid never landed late (the normal retry)", async () => {
+    const { bridge, taken } = bridgeWithLate({});
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    const res = await addNode().handler(
+      { node_type: "KSampler", retry_of: "rid-unknown" },
+      ctx,
+    );
+    expect(taken).toContain("rid-unknown"); // asked...
+    expect(textOf(res)).not.toMatch(/DID complete/); // ...and correctly told nothing
+  });
+
+  it("never asks when the caller passed no retry_of", async () => {
+    // The drain is destructive, so an unconditional probe would consume a notice
+    // meant for a caller who has not retried yet.
+    const { bridge, taken } = bridgeWithLate({
+      "rid-late": { cmd: "graph_set_node_mode", tabId: "tab-1", lateByMs: 1000 },
+    });
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    await addNode().handler({ node_type: "KSampler" }, ctx);
+    expect(taken).toEqual([]);
+  });
+
+  it("does NOT skip the dispatch — the retry still runs (#687 stays reverted)", async () => {
+    // Suppressing the write on the strength of a rid would be #683's inference
+    // with the arrow reversed: the bridge stores no fingerprint, so a stale or
+    // re-pasted token cannot prove the mutation being asked for now is the one
+    // that landed. Dedupe is the panel ledger's job (#521); this only reports.
+    const sent: Array<Record<string, unknown>> = [];
+    const { bridge } = bridgeWithLate({
+      "rid-late": { cmd: "graph_add_node", tabId: "tab-1", lateByMs: 900 },
+    });
+    (bridge as unknown as { send: (c: Record<string, unknown>) => Promise<unknown> }).send =
+      async (c) => {
+        sent.push(c);
+        return { ok: true };
+      };
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    await addNode().handler({ node_type: "KSampler", retry_of: "rid-late" }, ctx);
+    expect(sent.length).toBeGreaterThan(0);
+    expect(sent.some((c) => c.retry_of === "rid-late")).toBe(true);
+  });
+});

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -4676,6 +4676,164 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
   });
 });
 
+// ── #694: the unsolved half. A MUTATION that times out and then applies is
+// invisible — the panel does reply, just after the deadline, and the bridge
+// drops it ("Everything else drops", ui-bridge.ts:2230).
+//
+// This is NOT the #486 shape and must not be built like it. #486 buffers for a
+// caller that is STILL ALIVE polling within a grace window; a mutation caller
+// has already been handed an outcome-unknown rejection and moved on. There is
+// no poller, so the outcome has to be retained for a LATER interaction to find.
+//
+// The reporter's case verbatim (0.50.36 / panel 0.11.44): graph_set_node_mode
+// timed out at 6000 ms, and panel_query_graph immediately after showed the node
+// already switched. The write landed. Nothing ever told the caller.
+describe("UiBridge (late MUTATION outcome — #694)", () => {
+  /** Reply to `cmd` only after `delayMs`, and hand back the rid the bridge minted. */
+  function replyLate(sock: WebSocket, cmd: string, delayMs: number): Promise<string> {
+    return new Promise((resolve) => {
+      sock.on("message", (buf) => {
+        const msg = JSON.parse(buf.toString());
+        if (msg.rid && msg.cmd === cmd) {
+          resolve(msg.rid);
+          setTimeout(() => {
+            sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { mode: "active" } }));
+          }, delayMs);
+        }
+      });
+    });
+  }
+
+  it("retains a successful late mutation reply so a later call can report it applied", async () => {
+    const sock = await connectPanel("tab-late-mut", "wf");
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tab-late-mut")).toBe(true),
+    );
+    const ridP = replyLate(sock, "graph_set_node_mode", 80);
+
+    await expect(
+      bridge.send(
+        { cmd: "graph_set_node_mode", node_id: 126, mode: "active" },
+        { tabId: "tab-late-mut", timeoutMs: 30 },
+      ),
+    ).rejects.toThrow(/did not reply/i);
+    const rid = await ridP;
+
+    // The write DID land. Today this assertion fails because the reply is
+    // dropped on the floor and the bridge keeps no record that it ever arrived.
+    const late = await vi.waitFor(() => {
+      const got = bridge.takeLateMutation(rid);
+      expect(got, "late mutation outcome should be retained").toBeTruthy();
+      return got;
+    });
+    expect(late?.ok).toBe(true);
+    expect(late?.cmd).toBe("graph_set_node_mode");
+    expect(late?.tabId).toBe("tab-late-mut");
+    sock.close();
+  });
+
+  it("drains once — a second reader must not be told the same thing twice", async () => {
+    const sock = await connectPanel("tab-late-drain", "wf");
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tab-late-drain")).toBe(true),
+    );
+    const ridP = replyLate(sock, "graph_set_node_mode", 80);
+    await expect(
+      bridge.send(
+        { cmd: "graph_set_node_mode", node_id: 1, mode: "mute" },
+        { tabId: "tab-late-drain", timeoutMs: 30 },
+      ),
+    ).rejects.toThrow(/did not reply/i);
+    const rid = await ridP;
+
+    await vi.waitFor(() => expect(bridge.takeLateMutation(rid)).toBeTruthy());
+    expect(bridge.takeLateMutation(rid)).toBeUndefined();
+    sock.close();
+  });
+
+  it("does NOT retain a mutation that replied IN TIME (nothing to report)", async () => {
+    // Guards the obvious over-fire: a normal successful mutation resolves its
+    // caller directly, so a retained record would make every write look like a
+    // recovered timeout.
+    const sock = await connectPanel("tab-on-time", "wf");
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tab-on-time")).toBe(true),
+    );
+    let seen = "";
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "graph_set_node_mode") {
+        seen = msg.rid;
+        sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { mode: "active" } }));
+      }
+    });
+    await bridge.send(
+      { cmd: "graph_set_node_mode", node_id: 7, mode: "active" },
+      { tabId: "tab-on-time", timeoutMs: 2000 },
+    );
+    expect(seen).toBeTruthy();
+    expect(bridge.takeLateMutation(seen)).toBeUndefined();
+    sock.close();
+  });
+
+  it("does NOT retain a late FAILURE — only a write that demonstrably applied", async () => {
+    // A late ok:false says the mutation was refused, which is not news the
+    // caller needs: they were already told it did not complete. Retaining it
+    // would turn "we never found out" into "it failed", the #796 fold in the
+    // opposite direction.
+    const sock = await connectPanel("tab-late-fail", "wf");
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tab-late-fail")).toBe(true),
+    );
+    let rid = "";
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "graph_set_node_mode") {
+        rid = msg.rid;
+        setTimeout(() => {
+          sock.send(JSON.stringify({ rid: msg.rid, ok: false, error: "no such node" }));
+        }, 80);
+      }
+    });
+    await expect(
+      bridge.send(
+        { cmd: "graph_set_node_mode", node_id: 999, mode: "active" },
+        { tabId: "tab-late-fail", timeoutMs: 30 },
+      ),
+    ).rejects.toThrow(/did not reply/i);
+    await new Promise((r) => setTimeout(r, 140));
+    expect(rid).toBeTruthy();
+    expect(bridge.takeLateMutation(rid)).toBeUndefined();
+    sock.close();
+  });
+
+  it("does NOT retain a late READ reply — a read is retryable, so nothing is ambiguous", async () => {
+    // The asymmetry #1154 spells out: an abandoned read costs nothing because
+    // you just retry it. Retaining reads would make this buffer unbounded noise.
+    const sock = await connectPanel("tab-late-read", "wf");
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tab-late-read")).toBe(true),
+    );
+    let rid = "";
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "graph_outline") {
+        rid = msg.rid;
+        setTimeout(() => {
+          sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { late: true } }));
+        }, 80);
+      }
+    });
+    await expect(
+      bridge.send({ cmd: "graph_outline" }, { tabId: "tab-late-read", timeoutMs: 30 }),
+    ).rejects.toThrow(/did not reply|disconnected|gone/i);
+    await new Promise((r) => setTimeout(r, 140));
+    expect(rid).toBeTruthy();
+    expect(bridge.takeLateMutation(rid)).toBeUndefined();
+    sock.close();
+  });
+});
+
 // #952 — the headless tools failed with `fetch failed` while every panel tool
 // worked, and nothing in the error connected the two. They are separate targets
 // by design (the panel talks to whichever ComfyUI its browser tab is on; the

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -4689,6 +4689,65 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
 // timed out at 6000 ms, and panel_query_graph immediately after showed the node
 // already switched. The write landed. Nothing ever told the caller.
 describe("UiBridge (late MUTATION outcome — #694)", () => {
+  // Retention is FAIL-CLOSED: with no filter the bridge keeps nothing, because
+  // nothing could drain it either. Production installs this from
+  // RETRY_TOKEN_CMDS (orchestrator/index.ts); the suite states the same shape
+  // explicitly rather than importing it, so a change to that set shows up here
+  // as a deliberate decision instead of silently re-scoping these tests.
+  const RETAINED = new Set(["graph_set_node_mode", "graph_add_node"]);
+  beforeEach(() => bridge.setLateMutationFilter((c) => RETAINED.has(c)));
+  afterEach(() => bridge.setLateMutationFilter(null));
+
+  it("retains nothing when no filter is installed (fail closed)", async () => {
+    bridge.setLateMutationFilter(null);
+    const sock = await connectPanel("tab-nofilter", "wf");
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "tab-nofilter")).toBe(true),
+    );
+    let rid = "";
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "graph_set_node_mode") {
+        rid = msg.rid;
+        setTimeout(() => sock.send(JSON.stringify({ rid: msg.rid, ok: true })), 80);
+      }
+    });
+    await expect(
+      bridge.send(
+        { cmd: "graph_set_node_mode", node_id: 1, mode: "active" },
+        { tabId: "tab-nofilter", timeoutMs: 30 },
+      ),
+    ).rejects.toThrow(/did not reply/i);
+    await new Promise((r) => setTimeout(r, 140));
+    expect(bridge.takeLateMutation(rid)).toBeUndefined();
+    sock.close();
+  });
+
+  it("asks the FILTER, not the mutating flag — the #778 commands stay out", async () => {
+    // ctx.mutating is !BRIDGE_READONLY_CMDS.has(cmd), which this file documents
+    // as misclassifying graph_screenshot &c. The first cut of #694 gated on it
+    // and retained seven reads under a comment claiming reads were excluded.
+    // graph_screenshot is mutating:true AND not retainable — the exact pair that
+    // tells the two discriminators apart.
+    const sock = await connectPanel("tab-778", "wf");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-778")).toBe(true));
+    let rid = "";
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "graph_screenshot") {
+        rid = msg.rid;
+        setTimeout(() => sock.send(JSON.stringify({ rid: msg.rid, ok: true })), 80);
+      }
+    });
+    await expect(
+      bridge.send({ cmd: "graph_screenshot" }, { tabId: "tab-778", timeoutMs: 30 }),
+    ).rejects.toThrow(/did not reply/i);
+    await new Promise((r) => setTimeout(r, 140));
+    expect(rid, "graph_screenshot should have been dispatched").toBeTruthy();
+    expect(bridge.takeLateMutation(rid)).toBeUndefined();
+    sock.close();
+  });
+
   /** Reply to `cmd` only after `delayMs`, and hand back the rid the bridge minted. */
   function replyLate(sock: WebSocket, cmd: string, delayMs: number): Promise<string> {
     return new Promise((resolve) => {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -81,6 +81,7 @@ import {
   makePanelToolCtx,
   resolvePinTarget,
   secretSavedReply,
+  RETRY_TOKEN_CMDS,
 } from "./panel-tools.js";
 import {
   optionsAckFrame,
@@ -2487,6 +2488,10 @@ export async function runPanelOrchestrator(): Promise<void> {
   // unsends; it never deletes, so those answers are still reported.
   bridge.setTabTakenOverListener((tabId) => AskAnswers.closeAsks(tabId));
   bridge.setTabGoneListener((tabId, incarnation) => AskAnswers.retireDebt(tabId, incarnation));
+  // #694 — the bridge retains a late mutation only for commands that can come
+  // back as a retry token, which is the retry-token layer's own set. Installed
+  // here because ui-bridge cannot import panel-tools (panel-tools imports it).
+  bridge.setLateMutationFilter((cmdName) => RETRY_TOKEN_CMDS.has(cmdName));
   bridge.setLateAskReplySink((askId, result, tabId) => {
     if (!AskAnswers.tracks(askId)) return;
     const entry = AskAnswers.record(askId, result, { tabId });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6367,7 +6367,6 @@ function withRetryToken(d: PanelToolDef): PanelToolDef {
       // #683 mistake with the arrow reversed, and #687 reverted it for cause.
       // Double-apply is already the #521 panel ledger's job; this only makes the
       // outcome VISIBLE, which is the half of #694 nothing else does.
-      const landed = ctx.bridge?.takeLateMutation?.(retryOf);
       const wrapped = Object.create(ctx) as PanelToolCtx;
       wrapped.call = (
         cmd: Record<string, unknown>,
@@ -6395,7 +6394,29 @@ function withRetryToken(d: PanelToolDef): PanelToolDef {
           onDispatchedRid,
         );
       const out = await d.handler(args, wrapped);
-      if (!landed) return out;
+      // Drained AFTER the handler, deliberately, for two measured reasons.
+      //
+      // (1) The drain is destructive. Draining first meant a handler that threw
+      //     consumed the notice permanently: the retry failed, no new token was
+      //     minted, and a later successful retry reported nothing.
+      // (2) It widens the window. A late reply that lands WHILE the retry is in
+      //     flight is now caught; draining first stranded it in the map until
+      //     TTL, which is the common case when an agent retries promptly.
+      //
+      // Matched on COMMAND, not rid alone. A token names an attempt, and the
+      // sentence below claims "the attempt you are retrying" completed -- which
+      // is only true if the retained completion is for the command this tool
+      // actually dispatches. Without the check, pasting a stale token onto a
+      // different tool prints a confident notice about an unrelated write.
+      // …and not at all if the retry FAILED. `ctx.call` converts almost every
+      // dispatch failure into an isError result rather than throwing, so gating
+      // on a thrown exception alone still drained on a failed retry -- the same
+      // permanent loss, one layer over. The caller gets no new token from a
+      // failed retry, so a consumed notice here is unrecoverable.
+      if (out.isError) return out;
+      const expectedCmd = RETRY_TOKEN_CMD_BY_TOOL[d.name];
+      const landed = ctx.bridge?.takeLateMutation?.(retryOf);
+      if (!landed || (expectedCmd !== undefined && landed.cmd !== expectedCmd)) return out;
       const secs = (landed.lateByMs / 1000).toFixed(1);
       return {
         ...out,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6349,10 +6349,25 @@ function withRetryToken(d: PanelToolDef): PanelToolDef {
   return {
     ...d,
     schema: { ...d.schema, ...RETRY_OF_ARG },
-    handler: (args: Record<string, unknown>, ctx: PanelToolCtx): Promise<ToolResult> => {
+    handler: async (args: Record<string, unknown>, ctx: PanelToolCtx): Promise<ToolResult> => {
       const retryOf =
         typeof args.retry_of === "string" && args.retry_of !== "" ? args.retry_of : undefined;
       if (!retryOf) return d.handler(args, ctx);
+      // #694 — the retried attempt may have ALREADY LANDED. The bridge keeps a
+      // late completion when a mutation replies after its reply timeout, and
+      // this is the one moment we know the caller cares about that exact rid:
+      // they just named it. Drained here (once) and reported alongside the
+      // retry's own outcome.
+      //
+      // Deliberately NOT a short-circuit. Skipping the dispatch would be wrong
+      // whenever the token is stale or pasted onto different args -- the bridge
+      // stores the rid, not a fingerprint of what it carried, so "the write for
+      // this rid landed" does not prove "the write you are asking for now is
+      // that same write". Suppressing a real mutation on that inference is the
+      // #683 mistake with the arrow reversed, and #687 reverted it for cause.
+      // Double-apply is already the #521 panel ledger's job; this only makes the
+      // outcome VISIBLE, which is the half of #694 nothing else does.
+      const landed = ctx.bridge?.takeLateMutation?.(retryOf);
       const wrapped = Object.create(ctx) as PanelToolCtx;
       wrapped.call = (
         cmd: Record<string, unknown>,
@@ -6379,7 +6394,25 @@ function withRetryToken(d: PanelToolDef): PanelToolDef {
           timeoutMs,
           onDispatchedRid,
         );
-      return d.handler(args, wrapped);
+      const out = await d.handler(args, wrapped);
+      if (!landed) return out;
+      const secs = (landed.lateByMs / 1000).toFixed(1);
+      return {
+        ...out,
+        content: [
+          {
+            type: "text" as const,
+            text:
+              `NOTE — the attempt you are retrying DID complete. "${landed.cmd}" on tab ` +
+              `${landed.tabId} was acknowledged by the panel ${secs}s after its reply ` +
+              `timeout, so the earlier outcome-unknown warning has been resolved: it ` +
+              `applied. Read the retry's own result below to see the final state (a ` +
+              `panel that recognised the retry token will have answered it with the ` +
+              `original outcome rather than applying anything a second time).`,
+          },
+          ...out.content,
+        ],
+      };
     },
   };
 }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1528,6 +1528,39 @@ export class UiBridge {
    *  journal the sink feeds — so this stays short. */
   private static readonly LATE_ASK_TTL_MS = 5 * 60 * 1000;
   /**
+   * Mutations whose reply timer fired (rid -> what it was), so a reply arriving
+   * afterwards can be RECOGNISED as the late completion of a known write rather
+   * than an unknown rid to drop (#694).
+   *
+   * Deliberately narrow, and the negatives matter more than the positive:
+   *  - MUTATIONS only. A read that is abandoned costs nothing because you just
+   *    retry it (#1154's asymmetry); retaining reads would make this unbounded
+   *    noise for no recoverable information.
+   *  - populated only when the TIMER fires. A mutation that replies in time
+   *    resolves its caller directly and has nothing to report later.
+   */
+  private timedOutMutations = new Map<string, { cmd: string; tabId: string; ts: number }>();
+  /** Late completions of timed-out mutations (rid -> outcome), drained once via
+   *  takeLateMutation(). Success only: see the recordLateMutation comment. */
+  private lateMutations = new Map<
+    string,
+    { ok: true; cmd: string; tabId: string; ts: number; lateByMs: number }
+  >();
+  /**
+   * TTL for both maps above.
+   *
+   * Unlike the ask mapping below this one CAN have a clock, because the thing it
+   * enables is bounded: telling a caller "your earlier write did land" is only
+   * useful while that caller is still working on the same thing. Ten minutes
+   * comfortably covers an agent turn. Past it the honest state is the one the
+   * caller already has -- outcome unknown, verify by observation -- which is
+   * what the timeout disclosure told them to do in the first place.
+   */
+  private static readonly LATE_MUTATION_TTL_MS = 10 * 60 * 1000;
+  /** Hard cardinality bound, so a pathological tab timing out in a loop cannot
+   *  grow either map without limit even inside the TTL. */
+  private static readonly MAX_LATE_MUTATIONS = 256;
+  /**
    * Ask cards whose rid→ask_id mapping is retained.
    *
    * This mapping is a different thing from the buffer above, with a different
@@ -2248,11 +2281,13 @@ export class UiBridge {
               }
             }
           }
+          this.recordLateMutation(rid, msg);
           return;
         }
         clearTimeout(p.timer);
         this.pending.delete(rid);
         this.askRidToId.delete(rid);
+        this.timedOutMutations.delete(rid);
         if (msg.ok) {
           // #422 — the panel DEMONSTRABLY served this command. Record it on the LIVE
           // connection (following a same-socket tmp:→wf: migration whose reply landed
@@ -2916,6 +2951,74 @@ export class UiBridge {
 
   /** Drop expired late-ask entries (buffered answers + unresolved rid mappings) so
    *  an abandoned card never leaks memory. Cheap; called on each ask send/take. */
+  /**
+   * A reply landed for an rid nothing is waiting on. If it is the late
+   * completion of a mutation we abandoned, keep it (#694).
+   *
+   * SUCCESS ONLY, and that asymmetry is the point. A late `ok:false` says the
+   * write was refused -- which is not news: the caller was already told it did
+   * not complete, and they were told truthfully. Promoting it to "it failed"
+   * would convert "we never found out" into a verdict we did not earn, the same
+   * fold as #796 pointing the other way. Only `ok:true` carries information the
+   * caller does not already have.
+   */
+  private recordLateMutation(rid: string, msg: { ok?: unknown }): void {
+    const started = this.timedOutMutations.get(rid);
+    if (!started) return;
+    this.timedOutMutations.delete(rid);
+    if (msg.ok !== true) return;
+    const now = Date.now();
+    this.pruneLateMutations();
+    this.lateMutations.set(rid, {
+      ok: true,
+      cmd: started.cmd,
+      tabId: started.tabId,
+      ts: now,
+      lateByMs: now - started.ts,
+    });
+    logger.debug(
+      `[ui-bridge] "${started.cmd}" on tab ${started.tabId} completed ${now - started.ts} ms AFTER its reply timeout — retained for the caller (#694)`,
+    );
+  }
+
+  /**
+   * Drain the late outcome for `rid`, if the write landed after its timeout.
+   *
+   * Drains once: this exists so a caller can be TOLD, and telling them twice
+   * would read as two separate recoveries of the same write.
+   */
+  takeLateMutation(
+    rid: string,
+  ): { ok: true; cmd: string; tabId: string; lateByMs: number } | undefined {
+    this.pruneLateMutations();
+    const hit = this.lateMutations.get(rid);
+    if (!hit) return undefined;
+    this.lateMutations.delete(rid);
+    return { ok: true, cmd: hit.cmd, tabId: hit.tabId, lateByMs: hit.lateByMs };
+  }
+
+  /** TTL + cardinality bound for both #694 maps. */
+  private pruneLateMutations(): void {
+    const now = Date.now();
+    for (const [rid, e] of this.timedOutMutations) {
+      if (now - e.ts > UiBridge.LATE_MUTATION_TTL_MS) this.timedOutMutations.delete(rid);
+    }
+    for (const [rid, e] of this.lateMutations) {
+      if (now - e.ts > UiBridge.LATE_MUTATION_TTL_MS) this.lateMutations.delete(rid);
+    }
+    // Map iteration is insertion-ordered, so dropping from the front drops the
+    // oldest. Quiet, unlike the ask-mapping overflow: losing one of 256 late
+    // completions costs the caller a notice they can still get by looking, where
+    // losing an ask mapping loses a user's answer outright.
+    for (const map of [this.timedOutMutations, this.lateMutations]) {
+      while (map.size > UiBridge.MAX_LATE_MUTATIONS) {
+        const oldest = map.keys().next();
+        if (oldest.done) break;
+        map.delete(oldest.value);
+      }
+    }
+  }
+
   private pruneLateAsk(): void {
     const now = Date.now();
     for (const [id, e] of this.lateAskReplies) {
@@ -3778,6 +3881,14 @@ export class UiBridge {
     };
     const timer = setTimeout(() => {
       this.pending.delete(rid);
+      // #694 — remember that THIS rid was a mutation we stopped waiting for. The
+      // panel may still reply; without this the reply is an unknown rid and the
+      // message loop drops it, which is precisely how a write that landed stays
+      // invisible to the caller who was told "outcome unknown".
+      if (ctx.mutating) {
+        this.pruneLateMutations();
+        this.timedOutMutations.set(rid, { cmd: cmd.cmd, tabId: ctx.tabId, ts: Date.now() });
+      }
       // This timer only fires AFTER sock.send() below returned successfully — the command
       // WAS WRITTEN to the socket; the tab (possibly backgrounded/frozen) merely didn't
       // reply in time and may still apply it. So this is a POST-write outcome: tag it

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1540,6 +1540,9 @@ export class UiBridge {
    *    resolves its caller directly and has nothing to report later.
    */
   private timedOutMutations = new Map<string, { cmd: string; tabId: string; ts: number }>();
+  /** Installed by the retry-token layer; see setLateMutationFilter. Null means
+   *  retain nothing. */
+  private lateMutationFilter: ((cmdName: string) => boolean) | null = null;
   /** Late completions of timed-out mutations (rid -> outcome), drained once via
    *  takeLateMutation(). Success only: see the recordLateMutation comment. */
   private lateMutations = new Map<
@@ -2287,7 +2290,6 @@ export class UiBridge {
         clearTimeout(p.timer);
         this.pending.delete(rid);
         this.askRidToId.delete(rid);
-        this.timedOutMutations.delete(rid);
         if (msg.ok) {
           // #422 — the panel DEMONSTRABLY served this command. Record it on the LIVE
           // connection (following a same-socket tmp:→wf: migration whose reply landed
@@ -3080,6 +3082,26 @@ export class UiBridge {
    *  (#486). Called once at orchestrator start-up. */
   setLateAskReplySink(sink: (askId: string, result: unknown, tabId: string) => void): void {
     this.lateAskSink = sink;
+  }
+
+  /**
+   * Declare which commands are worth retaining a late completion for (#694).
+   *
+   * FAIL CLOSED: with no filter installed nothing is retained, because nothing
+   * could drain it either -- the drainer and the filter are the same layer.
+   *
+   * The bridge cannot answer this itself, and the first attempt at this proved
+   * why. It gated on `ctx.mutating`, i.e. `!BRIDGE_READONLY_CMDS.has(cmd)` --
+   * the discriminator this very file documents (see BRIDGE_READONLY_CMDS) as
+   * misclassifying graph_find_nodes, graph_list_subgraphs, graph_screenshot,
+   * graph_canvas, graph_select_nodes, graph_enter/exit_subgraph and
+   * graph_copy_nodes. That is #778, and re-asking it retained seven reads under
+   * a comment claiming reads were excluded. The real question is not "does this
+   * mutate" but "can this rid ever come back to us as a retry token", which only
+   * the retry-token layer knows. So it tells us.
+   */
+  setLateMutationFilter(fn: ((cmdName: string) => boolean) | null): void {
+    this.lateMutationFilter = fn;
   }
 
   /** Notified when a tab's PRIMARY connection is dropped and it leaves the
@@ -3885,7 +3907,7 @@ export class UiBridge {
       // panel may still reply; without this the reply is an unknown rid and the
       // message loop drops it, which is precisely how a write that landed stays
       // invisible to the caller who was told "outcome unknown".
-      if (ctx.mutating) {
+      if (this.lateMutationFilter?.(cmd.cmd)) {
         this.pruneLateMutations();
         this.timedOutMutations.set(rid, { cmd: cmd.cmd, tabId: ctx.tabId, ts: Date.now() });
       }


### PR DESCRIPTION
Closes the recoverability half of #694.

Most of #694 shipped in #704/#707 (retry_of, the #521 ledger, session epoch). The reopen was a recurrence #1154 explained. The owner's note scoped what remained, and it is this PR's whole boundary:

> this reduces how often the ambiguity happens, it does not make it recoverable

## The gap

A mutation that times out and then applies is invisible. The panel *does* reply — just after the deadline — and the message loop drops it. `ui-bridge.ts:2230` says so outright: **"Everything else drops."** The reporter's case: `graph_set_node_mode` timed out at 6000 ms, `panel_query_graph` immediately after showed the node already switched. The write landed. Nothing ever said so.

## Two commits

**1 — retention.** Two bounded maps: `timedOutMutations` (written only when the reply timer fires, only for `ctx.mutating`) and `lateMutations`, drained once. 10-min TTL + 256 cap.

The negatives are the design:
- **Reads excluded.** #1154's asymmetry — an abandoned read costs nothing, you retry it. Retaining reads is unbounded noise.
- **Late `ok:false` not retained.** The caller was already told the write didn't complete, and that was true. Promoting a late refusal to "it failed" converts *we never found out* into a verdict we didn't earn — the #796 fold, reversed.
- **On-time replies record nothing.**

Not modelled on #486, deliberately: that buffer serves a caller still alive polling in a grace window. A mutation caller has been handed an outcome-unknown rejection and moved on. There is no poller.

**2 — wiring.** `withRetryToken` drains on `retry_of` and prepends the outcome. **Not a short-circuit** — skipping the dispatch because a rid landed is #683's inference with the arrow reversed: the bridge stores the rid, not a fingerprint, so "the write for this rid landed" does not prove "the write asked for now is that write". A stale token would swallow a real mutation. #687 reverted that class for cause; dedupe stays the #521 ledger's job.

## Verification

9 tests. The 5 bridge tests were **red before the change**; every guard is mutation-verified to bite:

| mutation | test killed |
|---|---|
| drop the `ctx.mutating` guard | the read test |
| remove the `ok !== true` return | the late-failure test |
| record on the resolve path | the on-time test |
| remove the notice, keep the drain | the report test |
| probe unconditionally | the no-retry-token test |

I checked these because the first three would all have passed against a stub returning `undefined` — same-reason-red is weak red.

Full suite: **391 files, 7929 passed, 2 skipped.** `tsc --noEmit` clean.

## Not covered, stated plainly

A caller told outcome-unknown who **never retries** still learns nothing — the notice sits until TTL. That needs a tab-scoped drain on the next panel call, a wider blast radius than this. #694 should stay open for it, or get a follow-up issue.

Refs #517, #521, #683, #687, #704, #707, #1154.