### PR TITLE
chore(release): reconcile main to 0.50.69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.69] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- 127.0.0.1 and localhost are the same host, not a target drift (#1246)
+
+#### Changed
+- 0.50.68 (#1245)
+
+
 ## [0.50.68] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.68",
+  "version": "0.50.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.68",
+      "version": "0.50.69",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.68",
+  "version": "0.50.69",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.69` tag.

Ships **#1175** (recurrence) — `http://127.0.0.1:8188` and `http://localhost:8188` are one host. The orchestrator compared connected-panel origins to the headless target as raw strings, so it reported "a DIFFERENT address" and told the reporter to point `COMFYUI_URL` at the origin it was already pointed at. Comparison is now alias-aware, and the message names both spellings when they differ.

Verified on the compiled artifact against the reporter's exact pair; a genuinely different address is still reported as one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)