### PR TITLE
fix(fence): a relay session can adopt a workflow fence — it knows its own origin

### DIFF
--- a/src/__tests__/orchestrator/fence-refusal-reason.test.ts
+++ b/src/__tests__/orchestrator/fence-refusal-reason.test.ts
@@ -7,11 +7,17 @@
 //
 // That is unactionable in general and WRONG in one specific case. Identity is
 // bound to the connection's server-observed Origin, and a relay-backend
-// connection has none: `attachRelayConnection(sock)` calls `handleConnection(sock)`
+// connection had none: `attachRelayConnection(sock)` called `handleConnection(sock)`
 // with no origin argument, and the relay protocol does not forward the browser's
-// handshake Origin. So `workflowIdentityParts()` can never validate, the fence can
-// NEVER be adopted, and no amount of refreshing changes it. The reporter refreshed
-// repeatedly and closed and reopened the tab before tracing it to source.
+// handshake Origin. So `workflowIdentityParts()` could never validate, the fence
+// could NEVER be adopted, and no amount of refreshing changed it. The reporter
+// refreshed repeatedly and closed and reopened the tab before tracing it to source.
+//
+// THE RELAY HALF IS NOW FIXED and the wording moved with it: the Origin identifies
+// where the panel page is SERVED FROM, which is the ComfyUI the session already
+// points at, so `setupRelayBridge` supplies it from COMFYUI_URL and no relay
+// protocol change was needed. What remains here is the diagnosis for a connection
+// that genuinely has no origin from any source.
 //
 // They also had no orchestrator log to read, which is why the reason has to reach
 // the TOOL RESULT and not just stderr.
@@ -235,12 +241,25 @@ describe("the refusal reasons distinguish an AMBIGUOUS turn", () => {
     expect(r).not.toMatch(/refreshing the tab will not change it/);
   });
 
-  it("gate 3: a genuine no-Origin connection KEEPS the structural remedy", () => {
+  it("gate 3: a genuine no-Origin connection says refreshing will not help", () => {
     const r = identityReason(TAB, undefined, UUID, undefined);
 
     expect(r).toMatch(/no server-observed Origin/);
-    expect(r).toMatch(/structural, not transient/);
-    expect(r).toMatch(/COMFYUI_MCP_TUNNEL_BACKEND=relay/);
+    expect(r).toMatch(/[Rr]efreshing the tab will not/);
+    // ...and names something the reader can actually check.
+    expect(r).toMatch(/COMFYUI_URL/);
+  });
+
+  it("gate 3: no longer blames the relay backend, which is FIXED", () => {
+    // The relay path now supplies the origin it already knows from COMFYUI_URL
+    // (#1077), so a relay session adopts fences like any other. Telling a reader
+    // to stop using that backend would send them to change the one thing that is
+    // no longer the reason — a remedy that is worse than none, because it looks
+    // specific.
+    const r = identityReason(TAB, undefined, UUID, undefined);
+
+    expect(r).not.toMatch(/COMFYUI_MCP_TUNNEL_BACKEND/);
+    expect(r).not.toMatch(/can never be adopted/);
   });
 
   it("gate 3: an origin that IS present reports a validation failure, not absence", () => {

--- a/src/__tests__/services/relay-identity-origin.test.ts
+++ b/src/__tests__/services/relay-identity-origin.test.ts
@@ -50,6 +50,25 @@ describe("relayIdentityOrigin (#1077)", () => {
     expect(relayIdentityOrigin(url as string | undefined)).toBeUndefined();
   });
 
+  it("STRIPS credentials — an origin can be echoed back in a refusal", () => {
+    // COMFYUI_URL legitimately carries basic-auth credentials for a protected
+    // instance, and the refusal message prints the origin. `URL.origin` drops
+    // userinfo, which is what makes that safe; asserting it here means a future
+    // hand-rolled "scheme + host + port" cannot quietly reintroduce the leak.
+    const out = relayIdentityOrigin("http://user:hunter2@host.example:8188/comfy");
+    expect(out).toBe("http://host.example:8188");
+    expect(out).not.toContain("hunter2");
+    expect(out).not.toContain("user");
+  });
+
+  it.each([
+    ["data:text/plain,x", "a data URL"],
+    ["foo://bar", "a non-special scheme"],
+  ])("returns undefined for %s (%s)", (url) => {
+    // Both produce the literal string "null", which is truthy.
+    expect(relayIdentityOrigin(url)).toBeUndefined();
+  });
+
   it("does not invent an origin for a scheme that has none", () => {
     // `new URL("file:///x").origin` is the string "null" — which is truthy, and
     // would sail through as a real origin.

--- a/src/__tests__/services/relay-identity-origin.test.ts
+++ b/src/__tests__/services/relay-identity-origin.test.ts
@@ -1,0 +1,124 @@
+// #1077 Finding 1 — a relay-backend session could NEVER adopt a workflow fence.
+//
+// The workflow-instance fence is scoped to the connection's server-observed
+// `Origin`. The primary loopback listener reads it off the handshake and passes
+// it through; `attachRelayConnection(sock)` passed nothing at all, so every
+// relay-multiplexed connection had `serverOrigin === undefined`,
+// `workflowIdentityParts()` returned undefined, and the validator refused
+// unconditionally. `panel_graph_outline` and
+// `panel_set_workflow_target({mode:"current"})` were permanently stuck for the
+// whole session: the reporter hard-refreshed, closed and reopened the tab, and
+// finally traced it to source — nothing they could do would have worked.
+//
+// The reporter marked this upstream-only, expecting the relay protocol to have
+// to forward the browser's handshake Origin. It does not: the Origin identifies
+// WHERE THE PANEL PAGE IS SERVED FROM, and that is the ComfyUI the session is
+// already pointed at. `setupRelayBridge` holds that URL, so it supplies it.
+//
+// DERIVED, not observed — it asserts what the loopback path proves. On one
+// machine pointed at one ComfyUI those are the same fact, and the alternative it
+// replaces is a fence nobody can ever adopt.
+
+import { describe, expect, it } from "vitest";
+import { UiBridge } from "../../services/ui-bridge.js";
+import { relayIdentityOrigin } from "../../services/secure-bridge.js";
+
+describe("relayIdentityOrigin (#1077)", () => {
+  it.each([
+    ["http://127.0.0.1:8188", "http://127.0.0.1:8188"],
+    ["https://abc-8188.proxy.runpod.net", "https://abc-8188.proxy.runpod.net"],
+    // A path, a trailing slash and a query are not part of an Origin.
+    ["https://host.example/comfy/?x=1", "https://host.example"],
+    // Default ports are omitted, exactly as a browser omits them — otherwise the
+    // derived origin would never match one an observed handshake produced.
+    ["https://host.example:443/", "https://host.example"],
+    ["http://host.example:80", "http://host.example"],
+    // Case-normalised on the host.
+    ["http://LOCALHOST:8188", "http://localhost:8188"],
+  ])("derives %s -> %s", (url, expected) => {
+    expect(relayIdentityOrigin(url)).toBe(expected);
+  });
+
+  it.each([
+    ["", "empty"],
+    ["   ", "blank"],
+    ["not a url", "unparseable"],
+    [undefined, "absent"],
+  ])("returns undefined for %s input (%s)", (url) => {
+    // A WRONG origin is worse than none: none refuses adoption visibly, while a
+    // wrong one scopes the fence to an identity no other transport reproduces.
+    expect(relayIdentityOrigin(url as string | undefined)).toBeUndefined();
+  });
+
+  it("does not invent an origin for a scheme that has none", () => {
+    // `new URL("file:///x").origin` is the string "null" — which is truthy, and
+    // would sail through as a real origin.
+    expect(relayIdentityOrigin("file:///c:/comfy/index.html")).toBeUndefined();
+  });
+});
+
+/** The minimum of `BridgeSocket` the connection path touches. */
+function fakeSocket() {
+  const handlers: Record<string, (...a: unknown[]) => void> = {};
+  return {
+    readyState: 1,
+    sent: [] as string[],
+    send(data: string) {
+      this.sent.push(data);
+    },
+    close() {},
+    terminate() {},
+    ping() {},
+    on(event: string, listener: (...a: unknown[]) => void) {
+      handlers[event] = listener;
+    },
+    emit(event: string, ...a: unknown[]) {
+      handlers[event]?.(...a);
+    },
+  };
+}
+
+describe("attachRelayConnection carries the origin to the fence (#1077)", () => {
+  const ORIGIN = "https://abc-8188.proxy.runpod.net";
+
+  function attach(origin?: string) {
+    const bridge = new UiBridge(0);
+    const sock = fakeSocket();
+    bridge.attachRelayConnection(sock as never, origin);
+    // The panel announces itself exactly as it does over loopback.
+    sock.emit(
+      "message",
+      JSON.stringify({ type: "hello", tab_id: "tab-1", title: "wf" }),
+    );
+    return { bridge, sock };
+  }
+
+  it("reports the supplied origin for the attached tab", () => {
+    const { bridge } = attach(ORIGIN);
+    expect(bridge.tabServerOrigin("tab-1")).toBe(ORIGIN);
+  });
+
+  it("still reports NO origin when none is supplied — the pre-fix behaviour", () => {
+    // The regression guard for the fix itself: if the call site stops passing the
+    // origin, this is what the session goes back to, and the fence dies again.
+    const { bridge } = attach(undefined);
+    expect(bridge.tabServerOrigin("tab-1")).toBeUndefined();
+  });
+});
+
+// THE WIRING. Both halves above pass with `setupRelayBridge` still calling
+// `attachRelayConnection(sock)` with one argument — which IS the bug. Reaching
+// the real call site needs a live relay Worker, so this asserts it at the source,
+// the same way this repo pins other call-site-blind wiring.
+describe("setupRelayBridge actually passes the origin (#1077)", () => {
+  it("attaches with a derived origin, not bare", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(new URL("../../services/secure-bridge.ts", import.meta.url), "utf-8");
+
+    const call = src.match(/bridge\.attachRelayConnection\([^)]*\)/);
+    expect(call, "the relay attach call site moved or vanished").toBeTruthy();
+    expect(call![0], "it must pass an origin, or the fence can never be adopted").toMatch(
+      /relayIdentityOrigin\(/,
+    );
+  });
+});

--- a/src/orchestrator/fence-refusal.ts
+++ b/src/orchestrator/fence-refusal.ts
@@ -61,12 +61,17 @@ export function identityReason(
     return ambiguousTurn(tabId, "no single tab's identity could be read");
   }
   if (!origin) {
+    // The relay case USED to land here and was told, correctly at the time, that
+    // its problem was permanent. It no longer is: the relay path now supplies the
+    // origin it already knows from COMFYUI_URL, so a relay session adopts fences
+    // like any other. Naming a fixed cause as the "known case" would send a
+    // reader to change a backend that is no longer the reason (#1077).
     return (
       `this tab's connection carries no server-observed Origin, and the workflow identity is ` +
-      `bound to one — so the fence can never be adopted for it. This is structural, not ` +
-      `transient: refreshing the tab will not change it. Relay-backend connections ` +
-      `(COMFYUI_MCP_TUNNEL_BACKEND=relay) are the known case, because the relay protocol does ` +
-      `not forward the browser's handshake Origin.`
+      `bound to one — so the fence cannot be adopted for it. Refreshing the tab will not ` +
+      `change it. This means the connection reached the orchestrator by a path that neither ` +
+      `observed nor was told the panel's origin; if COMFYUI_URL is unset or unparseable for ` +
+      `this session, setting it to the URL the panel is served from is what supplies it.`
     );
   }
   return (

--- a/src/services/secure-bridge.ts
+++ b/src/services/secure-bridge.ts
@@ -220,6 +220,27 @@ export async function setupSecureBridge(opts: SetupSecureBridgeOpts): Promise<Se
  * bridge.attachRelayConnection, making it indistinguishable from a direct
  * loopback socket to the rest of the orchestrator.
  */
+/**
+ * The identity origin for a relay-attached panel connection (#1077).
+ *
+ * `scheme://host[:port]`, lowercased and port-normalised, matching the shape a
+ * browser sends as `Origin` and `workflowIdentityParts()` expects. Returns
+ * undefined when the URL cannot be parsed rather than inventing a string: a
+ * WRONG origin is worse than none, because none refuses adoption visibly while a
+ * wrong one scopes the fence to an identity no other transport will reproduce.
+ */
+export function relayIdentityOrigin(comfyuiUrl: string | undefined): string | undefined {
+  if (typeof comfyuiUrl !== "string" || !comfyuiUrl.trim()) return undefined;
+  try {
+    // `new URL().origin` already omits a default port and lowercases the host,
+    // which is exactly the normalisation the loopback path's header goes through.
+    const origin = new URL(comfyuiUrl.trim()).origin;
+    return origin && origin !== "null" ? origin.toLowerCase() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function setupRelayBridge(opts: SetupSecureBridgeOpts): Promise<SecureBridge> {
   const { comfyuiUrl, token, bridge } = opts;
   const relayUrl = process.env.COMFYUI_MCP_RELAY_URL?.trim();
@@ -238,7 +259,20 @@ async function setupRelayBridge(opts: SetupSecureBridgeOpts): Promise<SecureBrid
     sessionId,
     token,
     accessKey: process.env.COMFYUI_MCP_RELAY_KEY?.trim() || undefined,
-    onAttach: (sock) => bridge.attachRelayConnection(sock),
+    // #1077 — the workflow-instance fence is scoped to the connection's
+    // server-observed Origin, and a relay socket has no handshake to observe one
+    // from: `attachRelayConnection` passed none, so `workflowIdentityParts()`
+    // refused, and every relay-backend session was PERMANENTLY unable to adopt a
+    // fence. The reporter refreshed, closed and reopened the tab, and traced it
+    // to source before finding that nothing could have helped.
+    //
+    // It does not need the relay protocol to forward the browser's Origin. The
+    // Origin identifies WHERE THE PANEL PAGE IS SERVED FROM, and that is the
+    // ComfyUI this session is already pointed at — which the orchestrator holds
+    // right here. It is DERIVED rather than observed, so it asserts what the
+    // loopback path proves; in a single-machine session those are the same fact,
+    // and the alternative is a fence nobody can ever adopt.
+    onAttach: (sock) => bridge.attachRelayConnection(sock, relayIdentityOrigin(comfyuiUrl)),
   });
   client.start();
   try {

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1810,8 +1810,14 @@ export class UiBridge {
    * exact same hello/rid/tab-routing logic a direct loopback socket gets. From
    * here on the relay shim is indistinguishable from a real connection.
    */
-  attachRelayConnection(sock: BridgeSocket): void {
-    this.handleConnection(sock);
+  /**
+   * @param serverOrigin The origin to scope this connection's workflow identity
+   *   to. A relay socket has no handshake to observe one from (#1077), so the
+   *   caller supplies the one it already knows — see `setupRelayBridge`. Omitting
+   *   it leaves the connection unable to ever adopt a workflow fence.
+   */
+  attachRelayConnection(sock: BridgeSocket, serverOrigin?: string): void {
+    this.handleConnection(sock, false, serverOrigin);
   }
 
   /**

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1884,9 +1884,14 @@ export class UiBridge {
    *   and any LAN/pairing listener are all `false` — a browser reaching those can
    *   sit on a DIFFERENT machine yet advertise its OWN 127.0.0.1 ComfyUI, which
    *   must never be treated as the orchestrator's local host (#509).
-   * @param serverOrigin SERVER-OBSERVED handshake `Origin` (scheme://host:port), captured
-   *   from the WebSocket upgrade — NOT client-supplied. Undefined for non-browser/relay
-   *   connections. Bound to the tab so the reboot self-probe can trust which page it fronts.
+   * @param serverOrigin The origin (scheme://host:port) this connection's workflow
+   *   identity is scoped to, and which the reboot self-probe trusts to know which page
+   *   it fronts. NEVER client-supplied. Normally SERVER-OBSERVED, captured from the
+   *   WebSocket upgrade's `Origin` header. A relay socket has no upgrade to observe, so
+   *   `attachRelayConnection` passes the one the orchestrator DERIVES from its own
+   *   COMFYUI_URL (#1077) — the panel page is served by that ComfyUI, so it is the same
+   *   origin a browser would send. Undefined only when neither is available, which
+   *   leaves the connection unable to adopt a workflow fence.
    */
   private handleConnection(sock: BridgeSocket, local = false, serverOrigin?: string): void {
     // Track from ACCEPT, not from hello: an anonymous socket is still a socket,


### PR DESCRIPTION
Addresses **Finding 1** of #1077, which the reporter confirmed from source and marked upstream-only. The upstream part turns out not to be needed.

`attachRelayConnection(sock)` passed no `serverOrigin`, so every relay-multiplexed connection had `serverOrigin === undefined`, `workflowIdentityParts()` returned undefined, and the fence validator refused unconditionally — permanently, for the whole session, no matter how many times the tab was refreshed.

The relay protocol does not need to forward the browser's Origin: the Origin identifies where the panel page is *served from*, which is the ComfyUI the session already points at, and `setupRelayBridge` is holding that URL.

Also moves the refusal wording, which named the relay backend as the known cause — true when written, false now.

**Finding 2** (the same symptom on a cloudflared session, cause not pinned down) is NOT addressed; the issue stays open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)