### PR TITLE
release: v0.50.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.70] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- get_history shows output VALUES, not just their keys (#1229)
+- 127.0.0.1 and localhost are the same host, not a target drift (#1246)
+
+#### Changed
+- 0.50.68 (#1245)
+
+
 ## [0.50.68] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.68",
+  "version": "0.50.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.68",
+      "version": "0.50.70",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.68",
+  "version": "0.50.70",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the version bump and changelog for v0.50.70.

Ships #1229 (`466d126`): `get_history` rendered a non-media output's KEY and discarded its value, so a `PreviewAny` diagnostic showed as `Node 102: text` with the answer dropped — silently. Values now render for every non-media key, in **both** the media and no-media branches (stock `SaveAnimatedWEBP` emits `{images, animated}` and was losing `animated`), one key per line, bounded per value with an explicit truncation note.

Three review rounds, each verified against a live ComfyUI 0.31.1 capture rather than reasoning about output shapes — which is how the media-branch case and a later run-on defect were both found.

Numbering: v0.50.69 was cut without this commit while it was in review, so it lands in .70. Confirmed with `git tag --contains 466d126` → v0.50.70.

Gates on this tree: build ok, `tsc --noEmit` clean, suite 404 files / 8124 passed / 2 skipped.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>