### PR TITLE
chore(release): reconcile main to 0.50.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.65] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- enforce panel_graph_outline's max_chars when the live panel ignores it (#1228)
+- make an unreachable host say unreachable, not 'nothing found' (#1136)
+
+#### Changed
+- 0.50.63 (#1227)
+
+
 ## [0.50.64] - 2026-08-09
 
 _No user-facing changes._

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.64",
+  "version": "0.50.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.64",
+      "version": "0.50.65",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.64",
+  "version": "0.50.65",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.65` tag.

Ships **#1203** — `panel_graph_outline` now ENFORCES the `max_chars` it advertises when the connected panel build is too old to apply it. Previously the orchestrator detected the ignored budget and forwarded the unbounded outline anyway, with a note explaining that the bound had not applied; a caller asking for 18000 characters got the full 137-node outline.

Verified against the compiled artifact: the reported case drops from a ~60000-character reply to 1832 characters, the node/group counts survive, and a current panel's reply is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)