### PR TITLE
fix(restart): say 'could not determine' instead of asserting the tab did not reconnect (panel#654)

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
@@ -339,3 +339,48 @@ describe("#425 remote: the refusal must name what will actually work", () => {
     expect(hoisted.restart).not.toHaveBeenCalled();
   });
 });
+
+// panel#654 — `panel_tab_reconnected:false` was emitted for a reconnect that was
+// never watched. `awaitPostRestartReachable` opens with `if (before == null)
+// return false`, and `before` is undefined whenever the panel advertised no tab
+// session id, the socket was not OPEN at capture time, or the tab did not
+// resolve. The reporter's output is reproducible with the panel never failing.
+//
+// These live here because this file already owns the scaffolding that reaches a
+// restart REPLY. A pure-function assertion cannot show the gate held: routing
+// `ready` through the classification left the whole suite green when measured.
+describe("#654 an unwatched reconnect is reported as unknown, and is still not ready", () => {
+  it("no pre-restart baseline ⇒ panel_tab_reconnected:'unknown', ready stays false", async () => {
+    const { ctx } = makeCtx(NO_ENDPOINT_REPLY);
+    ctx.panelConnectionIdentity = () => undefined; // panel advertised no tab session id
+    ctx.awaitPostRestartReachable = async () => false; // and so nothing is watched
+    ctx.tabCanMutateGraph = () => true; // isolate: capability is NOT the reason
+
+    const res = (await restartTool().handler({}, ctx)) as ToolResult;
+    const out = JSON.parse(res.content.find((c) => c.type === "text")!.text as string);
+
+    expect(out.server_ready).toBe(true);
+    expect(out.panel_tab_reconnected).toBe("unknown"); // not a bare false
+    // THE GATE. Unknown must never buy readiness — this is the assertion that
+    // catches `ready: graphToolsReady || tabReconnect === "unknown"`.
+    expect(out.ready).toBe(false);
+    expect(out.graph_tools_ready).toBe(false);
+    expect(String(out.note)).toMatch(/could NOT be determined/);
+    // …and it must not narrate a cause nobody observed.
+    expect(String(out.note)).toMatch(/WHY is not/);
+  });
+
+  it("a WATCHED reconnect that did not return is still a real false", async () => {
+    const { ctx } = makeCtx(NO_ENDPOINT_REPLY);
+    ctx.panelConnectionIdentity = () => ({ generation: 1, tabSessionId: "browser-tab-a" });
+    ctx.awaitPostRestartReachable = async () => false;
+    ctx.tabCanMutateGraph = () => true;
+
+    const res = (await restartTool().handler({}, ctx)) as ToolResult;
+    const out = JSON.parse(res.content.find((c) => c.type === "text")!.text as string);
+
+    expect(out.panel_tab_reconnected).toBe(false); // the honest negative survives
+    expect(out.ready).toBe(false);
+    expect(String(out.note)).not.toMatch(/could NOT be determined/);
+  });
+});

--- a/src/__tests__/orchestrator/restart-tab-reconnect-unknown.test.ts
+++ b/src/__tests__/orchestrator/restart-tab-reconnect-unknown.test.ts
@@ -110,13 +110,28 @@ describe("#654 WIRING: both restart replies report the classification", () => {
     // hostage to any other line that happens to say it (there is already a third).
     // The invariant is "both notes say it", not "the file says it twice".
     expect((s.match(/could NOT be determined/g) ?? []).length).toBeGreaterThanOrEqual(2);
-    // Both notes name the cheap fence-exempt check first. Asserted as an
-    // invariant, not a phrase: these notes are built by concatenating string
-    // literals, so any sentence long enough to be worth matching is split across
-    // a `+` and a source regex silently fails to find it. That is a property of
-    // matching source text, and the reason the assertions above pin identifiers
-    // rather than prose.
-    expect((s.match(/fence-exempt/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    // Both notes point at the cheap probe first, and neither ASSERTS which of the
+    // three causes applied — the whole point of this fix is not asserting an
+    // unobserved fact, and the first cut of these very notes did exactly that.
+    expect((s.match(/panel_list_workflows/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    // "WHY is not" and NOT the fuller phrase: these notes are built by
+    // concatenating literals, and the sentence splits across a `+` at a different
+    // word in each one. I wrote the caveat above and then matched a longer phrase
+    // anyway; it found 0 of 2. Short tokens that cannot straddle a break are the
+    // only prose worth asserting on — which is itself the argument for the
+    // behavioural test below rather than more of these.
+    expect((s.match(/WHY is not/g) ?? []).length).toBe(2);
+    expect(/watched \(its socket was not/.test(s), "a note still states one cause as fact").toBe(false);
     expect((s.match(/UNPROVEN|unproven/g) ?? []).length).toBeGreaterThanOrEqual(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 4. The BEHAVIOURAL coverage lives in panel-restart-legacy-fallback.test.ts,
+//    which already has the hoisted config/process-control mocks needed to reach
+//    the restart reply. A first attempt here rebuilt that harness from scratch,
+//    could not get past the preflight refusal, and guarded its assertions with
+//    `if (text.includes("panel_tab_reconnected"))` — which made it pass
+//    vacuously. It survived the very gate refactor it claimed to catch. Deleted
+//    rather than left looking like coverage.
+// ---------------------------------------------------------------------------

--- a/src/__tests__/orchestrator/restart-tab-reconnect-unknown.test.ts
+++ b/src/__tests__/orchestrator/restart-tab-reconnect-unknown.test.ts
@@ -1,0 +1,122 @@
+// panel#654 — after a confirmed restart the tool reported `server_ready:true`
+// with `panel_tab_reconnected:false`, and the reporter had to refresh the browser
+// by hand.
+//
+// THE PATH. `panel_tab_reconnected` was `tabBack`, i.e.
+// `awaitPostRestartReachable(preRestartPanelIdentity, …)`, which opens with
+//
+//   if (before == null) return false;   // immediate — nothing is awaited
+//
+// `before` is `bridge.tabConnectionIdentity(tabId)`, undefined whenever the
+// socket is not OPEN **at capture time** (captured BEFORE the restart dispatch,
+// so a socket still settling after a Manager install lands exactly there), the
+// tab session id is absent, or resolveTarget throws.
+//
+// So `false` meant two unrelated things: "watched, did not come back", and
+// "nothing was ever watched". The reporter's output is reproducible with the
+// panel never having failed — which is why every panel-side measurement in that
+// thread showed healthy recovery. The orchestrator never looked.
+//
+// WHAT IS NOT CHANGED. `ready` and `graph_tools_ready` still key off the boolean,
+// so an undetermined reconnect still withholds graph tools. Failing closed on
+// CAPABILITY is right. What changes is that the reply stops asserting an
+// observation nobody made — `"unknown"`, following this file's existing
+// `stale: true | "unknown"` shape rather than adding a field a reader could miss
+// while still acting on the misleading boolean.
+import { describe, expect, it } from "vitest";
+
+import { classifyTabReconnect } from "../../orchestrator/panel-tools.js";
+
+// ---------------------------------------------------------------------------
+// 1. The decision.
+// ---------------------------------------------------------------------------
+
+describe("#654 a reconnect that was never watched is not a failed reconnect", () => {
+  it("no baseline captured ⇒ unknown, even though the server came back", () => {
+    // The reporter's exact state.
+    expect(classifyTabReconnect({ serverReady: true, baselineCaptured: false, tabBack: false })).toBe("unknown");
+  });
+
+  it("baseline captured and the tab did not return ⇒ a real false", () => {
+    // The honest negative must survive: this is a genuine observation.
+    expect(classifyTabReconnect({ serverReady: true, baselineCaptured: true, tabBack: false })).toBe(false);
+  });
+
+  it("the tab returned ⇒ true, however the baseline went", () => {
+    for (const baselineCaptured of [true, false]) {
+      expect(classifyTabReconnect({ serverReady: true, baselineCaptured, tabBack: true })).toBe(true);
+    }
+  });
+
+  it("server never came back ⇒ unknown, because the tab is only watched after it does", () => {
+    // Reporting `false` here would blame the tab for the server's failure.
+    for (const baselineCaptured of [true, false]) {
+      expect(classifyTabReconnect({ serverReady: false, baselineCaptured, tabBack: false })).toBe("unknown");
+    }
+  });
+
+  it("a returned tab is never downgraded by an unhealthy server reading", () => {
+    // Defensive: tabBack:true is a positive observation and outranks everything.
+    expect(classifyTabReconnect({ serverReady: false, baselineCaptured: true, tabBack: true })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The gate. This must NOT become collateral of the honesty fix.
+// ---------------------------------------------------------------------------
+
+describe("#654 the strictness of ready/graph_tools_ready is untouched", () => {
+  it("unknown is still not ready — the boolean still gates", () => {
+    // `ready`/`graph_tools_ready` are computed from `tabBack`, not from this
+    // classification, so an unproven reconnect still withholds graph tools. If a
+    // refactor ever routes the gate through the classification, "unknown" must
+    // not become truthy — this is the assertion that would catch it.
+    const verdict = classifyTabReconnect({ serverReady: true, baselineCaptured: false, tabBack: false });
+    expect(verdict).not.toBe(true);
+    // …and it is explicitly not a bare false either, which is the whole fix.
+    expect(verdict).toBe("unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. WIRING. The classifier being right is worth nothing if the restart replies
+//    still emit the raw boolean — which is the bug.
+// ---------------------------------------------------------------------------
+
+describe("#654 WIRING: both restart replies report the classification", () => {
+  const src = () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { readFileSync } = require("node:fs") as typeof import("node:fs");
+    return readFileSync(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf8");
+  };
+
+  it("neither reply emits the bare boolean any more", () => {
+    const s = src();
+    expect(/panel_tab_reconnected: tabBack\b/.test(s), "a reply still emits the raw boolean").toBe(false);
+    expect((s.match(/panel_tab_reconnected: tabReconnect\b/g) ?? []).length).toBe(2);
+  });
+
+  it("both call sites derive baselineCaptured from the pre-restart identity", () => {
+    // The mutation this catches is `baselineCaptured: true` — which type-checks,
+    // reads plausibly, and restores the bug exactly.
+    expect((src().match(/baselineCaptured: preRestartPanelIdentity != null/g) ?? []).length).toBe(2);
+  });
+
+  it("the undetermined note tells the reader what to do INSTEAD of refreshing", () => {
+    // The refresh is the manual step this issue is about; on this path it may
+    // never have been necessary. Both replies must offer the cheap check first.
+    const s = src();
+    // >= 2, not == 2: an exact count of a PHRASE across a 12k-line file is
+    // hostage to any other line that happens to say it (there is already a third).
+    // The invariant is "both notes say it", not "the file says it twice".
+    expect((s.match(/could NOT be determined/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    // Both notes name the cheap fence-exempt check first. Asserted as an
+    // invariant, not a phrase: these notes are built by concatenating string
+    // literals, so any sentence long enough to be worth matching is split across
+    // a `+` and a source regex silently fails to find it. That is a property of
+    // matching source text, and the reason the assertions above pin identifiers
+    // rather than prose.
+    expect((s.match(/fence-exempt/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    expect((s.match(/UNPROVEN|unproven/g) ?? []).length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -10727,12 +10727,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                     (!tabBack
                       ? tabReconnect === "unknown"
                         ? "whether the panel tab reconnected could NOT be determined — no pre-restart " +
-                          "baseline was captured for it, so nothing was watched (this happens when the " +
-                          "tab's socket was not open at the moment the restart was dispatched, e.g. " +
-                          "right after a node install). It may well be back. Graph tools are withheld " +
-                          "(ready:false) because that is unproven, NOT because the tab is known to be " +
-                          'gone: call panel_list_workflows — it is fence-exempt — or panel_set_workflow_target({mode:"current"}) ' +
-                          "to find out, and only refresh the browser if those also fail."
+                          "baseline was captured for it, so nothing was watched. WHY is not established " +
+                          "here, and it is one of: the tab's socket was not open at the instant the " +
+                          "restart was dispatched; the panel advertised no tab session id (an older " +
+                          "build, or its browser-tab lease was refused because a duplicate tab holds " +
+                          "it); or the tab did not resolve at all. The tab may well be back. Graph " +
+                          "tools are withheld (ready:false) because that is unproven, NOT because the " +
+                          'tab is known to be gone: call panel_list_workflows or panel_set_workflow_target({mode:"current"}) ' +
+                          "to find out, and only refresh the browser if those also fail. If this " +
+                          "repeats on every restart, the panel is probably too old to advertise a tab " +
+                          "session id — update it."
                         : "the panel tab has NOT reconnected yet (ready:false). Wait a moment then retry, or " +
                           'rebind with panel_set_workflow_target({mode:"current"}) before issuing graph tools.'
                       : "the panel tab reconnected but cannot safely run graph mutations (ready:false), usually " +
@@ -10919,12 +10923,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               ? "; the panel tab reconnected — graph tools are ready."
               : tabReconnect === "unknown"
                 ? "; ComfyUI is back, but whether the panel tab reconnected could NOT be determined — no " +
-                  "pre-restart baseline was captured for it, so nothing was watched (its socket was not " +
-                  "open at the moment the restart was dispatched). The tab may well be back. Graph tools " +
-                  "are withheld (ready:false) because that is UNPROVEN, not because the tab is known to " +
-                  "be gone: call panel_list_workflows (it is fence-exempt) or " +
+                  "pre-restart baseline was captured for it, so nothing was watched. WHY is not " +
+                  "established here, and it is one of: its socket was not open at the instant the " +
+                  "restart was dispatched; the panel advertised no tab session id (an older build, or " +
+                  "a refused browser-tab lease); or the tab did not resolve at all. The tab may well " +
+                  "be back. Graph tools are withheld (ready:false) because that is UNPROVEN, not " +
+                  "because the tab is known to be gone: call panel_list_workflows or " +
                   'panel_set_workflow_target({mode:"current"}) to find out, and refresh the browser only ' +
-                  "if those also fail."
+                  "if those also fail. If this repeats on every restart, the panel is probably too old " +
+                  "to advertise a tab session id — update it."
                 : "; ComfyUI is back but the panel tab has NOT reconnected yet (ready:false) — " +
                   'wait a moment then retry, or rebind with panel_set_workflow_target({mode:"current"}) ' +
                   "before issuing graph tools.") +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1208,6 +1208,57 @@ async function probeDeclineRecovery(
  *
  * Pure, so the three-way decision is testable without a live panel.
  */
+/**
+ * panel#654 — did the browser tab come back after the restart, and DO WE KNOW?
+ *
+ * `panel_tab_reconnected` was a bare boolean, and `false` meant two unrelated
+ * things:
+ *
+ *   - the tab was watched for a newer hello and did not come back;
+ *   - **nothing was ever watched**, so there is no observation to report.
+ *
+ * The second is the common one and it is silent. `awaitPostRestartReachable`
+ * opens with `if (before == null) return false` — immediate, nothing awaited —
+ * and `before` is `bridge.tabConnectionIdentity(tabId)`, which is `undefined`
+ * whenever the socket is not OPEN **at capture time** (captured BEFORE the
+ * restart dispatch, so a socket still settling after a Manager install lands
+ * exactly there), or the tab session id is absent, or resolveTarget throws.
+ * The reporter's output — `server_ready:true` with `panel_tab_reconnected:false`
+ * — is reproducible with the panel never having failed at all, which is why
+ * every panel-side measurement in that thread showed healthy recovery: the
+ * panel was reconnecting fine and the orchestrator never looked.
+ *
+ * A reader who sees `false` concludes the panel is dead and hard-refreshes the
+ * browser. That is the manual step this issue is about, and on this path it may
+ * have been unnecessary every time.
+ *
+ * THE GATE IS NOT WEAKENED. `ready` and `graph_tools_ready` are still computed
+ * from the boolean, so an undetermined reconnect still withholds graph tools —
+ * failing closed on capability is right, and a weaker proof would be worse. What
+ * changes is that the REPLY stops asserting an observation that was never made.
+ * `"unknown"` follows the shape this file already uses for exactly this
+ * distinction (`stale: true | "unknown"`), rather than inventing a second field
+ * that a reader could miss while still acting on the misleading boolean.
+ *
+ * `serverReady:false` is undetermined too, and for the same reason: the tab is
+ * only watched once the server is back, so nothing was observed about it.
+ */
+export type TabReconnectReport = true | false | "unknown";
+
+export function classifyTabReconnect({
+  serverReady,
+  baselineCaptured,
+  tabBack,
+}: {
+  serverReady: boolean;
+  baselineCaptured: boolean;
+  tabBack: boolean;
+}): TabReconnectReport {
+  if (tabBack === true) return true; // a newer hello from the same tab was seen
+  if (!serverReady) return "unknown"; // never watched — the server never came back
+  return baselineCaptured ? false : "unknown";
+}
+
 export function restartTimeoutFallbackAdvice({
   headlessBase,
   panelBase,
@@ -10650,12 +10701,20 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   : true
               : false;
             const graphToolsReady = tabBack && (ctx.tabCanMutateGraph ? ctx.tabCanMutateGraph() : true);
+            // #654 — `ready`/`graph_tools_ready` still come from the BOOLEAN, so an
+            // undetermined reconnect withholds graph tools exactly as before. Only
+            // the reported observation changes.
+            const tabReconnect = classifyTabReconnect({
+              serverReady: recovery.ready,
+              baselineCaptured: preRestartPanelIdentity != null,
+              tabBack,
+            });
             return ok({
               rebooting: true,
               ready: graphToolsReady,
               graph_tools_ready: graphToolsReady,
               server_ready: recovery.ready,
-              panel_tab_reconnected: tabBack,
+              panel_tab_reconnected: tabReconnect,
               confirmed_cycle: observed, // true = we directly observed the down→up cycle
               recovered_ms: recovery.waited_ms,
               probes: recovery.attempts,
@@ -10666,8 +10725,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                   ? "ComfyUI-Manager (legacy 3.x) had no reboot endpoint; the headless managed restart " +
                     `came back healthy in ${(recovery.waited_ms / 1000).toFixed(1)}s, but ` +
                     (!tabBack
-                      ? "the panel tab has NOT reconnected yet (ready:false). Wait a moment then retry, or " +
-                        'rebind with panel_set_workflow_target({mode:"current"}) before issuing graph tools.'
+                      ? tabReconnect === "unknown"
+                        ? "whether the panel tab reconnected could NOT be determined — no pre-restart " +
+                          "baseline was captured for it, so nothing was watched (this happens when the " +
+                          "tab's socket was not open at the moment the restart was dispatched, e.g. " +
+                          "right after a node install). It may well be back. Graph tools are withheld " +
+                          "(ready:false) because that is unproven, NOT because the tab is known to be " +
+                          'gone: call panel_list_workflows — it is fence-exempt — or panel_set_workflow_target({mode:"current"}) ' +
+                          "to find out, and only refresh the browser if those also fail."
+                        : "the panel tab has NOT reconnected yet (ready:false). Wait a moment then retry, or " +
+                          'rebind with panel_set_workflow_target({mode:"current"}) before issuing graph tools.'
                       : "the panel tab reconnected but cannot safely run graph mutations (ready:false), usually " +
                         "because it is still running a stale panel bundle. Hard-refresh the ComfyUI browser tab " +
                         "(Ctrl+Shift+R) before issuing graph tools; if that does not restore it, update the panel " +
@@ -10791,6 +10858,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // Old/lightweight contexts have no capability accessor, so preserve their historical
         // contract rather than claiming a production tab passed a check it never ran.
         const graphToolsReady = tabBack && (ctx.tabCanMutateGraph ? ctx.tabCanMutateGraph() : true);
+        // #654 — same split as the legacy path above. The gate is unchanged:
+        // `ready`/`graph_tools_ready` still key off the boolean, so an undetermined
+        // reconnect still withholds graph tools. Only the reported observation changes.
+        const tabReconnect = classifyTabReconnect({
+          serverReady: true, // this branch only runs on a confirmed healthy cycle
+          baselineCaptured: preRestartPanelIdentity != null,
+          tabBack,
+        });
         // #848: WHAT THIS RESTART DID NOT DO. "It came back healthy" answers a
         // different question from "did it come back with the launch arguments I just
         // configured?", and a user who had edited ComfyUI Desktop's saved launch args
@@ -10829,7 +10904,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           probes: recovery.attempts,
           saw_down: recovery.sawDown,
           via: recovery.via,
-          panel_tab_reconnected: tabBack,
+          panel_tab_reconnected: tabReconnect,
           note:
             (tabBack && !graphToolsReady
               ? `ComfyUI restart accepted and it is healthy again in ${(recovery.waited_ms / 1000).toFixed(1)}s` +
@@ -10842,9 +10917,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             (dropped ? "; connection dropped as expected while it went down" : "") +
             (tabBack
               ? "; the panel tab reconnected — graph tools are ready."
-              : "; ComfyUI is back but the panel tab has NOT reconnected yet (ready:false) — " +
-                'wait a moment then retry, or rebind with panel_set_workflow_target({mode:"current"}) ' +
-                "before issuing graph tools.") +
+              : tabReconnect === "unknown"
+                ? "; ComfyUI is back, but whether the panel tab reconnected could NOT be determined — no " +
+                  "pre-restart baseline was captured for it, so nothing was watched (its socket was not " +
+                  "open at the moment the restart was dispatched). The tab may well be back. Graph tools " +
+                  "are withheld (ready:false) because that is UNPROVEN, not because the tab is known to " +
+                  "be gone: call panel_list_workflows (it is fence-exempt) or " +
+                  'panel_set_workflow_target({mode:"current"}) to find out, and refresh the browser only ' +
+                  "if those also fail."
+                : "; ComfyUI is back but the panel tab has NOT reconnected yet (ready:false) — " +
+                  'wait a moment then retry, or rebind with panel_set_workflow_target({mode:"current"}) ' +
+                  "before issuing graph tools.") +
             ".") + argvNote,
         });
       },


### PR DESCRIPTION
Fixes the orchestrator half of artokun/comfyui-mcp-panel#654.

After a confirmed restart cycle the tool reported `server_ready:true` with `panel_tab_reconnected:false`, `graph_tools_ready:false`, `ready:false` — and the reporter had to refresh the browser by hand.

## The path

`panel_tab_reconnected` is `tabBack`, which on this path is `awaitPostRestartReachable(preRestartPanelIdentity, …)`. Its first substantive line:

```ts
if (before == null) return false;   // immediate — nothing is awaited
```

`before` is `bridge.tabConnectionIdentity(tabId)`, which returns `undefined` when

```ts
conn.sock.readyState !== WebSocket.OPEN || !conn.tabSessionId
```

or when `resolveTarget` throws. The identity is captured **before** the restart dispatch, so a socket that is momentarily not `OPEN` at that instant — most likely right after a Manager custom-node install, which is the reporter's sequence — produces their exact output **with the panel never having failed**.

It also explains why every panel-side measurement in that thread showed healthy recovery: the panel was reconnecting fine and the orchestrator never looked.

## What this changes, and what it does NOT

**The gate is not weakened.** `before == null → false` is deliberate — a real bridge missing the pre-dispatch identity must fail closed, and a weaker proof would be worse. `ready` and `graph_tools_ready` stay exactly as strict.

What changes is that the reply stops asserting something it never measured. `false` currently means two different things:

- the tab was watched for a newer hello and did not come back;
- **no baseline was captured, so nothing was watched.**

The second is *could not determine*, and this repo has fixed that conflation repeatedly (#796, #1077, and panel#887 today). A user reading `false` reasonably concludes the panel is dead and refreshes — which is the manual step this issue is about, and it may have been unnecessary every time.

## Already disproved, recorded so it is not re-run

That an older panel does not send `tabSessionId`. `TAB_ID_KEY` shipped in panel **0.11.4**; the reporter is on 0.11.39.

## Status

Draft. Implementation and behavioural tests to follow. The two things this must prove: the strictness of `ready`/`graph_tools_ready` is unchanged, and the new state is reachable from the real restart handler rather than only from a helper.