### PR TITLE
chore(release): 0.50.66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,34 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and the format follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## 0.50.66
+
+### Fixed
+
+- The restart-confirmation timeout no longer points you at a server it never checked. When
+  `panel_restart_comfyui`'s confirmation card times out it suggests the headless
+  `restart_comfyui` as a fallback — but that targets `COMFYUI_URL`, which is not
+  necessarily the ComfyUI the panel is running inside. It now says which server it would
+  restart, and refuses to recommend it outright when it can prove that is a different one.
+  A confirmed origin mismatch (a tab fronting a second local ComfyUI) reaches that strong
+  warning instead of being lost inside a proof that only answers "is it the same"; an
+  origin that merely cannot be proven stays a mild, target-naming note. The warning also
+  now names the worse outcome — restarting a live wrong target can succeed and take down a
+  ComfyUI you did not mean to touch, not merely find nothing there (#1233, panel#851)
+
 ## Unreleased
+
+## [0.50.66] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- a CONFIRMED origin mismatch must not be lost inside the proof (#1235)
+
+#### Changed
+- delete civitai-lookup.ts, which nothing has ever imported (#1236)
+- 0.50.65 (#1232)
+
 
 ## [0.50.65] - 2026-08-09
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.65",
+  "version": "0.50.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.65",
+      "version": "0.50.66",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.65",
+  "version": "0.50.66",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts 0.50.66 for #1233 (`b0597bd`), which landed after 0.50.65 was tagged.

**#1233 / panel#851** — the restart-confirmation timeout no longer points at a server it never checked. Three defects were found and fixed during that change, all sharing one shape: an inference drawn from evidence that cannot support it.

- `null` from a proof-of-*sameness* oracle conflated *provably different* with *cannot tell*, so a tab fronting a second local ComfyUI got the mild advice — the case panel#851 was filed about
- a pathless `Origin` compared path-aware read a basePath mount as a different server
- a DNS-ambiguous `localhost` canonicalized unequal to `127.0.0.1` and warned about the same instance

Resolution in all three: **unproven degrades to unknown, not to different.**

Gates: 1908 orchestrator tests, five mutations killed, CI green on ubuntu/windows/macos + pack & install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)