### PR TITLE
sweep(#796): 'unreachable' is a specific claim, not a synonym for 'it failed'

### DIFF
--- a/src/__tests__/services/local-models-fallback.test.ts
+++ b/src/__tests__/services/local-models-fallback.test.ts
@@ -148,12 +148,56 @@ describe("comfy_cli models_* local fallback (#460)", () => {
     await expect(listLocalModelsFallback({ action: "show", name: "flux" })).rejects.toThrow(/was not found/i);
   });
 
-  it("throws a clear error when neither comfy-cli nor a reachable server is available", async () => {
+  it("throws a clear error when neither comfy-cli nor a readable server is available", async () => {
     mocks.listLocalModels.mockResolvedValue([]);
     mocks.getSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
     await expect(listLocalModelsFallback({ action: "list-folders" })).rejects.toThrow(
-      /no local model source is available/i,
+      /no local model source could be established/i,
     );
+  });
+
+  // #796 — "UNREACHABLE" IS A SPECIFIC CLAIM, and this said it for every way the
+  // probe can fail. The remedy it offered — "connect to a running ComfyUI
+  // server" — is already done in most of them.
+  it("carries the REAL failure instead of asserting the server is unreachable", async () => {
+    mocks.listLocalModels.mockResolvedValue([]);
+    // The shape #828/#952/#954 built: something ANSWERED, and it was not the API.
+    mocks.getSystemStats.mockRejectedValue(
+      new Error(
+        "http://127.0.0.1:8188/system_stats answered 200 with an HTML page where JSON was " +
+          "expected. Content-Type: text/html.",
+      ),
+    );
+
+    const err = await listLocalModelsFallback({ action: "list-folders" }).catch((e) => e as Error);
+
+    expect(err.message, "the diagnosis must survive").toMatch(/HTML page where JSON was expected/);
+    expect(err.message, "and the wrong cause must not be asserted").not.toMatch(/is unreachable/);
+  });
+
+  it("does not tell someone to connect a server that already answered", async () => {
+    mocks.listLocalModels.mockResolvedValue([]);
+    mocks.getSystemStats.mockRejectedValue(new Error("answered 401 Unauthorized"));
+
+    const err = await listLocalModelsFallback({ action: "list-folders" }).catch((e) => e as Error);
+
+    expect(err.message).toMatch(/401/);
+    // "connect to a running ComfyUI server" is a dead remedy when one answered.
+    expect(err.message).not.toMatch(/connect to a running ComfyUI server/);
+    expect(err.message, "point at one whose API answers is the honest ask").toMatch(
+      /API answers/,
+    );
+  });
+
+  it("still names all three ways to fix it", async () => {
+    mocks.listLocalModels.mockResolvedValue([]);
+    mocks.getSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const err = await listLocalModelsFallback({ action: "list-folders" }).catch((e) => e as Error);
+
+    expect(err.message).toMatch(/comfy-cli/);
+    expect(err.message).toMatch(/COMFYUI_PATH/);
+    expect(err.message).toMatch(/ECONNREFUSED/);
   });
 
   it("returns an empty list (not an error) when the server is reachable but empty", async () => {

--- a/src/services/local-models-fallback.ts
+++ b/src/services/local-models-fallback.ts
@@ -70,10 +70,26 @@ async function assertLocalSourceAvailable(): Promise<void> {
   try {
     await getSystemStats();
     return; // server reachable — an empty result is a legitimate answer
-  } catch {
+  } catch (err) {
+    // #796 — "UNREACHABLE" IS A SPECIFIC CLAIM, and this made it for every way
+    // the probe can fail. A 401, a 500, a timeout, and an HTML page from a
+    // reverse proxy that forwards the UI but not the API all produced "the
+    // connected ComfyUI server is unreachable" and the remedy "connect to a
+    // running ComfyUI server" — which the user has already done in three of
+    // those four.
+    //
+    // The irony is that this threw the answer away: `getSystemStats` already
+    // fails with the diagnosis #828/#952/#954 built for exactly this, naming
+    // what answered, with which status and content type, and what to check. It
+    // is scrubbed at the source, so it is safe to carry.
+    //
+    // The claim is now the observation — the probe did not yield readable stats
+    // — and the CAUSE comes from the error rather than from a guess.
+    const why = err instanceof Error ? err.message : String(err);
     throw new Error(
-      "comfy-cli was not found and no local model source is available: COMFYUI_PATH is unset and the connected ComfyUI server is unreachable. " +
-        "Install comfy-cli>=1.11.1 (or set COMFY_CLI_PATH), set COMFYUI_PATH, or connect to a running ComfyUI server.",
+      "comfy-cli was not found and no local model source could be established: COMFYUI_PATH is unset, " +
+        `and the connected ComfyUI's /system_stats could not be read. ${why} ` +
+        "Install comfy-cli>=1.11.1 (or set COMFY_CLI_PATH), set COMFYUI_PATH, or point at a ComfyUI whose API answers.",
     );
   }
 }


### PR DESCRIPTION
Fourth #796 pass, continuing the cause-claim vein that produced the optional-dep fix.

Examining the sites that say a host **is unreachable** from inside a catch. A fetch fails for reasons with different remedies — DNS, TLS, a 500, a timeout, a refused connection — and only some of them mean nothing is listening.

Draft while I check which of these hold up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)