### PR TITLE
chore(release): 0.50.86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,14 +23,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [0.50.86] - 2026-08-09
 
+> Covers changes since 0.50.85.
+
 ### MCP
 
 #### Fixed
-- say why a CivitAI download failed, instead of a bare status (#1303)
 
-#### Changed
-- 0.50.85 (#1302)
-
+- **A failed model download now says WHY (#1300).** `download_model` reported
+  `Download failed: 404 ` and nothing else, so a missing CivitAI token and a genuinely
+  wrong URL were the same sentence — one reporter needed four attempts to download a
+  single file. The server's own explanation is now carried back (bounded and scrubbed),
+  and for CivitAI the message names the actual cause: no token configured, a token that
+  is invalid or unentitled, or a metadata-query URL that needs the `?fileId=` form.
 
 ## [0.50.85] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.86] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- say why a CivitAI download failed, instead of a bare status (#1303)
+
+#### Changed
+- 0.50.85 (#1302)
+
+
 ## [0.50.85] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.85",
+  "version": "0.50.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.85",
+      "version": "0.50.86",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.85",
+  "version": "0.50.86",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the version bump and changelog for the v0.50.86 tag (protected main).

Contains #1300 — a failed model download now carries the server's own explanation and, for CivitAI, names the actual cause instead of a bare status code.