### PR TITLE
chore(release): reconcile main to 0.50.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.76] - 2026-08-09
+
+### MCP
+
+#### Changed
+- 'no saved sessions' must not also mean 'could not read them' (#1269)
+- 0.50.75 (#1268)
+
+
 ## [0.50.75] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.75",
+  "version": "0.50.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.75",
+      "version": "0.50.76",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.75",
+  "version": "0.50.76",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.76` tag.

Ships a second **#796** sweep finding: `listSessions` reported "no saved sessions" for every directory read failure, not only a missing directory. It is a read — nothing is destroyed — but that particular wrong answer reads as data loss, and someone whose history is briefly unreadable goes looking for conversations they think they lost.

ENOENT still returns an empty list (a first run looks exactly like that). Anything else throws into the `.catch` the caller already had, which pushes the reason to the panel — plumbing that no read failure could previously reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)