### PR TITLE
fix(panel-tools): stop prescribing a rebind that needs the tab we just said is missing

### DIFF
--- a/src/__tests__/orchestrator/no-reachable-tab-remedy.test.ts
+++ b/src/__tests__/orchestrator/no-reachable-tab-remedy.test.ts
@@ -11,12 +11,17 @@
 //   4. which is step 1 — and whose only probe is a `workflow_list` call TO A TAB,
 //      so it needs exactly what step 3 just said is missing.
 //
-// The message folded two causes that want opposite advice:
+// The message folded two causes into one remedy, and they want different advice:
 //
-//   nothing connected      -> nothing to rebind ONTO; the rebind cannot help
-//   connected, none is ours -> the rebind is precisely right
+//   nothing connected       -> a rebind DEFERS (it clears the stale binding and
+//                              takes effect on the first tab that reconnects), so
+//                              it does not make this retryable now
+//   connected, none is ours -> a rebind is precisely right: it re-points the
+//                              session at the live tab
 //
-// The bridge can tell them apart, so the remedy now matches the cause.
+// The bridge can tell them apart, so the remedy now matches the cause. What the
+// zero-tab branch says was MEASURED against the real handler, not reasoned — see
+// the first test.
 
 import { describe, expect, it } from "vitest";
 
@@ -58,16 +63,22 @@ async function openWorkflow(bridge: PanelToolCtx["bridge"]): Promise<string> {
 }
 
 describe("the no-reachable-tab remedy matches its cause (#971)", () => {
-  it("NOTHING connected: does not send the caller to a rebind that cannot work", async () => {
-    // The reporter's loop. `mode:"current"` re-derives the fence from a
-    // `workflow_list` call to a tab — with none connected there is nothing to
-    // ask, so offering it is advice that cannot come true.
+  it("NOTHING connected: says the rebind DEFERS rather than repairs", async () => {
+    // MEASURED, and it corrected me. My first version of this asserted the
+    // rebind "cannot help" with zero tabs. Probed against the real handler: it
+    // returns `deferred: true`, CLEARS the stale binding, and arms a bind onto
+    // the first tab that reconnects. So it is worth doing — it simply does not
+    // make the command retryable now, which is what the caller is asking. The
+    // loop the reporter hit comes from not saying which of those it does.
     const text = await openWorkflow(bridgeWith([]));
 
     expect(text).toMatch(/NO panel tab is connected at all/);
-    expect(text).toMatch(/Rebinding CANNOT help while nothing is connected/);
-    // …and it names what does help instead.
-    expect(text).toMatch(/Wait for the tab to reconnect|open\/refresh the ComfyUI tab/);
+    expect(text).toMatch(/will NOT make this retryable yet/);
+    expect(text).toMatch(/clears the stale binding and DEFERS/);
+    // …and it names what actually brings a tab back.
+    expect(text).toMatch(/Wait for the reconnect|open\/refresh the ComfyUI browser tab/);
+    // The false claim must not come back.
+    expect(text).not.toMatch(/CANNOT help/);
   });
 
   it("CONNECTED but not ours: the rebind IS the right move, and is offered", async () => {
@@ -77,7 +88,7 @@ describe("the no-reachable-tab remedy matches its cause (#971)", () => {
 
     expect(text).toMatch(/1 panel tab\(s\) are connected/);
     expect(text).toMatch(/panel_set_workflow_target\(\{mode:"current"\}\)/);
-    expect(text).not.toMatch(/CANNOT help/);
+    expect(text).not.toMatch(/will NOT make this retryable yet/);
   });
 
   it("headless tabs do not count as something to rebind onto", async () => {

--- a/src/__tests__/orchestrator/no-reachable-tab-remedy.test.ts
+++ b/src/__tests__/orchestrator/no-reachable-tab-remedy.test.ts
@@ -1,0 +1,114 @@
+// #971 (panel) — the recovery told the caller to do the thing that had just
+// failed, using the thing that was missing.
+//
+// The reporter's trace is a loop:
+//
+//   1. panel_set_workflow_target(mode:"current")  -> reports `bound`
+//   2. panel_set_widget                           -> [root-workflow-uuid-mismatch]
+//   3. the prescribed recovery, panel_open_workflow
+//        -> "no reachable panel tab yet … or rebind with
+//            panel_set_workflow_target({mode:'current'})"
+//   4. which is step 1 — and whose only probe is a `workflow_list` call TO A TAB,
+//      so it needs exactly what step 3 just said is missing.
+//
+// The message folded two causes that want opposite advice:
+//
+//   nothing connected      -> nothing to rebind ONTO; the rebind cannot help
+//   connected, none is ours -> the rebind is precisely right
+//
+// The bridge can tell them apart, so the remedy now matches the cause.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+
+/** A bridge that reports `tabs` but never becomes reachable, which is the state
+ *  `awaitReachable` gives up on. */
+function bridgeWith(tabs: Array<{ tab_id: string; headless?: boolean }>) {
+  return {
+    send: async () => ({ ok: true }),
+    push: () => 1,
+    canReach: () => false,
+    isHeadless: (id: string) => tabs.find((t) => t.tab_id === id)?.headless === true,
+    tabs: () => tabs.map((t) => ({ tab_id: t.tab_id, title: "wf", connected_at: 0 })),
+    resolveActiveTabId: () => tabs[0]?.tab_id ?? TAB,
+    workflowUuidFor: () => ({ known: false }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+async function openWorkflow(bridge: PanelToolCtx["bridge"]): Promise<string> {
+  const ctx = makePanelToolCtx(bridge, TAB, new WorkflowTargetStore());
+  // The pre-send reachability wait is what produces this failure; make it give up
+  // immediately rather than waiting out the real budget.
+  (ctx as { awaitReachable?: () => Promise<boolean> }).awaitReachable = async () => false;
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_open_workflow");
+  if (!def) throw new Error("panel_open_workflow is not registered");
+  const res: ToolResult = await def.handler({ path: "workflows/b.json" }, ctx);
+  return (res.content[0] as { text: string }).text;
+}
+
+describe("the no-reachable-tab remedy matches its cause (#971)", () => {
+  it("NOTHING connected: does not send the caller to a rebind that cannot work", async () => {
+    // The reporter's loop. `mode:"current"` re-derives the fence from a
+    // `workflow_list` call to a tab — with none connected there is nothing to
+    // ask, so offering it is advice that cannot come true.
+    const text = await openWorkflow(bridgeWith([]));
+
+    expect(text).toMatch(/NO panel tab is connected at all/);
+    expect(text).toMatch(/Rebinding CANNOT help while nothing is connected/);
+    // …and it names what does help instead.
+    expect(text).toMatch(/Wait for the tab to reconnect|open\/refresh the ComfyUI tab/);
+  });
+
+  it("CONNECTED but not ours: the rebind IS the right move, and is offered", async () => {
+    // The other half of the old sentence, and here the advice is correct: there
+    // is a live tab to re-point the session at.
+    const text = await openWorkflow(bridgeWith([{ tab_id: "wf:workflows/other.json" }]));
+
+    expect(text).toMatch(/1 panel tab\(s\) are connected/);
+    expect(text).toMatch(/panel_set_workflow_target\(\{mode:"current"\}\)/);
+    expect(text).not.toMatch(/CANNOT help/);
+  });
+
+  it("headless tabs do not count as something to rebind onto", async () => {
+    // A headless tab is not a panel a user is looking at; counting it would give
+    // the "rebind onto the live one" advice when there is no live one.
+    const text = await openWorkflow(bridgeWith([{ tab_id: "hl:1", headless: true }]));
+    expect(text).toMatch(/NO panel tab is connected at all/);
+  });
+
+  it("an unreadable bridge keeps the old, cause-neutral wording", async () => {
+    // Fail toward what was there before rather than guessing which cause it is:
+    // asserting either one would be a claim we cannot support.
+    const blind = {
+      ...(bridgeWith([]) as object),
+      tabs: () => {
+        throw new Error("bridge is not enumerable here");
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const text = await openWorkflow(blind);
+
+    expect(text).toMatch(/no reachable panel tab yet/);
+    expect(text).not.toMatch(/NO panel tab is connected at all/);
+    expect(text).not.toMatch(/are connected/);
+  });
+
+  it("every branch still says NOTHING WAS SENT — that fact must not move", async () => {
+    // The pre-send wait exists so a mutating command is not fired into a dead
+    // binding. A caller that cannot tell whether it was sent retries blindly,
+    // which is the double-apply this guard prevents.
+    for (const bridge of [bridgeWith([]), bridgeWith([{ tab_id: "wf:other" }])]) {
+      expect(await openWorkflow(bridge)).toMatch(/Nothing was\s+sent/);
+    }
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4059,7 +4059,55 @@ async function waitForOpenReceipt(
  *  gave up (no tab reconnected within budget / an ambiguous multi-tab session). We
  *  must NOT dispatch — firing into a dead binding is exactly the OUTCOME-UNKNOWN /
  *  double-apply risk the pre-send wait exists to prevent (codex). */
-function noReachableTabFail(cmd: string): ToolResult {
+function noReachableTabFail(cmd: string, ctx?: PanelToolCtx): ToolResult {
+  // #971 — TWO CAUSES, OPPOSITE REMEDIES, and they were folded into one sentence
+  // that sent the reporter in a circle:
+  //
+  //   panel_open_workflow  -> "no reachable tab … or rebind with
+  //                            panel_set_workflow_target({mode:'current'})"
+  //   mode:"current"       -> its only probe is a workflow_list call TO A TAB
+  //
+  // So the advice needed exactly the thing whose absence caused the failure. The
+  // reporter had already run the rebind — it reported `bound` — and was sent back
+  // to it.
+  //
+  // The two causes want different answers, and the bridge can tell them apart:
+  //  • nothing connected  → there is nothing to rebind ONTO. Say so, and name the
+  //    thing that does help (the tab reconnecting, or the user opening/refreshing
+  //    one).
+  //  • tabs connected, none is ours → `mode:"current"` is exactly right: it
+  //    re-points the session at the active tab.
+  let connected: number | null = null;
+  try {
+    const tabs = ctx?.bridge?.tabs?.();
+    if (Array.isArray(tabs)) {
+      connected = tabs.filter(
+        (t) => !(typeof ctx?.bridge?.isHeadless === "function" && ctx.bridge.isHeadless(t.tab_id)),
+      ).length;
+    }
+  } catch {
+    connected = null; // an unreadable bridge earns the neutral wording below
+  }
+
+  if (connected === 0) {
+    return fail(
+      `${cmd} — this session has no reachable panel tab, and NO panel tab is connected at all ` +
+        `(still reconnecting after a restart/reload, or the ComfyUI browser tab is closed). ` +
+        `Nothing was sent. Rebinding CANNOT help while nothing is connected — ` +
+        `panel_set_workflow_target({mode:"current"}) has to reach a tab to do anything. Wait for ` +
+        `the tab to reconnect and retry, or ask the user to open/refresh the ComfyUI tab.`,
+    );
+  }
+  if (connected !== null && connected > 0) {
+    return fail(
+      `${cmd} — this session has no reachable panel tab, though ${connected} panel tab(s) are ` +
+        `connected — none of them is bound to this session (its tab was replaced, or several are ` +
+        `open and the session's is gone). Nothing was sent. Rebind onto the live one with ` +
+        `panel_set_workflow_target({mode:"current"}), then retry.`,
+    );
+  }
+  // Bridge could not enumerate tabs: keep the old, cause-neutral wording rather
+  // than guessing which of the two it is.
   return fail(
     `${cmd} — this session has no reachable panel tab yet (still reconnecting after a ` +
       `restart/reload, or multiple tabs are open and none is this session's). Nothing was ` +
@@ -4075,7 +4123,7 @@ async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<
   // OUTCOME UNKNOWN. A healthy session returns from this instantly; if no tab
   // reconnects within budget we REFUSE rather than dispatch into a dead binding.
   if (ctx.awaitReachable && !(await ctx.awaitReachable())) {
-    return noReachableTabFail("workflow_open");
+    return noReachableTabFail("workflow_open", ctx);
   }
   let dispatchedRid: string | undefined;
   const res = await ctx.call(
@@ -9255,7 +9303,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // if no tab reconnects within budget we REFUSE rather than fire into a dead
         // binding.
         if (ctx.awaitReachable && !(await ctx.awaitReachable())) {
-          return noReachableTabFail(args.name ? "workflow_save_as" : "workflow_save");
+          return noReachableTabFail(args.name ? "workflow_save_as" : "workflow_save", ctx);
         }
         const res = args.name
           ? await ctx.call({ cmd: "workflow_save_as", name: args.name }, 15000)

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4090,12 +4090,20 @@ function noReachableTabFail(cmd: string, ctx?: PanelToolCtx): ToolResult {
   }
 
   if (connected === 0) {
+    // MEASURED, not assumed. An earlier draft of this said "rebinding CANNOT
+    // help while nothing is connected". That is false: with zero tabs
+    // `mode:"current"` returns `deferred: true`, CLEARS the stale binding, and
+    // arms a bind onto the first tab that reconnects. It is worth doing — it
+    // just does not make the command retryable NOW, which is what the caller is
+    // actually asking. Saying which of those it does is the difference between
+    // a useful instruction and the loop the reporter hit.
     return fail(
       `${cmd} — this session has no reachable panel tab, and NO panel tab is connected at all ` +
         `(still reconnecting after a restart/reload, or the ComfyUI browser tab is closed). ` +
-        `Nothing was sent. Rebinding CANNOT help while nothing is connected — ` +
-        `panel_set_workflow_target({mode:"current"}) has to reach a tab to do anything. Wait for ` +
-        `the tab to reconnect and retry, or ask the user to open/refresh the ComfyUI tab.`,
+        `Nothing was sent. A rebind will NOT make this retryable yet: with nothing connected, ` +
+        `panel_set_workflow_target({mode:"current"}) clears the stale binding and DEFERS, taking ` +
+        `effect on the first tab that reconnects — useful, but it does not bring a tab back. ` +
+        `Wait for the reconnect and retry, or ask the user to open/refresh the ComfyUI browser tab.`,
     );
   }
   if (connected !== null && connected > 0) {


### PR DESCRIPTION
Draft — claiming the orchestrator half of artokun/comfyui-mcp-panel#971.

The reporter's trace is a **remedy loop**:

1. `panel_set_workflow_target(mode:"current")` → reports `bound`
2. `panel_set_widget` → `[root-workflow-uuid-mismatch]`
3. the prescribed recovery, `panel_open_workflow` → *"this session has no reachable panel tab yet … Retry in a moment, **or rebind with panel_set_workflow_target({mode:"current"})**"*
4. …which is step 1, and which needs a reachable tab to do anything: the rebind's only probe is a `workflow_list` call to a tab.

## The message folds two causes with one remedy

> still reconnecting after a restart/reload, **or** multiple tabs are open and none is this session's

Those want opposite advice:

- **no tab connected at all** — there is nothing to rebind *onto*. `mode:"current"` cannot help, and offering it sends the caller round the loop above.
- **tabs connected, none is ours** — `mode:"current"` is exactly right, because it re-points the session at the active tab.

The bridge can already tell these apart (`bridge.tabs()`, minus headless), so the remedy can match the cause.

## Scope

Only the remedy. The Save-As identity half of #971 is a different fix that has since shipped panel-side (0.11.81, #941) — the reporter is on panel 0.11.51 / mcp 0.50.52, roughly 30 releases back — and I will say so on the issue rather than re-fixing it blind.