### PR TITLE
chore(release): reconcile main to 0.50.63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.63] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- stop redacting file paths and module names, and filter the log BEFORE scrubbing (#1225)
+
+#### Changed
+- 0.50.62 (#1224)
+
+
 ## [0.50.62] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.62",
+  "version": "0.50.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.62",
+      "version": "0.50.63",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.62",
+  "version": "0.50.63",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the 0.50.63 tag.

Ships #1223 — the log scrub no longer redacts file paths and module names, and the keyword filter runs on the raw log instead of the redacted one.

Live-verified against this machine's real ComfyUI log: the old rule redacted inside 75 of 150 lines; the new one alters none, and a keyword search returns all 75 matching lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)