### PR TITLE
chore(release): reconcile main to 0.50.74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.74] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- a relaunch that exits 1 must say what the child printed (#1262)
+
+#### Changed
+- 0.50.73 (#1260)
+
+
 ## [0.50.73] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.73",
+  "version": "0.50.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.73",
+      "version": "0.50.74",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.73",
+  "version": "0.50.74",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.74` tag.

Ships **#1259** — a managed relaunch that fails now reports what the child printed, instead of an exit code and nothing else. The output goes to a file (the child is detached and must outlive us, so a pipe would risk EPIPE on a server that was starting fine), the command is written in first so an exec failure still leaves evidence, the tail is bounded and scrubbed, and the full log path is always named.

Verified against a real child that prints a traceback and exits 1: the traceback reaches the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)