### PR TITLE
fix(fence): investigate #1077 Finding 2 — permanent refusal without a relay backend

### DIFF
--- a/src/__tests__/orchestrator/repin-refusal-reason.test.ts
+++ b/src/__tests__/orchestrator/repin-refusal-reason.test.ts
@@ -12,12 +12,17 @@
 // `rebound: false`. A healthy pin correctly left alone and a permanent ambiguity
 // were the same value.
 //
-// And one of those four repeats forever. `mode:"current"` picks the active tab
-// when it is eligible, or the sole eligible tab — otherwise nothing. So when the
-// ACTIVE tab belongs to another backend's conversation and this one has two or
-// more tabs, every retry refuses identically, and nothing in the reply hinted
-// that naming a workflow is the way out. That is reachable in ordinary multi-tab
-// use, which is the shape the report describes.
+// And one of those four cannot be escaped BY RETRYING. `mode:"current"` picks the
+// active tab when it is eligible, or the sole eligible tab — otherwise nothing.
+// So when the ACTIVE tab belongs to another backend's conversation and this one
+// has two or more tabs, every retry refuses on identical inputs, and nothing in
+// the reply hinted that naming a workflow is the way out.
+//
+// Deliberately NOT called permanent, which the first draft of this claimed: the
+// active tab moves on the next `user_message`, so a message sent from one of this
+// conversation's own tabs also clears it. Both ways out were invisible; the retry
+// loop is the one a stuck caller actually sits in, which is what the report
+// describes.
 
 import { describe, expect, it } from "vitest";
 
@@ -63,15 +68,20 @@ function handlerFor(opts: {
 }
 
 describe("a declined repin says which branch declined it (#1077)", () => {
-  it("THE PERMANENT ONE: active tab on another backend, several eligible here", () => {
+  it("THE STUCK ONE: active tab on another backend, several eligible here", () => {
     // Two tabs for this conversation, and the active tab belongs to codex's.
     // `mode:"current"` cannot name one, so this refuses identically every retry.
     const repin = handlerFor({
       bridge: bridgeWith({
-        tabs: [{ tab_id: "wf:a" }, { tab_id: "wf:b" }, { tab_id: "wf:other" }],
-        active: "wf:other",
+        tabs: [
+          { tab_id: "wf:workflows/alpha.json" },
+          { tab_id: "wf:workflows/beta.json" },
+          { tab_id: "wf:workflows/other.json" },
+        ],
+        active: "wf:workflows/other.json",
       }),
-      backendForTab: (t) => (t === "wf:other" ? "codex" : "claude"),
+      backendForTab: (t) =>
+        t === "wf:workflows/other.json" ? "codex" : "claude",
     });
 
     const out = repin(SCOPE);
@@ -81,15 +91,27 @@ describe("a declined repin says which branch declined it (#1077)", () => {
     const reason = (out as { reason: string }).reason;
     expect(reason, "says how many tabs are eligible").toMatch(/2 eligible tabs/);
     expect(reason, "says the active tab is not one of them").toMatch(/is not among them/);
+    // #934's lesson, which this reason repeated: `slice(0, 8)` renders EVERY
+    // `wf:workflows/…` id as the literal "wf:workf", so a message naming two
+    // different workflow tabs read as naming the same one twice.
+    expect(reason, "the tab must be identifiable").toContain("other.json");
+    expect(reason).not.toContain("wf:workf ");
     // The way out, which the old reply never mentioned.
     expect(reason).toMatch(/panel_set_workflow_target with a path|panel_open_workflow/);
   });
 
-  it("it repeats identically — the retry cannot change the answer", () => {
-    // What made the reporter refresh, close and reopen the tab.
+  it("RETRYING alone cannot change the answer", () => {
+    // What made the reporter refresh, close and reopen the tab. Deliberately not
+    // called "permanent": the active tab moves on the next user_message, so a
+    // message from one of this conversation's own tabs clears it. It is the
+    // RETRY that is futile, and that is the loop a stuck caller is in.
     const repin = handlerFor({
       bridge: bridgeWith({
-        tabs: [{ tab_id: "wf:a" }, { tab_id: "wf:b" }, { tab_id: "wf:other" }],
+        tabs: [
+          { tab_id: "wf:workflows/alpha.json" },
+          { tab_id: "wf:workflows/beta.json" },
+          { tab_id: "wf:workflows/other.json" },
+        ],
         active: "wf:other",
       }),
       backendForTab: (t) => (t === "wf:other" ? "codex" : "claude"),

--- a/src/__tests__/orchestrator/repin-refusal-reason.test.ts
+++ b/src/__tests__/orchestrator/repin-refusal-reason.test.ts
@@ -1,0 +1,200 @@
+// #1077 Finding 2 — a scope repin that declines must say WHY.
+//
+// The reporter hit a fence refusal that repeated forever on a session with NO
+// relay backend, so the Finding 1 fix (a relay socket carrying no Origin) does
+// not explain it. They could not tell which internal branch returned false —
+// "no log file, ~/.comfyui-mcp only has session/cache state" — and refreshed,
+// closed and reopened the tab before tracing it to source.
+//
+// This does not claim to reproduce their session. What it does fix is the reason
+// they could not diagnose it: `makeScopeRepinHandler` returned a bare
+// `undefined` for FOUR different outcomes, and the caller collapsed that to
+// `rebound: false`. A healthy pin correctly left alone and a permanent ambiguity
+// were the same value.
+//
+// And one of those four repeats forever. `mode:"current"` picks the active tab
+// when it is eligible, or the sole eligible tab — otherwise nothing. So when the
+// ACTIVE tab belongs to another backend's conversation and this one has two or
+// more tabs, every retry refuses identically, and nothing in the reply hinted
+// that naming a workflow is the way out. That is reachable in ordinary multi-tab
+// use, which is the shape the report describes.
+
+import { describe, expect, it } from "vitest";
+
+import { makeScopeRepinHandler, TurnOriginTracker } from "../../orchestrator/turn-origins.js";
+
+const SCOPE = "orchestrator::claude";
+
+/** A bridge with the tabs and active-tab answer the case under test needs. */
+function bridgeWith(opts: {
+  tabs: Array<{ tab_id: string }>;
+  active?: string;
+  reachable?: (tabId: string) => boolean;
+  headless?: (tabId: string) => boolean;
+}) {
+  return {
+    tabs: () => opts.tabs,
+    canReach: (t: string) => opts.reachable?.(t) ?? false,
+    isHeadless: (t: string) => opts.headless?.(t) ?? false,
+    resolveActiveScopeTab: () => opts.active,
+  };
+}
+
+function handlerFor(opts: {
+  bridge: ReturnType<typeof bridgeWith>;
+  backendForTab: (t: string) => string;
+  pin?: string;
+}) {
+  const tracker = new TurnOriginTracker({
+    backendForTab: opts.backendForTab,
+    backendOfKey: () => "claude",
+    uuidOfTab: () => undefined,
+    warn: () => {},
+  });
+  if (opts.pin) tracker.repinTo(SCOPE, opts.pin);
+  return makeScopeRepinHandler({
+    bridge: opts.bridge as never,
+    tracker,
+    scopeAgentKeyOf: () => SCOPE,
+    backendForTab: opts.backendForTab,
+    backendOfKey: () => "claude",
+    info: () => {},
+  });
+}
+
+describe("a declined repin says which branch declined it (#1077)", () => {
+  it("THE PERMANENT ONE: active tab on another backend, several eligible here", () => {
+    // Two tabs for this conversation, and the active tab belongs to codex's.
+    // `mode:"current"` cannot name one, so this refuses identically every retry.
+    const repin = handlerFor({
+      bridge: bridgeWith({
+        tabs: [{ tab_id: "wf:a" }, { tab_id: "wf:b" }, { tab_id: "wf:other" }],
+        active: "wf:other",
+      }),
+      backendForTab: (t) => (t === "wf:other" ? "codex" : "claude"),
+    });
+
+    const out = repin(SCOPE);
+
+    expect(typeof out, "must not be a bare undefined").toBe("object");
+    expect(out).toMatchObject({ repinned: false });
+    const reason = (out as { reason: string }).reason;
+    expect(reason, "says how many tabs are eligible").toMatch(/2 eligible tabs/);
+    expect(reason, "says the active tab is not one of them").toMatch(/is not among them/);
+    // The way out, which the old reply never mentioned.
+    expect(reason).toMatch(/panel_set_workflow_target with a path|panel_open_workflow/);
+  });
+
+  it("it repeats identically — the retry cannot change the answer", () => {
+    // What made the reporter refresh, close and reopen the tab.
+    const repin = handlerFor({
+      bridge: bridgeWith({
+        tabs: [{ tab_id: "wf:a" }, { tab_id: "wf:b" }, { tab_id: "wf:other" }],
+        active: "wf:other",
+      }),
+      backendForTab: (t) => (t === "wf:other" ? "codex" : "claude"),
+    });
+
+    expect(repin(SCOPE)).toEqual(repin(SCOPE));
+  });
+
+  it("a HEALTHY pin is left alone, and says so rather than looking broken", () => {
+    // The outcome that is correct and used to be indistinguishable from failure.
+    const repin = handlerFor({
+      bridge: bridgeWith({
+        tabs: [{ tab_id: "wf:a" }],
+        active: "wf:a",
+        reachable: () => true,
+      }),
+      backendForTab: () => "claude",
+      pin: "wf:a",
+    });
+
+    const reason = (repin(SCOPE) as { reason: string }).reason;
+    expect(reason).toMatch(/still reaches a live tab/);
+    expect(reason, "and why that is deliberate").toMatch(/dead or ambiguous/);
+  });
+
+  it("NO tab on this backend is its own reason, not the ambiguity one", () => {
+    const repin = handlerFor({
+      bridge: bridgeWith({ tabs: [{ tab_id: "wf:other" }], active: "wf:other" }),
+      backendForTab: () => "codex",
+    });
+
+    const reason = (repin(SCOPE) as { reason: string }).reason;
+    expect(reason).toMatch(/no connected tab belongs to this conversation's backend/);
+    expect(reason, "must not blame ambiguity when there is none").not.toMatch(/eligible tabs and/);
+  });
+
+  it("STILL repins when it can — the reasons must not replace the recovery", () => {
+    // The half that matters most: this is a recovery path, and making it
+    // explain itself must not make it stop working.
+    const repin = handlerFor({
+      bridge: bridgeWith({ tabs: [{ tab_id: "wf:a" }, { tab_id: "wf:b" }], active: "wf:b" }),
+      backendForTab: () => "claude",
+    });
+
+    expect(repin(SCOPE), "the active eligible tab is chosen").toBe("wf:b");
+  });
+
+  it("repins onto the SOLE eligible tab even when the active one is foreign", () => {
+    const repin = handlerFor({
+      bridge: bridgeWith({
+        tabs: [{ tab_id: "wf:a" }, { tab_id: "wf:other" }],
+        active: "wf:other",
+      }),
+      backendForTab: (t) => (t === "wf:other" ? "codex" : "claude"),
+    });
+
+    expect(repin(SCOPE)).toBe("wf:a");
+  });
+});
+
+// THE DELIVERY. Everything above passes with the reason never reaching a tool
+// result — the call-site blindness this repo keeps getting caught by, and found
+// here by mutation: deleting the line that appends it to the note killed nothing.
+// A reason the user never sees fixes none of what Finding 2 reported.
+describe("the refusal reaches the tool result (#1077)", () => {
+  it("panel_set_workflow_target({mode:'current'}) reports WHY the pin did not move", async () => {
+    const { buildPanelToolDefs, makePanelToolCtx } = await import(
+      "../../orchestrator/panel-tools.js"
+    );
+    const { WorkflowTargetStore } = await import("../../services/workflow-target-store.js");
+
+    const REASON =
+      'this conversation has 2 eligible tabs and the active one (wf:other) is not among them, ' +
+      'so "current" does not identify which to bind';
+
+    const bridge = {
+      send: async () => ({ ok: true, workflows: [] }),
+      push: () => 1,
+      // The scope pin must be PROVABLY dead, or panel-tools returns before the
+      // repin is consulted at all — the recovery only fires for a dead pin.
+      canReach: (t: string) => t !== "orchestrator::claude",
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: "live-tab", title: "wf", connected_at: 0 }],
+      resolveActiveTabId: () => "live-tab",
+      workflowUuidFor: () => ({ known: false, uuid: undefined }),
+      tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+      // The bridge declines and says why — the shape this PR introduces.
+      repinScopeToActive: () => ({ repinned: false, reason: REASON }),
+    } as never;
+
+    const ctx = makePanelToolCtx(bridge, "orchestrator::claude", new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target")!;
+    const res = await def.handler({ mode: "current" }, ctx);
+
+    const text = res.content.map((c: { text?: string }) => c.text ?? "").join("\n");
+    // Parse rather than substring-match the raw text: the note is JSON-encoded,
+    // so the reason's own quotes arrive escaped and a naive `toContain` fails on
+    // formatting rather than on the property being tested.
+    const note = String(
+      JSON.parse(text.slice(text.indexOf("{"), text.lastIndexOf("}") + 1)).note,
+    );
+
+    expect(note, "the reason must be in what the caller reads").toContain(REASON);
+    expect(note, "and framed so it is not mistaken for the pin having moved").toMatch(
+      /pin was NOT moved/,
+    );
+  });
+});

--- a/src/__tests__/orchestrator/turn-origins.test.ts
+++ b/src/__tests__/orchestrator/turn-origins.test.ts
@@ -12,6 +12,16 @@ import {
   type ScopeRepinBridge,
 } from "../../orchestrator/turn-origins.js";
 
+/**
+ * #1077 Finding 2 — a declined repin now carries WHY, so it is an object rather
+ * than `undefined`. What these tests protect is unchanged: nothing was repinned.
+ * Asserting that directly says so, instead of pinning the representation.
+ */
+function expectDeclined(outcome: unknown): void {
+  expect(typeof outcome, "a declined repin must not return a tab id").not.toBe("string");
+  expect(outcome, "and it must say why").toMatchObject({ repinned: false });
+}
+
 const KEY = "orchestrator::claude";
 
 /** A tracker over a mutable backend map — mirrors index.ts's wiring exactly:
@@ -609,7 +619,7 @@ describe("makeScopeRepinHandler — explicit recovery gates (gate 3, P0)", () =>
     tracker.recordForMid("m1", "uuid-a", "tab-a");
     tracker.onSeen(KEY, "m1");
     await flushMicrotasks();
-    expect(repin("orchestrator")).toBeUndefined();
+    expectDeclined(repin("orchestrator"));
     expect(tracker.pinOf(KEY)).toBe("tab-a"); // untouched
   });
 
@@ -645,7 +655,7 @@ describe("makeScopeRepinHandler — explicit recovery gates (gate 3, P0)", () =>
       tabs: [{ id: "codex-tab", backend: "codex" }],
       active: "codex-tab",
     });
-    expect(repin("orchestrator")).toBeUndefined();
+    expectDeclined(repin("orchestrator"));
     expect(tracker.pinOf(KEY)).toBeUndefined();
   });
 
@@ -667,7 +677,7 @@ describe("makeScopeRepinHandler — explicit recovery gates (gate 3, P0)", () =>
       tabs: [{ id: "tab-a" }, { id: "tab-b" }],
       active: undefined,
     });
-    expect(repin("orchestrator")).toBeUndefined();
+    expectDeclined(repin("orchestrator"));
   });
 
   it("never adopts a headless viewer", () => {
@@ -675,6 +685,6 @@ describe("makeScopeRepinHandler — explicit recovery gates (gate 3, P0)", () =>
       tabs: [{ id: "phone", headless: true }],
       active: "phone",
     });
-    expect(repin("orchestrator")).toBeUndefined();
+    expectDeclined(repin("orchestrator"));
   });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1218,7 +1218,14 @@ describe("UiBridge (multi-tab)", () => {
       // Even a DIRECT repin call must refuse: the pin reaches a live tab, so
       // there is nothing to recover from — moving it would re-aim the running
       // turn's tool calls at a workflow it was never about.
-      expect(bridge.repinScopeToActive(SHARED_SESSION_SCOPE)).toBeUndefined();
+      // #1077 Finding 2 — the refusal now carries WHY. What matters here is
+      // unchanged (no tab id came back, the pin did not move); it now also says
+      // the pin is healthy, which is the whole point of distinguishing this
+      // correct refusal from the ones a user can act on.
+      const declined = bridge.repinScopeToActive(SHARED_SESSION_SCOPE);
+      expect(typeof declined).not.toBe("string");
+      expect(declined).toMatchObject({ repinned: false });
+      expect((declined as { reason: string }).reason).toMatch(/still reaches a live tab/);
       expect(tracker.pinOf(SCOPE_KEY)).toBe("wf:workflows/a.json");
       const still = await bridge.send({ cmd: "graph_outline" }, { tabId: SHARED_SESSION_SCOPE });
       expect(still).toMatchObject({ from: "tab-a" });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4946,7 +4946,7 @@ export interface PanelToolCtx {
      *  panel_reload's unconditional call was silently repinning healthy turns
      *  onto whichever tab was last active). Real-tab ctxs ignore this flag. */
     scopeRecoveryConsent?: boolean;
-  }) => { previous: string; current: string; rebound: boolean };
+  }) => { previous: string; current: string; rebound: boolean; repinRefusal?: string };
   /**
    * Best-effort in-place self-heal for the handful of tools that call the bridge
    * DIRECTLY (not via `ctx.call`) — e.g. panel_request_adult_consent's ask_user
@@ -5436,7 +5436,7 @@ export function makePanelToolCtx(
   // active tab can't be picked.
   const rebindToActiveTab = (opts?: {
     scopeRecoveryConsent?: boolean;
-  }): { previous: string; current: string; rebound: boolean } => {
+  }): { previous: string; current: string; rebound: boolean; repinRefusal?: string } => {
     const previous = ctx.tabId;
     // #884 P0 — a SCOPE-bound ctx must never be REPLACED by a real tab id (that
     // would permanently narrow the shared conversation's routing to one tab).
@@ -5463,8 +5463,22 @@ export function makePanelToolCtx(
       if (!opts?.scopeRecoveryConsent || !pinProvenDead) {
         return { previous, current: previous, rebound: false };
       }
-      const repinned = bridge.repinScopeToActive?.(previous);
-      return { previous, current: previous, rebound: Boolean(repinned) };
+      // #1077 Finding 2 — carry the REASON out when nothing was repinned. This
+      // collapsed to `Boolean(repinned)`, so four different refusals arrived at
+      // the caller as one bare `false` and the user was told only that the
+      // adoption was refused. One of those refusals repeats forever (an active
+      // tab on another backend's conversation while this one has several), and
+      // nothing in the reply hinted that naming a workflow is the way out.
+      const outcome = bridge.repinScopeToActive?.(previous);
+      const repinned = typeof outcome === "string" ? outcome : undefined;
+      const repinRefusal =
+        outcome && typeof outcome === "object" ? outcome.reason : undefined;
+      return {
+        previous,
+        current: previous,
+        rebound: Boolean(repinned),
+        ...(repinRefusal ? { repinRefusal } : {}),
+      };
     }
     // A healthy binding is left untouched (never disturb a live session). Recovery only
     // fires for an orphaned/stale tab id.
@@ -8946,7 +8960,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // THE explicit scope-recovery consent (#884 gate 3) — the only
             // caller that may escape a DEAD scope pin (a healthy pin still
             // stays put; see rebindToActiveTab's double gate).
-            ctx.rebindToActiveTab({ scopeRecoveryConsent: true });
+            const rebind = ctx.rebindToActiveTab({ scopeRecoveryConsent: true });
+            // #1077 Finding 2 — a scope repin that declined now says WHY, and
+            // this is where the user reads it. The refusal used to be a bare
+            // boolean, so a session stuck in the one state that repeats forever
+            // (the active tab belongs to another backend's conversation while
+            // this one has several eligible tabs) saw no difference from a
+            // healthy pin being correctly left alone.
+            if (rebind?.repinRefusal) {
+              rebindNote += ` The session pin was NOT moved: ${rebind.repinRefusal}.`;
+            }
           } catch (err) {
             // #474: with 2+ live tabs the rebind is AMBIGUOUS — fail so the user picks.
             // But with ZERO tabs connected (the "Connected: none" window right after a

--- a/src/orchestrator/turn-origins.ts
+++ b/src/orchestrator/turn-origins.ts
@@ -28,6 +28,7 @@
 // is unchanged, so the stamp would pass).
 
 import { randomUUID } from "node:crypto";
+import { shortTabId } from "../services/session-scope.js";
 
 export interface TurnOriginDeps {
   /** The backend a panel tab is CURRENTLY on (live tabBackends lookup). */
@@ -548,7 +549,7 @@ export function makeScopeRepinHandler(opts: {
       return {
         repinned: false,
         reason:
-          `the existing pin (${existing.slice(0, 8)}) still reaches a live tab of this ` +
+          `the existing pin (${shortTabId(existing)}) still reaches a live tab of this ` +
           `conversation, so it is healthy and was left alone — this recovery only displaces a ` +
           `pin that is dead or ambiguous`,
       };
@@ -572,10 +573,14 @@ export function makeScopeRepinHandler(opts: {
     // refreshed, closed and reopened the tab, and finally traced it to source.
     //
     // The state worth naming is the last one: `active` exists but belongs to a
-    // DIFFERENT backend's conversation while this one has two or more tabs. That
-    // is reachable in ordinary multi-tab use, it repeats on every retry, and
-    // nothing in the old reply hinted that targeting a workflow explicitly is the
-    // way out.
+    // DIFFERENT backend's conversation while this one has two or more tabs.
+    //
+    // NOT permanent, and saying so would overstate it — the active tab moves on
+    // the next user_message, so a message sent from one of this conversation's
+    // own tabs clears it. What IS true is that RETRYING THE TOOL never clears
+    // it: the inputs are identical every time, which is what the reporter
+    // experienced before refreshing and reopening the tab. Nothing in the old
+    // reply hinted at either way out.
     if (!tab) {
       if (eligible.length === 0) {
         return {
@@ -589,7 +594,7 @@ export function makeScopeRepinHandler(opts: {
         repinned: false,
         reason:
           `this conversation has ${eligible.length} eligible tabs and the active one ` +
-          `(${active ? active.slice(0, 8) : "none"}) is not among them, so "current" does not ` +
+          `(${active ? shortTabId(active) : "none"}) is not among them, so "current" does not ` +
           `identify which to bind. Name the workflow instead — panel_set_workflow_target with a ` +
           `path, or panel_open_workflow — and the pin follows it`,
       };

--- a/src/orchestrator/turn-origins.ts
+++ b/src/orchestrator/turn-origins.ts
@@ -516,6 +516,17 @@ export interface ScopeRepinBridge {
  *    otherwise the backend's SOLE interactive tab; 2+ candidates without a
  *    clear active one refuse rather than guess.
  */
+/**
+ * What an explicit `mode:"current"` repin did — or, when it did nothing, WHY
+ * (#1077 Finding 2).
+ *
+ * A bare `undefined` was indistinguishable across four different refusals, and
+ * the caller collapsed it to `rebound: false`. A session wedged on any of them
+ * saw only "the adoption was REFUSED" and had no way to tell a healthy pin it
+ * should leave alone from an ambiguity it could resolve by naming a workflow.
+ */
+export type ScopeRepinOutcome = string | { repinned: false; reason: string } | undefined;
+
 export function makeScopeRepinHandler(opts: {
   bridge: ScopeRepinBridge;
   tracker: TurnOriginTracker;
@@ -523,7 +534,7 @@ export function makeScopeRepinHandler(opts: {
   backendForTab: (tabId: string) => string;
   backendOfKey: (key: string) => string;
   info: (msg: string) => void;
-}): (scopeId: string) => string | undefined {
+}): (scopeId: string) => ScopeRepinOutcome {
   return (scopeId) => {
     const key = opts.scopeAgentKeyOf(scopeId);
     // RECOVERY ONLY: a pin that still reaches a live tab OF THIS conversation
@@ -534,7 +545,13 @@ export function makeScopeRepinHandler(opts: {
     // against the resolution-time refusal (codex gate-4 delta).
     const existing = opts.tracker.resolvedPinOf(key);
     if (typeof existing === "string" && opts.bridge.canReach(existing)) {
-      return undefined;
+      return {
+        repinned: false,
+        reason:
+          `the existing pin (${existing.slice(0, 8)}) still reaches a live tab of this ` +
+          `conversation, so it is healthy and was left alone — this recovery only displaces a ` +
+          `pin that is dead or ambiguous`,
+      };
     }
     const backend = opts.backendOfKey(key);
     const eligible = opts.bridge
@@ -548,7 +565,35 @@ export function makeScopeRepinHandler(opts: {
         : eligible.length === 1
           ? eligible[0]
           : undefined;
-    if (!tab) return undefined;
+    // #1077 Finding 2 — SAY WHY. Every refusal above and below returned a bare
+    // `undefined`, which the caller collapsed to `rebound: false`, so a session
+    // stuck here was told only that the adoption was refused. The reporter could
+    // not tell which branch fired and had no orchestrator log to read; they
+    // refreshed, closed and reopened the tab, and finally traced it to source.
+    //
+    // The state worth naming is the last one: `active` exists but belongs to a
+    // DIFFERENT backend's conversation while this one has two or more tabs. That
+    // is reachable in ordinary multi-tab use, it repeats on every retry, and
+    // nothing in the old reply hinted that targeting a workflow explicitly is the
+    // way out.
+    if (!tab) {
+      if (eligible.length === 0) {
+        return {
+          repinned: false,
+          reason:
+            `no connected tab belongs to this conversation's backend (${backend}) — ` +
+            `every eligible tab is either headless or bound to another backend`,
+        };
+      }
+      return {
+        repinned: false,
+        reason:
+          `this conversation has ${eligible.length} eligible tabs and the active one ` +
+          `(${active ? active.slice(0, 8) : "none"}) is not among them, so "current" does not ` +
+          `identify which to bind. Name the workflow instead — panel_set_workflow_target with a ` +
+          `path, or panel_open_workflow — and the pin follows it`,
+      };
+    }
     opts.tracker.repinTo(key, tab);
     opts.info(
       `[panel-orchestrator] ${key} re-pinned onto ${tab.slice(0, 8)} by explicit target request (#884 recovery)`,

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -25,6 +25,7 @@ import {
 import { primePanelBase, verifiedPanelDiskVersion } from "./panel-workspace.js";
 import { compareSemver, detectInstallMode } from "./self-update.js";
 import { SHARED_SESSION_SCOPE, isScopeAddress } from "./session-scope.js";
+import type { ScopeRepinOutcome } from "../orchestrator/turn-origins.js";
 
 export const DEFAULT_BRIDGE_PORT = 9101;
 
@@ -1389,7 +1390,7 @@ export class UiBridge {
    *  in-flight turn onto the tab that is active now (the documented
    *  panel_set_workflow_target({mode:"current"}) consent). Returns the tab it
    *  repinned to, or undefined when nothing is resolvable. */
-  private scopeRepinHandler: ((scopeId: string) => string | undefined) | null = null;
+  private scopeRepinHandler: ((scopeId: string) => ScopeRepinOutcome) | null = null;
   /** #884 — orchestrator-injected: normalize a hello's raw `backend` value the
    *  same way the orchestrator does (unknown/absent → the default backend), so
    *  the backend-qualified scope-buffer replay matches the conversation the
@@ -2716,15 +2717,18 @@ export class UiBridge {
   }
 
   /** #884 — inject the explicit-repin recovery handler (see the field doc). */
-  setScopeRepinHandler(fn: (scopeId: string) => string | undefined): void {
+  setScopeRepinHandler(fn: (scopeId: string) => ScopeRepinOutcome): void {
     this.scopeRepinHandler = fn;
   }
 
   /** #884 — EXPLICIT recovery consent (panel_set_workflow_target
    *  mode:"current" on a scope-bound session): re-pin the conversation's
    *  in-flight turn onto the tab that is active now, escaping a dead or
-   *  ambiguous pin. Returns the repinned tab id, or undefined. */
-  repinScopeToActive(scopeId: string): string | undefined {
+   *  ambiguous pin. Returns the repinned tab id, or — when nothing was
+   *  repinned — WHY (#1077 Finding 2). A bare undefined was indistinguishable
+   *  across four different refusals, and a session wedged on any of them was
+   *  told only that the adoption was refused. */
+  repinScopeToActive(scopeId: string): ScopeRepinOutcome {
     return this.scopeRepinHandler?.(scopeId);
   }
 


### PR DESCRIPTION
Finding 2 of #1077, the half that did NOT ship in 0.50.67.

The reporter saw the identical permanent fence refusal on a session with **no relay backend configured**, which routes through the primary listener and should capture a real `Origin`. Nothing in the Finding 1 fix explains that.

Their lead: `turnOrigins` and the `mode:"current"` repin guard, whose own comment says it deliberately "refuses to displace a pin that still reaches a live tab" — plausible if a dead prior tab is still considered reachable in some stale way. They had several full `no connected tab` drops and workflow-tab switches before the permanent state set in.

Draft while I investigate. If it turns out to be unreproducible I will say so rather than ship a speculative change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)