### PR TITLE
release: v0.50.59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.59] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- status must not report a LIVE download as missing (#1213)
+- type three test-only violations so `src/__tests__` can rejoin typechecking (#1204)
+
+
 ## [0.50.58] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.58",
+  "version": "0.50.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.58",
+      "version": "0.50.59",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.58",
+  "version": "0.50.59",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.59` tag.

**A status decline no longer reads as a vanished download** (#1183, via #1213).

A reporter polled a live 26.5GB local download for ~30 minutes — 20% → 67% → 79% → 85% → 89% → 95% — and then one poll returned `No download matching id …`. The file existed nowhere on disk, nothing had been cancelled, and re-issuing the same URL immediately re-adopted the **same id at 97%**: the job had been alive the whole time.

`getDownloadJob` declines rather than guessing when two live transfers share an id, and that refusal is right. Rendering it as an **absence** is not: "I will not choose between two" and "there is nothing here" are different facts, and only the second justifies telling someone their download vanished — which is what invites a redundant multi-gigabyte re-download, since an agent reacting to "not found" has no reason to re-issue the identical URL that would have hit the anti-duplication net.

A miss now asks the question it never asked — is anything still running under this id? — and answers in three distinct ways: **still running** (naming the tray ids when there is more than one), **stopped reporting N seconds ago** (hedged: a missed heartbeat is a liveness hint, not proof), or silence, so a genuine "not found" keeps its wording.

Reviewing against "does this fix the *reported* case?" caught that the first version used the same 60s freshness window as the lookup — so it would have gone silent in exactly the situation most likely to have caused the report. The codebase already states the rule (#761): an in-flight record is retained for 6h precisely because a missed heartbeat is not proof.

The ambiguity guards are untouched — nothing about which job the lookup returns has changed.

Verified live against the built artifact using the reporter's own id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)