### PR TITLE
fix(download): persist job records without a panel, so a restart can be survived

### DIFF
--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   resolvers: [] as Array<{ resolve: (p: string) => void; reject: (e: Error) => void; url: string }>,
@@ -116,7 +116,8 @@ import {
   downloadIdFor,
   describePlacement,
 } from "../../services/download-jobs.js";
-import { setProgressDir, PERSIST_OWNER } from "../../services/download-progress.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { setProgressDir, PERSIST_OWNER, __resetStableRecordsDir } from "../../services/download-progress.js";
 import * as progressModule from "../../services/download-progress.js";
 import { downloadModel, resolveDownloadTarget } from "../../services/model-resolver.js";
 import { mkdtemp, mkdir, symlink, writeFile, readFile, rm as fsRm } from "node:fs/promises";
@@ -186,6 +187,9 @@ const URL_A = "https://huggingface.co/org/repo/resolve/main/big.safetensors";
 const URL_B = "https://huggingface.co/org/repo/resolve/main/other.safetensors";
 
 describe("download job registry", () => {
+  let storeDir = "";
+  const savedDataDir = process.env.COMFYUI_MCP_DATA_DIR;
+
   beforeEach(() => {
     hoisted.resolvers.length = 0;
     hoisted.calls = 0;
@@ -198,6 +202,25 @@ describe("download job registry", () => {
     hoisted.lastOnTrayId = undefined;
     hoisted.lastOnLanded = undefined;
     resetDownloadJobs();
+    // #1148 — THE PERSISTED STORE IS NOW ON BY DEFAULT, so it needs isolating
+    // like every other on-disk state this suite touches. Without this, records
+    // written by one case are still on disk for the next and show up in
+    // `listDownloadJobs()`, which merges in-memory with persisted rows: cases
+    // asserting an exact job count started seeing the previous case's downloads.
+    //
+    // That accumulation is CORRECT in production — `action:"status"` with no
+    // selector is meant to list every tracked download, and records self-reap
+    // after 6h. It is only a test that needs each case to start empty.
+    storeDir = mkdtempSync(pathJoin(tmpdir(), "djobs-store-"));
+    process.env.COMFYUI_MCP_DATA_DIR = storeDir;
+    __resetStableRecordsDir();
+  });
+
+  afterEach(() => {
+    if (savedDataDir === undefined) delete process.env.COMFYUI_MCP_DATA_DIR;
+    else process.env.COMFYUI_MCP_DATA_DIR = savedDataDir;
+    __resetStableRecordsDir();
+    if (storeDir) rmSync(storeDir, { recursive: true, force: true });
   });
 
   it("reports a download as in flight rather than finished or failed", async () => {
@@ -1981,6 +2004,12 @@ describe("download job registry", () => {
     it("stops a completed job's heartbeat when persistence goes inactive (no forever-retrying interval)", async () => {
       const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
       setProgressDir(dir);
+      // A path whose parent is a FILE, used below to make the fallback store
+      // genuinely unavailable — which is what "persistence goes inactive" means
+      // now that a default records dir exists.
+      const blockedParent = pathJoin(dir, "i-am-a-file");
+      await writeFile(blockedParent, "not a directory");
+      const savedDataForHb = process.env.COMFYUI_MCP_DATA_DIR;
       vi.useFakeTimers();
       const clearSpy = vi.spyOn(globalThis, "clearInterval");
       try {
@@ -1990,7 +2019,12 @@ describe("download job registry", () => {
         // Persistence goes INACTIVE, then the download completes. The settled finally's
         // terminal persist no-ops (no dir → not durable), so it does NOT clear the
         // heartbeat there — the heartbeat itself must stop on its next tick.
+        // #1148 — clearing the progress dir alone no longer makes persistence
+        // inactive: it falls back to the stable records dir. Neutralise that too,
+        // so this still tests what it says it does.
         setProgressDir("");
+        process.env.COMFYUI_MCP_DATA_DIR = pathJoin(blockedParent, "nested");
+        __resetStableRecordsDir();
         hoisted.resolvers[0].resolve("/M/checkpoints/big.safetensors");
         await entry.settled;
         clearSpy.mockClear();
@@ -2001,15 +2035,25 @@ describe("download job registry", () => {
       } finally {
         vi.useRealTimers();
         setProgressDir("");
+        if (savedDataForHb === undefined) delete process.env.COMFYUI_MCP_DATA_DIR;
+        else process.env.COMFYUI_MCP_DATA_DIR = savedDataForHb;
+        __resetStableRecordsDir();
         await fsRm(dir, { recursive: true, force: true });
       }
     });
 
-    it("installs a heartbeat only when the persisted store is active (no leak on non-panel downloads)", async () => {
-      // No progress dir → persistence inactive → NO heartbeat interval (would otherwise
-      // leak, retrying a no-op forever since persist never reports durable).
+    it("installs a heartbeat whenever there is somewhere to persist — including without a panel", async () => {
+      // #1148 — THE PREMISE CHANGED, and the guarantee did not. This used to read
+      // "no progress dir -> no heartbeat", because a plain non-panel download had
+      // nowhere to persist and an interval there would retry a no-op forever.
+      // There is now a stable records dir by default, so a plain download DOES
+      // persist — which is the entire point: a record that was never written
+      // cannot survive a restart.
       const noPanel = await startDownloadJob(URL_A, "checkpoints");
-      expect((noPanel as { heartbeat?: unknown }).heartbeat).toBeUndefined();
+      expect(
+        (noPanel as { heartbeat?: unknown }).heartbeat,
+        "a plain download must persist, or nothing survives a restart",
+      ).toBeDefined();
 
       // With a progress dir → a heartbeat is installed (and cleared by resetDownloadJobs).
       const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
@@ -2020,6 +2064,29 @@ describe("download job registry", () => {
       } finally {
         setProgressDir("");
         await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("installs NO heartbeat when there is genuinely nowhere to persist", async () => {
+      // The guarantee the old test was really protecting: an interval with no
+      // store retries a no-op forever, because persist never reports durable.
+      // "Nowhere to persist" is now rare rather than the default — the records
+      // dir has to be unusable — so provoke it directly: a data dir whose PARENT
+      // is a file, so the mkdir fails with ENOTDIR.
+      const blockerDir = await mkdtemp(pathJoin(tmpdir(), "djobs-blocked-"));
+      const blocker = pathJoin(blockerDir, "i-am-a-file");
+      await writeFile(blocker, "not a directory");
+      const savedData = process.env.COMFYUI_MCP_DATA_DIR;
+      process.env.COMFYUI_MCP_DATA_DIR = pathJoin(blocker, "nested");
+      __resetStableRecordsDir();
+      try {
+        const nowhere = await startDownloadJob(URL_A, "checkpoints");
+        expect((nowhere as { heartbeat?: unknown }).heartbeat).toBeUndefined();
+      } finally {
+        if (savedData === undefined) delete process.env.COMFYUI_MCP_DATA_DIR;
+        else process.env.COMFYUI_MCP_DATA_DIR = savedData;
+        __resetStableRecordsDir();
+        await fsRm(blockerDir, { recursive: true, force: true });
       }
     });
 

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -11,6 +11,7 @@
 
 import { mkdirSync, readFileSync, readdirSync, writeFileSync, renameSync, rmSync } from "node:fs";
 import { createHash, randomBytes } from "node:crypto";
+import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
 /** Per-PROCESS owner nonce (#515/#529). Distinguishes THIS session's persisted job
@@ -73,8 +74,78 @@ let lateBoundDir = "";
 export function setProgressDir(dir: string): void {
   lateBoundDir = dir;
 }
+/**
+ * A STABLE per-user directory for persisted job records, used when nothing else
+ * set one (#1148).
+ *
+ * Without it, a plain stdio MCP server — no panel, no orchestrator, no
+ * COMFYUI_MCP_PROGRESS_DIR — had NO channel dir, so `persistedRecordsEnabled()`
+ * was false and not one job record was ever written. Every cross-restart
+ * mechanism built for #1148 was inert in that configuration, while
+ * `download_model action:"status"` went on promising that an interrupted
+ * download stays resolvable by id. A reporter lost a 5 GB transfer to exactly
+ * that gap and was told "No download matching id".
+ *
+ * DELIBERATELY NOT UNDER tmpdir. The orchestrator nonces its progress dir per
+ * start and REAPS earlier ones there — the very deletion #1148's carry-over
+ * exists to survive. A records dir a later orchestrator start could sweep would
+ * reintroduce the bug from the other side.
+ *
+ * SAFE ONLY BECAUSE ADOPTION IS LIVENESS-CHECKED (#1275). Enabling the store
+ * also enables cross-session adoption, and before that fix a record left behind
+ * by a crashed process was adoptable for up to a minute — a new download would
+ * take over a job nobody was running. Turning this on without that guard traded
+ * one silent failure for a worse one.
+ *
+ * Created lazily and memoized: `channelDir()` runs on every persist, and a
+ * failure to create it degrades to "no persistence" — the previous behaviour —
+ * rather than throwing inside a download.
+ */
+let defaultRecordsDir: string | undefined;
+let defaultRecordsDirTried = false;
+
+function stableRecordsDir(): string {
+  if (defaultRecordsDirTried) return defaultRecordsDir ?? "";
+  defaultRecordsDirTried = true;
+  try {
+    const dir = join(
+      process.env.COMFYUI_MCP_DATA_DIR?.trim() || join(homedir(), ".comfyui-mcp"),
+      "download-records",
+    );
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    defaultRecordsDir = dir;
+  } catch {
+    defaultRecordsDir = undefined;
+  }
+  return defaultRecordsDir ?? "";
+}
+
+/** Test seam: forget the memoized default so a case can point it somewhere else. */
+export function __resetStableRecordsDir(): void {
+  defaultRecordsDir = undefined;
+  defaultRecordsDirTried = false;
+}
+
 function channelDir(): string {
   return PROGRESS_DIR || lateBoundDir;
+}
+
+/**
+ * Where the persisted JOB RECORDS live — the channel dir when there is one, else
+ * the stable per-user default (#1148).
+ *
+ * Deliberately SEPARATE from `channelDir()`, which also drives the control
+ * channel (the MCP child's target-change requests, read by an orchestrator).
+ * Falling back for that one too would switch on a channel with nobody at the
+ * other end: a plain stdio server has no orchestrator to read it, and a test
+ * asserting the control channel is inactive without a progress dir caught
+ * exactly that over-reach.
+ *
+ * Only the RECORD store needs somewhere to write regardless of transport,
+ * because only it has to survive a restart.
+ */
+function recordsDir(): string {
+  return channelDir() || stableRecordsDir();
 }
 const lastWriteAt = new Map<string, number>();
 
@@ -228,7 +299,7 @@ export function progressEnabled(): boolean {
  *  when there is actually somewhere to persist/adopt (avoids a leaked no-op interval on
  *  plain non-panel downloads). */
 export function persistedRecordsEnabled(): boolean {
-  return !!channelDir();
+  return !!recordsDir();
 }
 
 function fileFor(id: string, target?: string, attempt?: number): string {
@@ -737,7 +808,7 @@ function sanitizeIdPart(id: string): string {
 /** THIS session's record file for a job id — owner-scoped, so a second session running
  *  the same id writes a DIFFERENT file rather than clobbering ours. */
 function jobFileFor(id: string): string {
-  return join(channelDir(), `${JOB_PREFIX}${sanitizeIdPart(id)}-${PERSIST_OWNER}.json`);
+  return join(recordsDir(), `${JOB_PREFIX}${sanitizeIdPart(id)}-${PERSIST_OWNER}.json`);
 }
 
 let persistSeq = 0;
@@ -760,7 +831,7 @@ let persistSeq = 0;
  *  "downloading" record (bounded by long record retention, but this recovers it sooner). Returns
  *  false when there is no channel dir (nothing to persist) or the replace didn't happen. */
 export function persistDownloadJob(job: Omit<PersistedDownloadJob, "updated">): boolean {
-  const dir = channelDir();
+  const dir = recordsDir();
   if (!dir) return false;
   try {
     mkdirSync(dir, { recursive: true });
@@ -808,7 +879,7 @@ export function persistDownloadJob(job: Omit<PersistedDownloadJob, "updated">): 
 
 /** Remove a persisted job record (e.g. once it's fully retired). Best-effort. */
 export function removePersistedDownloadJob(id: string): void {
-  const dir = channelDir();
+  const dir = recordsDir();
   if (!dir) return;
   try {
     rmSync(jobFileFor(id), { force: true });
@@ -828,7 +899,7 @@ export function removePersistedDownloadJob(id: string): void {
  *  a persistent failure is reported to the caller so it can DISCLOSE the leftover
  *  instead of claiming a clean close it did not observe (codex gate, round 2). */
 export function removePersistedDownloadJobFor(id: string, owner: string): boolean {
-  const dir = channelDir();
+  const dir = recordsDir();
   if (!dir || !owner) return false;
   const path = join(dir, `${JOB_PREFIX}${sanitizeIdPart(id)}-${sanitizeIdPart(owner)}.json`);
   for (let attempt = 0; attempt < 5; attempt++) {
@@ -907,7 +978,7 @@ export function readPersistedDownloadJob(id: string): PersistedDownloadJob | nul
 /** Every persisted job record (freshest not guaranteed; caller sorts). Used to
  *  list in-flight downloads after a reconnect and to look one up by URL/destination. */
 export function listPersistedDownloadJobs(): PersistedDownloadJob[] {
-  const dir = channelDir();
+  const dir = recordsDir();
   if (!dir) return [];
   const out: PersistedDownloadJob[] = [];
   let files: string[] = [];


### PR DESCRIPTION
#1148's root cause, now that its blocker shipped in 0.50.78.

The persisted job store is gated on a channel directory, set only by `COMFYUI_MCP_PROGRESS_DIR` or by the panel orchestrator late-binding its own. A plain stdio MCP server has neither, so `persistedRecordsEnabled()` is false and **no record is ever written** — every cross-restart mechanism built for #1148 is inert there, while `action:"status"` keeps promising an interrupted download stays resolvable by id.

I stopped short of this last cycle because enabling the store also switches on cross-session adoption, and a stale record could be adopted as the live writer for a new download. **#1275 fixed that**: adoption now requires the writer not be PROVEN gone. The specific hazard is closed, so this is a change worth making rather than a trade.

Draft while I work it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)