### PR TITLE
chore(release): 0.50.92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.92] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- anchor a relative launch script on Windows, where /proc has no equivalent (#1315)
+- stop prescribing a rebind that needs the tab we just said is missing (#1317)
+
+
 ## [0.50.91] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.91",
+  "version": "0.50.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.91",
+      "version": "0.50.92",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.91",
+  "version": "0.50.92",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release 0.50.92.

### Fixed

- **#535** — anchor a relative launch script on Windows, where `/proc` has no equivalent (#1315)
- stop prescribing a rebind that needs the tab we just said is missing (#1317)

## #535 — the Windows half

`restart_comfyui` / `panel_restart_comfyui` refused outright on a Windows install launched as `ComfyUI\main.py` with no canonical base:

> `Resolved ComfyUI script does not exist on disk: ComfyUI\main.py — could not locate the ComfyUI install`

The v0.48.23 fix for this issue anchors a relative launch script against the live process's working directory from `/proc/<pid>/cwd`. `resolveLiveProcessCwd` returns `undefined` on Windows, so the anchor never ran there and the refusal stood. That was called out as a known limitation at the time — accurately, but treating it as permanent is what let this issue be reopened a fourth time.

#1133 (0.50.90) established the Windows equivalent: identify the process listening on our port, correlate it against that server's own argv, and re-anchor the relative `main.py` on that interpreter's install tree. The ancestor it resolves against **is** the working directory the server must have had. It was already computed and discarded.

Verified on a real Windows install: `anchorDir` resolves and the relaunch script exists on disk.

### It only ever adds a way to succeed

This path stops a running server, so every guard fails closed:

- the anchor is bound to the process **instance** (pid + creation time), not the pid number — a recycled pid is refused;
- it is not adopted when any argument could be cwd-relative, because the anchor is *inferred*, and a symlinked launcher can satisfy the inference from a different directory;
- an unresolved or unconfirmed observation leaves the previous refusal untouched;
- Linux/procfs is unchanged — it short-circuits before any of this.

Three adversarial review rounds; two found real holes. One caught that the guard would have refused `--cache-none`, which is in the issue's own original report — the over-broad direction that silently un-ships a fix rather than weakening it. The suite now carries explicit allowed-through cases for it.

A **bare** `main.py` with no directory part still refuses, deliberately: with nothing to anchor, reaching a nested sibling install from an interpreter is a different inference on a destructive path.