### PR TITLE
docs(origin): delete a header claim about a caller that does not exist

### DIFF
--- a/src/utils/origin.ts
+++ b/src/utils/origin.ts
@@ -7,11 +7,22 @@
 // orchestrator still reported "a DIFFERENT address" and advised pointing
 // COMFYUI_URL at an origin it was already pointed at.
 //
-// The same blindness scopes the workflow-instance fence, which is keyed by
-// origin: a fence adopted under one spelling would refuse under the other. That
-// half is not hypothetical either, because the relay path now DERIVES its origin
-// from COMFYUI_URL (#1077) while the loopback path OBSERVES the browser's — two
-// independent sources that can easily disagree only in spelling.
+// NOT the workflow-instance fence — this header used to claim it was, and the
+// claim was wrong. `workflowIdentityParts` (orchestrator/session-store.ts) treats
+// the origin as a PRESENCE gate: it requires one to exist and never compares it
+// against a previously bound value. Both of its callers read `.uuid` and nothing
+// in the repo has ever read `identity.origin`, so two spellings of one host
+// cannot make a fence "adopted under one spelling refuse under the other".
+//
+// That sentence is deleted rather than softened because of what believing it
+// costs. The same false lead, in the pre-#1255 wording of the fence refusal
+// itself, already burned one full investigation and a closed-unmerged PR; it
+// then burned a second (#1321) via a stale quote of that message preserved in an
+// issue thread. A comment asserting a caller that does not exist is the same
+// defect as a message describing a check that does not run.
+//
+// If a fence ever does start comparing origins, wire it to `sameOrigin` and say
+// so here — but the wiring must come first, and the sentence second.
 //
 // WHY THIS IS ITS OWN MODULE. Three loopback notions already exist
 // (`isLoopbackServerUrl`, `port-owner`'s LOOPBACK/WILDCARD split,


### PR DESCRIPTION
`src/utils/origin.ts` opens by saying its blindness

> scopes the workflow-instance fence, which is keyed by origin: a fence adopted under one spelling would refuse under the other.

**That is not true**, and it is the third live copy of a false lead that has now cost three investigations.

`workflowIdentityParts` treats the origin as a **presence gate**: it requires one to exist and never compares it against a previously bound value. Its two callers (`index.ts:2845`, `index.ts:3494`) both read `.uuid`, and nothing in the repo has ever read `identity.origin`.

#1255 established exactly this and fixed the fence-refusal message that said the same wrong thing, recording the cost in the code:

> The old wording sent a reader hunting for an origin mismatch that cannot happen — it cost a whole investigation and a closed-unmerged PR before the mechanism was checked rather than believed.

It then cost a second one — mine, #1321 — reached through a **stale quote** of the pre-#1255 message preserved in an issue thread, where a code fix cannot reach it. This header is the copy a reader would consult to *check* that reasoning, so it converts the trap into a confirmation.

Deleted rather than softened, with a note saying that if a fence ever does compare origins, the wiring comes first and the sentence second.

A comment asserting a caller that does not exist is the same defect as a message describing a check that does not run — the class #796 is about, pointed at prose.

No behaviour change; the module keeps its real consumer (`comfyui/fetch.ts`) and its real rationale. `tsc --noEmit` clean.