### PR TITLE
release: v0.50.64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.64] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- the confirmation timeout must not recommend a server it never checked (#851)
+- make an unreachable host say unreachable, not 'nothing found' (#1136)
+- stop redacting file paths and module names, and filter the log BEFORE scrubbing (#1225)
+
+#### Changed
+- 0.50.62 (#1224)
+
+
 ## [0.50.62] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.62",
+  "version": "0.50.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.62",
+      "version": "0.50.64",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.62",
+  "version": "0.50.64",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",

--- a/src/__tests__/orchestrator/restart-timeout-target.test.ts
+++ b/src/__tests__/orchestrator/restart-timeout-target.test.ts
@@ -1,0 +1,75 @@
+// panel#851 — `panel_restart_comfyui` timed out on its confirmation card and told the
+// caller to "use restart_comfyui to restart the server directly". They did. That tool
+// targets COMFYUI_URL, NOT the ComfyUI the panel is running inside, so it failed with
+// `No ComfyUI process found on port 8188 to restart` while panel tools had been working
+// happily on the live canvas. The advice was given without ever checking which server it
+// pointed at.
+//
+// THE DISCRIMINATOR, and why it is used carefully. `captureRebootHealthBase()` is a
+// PROOF, not a comparison: null in remote/cloud mode, and whenever the tab's origin
+// cannot be shown to front the local boot instance. So "unproven" is deliberately NOT
+// folded into "different" — that would fire the warning on ordinary remote installs
+// where the two ARE the same server, trading a wrong recommendation for a wrong alarm.
+//
+// These drive the real decision function rather than asserting on source text. An
+// earlier version of this file asserted the branch's source, and a mutation that
+// inverted the logic while leaving both branches present SURVIVED it — which is why the
+// decision was extracted into a pure helper.
+import { describe, it, expect } from "vitest";
+import { restartTimeoutFallbackAdvice } from "../../orchestrator/panel-tools.js";
+
+const advice = (headlessBase: string, panelBase: string | null) =>
+  restartTimeoutFallbackAdvice({ headlessBase, panelBase });
+
+describe("#851 restart-timeout fallback advice", () => {
+  it("recommends restart_comfyui plainly when the targets PROVABLY match", () => {
+    const a = advice("http://127.0.0.1:8188", "http://127.0.0.1:8188");
+    expect(a).toContain("or use restart_comfyui to restart the server directly");
+    expect(a).not.toContain("Do NOT");
+  });
+
+  it("tolerates a trailing-slash difference — same server, not a mismatch", () => {
+    expect(advice("http://127.0.0.1:8188", "http://127.0.0.1:8188/")).toContain(
+      "or use restart_comfyui to restart the server directly",
+    );
+  });
+
+  it("REFUSES to recommend it when the targets are proven different, and names both", () => {
+    const a = advice("http://127.0.0.1:8188", "http://127.0.0.1:8199");
+    expect(a).toContain("Do NOT reach for restart_comfyui");
+    expect(a).toContain("http://127.0.0.1:8188");
+    expect(a).toContain("http://127.0.0.1:8199");
+    expect(a).toContain("different server than the one you have been working on");
+    // The reporter's exact harm: it may find nothing at all on the other target.
+    expect(a).toContain("may find nothing there at all");
+  });
+
+  it("a different PATH on the same host is still a different target", () => {
+    // sameHttpBase is path-aware: a basePath mount is a distinct instance.
+    expect(advice("http://127.0.0.1:8188/comfy", "http://127.0.0.1:8188")).toContain("Do NOT");
+  });
+
+  it("when the origin is UNPROVEN it keeps the advice but NAMES the target", () => {
+    // This is the anti-cry-wolf case: captureRebootHealthBase returns null by design on
+    // every remote/cloud install, where the two targets are usually the same server.
+    const a = advice("https://remote.example:8188", null);
+    expect(a).toContain("or use restart_comfyui, which restarts https://remote.example:8188");
+    expect(a).toContain("could not confirm which one this panel is running inside");
+    expect(a).not.toContain("Do NOT");
+  });
+
+  it("never recommends a bare restart without naming a server", () => {
+    // The regression this whole issue is: advice that does not say what it will hit.
+    for (const a of [
+      advice("http://127.0.0.1:8188", "http://127.0.0.1:8188"),
+      advice("http://127.0.0.1:8188", "http://127.0.0.1:8199"),
+      advice("https://remote.example:8188", null),
+    ]) {
+      expect(a).toContain("restart_comfyui");
+    }
+    // Only the provably-same case may omit an explicit origin, because it is the one
+    // case where "the server" is unambiguous.
+    expect(advice("http://127.0.0.1:8199", null)).toContain("http://127.0.0.1:8199");
+    expect(advice("http://a:1", "http://b:2")).toContain("http://b:2");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1187,6 +1187,47 @@ async function probeDeclineRecovery(
  *     Origin carries NO path, a boot target mounted under a basePath fails path-aware
  *     identity and is (soundly) fail-closed to dispatched-unconfirmed.
  */
+/**
+ * #851 — what to tell the caller about `restart_comfyui` when the panel's confirmation
+ * card timed out.
+ *
+ * The old text recommended it unconditionally. It targets COMFYUI_URL, not the ComfyUI
+ * the panel runs inside, so a reporter who followed that advice aimed a restart at a
+ * different server than the one they had been working on — and got "No ComfyUI process
+ * found on port 8188" while the panel was working fine on the live canvas.
+ *
+ * `panelBase` comes from captureRebootHealthBase(), which is a PROOF rather than a
+ * comparison: null in remote/cloud mode, and whenever the tab's origin cannot be shown
+ * to front the local boot instance. "Unproven" is deliberately NOT folded into
+ * "different" — that would fire the warning on ordinary remote installs where the two
+ * ARE the same server, trading a wrong recommendation for a wrong alarm.
+ *
+ * Pure, so the three-way decision is testable without a live panel.
+ */
+export function restartTimeoutFallbackAdvice({
+  headlessBase,
+  panelBase,
+}: {
+  headlessBase: string;
+  panelBase: string | null;
+}): string {
+  if (panelBase != null && sameHttpBase(headlessBase, panelBase)) {
+    return "or use restart_comfyui to restart the server directly without a panel card.";
+  }
+  if (panelBase != null) {
+    return (
+      `Do NOT reach for restart_comfyui here without checking: it targets ${headlessBase}, ` +
+      `while this panel is running inside ${panelBase}. Restarting the first would hit a ` +
+      "different server than the one you have been working on — and may find nothing there at all."
+    );
+  }
+  return (
+    `or use restart_comfyui, which restarts ${headlessBase} directly without a panel ` +
+    "card — check that this is the same ComfyUI you have been working on, since I " +
+    "could not confirm which one this panel is running inside."
+  );
+}
+
 function captureRebootHealthBase(ctx: PanelToolCtx): string | null {
   if (isCloudMode() || isRemoteMode()) return null;
   const bootBase = getBootLocalComfyUIBaseUrl(); // server-authorized, hello-immutable
@@ -9428,12 +9469,27 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           confirmBudget,
         );
         if (decision === "timeout") {
+          // #851 — the fallback used to be recommended unconditionally, and
+          // `restart_comfyui` targets COMFYUI_URL, NOT the ComfyUI the panel is
+          // running inside. A reporter followed this advice against a panel driving a
+          // different server and got `No ComfyUI process found on port 8188` while the
+          // panel was working fine on the live canvas — a restart aimed at the wrong
+          // machine, recommended by a call that never checked which machine that was.
+          //
+          // The information was already here and simply not consulted on this branch:
+          // captureRebootHealthBase() is the origin the PANEL answers on, and the
+          // adjacent decline branch already reads it. Only recommend the headless tool
+          // when it provably points at the same server; otherwise name both and say
+          // plainly that this call did not verify the other one.
+          const fallback = restartTimeoutFallbackAdvice({
+            headlessBase: getComfyUIBaseUrl(),
+            panelBase: captureRebootHealthBase(ctx),
+          });
           return ok(
             `No confirmation received within ${Math.round(confirmBudget / 1000)}s, so I did NOT ` +
               "restart ComfyUI. The panel tab may be backgrounded or still reconnecting after a " +
               "previous restart, so the confirmation card wasn't answered. Tell me to restart it " +
-              "and I'll re-ask, or use restart_comfyui to restart the server directly without a " +
-              "panel card.",
+              `and I'll re-ask. ${fallback}`,
           );
         }
         if (decision !== "yes") {


### PR DESCRIPTION
Reconciles the version bump and changelog for v0.50.64 back to protected main.

Ships #1136 (`0a2027d`): an unreachable host no longer reads as an empty result. npm's probe stops asserting "unreachable" for a registry that answered; `workflow-url`'s transport failures name the host; and the ComfyUI-Manager path — the one the reporting user actually hit — now says when the catalogue or the node mappings never answered, instead of rendering "not known to ComfyUI-Manager".

Numbering: v0.50.63 was cut for #1225/#851 while this was in its third review round, so #1136 lands in .64.

Gates on this tree: build ok, `tsc --noEmit` clean, suite 398 files / 8021 passed / 2 skipped.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>