### PR TITLE
chore(release): reconcile main to 0.50.79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.79] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- persist job records without a panel, so a restart can be survived (#1278)
+- do not adopt an in-flight record whose writer is PROVEN gone (#1275)
+
+#### Changed
+- 0.50.78 — an open that lands on another workflow stops reporting success (panel#887) (#1276)
+
+
 ## [0.50.78] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.78",
+  "version": "0.50.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.78",
+      "version": "0.50.79",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.78",
+  "version": "0.50.79",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.79` tag.

Ships **#1148's root cause**: the persisted download-record store was entirely disabled for a plain stdio MCP server, so nothing could survive a restart while `action:"status"` kept promising it would. There is now a stable per-user records directory when nothing else set one — deliberately not under tmpdir, which the orchestrator reaps.

Safe only because #1275 (0.50.78) made cross-session adoption liveness-checked; before that, enabling the store would have let a crashed process's record be adopted as the live writer for a new download.

Verified across two separate processes: a record written by one is found by the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)