### PR TITLE
fix(#1326): refuse an arbitrary-URL download once, before three requests fail

### DIFF
--- a/src/__tests__/services/manager-install-model-cause.test.ts
+++ b/src/__tests__/services/manager-install-model-cause.test.ts
@@ -96,18 +96,71 @@ describe("an install-model failure only claims a cause it can support (#1326)", 
     expect(msg).toContain("No space left on device");
   });
 
-  it("never echoes a credential from the request URL into the message", () => {
-    // A model URL routinely carries a token in its query. The body can echo the URL
-    // back, and an error message is the one place a secret must never surface.
-    const secret = "hf_SUPERSECRETTOKENVALUE123";
-    const url = `http://pod:8188/manager/queue/install_model?token=${secret}`;
+  it("never echoes the MODEL url's token — the path an endpoint-only redaction misses", () => {
+    // THE ONE THAT NEARLY SHIPPED A LEAK. My first version redacted only the query
+    // values of `details.url`, and my first test fed the secret in through exactly
+    // that — so it passed while proving nothing.
+    //
+    // `details.url` is the Manager ENDPOINT (…/manager/queue/install_model). The model
+    // url, which is the one carrying a Hugging Face / CivitAI token, is sent in the
+    // POST BODY (installModelViaManager -> taskParams.url). Manager echoes it back on a
+    // failed download, so the secret arrives by a route the endpoint url never covers.
+    // The secret is deliberately OPAQUE — no `hf_`/`sk-` prefix. An earlier version of
+    // this test used `hf_…`, which the token-SHAPE fallback catches, so it passed with
+    // the url redaction mutated away: it proved the fallback, not the thing it names.
+    // Verified by deleting the body-url redaction — this must fail.
+    const secret = "9f3a71c05b2e4d8899ab13ff5027cc41";
     const msg = annotateLegacyError(
-      managerHttpError(500, `failed fetching https://host/x.safetensors?token=${secret}`, url),
+      managerHttpError(
+        500,
+        `failed fetching https://civitai.com/api/download/models/123?token=${secret}&x=1`,
+        "http://pod:8188/manager/queue/install_model", // NO credential here
+      ),
       "install-model",
     ).message;
 
     expect(msg).not.toContain(secret);
     expect(msg).toContain("«redacted»");
+    // The shape survives so the reader can still see a token was involved.
+    expect(msg).toContain("token=");
+  });
+
+  it("redacts a token that is not a query value at all", () => {
+    const secret = "hf_ANOTHERSECRETTOKEN9876";
+    const msg = annotateLegacyError(
+      managerHttpError(500, `Traceback: Authorization: Bearer abcdefghijklmnop123456 / ${secret}`),
+      "install-model",
+    ).message;
+    expect(msg).not.toContain(secret);
+    expect(msg).not.toContain("abcdefghijklmnop123456");
+  });
+
+  it("keeps short structural query values readable", () => {
+    // Over-redaction would destroy the evidence this change exists to surface.
+    const msg = annotateLegacyError(
+      managerHttpError(500, "failed fetching https://host/m.safetensors?type=vae&page=2"),
+      "install-model",
+    ).message;
+    expect(msg).toContain("type=vae");
+    expect(msg).toContain("page=2");
+  });
+
+  it("an HTML error page is never 'proven' — certainty needs Manager, not a proxy", () => {
+    // "proven" is the only branch that speaks with certainty, so it must not be
+    // reachable from a page that merely contains the words.
+    const msg = annotateLegacyError(
+      managerHttpError(502, "<html><body>Bad Gateway: upstream model list unavailable</body></html>"),
+      "install-model",
+    ).message;
+    expect(msg).toMatch(/did NOT say so explicitly/);
+  });
+
+  it("a 403 that is NOT security_level stays undetermined, not excluded", () => {
+    // A proxy or auth gate in front of ComfyUI also answers 403, and that is not
+    // Manager speaking — treating it as a security_level refusal would suppress the
+    // only guidance the caller gets.
+    const msg = annotateLegacyError(managerHttpError(403, "Forbidden by corporate proxy"), "install-model").message;
+    expect(msg).toMatch(/did NOT say so explicitly/);
   });
 
   it("bounds the excerpt so a huge HTML error page cannot flood the reply", () => {

--- a/src/__tests__/services/manager-install-model-cause.test.ts
+++ b/src/__tests__/services/manager-install-model-cause.test.ts
@@ -1,0 +1,133 @@
+// #1326 — an install-model failure on legacy Manager asserted one cause for every
+// failure, and threw away the evidence that would have decided it.
+//
+// The reporter dispatched three Hugging Face URLs to a ComfyUI running Manager 3.x and
+// got, three times:
+//
+//   MODEL_ERROR: ComfyUI-Manager API 500 Internal Server Error for
+//   /manager/queue/install_model. Arbitrary-URL model installs REQUIRE Manager v4+
+//   (3.x only accepts whitelisted catalog models).
+//
+// The second sentence was appended unconditionally — `kind === "install-model"` was the
+// whole test. It is the likeliest cause and it was probably right here, but the same
+// line is produced by a security_level refusal, a 404 URL, and a full disk, and it sends
+// the reader through a Manager migration that would not fix any of those.
+//
+// Meanwhile Manager's own response body was captured in `details.body` and never shown:
+// explainManagerForbidden only speaks for 403, so a 500 reached the user as a bare
+// status. Same defect as #1300 (a download that reported a status instead of a reason).
+//
+// WHY NOT A BLANKET PREFLIGHT, which the report suggested. Manager 3.x does accept an
+// install whose URL is in its model-list catalog — `legacyTaskRequest` sends the same
+// body and 3.x validates it. Refusing every install-model on 3.x would therefore break
+// the whitelisted case that works today, which is the over-broad direction of a blocking
+// guard: invisible in its own output, and it un-ships a working feature.
+
+import { describe, expect, it } from "vitest";
+
+import { __managerCauseTestHooks } from "../../services/node-management.js";
+
+const { annotateLegacyError, NodeManagementError } = __managerCauseTestHooks;
+
+/** The shape managerFetch throws on a non-2xx: status and body ARE captured. */
+function managerHttpError(status: number, body: string, url = "http://pod:8188/manager/queue/install_model") {
+  return new NodeManagementError(`ComfyUI-Manager API ${status} Internal Server Error for /manager/queue/install_model`, {
+    url,
+    status,
+    body,
+  });
+}
+
+describe("an install-model failure only claims a cause it can support (#1326)", () => {
+  it("PROVEN whitelist rejection: still says exactly what it always said", () => {
+    // The common case must not regress — when Manager names the model list, the
+    // definite answer and its migration path are correct and stay.
+    const msg = annotateLegacyError(
+      managerHttpError(500, '{"error": "not found in the model list"}'),
+      "install-model",
+    ).message;
+
+    expect(msg).toContain("REQUIRE Manager v4+");
+    expect(msg).toContain("pip install -U comfyui_manager"); // the migration hint
+    expect(msg).not.toContain("did NOT say why");
+  });
+
+  it("UNDETERMINED cause: keeps the likely diagnosis, drops only the certainty", () => {
+    // The reporter's actual response: a 500 with nothing in it.
+    //
+    // My first version of this hedged the whole thing away — "this did NOT say why …
+    // do not migrate Manager on the strength of this line alone". The pre-existing #553
+    // test caught it, correctly: on 3.x the whitelist IS the usual cause and that
+    // migration IS the fix, so burying it under a disclaimer trades a probably-right
+    // answer for a definitely-useless one. Precision is not the defect; false certainty
+    // and the discarded evidence are.
+    const msg = annotateLegacyError(managerHttpError(500, ""), "install-model").message;
+
+    // The actionable diagnosis survives, in full.
+    expect(msg).toMatch(/REQUIRE Manager v4\+/);
+    expect(msg).toMatch(/usual cause is its model-list whitelist/);
+    expect(msg).toContain("pip install -U comfyui_manager");
+    // …now stated as likely rather than established, with the alternatives it hid.
+    expect(msg).toMatch(/did NOT say so explicitly/);
+    expect(msg).toMatch(/security_level/);
+    expect(msg).toMatch(/unreachable URL|no space/);
+  });
+
+  it("a 403 is a security refusal — the whitelist is EXCLUDED, not offered", () => {
+    // Adding "you need Manager v4+" beside the security_level explanation would give
+    // two causes for one failure, one of them wrong, and the wrong one is the expensive
+    // one to act on.
+    const msg = annotateLegacyError(
+      managerHttpError(403, '{"error": "security_level"}'),
+      "install-model",
+    ).message;
+
+    expect(msg).not.toContain("REQUIRE Manager v4+");
+    expect(msg).not.toContain("did NOT say why");
+  });
+
+  it("shows Manager's OWN words — the evidence that was being discarded", () => {
+    const msg = annotateLegacyError(
+      managerHttpError(500, '{"error": "No space left on device"}'),
+      "install-model",
+    ).message;
+
+    expect(msg).toContain("ComfyUI-Manager said:");
+    expect(msg).toContain("No space left on device");
+  });
+
+  it("never echoes a credential from the request URL into the message", () => {
+    // A model URL routinely carries a token in its query. The body can echo the URL
+    // back, and an error message is the one place a secret must never surface.
+    const secret = "hf_SUPERSECRETTOKENVALUE123";
+    const url = `http://pod:8188/manager/queue/install_model?token=${secret}`;
+    const msg = annotateLegacyError(
+      managerHttpError(500, `failed fetching https://host/x.safetensors?token=${secret}`, url),
+      "install-model",
+    ).message;
+
+    expect(msg).not.toContain(secret);
+    expect(msg).toContain("«redacted»");
+  });
+
+  it("bounds the excerpt so a huge HTML error page cannot flood the reply", () => {
+    const msg = annotateLegacyError(managerHttpError(500, "x".repeat(5000)), "install-model").message;
+    expect(msg).toContain("(truncated)");
+    expect(msg.length).toBeLessThan(2500);
+  });
+
+  it("a NON-install failure is untouched — the scope did not widen", () => {
+    // Only install-model ever carried this sentence; nothing else should gain it.
+    const msg = annotateLegacyError(managerHttpError(500, "boom"), "install").message;
+    expect(msg).not.toContain("REQUIRE Manager v4+");
+    expect(msg).not.toContain("did NOT say why");
+    expect(msg).not.toContain("ComfyUI-Manager said:");
+  });
+
+  it("survives an error carrying no details at all", () => {
+    const msg = annotateLegacyError(new Error("socket hang up"), "install-model").message;
+    expect(msg).toContain("socket hang up");
+    expect(msg).toContain("did NOT say so explicitly"); // undetermined, and says so
+    expect(msg).not.toContain("ComfyUI-Manager said:");
+  });
+});

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -636,35 +636,73 @@ function whitelistVerdict(details: unknown): "proven" | "excluded" | "unknown" {
   const d = details as { status?: unknown; body?: unknown } | undefined;
   const status = typeof d?.status === "number" ? d.status : undefined;
   const body = typeof d?.body === "string" ? d.body : "";
-  // 403 is Manager refusing on its own security level; explainManagerForbidden already
-  // says so in detail, and the whitelist is NOT the reason. Claiming it there would
-  // send the reader to migrate Manager when the fix is a config setting.
-  if (status === 403) return "excluded";
+  // A security_level refusal is a DIFFERENT fault with a different fix (a Manager
+  // config setting, not a migration), and explainManagerForbidden already spells it
+  // out. Offering the whitelist beside it would give two causes for one failure.
+  //
+  // Keyed on the marker, not on the bare 403: a proxy or auth gate in front of ComfyUI
+  // also answers 403, and that is not Manager speaking at all.
+  if (status === 403 && /"error"\s*:\s*"security_level"/.test(body)) return "excluded";
   // Manager 3.x names the model-list check when it rejects one. Only these positively
   // establish it — anything else stays "unknown" rather than defaulting to the guess.
+  //
+  // Not applied to an HTML page: a proxy error or a framework traceback can contain the
+  // words "model list" without being Manager's rejection, and "proven" is the one branch
+  // that speaks with certainty. Manager answers JSON/plain text here.
+  if (/^\s*<|<html/i.test(body)) return "unknown";
   if (/model[- _]?list|whitelist|not (?:in|found in) the model list|invalid model/i.test(body))
     return "proven";
   return "unknown";
 }
 
-/** Manager's own response body, bounded and stripped of any credential echoed from
- *  the request URL. This is the evidence #1326 lost. */
+/**
+ * Strip credentials out of text that is about to be shown to a user.
+ *
+ * Redacting only the values from `details.url` is NOT enough here, and getting that
+ * wrong would have leaked a token. `details.url` is the Manager ENDPOINT
+ * (`…/manager/queue/install_model`) — the MODEL url, which is the one carrying a
+ * Hugging Face / CivitAI token, travels in the POST BODY. Manager echoes that url back
+ * when the download fails ("failed fetching <url>"), so the secret arrives through a
+ * path an endpoint-only redaction never sees.
+ *
+ * So every url found in the text has its query VALUES redacted, whatever its origin,
+ * plus a few token shapes that travel outside a query string. Keys are kept: the reader
+ * still needs to see that a token was present.
+ */
+function redactCredentialsForDisplay(text: string, endpointUrl?: string): string {
+  let out = text;
+  const redactUrlValues = (raw: string): void => {
+    let url: URL;
+    try {
+      url = new URL(raw);
+    } catch {
+      return; // not a parseable url — nothing known to redact
+    }
+    for (const value of url.searchParams.values()) {
+      // Short values are structural (page=2, type=vae), not secrets.
+      if (!value || value.length < 12) continue;
+      for (const form of new Set([value, encodeURIComponent(value)])) {
+        out = out.split(form).join("«redacted»");
+      }
+    }
+  };
+  if (endpointUrl) redactUrlValues(endpointUrl);
+  for (const found of text.match(/https?:\/\/[^\s"'<>)\\]+/gi) ?? []) redactUrlValues(found);
+  // Token shapes that are not query values (an Authorization header echoed into a
+  // traceback, a bare token in a message).
+  out = out
+    .replace(/\b(hf_|sk-|ghp_|gho_|github_pat_)[A-Za-z0-9_-]{8,}/g, "«redacted»")
+    .replace(/\b([Bb]earer\s+)[A-Za-z0-9._~+/-]{12,}=*/g, "$1«redacted»");
+  return out;
+}
+
+/** Manager's own response body, bounded and stripped of credentials. This is the
+ *  evidence #1326 lost. */
 function managerBodyExcerpt(details: unknown): string {
   const d = details as { body?: unknown; url?: unknown } | undefined;
-  let body = typeof d?.body === "string" ? d.body.trim() : "";
-  if (!body) return "";
-  if (typeof d?.url === "string") {
-    try {
-      for (const value of new URL(d.url).searchParams.values()) {
-        if (!value || value.length < 12) continue;
-        for (const form of new Set([value, encodeURIComponent(value)])) {
-          body = body.split(form).join("«redacted»");
-        }
-      }
-    } catch {
-      /* an unparseable url contributes no known values */
-    }
-  }
+  const raw = typeof d?.body === "string" ? d.body.trim() : "";
+  if (!raw) return "";
+  const body = redactCredentialsForDisplay(raw, typeof d?.url === "string" ? d.url : undefined);
   const MAX = 600;
   const clipped = body.length > MAX ? `${body.slice(0, MAX)}… (truncated)` : body;
   return ` ComfyUI-Manager said: ${clipped}`;

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -615,6 +615,61 @@ const MANAGER_LEGACY_UI_HINT =
   "yanwk/comfyui-boot images that flag is hardcoded in the entrypoint). " +
   "See https://comfyui-mcp.artokun.io/docs/troubleshooting";
 
+/**
+ * #1326 — what an install-model failure on legacy Manager is allowed to CLAIM.
+ *
+ * The sentence below used to be appended to every `install-model` failure on 3.x,
+ * unconditionally: "Arbitrary-URL model installs REQUIRE Manager v4+". For the URL
+ * whitelist that is right, and it is the common case. For a security_level refusal, a
+ * 404 URL, a full disk or a Manager bug it is a confident answer to a question nobody
+ * asked — and it sends the reader through a Manager migration that will not fix it.
+ *
+ * The reporter of #1326 saw exactly the ambiguous form: a bare
+ * `ComfyUI-Manager API 500 Internal Server Error for /manager/queue/install_model`,
+ * with our v4 sentence attached. Manager's own response body — the one thing that
+ * would have said which it was — was captured in `details.body` and never shown.
+ *
+ * So: three states, not two (#796). Say WHICH when the evidence decides it, offer the
+ * candidates when it does not, and show Manager's own words either way.
+ */
+function whitelistVerdict(details: unknown): "proven" | "excluded" | "unknown" {
+  const d = details as { status?: unknown; body?: unknown } | undefined;
+  const status = typeof d?.status === "number" ? d.status : undefined;
+  const body = typeof d?.body === "string" ? d.body : "";
+  // 403 is Manager refusing on its own security level; explainManagerForbidden already
+  // says so in detail, and the whitelist is NOT the reason. Claiming it there would
+  // send the reader to migrate Manager when the fix is a config setting.
+  if (status === 403) return "excluded";
+  // Manager 3.x names the model-list check when it rejects one. Only these positively
+  // establish it — anything else stays "unknown" rather than defaulting to the guess.
+  if (/model[- _]?list|whitelist|not (?:in|found in) the model list|invalid model/i.test(body))
+    return "proven";
+  return "unknown";
+}
+
+/** Manager's own response body, bounded and stripped of any credential echoed from
+ *  the request URL. This is the evidence #1326 lost. */
+function managerBodyExcerpt(details: unknown): string {
+  const d = details as { body?: unknown; url?: unknown } | undefined;
+  let body = typeof d?.body === "string" ? d.body.trim() : "";
+  if (!body) return "";
+  if (typeof d?.url === "string") {
+    try {
+      for (const value of new URL(d.url).searchParams.values()) {
+        if (!value || value.length < 12) continue;
+        for (const form of new Set([value, encodeURIComponent(value)])) {
+          body = body.split(form).join("«redacted»");
+        }
+      }
+    } catch {
+      /* an unparseable url contributes no known values */
+    }
+  }
+  const MAX = 600;
+  const clipped = body.length > MAX ? `${body.slice(0, MAX)}… (truncated)` : body;
+  return ` ComfyUI-Manager said: ${clipped}`;
+}
+
 /** Wrap a legacy-Manager failure with the upgrade guidance (keeps details). */
 function annotateLegacyError(
   err: unknown,
@@ -622,15 +677,47 @@ function annotateLegacyError(
   hint: string = MANAGER_UPGRADE_HINT,
 ): NodeManagementError {
   const base = err instanceof Error ? err.message : String(err);
-  const extra =
-    kind === "install-model"
-      ? " Arbitrary-URL model installs REQUIRE Manager v4+ (3.x only accepts whitelisted catalog models)."
-      : "";
-  return new NodeManagementError(
-    `${base}${extra}\n${hint}`,
-    err instanceof NodeManagementError ? err.details : undefined,
-  );
+  const details = err instanceof NodeManagementError ? err.details : undefined;
+  let extra = "";
+  if (kind === "install-model") {
+    switch (whitelistVerdict(details)) {
+      case "proven":
+        extra =
+          " Arbitrary-URL model installs REQUIRE Manager v4+ (3.x only accepts whitelisted catalog models).";
+        break;
+      case "excluded":
+        // Deliberately silent: the 403 explanation is the answer, and adding the
+        // whitelist sentence beside it would offer a second, wrong cause.
+        break;
+      case "unknown":
+        // Still LEADS with the whitelist and keeps the upgrade path: on 3.x that is the
+        // usual cause and the migration below is the fix, which is real value (#553) and
+        // must not be hedged away. What changes is only the certainty — Manager did not
+        // say so here, and three other faults fail identically. Naming them costs a
+        // sentence; omitting them cost the reporter of #1326 a diagnosis.
+        extra =
+          " On Manager 3.x the usual cause is its model-list whitelist: arbitrary-URL model" +
+          " installs REQUIRE Manager v4+ (3.x only accepts whitelisted catalog models), and" +
+          " the recovery below is that upgrade. Manager did NOT say so explicitly here," +
+          " though — a security_level refusal, an unreachable URL, or no space on the host" +
+          " fail the same way. If the upgrade does not resolve it, the ComfyUI server log" +
+          " names which.";
+        break;
+    }
+    extra += managerBodyExcerpt(details);
+  }
+  return new NodeManagementError(`${base}${extra}\n${hint}`, details);
 }
+
+/** #1326 — the cause-attribution above is the whole user-visible product of a failed
+ *  install-model, and it is reached only through a live Manager. Exposed so it can be
+ *  asserted against real error shapes rather than through a mocked HTTP stack. */
+export const __managerCauseTestHooks = {
+  annotateLegacyError,
+  whitelistVerdict,
+  managerBodyExcerpt,
+  NodeManagementError,
+};
 
 /**
  * Translate one unified-task call into the legacy per-operation route + body.


### PR DESCRIPTION
Closes #1326

Claiming. The refusal text is already correct — `Arbitrary-URL model installs REQUIRE Manager v4+` — it just arrives *after* the request has been dispatched and 500'd, once per file.

Investigating whether the Manager version is knowable before dispatch, and whether a genuine fallback exists for a REMOTE host (where we cannot write the file ourselves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)