### PR TITLE
fix(panel_ask): the timeout must not offer a cause it already ruled out (#1243)

### DIFF
--- a/src/__tests__/orchestrator/ask-timeout-honesty.test.ts
+++ b/src/__tests__/orchestrator/ask-timeout-honesty.test.ts
@@ -1,0 +1,52 @@
+// #1243 — panel_ask's timeout told the agent two things that were not true together.
+//
+// 1. The tool description said it "BLOCKS until they pick" and never mentioned that the
+//    wait is capped at ASK_TOTAL_BUDGET_CAP_MS (285s). An agent budgeting a turn had no
+//    way to know a single unanswered question costs five minutes.
+// 2. The timeout result offered "or no interactive panel surface rendered it" as an
+//    alternative cause — but `ctx.ensureReachable()` had already run for this ask, so
+//    that cause was ALREADY excluded. Offering it sends the agent to re-invoke "from an
+//    interactive ComfyUI tab" it was demonstrably already on.
+//
+// The surface flag is threaded rather than assumed because `ensureReachable` is
+// optional-chained at the call site: when no check ran, the alternative is still live
+// and is still named.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync("src/orchestrator/panel-tools.ts", "utf8");
+
+describe("#1243 panel_ask timeout honesty", () => {
+  it("the tool description discloses the ceiling instead of promising an unbounded block", () => {
+    const at = src.indexOf('"panel_ask",');
+    const desc = src.slice(at, at + 1200);
+    expect(desc).toContain("does NOT block forever");
+    expect(desc).toMatch(/~?285s/);
+  });
+
+  it("a confirmed surface yields a TIMEOUT message, not a delivery-failure guess", () => {
+    const fn = src.slice(src.indexOf("function askTimeoutResult("), src.indexOf("function askTimeoutResult(") + 1800);
+    expect(fn).toContain("this is a timeout, not a delivery failure");
+    expect(fn).toContain("may simply not have been at the screen");
+  });
+
+  it("the ruled-out cause is only offered when NO reachability check ran", () => {
+    const fn = src.slice(src.indexOf("function askTimeoutResult("), src.indexOf("function askTimeoutResult(") + 1800);
+    // The no-surface wording must live on the surfaceConfirmed=false side only.
+    const branch = fn.indexOf("surfaceConfirmed");
+    const noSurface = fn.indexOf("no interactive panel surface rendered it");
+    const elseArm = fn.indexOf("    : `The question card was not answered within");
+    expect(branch).toBeGreaterThan(-1);
+    expect(noSurface).toBeGreaterThan(elseArm);
+  });
+
+  it("the ask call site passes surfaceConfirmed=true, because ensureReachable ran", () => {
+    expect(src).toContain("askTimeoutResult(tabId, fingerprint, outcome.recovery, true)");
+  });
+
+  it("both wordings state how long was actually waited", () => {
+    const fn = src.slice(src.indexOf("function askTimeoutResult("), src.indexOf("function askTimeoutResult(") + 1800);
+    expect(fn).toContain("const waited = ");
+    expect((fn.match(/\$\{waited\}/g) || []).length).toBe(2);
+  });
+});

--- a/src/__tests__/orchestrator/ask-timeout-honesty.test.ts
+++ b/src/__tests__/orchestrator/ask-timeout-honesty.test.ts
@@ -47,4 +47,16 @@ describe("#1243 panel_ask timeout honesty", () => {
     expect(desc).toContain("does NOT block forever");
     expect(desc).toMatch(/~?285s/);
   });
+
+  it("the CALL SITE derives the flag rather than hardcoding it", () => {
+    // Helper-only coverage cannot see this: mutating the call site to `true` left every
+    // behavioural test green, because they call askTimeoutResult directly. The risk here
+    // is someone changing the CALL, so the call shape is what is pinned.
+    const src = readFileSync("src/orchestrator/panel-tools.ts", "utf8");
+    expect(src).toContain('const surfaceConfirmed = typeof ctx.ensureReachable === "function";');
+    expect(src).toContain("askTimeoutResult(tabId, fingerprint, outcome.recovery, surfaceConfirmed)");
+    // A literal would make one branch unreachable in production while the helper tests
+    // still passed — the failure this assertion exists for.
+    expect(src).not.toContain("askTimeoutResult(tabId, fingerprint, outcome.recovery, true)");
+  });
 });

--- a/src/__tests__/orchestrator/ask-timeout-honesty.test.ts
+++ b/src/__tests__/orchestrator/ask-timeout-honesty.test.ts
@@ -1,52 +1,50 @@
 // #1243 — panel_ask's timeout told the agent two things that were not true together.
 //
-// 1. The tool description said it "BLOCKS until they pick" and never mentioned that the
-//    wait is capped at ASK_TOTAL_BUDGET_CAP_MS (285s). An agent budgeting a turn had no
-//    way to know a single unanswered question costs five minutes.
-// 2. The timeout result offered "or no interactive panel surface rendered it" as an
-//    alternative cause — but `ctx.ensureReachable()` had already run for this ask, so
-//    that cause was ALREADY excluded. Offering it sends the agent to re-invoke "from an
-//    interactive ComfyUI tab" it was demonstrably already on.
+// 1. The description said it "BLOCKS until they pick" and never disclosed the 285s cap.
+// 2. The timeout result offered "or no interactive panel surface rendered it" — a cause
+//    `ctx.ensureReachable()` had ALREADY excluded for this ask. Offering it sent the
+//    agent to re-invoke "from an interactive ComfyUI tab" it was demonstrably on.
 //
-// The surface flag is threaded rather than assumed because `ensureReachable` is
-// optional-chained at the call site: when no check ran, the alternative is still live
-// and is still named.
+// These call askTimeoutResult DIRECTLY. An earlier version asserted on source text, and
+// a mutation flipping `surfaceConfirmed` to a constant SURVIVED it — both branches were
+// still present in the source, so the assertions could not tell which one ran.
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
+import { askTimeoutResult } from "../../orchestrator/panel-tools.js";
 
-const src = readFileSync("src/orchestrator/panel-tools.ts", "utf8");
+const text = (surfaceConfirmed: boolean) => {
+  const r = askTimeoutResult("wf:t", "fp", { kind: "none" } as never, surfaceConfirmed);
+  return r.content.map((c: { text?: string }) => c.text ?? "").join("\n");
+};
 
 describe("#1243 panel_ask timeout honesty", () => {
-  it("the tool description discloses the ceiling instead of promising an unbounded block", () => {
-    const at = src.indexOf('"panel_ask",');
-    const desc = src.slice(at, at + 1200);
-    expect(desc).toContain("does NOT block forever");
-    expect(desc).toMatch(/~?285s/);
+  it("a CONFIRMED surface is reported as a timeout, not a delivery guess", () => {
+    const t = text(true);
+    expect(t).toContain("this is a timeout, not a delivery failure");
+    expect(t).toContain("may simply not have been at the screen");
+    expect(t).not.toContain("no interactive panel surface rendered it");
   });
 
-  it("a confirmed surface yields a TIMEOUT message, not a delivery-failure guess", () => {
-    const fn = src.slice(src.indexOf("function askTimeoutResult("), src.indexOf("function askTimeoutResult(") + 1800);
-    expect(fn).toContain("this is a timeout, not a delivery failure");
-    expect(fn).toContain("may simply not have been at the screen");
-  });
-
-  it("the ruled-out cause is only offered when NO reachability check ran", () => {
-    const fn = src.slice(src.indexOf("function askTimeoutResult("), src.indexOf("function askTimeoutResult(") + 1800);
-    // The no-surface wording must live on the surfaceConfirmed=false side only.
-    const branch = fn.indexOf("surfaceConfirmed");
-    const noSurface = fn.indexOf("no interactive panel surface rendered it");
-    const elseArm = fn.indexOf("    : `The question card was not answered within");
-    expect(branch).toBeGreaterThan(-1);
-    expect(noSurface).toBeGreaterThan(elseArm);
-  });
-
-  it("the ask call site passes surfaceConfirmed=true, because ensureReachable ran", () => {
-    expect(src).toContain("askTimeoutResult(tabId, fingerprint, outcome.recovery, true)");
+  it("an UNCONFIRMED surface still names the alternative — absence is not exclusion", () => {
+    // Suppressing it unconditionally would be the same bug pointing the other way.
+    const t = text(false);
+    expect(t).toContain("no interactive panel surface rendered it");
+    expect(t).toContain("could not establish which");
   });
 
   it("both wordings state how long was actually waited", () => {
-    const fn = src.slice(src.indexOf("function askTimeoutResult("), src.indexOf("function askTimeoutResult(") + 1800);
-    expect(fn).toContain("const waited = ");
-    expect((fn.match(/\$\{waited\}/g) || []).length).toBe(2);
+    for (const t of [text(true), text(false)]) expect(t).toMatch(/\b285s\b/);
+  });
+
+  it("both keep a usable next step rather than only reporting failure", () => {
+    for (const t of [text(true), text(false)]) expect(t).toContain("plain chat text");
+  });
+
+  it("the tool description discloses the ceiling instead of promising an unbounded block", () => {
+    const src = readFileSync("src/orchestrator/panel-tools.ts", "utf8");
+    const at = src.indexOf('"panel_ask",');
+    const desc = src.slice(at, at + 1400);
+    expect(desc).toContain("does NOT block forever");
+    expect(desc).toMatch(/~?285s/);
   });
 });

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4693,7 +4693,11 @@ describe("panel_ask keeps a validated answer across a tool timeout (#486)", () =
     // NOT answered — the scheduler question has no answer on file.
     expect(res.isError).toBe(true);
     const text = askText(res);
-    expect(text).toMatch(/not answered in time/i);
+    // #1243 — the wording now states the elapsed ceiling rather than a vague
+    // "in time", and distinguishes a timeout from a delivery failure. The
+    // assertion tracks the INTENT (it is reported as unanswered) rather than the
+    // old phrasing.
+    expect(text).toMatch(/went unanswered for \d+s|not answered within \d+s/i);
     // ...but the sampler answer is REPORTED rather than swallowed, quoted with
     // the question it actually answers and an explicit refusal to let it stand in.
     expect(text).toContain(SAMPLER.question);
@@ -4764,7 +4768,7 @@ describe("panel_ask keeps a validated answer across a tool timeout (#486)", () =
     } as unknown as PanelToolCtx;
     const res = await defByName("panel_ask").handler(SAMPLER as Record<string, unknown>, ctx);
     expect(res.isError).toBe(true);
-    expect(askText(res)).toMatch(/not answered in time/i);
+    expect(askText(res)).toMatch(/went unanswered for \d+s|not answered within \d+s/i);
     expect(askText(res)).not.toMatch(/HOWEVER/);
   });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6140,12 +6140,26 @@ function askTimeoutResult(
   tabId: string,
   fingerprint: string,
   recovery: AskRecovery,
+  /**
+   * #1243 — did a reachability check actually run before the wait? When it did, the
+   * "maybe nothing rendered the card" alternative has ALREADY been ruled out, and
+   * offering it anyway sends the agent to re-invoke from "an interactive tab" it was
+   * demonstrably already on. `ctx.ensureReachable` is optional-chained at the call
+   * site, so this is threaded rather than assumed — an absent check means the
+   * alternative is still live and is still named.
+   */
+  surfaceConfirmed: boolean,
 ): ToolResult {
-  let text =
-    "The question card was not answered in time (or no interactive panel surface " +
-    "rendered it — e.g. an exec/headless run), so nothing was selected. If you " +
-    "still need the decision, ask the user directly in plain chat text, or " +
-    "re-invoke panel_ask from an interactive ComfyUI tab.";
+  const waited = `${Math.round(ASK_TOTAL_BUDGET_CAP_MS / 1000)}s`;
+  let text = surfaceConfirmed
+    ? `The question card was delivered to the panel and went unanswered for ${waited}, ` +
+      "so nothing was selected — this is a timeout, not a delivery failure. The user " +
+      "may simply not have been at the screen. If you still need the decision, ask them " +
+      "directly in plain chat text, or re-invoke panel_ask when they are present."
+    : `The question card was not answered within ${waited} — either it went unanswered, ` +
+      "or no interactive panel surface rendered it (e.g. an exec/headless run), and this " +
+      "call could not establish which. If you still need the decision, ask the user " +
+      "directly in plain chat text, or re-invoke panel_ask from an interactive ComfyUI tab.";
   // What is surfaced, and why each:
   //  • an answer that reached NO tool call — nobody has it, so it must be told;
   //  • an answer to THIS EXACT question that DID reach a tool call but could not
@@ -6320,7 +6334,9 @@ async function askUserWithGrace(
       // a conversation replaced mid-ask would let the live turn's ack settle a
       // warning that conversation never saw — the debt path reaching a live turn
       // through a helper, which is how it slipped the gate before.
-      const body = askTimeoutResult(tabId, fingerprint, outcome.recovery);
+      // #1243 — ensureReachable ran above (line ~6258), so a surface WAS confirmed for
+      // this ask; say so rather than offering a cause already excluded.
+      const body = askTimeoutResult(tabId, fingerprint, outcome.recovery, true);
       return AskAnswers.askBelongsToLiveConversation(askId)
         ? withDroppedAnswerWarning(tabId, body)
         : body;
@@ -8775,7 +8791,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_ask",
-      "Ask the user to choose between options — renders an interactive question card in the panel chat and BLOCKS until they pick, returning their choice as text. Use this (NOT the AskUserQuestion tool, which never renders here) whenever you need the user to decide between options. Each option may carry a short description. The card always includes an 'Other…' free-text field, so the returned string may be a listed label or whatever the user typed (comma-joined for multi_select). Ask only when the answer genuinely changes what you do.",
+      "Ask the user to choose between options — renders an interactive question card in the panel chat and BLOCKS until they pick, returning their choice as text. It does NOT block forever: if nobody answers within ~285s the call returns an error saying so, and you must then ask in plain chat text or re-invoke when the user is present. Budget for that — a question asked while the user is away costs the better part of five minutes before you learn anything. Use this (NOT the AskUserQuestion tool, which never renders here) whenever you need the user to decide between options. Each option may carry a short description. The card always includes an 'Other…' free-text field, so the returned string may be a listed label or whatever the user typed (comma-joined for multi_select). Ask only when the answer genuinely changes what you do.",
       {
         question: z.string().describe("The question to ask, e.g. 'Which sampler should I use?'"),
         options: z

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6136,7 +6136,7 @@ function recoveredAskResult(entry: AskEntry): ToolResult {
  * the question at hand, which is the misattribution this whole path exists to
  * prevent. Reporting them beats swallowing them — the user did answer something.
  */
-function askTimeoutResult(
+export function askTimeoutResult(
   tabId: string,
   fingerprint: string,
   recovery: AskRecovery,

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6334,9 +6334,13 @@ async function askUserWithGrace(
       // a conversation replaced mid-ask would let the live turn's ack settle a
       // warning that conversation never saw — the debt path reaching a live turn
       // through a helper, which is how it slipped the gate before.
-      // #1243 — ensureReachable ran above (line ~6258), so a surface WAS confirmed for
-      // this ask; say so rather than offering a cause already excluded.
-      const body = askTimeoutResult(tabId, fingerprint, outcome.recovery, true);
+      // #1243 — derive this rather than hardcoding `true`. The reachability call above
+      // is optional-chained (`ctx.ensureReachable?.()`), so on a ctx that does not
+      // provide it NO check ran and the no-surface alternative is still live. Passing a
+      // literal would have made the false branch unreachable in production — dead code
+      // justified by a hypothetical, and a test exercising a path nothing takes.
+      const surfaceConfirmed = typeof ctx.ensureReachable === "function";
+      const body = askTimeoutResult(tabId, fingerprint, outcome.recovery, surfaceConfirmed);
       return AskAnswers.askBelongsToLiveConversation(askId)
         ? withDroppedAnswerWarning(tabId, body)
         : body;


### PR DESCRIPTION
Fixes #1243. Two things `panel_ask` told the agent that were not true together.

**1. The description hid the ceiling.** It said it "BLOCKS until they pick" and never mentioned `ASK_TOTAL_BUDGET_CAP_MS` (285s). An agent budgeting a turn had no way to know one unanswered question costs the better part of five minutes before it learns anything.

**2. The timeout offered a cause that had already been excluded.** It said *"or no interactive panel surface rendered it — e.g. an exec/headless run"* — but `ctx.ensureReachable()` had already run for this ask. Offering it sent the agent to re-invoke "from an interactive ComfyUI tab" it was demonstrably already on: a remedy the evidence in hand had ruled out.

It now says the card was delivered and went unanswered for N seconds — **a timeout, not a delivery failure** — and that the user may simply not have been at the screen, which is the likely explanation.

`surfaceConfirmed` is **threaded, not assumed**: `ctx.ensureReachable` is optional-chained at the call site, so when no check ran the alternative is still live and still named. Naming it unconditionally was the bug; suppressing it unconditionally would be the same bug pointing the other way.

## Verification

1914 orchestrator tests pass. Tests call `askTimeoutResult` **directly** — an earlier version asserted on source text and a mutation flipping the flag to a constant survived, because both branches remained in the file. Three mutations now die: forcing either branch, and dropping the elapsed figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)