### PR TITLE
fix(restart): a CONFIRMED origin mismatch must not be lost inside the proof (#1233)

### DIFF
--- a/src/__tests__/orchestrator/restart-timeout-target.test.ts
+++ b/src/__tests__/orchestrator/restart-timeout-target.test.ts
@@ -117,4 +117,22 @@ describe("#1233 confirmed mismatch reaches the strong warning", () => {
     expect(a).toContain("may find nothing there");
     expect(a).toContain("SUCCEED and take down a ComfyUI you did not mean to touch");
   });
+
+  it("#1233 a basePath mount is NOT a mismatch — the Origin is pathless and cannot say", () => {
+    // Found by probing this fix, not by review: tabServerOrigin carries scheme+host+port
+    // only, so a path-aware compare against a :8188/comfy base read a correctly-mounted
+    // install as a different server and fired the strong warning at the right one.
+    const a = advise("http://127.0.0.1:8188/comfy", null, "http://127.0.0.1:8188");
+    expect(a).not.toContain("Do NOT");
+    expect(a).toContain("could not confirm which one this panel is running inside");
+  });
+
+  it("#1233 a genuinely different PORT is still caught despite the origin-only compare", () => {
+    expect(advise("http://127.0.0.1:8188/comfy", null, "http://127.0.0.1:8189")).toContain("Do NOT");
+  });
+
+  it("#1233 loopback family folding does not manufacture a mismatch", () => {
+    // 127.0.0.1 vs a 0.0.0.0 bind is the same instance; sameHttpOrigin folds the family.
+    expect(advise("http://0.0.0.0:8188", null, "http://127.0.0.1:8188")).not.toContain("Do NOT");
+  });
 });

--- a/src/__tests__/orchestrator/restart-timeout-target.test.ts
+++ b/src/__tests__/orchestrator/restart-timeout-target.test.ts
@@ -135,4 +135,21 @@ describe("#1233 confirmed mismatch reaches the strong warning", () => {
     // 127.0.0.1 vs a 0.0.0.0 bind is the same instance; sameHttpOrigin folds the family.
     expect(advise("http://0.0.0.0:8188", null, "http://127.0.0.1:8188")).not.toContain("Do NOT");
   });
+
+  it("#1233 (codex) `localhost` vs a loopback literal is UNPROVEN, not a mismatch", () => {
+    // loopbackFamily() deliberately excludes localhost (coordinator P0: it can resolve to
+    // either family, or elsewhere), so it canonicalizes unequal to 127.0.0.1 — and firing
+    // the strong warning on that would accuse what is very likely the same instance.
+    expect(advise("http://localhost:8188", null, "http://127.0.0.1:8188")).not.toContain("Do NOT");
+    expect(advise("http://127.0.0.1:8188", null, "http://localhost:8188")).not.toContain("Do NOT");
+    expect(advise("http://localhost:8188", null, "http://[::1]:8188")).not.toContain("Do NOT");
+  });
+
+  it("#1233 (codex) an ambiguous host does not mask a genuinely different PORT", () => {
+    // Degrading to unproven must not become a blanket amnesty: the port still differs.
+    const a = advise("http://localhost:8188", null, "http://localhost:8189");
+    expect(a).not.toContain("Do NOT"); // ambiguous on both sides -> unknown, by design
+    // …but a concrete literal on both sides still proves it.
+    expect(advise("http://127.0.0.1:8188", null, "http://127.0.0.1:8189")).toContain("Do NOT");
+  });
 });

--- a/src/__tests__/orchestrator/restart-timeout-target.test.ts
+++ b/src/__tests__/orchestrator/restart-timeout-target.test.ts
@@ -73,3 +73,48 @@ describe("#851 restart-timeout fallback advice", () => {
     expect(advice("http://a:1", "http://b:2")).toContain("http://b:2");
   });
 });
+
+// ---------------------------------------------------------------------------
+// #1233 — a CONFIRMED mismatch must not be lost inside the proof's null.
+// ---------------------------------------------------------------------------
+
+describe("#1233 confirmed mismatch reaches the strong warning", () => {
+  const advise = (headlessBase: string, panelBase: string | null, observedOrigin: string | null) =>
+    restartTimeoutFallbackAdvice({ headlessBase, panelBase, observedOrigin });
+
+  it("a SECOND local instance on another port is proven different, not merely unproven", () => {
+    // panel#851's own motivating case. captureRebootHealthBase returns null here — it
+    // proves sameness with the BOOT base and a :8189 tab is not that — but the observed
+    // origin is positive evidence of a mismatch, and it used to be discarded.
+    const a = advise("http://127.0.0.1:8188", null, "http://127.0.0.1:8189");
+    expect(a).toContain("Do NOT reach for restart_comfyui");
+    expect(a).toContain("http://127.0.0.1:8189");
+  });
+
+  it("an observed origin that MATCHES does not manufacture a warning", () => {
+    // Unproven-but-consistent stays the mild, target-naming advice.
+    const a = advise("http://127.0.0.1:8188", null, "http://127.0.0.1:8188");
+    expect(a).not.toContain("Do NOT");
+    expect(a).toContain("or use restart_comfyui, which restarts http://127.0.0.1:8188");
+  });
+
+  it("no observed origin at all is still unproven — absence is not evidence", () => {
+    const a = advise("http://127.0.0.1:8188", null, null);
+    expect(a).not.toContain("Do NOT");
+    expect(a).toContain("could not confirm which one this panel is running inside");
+  });
+
+  it("the proof still wins when it is available", () => {
+    expect(advise("http://a:1", "http://a:1", "http://zzz:9")).toContain(
+      "or use restart_comfyui to restart the server directly",
+    );
+  });
+
+  it("the warning names the SUCCEED-on-the-wrong-server risk, not only the no-op", () => {
+    // The old text said only "may find nothing there at all". In this branch the other
+    // target is a LIVE server by construction, so succeeding is the worse outcome.
+    const a = advise("http://127.0.0.1:8188", "http://127.0.0.1:8189", null);
+    expect(a).toContain("may find nothing there");
+    expect(a).toContain("SUCCEED and take down a ComfyUI you did not mean to touch");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1229,7 +1229,17 @@ export function restartTimeoutFallbackAdvice({
   }
   // Proven different: either the proof resolved a base that differs, or the observed
   // origin — which the browser sets and page JS cannot forge — differs outright.
-  const proven = panelBase ?? (observedOrigin && !sameHttpBase(headlessBase, observedOrigin) ? observedOrigin : null);
+  // ORIGIN-only compare for the raw Origin, deliberately. `tabServerOrigin` is pathless
+  // (scheme+host+port — the browser sends no path on a WS upgrade), while `headlessBase`
+  // may carry a basePath mount such as :8188/comfy. A path-AWARE compare therefore reads
+  // a correctly-mounted install as a mismatch and fires the strong warning at a server
+  // that IS the right one — the cry-wolf failure this branch exists to avoid, which is
+  // how it was found. A pathless Origin can prove a different host:port; it cannot prove
+  // a different path, so it is only ever used for the claim it can actually support.
+  // (captureRebootHealthBase fails closed on the same ambiguity for the same reason.)
+  const originMismatch =
+    observedOrigin != null && !sameHttpOrigin(headlessBase, observedOrigin) ? observedOrigin : null;
+  const proven = panelBase ?? originMismatch;
   if (proven != null) {
     return (
       `Do NOT reach for restart_comfyui here without checking: it targets ${headlessBase}, ` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -897,7 +897,10 @@ function isLoopbackHostName(host: string): boolean {
 
 /** The scheme://host:port origin of a URL (default ports made explicit), or null if
  *  unparseable. Loopback hosts canonicalize to their FAMILY loopback (v4 → 127.0.0.1,
- *  v6 → ::1) — so localhost/127.0.0.1/0.0.0.0 compare equal, and ::1/:: compare equal,
+ *  v6 → ::1) — so 127.0.0.1/0.0.0.0 compare equal, and ::1/:: compare equal. NOTE:
+ *  `localhost` is deliberately NOT folded (loopbackFamily returns null for it), so it
+ *  compares UNEQUAL to a concrete literal — callers that would harm a user by treating
+ *  that as proof of difference must degrade it to "unknown" themselves (#1233),
  *  but a v4 host and a v6 host DIFFER (they may be different instances). Ports differ. */
 function httpOriginOf(rawUrl: string): string | null {
   try {
@@ -1237,8 +1240,28 @@ export function restartTimeoutFallbackAdvice({
   // how it was found. A pathless Origin can prove a different host:port; it cannot prove
   // a different path, so it is only ever used for the claim it can actually support.
   // (captureRebootHealthBase fails closed on the same ambiguity for the same reason.)
+  // #1233 (codex) — a DNS-ambiguous `localhost` on EITHER side is NOT proof of a
+  // different server. loopbackFamily() deliberately excludes it (a coordinator P0: it
+  // can resolve to either family, or to something else entirely), so `localhost:8188`
+  // vs `127.0.0.1:8188` canonicalizes unequal and would fire the strong warning at what
+  // is very likely the same instance. Absence of proof is not proof of difference, so
+  // an ambiguous host degrades to UNPROVEN — the same direction captureRebootHealthBase
+  // takes for the same input.
+  const dnsAmbiguous = (u: string | null) => {
+    if (!u) return false;
+    try {
+      return new URL(u).hostname.toLowerCase().replace(/^\[|\]$/g, "") === "localhost";
+    } catch {
+      return false;
+    }
+  };
   const originMismatch =
-    observedOrigin != null && !sameHttpOrigin(headlessBase, observedOrigin) ? observedOrigin : null;
+    observedOrigin != null &&
+    !dnsAmbiguous(observedOrigin) &&
+    !dnsAmbiguous(headlessBase) &&
+    !sameHttpOrigin(headlessBase, observedOrigin)
+      ? observedOrigin
+      : null;
   const proven = panelBase ?? originMismatch;
   if (proven != null) {
     return (

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1207,18 +1207,36 @@ async function probeDeclineRecovery(
 export function restartTimeoutFallbackAdvice({
   headlessBase,
   panelBase,
+  observedOrigin = null,
 }: {
   headlessBase: string;
   panelBase: string | null;
+  /**
+   * #1233 — the tab's SERVER-OBSERVED handshake Origin, read directly rather than
+   * through captureRebootHealthBase's proof.
+   *
+   * That proof answers "is this provably the boot instance", so it collapses a
+   * CONFIRMED MISMATCH into the same `null` as an absent or unprovable origin — and the
+   * confirmed mismatch is exactly the case panel#851 was filed about (a tab fronting a
+   * second local ComfyUI on another port). The evidence was computed and then discarded.
+   * Passing it separately lets a confirmed mismatch reach the strong warning without
+   * loosening the proof, which is correctly strict for its own purpose.
+   */
+  observedOrigin?: string | null;
 }): string {
   if (panelBase != null && sameHttpBase(headlessBase, panelBase)) {
     return "or use restart_comfyui to restart the server directly without a panel card.";
   }
-  if (panelBase != null) {
+  // Proven different: either the proof resolved a base that differs, or the observed
+  // origin — which the browser sets and page JS cannot forge — differs outright.
+  const proven = panelBase ?? (observedOrigin && !sameHttpBase(headlessBase, observedOrigin) ? observedOrigin : null);
+  if (proven != null) {
     return (
       `Do NOT reach for restart_comfyui here without checking: it targets ${headlessBase}, ` +
-      `while this panel is running inside ${panelBase}. Restarting the first would hit a ` +
-      "different server than the one you have been working on — and may find nothing there at all."
+      `while this panel is running inside ${proven}. Restarting the first would hit a ` +
+      "different server than the one you have been working on. That may find nothing there " +
+      "at all — or it may SUCCEED and take down a ComfyUI you did not mean to touch, which " +
+      "on a shared instance is the worse outcome."
     );
   }
   return (
@@ -9629,6 +9647,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           const fallback = restartTimeoutFallbackAdvice({
             headlessBase: getComfyUIBaseUrl(),
             panelBase: captureRebootHealthBase(ctx),
+            // #1233 — the raw observed origin, so a CONFIRMED mismatch is not lost inside
+            // the proof's null. Server-observed on the WS upgrade; page JS cannot forge it.
+            observedOrigin: ctx.bridge?.tabServerOrigin?.(ctx.tabId) ?? null,
           });
           return ok(
             `No confirmation received within ${Math.round(confirmBudget / 1000)}s, so I did NOT ` +


### PR DESCRIPTION
Fixes #1233. Follow-up to panel#851 (shipped in v0.50.64), from the adversarial review of that change.

`captureRebootHealthBase()` is a proof-of-**sameness** oracle — it returns non-null only when the tab's server-observed handshake Origin provably matches the boot base, and collapses everything else, *including a confirmed mismatch*, into `null`.

So the advice had three branches while the oracle could distinguish two:

| actual situation | oracle | branch |
|---|---|---|
| tab fronts the boot instance | base | proven same |
| runtime retarget moved the headless target | base | proven different |
| **tab fronts a SECOND local ComfyUI** | **null** | **unproven** ← wrong |

The third row is the case panel#851 was filed about. `tabServerOrigin` correctly reported the mismatch and it was discarded at the proof's return.

The observed Origin is now passed alongside the proof: a confirmed mismatch reaches the strong warning, a matching-but-unproven origin does **not** manufacture one, and an absent origin stays unproven — absence is not evidence. **The proof itself is untouched**; it is correctly strict for reboot-health certification and this advice path is not a reason to weaken it.

Also widens the warning: it said the other target "may find nothing there at all", but in that branch the other server is **live** by construction, so a restart can SUCCEED and take down a ComfyUI the user did not mean to touch.

## Gates
- 1903 orchestrator tests pass (101 files)
- three mutations killed: discarding the observed origin; treating any observed origin as a mismatch; dropping the succeed-on-wrong-server risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)