### PR TITLE
fix(#1327): a re-delivered completion must not disown a run we queued

### DIFF
--- a/src/__tests__/orchestrator/run-completion-race.test.ts
+++ b/src/__tests__/orchestrator/run-completion-race.test.ts
@@ -1,0 +1,173 @@
+// #1327 — a render that finished before its own ticket existed was disowned.
+//
+// The reporter queued `panel_run({to_node_id: 118})`, got back
+// prompt e69d89b1-…, and the completion came back saying:
+//
+//   This run (prompt e69d89b1-…) does NOT match any run you queued with panel_run
+//   — its origin is UNDETERMINED. Do NOT treat it as the render you are waiting on
+//
+// with the SAME id the call had just returned. That is not cosmetic: it tells the
+// agent to distrust a correct result and to go poll get_history, which is exactly the
+// behaviour the anti-poll guidance exists to prevent. Mid-A/B-comparison it invites
+// discarding a valid measurement.
+//
+// THE MECHANISM IS AN ORDERING ONE, and not the one the report guessed (it supposed
+// re-delivery consulted the registry — it does not; the verdict is frozen at arrival).
+// A ticket CANNOT be opened before dispatch, because ComfyUI mints the prompt id when
+// it accepts the run. Their render took 0.1s fully cached, so:
+//
+//   dispatch → ComfyUI runs → `executed` arrives → (no ticket yet) → journaled foreign
+//                                                → reply gets back → openRun()
+//
+// The dispatch timestamp settles it without heuristics: the id did not exist before
+// this call created it, so a completion carrying it that arrived at/after the dispatch
+// is necessarily this run's.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { RunCompletionJournalImpl } from "../../orchestrator/run-completion-journal.js";
+
+const TAB = "wf:workflows/a.json";
+const CONV = "conv-1";
+const PID = "e69d89b1-0705-4b3c-8e69-2f4d74c31e17";
+
+let journal: RunCompletionJournalImpl;
+
+beforeEach(() => {
+  journal = new RunCompletionJournalImpl();
+});
+
+/** Deliver everything pending for the tab and return the payloads handed over. */
+function drain(): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  journal.deliverPending(TAB, (payload) => {
+    out.push(payload as unknown as Record<string, unknown>);
+    return true;
+  });
+  return out;
+}
+
+describe("a completion that beats its own ticket is still OURS (#1327)", () => {
+  it("the reporter's sequence: 0.1s cached render lands before openRun", () => {
+    const dispatchedAt = Date.now();
+    // The render finishes and the panel forwards `executed` BEFORE the /prompt reply
+    // has made it back to us — so there is no ticket to correlate against yet.
+    journal.record(TAB, { prompt_id: PID, duration_s: 0.1 }, CONV);
+    // …and only now does panel_run learn the id and open the ticket.
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, toNodeId: 118, dispatchedAt });
+
+    const [payload] = drain();
+    expect(payload).toBeDefined();
+    expect(payload.prompt_id).toBe(PID);
+    // THE DEFECT: this used to be "foreign".
+    expect(payload.run_correlation).toBe("matched");
+    expect(payload.run_correlation_prior).toBeUndefined();
+  });
+
+  it("and the ticket is NOT poisoned as reused — the second-order harm", () => {
+    // The already-journaled entry made hasHistoryFor() true, so the fresh ticket was
+    // born `reused`, and EVERY later completion for that id read UNDETERMINED too.
+    // One race therefore degraded the whole run, not just one notification.
+    const dispatchedAt = Date.now();
+    journal.record(TAB, { prompt_id: PID, duration_s: 0.1 }, CONV);
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt });
+    drain();
+
+    // A second completion for the same run (a re-sent frame) must still correlate.
+    const again = journal.correlate(TAB, { prompt_id: PID }, CONV);
+    expect(again.status).toBe("matched");
+  });
+
+  it("a completion from BEFORE the dispatch is not claimed", () => {
+    // The guard's over-broad direction. An id genuinely reused by ComfyUI carries a
+    // completion that predates this dispatch, and claiming it would attribute an
+    // older run's result to a new one — the misattribution the journal is built to
+    // refuse, which is strictly worse than saying "undetermined".
+    journal.record(TAB, { prompt_id: PID, duration_s: 9 }, CONV);
+    const dispatchedAt = Date.now() + 5_000; // dispatch happens AFTER that arrival
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt });
+
+    const [payload] = drain();
+    expect(payload.run_correlation).not.toBe("matched");
+  });
+
+  it("another party's completion for the same id is not claimed", () => {
+    const dispatchedAt = Date.now();
+    journal.record("wf:other.json", { prompt_id: PID }, "conv-2");
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt });
+
+    // Nothing landed on OUR tab…
+    expect(drain()).toHaveLength(0);
+    // …and theirs was left alone.
+    const theirs: Array<Record<string, unknown>> = [];
+    journal.deliverPending("wf:other.json", (p) => {
+      theirs.push(p as unknown as Record<string, unknown>);
+      return true;
+    });
+    expect(theirs[0]?.run_correlation).not.toBe("matched");
+  });
+
+  it("a verdict already HANDED to an agent is never rewritten under it", () => {
+    // The journal's standing rule: a replay never re-correlates. The claim only ever
+    // corrects an entry nobody has been told about yet.
+    //
+    // MY FIRST VERSION OF THIS TEST PROVED NOTHING. It handed the entry off and then
+    // asserted over `deliverPending` again — but a handed-off entry is not in
+    // `pending()`, so the loop ran over an EMPTY array and passed vacuously. Deleting
+    // the guard left it green. The real path is a RELEASE (the carrying turn ended
+    // without an ack), which puts the entry back to `pending` — which is also why the
+    // guard is keyed on `attempts`, not on `state`.
+    const tokens: string[] = [];
+    journal.record(TAB, { prompt_id: PID }, CONV);
+    journal.deliverPending(TAB, (payload, token) => {
+      expect((payload as unknown as Record<string, unknown>).run_correlation).toBe("foreign");
+      tokens.push(token);
+      return true;
+    });
+    expect(tokens).toHaveLength(1);
+
+    // The turn that carried it ended without acking → back to pending for replay.
+    journal.release(tokens[0] as string, { carried: true });
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt: Date.now() });
+
+    const after = drain();
+    expect(after).toHaveLength(1); // the replay really happened — not a vacuous pass
+    expect(after[0]?.run_correlation).not.toBe("matched");
+    expect(after[0]?.replayed).toBe(true);
+  });
+
+  it("without a dispatch timestamp nothing is claimed — no proof, no change", () => {
+    // Callers that cannot supply the dispatch time keep exactly the old behaviour
+    // rather than getting a timing guess.
+    journal.record(TAB, { prompt_id: PID }, CONV);
+    journal.openRun(PID, { tabId: TAB, conversation: CONV });
+
+    const [payload] = drain();
+    expect(payload.run_correlation).toBe("foreign");
+  });
+
+  it("an ID-LESS completion is never claimed on timing alone", () => {
+    const dispatchedAt = Date.now();
+    journal.record(TAB, { duration_s: 0.1 }, CONV); // no prompt_id at all
+    journal.openRun(PID, { tabId: TAB, conversation: CONV, dispatchedAt });
+
+    const [payload] = drain();
+    expect(payload.run_correlation).toBe("unidentified");
+  });
+});
+
+describe("WIRING: panel_run stamps the dispatch time before dispatching (#1327)", () => {
+  it("captures it BEFORE ctx.call, and passes it to openRun", async () => {
+    // Order is the entire fix. Stamping it after the call would put the timestamp
+    // after the completion arrived, and the entry would fail the `arrivedAt >=
+    // dispatchedAt` test it exists to pass — the bug, with extra code.
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf-8");
+
+    const stamp = src.indexOf("const runDispatchedAt = Date.now();");
+    const call = src.indexOf("let res = await ctx.call(runCmd", stamp);
+    expect(stamp).toBeGreaterThan(-1);
+    expect(call).toBeGreaterThan(stamp); // stamped first
+    expect(src).toContain("dispatchedAt: runDispatchedAt,");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -8311,6 +8311,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // #704 — the OWNER of the run. Unlike the tab, this cannot drift between
         // the queue and the completion: it is this tool session's own binding.
         const runTicketConversation = journalConversationFor(ctx);
+        // #1327 — stamped BEFORE the dispatch, because the ticket cannot be opened
+        // until ComfyUI mints the prompt id and a cached render can finish before that
+        // reply gets back here. Any completion for that id which arrived after this
+        // instant belongs to this run: the id did not exist before this call created
+        // it. Without the timestamp the journal has no way to tell the agent's own
+        // 0.1s render from a stranger's, and reported it as UNDETERMINED.
+        const runDispatchedAt = Date.now();
         let res = await ctx.call(runCmd, 20000);
         // Derive the verdict from the AUTHORITATIVE reply, not a bare `queued`
         // flag. A rejection — a no-connected-tab / thrown-queuePrompt error
@@ -8431,6 +8438,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // which is what still holds after the panel reconnects under a new id.
           ...(runTicketConversation !== undefined ? { conversation: runTicketConversation } : {}),
           ...(typeof args.to_node_id === "number" ? { toNodeId: args.to_node_id } : {}),
+          // #1327 — lets the journal claim a completion that beat its own ticket.
+          dispatchedAt: runDispatchedAt,
         };
         // Every id gets its own ticket. `correlatable` stays the promise the
         // anti-poll note is allowed to make — true only if at least one run can

--- a/src/orchestrator/run-completion-journal.ts
+++ b/src/orchestrator/run-completion-journal.ts
@@ -394,8 +394,12 @@ export class RunCompletionJournalImpl {
    * was evicted. Only doing it on the reopen left the eviction ordering able to
    * present an older run's result as the newly queued one's.
    */
-  private retireOlderEntriesFor(promptId: string): void {
+  private retireOlderEntriesFor(promptId: string, keep?: Set<JournalEntry>): void {
     for (const entry of this.entries.values()) {
+      // #1327 — an entry this very dispatch produced is not an OLDER run's; retiring
+      // it would immediately undo the claim above and re-report the agent's own render
+      // as undetermined, which is the defect being fixed.
+      if (keep?.has(entry)) continue;
       if (
         entry.correlation.status === "unidentified" ||
         entry.correlation.promptId !== promptId ||
@@ -424,7 +428,65 @@ export class RunCompletionJournalImpl {
    *  been re-registered (the #704 gap) is still this conversation's own history,
    *  and missing it would let the re-queued id be treated as a clean identity —
    *  the exact misattribution-plus-loss the `reused` flag exists to prevent. */
-  private hasHistoryFor(key: string, promptId: string, conversation?: string): boolean {
+  /**
+   * #1327 — re-stamp any UNDELIVERED completion that this dispatch itself produced.
+   *
+   * Returns the entries proven to belong to the run being opened, so the caller can
+   * also stop counting them as prior history for the id.
+   *
+   * Two conditions, both required, and both are proof rather than heuristic:
+   *   • the entry ARRIVED at or after this dispatch — the prompt id did not exist
+   *     before ComfyUI minted it here, so nothing earlier can legitimately carry it;
+   *   • the entry has NOT been handed to an agent yet — nobody has read the wrong
+   *     verdict, so correcting it changes no answer already given.
+   *
+   * The second is what keeps this compatible with the journal's rule that a REPLAY
+   * never re-correlates. That rule exists so a delivered verdict cannot be rewritten
+   * under a later run; this only ever corrects a verdict still sitting unread, and only
+   * toward the run that demonstrably produced it.
+   */
+  private claimRaced(
+    promptId: string,
+    meta: { tabId: string; conversation?: string; dispatchedAt?: number },
+  ): Set<JournalEntry> {
+    const claimed = new Set<JournalEntry>();
+    // No dispatch time means no proof — do nothing rather than guess.
+    if (typeof meta.dispatchedAt !== "number") return claimed;
+    for (const entry of this.entries.values()) {
+      // NOBODY HAS BEEN TOLD YET is the real condition, and `attempts` is what says so
+      // — not `state`. A released entry (handed to an agent whose turn ended without an
+      // ack) goes back to `pending`, so a state check would silently re-stamp a verdict
+      // an agent had already been given. `attempts` survives that round trip.
+      if (entry.attempts > 0) continue;
+      if (entry.state !== "pending") continue;
+      // An ID-LESS completion carries no run identity at all, so nothing can prove it
+      // belongs here — it stays unidentified rather than being claimed on timing alone.
+      if (entry.correlation.status === "unidentified") continue;
+      if (entry.correlation.promptId !== promptId) continue;
+      if (entry.arrivedAt < meta.dispatchedAt) continue;
+      // Only for the party this dispatch belongs to; another tab's completion for
+      // the same id is not ours to claim.
+      const sameParty =
+        entry.key === meta.tabId ||
+        (meta.conversation !== undefined && entry.conversation === meta.conversation);
+      if (!sameParty) continue;
+      claimed.add(entry);
+      if (entry.correlation.status === "matched") continue;
+      entry.correlation = { status: "matched", promptId };
+      if (meta.conversation !== undefined) entry.conversation = meta.conversation;
+      logger.info(
+        `[run-completions] prompt ${promptId} completed before its ticket existed (a fast/cached run) — the journaled completion is re-attributed to the run that produced it instead of being reported as foreign`,
+      );
+    }
+    return claimed;
+  }
+
+  private hasHistoryFor(
+    key: string,
+    promptId: string,
+    conversation?: string,
+    exclude?: Set<JournalEntry>,
+  ): boolean {
     // BOTH owners: the memo may have been written under the tab (no conversation
     // known at the time, or an older entry) or under the conversation.
     const prefixes = [`${key}|${promptId}|`];
@@ -433,6 +495,7 @@ export class RunCompletionJournalImpl {
       if (prefixes.some((p) => memo.startsWith(p))) return true;
     }
     for (const entry of this.entries.values()) {
+      if (exclude?.has(entry)) continue; // #1327 — this dispatch's own completion
       if (
         (entry.key === key ||
           (conversation !== undefined && entry.conversation === conversation)) &&
@@ -451,9 +514,27 @@ export class RunCompletionJournalImpl {
    *  attribute. */
   openRun(
     promptId: string | null | undefined,
-    meta: { tabId: string; conversation?: string; toNodeId?: number },
+    meta: { tabId: string; conversation?: string; toNodeId?: number; dispatchedAt?: number },
   ): boolean {
     if (typeof promptId !== "string" || !promptId) return false;
+    // #1327 — CLAIM THE COMPLETION THAT BEAT ITS OWN TICKET.
+    //
+    // A ticket cannot be opened before dispatch, because ComfyUI mints the prompt id
+    // when it accepts the run. So a render that finishes faster than the reply travels
+    // back — the reporter's was 0.1s, fully cached — lands here BEFORE openRun and
+    // correlates against no ticket at all. It was journaled `foreign`, and the agent
+    // was told its own render "does NOT match any run you queued", with an instruction
+    // to go poll get_history and distrust the result.
+    //
+    // It also poisoned what came after: an already-journaled entry makes hasHistoryFor
+    // true below, so the fresh ticket was born `reused` and EVERY later completion for
+    // that id read UNDETERMINED too.
+    //
+    // The dispatch time settles it without guessing. The id did not exist before this
+    // dispatch created it, so a completion carrying it that arrived at/after that
+    // moment is necessarily this run's. Entries older than the dispatch are a genuinely
+    // reused id and keep the existing ambiguity handling.
+    const claimed = this.claimRaced(promptId, meta);
     // NOTE: no memo clearing is needed here. The delivered memo is keyed by
     // ticket GENERATION, and every path below either bumps the generation (a
     // reopen) or mints a fresh one (a new ticket), so a newly queued run's memo
@@ -478,7 +559,7 @@ export class RunCompletionJournalImpl {
       // on is unattributable (see RunTicket.reused) — reported UNDETERMINED, and
       // never suppressed as a duplicate of the other generation.
       existing.reused = true;
-      this.retireOlderEntriesFor(promptId);
+      this.retireOlderEntriesFor(promptId, claimed);
       return true;
     }
     // A FRESH ticket is only a fresh IDENTITY if this tab has no history for the
@@ -489,7 +570,11 @@ export class RunCompletionJournalImpl {
     // ambiguous: had it been treated as a clean identity, A's resend would
     // correlate as B, its ack would settle B, and B's real completion would then
     // be suppressed by B's own settled flag — misattribution AND loss.
-    const hasHistory = this.hasHistoryFor(meta.tabId, promptId, meta.conversation);
+    // #1327 — a completion this dispatch just produced is NOT prior history for the
+    // id. Counting it made the ticket `reused` and turned every later completion for
+    // the same run undetermined; `claimed` is exactly the set proven to be ours.
+    const hasHistory =
+      this.hasHistoryFor(meta.tabId, promptId, meta.conversation, claimed) || false;
     this.tickets.set(promptId, {
       promptId,
       tabId: meta.tabId,
@@ -509,7 +594,7 @@ export class RunCompletionJournalImpl {
     // still a NEW run for an id that already has journaled completions: without
     // this, an older `matched` entry survives untouched and goes on telling the
     // agent "this is the run YOU queued" for the id now outstanding.
-    this.retireOlderEntriesFor(promptId);
+    this.retireOlderEntriesFor(promptId, claimed);
     this.trimTickets();
     return true;
   }


### PR DESCRIPTION
Closes #1327

Claiming defect **1** (the main report). Scoping deliberately:

**In scope** — a completion that is buffered and RE-DELIVERED reports `origin is UNDETERMINED` even though its `prompt_id` is byte-identical to the one `panel_run` just returned. That is not noise: the warning tells the agent to distrust its own render and to go poll `get_history`, which the panel elsewhere tells agents not to do, and it weakens the duplicate-fence that leans on the same registry.

**Likely adjacent to #925**, which reworked exactly this correlation to use ownership evidence only.

**Defect 2** (`partial_execution_targets` not reaching `/prompt` via `app.queuePrompt` on frontend 1.48.6, build #556) is a panel/frontend-compat report and a separate change — it will be split out rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)