### PR TITLE
chore(release): reconcile main to 0.50.67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.67] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- a relay session can adopt a workflow fence — it knows its own origin (#1240)
+
+
 ## [0.50.66] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.66",
+  "version": "0.50.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.66",
+      "version": "0.50.67",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.66",
+  "version": "0.50.67",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.67` tag.

Ships:
- **#1077 (Finding 1)** — a relay-backend session can adopt a workflow fence. `attachRelayConnection` passed no `serverOrigin`, so `workflowIdentityParts()` could never validate and `panel_graph_outline` / `panel_set_workflow_target({mode:'current'})` were permanently refused for the whole session. No relay protocol change was needed: the Origin identifies where the panel page is served from, which is the ComfyUI the session already points at.
- **#1226** — deleted `civitai-lookup.ts`, which nothing has ever imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)