### PR TITLE
0.50.81 — naming a workflow now clears an ambiguous turn pin (panel#888)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.81] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- an explicit workflow pin must clear an AMBIGUOUS turn pin (panel#888) (#1279)
+
+#### Changed
+- 0.50.80 (#1283)
+
+
 ## [0.50.80] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.80",
+  "version": "0.50.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.80",
+      "version": "0.50.81",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.80",
+  "version": "0.50.81",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",

--- a/src/__tests__/orchestrator/route-path-spellings.test.ts
+++ b/src/__tests__/orchestrator/route-path-spellings.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { tabRouteCarriesPath } from "../../orchestrator/turn-origins.js";
+
+// panel#888 — the spellings a real caller produces, pinned against a route built
+// from data captured on the live rig (a genuine tabSessionId and the default
+// unsaved workflow, whose name contains a SPACE).
+//
+// ESCAPE-FREE BY CONSTRUCTION. The backslash is built with fromCharCode(92), not
+// written as a literal. When I first checked this by hand the shell ate the
+// escape in my probe, the input arrived with no backslash at all, and the result
+// looked exactly like a product bug — I nearly "fixed" correct code. The same
+// mangling had already corrupted this function's own source once. Any test about
+// separators has to be immune to the layer that mangles separators.
+const BS = String.fromCharCode(92);
+const SESSION = "75e73fe4-d8a1-426a-822e-ad1600ba43d8";
+const PATH = "workflows/Unsaved Workflow.json";
+const ROUTE = `wf:${SESSION}:${PATH}`;
+
+describe("#888 a route matches its workflow however the caller spells the path", () => {
+  it("matches the plain path", () => {
+    expect(tabRouteCarriesPath(ROUTE, PATH)).toBe(true);
+  });
+
+  it("matches Windows separators — the reporter's platform", () => {
+    expect(tabRouteCarriesPath(ROUTE, "workflows" + BS + "Unsaved Workflow.json")).toBe(true);
+  });
+
+  it("matches a ./ prefix and case differences", () => {
+    expect(tabRouteCarriesPath(ROUTE, "./workflows/Unsaved Workflow.json")).toBe(true);
+    expect(tabRouteCarriesPath(ROUTE, "WORKFLOWS/unsaved workflow.json")).toBe(true);
+  });
+
+  it("still matches the legacy handle-shaped id older panels send", () => {
+    expect(tabRouteCarriesPath(`wf:${PATH}`, PATH)).toBe(true);
+  });
+});
+
+describe("#888 and does NOT match what it should not", () => {
+  it("a different workflow in the same directory", () => {
+    expect(tabRouteCarriesPath(ROUTE, "workflows/Anima Wojak Batch.json")).toBe(false);
+  });
+
+  it("the route's own session segment is never mistaken for the path", () => {
+    // `wf:<tabRouteId>:<path>` — a caller passing the tab route id must not
+    // accidentally satisfy a workflow match.
+    expect(tabRouteCarriesPath(ROUTE, SESSION)).toBe(false);
+  });
+
+  it("a non-route id is refused outright", () => {
+    expect(tabRouteCarriesPath("tmp:2522828d", PATH)).toBe(false);
+    expect(tabRouteCarriesPath("", PATH)).toBe(false);
+  });
+});


### PR DESCRIPTION
Cuts **0.50.81**, carrying the panel#888 fix merged in #1279 (which landed after 0.50.80 was cut, so it is currently unreleased).

## What users get

After a reconnect delivers queued events from several tabs, `panel_graph_outline` refuses as ambiguous — correct, that is the #884 fence. Its refusal tells you to recover by targeting a workflow explicitly. **That advice now works.** `panel_set_workflow_target({mode:"pinned", path})` moves the session's turn pin onto the tab showing that workflow, so the next graph call resolves deterministically instead of returning the identical ambiguity error.

Previously only `mode:"current"` reached the recovery handler, so pinning reported success while the state actually blocking every subsequent command went untouched.

Safety is unchanged and shared, not re-implemented:
- a pin that still reaches a live tab is **never** displaced, however explicit the request;
- a named workflow open in **two** tabs refuses and names them rather than silently picking one;
- a workflow no eligible tab is showing refuses, and is never silently redirected to a different one.

## Also in this cut

One extra commit: the path-spelling matcher is pinned against a route built from data captured on the live rig, including Windows separators — the reporter's platform. Written escape-free on purpose, because a shell ate the escape while I was verifying it by hand and the mangled input looked exactly like a product bug.

## Verification

- 416 files / 8264+ passed, 2 skipped; typecheck clean
- four mutations killed on the fix, each confirmed applied — one initially **survived** and exposed a real coverage gap (two tabs showing one workflow), now closed
- route shape live-verified against the panel served by a running ComfyUI

## Worth knowing about this one

The first implementation of #1279 was **inert** — it compared the saved-workflow handle `wf:<path>` against bridge routes `wf:<tabRouteId>:<path>`, which never match. Adversarial review caught it, and caught that my wiring test could not have: it asserted on source text, which cannot distinguish reachable code from dead code. The replacement drives the real handler end to end and fails three ways against the broken derivation. Details in #1279; the stale comment that licensed the wrong shape is filed as #1285.