### PR TITLE
chore(release): 0.50.90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.90] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- resolve the panel base through the OS-observed process on Desktop (#1193)
+
+
 ## [0.50.89] - 2026-08-09
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.89",
+  "version": "0.50.90",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.89",
+      "version": "0.50.90",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.89",
+  "version": "0.50.90",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release 0.50.90.

### Fixed

- **#1133** — resolve the panel base through the OS-observed process on Desktop (#1193)

0.50.89 was cut from `1fc2e07`, just before #1193 merged, so it correctly ships without this. 0.50.90 is the first release carrying it.

## What was broken

On ComfyUI **Desktop**, every destructive panel operation refused. The reported cause was that `--input-directory`/`--output-directory` were being read as evidence of a split install — but nothing in the panel path has ever looked at either flag, so the suggested fix would have been a no-op that only *looked* like a fix in a changelog.

The real mechanism: Desktop reports a relative `ComfyUI\main.py` with no cwd, so neither `parseBaseDirFromArgv` nor `liveRootFromArgv` could yield anything. That left the configured path as the only candidate — which by construction the running server never vouched for — so the corroboration gate refused on **every Desktop install, universally**.

`resolveLiveServerRoot` already had a tier built for exactly that shape (#369): ask the OS which process is listening on our port, correlate it against that server's own argv, and re-anchor the relative `main.py` on that interpreter's install tree. `resolvePanelBase` was not using it — it re-parsed argv, which is precisely what `LiveServerSnapshot.liveRoot` warns consumers against.

This is not a relaxation of a guard that authorises a destructive directory swap; it supplies live-derived evidence the system already had. `--base-directory` still wins ahead of it, the observed root must still hold `custom_nodes`, and a failed observation still refuses.

## Two further defects fixed during review rather than shipped

- A **present but unresolvable** relative `--base-directory` used to read as "no flag at all", letting a derived root win — a confidently *wrong* tree handed to a destructive swap. It now poisons every candidate and fails closed. This hole predated the change on the `live-argv-root` tier and is closed there too, with its own refusal message (the generic "relaunch with an absolute main.py" remedy does not fix it).
- The process-table probe is **synchronous** (~1.27s measured, worse on its timeout path) and ran before candidate precedence, so servers whose `--base-directory` would win paid for a walk that could never be used. Now reached only after the flag candidate fails.

## Verification

Verified live against a real install, not only against mocks: the Desktop argv shape anchors to a real tree holding `main.py` and `custom_nodes`, via a real OS process observation. Known residual — the bare `main.py` shape (relDir `.`) still does not resolve, and deliberately so; reaching a nested sibling server dir from an interpreter anchor is a different inference deserving its own review.