### PR TITLE
fix(fence): the identity refusal must describe the check it actually ran (#1255)

### DIFF
--- a/src/__tests__/orchestrator/fence-refusal-reason.test.ts
+++ b/src/__tests__/orchestrator/fence-refusal-reason.test.ts
@@ -270,3 +270,43 @@ describe("the refusal reasons distinguish an AMBIGUOUS turn", () => {
     expect(r).not.toMatch(/no server-observed Origin/);
   });
 });
+
+// #1255 — a refusal must describe the check it actually ran.
+//
+// identityReason's last branch used to end "a malformed uuid, or one bound to a
+// different origin". workflowIdentityParts never compares origins: it requires
+// one to be PRESENT, and nothing in the repo has ever read `identity.origin`
+// (both call sites take `.uuid`). So the second half named a mechanism that does
+// not exist.
+//
+// That is not a cosmetic complaint. Reasoning from that sentence produced a
+// filed issue, a written fix and 7 tests before anyone checked whether the
+// comparison existed; the PR closed unmerged. Prose in the codebase gets read as
+// evidence about the codebase, so a message that overstates is a defect.
+describe("identityReason describes the check it actually performs (#1255)", () => {
+  const reason = () =>
+    identityReason("wf:x", "http://127.0.0.1:8188", "not-a-uuid", undefined);
+
+  it("does not claim the identity may be bound to a DIFFERENT origin", () => {
+    expect(reason()).not.toMatch(/bound to a different origin/i);
+  });
+
+  it("names the uuid as the thing that failed", () => {
+    const text = reason();
+    expect(text).toContain("not-a-uuid");
+    expect(text).toMatch(/not a well-formed workflow uuid/i);
+  });
+
+  it("says the origin was ACCEPTED, so a reader does not go hunting there", () => {
+    const text = reason();
+    expect(text).toContain("http://127.0.0.1:8188");
+    expect(text).toMatch(/present and accepted/i);
+    expect(text).toMatch(/does not compare it against a previously bound one/i);
+  });
+
+  it("still routes an AMBIGUOUS turn to its own branch, unchanged", () => {
+    // The no-origin branches are correct and must not be disturbed by this.
+    expect(identityReason("wf:x", undefined, "u", "ambiguous")).toMatch(/no single tab/i);
+    expect(identityReason("wf:x", undefined, "u", undefined)).toMatch(/no server-observed Origin/i);
+  });
+});

--- a/src/__tests__/orchestrator/fence-refusal-reason.test.ts
+++ b/src/__tests__/orchestrator/fence-refusal-reason.test.ts
@@ -25,6 +25,7 @@
 import { describe, expect, it } from "vitest";
 import { UiBridge } from "../../services/ui-bridge.js";
 import { unreachableReason, identityReason } from "../../orchestrator/fence-refusal.js";
+import { workflowIdentityParts } from "../../orchestrator/session-store.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 import {
   buildPanelToolDefs,
@@ -302,6 +303,20 @@ describe("identityReason describes the check it actually performs (#1255)", () =
     expect(text).toContain("http://127.0.0.1:8188");
     expect(text).toMatch(/present and accepted/i);
     expect(text).toMatch(/does not compare it against a previously bound one/i);
+  });
+
+  it("owns its own premise: a present origin IS accepted by the gate", () => {
+    // The message asserts the origin was accepted and is not compared. Nothing
+    // in this file held that claim to the CODE -- a reviewer showed that adding
+    // a real origin comparison to workflowIdentityParts leaves all of these
+    // green, so the sentence could silently become false again. This pins it:
+    // a well-formed uuid with a present origin must produce an identity.
+    expect(
+      workflowIdentityParts({
+        workflowUuid: "11111111-2222-4333-8444-555555555555",
+        origin: "http://127.0.0.1:8188",
+      }),
+    ).toBeDefined();
   });
 
   it("still routes an AMBIGUOUS turn to its own branch, unchanged", () => {

--- a/src/orchestrator/fence-refusal.ts
+++ b/src/orchestrator/fence-refusal.ts
@@ -74,8 +74,21 @@ export function identityReason(
       `this session, setting it to the URL the panel is served from is what supplies it.`
     );
   }
+  // #1255 — this used to end "a malformed uuid, or one bound to a different
+  // origin", which describes a comparison the code does not perform.
+  // workflowIdentityParts uses the origin as a PRESENCE gate: it requires one to
+  // exist, and never compares it against a previously bound value (nothing in
+  // the repo has ever read `identity.origin` -- both call sites take `.uuid`).
+  // Reaching here with an origin present therefore means the UUID failed its
+  // shape check, full stop.
+  //
+  // The old wording sent a reader hunting for an origin mismatch that cannot
+  // happen -- it cost a whole investigation and a closed-unmerged PR before the
+  // mechanism was checked rather than believed. A refusal must describe the
+  // check it actually ran.
   return (
-    `the workflow identity did not validate (uuid ${String(workflowUuid)} against origin ` +
-    `${origin}) — a malformed uuid, or one bound to a different origin.`
+    `the workflow identity did not validate: the uuid ${String(workflowUuid)} is not a ` +
+    `well-formed workflow uuid. (The origin ${origin} was present and accepted -- this gate ` +
+    `requires an origin to exist, it does not compare it against a previously bound one.)`
   );
 }


### PR DESCRIPTION
Re-scoped #1255 onto its real defect, after my first attempt at that issue was closed unmerged.

## The defect

`identityReason` (`fence-refusal.ts:77`) ended:

> …a malformed uuid, **or one bound to a different origin**.

`workflowIdentityParts` never compares origins. It uses the origin as a **presence** gate — it requires one to exist — and nothing in the repo has ever read `identity.origin`; both call sites (`orchestrator/index.ts:2851`, `:3558`) take `.uuid` and discard it. So reaching that branch with an origin present means exactly one thing: the uuid failed its shape check.

The message now says that, and states explicitly that the origin was **accepted and is not compared**, so a reader is not sent hunting for a mismatch that cannot happen.

## Why a wording fix is worth a PR

I am the evidence. I read that sentence as documentation and reasoned from it: measured that `localhost` and `127.0.0.1` produce different origin strings, filed #1255 as a confirmed defect, wrote a fix and 7 tests, and opened PR #1257. Review killed it — mutating the returned origin to a constant fails only the 3 files that unit-test the helper directly and passes every fence, hello, bridge, panel-tool and routing suite. The value is inert. PR closed unmerged, nothing shipped.

**Prose in a codebase is read as evidence about the codebase.** A refusal that overstates what it checked costs whoever believes it, and this is the cheapest place to stop that.

## Verification

4 tests. **No existing test asserted the old wording** — which is why it survived — so the mutation check is what matters here: restoring the false sentence kills 3. The ambiguous-turn and no-Origin branches are asserted unchanged, since those two are correct and must not be disturbed.

Suite: 408 files, 8173 passed, 2 skipped.

**Pre-existing, not mine:** `download-manager-routing.test.ts` "#420" fails on clean `origin/main` with these changes stashed — verified by stashing — and references nothing this commit touches. Flagged in an earlier review as order-dependent.

## Left open deliberately

Whether the fence *should* be origin-bound is a design question, not a wording one. This PR makes the message true about today's behaviour; it does not decide that. If the answer is "yes, it should be", that is a separate change with a real threat model behind it, and it should not ride in on a message fix.

Refs #1077, #1246, #1257.