### PR TITLE
fix(restart): the confirmation timeout must not recommend a server it never checked (#851)

### DIFF
--- a/src/__tests__/orchestrator/restart-timeout-target.test.ts
+++ b/src/__tests__/orchestrator/restart-timeout-target.test.ts
@@ -1,0 +1,17 @@
+// panel#851 — placeholder pinning the CURRENT wording; the fix follows.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync("src/orchestrator/panel-tools.ts", "utf8");
+
+describe("#851 restart confirmation timeout", () => {
+  it("today: recommends restart_comfyui unconditionally, with no target check", () => {
+    const branch = src.slice(
+      src.indexOf('No confirmation received within'),
+      src.indexOf('No confirmation received within') + 600,
+    );
+    expect(branch).toContain("use restart_comfyui to restart the server directly");
+    // Nothing compares the panel's ComfyUI against the headless target here.
+    expect(branch).not.toContain("captureRebootHealthBase");
+  });
+});


### PR DESCRIPTION
Orchestrator half of artokun/comfyui-mcp-panel#851. The panel half shipped in panel **0.11.54** (#858); this is the part that lives here, which the panel-side work explicitly could not reach.

## The harm

`panel_restart_comfyui` timed out waiting for the confirmation card and returned:

> …so I did NOT restart ComfyUI. … or use `restart_comfyui` to restart the server directly without a panel card.

The reporter followed that advice. `restart_comfyui` targets `COMFYUI_URL` (`127.0.0.1:8188`), **not** the browser tab's connected ComfyUI, and failed with `No ComfyUI process found on port 8188 to restart` — while panel tools had been operating happily on the live canvas the whole time.

So the fallback was recommended without ever checking that it points at the same server. When the panel drives a ComfyUI that is not the headless target — a remote, a tunnel, a second instance — the advice is not merely unhelpful, it aims a restart at the wrong machine.

## Why it is fixable now

The information was already here and simply not consulted on this branch. `captureRebootHealthBase(ctx)` returns the ComfyUI the **panel** is actually running inside, and `sameHttpBase()` compares it to `getComfyUIBaseUrl()`. The adjacent decline branch already calls it (`panel-tools.ts:9453`); the timeout branch does not.

And since panel 0.11.54 the panel carries `target` on every `comfy_reboot` reply, sourced from the same `comfyuiUrlForAgent()` value it hands over in `hello` — so the two sides cannot drift.

## The change

Make the recommendation conditional on the targets matching:

- **same server** → unchanged advice; `restart_comfyui` is a correct fallback.
- **different, or unknowable** → say so, name both origins, and do not recommend a restart of a server this call never checked.

The timeout branch is deliberately the only one touched — the decline and success paths already reason about the bound instance.

## Not claimed

The reporter also saw `backend-reconnecting`, then a successful `panel_refresh_nodes`, then `Connected: none` until a browser refresh. That is a reconnect-lifecycle question and is not addressed here; conflating it with the fallback advice would let a wrong recommendation hide behind a genuinely separate symptom.