### PR TITLE
fix(run-correlation): stop reporting a forgotten run as one you never queued

### DIFF
--- a/src/__tests__/orchestrator/run-correlation-prior.test.ts
+++ b/src/__tests__/orchestrator/run-correlation-prior.test.ts
@@ -1,0 +1,177 @@
+// #925 (panel) — "does NOT match any run you queued" was being said about a run
+// the session DID queue.
+//
+// The reporter queued a render with panel_run, got prompt id 8812f71b…, and its
+// re-delivered completion carried that exact id. ComfyUI's history confirmed the
+// prompt succeeded. The orchestrator told the agent it was not theirs.
+//
+// The cause is a fold, not a lost ticket. `correlate()` returns `foreign` for
+// every completion with no OPEN ticket, and `foreign` renders as a definite
+// negative — "does NOT match any run you queued". But "no open ticket" covers
+// two different facts:
+//
+//   never ours      a real run this session did not queue
+//   ours, forgotten the ticket was evicted (the map is capped at 64), the entry
+//                   was already delivered and acked, or the id was re-queued and
+//                   now stands for more than one run
+//
+// Both are UNDETERMINED, both must be refused identically — a completion that
+// cannot be proven to be yours must never satisfy an outstanding panel_run, and
+// that rule does not move here. What changes is that the orchestrator stops
+// asserting the one thing it does not know. The journal's own header says why
+// this matters: it "does not merely mislabel it: it TELLS THE AGENT TO DISBELIEVE
+// A CORRECT RESULT".
+
+import { describe, expect, it } from "vitest";
+
+import { RunCompletionJournalImpl } from "../../orchestrator/run-completion-journal.js";
+
+const TAB = "wf:workflows/a.json";
+const CONVO = "orchestrator::claude";
+const PID = "8812f71b-50c1-4d4f-b8e7-dc35d0093c1f";
+
+function journal() {
+  return new RunCompletionJournalImpl();
+}
+
+/** Queue, deliver and ACK a completion — the real lifecycle, because the ack is
+ *  what clears the ticket and produces the reporter's state. */
+function queueDeliverAck(j: RunCompletionJournalImpl, tab: string, convo: string, pid: string) {
+  j.openRun(pid, { tabId: tab, conversation: convo });
+  const entry = j.record(tab, { prompt_id: pid, kind: "executed" }, { conversation: convo });
+  const tokens: string[] = [];
+  j.deliverPending(tab, (_payload: unknown, token: string) => {
+    tokens.push(token);
+    return true;
+  });
+  for (const t of tokens) j.ack(t);
+  return { entry, tokens };
+}
+
+describe("a forgotten run is not reported as one you never queued (#925)", () => {
+  it("an id this session NEVER queued stays a plain foreign — that claim is true", () => {
+    const j = journal();
+    const c = j.correlate(TAB, { prompt_id: PID }, CONVO);
+    expect(c.status).toBe("foreign");
+    expect((c as { priorHistory?: boolean }).priorHistory).toBeFalsy();
+  });
+
+  it("a run this session queued correlates as matched while the ticket is held", () => {
+    const j = journal();
+    j.openRun(PID, { tabId: TAB, conversation: CONVO });
+    expect(j.correlate(TAB, { prompt_id: PID }, CONVO).status).toBe("matched");
+  });
+
+  it("an ack alone does NOT forget the run — measured, not assumed", () => {
+    // Worth pinning, because it was my first theory for the reporter's case and
+    // it is wrong: the ticket is marked settled but stays in the map, so a
+    // re-delivery still correlates as the run it is. Nothing to fix on this path.
+    const j = journal();
+    const { entry } = queueDeliverAck(j, TAB, CONVO, PID);
+    expect(entry.correlation.status).toBe("matched");
+    expect(j.correlate(TAB, { prompt_id: PID }, CONVO).status).toBe("matched");
+  });
+
+  it("THE FORGOTTEN CASE: the ticket is evicted, and the id is still known to be ours", () => {
+    // The ticket map is capped (MAX_TICKETS = 64) and eviction is documented as
+    // making later completions read `foreign` — "the honest reading once we've
+    // forgotten the run". Honest about UNDETERMINED; not honest about "does NOT
+    // match any run you queued", which is what the agent was actually told.
+    //
+    // The delivered-memo deliberately outlives the tickets (512 pairs vs 64), so
+    // the evidence needed to tell the two apart is already kept.
+    const j = journal();
+    queueDeliverAck(j, TAB, CONVO, PID);
+
+    // Push the original ticket out with a batch of later runs.
+    for (let i = 0; i < 80; i++) {
+      j.openRun(`later-${i}-0000-4000-8000-00000000${String(i).padStart(4, "0")}`, {
+        tabId: TAB,
+        conversation: CONVO,
+      });
+    }
+
+    const again = j.correlate(TAB, { prompt_id: PID }, CONVO);
+    expect(again.status, "with no ticket it cannot be proven to be the awaited run").toBe("foreign");
+    expect(
+      (again as { priorHistory?: boolean }).priorHistory,
+      "…but the journal KNOWS this id has been ours — that is the whole fix",
+    ).toBe(true);
+  });
+
+  it("survives the tab id churning, because the conversation outlives it", () => {
+    // A reconnecting panel re-registers under a new tab id (#704). The history
+    // lookup is by conversation as well as tab, so the re-delivery under a NEW
+    // address still knows the id was ours.
+    const j = journal();
+    queueDeliverAck(j, TAB, CONVO, PID);
+    for (let i = 0; i < 80; i++) {
+      j.openRun(`later-${i}-0000-4000-8000-00000000${String(i).padStart(4, "0")}`, {
+        tabId: TAB,
+        conversation: CONVO,
+      });
+    }
+
+    const afterReconnect = j.correlate("tmp:brand-new-id", { prompt_id: PID }, CONVO);
+    expect(afterReconnect.status).toBe("foreign");
+    expect((afterReconnect as { priorHistory?: boolean }).priorHistory).toBe(true);
+  });
+
+  it("a DIFFERENT conversation's run is still plainly foreign — no over-reach", () => {
+    // The fix must not start claiming other sessions' runs. Ownership is
+    // unchanged; only the wording for our own forgotten ids moves.
+    const j = journal();
+    queueDeliverAck(j, TAB, CONVO, PID);
+    for (let i = 0; i < 80; i++) {
+      j.openRun(`later-${i}-0000-4000-8000-00000000${String(i).padStart(4, "0")}`, {
+        tabId: TAB,
+        conversation: CONVO,
+      });
+    }
+
+    const other = j.correlate("wf:workflows/b.json", { prompt_id: PID }, "orchestrator::codex");
+    expect(other.status).toBe("foreign");
+    expect(
+      (other as { priorHistory?: boolean }).priorHistory,
+      "another conversation has no history for this id and must not be told it does",
+    ).toBeFalsy();
+  });
+
+  it("an id with no prompt id at all is unchanged — still unidentified", () => {
+    const j = journal();
+    expect(j.correlate(TAB, {}, CONVO).status).toBe("unidentified");
+  });
+});
+
+// ── THE WORDING ───────────────────────────────────────────────────────────
+// `runIdentityPreamble` is module-private, so the sentence the agent actually
+// reads is pinned at source. Without this the journal could carry the flag
+// correctly while the message stayed wrong — and the message IS the defect.
+describe("the sentence the agent reads (#925)", () => {
+  it("stops claiming 'does NOT match any run you queued' for an id that was ours", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(
+      new URL("../../orchestrator/panel-agent.ts", import.meta.url),
+      "utf-8",
+    );
+    const fn = src.slice(src.indexOf("function runIdentityPreamble"));
+    const body = fn.slice(0, fn.indexOf("\n}\n"));
+
+    // The flag has to be READ here, or the journal's work never reaches anyone.
+    expect(body).toContain("ev.run_correlation_prior");
+    // The prior branch must come BEFORE the blanket negative, or the old
+    // sentence wins and nothing changes for the caller.
+    expect(body.indexOf("run_correlation_prior")).toBeLessThan(
+      body.indexOf("does NOT match any run you queued"),
+    );
+    // It still refuses: UNDETERMINED, and do not treat it as the awaited render.
+    const priorBranch = body.slice(
+      body.indexOf("run_correlation_prior"),
+      body.indexOf("does NOT match any run you queued"),
+    );
+    expect(priorBranch).toMatch(/UNDETERMINED/);
+    expect(priorBranch).toMatch(/Do NOT treat it as that render/);
+    // …and it does not tell the agent the id was not its own.
+    expect(priorBranch).not.toMatch(/does NOT match/);
+  });
+});

--- a/src/__tests__/orchestrator/run-correlation-prior.test.ts
+++ b/src/__tests__/orchestrator/run-correlation-prior.test.ts
@@ -137,6 +137,91 @@ describe("a forgotten run is not reported as one you never queued (#925)", () =>
     ).toBeFalsy();
   });
 
+  // ── THE CLAIM MUST BE ABOUT OWNERSHIP, NOT ACQUAINTANCE (codex) ──────────
+  // The sentence says "WAS queued from this session". Evidence that only shows
+  // the id has been SEEN here would make that false in two reachable ways.
+
+  it("a FOREIGN completion seen here once does not become 'yours' on re-delivery", () => {
+    // Never queued: no ticket was ever opened for this id. It is delivered and
+    // acked like any other completion.
+    //
+    // HONEST LIMIT: this case passes under BOTH the old "has this party seen the
+    // id" evidence and the ownership evidence that replaced it, so it does not by
+    // itself prove the narrowing was necessary — the memo apparently is not
+    // written for a completion with no ticket. It is kept because the property it
+    // states is the one that matters (acquaintance is not ownership), and because
+    // a future change to when the memo is written would land here first. The case
+    // that DOES discriminate is the cross-conversation reused ticket below.
+    const j = journal();
+    const foreignPid = "ffffffff-0000-4000-8000-000000000001";
+    j.record(TAB, { prompt_id: foreignPid, kind: "executed" }, { conversation: CONVO });
+    const tokens: string[] = [];
+    j.deliverPending(TAB, (_p: unknown, token: string) => {
+      tokens.push(token);
+      return true;
+    });
+    for (const t of tokens) j.ack(t);
+
+    const again = j.correlate(TAB, { prompt_id: foreignPid }, CONVO);
+    expect(again.status).toBe("foreign");
+    expect(
+      (again as { priorHistory?: boolean }).priorHistory,
+      "seen here before, but never queued here — the wording must not claim otherwise",
+    ).toBeFalsy();
+  });
+
+  it("ANOTHER conversation's reused ticket is not our history", () => {
+    // A live ticket for this id exists, is flagged `reused`, and belongs to a
+    // different conversation. Reading `reused` without an ownership test would
+    // tell this session it had queued the run.
+    const j = journal();
+    j.openRun(PID, { tabId: TAB, conversation: "orchestrator::codex" });
+    j.openRun(PID, { tabId: TAB, conversation: "orchestrator::codex" }); // re-queue -> reused
+
+    const ours = j.correlate("wf:workflows/b.json", { prompt_id: PID }, CONVO);
+    expect(ours.status).toBe("foreign");
+    expect(
+      (ours as { priorHistory?: boolean }).priorHistory,
+      "another conversation's run, however it is flagged, is not ours",
+    ).toBeFalsy();
+  });
+
+  it("OUR OWN reused id does report prior history", () => {
+    // The neighbouring positive: same shape, our conversation. The id now stands
+    // for more than one of our runs, which is a real "we cannot tell which".
+    const j = journal();
+    j.openRun(PID, { tabId: TAB, conversation: CONVO });
+    j.openRun(PID, { tabId: TAB, conversation: CONVO });
+
+    const ours = j.correlate(TAB, { prompt_id: PID }, CONVO);
+    expect(ours.status).toBe("foreign");
+    expect((ours as { priorHistory?: boolean }).priorHistory).toBe(true);
+  });
+
+  it("BEHAVIOURAL: the flag survives to the delivered payload", () => {
+    // Not a source check (codex): the property could be correct in the journal
+    // and dropped at the wire boundary, and then nothing changes for the agent.
+    const j = journal();
+    queueDeliverAck(j, TAB, CONVO, PID);
+    for (let i = 0; i < 80; i++) {
+      j.openRun(`later-${i}-0000-4000-8000-00000000${String(i).padStart(4, "0")}`, {
+        tabId: TAB,
+        conversation: CONVO,
+      });
+    }
+    j.record(TAB, { prompt_id: PID, kind: "executed" }, { conversation: CONVO });
+
+    const payloads: Array<Record<string, unknown>> = [];
+    j.deliverPending(TAB, (payload: Record<string, unknown>) => {
+      payloads.push(payload);
+      return true;
+    });
+    const delivered = payloads.find((p) => p.prompt_id === PID);
+    expect(delivered, "the completion must still be delivered").toBeTruthy();
+    expect(delivered?.run_correlation).toBe("foreign");
+    expect(delivered?.run_correlation_prior).toBe(true);
+  });
+
   it("an id with no prompt id at all is unchanged — still unidentified", () => {
     const j = journal();
     expect(j.correlate(TAB, {}, CONVO).status).toBe("unidentified");

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -79,11 +79,12 @@ function runIdentityPreamble(ev: {
       // changes is that we stop asserting the one thing we do not know.
       if (ev.run_correlation_prior) {
         return (
-          `This run (prompt ${pid}) WAS queued from this session, but its ticket is no longer held — ` +
-          `tickets are bounded, an acked completion clears one, and a re-queued id can stand for more ` +
-          `than one run. So it CANNOT be proven to be the render you are waiting on: its origin is ` +
-          `UNDETERMINED even though the id is one of yours. Do NOT treat it as that render; confirm ` +
-          `with get_history (action:"list") which of your runs this id belongs to before acting. `
+          `This run (prompt ${pid}) WAS queued from this session, but it can no longer be tied to a ` +
+          `specific run of yours — the orchestrator tracks a bounded number of runs and this one has ` +
+          `aged out, or the id was queued again and now stands for more than one. So its origin is ` +
+          `UNDETERMINED even though the id is one of yours, and it CANNOT be treated as proof that ` +
+          `the render you are waiting on finished. Do NOT treat it as that render; confirm with ` +
+          `get_history (action:"list") which of your runs this id belongs to before acting. `
         );
       }
       return (

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -57,12 +57,35 @@ function msgOf(err: unknown): string {
  * An event with no correlation field (a legacy/simulated frame) gets the old
  * neutral wording — unchanged behavior.
  */
-function runIdentityPreamble(ev: { prompt_id?: string; run_correlation?: string }): string {
+function runIdentityPreamble(ev: {
+  prompt_id?: string;
+  run_correlation?: string;
+  /** #925 — the id has been ours before; see run-completion-journal. */
+  run_correlation_prior?: boolean;
+}): string {
   const pid = typeof ev.prompt_id === "string" && ev.prompt_id.trim() ? ev.prompt_id.trim() : null;
   switch (ev.run_correlation) {
     case "matched":
       return `This is the run YOU queued with panel_run (prompt ${pid}). `;
     case "foreign":
+      // #925 — TWO DIFFERENT FACTS, and only one of them is "not yours". A
+      // completion with no open ticket may be a run this session never queued,
+      // or a run it DID queue whose ticket has since been evicted (the map is
+      // capped), or a re-delivery after the first was acked. The reporter hit the
+      // second: their own prompt id, confirmed successful in ComfyUI's history,
+      // and the orchestrator told the agent it was not theirs — which does not
+      // merely mislabel it, it instructs the agent to disbelieve a correct
+      // result. Both stay UNDETERMINED and both are refused identically; what
+      // changes is that we stop asserting the one thing we do not know.
+      if (ev.run_correlation_prior) {
+        return (
+          `This run (prompt ${pid}) WAS queued from this session, but its ticket is no longer held — ` +
+          `tickets are bounded, an acked completion clears one, and a re-queued id can stand for more ` +
+          `than one run. So it CANNOT be proven to be the render you are waiting on: its origin is ` +
+          `UNDETERMINED even though the id is one of yours. Do NOT treat it as that render; confirm ` +
+          `with get_history (action:"list") which of your runs this id belongs to before acting. `
+        );
+      }
       return (
         `This run (prompt ${pid}) does NOT match any run you queued with panel_run — its origin is UNDETERMINED. ` +
         `Do NOT treat it as the render you are waiting on; if you are still waiting on your own run, verify it with get_history (action:"list") before acting. `
@@ -627,6 +650,7 @@ export class PanelAgent {
       /** #468 — run identity + how it correlates to a run this session queued. */
       prompt_id?: string;
       run_correlation?: "matched" | "foreign" | "unidentified";
+      run_correlation_prior?: boolean;
       replayed?: boolean;
       dropped_completions?: number;
       possible_repeat?: boolean;
@@ -2311,6 +2335,7 @@ export class PanelAgentManager {
       downloads?: Array<{ name: string; status: string; supersededByLive?: boolean }>;
       prompt_id?: string;
       run_correlation?: "matched" | "foreign" | "unidentified";
+      run_correlation_prior?: boolean;
       replayed?: boolean;
       dropped_completions?: number;
       possible_repeat?: boolean;

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -246,6 +246,11 @@ const MAX_ENTRIES_TOTAL = 96;
 const MAX_DELIVERED_MEMO = 512;
 /** Tabs whose evicted-completion counter is retained. */
 const MAX_DROPPED_KEYS = 64;
+/** Prompt ids whose ticket THIS party opened and which have since been evicted
+ *  (#925). Bounded, and keyed by the same owner the ticket was keyed by, because
+ *  the claim it supports is "you queued this", not "this id has been seen here"
+ *  (codex). Sized to outlive the ticket map several times over. */
+const MAX_FORGOTTEN_OWN_RUNS = 512;
 /** How many times a completion may be CARRIED BY A TURN THAT THEN ENDED without a
  *  provable ack before the journal settles it anyway.
  *
@@ -316,6 +321,9 @@ export class RunCompletionJournalImpl {
    *  exact match is proof of identity on its own and survives a session's tab
    *  id being rebound between the queue and the completion. */
   private tickets = new Map<string, RunTicket>();
+  /** `<owner>|<promptId>` for runs THIS party opened whose ticket was evicted.
+   *  Insertion-ordered and bounded; see MAX_FORGOTTEN_OWN_RUNS (#925). */
+  private forgottenOwnRuns = new Set<string>();
   /** token → entry (insertion-ordered, which is also delivery order). */
   private entries = new Map<string, JournalEntry>();
   /** (tab, run) pairs whose completion was ACKED — a bounded FIFO memo so a
@@ -534,7 +542,17 @@ export class RunCompletionJournalImpl {
     // delivered-memo holds MAX_DELIVERED_MEMO pairs against MAX_TICKETS tickets),
     // which is exactly the evidence separating "never yours" from "yours, and we
     // no longer hold the ticket".
-    const priorHistory = this.hasHistoryFor(key, pid, conversation) || Boolean(ticket?.reused);
+    // OWNERSHIP EVIDENCE ONLY (codex). `hasHistoryFor` answers "has this party
+    // ever SEEN this id" — which is also true of a foreign completion delivered
+    // here once, and of another conversation's reused ticket. Neither means "you
+    // queued it", and the sentence this drives says exactly that. So the evidence
+    // is narrowed to two facts that are about OUR OWN runs:
+    //   • a ticket we opened and later evicted (recorded at the eviction), or
+    //   • a live ticket WE own whose id was re-queued, so it now stands for more
+    //     than one of our runs.
+    const priorHistory =
+      this.forgotOwnRun(pid, key, conversation) ||
+      Boolean(ticket?.reused && ownsRun(ticket, key, conversation));
     return priorHistory
       ? { status: "foreign", promptId: pid, priorHistory: true }
       : { status: "foreign", promptId: pid };
@@ -1126,6 +1144,7 @@ export class RunCompletionJournalImpl {
     this.dropped.clear();
     this.delivered.clear();
     this.idlessSeen.clear();
+    this.forgottenOwnRuns.clear();
     this.seq = 0;
   }
   /** Evicted completions this tab has not been told about yet — wherever the
@@ -1135,6 +1154,31 @@ export class RunCompletionJournalImpl {
       .filter((e) => e.key === key)
       .reduce((n, e) => n + (e.disclose ?? 0), 0);
     return carried + (this.dropped.get(key) ?? 0);
+  }
+
+  /** The owner a ticket is keyed by, mirroring ownsRun(): the conversation when
+   *  there is one, else the tab. */
+  private ownerOf(ticket: RunTicket): string {
+    return ticket.conversation !== undefined ? ticket.conversation : ticket.tabId;
+  }
+
+  /** #925 — remember that a run WE opened has been forgotten, so a later
+   *  completion for it can be told apart from one this session never queued. */
+  private noteForgottenOwnRun(ticket: RunTicket): void {
+    this.forgottenOwnRuns.add(`${this.ownerOf(ticket)}|${ticket.promptId}`);
+    while (this.forgottenOwnRuns.size > MAX_FORGOTTEN_OWN_RUNS) {
+      const oldest = this.forgottenOwnRuns.values().next().value;
+      if (oldest === undefined) break;
+      this.forgottenOwnRuns.delete(oldest);
+    }
+  }
+
+  /** Did this party open a ticket for `pid` that has since been evicted? */
+  private forgotOwnRun(pid: string, key: string, conversation?: string): boolean {
+    if (conversation !== undefined && this.forgottenOwnRuns.has(`${conversation}|${pid}`)) {
+      return true;
+    }
+    return this.forgottenOwnRuns.has(`${key}|${pid}`);
   }
 
   private trimTickets(): void {
@@ -1155,6 +1199,12 @@ export class RunCompletionJournalImpl {
       // ack() writes it to the delivered memo at the same moment it sets
       // `settled`, and MAX_DELIVERED_MEMO is deliberately far larger than
       // MAX_TICKETS so the memo always outlives the ticket that mirrors it.
+      // #925 — RECORD THAT IT WAS OURS ON THE WAY OUT. This is the last moment
+      // the ownership is still known: once the ticket is gone, a later completion
+      // for the id is indistinguishable from a run this session never queued, and
+      // reporting it as such is the false claim this fixes.
+      const evicted = this.tickets.get(victim);
+      if (evicted) this.noteForgottenOwnRun(evicted);
       this.tickets.delete(victim);
     }
   }

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -67,7 +67,19 @@ export type RunCorrelation =
   | { status: "matched"; promptId: string }
   /** Carries a prompt id, but no run this session queued has that id. Real, but
    *  NOT ours — it must never satisfy an outstanding `panel_run`. */
-  | { status: "foreign"; promptId: string }
+  /** `priorHistory` separates the two very different facts this used to fold
+   *  (#925). Both are UNDETERMINED and both are refused identically; they are
+   *  not the same claim:
+   *
+   *    false — no run this session queued has ever carried this id. "Not yours"
+   *            is a true statement.
+   *    true  — this id HAS been ours: its ticket was evicted (the map is capped),
+   *            or the completion was already delivered and acked, or the id was
+   *            re-queued and now stands for more than one run. We have forgotten
+   *            WHICH run it was, not WHETHER it was ours — and telling the agent
+   *            it "does NOT match any run you queued" is then a false claim,
+   *            about its own correct result. */
+  | { status: "foreign"; promptId: string; priorHistory?: boolean }
   /** No prompt id at all. Unattributable in principle; reported as such. */
   | { status: "unidentified" };
 
@@ -513,8 +525,18 @@ export class RunCompletionJournalImpl {
     // A REUSED id proves nothing: the panel sends only the id, so a completion
     // for it could belong to either generation. Report it as foreign — real, but
     // UNDETERMINED — rather than claiming it is the run now outstanding.
-    return ticket && ownsRun(ticket, key, conversation) && !ticket.reused
-      ? { status: "matched", promptId: pid }
+    if (ticket && ownsRun(ticket, key, conversation) && !ticket.reused) {
+      return { status: "matched", promptId: pid };
+    }
+    // #925 — SAY WHICH KIND OF UNDETERMINED THIS IS. The refusal is unchanged;
+    // only the claim attached to it. `hasHistoryFor` answers "has this party ever
+    // seen this id" from stores that deliberately outlive the ticket map (the
+    // delivered-memo holds MAX_DELIVERED_MEMO pairs against MAX_TICKETS tickets),
+    // which is exactly the evidence separating "never yours" from "yours, and we
+    // no longer hold the ticket".
+    const priorHistory = this.hasHistoryFor(key, pid, conversation) || Boolean(ticket?.reused);
+    return priorHistory
+      ? { status: "foreign", promptId: pid, priorHistory: true }
       : { status: "foreign", promptId: pid };
   }
 
@@ -792,6 +814,12 @@ export class RunCompletionJournalImpl {
       const payload: CompletionPayload = {
         ...entry.payload,
         run_correlation: entry.correlation.status,
+        // #925 — carried ALONGSIDE the status rather than as a fourth status, so
+        // every existing consumer of `run_correlation` keeps working and only the
+        // wording gains a case.
+        ...(entry.correlation.status === "foreign" && entry.correlation.priorHistory
+          ? { run_correlation_prior: true }
+          : {}),
         ...(entry.correlation.status === "unidentified"
           ? {}
           : { prompt_id: entry.correlation.promptId }),


### PR DESCRIPTION
Draft — claiming artokun/comfyui-mcp-panel#925. The panel triage on that issue established the message is orchestrator-side, so the fix lives here.

## The defect is a #796 fold

`correlate()` returns `foreign` whenever there is no open ticket for the prompt id. `foreign` is then rendered as:

> This run (prompt …) does **NOT** match any run you queued with panel_run — its origin is UNDETERMINED.

But "no ticket" covers two different facts:

| | truth | what the agent is told |
|---|---|---|
| never ours | a real run this session did not queue | correct |
| **ours, forgotten** | ticket evicted (cap is 64), or a re-delivery after the entry was acked | **"does NOT match any run you queued"** |

The second is the reporter's case exactly: their own prompt id, ComfyUI history confirming it succeeded, and the orchestrator telling the agent it was not theirs. The journal's own header already names this as the thing to avoid — *"it does not merely mislabel it: it TELLS THE AGENT TO DISBELIEVE A CORRECT RESULT"* — and the eviction path even documents `foreign` as "the honest reading once we've forgotten the run". It is honest about UNDETERMINED; it is not honest about *does not match any run you queued*.

## What I intend to change

Only the claim, not the correlation. A completion that cannot be proven to be yours must still never be presented as the awaited render — that rule stays. What changes is that "we forgot" stops being reported as "it was not yours", where the journal can tell the difference (it already keeps a delivered-memo of (tab, run) pairs well beyond the ticket cap, and knows when it evicts).

Unit-testable end to end, which is why I picked it: the dev rig's ComfyUI is currently serving another session's branch, so panel-mounting e2e is unavailable to me.