### PR TITLE
chore(release): 0.50.95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.95] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- ui-bridge.test.ts is load-sensitive — find the real rejection, don't loosen the assertion (#1336)
+- the prescribed recovery from a lost tab binding is a dead end (#1322)
+
+
 ## [0.50.94] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.94",
+  "version": "0.50.95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.94",
+      "version": "0.50.95",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.94",
+  "version": "0.50.95",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.95` tag (the tag publishes).

### Fixed
- **#1322** (panel #971) — `panel_set_workflow_target` refused with *"pass tab_id"*, a parameter it does not accept; since #754 made these schemas strict, that instruction could not be followed at all. Together with #1317 this closes the loop the reporter was stuck in. A second defect found while fixing it: the replacement text said *"click the tab you want"*, which does **not** mark a tab active — measured, `setLastActiveTab`'s only setting call site is gated on `msg.type === "user_message"`.
- **#1336** (#1325) — `ui-bridge.test.ts` load sensitivity. Could not reproduce in three full-suite runs (two under 8–12× CPU contention), so this fixes what is provable: the `#357` test now names its own rejection instead of reporting `expected true to be false`, and `settle()` scales with measured event-loop lag instead of guessing 60 ms. The comment states the limit — it does not adapt to cross-process starvation, and vitest workers are separate processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)