### PR TITLE
fix(open): tell the caller when the post-open read contradicts the open (panel#887)

### DIFF
--- a/src/__tests__/orchestrator/open-workflow-drift-surfaced.test.ts
+++ b/src/__tests__/orchestrator/open-workflow-drift-surfaced.test.ts
@@ -64,7 +64,17 @@ const ACTIVE_RECORDS: Record<ActiveShape, unknown> = {
   },
   // An unsaved tab has no saved path — `tmp:` keys are deliberately rejected as
   // saved identities, which is exactly why the adoption gate cannot be reused.
-  unsavedTab: { filename: "Unsaved Workflow", key: "tmp:2522828d", routing_key: "tmp:2522828d" },
+  // THE REAL SHAPE: the panel nulls `path` AND `filename` and puts the human label
+  // on `title`. An earlier fixture here put the label on `filename`, which passed
+  // for the wrong reason — it exercised a payload the panel never sends, and would
+  // have hidden that the warning named a bare `tmp:` handle at the user.
+  unsavedTab: {
+    path: null,
+    filename: null,
+    title: "Unsaved Workflow",
+    key: "tmp:2522828d",
+    routing_key: "tmp:2522828d",
+  },
   empty: {},
   missing: null,
 };
@@ -206,9 +216,13 @@ describe("#887 readOpenActiveAgainstTarget separates cannot-tell from proven-dif
 });
 
 describe("#887 describeActiveRecord names something a human can act on", () => {
-  it("prefers the filename, then the path, then the routing key", () => {
-    expect(describeActiveRecord({ filename: "b.json", path: "workflows/b.json" })).toBe("b.json");
-    expect(describeActiveRecord({ path: "workflows/b.json" })).toBe("workflows/b.json");
+  it("prefers the PATH, then title, then filename, then the routing key", () => {
+    // Path first on purpose: the case this guard exists for is a same-basename
+    // workflow in another directory, and a bare filename makes the warning refute
+    // itself ("workflows/a/foo.json was opened, but foo.json is active now").
+    expect(describeActiveRecord({ filename: "b.json", path: "workflows/b.json" })).toBe("workflows/b.json");
+    expect(describeActiveRecord({ title: "Unsaved Workflow", key: "tmp:abc" })).toBe("Unsaved Workflow");
+    expect(describeActiveRecord({ filename: "b.json" })).toBe("b.json");
     expect(describeActiveRecord({ key: "tmp:abc" })).toBe("tmp:abc");
   });
 
@@ -245,5 +259,157 @@ describe("#887 a same-workflow record whose IDENTITY merely failed to canonicali
         "workflows/a/foo.json",
       ),
     ).toBe("different");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. THE REPORTER'S OWN PATH. The first cut of this fix missed it entirely.
+//
+// The panel throws for every open verdict short of PROVEN, so #887's scenario —
+// its step 3 reads "Tool errors saying the requested workflow is active" —
+// arrives as an ERROR result. The corroborating read was gated on success, which
+// left precisely the filed case unexamined. Adversarial review caught it.
+// ---------------------------------------------------------------------------
+
+/** The panel's real CONTENT_UNVERIFIED throw: it ASSERTS the target is active. */
+const PANEL_ASSERTS_ACTIVE =
+  `workflow_open RAN and the canvas IS bound to a.json — that much was proven — but the graph ` +
+  `on it does not match the state that was loaded. You are NOT on the wrong workflow: a.json IS ` +
+  `the active one.`;
+
+function erroringBridge(activeShape: ActiveShape) {
+  return {
+    ...bridgeFor(activeShape),
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "workflow_open") throw new Error(PANEL_ASSERTS_ACTIVE);
+      if (cmd.cmd === "workflow_list") {
+        return { active: ACTIVE_RECORDS[activeShape], active_confirmed: true, workflows: [] };
+      }
+      return { ok: true };
+    },
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+describe("#887 the reporter's erroring open is checked too", () => {
+  it("contradicts the panel's own 'X IS the active one' assertion when it is false", async () => {
+    const res = await openWorkflow().handler({ path: PATH }, ctxWith(erroringBridge("otherSaved")));
+
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain(PANEL_ASSERTS_ACTIVE); // the original failure is preserved, not replaced
+    expect(text).toContain("workflows/somethingelse.json"); // named WITH its directory
+    expect(text).toMatch(/is the ACTIVE workflow now/);
+    expect(text).toMatch(/Do NOT save/i);
+  });
+
+  it("adopts NOTHING on the erroring path — observation must not stamp a fence", async () => {
+    await openWorkflow().handler({ path: PATH }, ctxWith(erroringBridge("otherSaved")));
+
+    expect(stamps).toEqual([]);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it("leaves a failed open alone when the active workflow IS the target", async () => {
+    const res = await openWorkflow().handler({ path: PATH }, ctxWith(erroringBridge("target")));
+
+    expect(textOf(res)).toContain(PANEL_ASSERTS_ACTIVE);
+    expect(textOf(res)).not.toMatch(/is the ACTIVE workflow now/);
+    expect(stamps).toEqual([]); // still no adoption: the open never proved itself
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. FALSE ALARMS that would FAIL A HEALTHY OPEN. The dangerous direction.
+// ---------------------------------------------------------------------------
+
+describe("#887 spelling differences are never drift", () => {
+  // Each of these is the SAME file as `workflows/a.json`, reached by a spelling the
+  // strict identity gate rejects when routing_key does not corroborate. Declaring
+  // any of them drift fails a perfectly good open — on Windows, the reporter's
+  // platform, the backslash and case forms are ordinary.
+  const SAME_FILE_SPELLINGS: Array<[string, unknown]> = [
+    ["./ prefix on the request", { path: "workflows/a.json", routing_key: "tmp:abc" }],
+    ["backslash separators", { path: "workflows/a.json", routing_key: null }],
+    ["case difference", { path: "workflows/a.json", routing_key: "wf:workflows/a.json" }],
+  ];
+  const REQUESTS = ["./workflows/a.json", "workflows\a.json", "Workflows/A.json"];
+
+  REQUESTS.forEach((requested, i) => {
+    const [label, active] = SAME_FILE_SPELLINGS[i];
+    it(`${label}: ${requested} vs workflows/a.json is NOT drift`, () => {
+      expect(readOpenActiveAgainstTarget(active, requested)).not.toBe("different");
+    });
+  });
+
+  it("an unconfirmed active record is never used to fail an open", () => {
+    // active_confirmed:false is the panel saying the value is untrustworthy. It is
+    // already refused as adoption evidence; it cannot be better evidence for
+    // failing an open than for stamping one.
+    expect(readOpenActiveAgainstTarget(ACTIVE_RECORDS.otherSaved, PATH, false)).toBe("indeterminate");
+    expect(readOpenActiveAgainstTarget(ACTIVE_RECORDS.otherSaved, PATH, true)).toBe("different");
+  });
+});
+
+describe("#887 the drift message names the DIRECTORY, not just the basename", () => {
+  it("a same-basename workflow elsewhere is named in full", () => {
+    // "workflows/a/foo.json was opened, but foo.json is active" refutes itself.
+    expect(describeActiveRecord({ path: "workflows/b/foo.json", filename: "foo.json" })).toBe(
+      "workflows/b/foo.json",
+    );
+  });
+
+  it("an unsaved tab still gets its human label, where the panel actually puts it", () => {
+    // The panel nulls path AND filename for an unsaved tab and labels it via title.
+    expect(describeActiveRecord({ path: null, filename: null, title: "Unsaved Workflow", key: "tmp:abc" })).toBe(
+      "Unsaved Workflow",
+    );
+  });
+});
+
+describe("#887 a genuine acked failure is left completely alone", () => {
+  // The open never ran, so another workflow being active is the EXPECTED state,
+  // not drift. This repo already pins that a genuine error must not trigger a
+  // workflow_list round trip; a blanket observe-on-every-error broke two existing
+  // tests, which is how this boundary was found.
+  it("a missing-file error neither warns nor makes a corroborating read", async () => {
+    let listCalls = 0;
+    const bridge = {
+      ...bridgeFor("otherSaved"),
+      send: async (cmd: Record<string, unknown>) => {
+        if (cmd.cmd === "workflow_open") throw new Error(`no workflow matching "${PATH}"`);
+        if (cmd.cmd === "workflow_list") {
+          listCalls++;
+          return { active: ACTIVE_RECORDS.otherSaved, active_confirmed: true, workflows: [] };
+        }
+        return { ok: true };
+      },
+    } as unknown as PanelToolCtx["bridge"];
+
+    const res = await openWorkflow().handler({ path: PATH }, ctxWith(bridge));
+
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toMatch(/no workflow matching/i);
+    expect(textOf(res)).not.toMatch(/is the ACTIVE workflow now/);
+    expect(listCalls).toBe(0); // the round trip is not made at all
+  });
+
+  it("but a rebind-unproven error IS examined — the panel says the load RAN", async () => {
+    let listCalls = 0;
+    const bridge = {
+      ...bridgeFor("otherSaved"),
+      send: async (cmd: Record<string, unknown>) => {
+        if (cmd.cmd === "workflow_open") throw new Error(PANEL_ASSERTS_ACTIVE);
+        if (cmd.cmd === "workflow_list") {
+          listCalls++;
+          return { active: ACTIVE_RECORDS.otherSaved, active_confirmed: true, workflows: [] };
+        }
+        return { ok: true };
+      },
+    } as unknown as PanelToolCtx["bridge"];
+
+    const res = await openWorkflow().handler({ path: PATH }, ctxWith(bridge));
+
+    expect(listCalls).toBe(1);
+    expect(textOf(res)).toMatch(/is the ACTIVE workflow now/);
   });
 });

--- a/src/__tests__/orchestrator/open-workflow-drift-surfaced.test.ts
+++ b/src/__tests__/orchestrator/open-workflow-drift-surfaced.test.ts
@@ -1,0 +1,249 @@
+// panel#887 — `panel_open_workflow` reported the target was active while
+// `panel_list_workflows`, called immediately afterwards, named a different one.
+// The reporter's concern is the sharp end: a Save-As on that state writes the
+// wrong canvas.
+//
+// WHERE THIS IS NOT. The first attempt (panel PR #896, withdrawn) tried to re-read
+// the active pointer inside the panel's own post-load window. That cannot work:
+// from `loadGraphData` resolving to the reply being built there is no `await`, so
+// the "second" read is the same instant as the first and returns the same answer.
+// Both branches it added were unreachable in production, and a green suite with
+// killed mutations could not say so — mutations prove the tests match the code,
+// never that the code is reachable.
+//
+// WHERE IT IS. `refreshOpenWorkflowUuid` is the ONLY observation in the whole open
+// path taken after a real round trip (`await ctx.call({cmd:"workflow_list"})`), so
+// it is the only thing that can see the active pointer having settled elsewhere.
+// It already detected the contradiction and correctly declined to adopt the uuid —
+// and then returned silently, leaving the tool result a plain success naming the
+// path the caller asked for. Detected, handled, and not disclosed.
+//
+// THE DISTINCTION THAT MAKES THIS SAFE. `activeMatchesOpenRefreshTarget` is a
+// UUID-ADOPTION gate: for adoption, "a different workflow is active" and "I cannot
+// tell what is active" both correctly mean *do not adopt*, so it answers false to
+// both. WARNING on that same false would be a different claim on the same
+// evidence — and it returns false whenever the active record has no canonical
+// SAVED identity, which includes an ordinary unsaved tab. Every open made while
+// "Unsaved Workflow" is active would raise a wrong-canvas alarm. So the warning
+// requires a POSITIVE identification of what is active, and an unreadable active
+// record stays silent: unproven degrades to unknown, never to the negative.
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  readOpenActiveAgainstTarget,
+  describeActiveRecord,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const OPENED_UUID = "11111111-2222-4333-8444-555555555555";
+const PRIOR_UUID = "99999999-8888-4777-a666-555555555555";
+const OTHER_UUID = "22222222-3333-4444-8555-666666666666";
+
+const PATH = "workflows/a.json";
+const ROUTING = `wf:${PATH}`;
+
+let fence: string | undefined;
+let stamps: string[];
+
+const textOf = (res: ToolResult): string => (res.content[0] as { text: string }).text;
+
+/** `active` shapes the panel can actually return after an open. */
+type ActiveShape = "target" | "otherSaved" | "unsavedTab" | "empty" | "missing";
+
+const ACTIVE_RECORDS: Record<ActiveShape, unknown> = {
+  target: { path: PATH, filename: "a.json", key: ROUTING, routing_key: ROUTING, workflow_uuid: OPENED_UUID },
+  otherSaved: {
+    path: "workflows/somethingelse.json",
+    filename: "somethingelse.json",
+    key: "wf:workflows/somethingelse.json",
+    routing_key: "wf:workflows/somethingelse.json",
+    workflow_uuid: OTHER_UUID,
+  },
+  // An unsaved tab has no saved path — `tmp:` keys are deliberately rejected as
+  // saved identities, which is exactly why the adoption gate cannot be reused.
+  unsavedTab: { filename: "Unsaved Workflow", key: "tmp:2522828d", routing_key: "tmp:2522828d" },
+  empty: {},
+  missing: null,
+};
+
+function bridgeFor(shape: ActiveShape) {
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "workflow_open") {
+        return {
+          opened: { path: PATH, filename: "a.json" },
+          routing_key: ROUTING,
+          workflow_uuid: OPENED_UUID,
+          modified: false,
+          open_seq: 7,
+        };
+      }
+      if (cmd.cmd === "workflow_list") {
+        return { active: ACTIVE_RECORDS[shape], active_confirmed: true, workflows: [] };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: "tab-1", title: "A", connected_at: 0 }],
+    resolveActiveTabId: () => "tab-1",
+    workflowUuidFor: () => ({ known: true, uuid: fence }),
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      fence = uuid;
+      stamps.push(uuid);
+      return true;
+    },
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+const ctxWith = (b: ReturnType<typeof bridgeFor>): PanelToolCtx => makePanelToolCtx(b, "tab-1");
+const openWorkflow = () => buildPanelToolDefs().find((d) => d.name === "panel_open_workflow")!;
+
+beforeEach(() => {
+  stamps = [];
+  fence = PRIOR_UUID;
+});
+
+// ---------------------------------------------------------------------------
+// 1. REACHABILITY. The whole point. These drive the real `panel_open_workflow`
+//    handler end to end through the real bridge, so a passing test here is
+//    evidence that PRODUCTION reaches the new branch — which is precisely what
+//    the withdrawn panel-side attempt could not show about its own code.
+// ---------------------------------------------------------------------------
+
+describe("#887 the contradiction the orchestrator already saw is now disclosed", () => {
+  it("REACHABILITY: the real open handler FAILS when the post-open read names another workflow", async () => {
+    const res = await openWorkflow().handler({ path: PATH }, ctxWith(bridgeFor("otherSaved")));
+
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain(PATH); // what was asked for
+    expect(text).toContain("somethingelse.json"); // what is ACTUALLY active
+    expect(text).toMatch(/Do NOT save/i);
+  });
+
+  it("the session's fence is left alone — the active tab keeps its own protection", async () => {
+    await openWorkflow().handler({ path: PATH }, ctxWith(bridgeFor("otherSaved")));
+
+    // Unchanged from the pre-fix behaviour, and the reason this is safe to fail:
+    // nothing was adopted, so the workflow that IS active is still fenced as its own.
+    expect(stamps).toEqual([]);
+    expect(fence).toBe(PRIOR_UUID);
+  });
+
+  it("an UNSAVED tab winning the slot is drift too — it cannot be the saved target", async () => {
+    // The case the adoption gate cannot distinguish, and the reason the warning
+    // needed its own predicate rather than reusing that gate's boolean.
+    const res = await openWorkflow().handler({ path: PATH }, ctxWith(bridgeFor("unsavedTab")));
+
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain("Unsaved Workflow");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. NO FALSE ALARMS. The other half of failing closed.
+// ---------------------------------------------------------------------------
+
+describe("#887 an open that landed is untouched", () => {
+  it("a confirming read still succeeds and still adopts the fresher uuid", async () => {
+    const res = await openWorkflow().handler({ path: PATH }, ctxWith(bridgeFor("target")));
+
+    expect(res.isError).toBeFalsy();
+    expect(textOf(res)).toContain(PATH);
+    expect(fence).toBe(OPENED_UUID);
+  });
+
+  for (const shape of ["empty", "missing"] as const) {
+    it(`an UNREADABLE active record (${shape}) claims nothing in either direction`, async () => {
+      const res = await openWorkflow().handler({ path: PATH }, ctxWith(bridgeFor(shape)));
+
+      // Not a failure: nothing was observed about what is active, so inventing a
+      // wrong-canvas warning here would be the same defect pointing the other way.
+      expect(res.isError).toBeFalsy();
+      expect(textOf(res)).not.toMatch(/Do NOT save/i);
+      // ...and still no adoption, exactly as before.
+      expect(stamps).toEqual([]);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. The reading itself.
+// ---------------------------------------------------------------------------
+
+describe("#887 readOpenActiveAgainstTarget separates cannot-tell from proven-different", () => {
+  it("the target itself reads SAME", () => {
+    expect(readOpenActiveAgainstTarget(ACTIVE_RECORDS.target, PATH)).toBe("same");
+  });
+
+  it("a positively identified other workflow reads DIFFERENT", () => {
+    expect(readOpenActiveAgainstTarget(ACTIVE_RECORDS.otherSaved, PATH)).toBe("different");
+    expect(readOpenActiveAgainstTarget(ACTIVE_RECORDS.unsavedTab, PATH)).toBe("different");
+  });
+
+  it("an active record carrying NO identifying field reads INDETERMINATE", () => {
+    // The alarm-on-every-open case if this collapsed into `different`.
+    for (const v of [null, undefined, {}, { title: "Untitled" }, 42, "a.json"]) {
+      expect(readOpenActiveAgainstTarget(v, PATH)).toBe("indeterminate");
+    }
+  });
+
+  it("an unreadable TARGET is indeterminate too — our own side can fail to canonicalize", () => {
+    for (const p of ["", "tmp:2522828d", "wf:workflows/a.json"]) {
+      expect(readOpenActiveAgainstTarget(ACTIVE_RECORDS.otherSaved, p)).toBe("indeterminate");
+    }
+  });
+
+  it("an empty-string identifier does not count as an identification", () => {
+    expect(readOpenActiveAgainstTarget({ path: "", filename: "", key: "" }, PATH)).toBe("indeterminate");
+  });
+});
+
+describe("#887 describeActiveRecord names something a human can act on", () => {
+  it("prefers the filename, then the path, then the routing key", () => {
+    expect(describeActiveRecord({ filename: "b.json", path: "workflows/b.json" })).toBe("b.json");
+    expect(describeActiveRecord({ path: "workflows/b.json" })).toBe("workflows/b.json");
+    expect(describeActiveRecord({ key: "tmp:abc" })).toBe("tmp:abc");
+  });
+
+  it("falls back to a neutral phrase rather than printing undefined at the user", () => {
+    for (const v of [null, undefined, {}, 7]) {
+      expect(describeActiveRecord(v)).toBe("another workflow");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. The false alarm the existing #716 P1 suite caught, pinned here directly.
+// ---------------------------------------------------------------------------
+
+describe("#887 a same-workflow record whose IDENTITY merely failed to canonicalize is not drift", () => {
+  // The strict adoption gate refuses a record with an absent/replayed/malformed
+  // routing_key even when its PATH is the workflow we opened. Declining to adopt a
+  // uuid there is correct; announcing a different canvas is not. Three existing
+  // #716 P1 tests failed on exactly this before the looser positive check was
+  // added — the suite caught a real false alarm, which is what it is for.
+  for (const routing_key of [undefined, "wf:workflows/replayed.json", "not-a-routing-key"]) {
+    it(`routing_key=${String(routing_key)} reads INDETERMINATE, never different`, () => {
+      const active = { path: PATH, routing_key, workflow_uuid: OPENED_UUID };
+      expect(readOpenActiveAgainstTarget(active, PATH)).toBe("indeterminate");
+    });
+  }
+
+  it("a same-BASENAME workflow in another directory is still real drift", () => {
+    // The boundary: loosening must not swallow the case the guard exists for.
+    // workflows/b/foo.json cannot satisfy a request for workflows/a/foo.json.
+    expect(
+      readOpenActiveAgainstTarget(
+        { path: "workflows/b/foo.json", routing_key: "wf:workflows/b/foo.json" },
+        "workflows/a/foo.json",
+      ),
+    ).toBe("different");
+  });
+});

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -3675,8 +3675,18 @@ describe("#716 workflow UUID refresh after reconnect/open/re-pin", () => {
     };
 
     const res = await defByName("panel_open_workflow").handler({ path: requested }, ctx);
-    expect(res.isError).toBeFalsy();
+    // #716 P1's subject — the uuid must NOT be adopted from a same-basename
+    // workflow in another directory — is unchanged and is still the point here.
     expect(refresh).not.toHaveBeenCalled();
+    // #887 — but the OPEN is no longer reported as a success. This assertion was
+    // `toBeFalsy()` and is deliberately inverted: the caller asked for
+    // workflows/a/foo.json, the panel's post-open re-read says workflows/b/foo.json
+    // is active, and answering "opened workflows/a/foo.json" to that is the exact
+    // report that let a reporter Save-As onto the wrong canvas. Suppressing the
+    // refresh protected the FENCE; it never protected the CALLER, who was told the
+    // open landed. Both halves are now covered.
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toContain("workflows/b/foo.json");
   });
 
   it("does not promote an alias request to a reply-resolved path for fast-success refresh (#716 P1)", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2697,6 +2697,64 @@ function activeMatchesOpenRefreshTarget(active: unknown, path: string): boolean 
   return !!targetIdentity && canonicalSavedRecordIdentity(active) === targetIdentity;
 }
 
+/**
+ * #887 — THREE readings of the post-open active record, because
+ * `activeMatchesOpenRefreshTarget` returning false is not one answer.
+ *
+ * That predicate is a UUID-adoption gate, and for adoption both "a different
+ * workflow is active" and "I cannot tell what is active" correctly mean *do not
+ * adopt*. Reusing it to WARN would be a different claim on the same evidence:
+ * it returns false whenever `canonicalSavedRecordIdentity(active)` is null, which
+ * includes an ordinary UNSAVED tab (`tmp:` routing keys are deliberately rejected
+ * as saved identities). An open whose caller then has "Unsaved Workflow" active —
+ * the single most common state there is — would raise a wrong-canvas alarm on
+ * every call.
+ *
+ * So `different` is only returned when the panel POSITIVELY identified what is
+ * active and it is not the target. An active record we cannot read at all stays
+ * `indeterminate`, and the caller says nothing: unproven degrades to unknown,
+ * never to the negative. That rule is why the previous attempt at this issue was
+ * withdrawn, and it is the rule this module already states for every other
+ * proof-of-sameness oracle.
+ *
+ * An unsaved tab IS a positive identification: a `tmp:` routing key cannot be the
+ * saved workflow the caller named, so that case is genuinely `different` — but it
+ * reaches that verdict by being READ, not by failing to canonicalize.
+ */
+export type OpenActiveReading = "same" | "different" | "indeterminate";
+
+/** #887 — what the post-open corroborating read OBSERVED, when it contradicts the open. */
+export type OpenDriftNotice = { drifted: true; activeLabel: string };
+
+export function readOpenActiveAgainstTarget(active: unknown, path: string): OpenActiveReading {
+  if (activeMatchesOpenRefreshTarget(active, path)) return "same";
+  if (!canonicalRequestedSavedIdentity(path)) return "indeterminate"; // our own side is unreadable
+  if (!active || typeof active !== "object") return "indeterminate";
+  // The STRICT gate above failing is not enough to warn. It requires a canonical
+  // saved identity on both sides, and it refuses a record whose routing_key is
+  // absent, replayed, or malformed (#716 P1) — even when that record's PATH is the
+  // very workflow we opened. Declining to adopt a uuid on that evidence is right;
+  // telling the caller a different canvas is mounted would be a false alarm on the
+  // same workflow. So a looser positive match still counts as NOT-different.
+  if (activeMatchesTarget(active, path)) return "indeterminate";
+  const a = active as { path?: unknown; filename?: unknown; key?: unknown };
+  const identified =
+    (typeof a.path === "string" && a.path !== "") ||
+    (typeof a.filename === "string" && a.filename !== "") ||
+    (typeof a.key === "string" && a.key !== "");
+  return identified ? "different" : "indeterminate";
+}
+
+/** Human-readable name for whatever the panel says is active, for the #887 warning. */
+export function describeActiveRecord(active: unknown): string {
+  if (!active || typeof active !== "object") return "another workflow";
+  const a = active as { path?: unknown; filename?: unknown; key?: unknown };
+  for (const v of [a.filename, a.path, a.key]) {
+    if (typeof v === "string" && v !== "") return v;
+  }
+  return "another workflow";
+}
+
 /** Normalizes only syntax the panel's saved-path/routing identity normalizes. */
 function canonicalSavedWorkflowPath(value: unknown): string | null {
   if (typeof value !== "string" || !value) return null;
@@ -3524,7 +3582,7 @@ async function refreshOpenWorkflowUuid(
   ctx: PanelToolCtx,
   requestedPath: string,
   openResult: ToolResult,
-): Promise<void> {
+): Promise<OpenDriftNotice | null> {
   const parsedOpen = parseToolResultJson(openResult);
   const opened = parsedOpen?.opened;
   const openedPath =
@@ -3556,7 +3614,7 @@ async function refreshOpenWorkflowUuid(
     if (requestedUnsaved && requestedUnsaved === parsedOpen?.routing_key) {
       refreshWorkflowUuid(ctx, parsedOpen);
     }
-    return;
+    return null;
   }
 
   // THREE outcomes for this corroborating read, not two — and conflating the last
@@ -3592,9 +3650,22 @@ async function refreshOpenWorkflowUuid(
     // value, which is fresher than the reply — or it names a DIFFERENT active
     // workflow, in which case another tab won the slot and adopting our target's
     // uuid would fence this session to a canvas that is not mounted. Adopt nothing.
-    if (!activeMatchesOpenRefreshTarget(list!.active, requestedPath)) return;
+    //
+    // #887 — declining to adopt was right and was never enough. This is the ONLY
+    // genuinely later observation in the whole open path: it sits behind a real
+    // `await ctx.call(...)` round trip to the panel, so unlike anything inside the
+    // panel's own synchronous post-load window it can actually see the active
+    // pointer having settled somewhere else. It saw the contradiction, kept the
+    // session safe, and told the CALLER nothing — the tool result still reported a
+    // plain success naming the path the agent asked for. The agent then had every
+    // reason to Save-As onto what it believed was that canvas.
+    const reading = readOpenActiveAgainstTarget(list!.active, requestedPath);
+    if (reading === "different") {
+      return { drifted: true, activeLabel: describeActiveRecord(list!.active) };
+    }
+    if (reading === "indeterminate") return null;
     refreshWorkflowUuid(ctx, list!.active) || refreshWorkflowUuid(ctx, parsedOpen);
-    return;
+    return null;
   }
 
   // COULD NOT ASK — the wedged case. Fall back to the reply's proven uuid rather
@@ -3604,7 +3675,12 @@ async function refreshOpenWorkflowUuid(
   // actually mounted, whereas doing nothing here guarantees every subsequent
   // command is refused. A reply that carries no uuid (the panel could not prove
   // it) still refreshes nothing, so fail-closed is preserved.
+  //
+  // #887 — and NO drift notice from here, deliberately. This branch is reached
+  // precisely because the corroborating read could not be made, so nothing was
+  // observed about what is active. Warning here would be inventing the finding.
   refreshWorkflowUuid(ctx, parsedOpen);
+  return null;
 }
 
 /** Exact resolved-path check for an open receipt. A filename/basename is not a
@@ -3744,7 +3820,30 @@ async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<
     // #716 — re-read the active record after this exact successful open before
     // refreshing the next command's stamp. This prevents a late reply from an
     // earlier open from overwriting the fence after another tab became active.
-    if (!res.isError) await refreshOpenWorkflowUuid(ctx, path, res);
+    if (!res.isError) {
+      const drift = await refreshOpenWorkflowUuid(ctx, path, res);
+      // #887 — the read above is the ONLY observation in this whole path taken
+      // after a real round trip, so it is the only thing that can catch the active
+      // pointer having settled elsewhere. It already declined to adopt the uuid;
+      // reporting a plain success alongside that silence is what let an agent
+      // Save-As onto the wrong canvas.
+      //
+      // This FAILS the open rather than annotating it. The caller asked for a
+      // workflow to be made active and it is not active — a success naming the
+      // requested path is false on the one point the caller acts on, and the next
+      // act is typically a write. The session's fence is untouched (nothing was
+      // adopted), so the tab that IS active keeps its own protection.
+      if (drift) {
+        return fail(
+          `workflow_open: ${path} was opened, but ${drift.activeLabel} is the ACTIVE workflow now — ` +
+            `the panel confirmed this on a re-read after the open completed. This session's ` +
+            `workflow identity was NOT re-pointed at ${path}, so the canvas you would read or ` +
+            `write is ${drift.activeLabel}, not ${path}. Do NOT save, save-as, or edit expecting ` +
+            `${path}. Call panel_list_workflows to see the current state, then re-open ${path} ` +
+            `if you still need it — another tab became active during or after the open.`,
+        );
+      }
+    }
     return res;
   }
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2726,7 +2726,47 @@ export type OpenActiveReading = "same" | "different" | "indeterminate";
 /** #887 — what the post-open corroborating read OBSERVED, when it contradicts the open. */
 export type OpenDriftNotice = { drifted: true; activeLabel: string };
 
-export function readOpenActiveAgainstTarget(active: unknown, path: string): OpenActiveReading {
+/**
+ * Would this active record plausibly BE the requested workflow? Used only to
+ * SUPPRESS a drift warning, never to prove sameness, so it is deliberately
+ * generous: every normalization that could make two spellings the same file is
+ * applied, and ties break toward silence. A miss here costs a warning we could
+ * have given; a false positive here FAILS a healthy open, which is far worse.
+ *
+ * `activeMatchesTarget` alone is not enough — it is raw string equality, so
+ * `./workflows/a.json`, `workflows\a.json` and `Workflows/A.json` all read as
+ * different files from `workflows/a.json`. This file already warns against
+ * exactly that conflation for the recovery path. Case folding is safe HERE
+ * (and only here) because the generous direction is the silent one.
+ */
+function plausiblySameSavedWorkflow(active: unknown, path: string): boolean {
+  if (activeMatchesTarget(active, path)) return true;
+  if (!active || typeof active !== "object") return false;
+  const want = canonicalSavedWorkflowPath(path);
+  if (!want) return false;
+  const fold = (s: string) => s.toLowerCase();
+  const wantFolded = fold(want);
+  const wantNoExt = stripJsonExt(wantFolded);
+  const a = active as { path?: unknown; filename?: unknown; key?: unknown };
+  for (const raw of [a.path, a.filename, a.key]) {
+    const got = canonicalSavedWorkflowPath(raw);
+    if (!got) continue;
+    const gotFolded = fold(got);
+    if (gotFolded === wantFolded) return true;
+    if (wantNoExt !== null && stripJsonExt(gotFolded) === wantNoExt) return true;
+  }
+  return false;
+}
+
+export function readOpenActiveAgainstTarget(
+  active: unknown,
+  path: string,
+  activeConfirmed?: unknown,
+): OpenActiveReading {
+  // #433/#3014 — `active_confirmed:false` is the panel telling us this value is
+  // untrustworthy. It is already refused as adoption evidence; it cannot be
+  // better evidence for failing an open than it is for stamping one.
+  if (activeConfirmed === false) return "indeterminate";
   if (activeMatchesOpenRefreshTarget(active, path)) return "same";
   if (!canonicalRequestedSavedIdentity(path)) return "indeterminate"; // our own side is unreadable
   if (!active || typeof active !== "object") return "indeterminate";
@@ -2735,8 +2775,8 @@ export function readOpenActiveAgainstTarget(active: unknown, path: string): Open
   // absent, replayed, or malformed (#716 P1) — even when that record's PATH is the
   // very workflow we opened. Declining to adopt a uuid on that evidence is right;
   // telling the caller a different canvas is mounted would be a false alarm on the
-  // same workflow. So a looser positive match still counts as NOT-different.
-  if (activeMatchesTarget(active, path)) return "indeterminate";
+  // same workflow.
+  if (plausiblySameSavedWorkflow(active, path)) return "indeterminate";
   const a = active as { path?: unknown; filename?: unknown; key?: unknown };
   const identified =
     (typeof a.path === "string" && a.path !== "") ||
@@ -2745,11 +2785,50 @@ export function readOpenActiveAgainstTarget(active: unknown, path: string): Open
   return identified ? "different" : "indeterminate";
 }
 
-/** Human-readable name for whatever the panel says is active, for the #887 warning. */
+/**
+ * #887 — observe what is active after an open, WITHOUT adopting anything.
+ *
+ * Split out of `refreshOpenWorkflowUuid` because the two questions have different
+ * preconditions. Adoption is gated on the open reply corroborating the requested
+ * identity — a reply that cannot prove which workflow it opened must never
+ * authorize a fence refresh. Pure observation needs none of that: "what does the
+ * panel say is active right now" is answerable regardless of what the open replied,
+ * and on the path that matters most the open reply is an ERROR carrying no JSON at
+ * all. Requiring corroboration there is what kept the reporter's own case
+ * unexamined.
+ */
+async function observeActiveAfterOpen(
+  ctx: PanelToolCtx,
+  requestedPath: string,
+): Promise<OpenDriftNotice | null> {
+  let list: Record<string, unknown> | null = null;
+  try {
+    const res = await ctx.call({ cmd: "workflow_list" }, 6000);
+    if (!res?.isError) list = parseToolResultJson(res);
+  } catch {
+    return null; // could not ask — nothing was observed, so nothing is claimed
+  }
+  if (!list) return null;
+  if (readOpenActiveAgainstTarget(list.active, requestedPath, list.active_confirmed) !== "different") {
+    return null;
+  }
+  return { drifted: true, activeLabel: describeActiveRecord(list.active) };
+}
+
+/**
+ * Human-readable name for whatever the panel says is active, for the #887 warning.
+ *
+ * PATH FIRST, deliberately. The case this guard exists for is a same-basename
+ * workflow in another directory, and naming it by its bare `filename` produces a
+ * sentence that refutes itself — "workflows/a/foo.json was opened, but foo.json is
+ * active now" reads as the same file. The directory IS the distinguishing
+ * information. `title` precedes the bare filename for the unsaved case, where the
+ * panel puts the human label there and leaves path/filename null.
+ */
 export function describeActiveRecord(active: unknown): string {
   if (!active || typeof active !== "object") return "another workflow";
-  const a = active as { path?: unknown; filename?: unknown; key?: unknown };
-  for (const v of [a.filename, a.path, a.key]) {
+  const a = active as { path?: unknown; filename?: unknown; key?: unknown; title?: unknown };
+  for (const v of [a.path, a.title, a.filename, a.key]) {
     if (typeof v === "string" && v !== "") return v;
   }
   return "another workflow";
@@ -3659,7 +3738,7 @@ async function refreshOpenWorkflowUuid(
     // session safe, and told the CALLER nothing — the tool result still reported a
     // plain success naming the path the agent asked for. The agent then had every
     // reason to Save-As onto what it believed was that canvas.
-    const reading = readOpenActiveAgainstTarget(list!.active, requestedPath);
+    const reading = readOpenActiveAgainstTarget(list!.active, requestedPath, list!.active_confirmed);
     if (reading === "different") {
       return { drifted: true, activeLabel: describeActiveRecord(list!.active) };
     }
@@ -3820,7 +3899,38 @@ async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<
     // #716 — re-read the active record after this exact successful open before
     // refreshing the next command's stamp. This prevents a late reply from an
     // earlier open from overwriting the fence after another tab became active.
-    if (!res.isError) {
+    if (res.isError) {
+      // #887 — THE REPORTER'S OWN PATH. The panel throws for every open verdict
+      // short of PROVEN, so the case in the ticket ("Tool errors saying the
+      // requested workflow is active") arrives here, not below. Gating the
+      // corroborating read on success left exactly the reported scenario
+      // unexamined: the panel's message asserts the target IS active, and nothing
+      // in this process ever checked whether it still was.
+      //
+      // OBSERVE ONLY — never adopt. The open did not prove itself, and the panel
+      // deliberately withholds `workflow_uuid` in that case to keep the fence
+      // fail-closed. Reading what is active cannot change that; it only adds a
+      // fact to a message that is already an error.
+      //
+      // AND ONLY FOR THE CLASS WHERE THE LOAD ACTUALLY RAN. A genuine acked
+      // failure — a missing file, a real executor error — means nothing was
+      // opened, so another workflow being active is the expected state, not
+      // drift; warning there would be noise, and this repo already pins that a
+      // genuine error must not trigger a workflow_list round trip at all. Every
+      // rebind-unproven message the panel emits opens with `workflow_open RAN`
+      // (its own contract wording for "the load executed, the proof did not"),
+      // which is exactly the class that can assert a false active workflow.
+      if (!/workflow_open RAN/i.test(toolResultText(res))) return res;
+      const drift = await observeActiveAfterOpen(ctx, path);
+      if (!drift) return res;
+      return fail(
+        `${toolResultText(res)}\n\nAND — checked after that failure — ${drift.activeLabel} is the ` +
+          `ACTIVE workflow now, not ${path}. Whatever that message says about ${path} being active, ` +
+          `it is not: the canvas you would read or write is ${drift.activeLabel}. Do NOT save, ` +
+          `save-as, or edit expecting ${path}. Call panel_list_workflows to see the current state.`,
+      );
+    }
+    {
       const drift = await refreshOpenWorkflowUuid(ctx, path, res);
       // #887 — the read above is the ONLY observation in this whole path taken
       // after a real round trip, so it is the only thing that can catch the active


### PR DESCRIPTION
Fixes the orchestrator half of artokun/comfyui-mcp-panel#887.

`panel_open_workflow` reported the requested workflow was active while `panel_list_workflows`, called immediately afterwards, named a different one. The sharp end, in the reporter's words: a Save-As on that state writes the wrong canvas.

## The contradiction was already detected — and swallowed

`refreshOpenWorkflowUuid` is the **only** observation in the entire open path taken after a real round trip (`await ctx.call({cmd:"workflow_list"})`). That makes it the only thing that can see the active pointer having settled somewhere else. It saw the contradiction, correctly declined to adopt the target's uuid, and then `return`ed — leaving the tool result a plain success naming the path the caller asked for.

Detected, handled, not disclosed. **Suppressing the refresh protected the fence; it never protected the caller**, who was told the open landed.

It now fails the open and names what is actually active. The session's fence is untouched, so the workflow that *is* active keeps its own protection.

## Why the warning needed its own predicate

The obvious move — warn wherever `activeMatchesOpenRefreshTarget` returns false — is wrong, and dangerously so.

That predicate is a **uuid-adoption gate**. For adoption, "a different workflow is active" and "I cannot tell what is active" both correctly mean *do not adopt*, so it collapses them into one `false`. Warning on that same `false` is a different claim on the same evidence. It returns false for any record without a canonical **saved** identity — which includes an ordinary unsaved tab, since `tmp:` keys are deliberately rejected as saved identities. Every open made while "Unsaved Workflow" is active would have raised a wrong-canvas alarm.

`readOpenActiveAgainstTarget` returns `different` only on a **positive identification** of what is active. An unreadable record stays `indeterminate` and says nothing: unproven degrades to unknown, never to the negative.

## The existing suite caught a real false alarm mid-change

Three #716 P1 tests failed on the first cut. A record whose **path** is the workflow we opened but whose `routing_key` is absent, replayed, or malformed fails the strict gate while being the same workflow — my predicate called that drift. A looser positive match now short-circuits it to `indeterminate`, and the same-basename-other-directory case is pinned separately to prove the loosening did not swallow real drift.

That is the suite doing its job, and I would rather report it than quietly absorb it.

## One pre-existing assertion is deliberately inverted

`"does not refresh a successful open from a different same-basename active workflow (#716 P1)"` asserted `res.isError` **falsy**. Its #716 subject — the uuid must not be adopted from a same-basename workflow in another directory — is unchanged and still asserted. The success claim alongside it was the defect: the caller asked for `workflows/a/foo.json`, the re-read says `workflows/b/foo.json` is active, and answering "opened `workflows/a/foo.json`" is exactly the report that enables the wrong write. Changed in place, with the reasoning next to it.

## Verification

Driven through the **real `panel_open_workflow` handler** end to end via `buildPanelToolDefs()` and a mock bridge — that is what makes these *reachability* evidence rather than helper coverage.

That distinction is the whole lesson from the first attempt at this issue: [panel PR #896](https://github.com/artokun/comfyui-mcp-panel/pull/896) was withdrawn because its new branches were **unreachable in production** — it re-read a value with no `await` between the two reads — and a green suite with five killed mutations could not say so. Mutations prove the tests match the code; they never prove the code is reachable.

Four mutations, each confirmed applied before its result was trusted:

| mutation | |
|---|---|
| restore the swallow (detect drift, return null) | killed |
| collapse `indeterminate` into `different` (alarm on every unsaved-active open) | killed |
| call site ignores the notice | killed |
| treat an unreadable active record as drift | killed |

8215/8215 tests, typecheck clean, no control bytes in changed files.

## Scope

The panel-side half of #887 needs nothing: the panel's message is accurate at the instant it is composed, and no panel-side re-read can be later than itself. This is the only place in the stack where the observation is genuinely later.