### PR TITLE
fix(download): say why a CivitAI download failed, instead of a bare status

### DIFF
--- a/src/__tests__/services/download-failure-hint.test.ts
+++ b/src/__tests__/services/download-failure-hint.test.ts
@@ -48,6 +48,35 @@ describe("the CivitAI hint fires on the status the reporter actually got (#1300)
     expect(hint).not.toMatch(/Set it in panel Settings/);
   });
 
+  it("BUT a 401/403 WITH a token means the token is bad — not 'probably not auth'", () => {
+    // Ignoring the status here would repeat the original bug one layer along:
+    // an invalid, expired or unentitled token produces exactly this status, and
+    // steering that caller away from auth is the same wrong answer (codex).
+    for (const status of [401, 403]) {
+      const hint = downloadFailureHint({ status, url: METADATA_URL, hasCivitaiToken: true });
+      expect(hint, `status ${status}`).toMatch(/INVALID, expired, or lacks access/);
+      expect(hint).not.toMatch(/probably not an auth failure/);
+    }
+  });
+
+  it("the fileId remedy is for a 404 only, not for 429 or 5xx", () => {
+    for (const status of [429, 500, 503]) {
+      const hint = downloadFailureHint({ status, url: METADATA_URL, hasCivitaiToken: true });
+      expect(hint, `status ${status}`).not.toMatch(/selects a file by METADATA/);
+    }
+  });
+
+  it("a trailing-dot FQDN is the same host", () => {
+    // `civitai.com.` is a legitimate spelling; WHATWG URL keeps the dot (codex).
+    expect(
+      downloadFailureHint({
+        status: 404,
+        url: "https://civitai.com./api/download/models/1",
+        hasCivitaiToken: false,
+      }),
+    ).toMatch(/no CIVITAI_API_TOKEN/);
+  });
+
   it("with a token, a METADATA-query url gets the fileId remedy they found", () => {
     // Established by their curl, not inferred: `?type=…&format=…&fp=…` 404s even
     // with a valid token when a version publishes several files.
@@ -140,6 +169,60 @@ describe("the server's own explanation is carried back (#1300)", () => {
   it("does not invent a body when there is none", async () => {
     expect(await readErrorBody({ text: async () => "" })).toBe("");
   });
+
+  it("REDACTS a credential the host echoed back from our own query string", async () => {
+    // A signed download URL carries its credential in the query, and a host that
+    // reflects the request would otherwise republish it (codex). These values are
+    // ours, so they are redacted by identity, not by shape.
+    const token = "sk-live-abcdefghijklmnop";
+    const url = `https://civitai.com/api/download/models/1?token=${token}`;
+    const b = await readErrorBody({ text: async () => `{"error":"bad token ${token}"}` }, url);
+    expect(b).not.toContain(token);
+  });
+
+  it("…and in percent-encoded form", async () => {
+    const value = "abc/def+ghi=jkl mno";
+    const url = `https://civitai.com/api/download/models/1?sig=${encodeURIComponent(value)}`;
+    const b = await readErrorBody(
+      { text: async () => `{"echo":"${encodeURIComponent(value)}"}` },
+      url,
+    );
+    expect(b).not.toContain(encodeURIComponent(value));
+  });
+
+  it("does NOT redact short query values — type=UNet is the diagnosis, not a secret", async () => {
+    const url = "https://civitai.com/api/download/models/1?type=UNet&format=SafeTensor";
+    const b = await readErrorBody({ text: async () => '{"error":"no file for type UNet"}' }, url);
+    expect(b).toContain("UNet");
+  });
+
+  it("STOPS READING at the byte cap — the output bound is not a read bound", async () => {
+    // res.text() drains the whole response first, so a huge or never-ending error
+    // body could hang the download while we improved its message (codex).
+    let delivered = 0;
+    const reader = {
+      read: async () => {
+        delivered += 1024;
+        return { done: false, value: new Uint8Array(1024).fill(65) };
+      },
+      cancel: async () => undefined,
+    };
+    const b = await readErrorBody({ body: { getReader: () => reader } });
+    expect(delivered, "must stop near the cap, not read forever").toBeLessThanOrEqual(16 * 1024);
+    expect(b.length).toBeLessThanOrEqual(401);
+  });
+
+  it("cancels the stream it stopped reading", async () => {
+    let cancelled = false;
+    const reader = {
+      read: async () => ({ done: false, value: new Uint8Array(4096).fill(66) }),
+      cancel: async () => {
+        cancelled = true;
+      },
+    };
+    await readErrorBody({ body: { getReader: () => reader } });
+    expect(cancelled, "a body nobody will read must not be left draining").toBe(true);
+  });
 });
 
 // The wiring: the failure path must actually call both, or none of the above
@@ -154,7 +237,8 @@ describe("WIRING: the download failure path uses them (#1300)", () => {
     const at = src.indexOf("if (!res.ok) {");
     expect(at, "the failure branch moved").toBeGreaterThan(-1);
     const branch = src.slice(at, at + 1200);
-    expect(branch).toContain("await readErrorBody(res)");
+    // The request URL is passed so a reflected query credential is redacted.
+    expect(branch).toContain("await readErrorBody(res, currentUrl)");
     expect(branch).toContain("downloadFailureHint({");
     expect(branch).toContain("hasCivitaiToken: Boolean(config.civitaiApiToken)");
     // The status is still reported — the body and hint are additions, not a

--- a/src/__tests__/services/download-failure-hint.test.ts
+++ b/src/__tests__/services/download-failure-hint.test.ts
@@ -1,0 +1,175 @@
+// #1300 — one file took four attempts, because the failure said only
+// `Download failed: 404 `.
+//
+// What the reporter had to do by hand, because the tool would not say it:
+//
+//   1. download with the metadata-query URL   -> bare 404
+//   2. re-read the CivitAI API, retry canonical downloadUrl -> bare 404
+//   3. curl the same URL by hand              -> 401, no token configured
+//   4. set a token, retry                     -> STILL 404 (genuine; URL form)
+//   5. switch to ?fileId=…                    -> 206, downloads
+//
+// Two defects, and the first is why the second was never reached: the response
+// body was discarded, and the CivitAI token hint was gated on 401/403 while the
+// server answered 404.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  downloadFailureHint,
+  readErrorBody,
+} from "../../services/download-failure-hint.js";
+
+const CIVITAI = "https://civitai.com/api/download/models/3155593";
+const METADATA_URL = `${CIVITAI}?type=UNet&format=SafeTensor&fp=int8`;
+const FILEID_URL = `${CIVITAI}?fileId=3036509`;
+
+describe("the CivitAI hint fires on the status the reporter actually got (#1300)", () => {
+  it("names the missing token on a 404 — the case that was silent", () => {
+    // The whole defect in one assertion. The old hint required 401/403; CivitAI
+    // answered 404, so the message that solves this never appeared.
+    const hint = downloadFailureHint({ status: 404, url: METADATA_URL, hasCivitaiToken: false });
+    expect(hint).toMatch(/no CIVITAI_API_TOKEN is configured/);
+    expect(hint).toMatch(/civitai\.com\/user\/account/);
+  });
+
+  it("still fires on 401 and 403", () => {
+    for (const status of [401, 403]) {
+      expect(
+        downloadFailureHint({ status, url: CIVITAI, hasCivitaiToken: false }),
+        `status ${status}`,
+      ).toMatch(/no CIVITAI_API_TOKEN is configured/);
+    }
+  });
+
+  it("does NOT send you back to auth when a token IS set — the reporter's attempt 4", () => {
+    const hint = downloadFailureHint({ status: 404, url: METADATA_URL, hasCivitaiToken: true });
+    expect(hint).toMatch(/IS configured, so this is probably not an auth failure/);
+    expect(hint).not.toMatch(/Set it in panel Settings/);
+  });
+
+  it("with a token, a METADATA-query url gets the fileId remedy they found", () => {
+    // Established by their curl, not inferred: `?type=…&format=…&fp=…` 404s even
+    // with a valid token when a version publishes several files.
+    const hint = downloadFailureHint({ status: 404, url: METADATA_URL, hasCivitaiToken: true });
+    expect(hint).toMatch(/selects a file by METADATA/);
+    expect(hint).toMatch(/\?fileId=<fileId>/);
+  });
+
+  it("with a token, a fileId url does NOT get that remedy — it is already the fix", () => {
+    const hint = downloadFailureHint({ status: 404, url: FILEID_URL, hasCivitaiToken: true });
+    expect(hint).not.toMatch(/selects a file by METADATA/);
+  });
+
+  it("says nothing about CivitAI for other hosts", () => {
+    for (const url of [
+      "https://huggingface.co/x/resolve/main/model.safetensors",
+      "https://example.com/model.safetensors",
+      // Not a civitai.com host, however it is spelled.
+      "https://civitai.com.evil.example/api/download/models/1",
+    ]) {
+      expect(downloadFailureHint({ status: 404, url, hasCivitaiToken: false }), url).toBe("");
+    }
+  });
+
+  it("subdomains of civitai.com still count", () => {
+    expect(
+      downloadFailureHint({
+        status: 404,
+        url: "https://cdn.civitai.com/api/download/models/1",
+        hasCivitaiToken: false,
+      }),
+    ).toMatch(/no CIVITAI_API_TOKEN/);
+  });
+
+  it("an unparseable url earns no host-specific advice, and does not throw", () => {
+    expect(() =>
+      downloadFailureHint({ status: 404, url: "not a url", hasCivitaiToken: false }),
+    ).not.toThrow();
+    expect(downloadFailureHint({ status: 404, url: "not a url", hasCivitaiToken: false })).toBe("");
+  });
+});
+
+describe("the server's own explanation is carried back (#1300)", () => {
+  it("quotes the body, which is what distinguishes 401-needs-token from a real 404", async () => {
+    const b = await readErrorBody({ text: async () => '{"error":"Unauthorized"}' });
+    expect(b).toContain("Unauthorized");
+  });
+
+  it("collapses whitespace so a multi-line body stays one readable line", async () => {
+    const b = await readErrorBody({ text: async () => "line one\n\n   line two\t" });
+    expect(b).toBe("line one line two");
+  });
+
+  it("is BOUNDED — an error path must not be fed an unbounded body", async () => {
+    // Realistic prose, not one long run: a single opaque 5000-char run is
+    // REDACTED by the scrubber before the bound is reached, which would have made
+    // this pass without the truncation ever running.
+    const long = "the server rejected this request because ".repeat(200);
+    const b = await readErrorBody({ text: async () => long });
+    expect(b.length).toBeLessThanOrEqual(401);
+    expect(b.endsWith("…")).toBe(true);
+  });
+
+  it("a long opaque run is REDACTED rather than truncated — order matters", async () => {
+    // Scrub-then-bound, not bound-then-scrub: truncating first could cut a secret
+    // in half and leave the first 400 characters of it in the message.
+    const b = await readErrorBody({ text: async () => "x".repeat(5000) });
+    expect(b).not.toContain("x".repeat(64));
+  });
+
+  it("SCRUBS — an auth challenge is exactly what echoes a credential back", async () => {
+    // A token-shaped run must not survive into a tool result or the logs.
+    const secretish = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH";
+    const b = await readErrorBody({ text: async () => `{"error":"bad token ${secretish}"}` });
+    expect(b).not.toContain(secretish);
+  });
+
+  it("never throws, whatever the response does", async () => {
+    expect(await readErrorBody({})).toBe("");
+    expect(
+      await readErrorBody({
+        text: async () => {
+          throw new Error("socket closed");
+        },
+      }),
+    ).toBe("");
+    expect(await readErrorBody({ text: async () => "   " })).toBe("");
+  });
+
+  it("does not invent a body when there is none", async () => {
+    expect(await readErrorBody({ text: async () => "" })).toBe("");
+  });
+});
+
+// The wiring: the failure path must actually call both, or none of the above
+// reaches a caller.
+describe("WIRING: the download failure path uses them (#1300)", () => {
+  it("reads the body and appends the hint", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(
+      new URL("../../services/download-cache.ts", import.meta.url),
+      "utf-8",
+    );
+    const at = src.indexOf("if (!res.ok) {");
+    expect(at, "the failure branch moved").toBeGreaterThan(-1);
+    const branch = src.slice(at, at + 1200);
+    expect(branch).toContain("await readErrorBody(res)");
+    expect(branch).toContain("downloadFailureHint({");
+    expect(branch).toContain("hasCivitaiToken: Boolean(config.civitaiApiToken)");
+    // The status is still reported — the body and hint are additions, not a
+    // replacement for the fact the caller already had.
+    expect(branch).toMatch(/Download failed: \$\{res\.status\}/);
+  });
+
+  it("does not log the token itself anywhere in the hint module", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(
+      new URL("../../services/download-failure-hint.ts", import.meta.url),
+      "utf-8",
+    );
+    // Only PRESENCE may cross this boundary, never the value.
+    expect(src).not.toMatch(/civitaiApiToken\s*\)/);
+    expect(src).toContain("hasCivitaiToken");
+  });
+});

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -1717,7 +1717,7 @@ async function streamUrlToFile(
     // with a body explaining itself and we threw it away, so a missing-token
     // failure and a wrong-URL failure were the same sentence. Read a bounded,
     // scrubbed slice of it: it is the only thing that distinguishes them.
-    const body = await readErrorBody(res);
+    const body = await readErrorBody(res, currentUrl);
     const hint = downloadFailureHint({
       status: res.status,
       url: currentUrl,

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -18,6 +18,8 @@ import { basename, dirname, extname, join, resolve } from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { ModelError, describeFetchFailure } from "../utils/errors.js";
+import { config } from "../config.js";
+import { downloadFailureHint, readErrorBody } from "./download-failure-hint.js";
 import { logger } from "../utils/logger.js";
 import { redactUrlForLogs } from "./download-auth.js";
 import { reportDownloadProgress, type DownloadProgress } from "./download-progress.js";
@@ -1711,15 +1713,18 @@ async function streamUrlToFile(
   }
 
   if (!res.ok) {
-    // Civitai requires an account token for ALL downloads (401 keyless, 403
-    // for gated/early-access) — a raw status code leaves agents flailing
-    // through retries (live E2E), so name the fix.
-    const civitaiAuthHint =
-      (res.status === 401 || res.status === 403) && /(^|\.)civitai\.com$/i.test(new URL(currentUrl).hostname)
-        ? " — CivitAI requires an API token for downloads. Set CIVITAI_API_TOKEN (panel Settings › “Set CivitAI token…”, or the env var; create one at civitai.com/user/account) and retry. Do NOT retry other model ids — they will all fail the same way until a token is set."
-        : "";
+    // #1300 — A BARE STATUS CODE COST A REPORTER FOUR ATTEMPTS. The host answers
+    // with a body explaining itself and we threw it away, so a missing-token
+    // failure and a wrong-URL failure were the same sentence. Read a bounded,
+    // scrubbed slice of it: it is the only thing that distinguishes them.
+    const body = await readErrorBody(res);
+    const hint = downloadFailureHint({
+      status: res.status,
+      url: currentUrl,
+      hasCivitaiToken: Boolean(config.civitaiApiToken),
+    });
     throw new ModelError(
-      `Download failed: ${res.status} ${res.statusText}${civitaiAuthHint}`,
+      `Download failed: ${res.status} ${res.statusText}${body ? ` — the server said: ${body}` : ""}${hint}`,
       { url: currentUrl === url ? logUrl : redactUrlForLogs(currentUrl), status: res.status },
     );
   }

--- a/src/services/download-failure-hint.ts
+++ b/src/services/download-failure-hint.ts
@@ -1,0 +1,93 @@
+// #1300 — a bare status code cost a reporter four attempts.
+//
+// `download_model action:"download"` reported `Download failed: 404 ` and nothing
+// else. The host had explained itself in the response body, and we discarded it;
+// the CivitAI token hint existed but was gated on 401/403, and CivitAI answered
+// the unauthenticated request with 404 (curl saw 401 for the same URL). So a
+// missing-token failure and a wrong-URL failure arrived as the same sentence,
+// and the one message that would have solved it on attempt one stayed silent.
+//
+// Both halves live here so the branches are testable without a network.
+
+import { scrubSecretShapedText } from "../comfyui/json-guard.js";
+
+/** Longest error body we will quote back. */
+const MAX_BODY_CHARS = 400;
+
+/**
+ * The server's own explanation, bounded and safe to show.
+ *
+ * BOUNDED because this is an error path fed by a remote host: an unbounded read
+ * during a failure is a second failure waiting to happen.
+ *
+ * SCRUBBED because an auth challenge is exactly the kind of body that echoes a
+ * credential back, and this string lands in a tool result and the logs. The
+ * scrubber already knows every credential this process is configured with,
+ * including the CivitAI token.
+ *
+ * NEVER THROWS: a diagnostic that fails must not replace the status we already
+ * have with an error about the diagnostic.
+ */
+export async function readErrorBody(res: { text?: () => Promise<string> }): Promise<string> {
+  try {
+    if (typeof res.text !== "function") return "";
+    const raw = await res.text();
+    if (typeof raw !== "string" || !raw.trim()) return "";
+    const scrubbed = (scrubSecretShapedText(raw) ?? raw).replace(/\s+/g, " ").trim();
+    if (!scrubbed) return "";
+    return scrubbed.length > MAX_BODY_CHARS ? `${scrubbed.slice(0, MAX_BODY_CHARS)}…` : scrubbed;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * What to DO about it, keyed on the two facts that decide the answer: the host,
+ * and whether a token is configured.
+ *
+ * WHY NOT GATE ON THE STATUS. The hint this replaces fired only on 401/403, and
+ * the reporter got a 404 — so it never appeared. CivitAI requires a token for
+ * EVERY model download, which makes "no token is configured" worth saying on any
+ * failing status from that host. Note what that sentence is: a statement about
+ * OUR configuration, which we know for certain, not a claim about what the
+ * server meant by its status, which we do not.
+ *
+ * WHEN A TOKEN IS SET, do not send the reader back to auth — that was the
+ * reporter's fourth attempt. Their residual 404 was a URL-FORM problem, and they
+ * established the remedy by hand: a metadata-query downloadUrl
+ * (`?type=…&format=…&fp=…`) 404s even with a valid token when a version
+ * publishes several files, while `?fileId=…` downloads. That is quoted because
+ * they measured it, not inferred from a status.
+ */
+export function downloadFailureHint(opts: {
+  status: number;
+  url: string;
+  hasCivitaiToken: boolean;
+}): string {
+  let host = "";
+  try {
+    host = new URL(opts.url).hostname;
+  } catch {
+    return ""; // an unparseable url earns no host-specific advice
+  }
+  if (!/(^|\.)civitai\.com$/i.test(host)) return "";
+
+  if (!opts.hasCivitaiToken) {
+    return (
+      " — NOTE: no CIVITAI_API_TOKEN is configured, and CivitAI requires a token for ALL model " +
+      "downloads, so that is the most likely cause whatever status came back (an unauthenticated " +
+      "download answers 401 or 404 depending on the URL form). Set it in panel Settings › " +
+      "“Set CivitAI token…”, or the env var; create one at civitai.com/user/account. Do NOT retry " +
+      "other model ids first — they will fail the same way until a token is set."
+    );
+  }
+
+  const isMetadataQuery = /[?&](type|format|fp|size)=/i.test(opts.url);
+  const fileIdTip = isMetadataQuery
+    ? " This URL selects a file by METADATA (type/format/fp). CivitAI's own API returns that form, " +
+      "but it can 404 even with a valid token when a version publishes several files — address the " +
+      "file directly instead: https://civitai.com/api/download/models/<versionId>?fileId=<fileId>, " +
+      "taking fileId from that version's `files[]` in the CivitAI API."
+    : "";
+  return ` — a CIVITAI_API_TOKEN IS configured, so this is probably not an auth failure.${fileIdTip}`;
+}

--- a/src/services/download-failure-hint.ts
+++ b/src/services/download-failure-hint.ts
@@ -13,27 +13,96 @@ import { scrubSecretShapedText } from "../comfyui/json-guard.js";
 
 /** Longest error body we will quote back. */
 const MAX_BODY_CHARS = 400;
+/** Bytes we are willing to READ before giving up on the explanation. The output
+ *  cap alone is not a bound: `res.text()` drains the whole response first, so a
+ *  huge or never-ending error body could hang the download or exhaust memory
+ *  while we were busy improving its error message (codex). */
+const MAX_BODY_BYTES = 8 * 1024;
+/** And a clock, because a body can stall without ending. */
+const BODY_READ_TIMEOUT_MS = 3_000;
+
+interface ErrorBodySource {
+  text?: () => Promise<string>;
+  body?: {
+    getReader?: () => {
+      read: () => Promise<{ done: boolean; value?: Uint8Array }>;
+      cancel?: () => Promise<unknown> | unknown;
+    };
+  } | null;
+}
+
+/** Read at most MAX_BODY_BYTES from the stream, then STOP — and cancel, so the
+ *  socket is not left draining a body nobody is going to read. */
+async function readCapped(source: ErrorBodySource): Promise<string> {
+  const reader = source.body?.getReader?.();
+  if (!reader) {
+    if (typeof source.text !== "function") return "";
+    // No stream to cap; bound the wait instead, and let the body be collected.
+    return await Promise.race([
+      source.text(),
+      new Promise<string>((resolve) => setTimeout(() => resolve(""), BODY_READ_TIMEOUT_MS)),
+    ]);
+  }
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const deadline = Date.now() + BODY_READ_TIMEOUT_MS;
+  try {
+    for (;;) {
+      if (Date.now() > deadline) break;
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value?.length) {
+        chunks.push(value);
+        total += value.length;
+        if (total >= MAX_BODY_BYTES) break;
+      }
+    }
+  } finally {
+    try {
+      await reader.cancel?.();
+    } catch {
+      /* the response is already an error; cancelling is best effort */
+    }
+  }
+  if (!chunks.length) return "";
+  const joined = new Uint8Array(total);
+  let at = 0;
+  for (const c of chunks) {
+    joined.set(c.subarray(0, Math.min(c.length, total - at)), at);
+    at += c.length;
+    if (at >= total) break;
+  }
+  return new TextDecoder().decode(joined.subarray(0, Math.min(at, MAX_BODY_BYTES)));
+}
 
 /**
  * The server's own explanation, bounded and safe to show.
  *
- * BOUNDED because this is an error path fed by a remote host: an unbounded read
- * during a failure is a second failure waiting to happen.
- *
  * SCRUBBED because an auth challenge is exactly the kind of body that echoes a
- * credential back, and this string lands in a tool result and the logs. The
- * scrubber already knows every credential this process is configured with,
- * including the CivitAI token.
+ * credential back, and this string lands in a tool result and the logs. Two
+ * passes, because they catch different things:
+ *
+ *  1. the shared scrubber — every credential this process is configured with,
+ *     plus any opaque run long enough to be one;
+ *  2. the REQUEST URL's own query values (codex). A signed or pre-authenticated
+ *     download URL carries its credential in the query string, and a host that
+ *     reflects the request back would otherwise republish it. Those values are
+ *     ours and we know them exactly, so they are redacted by identity rather
+ *     than by shape.
+ *
+ * SCRUB THEN BOUND, in that order: truncating first could cut a secret in half
+ * and leave 400 characters of it in the message.
  *
  * NEVER THROWS: a diagnostic that fails must not replace the status we already
  * have with an error about the diagnostic.
  */
-export async function readErrorBody(res: { text?: () => Promise<string> }): Promise<string> {
+export async function readErrorBody(source: ErrorBodySource, requestUrl?: string): Promise<string> {
   try {
-    if (typeof res.text !== "function") return "";
-    const raw = await res.text();
+    const raw = await readCapped(source);
     if (typeof raw !== "string" || !raw.trim()) return "";
-    const scrubbed = (scrubSecretShapedText(raw) ?? raw).replace(/\s+/g, " ").trim();
+    let out = scrubSecretShapedText(raw) ?? raw;
+    out = redactUrlQueryValues(out, requestUrl);
+    const scrubbed = out.replace(/\s+/g, " ").trim();
     if (!scrubbed) return "";
     return scrubbed.length > MAX_BODY_CHARS ? `${scrubbed.slice(0, MAX_BODY_CHARS)}…` : scrubbed;
   } catch {
@@ -41,23 +110,44 @@ export async function readErrorBody(res: { text?: () => Promise<string> }): Prom
   }
 }
 
+/** Redact any query VALUE from our own request URL that the body echoed back, in
+ *  raw and percent-encoded form. Short values are skipped: `type=UNet` is not a
+ *  secret, and redacting it would destroy the diagnosis this exists to give. */
+function redactUrlQueryValues(text: string, requestUrl?: string): string {
+  if (!requestUrl) return text;
+  let out = text;
+  try {
+    const url = new URL(requestUrl);
+    for (const value of url.searchParams.values()) {
+      if (!value || value.length < 12) continue;
+      for (const form of new Set([value, encodeURIComponent(value)])) {
+        out = out.split(form).join("«redacted»");
+      }
+    }
+  } catch {
+    /* an unparseable url contributes no known values */
+  }
+  return out;
+}
+
 /**
- * What to DO about it, keyed on the two facts that decide the answer: the host,
- * and whether a token is configured.
+ * What to DO about it, keyed on the facts that decide the answer: the host,
+ * whether a token is configured, and — where it is genuinely informative — the
+ * status.
  *
- * WHY NOT GATE ON THE STATUS. The hint this replaces fired only on 401/403, and
- * the reporter got a 404 — so it never appeared. CivitAI requires a token for
- * EVERY model download, which makes "no token is configured" worth saying on any
- * failing status from that host. Note what that sentence is: a statement about
- * OUR configuration, which we know for certain, not a claim about what the
- * server meant by its status, which we do not.
+ * WHY NOT GATE THE NO-TOKEN CASE ON THE STATUS. The hint this replaces fired only
+ * on 401/403, and the reporter got a 404 — so it never appeared. CivitAI requires
+ * a token for EVERY model download, which makes "no token is configured" worth
+ * saying on any failing status from that host. Note what that sentence is: a
+ * statement about OUR configuration, which we know for certain, not a claim about
+ * what the server meant by its status, which we do not.
  *
- * WHEN A TOKEN IS SET, do not send the reader back to auth — that was the
- * reporter's fourth attempt. Their residual 404 was a URL-FORM problem, and they
- * established the remedy by hand: a metadata-query downloadUrl
- * (`?type=…&format=…&fp=…`) 404s even with a valid token when a version
- * publishes several files, while `?fileId=…` downloads. That is quoted because
- * they measured it, not inferred from a status.
+ * WHEN A TOKEN IS SET the status matters, and ignoring it was its own wrong
+ * answer (codex): a 401/403 with a token configured is precisely the signal for
+ * an INVALID, expired or insufficient one, and telling that caller "probably not
+ * an auth failure" would send them off exactly as the original bug did, one
+ * layer along. Only a 404 gets the URL-form remedy — the case the reporter
+ * actually established.
  */
 export function downloadFailureHint(opts: {
   status: number;
@@ -66,7 +156,9 @@ export function downloadFailureHint(opts: {
 }): string {
   let host = "";
   try {
-    host = new URL(opts.url).hostname;
+    // A trailing dot is a legitimate spelling of the same FQDN (codex); strip it
+    // for the comparison only.
+    host = new URL(opts.url).hostname.replace(/\.$/, "");
   } catch {
     return ""; // an unparseable url earns no host-specific advice
   }
@@ -82,12 +174,23 @@ export function downloadFailureHint(opts: {
     );
   }
 
+  if (opts.status === 401 || opts.status === 403) {
+    return (
+      " — a CIVITAI_API_TOKEN is configured, and this status is what CivitAI returns for a token " +
+      "that is INVALID, expired, or lacks access to this model (early-access and gated models " +
+      "need entitlement, not just any token). Re-create the token at civitai.com/user/account and " +
+      "set it again, and check whether this model requires purchase or early-access on its page."
+    );
+  }
+
   const isMetadataQuery = /[?&](type|format|fp|size)=/i.test(opts.url);
-  const fileIdTip = isMetadataQuery
-    ? " This URL selects a file by METADATA (type/format/fp). CivitAI's own API returns that form, " +
-      "but it can 404 even with a valid token when a version publishes several files — address the " +
-      "file directly instead: https://civitai.com/api/download/models/<versionId>?fileId=<fileId>, " +
-      "taking fileId from that version's `files[]` in the CivitAI API."
-    : "";
+  const fileIdTip =
+    opts.status === 404 && isMetadataQuery
+      ? " This URL selects a file by METADATA (type/format/fp). CivitAI's own API returns that " +
+        "form, but it can 404 even with a valid token when a version publishes several files — " +
+        "address the file directly instead: " +
+        "https://civitai.com/api/download/models/<versionId>?fileId=<fileId>, taking fileId from " +
+        "that version's `files[]` in the CivitAI API."
+      : "";
   return ` — a CIVITAI_API_TOKEN IS configured, so this is probably not an auth failure.${fileIdTip}`;
 }


### PR DESCRIPTION
Draft — claiming #1300.

The reporter needed **four attempts** to download one file, because `download_model action:"download"` says only `Download failed: 404`.

Two things are wrong, and the first explains why the second was never reached:

1. **The response body is thrown away.** CivitAI answers with a JSON error explaining the problem; the tool reports the status code alone. A 401-needs-token and a genuine 404 are indistinguishable.
2. **The auth hint exists but did not fire.** There IS a CivitAI token hint — gated on `401 || 403`. The reporter got a **404** (curl showed 401 for the same URL unauthenticated), so the one message that would have solved it on attempt one stayed silent.

I will also record what they established about URL forms — a metadata-query `downloadUrl` (`?type=UNet&format=SafeTensor&fp=int8`) 404s even WITH a valid token, while `?fileId=…` works — since that is the actual remedy for the residual 404 and it came from their curl, not from a guess.

Nothing here logs a token value; only whether one is configured.