### PR TITLE
sweep(#796): 'no saved sessions' must not also mean 'could not read them'

### DIFF
--- a/src/__tests__/orchestrator/history-unreadable.test.ts
+++ b/src/__tests__/orchestrator/history-unreadable.test.ts
@@ -1,0 +1,123 @@
+// #796 sweep — "you have no saved sessions" was also being said when the
+// directory could not be READ.
+//
+// `listSessions` caught every `readdir` failure and returned `[]`. ENOENT is a
+// real answer — a first run has no directory yet, and an empty list is the truth.
+// EACCES, EPERM, EIO and a network path that went away are not.
+//
+// This one is worth fixing for what it says rather than what it does: it is a
+// read, nothing is destroyed. But "you have no saved sessions" is the single
+// wrong answer here that reads as DATA LOSS. Someone whose history is briefly
+// unreadable is told their conversations are gone, and goes looking for them.
+//
+// It THROWS rather than returning a flag because the one caller in
+// orchestrator/index.ts already wraps this in a `.catch` that pushes
+// `{ sessions: [], error }` to the panel — plumbing that could never fire for a
+// read failure, because this swallowed every one of them.
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  readdirError: undefined as NodeJS.ErrnoException | undefined,
+}));
+
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return {
+    ...actual,
+    readdir: async (p: unknown, ...rest: unknown[]) => {
+      if (hoisted.readdirError) throw hoisted.readdirError;
+      return (actual.readdir as (...a: unknown[]) => Promise<unknown>)(p, ...rest);
+    },
+  };
+});
+
+const { listSessions } = await import("../../orchestrator/history.js");
+
+let home: string;
+let savedHome: string | undefined;
+
+function errno(code: string): NodeJS.ErrnoException {
+  const e = new Error(`${code}: simulated`) as NodeJS.ErrnoException;
+  e.code = code;
+  return e;
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "hist796-"));
+  savedHome = process.env.HOME;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  hoisted.readdirError = undefined;
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.HOME;
+  else process.env.HOME = savedHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("an UNREADABLE history directory is not an empty one (#796)", () => {
+  it.each(["EACCES", "EPERM", "EIO", "EBUSY"])("throws on %s rather than reporting none", async (code) => {
+    hoisted.readdirError = errno(code);
+
+    await expect(listSessions("C:/some/project")).rejects.toThrow(
+      /NOT the same as having no saved sessions/,
+    );
+  });
+
+  it("names the directory, so the reader can go and look", async () => {
+    hoisted.readdirError = errno("EACCES");
+    await expect(listSessions("C:/some/project")).rejects.toThrow(/projects/);
+  });
+
+  it("a MISSING directory is still an empty list — a first run looks like this", async () => {
+    // The other direction, and the one that must not regress. Throwing here would
+    // turn every fresh install into an error.
+    hoisted.readdirError = errno("ENOENT");
+    await expect(listSessions("C:/some/project")).resolves.toEqual([]);
+  });
+
+  it("ENOTDIR is also a real answer, not an unknown", async () => {
+    hoisted.readdirError = errno("ENOTDIR");
+    await expect(listSessions("C:/some/project")).resolves.toEqual([]);
+  });
+
+  it("an unparseable session FILE is still skipped, not fatal", async () => {
+    // Content stays best-effort: one corrupt transcript must not hide the rest.
+    // Only the DIRECTORY read changed.
+    const dir = join(home, ".claude", "projects", "C--proj");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "broken.jsonl"), "{not json\n");
+    writeFileSync(
+      join(dir, "good.jsonl"),
+      JSON.stringify({ message: { role: "user", content: "hello there" } }) + "\n",
+    );
+
+    const out = await listSessions("C:/proj");
+
+    expect(out.map((s) => s.sessionId)).toEqual(["good"]);
+  });
+
+  it("a session ENTRY that cannot be read at all is skipped, not fatal", async () => {
+    // The malformed-JSON case above is caught by an inner parse guard, so it
+    // never reaches the per-file catch — found by mutation, which made that catch
+    // rethrow and killed nothing. A DIRECTORY named `*.jsonl` makes readFile
+    // throw EISDIR and does reach it. Content stays best-effort; only the
+    // directory read changed.
+    const dir = join(home, ".claude", "projects", "C--proj2");
+    mkdirSync(join(dir, "a-directory.jsonl"), { recursive: true });
+    writeFileSync(
+      join(dir, "good.jsonl"),
+      JSON.stringify({ message: { role: "user", content: "hello there" } }) + "\n",
+    );
+
+    const out = await listSessions("C:/proj2");
+
+    expect(out.map((s) => s.sessionId)).toEqual(["good"]);
+  });
+});

--- a/src/orchestrator/history.ts
+++ b/src/orchestrator/history.ts
@@ -80,9 +80,14 @@ function cleanUserText(raw: string): string {
 }
 
 /**
- * List the agent's saved sessions for [cwd], newest first. Best-effort: a
- * missing dir or unparseable file yields an empty/short list rather than throwing.
- * [limit] caps how many are returned.
+ * List the agent's saved sessions for [cwd], newest first. [limit] caps how many
+ * are returned.
+ *
+ * Best-effort about CONTENT: an unparseable file is skipped rather than failing
+ * the list. NOT best-effort about the DIRECTORY (#796): a missing directory is an
+ * empty list (a first run looks exactly like that), but one that exists and
+ * cannot be read THROWS — reporting "no saved sessions" for a permission or IO
+ * error is a wrong answer that reads as data loss.
  */
 export async function listSessions(
   cwd: string,
@@ -92,8 +97,28 @@ export async function listSessions(
   let files: string[];
   try {
     files = (await readdir(dir)).filter((f) => f.endsWith(".jsonl"));
-  } catch {
-    return [];
+  } catch (err) {
+    // #796 — "you have no saved sessions" and "your sessions could not be read"
+    // are different answers, and this returned the first for both.
+    //
+    // ENOENT/ENOTDIR is genuine: the directory has not been created yet, which is
+    // what a first run looks like, and an empty list is the truth. A permission
+    // error, an IO error or a network path that went away is NOT — and telling
+    // someone their history is empty is the one wrong answer that reads as data
+    // loss. They go looking for conversations they think they lost.
+    //
+    // Thrown rather than returned-with-a-flag because the ONE caller already
+    // wraps this in a `.catch` that pushes `{ sessions: [], error }` to the
+    // panel — plumbing that could never fire for a read failure, because this
+    // swallowed every one of them.
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT" || code === "ENOTDIR") return [];
+    throw new Error(
+      `Could not read the saved-session directory (${dir}): ${
+        err instanceof Error ? err.message : String(err)
+      }. This is NOT the same as having no saved sessions — none could be listed, ` +
+        `so nothing about their existence is known.`,
+    );
   }
 
   const summaries = await Promise.all(


### PR DESCRIPTION
Second #796 sweep pass. Fixes `listSessions`, and **corrects the candidate I named when the last sweep shipped**.

**`isManagerAvailable` does not hold.** I flagged it as conflating "Manager is absent" with "Manager errored", with a silent filesystem fallback as the consequence. Reading it properly: it is only consulted when there is no local path, and its false branch returns a controller that refuses with a message already covering both — *"ensure ComfyUI-Manager is installed and reachable"*. No silent fallback, no wrong action.

**`listSessions` does.** Every `readdir` failure returned `[]`. ENOENT is a real answer; EACCES/EPERM/EIO are not. It is a read, so nothing is destroyed — the severity is in what it says: *"you have no saved sessions"* is the one wrong answer here that reads as data loss.

It throws rather than returning a flag because the caller already wraps it in a `.catch` that pushes `{ sessions: [], error }` to the panel — plumbing no read failure could reach, because this swallowed them all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)