### PR TITLE
fix(install): 'latest' is not a git ref — do not check it out

### DIFF
--- a/src/__tests__/services/git-latest-not-a-ref.test.ts
+++ b/src/__tests__/services/git-latest-not-a-ref.test.ts
@@ -1,0 +1,122 @@
+// #1254 — "latest" reached `git checkout` as though it were a ref.
+//
+//   install_custom_node(id: "https://github.com/…/comfyUI-blender-wrapper.git",
+//                       source: "git", version: "latest")
+//
+//   → git checkout --detach --end-of-options latest
+//   → fatal: git checkout: --detach does not take a path argument 'latest'
+//
+// `version` DEFAULTS to "latest", so this is the plain no-options install of any
+// git URL, not an exotic argument. And the cost is not just a failed command:
+// the checkout failure discards the clone as a husk, so the node is left
+// partially installed after a clone that had already succeeded.
+//
+// "latest" is this tool's own word for "whatever is newest". A fresh clone is
+// already on the default branch, which is exactly that — so the fix is to check
+// out nothing, which also restores the shallow clone (full history is fetched
+// only because a concrete ref might need it).
+//
+// The registry path has always treated the word as a sentinel (it rewrites an
+// absent or "latest" version to "nightly"), so the two now share one test for
+// what the word means rather than each having their own idea.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  gitRefForInstall,
+  isLatestSentinel,
+  normalizeGitUrlInstallArgs,
+} from "../../services/node-management.js";
+
+describe("isLatestSentinel (#1254)", () => {
+  it.each(["latest", "LATEST", "Latest", "  latest  "])("treats %o as the sentinel", (v) => {
+    expect(isLatestSentinel(v)).toBe(true);
+  });
+
+  it.each([
+    ["v1.2.3", "a tag"],
+    ["main", "a branch"],
+    ["nightly", "the registry's own word — a real version there, not this sentinel"],
+    ["latest-stable", "a ref that merely starts with it"],
+    ["release/latest", "a ref that merely contains it"],
+    ["", "empty"],
+    [undefined, "absent"],
+    [42, "not a string"],
+  ])("does NOT treat %o as the sentinel (%s)", (v) => {
+    expect(isLatestSentinel(v)).toBe(false);
+  });
+});
+
+describe("gitRefForInstall (#1254)", () => {
+  it("derives NO ref from a 'latest' version — the reported call", () => {
+    // install_custom_node(source:"git", version:"latest") with nothing else set.
+    expect(gitRefForInstall({ version: "latest" })).toBeUndefined();
+  });
+
+  it.each(["LATEST", " latest "])("derives no ref from %o either", (version) => {
+    expect(gitRefForInstall({ version })).toBeUndefined();
+  });
+
+  it("passes a REAL version through as the ref", () => {
+    expect(gitRefForInstall({ version: "v1.2.3" })).toBe("v1.2.3");
+  });
+
+  it("derives nothing when no version was given at all", () => {
+    expect(gitRefForInstall({})).toBeUndefined();
+  });
+
+  it("honours an EXPLICIT ref literally, even the sentinel word", () => {
+    // Repositories do carry a tag called `latest`. Ignoring it would check out a
+    // different commit than the one asked for — a wrong answer, where the bug
+    // being fixed was only a failure.
+    expect(gitRefForInstall({ ref: "latest", version: "latest" })).toBe("latest");
+    expect(gitRefForInstall({ ref: "v9", version: "latest" })).toBe("v9");
+  });
+
+  it("honours a #ref from the URL the same way", () => {
+    expect(gitRefForInstall({ urlRef: "latest", version: "latest" })).toBe("latest");
+    expect(gitRefForInstall({ urlRef: "abc1234", version: "latest" })).toBe("abc1234");
+  });
+
+  it("an explicit ref beats a URL ref, which beats the version", () => {
+    expect(gitRefForInstall({ ref: "a", urlRef: "b", version: "c" })).toBe("a");
+    expect(gitRefForInstall({ urlRef: "b", version: "c" })).toBe("b");
+  });
+
+  it("treats parseGitUrl's NULL 'no fragment' as absent, not as a ref", () => {
+    // parseGitUrl reports a missing fragment as null. Passing that through would
+    // make `git checkout null` — the same class of bug one value over.
+    expect(gitRefForInstall({ urlRef: null, version: "latest" })).toBeUndefined();
+    expect(gitRefForInstall({ urlRef: null, version: "v1" })).toBe("v1");
+  });
+});
+
+// The OTHER consumer of the word, which must keep agreeing with the first.
+describe("the registry path still rewrites 'latest' to nightly (#1254)", () => {
+  it.each(["latest", "LATEST", " latest "])("rewrites %o", (version) => {
+    const out = normalizeGitUrlInstallArgs({
+      repository: "https://github.com/example/pack.git",
+      version,
+    });
+    expect(out.version).toBe("nightly");
+    expect(out.note, "and says why, since the version it was given is not what runs").toMatch(
+      /nightly/,
+    );
+  });
+
+  it("leaves a real version alone", () => {
+    const out = normalizeGitUrlInstallArgs({
+      repository: "https://github.com/example/pack.git",
+      version: "v2.0.1",
+    });
+    expect(out.version).toBe("v2.0.1");
+    expect(out.note).toBeUndefined();
+  });
+
+  it("an absent version is the sentinel too", () => {
+    const out = normalizeGitUrlInstallArgs({
+      repository: "https://github.com/example/pack.git",
+    });
+    expect(out.version).toBe("nightly");
+  });
+});

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1528,6 +1528,58 @@ function stripUrlSuffix(value: string): string {
   return value.replace(/[?#].*$/, "").replace(/\/+$/, "");
 }
 
+/**
+ * Is this version string the "newest, whatever that is" SENTINEL (#1254)?
+ *
+ * Exported for the registry path's own translation of the same word, so the two
+ * cannot drift into disagreeing about what "latest" means. Case- and
+ * whitespace-insensitive because it arrives from a tool argument, not from git.
+ */
+export function isLatestSentinel(version: unknown): boolean {
+  return typeof version === "string" && version.trim().toLowerCase() === "latest";
+}
+
+/**
+ * Which git ref an install should check out, or undefined for "leave the clone
+ * where it landed" (#1254).
+ *
+ * "latest" IS NOT A GIT REF. It is this tool's own word for "whatever is
+ * newest", and `version` defaults to it — so a plain
+ * install_custom_node(source:"git", version:"latest") fell straight through to
+ * `git checkout --detach --end-of-options latest` and failed. Worse than a
+ * failed command: the checkout failure discards the clone as a husk, so a clone
+ * that had already succeeded left a partially installed node behind.
+ *
+ * A fresh clone is ALREADY on the default branch, which is exactly what "latest"
+ * means for a git source, so the answer is to check out nothing. That also
+ * restores the shallow clone — the full history is fetched only because a
+ * concrete ref might need it.
+ *
+ * AN EXPLICIT ref is honoured LITERALLY, sentinel word or not. `ref` and a
+ * `#ref` in the URL are the caller naming a ref, and repositories do carry tags
+ * called `latest`; ignoring one would check out a different commit than the one
+ * asked for — a wrong answer, where the bug this fixes was only a failure.
+ *
+ * A separate exported function rather than an expression inline, so the rule can
+ * be tested as behaviour instead of asserted against source text.
+ */
+export function gitRefForInstall(opts: {
+  /** An explicitly requested ref. */
+  ref?: string;
+  /** A `#ref` parsed out of the repository URL. `null` is how parseGitUrl
+   *  reports "no fragment", and it must read as absent, not as a ref. */
+  urlRef?: string | null;
+  /** The version selector, which defaults to the "latest" sentinel. */
+  version?: string;
+}): string | undefined {
+  // `??` already collapses parseGitUrl's `null` "no fragment" into undefined, so
+  // there is no separate null check here — one would read as load-bearing and
+  // never fire.
+  const explicit = opts.ref ?? opts.urlRef ?? undefined;
+  if (explicit !== undefined) return explicit;
+  return isLatestSentinel(opts.version) ? undefined : opts.version;
+}
+
 function validateGitRef(ref: string): string {
   if (ref.length === 0) {
     throw new ValidationError("Git ref must be a non-empty string.");
@@ -2340,7 +2392,11 @@ async function installCustomNodeImpl(
   const { id, version, mode = "remote", channel = "default" } = opts;
   const parsedGit = parseGitUrl(id);
   const gitId = parsedGit.baseUrl;
-  const gitRefCandidate = opts.ref ?? parsedGit.ref ?? version;
+  const gitRefCandidate = gitRefForInstall({
+    ref: opts.ref,
+    urlRef: parsedGit.ref,
+    version,
+  });
   const source =
     opts.source && opts.source !== "auto"
       ? opts.source
@@ -3883,7 +3939,10 @@ export function normalizeGitUrlInstallArgs(
   // forwarded as both (routing off the id path is the whole point), and
   // id+repository together were refused above.
   const out: NormalizedGitUrlInstallArgs = { repository: gitTarget };
-  if (version === undefined || version.length === 0 || version.toLowerCase() === "latest") {
+  // #1254 — the same sentinel test the git path uses, so "latest" cannot come to
+  // mean one thing here and another there. This site already trimmed; the helper
+  // trims too, which makes " Latest " behave like "latest" on both paths.
+  if (version === undefined || version.length === 0 || isLatestSentinel(version)) {
     out.version = "nightly";
     out.note =
       `"${gitTarget}" is a git repository URL, so this was queued as a from-source ` +


### PR DESCRIPTION
Fixes #1254.

`install_custom_node(action:'install', source:'git', version:'latest')` clones, then runs `git checkout --detach --end-of-options latest` — and `latest` is not a branch or tag, so the checkout fails and the node is left partially installed.

`latest` is the tool's own word for "whatever the default branch is", which a fresh clone is already on.

Draft while I work it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)