### PR TITLE
fix(panel): absorb the post-restart reconciliation window in mode:"current" (#1292)

### DIFF
--- a/src/__tests__/orchestrator/fence-rebind-transient.test.ts
+++ b/src/__tests__/orchestrator/fence-rebind-transient.test.ts
@@ -102,8 +102,11 @@ describe("mode:'current' absorbs the post-restart reconciliation window (#1292)"
     expect(stamp, "the live canvas's identity was adopted").toBe(LIVE);
     expect(res.isError).toBeFalsy();
     expect(text).toMatch(/"graph_binding": "bound"/);
-    // It re-read rather than reasoning its way past the refusal.
-    expect(listCalls).toBeGreaterThan(1);
+    // It re-read rather than reasoning its way past the refusal — and STOPPED at
+    // the read that succeeded. No further round trip happens between the read we
+    // corroborated and the stamp we write from it, which is what keeps the
+    // adopted record and the tab being stamped the same tab (codex review, P1).
+    expect(listCalls, "one recheck, then adopt — no read after the good one").toBe(2);
   });
 
   it("recovers from a MIXED list too — same window, different symptom", async () => {
@@ -186,6 +189,45 @@ describe("mode:'current' absorbs the post-restart reconciliation window (#1292)"
     expect(text).not.toMatch(/call this again in a moment/);
     // The remedy that HAS not been tried is the one offered.
     expect(text).toMatch(/manually refresh/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rechecking a fact that CANNOT change is just a slower version of the same
+  // error (codex review, P2). The split is snapshot-vs-shape, not failure-vs-
+  // success: what is open and which entry is flagged can change in 400ms; which
+  // FIELDS a build sends cannot.
+  // ---------------------------------------------------------------------------
+
+  it("does NOT recheck a reply whose SHAPE can never corroborate", async () => {
+    // An older panel that sends no open-workflow list at all. Every later read
+    // says exactly the same thing, so the rechecks would only add ~2.9s to an
+    // error the caller was going to get anyway.
+    const active = { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE };
+    listReplies = [{ active }];
+
+    const started = Date.now();
+    const { text } = await setCurrent();
+
+    expect(listCalls, "nothing to wait for — one read").toBe(1);
+    expect(Date.now() - started).toBeLessThan(400);
+    expect(stamp, "still refused — not rechecking is not accepting").toBe(STALE);
+    // …and the remedy stops promising that waiting helps.
+    expect(text).toMatch(/WHY RETRYING WILL NOT HELP/);
+    expect(text).not.toMatch(/call this again in a moment/);
+  });
+
+  it("DOES recheck an EMPTY open-workflow list — that one is a snapshot", async () => {
+    // The neighbouring case, and the reason the two are not folded: an absent
+    // `workflows` field is a property of the build, an empty one is a mid-restore
+    // panel that has not re-listed its tabs yet.
+    const active = { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE };
+    listReplies = [{ active, workflows: [] }, settled(LIVE)];
+
+    const { res } = await setCurrent();
+
+    expect(listCalls).toBe(2);
+    expect(stamp).toBe(LIVE);
+    expect(res.isError).toBeFalsy();
   });
 
   it("does not recheck a panel that reports NO identity — a different failure", async () => {

--- a/src/__tests__/orchestrator/fence-rebind-transient.test.ts
+++ b/src/__tests__/orchestrator/fence-rebind-transient.test.ts
@@ -1,0 +1,204 @@
+// #1292 — A RECOVERY OPERATION THAT TELLS YOU TO RETRY IT HAS NOT FINISHED
+// RECOVERING.
+//
+// Immediately after panel_restart_comfyui and the tab's reconnect, the panel is
+// mid-reconciliation: it answers workflow_list, but marks its active record
+// UNCONFIRMED. Corroboration correctly refuses to adopt through that — a stale
+// or mixed reply can carry ANOTHER canvas's perfectly valid uuid, and stamping
+// it would wedge the tab while reporting `bound`.
+//
+// So the refusal is right. What was wrong is who paid for it. The caller got a
+// hard failure whose own remedy was "call this again in a moment" — and the
+// reporter did, five seconds later, and the identical call returned
+// `already_current` with no user action in between. The window belongs to the
+// operation, not to the caller.
+//
+// THE CORROBORATION RULE DOES NOT MOVE. Every recheck is judged by the same
+// fail-closed test; what a recheck buys is a FRESH SNAPSHOT to judge, never a
+// lower bar. The two properties below are therefore inseparable, and both are
+// asserted here: the transient window is absorbed, AND a reply that stays
+// contradictory is still refused no matter how many times it is re-read.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+const STALE = "11111111-1111-4111-8111-111111111111";
+const LIVE = "22222222-2222-4222-8222-222222222222";
+const OTHER = "33333333-3333-4333-8333-333333333333";
+
+/** Successive workflow_list replies; the last one repeats once exhausted. */
+let listReplies: Array<Record<string, unknown>>;
+let listCalls: number;
+let stamp: string | undefined;
+
+/** A healthy, self-corroborating reply: the active record also appears in the
+ *  open-workflow list flagged active. */
+function settled(uuid: string): Record<string, unknown> {
+  const active = { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: uuid };
+  return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+}
+
+/** The reporter's shape: the panel answers, but says its own active record is
+ *  NOT confirmed — the post-restart reconciliation window. */
+function reconciling(): Record<string, unknown> {
+  const active = { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE };
+  return { active, workflows: [{ ...active, active: true }], active_confirmed: false };
+}
+
+function bridge() {
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "workflow_list") {
+        const n = listCalls;
+        listCalls += 1;
+        return listReplies[Math.min(n, listReplies.length - 1)];
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: (id: string) => id === TAB,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      stamp = uuid;
+      return true;
+    },
+    workflowUuidFor: () => ({ known: true, uuid: stamp }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+async function setCurrent(): Promise<{ res: ToolResult; text: string }> {
+  const ctx = makePanelToolCtx(bridge(), TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target");
+  if (!def) throw new Error("panel_set_workflow_target is not registered");
+  const res: ToolResult = await def.handler({ mode: "current" }, ctx);
+  return { res, text: (res.content[0] as { text: string }).text };
+}
+
+beforeEach(() => {
+  listCalls = 0;
+  stamp = STALE;
+});
+
+describe("mode:'current' absorbs the post-restart reconciliation window (#1292)", () => {
+  it("RECOVERS when the panel settles on a later read — the reported case", async () => {
+    // Exactly the report: UNCONFIRMED immediately after the restart, correct on
+    // the next read. Before this fix the caller saw a hard failure here and had
+    // to make the identical call again themselves.
+    listReplies = [reconciling(), settled(LIVE)];
+
+    const { res, text } = await setCurrent();
+
+    expect(stamp, "the live canvas's identity was adopted").toBe(LIVE);
+    expect(res.isError).toBeFalsy();
+    expect(text).toMatch(/"graph_binding": "bound"/);
+    // It re-read rather than reasoning its way past the refusal.
+    expect(listCalls).toBeGreaterThan(1);
+  });
+
+  it("recovers from a MIXED list too — same window, different symptom", async () => {
+    // Two entries flagged active is the other face of a half-reconciled panel.
+    const active = { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE };
+    listReplies = [
+      {
+        active,
+        workflows: [
+          { ...active, active: true },
+          { path: "workflows/b.json", routing_key: "wf:workflows/b.json", active: true },
+        ],
+      },
+      settled(LIVE),
+    ];
+
+    const { res } = await setCurrent();
+
+    expect(stamp).toBe(LIVE);
+    expect(res.isError).toBeFalsy();
+  });
+
+  it("does NOT wait when the FIRST read already corroborates", async () => {
+    // The common path must not pay for the rare one.
+    listReplies = [settled(LIVE)];
+
+    const started = Date.now();
+    const { res } = await setCurrent();
+
+    expect(res.isError).toBeFalsy();
+    expect(stamp).toBe(LIVE);
+    expect(listCalls, "one read is enough when it answers cleanly").toBe(1);
+    expect(Date.now() - started, "no recheck delay on the happy path").toBeLessThan(400);
+  });
+
+  // ---------------------------------------------------------------------------
+  // The half that makes the retry safe. A recheck must buy a fresh snapshot to
+  // judge — never a lower bar to clear.
+  // ---------------------------------------------------------------------------
+
+  it("STILL REFUSES a reply that never settles — the bar does not drop with attempts", async () => {
+    // A permanently contradictory reply: the active record names canvas B while
+    // the panel's own list says A is active. Re-reading it four times must not
+    // make the fourth answer more adoptable than the first.
+    const active = { path: "workflows/b.json", routing_key: "wf:workflows/b.json", workflow_uuid: OTHER };
+    listReplies = [
+      { active, workflows: [{ path: "workflows/a.json", routing_key: "wf:workflows/a.json", active: true }] },
+    ];
+
+    const { res, text } = await setCurrent();
+
+    expect(stamp, "the other canvas's uuid never reached the fence").toBe(STALE);
+    expect(res.isError).toBe(true);
+    expect(text).not.toMatch(/"graph_binding": "bound"/);
+    expect(listCalls, "it did recheck — and still refused").toBeGreaterThan(1);
+  });
+
+  it("REFUSES an UNCONFIRMED record that never becomes confirmed", async () => {
+    // The reporter's exact symptom, but permanent. The refusal is the same one
+    // #514 installed; only the number of attempts before it changed.
+    listReplies = [reconciling()];
+
+    const { res, text } = await setCurrent();
+
+    expect(stamp).toBe(STALE);
+    expect(res.isError).toBe(true);
+    expect(text).toMatch(/UNCONFIRMED/);
+  });
+
+  it("STOPS PRESCRIBING the retry it just performed", async () => {
+    // The old remedy was "call this again in a moment". After four rechecks over
+    // ~2.9s that is the least likely thing left to work, and it reads as though
+    // nothing was tried. Report what was done, then name the remedy that has not
+    // been.
+    listReplies = [reconciling()];
+
+    const { text } = await setCurrent();
+
+    expect(text).toMatch(/ALREADY TRIED: the panel was re-read \d+ times over ~\d/);
+    expect(text).not.toMatch(/call this again in a moment/);
+    // The remedy that HAS not been tried is the one offered.
+    expect(text).toMatch(/manually refresh/);
+  });
+
+  it("does not recheck a panel that reports NO identity — a different failure", async () => {
+    // `no_uuid` means the installed pack exposes no workflow identity at all.
+    // Rechecking a build that will never answer differently only makes the same
+    // error slower, and its remedy (update the panel) is unrelated to settling.
+    const active = { path: "workflows/a.json", routing_key: "wf:workflows/a.json" };
+    listReplies = [{ active, workflows: [{ ...active, active: true }], active_confirmed: true }];
+
+    const { text } = await setCurrent();
+
+    expect(listCalls, "one read — there is nothing to wait for").toBe(1);
+    expect(text).toMatch(/must be UPDATED/);
+    expect(text).not.toMatch(/ALREADY TRIED/);
+  });
+});

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -5194,9 +5194,14 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     expect(text).toMatch(/name DIFFERENT workflows \(a stale or mixed reply\)/);
     // The reason it matters, stated: this is what protects the tab.
     expect(text).toMatch(/could have stamped ANOTHER canvas's identity onto this tab/);
-    // The remedy fits the cause — transient, so retry; not "update your panel".
-    expect(text).toMatch(/call this again in a moment/);
+    // The remedy fits the cause — not "update your panel", which is the sibling
+    // failure's fix and unactionable here.
     expect(text).not.toMatch(/must be UPDATED/);
+    // #1292 — and it no longer prescribes the retry the tool JUST PERFORMED. This
+    // stub never settles, so all four reads refused; saying "call this again in a
+    // moment" after that sends the caller to do the least likely thing left.
+    expect(text).toMatch(/ALREADY TRIED: the panel was re-read \d+ times/);
+    expect(text).not.toMatch(/call this again in a moment/);
   });
 
   it("REFUSES to adopt from a reply with no open-workflow list to corroborate against", async () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -5012,6 +5012,9 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
      *  a safe fixture: it is the exact reply shape that let another canvas's uuid
      *  overwrite this tab's stamp, so the default must not encode it. */
     workflows?: Array<Record<string, unknown>>;
+    /** Send NO `workflows` field at all — an older build, as distinct from a
+     *  build that sends an empty one (#1292). */
+    omitWorkflows?: boolean;
     activeConfirmed?: boolean;
     listThrows?: string;
     refreshReturns?: boolean;
@@ -5034,6 +5037,14 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
           // Mirror `active` into a corroborating `active:true` entry unless the
           // test is deliberately modelling a stale/mixed/absent list.
           const workflows = opts.workflows ?? [{ ...opts.active, active: true }];
+          if (opts.omitWorkflows) {
+            return {
+              active: opts.active,
+              ...(opts.activeConfirmed === undefined
+                ? {}
+                : { active_confirmed: opts.activeConfirmed }),
+            };
+          }
           return {
             active: opts.active,
             workflows,
@@ -5215,7 +5226,31 @@ describe("panel-tools: mode:'current' re-derives the workflow command fence (#77
     expect(refresh).not.toHaveBeenCalled();
     expect(currentStamp()).toBe(STALE);
     expect(res.isError).toBe(true);
+    // #1292 split what this message used to fold. An EMPTY list is a snapshot of
+    // what is open right now — a mid-restore panel reports it before its tabs
+    // come back, so it is worth re-reading. An ABSENT `workflows` field is a
+    // property of the installed build and will never change; that one keeps the
+    // original wording and is NOT re-read. Both still refuse.
+    expect(text).toMatch(/open-workflow list was empty, so nothing corroborates the active record/);
+  });
+
+  it("REFUSES — and does not re-read — a reply that carries NO open-workflow field at all", async () => {
+    // The other half of the split above: rechecking a build that cannot answer
+    // differently would only make the identical error ~2.9s slower (#1292).
+    const { bridge, refresh, tab, currentStamp, sent } = fenceBridge({
+      fence: STALE,
+      active: { path: "workflows/a.json", routing_key: "wf:workflows/a.json", workflow_uuid: LIVE },
+      workflows: undefined as unknown as Array<Record<string, unknown>>,
+      omitWorkflows: true,
+    });
+    const { res, text } = await setCurrent(bridge, tab);
+
+    expect(refresh).not.toHaveBeenCalled();
+    expect(currentStamp()).toBe(STALE);
+    expect(res.isError).toBe(true);
     expect(text).toMatch(/no open-workflow list to corroborate the active record against/);
+    expect(sent.filter((c) => c.cmd === "workflow_list")).toHaveLength(1);
+    expect(text).toMatch(/WHY RETRYING WILL NOT HELP/);
   });
 
   it("REFUSES a MIXED list with two entries marked active, rather than arbitrating", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3041,6 +3041,10 @@ export type WorkflowFenceRebind =
       before: FenceRead;
       kind: "no_uuid" | "uncorroborated";
       why: string;
+      /** #1292 — how hard we already tried, so the remedy can stop telling a
+       *  caller to do the thing this function just did. Present only on the
+       *  `uncorroborated` path, which is the one that rechecks. */
+      rechecks?: { attempts: number; waitedMs: number };
     }
   /** A live identity was read, but the bridge declined to adopt it (the tab stopped
    *  being reachable, or the uuid failed the orchestrator's shape/origin check).
@@ -3205,6 +3209,37 @@ WHY THIS READ WAS NEEDED AT ALL: this session's panel is ${v.version}, and a ` +
   }
 }
 
+/**
+ * #1292 — THE RECONCILIATION WINDOW IS OURS TO ABSORB, NOT THE CALLER'S TO WAIT OUT.
+ *
+ * Right after `panel_restart_comfyui` and the tab's reconnect, the panel is
+ * briefly mid-reconciliation: it answers `workflow_list`, but its active record
+ * is marked UNCONFIRMED (or the list is momentarily mixed). Corroboration
+ * correctly refuses — and the caller got a hard failure for a state that fixes
+ * itself, with the remedy "call this again in a moment". The reporter did, and
+ * the identical call returned `already_current`.
+ *
+ * A recovery operation that tells you to retry it is one that has not finished
+ * recovering. So this path rechecks with a FRESH read, three times over ~2.9s.
+ *
+ * WHY THESE AND NOT A LONGER BUDGET: this runs only when the rebind has already
+ * failed, so the cost is paid on a path that was going to fail anyway — but it is
+ * still latency added to a tool call, and the window this covers is a local
+ * process reconnecting. The reporter's five seconds is an upper bound with a
+ * human in it, not a measurement of the settle.
+ *
+ * WHY ONLY `uncorroborated`: the sibling failure `no_uuid` means the installed
+ * panel exposes no workflow identity at all. Rechecking a build that will never
+ * answer differently just makes the same error slower — the distinction the
+ * status already draws, now with teeth.
+ *
+ * The corroboration rule itself does NOT move. It still fails closed on every
+ * attempt; a recheck buys a fresh snapshot to judge, never a lower bar. What
+ * would be unsafe is arbitrating a mixed reply, and that is exactly what is not
+ * happening here.
+ */
+const FENCE_CORROBORATION_RECHECK_STEPS_MS = [400, 900, 1600] as const;
+
 async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebind> {
   const tabAtStart = ctx.tabId;
   let before = currentWorkflowFence(ctx);
@@ -3217,32 +3252,71 @@ async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebi
   const syncFenceToCurrentTab = (): void => {
     if (ctx.tabId !== tabAtStart) before = currentWorkflowFence(ctx);
   };
-  let parsed: Record<string, unknown> | null = null;
-  try {
-    const res = await ctx.call({ cmd: "workflow_list" }, 6000);
-    syncFenceToCurrentTab();
-    if (res?.isError) {
-      return await unreadableOrHealed(ctx, before, toolResultText(res));
+  // One read + corroboration. Returns null when the READ failed in a way that is
+  // its own status (`unreadable`/`healed_by_panel`) — those are not the transient
+  // window this rechecks, and the settle inside unreadableOrHealed already covers
+  // the case where the refusal itself repaired the fence.
+  const readAndCorroborate = async (): Promise<
+    | { done: WorkflowFenceRebind }
+    | { corroborated: ReturnType<typeof corroborateActiveForFence> }
+  > => {
+    let parsed: Record<string, unknown> | null = null;
+    try {
+      const res = await ctx.call({ cmd: "workflow_list" }, 6000);
+      syncFenceToCurrentTab();
+      if (res?.isError) {
+        return { done: await unreadableOrHealed(ctx, before, toolResultText(res)) };
+      }
+      parsed = parseToolResultJson(res);
+    } catch (err) {
+      syncFenceToCurrentTab();
+      return {
+        done: await unreadableOrHealed(
+          ctx,
+          before,
+          err instanceof Error ? err.message : String(err ?? "unknown error"),
+        ),
+      };
     }
-    parsed = parseToolResultJson(res);
-  } catch (err) {
-    syncFenceToCurrentTab();
-    return await unreadableOrHealed(
-      ctx,
-      before,
-      err instanceof Error ? err.message : String(err ?? "unknown error"),
-    );
+    if (!parsed) {
+      return {
+        done: await unreadableOrHealed(
+          ctx,
+          before,
+          "the panel's workflow_list reply was not readable as JSON",
+        ),
+      };
+    }
+    // CORROBORATE before adopting. The uuid must come from a record the panel's own
+    // open-workflow list agrees is the live canvas — otherwise a stale or mixed
+    // reply's uuid (valid in shape, belonging to ANOTHER canvas) would overwrite
+    // this tab's stamp and be reported as a successful rebind.
+    return { corroborated: corroborateActiveForFence(parsed) };
+  };
+
+  const first = await readAndCorroborate();
+  if ("done" in first) return first.done;
+  let corroborated = first.corroborated;
+  let attempts = 1;
+  let waitedMs = 0;
+  // #1292 — recheck the RECONCILIATION WINDOW with a fresh read, never a lower bar.
+  for (const waitMs of FENCE_CORROBORATION_RECHECK_STEPS_MS) {
+    if (corroborated.ok) break;
+    await sleep(waitMs);
+    waitedMs += waitMs;
+    attempts++;
+    const next = await readAndCorroborate();
+    if ("done" in next) return next.done;
+    corroborated = next.corroborated;
   }
-  if (!parsed) {
-    return await unreadableOrHealed(ctx, before, "the panel's workflow_list reply was not readable as JSON");
-  }
-  // CORROBORATE before adopting. The uuid must come from a record the panel's own
-  // open-workflow list agrees is the live canvas — otherwise a stale or mixed
-  // reply's uuid (valid in shape, belonging to ANOTHER canvas) would overwrite
-  // this tab's stamp and be reported as a successful rebind.
-  const corroborated = corroborateActiveForFence(parsed);
   if (!corroborated.ok) {
-    return { status: "no_identity", before, kind: "uncorroborated", why: corroborated.why };
+    return {
+      status: "no_identity",
+      before,
+      kind: "uncorroborated",
+      why: corroborated.why,
+      rechecks: { attempts, waitedMs },
+    };
   }
   const active = corroborated.active;
   const uuid = responseWorkflowUuid(active);
@@ -3596,9 +3670,20 @@ function describeFenceRebind(
             `plain reload can serve the same cached bundle again; only a hard refresh replaces ` +
             `it. If a hard refresh does not help, the installed pack itself predates the ` +
             `per-workflow identity and must be UPDATED — no rebind can add it.`
-          : `\n\nWHAT TO DO: call this again in a moment. A stale or mixed workflow list is ` +
-            `usually transient — it settles once the panel finishes reconciling its tabs. If ` +
-            `it persists across a few attempts: ${RELOAD_TAB_REMEDY}`;
+          : // #1292 — DO NOT PRESCRIBE WHAT WE JUST DID. This path now rechecks
+            // with fresh reads before failing, so "call this again in a moment"
+            // would be advice the tool already took on the caller's behalf — and
+            // taking it a fourth time is the least likely thing left to work.
+            // When the rechecks ran, say so and move on to the remedy that has
+            // not been tried.
+            (r.rechecks && r.rechecks.attempts > 1
+              ? `\n\nALREADY TRIED: the panel was re-read ${r.rechecks.attempts} times over ` +
+                `~${(r.rechecks.waitedMs / 1000).toFixed(1)}s and never corroborated. That window ` +
+                `covers the usual post-restart reconciliation, so this is probably NOT the ` +
+                `transient case.\n\nWHAT TO DO: ${RELOAD_TAB_REMEDY}`
+              : `\n\nWHAT TO DO: call this again in a moment. A stale or mixed workflow list is ` +
+                `usually transient — it settles once the panel finishes reconciling its tabs. ` +
+                `If it persists across a few attempts: ${RELOAD_TAB_REMEDY}`);
       if (!r.before.known) {
         return {
           binding: "unverified",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3043,8 +3043,11 @@ export type WorkflowFenceRebind =
       why: string;
       /** #1292 — how hard we already tried, so the remedy can stop telling a
        *  caller to do the thing this function just did. Present only on the
-       *  `uncorroborated` path, which is the one that rechecks. */
-      rechecks?: { attempts: number; waitedMs: number };
+       *  `uncorroborated` path, which is the one that rechecks. `settles` is
+       *  whether waiting could EVER have helped: false means the reply's SHAPE
+       *  is wrong (an older build sends no open-workflow list), and telling that
+       *  caller to try again in a moment is advice that can never come true. */
+      rechecks?: { attempts: number; waitedMs: number; settles: boolean };
     }
   /** A live identity was read, but the bridge declined to adopt it (the tab stopped
    *  being reachable, or the uuid failed the orchestrator's shape/origin check).
@@ -3086,23 +3089,52 @@ export type WorkflowFenceRebind =
  */
 function corroborateActiveForFence(
   parsed: Record<string, unknown>,
-): { ok: true; active: Record<string, unknown> } | { ok: false; why: string } {
+):
+  | { ok: true; active: Record<string, unknown> }
+  /** `settles` — could a LATER read of the same panel answer differently? #1292
+   *  rechecks, and rechecking a fact that cannot change only makes the same
+   *  error slower. A SNAPSHOT fact (what is open, which entry is flagged, whether
+   *  the panel has finished confirming) settles; a SHAPE fact (this build does
+   *  not send a `workflows` array; these records share no comparable identity
+   *  field) does not, no matter how long anyone waits. */
+  | { ok: false; why: string; settles: boolean } {
   const active = parsed.active;
   if (!active || typeof active !== "object") {
-    return { ok: false, why: "the reply carried no active-workflow record" };
+    // SETTLES: mid-restore the frontend genuinely has no active workflow yet —
+    // that is #1184's finding in this reply's terms, and it is the window here.
+    return { ok: false, why: "the reply carried no active-workflow record", settles: true };
   }
   // #514: the panel says so itself when its active record is not confirmed. An
   // explicit `false` is the panel telling us the value is untrustworthy — never
   // adopt through that. (Absent = an older panel that cannot say; the list
   // corroboration below then has to carry the whole weight.)
   if (parsed.active_confirmed === false) {
-    return { ok: false, why: "the panel reported its active workflow as UNCONFIRMED" };
+    // SETTLES: this is the reported window itself — the panel says "not yet",
+    // and a moment later it says otherwise (#1292).
+    return {
+      ok: false,
+      why: "the panel reported its active workflow as UNCONFIRMED",
+      settles: true,
+    };
   }
   const list = parsed.workflows;
-  if (!Array.isArray(list) || list.length === 0) {
+  // TWO DIFFERENT FACTS, and #1292 made the difference cost real time. An ABSENT
+  // `workflows` field is a property of the installed build — it will not appear
+  // by waiting — while an EMPTY list is a snapshot of what is open right now,
+  // which a mid-restore panel reports before its tabs come back. Folding them
+  // would make every recovery on an older panel 2.9s slower for nothing.
+  if (!Array.isArray(list)) {
     return {
       ok: false,
       why: "the reply carried no open-workflow list to corroborate the active record against",
+      settles: false,
+    };
+  }
+  if (list.length === 0) {
+    return {
+      ok: false,
+      why: "the reply's open-workflow list was empty, so nothing corroborates the active record",
+      settles: true,
     };
   }
   // Only an AFFIRMATIVE per-record flag can nominate the corroborating entry;
@@ -3112,7 +3144,12 @@ function corroborateActiveForFence(
       !!w && typeof w === "object" && (w as { active?: unknown }).active === true,
   );
   if (flaggedActive.length === 0) {
-    return { ok: false, why: "no entry in the open-workflow list is marked active" };
+    // SETTLES: a snapshot taken before the panel re-flagged its active tab.
+    return {
+      ok: false,
+      why: "no entry in the open-workflow list is marked active",
+      settles: true,
+    };
   }
   if (flaggedActive.length > 1) {
     // A mixed/partial snapshot. Exactly the shape that would let another canvas's
@@ -3120,6 +3157,8 @@ function corroborateActiveForFence(
     return {
       ok: false,
       why: `${flaggedActive.length} entries in the open-workflow list are marked active (a mixed reply)`,
+      // SETTLES: "mixed" IS the half-reconciled state, by definition.
+      settles: true,
     };
   }
   // Same tri-state primitive the pin path uses. `false` = they name DIFFERENT
@@ -3130,12 +3169,17 @@ function corroborateActiveForFence(
     return {
       ok: false,
       why: "the active record and the entry marked active in the open-workflow list name DIFFERENT workflows (a stale or mixed reply)",
+      // SETTLES: a stale half of the snapshot catches up.
+      settles: true,
     };
   }
   if (verdict !== true) {
     return {
       ok: false,
       why: "the active record and the open-workflow list share no comparable identity field, so nothing corroborates it",
+      // DOES NOT SETTLE: a field the records do not carry will not appear by
+      // waiting — that is the reply's SHAPE, not its timing.
+      settles: false,
     };
   }
   return { ok: true, active: active as Record<string, unknown> };
@@ -3300,8 +3344,13 @@ async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebi
   let attempts = 1;
   let waitedMs = 0;
   // #1292 — recheck the RECONCILIATION WINDOW with a fresh read, never a lower bar.
+  // Only a failure that CAN settle is worth re-reading (codex review, P2): a reply
+  // whose SHAPE is wrong — an older build that sends no `workflows` array, records
+  // sharing no comparable identity field — will say exactly the same thing 2.9s
+  // later, so retrying it just makes the identical error slower. That is the same
+  // reasoning that keeps `no_uuid` out of this loop, applied one level down.
   for (const waitMs of FENCE_CORROBORATION_RECHECK_STEPS_MS) {
-    if (corroborated.ok) break;
+    if (corroborated.ok || !corroborated.settles) break;
     await sleep(waitMs);
     waitedMs += waitMs;
     attempts++;
@@ -3315,7 +3364,7 @@ async function rebindWorkflowFence(ctx: PanelToolCtx): Promise<WorkflowFenceRebi
       before,
       kind: "uncorroborated",
       why: corroborated.why,
-      rechecks: { attempts, waitedMs },
+      rechecks: { attempts, waitedMs, settles: corroborated.settles },
     };
   }
   const active = corroborated.active;
@@ -3676,7 +3725,15 @@ function describeFenceRebind(
             // taking it a fourth time is the least likely thing left to work.
             // When the rechecks ran, say so and move on to the remedy that has
             // not been tried.
-            (r.rechecks && r.rechecks.attempts > 1
+            (r.rechecks && !r.rechecks.settles
+              ? // Waiting cannot fix a reply whose SHAPE is wrong, so do not
+                // prescribe waiting. This said "call this again in a moment" to
+                // a caller whose panel will answer identically forever.
+                `\n\nWHY RETRYING WILL NOT HELP: this is the shape of the panel's reply, not a ` +
+                `moment in its reconciliation — a later read answers the same way. ` +
+                `${RELOAD_TAB_REMEDY} If it survives a hard refresh, the installed pack is too ` +
+                `old to corroborate its own active workflow and must be UPDATED.`
+              : r.rechecks && r.rechecks.attempts > 1
               ? `\n\nALREADY TRIED: the panel was re-read ${r.rechecks.attempts} times over ` +
                 `~${(r.rechecks.waitedMs / 1000).toFixed(1)}s and never corroborated. That window ` +
                 `covers the usual post-restart reconciliation, so this is probably NOT the ` +


### PR DESCRIPTION
Fixes #1292

A recovery operation that tells you to retry it has not finished recovering.

Right after `panel_restart_comfyui` and the tab's reconnect, the panel answers `workflow_list` but marks its active record UNCONFIRMED. Corroboration correctly refuses — a stale or mixed reply can carry another canvas's perfectly valid uuid, and stamping it would wedge the tab while reporting `bound`. So the refusal is right; what was wrong is **who paid for it**. The caller got a hard failure whose own remedy was "call this again in a moment" — and the reporter did, five seconds later, and the identical call returned `already_current` with no user action in between.

`mode:"current"` now rechecks with a **fresh read**, three times over ~2.9s, before failing.

**The corroboration rule does not move.** Every recheck is judged by the same fail-closed test; a recheck buys a fresh snapshot to judge, never a lower bar. Both halves are asserted.

Only the `uncorroborated` failure rechecks. Its sibling `no_uuid` means the installed pack exposes no workflow identity at all — rechecking a build that will never answer differently just makes the same error slower.

And the remedy no longer prescribes what the tool just did: after four refused reads, "call this again in a moment" is the least likely thing left to work and reads as though nothing was tried. It now reports the rechecks and names the remedy that has *not* been tried.

Status: draft — full suite and review pending.