### PR TITLE
chore(release): reconcile main to 0.50.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.75] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- download-manager-routing depends on state a neighbour primes (#1266)
+- the identity refusal must describe the check it actually ran (#1255)
+
+#### Changed
+- a probe that FAILED must not answer 'no' (#1267)
+- 0.50.74 (#1265)
+
+
 ## [0.50.74] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.74",
+  "version": "0.50.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.74",
+      "version": "0.50.75",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.74",
+  "version": "0.50.75",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.75` tag.

Ships a **#796** sweep finding: an UNREADABLE `custom_nodes` was reported as an absent one. A permission or IO error on the live root disqualified it, the resolution fell back to the CONFIGURED tree — which on a Comfy Desktop split install is exactly the tree the server does not read — and the panel installer then operated there.

The guard is unchanged (an unread directory is still not proof), but the reason is now carried out, and the uncorroborated message has a branch that names the right remedy instead of offering two that cannot apply.

Also includes the #1263 test fix (test-only, no runtime change) that was waiting to ride along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)