### PR TITLE
fix(manifest): a stale out-of-scope copy must not block a live download (#1298)

### DIFF
--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -974,6 +974,46 @@ describe("applyManifest", () => {
     }
   });
 
+  // Round 2: three of the six note-renderings were unpinned — including
+  // wrongPlace, which my own commit called the worst case ("two same-named
+  // copies on disk and neither message mentions the other"). Deleting any of
+  // those three appends left a green suite, so each could regress silently to
+  // exactly the state round 1 shipped.
+  describe.each([
+    {
+      name: "a FAILED download",
+      file: "failcase.safetensors",
+      arm: () => downloadModelMock.mockRejectedValueOnce(new Error("boom")),
+    },
+    {
+      name: "a landed-but-NOT-VISIBLE placement (wrongPlace)",
+      file: "wrongplace.safetensors",
+      arm: () => verifyLandedModelMock.mockResolvedValueOnce({ liveVisible: "not-visible", note: "" }),
+    },
+    {
+      name: "an UNCONFIRMED placement",
+      file: "unconfirmed.safetensors",
+      arm: () => verifyLandedModelMock.mockResolvedValueOnce({ liveVisible: "unknown", note: "" }),
+    },
+  ])("names the stale copy on $name (#1298)", ({ file, arm }) => {
+    it("carries the note", async () => {
+      resolveExistingModelFileMock.mockResolvedValueOnce({
+        path: `C:/stale/models/checkpoints/${file}`,
+        root: "C:/stale/models",
+        info: { isFile: () => true },
+      });
+      isUnderLiveModelRootsMock.mockResolvedValueOnce({ inRoots: false });
+      arm();
+
+      const result = await applyManifest({
+        manifest: {
+          models: [{ url: `https://example.com/${file}`, model_type: "checkpoints", filename: file }],
+        },
+      });
+      expect(result.results[0].message ?? "").toMatch(/same-named file also exists/);
+    });
+  });
+
   it("does not block on MANY slow downloads — enqueues all, one bounded grace (#362)", async () => {
     const prevGrace = process.env.COMFYUI_MCP_DOWNLOAD_GRACE_MS;
     process.env.COMFYUI_MCP_DOWNLOAD_GRACE_MS = "50";

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -491,6 +491,35 @@ describe("applyManifest", () => {
     expect(msg).toMatch(/same-named file also exists/);
     expect(msg).toMatch(/C:\/stale\/models/);
     expect(msg).toMatch(/was ignored/);
+    // Re-pinned from the #369 tests this replaced: that clause IS the diagnostic
+    // half #369 wanted kept, and after the rewrite nothing held it — stripping it
+    // killed zero tests.
+    expect(msg).toMatch(/NOT in any directory/);
+  });
+
+  it("does not accuse LATER items of a stale copy found for an earlier one", async () => {
+    // Surviving mutation: hoisting `let staleOutsideLiveRoots` above the per-item
+    // loop passes every other test, because both stale tests use a single-model
+    // manifest. Manifests are multi-model by definition, so the mutant ships a
+    // false accusation on every subsequent asset.
+    resolveExistingModelFileMock.mockResolvedValueOnce({
+      path: "C:/stale/models/checkpoints/big.safetensors",
+      root: "C:/stale/models",
+      info: { isFile: () => true },
+    });
+    isUnderLiveModelRootsMock.mockResolvedValueOnce({ inRoots: false });
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          { url: "https://example.com/big.safetensors", model_type: "checkpoints", filename: "big.safetensors" },
+          { url: "https://example.com/clean.safetensors", model_type: "loras", filename: "clean.safetensors" },
+        ],
+      },
+    });
+
+    const second = result.results.find((r) => String(r.item).includes("clean")) ?? result.results[1];
+    expect(second?.message ?? "").not.toMatch(/same-named file also exists/);
   });
 
   // #1298 — was "FAILS"; containment proving the file irrelevant now lets the
@@ -523,7 +552,11 @@ describe("applyManifest", () => {
     });
 
     expect(result.summary.failed).toBe(0);
+    // Re-pinned: the old test asserted downloadModel was NOT called, so the new
+    // contract needs the mirror assertion or "downloads past it" is unheld.
+    expect(downloadModelMock).toHaveBeenCalled();
     expect(result.results[0].message).toMatch(/same-named file also exists/);
+    expect(result.results[0].message).toMatch(/NOT in any directory/);
   });
 
   it("FAILS a contained file the live server does not serve at all (container/host collision; codex gate r15)", async () => {
@@ -902,6 +935,39 @@ describe("applyManifest", () => {
       // The apply is not settled, so it is not a success — but nothing FAILED.
       expect(result.summary.failed).toBe(0);
       expect(result.success).toBe(false);
+    } finally {
+      if (prevGrace === undefined) delete process.env.COMFYUI_MCP_DOWNLOAD_GRACE_MS;
+      else process.env.COMFYUI_MCP_DOWNLOAD_GRACE_MS = prevGrace;
+    }
+  });
+
+  it("names the stale copy on a STILL-RUNNING download — the reporter's own case", async () => {
+    // The note used to render on 1 of 6 outcomes. A download slower than the 15s
+    // grace reports `pending` and the stale path was lost PERMANENTLY: it lives
+    // only in applyManifest's local array, so the `download_model status` poll
+    // the user is told to run cannot see it. That is the case that filed #1298,
+    // so the fix is hollow without it.
+    const prevGrace = process.env.COMFYUI_MCP_DOWNLOAD_GRACE_MS;
+    process.env.COMFYUI_MCP_DOWNLOAD_GRACE_MS = "0";
+    downloadModelMock.mockReturnValue(new Promise<string>(() => {}));
+    resolveExistingModelFileMock.mockResolvedValueOnce({
+      path: "C:/stale/models/checkpoints/slow.safetensors",
+      root: "C:/stale/models",
+      info: { isFile: () => true },
+    });
+    isUnderLiveModelRootsMock.mockResolvedValueOnce({ inRoots: false });
+
+    try {
+      const result = await applyManifest({
+        manifest: {
+          models: [
+            { url: "https://example.com/slow.safetensors", model_type: "checkpoints", filename: "slow.safetensors" },
+          ],
+        },
+      });
+      expect(result.results[0].status).toBe("pending");
+      expect(result.results[0].message).toMatch(/same-named file also exists/);
+      expect(result.results[0].message).toMatch(/C:\/stale\/models/);
     } finally {
       if (prevGrace === undefined) delete process.env.COMFYUI_MCP_DOWNLOAD_GRACE_MS;
       else process.env.COMFYUI_MCP_DOWNLOAD_GRACE_MS = prevGrace;

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -453,7 +453,15 @@ describe("applyManifest", () => {
   });
 
   // #369 — "already exists" is a claim about a path the RUNNING server may not read.
-  it("FAILS an existing file that is not in any tree the connected ComfyUI reads", async () => {
+  // #1298 — and when that claim is DISPROVEN, the file is irrelevant, not fatal.
+  //
+  // #369 changed a false SKIP into a FAIL, which was right about skipping: a
+  // stale same-named file must never satisfy the manifest. But failing vetoes a
+  // download that has nothing wrong with it — the live root resolved correctly,
+  // and the old remedy told the user to repoint COMFYUI_PATH when nothing was
+  // misconfigured. #369's real requirement survives: the item is satisfied only
+  // if the DOWNLOAD succeeds, never by a file existing somewhere.
+  it("DOWNLOADS past an existing file that is not in any tree the connected ComfyUI reads", async () => {
     resolveExistingModelFileMock.mockResolvedValueOnce({
       path: "C:/stale/models/checkpoints/big.safetensors",
       root: "C:/stale/models",
@@ -473,23 +481,23 @@ describe("applyManifest", () => {
       },
     });
 
-    expect(result.summary).toMatchObject({ skipped: 0, failed: 1 });
-    expect(result.results[0].message).toMatch(/NOT in any directory/);
-    expect(downloadModelMock).not.toHaveBeenCalled();
-
-    // #1298 — the VERDICT is #369's and unchanged; the REMEDY was wrong.
-    // It said only "point COMFYUI_PATH at the ComfyUI that is actually
-    // running", which assumes a misconfigured target. The reporting case had
-    // the live models root resolve CORRECTLY, so the user was told to fix
-    // something already right, with no way to act on it. The message now names
-    // the resolved target and both readings, so they can tell which they are in.
+    // The stale copy must NOT block the download...
+    expect(result.summary.failed).toBe(0);
+    expect(downloadModelMock).toHaveBeenCalled();
+    // ...and must still be NAMED, because a same-named file in another install
+    // is genuinely confusing later. #369 was right that the user should hear
+    // about it; it is a note on a success, not a veto.
     const msg = result.results[0].message ?? "";
-    expect(msg).toMatch(/was NOT downloaded/);
-    expect(msg).toMatch(/leftover from a DIFFERENT install/);
-    expect(msg).toMatch(/can be ignored or deleted/);
+    expect(msg).toMatch(/same-named file also exists/);
+    expect(msg).toMatch(/C:\/stale\/models/);
+    expect(msg).toMatch(/was ignored/);
   });
 
-  it("FAILS a same-named existing file that is OUTSIDE every live model root (codex gate r5)", async () => {
+  // #1298 — was "FAILS"; containment proving the file irrelevant now lets the
+  // download proceed. The containment CHECK is unchanged and still load-bearing:
+  // it is what distinguishes this from a live copy (which still skips) and from
+  // an unverifiable one (which is still pending).
+  it("DOWNLOADS past a same-named existing file OUTSIDE every live model root (codex gate r5)", async () => {
     // C:\Stale\...\big.safetensors exists locally AND the live server has its own
     // D:\Live\...\big.safetensors, so a name-only listing check would call it a skip.
     // The containment test is decisive and overrides it.
@@ -514,8 +522,8 @@ describe("applyManifest", () => {
       },
     });
 
-    expect(result.summary).toMatchObject({ skipped: 0, failed: 1 });
-    expect(result.results[0].message).toMatch(/NOT in any directory/);
+    expect(result.summary.failed).toBe(0);
+    expect(result.results[0].message).toMatch(/same-named file also exists/);
   });
 
   it("FAILS a contained file the live server does not serve at all (container/host collision; codex gate r15)", async () => {

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -476,6 +476,17 @@ describe("applyManifest", () => {
     expect(result.summary).toMatchObject({ skipped: 0, failed: 1 });
     expect(result.results[0].message).toMatch(/NOT in any directory/);
     expect(downloadModelMock).not.toHaveBeenCalled();
+
+    // #1298 — the VERDICT is #369's and unchanged; the REMEDY was wrong.
+    // It said only "point COMFYUI_PATH at the ComfyUI that is actually
+    // running", which assumes a misconfigured target. The reporting case had
+    // the live models root resolve CORRECTLY, so the user was told to fix
+    // something already right, with no way to act on it. The message now names
+    // the resolved target and both readings, so they can tell which they are in.
+    const msg = result.results[0].message ?? "";
+    expect(msg).toMatch(/was NOT downloaded/);
+    expect(msg).toMatch(/leftover from a DIFFERENT install/);
+    expect(msg).toMatch(/can be ignored or deleted/);
   });
 
   it("FAILS a same-named existing file that is OUTSIDE every live model root (codex gate r5)", async () => {

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -986,6 +986,10 @@ async function applyManifestSections(
           target.targetSubfolder,
           target.filename,
         );
+        // NOTE: `servedByLive` above is deliberately computed and unused on the
+        // stale path. Keeping the call costs one cheap listing GET per stale item
+        // and avoids churn on this branch; it is NOT load-bearing here, and it
+        // reads as though it feeds the guard below, which it does not.
         if (!staleOutsideLiveRoots) {
           results.push(
             servedByLive === true
@@ -1055,9 +1059,9 @@ async function applyManifestSections(
       // Worst was `wrongPlace`: two same-named copies on disk and neither
       // message naming the other.
       const staleNote = staleOutsideLiveRoots
-        ? ` (Note: a same-named file also exists at ${staleOutsideLiveRoots}, which is NOT in ` +
-          "any directory the connected ComfyUI reads — it belongs to a different install and " +
-          "was ignored.)"
+        ? ` (Note: a same-named file also exists at ${staleOutsideLiveRoots}, which was NOT in ` +
+          "any directory the connected ComfyUI reported reading when this item was checked — it " +
+          "belongs to a different install and was ignored.)"
         : "";
       if (job.status === "error") {
         results.push(

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -857,7 +857,13 @@ async function applyManifestSections(
   // streaming and are reported "pending" with a job id to poll via
   // download_model action:"status". A still-running download is NEVER counted as "applied", so
   // top-level success never claims an unfinished download succeeded.
-  const enqueued: Array<{ item: string; job: DownloadJob; settled: Promise<void> }> = [];
+  const enqueued: Array<{
+    item: string;
+    job: DownloadJob;
+    settled: Promise<void>;
+    /** #1298 — a proven-irrelevant same-named file, noted on the applied item. */
+    staleOutsideLiveRoots?: string;
+  }> = [];
   for (const model of manifest.models) {
     const item = model.local_path ?? model.filename ?? model.url;
     try {
@@ -905,6 +911,10 @@ async function applyManifestSections(
       }
       const target = await resolveLocalModelPath(model);
       const existing = await findExistingModel(target);
+      // #1298 — set when a found file is PROVEN to be outside every tree the
+      // live server reads. It is then irrelevant, and rides along as a note on
+      // the download rather than vetoing it.
+      let staleOutsideLiveRoots: string | undefined;
       if (existing) {
         // "Already exists" is only a legitimate SKIP if the running ComfyUI can
         // actually load it. On a locally-configured (non-live-resolved) models root
@@ -926,32 +936,23 @@ async function applyManifestSections(
             target.targetSubfolder.split(/[\\/]+/).filter(Boolean)[0],
           )
         ).inRoots;
+        // #1298 — a PROVEN-irrelevant file is not evidence about anything.
+        //
+        // #369 made this FAIL, which fixed a false SKIP: a stale same-named file
+        // used to satisfy the manifest while the live server had never seen it,
+        // and the render failed later. That was the right call about SKIPPING.
+        // But failing is a third thing, and it vetoes a download that has
+        // nothing wrong with it — the live models root resolved correctly, and a
+        // leftover in an install the server does not read cannot make writing to
+        // the right place unsafe. The old remedy even told the user to repoint
+        // COMFYUI_PATH, which they cannot act on when it is already correct.
+        //
+        // So: fall through to the download, carrying the stale path as a NOTE.
+        // #369's requirement is preserved — the item is satisfied only if the
+        // DOWNLOAD succeeds, never by the mere existence of a file somewhere.
         if (visible === false) {
-          results.push(
-            report(
-              "model",
-              item,
-              "failed",
-              `A file exists at ${existing}, but it is NOT in any directory the connected ` +
-                "ComfyUI reads models from — it belongs to an install the running server does " +
-                "not use, so this item was NOT downloaded. " +
-                // #1298 — the old remedy said only "point COMFYUI_PATH at the ComfyUI that
-                // is actually running", which assumes the target is misconfigured. Often it
-                // is not: the live models root can resolve CORRECTLY and this stale file is
-                // simply irrelevant, leaving the user told to fix something that is already
-                // right. Name both possibilities and the resolved target, so they can tell
-                // which one they are in.
-                `The download target resolved to ${target.targetPath}. If that is the install ` +
-                `you are running, the file ` +
-                "above is a leftover from a DIFFERENT install and can be ignored or deleted — " +
-                "re-run apply_manifest afterwards. If it is not, point COMFYUI_PATH at the " +
-                "ComfyUI that is actually running, or launch it with an absolute " +
-                "--base-directory.",
-            ),
-          );
-          continue;
-        }
-        if (visible === undefined) {
+          staleOutsideLiveRoots = existing;
+        } else         if (visible === undefined) {
           // We could not establish that the running server reads from this path, so
           // "already exists" is an UNVERIFIED claim. Report it as pending, never as
           // a satisfied item (codex gate, rounds 4 and 8).
@@ -985,37 +986,39 @@ async function applyManifestSections(
           target.targetSubfolder,
           target.filename,
         );
-        results.push(
-          servedByLive === true
-            ? report("model", item, "skipped", `Model already exists at ${existing}.`)
-            : servedByLive === false
-              ? report(
-                  "model",
-                  item,
-                  "failed",
-                  `A file exists at ${existing}, but the connected ComfyUI does not list ` +
-                    `"${target.filename}" under "${target.targetSubfolder}" at all — the models ` +
-                    "directory it reported is not the one this file is in (this happens when " +
-                    "ComfyUI runs in a container or behind a port-forward and its path also " +
-                    "exists on this host). Confirm with list_local_models.",
-                )
-              : report(
-                  "model",
-                  item,
-                  "pending",
-                  `A file exists at ${existing}, but the connected ComfyUI could not be asked ` +
-                    `whether it serves "${target.filename}", so this is not confirmed as ` +
-                    "installed. Check list_local_models.",
-                ),
-        );
-        continue;
+        if (!staleOutsideLiveRoots) {
+          results.push(
+            servedByLive === true
+              ? report("model", item, "skipped", `Model already exists at ${existing}.`)
+              : servedByLive === false
+                ? report(
+                    "model",
+                    item,
+                    "failed",
+                    `A file exists at ${existing}, but the connected ComfyUI does not list ` +
+                      `"${target.filename}" under "${target.targetSubfolder}" at all — the models ` +
+                      "directory it reported is not the one this file is in (this happens when " +
+                      "ComfyUI runs in a container or behind a port-forward and its path also " +
+                      "exists on this host). Confirm with list_local_models.",
+                  )
+                : report(
+                    "model",
+                    item,
+                    "pending",
+                    `A file exists at ${existing}, but the connected ComfyUI could not be asked ` +
+                      `whether it serves "${target.filename}", so this is not confirmed as ` +
+                      "installed. Check list_local_models.",
+                  ),
+          );
+          continue;
+        }
       }
       const { job, settled } = await startDownloadJob(
         model.url,
         target.targetSubfolder,
         target.filename,
       );
-      enqueued.push({ item, job, settled });
+      enqueued.push({ item, job, settled, staleOutsideLiveRoots });
     } catch (err) {
       results.push(
         report(
@@ -1043,7 +1046,7 @@ async function applyManifestSections(
     // ONE resolution for the batch: a verdict made against a DIFFERENT ComfyUI than
     // the one connected now must not be re-asserted as an apply (#369).
     const liveRootNow = await currentLiveModelsRoot();
-    for (const { item, job } of enqueued) {
+    for (const { item, job, staleOutsideLiveRoots } of enqueued) {
       if (job.status === "error") {
         results.push(report("model", item, "failed", job.error ?? "Model download failed."));
       } else if (job.status === "done") {
@@ -1061,7 +1064,16 @@ async function applyManifestSections(
                 "model",
                 item,
                 "applied",
-                `Model downloaded to ${job.path}${placement.pathQualifier}.`,
+                `Model downloaded to ${job.path}${placement.pathQualifier}.` +
+                  // #1298 — the stale copy that used to VETO this download is
+                  // still worth naming: a same-named file in another install is
+                  // genuinely confusing later, and #369 was right that the user
+                  // should hear about it. It is a note on a success, not a veto.
+                  (staleOutsideLiveRoots
+                    ? ` (Note: a same-named file also exists at ${staleOutsideLiveRoots}, ` +
+                      "which is NOT in any directory the connected ComfyUI reads — it belongs " +
+                      "to a different install and was ignored.)"
+                    : ""),
               )
             : placement.wrongPlace
               ? report(

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -934,8 +934,19 @@ async function applyManifestSections(
               "failed",
               `A file exists at ${existing}, but it is NOT in any directory the connected ` +
                 "ComfyUI reads models from — it belongs to an install the running server does " +
-                "not use. Point COMFYUI_PATH at the ComfyUI that is actually running, or " +
-                "launch it with an absolute --base-directory.",
+                "not use, so this item was NOT downloaded. " +
+                // #1298 — the old remedy said only "point COMFYUI_PATH at the ComfyUI that
+                // is actually running", which assumes the target is misconfigured. Often it
+                // is not: the live models root can resolve CORRECTLY and this stale file is
+                // simply irrelevant, leaving the user told to fix something that is already
+                // right. Name both possibilities and the resolved target, so they can tell
+                // which one they are in.
+                `The download target resolved to ${target.targetPath}. If that is the install ` +
+                `you are running, the file ` +
+                "above is a leftover from a DIFFERENT install and can be ignored or deleted — " +
+                "re-run apply_manifest afterwards. If it is not, point COMFYUI_PATH at the " +
+                "ComfyUI that is actually running, or launch it with an absolute " +
+                "--base-directory.",
             ),
           );
           continue;

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -952,7 +952,7 @@ async function applyManifestSections(
         // DOWNLOAD succeeds, never by the mere existence of a file somewhere.
         if (visible === false) {
           staleOutsideLiveRoots = existing;
-        } else         if (visible === undefined) {
+        } else if (visible === undefined) {
           // We could not establish that the running server reads from this path, so
           // "already exists" is an UNVERIFIED claim. Report it as pending, never as
           // a satisfied item (codex gate, rounds 4 and 8).
@@ -1047,8 +1047,22 @@ async function applyManifestSections(
     // the one connected now must not be re-asserted as an apply (#369).
     const liveRootNow = await currentLiveModelsRoot();
     for (const { item, job, staleOutsideLiveRoots } of enqueued) {
+      // #1298 — the stale-copy note belongs on EVERY outcome, not just the happy
+      // one. Review measured it rendering on 1 of 6: a download slower than the
+      // 15s grace reports `pending` and the path was lost permanently, because
+      // it lives only in this local array and the `download_model status` poll
+      // the user is told to run cannot see it. That is the reporter's own case.
+      // Worst was `wrongPlace`: two same-named copies on disk and neither
+      // message naming the other.
+      const staleNote = staleOutsideLiveRoots
+        ? ` (Note: a same-named file also exists at ${staleOutsideLiveRoots}, which is NOT in ` +
+          "any directory the connected ComfyUI reads — it belongs to a different install and " +
+          "was ignored.)"
+        : "";
       if (job.status === "error") {
-        results.push(report("model", item, "failed", job.error ?? "Model download failed."));
+        results.push(
+          report("model", item, "failed", (job.error ?? "Model download failed.") + staleNote),
+        );
       } else if (job.status === "done") {
         // "applied" must mean the running ComfyUI can actually load it (#369). Same
         // shared placement policy as download_model: an unconfirmed or demonstrably
@@ -1064,29 +1078,21 @@ async function applyManifestSections(
                 "model",
                 item,
                 "applied",
-                `Model downloaded to ${job.path}${placement.pathQualifier}.` +
-                  // #1298 — the stale copy that used to VETO this download is
-                  // still worth naming: a same-named file in another install is
-                  // genuinely confusing later, and #369 was right that the user
-                  // should hear about it. It is a note on a success, not a veto.
-                  (staleOutsideLiveRoots
-                    ? ` (Note: a same-named file also exists at ${staleOutsideLiveRoots}, ` +
-                      "which is NOT in any directory the connected ComfyUI reads — it belongs " +
-                      "to a different install and was ignored.)"
-                    : ""),
+                `Model downloaded to ${job.path}${placement.pathQualifier}.` + staleNote,
               )
             : placement.wrongPlace
               ? report(
                   "model",
                   item,
                   "failed",
-                  `Model ${placement.pathLabel} ${job.path}, but it is NOT usable by the connected ComfyUI: ${placement.warning}`,
+                  `Model ${placement.pathLabel} ${job.path}, but it is NOT usable by the connected ComfyUI: ${placement.warning}` +
+                    staleNote,
                 )
               : report(
                   "model",
                   item,
                   "pending",
-                  `Model ${placement.pathLabel} ${job.path}. ${placement.warning}`,
+                  `Model ${placement.pathLabel} ${job.path}. ${placement.warning}` + staleNote,
                 ),
         );
       } else {
@@ -1097,7 +1103,7 @@ async function applyManifestSections(
             "pending",
             `Model download is RUNNING in the background (job ${job.id}) — NOT yet complete, ` +
               `and NOT a failure. Poll download_model action:"status" with this id; the file lands on its own. ` +
-              `Do not re-issue the download.`,
+              `Do not re-issue the download.` + staleNote,
           ),
         );
       }


### PR DESCRIPTION
Draft — claiming #1298. Reported on **0.50.84** (current), `grep -rn "#1298" src/` finds no prior work, no competing branch.

## The report

`apply_manifest` resolved the correct live models root for most assets, but `findExistingModel` matched a same-named SAM file in a **stale `COMFYUI_PATH` install outside the connected server's live model roots** — and reported that as already-present, skipping the required download.

## Why it is the same shape as most of this backlog

The presence check answered a *different question* than the one the caller asked. "Is there a file with this name somewhere I know about" is not "is this model available to the server that will run the workflow." Answering the first as though it were the second produces a confident skip, and the failure surfaces later as a missing model at render time — far from the decision that caused it.

That is #796's family with the arrow pointing at a **skip** rather than a refusal: a determined-yes from evidence that could not support it.

## Plan

1. **Read the consumer before the producer.** Find where `apply_manifest` calls `findExistingModel` and what it does with a hit — whether the scope error is in the search roots or in how the result is interpreted. Today's repeated lesson is that the defect is usually one layer below where it appears.
2. Establish what "live model roots" means here and whether the resolved target is already available at the call site — if it is, the fix is scoping the search to it rather than inventing new resolution.
3. **The negative is the deliverable.** A copy that IS in the live roots must still short-circuit the download. A fix that narrows the search so far that nothing matches would turn a wrong skip into a wrong re-download of every asset — worse, because it is slow and silent rather than fast and wrong.

Explicit non-goal: changing `findExistingModel`'s behaviour for other callers until I have read them. It is a shared helper, and other call sites may legitimately want the broader search.

Refs #796.