### PR TITLE
chore(release): 0.50.98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.98] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- corroborate a fence mismatch before failing 14 calls closed (#1344)
+
+
 ## [0.50.97] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.97",
+  "version": "0.50.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.97",
+      "version": "0.50.98",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.97",
+  "version": "0.50.98",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.98` tag (the tag publishes).

### Fixed
- **#1330** — a transient workflow-instance mismatch cost the reporter 14 refused `panel_connect` calls. On a mismatch against a mutating command the orchestrator now performs the same read-only re-derivation the documented recovery performs, and reports which of three states it found — transient (retry this call once, don't re-issue the build), genuinely different (fence re-derived onto the live canvas), or unreadable (promises nothing). The fence is not weakened and nothing is auto-applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)