### PR TITLE
chore(release): reconcile main to 0.50.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.72] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- investigate #1077 Finding 2 — permanent refusal without a relay backend (#1252)
+
+#### Changed
+- reset the panel-base cache in the five files that never did (#1253)
+- 0.50.71 (#1251)
+
+
 ## [0.50.71] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.71",
+  "version": "0.50.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.71",
+      "version": "0.50.72",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.71",
+  "version": "0.50.72",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.72` tag.

Ships **#1077 Finding 2** (diagnosis, not a reproduction) — a declined scope repin now says which of four branches declined it. Previously all four returned a bare `undefined` and the caller collapsed that to `rebound: false`, so a healthy pin correctly left alone was indistinguishable from an ambiguity a user could resolve. The reporter said exactly that: they could not tell which branch refused, and there is no orchestrator log to read.

The branch worth naming is the one retrying cannot escape — the active tab belongs to another backend's conversation while this one has several eligible tabs — and its reason now names the workflow and the way out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)