### PR TITLE
fix(#971): the prescribed recovery from a lost tab binding is a dead end

### DIFF
--- a/src/__tests__/orchestrator/panel-971-recovery-deadend.test.ts
+++ b/src/__tests__/orchestrator/panel-971-recovery-deadend.test.ts
@@ -109,7 +109,7 @@ it("#971 with NO last-active tab, the prescribed recovery is a dead end", async 
   // And whatever it says, it must leave the caller somewhere other than where it
   // started: either rebound, or told an action that does not require a parameter
   // this tool does not have.
-  const recovered = ctx.tabId !== "stale-tab" || /switch to|focus/i.test(textOf(rec2));
+  const recovered = ctx.tabId !== "stale-tab" || /sent from its Agent panel/i.test(textOf(rec2));
   expect(recovered).toBe(true);
 });
 
@@ -126,5 +126,40 @@ it("#971 a NON-ambiguity failure keeps its own words", async () => {
   const res = (await target.handler({ mode: "current" }, ctx)) as ToolResult;
   expect(res.isError).toBe(true);
   expect(textOf(res)).toMatch(/bridge exploded while resolving/);
-  expect(textOf(res)).not.toMatch(/Switch to \(click\)/);
+  expect(textOf(res)).not.toMatch(/Agent panel/);
+});
+
+it("#971 no recovery message tells the user to do something that does not work", async () => {
+  // The mechanism, from ui-bridge.ts: setLastActiveTab is documented as the ONLY
+  // writer of lastActiveTabId and is called on `msg.type === "user_message"`. A tab
+  // becomes last-active when a MESSAGE IS SENT from its Agent panel. Focusing or
+  // clicking the browser tab never touches it.
+  //
+  // Four messages in panel-tools.ts prescribe this recovery, and three of them said
+  // "Switch to the tab you want" — an instruction that leaves the state exactly as it
+  // was and sends the user around the loop again. This asserts on the SOURCE because
+  // three of the four are on paths (mobile-client, panel_reload) this file cannot
+  // reach, and a message that is wrong is wrong whether or not a test can drive it.
+  const { readFileSync } = await import("node:fs");
+  const src = readFileSync(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf8");
+
+  const prescribes = src.split(/\r?\n/).filter((l) => /panel_set_workflow_target\(\{mode:"current"\}\)/.test(l));
+  expect(prescribes.length).toBeGreaterThan(0);
+
+  // No user-facing recovery TEXT may claim that switching/focusing a tab does it.
+  // Comment lines are excluded deliberately: the doc comment on
+  // ambiguousRebindGuidance quotes the wrong advice in order to explain why it is
+  // wrong, and a gate that cannot tell an explanation from an instruction would
+  // force that explanation to be deleted. Checked against a known site below.
+  const codeLines = src
+    .split(String.fromCharCode(10))
+    .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
+    .join(String.fromCharCode(10));
+  expect(codeLines).not.toMatch(/Switch to (the|\(click\) the) (ComfyUI )?tab you want/i);
+  // The filter must not be so aggressive that it would miss a real one: prove it
+  // still sees ordinary string content on these same lines.
+  expect(codeLines).toMatch(/panel_set_workflow_target/);
+  // And the real mechanism must be stated wherever the recovery is prescribed.
+  expect((src.match(/not focusing the tab/g) ?? []).length).toBeGreaterThanOrEqual(3);
+  expect(src).toMatch(/sent from its Agent panel|send a message from the Agent panel/i);
 });

--- a/src/__tests__/orchestrator/panel-971-recovery-deadend.test.ts
+++ b/src/__tests__/orchestrator/panel-971-recovery-deadend.test.ts
@@ -112,3 +112,19 @@ it("#971 with NO last-active tab, the prescribed recovery is a dead end", async 
   const recovered = ctx.tabId !== "stale-tab" || /switch to|focus/i.test(textOf(rec2));
   expect(recovered).toBe(true);
 });
+
+it("#971 a NON-ambiguity failure keeps its own words", async () => {
+  // The guard's false-positive direction is invisible in the tests above: if
+  // ambiguousRebindGuidance rewrote everything, they would still pass while every
+  // unrelated rebind failure was replaced by advice about switching tabs.
+  const { bridge } = reconnectingBridge(["tab-a", "tab-b"]);
+  (bridge as unknown as { resolveActiveTabId: () => string }).resolveActiveTabId = () => {
+    throw new Error("bridge exploded while resolving");
+  };
+  const ctx = makePanelToolCtx(bridge, "stale-tab", new WorkflowTargetStore());
+  const target = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target")!;
+  const res = (await target.handler({ mode: "current" }, ctx)) as ToolResult;
+  expect(res.isError).toBe(true);
+  expect(textOf(res)).toMatch(/bridge exploded while resolving/);
+  expect(textOf(res)).not.toMatch(/Switch to \(click\)/);
+});

--- a/src/__tests__/orchestrator/panel-971-recovery-deadend.test.ts
+++ b/src/__tests__/orchestrator/panel-971-recovery-deadend.test.ts
@@ -1,0 +1,114 @@
+// PROBE for panel#971 — not a fix, and not intended to be merged as-is.
+//
+// Reporter's wedge: after Save-As, panel_set_workflow_target({mode:"current"})
+// reports BOUND, panel_set_widget still fails [root-workflow-uuid-mismatch], and
+// the prescribed recovery panel_open_workflow then refuses with
+// "this session has no reachable panel tab yet".
+//
+// The question this probe answers, and nothing more: does the recovery the
+// refusal MESSAGE names actually restore reachability for the command that
+// refused? awaitReachable's own comment justifies returning early by asserting
+// that "panel_set_workflow_target proceeds to its explicit last-active rebind",
+// so if that rebind does not move ctx.tabId, the advice is a loop.
+import { beforeEach, afterEach, expect, it, vi } from "vitest";
+import { __resetPanelBaseCache } from "../../services/panel-workspace.js";
+
+const resetClient = vi.fn();
+const resetObjectInfoCache = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: () => resetClient(),
+  resetObjectInfoCache: () => resetObjectInfoCache(),
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx, __panelToolsTestHooks } = await import(
+  "../../orchestrator/panel-tools.js"
+);
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import { markDispatched } from "../../services/ui-bridge.js";
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+
+const textOf = (res: ToolResult): string =>
+  res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+
+function reconnectingBridge(initial: string[] = []) {
+  const live = new Set(initial);
+  const headless = new Set<string>();
+  const sent: Array<{ cmd: Record<string, unknown>; tabId?: string }> = [];
+  const bridge = {
+    send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+      const id = opts?.tabId;
+      if (id && !live.has(id)) {
+        const connected = [...live].map((t) => `${t.slice(0, 8)} ("${t}")`).join(", ") || "none";
+        throw markDispatched(new Error(`no connected tab with id "${id}". Connected: ${connected}`), false);
+      }
+      sent.push({ cmd, tabId: id });
+      if (cmd.cmd === "workflow_list") {
+        return { workflows: [...live].map((t) => ({ key: t, active: true })), active: { key: id } };
+      }
+      return { ok: true, routedTo: id };
+    },
+    push: () => 1,
+    canReach: (id: string) => live.has(id),
+    isHeadless: (id: string) => headless.has(id),
+    tabs: () => [...live].map((t) => ({ tab_id: t, title: t, connected_at: 0 })),
+    resolveActiveTabId: () => {
+      if (live.size === 1) return [...live][0];
+      if (live.size === 0) throw new Error("Panel not reachable: no panel connected");
+      throw new Error("Multiple panel tabs are connected and none is last active — pass tab_id.");
+    },
+  } as unknown as PanelToolCtx["bridge"];
+  return { bridge, live, headless, sent };
+}
+
+beforeEach(() => {
+  __resetPanelBaseCache();
+  __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 300, intervalMs: 5 });
+});
+afterEach(() => {
+  __panelToolsTestHooks.setReconnectWaitTiming(null);
+});
+
+it("#971 the last-active case works — this is the path the design documents", async () => {
+  const { bridge } = reconnectingBridge(["tab-a", "tab-b"]);
+  (bridge as unknown as { resolveActiveTabId: () => string }).resolveActiveTabId = () => "tab-b";
+  const ctx = makePanelToolCtx(bridge, "stale-tab", new WorkflowTargetStore());
+  expect(await ctx.awaitReachable!()).toBe(false);
+
+  const target = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target")!;
+  const res = (await target.handler({ mode: "current" }, ctx)) as ToolResult;
+  expect(res.isError).toBeFalsy();
+  expect(ctx.tabId).toBe("tab-b"); // the rebind moved the session
+  expect(await ctx.awaitReachable!()).toBe(true);
+
+  const open = buildPanelToolDefs().find((d) => d.name === "panel_open_workflow")!;
+  expect(((await open.handler({ path: "demo.json" }, ctx)) as ToolResult).isError).toBeFalsy();
+});
+
+it("#971 with NO last-active tab, the prescribed recovery is a dead end", async () => {
+  // Reporter's wedge. panel_open_workflow refuses and names
+  // panel_set_workflow_target({mode:"current"}) as the way out; that tool then
+  // fails with the bridge's raw "pass tab_id" — and the tool has NO tab_id
+  // parameter, with #754 strict schemas making an unknown key a hard validation
+  // error. The agent is told to pass something it cannot pass.
+  const { bridge } = reconnectingBridge(["tab-a", "tab-b"]); // resolveActiveTabId throws
+  const ctx = makePanelToolCtx(bridge, "stale-tab", new WorkflowTargetStore());
+
+  const open = buildPanelToolDefs().find((d) => d.name === "panel_open_workflow")!;
+  const refusal = textOf((await open.handler({ path: "demo.json" }, ctx)) as ToolResult);
+  expect(refusal).toMatch(/panel_set_workflow_target\(\{mode:"current"\}\)/);
+
+  const target = buildPanelToolDefs().find((d) => d.name === "panel_set_workflow_target")!;
+  const rec2 = (await target.handler({ mode: "current" }, ctx)) as ToolResult;
+
+  // The tool has no tab_id to offer, so an error demanding one cannot be followed.
+  expect(Object.keys(target.schema ?? {})).not.toContain("tab_id");
+  expect(textOf(rec2)).not.toMatch(/pass tab_id/i);
+
+  // And whatever it says, it must leave the caller somewhere other than where it
+  // started: either rebound, or told an action that does not require a parameter
+  // this tool does not have.
+  const recovered = ctx.tabId !== "stale-tab" || /switch to|focus/i.test(textOf(rec2));
+  expect(recovered).toBe(true);
+});

--- a/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
+++ b/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
@@ -331,7 +331,13 @@ describe("#474 panel_set_workflow_target({mode:'current'}) recovery", () => {
     const ctx = makePanelToolCtx(bridge, "dead-tab", new WorkflowTargetStore());
     const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
     expect(res.isError).toBe(true);
-    expect(textOf(res)).toMatch(/Multiple panel tabs/);
+    // #971 — this used to match the BRIDGE's raw /Multiple panel tabs/, which ended
+    // "— pass tab_id". This tool has no tab_id parameter and #754 strict schemas make
+    // an unknown key a hard error, so that instruction could not be followed and the
+    // session had no exit. The refusal is unchanged (still fails, still does not
+    // defer, still does not guess); only its wording is now actionable.
+    expect(textOf(res)).toMatch(/Several ComfyUI tabs are connected/i);
+    expect(textOf(res)).not.toMatch(/pass tab_id/i);
     expect(ctx.tabId).toBe("dead-tab");
   });
 

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -1710,7 +1710,11 @@ describe("panel-tools: post-reconnect retry-once (#278/#310/#332/#481)", () => {
     const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
     expect(res.isError).toBe(true);
     expect((res.content[0] as { text: string }).text).not.toMatch(/conns/i);
-    expect((res.content[0] as { text: string }).text).toMatch(/multiple|last active|pass tab_id/i);
+    // #971 — the ambiguity error is still produced and still does not guess; it is
+    // now worded so it can be acted on (the old text ended "— pass tab_id", which
+    // this tool has no parameter for). What this test is really about is that the
+    // BOUND isHeadless call worked, so keep pinning "not /conns/" above.
+    expect((res.content[0] as { text: string }).text).toMatch(/Several ComfyUI tabs are connected/i);
   });
 
   // #884 confirming gate 3, P0 — the scope-repin double gate. A SCOPE-bound ctx
@@ -2150,7 +2154,10 @@ describe("panel-tools: session tabId self-heal (#322 reload / #331 workflow-swit
 
     const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
     expect(res.isError).toBe(true);
-    expect((res.content[0] as { text: string }).text).toMatch(/Multiple panel tabs/);
+    // #971 — same refusal, actionable wording. The behavioural assertions (isError,
+    // and tabId untouched below) are what "no guess" actually means here.
+    expect((res.content[0] as { text: string }).text).toMatch(/Several ComfyUI tabs are connected/i);
+    expect((res.content[0] as { text: string }).text).not.toMatch(/pass tab_id/i);
     // tabId is NOT silently changed to some arbitrary tab.
     expect(ctx.tabId).toBe("dead-tab");
   });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -227,6 +227,51 @@ function fail(err: unknown): ToolResult {
   const msg = err instanceof Error ? err.message : String(err);
   return { content: [{ type: "text", text: `Error: ${msg}` }], isError: true };
 }
+/**
+ * #971 — the AMBIGUOUS-rebind refusal, worded so it can be acted on.
+ *
+ * Refusing here is right (#474: with 2+ live tabs the rebind is ambiguous, so the
+ * user picks rather than us guessing). What was wrong is what it refused WITH:
+ * rebindToActiveTab propagates the bridge's raw resolve error, which ends
+ * "— pass tab_id". This tool has no tab_id parameter (schema: mode/path/filename)
+ * and #754 made these schemas strict, so an unknown key is a hard validation error
+ * rather than a no-op. Since panel_open_workflow's own refusal names THIS tool as
+ * the way out, an instruction that cannot be followed closes the loop and the
+ * session stays wedged with no exit — the reporter's wedge.
+ *
+ * Focusing a tab is what MAKES it last-active, so the action that actually works is
+ * the one panel_reload already prescribes. Name the connected tabs too, so the user
+ * knows what they are choosing among.
+ */
+function ambiguousRebindGuidance(ctx: PanelToolCtx, err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err ?? "");
+  // Only reword the ambiguity refusal — every other failure keeps its own words.
+  if (!/multiple|last active|pass tab_id/i.test(raw)) return raw;
+  let listed = "";
+  try {
+    const live = typeof ctx.bridge.tabs === "function" ? ctx.bridge.tabs() : undefined;
+    if (Array.isArray(live)) {
+      // isHeadless THROUGH the bridge — a detached reference loses `this` and throws
+      // on `this.conns` (#478). A headless viewer is not a pickable canvas tab.
+      const isHeadlessTab = (id: string): boolean =>
+        typeof ctx.bridge.isHeadless === "function" && ctx.bridge.isHeadless(id);
+      const names = live
+        .filter((t) => !isHeadlessTab(t.tab_id))
+        .map((t) => (t.title ? `${shortTabId(t.tab_id)} ("${t.title}")` : shortTabId(t.tab_id)));
+      if (names.length) listed = ` Connected ComfyUI tabs: ${names.join(", ")}.`;
+    }
+  } catch {
+    // Enumeration is best-effort; the instruction below stands without the list.
+  }
+  return (
+    "Several ComfyUI tabs are connected and none is marked active, so this session cannot " +
+    "tell which one to follow — and this tool takes no tab_id to disambiguate with." +
+    `${listed} Switch to (click) the ComfyUI tab you want the agent to work in, which makes ` +
+    'it the active tab, then call panel_set_workflow_target({mode:"current"}) again. ' +
+    "Nothing was rebound."
+  );
+}
+
 
 // ── Honest secret-save reporting (#826) ─────────────────────────────────────
 // `panel_request_secret` used to answer "the comfyui tools respawn with it as
@@ -9457,7 +9502,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 /no panel connected|not reachable|connected:\s*none|no connected tab/i.test(msg) &&
                 !/multiple|last active|pass tab_id/i.test(msg);
             }
-            if (!noTabsConnected) return fail(err);
+            if (!noTabsConnected) return fail(ambiguousRebindGuidance(ctx, err));
             deferredBind = true;
             rebindNote =
               " No panel tab is connected yet — cleared the stale binding; this session will " +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -239,9 +239,13 @@ function fail(err: unknown): ToolResult {
  * the way out, an instruction that cannot be followed closes the loop and the
  * session stays wedged with no exit — the reporter's wedge.
  *
- * Focusing a tab is what MAKES it last-active, so the action that actually works is
- * the one panel_reload already prescribes. Name the connected tabs too, so the user
- * knows what they are choosing among.
+ * The action named here is the one that actually works, which is NOT the obvious one.
+ * UiBridge.setLastActiveTab is documented as the ONLY writer of lastActiveTabId and
+ * fires on `msg.type === "user_message"` (ui-bridge.ts) — a tab becomes last-active
+ * when a MESSAGE IS SENT from its Agent panel, not when the browser tab is focused or
+ * clicked. "Switch to the tab you want" (which panel_reload's sibling message says)
+ * would leave the state unchanged and send the user round the loop again.
+ * Name the connected tabs too, so the user knows what they are choosing among.
  */
 function ambiguousRebindGuidance(ctx: PanelToolCtx, err: unknown): string {
   const raw = err instanceof Error ? err.message : String(err ?? "");
@@ -266,9 +270,10 @@ function ambiguousRebindGuidance(ctx: PanelToolCtx, err: unknown): string {
   return (
     "Several ComfyUI tabs are connected and none is marked active, so this session cannot " +
     "tell which one to follow — and this tool takes no tab_id to disambiguate with." +
-    `${listed} Switch to (click) the ComfyUI tab you want the agent to work in, which makes ` +
-    'it the active tab, then call panel_set_workflow_target({mode:"current"}) again. ' +
-    "Nothing was rebound."
+    `${listed} A tab becomes the active one when a message is SENT from its Agent panel ` +
+    "(focusing or clicking the browser tab does not do it), so ask the user to send any " +
+    "message from the Agent panel in the ComfyUI tab they want you working in, then call " +
+    'panel_set_workflow_target({mode:"current"}) again. Nothing was rebound.'
   );
 }
 
@@ -6545,8 +6550,9 @@ function desktopCanvasRedirect(
     error:
       `${label} needs an open ComfyUI desktop panel canvas, but this session is bound to ` +
       `a canvas-less (mobile/remote) client and multiple desktop tabs are open — it can't ` +
-      `pick one automatically. Switch to the ComfyUI tab you want, rebind with ` +
-      `panel_set_workflow_target({mode:"current"}), then retry.`,
+      `pick one automatically. Ask the user to send a message from the Agent panel in the ` +
+      `ComfyUI tab they want (that — not focusing the tab — is what marks it active), ` +
+      `rebind with panel_set_workflow_target({mode:"current"}), then retry.`,
   };
 }
 
@@ -8567,9 +8573,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             return fail(
               "This conversation's current turn is pinned to a tab that is no longer " +
                 "reachable (it disconnected or its origin is ambiguous), so the reload " +
-                "frame has nowhere safe to go. Switch to the ComfyUI tab you want, call " +
-                'panel_set_workflow_target({mode:"current"}) to re-bind this session onto ' +
-                "it, then retry panel_reload.",
+                "frame has nowhere safe to go. Ask the user to send a message from the Agent " +
+                "panel in the ComfyUI tab they want (that — not focusing the tab — is what " +
+                'marks it active), call panel_set_workflow_target({mode:"current"}) to ' +
+                "re-bind this session onto it, then retry panel_reload.",
             );
           }
         } else if (ctx.rebindToActiveTab) {
@@ -8596,8 +8603,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           if (orphaned && Array.isArray(interactive) && interactive.length > 1) {
             return fail(
               "This session's ComfyUI tab was replaced and multiple tabs are now open — " +
-                "can't safely pick one. Switch to the tab you want, then call " +
-                'panel_set_workflow_target({mode:"current"}) before panel_reload.',
+                "can't safely pick one. Ask the user to send a message from the Agent panel " +
+                "in the tab they want (that — not focusing the tab — is what marks it " +
+                'active), then call panel_set_workflow_target({mode:"current"}) before ' +
+                "panel_reload.",
             );
           }
           try {


### PR DESCRIPTION
Draft — reproducing test is in, fix in progress.

Tracks **artokun/comfyui-mcp-panel#971**.

The reporter's wedge, reproduced at the orchestrator seam and scoped to one state:

| bridge's last-active tab | `set_workflow_target({mode:"current"})` | result |
|---|---|---|
| known | rebinds `stale-tab` → `tab-b` | `panel_open_workflow` succeeds — design works |
| **unknown** | errors *"…none is last active — pass tab_id"* | **closed loop** |

In the broken state `panel_open_workflow` refuses and names `panel_set_workflow_target({mode:"current"})` as the way out; that tool fails demanding `tab_id`; and its schema is `["mode","path","filename"]` — no `tab_id`, with #754 strict schemas turning an unknown key into a hard validation error. The agent is told to pass something it cannot pass.

`panel_reload` already words this correctly (*"Switch to the tab you want, then call panel_set_workflow_target…"*) — focusing a tab is what makes it last-active. The raw bridge error leaks through `set_workflow_target` without that framing.

Note the reporter is on 0.50.52 / panel 0.11.51; the refusal text they quoted has already been improved since. This dead end still reproduces on **0.50.91**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)