### PR TITLE
fix(#1330): corroborate a fence mismatch before failing 14 calls closed

### DIFF
--- a/src/__tests__/orchestrator/fence-mismatch-corroborates.test.ts
+++ b/src/__tests__/orchestrator/fence-mismatch-corroborates.test.ts
@@ -1,0 +1,148 @@
+// #1330 — a mismatch that clears by itself still cost fourteen refusals.
+//
+// The reporter built a new workflow: panel_add_node and panel_set_widget succeeded for
+// 12 nodes, then EVERY panel_connect was refused with
+//
+//   workflow instance mismatch: this command was issued for workflow instance
+//   3282b824-…, and the active canvas reports cf8f83cd-…. Nothing was applied.
+//
+// Calling panel_set_workflow_target({mode:"current"}) immediately afterwards reported
+// `already_current` naming 3282b824 — the SAME uuid the refused commands carried — and
+// every retried connect then succeeded. So the canvas identity flipped and settled back
+// while a new unsaved workflow was materialising, and nothing in the refusal separated
+// that from "you are genuinely pointed at another workflow".
+//
+// THE FENCE IS NOT WEAKENED AND NOTHING IS AUTO-APPLIED. The refusal still stands; what
+// changes is that the orchestrator now performs the same read-only re-derivation the
+// documented recovery performs, and reports WHICH of the two states it found. One
+// informed retry replaces fourteen blind ones.
+//
+// Recommending a retry is safe here specifically because the panel checks the fence
+// BEFORE running the handler — "Nothing was applied" is structural, not an echoed claim.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+const STAMP = "3282b824-5890-4c87-9da4-7936c155aa8c"; // what the command carried
+const OTHER = "cf8f83cd-ce65-4307-ad9c-0dc5f5d491d4"; // what the canvas transiently said
+
+let listCalls: number;
+let stamp: string | undefined;
+
+/** A self-corroborating workflow_list reply — the active record also appears in the
+ *  open-workflow list flagged active, which is what corroboration requires. */
+function settled(uuid: string): Record<string, unknown> {
+  const active = { path: "workflows/a.json", routing_key: TAB, workflow_uuid: uuid };
+  return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+}
+
+/** `liveUuid` is what workflow_list reports the canvas to be when the orchestrator
+ *  re-reads it after the refusal. */
+function bridge(liveUuid: string | null) {
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "workflow_list") {
+        listCalls += 1;
+        if (!liveUuid) throw new Error("panel did not answer");
+        return settled(liveUuid);
+      }
+      // Any MUTATING graph command is refused by the panel's fence, exactly as the
+      // panel words it (the leading token is preserved deliberately, so it is matched).
+      throw new Error(
+        `workflow instance mismatch: this command was issued for workflow instance ${STAMP}, ` +
+          `and the active canvas reports ${OTHER}. Nothing was applied.`,
+      );
+    },
+    push: () => 1,
+    canReach: (id: string) => id === TAB,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_tabId: string, uuid: string) => {
+      stamp = uuid;
+      return true;
+    },
+    workflowUuidFor: () => ({ known: true, uuid: stamp }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+/** Drive a real MUTATING tool (panel_connect) through the real ctx.call path. */
+async function connect(liveUuid: string | null): Promise<string> {
+  const ctx = makePanelToolCtx(bridge(liveUuid), TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_connect");
+  if (!def) throw new Error("panel_connect is not registered");
+  const res: ToolResult = await def.handler(
+    { from_node_id: 1, to_node_id: 2 } as never,
+    ctx,
+  );
+  return res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+}
+
+beforeEach(() => {
+  listCalls = 0;
+  stamp = STAMP; // the session is fenced to the uuid the command carries
+});
+
+describe("a fenced mutation is corroborated before the caller retries blindly (#1330)", () => {
+  it("TRANSIENT: the canvas settles back to the stamped id — say so, and retry ONCE", async () => {
+    // The reporter's exact state: re-reading finds the fence already names the live
+    // canvas, so the disagreement is gone by the time we look.
+    const text = await connect(STAMP);
+
+    // The re-derivation really ran — without this the assertions below could all be
+    // satisfied by a message that never consulted the panel at all.
+    expect(listCalls).toBeGreaterThan(0);
+
+    expect(text).toMatch(/AUTO-REBIND: ATTEMPTED/);
+    expect(text).toMatch(/TRANSIENT/);
+    expect(text).toMatch(/RETRY THIS EXACT CALL ONCE/);
+    // The instruction that actually saves the 14 calls.
+    expect(text).toMatch(/re-issuing the whole build would duplicate/i);
+    // The refusal itself is preserved verbatim — the comparison is the evidence.
+    expect(text).toContain(STAMP);
+    expect(text).toMatch(/NOT applied — nothing changed/);
+  });
+
+  it("GENUINELY DIFFERENT: the fence is re-derived and the caller is told which", async () => {
+    // Not the reporter's case, and it must not be described as transient — telling an
+    // agent to retry into a different workflow is how an edit lands on the wrong graph.
+    stamp = STAMP;
+    const text = await connect(OTHER);
+
+    expect(listCalls).toBeGreaterThan(0);
+    expect(text).toMatch(/RE-DERIVED onto the live canvas/);
+    expect(text).toContain(OTHER);
+    expect(text).toMatch(/panel_open_workflow/);
+    expect(text).not.toMatch(/TRANSIENT/);
+  });
+
+  it("UNREADABLE: promises nothing, because nothing was established", async () => {
+    // The failure direction that matters. If the re-derivation could not read the
+    // panel, claiming the retry will work would send the agent back into the same
+    // loop this issue is about — with our encouragement this time.
+    const text = await connect(null);
+
+    expect(text).toMatch(/did NOT succeed/);
+    expect(text).toMatch(/a bare retry will fail the same way/);
+    expect(text).not.toMatch(/TRANSIENT/);
+    expect(text).not.toMatch(/RETRY THIS EXACT CALL ONCE/);
+  });
+
+  it("the fence still REFUSES — this discloses, it never applies", async () => {
+    // The whole point of the fence is that a mutation cannot land on the wrong graph.
+    // Corroboration must not become a way to smuggle one through.
+    const text = await connect(STAMP);
+    expect(text).toMatch(/^Error:/);
+    expect(text).toMatch(/Nothing was applied/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -859,6 +859,23 @@ function isWorkflowSwitchGuardRefusal(err: unknown): boolean {
   return /panel is switching\/refreshing|panel is switching or reloading/i.test(msg);
 }
 
+/**
+ * #1330 — the panel's workflow-instance fence refused this command.
+ *
+ * Distinct from every other refusal here in one way that matters: the panel checks the
+ * fence BEFORE the handler runs, so "Nothing was applied" is structural, not a claim.
+ * That is what makes it safe to tell a caller to retry — and it is why this is worth
+ * separating from the transport failures around it, where the outcome is unknown.
+ *
+ * Matched on the leading token the panel preserves deliberately for exactly this
+ * purpose (see workflowInstanceMismatchMessage: "the leading `workflow instance
+ * mismatch:` token is preserved deliberately").
+ */
+function isWorkflowInstanceMismatch(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  return /workflow instance mismatch/i.test(msg);
+}
+
 let retrySettleMsOverride: number | null = null;
 /** Short pause before the single post-drop retry, letting the replacement tab
  *  finish its reconnect hello so ensureReachable can resolve it. Test-overridable. */
@@ -5803,6 +5820,65 @@ export function makePanelToolCtx(
       // sent agents into a futile retry/rebind loop that contradicted the embedded
       // guidance. Key on the TYPED marker and surface the cause verbatim instead; it
       // already names the real recovery (update + restart + browser hard-refresh).
+      // #1330 — CORROBORATE A FENCE MISMATCH INSTEAD OF LETTING IT REPEAT.
+      //
+      // The reporter built 12 nodes successfully, then EVERY panel_connect was refused
+      // on an instance mismatch. Calling panel_set_workflow_target({mode:"current"})
+      // straight afterwards reported `already_current` naming the SAME uuid the command
+      // had been issued for, and the retried connects all succeeded. So the mismatch was
+      // transient and self-correcting, and the caller paid 14 refusals to find that out —
+      // because nothing in the refusal distinguishes "the canvas really is a different
+      // workflow" from "the identity flipped for a moment while you were building".
+      //
+      // The fence is NOT weakened and nothing is auto-applied. This performs the same
+      // read-only re-derivation the documented recovery performs, then says which of the
+      // two states was found. One informed retry replaces fourteen blind ones.
+      //
+      // Safe to recommend a retry because a fence refusal is checked BEFORE the handler
+      // runs — "Nothing was applied" is structural here, not an echoed claim.
+      if (isWorkflowInstanceMismatch(err) && isMutatingGraphCmd(cmd)) {
+        const name = typeof cmd.cmd === "string" ? cmd.cmd : "panel command";
+        const raw = err instanceof Error ? err.message : String(err);
+        // The uuid the command CARRIED, read from the panel's own refusal rather than
+        // from `cmd`: the stamp is applied downstream of here, so `cmd.workflow_uuid`
+        // is undefined at this point and keying on it silently disabled the transient
+        // branch — the one case this whole block exists for. The panel states both
+        // sides of the comparison it performed, which is the authoritative record of
+        // what was compared.
+        const stamped = /issued for workflow instance ([0-9a-f-]{36})/i.exec(
+          err instanceof Error ? err.message : String(err),
+        )?.[1] ?? null;
+        let verdict: string;
+        try {
+          const rebind = await rebindWorkflowFence(ctx);
+          verdict =
+            rebind.status === "already_current" && stamped && rebind.uuid === stamped
+              ? `\n\nAUTO-REBIND: ATTEMPTED, and the live canvas now reports the SAME workflow ` +
+                `instance this command carried (${stamped}) — nothing needed repairing. The ` +
+                `mismatch was TRANSIENT: the identity flipped and settled back, which happens ` +
+                `while a new unsaved workflow is still materialising. RETRY THIS EXACT CALL ONCE. ` +
+                `Nothing was applied, so a retry cannot double-apply, and re-issuing the whole ` +
+                `build would duplicate the work that already succeeded.`
+              : rebind.status === "already_current"
+                ? `\n\nAUTO-REBIND: ATTEMPTED; the fence already named the live canvas ` +
+                  `(${rebind.uuid}), so it was not the stale side. Retry once — if it refuses ` +
+                  `again with the same pair, the two identities are genuinely disagreeing and ` +
+                  `panel_open_workflow is the way to settle which one you mean.`
+                : rebind.status === "refreshed"
+                  ? `\n\nAUTO-REBIND: ATTEMPTED and the fence was RE-DERIVED onto the live canvas ` +
+                    `(now ${rebind.uuid}). Retry once. If you meant the EARLIER workflow, re-select ` +
+                    `it with panel_open_workflow first — this session now points at the live one.`
+                  : `\n\nAUTO-REBIND: ATTEMPTED and did NOT succeed (${rebind.status}), so the fence ` +
+                    `is unchanged and a bare retry will fail the same way. Re-select the workflow ` +
+                    `you mean with panel_open_workflow, then retry.`;
+        } catch (rebindErr) {
+          // Never let the diagnosis fail the call differently than it already failed.
+          verdict =
+            `\n\nAUTO-REBIND: ATTEMPTED and threw, so the fence state is UNKNOWN — this refusal ` +
+            `stands on its own terms. (${rebindErr instanceof Error ? rebindErr.message : String(rebindErr)})`;
+        }
+        return fail(`${name} was NOT applied — nothing changed. ${raw}${verdict}`);
+      }
       if (isCapabilityRefusal(err)) {
         return fail(err instanceof Error ? err.message : String(err));
       }


### PR DESCRIPTION
Closes #1330

Claiming. The reporter built 12 nodes successfully, then **every** `panel_connect` failed closed on a workflow-instance mismatch — and `panel_set_workflow_target({mode:"current"})` immediately reported `already_current` with the *same* uuid the command had been issued for. Retrying then worked.

So the mismatch was transient and self-correcting, and the caller paid 14 refusals to discover that.

Investigating whether the existing corroboration path (`readAndCorroborate` / `FENCE_CORROBORATION_RECHECK_STEPS_MS`) covers this route at all, and whether this is the known embed/swap race where the first record embeds the PRE-swap uuid.

Not planning to weaken fail-closed: the fence exists so a mutation cannot land on the wrong graph. The question is whether a mismatch that corroboration would clear should ever have been reported as one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)