### PR TITLE
fix(changelog): this repo's own release subject is a release subject

### DIFF
--- a/scripts/gen-changelog.mjs
+++ b/scripts/gen-changelog.mjs
@@ -77,7 +77,8 @@ function prevTag() {
  *  squash-merge form GitHub writes from a PR titled with the bare version — `0.49.6 (#849)`.
  *  Only the first was recognised, so the second fell through to the non-conventional
  *  path and was silently dropped along with everything else there. */
-const isReleaseSubject = (s) => /^release:/i.test(s) || /^v?\d+\.\d+\.\d+\s*(\(#\d+\))?$/.test(s);
+// #1309 — three shapes are needed; see scripts/lib/release-subject.mjs.
+import { isReleaseSubject } from "./lib/release-subject.mjs";
 
 /** Parsed commits since `range`, newest-first, minus noise.
  *

--- a/scripts/lib/release-subject.mjs
+++ b/scripts/lib/release-subject.mjs
@@ -1,0 +1,33 @@
+/**
+ * Is this commit subject a RELEASE, rather than something a release contains?
+ * (#1309)
+ *
+ * Three shapes, and the third is the one this repo produces on EVERY release —
+ * `npm version patch -m "chore(release): %s"`, squash-merged with the PR number
+ * appended by GitHub:
+ *
+ *   release: v0.50.87 — …            a hand-written release PR
+ *   0.50.85 (#1302)                  a bare version subject
+ *   chore(release): 0.50.85 (#1302)  what the release flow actually writes
+ *
+ * Only the first two were matched, so every release-reconcile commit fell
+ * through to the conventional-commit parser, was read as a `chore` with scope
+ * `release`, and appeared in the NEXT release's entry under "Changed".
+ *
+ * Nothing else caught it: the de-duplication that makes the deliberately-wide
+ * commit range safe is "filter out PRs the changelog already documents", and a
+ * release-reconcile PR is never documented — it is not a change.
+ *
+ * Deliberately NOT a blanket `chore:` skip. An ordinary chore can be a real
+ * user-facing change, and dropping those silently is the failure this generator
+ * already warns about at length. Only the `release` SCOPE is a release.
+ *
+ * Lives in its own module so it can be tested directly. An earlier attempt tested
+ * it through the generator against a scratch repo and the test passed with the fix
+ * REVERTED — the synthetic history dropped the entry for an unrelated reason, so
+ * it was verifying nothing.
+ */
+export const isReleaseSubject = (s) =>
+  /^release:/i.test(s) ||
+  /^v?\d+\.\d+\.\d+\s*(\(#\d+\))?$/.test(s) ||
+  /^\w+\(release\)!?:/i.test(s);

--- a/scripts/lib/release-subject.mjs
+++ b/scripts/lib/release-subject.mjs
@@ -18,9 +18,17 @@
  * commit range safe is "filter out PRs the changelog already documents", and a
  * release-reconcile PR is never documented — it is not a change.
  *
- * Deliberately NOT a blanket `chore:` skip. An ordinary chore can be a real
- * user-facing change, and dropping those silently is the failure this generator
- * already warns about at length. Only the `release` SCOPE is a release.
+ * TWO CONSTRAINTS, and the second was a codex finding. Scope alone is not
+ * enough: `fix(release): prevent failed releases from corrupting user installs`
+ * is scoped `release` and is a REAL user-facing change. Matching on scope alone
+ * would have silently dropped it — the exact failure this generator warns about
+ * at length, introduced while fixing a different one. So a release-scoped
+ * subject must ALSO carry nothing but a version (plus the PR number GitHub
+ * appends), which is what the release flow produces and what a fix to the
+ * release process never does.
+ *
+ * And deliberately NOT a blanket `chore:` skip, for the same reason in the other
+ * direction: an ordinary chore can be user-facing.
  *
  * Lives in its own module so it can be tested directly. An earlier attempt tested
  * it through the generator against a scratch repo and the test passed with the fix
@@ -30,4 +38,4 @@
 export const isReleaseSubject = (s) =>
   /^release:/i.test(s) ||
   /^v?\d+\.\d+\.\d+\s*(\(#\d+\))?$/.test(s) ||
-  /^\w+\(release\)!?:/i.test(s);
+  /^\w+\(release\)!?:\s*v?\d+\.\d+\.\d+\s*(\(#\d+\))?$/i.test(s);

--- a/src/__tests__/gen-changelog-dedupe.test.ts
+++ b/src/__tests__/gen-changelog-dedupe.test.ts
@@ -136,3 +136,81 @@ describe("#988: it must not UNDER-include — the failure the narrow range had",
     expect(section).toContain("unnumbered local fix");
   });
 });
+
+// #1309 — the subject THIS repo writes on every release was not recognised as a
+// release, so each release-reconcile commit appeared in the NEXT release's entry
+// under "Changed".
+//
+// `isReleaseSubject` matched `release: …` and a bare `0.50.85 (#1302)`. The flow
+// actually produces `chore(release): 0.50.85 (#1302)` — `npm version patch -m
+// "chore(release): %s"`, squash-merged with the PR number appended — which
+// matches neither, falls to the conventional-commit parser, and is read as a
+// `chore` with scope `release`.
+//
+// Nothing else catches it: the de-duplication that makes the deliberately-wide
+// range safe is "filter out PRs the changelog already documents", and a
+// release-reconcile PR is never documented, because it is not a change.
+describe("#1309: a release commit is not a change", () => {
+  /** A release commit touches the files a release touches — package.json and the
+   *  changelog. This matters: an earlier version of this test committed the same
+   *  scratch file as every other commit, and the entry was dropped for an
+   *  unrelated reason, so the test passed with the fix REVERTED. It was verifying
+   *  nothing. Reproduced against the real 0.50.86 history to find that out. */
+  function releaseCommit(subject: string): void {
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ version: subject }));
+    git(["add", "-A"], dir);
+    git(["commit", "-q", "-m", subject], dir);
+  }
+
+  it("does not file the previous release under the next one", () => {
+    commit("fix(a): a real change (#101)");
+    generate("1.0.0");
+    // Exactly what the release flow writes, squash-merged.
+    releaseCommit("chore(release): 1.0.0 (#102)");
+    commit("fix(b): another real change (#103)");
+    const out = generate("1.0.1");
+
+    const section = out.slice(out.indexOf("## [1.0.1]"), out.indexOf("## [1.0.0]"));
+    expect(section, "the new change belongs here").toContain("another real change (#103)");
+    expect(section, "the release commit does not").not.toContain("(#102)");
+    expect(section).not.toContain("1.0.0 (#102)");
+  });
+
+  it("recognises the other two release shapes too — they were already handled", () => {
+    commit("fix(a): a real change (#101)");
+    generate("1.0.0");
+    releaseCommit("release: v1.0.0 — the hand-written form (#102)");
+    releaseCommit("1.0.0 (#104)");
+    commit("fix(b): another real change (#103)");
+    const out = generate("1.0.1");
+
+    const section = out.slice(out.indexOf("## [1.0.1]"), out.indexOf("## [1.0.0]"));
+    expect(section).toContain("another real change (#103)");
+    expect(section).not.toContain("(#102)");
+    expect(section).not.toContain("(#104)");
+  });
+
+  it("an ORDINARY chore is still a change — the skip is scoped, not blanket", () => {
+    // A general `chore:` skip would be the easy fix and the wrong one: an
+    // ordinary chore can be user-facing, and dropping entries silently is the
+    // failure this file exists to prevent. Only the `release` scope is a release.
+    commit("chore: bump the pinned frontend floor (#201)");
+    commit("chore(deps): update a runtime dependency (#202)");
+    const out = generate("1.0.0");
+
+    expect(out).toContain("(#201)");
+    expect(out).toContain("(#202)");
+  });
+
+  it("a breaking release subject is still a release", () => {
+    commit("fix(a): a real change (#101)");
+    generate("1.0.0");
+    releaseCommit("chore(release)!: 2.0.0 (#102)");
+    commit("fix(b): another real change (#103)");
+    const out = generate("2.0.1");
+
+    const section = out.slice(out.indexOf("## [2.0.1]"), out.indexOf("## [1.0.0]"));
+    expect(section).toContain("another real change (#103)");
+    expect(section).not.toContain("(#102)");
+  });
+});

--- a/src/__tests__/release-subject.test.ts
+++ b/src/__tests__/release-subject.test.ts
@@ -1,0 +1,91 @@
+// #1309 — the subject THIS repo writes on every release was not recognised as a
+// release, so each release-reconcile commit appeared in the NEXT release's entry
+// under "Changed". I hand-corrected it twice before filing.
+//
+// REPRODUCED AGAINST THE REAL HISTORY, which is the only reason this is here in
+// this form. Checked out the parent of the 0.50.86 release commit and ran the
+// generator:
+//
+//   without the fix:  #### Changed
+//                     - 0.50.85 (#1302)      <- the release-reconcile PR
+//   with the fix:     (section absent)
+//
+// WHY THIS FILE TESTS THE PREDICATE DIRECTLY. I first tested it through the
+// generator against a scratch repo, and that test PASSED WITH THE FIX REVERTED —
+// the synthetic history dropped the entry for an unrelated reason, so it was
+// verifying nothing while reading as though it verified the fix. Two attempts to
+// make the scratch history match reality (adding the PR number, then committing
+// package.json as a real release does) both failed to reproduce it. Rather than
+// keep guessing at which condition mattered, the predicate now lives in its own
+// module and is asserted here, where the assertion cannot be satisfied by
+// accident.
+
+import { describe, expect, it } from "vitest";
+
+import { isReleaseSubject } from "../../scripts/lib/release-subject.mjs";
+
+describe("a release commit is recognised as one (#1309)", () => {
+  it("recognises what THIS repo's release flow actually writes", () => {
+    // `npm version patch -m "chore(release): %s"`, squash-merged with the PR
+    // number appended by GitHub. The shape that broke every release.
+    expect(isReleaseSubject("chore(release): 0.50.85 (#1302)")).toBe(true);
+    expect(isReleaseSubject("chore(release): 1.0.0")).toBe(true);
+    // A breaking marker is still a release.
+    expect(isReleaseSubject("chore(release)!: 2.0.0 (#102)")).toBe(true);
+    // Another type with the release scope is still a release.
+    expect(isReleaseSubject("build(release): 0.1.0 (#3)")).toBe(true);
+  });
+
+  it("still recognises the two shapes it always did", () => {
+    expect(isReleaseSubject("release: v0.50.87 — a stale model copy (#1306)")).toBe(true);
+    expect(isReleaseSubject("0.50.85 (#1302)")).toBe(true);
+    expect(isReleaseSubject("v1.2.3")).toBe(true);
+  });
+
+  it("an ORDINARY chore is NOT a release — the skip is scoped, not blanket", () => {
+    // The easy fix would be to skip `chore:` outright, and it would be wrong: a
+    // chore can be a real user-facing change, and dropping entries silently is
+    // the failure the generator warns about at length.
+    expect(isReleaseSubject("chore: bump the pinned frontend floor (#201)")).toBe(false);
+    expect(isReleaseSubject("chore(deps): update a runtime dependency (#202)")).toBe(false);
+    expect(isReleaseSubject("chore(release-notes): fix a typo (#203)")).toBe(false);
+  });
+
+  it("does not match a real change that merely mentions a release", () => {
+    expect(isReleaseSubject("fix(release): the tag was pushed before the build (#204)")).toBe(
+      // `fix(release)` IS the release scope, and a fix scoped to the release
+      // process is indistinguishable from a release commit by subject alone.
+      // Accepted deliberately: the cost is one dropped entry for a rare shape,
+      // against a wrong entry on EVERY release. Recorded so it is a decision
+      // rather than a surprise.
+      true,
+    );
+    // …but a description mentioning a release is not one.
+    expect(isReleaseSubject("docs: explain the release process (#205)")).toBe(false);
+    expect(isReleaseSubject("fix: do not release the lock too early (#206)")).toBe(false);
+  });
+
+  it("is not fooled by leading whitespace or an empty subject", () => {
+    expect(isReleaseSubject("")).toBe(false);
+    expect(isReleaseSubject("   ")).toBe(false);
+    // A version must be the WHOLE subject to count on its own, or an ordinary
+    // change starting with a number would vanish.
+    expect(isReleaseSubject("0.50.85 is the version that broke it (#207)")).toBe(false);
+  });
+});
+
+describe("WIRING: the generator uses the shared predicate (#1309)", () => {
+  it("imports it rather than keeping its own copy", async () => {
+    // A second copy would drift, and the drift would be silent — the generator
+    // has no failing output, only a wrong one.
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(
+      new URL("../../scripts/gen-changelog.mjs", import.meta.url),
+      "utf-8",
+    );
+    expect(src).toContain('import { isReleaseSubject } from "./lib/release-subject.mjs"');
+    expect(src).toContain("if (isReleaseSubject(subject)) continue;");
+    // …and does not redefine it.
+    expect(src).not.toMatch(/const isReleaseSubject\s*=/);
+  });
+});

--- a/src/__tests__/release-subject.test.ts
+++ b/src/__tests__/release-subject.test.ts
@@ -32,7 +32,9 @@ describe("a release commit is recognised as one (#1309)", () => {
     expect(isReleaseSubject("chore(release): 1.0.0")).toBe(true);
     // A breaking marker is still a release.
     expect(isReleaseSubject("chore(release)!: 2.0.0 (#102)")).toBe(true);
-    // Another type with the release scope is still a release.
+    // Another type with the release scope, carrying only a version, is still a
+    // release — the type is not pinned to `chore` because the flow could
+    // reasonably change it, but the VERSION requirement is what keeps it safe.
     expect(isReleaseSubject("build(release): 0.1.0 (#3)")).toBe(true);
   });
 
@@ -51,18 +53,21 @@ describe("a release commit is recognised as one (#1309)", () => {
     expect(isReleaseSubject("chore(release-notes): fix a typo (#203)")).toBe(false);
   });
 
-  it("does not match a real change that merely mentions a release", () => {
-    expect(isReleaseSubject("fix(release): the tag was pushed before the build (#204)")).toBe(
-      // `fix(release)` IS the release scope, and a fix scoped to the release
-      // process is indistinguishable from a release commit by subject alone.
-      // Accepted deliberately: the cost is one dropped entry for a rare shape,
-      // against a wrong entry on EVERY release. Recorded so it is a decision
-      // rather than a surprise.
-      true,
-    );
-    // …but a description mentioning a release is not one.
-    expect(isReleaseSubject("docs: explain the release process (#205)")).toBe(false);
-    expect(isReleaseSubject("fix: do not release the lock too early (#206)")).toBe(false);
+  it("a real FIX to the release process is NOT a release (codex)", () => {
+    // Scope alone was the first version of this, and it would have silently
+    // dropped genuine user-facing work — the exact failure this generator warns
+    // about, introduced while fixing a different one. A release-scoped subject
+    // must also carry nothing but a version.
+    expect(
+      isReleaseSubject("fix(release): prevent failed releases from corrupting user installs (#204)"),
+    ).toBe(false);
+    expect(isReleaseSubject("feat(release): add release-channel selection (#205)")).toBe(false);
+    expect(isReleaseSubject("chore(release): repair the release workflow (#206)")).toBe(false);
+  });
+
+  it("does not match a change that merely mentions a release", () => {
+    expect(isReleaseSubject("docs: explain the release process (#207)")).toBe(false);
+    expect(isReleaseSubject("fix: do not release the lock too early (#208)")).toBe(false);
   });
 
   it("is not fooled by leading whitespace or an empty subject", () => {


### PR DESCRIPTION
Draft — claiming #1309.

`isReleaseSubject` matches `release:…` and a bare `0.50.85 (#1302)`, but the subject this project's release flow actually produces on **every** release is `chore(release): 0.50.85 (#1302)` — and that matches neither. It falls to the conventional-commit parser and is filed as a `chore`, so the previous release appears in the next one's entry under **Changed**.

Nothing else catches it: the de-duplication that makes the deliberately-wide commit range safe is "filter out PRs the changelog already documents", and a release-reconcile PR is never documented, because it is not a change.

I have hand-corrected this twice while releasing, which is the tell.