### PR TITLE
chore(release): 0.50.94

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.94] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- tell the user the install is damaged, instead of printing a resolver path (#1333)
+
+#### Changed
+- delete a header claim about a caller that does not exist (#1324)
+
+
 ## [0.50.93] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.93",
+  "version": "0.50.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.93",
+      "version": "0.50.94",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.93",
+  "version": "0.50.94",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.94` tag (the tag is what publishes).

### Fixed
- **#1318** — a half-extracted install now says so, instead of printing a resolver path. `src/index.ts` becomes a thin launcher that dynamic-imports the real entry (`src/boot.ts`, a byte-identical rename) and translates only module-resolution failures. Verified against a reproduced damaged install: the reporter's exact state (`@modelcontextprotocol/sdk/dist/esm/server/` with 0 entries where a healthy install has 42).

### Changed
- **#1324** — deleted a header comment asserting the workflow-instance fence is keyed by origin. It is not; the same false lead had already cost two investigations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)