### PR TITLE
chore(release): 0.50.93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.93] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- anchor a relative launch script on Windows, where /proc has no equivalent (#1315)
+
+
 ## [0.50.92] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.92",
+  "version": "0.50.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.92",
+      "version": "0.50.93",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.92",
+  "version": "0.50.93",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release 0.50.93 — ships **#535** (#1315).

0.50.92 was tagged from a commit that predates the #535 merge, so it shipped without it. This is the first release carrying the fix.

### Fixed

- **#535** — anchor a relative launch script on Windows, where `/proc` has no equivalent

`restart_comfyui` / `panel_restart_comfyui` refused outright on a Windows install launched as `ComfyUI\main.py` with no canonical base:

> `Resolved ComfyUI script does not exist on disk: ComfyUI\main.py — could not locate the ComfyUI install`

The v0.48.23 fix anchors a relative launch script against `/proc/<pid>/cwd`. `resolveLiveProcessCwd` returns `undefined` on Windows, so the anchor never ran there. That was recorded as a known limitation at the time — accurately, but treating it as permanent is why this issue was reopened a fourth time.

#1133 (0.50.90) supplied the Windows equivalent: identify the process listening on our port, correlate it against that server's own argv, and re-anchor the relative `main.py` on that interpreter's install tree. The ancestor it resolves against **is** the working directory the server must have had — the same fact procfs states directly. It was already computed and discarded.

Verified on a real Windows install: `anchorDir` resolves and the relaunch script exists on disk.

### Every guard fails closed

This path stops a running server, so the anchor may only ever *add* a way to succeed:

- bound to the process **instance** (pid + creation time), not the pid number — a recycled pid is refused
- not adopted when any argument could be cwd-relative, since the anchor is *inferred* and a symlinked launcher can satisfy the inference from a different directory
- an unresolved or unconfirmed observation leaves the previous refusal untouched
- Linux/procfs unchanged — it short-circuits before any of this

Three adversarial rounds; two found real holes. One caught that the guard would have refused `--cache-none`, which appears in the issue's own original report — the over-broad direction that silently un-ships a fix rather than weakening it. The suite carries explicit allowed-through cases for it now.

A **bare** `main.py` still refuses, deliberately: with no directory part to anchor, reaching a nested sibling install from an interpreter is a different inference on a destructive path.