### PR TITLE
fix(#1332): stop reporting a lost transport as "the user cancelled"

### DIFF
--- a/src/__tests__/orchestrator/confirm-unreachable-is-not-a-decline.test.ts
+++ b/src/__tests__/orchestrator/confirm-unreachable-is-not-a-decline.test.ts
@@ -1,0 +1,150 @@
+// #1332 — "Cancelled — ComfyUI was not restarted." was said about a ComfyUI that had
+// just restarted.
+//
+// The reporter accepted the guarded restart. ComfyUI restarted — a fresh startup line
+// in the server log proved it — and the tool reported a cancellation. The next panel
+// call then failed with "still reconnecting after a restart/reload", which is the
+// restart this reply had just denied.
+//
+// THE CAUSE IS ONE `catch`. ConfirmOutcome was tri-state, and its catch mapped every
+// non-timeout failure to "no":
+//
+//   // Any other error (no panel, transport failure) → "no" so the destructive op is SKIPPED
+//   return "no";
+//
+// Skipping is correct and does not change. What was wrong is the CLAIM built on it: a
+// dropped transport is not a person saying no, and a restart is precisely the event
+// that drops the transport its own confirmation has to travel back on. #796's defect
+// class — "could not determine X" reported as "determined X is not the case".
+//
+// `unreachable` is that fourth fact. Every caller branches `!== "yes"`, so the
+// destructive operation is still skipped by construction; only the sentence changes.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type ConfirmOutcome,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+
+function bridge() {
+  return {
+    send: async () => ({ ok: true }),
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabServerOrigin: () => null,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+/** Drive a tool whose confirmation returns `outcome`, and read what it tells the user. */
+async function runWithConfirm(tool: string, outcome: ConfirmOutcome, args: object = {}): Promise<string> {
+  const ctx = makePanelToolCtx(bridge(), TAB, new WorkflowTargetStore());
+  ctx.confirm = async () => outcome;
+  const def = buildPanelToolDefs().find((d) => d.name === tool);
+  if (!def) throw new Error(`${tool} is not registered`);
+  const res: ToolResult = await def.handler(args as never, ctx);
+  return res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+}
+
+describe("an unaskable question is not a decline (#1332)", () => {
+  it("RESTART: stops claiming ComfyUI was not restarted when it cannot know", async () => {
+    const text = await runWithConfirm("panel_restart_comfyui", "unreachable");
+
+    // The exact false sentence from the report must not appear.
+    expect(text).not.toContain("Cancelled — ComfyUI was not restarted.");
+    // What IS true: this call dispatched nothing.
+    expect(text).toMatch(/did NOT dispatch a restart/);
+    // …and why the question of whether one happened is open.
+    expect(text).toMatch(/could not be reached to ask/);
+    expect(text).toMatch(/no decision was made either way/);
+    // The reporter's own recovery, named so the next person does not need the log hunt
+    // to disbelieve us.
+    expect(text).toMatch(/fresh startup line/);
+  });
+
+  it("RESTART: an EXPLICIT decline still says so, plainly", async () => {
+    // The fix must not blur a real user decision into hedging. When the user says no,
+    // "cancelled" is the truth and stays.
+    const text = await runWithConfirm("panel_restart_comfyui", "no");
+
+    expect(text).toContain("Cancelled — ComfyUI was not restarted.");
+    expect(text).not.toMatch(/could not be reached to ask/);
+  });
+
+  it("RESTART: a TIMEOUT keeps its own distinct wording", async () => {
+    // Three refusals, three meanings: declined, unanswered, unaskable.
+    const text = await runWithConfirm("panel_restart_comfyui", "timeout");
+
+    expect(text).toMatch(/No confirmation received within/);
+    expect(text).not.toContain("Cancelled — ComfyUI was not restarted.");
+    expect(text).not.toMatch(/could not be reached to ask/);
+  });
+
+  it("CLEAR CANVAS: the other caller does not credit a decision nobody made", async () => {
+    const text = await runWithConfirm("panel_clear", "unreachable");
+
+    expect(text).toMatch(/NOT because it was declined/);
+    expect(text).toMatch(/the question never appeared/);
+    expect(text).not.toContain("Cancelled — the canvas was left as-is.");
+  });
+
+  it("CLEAR CANVAS: an explicit decline is still a cancellation", async () => {
+    const text = await runWithConfirm("panel_clear", "no");
+    expect(text).toContain("Cancelled — the canvas was left as-is.");
+  });
+
+  it("WIRING: the REAL confirm turns a transport failure into `unreachable`", async () => {
+    // WITHOUT THIS TEST THE FIX WAS UNPROVEN. Every case above injects
+    // `ctx.confirm = async () => outcome`, so they pin what each CALLER says and never
+    // touch the one line that decides which outcome a dropped socket produces.
+    // Verified: reverting that line to `return "no"` left all of them green.
+    //
+    // So drive the real implementation. A non-timeout throw is exactly what a restart
+    // does to the socket its own confirmation card must answer on.
+    const b = {
+      ...(bridge() as object),
+      send: async () => {
+        throw new Error("panel tab is not open");
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+
+    const outcome = await ctx.confirm("Restart ComfyUI now?", "Restart ComfyUI", 500);
+
+    expect(outcome).toBe("unreachable");
+    // …and specifically NOT the value that made the reporter's message false.
+    expect(outcome).not.toBe("no");
+  });
+
+  it("THE SAFE PATH IS UNCHANGED: nothing destructive runs on `unreachable`", async () => {
+    // The whole reason the old code returned "no" was to SKIP. That property is what
+    // must survive this change — a clearer message would be a poor trade for a canvas
+    // cleared without consent.
+    const sent: string[] = [];
+    const b = {
+      ...(bridge() as object),
+      send: async (cmd: Record<string, unknown>) => {
+        sent.push(String(cmd.cmd));
+        return { ok: true };
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+    ctx.confirm = async () => "unreachable";
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_clear");
+    if (!def) throw new Error("panel_clear is not registered");
+    await def.handler({} as never, ctx);
+
+    expect(sent).not.toContain("graph_clear");
+  });
+});

--- a/src/__tests__/orchestrator/confirm-unreachable-is-not-a-decline.test.ts
+++ b/src/__tests__/orchestrator/confirm-unreachable-is-not-a-decline.test.ts
@@ -58,29 +58,18 @@ async function runWithConfirm(tool: string, outcome: ConfirmOutcome, args: objec
 }
 
 describe("an unaskable question is not a decline (#1332)", () => {
-  it("RESTART: stops claiming ComfyUI was not restarted when it cannot know", async () => {
-    const text = await runWithConfirm("panel_restart_comfyui", "unreachable");
-
-    // The exact false sentence from the report must not appear.
-    expect(text).not.toContain("Cancelled — ComfyUI was not restarted.");
-    // What IS true: this call dispatched nothing.
-    expect(text).toMatch(/did NOT dispatch a restart/);
-    // …and why the question of whether one happened is open.
-    expect(text).toMatch(/could not be reached to ask/);
-    expect(text).toMatch(/no decision was made either way/);
-    // The reporter's own recovery, named so the next person does not need the log hunt
-    // to disbelieve us.
-    expect(text).toMatch(/fresh startup line/);
-  });
-
-  it("RESTART: an EXPLICIT decline still says so, plainly", async () => {
-    // The fix must not blur a real user decision into hedging. When the user says no,
-    // "cancelled" is the truth and stays.
-    const text = await runWithConfirm("panel_restart_comfyui", "no");
-
-    expect(text).toContain("Cancelled — ComfyUI was not restarted.");
-    expect(text).not.toMatch(/could not be reached to ask/);
-  });
+  // THE TWO RESTART DECLINE CASES LIVE IN panel-restart-cancel-truth.test.ts, not here.
+  //
+  // They were here first and they passed locally and failed on macOS and Windows CI.
+  // The decline branch probes ComfyUI's health for ~6s; my workstation has a live
+  // ComfyUI on 8188 that answered, and CI has none, so the probe ran its full window
+  // and reported the server DOWN instead of reaching the wording under test. The
+  // assertion's outcome depended on the machine rather than the code — #1263's exact
+  // shape, in a test written to fix a truthfulness bug.
+  //
+  // That file already owns this path and has the harness for it: a stubbed health
+  // probe (setHealthProbe), a shrunk recheck window (setDeclineProbeTiming), and mocked
+  // config/process-control. Re-deriving that here would have been a second, weaker copy.
 
   it("RESTART: a TIMEOUT keeps its own distinct wording", async () => {
     // Three refusals, three meanings: declined, unanswered, unaskable.

--- a/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-cancel-truth.test.ts
@@ -59,7 +59,9 @@ const text = (res: ToolResult): string =>
 const parse = (res: ToolResult): Record<string, unknown> => JSON.parse(text(res));
 
 function makeCtx(opts: {
-  confirm: "yes" | "no";
+  /** #1332 — "unreachable" is the fourth outcome: the card could not be put to the
+   *  user, or its answer could not be retrieved. It reaches the same decline branch. */
+  confirm: "yes" | "no" | "unreachable";
   /** Whether the bound tab provably fronts our local boot instance (the gate
    *  for both the boot-endpoint probe and the #742 preflight). */
   frontsBoot?: boolean;
@@ -298,6 +300,42 @@ describe("panel_restart_comfyui — decline truthfulness (#742)", () => {
     expect(t3).toMatch(/no restart was dispatched/i);
     expect(t3).not.toMatch(/restart initiated earlier/i);
     expect(t3).not.toMatch(/STOPPED and did not come back/i);
+  });
+
+  it("#1332: an UNREACHABLE card does not claim ComfyUI was not restarted", async () => {
+    // The reporter accepted the restart, ComfyUI restarted (a fresh startup line in
+    // their server log), and this tool answered "Cancelled — ComfyUI was not
+    // restarted." The restart is what dropped the socket its own confirmation had to
+    // travel back on, and that transport failure used to arrive here as a decline.
+    //
+    // The server is HEALTHY throughout, which is the case the probes above cannot
+    // distinguish: "nothing happened" and "it restarted and came back" look identical
+    // from here. With an explicit decline we know which. Without one we do not.
+    __panelToolsTestHooks.setHealthProbe(async () => "healthy");
+    const { ctx, sends } = makeCtx({ confirm: "unreachable" });
+
+    const t = text(await restartTool().handler({}, ctx));
+
+    expect(t).not.toContain("Cancelled — ComfyUI was not restarted.");
+    expect(t).toMatch(/did NOT dispatch a restart/);
+    expect(t).toMatch(/could not be reached to ask/);
+    expect(t).toMatch(/no decision was made either way/);
+    expect(t).toMatch(/fresh startup line/);
+    // Still nothing dispatched — the safe behaviour is untouched.
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  it("#1332: an EXPLICIT decline still says Cancelled — the truth is kept", async () => {
+    // The fix must not blur a real decision into hedging: when the user says no,
+    // "ComfyUI was not restarted" is an observation, not a guess.
+    __panelToolsTestHooks.setHealthProbe(async () => "healthy");
+    const { ctx, sends } = makeCtx({ confirm: "no" });
+
+    const t = text(await restartTool().handler({}, ctx));
+
+    expect(t).toContain("Cancelled — ComfyUI was not restarted.");
+    expect(t).not.toMatch(/could not be reached to ask/);
+    expect(sends.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
   it("a decline with the server down-then-HEALTHY inside the window does NOT declare a loss", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -5420,7 +5420,22 @@ const nodeSize = () =>
  * confirmation"), never silently treated as a decline. Any non-timeout failure
  * (no panel, transport error) maps to "no" so the destructive op is SKIPPED.
  */
-export type ConfirmOutcome = "yes" | "no" | "timeout";
+/**
+ * #1332 — FOUR outcomes, because there are four facts.
+ *
+ * `no` used to carry two of them: the user said no, AND the question could not be put
+ * to them at all (no panel, dropped transport). Skipping the destructive operation is
+ * correct for both — that part does not change — but the SENTENCE built on it is not:
+ * `panel_restart_comfyui` answered "Cancelled — ComfyUI was not restarted" to a
+ * reporter whose ComfyUI had demonstrably restarted, because the restart itself dropped
+ * the socket the answer had to come back on.
+ *
+ * `unreachable` is that second fact, separated. It is deliberately NOT a failure state:
+ * every caller already branches `!== "yes"`, so the safe path is preserved by
+ * construction, and only what we CLAIM about it changes (#796's defect class — "could
+ * not determine X" reported as "determined X is not the case").
+ */
+export type ConfirmOutcome = "yes" | "no" | "timeout" | "unreachable";
 
 /**
  * The execution context every tool handler receives. Both transports (Anthropic
@@ -6003,14 +6018,16 @@ export function makePanelToolCtx(
     } catch (err) {
       // Only a card-reply TIMEOUT is recoverable/honest-as-timeout: poll the late
       // buffer, then report "timeout" if still unanswered. Any other error (no
-      // panel, transport failure) → "no" so the destructive op is SKIPPED, exactly
-      // as the previous catch-all did.
+      // panel, transport failure) still SKIPS the destructive op — but it is reported
+      // as `unreachable`, not `no` (#1332). The user did not decline; we never got to
+      // ask them, and a caller that says "cancelled" on this is describing a decision
+      // nobody made.
       if (isReplyTimeoutError(err)) {
         const late = await pollLateAskReply(bridge, askId, timing, budgetEnd);
         if (late !== undefined) return isAffirmative(late) ? "yes" : "no";
         return "timeout";
       }
-      return "no";
+      return "unreachable";
     }
   };
 
@@ -7805,6 +7822,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           return ok(
             "Timed out waiting for your confirmation, so I left the canvas as-is. " +
               "Tell me to clear it again when you're ready.",
+          );
+        }
+        if (decision === "unreachable") {
+          // #1332 — the canvas is still untouched, which is the part that matters, but
+          // the user never saw the question. Saying "cancelled" would credit them with
+          // a decision they were never offered.
+          return ok(
+            "The canvas was left as-is — but NOT because it was declined: the panel could " +
+              "not be reached to ask, so the question never appeared. Nothing was cleared. " +
+              "Check the panel tab is connected, then ask again.",
           );
         }
         if (decision !== "yes") {
@@ -10519,7 +10546,28 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                     "unreachable but is healthy again.",
             );
           }
-          return ok("Cancelled — ComfyUI was not restarted.");
+          // #1332 — the reporter's exact string, and it was FALSE. They accepted the
+          // restart, ComfyUI restarted (a fresh startup in the server log), and this
+          // said it had not — because the restart dropped the socket the answer had to
+          // travel back on, and a transport failure used to arrive here as "no".
+          //
+          // The probes above already refuse to claim "not restarted" while the server
+          // is DOWN. This is the remaining case: the server is HEALTHY, which is
+          // equally true of "nothing happened" and of "it restarted and came back".
+          // With an explicit decline we know which; without one we do not, and the
+          // sentence must stop asserting it.
+          return ok(
+            decision === "unreachable"
+              ? "This call did NOT dispatch a restart. Whether ComfyUI restarted for some " +
+                  "other reason cannot be told from here: the panel could not be reached to " +
+                  "ask for confirmation — the question never appeared — so no decision was " +
+                  "made either way, and the server is reachable now, which looks the same " +
+                  "whether it never went down or went down and came back. If you asked for a " +
+                  "restart and one has already happened, this is that transport loss, not a " +
+                  "cancellation. Check the ComfyUI log for a fresh startup line before " +
+                  "restarting again."
+              : "Cancelled — ComfyUI was not restarted.",
+          );
         }
         // Heal an orphaned session onto the live tab FIRST, then bind the reboot dispatch
         // to that ONE tab id (no await between capture and dispatch, so JS run-to-


### PR DESCRIPTION
Closes #1332

`panel_restart_comfyui` returned **`Cancelled — ComfyUI was not restarted.`** and ComfyUI had in fact restarted (a fresh startup in the server log).

Root cause found: `ConfirmOutcome` is tri-state, and its catch collapses three different facts into one —

```js
// Any other error (no panel, transport failure) → "no" so the destructive op is SKIPPED
return "no";
```

Skipping is right. **Saying the user declined is not**, and neither is the sentence built on it: *"ComfyUI was not restarted"* asserts an observation nobody made. Same defect class as #796 — "could not determine X" folded into "determined X is not the case".

Plan: a fourth outcome for "the question could not be put, or its answer could not be retrieved". Behaviour is unchanged (still skipped, still fail-safe); only the claim changes. Both `confirm` callers already branch `!== "yes"`, so the safe path is preserved by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)