### PR TITLE
fix(logs): stop redacting file paths and module names, and filter the log BEFORE scrubbing

### DIFF
--- a/src/__tests__/comfyui/log-overredaction.test.ts
+++ b/src/__tests__/comfyui/log-overredaction.test.ts
@@ -1,0 +1,133 @@
+// #1223 — the #1206 scrub redacted the diagnosis.
+//
+// `get_system_stats action:"logs"` came back with every custom-node path and
+// every dotted module name replaced by «redacted»:
+//
+//   [INFO]  0.0 seconds (IMPORT FAILED): «redacted»
+//     - «redacted»: ImportError: cannot import name 'pad' from '«redacted»' («redacted»)
+//
+// Diagnosing an IMPORT FAILED needs exactly those two things — which pack failed
+// (a path) and which module the missing symbol came from. Redacting both reduces
+// the log tool to "something, somewhere, failed", and the reporter had to bypass
+// it and curl ComfyUI's own endpoint to get the answer.
+//
+// The cause: the opaque-run pass matches 24+ characters of an alphabet that
+// includes `/`, `.`, `-` and `_`, on the reasoning that "ordinary prose breaks
+// well before 24 chars". True of prose. False of a LOG, where paths are the
+// dominant content.
+//
+// These are the real strings from the report. This file exists to keep them
+// readable — but a redaction test that only checks the KEPT direction is
+// worthless, so the credential half is asserted right alongside them.
+
+import { describe, expect, it, vi } from "vitest";
+
+const HF = "hf_aBcD3fGh1jKlMnOpQrStUvWxYz";
+
+vi.mock("../../config.js", () => ({
+  getComfyUIAuthHeaders: () => ({}),
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  config: { huggingfaceToken: HF, civitaiApiToken: undefined, comfyuiApiKey: undefined },
+}));
+
+const { scrubLogLines } = await import("../../comfyui/json-guard.js");
+
+const one = (line: string): string => scrubLogLines([line])[0];
+
+describe("a log keeps its paths and module names (#1223)", () => {
+  // Verbatim from the issue.
+  it.each([
+    ["custom-node path", "[INFO]   10.8 seconds: /basedir/custom_nodes/comfyui-easy-use"],
+    ["IMPORT FAILED path", "[INFO]    0.0 seconds (IMPORT FAILED): /basedir/custom_nodes/ComfyUI-LTXVideo"],
+    ["dotted module", "cannot import name 'pad' from 'kornia.geometry.transform.pyramid'"],
+    [
+      "site-packages file",
+      "(/comfy/mnt/venv/lib/python3.12/site-packages/kornia/geometry/transform/pyramid.py)",
+    ],
+    ["module-not-found", "  - .VRGDG_LTXLoopingSampler: ModuleNotFoundError: No module named 'ComfyUI-LTXVideo'"],
+    ["output dir", "[VRGDG] Created 12 placeholder text file(s) in /basedir/output/VRGDG_TEMP/TextFiles"],
+    ["windows path", "C:/Users/artokun/comfy/custom_nodes/ComfyUI-AnimateDiff-Evolved/nodes.py"],
+    ["model filename", "loading model sd_xl_base_1.0.safetensors from checkpoints"],
+    // DIGIT-LED names. Found by mutation: a letters-then-digits rule reads `4x`
+    // as a blob, so the most common upscale filenames in any ComfyUI log would
+    // have come back redacted — the very bug this fixes.
+    ["digit-led upscale model", "/basedir/models/upscale_models/4x-UltraSharp.pth"],
+    ["digit-led ESRGAN variant", "/basedir/models/upscale_models/8x_NMKD-Superscale.pth"],
+    ["versioned checkpoint", "/basedir/models/checkpoints/v2-1_768-ema-pruned.ckpt"],
+    // INTERLEAVED digits. `t5xxl` has one in the middle, and so do half the
+    // text-encoder filenames in a modern ComfyUI log.
+    ["interleaved text encoder", "/basedir/models/text_encoders/t5xxl_fp16.safetensors"],
+    ["interleaved fp8 encoder", "/basedir/models/text_encoders/umt5_xxl_fp8_e4m3fn.safetensors"],
+  ])("keeps %s intact", (_name, line) => {
+    expect(one(line)).toBe(line);
+  });
+
+  it("keeps the pack name a keyword search would look for", () => {
+    // The concrete downstream failure: the substring has to survive, or the
+    // filter finds nothing and the tool claims the line does not exist.
+    const line = "[INFO]    0.0 seconds (IMPORT FAILED): /basedir/custom_nodes/ComfyUI-LTXVideo";
+    expect(one(line).toLowerCase()).toContain("ltxvideo");
+  });
+});
+
+// THE OTHER DIRECTION. Narrowing a redaction rule is only safe if the thing it
+// was for still goes. Each of these is a shape the old flat rule caught, and
+// every one must still be caught by the new structure-aware one.
+describe("credential shapes are still redacted (#1223)", () => {
+  it.each([
+    ["configured HF token", `[INFO] using ${HF} for auth`],
+    ["unknown base64 blob", "[INFO] sig=YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY3ODkw"],
+    ["hex digest", "[INFO] checksum d41d8cd98f00b204e9800998ecf8427e1a2b3c4d"],
+    ["digit-led opaque run", "[INFO] id 9f2b7c41aa6e4d0e8b3f5a1c7e9d0b2f4a6c8e1d"],
+    // Prefixed-key shape (`<prefix>_<blob>`). Deliberately NOT spelled like any
+    // real vendor's live-key format — the first draft used one and GitHub push
+    // protection rejected the commit, which is the correct outcome for a fixture
+    // that pattern-matches a credential a scanner has to treat as real.
+    ["prefixed vendor key", "[INFO] zq_demo_KjLmNoPqRsTuVwXyZ0123456789abcdef"],
+    ["jwt-ish segment", "[INFO] eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9abcdefgh"],
+  ])("still redacts a %s", (_name, line) => {
+    const out = one(line);
+    expect(out).toContain("redacted");
+    expect(out).not.toBe(line);
+  });
+
+  it("redacts a token EMBEDDED in an otherwise ordinary path", () => {
+    // The interesting mixed case: real structure around a real blob. The path
+    // must survive and the blob must not.
+    const out = one(`GET /basedir/custom_nodes/${HF}/x.py`);
+    expect(out).not.toContain(HF);
+    expect(out).toContain("custom_nodes");
+  });
+
+  // SEPARATED blobs — the ones that actually exercise the per-part word test.
+  //
+  // Found by mutation: making the word test return `true` unconditionally killed
+  // nothing, because every credential fixture above is either a CONFIGURED value
+  // (caught by name in pass 1) or has no `/` or `.` at all (so it short-circuits
+  // as one unbroken blob and never reaches the word test). The branch that
+  // decides whether a SEPARATED run is a path or a secret had no coverage — and
+  // it is the only branch this change actually loosened.
+  it.each([
+    ["a real 3-part JWT", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r"],
+    ["standard base64 carrying a slash", "YWJjZGVmZ2hpamts/bW5vcHFyc3R1dnd4eXoxMjM0"],
+    ["an unknown token inside a path", "/basedir/custom_nodes/QNhK3xVmZp0RtLwYc7BdEf9Gs2Ju/x.py"],
+    ["a dotted opaque pair", "aGVsbG93b3JsZGZvb2Jhcg.YmFyYmF6cXV4Y29ycmdl"],
+    // No digits at all, so only the LENGTH cap can catch it — a chunk this long
+    // is not a word whatever its spelling.
+    ["a long all-alphabetic blob in a path", "/api/v1/QNhKxVmZpRtLwYcBdEfGsJuAbCdEfGhIjKl/logs"],
+    // Interleaved and past the short-name allowance: a hex session id in a path
+    // is the shape the digits-at-the-edges rule exists for, and it is under the
+    // length cap, so ONLY that rule can catch it.
+    ["a hex id inside a route", "/api/v1/sessions/9f2b7c41aa6e4d0e/logs"],
+  ])("redacts %s even though it is separated", (_name, blob) => {
+    const out = one(`[INFO] value ${blob}`);
+    expect(out, `leaked: ${out}`).not.toContain(blob);
+    expect(out).toContain("redacted");
+  });
+
+  it("redacts a labelled secret whatever its shape", () => {
+    // Pass 2 is untouched by this change, and it is what covers a credential
+    // that happens to be spelled like a word.
+    expect(one("[INFO] api_key=correcthorsebatterystaple")).not.toContain("correcthorse");
+  });
+});

--- a/src/__tests__/comfyui/log-overredaction.test.ts
+++ b/src/__tests__/comfyui/log-overredaction.test.ts
@@ -131,3 +131,55 @@ describe("credential shapes are still redacted (#1223)", () => {
     expect(one("[INFO] api_key=correcthorsebatterystaple")).not.toContain("correcthorse");
   });
 });
+
+// CODEX REVIEW of this fix. It constructed credentials that the narrowed rule
+// let through, and the two that were real are pinned here.
+describe("codex review: credentials that survived the first draft (#1223)", () => {
+  it("redacts a dotted token whose every part is individually name-shaped", () => {
+    // Four 8-character mixed chunks. Each one passes the short-name allowance on
+    // its own; granting that allowance per PART rather than per RUN let the whole
+    // token out. A real name spends it at most once.
+    //
+    // Deliberately NO `Bearer` in front of it: the first version of this test had
+    // one, so the scheme rule caught the line and the budget mutation survived —
+    // the test proved the wrong mechanism. This is the shape rule alone.
+    const token = "AbcD3fGh.IjKl9mNo.PqRs7tUv.WxYz2aBc";
+    const out = one(`[WARN] upstream rejected ${token}`);
+    expect(out, `leaked: ${out}`).not.toContain(token);
+    // And NOT part-by-part: redacting the parts after the budget ran out would
+    // still emit the first eight characters, which is a partial credential and a
+    // false impression that the line was handled.
+    expect(out, `leaked a fragment: ${out}`).not.toContain("AbcD3fGh");
+  });
+
+  it("redacts a bare `Bearer <token>` with no field name in front of it", () => {
+    // No `=` or `:`, so the by-name pass never saw it — the flat opaque rule was
+    // carrying this case by accident, and narrowing it exposed the gap.
+    const token = "ABCDEFGHIJKLMNOPQRS/TUVWXYZabcdefghijklm";
+    const out = one(`[WARN] upstream rejected Bearer ${token}`);
+    expect(out, `leaked: ${out}`).not.toContain(token);
+  });
+
+  it.each([
+    // Short enough that the scheme rule's length floor already excludes it.
+    "[INFO] bearer authentication succeeded for the configured host",
+    // Long enough to reach the rule — only the all-lowercase guard keeps this
+    // one intact, and without it the log would read "basic «redacted» of ...".
+    "[INFO] basic responsibilities of the node were restored after reload",
+  ])("does NOT fire on an auth-scheme word used as ordinary English: %s", (line) => {
+    // The other direction of the same rule: over-redacting prose would be the
+    // same mistake this whole issue is about.
+    expect(one(line)).toBe(line);
+  });
+
+  it("keeps a model name that spends the mixed allowance exactly once", () => {
+    // The budget must be one, not zero — these are real filenames.
+    for (const line of [
+      "/basedir/models/text_encoders/umt5_xxl_fp8_e4m3fn.safetensors",
+      "/basedir/models/diffusion_models/wan2.1_t2v_1.3B_bf16.safetensors",
+      "/basedir/models/checkpoints/hunyuan_video_t2v_720p_bf16.safetensors",
+    ]) {
+      expect(one(line), line).toBe(line);
+    }
+  });
+});

--- a/src/__tests__/comfyui/log-scrub.test.ts
+++ b/src/__tests__/comfyui/log-scrub.test.ts
@@ -107,10 +107,22 @@ describe("both log consumers scrub (#1206)", () => {
     );
 
     // getLogs has TWO return paths — JSON-encoded and raw text — and both carry
-    // the same exposure.
+    // the same exposure. They now converge on one selectAndScrubLogLines call
+    // (#1223, which moved the caller's keyword filter in front of the scrub), so
+    // what has to be true is that NO return path skips it: every `return` in the
+    // body is either that call or the cloud branch, which throws.
     const start = client.indexOf("export async function getLogs");
     const body = client.slice(start, client.indexOf("\n}", start));
-    expect(body.split("scrubLogLines(").length - 1).toBe(2);
+    const returns = body.match(/return .*/g) ?? [];
+    expect(returns.length).toBeGreaterThan(0);
+    for (const r of returns) {
+      expect(r, `a getLogs return path skips the scrub: ${r}`).toMatch(
+        /selectAndScrubLogLines\(|cloudClient\.getLogs\(\)/,
+      );
+    }
+    // And the helper they converge on actually scrubs.
+    const helper = client.slice(client.indexOf("function selectAndScrubLogLines"));
+    expect(helper.slice(0, helper.indexOf("\n}"))).toContain("scrubLogLines(");
 
     // The health report emits matching error lines into its own text.
     expect(health).toContain("scrubLogLines(");

--- a/src/__tests__/comfyui/log-select-order.test.ts
+++ b/src/__tests__/comfyui/log-select-order.test.ts
@@ -1,0 +1,114 @@
+// #1223 — the log was FILTERED AFTER it was REDACTED.
+//
+// `get_system_stats action:"logs"` read the whole log, scrubbed it, and only
+// then applied the caller's keyword. So a keyword matching any text the scrub
+// had rewritten found nothing, and the tool answered:
+//
+//     No log lines found matching "ltxvideo".
+//
+// for a log that contained it. That is a FALSE ABSENCE, and it is worse than a
+// redacted match by a wide margin: a redacted line still tells the caller the
+// event happened, when, and in what context, and they can go look. "No log lines
+// found" tells them to stop looking.
+//
+// The ordering is now structural rather than remembered — `getLogs` takes the
+// selection and never hands raw lines out, so no call site CAN filter after the
+// scrub. These tests pin the order, because a future refactor that moves
+// filtering back out would still pass every redaction test in the suite.
+
+import { describe, expect, it, vi } from "vitest";
+
+// Force local mode and stub the underlying SDK Client so /internal/logs is
+// served from this file and never from a real ComfyUI. Mirrors
+// get-logs-retry.test.ts — and it is load-bearing: the first draft mocked a
+// module client.ts does not import, so these tests silently reached the ComfyUI
+// running on this machine and asserted against ITS log.
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
+  return {
+    ...actual,
+    isCloudMode: () => false,
+    getComfyUIApiHost: () => "127.0.0.1:8188",
+    getComfyUIAuthHeaders: () => ({}),
+    config: { ...actual.config, comfyuiApiKey: undefined, huggingfaceToken: undefined, civitaiApiToken: undefined },
+  };
+});
+
+const fetchApi = vi.fn();
+vi.mock("@stable-canvas/comfyui-client", () => ({
+  Client: class {
+    apiURL(p: string) {
+      return p;
+    }
+    apiHeaders(init?: { headers?: unknown }) {
+      return (init && init.headers) || {};
+    }
+    async fetch(u: string, init?: unknown) {
+      return (this as unknown as { fetchApi: (u: string, i?: unknown) => unknown }).fetchApi(u, init);
+    }
+    fetchApi = fetchApi;
+    close() {}
+  },
+}));
+
+const { getLogs } = await import("../../comfyui/client.js");
+
+/** Serve `lines` as ComfyUI's raw-text /internal/logs body. */
+function serve(lines: string[]): void {
+  fetchApi.mockReset();
+  fetchApi.mockResolvedValue({ text: async () => lines.join("\n") });
+}
+
+const IMPORT_FAILED = "[INFO] 0.0 seconds (IMPORT FAILED): /basedir/custom_nodes/ComfyUI-LTXVideo";
+
+describe("getLogs selects BEFORE it scrubs (#1223)", () => {
+  it("finds the pack name the reporter searched for", async () => {
+    serve(["[INFO] boot", IMPORT_FAILED, "[INFO] done"]);
+    expect(await getLogs({ keyword: "ltxvideo" })).toEqual([IMPORT_FAILED]);
+  });
+
+  it("matches text that the scrub will then REDACT", async () => {
+    // The ordering's whole point, isolated: a checksum a user is grepping for is
+    // credential-shaped, so it IS redacted — and must still be findable. Under
+    // the old order this returned "No log lines found".
+    const digest = "d41d8cd98f00b204e9800998ecf8427e1a2b3c4d";
+    serve(["[INFO] boot", `[INFO] verified ${digest}`]);
+    const out = await getLogs({ keyword: digest });
+
+    expect(out, "the line must be FOUND").toHaveLength(1);
+    expect(out[0], "and it must still be redacted").not.toContain(digest);
+    expect(out[0], "with enough context to be worth having").toContain("verified");
+  });
+
+  it("tails to maxLines AFTER filtering, not before", async () => {
+    // A tail applied first would return the last N lines of the WHOLE log and
+    // then filter them — quietly answering about the wrong window.
+    serve(["error one", "error two", "boot ok", "shutdown ok"]);
+    expect(await getLogs({ keyword: "error", maxLines: 1 })).toEqual(["error two"]);
+  });
+
+  it("returns every line when no keyword is given", async () => {
+    serve(["a", "b"]);
+    expect(await getLogs()).toEqual(["a", "b"]);
+  });
+
+  it("treats an EMPTY keyword as no filter, as it always has", async () => {
+    serve(["a", "b"]);
+    expect(await getLogs({ keyword: "" })).toEqual(["a", "b"]);
+  });
+
+  it("still scrubs when nothing is selected away", async () => {
+    // The narrowing must not create a path where the scrub is skipped.
+    serve(["[INFO] sig=YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY3ODkw"]);
+    expect((await getLogs())[0]).toContain("redacted");
+  });
+
+  it("handles ComfyUI's JSON-encoded log body the same way", async () => {
+    // /internal/logs is a JSON string on some versions and raw text on others,
+    // and the selection has to apply to both — a version-shaped hole here would
+    // put the filter back after the scrub for half the fleet.
+    fetchApi.mockReset();
+    fetchApi.mockResolvedValue({ text: async () => JSON.stringify(["x", IMPORT_FAILED].join("\n")) });
+    expect(await getLogs({ keyword: "ltxvideo" })).toEqual([IMPORT_FAILED]);
+  });
+});

--- a/src/__tests__/tools/system-stats.test.ts
+++ b/src/__tests__/tools/system-stats.test.ts
@@ -145,27 +145,32 @@ describe("get_system_stats actions call the same services with the same argument
     expect(mocks.runHealthCheck).not.toHaveBeenCalled();
   });
 
-  // The non-matching lines sit LAST on purpose: a tail that ignored `keyword`
-  // would return them, and this assertion catches it. With the noise first, a
-  // broken filter still produced the right two lines and the test passed.
-  it('action:"logs" filters by keyword, tails to max_lines and strips ANSI', async () => {
-    mocks.getLogs.mockResolvedValueOnce([
-      "\x1b[31mERROR one\x1b[0m",
-      "error two",
-      "error three",
-      "boot ok",
-      "shutdown ok",
-    ]);
-    const res = await call({ action: "logs", keyword: "error", max_lines: 2 });
-    expect(text(res)).toBe("error two\nerror three");
+  // #1223 — the keyword filter and the tail MOVED into getLogs, so they run on
+  // the raw log before redaction. Filtering here matched against text the scrub
+  // had already rewritten, and answered "No log lines found" for lines that were
+  // right there. What this tool still owns is FORWARDING them, and the selection
+  // semantics themselves are tested in log-select-order.test.ts.
+  it('action:"logs" forwards the keyword and the tail to getLogs', async () => {
+    mocks.getLogs.mockResolvedValueOnce([]);
+    await call({ action: "logs", keyword: "error", max_lines: 2 });
+    expect(mocks.getLogs).toHaveBeenCalledWith({ keyword: "error", maxLines: 2 });
+  });
 
+  it('action:"logs" forwards the DEFAULT tail of 100 when max_lines is omitted', async () => {
+    // The default has to reach getLogs now — leaving it undefined would return
+    // the whole log, which is the #1146 shape (an omitted limit meaning "all").
+    mocks.getLogs.mockResolvedValueOnce([]);
+    await call({ action: "logs" });
+    expect(mocks.getLogs).toHaveBeenCalledWith({ keyword: undefined, maxLines: 100 });
+  });
+
+  it('action:"logs" strips ANSI from what comes back', async () => {
     mocks.getLogs.mockResolvedValueOnce(["\x1b[31mERROR one\x1b[0m"]);
-    const all = await call({ action: "logs" });
-    expect(text(all)).toBe("ERROR one");
+    expect(text(await call({ action: "logs" }))).toBe("ERROR one");
   });
 
   it('action:"logs" reports the keyword back when nothing matched', async () => {
-    mocks.getLogs.mockResolvedValueOnce(["boot ok"]);
+    mocks.getLogs.mockResolvedValueOnce([]);
     const res = await call({ action: "logs", keyword: "traceback" });
     expect(text(res)).toBe('No log lines found matching "traceback".');
   });
@@ -223,10 +228,10 @@ describe("value constraints are unchanged at the zod layer", () => {
 
   // ...and an explicit max_lines of the schema minimum must not be mistaken for
   // "unset" and replaced by the 100 default.
-  it("max_lines:1 tails to one line rather than falling back to the default", async () => {
-    mocks.getLogs.mockResolvedValueOnce(["a", "b", "c"]);
-    const res = await call({ action: "logs", max_lines: 1 });
-    expect(text(res)).toBe("c");
+  it("max_lines:1 reaches getLogs as 1 rather than falling back to the default", async () => {
+    mocks.getLogs.mockResolvedValueOnce([]);
+    await call({ action: "logs", max_lines: 1 });
+    expect(mocks.getLogs).toHaveBeenCalledWith({ keyword: undefined, maxLines: 1 });
   });
 });
 

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -799,7 +799,20 @@ export function getComfyUIPath(): string | undefined {
   return config.comfyuiPath;
 }
 
-export async function getLogs(): Promise<string[]> {
+/**
+ * Which lines the caller wants — applied to the RAW log, before redaction.
+ * See `selectAndScrubLogLines` for why this cannot be the caller's job (#1223).
+ */
+export interface GetLogsOptions {
+  /** Case-insensitive substring the line must contain. */
+  keyword?: string;
+  /** Keep only the last N matching lines. */
+  maxLines?: number;
+}
+
+export async function getLogs(opts?: GetLogsOptions): Promise<string[]> {
+  // Cloud mode has no /internal/logs equivalent; this always throws
+  // CLOUD_UNSUPPORTED, so there is nothing to select or scrub.
   if (isCloudMode()) return cloudClient.getLogs();
 
   // A managed/panel restart or Manager reboot leaves the cached client bound to
@@ -838,15 +851,43 @@ export async function getLogs(): Promise<string[]> {
 
   // ComfyUI returns logs as a JSON-encoded string with \n separators,
   // or as raw text depending on version. Handle both.
+  let lines: string[];
   try {
     const parsed = JSON.parse(text);
-    if (typeof parsed === "string") {
-      return scrubLogLines(parsed.split("\n").filter(Boolean));
-    }
+    lines = (typeof parsed === "string" ? parsed : text).split("\n").filter(Boolean);
   } catch {
     // Not JSON — treat as raw text
+    lines = text.split("\n").filter(Boolean);
   }
-  return scrubLogLines(text.split("\n").filter(Boolean));
+  return selectAndScrubLogLines(lines, opts);
+}
+
+/**
+ * Select the requested lines, THEN scrub them (#1223).
+ *
+ * The order is the whole point, and getting it backwards is a false ABSENCE:
+ * `get_system_stats action:"logs"` filtered by keyword AFTER this function had
+ * already redacted, so a keyword matching redacted text — `keyword:"ltxvideo"`,
+ * `keyword:"LTXLoopingSampler"` — reported "No log lines found" while the
+ * matching lines sat in the log. Reporting nothing found is much worse than
+ * reporting a redacted match: the caller stops looking.
+ *
+ * Selection lives HERE rather than in the caller so the raw text never leaves
+ * this function. Callers get scrubbed lines and cannot filter on anything else,
+ * which is what makes the ordering a property of the code rather than a rule
+ * every future call site has to remember.
+ */
+function selectAndScrubLogLines(lines: string[], opts?: GetLogsOptions): string[] {
+  let selected = lines;
+  if (opts?.keyword) {
+    const kw = opts.keyword.toLowerCase();
+    selected = selected.filter((line) => line.toLowerCase().includes(kw));
+  }
+  // Tail before scrubbing: strictly less work, and identical output either way.
+  if (typeof opts?.maxLines === "number" && selected.length > opts.maxLines) {
+    selected = selected.slice(-opts.maxLines);
+  }
+  return scrubLogLines(selected);
 }
 
 

--- a/src/comfyui/json-guard.ts
+++ b/src/comfyui/json-guard.ts
@@ -384,6 +384,21 @@ export function scrubSecretShapedText(text: string): string | null {
       `${name}${sep}${scheme ? `${scheme}${gap ?? " "}` : ""}${REDACTED}`,
   );
 
+  // 2b. A credential introduced by its AUTH SCHEME rather than by a field name.
+  //     `Bearer <token>` in a log line has no `=` or `:`, so pass 2 never saw it
+  //     — the flat opaque-run rule was carrying it by accident, and narrowing
+  //     that rule is what made the gap visible (codex review of #1223).
+  //
+  //     Named schemes only, and only for a value long enough and mixed enough to
+  //     be a credential: `Bearer` is also an ordinary English word, and a rule
+  //     that fires on "token authentication failed" would be the same class of
+  //     mistake in the other direction.
+  out = out.replace(
+    /\b(bearer|basic)(\s+)([A-Za-z0-9\-._~+/=%]{16,})/gi,
+    (whole, scheme: string, gap: string, value: string) =>
+      /^[a-z]+$/.test(value) ? whole : `${scheme}${gap}${REDACTED}`,
+  );
+
   // 3. Long opaque runs of the credential alphabet (base64 / hex / url-safe /
   //    percent-encoded). Ordinary prose and HTML break well before 24 chars —
   //    tags, spaces and punctuation are all outside this class.
@@ -429,23 +444,43 @@ export function scrubSecretShapedText(text: string): string | null {
  * is newly allowed through is a run that carries no credential label, matches no
  * configured value, and is spelled like a path or an identifier.
  *
- * ACCEPTED RESIDUAL: an unlabelled, unknown, ALL-ALPHABETIC secret of 24+ chars
- * with no interleaved digits reads as a word and survives. That is a narrow
- * shape — base64 and hex of that length carry digits with overwhelming
- * probability — and it is the deliberate trade for a log tool that can still
- * name the pack that failed to import.
+ * ACCEPTED RESIDUAL, stated precisely because a redaction rule that overstates
+ * its own coverage is worse than one that admits a gap: an unlabelled secret
+ * that this process does not hold, whose separator-delimited parts are EVERY ONE
+ * of them alphabetic (or digit-edged) and under 20 characters, reads as a name
+ * and survives — `ABCDEFGHIJKLMNOPQRS/TUVWXYZabcdefghijklm`.
+ *
+ * No shape rule can close that: a token spelled entirely in path-like parts IS
+ * shaped like a path, and the same rule that redacts it redacts
+ * `/models/upscale_models/4x-UltraSharp.pth`. Base64 and hex reach it with low
+ * probability — every part alphabetic, no digits anywhere — and a credential
+ * that IS held, or that arrives with a name or an auth scheme in front of it, is
+ * caught by passes 1, 2 and 2b regardless of shape. That is the trade, and it is
+ * the right one for a tool whose entire purpose is naming the thing that broke.
  */
 function redactOpaqueRun(run: string): string {
   const parts = run.split(/([/.])/);
   // No separator: one unbroken blob, which is the shape this pass was built for.
   if (parts.length === 1) return REDACTED;
-  return parts
-    .map((part) =>
-      part === "/" || part === "." || part === "" || looksLikeWords(part)
-        ? part
-        : REDACTED,
-    )
-    .join("");
+
+  // The interleave allowance is BUDGETED across the whole run, not granted per
+  // part (codex review of #1223). Granted per part, four of them in a row spell
+  // a credential that every individual test waves through:
+  //
+  //     Bearer AbcD3fGh.IjKl9mNo.PqRs7tUv.WxYz2aBc
+  //
+  // Every chunk there is eight characters of mixed case and digits — a shape a
+  // real name reaches at most once (`t5xxl_fp16`, `umt5_xxl_fp8_e4m3fn`), and a
+  // random token reaches every time. So one is a name and several is a blob.
+  const budget = { mixed: 1 };
+  const kept = parts.map((part) =>
+    part === "/" || part === "." || part === "" || looksLikeWords(part, budget)
+      ? part
+      : REDACTED,
+  );
+  // Over budget means the run was never a name — redact it whole rather than
+  // leave the parts that happened to be judged before the budget ran out.
+  return budget.mixed < 0 ? REDACTED : kept.join("");
 }
 
 /** Longest chunk still plausibly a word and not a blob. `AnimateDiff` is 11. */
@@ -479,17 +514,21 @@ const MAX_MIXED_CHUNK = 8;
  * out as `/basedir/models/upscale_models/«redacted».pth`, reintroducing exactly
  * the bug being fixed on some of the most common filenames in a ComfyUI log.
  */
-function looksLikeWords(part: string): boolean {
+function looksLikeWords(part: string, budget: { mixed: number }): boolean {
   const chunks = part.split(/[-_+=~%]/).filter((c) => c.length > 0);
   if (chunks.length === 0) return false;
-  return chunks.every(isNameChunk);
+  // `every` would short-circuit and stop spending, which would make the budget
+  // depend on which part happened to fail first.
+  return chunks.map((c) => isNameChunk(c, budget)).every(Boolean);
 }
 
-function isNameChunk(c: string): boolean {
+function isNameChunk(c: string, budget: { mixed: number }): boolean {
   if (c.length > MAX_WORD_CHUNK) return false;
   if (/^\d+$/.test(c)) return true; // 768, 12
   if (/^\d*[A-Za-z]+\d*$/.test(c)) return true; // ComfyUI, python3, 4x, v1
-  return c.length <= MAX_MIXED_CHUNK; // t5xxl, x4v3 — see MAX_MIXED_CHUNK
+  if (c.length > MAX_MIXED_CHUNK) return false;
+  budget.mixed -= 1; // t5xxl, x4v3 — see MAX_MIXED_CHUNK and redactOpaqueRun
+  return budget.mixed >= 0;
 }
 
 /**

--- a/src/comfyui/json-guard.ts
+++ b/src/comfyui/json-guard.ts
@@ -387,9 +387,109 @@ export function scrubSecretShapedText(text: string): string | null {
   // 3. Long opaque runs of the credential alphabet (base64 / hex / url-safe /
   //    percent-encoded). Ordinary prose and HTML break well before 24 chars —
   //    tags, spaces and punctuation are all outside this class.
-  out = out.replace(/[A-Za-z0-9\-._~+/=%]{24,}/g, REDACTED);
+  //
+  //    But a FILESYSTEM PATH and a DOTTED MODULE NAME do not (#1223): `/`, `.`,
+  //    `-` and `_` are all in this alphabet, so `/basedir/custom_nodes/ComfyUI-
+  //    LTXVideo` and `kornia.geometry.transform.pyramid` matched whole and left
+  //    `«redacted»`. See `redactOpaqueRun` — it keeps the structure and redacts
+  //    only the parts that are actually opaque.
+  out = out.replace(/[A-Za-z0-9\-._~+/=%]{24,}/g, redactOpaqueRun);
 
   return out;
+}
+
+/**
+ * Redact the credential-shaped PARTS of a long run, keeping the structure.
+ *
+ * #1223 — the flat 24-char rule assumed "ordinary prose breaks well before 24
+ * chars". True of prose; false of a LOG, where paths and dotted module names are
+ * the dominant content and routinely run past 24. So the pass that exists to
+ * catch an unanticipated credential encoding erased the diagnosis instead:
+ *
+ *     [INFO]  0.0 seconds (IMPORT FAILED): «redacted»
+ *       - «redacted»: ImportError: cannot import name 'pad' from '«redacted»'
+ *
+ * That is 100% of the content of an IMPORT FAILED line — which pack failed and
+ * which module the missing symbol came from are the only two things the line is
+ * for. The reporter had to bypass the tool and curl ComfyUI directly.
+ *
+ * So the run is split on the separators that give it STRUCTURE (`/` and `.`) and
+ * each part judged on its own. A part is kept when it is a WORD rather than a
+ * blob — its `-`/`_`/`+`/`=`/`~`/`%` chunks are each letters-then-optional-digits
+ * (`ComfyUI`, `AnimateDiff`, `python3`, `v1`) or all digits, and none is longer
+ * than a plausible word. A credential fails this: its digits interleave with its
+ * letters (`aBcD3fGh1jKlMnOpQrStUvWxYz`), or it starts with one
+ * (`9f2b7c41aa6e4d0e8b3f5a1c`).
+ *
+ * WHAT THIS DOES AND DOES NOT WEAKEN. Only this pass, and only for unlabelled
+ * runs of unknown value. A configured credential is still matched by VALUE in
+ * pass 1 (exactly, in every encoding, failing closed when it cannot be replaced
+ * safely), and anything introduced by its own name — `token=`, `api_key:`,
+ * `Authorization: Bearer` — is still redacted by pass 2 whatever its shape. What
+ * is newly allowed through is a run that carries no credential label, matches no
+ * configured value, and is spelled like a path or an identifier.
+ *
+ * ACCEPTED RESIDUAL: an unlabelled, unknown, ALL-ALPHABETIC secret of 24+ chars
+ * with no interleaved digits reads as a word and survives. That is a narrow
+ * shape — base64 and hex of that length carry digits with overwhelming
+ * probability — and it is the deliberate trade for a log tool that can still
+ * name the pack that failed to import.
+ */
+function redactOpaqueRun(run: string): string {
+  const parts = run.split(/([/.])/);
+  // No separator: one unbroken blob, which is the shape this pass was built for.
+  if (parts.length === 1) return REDACTED;
+  return parts
+    .map((part) =>
+      part === "/" || part === "." || part === "" || looksLikeWords(part)
+        ? part
+        : REDACTED,
+    )
+    .join("");
+}
+
+/** Longest chunk still plausibly a word and not a blob. `AnimateDiff` is 11. */
+const MAX_WORD_CHUNK = 20;
+
+/**
+ * Longest chunk allowed to INTERLEAVE letters and digits and still read as a
+ * name — `t5xxl`, `x4v3`, `sd3m`.
+ *
+ * Model filenames do this constantly (`t5xxl_fp16.safetensors`,
+ * `umt5_xxl_fp8_e4m3fn.safetensors`), and an interleave rule without this
+ * allowance redacts them — the same class of mistake as the flat 24-char rule,
+ * one level down. Kept SHORT because interleaving is otherwise the strongest
+ * signal of a blob: at eight characters a run carries too little entropy to be
+ * worth protecting on its own, and anything longer must justify itself by having
+ * its digits at the edges like a real name does.
+ */
+const MAX_MIXED_CHUNK = 8;
+
+/**
+ * Is this a human-written identifier rather than an opaque blob?
+ *
+ * Chunk-wise, because real names are compounds: `comfyui-easy-use`,
+ * `custom_nodes`, `sd_xl_base_1`. A chunk is a word when its digits sit at the
+ * EDGES — `python3`, `v1`, `4x`, `768` — and a blob when they INTERLEAVE, which
+ * is what `d41d8cd98f00b204` and `aBcD3fGh1jKl` do and what no human name does.
+ *
+ * The leading-digit half of that is not hypothetical: mutation testing showed
+ * this rule started as letters-then-digits, which reads `4x-UltraSharp` as a
+ * blob — so `/basedir/models/upscale_models/4x-UltraSharp.pth` would have gone
+ * out as `/basedir/models/upscale_models/«redacted».pth`, reintroducing exactly
+ * the bug being fixed on some of the most common filenames in a ComfyUI log.
+ */
+function looksLikeWords(part: string): boolean {
+  const chunks = part.split(/[-_+=~%]/).filter((c) => c.length > 0);
+  if (chunks.length === 0) return false;
+  return chunks.every(isNameChunk);
+}
+
+function isNameChunk(c: string): boolean {
+  if (c.length > MAX_WORD_CHUNK) return false;
+  if (/^\d+$/.test(c)) return true; // 768, 12
+  if (/^\d*[A-Za-z]+\d*$/.test(c)) return true; // ComfyUI, python3, 4x, v1
+  return c.length <= MAX_MIXED_CHUNK; // t5xxl, x4v3 — see MAX_MIXED_CHUNK
 }
 
 /**

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -232,19 +232,14 @@ export async function getLogsAction(args: {
   max_lines?: number;
   keyword?: string;
 }): Promise<CallToolResult> {
-  let lines = await getLogs();
-
-  // Filter by keyword if provided
-  if (args.keyword) {
-    const kw = args.keyword.toLowerCase();
-    lines = lines.filter((line) => line.toLowerCase().includes(kw));
-  }
-
-  // Tail to max_lines
+  // #1223 — the keyword filter and the tail are handed to getLogs so they run on
+  // the RAW log, BEFORE redaction. Filtering here meant matching against text the
+  // scrub had already rewritten, so `keyword:"ltxvideo"` answered "No log lines
+  // found" for a log that contained it — an absence claim about a line that was
+  // right there. Selection and redaction have to happen in that order, and the
+  // only way to guarantee it is to not have the raw lines here at all.
   const maxLines = args.max_lines ?? 100;
-  if (lines.length > maxLines) {
-    lines = lines.slice(-maxLines);
-  }
+  const lines = await getLogs({ keyword: args.keyword, maxLines });
 
   // Strip ANSI escape codes for readability
   const clean = lines.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ""));


### PR DESCRIPTION
Fixes #1223.

Two defects, both regressions from the #1206 log scrub:

1. The opaque-run shape pass eats ordinary paths (`/basedir/custom_nodes/ComfyUI-LTXVideo`) and dotted module names (`kornia.geometry.transform.pyramid`), which is 100% of an `IMPORT FAILED` line's content.
2. `get_system_stats action:"logs"` applies the keyword filter AFTER the scrub, so a keyword matching redacted text returns "No log lines found" — reporting absence where there is a match.

Draft while I work it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)