### PR TITLE
chore(release): 0.50.97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.97] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- a re-delivered completion must not disown a run we queued (#1342)
+
+
 ## [0.50.96] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.96",
+  "version": "0.50.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.96",
+      "version": "0.50.97",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.96",
+  "version": "0.50.97",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.97` tag (the tag publishes).

### Fixed
- **#1327** — a render that finished before its own ticket existed was reported to the agent as `origin is UNDETERMINED`, telling it to distrust its own result and go poll `get_history`. A ticket cannot be opened before dispatch (ComfyUI mints the prompt id when it accepts the run), so a 0.1s fully-cached render beat it. The dispatch timestamp settles ownership without heuristics. It also fixes second-order damage: the already-journaled completion made the fresh ticket born `reused`, so *every later* completion for that run also read UNDETERMINED.

Defect 2 of that report (`partial_execution_targets` not reaching `/prompt` via `app.queuePrompt` on frontend 1.48.6) is split to artokun/comfyui-mcp-panel#996 rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)