### PR TITLE
chore(release): 0.50.96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.96] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- refuse an arbitrary-URL download once, before three requests fail (#1338)
+
+
 ## [0.50.95] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.95",
+  "version": "0.50.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.95",
+      "version": "0.50.96",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.95",
+  "version": "0.50.96",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.96` tag (the tag publishes).

### Fixed
- **#1326** — an install-model failure on legacy ComfyUI-Manager 3.x asserted one cause for every failure (`kind === "install-model"` was the entire test) while discarding Manager's own response body. Now: a `security_level` refusal excludes the whitelist claim, a body naming the model list proves it, and otherwise the whitelist still leads with its full upgrade path but is stated as likely rather than established. Manager's own words are shown either way, bounded and credential-stripped.

Review-pass finding folded in: surfacing the body would have **leaked a token**. The model URL carrying the HF/CivitAI credential travels in the POST body, not the endpoint URL, and Manager echoes it back on a failed download — every URL in the text now has its query values redacted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)