### PR TITLE
fix(#1331): name the remedy that restores a trusted identity, not the one that cannot

### DIFF
--- a/src/__tests__/orchestrator/no-trusted-identity-remedy.test.ts
+++ b/src/__tests__/orchestrator/no-trusted-identity-remedy.test.ts
@@ -1,0 +1,149 @@
+// #1331 — the remedy for "no trusted identity" was right for one state and wrong for
+// the other, and only one of them was ever printed.
+//
+// The reporter built a workflow in-session (new → paste → rename → save), survived a
+// ComfyUI reconnect, and then every MUTATING panel_* call was refused:
+//
+//   "graph_set_widget" cannot be safely targeted to the active workflow: this workflow
+//   has no trusted identity for the panel to fence the command against.
+//
+// wrapped with "Retry in a moment, or rebind with
+// panel_set_workflow_target({mode:"current"})". They followed it. It did not work.
+// Recovery took panel_open_workflow on the workflow that was ALREADY active — four
+// calls to reach a state the panel already believed it was in.
+//
+// TWO STATES, ONE MESSAGE. The bridge cannot tell them apart; from its side both are
+// "no identity":
+//
+//   session bound to a STALE tab, live canvas HAS an identity
+//        → the rebind re-resolves it. Retry/rebind is CORRECT (#709).
+//   the LIVE canvas itself has none
+//        → the rebind READS an identity to adopt and finds none, so it reports success
+//          while every mutation keeps failing. Only re-opening mints one.
+//
+// The orchestrator can tell them apart, with the same read-only re-derivation the
+// documented recovery performs. So it measures once and names the remedy that fits.
+//
+// This is deliberately NOT a blanket replacement. My first attempt deleted the
+// retry/rebind advice outright and #709's own test caught it — that advice is correct
+// in its state, and removing it would have broken a working recovery to fix a broken
+// one.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { markDispatched } from "../../services/ui-bridge.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/niji_holo_impasto.json";
+const LIVE_UUID = "55555555-5555-4555-8555-555555555555";
+
+const identityRefusal = () =>
+  markDispatched(
+    new Error(
+      `"graph_set_widget" cannot be safely targeted to the active workflow: this workflow has ` +
+        `no trusted identity for the panel to fence the command against. Reads and view-only ` +
+        `commands still work (graph_outline, graph_query, graph_get_state).`,
+    ),
+    false,
+  );
+
+/** `activeUuid: null` is #1331 — the live canvas has no identity either.
+ *  `"throw"` is the unreadable case: the re-read itself fails. */
+function bridge(activeUuid: string | null | "throw") {
+  let listCalls = 0;
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "workflow_list") {
+        listCalls += 1;
+        if (activeUuid === "throw") throw new Error("panel did not answer");
+        const active = {
+          path: "workflows/niji_holo_impasto.json",
+          routing_key: TAB,
+          // The #1331 shape: a real saved path, and NO workflow_uuid on the record.
+          ...(activeUuid ? { workflow_uuid: activeUuid } : {}),
+        };
+        return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+      }
+      throw identityRefusal();
+    },
+    push: () => 1,
+    canReach: (id: string) => id === TAB,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: () => true,
+    workflowUuidFor: () => ({ known: false }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, reads: () => listCalls };
+}
+
+async function setWidget(activeUuid: string | null | "throw"): Promise<{ text: string; reads: number }> {
+  const { b, reads } = bridge(activeUuid);
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_set_widget");
+  if (!def) throw new Error("panel_set_widget is not registered");
+  const res: ToolResult = await def.handler({ node_id: 7, widget: "steps", value: 20 } as never, ctx);
+  return { text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "), reads: reads() };
+}
+
+describe("a no-trusted-identity refusal names the remedy that fits (#1331)", () => {
+  it("LIVE CANVAS HAS NONE: says the rebind cannot help, and names what can", async () => {
+    const { text, reads } = await setWidget(null);
+
+    // The re-derivation really ran — otherwise every assertion below could be satisfied
+    // by a message that consulted nothing.
+    expect(reads).toBeGreaterThan(0);
+
+    expect(text).toMatch(/CHECKED, so this is not a guess/);
+    expect(text).toMatch(/will NOT clear this/);
+    expect(text).toMatch(/cannot mint an identity for one that has none/);
+    // The remedy the reporter had to find by hand.
+    expect(text).toMatch(/panel_open_workflow\(<path>\)/);
+    // …and the case where there is no path to re-open.
+    expect(text).toMatch(/panel_save_workflow/);
+    // The cause is never replaced, only explained.
+    expect(text).toMatch(/no trusted identity/);
+  });
+
+  it("LIVE CANVAS HAS ONE: the rebind is the right move and is performed, not prescribed", async () => {
+    // #709's state. The advice that was wrong for #1331 is right here — and rather than
+    // telling the caller to run the rebind, the orchestrator has already run it.
+    const { text, reads } = await setWidget(LIVE_UUID);
+
+    expect(reads).toBeGreaterThan(0);
+    expect(text).toMatch(/CHECKED: the live canvas DOES carry an identity/);
+    expect(text).toContain(LIVE_UUID);
+    expect(text).toMatch(/RETRY THIS EXACT CALL ONCE/);
+    // It must NOT send them re-opening a workflow that is perfectly fine.
+    expect(text).not.toMatch(/panel_open_workflow\(<path>\)/);
+  });
+
+  it("UNREADABLE: refuses to pick a side, and names the recovery that works either way", async () => {
+    // The failure direction that matters. Asserting either state here would be a claim
+    // nothing supports — and half the time it would send the caller down the exact path
+    // that cost the reporter four calls.
+    const { text } = await setWidget("throw");
+
+    expect(text).toMatch(/the answer is UNKNOWN/);
+    expect(text).toMatch(/works in BOTH states/);
+    expect(text).not.toMatch(/CHECKED, so this is not a guess/);
+    expect(text).not.toMatch(/DOES carry an identity/);
+  });
+
+  it("every branch still REFUSES — nothing is applied, in any state", async () => {
+    // The fence exists so a mutation cannot land on an unidentified graph. Explaining
+    // the refusal better must never turn into letting one through.
+    for (const state of [null, LIVE_UUID, "throw"] as const) {
+      const { text } = await setWidget(state);
+      expect(text).toMatch(/^Error:/);
+    }
+  });
+});

--- a/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
+++ b/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
@@ -452,12 +452,29 @@ describe("#442 defect 4: a MUTATING panel command names the rebind on a no-route
     expect(text).not.toMatch(/Retry in a moment/);
   });
 
-  it("#709: a NO-IDENTITY refusal (not capability-marked) keeps the retry/rebind wrapper", async () => {
+  it("#709/#1331: a NO-IDENTITY refusal carries an actionable recovery, now MEASURED", async () => {
     // Same gate, THIRD branch: the panel enforces the stamp but the workflow has no
-    // trusted identity to fence against — a binding/identity problem where retrying
-    // or rebinding onto the live tab genuinely re-resolves the identity. The error
-    // is dispatched:false but deliberately NOT capability-marked, so the generic
-    // recovery wrapper MUST still fire.
+    // trusted identity to fence against. The error is dispatched:false but deliberately
+    // NOT capability-marked, so this must NOT be left bare — #709's requirement, and it
+    // still holds.
+    //
+    // WHAT CHANGED (#1331), and why this test moved with it. #709 asserted the LITERAL
+    // generic wrapper, "rebind with panel_set_workflow_target({mode:'current'})". Two
+    // different states produce this identical message and they need opposite remedies:
+    // when the session is bound to a stale tab and the LIVE canvas has an identity, the
+    // rebind genuinely re-resolves it; when the live canvas has none, the rebind reads
+    // an identity to adopt, finds none, and reports success while every mutation keeps
+    // failing. The reporter of #1331 got the second and followed the advice for the
+    // first, costing four calls to reach a state the panel already believed it was in.
+    //
+    // So the orchestrator now MEASURES which state it is in rather than printing one
+    // remedy for both. The requirement #709 protects — an actionable recovery, the
+    // cause preserved, nothing applied — is unchanged and asserted below.
+    //
+    // The bridge also had to become realistic: it used to throw the identity refusal
+    // for EVERY command, including workflow_list. That state cannot occur — the
+    // refusal's own text says read-only commands still work — and it is what a
+    // re-derivation reads.
     const identityCause = markDispatched(
       new Error(
         `"graph_set_widget" cannot be safely targeted to the active workflow: this workflow ` +
@@ -468,15 +485,31 @@ describe("#442 defect 4: a MUTATING panel command names the rebind on a no-route
     );
     const live = new Set(["wf:workflows/x.json"]);
     const sent: Array<{ cmd: Record<string, unknown> }> = [];
+    const LIVE_UUID = "44444444-4444-4444-8444-444444444444";
+    let listCalls = 0;
     const bridge = {
       send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
         if (opts?.tabId && !live.has(opts.tabId)) throw new Error("unexpected route");
+        if (cmd.cmd === "workflow_list") {
+          // #709's actual state: the LIVE canvas does have an identity, so the rebind
+          // can re-resolve it — which is precisely why retry/rebind was right here.
+          listCalls += 1;
+          const active = {
+            path: "workflows/x.json",
+            routing_key: "wf:workflows/x.json",
+            workflow_uuid: LIVE_UUID,
+          };
+          return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+        }
         throw identityCause;
       },
       push: () => 1,
       canReach: (id: string) => live.has(id),
+      isHeadless: () => false,
       tabs: () => [...live].map((t) => ({ tab_id: t, title: t, connected_at: 0 })),
       resolveActiveTabId: () => [...live][0],
+      refreshWorkflowUuid: () => true,
+      workflowUuidFor: () => ({ known: true, uuid: LIVE_UUID }),
     } as unknown as PanelToolCtx["bridge"];
     const ctx = makePanelToolCtx(bridge, "wf:workflows/x.json", new WorkflowTargetStore());
 
@@ -488,8 +521,13 @@ describe("#442 defect 4: a MUTATING panel command names the rebind on a no-route
     expect(sent.length).toBe(0);
     const text = textOf(res);
     expect(text).toMatch(/no trusted identity/); // the cause is preserved…
-    expect(text).toContain('rebind with panel_set_workflow_target({mode:"current"})'); // …AND the wrapper fires
-    expect(text).toMatch(/Nothing was applied/i);
+    // …the live canvas was actually re-read — not asserted from text alone…
+    expect(listCalls).toBeGreaterThan(0);
+    // …and the recovery is the one that fits THIS state: the fence was re-derived, so
+    // the caller retries rather than being sent to re-open a workflow that is fine.
+    expect(text).toMatch(/CHECKED: the live canvas DOES carry an identity/);
+    expect(text).toContain(LIVE_UUID);
+    expect(text).toMatch(/RETRY THIS EXACT CALL ONCE/);
   });
 
   it("does NOT mis-wrap a POST-dispatch executor failure that merely quotes 'no connected tab' as 'nothing applied'", async () => {    // A LIVE tab that ACCEPTS the command (it IS dispatched, pushed to `sent`) but whose

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -859,6 +859,21 @@ function isWorkflowSwitchGuardRefusal(err: unknown): boolean {
   return /panel is switching\/refreshing|panel is switching or reloading/i.test(msg);
 }
 
+/**
+ * #1331 — the bridge refused a mutation because the active workflow has no identity to
+ * fence against (ui-bridge's `no trusted identity` branch).
+ *
+ * Kept separate from the capability refusal beside it because the two need opposite
+ * advice: a capability gap needs a panel UPDATE, this needs the workflow re-opened. What
+ * they share is that the generic "retry / rebind with mode:current" wrapper can clear
+ * NEITHER, and appending it sent the reporter of #1331 through four calls to reach a
+ * state the panel already believed it was in.
+ */
+function isNoTrustedIdentityRefusal(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  return /no trusted identity/i.test(msg);
+}
+
 let retrySettleMsOverride: number | null = null;
 /** Short pause before the single post-drop retry, letting the replacement tab
  *  finish its reconnect hello so ensureReachable can resolve it. Test-overridable. */
@@ -5803,6 +5818,62 @@ export function makePanelToolCtx(
       // sent agents into a futile retry/rebind loop that contradicted the embedded
       // guidance. Key on the TYPED marker and surface the cause verbatim instead; it
       // already names the real recovery (update + restart + browser hard-refresh).
+      // #1331 — DECIDE WHICH "no trusted identity" THIS IS, instead of asserting one.
+      //
+      // The reporter was told to "retry in a moment, or rebind with
+      // panel_set_workflow_target({mode:"current"})", followed it, and it did not work:
+      // recovery took panel_open_workflow on the workflow that was ALREADY active —
+      // four calls to reach a state the panel already believed it was in.
+      //
+      // But that advice is NOT always wrong, and my first attempt at this deleted it
+      // outright — which #709's test caught. Two different states produce the identical
+      // bridge message, and they need opposite remedies:
+      //
+      //   session bound to a STALE tab, live canvas HAS an identity
+      //        → rebinding genuinely re-resolves it (#709). The advice is correct.
+      //   the LIVE canvas itself has no identity
+      //        → the rebind READS an identity to adopt and finds none, so it reports
+      //          success while every mutation keeps failing (#1331).
+      //
+      // The bridge cannot tell them apart — from its side both are "no identity". The
+      // orchestrator can, with the same read-only re-derivation the documented recovery
+      // performs. So it is measured, once, and the answer names the remedy that fits.
+      if (isNoTrustedIdentityRefusal(err) && isMutatingGraphCmd(cmd)) {
+        const raw = err instanceof Error ? err.message : String(err);
+        try {
+          const rebind = await rebindWorkflowFence(ctx);
+          if (rebind.status === "no_identity") {
+            return fail(
+              `${raw}\n\nCHECKED, so this is not a guess: the live canvas was re-read and it ` +
+                `carries no workflow identity either (${rebind.why}). ` +
+                `panel_set_workflow_target({mode:"current"}) will NOT clear this — it chooses ` +
+                `WHICH workflow to fence against and cannot mint an identity for one that has ` +
+                `none, so it reports success while every mutation keeps failing. RECOVERY: ` +
+                `panel_open_workflow(<path>) on this same workflow; re-opening it is what gives ` +
+                `it an identity. If it has never been saved there is no path to re-open — save ` +
+                `it first with panel_save_workflow, which also gives it a stable identity.`,
+            );
+          }
+          if (rebind.status === "refreshed" || rebind.status === "already_current") {
+            return fail(
+              `${raw}\n\nCHECKED: the live canvas DOES carry an identity (${rebind.uuid}) and ` +
+                `this session's fence has been re-derived onto it. RETRY THIS EXACT CALL ONCE — ` +
+                `nothing was applied, so a retry cannot double-apply.`,
+            );
+          }
+          // unreadable / uncorroborated — say so rather than picking a remedy.
+          return fail(
+            `${raw}\n\nCHECKED, and the answer is UNKNOWN: the live canvas could not be re-read ` +
+              `well enough to say whether it has an identity. Try ` +
+              `panel_open_workflow(<path>) on the workflow you mean — it is the only recovery ` +
+              `that works in BOTH states, because it gives the workflow an identity rather than ` +
+              `adopting one that may not exist.`,
+          );
+        } catch {
+          // The diagnosis must never change how the call failed.
+          return fail(raw);
+        }
+      }
       if (isCapabilityRefusal(err)) {
         return fail(err instanceof Error ? err.message : String(err));
       }


### PR DESCRIPTION
Refs #1331 (bug 1's remedy half)

Scoping this deliberately, because the report contains three distinct defects and two of them are panel-side.

**In scope, and provable from this repo:** a mutation refused for `no trusted identity` is wrapped with *"retry in a moment, or rebind with panel_set_workflow_target({mode:\"current\"})"*. The reporter proved that does not work — recovery took `panel_open_workflow` on the workflow that was *already active*.

It cannot work, structurally: `rebindWorkflowFence` **reads** the active record's `workflow_uuid`. When the workflow has none it returns `no_identity`/`no_uuid` (`panel-tools.ts:3472-3478`) — re-targeting cannot mint an identity that is not there. Meanwhile the no-identity branch is the only one of the three in `ui-bridge.ts:3834` that appends **no** recovery of its own, so the generic wrapper supplies the useless one.

**Out of scope here, and panel-side:**
- re-deriving identity from the saved path after a reconnect (the root cause of bug 1);
- the `workflow_open` post-load compare racing the frontend's normalisation (the false `nodes` mismatch);
- bug 2, `panel_request_secret` timing out at 300s while awaiting human input.

Each will be split out rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)