### PR TITLE
0.50.78 — an open that lands on another workflow stops reporting success (panel#887)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.78] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- tell the caller when the post-open read contradicts the open (panel#887) (#1272)
+
+#### Changed
+- 0.50.77 (#1273)
+
+
 ## [0.50.77] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.77",
+  "version": "0.50.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.77",
+      "version": "0.50.78",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.77",
+  "version": "0.50.78",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",

--- a/src/__tests__/orchestrator/open-drift-live-shapes.test.ts
+++ b/src/__tests__/orchestrator/open-drift-live-shapes.test.ts
@@ -1,0 +1,43 @@
+// panel#887 — the drift predicate measured against records CAPTURED FROM THE LIVE
+// PANEL, not invented.
+//
+// Both earlier fixtures for the unsaved-tab case were wrong, in opposite ways: the
+// first put the label on `filename`; review "corrected" it to `path:null,
+// filename:null, title:"Unsaved Workflow"`. The running panel (ComfyUI 0.31.1)
+// actually emits a POPULATED synthetic path, the label on `filename`, and `title`
+// null:
+//
+//   { path: "workflows/Unsaved Workflow.json", filename: "Unsaved Workflow",
+//     title: null, key: "Unsaved Workflow.json" }
+//
+// That matters because this predicate can FAIL A HEALTHY OPEN. A fixture the panel
+// never sends proves nothing about that risk, so these cases are pinned from real
+// data and the same-file spellings are the ones a Windows user actually produces.
+import { describe, expect, it } from "vitest";
+import { readOpenActiveAgainstTarget, describeActiveRecord } from "../../orchestrator/panel-tools.js";
+const LIVE_UNSAVED = { path: "workflows/Unsaved Workflow.json", filename: "Unsaved Workflow", title: null, key: "Unsaved Workflow.json" };
+const LIVE_SAVED = { path: "workflows/Anima Wojak Batch.json", filename: "Anima Wojak Batch", title: null, key: "Anima Wojak Batch.json" };
+describe("live shapes", () => {
+  it("same file, many spellings, is NEVER drift", () => {
+    for (const t of [
+      "workflows/Anima Wojak Batch.json",
+      "./workflows/Anima Wojak Batch.json",
+      "workflows\Anima Wojak Batch.json",
+      "Workflows/anima wojak batch.json",
+      "Anima Wojak Batch.json",
+    ]) {
+      expect(readOpenActiveAgainstTarget(LIVE_SAVED, t, true), t).not.toBe("different");
+    }
+  });
+  it("a genuinely different workflow IS drift", () => {
+    expect(readOpenActiveAgainstTarget(LIVE_SAVED, "workflows/Artokun Flow v1.json", true)).toBe("different");
+    expect(readOpenActiveAgainstTarget(LIVE_UNSAVED, "workflows/Anima Wojak Batch.json", true)).toBe("different");
+  });
+  it("the unsaved tab is not drift against its own path", () => {
+    expect(readOpenActiveAgainstTarget(LIVE_UNSAVED, "workflows/Unsaved Workflow.json", true)).not.toBe("different");
+  });
+  it("labels are human-readable on the REAL shapes", () => {
+    expect(describeActiveRecord(LIVE_UNSAVED)).toBe("workflows/Unsaved Workflow.json");
+    expect(describeActiveRecord(LIVE_SAVED)).toBe("workflows/Anima Wojak Batch.json");
+  });
+});


### PR DESCRIPTION
Cuts **0.50.78**, carrying the panel#887 fix merged in #1272 (which landed after 0.50.77 was cut, so it is currently unreleased).

## What users get

`panel_open_workflow` no longer reports success when the workflow it opened is not the one that ended up active. The orchestrator was **already detecting** that contradiction on its post-open `workflow_list` round trip and correctly declining to adopt the uuid — then returning silently, so the tool still answered with a plain success naming the requested path. An agent's next act after an open is often a Save-As, which is how this became "the wrong canvas gets written".

It now fails the open and names what is actually active, including on the **erroring** path — which is where the reported case actually lands, since the panel throws for any open verdict short of PROVEN.

Fails closed in both directions: drift is claimed only when the panel positively identifies a different workflow; an unreadable or unconfirmed active record says nothing at all.

## Also in this cut

One extra commit on top of #1272: the drift predicate is now pinned against active records **captured from the live panel**, not invented ones. Both earlier fixtures for the unsaved-tab shape were wrong in opposite directions, and this predicate can fail a healthy open — so the same-file spellings a Windows user actually produces (`./` prefix, backslashes, case differences, bare basename) are asserted from real data. None read as drift; a genuinely different workflow still does.

## Verification

- 8226 passed / 2 skipped across 411 files; typecheck clean
- five mutations killed on the fix, each confirmed applied **and** effective
- live-verified on the rig against the running ComfyUI 0.31.1 panel

Two adversarial review rounds ran on this change. The first killed an earlier panel-side attempt outright (unreachable code — closed unmerged); the second caught that the first version of this fix missed the reporter's own erroring path and would have raised false alarms on Windows path spellings. Both are described in #1272.