### PR TITLE
fix(ui-bridge): the interactive remedy repeated its own lead

### DIFF
--- a/src/__tests__/services/mid-command-remedy.test.ts
+++ b/src/__tests__/services/mid-command-remedy.test.ts
@@ -89,6 +89,10 @@ describe("the disconnect remedy fits what was interrupted (#952)", () => {
     expect(midCommandDisconnectMessage({ short: "wf:1", cmd: "request_secret" })).toMatch(
       /card may already be on screen/,
     );
+    // …and says it ONCE. The lead sentence and the clause both used to open with
+    // it, which read as though two separate facts were being reported.
+    const msg = midCommandDisconnectMessage({ short: "wf:1", cmd: "request_secret" });
+    expect(msg.match(/may already be (on screen|SHOWING)/g)?.length).toBe(1);
   });
 
   it("the two interactive commands differ ONLY in the route they are given", () => {

--- a/src/services/mid-command-remedy.ts
+++ b/src/services/mid-command-remedy.ts
@@ -64,7 +64,7 @@ export function midCommandVerifyClause(cmd: string): string {
           `conversation, where you would see it and it would be recorded.`
         : `Re-issue the question on the current connection, or simply ask it in conversation.`;
     return (
-      `The panel may already be SHOWING this card. Nothing in the tool surface can check that — ` +
+      `Nothing in the tool surface can check that — ` +
       `there is no pending-card query — and the answer to it will NOT reach you: the panel ` +
       `deliberately does not replay a reply of this kind across a reconnect (nothing was applied ` +
       `and nothing was stored). ${reissue} Expect the stale card to remain on screen: retry ` +


### PR DESCRIPTION
Follow-up to #1305, caught by reading the message the **built artifact** produces rather than the source: the lead sentence and the verify clause both opened with *"the card may already be on screen"*, so one fact was reported as two.

Pinned by a test that counts the phrase.