### PR TITLE
chore(release): reconcile main to 0.50.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.68] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- the stale-heartbeat note must not tell a Manager dispatch to re-issue (#1242)
+
+#### Changed
+- 0.50.67 (#1241)
+
+
 ## [0.50.67] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.67",
+  "version": "0.50.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.67",
+      "version": "0.50.68",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.67",
+  "version": "0.50.68",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.68` tag.

Ships **#1148** — the stale-heartbeat NOTE no longer gives local recovery advice to a ComfyUI-Manager dispatch, where re-issuing is a duplicate server-side dispatch that corrupts the model (#1197). The route is three states: manager, local, and *unknown* for records written before the route was stored — the last gets its own cautious wording rather than falling through to "local", which codex review caught as the same fold one level down.

The cancellation reply, which still asserted a resumable partial and advised re-issuing, now shares one advice function with the note so the two cannot contradict each other again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)