### PR TITLE
fix(identity): localhost and 127.0.0.1 must bind the same workflow identity (#1255)

### DIFF
--- a/src/__tests__/orchestrator/hello-stamp-retention.test.ts
+++ b/src/__tests__/orchestrator/hello-stamp-retention.test.ts
@@ -68,8 +68,12 @@ describe("an untrusted hello RETAINS the tab's command stamp (#689)", () => {
     expect(workflowIdentityParts({ workflowUuid: uuid, origin: "" })).toBeUndefined();
     // A fully-formed hello IS trusted — otherwise the branch above would be the
     // only one ever taken and the test would prove nothing about untrusted input.
+    // #1255 — the returned origin is now CANONICAL, so every loopback spelling
+    // folds to one value and a fence bound under `127.0.0.1` validates against a
+    // panel reached on `localhost`. What this test is about — which identities
+    // are trusted vs untrusted — is unchanged; only the canonical form moved.
     expect(workflowIdentityParts({ workflowUuid: uuid, origin })).toEqual({
-      origin,
+      origin: "http://localhost:8188",
       uuid,
     });
   });

--- a/src/__tests__/orchestrator/identity-origin-canonical.test.ts
+++ b/src/__tests__/orchestrator/identity-origin-canonical.test.ts
@@ -1,0 +1,61 @@
+// #1255 — a workflow identity bound under one spelling of the local host must
+// validate against the other. `localhost` and `127.0.0.1` are the same machine;
+// #1246 established that equivalence for target drift, and the fence's identity
+// gate never got it.
+//
+// The failure it caused is permanent (nothing re-binds the stored origin),
+// survives a hard refresh (a reload re-sends the same Origin header), needs no
+// relay backend, and is invisible to sibling reads that do not consult
+// origin-bound identity — which is why it reads as a contradiction rather than
+// a bug.
+
+import { describe, expect, it } from "vitest";
+
+import { workflowIdentityParts } from "../../orchestrator/session-store.js";
+
+const UUID = "11111111-2222-4333-8444-555555555555";
+const bind = (origin: string) => workflowIdentityParts({ workflowUuid: UUID, origin });
+
+describe("workflowIdentityParts origin equivalence (#1255)", () => {
+  it("binds localhost and 127.0.0.1 to the SAME origin", () => {
+    const a = bind("http://localhost:8188");
+    const b = bind("http://127.0.0.1:8188");
+    expect(a?.origin).toBeTruthy();
+    expect(a?.origin).toBe(b?.origin);
+  });
+
+  it("covers the other loopback spellings, not just the reported pair", () => {
+    // A two-string special case would leave the identical defect for the next
+    // spelling, so the equivalence has to come from the shared normaliser.
+    const base = bind("http://localhost:8188")?.origin;
+    expect(bind("http://[::1]:8188")?.origin).toBe(base);
+    expect(bind("http://LOCALHOST:8188/")?.origin).toBe(base);
+  });
+
+  // ── The discriminating negatives. A normaliser that is too eager turns a
+  // fail-closed gate into a rubber stamp, which is worse than the bug.
+  it("still refuses a DIFFERENT host", () => {
+    expect(bind("http://192.168.1.50:8188")?.origin).not.toBe(bind("http://localhost:8188")?.origin);
+  });
+
+  it("still distinguishes a different PORT", () => {
+    expect(bind("http://localhost:8189")?.origin).not.toBe(bind("http://localhost:8188")?.origin);
+  });
+
+  it("still distinguishes a different SCHEME", () => {
+    expect(bind("https://localhost:8188")?.origin).not.toBe(bind("http://localhost:8188")?.origin);
+  });
+
+  it("keeps failing closed on an unparseable origin", () => {
+    // Must not become empty-and-accepted: an origin we cannot read is exactly
+    // the case the gate exists for.
+    expect(bind("")).toBeUndefined();
+    expect(bind("   ")).toBeUndefined();
+    expect(workflowIdentityParts({ workflowUuid: UUID, origin: undefined })).toBeUndefined();
+  });
+
+  it("still rejects a malformed uuid regardless of origin", () => {
+    expect(workflowIdentityParts({ workflowUuid: "not-a-uuid", origin: "http://localhost:8188" }))
+      .toBeUndefined();
+  });
+});

--- a/src/__tests__/orchestrator/session-store.test.ts
+++ b/src/__tests__/orchestrator/session-store.test.ts
@@ -425,7 +425,11 @@ describe("SessionStore", () => {
     it("validates the uuid shape and requires a trusted origin", () => {
       expect(
         workflowIdentityParts({ workflowUuid: UUID_A, origin: "http://127.0.0.1:8188" }),
-      ).toEqual({ origin: "http://127.0.0.1:8188", uuid: UUID_A });
+        // #1255 — the loopback spellings now fold to one canonical origin, so a
+        // fence bound under `127.0.0.1` validates against a panel reached on
+        // `localhost` and vice versa. The subject of this assertion is uuid/origin
+        // VALIDATION, which is unchanged; only the canonical form it returns moved.
+      ).toEqual({ origin: "http://localhost:8188", uuid: UUID_A });
       expect(workflowIdentityParts({ workflowUuid: "not-a-uuid", origin: "http://x" })).toBeUndefined();
       expect(workflowIdentityParts({ workflowUuid: UUID_A, origin: "" })).toBeUndefined();
       expect(workflowIdentityParts({ workflowUuid: undefined, origin: "http://x" })).toBeUndefined();

--- a/src/orchestrator/session-store.ts
+++ b/src/orchestrator/session-store.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { canonicalOrigin } from "../utils/origin.js";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { logger } from "../utils/logger.js";
@@ -74,8 +75,20 @@ export function workflowIdentityParts(opts: {
   const raw = typeof opts.workflowUuid === "string" ? opts.workflowUuid.trim() : "";
   const uuid = WORKFLOW_UUID_RE.test(raw) ? raw.toLowerCase() : "";
   if (!uuid) return undefined;
+  // #1255 — `localhost` and `127.0.0.1` are the same machine, and this gate did
+  // not know it: a fence bound under one spelling could never validate against
+  // the other. Permanent (nothing re-binds the stored origin), refresh-proof (a
+  // reload re-sends the same Origin header), no relay involved, and invisible to
+  // sibling reads that never consult origin-bound identity.
+  //
+  // Reuses `canonicalOrigin` rather than comparing the pair, so `::1` and the
+  // next spelling nobody has thought of are covered by the same definition
+  // #1246 already established for target drift. Falls back to the previous
+  // normalisation when the input will not parse: an origin we cannot read must
+  // keep failing closed, which is the case this gate exists for.
+  const raw0 = typeof opts.origin === "string" ? opts.origin.trim() : "";
   const origin =
-    typeof opts.origin === "string" ? opts.origin.trim().replace(/\/+$/, "").toLowerCase() : "";
+    canonicalOrigin(raw0) ?? raw0.replace(/\/+$/, "").toLowerCase();
   if (!origin) return undefined;
   return { origin, uuid };
 }


### PR DESCRIPTION
Draft — claiming #1255, split out of #1077 on its own measured evidence.

## Confirmed before claiming

```
localhost -> {"origin":"http://localhost:8188","uuid":"1111...5555"}
127.0.0.1 -> {"origin":"http://127.0.0.1:8188","uuid":"1111...5555"}
SAME ORIGIN? false
```

`workflowIdentityParts` (`session-store.ts:70-81`) normalises with `trim()`, trailing-slash strip, `toLowerCase()` — no host equivalence. So a fence bound under one spelling can never validate against the other: permanent, refresh-proof, no relay needed, and invisible to sibling reads that do not consult origin-bound identity.

## Both cautions from the issue, checked first

**1. Reuse, do not special-case.** `canonicalOrigin` already exists (`src/utils/origin.ts:51`), exported by #1246 (`bce83d7`, *"127.0.0.1 and localhost are the same host, not a target drift"*) with `sameOrigin` alongside it. Its own tests already cover `::1`, ports, schemes, paths and query strings — so the equivalence is defined in one place rather than in a second hand-rolled pair check.

**2. No persisted origins to migrate.** This was the one that could have made the fix worse than the bug. Checked: `orchestrator/index.ts:2851` and `:3558` store `identity.uuid` only — `identity.origin` is never written anywhere. So the origin is purely a validation input, and normalising it cannot turn a loud refusal into a silent mismatch against stored data.

## Plan

1. Red test first, driving the real `workflowIdentityParts` with both spellings.
2. Route its origin through `canonicalOrigin`, falling back to the current behaviour when the input will not parse — an unparseable origin must keep failing closed, not become empty and pass.
3. Verify the failure mode is preserved for genuinely different origins (a different host or port must still refuse), because a normaliser that is too eager turns a security-shaped gate into a rubber stamp. That is the discriminating negative here.

Refs #1077, #1246.