### PR TITLE
fix(panel): enforce panel_graph_outline's max_chars when the live panel ignores it

### DIFF
--- a/src/__tests__/orchestrator/outline-budget-enforced.test.ts
+++ b/src/__tests__/orchestrator/outline-budget-enforced.test.ts
@@ -1,0 +1,162 @@
+// #1203 — `panel_graph_outline` advertised a bound it did not enforce.
+//
+// A panel build older than the budget protocol ignores `max_chars` and returns
+// the whole outline. The orchestrator NOTICED — it appends a note saying the
+// budget "was NOT applied" — and forwarded the unbounded reply anyway. A caller
+// that explicitly asked for 18000 characters got the full 137-node outline plus
+// a warning about it.
+//
+// A warning is not a bound. The disclosure arrives after the cost is paid, and
+// the cost is the thing the parameter exists to prevent.
+//
+// WHY REFUSING IS THE FIX AND TRUNCATING IS NOT. The tool's contract is that
+// coverage is never traded away — over budget it sheds RESOLUTION and still
+// describes every node, and if even that will not fit it returns NO outline
+// rather than a partial one that reads as complete. Cutting the rendered text at
+// a character count breaks precisely that: the reply would look like a finished
+// outline that simply ends, and a caller acting on it would believe the graph
+// stops where the string does. That is #1184 again with the truncation
+// invisible. Shedding resolution needs the graph; the orchestrator has only the
+// rendering, so it does what the panel does at its own floor.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+let reply: Record<string, unknown>;
+
+function bridge() {
+  return {
+    send: async (cmd: Record<string, unknown>) => (cmd.cmd === "graph_outline" ? reply : { ok: true }),
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: "tab-1", title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => "tab-1",
+    workflowUuidFor: () => ({ known: true, uuid: "11111111-2222-4333-8444-555555555555" }),
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+async function callOutline(args: Record<string, unknown>): Promise<Record<string, any>> {
+  const ctx = makePanelToolCtx(bridge(), "tab-1");
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_graph_outline")!;
+  const res = (await def.handler(args, ctx)) as ToolResult;
+  const t = res.content.find((c) => c.type === "text")!.text as string;
+  return JSON.parse(t.slice(t.indexOf("{"), t.lastIndexOf("}") + 1));
+}
+
+/** An OLD panel: returns the full outline and does NOT echo `max_chars`. */
+const oldPanel = (chars: number, nodes = 137) => ({
+  node_count: nodes,
+  group_count: 4,
+  viewing: "workflow.json",
+  outline: "x".repeat(chars),
+});
+
+beforeEach(() => {
+  reply = oldPanel(60_000);
+});
+
+describe("the orchestrator enforces max_chars the panel ignored (#1203)", () => {
+  it("does NOT forward an outline that blows the bound", async () => {
+    const out = await callOutline({ max_chars: 18_000 });
+    expect(out.outline, "the 60k-char outline must not reach the caller").toBe("");
+    expect(out.detail_level).toBe("refused");
+  });
+
+  it("says WHO applied the bound and how big the reply actually was", async () => {
+    const out = await callOutline({ max_chars: 18_000 });
+    expect(out.budget_applied_by).toBe("orchestrator");
+    expect(out.unbounded_chars).toBe(60_000);
+    // The counts are small, true and independent of the budget — they are the
+    // part of the reply worth keeping.
+    expect(out.node_count).toBe(137);
+    expect(out.group_count).toBe(4);
+  });
+
+  it("names all three levers, including the one that actually fixes it", async () => {
+    const out = await callOutline({ max_chars: 18_000 });
+    const prose = JSON.stringify(out);
+    expect(prose, "raising the bound, WITH its ceiling").toMatch(/Raise `max_chars` up to 60000/);
+    expect(prose, "updating the panel").toMatch(/update the ComfyUI Agent Panel/i);
+    expect(prose, "scoping the read").toContain("panel_query_graph");
+  });
+
+  it("says raising is USELESS when the outline is past the ceiling", async () => {
+    // A dead retry offered inside the message explaining the first failure is
+    // the recurring mistake this repo keeps catching.
+    reply = oldPanel(400_000);
+    const prose = JSON.stringify(await callOutline({ max_chars: 18_000 }));
+    expect(prose).toMatch(/will NOT help/);
+    expect(prose).not.toMatch(/Raise `max_chars` up to/);
+  });
+
+  it("does NOT claim the outline below is unbounded when there is none", async () => {
+    // The old single sentence said exactly that, and it is now false.
+    const prose = JSON.stringify(await callOutline({ max_chars: 18_000 }));
+    expect(prose).not.toMatch(/the outline below is the full, unbounded one/);
+  });
+});
+
+describe("what it must NOT do (#1203)", () => {
+  it("passes through an outline that FITS, even though the panel ignored the bound", async () => {
+    // A bound in name only would be the same defect in the other direction:
+    // refusing a reply that satisfies the request.
+    reply = oldPanel(5_000);
+    const out = await callOutline({ max_chars: 18_000 });
+    expect(out.outline).toHaveLength(5_000);
+    expect(out.detail_level).toBeUndefined();
+    expect(out.budget_applied_by).toBeUndefined();
+  });
+
+  it("tells the truth in the FITS case rather than warning about a flood", async () => {
+    reply = oldPanel(5_000);
+    const prose = JSON.stringify(await callOutline({ max_chars: 18_000 }));
+    expect(prose).toMatch(/happens to fit within your bound/);
+  });
+
+  it("leaves a MODERN panel's reply completely alone", async () => {
+    // It echoes max_chars back, having already walked its own shed ladder. Its
+    // outline legitimately exceeds nothing, and second-guessing it would undo the
+    // coverage guarantee it just honoured.
+    reply = {
+      node_count: 137,
+      group_count: 4,
+      outline: "y".repeat(60_000),
+      max_chars: 18_000,
+      detail_level: "no_values",
+      degraded: true,
+      degraded_reason: "Per-node detail reduced.",
+    };
+    const out = await callOutline({ max_chars: 18_000 });
+    expect(out.outline).toHaveLength(60_000);
+    expect(out.detail_level).toBe("no_values");
+    expect(out.budget_applied_by).toBeUndefined();
+  });
+
+  it("leaves the reply alone when the caller set NO bound", async () => {
+    // No bound means no bound. The default belongs to the panel, and inventing
+    // one here would refuse a call that asked for everything.
+    reply = oldPanel(60_000);
+    const out = await callOutline({});
+    expect(out.outline).toHaveLength(60_000);
+    expect(out.detail_level).toBeUndefined();
+  });
+
+  it("never truncates — the outline is whole or absent, never cut", async () => {
+    // The property that makes this fix safe. A cut string would read as a
+    // complete outline that simply ends.
+    for (const size of [17_999, 18_000, 18_001, 60_000]) {
+      reply = oldPanel(size);
+      const out = await callOutline({ max_chars: 18_000 });
+      expect([0, size], `size ${size} produced a ${out.outline.length}-char outline`).toContain(
+        out.outline.length,
+      );
+    }
+  });
+});

--- a/src/__tests__/orchestrator/outline-budget-enforced.test.ts
+++ b/src/__tests__/orchestrator/outline-budget-enforced.test.ts
@@ -65,8 +65,13 @@ beforeEach(() => {
 describe("the orchestrator enforces max_chars the panel ignored (#1203)", () => {
   it("does NOT forward an outline that blows the bound", async () => {
     const out = await callOutline({ max_chars: 18_000 });
-    expect(out.outline, "the 60k-char outline must not reach the caller").toBe("");
+    expect(out.outline, "the 60k-char outline must not reach the caller").not.toContain("x".repeat(100));
     expect(out.detail_level).toBe("refused");
+    // codex review: NOT an empty string. An empty outline beside node_count:137
+    // is the #1184 contradiction — a consumer reading `outline` would be told
+    // the canvas is empty by a reply whose own counts say otherwise.
+    expect(out.outline, "the field must SAY it was withheld").toMatch(/NO OUTLINE/);
+    expect(out.outline.length, "and stay small").toBeLessThan(600);
   });
 
   it("says WHO applied the bound and how big the reply actually was", async () => {
@@ -148,15 +153,37 @@ describe("what it must NOT do (#1203)", () => {
     expect(out.detail_level).toBeUndefined();
   });
 
-  it("never truncates — the outline is whole or absent, never cut", async () => {
+  it("never truncates — the outline is whole or withheld, never cut", async () => {
     // The property that makes this fix safe. A cut string would read as a
     // complete outline that simply ends.
     for (const size of [17_999, 18_000, 18_001, 60_000]) {
       reply = oldPanel(size);
       const out = await callOutline({ max_chars: 18_000 });
-      expect([0, size], `size ${size} produced a ${out.outline.length}-char outline`).toContain(
-        out.outline.length,
+      const whole = out.outline.length === size;
+      const withheld = out.outline.startsWith("NO OUTLINE");
+      expect(whole || withheld, `size ${size} produced a ${out.outline.length}-char outline`).toBe(
+        true,
       );
     }
+  });
+
+  // codex review: the loop above accepts EITHER outcome at every size, so it
+  // cannot catch a `<=` becoming `<` — which would refuse an outline that
+  // exactly meets the bound. The boundary needs asserting in one direction each.
+  it.each([
+    [17_999, "under"],
+    [18_000, "exactly at"],
+  ])("forwards an outline %d chars long (%s the bound)", async (size) => {
+    reply = oldPanel(size);
+    const out = await callOutline({ max_chars: 18_000 });
+    expect(out.outline).toHaveLength(size);
+    expect(out.detail_level).toBeUndefined();
+  });
+
+  it("withholds an outline ONE character over the bound", async () => {
+    reply = oldPanel(18_001);
+    const out = await callOutline({ max_chars: 18_000 });
+    expect(out.detail_level).toBe("refused");
+    expect(out.unbounded_chars).toBe(18_001);
   });
 });

--- a/src/__tests__/tools/truncation-remedies.test.ts
+++ b/src/__tests__/tools/truncation-remedies.test.ts
@@ -807,11 +807,30 @@ describe("#809 truncation remedies name a lever that actually exists", () => {
     const hint = legacy.max_chars_hint as string;
     expect(typeof hint).toBe("string");
     expect(hint).toMatch(/does not support `max_chars`/);
-    expect(hint).toMatch(/was NOT applied/);
+    expect(hint).toMatch(/was not applied by the panel/);
     expect(hint).toMatch(/690 node\(s\)/);
     // The synthetic flag is plumbing and must never reach the caller.
     expect(legacy.__budget_ignored).toBeUndefined();
     assertRemedyIsActionable("panel_graph_outline", "panel_graph_outline legacy", hint);
+
+    // #1203 — this fixture's outline is ONE character, so it fits the 4000 bound
+    // and the reply is forwarded. The rider must say that, not warn about a
+    // flood that did not happen. The OTHER branch — an outline that actually
+    // blows the bound — is where the orchestrator now enforces it, and the two
+    // must not share a sentence: this test used to assert wording that described
+    // only the bad case, on a fixture that was the good one.
+    expect(hint).toMatch(/happens to fit within your bound/);
+
+    const flooded = await runPanelTool(
+      "panel_graph_outline",
+      { max_chars: 4000 },
+      { node_count: 690, group_count: 12, outline: "x".repeat(40_000) },
+    );
+    const floodHint = flooded.max_chars_hint as string;
+    expect(flooded.outline, "the 40k outline must not reach the caller").toBe("");
+    expect(floodHint).toMatch(/NO outline is included/);
+    expect(floodHint).not.toMatch(/happens to fit/);
+    assertRemedyIsActionable("panel_graph_outline", "panel_graph_outline enforced", floodHint);
 
     // A current panel echoes the budget back, so the rider stays silent.
     const current = await runPanelTool(

--- a/src/__tests__/tools/truncation-remedies.test.ts
+++ b/src/__tests__/tools/truncation-remedies.test.ts
@@ -827,7 +827,8 @@ describe("#809 truncation remedies name a lever that actually exists", () => {
       { node_count: 690, group_count: 12, outline: "x".repeat(40_000) },
     );
     const floodHint = flooded.max_chars_hint as string;
-    expect(flooded.outline, "the 40k outline must not reach the caller").toBe("");
+    expect(flooded.outline, "the 40k outline must not reach the caller").not.toContain("x".repeat(100));
+    expect(flooded.outline, "and the field says so rather than going blank").toMatch(/NO OUTLINE/);
     expect(floodHint).toMatch(/NO outline is included/);
     expect(floodHint).not.toMatch(/happens to fit/);
     assertRemedyIsActionable("panel_graph_outline", "panel_graph_outline enforced", floodHint);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1733,7 +1733,17 @@ function enforceOutlineBudget(res: ToolResult, requested: unknown): ToolResult {
     nodes != null
       ? `The graph has ${nodes} node(s)${groups != null ? ` and ${groups} group(s)` : ""}.`
       : "";
-  payload.outline = "";
+  // The refusal goes IN the outline field, not an empty string (codex review).
+  // Two reasons. It is what the panel itself does at its own floor, so a caller
+  // that handles one refusal handles both. And an empty outline next to
+  // `node_count: 137` is exactly the contradiction #1184 was about — a consumer
+  // that reads `outline` and finds nothing has been told the canvas is empty by
+  // a reply whose own counts say otherwise. Bounded and fixed-length, so it
+  // cannot itself overrun a budget whose floor is OUTLINE_MAX_CHARS_FLOOR.
+  payload.outline =
+    `NO OUTLINE — this panel build ignores \`max_chars\`, and its full reply (${outline.length} chars) exceeds the bound of ${requested} you set. ` +
+    `It is withheld rather than cut, because a truncated outline would read as a complete one. ` +
+    `${shape} See \`max_chars_hint\` for what to do.`.trim();
   payload.detail_level = "refused";
   payload.degraded = true;
   payload.budget_applied_by = "orchestrator";

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1681,6 +1681,97 @@ async function confirmEmptyOutline(
  */
 const EMPTY_OUTLINE_RECHECK_STEPS_MS = [250, 400, 550] as const;
 
+/**
+ * Enforce `max_chars` when the PANEL could not (#1203).
+ *
+ * A panel older than the budget protocol ignores `max_chars` and returns the
+ * whole outline. The orchestrator already noticed — that is what
+ * `markBudgetIgnored` is for — and then forwarded the unbounded reply anyway,
+ * with a note explaining that the bound the caller had explicitly set did not
+ * apply. A 137-node outline arrived that way, which is the exact context flood
+ * `max_chars` exists to prevent, and the disclosure came AFTER the cost was
+ * already paid. A warning is not a bound.
+ *
+ * WHY REFUSE RATHER THAN TRUNCATE. This tool's contract is that coverage is
+ * never traded away: over budget the outline sheds RESOLUTION — widget values,
+ * then titles, then a per-group summary — so whatever comes back still describes
+ * the whole graph, and if even the floor will not fit it returns NO outline
+ * rather than a partial one that reads as complete. Cutting the rendered text at
+ * a character count would break exactly that guarantee: the result would look
+ * like a finished outline that simply ends, and a caller acting on it would
+ * believe the graph stops where the string does — the #1184 failure again, with
+ * the truncation invisible instead of announced.
+ *
+ * Shedding resolution is the panel's job and needs the graph, not its rendering.
+ * The orchestrator has only the rendered text, so the honest move is the one the
+ * panel itself makes at its floor: return no outline, and say precisely what
+ * happened, how big the outline actually was, and which of the three levers
+ * (raise the bound, update the panel, scope the read) will work.
+ *
+ * The counts and `viewing` survive — they are the part of the reply that is
+ * small, true, and independent of the budget.
+ */
+function enforceOutlineBudget(res: ToolResult, requested: unknown): ToolResult {
+  if (typeof requested !== "number") return res;
+  const payload = parseToolResultJson(res);
+  if (!payload) return res;
+  // A panel that supports the budget echoes it back and has already applied its
+  // own ladder. Nothing to enforce, and second-guessing it would be wrong.
+  if (typeof payload.max_chars === "number") return res;
+  const outline = payload.outline;
+  if (typeof outline !== "string") return res;
+  // Within the bound already. The panel ignored the parameter, but the reply
+  // honours it, and refusing a reply that FITS would be a bound in name only.
+  if (outline.length <= requested) return res;
+
+  const idx = res.content.findIndex((c) => c.type === "text");
+  if (idx < 0) return res;
+
+  const nodes = typeof payload.node_count === "number" ? payload.node_count : null;
+  const groups = typeof payload.group_count === "number" ? payload.group_count : null;
+  const shape =
+    nodes != null
+      ? `The graph has ${nodes} node(s)${groups != null ? ` and ${groups} group(s)` : ""}.`
+      : "";
+  payload.outline = "";
+  payload.detail_level = "refused";
+  payload.degraded = true;
+  payload.budget_applied_by = "orchestrator";
+  payload.unbounded_chars = outline.length;
+  payload.degraded_reason =
+    `This panel build ignores \`max_chars\`, so it returned the FULL outline (${outline.length} chars) against a bound of ${requested}. ` +
+    `It is withheld rather than cut: a truncated outline would read as a complete one. ${shape}`.trim();
+
+  return {
+    ...res,
+    content: res.content.map((c, i) =>
+      i === idx && c.type === "text" ? { ...c, text: JSON.stringify(payload, null, 2) } : c,
+    ),
+  };
+}
+
+/** The three levers when the orchestrator had to withhold an outline (#1203),
+ *  in the order worth trying. Shared so the two riders cannot drift. */
+function outlineBudgetRemedies(unbounded: number | null): string {
+  // Every "raise it" must name the ceiling, or a caller already at the maximum
+  // is sent on a retry that cannot change anything (the repo-wide remedy check,
+  // which caught this text before it shipped).
+  // The ceiling has to sit next to the parameter name, not at the end of the
+  // sentence: the remedy check reads "raise `X` … up to N" as one phrase, and it
+  // is right to — a caller skimming for whether the retry is possible should not
+  // have to finish the clause.
+  const raise =
+    unbounded == null
+      ? `Raise \`max_chars\` up to ${OUTLINE_MAX_CHARS_CEILING}`
+      : unbounded <= OUTLINE_MAX_CHARS_CEILING
+        ? `Raise \`max_chars\` up to ${OUTLINE_MAX_CHARS_CEILING} — this outline needs at least ${unbounded} to be accepted whole`
+        : `Raising \`max_chars\` will NOT help — the full outline is past its ceiling of ${OUTLINE_MAX_CHARS_CEILING}`;
+  return (
+    `${raise}; update the ComfyUI Agent Panel, which can shed per-node detail and still cover every node inside a smaller bound; ` +
+    `or scope the read with panel_query_graph {ids:[…], fields:'detail'}.`
+  );
+}
+
 function markBudgetIgnored(res: ToolResult, requested: unknown): ToolResult {
   if (typeof requested !== "number") return res;
   const payload = parseToolResultJson(res);
@@ -6642,11 +6733,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // The synthetic `__budget_ignored` flag below is derived from the reply, not
           // sent by the panel: a build that supports the budget echoes `max_chars` back.
           markBudgetIgnored(
-            // #1184 — an empty outline is re-verified before it is believed.
-            await confirmEmptyOutline(
-              ctx,
-              await ctx.call({ cmd: "graph_outline", max_chars: args.max_chars }),
-              () => ctx.call({ cmd: "graph_outline", max_chars: args.max_chars }),
+            // #1203 — and ENFORCE it here when the panel could not, before the
+            // unbounded outline reaches the caller who asked for a bound.
+            enforceOutlineBudget(
+              // #1184 — an empty outline is re-verified before it is believed.
+              await confirmEmptyOutline(
+                ctx,
+                await ctx.call({ cmd: "graph_outline", max_chars: args.max_chars }),
+                () => ctx.call({ cmd: "graph_outline", max_chars: args.max_chars }),
+              ),
+              args.max_chars,
             ),
             args.max_chars,
           ),
@@ -6659,9 +6755,30 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               // unbounded reply as "this fitted".
               flag: "__budget_ignored",
               key: "max_chars_hint",
-              text: (p) =>
-                `This panel build does not support \`max_chars\` on the outline, so the budget you set (${typeof args.max_chars === "number" ? args.max_chars : OUTLINE_MAX_CHARS_DEFAULT}) was NOT applied and the outline below is the full, unbounded one (${typeof p.node_count === "number" ? p.node_count : "all"} node(s)). ` +
-                `Update the ComfyUI Agent Panel to bound it, or scope the read with panel_query_graph in the meantime.`,
+              text: (p) => {
+                const asked =
+                  typeof args.max_chars === "number" ? args.max_chars : OUTLINE_MAX_CHARS_DEFAULT;
+                const nodes = typeof p.node_count === "number" ? p.node_count : "all";
+                // #1203 — three different situations used to share one sentence
+                // that described only the worst of them. Saying "the outline
+                // below is the full, unbounded one" when it was withheld, or
+                // when it fitted anyway, is its own false report.
+                if (p.budget_applied_by === "orchestrator") {
+                  const unbounded =
+                    typeof p.unbounded_chars === "number" ? p.unbounded_chars : null;
+                  return (
+                    `This panel build does not support \`max_chars\`, so it returned the FULL outline for all ${nodes} node(s)` +
+                    `${unbounded != null ? ` (${unbounded} chars)` : ""} against your bound of ${asked}. ` +
+                    `NO outline is included: it is withheld rather than cut, because a truncated outline would read as a complete one. ` +
+                    outlineBudgetRemedies(unbounded)
+                  );
+                }
+                return (
+                  `This panel build does not support \`max_chars\`, so the budget you set (${asked}) was not applied by the panel — ` +
+                  `the outline below is its full, unbounded reply for all ${nodes} node(s), which happens to fit within your bound. ` +
+                  `Update the ComfyUI Agent Panel to have the budget applied properly; on a larger graph an unbounded reply will not fit.`
+                );
+              },
             },
             {
               // On an older panel this is never set either, so the rider is inert there.
@@ -6682,6 +6799,24 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 // it "still covers ALL nodes" would describe content the reader cannot
                 // see, which is the same lie as a silent cut.
                 if (p.detail_level === "refused") {
+                  // #1203 — an ORCHESTRATOR refusal is a different situation and
+                  // needs different advice. The panel refuses because even its
+                  // smallest whole-graph form did not fit, so the question is
+                  // whether raising the bound can ever help. Here the panel never
+                  // applied the bound at all: the full outline's size is known
+                  // exactly, updating the panel unlocks the shed ladder, and the
+                  // generic text's "this build does not report how large the
+                  // smallest form would be" would send the reader chasing a
+                  // capability the reply is already explaining is absent.
+                  if (p.budget_applied_by === "orchestrator") {
+                    const unbounded =
+                      typeof p.unbounded_chars === "number" ? p.unbounded_chars : null;
+                    return (
+                      `NO outline was returned: this panel build ignores \`max_chars\`, so its reply${unbounded != null ? ` (${unbounded} chars)` : ""} exceeded \`max_chars\`=${inForce} and a PARTIAL outline is deliberately withheld because it would read as complete. ` +
+                      `The graph has ${nodes} node(s) and ${groups} group(s). ` +
+                      outlineBudgetRemedies(unbounded)
+                    );
+                  }
                   // And if the floor exceeds the CEILING, raising is a guaranteed second
                   // refusal — a dead retry inside the message explaining the first.
                   //


### PR DESCRIPTION
Fixes #1203.

`panel_graph_outline` advertises `max_chars`, but a panel build older than the budget protocol ignores it and returns the full outline. The orchestrator DETECTED that (it already appends a "was NOT applied" note) and forwarded the unbounded reply anyway — so a caller that explicitly asked for a bound got a 137-node context flood plus a post-hoc warning.

Draft while I work it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)