### PR TITLE
release: v0.50.87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.87] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- a proven-irrelevant stale copy no longer vetoes the download (#1298)
+- say why a CivitAI download failed, instead of a bare status (#1303)
+
+#### Changed
+- 0.50.86 (#1304)
+- 0.50.85 (#1302)
+
+
 ## [0.50.86] - 2026-08-09
 
 > Covers changes since 0.50.85.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.86",
+  "version": "0.50.87",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.86",
+      "version": "0.50.87",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.86",
+  "version": "0.50.87",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the version bump and changelog for v0.50.87.

Ships #1298 (`dcc7022`): `apply_manifest` reported `failed` and skipped the download when it found a same-named file in a **stale install outside every tree the connected ComfyUI reads** — and its remedy told the user to repoint `COMFYUI_PATH` when the live root had already resolved correctly, so there was no action available. A proven-irrelevant file now downloads to the resolved target with the stale path named as a note on the item.

#369's requirement is preserved and was reviewed four ways: the item is satisfied only if the download succeeds, never by a file existing somewhere. The containment check is unchanged — a live copy still skips, an unverifiable one is still pending.

Two review rounds, both finding real gaps: the note initially rendered on 1 of 6 outcomes (missing the reporter's own, a download slower than the 15s grace), and three of the six renderings were later found pinned by nothing.

Gates on this tree: build ok, `tsc --noEmit` clean, suite 423 files / 8352 passed / 2 skipped. `git tag --contains dcc7022` → v0.50.87.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>