### PR TITLE
chore(release): reconcile main to 0.50.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.77] - 2026-08-09
+
+### MCP
+
+#### Changed
+- a failure message must not name a cause nobody observed (#1271)
+- 0.50.76 (#1270)
+
+
 ## [0.50.76] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.76",
+  "version": "0.50.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.76",
+      "version": "0.50.77",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.76",
+  "version": "0.50.77",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.77` tag.

Ships a third **#796** sweep finding: `requireOptionalDep` said *"is not installed — run npm install X"* for every way a dynamic import can fail. That command fixes one of the three: a package that is present but broken, or whose own dependency is missing, leaves the user running a command that reports "already up to date".

Verified against real Node across all four shapes — absent, subpath request, present-but-throws, and broken dependency tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)