### PR TITLE
chore(release): reconcile main to 0.50.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.80] - 2026-08-09
+
+### MCP
+
+#### Changed
+- 'unreachable' is a specific claim, not a synonym for 'it failed' (#1281)
+- 0.50.79 (#1280)
+
+
 ## [0.50.79] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.79",
+  "version": "0.50.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.79",
+      "version": "0.50.80",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.79",
+  "version": "0.50.80",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.80` tag.

Ships a fourth **#796** sweep finding: the local-models fallback reported *"the connected ComfyUI server is unreachable"* for every way its `/system_stats` probe can fail — a 401, a 500, a timeout, or an HTML page from a reverse proxy — and offered "connect to a running ComfyUI server", which the user has already done in most of those. It also discarded the diagnosis #828/#952/#954 exist to produce. The claim is now the observation, and the cause comes from the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)