### PR TITLE
sweep(#796): a probe that FAILED must not answer 'no'

### DIFF
--- a/src/__tests__/services/custom-nodes-unreadable.test.ts
+++ b/src/__tests__/services/custom-nodes-unreadable.test.ts
@@ -160,3 +160,35 @@ describe("an UNREADABLE custom_nodes is not an absent one (#796)", () => {
     expect(res.liveRootUnreadable).toBeUndefined();
   });
 });
+
+// THE REMEDY. Recording the state is only half of it: without this, the new
+// field is plumbing nothing reads — and the uncorroborated message would keep
+// offering one of two remedies that cannot apply. The argv was fine (so
+// relaunching with an absolute main.py changes nothing) and ComfyUI is reachable
+// (so "start/reach ComfyUI" is already true).
+describe("the uncorroborated message names the RIGHT remedy (#796)", () => {
+  it("has a distinct branch for an unreadable root, before the underivable one", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(
+      new URL("../../services/panel-installer.ts", import.meta.url),
+      "utf-8",
+    );
+
+    const at = src.indexOf("baseResolution?.liveRootUnreadable");
+    expect(at, "the unreadable case must be handled").toBeGreaterThan(-1);
+
+    // ORDER MATTERS: underivable is the fallback of the two, so unreadable has to
+    // be tested first or it can never be reached.
+    const underivableAt = src.indexOf("baseResolution?.liveRootUnderivable");
+    expect(at, "unreadable must be checked before underivable").toBeLessThan(underivableAt);
+
+    const branch = src.slice(at, underivableAt);
+    expect(branch, "it must name the path that could not be read").toContain(
+      "baseResolution.liveRootUnreadable",
+    );
+    expect(branch, "and say what to do about it").toMatch(/readable/);
+    // The remedies that do NOT apply here must not appear in this branch.
+    expect(branch).not.toMatch(/ABSOLUTE path to main\.py/);
+    expect(branch).not.toMatch(/Start\/reach/);
+  });
+});

--- a/src/__tests__/services/custom-nodes-unreadable.test.ts
+++ b/src/__tests__/services/custom-nodes-unreadable.test.ts
@@ -1,0 +1,162 @@
+// #796 sweep — "this root has no custom_nodes" was also being said when the
+// directory could not be READ.
+//
+// `hasCustomNodes` was `statSync(...).isDirectory()` inside a bare `try/catch`
+// returning `false`. ENOENT is a real answer: nothing is there. EACCES, EPERM,
+// EIO and a dead UNC share are not — they mean the question could not be asked.
+//
+// It mattered because of what the caller does with a `false`. The live root is
+// skipped, the resolution falls back to the CONFIGURED path, and the panel
+// installer then operates on a different tree — while that caller's own comment
+// says the point is to accept only a base it can PROVE holds custom_nodes. A
+// base nobody could read is not disproof.
+//
+// On a Comfy Desktop split install the configured tree is precisely the one the
+// server does NOT read (#766), so this fold turns an unreadable directory into a
+// confident answer about the wrong tree.
+//
+// The skip is UNCHANGED — loosening a guard on an unread directory is the wrong
+// direction. What changed is that the reason is now carried out instead of
+// vanishing, in the same idiom this file already uses for `liveProbeFailed` vs
+// `liveRootUnderivable` (#916).
+
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  argv: undefined as string[] | undefined,
+  reachable: true,
+  configured: undefined as string | undefined,
+  statError: undefined as NodeJS.ErrnoException | undefined,
+}));
+
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
+  return { ...actual, isLocalMode: () => true };
+});
+
+vi.mock("../../services/workspace-env.js", async () => {
+  const actual = await vi.importActual<typeof import("../../services/workspace-env.js")>(
+    "../../services/workspace-env.js",
+  );
+  return {
+    ...actual,
+    resolveEffectiveComfyUIBase: () => hoisted.configured,
+    getLiveServerSnapshot: async () => ({
+      reachable: hoisted.reachable,
+      argv: hoisted.argv,
+      cwd: undefined,
+    }),
+    liveRootFromArgv: (argv: string[] | undefined) => (argv ? argv[0] : undefined),
+  };
+});
+
+// The real statSync, except that a chosen path raises a chosen errno — the
+// permission/IO failure this is about, which cannot be produced portably on a
+// developer machine or on CI.
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    statSync: (p: string, ...rest: unknown[]) => {
+      if (hoisted.statError && String(p).includes("unreadable")) throw hoisted.statError;
+      return (actual.statSync as (...a: unknown[]) => unknown)(p, ...rest);
+    },
+  };
+});
+
+const { resolvePanelBase, __resetPanelBaseCache } = await import(
+  "../../services/panel-workspace.js"
+);
+
+let root: string;
+
+function errno(code: string): NodeJS.ErrnoException {
+  const e = new Error(`${code}: simulated`) as NodeJS.ErrnoException;
+  e.code = code;
+  return e;
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "cnstate-"));
+  hoisted.argv = undefined;
+  hoisted.reachable = true;
+  hoisted.configured = undefined;
+  hoisted.statError = undefined;
+  __resetPanelBaseCache();
+});
+
+afterEach(() => {
+  __resetPanelBaseCache();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("an UNREADABLE custom_nodes is not an absent one (#796)", () => {
+  it("records the live root it could not read, instead of silently falling back", async () => {
+    const live = join(root, "unreadable-live");
+    mkdirSync(join(live, "custom_nodes"), { recursive: true });
+    const configured = join(root, "configured");
+    mkdirSync(join(configured, "custom_nodes"), { recursive: true });
+
+    hoisted.argv = [live];
+    hoisted.configured = configured;
+    hoisted.statError = errno("EACCES");
+
+    const res = await resolvePanelBase();
+
+    expect(res.source, "the guard still refuses an unproven live root").toBe("configured");
+    expect(res.liveRootUnreadable, "but the reason is carried out").toBe(live);
+  });
+
+  it.each(["EPERM", "EIO", "EBUSY"])("treats %s as unreadable too", async (code) => {
+    const live = join(root, "unreadable-live");
+    mkdirSync(join(live, "custom_nodes"), { recursive: true });
+    hoisted.argv = [live];
+    hoisted.statError = errno(code);
+
+    expect((await resolvePanelBase()).liveRootUnreadable).toBe(live);
+  });
+
+  it("a genuinely ABSENT custom_nodes stays absent, with nothing recorded", async () => {
+    // The other direction, and the one that must not regress: ENOENT is a real
+    // answer, so it is a disqualification rather than an unanswered question.
+    const live = join(root, "no-custom-nodes");
+    mkdirSync(live, { recursive: true });
+    hoisted.argv = [live];
+
+    const res = await resolvePanelBase();
+
+    expect(res.source).toBe("none");
+    expect(res.liveRootUnreadable, "ENOENT is not an unknown").toBeUndefined();
+  });
+
+  it("a root that DOES hold custom_nodes is still accepted", async () => {
+    // The guard must keep working; this is the ordinary case.
+    const live = join(root, "good-live");
+    mkdirSync(join(live, "custom_nodes"), { recursive: true });
+    hoisted.argv = [live];
+
+    const res = await resolvePanelBase();
+
+    expect(res.base).toBe(live);
+    expect(res.source).toBe("live-argv-root");
+    expect(res.liveRootUnreadable).toBeUndefined();
+  });
+
+  it("a FILE named custom_nodes is absent, not unreadable", async () => {
+    // isDirectory() false — the stat succeeded, so the question was answered.
+    const live = join(root, "file-not-dir");
+    mkdirSync(live, { recursive: true });
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(join(live, "custom_nodes"), "not a directory");
+    hoisted.argv = [live];
+
+    const res = await resolvePanelBase();
+
+    expect(res.source).toBe("none");
+    expect(res.liveRootUnreadable).toBeUndefined();
+  });
+});

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -2005,7 +2005,20 @@ export async function panelStatus(
         `serves from, so "not installed" is UNCORROBORATED. On a split install ` +
         `(Comfy Desktop's --base-directory, #766) the panel lives elsewhere and ` +
         `installing here would land in a custom_nodes nothing loads. ` +
-        (baseResolution?.liveRootUnderivable
+        // #796 — THREE causes, three remedies. The unreadable case used to take
+        // one of the other two branches, and both give advice that cannot work:
+        // the argv was fine (so relaunching with an absolute main.py changes
+        // nothing) and ComfyUI is reachable (so "start/reach ComfyUI" is already
+        // true). Naming a remedy that cannot apply is worse than naming none.
+        (baseResolution?.liveRootUnreadable
+          ? `ComfyUI IS running and DID identify an install root — ` +
+            `${baseResolution.liveRootUnreadable} — but its custom_nodes could not be ` +
+            `READ from here (a permission error, an IO error, or a network path that ` +
+            `is not available to this process), so it could not be confirmed as the ` +
+            `serving tree. That is not evidence it lacks one. Make that directory ` +
+            `readable by whoever runs this MCP — or run install_comfyui ` +
+            `(action:"panel") from a process that can read it — before installing.`
+          : baseResolution?.liveRootUnderivable
           ? `ComfyUI IS running, but its reported launch arguments did not identify ` +
             `an install root holding custom_nodes (a relative main.py with no ` +
             `reported working directory), so reaching it again will not change this — ` +

--- a/src/services/panel-workspace.ts
+++ b/src/services/panel-workspace.ts
@@ -93,6 +93,19 @@ export interface PanelBaseResolution {
    * is a dead remedy here because ComfyUI is already running (#890/#916).
    */
   liveRootUnderivable?: boolean;
+  /**
+   * The live root that was skipped because its `custom_nodes` could NOT BE READ
+   * — a permission error, an IO error, a share that went away — as distinct from
+   * one that provably has none (#796).
+   *
+   * Both used to end here identically, and the difference decides what the
+   * fallback means: falling back to the CONFIGURED tree after disproving the
+   * live one is a conclusion, while doing it after failing to read the live one
+   * is a guess wearing the same clothes. On a Desktop split install the
+   * configured tree is exactly the one the server does not read, so a caller
+   * about to write needs to know which of the two it is standing on.
+   */
+  liveRootUnreadable?: string;
 }
 
 /**
@@ -116,12 +129,32 @@ export function isLiveDerivedBase(
   );
 }
 
-/** Does this candidate root actually hold a custom_nodes directory? */
-function hasCustomNodes(base: string): boolean {
+/**
+ * Does this candidate root hold a `custom_nodes` directory — THREE answers (#796).
+ *
+ * `statSync` throws for two entirely different reasons and this returned `false`
+ * for both. ENOENT/ENOTDIR is a real answer: nothing is there. EACCES, EPERM,
+ * EIO, EBUSY and a dead UNC share are NOT — they mean the question could not be
+ * asked. This file already knows that hazard; `safeExists` a few hundred lines
+ * down avoids UNC paths precisely because "a dead network share can block
+ * existsSync for seconds".
+ *
+ * Folding them mattered here because of what the caller does next: an unreadable
+ * LIVE root is skipped, the resolution falls back to the CONFIGURED path, and
+ * the panel installer then operates on a different tree — while the caller's own
+ * comment says the point is to accept only a base we can PROVE holds
+ * custom_nodes. A base we could not read is not disproof.
+ */
+type CustomNodesState = "present" | "absent" | "unknown";
+
+function customNodesState(base: string): CustomNodesState {
   try {
-    return statSync(join(base, "custom_nodes")).isDirectory();
-  } catch {
-    return false;
+    return statSync(join(base, "custom_nodes")).isDirectory() ? "present" : "absent";
+  } catch (err) {
+    // Only these two prove absence. Everything else — permissions, IO, a share
+    // that went away — is an unanswered question, not a negative answer.
+    const code = (err as NodeJS.ErrnoException)?.code;
+    return code === "ENOENT" || code === "ENOTDIR" ? "absent" : "unknown";
   }
 }
 
@@ -137,6 +170,9 @@ export async function resolvePanelBase(): Promise<PanelBaseResolution> {
 
   const configured = resolveEffectiveComfyUIBase();
   const snapshot = await getLiveServerSnapshot();
+  /** #796 — a live candidate whose custom_nodes could not be READ (permissions,
+   *  IO, a dead share), as opposed to one that provably lacks it. */
+  let liveRootUnreadable: string | undefined;
   if (snapshot.reachable) {
     // `--base-directory` FIRST: when ComfyUI is launched with it, that flag —
     // not the main.py location — is the root it derives custom_nodes/ from.
@@ -148,7 +184,19 @@ export async function resolvePanelBase(): Promise<PanelBaseResolution> {
       // Only accept a live base we can PROVE holds custom_nodes. An argv root
       // without one is not the tree the panel lives in, and pointing the
       // installer at it would manufacture a false "not installed".
-      if (!candidate || !hasCustomNodes(candidate)) continue;
+      if (!candidate) continue;
+      const state = customNodesState(candidate);
+      if (state === "unknown") {
+        // #796 — STILL SKIPPED: "we could not read it" is not the proof this
+        // branch requires, and loosening a guard on an unread directory is the
+        // wrong direction. But it is not disproof either, so it is recorded
+        // instead of vanishing — the fallback below otherwise hands the caller a
+        // CONFIGURED tree while silently implying the live one was disqualified
+        // on the evidence.
+        liveRootUnreadable ??= candidate;
+        continue;
+      }
+      if (state === "absent") continue;
       return {
         base: candidate,
         source,
@@ -163,9 +211,15 @@ export async function resolvePanelBase(): Promise<PanelBaseResolution> {
   // the remedy for each is different (#916).
   const liveRootUnderivable = snapshot.reachable;
   if (configured) {
-    return { base: configured, source: "configured", liveProbeFailed, liveRootUnderivable };
+    return {
+      base: configured,
+      source: "configured",
+      liveProbeFailed,
+      liveRootUnderivable,
+      liveRootUnreadable,
+    };
   }
-  return { source: "none", liveProbeFailed, liveRootUnderivable };
+  return { source: "none", liveProbeFailed, liveRootUnderivable, liveRootUnreadable };
 }
 
 /*


### PR DESCRIPTION
A bounded sweep for #796's class, not a closure of it.

Hunting one specific shape: a function that answers a yes/no question, swallows its own failure, and returns the definite negative — so "I could not find out" is delivered as "no".

The `check:unknown-collapse` gate reports 0 known sites, but it only sees sites someone has already marked. This looks for ones it cannot.

Draft while I sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)