### PR TITLE
chore(release): reconcile main to 0.50.73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.73] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- 'latest' is not a git ref — do not check it out (#1258)
+
+#### Changed
+- 0.50.72 (#1256)
+
+
 ## [0.50.72] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.72",
+  "version": "0.50.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.72",
+      "version": "0.50.73",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.72",
+  "version": "0.50.73",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.73` tag.

Ships **#1254** — `install_custom_node(source:"git", version:"latest")` no longer hands "latest" to `git checkout` as a literal ref. `version` defaults to "latest", so this was the plain install of any git URL, and the checkout failure discarded the clone as a husk — leaving a partially installed node after a clone that had already succeeded.

Verified against the reporter's actual repository: the old command reproduces their error verbatim, and the fixed path shallow-clones onto `main` with a complete pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)