### PR TITLE
chore(release): reconcile main to 0.50.82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.82] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- a tab id is a bridge ROUTE, not a workflow path (#1287)
+
+
 ## [0.50.81] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.81",
+  "version": "0.50.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.81",
+      "version": "0.50.82",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.81",
+  "version": "0.50.82",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog for the `v0.50.82` tag.

Ships **#1285** — a panel tab id is a bridge ROUTE (`wf:<tabRouteId>:<path>`), not a workflow path. Nine places said otherwise, and `shortTabId` acted on it: it rendered a route down to its basename, discarding the one component that distinguishes two tabs showing the same file — #934's failure returning by another door, inside the messages written to tell those tabs apart.

Shapes verified against the live served panel, not repo source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)