### PR TITLE
test(recovery): reset the panel-base cache in the five suites that never did (follows #1250)

### DIFF
--- a/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
+++ b/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
@@ -13,6 +13,7 @@
 // window and rebinds a current-mode session onto the reconnected tab.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetPanelBaseCache } from "../../services/panel-workspace.js";
 
 const resetClient = vi.fn();
 const resetObjectInfoCache = vi.fn();
@@ -81,6 +82,18 @@ function reconnectingBridge(initial: string[] = []) {
 }
 
 beforeEach(() => {
+  // #1222 - the panel-base cache is module-level. Its production guards
+  // (target key, target generation, 60s TTL) never fire inside one test file,
+  // so a resolution primed by one test is inherited by the next -- and
+  // panelRecoveryContext() reads it to choose between two ENTIRELY different
+  // remedies, making which assertion passes depend on execution order.
+  //
+  // Per FILE, not global: a setup file cannot import this module, because
+  // setupFiles runs before per-suite vi.mock factories apply and the early
+  // import resolves against the real environment instead. Copied from
+  // panel-recovery-cluster.test.ts, which does this correctly and is not
+  // one of the flaky files.
+  __resetPanelBaseCache();
   // Keep the reconnect wait fast so tests don't sit through the real ~20s budget.
   __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 500, intervalMs: 5 });
   // The #742 refuse-safe preflight passes by default here (the live one would

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -1,4 +1,5 @@
-import { afterAll, describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, vi, beforeEach } from "vitest";
+import { __resetPanelBaseCache } from "../../services/panel-workspace.js";
 import { join } from "node:path";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -243,6 +244,18 @@ function makeDeps(opts: {
   };
   return { deps, installs, updates, reinstalls, gitPulls, counters };
 }
+
+beforeEach(() => {
+  // #1222 - this file had no hook at all, so a panel-base resolution primed
+  // by one test was inherited by every later one. panelRecoveryContext() reads
+  // it to choose between two ENTIRELY different remedy wordings, so which
+  // assertion passes depended on execution order.
+  //
+  // Per FILE, not global: setupFiles runs before per-suite vi.mock factories
+  // apply, so importing this module there resolves against the real
+  // environment and defeats the mocks this file installs.
+  __resetPanelBaseCache();
+});
 
 describe("detectPanelInstall", () => {
   it("#700: default deps inspect the saved local workspace when COMFYUI_PATH is unset", async () => {

--- a/src/__tests__/services/panel-pin-bypass.test.ts
+++ b/src/__tests__/services/panel-pin-bypass.test.ts
@@ -11,6 +11,7 @@
 // critically, that they refuse BEFORE any Manager request is issued.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetPanelBaseCache } from "../../services/panel-workspace.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -112,6 +113,18 @@ import {
 let dir: string;
 
 beforeEach(() => {
+  // #1222 - the panel-base cache is module-level. Its production guards
+  // (target key, target generation, 60s TTL) never fire inside one test file,
+  // so a resolution primed by one test is inherited by the next -- and
+  // panelRecoveryContext() reads it to choose between two ENTIRELY different
+  // remedies, making which assertion passes depend on execution order.
+  //
+  // Per FILE, not global: a setup file cannot import this module, because
+  // setupFiles runs before per-suite vi.mock factories apply and the early
+  // import resolves against the real environment instead. Copied from
+  // panel-recovery-cluster.test.ts, which does this correctly and is not
+  // one of the flaky files.
+  __resetPanelBaseCache();
   managerCalls.length = 0;
   managerGate = null;
   managerFailAfterGate = false;

--- a/src/__tests__/services/panel-pin-cancel.test.ts
+++ b/src/__tests__/services/panel-pin-cancel.test.ts
@@ -14,6 +14,7 @@
 // only); remote reports "cannot cancel — remote host" truthfully.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetPanelBaseCache } from "../../services/panel-workspace.js";
 import {
   existsSync,
   mkdirSync,
@@ -79,6 +80,18 @@ import { panelAction } from "../../tools/install-panel.js";
 let dir: string;
 
 beforeEach(() => {
+  // #1222 - the panel-base cache is module-level. Its production guards
+  // (target key, target generation, 60s TTL) never fire inside one test file,
+  // so a resolution primed by one test is inherited by the next -- and
+  // panelRecoveryContext() reads it to choose between two ENTIRELY different
+  // remedies, making which assertion passes depend on execution order.
+  //
+  // Per FILE, not global: a setup file cannot import this module, because
+  // setupFiles runs before per-suite vi.mock factories apply and the early
+  // import resolves against the real environment instead. Copied from
+  // panel-recovery-cluster.test.ts, which does this correctly and is not
+  // one of the flaky files.
+  __resetPanelBaseCache();
   managerCalls.length = 0;
   managerHandler = () => new Response("not found", { status: 404 });
   currentBase = ORIG;

--- a/src/__tests__/services/panel-pin-guard.test.ts
+++ b/src/__tests__/services/panel-pin-guard.test.ts
@@ -7,6 +7,7 @@
 // the guard. A pinned user was one generic call away from being moved.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetPanelBaseCache } from "../../services/panel-workspace.js";
 import {
   mkdtempSync,
   existsSync,
@@ -143,6 +144,18 @@ import { setPanelVersionPin, PANEL_PIN_ENV_VAR } from "../../services/panel-sett
 let dir: string;
 
 beforeEach(() => {
+  // #1222 - the panel-base cache is module-level. Its production guards
+  // (target key, target generation, 60s TTL) never fire inside one test file,
+  // so a resolution primed by one test is inherited by the next -- and
+  // panelRecoveryContext() reads it to choose between two ENTIRELY different
+  // remedies, making which assertion passes depend on execution order.
+  //
+  // Per FILE, not global: a setup file cannot import this module, because
+  // setupFiles runs before per-suite vi.mock factories apply and the early
+  // import resolves against the real environment instead. Copied from
+  // panel-recovery-cluster.test.ts, which does this correctly and is not
+  // one of the flaky files.
+  __resetPanelBaseCache();
   dir = mkdtempSync(join(tmpdir(), "cmcp-pinguard-"));
   process.env.COMFYUI_MCP_PANEL_SETTINGS = join(dir, "panel-settings.json");
   process.env.COMFYUI_MCP_PANEL_LOCK = join(dir, "panel-op.lock");


### PR DESCRIPTION
Follows #1250, which fixed the real cause — a production race where a cache CLEAR could lose to a probe that started before it. **This is not that fix.** It is the test-isolation gap #1250's squash left behind.

## What it does

Adds `__resetPanelBaseCache()` to five suites that had no reset at all — `panel-installer.test.ts` had no `beforeEach` whatsoever. Copied from `panel-recovery-cluster.test.ts`, which does it in both hooks.

## What it is, measured — a no-op safety net, not a demonstrated fix

The original version of this description said these five "assert `panelRecoveryContext()` remedy wording" and that "a resolution primed by one test is inherited by the next." **Review measured both claims and neither is true of these files**, so they are corrected here rather than left for someone to cite:

- **Inheritance across tests: 0 of 360.** Instrumenting the reset to report what it discards gives `hadCached=no` on all 360 tests. Control: `panel-recovery-cluster.test.ts` fires 17 live discards, so the probe is sensitive. 28 cache writes do occur, but all 28 are cleared inside their own test by the production path (`clearPanelDiskObservation` → `forgetResolvedBase`).
- **Only one of the five has an `installPanelUsable`-sensitive assertion** (`panel-installer.test.ts:495`). Confirmed by mutation: flipping the discriminator at `panel-recovery.ts:140` produces identical failure sets with and without this reset — 1 failed / 359 passed both ways. No assertion is weaker or vacuous as a result of this change.

So: the leak mechanism is real (`panel-recovery-cluster` proves it), it just does not currently bite in these five. This is cheap insurance that costs one line per file and makes the ordering dependence unrepresentable if one of them later grows an assertion that does depend on it.

## Why per-file and not global

A global `beforeEach` in `setupFiles` looks principled and **cannot work here**: `setupFiles` runs before per-suite `vi.mock` factories apply, so importing `panel-workspace` there pulls the real module graph past the mock boundary. Observed while trying it: `expected '0.11.62' to be '0.11.38'`, where `0.11.62` was the panel actually installed on the machine.

`beforeEach` alone is sufficient. Vitest's default `pool: 'forks', isolate: true` gives one module instance per file (verified: 5 distinct instance ids in one run), so nothing survives a file and `afterEach` would be redundant.

## My analysis on #1250 was wrong

I concluded "test isolation, not a user-facing bug" after verifying `cachedResolution()`'s validity guards all fire in production. They do — but I never asked whether a write could land *after* an invalidation, which is the race #1250 actually fixed. Verifying a guard's conditions is not verifying the guarded thing.

Suite: 406 files, 8137 passed, 2 skipped. Zero production files.

Refs #1222, #1250, #1208.