### PR TITLE
fix(test): de-flake two timing-dependent tests

### DIFF
--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -108,6 +108,7 @@ import {
   startDownloadJob,
   getDownloadJob,
   findDownloadJob,
+  compareTrayIds,
   listDownloadJobs,
   listDownloadJobCandidates,
   cancelDownloadJob,
@@ -2107,5 +2108,41 @@ describe("download job registry", () => {
       expect(r.confirmed).toBe(false);
       expect(r.warning).toMatch(/NOT verified as landed/);
     });
+  });
+});
+
+// #1208 (codex review) — the tiebreak must be DETERMINISTIC ACROSS MACHINES.
+//
+// The first version used `String(a.trayId).localeCompare(String(b.trayId))`.
+// localeCompare is locale-aware by definition and its collation depends on the
+// runtime's ICU build, so `tray-B` vs `tray-a` orders one way here and can order
+// the other way elsewhere:
+//
+//     "tray-B".localeCompare("tray-a")  →  1
+//     "tray-B" < "tray-a"               →  false  (raw: -1 the other direction)
+//
+// That would have traded a timing flake for a portability flake, in the one
+// function whose job is to be identical on every machine.
+describe("compareTrayIds (#1208)", () => {
+  it("orders by RAW string comparison, not locale collation", () => {
+    // The exact pair where the two disagree.
+    expect(compareTrayIds("tray-B", "tray-a")).toBeLessThan(0);
+    expect("tray-B".localeCompare("tray-a")).toBeGreaterThan(0);
+  });
+
+  it("is antisymmetric and reflexive — a sort comparator must be", () => {
+    expect(compareTrayIds("a", "b")).toBeLessThan(0);
+    expect(compareTrayIds("b", "a")).toBeGreaterThan(0);
+    expect(compareTrayIds("a", "a")).toBe(0);
+  });
+
+  it("sorts a MISSING trayId last without colliding on 'undefined'", () => {
+    // String(undefined) === "undefined" would have made every id-less job equal
+    // to every other AND sortable against real ids by that literal.
+    expect(compareTrayIds(undefined, "a")).toBeGreaterThan(0);
+    expect(compareTrayIds("a", undefined)).toBeLessThan(0);
+    expect(compareTrayIds(undefined, undefined)).toBe(0);
+    // …and it must not sort as the literal string.
+    expect(compareTrayIds(undefined, "zzzz")).toBeGreaterThan(0);
   });
 });

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -416,12 +416,33 @@ describe("download job registry", () => {
     expect(listDownloadJobs()).toHaveLength(1);
   });
 
+  // #1208 — this raced the clock. It started two jobs 2 ms apart and asserted an
+  // order derived from `b.started_at - a.started_at`, a MILLISECOND timestamp
+  // with no tiebreak, so when both landed in the same millisecond the result fell
+  // back to Map insertion order. It failed on all three platforms at once during
+  // a release build and went green on an unchanged re-run.
+  //
+  // Now it controls what it asserts: the timestamps are set explicitly, so the
+  // ordering is a property of the comparator rather than of how busy the machine
+  // was.
   it("lists newest first", async () => {
-    await startDownloadJob(URL_A, "checkpoints");
-    await new Promise((r) => setTimeout(r, 2));
-    await startDownloadJob(URL_B, "loras");
+    const a = await startDownloadJob(URL_A, "checkpoints");
+    const b = await startDownloadJob(URL_B, "loras");
+    a.job.started_at = 1_000;
+    b.job.started_at = 2_000;
     expect(listDownloadJobs()[0].url).toBe(URL_B);
   });
+
+  // NOT unit-tested here, deliberately, and worth saying why rather than
+  // shipping a test that passes for the wrong reason: the comparator's trayId
+  // tiebreak only shows itself when two jobs share a millisecond, and that
+  // cannot be forced through the public API — `listDownloadJobs()` returns FRESH
+  // objects, so assigning `started_at` on the returned array mutates throwaway
+  // copies. An earlier attempt did exactly that and was vacuous.
+  //
+  // The tiebreak is defensive and cheap; what this file DOES pin is the ordering
+  // itself, above, now that the test no longer races a 2 ms gap to establish it.
+
 
   // #467 P1-A: the job layer dedups BEFORE the header-aware cache layer, so it must
   // fold auth into its keys — otherwise two concurrent same-URL+same-dest calls with

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2513,9 +2513,22 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     expect(msg).toMatch(/UNCONFIRMED/);
     expect(msg).toMatch(/could not be read just now/);
     // …and the two costless checks must come before the remedy that has a cost.
-    expect(msg.search(/RETRY this command/)).toBeLessThan(
-      msg.search(/panel_action:'update'/),
-    );
+    //
+    // #1208 — this compared two `search()` indices WITHOUT asserting either term
+    // was present, so an absent term (-1) made the comparison meaningless and the
+    // test failed intermittently. The remedy has TWO wordings depending on
+    // `installPanelUsable`: "install_comfyui(action:'panel', panel_action:'update')"
+    // when this surface can drive the update, and "Update the panel ON THE
+    // COMFYUI HOST" when it cannot. Only the first contains `panel_action:'update'`,
+    // so on the other branch the index was -1 and `694 < -1` failed — an
+    // environmental difference, not a regression.
+    //
+    // Assert presence FIRST, and anchor on a pattern that covers both branches.
+    const retryAt = msg.search(/RETRY this command/);
+    const remedyAt = msg.search(/panel_action:'update'|Update the panel ON THE COMFYUI HOST/);
+    expect(retryAt, "the free RETRY check must be present").toBeGreaterThan(-1);
+    expect(remedyAt, "an update remedy must be present in either wording").toBeGreaterThan(-1);
+    expect(retryAt).toBeLessThan(remedyAt);
     expect(msg.search(/HARD-REFRESH/)).toBeLessThan(msg.search(/panel_action:'update'/));
     // The update is DEMOTED, not deleted — it is still right when the install
     // really is behind, and this branch cannot rule that out either.

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -1057,7 +1057,19 @@ export function listDownloadJobCandidates(id: string): DownloadJob[] {
       byKey.set(k, job);
     }
   }
-  return [...byKey.values()].sort((a, b) => b.started_at - a.started_at);
+  // #1208 — a DETERMINISTIC tiebreak. started_at is a millisecond timestamp, so
+  // two jobs begun in the same millisecond compared equal and the order fell back
+  // to Map insertion order: stable locally, evidently not on a loaded CI runner.
+  // "lists newest first" failed on all THREE platforms at once and went green on
+  // an unchanged re-run — and a flake that fails everywhere simultaneously reads
+  // like a regression, which is what it costs to rule out.
+  //
+  // trayId is the right tiebreak: it is unique per physical download (two URLs
+  // sharing an id differ there), so equal timestamps order identically on every
+  // run and in every process.
+  return [...byKey.values()].sort(
+    (a, b) => b.started_at - a.started_at || String(a.trayId).localeCompare(String(b.trayId)),
+  );
 }
 
 /**
@@ -1285,7 +1297,19 @@ export function listDownloadJobs(): DownloadJob[] {
       byKey.set(k, job);
     }
   }
-  return [...byKey.values()].sort((a, b) => b.started_at - a.started_at);
+  // #1208 — a DETERMINISTIC tiebreak. started_at is a millisecond timestamp, so
+  // two jobs begun in the same millisecond compared equal and the order fell back
+  // to Map insertion order: stable locally, evidently not on a loaded CI runner.
+  // "lists newest first" failed on all THREE platforms at once and went green on
+  // an unchanged re-run — and a flake that fails everywhere simultaneously reads
+  // like a regression, which is what it costs to rule out.
+  //
+  // trayId is the right tiebreak: it is unique per physical download (two URLs
+  // sharing an id differ there), so equal timestamps order identically on every
+  // run and in every process.
+  return [...byKey.values()].sort(
+    (a, b) => b.started_at - a.started_at || String(a.trayId).localeCompare(String(b.trayId)),
+  );
 }
 
 /**

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -1068,7 +1068,7 @@ export function listDownloadJobCandidates(id: string): DownloadJob[] {
   // sharing an id differ there), so equal timestamps order identically on every
   // run and in every process.
   return [...byKey.values()].sort(
-    (a, b) => b.started_at - a.started_at || String(a.trayId).localeCompare(String(b.trayId)),
+    (a, b) => b.started_at - a.started_at || compareTrayIds(a.trayId, b.trayId),
   );
 }
 
@@ -1264,6 +1264,27 @@ export function findDownloadJob(query: { url?: string; destKey?: string }): Down
   return persisted ? jobFromPersisted(persisted) : undefined;
 }
 
+/**
+ * The ordering tiebreak for two jobs that share a millisecond (#1208).
+ *
+ * RAW comparison, not localeCompare (codex review). localeCompare is
+ * locale-aware by definition and its collation depends on the runtime's ICU
+ * build, so `tray-B` vs `tray-a` can order differently on Windows and Linux —
+ * which would have traded a timing flake for a portability flake, in a function
+ * whose whole job here is to be identical on every machine.
+ *
+ * A missing trayId sorts LAST rather than colliding on the string "undefined":
+ * two absent ids still compare equal (nothing can separate them), but an absent
+ * one never displaces a present one, so the order stays stable as far as the
+ * data allows.
+ */
+export function compareTrayIds(a: string | undefined, b: string | undefined): number {
+  if (a === b) return 0;
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
 export function listDownloadJobs(): DownloadJob[] {
   // One Entry is indexed under multiple keys — dedup by identity so a job appears once
   // regardless of how many keys point at it. Identity is (id, trayId), NOT id alone:
@@ -1308,7 +1329,7 @@ export function listDownloadJobs(): DownloadJob[] {
   // sharing an id differ there), so equal timestamps order identically on every
   // run and in every process.
   return [...byKey.values()].sort(
-    (a, b) => b.started_at - a.started_at || String(a.trayId).localeCompare(String(b.trayId)),
+    (a, b) => b.started_at - a.started_at || compareTrayIds(a.trayId, b.trayId),
   );
 }
 


### PR DESCRIPTION
Fixes #1208. **Draft — claiming the issue, work in progress.**

## Two flakes, both observed in one session

**1. `lists newest first`** (`download-jobs.test.ts`) — failed on **all three platforms** and blocked the `v0.50.56` release build; an unchanged re-run went green. It starts two jobs 2 ms apart and asserts ordering from `b.started_at - a.started_at`, a **millisecond** timestamp with no tiebreak.

**2. `an UNREADABLE disk version leads with the two free checks, not with an update`** (`ui-bridge.test.ts`) — failed once during a local full-suite run, passed on an immediate unchanged re-run.

## Why these are worth fixing rather than re-running

A flake that fails **all three platforms at once** does not read like a flake — it reads like a real regression, and that is what it costs. Ruling the first one out meant reading the diff to confirm `download-jobs.ts` was untouched and checking the failure history. The second one caused me to commit while the suite was red, then re-verify.

The expense is not the re-run. It is the minutes spent proving a change was innocent, every time, on the branch where you can least afford the doubt.

## Plan

Do not race the clock:

- give `listDownloadJobs()`'s comparator a deterministic tiebreak so equal timestamps still order stably;
- have the test assert on something it controls rather than on a 2 ms wall-clock gap.

Then diagnose the second one properly rather than assuming it is the same shape — I have not traced it yet, and guessing would be the same mistake this issue is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)