### PR TITLE
chore(release): 0.50.99

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.99] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- name the remedy that restores a trusted identity, not the one that cannot (#1346)
+
+
 ## [0.50.98] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.98",
+  "version": "0.50.99",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.98",
+      "version": "0.50.99",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.98",
+  "version": "0.50.99",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.99` tag (the tag publishes).

### Fixed
- **#1331** (bug 1's remedy half) — a mutation refused for `no trusted identity` was wrapped with *"rebind with panel_set_workflow_target({mode:'current'})"*, which the reporter followed and which cannot mint an identity that is not there. Two different states produce that identical message and need opposite remedies, so the orchestrator now **measures** which one it is (the same read-only re-derivation the documented recovery performs) and names the remedy that fits — including saying the answer is UNKNOWN when the re-read fails, rather than guessing.

The other two defects in that report (identity not re-derived from the saved path after a reconnect; `workflow_open`'s post-load compare racing the frontend's normalisation) are panel-side, as is bug 2 (`panel_request_secret` timing out at 300s). They are named in #1346 for splitting rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)