### PR TITLE
test(recovery): stop panelRecoveryContext wording depending on which test ran first

### DIFF
--- a/src/__tests__/services/panel-base-clear-epoch.test.ts
+++ b/src/__tests__/services/panel-base-clear-epoch.test.ts
@@ -39,6 +39,7 @@ const {
   lastPanelBaseResolution,
   __resetPanelBaseCache,
   __setPanelBaseForTests,
+  clearPanelDiskObservation,
 } = await import("../../services/panel-workspace.js");
 
 beforeEach(() => {
@@ -125,6 +126,39 @@ describe("a clear beats a probe that started before it (#1222)", () => {
     const inFlight = primePanelBase({ force: true });
     __resetPanelBaseCache();
     __resetPanelBaseCache();
+    await inFlight;
+
+    expect(lastPanelBaseResolution()).toBeUndefined();
+  });
+});
+
+// CODEX REVIEW asked which OTHER paths clear the cache, and found a production
+// one: `clearPanelDiskObservation()` also drops the resolved base, and it runs on
+// every panel hello — the moment ComfyUI may have restarted with different launch
+// flags and therefore a different custom_nodes tree. Its own comment says keeping
+// the previous root would "let the very next operation freeze the wrong tree",
+// which is exactly what an in-flight probe does when it writes its pre-hello
+// answer back in a moment later. Tests were covered by __resetPanelBaseCache;
+// production was not.
+describe("a hello's clear also beats an in-flight probe (#1222)", () => {
+  it("clearPanelDiskObservation is not undone by a probe that predates it", async () => {
+    __setPanelBaseForTests("/pre-restart/base");
+    const inFlight = primePanelBase({ force: true });
+
+    clearPanelDiskObservation();
+    expect(lastPanelBaseResolution(), "the hello cleared it").toBeUndefined();
+
+    await inFlight;
+
+    expect(
+      lastPanelBaseResolution(),
+      "the pre-restart root must not be frozen back in",
+    ).toBeUndefined();
+  });
+
+  it("holds for the empty-cache start, the case reference comparison cannot see", async () => {
+    const inFlight = primePanelBase();
+    clearPanelDiskObservation();
     await inFlight;
 
     expect(lastPanelBaseResolution()).toBeUndefined();

--- a/src/__tests__/services/panel-base-clear-epoch.test.ts
+++ b/src/__tests__/services/panel-base-clear-epoch.test.ts
@@ -1,0 +1,132 @@
+// #1222 — a background prime landed its answer AFTER the cache was cleared.
+//
+// Three tests in the recovery-wording family flaked, and the wording is what
+// makes it expensive: `panelRecoveryContext()` picks between two entirely
+// different remedies depending on `installPanelUsable`, one input to which is
+// the panel-base cache. A test that inherits a primed cache gets the other
+// remedy and fails on an assertion about English, which is indistinguishable
+// from a real regression.
+//
+// MY FILED DIAGNOSIS WAS WRONG, and this file exists partly to record that: the
+// issue said the affected tests never call `__resetPanelBaseCache()`. They all
+// do, and had for days. The actual cause is written down in
+// ui-bridge.test.ts's own comment — a capability refusal fires an unawaited
+// `void primePanelBase()`, and "a late resolution lands in whichever test is
+// running when it settles". A reset cannot fix that: the write arrives mid-test,
+// after the reset has run.
+//
+// WHY THE EXISTING GUARD MISSED IT. `primePanelBase` already refuses to clobber
+// a newer write, by capturing `cached` at probe start and comparing by
+// reference. That has exactly one blind spot and it is the common case: a probe
+// that starts with an EMPTY cache records `undefined`, a clear leaves it
+// `undefined`, and the two compare equal — so the clear is invisible and the
+// stale answer is written in. A clear is an EVENT, not a value, so it is now
+// counted; `undefined → undefined` is indistinguishable by reference and
+// unmistakable by count.
+//
+// The mitigation until now was POSITIONAL — those tests sit last in their
+// describe so a late resolution has nothing left to perturb. That works until
+// someone adds a test after them.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// The race is a SEQUENCE here, not a timing hope: `primePanelBase` awaits at
+// least once before it writes, so clearing synchronously after the call — and
+// awaiting afterwards — puts the clear strictly between probe-start and
+// probe-settle every run. No sleeps, no ordering luck, no mocks.
+const {
+  primePanelBase,
+  lastPanelBaseResolution,
+  __resetPanelBaseCache,
+  __setPanelBaseForTests,
+} = await import("../../services/panel-workspace.js");
+
+beforeEach(() => {
+  __resetPanelBaseCache();
+});
+
+afterEach(() => {
+  __resetPanelBaseCache();
+});
+
+describe("a clear beats a probe that started before it (#1222)", () => {
+  it("does not repopulate the cache after __resetPanelBaseCache", async () => {
+    // Seed, so there is something for a stale probe to differ from.
+    __setPanelBaseForTests("/seeded/base");
+    expect(lastPanelBaseResolution()?.base).toBe("/seeded/base");
+
+    // A probe starts while a value is cached...
+    const inFlight = primePanelBase({ force: true });
+    // ...the cache is cleared mid-probe (the afterEach of the test that fired it)...
+    __resetPanelBaseCache();
+    expect(lastPanelBaseResolution(), "cleared means cleared").toBeUndefined();
+
+    // ...and the probe settles.
+    await inFlight;
+
+    expect(
+      lastPanelBaseResolution(),
+      "a probe that predates the clear must not undo it",
+    ).toBeUndefined();
+  });
+
+  it("holds even when the cache was EMPTY when the probe started", async () => {
+    // THE REPORTED SHAPE. A capability refusal fires the background prime
+    // precisely because nothing was primed yet, so `cached` is undefined at
+    // start — and the reference guard compares undefined to undefined and lets
+    // the write through. This is the case that actually flaked.
+    expect(lastPanelBaseResolution()).toBeUndefined();
+
+    const inFlight = primePanelBase();
+    __resetPanelBaseCache();
+    await inFlight;
+
+    expect(
+      lastPanelBaseResolution(),
+      "the empty-to-empty case is the one the reference check cannot see",
+    ).toBeUndefined();
+  });
+
+  it("still caches normally when NO clear intervenes", async () => {
+    // The other direction: the guard must not disable caching outright, or every
+    // caller re-probes and the cache stops being a cache.
+    __setPanelBaseForTests("/kept/base");
+    const before = lastPanelBaseResolution();
+    expect(before?.base).toBe("/kept/base");
+
+    await primePanelBase();
+
+    expect(lastPanelBaseResolution(), "an untouched cache survives").toBeDefined();
+  });
+
+  it("returns the probe's own answer to ITS caller even when the cache is left alone", async () => {
+    // The caller asked and this is what the probe found — withholding it would
+    // turn a cache-hygiene rule into a wrong answer for the one caller who is
+    // entitled to it.
+    //
+    // Compared against a CONTROL run rather than checked for truthiness: a bare
+    // `{ source: "none" }` placeholder is also truthy, and substituting one drops
+    // the diagnostic fields (`liveProbeFailed`, `liveRootUnderivable`) that
+    // downstream uses to explain WHY nothing resolved. Asserting deep equality
+    // with the un-cleared answer pins the property without naming those fields,
+    // so it keeps holding as they change.
+    const control = await primePanelBase({ force: true });
+    __resetPanelBaseCache();
+
+    const inFlight = primePanelBase({ force: true });
+    __resetPanelBaseCache();
+    const answer = await inFlight;
+
+    expect(answer, "the caller gets the probe's OWN answer, not a placeholder").toEqual(control);
+    expect(lastPanelBaseResolution(), "but the shared cache stays cleared").toBeUndefined();
+  });
+
+  it("counts EVERY clear, so two in a row are not one", async () => {
+    const inFlight = primePanelBase({ force: true });
+    __resetPanelBaseCache();
+    __resetPanelBaseCache();
+    await inFlight;
+
+    expect(lastPanelBaseResolution()).toBeUndefined();
+  });
+});

--- a/src/services/panel-workspace.ts
+++ b/src/services/panel-workspace.ts
@@ -203,6 +203,29 @@ let cached:
  */
 let clearEpoch = 0;
 
+/**
+ * Forget the resolved base, countably (#1222).
+ *
+ * The one way to clear it deliberately. A bare `cached = undefined` at a fourth
+ * call site would reintroduce the whole bug silently — the clear would happen and
+ * an in-flight probe would put its pre-clear answer straight back — so the count
+ * lives with the assignment rather than next to it.
+ *
+ * NOT used by the retarget bail inside `primePanelBase`. That one is discarding
+ * its OWN answer because the target moved, and the target/generation checks
+ * already stop anyone acting on it. Bumping there would additionally stop a
+ * CONCURRENT probe against the new target from caching a result that is
+ * perfectly good — which costs a re-probe rather than correctness, so it is a
+ * deliberate scope line and not a safety one. Stated that way because it is not
+ * pinned by a test: mutating it to bump changes no observable answer, only how
+ * often the next caller re-resolves, and a test asserting that would be pinning
+ * a performance detail as though it were a contract.
+ */
+function forgetResolvedBase(): void {
+  cached = undefined;
+  clearEpoch += 1;
+}
+
 /** Cache key: which ComfyUI this resolution describes. Never throws. */
 function targetKey(): string {
   try {
@@ -375,9 +398,8 @@ export function lastPanelBaseResolution(): PanelBaseResolution | undefined {
  * exactly like a real regression.
  */
 export function __resetPanelBaseCache(): void {
-  cached = undefined;
   diskObservation = undefined;
-  clearEpoch += 1;
+  forgetResolvedBase();
 }
 
 /**
@@ -477,7 +499,12 @@ export function clearPanelDiskObservation(): void {
   // restarted with different launch flags — and therefore a different
   // custom_nodes — so keeping the previous root cached would let the very next
   // operation freeze the wrong tree.
-  cached = undefined;
+  //
+  // #1222 — through `forgetResolvedBase`, because an in-flight probe that
+  // started BEFORE this hello would otherwise write the pre-restart root back in
+  // a moment later, which is precisely the freezing this exists to prevent. That
+  // is a PRODUCTION path, not only a test one: the clear runs on every hello.
+  forgetResolvedBase();
 }
 
 /**

--- a/src/services/panel-workspace.ts
+++ b/src/services/panel-workspace.ts
@@ -187,6 +187,22 @@ let cached:
   | { at: number; target: string; generation: number; resolution: PanelBaseResolution }
   | undefined;
 
+/**
+ * How many times the cache has been deliberately CLEARED (#1222).
+ *
+ * The in-flight guard below compares `cached` by reference to catch "a newer
+ * write landed while we were probing". That comparison has one blind spot, and
+ * it is the one that bites: a probe which STARTS with an empty cache records
+ * `undefined`, a clear leaves it `undefined`, and the two compare equal — so the
+ * clear is invisible and the stale probe writes its pre-clear answer in
+ * afterwards.
+ *
+ * A clear is an EVENT, not a value, so counting it is what makes it observable.
+ * `undefined → undefined` is indistinguishable by reference and unmistakable by
+ * count.
+ */
+let clearEpoch = 0;
+
 /** Cache key: which ComfyUI this resolution describes. Never throws. */
 function targetKey(): string {
   try {
@@ -263,6 +279,9 @@ export async function primePanelBase(
   // primePanelBase()` a refusal fires in the background did exactly that to a
   // base seeded after it started (#879 test isolation surfaced it).
   const cacheAtStart = cached;
+  // #1222 — and the CLEAR COUNT, because the reference comparison above cannot
+  // see a clear that leaves the cache as empty as it found it.
+  const clearEpochAtStart = clearEpoch;
 
   let resolution: PanelBaseResolution;
   try {
@@ -307,6 +326,20 @@ export async function primePanelBase(
     return cachedResolution() ?? resolution;
   }
 
+  // #1222 — the cache was deliberately CLEARED while this probe was in flight.
+  // Same rule as above and the same reason: this answer predates the clear, so
+  // writing it would silently undo an explicit "forget what you knew". The
+  // reference check misses it whenever the cache was already empty when the
+  // probe started, which is the common case — a refusal fires the background
+  // prime precisely because nothing was primed yet.
+  //
+  // The ANSWER is still returned: this caller asked and this is what the probe
+  // found. Only the shared cache is left alone, so the next caller re-resolves
+  // rather than inheriting a resolution someone asked to be forgotten.
+  if (clearEpoch !== clearEpochAtStart) {
+    return resolution;
+  }
+
   cached = { at: Date.now(), target: atTarget, generation: atGeneration, resolution };
   return resolution;
 }
@@ -331,10 +364,20 @@ export function lastPanelBaseResolution(): PanelBaseResolution | undefined {
   return cachedResolution();
 }
 
-/** Test hook — drop the cache so the next prime re-resolves. */
+/**
+ * Test hook — drop the cache so the next prime re-resolves.
+ *
+ * Bumps the clear epoch (#1222) so a probe already in flight cannot land its
+ * pre-clear answer afterwards. Without that, this hook cleared the cache and an
+ * unawaited background prime — the one a capability refusal fires — repopulated
+ * it seconds later, inside whichever test happened to be running. That produced
+ * three flakes whose only symptom was the wrong remedy WORDING, which reads
+ * exactly like a real regression.
+ */
 export function __resetPanelBaseCache(): void {
   cached = undefined;
   diskObservation = undefined;
+  clearEpoch += 1;
 }
 
 /**


### PR DESCRIPTION
Fixes #1222.

`panelRecoveryContext()` decides `installPanelUsable`, which selects between two entirely different remedy wordings. One input is `lastPanelBaseResolution()`, a module-level cache in `panel-workspace.ts` that no affected test resets — so which wording a test sees depends on whichever test primed the cache before it.

A reset hook (`__resetPanelBaseCache()`) already exists and is simply not called. Three flakes in this family so far; a flake here is indistinguishable from a real regression, which is what it actually costs.

Draft while I work it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)