### PR TITLE
fix(panel): a 0-node outline right after a restore is not an observation

### DIFF
--- a/src/__tests__/orchestrator/empty-outline-recheck.test.ts
+++ b/src/__tests__/orchestrator/empty-outline-recheck.test.ts
@@ -27,6 +27,10 @@ import {
 let outlineReplies: Array<Record<string, unknown>>;
 let outlineCalls: number;
 let rereadThrows: boolean;
+/** Successive answers from the session's workflow fence — index 0 before the
+ *  first re-read, index 1 after, so a mid-poll tab switch can be modelled. */
+let fenceUuids: string[];
+let fenceReads: number;
 
 function bridge() {
   return {
@@ -44,7 +48,11 @@ function bridge() {
     isHeadless: () => false,
     tabs: () => [{ tab_id: "tab-1", title: "wf", connected_at: 0 }],
     resolveActiveTabId: () => "tab-1",
-    workflowUuidFor: () => ({ known: true, uuid: undefined }),
+    workflowUuidFor: () => {
+      const uuid = fenceUuids[Math.min(fenceReads, fenceUuids.length - 1)];
+      fenceReads += 1;
+      return { known: true, uuid };
+    },
     tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
   } as unknown as PanelToolCtx["bridge"];
 }
@@ -61,6 +69,8 @@ async function callOutline(): Promise<Record<string, unknown>> {
 beforeEach(() => {
   outlineCalls = 0;
   rereadThrows = false;
+  fenceReads = 0;
+  fenceUuids = ["11111111-2222-4333-8444-555555555555"];
 });
 
 describe("an empty outline is re-verified before it is believed (#1184)", () => {
@@ -74,7 +84,7 @@ describe("an empty outline is re-verified before it is believed (#1184)", () => 
     const out = await callOutline();
 
     expect(out.node_count, "the empty first read must not be reported").toBe(7);
-    expect(outlineCalls, "it must actually re-read").toBe(2);
+    expect(outlineCalls, "it must actually re-read").toBe(2); // stops as soon as nodes appear
   });
 
   it("reports empty plainly when the canvas is GENUINELY empty", async () => {
@@ -86,7 +96,9 @@ describe("an empty outline is re-verified before it is believed (#1184)", () => 
     const out = await callOutline();
 
     expect(out.node_count).toBe(0);
-    expect(outlineCalls, "confirmed by a second read").toBe(2);
+    // The poll runs its full schedule before concluding empty — a single attempt
+    // would be an arbitrary cliff for a slower restore (codex review).
+    expect(outlineCalls, "confirmed by the full re-read schedule").toBeGreaterThan(1);
     expect(JSON.stringify(out)).not.toMatch(/restor|still loading/i);
   });
 
@@ -129,5 +141,36 @@ describe("an empty outline is re-verified before it is believed (#1184)", () => 
 
     expect(out.node_count).toBe(0);
     expect(out.detail_level).toBe("full");
+  });
+
+  it("keeps polling for a SLOWER restore instead of giving up after one try", async () => {
+    // codex review: one fixed retry is an arbitrary cliff. A restore that is
+    // still going at the first re-read must not be reported as an empty canvas.
+    outlineReplies = [
+      { node_count: 0, group_count: 0, outline: "0 nodes" },
+      { node_count: 0, group_count: 0, outline: "0 nodes" },
+      { node_count: 7, group_count: 0, outline: "7 nodes" },
+    ];
+
+    const out = await callOutline();
+
+    expect(out.node_count).toBe(7);
+    expect(outlineCalls).toBe(3);
+  });
+
+  it("does NOT adopt a second read taken after the workflow CHANGED", async () => {
+    // codex review, and the sharper risk: the user can switch tabs during the
+    // poll, so a non-empty second outline may describe a DIFFERENT workflow.
+    // Reporting it as though it confirmed a read of the first is worse than the
+    // empty read this exists to fix — the honest empty answer stands.
+    outlineReplies = [
+      { node_count: 0, group_count: 0, outline: "0 nodes" },
+      { node_count: 9, group_count: 0, outline: "9 nodes of ANOTHER workflow" },
+    ];
+    fenceUuids = ["11111111-2222-4333-8444-555555555555", "99999999-8888-4777-a666-555555555555"];
+
+    const out = await callOutline();
+
+    expect(out.node_count, "another workflow's graph must not be substituted").toBe(0);
   });
 });

--- a/src/__tests__/orchestrator/empty-outline-recheck.test.ts
+++ b/src/__tests__/orchestrator/empty-outline-recheck.test.ts
@@ -1,0 +1,133 @@
+// #1184 — a 0-node outline is a CLAIM, and one made mid-restore is not
+// established.
+//
+// Right after a ComfyUI restart and a tab switch, panel_graph_outline returned
+// `node_count: 0` for a tab holding a 7-node starter graph: the frontend was
+// still restoring and the canvas transiently had nothing on it. The agent
+// trusted the empty read, reported the canvas empty, and BUILT A NEW 9-NODE
+// PIPELINE alongside the invisible one. A later panel_query_graph showed 16
+// nodes — ids 1–7 had been there all along, which the frontend knew, because the
+// new adds started at id 8.
+//
+// That is the worst shape of this defect class: the action taken on the false
+// read destroys work. A duplicate pipeline cannot be un-built, and the user is
+// left with two overlapping graphs and no way to tell which nodes are theirs.
+//
+// It is also unusually cheap to get right — an empty outline is trivially
+// re-verifiable, because the restore has either finished or it has not.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+let outlineReplies: Array<Record<string, unknown>>;
+let outlineCalls: number;
+let rereadThrows: boolean;
+
+function bridge() {
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "graph_outline") {
+        const n = outlineCalls;
+        outlineCalls += 1;
+        if (rereadThrows && n > 0) throw new Error("panel went away mid-recheck");
+        return outlineReplies[Math.min(n, outlineReplies.length - 1)];
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: "tab-1", title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => "tab-1",
+    workflowUuidFor: () => ({ known: true, uuid: undefined }),
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+async function callOutline(): Promise<Record<string, unknown>> {
+  const ctx = makePanelToolCtx(bridge(), "tab-1");
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_graph_outline");
+  if (!def) throw new Error("panel_graph_outline is not registered");
+  const res: ToolResult = await def.handler({}, ctx);
+  const text = (res.content.find((c) => c.type === "text") as { text: string } | undefined)?.text;
+  return JSON.parse(text ?? "{}") as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  outlineCalls = 0;
+  rereadThrows = false;
+});
+
+describe("an empty outline is re-verified before it is believed (#1184)", () => {
+  it("reports the REAL graph when the first read caught a restore in progress", async () => {
+    // The reporter's shape exactly: transiently 0, then the 7 nodes appear.
+    outlineReplies = [
+      { node_count: 0, group_count: 0, outline: "0 nodes" },
+      { node_count: 7, group_count: 0, outline: "7 nodes" },
+    ];
+
+    const out = await callOutline();
+
+    expect(out.node_count, "the empty first read must not be reported").toBe(7);
+    expect(outlineCalls, "it must actually re-read").toBe(2);
+  });
+
+  it("reports empty plainly when the canvas is GENUINELY empty", async () => {
+    // A blank canvas is a normal state. Having confirmed it twice, it must be
+    // reported without hedging — turning every blank canvas into a warning would
+    // be its own false signal.
+    outlineReplies = [{ node_count: 0, group_count: 0, outline: "0 nodes" }];
+
+    const out = await callOutline();
+
+    expect(out.node_count).toBe(0);
+    expect(outlineCalls, "confirmed by a second read").toBe(2);
+    expect(JSON.stringify(out)).not.toMatch(/restor|still loading/i);
+  });
+
+  it("does NOT re-read when the first outline already has nodes", async () => {
+    // The cost must fall only on the empty case.
+    outlineReplies = [{ node_count: 3, group_count: 1, outline: "3 nodes" }];
+
+    const out = await callOutline();
+
+    expect(out.node_count).toBe(3);
+    expect(outlineCalls).toBe(1);
+  });
+
+  it("keeps the FIRST reply's fields when the re-read is also empty", async () => {
+    // The second read is the same ANSWER, so the original reply — with whatever
+    // else it carried — is what gets returned.
+    //
+    // The two empty replies are deliberately DISTINGUISHABLE: with identical
+    // fixtures this test could not tell which one came back, and a mutation that
+    // returned the second passed it. (Caught by mutating the empty-second-read
+    // guard away.)
+    outlineReplies = [
+      { node_count: 0, group_count: 0, outline: "0 nodes", detail_level: "full", max_chars: 4000 },
+      { node_count: 0, group_count: 0, outline: "0 nodes", detail_level: "SECOND", max_chars: 1 },
+    ];
+
+    const out = await callOutline();
+
+    expect(out.detail_level).toBe("full");
+    expect(out.max_chars).toBe(4000);
+  });
+
+  it("keeps the first reply when the RE-READ errors", async () => {
+    // A failed confirmation must not downgrade a reply we already have. The
+    // re-read is a chance to learn more, never a way to lose what was known.
+    outlineReplies = [{ node_count: 0, group_count: 0, outline: "0 nodes", detail_level: "full" }];
+    rereadThrows = true;
+
+    const out = await callOutline();
+
+    expect(out.node_count).toBe(0);
+    expect(out.detail_level).toBe("full");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1618,6 +1618,7 @@ function withTruncationHints(res: ToolResult, rules: TruncationRule[]): ToolResu
  * Never throws: a failed re-read leaves the original reply exactly as it was.
  */
 async function confirmEmptyOutline(
+  ctx: PanelToolCtx,
   res: ToolResult,
   reread: () => Promise<ToolResult>,
 ): Promise<ToolResult> {
@@ -1625,28 +1626,60 @@ async function confirmEmptyOutline(
     if (res.isError) return res;
     const first = parseToolResultJson(res);
     if (!first || first.node_count !== 0) return res;
-    await sleep(EMPTY_OUTLINE_RECHECK_MS);
-    const second = await reread();
-    // Redundant with the parsed-null guard below TODAY — an error result carries
-    // no parseable JSON, so that branch already returns `res` — and kept anyway:
-    // it states the intent directly, and it would still hold if an error result
-    // ever carried a structured body. No test kills this line alone; saying so
-    // beats inventing one that pretends otherwise.
-    if (second.isError) return res;
-    const parsed = parseToolResultJson(second);
-    // Only a NON-empty second read replaces the first. A second empty read is the
-    // same answer, and returning the original keeps every other field it carried.
-    if (!parsed || parsed.node_count === 0) return res;
-    return second;
+
+    // Which workflow this empty answer is ABOUT (codex review). The re-read is a
+    // second round trip, and the user can switch tabs during it — so a non-empty
+    // second outline might describe a DIFFERENT workflow entirely. Substituting
+    // it would report workflow B's graph as though it confirmed a read of A,
+    // which is a worse failure than the empty read this exists to fix.
+    const identityBefore = currentWorkflowFence(ctx);
+
+    // A BOUNDED POLL, not a single retry (codex review). A restore after a
+    // ComfyUI restart has no guaranteed duration, and one 400ms attempt is an
+    // arbitrary cliff: if the restore is still going at that instant, the fix
+    // silently fails to cover the very report it is for. Poll briefly instead,
+    // stopping the moment nodes appear.
+    for (const waitMs of EMPTY_OUTLINE_RECHECK_STEPS_MS) {
+      await sleep(waitMs);
+      const second = await reread();
+      // Redundant with the parsed-null guard below TODAY — an error result carries
+      // no parseable JSON — and kept anyway: it states the intent directly, and
+      // would still hold if an error result ever carried a structured body.
+      if (second.isError) continue;
+      const parsed = parseToolResultJson(second);
+      if (!parsed || parsed.node_count === 0) continue;
+
+      // Nodes appeared — but only adopt them if the canvas is still the SAME
+      // workflow. A changed identity means the second read answers a different
+      // question, so the original (honest, empty) answer stands.
+      const identityAfter = currentWorkflowFence(ctx);
+      if (
+        identityBefore.known &&
+        identityAfter.known &&
+        identityBefore.uuid !== identityAfter.uuid
+      ) {
+        return res;
+      }
+      return second;
+    }
+    return res;
   } catch {
     return res;
   }
 }
 
-/** How long to let a restoring canvas settle before re-reading an empty outline
- *  (#1184). Long enough for a frontend mid-restore to finish attaching nodes,
- *  short enough that a genuinely blank canvas is not a noticeable pause. */
-const EMPTY_OUTLINE_RECHECK_MS = 400;
+/**
+ * The back-off schedule for re-reading an empty outline (#1184).
+ *
+ * A bounded poll rather than one attempt: a restore after a ComfyUI restart has
+ * no guaranteed duration, so a single fixed wait is an arbitrary cliff that would
+ * silently miss a slower restore (codex review). Stops the moment nodes appear.
+ *
+ * Bounded deliberately at ~1.2s total. A genuinely blank canvas is a COMMON
+ * state and pays this whole cost, so it has to stay small enough not to be felt;
+ * a longer poll would buy rarer restores at the expense of every empty read.
+ */
+const EMPTY_OUTLINE_RECHECK_STEPS_MS = [250, 400, 550] as const;
 
 function markBudgetIgnored(res: ToolResult, requested: unknown): ToolResult {
   if (typeof requested !== "number") return res;
@@ -6611,6 +6644,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           markBudgetIgnored(
             // #1184 — an empty outline is re-verified before it is believed.
             await confirmEmptyOutline(
+              ctx,
               await ctx.call({ cmd: "graph_outline", max_chars: args.max_chars }),
               () => ctx.call({ cmd: "graph_outline", max_chars: args.max_chars }),
             ),

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1586,6 +1586,68 @@ function withTruncationHints(res: ToolResult, rules: TruncationRule[]): ToolResu
  * the bound this tool advertises did not apply. The flag is stripped again before the
  * result is returned — it exists only to drive the rider.
  */
+/**
+ * A 0-node outline is a CLAIM, and one made mid-restore is not established (#1184).
+ *
+ * Right after a ComfyUI restart and a tab switch, graph_outline returned
+ * `node_count: 0` for a tab holding a 7-node starter graph — the frontend was
+ * still restoring, and the canvas transiently had nothing on it. The agent
+ * trusted the empty read, reported the canvas empty, and BUILT A NEW 9-NODE
+ * PIPELINE alongside the invisible one. A later panel_query_graph showed 16
+ * nodes: ids 1–7 had been there the whole time, which the frontend knew, because
+ * the new adds started at id 8.
+ *
+ * That is the worst shape of this defect class, because the action taken on the
+ * false read DESTROYS WORK: a duplicate pipeline cannot be un-built, and the user
+ * is left with two overlapping graphs and no way to tell which nodes are theirs.
+ *
+ * It is also unusually cheap to get right. Unlike most "could not determine"
+ * cases, an empty outline is trivially RE-VERIFIABLE: read it again, and the
+ * restore has either finished or it has not.
+ *
+ * So an empty first read is re-read once after a short settle:
+ *   - second read non-empty  → the first was a race; report the real graph.
+ *   - second read still empty → "empty" is now OBSERVED TWICE, not assumed, and
+ *     is reported plainly with no hedge (a blank canvas is a normal state and
+ *     must not be narrated as suspicious).
+ *
+ * The whole cost lands on the genuinely-empty case — one extra cheap read — which
+ * is the right place for it: a blank canvas is common but harmless to re-check,
+ * while a false empty is rare and expensive.
+ *
+ * Never throws: a failed re-read leaves the original reply exactly as it was.
+ */
+async function confirmEmptyOutline(
+  res: ToolResult,
+  reread: () => Promise<ToolResult>,
+): Promise<ToolResult> {
+  try {
+    if (res.isError) return res;
+    const first = parseToolResultJson(res);
+    if (!first || first.node_count !== 0) return res;
+    await sleep(EMPTY_OUTLINE_RECHECK_MS);
+    const second = await reread();
+    // Redundant with the parsed-null guard below TODAY — an error result carries
+    // no parseable JSON, so that branch already returns `res` — and kept anyway:
+    // it states the intent directly, and it would still hold if an error result
+    // ever carried a structured body. No test kills this line alone; saying so
+    // beats inventing one that pretends otherwise.
+    if (second.isError) return res;
+    const parsed = parseToolResultJson(second);
+    // Only a NON-empty second read replaces the first. A second empty read is the
+    // same answer, and returning the original keeps every other field it carried.
+    if (!parsed || parsed.node_count === 0) return res;
+    return second;
+  } catch {
+    return res;
+  }
+}
+
+/** How long to let a restoring canvas settle before re-reading an empty outline
+ *  (#1184). Long enough for a frontend mid-restore to finish attaching nodes,
+ *  short enough that a genuinely blank canvas is not a noticeable pause. */
+const EMPTY_OUTLINE_RECHECK_MS = 400;
+
 function markBudgetIgnored(res: ToolResult, requested: unknown): ToolResult {
   if (typeof requested !== "number") return res;
   const payload = parseToolResultJson(res);
@@ -6547,7 +6609,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // The synthetic `__budget_ignored` flag below is derived from the reply, not
           // sent by the panel: a build that supports the budget echoes `max_chars` back.
           markBudgetIgnored(
-            await ctx.call({ cmd: "graph_outline", max_chars: args.max_chars }),
+            // #1184 — an empty outline is re-verified before it is believed.
+            await confirmEmptyOutline(
+              await ctx.call({ cmd: "graph_outline", max_chars: args.max_chars }),
+              () => ctx.call({ cmd: "graph_outline", max_chars: args.max_chars }),
+            ),
             args.max_chars,
           ),
           [


### PR DESCRIPTION
Fixes #1184. **Draft — claiming the issue, work in progress.**

## The report

Right after a ComfyUI restart and a tab switch, `panel_graph_outline` returned `node_count: 0` with an empty outline for a tab that actually held a 7-node starter graph. The agent trusted it, reported the canvas empty, and **built a new 9-node pipeline alongside the invisible existing one**. A later `panel_query_graph` showed 16 nodes — the pre-existing ids 1–7 had been there all along, which the frontend knew, since the new adds started at id 8.

## Why this is the worst shape of the house defect

An empty read is indistinguishable from an empty canvas, and here the *action taken on it destroys work*: you cannot un-build a duplicate pipeline, and the user is left with two overlapping graphs and no indication which nodes are theirs.

It is also cheap to get right. Unlike most "could not determine" cases, a 0-node outline is **trivially re-verifiable** — reading it again costs one round trip, and the restore either finished or it did not.

## Plan

Treat a 0-node outline as a claim requiring confirmation rather than an observation to report:

- when the outline comes back empty, re-read once after a short settle before reporting;
- if the second read is non-empty, the first was a race and the real graph is reported;
- if it is still empty, "empty" is now established rather than assumed, and can be reported plainly.

The cost falls entirely on the genuinely-empty case (one extra cheap read), which is the correct place to put it. A blank canvas is common but harmless to re-check; a false empty is rare and expensive.

Investigate first whether the orchestrator can additionally *know* a restore is in flight (a recent hello / reconnect), since that would let the disclosure be specific rather than generic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)