### PR TITLE
fix(ui-bridge): give an interactive card a disconnect remedy that applies to it

### DIFF
--- a/src/__tests__/services/mid-command-remedy.test.ts
+++ b/src/__tests__/services/mid-command-remedy.test.ts
@@ -35,17 +35,44 @@ describe("the disconnect remedy fits what was interrupted (#952)", () => {
   it("…and says the thing that is actually true of it", () => {
     const msg = midCommandDisconnectMessage(ASK);
     expect(msg).toMatch(/card may already be on screen/);
-    // The fact from the panel trace: a retry is not merely unverifiable, it is
-    // known to duplicate after a reconnect.
-    expect(msg).toMatch(/paints a SECOND card/);
-    expect(msg).toMatch(/cannot be withdrawn/);
+    // The fact from the panel trace: a retry is not merely unverifiable, it
+    // duplicates after a reconnect because suppression is keyed to the dead
+    // socket. Stated as the consequence the user sees.
+    expect(msg).toMatch(/retry\s+suppression is keyed to the socket that dropped/);
+    expect(msg).toMatch(/user may see two/);
   });
 
-  it("names what the caller CAN do, since it forbids the obvious move", () => {
+  it("does NOT promise the answer will arrive — it will not (codex)", () => {
+    // An earlier draft said "if the user answers the card already up, the answer
+    // still arrives". Checked against the panel: `redactSensitiveReply` replaces
+    // an ask_user/request_secret reply that cannot cross the dropped connection
+    // with a payload-free failure, deliberately, and tells the caller to ask
+    // again on the current connection. Waiting is not a recovery, and advising it
+    // would have parked the agent forever.
+    const msg = midCommandDisconnectMessage(ASK);
+    expect(msg).toMatch(/will NOT reach you/);
+    expect(msg).not.toMatch(/Prefer to wait/);
+    expect(msg).not.toMatch(/still arrives/);
+  });
+
+  it("names a route that works, since it forbids the obvious move", () => {
     // A refusal with no alternative is how an agent ends up retrying anyway.
     const msg = midCommandDisconnectMessage(ASK);
-    expect(msg).toMatch(/Prefer to wait/);
-    expect(msg).toMatch(/ask the question directly in conversation/);
+    expect(msg).toMatch(/Re-issue the question on the current connection/);
+    expect(msg).toMatch(/ask it in conversation/);
+    // …and warns about the consequence the panel trace established.
+    expect(msg).toMatch(/user may see two/);
+  });
+
+  it("a SECRET is never routed through the conversation (codex)", () => {
+    // The card exists so the value reaches the panel through a masked input,
+    // unseen by the agent and unrecorded in chat. "Just ask them for it" would
+    // defeat exactly that, and this message is read by an agent that will act
+    // on it.
+    const msg = midCommandDisconnectMessage({ short: "wf:1", cmd: "request_secret" });
+    expect(msg).toMatch(/Re-issue panel_request_secret on the current connection/);
+    expect(msg).toMatch(/never ask the user to paste a secret into the conversation/);
+    expect(msg).not.toMatch(/ask it in conversation/);
   });
 
   it("does NOT invent a recovery that does not exist", () => {
@@ -62,6 +89,18 @@ describe("the disconnect remedy fits what was interrupted (#952)", () => {
     expect(midCommandDisconnectMessage({ short: "wf:1", cmd: "request_secret" })).toMatch(
       /card may already be on screen/,
     );
+  });
+
+  it("the two interactive commands differ ONLY in the route they are given", () => {
+    // Same facts, different safe action. If these ever collapse to one string,
+    // one of them is being given the other's advice.
+    const ask = midCommandDisconnectMessage(ASK);
+    const secret = midCommandDisconnectMessage({ short: ASK.short, cmd: "request_secret" });
+    expect(ask).not.toBe(secret);
+    for (const m of [ask, secret]) {
+      expect(m).toMatch(/will NOT reach you/);
+      expect(m).toMatch(/user may see two/);
+    }
   });
 
   it("every OTHER command keeps the queue/output check — it is real evidence there", () => {

--- a/src/__tests__/services/mid-command-remedy.test.ts
+++ b/src/__tests__/services/mid-command-remedy.test.ts
@@ -1,0 +1,111 @@
+// #952 (panel) — an interactive question card was told to go and check the
+// render queue.
+//
+// `panel_ask` was interrupted by a tab disconnect and the OUTCOME UNKNOWN error
+// ended with the only remedy this path had: check `queue action:"list"` /
+// `get_image (action:"list_outputs")`. Neither can observe whether a question is
+// on a human's screen. The reporter said so plainly, and they were right.
+//
+// The panel-side trace on that issue supplies the fact that makes this more than
+// wording: for THIS trigger a blind retry really does duplicate the card. The
+// dedupe ledger is keyed by the socket's bridge epoch; a reconnect mints a new
+// one; the retry lands in a different scope, `lookupRetry` misses, and it fails
+// open and re-executes. Failing open is correct for a read or an idempotent
+// write. For a question it means a second card in front of a person, and there
+// is no way to withdraw the first.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  isInteractiveCommand,
+  midCommandDisconnectMessage,
+  midCommandVerifyClause,
+} from "../../services/mid-command-remedy.js";
+
+const ASK = { short: "wf:728f6", cmd: "ask_user" };
+const RUN = { short: "wf:728f6", cmd: "graph_run" };
+
+describe("the disconnect remedy fits what was interrupted (#952)", () => {
+  it("an ask card is NOT sent to the render queue — the reporter's complaint", () => {
+    const msg = midCommandDisconnectMessage(ASK);
+    expect(msg).not.toMatch(/queue action:"list"/);
+    expect(msg).not.toMatch(/list_outputs/);
+  });
+
+  it("…and says the thing that is actually true of it", () => {
+    const msg = midCommandDisconnectMessage(ASK);
+    expect(msg).toMatch(/card may already be on screen/);
+    // The fact from the panel trace: a retry is not merely unverifiable, it is
+    // known to duplicate after a reconnect.
+    expect(msg).toMatch(/paints a SECOND card/);
+    expect(msg).toMatch(/cannot be withdrawn/);
+  });
+
+  it("names what the caller CAN do, since it forbids the obvious move", () => {
+    // A refusal with no alternative is how an agent ends up retrying anyway.
+    const msg = midCommandDisconnectMessage(ASK);
+    expect(msg).toMatch(/Prefer to wait/);
+    expect(msg).toMatch(/ask the question directly in conversation/);
+  });
+
+  it("does NOT invent a recovery that does not exist", () => {
+    // There is no pending-card query, and `retry_of` does not survive the
+    // reconnect this message is about. Both are open design questions on the
+    // issue; promising either would send the caller to something that fails.
+    const msg = midCommandDisconnectMessage(ASK);
+    expect(msg).toMatch(/there is no pending-card query/);
+    expect(msg).not.toMatch(/retry_of/);
+  });
+
+  it("request_secret is interactive too — same human, same duplicate", () => {
+    expect(isInteractiveCommand("request_secret")).toBe(true);
+    expect(midCommandDisconnectMessage({ short: "wf:1", cmd: "request_secret" })).toMatch(
+      /card may already be on screen/,
+    );
+  });
+
+  it("every OTHER command keeps the queue/output check — it is real evidence there", () => {
+    const msg = midCommandDisconnectMessage(RUN);
+    expect(msg).toMatch(/queue action:"list"/);
+    expect(msg).toMatch(/list_outputs/);
+    expect(msg).toMatch(/ComfyUI may already be rendering/);
+    expect(msg).not.toMatch(/card may already be on screen/);
+  });
+
+  it("still reports OUTCOME UNKNOWN and the tab, whichever branch it takes", () => {
+    // The parts callers and the existing detectors key on must not move: several
+    // call sites match /disconnected mid-command|OUTCOME UNKNOWN/.
+    for (const ctx of [ASK, RUN]) {
+      const msg = midCommandDisconnectMessage(ctx);
+      expect(msg, ctx.cmd).toMatch(/disconnected mid-command \("/);
+      expect(msg).toMatch(/OUTCOME UNKNOWN/);
+      expect(msg).toContain(ctx.short);
+      expect(msg).toContain(ctx.cmd);
+    }
+  });
+
+  it("an unknown or malformed command is treated as NON-interactive", () => {
+    // Fail toward the existing behaviour: the queue/output advice is merely
+    // unhelpful for something else, while claiming "a card may be on screen"
+    // about a write would be false.
+    for (const cmd of ["", "   ", "graph_add_node", "ask_user_extra"]) {
+      expect(isInteractiveCommand(cmd), cmd).toBe(false);
+    }
+    expect(midCommandVerifyClause("graph_add_node")).toMatch(/queue action:"list"/);
+  });
+});
+
+describe("WIRING: the bridge uses it (#952)", () => {
+  it("the mid-command disconnect path builds its message here", async () => {
+    // The helper is worthless if the bridge keeps its own hardcoded string, and
+    // the branch is inside a long method that no unit test constructs.
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(new URL("../../services/ui-bridge.ts", import.meta.url), "utf-8");
+    expect(src).toContain('import { midCommandDisconnectMessage } from "./mid-command-remedy.js"');
+    expect(src).toContain("midCommandDisconnectMessage({ short, cmd })");
+    // …and the old hardcoded remedy is gone from the mutating branch.
+    expect(src).not.toMatch(
+      /OUTCOME UNKNOWN: the command was already sent, so the panel may have applied it/,
+    );
+  });
+});

--- a/src/services/mid-command-remedy.ts
+++ b/src/services/mid-command-remedy.ts
@@ -1,0 +1,75 @@
+// #952 (panel) — an interactive question card was told to go and check the
+// render queue.
+//
+// `panel_ask` was interrupted by a tab disconnect, and the OUTCOME UNKNOWN error
+// ended with the only remedy this path has ever offered:
+//
+//   Verify before retrying (e.g. check queue action:"list" /
+//   get_image (action:"list_outputs")) instead of re-issuing it blindly.
+//
+// The reporter's objection is exact: "The suggested verification examples concern
+// render queues/media and do not apply to an ask card." Neither of those tools
+// can tell you whether a question is currently on a human's screen.
+//
+// WHY THIS IS NOT COSMETIC. The panel-side trace on that issue established that
+// for THIS trigger a blind retry really does duplicate the card: the dedupe
+// ledger is keyed by the socket's bridge epoch, a reconnect mints a new one, so
+// the retry lands in a different scope, `lookupRetry` misses, and it fails open
+// and re-executes. Failing open is right for a read or an idempotent write —
+// re-running one is cheaper than refusing. It is wrong for a question, because
+// the cost is a second card in front of a person and there is no way to withdraw
+// the first.
+//
+// So the remedy has to say what actually applies. What it must NOT do is invent
+// a recovery: there is no pending-card query today, and `retry_of` does not help
+// across a reconnect for the reason above. Both of those are open design
+// questions on the issue and this does not pre-empt them.
+
+/** Panel commands that put something in front of a HUMAN and wait. */
+const INTERACTIVE_COMMANDS = new Set(["ask_user", "request_secret"]);
+
+export function isInteractiveCommand(cmd: string): boolean {
+  return INTERACTIVE_COMMANDS.has(String(cmd ?? "").trim());
+}
+
+/**
+ * The "verify before retrying" clause, chosen by what the command actually did.
+ *
+ * Two kinds, because they have different evidence and different costs:
+ *
+ *  • an INTERACTIVE card — nothing in the tool surface can observe it, and a
+ *    retry is known to duplicate it after a reconnect. Say both, and say what
+ *    the caller can do instead: wait for the answer to arrive, or ask the user
+ *    directly in conversation.
+ *  • anything else — the existing queue/output check, which is real evidence for
+ *    a run or a write.
+ */
+export function midCommandVerifyClause(cmd: string): string {
+  if (isInteractiveCommand(cmd)) {
+    return (
+      `The panel may already be SHOWING this card to the user. Nothing in the tool surface can ` +
+      `check that — there is no pending-card query — and re-issuing it is NOT safe here: the ` +
+      `panel's duplicate-suppression is keyed to the socket that dropped, so a retry after a ` +
+      `reconnect is treated as a new command and paints a SECOND card, which cannot be withdrawn. ` +
+      `Prefer to wait: if the user answers the card that is already up, the answer still arrives. ` +
+      `If you cannot wait, ask the question directly in conversation rather than re-issuing this ` +
+      `tool, and do not assume the card was never shown.`
+    );
+  }
+  return (
+    `Verify before retrying (e.g. check queue action:"list" / get_image (action:"list_outputs")) ` +
+    `instead of re-issuing it blindly.`
+  );
+}
+
+/** The full OUTCOME UNKNOWN sentence for a mid-command disconnect. */
+export function midCommandDisconnectMessage(opts: { short: string; cmd: string }): string {
+  const interactive = isInteractiveCommand(opts.cmd);
+  const applied = interactive
+    ? `the command was already sent, so the card may already be on screen`
+    : `the command was already sent, so the panel may have applied it (for a run, ComfyUI may already be rendering)`;
+  return (
+    `panel tab ${opts.short} disconnected mid-command ("${opts.cmd}") — OUTCOME UNKNOWN: ` +
+    `${applied}. ${midCommandVerifyClause(opts.cmd)}`
+  );
+}

--- a/src/services/mid-command-remedy.ts
+++ b/src/services/mid-command-remedy.ts
@@ -38,22 +38,38 @@ export function isInteractiveCommand(cmd: string): boolean {
  * Two kinds, because they have different evidence and different costs:
  *
  *  • an INTERACTIVE card — nothing in the tool surface can observe it, and a
- *    retry is known to duplicate it after a reconnect. Say both, and say what
- *    the caller can do instead: wait for the answer to arrive, or ask the user
- *    directly in conversation.
+ *    the answer to it will NEVER arrive (the panel refuses to replay a reply of
+ *    this kind across a reconnect), and a retry duplicates the card. Say all
+ *    three, and give the route that works — which differs for a secret.
  *  • anything else — the existing queue/output check, which is real evidence for
  *    a run or a write.
  */
 export function midCommandVerifyClause(cmd: string): string {
   if (isInteractiveCommand(cmd)) {
+    // WAITING IS NOT A RECOVERY, and an earlier draft of this said it was
+    // (codex). Checked against the panel: `redactSensitiveReply` replaces an
+    // `ask_user`/`request_secret` reply that cannot cross the dropped connection
+    // with a payload-free failure — deliberately, because the content is the
+    // user's own input and a replay could land on a different orchestrator. Its
+    // own words are "ask again on the current connection". So the answer to the
+    // card already on screen will NOT reach you, however long you wait.
+    const reissue =
+      cmd === "request_secret"
+        ? // NEVER route a secret through the conversation (codex). The whole
+          // point of this card is a masked input the agent never sees and that
+          // is never written to chat history; "just ask them for it" would
+          // defeat the guarantee the tool makes.
+          `Re-issue panel_request_secret on the current connection — that is what the panel itself ` +
+          `advises, and it is the ONLY safe route: never ask the user to paste a secret into the ` +
+          `conversation, where you would see it and it would be recorded.`
+        : `Re-issue the question on the current connection, or simply ask it in conversation.`;
     return (
-      `The panel may already be SHOWING this card to the user. Nothing in the tool surface can ` +
-      `check that — there is no pending-card query — and re-issuing it is NOT safe here: the ` +
-      `panel's duplicate-suppression is keyed to the socket that dropped, so a retry after a ` +
-      `reconnect is treated as a new command and paints a SECOND card, which cannot be withdrawn. ` +
-      `Prefer to wait: if the user answers the card that is already up, the answer still arrives. ` +
-      `If you cannot wait, ask the question directly in conversation rather than re-issuing this ` +
-      `tool, and do not assume the card was never shown.`
+      `The panel may already be SHOWING this card. Nothing in the tool surface can check that — ` +
+      `there is no pending-card query — and the answer to it will NOT reach you: the panel ` +
+      `deliberately does not replay a reply of this kind across a reconnect (nothing was applied ` +
+      `and nothing was stored). ${reissue} Expect the stale card to remain on screen: retry ` +
+      `suppression is keyed to the socket that dropped, so this counts as a new command and the ` +
+      `user may see two. Tell them which one to answer.`
     );
   }
   return (

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -18,6 +18,7 @@
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import { WebSocketServer, WebSocket } from "ws";
 import { logger } from "../utils/logger.js";
+import { midCommandDisconnectMessage } from "./mid-command-remedy.js";
 import {
   describePanelUpdateRecovery,
   type PanelBundleSkew,
@@ -4077,7 +4078,10 @@ export class UiBridge {
       ctx.reject(
         markDispatched(
           new Error(
-            `panel tab ${short} disconnected mid-command ("${cmd}") — OUTCOME UNKNOWN: the command was already sent, so the panel may have applied it (for a run, ComfyUI may already be rendering). Verify before retrying (e.g. check queue action:"list" / get_image (action:"list_outputs")) instead of re-issuing it blindly.`,
+            // #952 — the remedy depends on WHAT was interrupted. An interactive
+            // card cannot be checked with queue/get_image, and a retry after a
+            // reconnect duplicates it in front of a human.
+            midCommandDisconnectMessage({ short, cmd }),
           ),
           true,
         ),


### PR DESCRIPTION
Draft — claiming the orchestrator half of artokun/comfyui-mcp-panel#952.

The reporter's `panel_ask` was interrupted by a tab disconnect and got:

> OUTCOME UNKNOWN: the command was already sent … Verify before retrying (e.g. check queue action:"list" / get_image (action:"list_outputs"))

Their words: *"The suggested verification examples concern render queues/media and do not apply to an ask card."* They are right — that sentence is hardcoded for every command, so an interactive card gets told to go and check the render queue.

**Scope, deliberately narrow.** The panel-side trace on that issue ends on two open design questions (should interactive cards dedupe on a scope that survives a reconnect; what a retry should return while the original card is unanswered), and it was left open rather than guessed at. I am not settling those.

What I *can* fix is the part that is wrong today regardless of how they are settled: the remedy. And the panel trace establishes something the message must not omit — for this exact trigger, a blind retry **does** paint a second card, because the dedupe ledger is keyed by the socket's bridge epoch and a reconnect changes it, so `lookupRetry` misses and fails open.

So an ask/secret card should be told what actually applies: the card may already be on screen, a retry may duplicate it in front of a human, and there is no way to withdraw the first one.