### PR TITLE
fix(target): 127.0.0.1 and localhost are the same host, not a target drift

### DIFF
--- a/src/__tests__/comfyui/loopback-alias-origin.test.ts
+++ b/src/__tests__/comfyui/loopback-alias-origin.test.ts
@@ -1,0 +1,117 @@
+// #1175 (recurrence) — two spellings of loopback read as two different servers.
+//
+// The reporter's panel was on `http://127.0.0.1:8188` while the headless target
+// was `http://localhost:8188`. Both reach the same ComfyUI — the headless
+// restart succeeded and then probed 127.0.0.1:8188 — but the origins were
+// compared with `Array.includes`, so the orchestrator reported "a DIFFERENT
+// address" and told them to point COMFYUI_URL at the origin it was already
+// pointed at.
+//
+// That is a diagnosis that sends the reader to fix something that is not broken,
+// which is worse than no diagnosis: the previous message at least admitted it
+// did not know.
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { canonicalOrigin, sameOrigin } from "../../utils/origin.js";
+import { describeTargetDrift, setConnectedPanelOrigins } from "../../comfyui/fetch.js";
+
+afterEach(() => setConnectedPanelOrigins(null));
+
+describe("canonicalOrigin (#1175)", () => {
+  it.each([
+    ["http://127.0.0.1:8188", "http://localhost:8188"],
+    ["http://localhost:8188", "http://localhost:8188"],
+    ["http://[::1]:8188", "http://localhost:8188"],
+    ["http://LOCALHOST:8188", "http://localhost:8188"],
+    // A path, query and trailing slash are not part of an origin.
+    ["http://127.0.0.1:8188/comfy/?x=1", "http://localhost:8188"],
+    // A default port is dropped, matching what a browser sends as Origin.
+    ["http://localhost:80", "http://localhost"],
+    ["https://127.0.0.1:443", "https://localhost"],
+  ])("collapses %s -> %s", (input, expected) => {
+    expect(canonicalOrigin(input)).toBe(expected);
+  });
+
+  it.each([
+    ["", "empty"],
+    ["   ", "blank"],
+    ["not a url", "unparseable"],
+    ["file:///c:/x.html", "no authority (origin is the literal 'null')"],
+    [undefined, "absent"],
+  ])("returns undefined for %s (%s)", (input) => {
+    expect(canonicalOrigin(input as string | undefined)).toBeUndefined();
+  });
+
+  it("does NOT collapse a non-loopback host that merely looks local", () => {
+    // 127.0.0.2 is loopback by RFC, but two servers really can hold
+    // 127.0.0.1:8188 and 127.0.0.2:8188 at once — calling those one origin would
+    // be a false identity, the same failure mirrored.
+    expect(canonicalOrigin("http://127.0.0.2:8188")).toBe("http://127.0.0.2:8188");
+    expect(sameOrigin("http://127.0.0.1:8188", "http://127.0.0.2:8188")).toBe(false);
+  });
+
+  it("does NOT collapse across schemes or ports", () => {
+    expect(sameOrigin("http://localhost:8188", "https://localhost:8188")).toBe(false);
+    expect(sameOrigin("http://localhost:8188", "http://localhost:8189")).toBe(false);
+  });
+
+  it("two unparseable inputs are NOT 'the same origin'", () => {
+    // Callers use this to decide whether to report a mismatch; making junk equal
+    // to junk would silently suppress every real one.
+    expect(sameOrigin("nonsense", "nonsense")).toBe(false);
+    expect(sameOrigin(undefined, undefined)).toBe(false);
+  });
+});
+
+describe("describeTargetDrift with aliased loopback (#1175)", () => {
+  it("does NOT claim a different address for 127.0.0.1 vs localhost", () => {
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8188"]);
+    const out = describeTargetDrift("http://localhost:8188/system_stats");
+
+    expect(out, "the reported false diagnosis").not.toMatch(/DIFFERENT address/);
+    expect(out, "and the retry it recommended").not.toMatch(/Point COMFYUI_URL/);
+    expect(out).toMatch(/same origin/);
+  });
+
+  it("names BOTH spellings so 'same origin' does not read as a contradiction", () => {
+    // Two visibly different strings next to the words "this same origin" is what
+    // sent the reporter looking for a mismatch that did not exist.
+    setConnectedPanelOrigins(() => ["http://127.0.0.1:8188"]);
+    const out = describeTargetDrift("http://localhost:8188/x");
+
+    expect(out).toContain("http://127.0.0.1:8188");
+    expect(out).toContain("http://localhost:8188");
+    expect(out).toMatch(/the same host/);
+  });
+
+  it("says nothing extra when the spellings are already identical", () => {
+    setConnectedPanelOrigins(() => ["http://localhost:8188"]);
+    const out = describeTargetDrift("http://localhost:8188/x");
+
+    expect(out).toMatch(/same origin/);
+    expect(out, "no alias clause when there is no alias").not.toMatch(/the same host/);
+  });
+
+  it("STILL reports a genuinely different address", () => {
+    // The half that must not regress: collapsing aliases must not collapse a
+    // real mismatch, which is the whole value of this diagnostic.
+    setConnectedPanelOrigins(() => ["http://192.168.1.50:8188"]);
+    const out = describeTargetDrift("http://localhost:8188/x");
+
+    expect(out).toMatch(/DIFFERENT address/);
+    expect(out).toContain("http://192.168.1.50:8188");
+  });
+
+  it("matches an aliased origin among SEVERAL connected panels", () => {
+    // The match has to be found by comparison, not by luck of ordering.
+    setConnectedPanelOrigins(() => ["http://192.168.1.50:8188", "http://127.0.0.1:8188"]);
+    expect(describeTargetDrift("http://localhost:8188/x")).toMatch(/same origin/);
+  });
+
+  it("stays silent when there is no panel to compare against", () => {
+    // An absent comparison is not a negative result.
+    setConnectedPanelOrigins(() => []);
+    expect(describeTargetDrift("http://localhost:8188/x")).toBe("");
+  });
+});

--- a/src/__tests__/comfyui/loopback-alias-origin.test.ts
+++ b/src/__tests__/comfyui/loopback-alias-origin.test.ts
@@ -29,6 +29,11 @@ describe("canonicalOrigin (#1175)", () => {
     // A default port is dropped, matching what a browser sends as Origin.
     ["http://localhost:80", "http://localhost"],
     ["https://127.0.0.1:443", "https://localhost"],
+    // A single trailing dot is the fully-qualified spelling of the same name,
+    // and a browser sends it verbatim as an Origin.
+    ["http://localhost.:8188", "http://localhost:8188"],
+    // Non-http schemes keep their scheme rather than being rejected.
+    ["ws://127.0.0.1:8188", "ws://localhost:8188"],
   ])("collapses %s -> %s", (input, expected) => {
     expect(canonicalOrigin(input)).toBe(expected);
   });
@@ -113,5 +118,34 @@ describe("describeTargetDrift with aliased loopback (#1175)", () => {
     // An absent comparison is not a negative result.
     setConnectedPanelOrigins(() => []);
     expect(describeTargetDrift("http://localhost:8188/x")).toBe("");
+  });
+});
+
+// The empirical checks a review asked for, pinned so the answers stay answers.
+describe("canonicalOrigin on inputs that are easy to get wrong (#1175)", () => {
+  it("does not leak userinfo into the origin", () => {
+    // COMFYUI_URL can legitimately carry basic-auth credentials, and this string
+    // is printed in a diagnostic. Building from protocol+hostname+port drops
+    // them; a hand-rolled string split would not.
+    const out = canonicalOrigin("http://user:hunter2@127.0.0.1:8188/x");
+    expect(out).toBe("http://localhost:8188");
+    expect(out).not.toContain("hunter2");
+  });
+
+  it("normalises an uppercase scheme and host", () => {
+    expect(canonicalOrigin("HTTP://LocalHost:8188")).toBe("http://localhost:8188");
+  });
+
+  it("matches the BRACKETED IPv6 form URL.hostname actually produces", () => {
+    // `new URL("http://[::1]:8188").hostname` is "[::1]", with brackets — a bare
+    // "::1" in the alias set would never be reached.
+    expect(canonicalOrigin("http://[::1]:8188")).toBe("http://localhost:8188");
+    expect(sameOrigin("http://[::1]:8188", "http://127.0.0.1:8188")).toBe(true);
+  });
+
+  it("leaves a non-loopback host's spelling alone, trailing dot included", () => {
+    // The dot strip is for the LOOKUP only. Rewriting an unrelated host would
+    // change an origin nobody asked us to normalise.
+    expect(canonicalOrigin("http://example.com.:8188")).toBe("http://example.com.:8188");
   });
 });

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -1,5 +1,6 @@
 import { getComfyUIAuthHeaders } from "../config.js";
 import { describeFetchFailure, isBareFetchFailure } from "../utils/errors.js";
+import { sameOrigin } from "../utils/origin.js";
 
 /** The request target, for the diagnostic. Never throws on an odd input. */
 export function targetOf(input: string | URL | Request): string {
@@ -77,9 +78,22 @@ export function describeTargetDrift(target: string): string {
   const want = originOf(target);
   if (!want) return "";
   const distinct = [...new Set(origins)];
-  if (distinct.includes(want)) {
+  // #1175 — `includes` compares spellings, not servers. A panel on
+  // http://127.0.0.1:8188 against a target of http://localhost:8188 is ONE
+  // ComfyUI, and reporting it as "a DIFFERENT address" sent a reporter to point
+  // COMFYUI_URL at the origin it was already pointed at.
+  const match = distinct.find((o) => sameOrigin(o, want));
+  if (match !== undefined) {
+    // Name BOTH spellings when they differ textually. "This same origin" reads
+    // as a contradiction next to two visibly different strings, and the reader
+    // has no way to know the comparison was alias-aware — which is what sent the
+    // #1175 reporter looking for a target mismatch that did not exist.
+    const alias =
+      match === want
+        ? ""
+        : ` (spelled ${match} there and ${want} here — the same host, so this is not a mismatch)`;
     return (
-      ` A connected panel is on this same origin, so this is NOT a wrong-address problem: ` +
+      ` A connected panel is on this same origin${alias}, so this is NOT a wrong-address problem: ` +
       `the browser can reach ${want} and this process cannot (a firewall, a container ` +
       `boundary, or a server bound to one interface).`
     );

--- a/src/utils/origin.ts
+++ b/src/utils/origin.ts
@@ -32,8 +32,12 @@
  * and this process cannot — a firewall, a container boundary, or a server bound
  * to one interface") is a BETTER description of a v4/v6 split than "point
  * COMFYUI_URL somewhere else" was.
+ *
+ * `[::1]` carries its brackets because that is what `URL.hostname` returns for
+ * an IPv6 literal — a bare `"::1"` here would be dead code, since every input
+ * reaches this set through `new URL()`.
  */
-const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
 /** The canonical loopback spelling, so every alias collapses to one key. */
 const LOOPBACK_CANONICAL = "localhost";
@@ -55,8 +59,14 @@ export function canonicalOrigin(url: string | undefined): string | undefined {
   const origin = parsed.origin;
   // A scheme with no authority (file:, data:) has the literal origin "null".
   if (!origin || origin === "null") return undefined;
+  // A single trailing dot is the fully-qualified spelling of the same name
+  // (`localhost.` is `localhost` rooted at the DNS root), and browsers will send
+  // it verbatim as an Origin. Stripped before the lookup, and only for the
+  // lookup — a non-loopback host keeps whatever spelling it arrived with, since
+  // rewriting it would change an origin nobody asked us to normalise.
   const host = parsed.hostname.toLowerCase();
-  const canonHost = LOOPBACK_HOSTS.has(host) ? LOOPBACK_CANONICAL : host;
+  const bare = host.endsWith(".") ? host.slice(0, -1) : host;
+  const canonHost = LOOPBACK_HOSTS.has(bare) ? LOOPBACK_CANONICAL : host;
   // Rebuild rather than string-replace: `parsed.port` is "" for a default port,
   // which is exactly the normalisation `origin` already applies, and a host can
   // otherwise appear inside the scheme or a userinfo section.

--- a/src/utils/origin.ts
+++ b/src/utils/origin.ts
@@ -1,0 +1,74 @@
+// Comparing two ORIGINS for "is this the same server" (#1175).
+//
+// `http://127.0.0.1:8188` and `http://localhost:8188` are the same ComfyUI, and
+// comparing the strings says they are not. A reporter's panel was on the first
+// while the headless target was the second — the headless restart worked and
+// then probed 127.0.0.1:8188, proving they were one instance — and the
+// orchestrator still reported "a DIFFERENT address" and advised pointing
+// COMFYUI_URL at an origin it was already pointed at.
+//
+// The same blindness scopes the workflow-instance fence, which is keyed by
+// origin: a fence adopted under one spelling would refuse under the other. That
+// half is not hypothetical either, because the relay path now DERIVES its origin
+// from COMFYUI_URL (#1077) while the loopback path OBSERVES the browser's — two
+// independent sources that can easily disagree only in spelling.
+//
+// WHY THIS IS ITS OWN MODULE. Three loopback notions already exist
+// (`isLoopbackServerUrl`, `port-owner`'s LOOPBACK/WILDCARD split,
+// `env-capabilities`' LOCAL/REMOTE test) and they legitimately differ — one
+// treats `0.0.0.0` as local, another must keep bind-wildcards separate from
+// connect addresses. None of them answers "are these two origins the same
+// server", so this adds that one question rather than bending any of them.
+
+/**
+ * Loopback spellings treated as ONE host.
+ *
+ * Deliberately the exact four, not all of 127.0.0.0/8: two servers really can
+ * bind 127.0.0.1:8188 and 127.0.0.2:8188 at the same time, and calling those the
+ * same origin would be a false identity — the failure this exists to prevent,
+ * mirrored. `localhost` can resolve to ::1 rather than 127.0.0.1 on some
+ * systems, which is the one genuine assumption here; it is the right one,
+ * because when it is wrong the resulting message ("the browser can reach this
+ * and this process cannot — a firewall, a container boundary, or a server bound
+ * to one interface") is a BETTER description of a v4/v6 split than "point
+ * COMFYUI_URL somewhere else" was.
+ */
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+/** The canonical loopback spelling, so every alias collapses to one key. */
+const LOOPBACK_CANONICAL = "localhost";
+
+/**
+ * `scheme://host[:port]` with loopback aliases collapsed, or undefined when
+ * `url` is not a URL. The SCHEME is never collapsed: http and https on one host
+ * are different origins by every other rule in this codebase, and a proxy can
+ * genuinely serve different things on each.
+ */
+export function canonicalOrigin(url: string | undefined): string | undefined {
+  if (typeof url !== "string" || !url.trim()) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(url.trim());
+  } catch {
+    return undefined;
+  }
+  const origin = parsed.origin;
+  // A scheme with no authority (file:, data:) has the literal origin "null".
+  if (!origin || origin === "null") return undefined;
+  const host = parsed.hostname.toLowerCase();
+  const canonHost = LOOPBACK_HOSTS.has(host) ? LOOPBACK_CANONICAL : host;
+  // Rebuild rather than string-replace: `parsed.port` is "" for a default port,
+  // which is exactly the normalisation `origin` already applies, and a host can
+  // otherwise appear inside the scheme or a userinfo section.
+  return `${parsed.protocol}//${canonHost}${parsed.port ? `:${parsed.port}` : ""}`;
+}
+
+/** True when two URLs name the same origin, loopback aliases included. */
+export function sameOrigin(a: string | undefined, b: string | undefined): boolean {
+  const left = canonicalOrigin(a);
+  const right = canonicalOrigin(b);
+  // Two unparseable inputs are not "the same origin" — that would make every
+  // piece of junk equal to every other, and callers use this to decide whether
+  // to report a mismatch.
+  return left !== undefined && left === right;
+}


### PR DESCRIPTION
Addresses the **recurrence** reported on #1175 (comfyui-mcp 0.50.64, panel 0.11.59, Windows 11 ComfyUI Desktop).

The panel is on `http://127.0.0.1:8188`; the headless target is `http://localhost:8188`. Both reach the same instance — the headless restart succeeds and later probes `127.0.0.1:8188` — but the origins are compared as raw strings, so the orchestrator reports them as a DIFFERENT address and advises pointing `COMFYUI_URL` somewhere it is already pointed.

`describeTargetDrift` (`src/comfyui/fetch.ts`) does `distinct.includes(want)`, which cannot see that two spellings of loopback name one host.

Draft while I map every origin comparison this affects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)