### PR TITLE
fix(docs): a tab id is a bridge ROUTE, not a workflow path

### DIFF
--- a/src/__tests__/services/short-tab-id-route.test.ts
+++ b/src/__tests__/services/short-tab-id-route.test.ts
@@ -1,0 +1,86 @@
+// #1285 — a tab id is a bridge ROUTE, and `shortTabId` was written for a path.
+//
+// The panel's own bridge-route.js (#640) defines two shapes and says they are
+// not interchangeable — confirmed here against the LIVE served panel, not just
+// repo source:
+//
+//   savedWorkflowHandle(path)            -> wf:<path>               names a WORKFLOW
+//   savedWorkflowRoute(tabRouteId, path) -> wf:<tabRouteId>:<path>  names a TAB
+//
+// The handle is path-only PRECISELY BECAUSE two browser tabs can show the same
+// file, so it cannot address one of them. `bridge.tabs()` returns routes.
+//
+// `shortTabId` sliced the `wf:` prefix and treated the whole remainder as a
+// path, so a route rendered down to just its basename — throwing away the one
+// component that distinguishes two tabs showing the SAME file. That is #934's
+// failure returning by another door: two different tabs rendering identically,
+// inside the messages written to tell them apart.
+//
+// THE SEPARATOR IS THE FIRST COLON, because `savedWorkflowRoute` refuses a
+// tabRouteId containing one. A path may contain colons (`C:\…`), so a head that
+// is a single character, or that holds a path separator, is not a route id.
+
+import { describe, expect, it } from "vitest";
+
+import { shortTabId } from "../../services/session-scope.js";
+
+describe("shortTabId renders a ROUTE as a tab, not a path (#1285)", () => {
+  it("keeps the tab route id, which is what distinguishes two tabs", () => {
+    const a = shortTabId("wf:tabAAAA:workflows/portrait.json");
+    const b = shortTabId("wf:tabBBBB:workflows/portrait.json");
+
+    expect(a).not.toBe(b);
+    expect(a).toContain("portrait.json");
+    expect(b).toContain("portrait.json");
+  });
+
+  it("SAME FILE, TWO TABS must not render identically — the #934 failure", () => {
+    // Exactly the shape that produced "Rebound this session from tab wf:workf
+    // onto the active tab wf:workf" for a rebind between two different tabs.
+    const rendered = new Set([
+      shortTabId("wf:aaa111:workflows/video_minimax.json"),
+      shortTabId("wf:bbb222:workflows/video_minimax.json"),
+    ]);
+    expect(rendered.size).toBe(2);
+  });
+
+  it("still keeps the filename, which is what a reader recognises", () => {
+    expect(shortTabId("wf:tab123:workflows/nested/deep/flux_dev.json")).toContain(
+      "flux_dev.json",
+    );
+  });
+
+  it("bounds a very long filename rather than dumping it", () => {
+    const long = `wf:tab123:workflows/${"x".repeat(200)}.json`;
+    expect(shortTabId(long).length).toBeLessThan(60);
+  });
+});
+
+describe("shortTabId still handles the shapes that are NOT routes (#1285)", () => {
+  it("a HANDLE (wf:<path>, no tab id) keeps its old rendering", () => {
+    // bridge-route.js marks this "NOT a bridge route", but it exists and may
+    // reach here; treating its path as a route id would mangle it.
+    expect(shortTabId("wf:workflows/portrait.json")).toBe("wf:portrait.json");
+  });
+
+  it("a WINDOWS path in a handle is not mistaken for a route id", () => {
+    // `C:` would be the first colon. A one-character head is not a tab route id,
+    // and the path must survive intact.
+    expect(shortTabId("wf:C:/Users/me/workflows/portrait.json")).toBe("wf:portrait.json");
+    expect(shortTabId("wf:C:\\Users\\me\\workflows\\portrait.json")).toBe("wf:portrait.json");
+  });
+
+  it("a head containing a path separator is not a route id", () => {
+    // `workflows/a:b.json` has a colon inside the path, after a separator.
+    expect(shortTabId("wf:workflows/odd:name.json")).toContain("odd:name.json");
+  });
+
+  it("a non-wf id keeps the 8-char slice", () => {
+    expect(shortTabId("tmp:0123456789abcdef")).toBe("tmp:0123");
+    expect(shortTabId("orchestrator::claude")).toBe("orchestr"); // 8 chars
+  });
+
+  it.each([undefined, null, ""])("survives %o without throwing", (id) => {
+    expect(() => shortTabId(id as string | undefined | null)).not.toThrow();
+  });
+});

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1365,7 +1365,7 @@ describe("UiBridge (multi-tab)", () => {
     });
 
     it("a pin whose id is REVIVED by another backend's tab is refused at resolution (codex gate-4 delta P0)", async () => {
-      // wf:<hash> ids are deterministic and recur. A Claude turn pins tab A;
+      // wf:<tabRouteId>:<path> ids are deterministic and recur. A Claude turn pins tab A;
       // A disconnects (no switch event will ever fire for it); a NEW socket
       // hellos under the SAME id on Codex. The pin now resolves exact-match
       // onto the revived tab, and a provider switch does not change the
@@ -1748,7 +1748,7 @@ describe("UiBridge (multi-tab)", () => {
 
   it("follows MIGRATION CHAINS: uuid → tmp: → wf: (the exact #210 field sequence)", async () => {
     // The reported failure re-helloed TWICE: legacy random UUID, then the
-    // unsaved-tab tmp:<uuid> id, then the saved wf:<hash> id. The ORIGINAL id
+    // unsaved-tab tmp:<uuid> id, then the saved wf:<tabRouteId>:<path> id. The ORIGINAL id
     // must still resolve after both hops (single-hop lookup lands on the dead
     // tmp: id) — the map path-compresses so every historical id points at the
     // live tab.
@@ -4168,7 +4168,7 @@ describe("UiBridge.send (graceful gate end-to-end)", () => {
   });
 
   // #422 — the proven veto must SURVIVE a same-socket tab-id MIGRATION (tmp:<uuid> →
-  // wf:<hash>), which is exactly what a workflow-tab switch / graph edit triggers. A
+  // wf:<tabRouteId>:<path>), which is exactly what a workflow-tab switch / graph edit triggers. A
   // command served under the pre-migration id, then an undercutting-version hello under
   // the migrated id, must NOT be re-gated. FAIL-before: the migration deletes the old
   // conn, so the new conn started with an empty proven set and the gate fired.
@@ -4476,7 +4476,7 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
     bridge.setTabGoneListener(() => {});
   });
 
-  // Coordinator gate: SAME KEY IS NOT THE SAME TAB. A `wf:<hash>` id names a
+  // Coordinator gate: SAME KEY IS NOT THE SAME TAB. A `wf:` route id names a
   // saved workflow, so a different browser tab opening that workflow takes the
   // key over. Keyed on the id alone, that stranger's hello cancelled the
   // departed tab's clock (and satisfied the timer's re-check), so the departed

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -248,7 +248,7 @@ export interface AskEntry {
   /**
    * Which browser-tab INCARNATION this answer belongs to, captured at arrival.
    *
-   * Entries are keyed by panel tab id, and that id recurs — `wf:<hash>` names a
+   * Entries are keyed by panel tab id, and that id recurs — `wf:` route names a
    * saved workflow, so a second browser tab can hold it. Re-keying every entry by
    * incarnation would break the thing tab-keying is FOR (a reload keeps its
    * answers), so the incarnation is carried alongside and checked at the point of
@@ -456,7 +456,7 @@ export class AskAnswerJournalImpl {
   /**
    * Which browser-tab INCARNATION currently holds a panel tab (#486).
    *
-   * A `wf:<hash>` tab id names a saved workflow, so it recurs: a second browser
+   * A `wf:` route tab id names a saved workflow, so it recurs: a second browser
    * tab opening that workflow takes the key over. Anything that holds or settles
    * per-tab state must therefore be scoped to (tab, incarnation) — otherwise the
    * newcomer reads, reports and ACKS the departed tab's bookkeeping, and the

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2469,7 +2469,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   // receipt for the ordinary path and must treat every answer as possibly lost;
   // with it, "the model read this" is a fact and only the genuinely unconfirmed
   // ones are held open (#486).
-  // #486 — a `wf:<hash>` tab id names a WORKFLOW, so a second browser tab can
+  // #486 — a `wf:` route tab id names a WORKFLOW, so a second browser tab can
   // take it over. The journal scopes every per-tab debt to whoever is actually
   // holding the key, so the newcomer can neither be told nor settle the
   // departed tab's owed disclosure.
@@ -2481,7 +2481,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   // warning is owed), so it needs a LIFECYCLE end instead: a tab leaving the
   // bridge's connection map surfaces whatever it is still owed and retires it.
   // Journal entries survive — a disconnect is usually a reload.
-  // #486 — a DIFFERENT browser tab taking over a recurring `wf:<hash>` key is a
+  // #486 — a DIFFERENT browser tab taking over a recurring `wf:` route key is a
   // CONVERSATION BOUNDARY, exactly like New chat or a provider switch: the
   // newcomer never asked the previous occupant's questions, so its answers must
   // stop being recoverable and stop being pushed. closeAsks downgrades and

--- a/src/orchestrator/turn-origins.ts
+++ b/src/orchestrator/turn-origins.ts
@@ -410,7 +410,7 @@ export class TurnOriginTracker {
    * only at the switch event (codex gate-4 delta, P0). Event-driven
    * invalidation ({@link tabChangedBackend}) fires when a switch is
    * OBSERVABLE, but a pin can land on a foreign-backend tab with no event at
-   * all: wf:<hash> ids are deterministic and recur, so after the pinned
+   * all: wf:<tabRouteId>:<path> ids are deterministic and recur, so after the pinned
    * surface migrates away (deleting its backend record) and disconnects
    * (pruning its alias), a NEW socket can hello under the pin's exact id on
    * another backend — `prev` is gone, no switch is seen, and the stale pin

--- a/src/services/session-scope.ts
+++ b/src/services/session-scope.ts
@@ -175,10 +175,31 @@ export function workflowOriginNote(opts: {
 export function shortTabId(id: string | undefined | null): string {
   if (!id) return String(id ?? "");
   if (!id.startsWith("wf:")) return id.slice(0, 8);
-  const path = id.slice(3);
+  const rest = id.slice(3);
+  // #1285 — A TAB ID IS A ROUTE, NOT A PATH. The panel's own bridge-route.js
+  // (#640) defines two shapes and says they are not interchangeable:
+  //
+  //   savedWorkflowHandle(path)           -> wf:<path>              names a WORKFLOW
+  //   savedWorkflowRoute(tabRouteId,path) -> wf:<tabRouteId>:<path> names a TAB
+  //
+  // `bridge.tabs()` returns ROUTES, and this treated the whole remainder as a
+  // path — so it rendered `wf:<tabRouteId>:<path>` down to just the basename and
+  // threw away the ONE component that distinguishes two tabs showing the SAME
+  // file. That is #934's failure returning by another door: two different tabs
+  // rendering identically, in the messages written to tell them apart.
+  //
+  // The separator is the FIRST colon, because savedWorkflowRoute refuses a
+  // tabRouteId containing one (verified against the live served panel). A path
+  // may contain colons — `C:\…` — so a head that is one character, or that holds
+  // a path separator, is not a route id and the whole remainder stays a path.
+  const sep = rest.indexOf(":");
+  const head = sep === -1 ? "" : rest.slice(0, sep);
+  const isRoute = sep > 1 && !/[/\\]/.test(head);
+  const path = isRoute ? rest.slice(sep + 1) : rest;
   // The basename is what distinguishes two workflow tabs; the directory prefix
   // is shared by all of them and is exactly what the old slice kept.
   const base = path.split(/[/\\]/).pop() || path;
   const MAX = 40;
-  return `wf:${base.length > MAX ? `…${base.slice(-MAX)}` : base}`;
+  const shownPath = base.length > MAX ? `…${base.slice(-MAX)}` : base;
+  return isRoute ? `wf:${head.slice(0, 6)}:${shownPath}` : `wf:${shownPath}`;
 }

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -107,9 +107,16 @@ interface Conn {
    * panel registration rather than mistaking the pre-restart socket for a reconnect. */
   helloGeneration: number;
   /** Browser-tab-scoped session identity supplied by current panel builds.
-   * Unlike `tabId`, which is commonly derived from a saved workflow path and
-   * can therefore recur in a second browser tab, this stays with one browser
-   * tab across a ComfyUI restart. It is used only as an accidental-routing
+   * Unlike `tabId` — a bridge ROUTE, `wf:<tabRouteId>:<path>`, whose shape is
+   * defined by the panel's own bridge-route.js (#640) and which can recur when a
+   * tab route id is reused — this stays with one browser tab across a ComfyUI
+   * restart.
+   *
+   * #1285 — this used to say a tabId is "commonly derived from a saved workflow
+   * path". That is the HANDLE (`wf:<path>`), which bridge-route.js explicitly
+   * marks as NOT a route because two browser tabs can show the same file. A
+   * reader believed this sentence, derived `wf:<path>`, compared it against
+   * `bridge.tabs()`, and shipped a fix that never matched anything. It is used only as an accidental-routing
    * correctness proof for restart readiness; absence fails that proof closed. */
   tabSessionId?: string;
   /**
@@ -1270,7 +1277,8 @@ function mutatedButUnacked(ctx: SendCtx): string {
 /**
  * Key for a pending "is this tab gone?" clock (#486).
  *
- * (tab id, INCARNATION) — a `wf:<hash>` tab id recurs, so it names a workflow,
+ * (tab id, INCARNATION) — a `wf:` route recurs (#1285: it is
+ * `wf:<tabRouteId>:<path>`, not a hash), so it names a workflow,
  * not a browser tab. The incarnation is the panel's sessionStorage-backed
  * `tab_session_id`: unique per browser tab and stable across a reload, which is
  * exactly the distinction the clock has to draw. JSON-encoded so neither part
@@ -1514,7 +1522,7 @@ export class UiBridge {
    * Which (tab, incarnation) each live socket registered as.
    *
    * The close handler needs this because "was I the primary connection?" is the
-   * WRONG question: when a second tab takes over a recurring `wf:<hash>` key the
+   * WRONG question: when a second tab takes over a recurring `wf:` route key the
    * bridge closes the first socket, and by the time that close fires the map
    * already points at the newcomer — so the departing tab was never armed at all
    * and could never be declared gone. The socket knows who it was; ask it.
@@ -1907,7 +1915,7 @@ export class UiBridge {
     // hellos is client-controlled, so a headless viewer could otherwise flip it to
     // `false` to pass the same-kind takeover check and seize a desktop tab's id.
     let socketHeadless: boolean | null = null;
-    // #422: capability proven under a PRE-MIGRATION tab id (tmp:<uuid> → wf:<hash>,
+    // #422: capability proven under a PRE-MIGRATION tab id (tmp:<uuid> → wf:<tabRouteId>:<path>,
     // same socket/panel) so the veto survives the id change. The retiring conn is
     // deleted during migration below; without carrying this, a graph-edit-triggered
     // migration + undercutting-version hello would reintroduce the false "too old" gate.
@@ -1935,11 +1943,11 @@ export class UiBridge {
         // the newly-targeted view (frames carry no tab_id — the socket is the tab).
         if (tabId && tabId !== msg.tab_id && this.conns.get(tabId)?.sock === sock) {
           // PATH-COMPRESS the migration map: the reported field failure chains
-          // ids (random UUID → tmp:<uuid> → wf:<hash>). A single-hop lookup on
+          // ids (random UUID → tmp:<uuid> → wf:<tabRouteId>:<path>). A single-hop lookup on
           // the ORIGINAL id would land on the dead intermediate — rewrite every
           // entry pointing at the id being retired so any historical id resolves
           // to the LIVE tab in one step, and the map never grows chains. Entries
-          // are SOCKET-SCOPED (codex review): wf:<hash> ids are deterministic and
+          // are SOCKET-SCOPED (codex review): wf:<tabRouteId>:<path> ids are deterministic and
           // recur across reconnects, so a migration must only ever route to the
           // socket that created it — compression too stays within this socket.
           for (const [from, entry] of this.tabMigrations) {
@@ -2045,7 +2053,7 @@ export class UiBridge {
         // #486 — THIS tab is back. Cancel its pending "is it gone?" clock, so an
         // ordinary reload never retires state only this tab can be told about.
         //
-        // Matched on the BROWSER-TAB SESSION, not the key: a `wf:<hash>` key
+        // Matched on the BROWSER-TAB SESSION, not the key: a `wf:` route key
         // recurs, so a DIFFERENT tab opening the same saved workflow takes it
         // over. Keyed on the id alone, that stranger's hello would cancel the
         // departed tab's clock — and a later result from the stranger could then
@@ -2136,7 +2144,7 @@ export class UiBridge {
           // window.location the browser was served from — the ComfyUI instance THIS
           // tab fronts. Preserved across a SAME-SOCKET re-hello that omits it, but
           // NEVER inherited by a DIFFERENT socket reusing this (possibly recurring
-          // wf:<hash>) tab id — that could let an unrelated instance's origin certify
+          // wf:<tabRouteId>:<path>) tab id — that could let an unrelated instance's origin certify
           // this tab's restart (#509, codex: cross-ownership inheritance).
           originUrl:
             typeof (msg as { comfyui_url?: unknown }).comfyui_url === "string" &&
@@ -3173,7 +3181,7 @@ export class UiBridge {
   private armTabGone(tabId: string, incarnation: string): void {
     if (!this.onTabGone) return;
     // Keyed per INCARNATION, so two browser tabs that share a recurring
-    // `wf:<hash>` key each get their own clock. Keyed by tab id alone, the
+    // `wf:` route key each get their own clock. Keyed by tab id alone, the
     // second tab's departure would silently drop the first tab's pending
     // signal and it would never be declarable gone at all.
     const slot = tabIncarnationSlot(tabId, incarnation);
@@ -3222,7 +3230,7 @@ export class UiBridge {
    * THIS tab is back (or is being torn down deliberately) — it is not gone.
    *
    * Only the SAME incarnation cancels. A different browser tab taking over a
-   * recurring `wf:<hash>` key must leave the departed tab's clock running, or
+   * recurring `wf:` route key must leave the departed tab's clock running, or
    * the departed tab becomes permanently undeclarable and its disclosure can be
    * settled by a conversation that never owned it. `undefined` cancels
    * unconditionally, for the deliberate teardown path that has no incarnation to
@@ -3250,7 +3258,7 @@ export class UiBridge {
 
   /** The incarnation currently holding `tabId` — the identity every structure
    *  that stores per-tab state must scope to, so a different browser tab taking
-   *  over a recurring `wf:<hash>` key cannot read, settle or inherit it (#486). */
+   *  over a recurring `wf:` route key cannot read, settle or inherit it (#486). */
   tabIncarnation(tabId: string): string | undefined {
     return this.conns.get(tabId)?.incarnationId;
   }
@@ -3403,7 +3411,7 @@ export class UiBridge {
       // Tab-id migration fallback — checked AFTER prefix matching (codex
       // review: a stale alias must never shadow a legitimately connected
       // prefix match), and only honored when the live connection is STILL the
-      // socket that created the migration (wf:<hash> ids recur — an unrelated
+      // socket that created the migration (wf:<tabRouteId>:<path> ids recur — an unrelated
       // later tab reusing the id must not inherit someone else's alias).
       if (prefixed.length === 0) {
         const migrated = this.tabMigrations.get(tabId);
@@ -3490,7 +3498,7 @@ export class UiBridge {
    *  socket, else the socket-scoped migration target it was renamed to (tmp:→wf:). Used
    *  by the #422 proven-supported bookkeeping so an in-flight reply that lands AFTER a
    *  same-socket re-hello migration records/clears on the migrated connection — and NEVER
-   *  on an UNRELATED tab that reused the (recurring wf:<hash> / recycled tmp:) id on a
+   *  on an UNRELATED tab that reused the (recurring wf:<tabRouteId>:<path> / recycled tmp:) id on a
    *  DIFFERENT socket, which the socket check rejects (codex round-4/7 P1). Returns
    *  undefined when neither resolves for this socket. */
   private liveConnForTab(tabId: string, sock: BridgeSocket): Conn | undefined {


### PR DESCRIPTION
Fixes #1285.

Three places document a panel `tab_id` as derived from a workflow path. That stopped being true with panel #640, and the stale wording caused a shipped fix to be completely inert — the author read it, derived `wf:<path>`, and compared against `bridge.tabs()`, which returns `wf:<tabRouteId>:<path>`. It never matched.

`shortTabId` is the one with a behavioural consequence: it slices the `wf:` prefix and treats the remainder as a path, so for a route it takes a "basename" of `<tabRouteId>:<path>`.

Draft while I verify the shapes against the live panel and fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)