### PR TITLE
chore(release): reconcile main to 0.50.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.71] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- the timeout must not offer a cause it already ruled out (#1247)
+- get_history shows output VALUES, not just their keys (#1229)
+
+#### Changed
+- stop panelRecoveryContext wording depending on which test ran first (#1250)
+- 0.50.70 (#1249)
+- 0.50.69 (#1248)
+
+
 ## [0.50.70] - 2026-08-09
 
 _No user-facing changes._

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.70",
+  "version": "0.50.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.70",
+      "version": "0.50.71",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.70",
+  "version": "0.50.71",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.71` tag.

Ships **#1222** — a deliberate cache clear now beats a probe that started before it.

`primePanelBase` guards against clobbering a newer write by comparing `cached` by reference, which is blind to a clear that leaves the cache as empty as it found it — the common case, since the background prime fires precisely because nothing was primed. Clears are now counted.

Not only a test fix: `clearPanelDiskObservation()` runs on every panel hello, when ComfyUI may have restarted onto a different `custom_nodes` tree, and an in-flight probe could write the pre-restart root back in — the exact freezing that function exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)