### PR TITLE
fix(#535): anchor a relative launch script on Windows, where /proc has no equivalent

### DIFF
--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -436,6 +436,122 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
     killSpy.mockRestore();
   });
 
+  it("WINDOWS: a RELATIVE path argument blocks the inferred anchor (#535 codex gate)", async () => {
+    // The anchor is INFERRED, not observed — a directory from which this relative
+    // script WOULD name this install, which is not "the directory it was started
+    // in". A symlinked launcher satisfies the inference from the wrong place. That
+    // gap is harmless for the panel base (#1133) and NOT harmless here, because the
+    // value becomes the relaunch's working directory. So when any argument could
+    // itself be cwd-relative, the anchor is not adopted.
+    const LIVE_CWD = resolve("bundle");
+    mockResolveBase.mockReturnValue(undefined);
+    mockLiveRootFromArgv.mockReturnValue(undefined);
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        // `out` is cwd-relative: after a restart from a different cwd it would
+        // point somewhere else entirely.
+        argv: [join("ComfyUI", "main.py"), "--output-directory", "out"],
+      },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === ABS_PYTHON || s === join(LIVE_CWD, "ComfyUI", "main.py");
+    });
+    __processControlTestHooks.setLiveCwdResolver(() => undefined);
+    mockResolveLiveServerRoot.mockReturnValue({
+      source: "observed-process",
+      anchorDir: LIVE_CWD,
+      observedPid: 4321,
+    });
+    mockLivePortThenFree();
+    mockSpawn.mockImplementation(() => new FakeChild());
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(result.stopped).toBe(false);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("WINDOWS: a plain non-path value (`--port 8188`) does NOT block the anchor (#535)", async () => {
+    // The guard above must not be so broad it refuses the very case this issue is
+    // about. The reporter's argv carries `--port 8188`; a number cannot be a path.
+    const LIVE_CWD = resolve("bundle2");
+    const LIVE_MAIN = join(LIVE_CWD, "ComfyUI", "main.py");
+    mockResolveBase.mockReturnValue(undefined);
+    mockLiveRootFromArgv.mockReturnValue(undefined);
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: [join("ComfyUI", "main.py"), "--port", "8188", "--enable-manager"],
+      },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === ABS_PYTHON || s === LIVE_MAIN;
+    });
+    __processControlTestHooks.setLiveCwdResolver(() => undefined);
+    mockResolveLiveServerRoot.mockReturnValue({
+      source: "observed-process",
+      anchorDir: LIVE_CWD,
+      observedPid: 4321,
+    });
+    mockLivePortThenFree();
+    mockSpawn.mockImplementation(() => new FakeChild());
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(mockSpawn.mock.calls[0][1][0]).toBe(LIVE_MAIN);
+
+    killSpy.mockRestore();
+  });
+
+  it("WINDOWS: an UNREADABLE creation stamp fails closed, it does not pass on the pid number (#535 codex gate)", async () => {
+    // pid + creation time is this file's standard for process identity, because
+    // pid equality across a window is exactly what pid REUSE defeats. The observed
+    // resolver re-queries the port owner AFTER the identity bracket has closed, so
+    // it needs its own continuity proof. "Could not read the stamp" is not
+    // "the stamp matched".
+    const LIVE_CWD = resolve("bundle3");
+    mockResolveBase.mockReturnValue(undefined);
+    mockLiveRootFromArgv.mockReturnValue(undefined);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [join("ComfyUI", "main.py"), "--port", "8188"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === ABS_PYTHON || s === join(LIVE_CWD, "ComfyUI", "main.py");
+    });
+    __processControlTestHooks.setLiveCwdResolver(() => undefined);
+    // No stamp available on this host.
+    __processControlTestHooks.setProcessIdentityResolver(() => undefined);
+    mockResolveLiveServerRoot.mockReturnValue({
+      source: "observed-process",
+      anchorDir: LIVE_CWD,
+      observedPid: 4321,
+    });
+    mockLivePortThenFree();
+    mockSpawn.mockImplementation(() => new FakeChild());
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
   it("an UNRESOLVED observation changes nothing — the pre-#535 refusal stands (#535)", async () => {
     // The tri-state discipline: "could not observe" is not "observed something
     // usable". This is the branch that must never become a success.

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -705,6 +705,88 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
     },
   );
 
+  it("WINDOWS: a SECOND value of a multi-value path flag is checked too (#535 codex round 3)", async () => {
+    // ComfyUI declares `--extra-model-paths-config` as nargs='+', so it carries
+    // one-or-more paths. Checking only the first let `two.yaml` — relative, and
+    // separator-free so the positional check waves it through — reach the anchor.
+    const LIVE_CWD = resolve("bundle-multi");
+    mockResolveBase.mockReturnValue(undefined);
+    mockLiveRootFromArgv.mockReturnValue(undefined);
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: [
+          join("ComfyUI", "main.py"),
+          "--extra-model-paths-config",
+          resolve("cfg", "one.yaml"), // absolute — fine on its own
+          "two.yaml", // RELATIVE, and the one that used to slip
+        ],
+      },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === ABS_PYTHON || s === join(LIVE_CWD, "ComfyUI", "main.py");
+    });
+    __processControlTestHooks.setLiveCwdResolver(() => undefined);
+    mockResolveLiveServerRoot.mockReturnValue({
+      source: "observed-process",
+      anchorDir: LIVE_CWD,
+      observedPid: 4321,
+    });
+    mockLivePortThenFree();
+    mockSpawn.mockImplementation(() => new FakeChild());
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it.each([
+    ["a device index on --directml", ["--directml", "0"]],
+    ["a URL value carrying slashes", ["--comfy-api-base", "https://api.comfy.org"]],
+  ])(
+    "WINDOWS: %s does NOT block the anchor (#535 codex round 3)",
+    async (_label, extra) => {
+      // Two more over-broad cases. `--directml` takes a DEVICE INDEX, not a path —
+      // I had wrongly enumerated it. And a URL carries slashes without being
+      // something a working directory can move.
+      const LIVE_CWD = resolve("bundle-ok");
+      const LIVE_MAIN = join(LIVE_CWD, "ComfyUI", "main.py");
+      mockResolveBase.mockReturnValue(undefined);
+      mockLiveRootFromArgv.mockReturnValue(undefined);
+      mockGetSystemStats.mockResolvedValue({
+        system: { argv: [join("ComfyUI", "main.py"), ...extra] },
+      });
+      mockExistsSync.mockImplementation((p: string) => {
+        const s = String(p);
+        return s === ABS_PYTHON || s === LIVE_MAIN;
+      });
+      __processControlTestHooks.setLiveCwdResolver(() => undefined);
+      mockResolveLiveServerRoot.mockReturnValue({
+        source: "observed-process",
+        anchorDir: LIVE_CWD,
+        observedPid: 4321,
+      });
+      mockLivePortThenFree();
+      mockSpawn.mockImplementation(() => new FakeChild());
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => ({ ok: true }) as Response),
+      );
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      const result = await restartComfyUI();
+
+      expect(result.message).not.toMatch(/refusing to restart/i);
+      expect(mockSpawn.mock.calls[0][1][0]).toBe(LIVE_MAIN);
+
+      killSpy.mockRestore();
+    },
+  );
+
   it("an UNRESOLVED observation changes nothing — the pre-#535 refusal stands (#535)", async () => {
     // The tri-state discipline: "could not observe" is not "observed something
     // usable". This is the branch that must never become a success.

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -660,6 +660,51 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
     killSpy.mockRestore();
   });
 
+  it.each([
+    ["a BOOLEAN flag that merely reads path-ish", ["--cache-none", "--port", "8188"]],
+    ["a counted flag whose value is not a path", ["--cache-lru", "10"]],
+    ["a boolean flag before a path flag", ["--log-stdout", "--port", "8188"]],
+  ])(
+    "WINDOWS: %s does NOT block the anchor — the guard must not refuse ordinary launches (#535)",
+    async (_label, extra) => {
+      // The over-broad direction, and the one that would quietly un-fix this issue.
+      // `--cache-none` and `--log-stdout` are BOOLEAN; a substring test on
+      // dir|cache|log treats them as path-valued, eats the next token as their
+      // "value", and refuses. `--cache-none` is in this issue's ORIGINAL report.
+      const LIVE_CWD = resolve("bundle-bool");
+      const LIVE_MAIN = join(LIVE_CWD, "ComfyUI", "main.py");
+      mockResolveBase.mockReturnValue(undefined);
+      mockLiveRootFromArgv.mockReturnValue(undefined);
+      mockGetSystemStats.mockResolvedValue({
+        system: { argv: [join("ComfyUI", "main.py"), ...extra] },
+      });
+      mockExistsSync.mockImplementation((p: string) => {
+        const s = String(p);
+        return s === ABS_PYTHON || s === LIVE_MAIN;
+      });
+      __processControlTestHooks.setLiveCwdResolver(() => undefined);
+      mockResolveLiveServerRoot.mockReturnValue({
+        source: "observed-process",
+        anchorDir: LIVE_CWD,
+        observedPid: 4321,
+      });
+      mockLivePortThenFree();
+      mockSpawn.mockImplementation(() => new FakeChild());
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => ({ ok: true }) as Response),
+      );
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      const result = await restartComfyUI();
+
+      expect(result.message).not.toMatch(/refusing to restart/i);
+      expect(mockSpawn.mock.calls[0][1][0]).toBe(LIVE_MAIN);
+
+      killSpy.mockRestore();
+    },
+  );
+
   it("an UNRESOLVED observation changes nothing — the pre-#535 refusal stands (#535)", async () => {
     // The tri-state discipline: "could not observe" is not "observed something
     // usable". This is the branch that must never become a success.

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -622,6 +622,44 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
     killSpy.mockRestore();
   });
 
+  // Codex round 2: judging the VALUE was bypassable three ways, because `auto`,
+  // `8188` and `-` are all legal directory names. The guard now keys on the FLAG
+  // name, whose vocabulary is knowable. Each of these was a live bypass.
+  it.each([
+    ["a value that looks numeric", ["--output-directory", "8188"]],
+    ["a value that looks enum-ish", ["--output-directory", "auto"]],
+    ["a value that is a bare dash", ["--output-directory", "-"]],
+    ["a positional after `--`", ["--", "relative/thing"]],
+  ])("WINDOWS: %s still blocks the inferred anchor (#535 codex round 2)", async (_label, extra) => {
+    const LIVE_CWD = resolve("bundle-bypass");
+    mockResolveBase.mockReturnValue(undefined);
+    mockLiveRootFromArgv.mockReturnValue(undefined);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [join("ComfyUI", "main.py"), ...extra] },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === ABS_PYTHON || s === join(LIVE_CWD, "ComfyUI", "main.py");
+    });
+    __processControlTestHooks.setLiveCwdResolver(() => undefined);
+    mockResolveLiveServerRoot.mockReturnValue({
+      source: "observed-process",
+      anchorDir: LIVE_CWD,
+      observedPid: 4321,
+    });
+    mockLivePortThenFree();
+    mockSpawn.mockImplementation(() => new FakeChild());
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
   it("an UNRESOLVED observation changes nothing — the pre-#535 refusal stands (#535)", async () => {
     // The tri-state discipline: "could not observe" is not "observed something
     // usable". This is the branch that must never become a success.

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -75,6 +75,13 @@ const mockResolveBase = vi.hoisted(() => vi.fn<[], string | undefined>());
 const mockLiveRootFromArgv = vi.hoisted(() =>
   vi.fn<[string[], string?], string | undefined>(),
 );
+// #535 — the observed-process resolver process-control now falls back to when
+// `/proc/<pid>/cwd` yields nothing (i.e. on Windows). Defaults to "unresolved".
+const mockResolveLiveServerRoot = vi.hoisted(() =>
+  vi.fn<[], { source: string; anchorDir?: string; observedPid?: number }>(() => ({
+    source: "unresolved",
+  })),
+);
 
 vi.mock("../../config.js", () => ({
   config: mockConfig,
@@ -133,6 +140,10 @@ vi.mock("../../services/env-capabilities.js", () => ({
 vi.mock("../../services/workspace-env.js", () => ({
   resolveEffectiveComfyUIBase: mockResolveBase,
   liveRootFromArgv: mockLiveRootFromArgv,
+  // #535 Windows anchor — the OS-observed stand-in for `/proc/<pid>/cwd`. Default
+  // `unresolved` keeps every pre-existing case in this file describing exactly the
+  // server it described before.
+  resolveLiveServerRoot: mockResolveLiveServerRoot,
   // Launched-by-us env-trust flag (#633 P1b) — inert here; start/stop just toggle it.
   markLocalComfyUILaunched: vi.fn(),
   resetLocalComfyUILaunchState: vi.fn(),
@@ -192,6 +203,12 @@ beforeEach(() => {
   mockFindComfyuiPython.mockReturnValue(ABS_PYTHON);
   // Portable launcher: relative argv → no argv-derived live root.
   mockLiveRootFromArgv.mockReturnValue(undefined);
+  // #535 — restored explicitly because `clearAllMocks` above drops the factory
+  // default, and an `undefined` return is NOT something the real resolver can do.
+  // Leaving it cleared would only "work" because a try/catch swallows the
+  // resulting TypeError — a harness disagreeing with production about its own
+  // contract, which is how a mock starts proving nothing.
+  mockResolveLiveServerRoot.mockReturnValue({ source: "unresolved" });
   // The env service knows the canonical absolute install.
   mockResolveBase.mockReturnValue(BASE);
   // Everything that resolves to the absolute canonical install exists on disk.
@@ -330,6 +347,116 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
     expect(args[0]).toBe(LIVE_MAIN);
     // Spawn FROM the live cwd, not a stale/undefined config.comfyuiPath (#535 P1).
     expect((opts as { cwd?: string }).cwd).toBe(LIVE_CWD);
+
+    killSpy.mockRestore();
+  });
+
+  it("WINDOWS: anchors a relative `ComfyUI\\main.py` on the OS-observed process when /proc yields nothing (#535)", async () => {
+    // The 2026-08-10 recurrence. `resolveLiveProcessCwd` returns undefined on
+    // Windows (no /proc), so the live-cwd anchor never fired and a relative script
+    // with no canonical base was refused outright:
+    //   "Resolved ComfyUI script does not exist on disk: ComfyUI\main.py"
+    // The observed-process tier supplies the same fact the /proc symlink does — the
+    // directory the server's relative main.py must have been resolved against.
+    const LIVE_CWD = resolve("bundle");
+    const LIVE_MAIN = join(LIVE_CWD, "ComfyUI", "main.py");
+    mockResolveBase.mockReturnValue(undefined); // no canonical base
+    mockLiveRootFromArgv.mockReturnValue(undefined); // no argv root
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [join("ComfyUI", "main.py"), "--port", "8188"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === ABS_PYTHON || s === LIVE_MAIN;
+    });
+    // No /proc — exactly what Windows gives us.
+    __processControlTestHooks.setLiveCwdResolver(() => undefined);
+    // …but the OS knows which process holds the port, and its interpreter anchors
+    // the relative dir. `anchorDir` is that resolved ancestor: the process's cwd.
+    mockResolveLiveServerRoot.mockReturnValue({
+      source: "observed-process",
+      anchorDir: LIVE_CWD,
+      observedPid: 4321, // the pid the port probe reports
+    });
+    mockLivePortThenFree();
+    mockSpawn.mockImplementation(() => new FakeChild());
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    const [exe, args, opts] = mockSpawn.mock.calls[0];
+    expect(exe).toBe(ABS_PYTHON);
+    expect(args[0]).toBe(LIVE_MAIN); // the FULL relative path re-anchored, not the basename
+    expect((opts as { cwd?: string }).cwd).toBe(LIVE_CWD);
+
+    killSpy.mockRestore();
+  });
+
+  it("WINDOWS: a PID MISMATCH discards the observed anchor and keeps the refusal (#535)", async () => {
+    // The safety property. The observation is anchored on "whatever is listening on
+    // our port"; if that is a DIFFERENT process than the one we are about to kill,
+    // its install is not the one being stopped. Anchoring on it would restart the
+    // wrong tree after killing the right one — strictly worse than refusing.
+    const OTHER_CWD = resolve("someone-elses-bundle");
+    mockResolveBase.mockReturnValue(undefined);
+    mockLiveRootFromArgv.mockReturnValue(undefined);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [join("ComfyUI", "main.py"), "--port", "8188"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === ABS_PYTHON || s === join(OTHER_CWD, "ComfyUI", "main.py");
+    });
+    __processControlTestHooks.setLiveCwdResolver(() => undefined);
+    mockResolveLiveServerRoot.mockReturnValue({
+      source: "observed-process",
+      anchorDir: OTHER_CWD,
+      observedPid: 9999, // NOT the 4321 on our port
+    });
+    mockLivePortThenFree();
+    mockSpawn.mockImplementation(() => new FakeChild());
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    // Refuse-safe: nothing stopped, nothing spawned, server left running.
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("an UNRESOLVED observation changes nothing — the pre-#535 refusal stands (#535)", async () => {
+    // The tri-state discipline: "could not observe" is not "observed something
+    // usable". This is the branch that must never become a success.
+    mockResolveBase.mockReturnValue(undefined);
+    mockLiveRootFromArgv.mockReturnValue(undefined);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [join("ComfyUI", "main.py"), "--port", "8188"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => String(p) === ABS_PYTHON);
+    __processControlTestHooks.setLiveCwdResolver(() => undefined);
+    mockResolveLiveServerRoot.mockReturnValue({ source: "unresolved" });
+    mockLivePortThenFree();
+    mockSpawn.mockImplementation(() => new FakeChild());
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(result.stopped).toBe(false);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
 
     killSpy.mockRestore();
   });

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -585,13 +585,24 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
     killSpy.mockRestore();
   });
 
-  it("WINDOWS: an UNREADABLE creation stamp fails closed, it does not pass on the pid number (#535 codex gate)", async () => {
+  it("a CHANGED creation stamp discards the observed anchor — pid equality is not identity (#535 codex gate)", async () => {
     // pid + creation time is this file's standard for process identity, because
     // pid equality across a window is exactly what pid REUSE defeats. The observed
     // resolver re-queries the port owner AFTER the identity bracket has closed, so
-    // it needs its own continuity proof. "Could not read the stamp" is not
-    // "the stamp matched".
+    // it needs its own continuity proof.
+    //
+    // The bracket is left INTACT on purpose. Simply removing the stamp makes
+    // `gatherProcessInfo` refuse earlier, with a different (also correct) message —
+    // which passed on Windows and failed on Linux, and proved nothing about this
+    // guard on either. So the bracket gets a consistent stamp and only the LATER
+    // read differs, which is exactly the pid-reuse shape.
     const LIVE_CWD = resolve("bundle3");
+    let reads = 0;
+    __processControlTestHooks.setProcessIdentityResolver(() => ({
+      // The bracket reads it twice (before/after the request) and must agree;
+      // everything after that is the post-bracket world.
+      startedAt: ++reads <= 2 ? "stable-stamp" : "recycled-pid-different-process",
+    }));
     mockResolveBase.mockReturnValue(undefined);
     mockLiveRootFromArgv.mockReturnValue(undefined);
     mockGetSystemStats.mockResolvedValue({
@@ -602,8 +613,6 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
       return s === ABS_PYTHON || s === join(LIVE_CWD, "ComfyUI", "main.py");
     });
     __processControlTestHooks.setLiveCwdResolver(() => undefined);
-    // No stamp available on this host.
-    __processControlTestHooks.setProcessIdentityResolver(() => undefined);
     mockResolveLiveServerRoot.mockReturnValue({
       source: "observed-process",
       anchorDir: LIVE_CWD,
@@ -615,7 +624,12 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
 
     const result = await restartComfyUI();
 
-    expect(result.message).toMatch(/refusing to restart/i);
+    // The refuse-safe INVARIANT, not a particular sentence: nothing was stopped,
+    // nothing was spawned, the server is left running. The wording of the refusal
+    // differs by which guard fires first, and asserting it is what made this test
+    // platform-dependent.
+    expect(result.started).toBe(false);
+    expect(result.stopped).toBe(false);
     expect(mockSpawn).not.toHaveBeenCalled();
     expect(killSpy).not.toHaveBeenCalled();
 

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -477,6 +477,76 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
     killSpy.mockRestore();
   });
 
+  it("WINDOWS: an EQUALS-FORM relative path blocks the anchor too (#535)", async () => {
+    // `--output-directory=out` hides its value inside the flag token, so a guard
+    // that skips everything starting with "-" walks straight past it.
+    const LIVE_CWD = resolve("bundle-eq");
+    mockResolveBase.mockReturnValue(undefined);
+    mockLiveRootFromArgv.mockReturnValue(undefined);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [join("ComfyUI", "main.py"), "--output-directory=out"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === ABS_PYTHON || s === join(LIVE_CWD, "ComfyUI", "main.py");
+    });
+    __processControlTestHooks.setLiveCwdResolver(() => undefined);
+    mockResolveLiveServerRoot.mockReturnValue({
+      source: "observed-process",
+      anchorDir: LIVE_CWD,
+      observedPid: 4321,
+    });
+    mockLivePortThenFree();
+    mockSpawn.mockImplementation(() => new FakeChild());
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("WINDOWS: an equals-form ABSOLUTE path does NOT block the anchor (#535)", async () => {
+    // The mirror: unwrapping the payload must not turn every `--flag=…` into a
+    // refusal. An absolute value is still cwd-independent.
+    const LIVE_CWD = resolve("bundle-eq2");
+    const LIVE_MAIN = join(LIVE_CWD, "ComfyUI", "main.py");
+    mockResolveBase.mockReturnValue(undefined);
+    mockLiveRootFromArgv.mockReturnValue(undefined);
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: [join("ComfyUI", "main.py"), `--output-directory=${resolve("outdir")}`],
+      },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === ABS_PYTHON || s === LIVE_MAIN;
+    });
+    __processControlTestHooks.setLiveCwdResolver(() => undefined);
+    mockResolveLiveServerRoot.mockReturnValue({
+      source: "observed-process",
+      anchorDir: LIVE_CWD,
+      observedPid: 4321,
+    });
+    mockLivePortThenFree();
+    mockSpawn.mockImplementation(() => new FakeChild());
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(mockSpawn.mock.calls[0][1][0]).toBe(LIVE_MAIN);
+
+    killSpy.mockRestore();
+  });
+
   it("WINDOWS: a plain non-path value (`--port 8188`) does NOT block the anchor (#535)", async () => {
     // The guard above must not be so broad it refuses the very case this issue is
     // about. The reporter's argv carries `--port 8188`; a number cannot be a path.

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1616,18 +1616,22 @@ function argvHasRelativePathArg(argv: string[]): boolean {
     }
     // The token immediately after a path-valued flag is ITS VALUE, whatever it
     // looks like — `--output-directory -` names a directory called `-`, and
-    // treating it as the next flag is how that slips through (codex round 2).
-    if (pendingPathFlag) {
+    // treating it as the next flag is how that slipped through (codex round 2).
+    // A token starting with `--` is the exception: no ComfyUI path flag takes a
+    // `--`-prefixed value, so that is the NEXT FLAG and the previous one was a
+    // boolean we misread.
+    if (pendingPathFlag && !raw.startsWith("--")) {
       pendingPathFlag = false;
       if (!isAbsolutePath(raw)) return true;
       continue;
     }
+    pendingPathFlag = false;
     if (raw.startsWith("-")) {
       // `--flag=value` carries its value INSIDE the token.
       const eq = raw.indexOf("=");
       const name = eq >= 0 ? raw.slice(0, eq) : raw;
       const attached = eq >= 0 ? raw.slice(eq + 1) : undefined;
-      if (!PATH_VALUED_FLAG.test(name)) continue; // --port, --enable-manager, …
+      if (!KNOWN_PATH_FLAG.test(name)) continue; // --port, --cache-none, …
       if (attached === undefined) {
         pendingPathFlag = true; // its value is the next token
         continue;
@@ -1635,8 +1639,9 @@ function argvHasRelativePathArg(argv: string[]): boolean {
       if (attached && !isAbsolutePath(attached)) return true;
       continue;
     }
-    // A bare positional. Only a path-SHAPED one is a concern; a stray value that
-    // is not a path cannot be re-resolved into something else.
+    // Any other token: only a path-SHAPED one is a concern. A stray value that is
+    // not a path (`8188` after `--port`, `10` after `--cache-lru`) cannot be
+    // re-resolved into something else by a different cwd.
     if (raw === "." || raw === ".." || /[\\/]/.test(raw)) {
       if (!isAbsolutePath(raw)) return true;
     }
@@ -1647,24 +1652,29 @@ function argvHasRelativePathArg(argv: string[]): boolean {
 }
 
 /**
- * Flags whose value is a PATH, matched on the flag NAME rather than on what the
- * value looks like (codex round 2).
+ * ComfyUI's flags whose value is a PATH, matched on the flag NAME rather than on
+ * what the value looks like (codex round 2).
  *
  * Judging the value was the wrong instinct and bypassable three ways: `auto`,
  * `8188` and `-` are all perfectly legal directory names, so an allowlist of
  * "values that cannot be paths" cannot exist. The flag name is the part whose
- * vocabulary is knowable — ComfyUI's own `--input-directory`, `--output-directory`,
- * `--base-directory`, `--models-directory`, `--extra-model-paths-config`,
- * `--temp-directory`, `--user-directory`, `--log-file` — and the pattern is
- * deliberately broad so an unfamiliar path flag is treated as one rather than
- * waved through.
+ * vocabulary is knowable.
  *
- * Erring broad costs a refusal (the manual restart the user already has today);
- * erring narrow relaunches a server into a directory where its own arguments
- * point somewhere else.
+ * ENUMERATED, not pattern-matched. A broad `/dir|path|cache|log|…/` substring
+ * test is over-broad in the direction that BREAKS the fix: `--cache-none` and
+ * `--log-stdout` are BOOLEAN flags that match it, so the next token gets eaten as
+ * their "value" and a perfectly ordinary launch is refused. `--cache-none` is in
+ * this issue's own original report, so the heuristic would have refused the very
+ * argv it exists to support.
+ *
+ * A path flag missing from this list degrades to the positional check below —
+ * blocked when the value is path-SHAPED, allowed when it is not. That residual
+ * (an unknown path flag carrying a relative value that looks like nothing,
+ * e.g. `--future-dir auto`, on a symlinked launcher) is narrower than the
+ * blanket refusal it replaces, and is stated rather than hidden.
  */
-const PATH_VALUED_FLAG =
-  /(dir|directory|path|paths|file|config|folder|cache|log|output|input|models?|workspace|checkpoint)/i;
+const KNOWN_PATH_FLAG =
+  /^--(base|input|output|temp|user|models|custom-nodes|front-end-root)-director(y|ies)$|^--(models-dir|extra-model-paths-config|tls-keyfile|tls-certfile|log-file|directml)$/i;
 
 /** Absolute on either host convention — POSIX, Windows drive, or UNC. */
 function isAbsolutePath(p: string): boolean {

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1544,16 +1544,71 @@ function resolveLiveProcessCwd(pid: number): string | undefined {
  *
  * Never throws: a failure here must degrade to the old refusal, never break a stop.
  */
-function observedLiveCwd(pid: number, argv: string[]): string | undefined {
+function observedLiveCwd(
+  pid: number,
+  argv: string[],
+  expectedStartedAt: string | undefined,
+): string | undefined {
   if (!pid) return undefined;
+  // The anchor is INFERRED, never observed: it is a directory from which this
+  // relative script WOULD name this install, which is not the same claim as
+  // "the directory the process was started in". A launcher that keeps
+  // `C:\launcher\main.py` symlinked to `C:\bundle\main.py` is started from
+  // `C:\launcher`, yet `C:\bundle` satisfies the inference (codex gate).
+  //
+  // For the panel base (#1133) that gap is harmless — both spellings name the same
+  // install root. Here it is not: this value becomes the relaunch's WORKING
+  // DIRECTORY, so any relative argument would resolve somewhere else after the
+  // restart. So only adopt it when the choice of cwd CANNOT change what an
+  // argument means: every token after the script must be a flag, an absolute path,
+  // or a plain non-path value. Anything that could be a relative path leaves the
+  // pre-existing refusal in place.
+  if (argvHasRelativePathArg(argv)) return undefined;
   try {
     const live = resolveLiveServerRoot(argv, undefined, { remote: false });
     if (live.source !== "observed-process" || !live.anchorDir) return undefined;
     if (live.observedPid !== pid) return undefined;
+    // …and bind it to the process INSTANCE, not to the pid NUMBER. This resolver
+    // re-queries the port owner at its own moment, after the identity bracket
+    // above has already closed; a pid recycled in that window would satisfy a
+    // numeric comparison while describing a different server. The codebase's rule
+    // is pid + creation time, and an unreadable stamp is "did not observe", never
+    // "observed the same" — so it fails closed to the old refusal (#535 codex gate).
+    const nowStartedAt = resolveProcessIdentity(pid)?.startedAt;
+    if (!expectedStartedAt || !nowStartedAt || nowStartedAt !== expectedStartedAt) {
+      return undefined;
+    }
     return isAbsolute(live.anchorDir) ? live.anchorDir : undefined;
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Does any argument AFTER the launch script depend on the working directory?
+ *
+ * Conservative on purpose (#535): a token counts as a possible relative path
+ * unless it is a flag, an absolute path, or a plain value that cannot be one (a
+ * number, a `key=value` flag payload, a bare `true`/`false`). `--port 8188` is
+ * safe; `--output-directory out` is not, and neither is anything carrying a path
+ * separator without a root.
+ *
+ * The asymmetry is deliberate. A false positive costs a Windows user the same
+ * manual restart they have today; a false negative relaunches a server into a
+ * directory where its own arguments point somewhere else.
+ */
+function argvHasRelativePathArg(argv: string[]): boolean {
+  for (let i = 1; i < argv.length; i++) {
+    const token = argv[i];
+    if (!token || token.startsWith("-")) continue; // a flag, not a value
+    if (isAbsolute(token) || /^[a-zA-Z]:[\\/]/.test(token) || /^\\\\/.test(token)) {
+      continue; // absolute — cwd cannot change it
+    }
+    if (/^-?\d+(\.\d+)?$/.test(token)) continue; // numeric value (--port 8188)
+    if (/^(true|false|none|auto)$/i.test(token)) continue; // plain enum-ish value
+    return true; // could be a relative path
+  }
+  return false;
 }
 
 /**
@@ -2260,6 +2315,7 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
 
   let argv: string[] = [];
   let pid: number | null = null;
+  let ownerStartedAt: string | undefined;
   let bracketed = false;
   for (let attempt = 0; attempt < 2; attempt++) {
     const before = observeOwner();
@@ -2284,6 +2340,9 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
       }
       const after = observeOwner();
       pid = after?.pid ?? before?.pid ?? null;
+      // Keep the bracketed instance stamp: the observed-cwd fallback (#535) must
+      // bind to this PROCESS INSTANCE, not to a pid number it can re-observe later.
+      ownerStartedAt = after?.startedAt ?? before?.startedAt;
       if (pid == null) {
         try {
           pid = findPidByPort(port);
@@ -2403,8 +2462,9 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   // process observation instead of from procfs: the directory the server's relative
   // `main.py` must have been resolved against for it to name the install its own
   // interpreter lives in.
-  const liveCwd =
-    desktop ? undefined : (resolveLiveProcessCwd(pid) ?? observedLiveCwd(pid, argv));
+  const liveCwd = desktop
+    ? undefined
+    : (resolveLiveProcessCwd(pid) ?? observedLiveCwd(pid, argv, ownerStartedAt));
   // Same live-only window for the ENVIRONMENT (#776): read it now, while the pid
   // is guaranteed alive, so a relaunch can reproduce the launcher environment the
   // server was actually started with instead of substituting the orchestrator's.

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1599,13 +1599,25 @@ function observedLiveCwd(
  */
 function argvHasRelativePathArg(argv: string[]): boolean {
   for (let i = 1; i < argv.length; i++) {
-    const token = argv[i];
-    if (!token || token.startsWith("-")) continue; // a flag, not a value
+    const raw = argv[i];
+    if (!raw) continue; // an empty token is not a path
+    // `--flag=value` carries its value INSIDE the flag token, so skipping every
+    // token that starts with "-" would walk straight past a relative path
+    // (`--output-directory=out`). Unwrap the payload and judge that instead.
+    const eq = raw.startsWith("-") ? raw.indexOf("=") : -1;
+    const token = eq >= 0 ? raw.slice(eq + 1) : raw;
+    if (eq < 0 && raw.startsWith("-")) continue; // a bare flag, no value attached
+    if (!token) continue; // `--flag=` carries nothing
     if (isAbsolute(token) || /^[a-zA-Z]:[\\/]/.test(token) || /^\\\\/.test(token)) {
       continue; // absolute — cwd cannot change it
     }
     if (/^-?\d+(\.\d+)?$/.test(token)) continue; // numeric value (--port 8188)
-    if (/^(true|false|none|auto)$/i.test(token)) continue; // plain enum-ish value
+    // Plain enum-ish values ComfyUI really passes (`--preview-method auto`,
+    // `--force-fp16 true`). A directory named exactly one of these, handed over as
+    // a RELATIVE path while every other argument is absolute, is the one shape this
+    // allowlist could miss — accepted deliberately, because without it the fix
+    // would refuse most real launches.
+    if (/^(true|false|none|auto)$/i.test(token)) continue;
     return true; // could be a relative path
   }
   return false;

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1598,29 +1598,77 @@ function observedLiveCwd(
  * directory where its own arguments point somewhere else.
  */
 function argvHasRelativePathArg(argv: string[]): boolean {
+  let sawSeparator = false;
+  let pendingPathFlag = false;
   for (let i = 1; i < argv.length; i++) {
     const raw = argv[i];
-    if (!raw) continue; // an empty token is not a path
-    // `--flag=value` carries its value INSIDE the flag token, so skipping every
-    // token that starts with "-" would walk straight past a relative path
-    // (`--output-directory=out`). Unwrap the payload and judge that instead.
-    const eq = raw.startsWith("-") ? raw.indexOf("=") : -1;
-    const token = eq >= 0 ? raw.slice(eq + 1) : raw;
-    if (eq < 0 && raw.startsWith("-")) continue; // a bare flag, no value attached
-    if (!token) continue; // `--flag=` carries nothing
-    if (isAbsolute(token) || /^[a-zA-Z]:[\\/]/.test(token) || /^\\\\/.test(token)) {
-      continue; // absolute — cwd cannot change it
+    if (raw === undefined) continue;
+    // Everything after a bare `--` is positional, so nothing there is a flag and
+    // a leading dash no longer means what it did.
+    if (!sawSeparator && raw === "--") {
+      sawSeparator = true;
+      pendingPathFlag = false;
+      continue;
     }
-    if (/^-?\d+(\.\d+)?$/.test(token)) continue; // numeric value (--port 8188)
-    // Plain enum-ish values ComfyUI really passes (`--preview-method auto`,
-    // `--force-fp16 true`). A directory named exactly one of these, handed over as
-    // a RELATIVE path while every other argument is absolute, is the one shape this
-    // allowlist could miss — accepted deliberately, because without it the fix
-    // would refuse most real launches.
-    if (/^(true|false|none|auto)$/i.test(token)) continue;
-    return true; // could be a relative path
+    if (sawSeparator) {
+      if (!isAbsolutePath(raw)) return true; // a positional we cannot vouch for
+      continue;
+    }
+    // The token immediately after a path-valued flag is ITS VALUE, whatever it
+    // looks like — `--output-directory -` names a directory called `-`, and
+    // treating it as the next flag is how that slips through (codex round 2).
+    if (pendingPathFlag) {
+      pendingPathFlag = false;
+      if (!isAbsolutePath(raw)) return true;
+      continue;
+    }
+    if (raw.startsWith("-")) {
+      // `--flag=value` carries its value INSIDE the token.
+      const eq = raw.indexOf("=");
+      const name = eq >= 0 ? raw.slice(0, eq) : raw;
+      const attached = eq >= 0 ? raw.slice(eq + 1) : undefined;
+      if (!PATH_VALUED_FLAG.test(name)) continue; // --port, --enable-manager, …
+      if (attached === undefined) {
+        pendingPathFlag = true; // its value is the next token
+        continue;
+      }
+      if (attached && !isAbsolutePath(attached)) return true;
+      continue;
+    }
+    // A bare positional. Only a path-SHAPED one is a concern; a stray value that
+    // is not a path cannot be re-resolved into something else.
+    if (raw === "." || raw === ".." || /[\\/]/.test(raw)) {
+      if (!isAbsolutePath(raw)) return true;
+    }
   }
+  // A trailing path flag with no value left to take is malformed argv, not a
+  // relative path — there is nothing for a different cwd to re-resolve.
   return false;
+}
+
+/**
+ * Flags whose value is a PATH, matched on the flag NAME rather than on what the
+ * value looks like (codex round 2).
+ *
+ * Judging the value was the wrong instinct and bypassable three ways: `auto`,
+ * `8188` and `-` are all perfectly legal directory names, so an allowlist of
+ * "values that cannot be paths" cannot exist. The flag name is the part whose
+ * vocabulary is knowable — ComfyUI's own `--input-directory`, `--output-directory`,
+ * `--base-directory`, `--models-directory`, `--extra-model-paths-config`,
+ * `--temp-directory`, `--user-directory`, `--log-file` — and the pattern is
+ * deliberately broad so an unfamiliar path flag is treated as one rather than
+ * waved through.
+ *
+ * Erring broad costs a refusal (the manual restart the user already has today);
+ * erring narrow relaunches a server into a directory where its own arguments
+ * point somewhere else.
+ */
+const PATH_VALUED_FLAG =
+  /(dir|directory|path|paths|file|config|folder|cache|log|output|input|models?|workspace|checkpoint)/i;
+
+/** Absolute on either host convention — POSIX, Windows drive, or UNC. */
+function isAbsolutePath(p: string): boolean {
+  return isAbsolute(p) || /^[a-zA-Z]:[\\/]/.test(p) || /^\\\\/.test(p);
 }
 
 /**

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1620,10 +1620,14 @@ function argvHasRelativePathArg(argv: string[]): boolean {
     // A token starting with `--` is the exception: no ComfyUI path flag takes a
     // `--`-prefixed value, so that is the NEXT FLAG and the previous one was a
     // boolean we misread.
+    // KEEP consuming while the flag can still take values. ComfyUI declares
+    // `--extra-model-paths-config` as `nargs='+'`, so `--extra-model-paths-config
+    // C:\one.yaml two.yaml` carries TWO paths and only the first was being checked
+    // (codex round 3) — `two.yaml` then fell to the positional check, which lets a
+    // separator-free name through. argparse ends the list at the next option.
     if (pendingPathFlag && !raw.startsWith("--")) {
-      pendingPathFlag = false;
       if (!isAbsolutePath(raw)) return true;
-      continue;
+      continue; // stay pending: there may be more values
     }
     pendingPathFlag = false;
     if (raw.startsWith("-")) {
@@ -1641,8 +1645,10 @@ function argvHasRelativePathArg(argv: string[]): boolean {
     }
     // Any other token: only a path-SHAPED one is a concern. A stray value that is
     // not a path (`8188` after `--port`, `10` after `--cache-lru`) cannot be
-    // re-resolved into something else by a different cwd.
-    if (raw === "." || raw === ".." || /[\\/]/.test(raw)) {
+    // re-resolved into something else by a different cwd. A URL carries slashes
+    // without being a path — `--comfy-api-base https://api.comfy.org` is not
+    // something a working directory can move (codex round 3).
+    if (raw === "." || raw === ".." || (/[\\/]/.test(raw) && !isUrlLike(raw))) {
       if (!isAbsolutePath(raw)) return true;
     }
   }
@@ -1674,11 +1680,16 @@ function argvHasRelativePathArg(argv: string[]): boolean {
  * blanket refusal it replaces, and is stated rather than hidden.
  */
 const KNOWN_PATH_FLAG =
-  /^--(base|input|output|temp|user|models|custom-nodes|front-end-root)-director(y|ies)$|^--(models-dir|extra-model-paths-config|tls-keyfile|tls-certfile|log-file|directml)$/i;
+  /^--(base|input|output|temp|user|models|custom-nodes|front-end-root)-director(y|ies)$|^--(models-dir|extra-model-paths-config|tls-keyfile|tls-certfile|log-file)$/i;
 
 /** Absolute on either host convention — POSIX, Windows drive, or UNC. */
 function isAbsolutePath(p: string): boolean {
   return isAbsolute(p) || /^[a-zA-Z]:[\\/]/.test(p) || /^\\\\/.test(p);
+}
+
+/** A URL, not a filesystem path — it carries slashes but no cwd can move it. */
+function isUrlLike(p: string): boolean {
+  return /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(p);
 }
 
 /**

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -68,6 +68,7 @@ import {
 import {
   liveRootFromArgv,
   resolveEffectiveComfyUIBase,
+  resolveLiveServerRoot,
   markLocalComfyUILaunched,
   resetLocalComfyUILaunchState,
 } from "./workspace-env.js";
@@ -1522,6 +1523,40 @@ function resolveLiveProcessCwd(pid: number): string | undefined {
 }
 
 /**
+ * The live process's working directory, reconstructed from the OS process
+ * observation rather than from procfs (#535) — the Windows path, where
+ * `/proc/<pid>/cwd` does not exist.
+ *
+ * `resolveLiveServerRoot`'s observed-process tier walks up from the interpreter the
+ * OS reports for the server on our port and accepts the first ancestor under which
+ * `<ancestor>/<relDir>/main.py` exists AND the interpreter belongs to that install.
+ * That accepted ancestor IS the working directory the server must have had for its
+ * relative `main.py` to name this install — the same fact `/proc/<pid>/cwd` states
+ * directly.
+ *
+ * THE PID MUST MATCH. This value is used to decide a relaunch of a process we are
+ * about to KILL, and the observation is anchored on "whatever is listening on our
+ * port". If that is a different process than `pid` — a second ComfyUI, a proxy, a
+ * pid we resolved from a stale record — then its install is not the one being
+ * stopped, and anchoring the relaunch on it would restart the wrong tree after
+ * killing the right one. An unconfirmed observation is discarded, leaving the
+ * pre-existing refusal exactly as it was.
+ *
+ * Never throws: a failure here must degrade to the old refusal, never break a stop.
+ */
+function observedLiveCwd(pid: number, argv: string[]): string | undefined {
+  if (!pid) return undefined;
+  try {
+    const live = resolveLiveServerRoot(argv, undefined, { remote: false });
+    if (live.source !== "observed-process" || !live.anchorDir) return undefined;
+    if (live.observedPid !== pid) return undefined;
+    return isAbsolute(live.anchorDir) ? live.anchorDir : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * The argv a relaunch is built from: the SERVER's own `sys.argv` when it could tell
  * us, otherwise the OS's view of the same process (#767).
  *
@@ -2360,7 +2395,16 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
   const desktopExe = desktop ? findDesktopExePath(identifyingArgv) : undefined;
   // Capture the live process cwd NOW, while the pid is guaranteed alive — the
   // `/proc/<pid>/cwd` symlink is gone the instant a later stop kills it (#535).
-  const liveCwd = desktop ? undefined : resolveLiveProcessCwd(pid);
+  //
+  // On Windows there is no `/proc`, so this returned undefined and the relative-script
+  // anchor downstream could never fire — a `ComfyUI\main.py` launch was refused
+  // outright with "could not locate the ComfyUI install", which is the #535 recurrence
+  // that kept coming back. `observedLiveCwd` reconstructs the SAME fact from the OS
+  // process observation instead of from procfs: the directory the server's relative
+  // `main.py` must have been resolved against for it to name the install its own
+  // interpreter lives in.
+  const liveCwd =
+    desktop ? undefined : (resolveLiveProcessCwd(pid) ?? observedLiveCwd(pid, argv));
   // Same live-only window for the ENVIRONMENT (#776): read it now, while the pid
   // is guaranteed alive, so a relaunch can reproduce the launcher environment the
   // server was actually started with instead of substituting the orchestrator's.

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -643,6 +643,24 @@ export interface LiveServerRootResolution {
   relDir?: string;
   /** The interpreter the OS reports for the process on our port, when observed. */
   observedPython?: string;
+  /**
+   * The directory `relDir` was resolved AGAINST to produce `root` — i.e. the
+   * working directory the running server must have had for its relative
+   * `main.py` to name that install (`observed-process` only).
+   *
+   * This is the WINDOWS equivalent of `/proc/<pid>/cwd` (#535). `resolveLiveProcessCwd`
+   * returns undefined on Windows, so the restart path's live-cwd anchor could never
+   * fire there and a relative launch script was refused outright. Recovering the
+   * anchor directory here reconstructs the same fact from the OS process
+   * observation instead of from procfs.
+   *
+   * Only meaningful with `observedPid`: it describes THAT process, and a caller
+   * about to stop a server must confirm it is the same one before trusting it.
+   */
+  anchorDir?: string;
+  /** The PID the observation was made against, so a caller can confirm the
+   *  anchor describes the very process it is acting on (#535). */
+  observedPid?: number;
 }
 
 /** How far up from the observed interpreter we look for the live install root.
@@ -715,14 +733,23 @@ function interpreterBelongsToInstall(python: string, base: string, root: string)
  * interpreter is positioned inside that install (interpreterBelongsToInstall), so
  * an unrelated `main.py` further up the filesystem can never be adopted. Returns
  * undefined when nothing on the bounded path qualifies.
+ *
+ * Returns the accepted install root together with the ancestor it was resolved
+ * AGAINST. That ancestor is the working directory the server must have had for its
+ * relative `main.py` to name this install — the fact `/proc/<pid>/cwd` supplies on
+ * Linux and nothing supplied on Windows (#535). It falls out of the walk for free;
+ * discarding it was why the restart path had no Windows anchor to use.
  */
-function anchorRelDirOnInterpreter(python: string, relDir: string): string | undefined {
+function anchorRelDirOnInterpreter(
+  python: string,
+  relDir: string,
+): { root: string; anchorDir: string } | undefined {
   if (!isAbsolute(python)) return undefined;
   let dir = dirname(pathResolve(python));
   for (let i = 0; i < OBSERVED_ROOT_MAX_ASCENT; i++) {
     const candidate = pathResolve(dir, relDir);
     if (hasMainPy(candidate) && interpreterBelongsToInstall(python, dir, candidate)) {
-      return candidate;
+      return { root: candidate, anchorDir: dir };
     }
     const parent = dirname(dir);
     if (parent === dir) break;
@@ -743,7 +770,9 @@ function anchorRelDirOnInterpreter(python: string, relDir: string): string | und
  * #369 is about (codex gate, round 1). Each resolution re-observes the process
  * that is live right now; correctness here outranks a few hundred milliseconds.
  */
-function observeLivePython(argv: string[] | undefined): string | undefined {
+function observeLivePython(
+  argv: string[] | undefined,
+): { python: string; pid: number } | undefined {
   let statsHost: string | undefined;
   try {
     statsHost = new URL(getComfyUIBaseUrl()).hostname;
@@ -751,12 +780,16 @@ function observeLivePython(argv: string[] | undefined): string | undefined {
     /* unparseable target → no host filter */
   }
   try {
-    return resolveLiveInterpreter({
+    const live = resolveLiveInterpreter({
       port: config.resolvedPort,
       host: statsHost,
       remote: false,
       serverArgv: argv,
-    })?.python;
+    });
+    // The PID travels with the interpreter (#535). A caller that is about to STOP
+    // a process must be able to confirm the anchor describes that very process
+    // and not some other ComfyUI — an interpreter path alone cannot prove it.
+    return live ? { python: live.python, pid: live.pid } : undefined;
   } catch {
     return undefined;
   }
@@ -797,6 +830,8 @@ export function resolveLiveServerRoot(
   opts?: {
     /** Test seam / caller-supplied observation, bypassing the process-table probe. */
     observedPython?: string;
+    /** PID the caller-supplied observation belongs to (test seam companion). */
+    observedPid?: number;
     /** Skip the process-table probe entirely (remote server). Defaults to isRemoteMode(). */
     remote?: boolean;
   },
@@ -808,14 +843,26 @@ export function resolveLiveServerRoot(
   if (remote || relDir === undefined) return { source: "unresolved", relDir };
 
   let observedPython = opts?.observedPython;
-  if (!observedPython) observedPython = observeLivePython(argv);
+  let observedPid = opts?.observedPid;
+  if (!observedPython) {
+    const observed = observeLivePython(argv);
+    observedPython = observed?.python;
+    observedPid = observed?.pid;
+  }
   if (!observedPython) return { source: "unresolved", relDir };
 
   const anchored = anchorRelDirOnInterpreter(observedPython, relDir);
   if (anchored) {
-    return { root: anchored, source: "observed-process", relDir, observedPython };
+    return {
+      root: anchored.root,
+      source: "observed-process",
+      relDir,
+      observedPython,
+      observedPid,
+      anchorDir: anchored.anchorDir,
+    };
   }
-  return { source: "unresolved", relDir, observedPython };
+  return { source: "unresolved", relDir, observedPython, observedPid };
 }
 
 /**


### PR DESCRIPTION
Claiming the newest recurrence of #535 — the 2026-08-10 Windows 10 report:

> `Resolved ComfyUI script does not exist on disk: ComfyUI\main.py — could not locate the ComfyUI install; set COMFYUI_PATH or a default workspace.`

## Why the v0.48.23 fix does not cover it

That fix was right, and it works — on Linux. It anchors a relative launch script against the live process's own working directory, read from `/proc/<pid>/cwd` while the process is still alive.

`resolveLiveProcessCwd` (`src/services/process-control.ts`) opens with:

```ts
if (!pid || IS_WIN) return undefined;
```

So on Windows `info.liveCwd` is always `undefined`, the anchor at the `!scriptIsAbsolute && info.liveCwd` branch never fires, and the original refusal stands. My own close comment on this issue named that explicitly — *"Other OSes have no cheap `/proc` equivalent … a known limitation rather than an oversight."*

The limitation was accurate. It is no longer necessary.

## What changed since

#1133 (shipping in 0.50.90) established that Windows **does** have a usable equivalent for exactly this shape. `resolveLiveServerRoot`'s `observed-process` tier identifies the process listening on our port, correlates it against that server's own argv, and re-anchors a relative `main.py` on that interpreter's install tree — accepting the result only when the anchored directory really holds `main.py` and the interpreter belongs to that install.

I verified that tier live on a Windows rig while working #1133: the argv shape `ComfyUI\main.py` — the same one in this report — anchored to a real tree holding `main.py` and `custom_nodes`.

## Plan

- [ ] Confirm the Windows recurrence reaches the `!scriptIsAbsolute` refusal for the reason above, not a different one
- [ ] Anchor the relative script via the observed-process tier when `liveCwd` is unavailable
- [ ] Anchor the **interpreter** too — a relative script fixed with a bare `python` still relaunches into the wrong environment (the 2026-08-04 `spawn python.exe ENOENT` recurrence on this same issue)
- [ ] Keep refuse-safe: if the anchored path is still not a regular file, refuse and leave ComfyUI running. The anchor may only ever *add* a way to succeed.
- [ ] Platform-pinned tests (`node:os` `platform()` mocked both ways) — this path passes trivially on the wrong host

Draft until the mechanism is confirmed rather than assumed. This one has been closed-then-reopened three times, so the bar is a reproduction traced to the specific branch, not a plausible story.