### PR TITLE
0.50.83 — a restart stops claiming the panel tab failed to reconnect when it never checked (panel#654)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.83] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- say 'could not determine' instead of asserting the tab did not reconnect (panel#654) (#1289)
+
+#### Changed
+- fail when a test reaches the live-process probe unstubbed (#1291)
+- 0.50.82 (#1288)
+
+
 ## [0.50.82] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.82",
+  "version": "0.50.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.82",
+      "version": "0.50.83",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.82",
+  "version": "0.50.83",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Cuts **0.50.83**, carrying the panel#654 fix merged in #1289 (which landed after 0.50.82 was cut, so it is currently unreleased).

## What users get

After a confirmed ComfyUI restart, `panel_restart_comfyui` no longer reports `panel_tab_reconnected:false` for a reconnect it never watched.

`awaitPostRestartReachable` opens with `if (before == null) return false` — immediate, nothing awaited — and `before` is undefined whenever the panel advertised no tab session id, the socket was not `OPEN` at capture time (captured *before* the dispatch), or the tab did not resolve. So `false` meant both "watched and it did not come back" **and** "nothing was ever watched". The reporter's exact output is reproducible with the panel never having failed — which is why every panel-side measurement in that thread showed healthy recovery: the panel was reconnecting fine and the orchestrator never looked.

It now reports `"unknown"` for that case, following the `stale: true | "unknown"` shape this file already uses, and both restart replies say what to check instead of hard-refreshing the browser — which is the manual step the issue is about, and on this path may never have been necessary.

**The gate is not weakened.** `ready` and `graph_tools_ready` still key off the boolean, so an undetermined reconnect still withholds graph tools. Failing closed on capability is right; a weaker proof would be worse.

## Live-verified before release

The risk of this change is turning healthy setups into `"unknown"`. Measured against the panel served by a running ComfyUI:

```
stored tabSessionId       e4da4606-…      (present)
buildHelloPayload -> tab_session_id  present when the id exists
                                     omitted when it does not
```

So current panels still get a determined `true`/`false`; only genuinely unidentifiable ones become `"unknown"`.

## Verification

- 419 files / 8297 passed, 2 skipped; typecheck clean; no control bytes
- mutations killed, each confirmed applied: fold `unknown` back into `false`, hardcode `baselineCaptured`, route the gate through the classification

## Review notes

Adversarial review found three real problems in the first cut, all fixed in `553c853`: the remedy text asserted one of three possible causes as fact (the same sin the fix is about), the "gate is untouched" test could not observe the gate (a measured 1996/1996 green against the refactor it claimed to catch), and my first behavioural test was vacuous. Details in #1289.