### PR TITLE
release: v0.50.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.61] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- de-flake two timing-dependent tests (#1216)
+
+
 ## [0.50.60] - 2026-08-09
 
 _No user-facing changes._

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.60",
+  "version": "0.50.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.60",
+      "version": "0.50.61",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.60",
+  "version": "0.50.61",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the published `v0.50.61` tag.

**Two flaky tests are fixed** (#1208, via #1216). Both fired in a single session; neither was a regression, and that is the cost — a flake is indistinguishable from a real failure at the moment you see it, so each is paid for in the minutes spent proving a change innocent.

- **`lists newest first`** failed on **all three platforms** and blocked the `v0.50.56` release build. It started two jobs 2 ms apart and asserted an order derived from a millisecond timestamp with no tiebreak, so when both landed in the same millisecond the result fell back to Map insertion order. The comparator now has a deterministic tiebreak (both copies of it) and the test sets timestamps explicitly instead of racing the clock.
- **`an UNREADABLE disk version…`** reproduced at ~1 run in 6 and was traced rather than guessed: it compared two `search()` indices without asserting either term was present, and the remedy has two wordings — only one contains `panel_action:'update'`, so the other branch yielded `-1`. Now 0 failures in 22 runs.

Review then caught that the tiebreak I added introduced a *portability* flake: `localeCompare` is locale-aware and ICU-dependent, so `"tray-B"` vs `"tray-a"` can order differently across machines. Raw comparison now, with a missing id sorting last rather than collapsing to the literal `"undefined"`.

No behaviour changes for users — this is test and ordering determinism only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)