### PR TITLE
fix(routing): an explicit workflow pin must clear an AMBIGUOUS turn pin (panel#888)

### DIFF
--- a/src/__tests__/orchestrator/explicit-pin-clears-ambiguity.test.ts
+++ b/src/__tests__/orchestrator/explicit-pin-clears-ambiguity.test.ts
@@ -1,0 +1,205 @@
+// panel#888 — after a reconnect delivered queued events from several tabs,
+// `panel_graph_outline` refused as ambiguous (correct — #884's fence). The
+// refusal names the way out:
+//
+//   Target a workflow explicitly (panel_set_workflow_target / panel_open_workflow)
+//   or wait for the next single-origin message.
+//
+// The reporter did exactly that — `mode:"pinned"` with the exact active path. It
+// reported success. The next `panel_graph_outline` returned the identical error.
+//
+// THE ADVICE WAS WIRED TO ONE MODE. `resolveTarget` throws the ambiguity error the
+// moment `scopeTargetResolver` returns null. The escape hatch exists —
+// `setScopeRepinHandler`, documented "EXPLICIT recovery from a DEAD or AMBIGUOUS
+// pin" — but only `mode:"current"` ever reached it. `mode:"pinned"` wrote the
+// workflow-target store and nothing else, so the tool reported success truthfully
+// while the state actually blocking every subsequent command went untouched.
+//
+// The repin handler's OWN refusal already told the agent to do what did not work:
+// "Name the workflow instead — panel_set_workflow_target with a path, or
+// panel_open_workflow — and the pin follows it." It did not follow.
+//
+// WHY ROUTING `pinned` THROUGH THE SAME HANDLER IS SAFE. The P0 gate is shared
+// rather than re-implemented: a pin that still reaches a live tab of this
+// conversation is never displaced, however explicit the request. Only a dead or
+// ambiguous pin can be recovered. A NAMED tab that is not eligible REFUSES —
+// silently redirecting an explicit request to another workflow is the exact hazard
+// #884 exists to prevent, and would be a worse bug than the one being fixed.
+import { describe, expect, it, vi } from "vitest";
+
+import { makeScopeRepinHandler, type ScopeRepinBridge } from "../../orchestrator/turn-origins.js";
+
+const KEY = "orchestrator::codex";
+const TAB_A = "wf:workflows/a.json";
+const TAB_B = "wf:workflows/b.json";
+
+/** `resolvedPinOf` is the real discriminator: string = a pin, null = ambiguous. */
+function harness(opts: {
+  pin: string | null | undefined;
+  tabs: string[];
+  reachable?: string[];
+  active?: string;
+  headless?: string[];
+  backendOf?: (t: string) => string;
+}) {
+  const repinTo = vi.fn();
+  const reachable = new Set(opts.reachable ?? opts.tabs);
+  const bridge: ScopeRepinBridge = {
+    canReach: (t) => reachable.has(t),
+    resolveActiveScopeTab: () => opts.active,
+    isHeadless: (t) => (opts.headless ?? []).includes(t),
+    tabs: () => opts.tabs.map((tab_id) => ({ tab_id })),
+  };
+  const handler = makeScopeRepinHandler({
+    bridge,
+    tracker: { resolvedPinOf: () => opts.pin, repinTo } as never,
+    scopeAgentKeyOf: () => KEY,
+    backendForTab: opts.backendOf ?? (() => "codex"),
+    backendOfKey: () => "codex",
+    info: () => {},
+  });
+  return { handler, repinTo };
+}
+
+// ---------------------------------------------------------------------------
+// 1. The fix: a NAMED workflow recovers an ambiguous pin.
+// ---------------------------------------------------------------------------
+
+describe("#888 naming a workflow recovers an AMBIGUOUS turn pin", () => {
+  it("pins to the named tab", () => {
+    // The reporter's state: pin is null (mixed-origin batch), several tabs live.
+    const { handler, repinTo } = harness({ pin: null, tabs: [TAB_A, TAB_B] });
+
+    expect(handler(KEY, TAB_B)).toBe(TAB_B);
+    expect(repinTo).toHaveBeenCalledWith(KEY, TAB_B);
+  });
+
+  it("recovers even when NO active tab is among the eligible ones", () => {
+    // This is the state whose own refusal says to name a workflow — and where
+    // "current" is legitimately unable to choose. Naming one has to work here or
+    // the advice is still a dead end.
+    const { handler, repinTo } = harness({
+      pin: null,
+      tabs: [TAB_A, TAB_B],
+      active: "wf:workflows/somebody-elses.json",
+    });
+
+    expect(handler(KEY, TAB_A)).toBe(TAB_A);
+    expect(repinTo).toHaveBeenCalledWith(KEY, TAB_A);
+  });
+
+  it("recovers a DEAD pin by name too, not just an ambiguous one", () => {
+    const { handler } = harness({ pin: "wf:workflows/gone.json", tabs: [TAB_A, TAB_B], reachable: [TAB_A, TAB_B] });
+
+    expect(handler(KEY, TAB_B)).toBe(TAB_B);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The P0 property. This must not become collateral of the fix.
+// ---------------------------------------------------------------------------
+
+describe("#888 a HEALTHY pin is still never displaced", () => {
+  it("refuses even when a workflow is named explicitly", () => {
+    // The whole point of the gate: an explicit request is not consent to steal a
+    // live turn's binding. Naming a workflow must not become a way around it.
+    const { handler, repinTo } = harness({ pin: TAB_A, tabs: [TAB_A, TAB_B] });
+
+    const out = handler(KEY, TAB_B);
+    expect(typeof out).toBe("object");
+    expect((out as { reason: string }).reason).toMatch(/still reaches a live tab/);
+    expect(repinTo).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. A named tab that is not eligible REFUSES — never a silent redirect.
+// ---------------------------------------------------------------------------
+
+describe("#888 an ineligible named tab refuses loudly", () => {
+  it("does not fall back to the active tab", () => {
+    // Falling back would answer an explicit "target workflow B" by pinning A —
+    // a silent wrong-canvas re-target, worse than the bug being fixed.
+    const { handler, repinTo } = harness({ pin: null, tabs: [TAB_A], active: TAB_A });
+
+    const out = handler(KEY, "wf:workflows/not-open.json");
+    expect(typeof out).toBe("object");
+    expect((out as { reason: string }).reason).toMatch(/not a tab of this conversation/i);
+    expect((out as { reason: string }).reason).toMatch(/NOT moved|not silently redirected/i);
+    expect(repinTo).not.toHaveBeenCalled();
+  });
+
+  it("refuses a named tab that belongs to ANOTHER backend's conversation", () => {
+    const { handler, repinTo } = harness({
+      pin: null,
+      tabs: [TAB_A, TAB_B],
+      backendOf: (t) => (t === TAB_B ? "claude" : "codex"),
+    });
+
+    expect(typeof handler(KEY, TAB_B)).toBe("object");
+    expect(repinTo).not.toHaveBeenCalled();
+  });
+
+  it("refuses a named tab that is headless", () => {
+    const { handler, repinTo } = harness({ pin: null, tabs: [TAB_A, TAB_B], headless: [TAB_B] });
+
+    expect(typeof handler(KEY, TAB_B)).toBe("object");
+    expect(repinTo).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Naming nothing keeps the old behaviour exactly.
+// ---------------------------------------------------------------------------
+
+describe("#888 mode:'current' is unchanged", () => {
+  it("still resolves via the active tab when no workflow is named", () => {
+    const { handler } = harness({ pin: null, tabs: [TAB_A, TAB_B], active: TAB_B });
+
+    expect(handler(KEY)).toBe(TAB_B);
+  });
+
+  it("still refuses when 'current' cannot identify one of several tabs", () => {
+    const { handler } = harness({ pin: null, tabs: [TAB_A, TAB_B], active: "wf:other.json" });
+
+    const out = handler(KEY);
+    expect(typeof out).toBe("object");
+    // ...and still points at the recovery that now actually works.
+    expect((out as { reason: string }).reason).toMatch(/Name the workflow instead/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. WIRING / REACHABILITY. The helper being right is worth nothing if
+//    `mode:"pinned"` never calls it — which was the entire bug.
+// ---------------------------------------------------------------------------
+
+describe("#888 WIRING: the pinned path actually reaches the handler", () => {
+  const src = () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { readFileSync } = require("node:fs") as typeof import("node:fs");
+    return readFileSync(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf8");
+  };
+
+  it("panel_set_workflow_target calls repinScopeToTab on the pinned branch", () => {
+    // The mutation this catches is deleting the call: every behavioural test
+    // above still passes, because they drive the handler directly. Only the call
+    // site can show the production path reaches it — the exact gap that made the
+    // previous attempt at panel#887 a no-op.
+    const s = src();
+    expect(s).toMatch(/scopeRepin = ctx\.bridge\.repinScopeToTab\(ctx\.tabId, namedTab\)/);
+    expect(s).toMatch(/mode === "pinned" && pinPath && isScopeAddress\(ctx\.tabId\)/);
+  });
+
+  it("the named tab is derived from the pinned PATH, not the active tab", () => {
+    // `canonicalRequestedSavedIdentity` yields `wf:<canonical path>` and returns
+    // null for a bare basename, which is why an alias cannot repin.
+    expect(src()).toMatch(/const namedTab = canonicalRequestedSavedIdentity\(pinPath\)/);
+  });
+
+  it("the outcome is reported to the caller, not swallowed", () => {
+    const s = src();
+    expect(s).toMatch(/turn_routing: "repinned"/);
+    expect(s).toMatch(/was NOT re-pinned: \$\{scopeRepin\.reason\}/);
+  });
+});

--- a/src/__tests__/orchestrator/explicit-pin-clears-ambiguity.test.ts
+++ b/src/__tests__/orchestrator/explicit-pin-clears-ambiguity.test.ts
@@ -30,8 +30,13 @@ import { describe, expect, it, vi } from "vitest";
 import { makeScopeRepinHandler, type ScopeRepinBridge } from "../../orchestrator/turn-origins.js";
 
 const KEY = "orchestrator::codex";
-const TAB_A = "wf:workflows/a.json";
-const TAB_B = "wf:workflows/b.json";
+// REAL bridge routes: `wf:<tabRouteId>:<path>` (panel #640). The first cut of
+// this suite used `wf:<path>` — the saved-workflow HANDLE — which production
+// never emits as a tab id, so every test was green on a shape that cannot occur.
+const TAB_A = "wf:tab-one:workflows/a.json";
+const TAB_B = "wf:tab-two:workflows/b.json";
+const PATH_A = "workflows/a.json";
+const PATH_B = "workflows/b.json";
 
 /** `resolvedPinOf` is the real discriminator: string = a pin, null = ambiguous. */
 function harness(opts: {
@@ -70,7 +75,7 @@ describe("#888 naming a workflow recovers an AMBIGUOUS turn pin", () => {
     // The reporter's state: pin is null (mixed-origin batch), several tabs live.
     const { handler, repinTo } = harness({ pin: null, tabs: [TAB_A, TAB_B] });
 
-    expect(handler(KEY, TAB_B)).toBe(TAB_B);
+    expect(handler(KEY, PATH_B)).toBe(TAB_B);
     expect(repinTo).toHaveBeenCalledWith(KEY, TAB_B);
   });
 
@@ -84,14 +89,14 @@ describe("#888 naming a workflow recovers an AMBIGUOUS turn pin", () => {
       active: "wf:workflows/somebody-elses.json",
     });
 
-    expect(handler(KEY, TAB_A)).toBe(TAB_A);
+    expect(handler(KEY, PATH_A)).toBe(TAB_A);
     expect(repinTo).toHaveBeenCalledWith(KEY, TAB_A);
   });
 
   it("recovers a DEAD pin by name too, not just an ambiguous one", () => {
     const { handler } = harness({ pin: "wf:workflows/gone.json", tabs: [TAB_A, TAB_B], reachable: [TAB_A, TAB_B] });
 
-    expect(handler(KEY, TAB_B)).toBe(TAB_B);
+    expect(handler(KEY, PATH_B)).toBe(TAB_B);
   });
 });
 
@@ -105,7 +110,7 @@ describe("#888 a HEALTHY pin is still never displaced", () => {
     // live turn's binding. Naming a workflow must not become a way around it.
     const { handler, repinTo } = harness({ pin: TAB_A, tabs: [TAB_A, TAB_B] });
 
-    const out = handler(KEY, TAB_B);
+    const out = handler(KEY, PATH_B);
     expect(typeof out).toBe("object");
     expect((out as { reason: string }).reason).toMatch(/still reaches a live tab/);
     expect(repinTo).not.toHaveBeenCalled();
@@ -122,9 +127,9 @@ describe("#888 an ineligible named tab refuses loudly", () => {
     // a silent wrong-canvas re-target, worse than the bug being fixed.
     const { handler, repinTo } = harness({ pin: null, tabs: [TAB_A], active: TAB_A });
 
-    const out = handler(KEY, "wf:workflows/not-open.json");
+    const out = handler(KEY, "workflows/not-open.json");
     expect(typeof out).toBe("object");
-    expect((out as { reason: string }).reason).toMatch(/not a tab of this conversation/i);
+    expect((out as { reason: string }).reason).toMatch(/no connected tab .* is showing that/i);
     expect((out as { reason: string }).reason).toMatch(/NOT moved|not silently redirected/i);
     expect(repinTo).not.toHaveBeenCalled();
   });
@@ -136,14 +141,35 @@ describe("#888 an ineligible named tab refuses loudly", () => {
       backendOf: (t) => (t === TAB_B ? "claude" : "codex"),
     });
 
-    expect(typeof handler(KEY, TAB_B)).toBe("object");
+    expect(typeof handler(KEY, PATH_B)).toBe("object");
     expect(repinTo).not.toHaveBeenCalled();
   });
 
   it("refuses a named tab that is headless", () => {
     const { handler, repinTo } = harness({ pin: null, tabs: [TAB_A, TAB_B], headless: [TAB_B] });
 
-    expect(typeof handler(KEY, TAB_B)).toBe("object");
+    expect(typeof handler(KEY, PATH_B)).toBe("object");
+    expect(repinTo).not.toHaveBeenCalled();
+  });
+});
+
+
+describe("#888 naming a workflow open in TWO tabs does not silently pick one", () => {
+  it("refuses, and says which tabs are showing it", () => {
+    // This is the case the panel's own bridge-route module exists for: the
+    // path-only handle cannot address one of two browser tabs showing the same
+    // file. Matching by path inherits that ambiguity, so the match is only ACTED
+    // on when exactly one tab has it. Taking matches[0] would be a silent
+    // wrong-tab choice — the same class of defect as the silent redirect above,
+    // and invisible to the caller because the tool would report success.
+    const { handler, repinTo } = harness({
+      pin: null,
+      tabs: ["wf:tab-one:workflows/a.json", "wf:tab-two:workflows/a.json"],
+    });
+
+    const out = handler(KEY, PATH_A);
+    expect(typeof out).toBe("object");
+    expect((out as { reason: string }).reason).toMatch(/2 connected tabs are showing that workflow/);
     expect(repinTo).not.toHaveBeenCalled();
   });
 });
@@ -174,32 +200,13 @@ describe("#888 mode:'current' is unchanged", () => {
 //    `mode:"pinned"` never calls it — which was the entire bug.
 // ---------------------------------------------------------------------------
 
-describe("#888 WIRING: the pinned path actually reaches the handler", () => {
-  const src = () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { readFileSync } = require("node:fs") as typeof import("node:fs");
-    return readFileSync(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf8");
-  };
-
-  it("panel_set_workflow_target calls repinScopeToTab on the pinned branch", () => {
-    // The mutation this catches is deleting the call: every behavioural test
-    // above still passes, because they drive the handler directly. Only the call
-    // site can show the production path reaches it — the exact gap that made the
-    // previous attempt at panel#887 a no-op.
-    const s = src();
-    expect(s).toMatch(/scopeRepin = ctx\.bridge\.repinScopeToTab\(ctx\.tabId, namedTab\)/);
-    expect(s).toMatch(/mode === "pinned" && pinPath && isScopeAddress\(ctx\.tabId\)/);
-  });
-
-  it("the named tab is derived from the pinned PATH, not the active tab", () => {
-    // `canonicalRequestedSavedIdentity` yields `wf:<canonical path>` and returns
-    // null for a bare basename, which is why an alias cannot repin.
-    expect(src()).toMatch(/const namedTab = canonicalRequestedSavedIdentity\(pinPath\)/);
-  });
-
-  it("the outcome is reported to the caller, not swallowed", () => {
-    const s = src();
-    expect(s).toMatch(/turn_routing: "repinned"/);
-    expect(s).toMatch(/was NOT re-pinned: \$\{scopeRepin\.reason\}/);
-  });
-});
+// The WIRING assertions that used to live here read panel-tools.ts and regexed
+// it for the call. They passed while the branch was provably inert: a source-text
+// grep cannot tell reachable code from dead code, and one of them even pinned the
+// defective derivation in place, so fixing the bug required deleting the test
+// that claimed to protect it.
+//
+// Replaced by pin-repin-uses-a-real-tab-id.test.ts, which drives the real
+// panel_set_workflow_target handler through the real repin handler and asserts
+// the pin lands on a tab the bridge actually holds. It fails against the broken
+// derivation, three different ways.

--- a/src/__tests__/orchestrator/pin-repin-uses-a-real-tab-id.test.ts
+++ b/src/__tests__/orchestrator/pin-repin-uses-a-real-tab-id.test.ts
@@ -1,0 +1,105 @@
+// panel#888 — the test that would have caught BOTH no-op attempts.
+//
+// A source-text grep ("does panel-tools.ts contain the call?") cannot tell
+// reachable code from dead code. My WIRING tests did exactly that and passed
+// while the branch provably never fired. This drives the REAL
+// panel_set_workflow_target handler and asserts the one property that matters:
+//
+//   the tab id handed to repinScopeToTab must be a tab that actually EXISTS.
+//
+// A route the bridge has never heard of refuses every time, which is
+// indistinguishable from the bug the fix was meant to close.
+//
+// THE SHAPE THAT BROKE IT. The panel's own bridge-route module (#640) defines
+// two DIFFERENT strings and warns they must not be confused:
+//   saved-workflow HANDLE : wf:<path>              <- what the fix derived
+//   bridge ROUTE (tab_id) : wf:<tabRouteId>:<path> <- what bridge.tabs() returns
+// The handle is path-only *because* two browser tabs can show the same file, so
+// it cannot address one of them. ui-bridge.ts's own comment still calls tabId
+// "commonly derived from a saved workflow path", which predates #640 and is what
+// licensed the wrong derivation.
+import { describe, expect, it, vi } from "vitest";
+
+import { buildPanelToolDefs, type PanelToolCtx } from "../../orchestrator/panel-tools.js";
+import { makeScopeRepinHandler } from "../../orchestrator/turn-origins.js";
+
+const SCOPE = "orchestrator::claude";
+/** A REAL connected tab id: route form, not the path-only handle. */
+const LIVE_TAB = "wf:tab-one:workflows/a.json";
+
+const setTarget = () => buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target")!;
+
+function ctxWith(realHandler: (s: string, p: string) => unknown, listBehaviour: "ambiguous" | "ok"): PanelToolCtx {
+  return {
+    tabId: SCOPE,
+    confirm: async () => "yes" as const,
+    call: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "workflow_list") {
+        if (listBehaviour === "ambiguous") {
+          // The reported state: the corroborating read is refused by the very
+          // fence this recovery exists to clear.
+          throw new Error(
+            `no connected tab can be chosen for "${SCOPE}": the current turn was issued from ` +
+              `multiple workflows at once, so its target is ambiguous.`,
+          );
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                active: { path: "workflows/a.json", key: "a.json", routing_key: LIVE_TAB },
+                workflows: [{ path: "workflows/a.json", key: "a.json", routing_key: LIVE_TAB, active: true }],
+              }),
+            },
+          ],
+        };
+      }
+      return { content: [{ type: "text", text: "{}" }] };
+    },
+    bridge: {
+      tabs: () => [{ tab_id: LIVE_TAB }],
+      canReach: () => true,
+      isHeadless: () => false,
+      push: () => 1,
+      refreshWorkflowUuid: () => true,
+      repinScopeToWorkflow: (scope: string, wfPath: string) => realHandler(scope, wfPath),
+      repinScopeToActive: () => undefined,
+    } as unknown as PanelToolCtx["bridge"],
+    workflowTarget: {
+      get: () => ({ mode: "current" as const }),
+      set: (_t: string, v: unknown) => v,
+    } as unknown as PanelToolCtx["workflowTarget"],
+  } as unknown as PanelToolCtx;
+}
+
+describe("#888 the repin must land on a tab the bridge actually has", () => {
+  for (const listBehaviour of ["ambiguous", "ok"] as const) {
+    it(`resolves the pinned path to a REAL connected tab (workflow_list ${listBehaviour})`, async () => {
+      // The REAL handler is wired in, so this drives the whole chain:
+      // panel_set_workflow_target -> bridge -> route matching -> repinTo.
+      // A spy on the bridge would only prove "some string was passed", which is
+      // what the first attempt proved while being inert.
+      const repinTo = vi.fn();
+      const realHandler = makeScopeRepinHandler({
+        bridge: {
+          canReach: () => true,
+          resolveActiveScopeTab: () => undefined,
+          isHeadless: () => false,
+          tabs: () => [{ tab_id: LIVE_TAB }],
+        },
+        tracker: { resolvedPinOf: () => null, repinTo } as never, // null = the ambiguous pin
+        scopeAgentKeyOf: () => SCOPE,
+        backendForTab: () => "claude",
+        backendOfKey: () => "claude",
+        info: () => {},
+      });
+
+      await setTarget().handler({ mode: "pinned", path: "workflows/a.json" }, ctxWith(realHandler, listBehaviour));
+
+      expect(repinTo, "the ambiguous turn pin was never moved").toHaveBeenCalled();
+      const [, tabArg] = repinTo.mock.calls[0] as [string, string];
+      expect([LIVE_TAB], `repin landed on ${JSON.stringify(tabArg)}, which is not a connected tab`).toContain(tabArg);
+    });
+  }
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -9277,14 +9277,18 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // succeeded and is what the caller asked for. A repin that cannot happen
         // must not retract it, so the outcome is reported, never thrown.
         let scopeRepin: ScopeRepinOutcome | undefined;
-        if (mode === "pinned" && pinPath && isScopeAddress(ctx.tabId) && ctx.bridge.repinScopeToTab) {
-          const namedTab = canonicalRequestedSavedIdentity(pinPath);
-          if (namedTab) {
-            try {
-              scopeRepin = ctx.bridge.repinScopeToTab(ctx.tabId, namedTab);
-            } catch {
-              scopeRepin = undefined; // never worse than the pre-#888 silence
-            }
+        if (mode === "pinned" && pinPath && isScopeAddress(ctx.tabId)) {
+          // The PATH, never a tab id derived from it. `wf:<path>` is the saved
+          // workflow HANDLE; a real tab id is a bridge ROUTE, `wf:<route>:<path>`
+          // (panel #640). The first cut of this fix compared the handle against
+          // routes, so it never matched and refused every time — inert, while a
+          // source-text "wiring" assertion passed, because grepping for a call
+          // cannot tell reachable code from dead code. The handler now does the
+          // matching against the routes the bridge actually holds.
+          try {
+            scopeRepin = ctx.bridge.repinScopeToWorkflow?.(ctx.tabId, pinPath);
+          } catch {
+            scopeRepin = undefined; // never worse than the pre-#888 silence
           }
         }
         ctx.bridge.push({ type: "workflow_target", target }, ctx.tabId);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -47,6 +47,7 @@ import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UiBridge } from "../services/ui-bridge.js";
 import { conversationOfScopeAddress, isScopeAddress, shortTabId } from "../services/session-scope.js";
+import type { ScopeRepinOutcome } from "./turn-origins.js";
 
 /** #884 — journal TICKETS (run completions #468, ask answers #486) must be
  *  keyed by the REAL tab a run/card was routed to: the panel reports back under
@@ -9253,6 +9254,39 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         if (mode === "pinned" && pinnedWorkflowUuid) {
           refreshWorkflowUuid(ctx, { workflow_uuid: pinnedWorkflowUuid });
         }
+        // #888 — make the SCOPE PIN follow the named workflow.
+        //
+        // Pinning wrote the workflow-target store above and, until now, nothing
+        // else. But after a mixed-origin turn the thing refusing every subsequent
+        // scope-addressed command is a DIFFERENT piece of state — the turn-origin
+        // pin, left ambiguous (`null`) by the #884 fence. So this tool reported
+        // success truthfully while the actual blocker went untouched, and the next
+        // `panel_graph_outline` returned the identical ambiguity error.
+        //
+        // The advice to do this is already in the code: the repin handler's own
+        // refusal says "Name the workflow instead — panel_set_workflow_target with
+        // a path, or panel_open_workflow — and the pin follows it." It did not
+        // follow, because only `mode:"current"` ever reached that handler.
+        //
+        // Routed through the SAME handler, so the P0 safety gate is shared rather
+        // than re-implemented: a pin that still reaches a live tab of this
+        // conversation is never displaced, however explicit the request. This can
+        // only ever recover a pin that is dead or ambiguous.
+        //
+        // Best-effort by construction: the pin store write above has already
+        // succeeded and is what the caller asked for. A repin that cannot happen
+        // must not retract it, so the outcome is reported, never thrown.
+        let scopeRepin: ScopeRepinOutcome | undefined;
+        if (mode === "pinned" && pinPath && isScopeAddress(ctx.tabId) && ctx.bridge.repinScopeToTab) {
+          const namedTab = canonicalRequestedSavedIdentity(pinPath);
+          if (namedTab) {
+            try {
+              scopeRepin = ctx.bridge.repinScopeToTab(ctx.tabId, namedTab);
+            } catch {
+              scopeRepin = undefined; // never worse than the pre-#888 silence
+            }
+          }
+        }
         ctx.bridge.push({ type: "workflow_target", target }, ctx.tabId);
         // #770/#803/#716 — ROUTING is only half of "follow the tab that's live now".
         // rebindToActiveTab is a NO-OP whenever the bound tab is still REACHABLE, which
@@ -9388,12 +9422,24 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               `mode:"current"${rebindNote ? `.${rebindNote}` : "."}\n\nNOT APPLIED:${fence.note}`,
           );
         }
+        // #888 — SAY what the scope repin did. A silent success is as unhelpful
+        // here as the silent refusal #1077 fixed: the whole complaint is that
+        // pinning reported success while routing stayed ambiguous, so "the routing
+        // ambiguity is cleared" is the one fact that makes this reply actionable.
+        // A refusal carries its own reason out for the same reason.
+        const scopeRepinNote =
+          typeof scopeRepin === "string"
+            ? ` This session's turn routing was AMBIGUOUS (a reconnect delivered messages from several workflows at once) and is now pinned to this workflow, so graph tools will resolve deterministically.`
+            : scopeRepin && typeof scopeRepin === "object" && scopeRepin.reason
+              ? ` NOTE — the workflow target was set, but this session's turn routing was NOT re-pinned: ${scopeRepin.reason}.`
+              : "";
         return ok({
           ...target,
           ...(deferredBind ? { deferred: true } : {}),
           ...(fence ? { graph_binding: fence.binding } : {}),
           ...(fenceRebind ? { graph_binding_status: fenceRebind.status } : {}),
-          note: hint + rebindNote + (fence?.note ?? ""),
+          ...(typeof scopeRepin === "string" ? { turn_routing: "repinned" } : {}),
+          note: hint + rebindNote + (fence?.note ?? "") + scopeRepinNote,
         });
       },
     ),

--- a/src/orchestrator/turn-origins.ts
+++ b/src/orchestrator/turn-origins.ts
@@ -528,6 +528,59 @@ export interface ScopeRepinBridge {
  */
 export type ScopeRepinOutcome = string | { repinned: false; reason: string } | undefined;
 
+
+/**
+ * #888 — does this BRIDGE ROUTE address a tab showing `path`?
+ *
+ * The panel's bridge-route module (#640) defines two strings that look alike and
+ * are not interchangeable:
+ *
+ *   saved-workflow HANDLE : `wf:<path>`                 — names a WORKFLOW
+ *   bridge ROUTE (tab_id) : `wf:<tabRouteId>:<path>`    — names a TAB
+ *
+ * The handle is path-only *precisely because* two browser tabs can show the same
+ * file, so it cannot address one of them. `bridge.tabs()` returns ROUTES.
+ *
+ * The first attempt at #888 compared a derived handle against those routes; it
+ * never matched, so the recovery refused every time and the fix was inert — while
+ * a source-text "wiring" assertion passed, because grepping for a call cannot tell
+ * reachable code from dead code. `ui-bridge.ts`'s own comment still describes
+ * tabId as "commonly derived from a saved workflow path", which predates #640 and
+ * is what licensed the wrong derivation.
+ *
+ * Matching is on the PATH SUFFIX of the route, normalized the way every other
+ * saved-path comparison here normalizes (separators, `./`, case), and it also
+ * accepts a legacy handle-shaped id so an older panel is not silently excluded.
+ * Generous on purpose: a miss refuses the recovery, and refusing is the failure
+ * this issue is about — but a match is only ever ACTED on when exactly one tab
+ * matches, so generosity cannot silently redirect to the wrong tab.
+ */
+export function tabRouteCarriesPath(tabId: string, path: string): boolean {
+  if (typeof tabId !== "string" || !tabId.startsWith("wf:")) return false;
+  // Escape-free by construction: split/join instead of a backslash class. An
+  // earlier cut of this line was written through a shell heredoc and arrived with
+  // its escapes mangled — the file stayed valid-looking text and the regex was
+  // silently wrong, which is a documented trap in this repo.
+  const norm = (v: string) =>
+    v
+      .split("\\")
+      .join("/")
+      .replace(/^(?:\.\/)+/, "")
+      .replace(/\/{2,}/g, "/")
+      .replace(/\.json$/i, "")
+      .toLowerCase();
+  const want = norm(path);
+  if (!want) return false;
+  const rest = tabId.slice(3);
+  const sep = rest.indexOf(":");
+  // `wf:<route>:<path>` (current) and `wf:<path>` (legacy/no-route panels).
+  const candidates = sep >= 0 ? [rest.slice(sep + 1), rest] : [rest];
+  return candidates.some((c) => {
+    const got = norm(c);
+    return got === want || got.endsWith(`/${want}`) || want.endsWith(`/${got}`);
+  });
+}
+
 export function makeScopeRepinHandler(opts: {
   bridge: ScopeRepinBridge;
   tracker: TurnOriginTracker;
@@ -535,8 +588,8 @@ export function makeScopeRepinHandler(opts: {
   backendForTab: (tabId: string) => string;
   backendOfKey: (key: string) => string;
   info: (msg: string) => void;
-}): (scopeId: string, preferredTab?: string) => ScopeRepinOutcome {
-  return (scopeId, preferredTab) => {
+}): (scopeId: string, preferredWorkflowPath?: string) => ScopeRepinOutcome {
+  return (scopeId, preferredWorkflowPath) => {
     const key = opts.scopeAgentKeyOf(scopeId);
     // RECOVERY ONLY: a pin that still reaches a live tab OF THIS conversation
     // is healthy — never displace it (null = ambiguous/ownership-refused and
@@ -577,15 +630,21 @@ export function makeScopeRepinHandler(opts: {
     // A named tab that is NOT eligible REFUSES rather than falling back to the
     // active tab. Silently re-aiming an explicit request at a different
     // workflow is the precise hazard this fence exists for (#884 gate 3, P0).
-    const named = preferredTab && eligible.includes(preferredTab) ? preferredTab : undefined;
-    if (preferredTab && !named) {
+    const matches = preferredWorkflowPath ? eligible.filter((t) => tabRouteCarriesPath(t, preferredWorkflowPath)) : [];
+    const named = matches.length === 1 ? matches[0] : undefined;
+    if (preferredWorkflowPath && !named) {
       return {
         repinned: false,
         reason:
-          `the named workflow resolves to ${shortTabId(preferredTab)}, which is not a tab of ` +
-          `this conversation's backend (${backend}) — or is headless, or is not connected. The ` +
-          `pin was NOT moved to it, and was not silently redirected to another tab either. ` +
-          `Check panel_list_workflows for which workflows this session can reach`,
+          matches.length > 1
+            ? `${matches.length} connected tabs are showing that workflow (${matches
+                .map(shortTabId)
+                .join(", ")}), so naming it does not identify ONE of them — the pin was not moved. ` +
+              `Close the duplicate tab, or issue a message from the tab you mean`
+            : `no connected tab of this conversation's backend (${backend}) is showing that ` +
+              `workflow — it may be open in another browser tab, on another backend's ` +
+              `conversation, or not open at all. The pin was NOT moved, and was not silently ` +
+              `redirected to a different workflow either. Check panel_list_workflows`,
       };
     }
     const active = opts.bridge.resolveActiveScopeTab();

--- a/src/orchestrator/turn-origins.ts
+++ b/src/orchestrator/turn-origins.ts
@@ -535,8 +535,8 @@ export function makeScopeRepinHandler(opts: {
   backendForTab: (tabId: string) => string;
   backendOfKey: (key: string) => string;
   info: (msg: string) => void;
-}): (scopeId: string) => ScopeRepinOutcome {
-  return (scopeId) => {
+}): (scopeId: string, preferredTab?: string) => ScopeRepinOutcome {
+  return (scopeId, preferredTab) => {
     const key = opts.scopeAgentKeyOf(scopeId);
     // RECOVERY ONLY: a pin that still reaches a live tab OF THIS conversation
     // is healthy — never displace it (null = ambiguous/ownership-refused and
@@ -559,13 +559,43 @@ export function makeScopeRepinHandler(opts: {
       .tabs()
       .map((t) => t.tab_id)
       .filter((t) => opts.bridge.isHeadless?.(t) !== true && opts.backendForTab(t) === backend);
+    // #888 — a NAMED workflow decides which tab, where "current" cannot.
+    //
+    // The refusal below already tells the agent to do exactly this ("Name the
+    // workflow instead — panel_set_workflow_target with a path ... and the pin
+    // follows it"), and until now nothing made the pin follow: `mode:"pinned"`
+    // wrote the workflow-target store and never reached this handler at all, so
+    // a successful pin left the ambiguous turn pin in place and every following
+    // scope-addressed command hit the same ambiguity refusal.
+    //
+    // Eligibility is the SAME as for the active tab — this conversation's
+    // backend, not headless — so naming a workflow cannot reach a tab that
+    // "current" would have been refused for. The healthy-pin gate above still
+    // runs first and is untouched: a live pin is never displaced, however
+    // explicit the request.
+    //
+    // A named tab that is NOT eligible REFUSES rather than falling back to the
+    // active tab. Silently re-aiming an explicit request at a different
+    // workflow is the precise hazard this fence exists for (#884 gate 3, P0).
+    const named = preferredTab && eligible.includes(preferredTab) ? preferredTab : undefined;
+    if (preferredTab && !named) {
+      return {
+        repinned: false,
+        reason:
+          `the named workflow resolves to ${shortTabId(preferredTab)}, which is not a tab of ` +
+          `this conversation's backend (${backend}) — or is headless, or is not connected. The ` +
+          `pin was NOT moved to it, and was not silently redirected to another tab either. ` +
+          `Check panel_list_workflows for which workflows this session can reach`,
+      };
+    }
     const active = opts.bridge.resolveActiveScopeTab();
     const tab =
-      active && eligible.includes(active)
+      named ??
+      (active && eligible.includes(active)
         ? active
         : eligible.length === 1
           ? eligible[0]
-          : undefined;
+          : undefined);
     // #1077 Finding 2 — SAY WHY. Every refusal above and below returned a bare
     // `undefined`, which the caller collapsed to `rebound: false`, so a session
     // stuck here was told only that the adoption was refused. The reporter could

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1390,7 +1390,7 @@ export class UiBridge {
    *  in-flight turn onto the tab that is active now (the documented
    *  panel_set_workflow_target({mode:"current"}) consent). Returns the tab it
    *  repinned to, or undefined when nothing is resolvable. */
-  private scopeRepinHandler: ((scopeId: string, preferredTab?: string) => ScopeRepinOutcome) | null = null;
+  private scopeRepinHandler: ((scopeId: string, preferredWorkflowPath?: string) => ScopeRepinOutcome) | null = null;
   /** #884 — orchestrator-injected: normalize a hello's raw `backend` value the
    *  same way the orchestrator does (unknown/absent → the default backend), so
    *  the backend-qualified scope-buffer replay matches the conversation the
@@ -2717,7 +2717,7 @@ export class UiBridge {
   }
 
   /** #884 — inject the explicit-repin recovery handler (see the field doc). */
-  setScopeRepinHandler(fn: (scopeId: string, preferredTab?: string) => ScopeRepinOutcome): void {
+  setScopeRepinHandler(fn: (scopeId: string, preferredWorkflowPath?: string) => ScopeRepinOutcome): void {
     this.scopeRepinHandler = fn;
   }
 
@@ -2743,8 +2743,8 @@ export class UiBridge {
    * which is precisely the state that refusal already tells the agent to escape
    * by naming a workflow. Until now nothing made the pin follow the name.
    */
-  repinScopeToTab(scopeId: string, tabId: string): ScopeRepinOutcome {
-    return this.scopeRepinHandler?.(scopeId, tabId);
+  repinScopeToWorkflow(scopeId: string, workflowPath: string): ScopeRepinOutcome {
+    return this.scopeRepinHandler?.(scopeId, workflowPath);
   }
 
   /** #884 — inject the hello-backend normalizer (see the field doc). */

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1390,7 +1390,7 @@ export class UiBridge {
    *  in-flight turn onto the tab that is active now (the documented
    *  panel_set_workflow_target({mode:"current"}) consent). Returns the tab it
    *  repinned to, or undefined when nothing is resolvable. */
-  private scopeRepinHandler: ((scopeId: string) => ScopeRepinOutcome) | null = null;
+  private scopeRepinHandler: ((scopeId: string, preferredTab?: string) => ScopeRepinOutcome) | null = null;
   /** #884 — orchestrator-injected: normalize a hello's raw `backend` value the
    *  same way the orchestrator does (unknown/absent → the default backend), so
    *  the backend-qualified scope-buffer replay matches the conversation the
@@ -2717,7 +2717,7 @@ export class UiBridge {
   }
 
   /** #884 — inject the explicit-repin recovery handler (see the field doc). */
-  setScopeRepinHandler(fn: (scopeId: string) => ScopeRepinOutcome): void {
+  setScopeRepinHandler(fn: (scopeId: string, preferredTab?: string) => ScopeRepinOutcome): void {
     this.scopeRepinHandler = fn;
   }
 
@@ -2730,6 +2730,21 @@ export class UiBridge {
    *  told only that the adoption was refused. */
   repinScopeToActive(scopeId: string): ScopeRepinOutcome {
     return this.scopeRepinHandler?.(scopeId);
+  }
+
+  /**
+   * #888 — the same EXPLICIT recovery, aimed at a NAMED workflow's tab instead
+   * of "the active one".
+   *
+   * Same handler, so the P0 gate is shared by construction: a pin that still
+   * reaches a live tab of this conversation is never displaced, however explicit
+   * the request. What a NAME adds is recovery in the state where "current" is
+   * legitimately refused — several eligible tabs and no active one among them —
+   * which is precisely the state that refusal already tells the agent to escape
+   * by naming a workflow. Until now nothing made the pin follow the name.
+   */
+  repinScopeToTab(scopeId: string, tabId: string): ScopeRepinOutcome {
+    return this.scopeRepinHandler?.(scopeId, tabId);
   }
 
   /** #884 — inject the hello-backend normalizer (see the field doc). */


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#888.

After a reconnect with queued events from several tabs, `panel_graph_outline` refuses as ambiguous — correct, that is #884's fence. The refusal names the way out:

> Target a workflow explicitly (**panel_set_workflow_target** / panel_open_workflow) or wait for the next single-origin message.

The reporter did exactly that: `panel_set_workflow_target` with `mode:"pinned"` and the exact active path. It reported success. The next `panel_graph_outline` returned the identical ambiguity error.

## Localized

The advertised recovery is wired to **one mode only**.

- `ui-bridge.ts:3359` — `resolveTarget` asks `scopeTargetResolver` for the **turn-origin** pin. `null` means the batch was mixed-origin, and it throws the ambiguity error immediately.
- The escape hatch exists — `setScopeRepinHandler`, documented as *"EXPLICIT recovery from a DEAD or AMBIGUOUS pin, and from those only"*.
- But `panel-tools.ts:9160` / `:9276` gate reaching it on `mode === "current" && ctx.rebindToActiveTab`. **`mode:"pinned"` never calls it**, so the ambiguous turn pin survives a successful pin, and every subsequent scope-addressed command keeps hitting the same refusal.

So the tool reports success truthfully — it *did* set the session's workflow target — while the thing actually blocking the next call is a different piece of state it never touched.

## Why routing `pinned` through the same handler is safe

The handler already carries the safety property, and it is not weakened here: it **refuses to displace a pin that still reaches a live tab** (confirming gate 3, P0 — the recovery path was previously repinning healthy turns via `panel_reload`, the exact silent re-target #884 exists to prevent). An *ambiguous* pin is `null`; there is no live tab behind it to protect, which is precisely why the handler already treats ambiguous and dead alike.

`mode:"pinned"` with an explicit path is a stronger, more specific statement of intent than `mode:"current"`, so it is odd that the weaker one is the only one that recovers.

## Status

Draft — localization committed, implementation and tests to follow. The two things this has to prove are that a HEALTHY pin is still never displaced, and that the new path is genuinely reachable from the real `panel_set_workflow_target` handler rather than only from the helper.