### PR TITLE
chore(release): reconcile main to 0.50.78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.78] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- do not adopt an in-flight record whose writer is PROVEN gone (#1275)
+- tell the caller when the post-open read contradicts the open (panel#887) (#1272)
+
+#### Changed
+- 0.50.77 (#1273)
+
+
 ## [0.50.77] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.77",
+  "version": "0.50.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.77",
+      "version": "0.50.78",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.77",
+  "version": "0.50.78",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.78` tag.

Ships the #1148 blocker: cross-session download adoption no longer treats a fresh heartbeat as a live writer. A process that died within the last 60 seconds left a record that still looked current, and adopting it handed the caller a job nobody was running — reported as in-flight, polled forever, nothing downloading.

Only a PROVEN-gone writer (ESRCH) is rejected; "could not tell" still adopts, because refusing there would start a second writer for a download that is genuinely running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)