### PR TITLE
fix(#1334): consume a control_after_generate slot only when it holds a control mode

### DIFF
--- a/src/__tests__/services/nested-seed-without-phantom.test.ts
+++ b/src/__tests__/services/nested-seed-without-phantom.test.ts
@@ -1,0 +1,139 @@
+// #1334 — a nested seed with NO control_after_generate phantom shifted every widget
+// after it, and the API prompt came out silently wrong.
+//
+// `specHasControlAfterGenerate` INFERS a phantom from "INT named seed/noise_seed/
+// rand_seed". That is correct for the frontend's auto-augmented TOP-LEVEL seeds
+// (UltimateSDUpscale.seed, KSamplerAdvanced.noise_seed) and wrong for a V3
+// dynamic-combo NESTED `seed`, which need not have one at all.
+//
+// On the reporter's TongzeArkReferenceToVideo (frontend 1.48.7) the row carried no
+// phantom, the converter consumed the real next value anyway, and everything after it
+// slid by one:
+//
+//   intended                       produced
+//   watermark        = false       watermark        = true
+//   generate_audio   = true        generate_audio   = "default"
+//   priority         = 0           priority         = 172800
+//
+// The saved UI graph was correct and the live panel widget map was correct; only
+// UI→API conversion was wrong — so nothing on screen contradicted it.
+//
+// THE PHANTOM IS A FRONTEND-OWNED COMBO, so its serialized value is always one of four
+// known strings. The slot's own content is therefore better evidence than any inference
+// from name and type, and checking it costs nothing when a phantom really is present.
+
+import { describe, expect, it } from "vitest";
+
+import { convertUiToApi } from "../../services/workflow-converter.js";
+
+/** The reporter's node, reduced to what drives the mapping: a dynamic combo whose
+ *  selected option nests `seed` (no control_after_generate) followed by three more. */
+function arkNodeDef(): Record<string, unknown> {
+  return {
+    input: {
+      required: {
+        model: [
+          "COMFY_DYNAMICCOMBO_V3",
+          {
+            options: [
+              {
+                key: "doubao-seedance-2-5-260628",
+                inputs: {
+                  required: {
+                    // No control_after_generate flag — this is the whole point.
+                    seed: ["INT", { default: -1 }],
+                    watermark: ["BOOLEAN", { default: false }],
+                    generate_audio: ["BOOLEAN", { default: true }],
+                    priority: ["INT", { default: 0 }],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  };
+}
+
+/** A node whose nested seed DOES carry a phantom, to prove the skip still happens. */
+function seededNodeDef(): Record<string, unknown> {
+  return {
+    input: {
+      required: {
+        model: [
+          "COMFY_DYNAMICCOMBO_V3",
+          {
+            options: [
+              {
+                key: "m",
+                inputs: {
+                  required: {
+                    seed: ["INT", { default: 0, control_after_generate: true }],
+                    watermark: ["BOOLEAN", { default: false }],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  };
+}
+
+const OBJECT_INFO = {
+  TongzeArkReferenceToVideo: arkNodeDef(),
+  SeededArk: seededNodeDef(),
+} as unknown as Parameters<typeof convertUiToApi>[1];
+
+function convert(type: string, widgetsValues: unknown[]) {
+  const graph = {
+    nodes: [{ id: 7, type, widgets_values: widgetsValues, inputs: [] }],
+    links: [],
+  };
+  const { workflow } = convertUiToApi(graph as never, OBJECT_INFO);
+  return (workflow as Record<string, { inputs: Record<string, unknown> }>)["7"].inputs;
+}
+
+describe("a nested seed WITHOUT a phantom does not eat the next widget (#1334)", () => {
+  it("maps the reporter's row exactly as saved", () => {
+    // ["model", -1, false, true, 0] — no phantom anywhere in it.
+    const inputs = convert("TongzeArkReferenceToVideo", [
+      "doubao-seedance-2-5-260628",
+      -1,
+      false,
+      true,
+      0,
+    ]);
+
+    expect(inputs["model.seed"]).toBe(-1);
+    // Each of these was wrong before, by exactly one slot.
+    expect(inputs["model.watermark"]).toBe(false);
+    expect(inputs["model.generate_audio"]).toBe(true);
+    expect(inputs["model.priority"]).toBe(0);
+  });
+
+  it("a nested seed WITH a phantom still skips it — the inference is not lost", () => {
+    // The direction that would break real workflows if the fix were a blanket removal:
+    // when the slot IS a control mode it must still be consumed, or the following
+    // widget shifts the other way.
+    const inputs = convert("SeededArk", ["m", 12345, "randomize", true]);
+
+    expect(inputs["model.seed"]).toBe(12345);
+    expect(inputs["model.watermark"]).toBe(true); // not "randomize"
+  });
+
+  it("every control mode is recognised, not just randomize", () => {
+    for (const mode of ["fixed", "randomize", "increment", "decrement"]) {
+      const inputs = convert("SeededArk", ["m", 1, mode, true]);
+      expect(inputs["model.watermark"]).toBe(true);
+    }
+  });
+
+  it("a phantom-flagged seed at the END of the row does not over-consume", () => {
+    // Nothing follows the seed, so there is no slot to skip and nothing to shift.
+    const inputs = convert("SeededArk", ["m", 99]);
+    expect(inputs["model.seed"]).toBe(99);
+  });
+});

--- a/src/__tests__/services/nested-seed-without-phantom.test.ts
+++ b/src/__tests__/services/nested-seed-without-phantom.test.ts
@@ -10,10 +10,10 @@
 // phantom, the converter consumed the real next value anyway, and everything after it
 // slid by one:
 //
-//   intended                       produced
-//   watermark        = false       watermark        = true
-//   generate_audio   = true        generate_audio   = "default"
-//   priority         = 0           priority         = 172800
+//   widget            intended   produced
+//   watermark         false      true
+//   generate_audio    true       "default"
+//   priority          0          172800
 //
 // The saved UI graph was correct and the live panel widget map was correct; only
 // UI→API conversion was wrong — so nothing on screen contradicted it.

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -509,10 +509,10 @@ const CONTROL_AFTER_GENERATE_MODES = new Set(["fixed", "randomize", "increment",
  * for the frontend's auto-augmented top-level seeds, and wrong for a V3 dynamic-combo
  * nested `seed` that has no such widget. #1334: `TongzeArkReferenceToVideo` on frontend
  * 1.48.7 has a nested `seed` with no phantom, the converter skipped the real next value
- * anyway, and every following widget shifted by one — `watermark=false` became
- * `generate_audio`, `service_tier="default"` became `generate_audio`, and a
- * 172800-second expiry landed in `priority`. Silently wrong output, from a graph that
- * was correct on disk and correct in the live panel.
+ * anyway, and every following widget shifted by one: the watermark flag took the audio
+ * flag's value, the audio flag took `service_tier`'s, and a 172800-second expiry landed
+ * in `priority`. Silently wrong output, from a graph that was correct on disk and
+ * correct in the live panel.
  *
  * Checking the value closes that gap without giving up the inference: when a phantom is
  * really there the slot holds one of four known strings, and when it is not the slot

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -493,6 +493,42 @@ function autogrowParentPath(
  * no entry in def.input), so nested controlled seeds skip their phantom
  * "fixed"/"randomize" slot too instead of shifting every following widget.
  */
+/**
+ * #1334 — the four values a control_after_generate slot can hold.
+ *
+ * The phantom is a frontend-owned combo, not a free field: its serialized value is
+ * always one of these. So the slot's OWN content is the evidence that it is a phantom,
+ * and it is stronger evidence than any inference from the name and type.
+ */
+const CONTROL_AFTER_GENERATE_MODES = new Set(["fixed", "randomize", "increment", "decrement"]);
+
+/**
+ * Is the value sitting in the next serialized slot actually a control mode?
+ *
+ * `specHasControlAfterGenerate` INFERS a phantom from "INT named seed" — which is right
+ * for the frontend's auto-augmented top-level seeds, and wrong for a V3 dynamic-combo
+ * nested `seed` that has no such widget. #1334: `TongzeArkReferenceToVideo` on frontend
+ * 1.48.7 has a nested `seed` with no phantom, the converter skipped the real next value
+ * anyway, and every following widget shifted by one — `watermark=false` became
+ * `generate_audio`, `service_tier="default"` became `generate_audio`, and a
+ * 172800-second expiry landed in `priority`. Silently wrong output, from a graph that
+ * was correct on disk and correct in the live panel.
+ *
+ * Checking the value closes that gap without giving up the inference: when a phantom is
+ * really there the slot holds one of four known strings, and when it is not the slot
+ * holds the next real widget's value.
+ *
+ * RESIDUAL RISK, stated rather than hidden: a genuine widget whose value is literally
+ * the string "fixed"/"randomize"/… in exactly that position would still be eaten. That
+ * is far narrower than what it replaces (every nested seed without a phantom, always),
+ * and it fails the same way the old code did rather than a new way.
+ */
+function nextValueIsControlMode(values: readonly unknown[], idx: number): boolean {
+  if (idx >= values.length) return false;
+  const v = values[idx];
+  return typeof v === "string" && CONTROL_AFTER_GENERATE_MODES.has(v);
+}
+
 function specHasControlAfterGenerate(name: string, spec: unknown): boolean {
   if (!Array.isArray(spec)) return false;
   if ((spec[1] as Record<string, unknown> | undefined)?.control_after_generate === true)
@@ -2630,8 +2666,12 @@ export function convertUiToApi(
       inputs[name] = value;
       widgetIdx++;
 
-      // If this input has control_after_generate, skip the next widgets_values entry
-      if (hasControlAfterGenerate(name, def) && widgetIdx < widgetValues.length) {
+      // If this input has control_after_generate, skip the next widgets_values entry —
+      // but ONLY when that entry actually holds a control mode (#1334). The reporter's
+      // defect was nested, and the same inference runs here, so the same guard applies:
+      // a node whose object_info flags a phantom the saved row does not contain would
+      // shift every following widget in exactly the same way.
+      if (hasControlAfterGenerate(name, def) && nextValueIsControlMode(widgetValues, widgetIdx)) {
         widgetIdx++;
       }
 
@@ -2870,9 +2910,12 @@ export function convertUiToApi(
           // A nested seed-type / control_after_generate leaf carries a phantom
           // "fixed"/"randomize" value right after it (same as top-level seeds), so
           // skip that slot or every following widget shifts by one.
+          // #1334 — and only when the slot actually HOLDS a control mode. A V3
+          // dynamic-combo nested `seed` need not have a phantom at all; consuming the
+          // slot on the name/type inference alone shifted every following widget.
           if (
             specHasControlAfterGenerate(nName, nSpec) &&
-            widgetIdx < widgetValues.length
+            nextValueIsControlMode(widgetValues, widgetIdx)
           ) {
             widgetIdx++;
           }

--- a/src/tools/vocabulary.ts
+++ b/src/tools/vocabulary.ts
@@ -1783,6 +1783,23 @@ export const DEAD_NAMES: readonly DeadName[] = [
     name: "generate_audio",
     since: "0.50.0",
     replacement: 'generate_image (action:"audio")',
+    allowedIn: [
+      {
+        path: "src/__tests__/services/nested-seed-without-phantom.test.ts",
+        context: "//   generate_audio    true       \"default\"",
+        why: "NOT our retired tool — a homonym in a different namespace. This is a WIDGET name on a third-party ComfyUI node (TongzeArkReferenceToVideo), quoted from #1334's measured wrong output to record which value landed in which slot. The gate cannot know the namespace, so the collision is declared here rather than worked around: renaming the widget would make the fixture stop reproducing the reporter's row, which is the only thing that makes the regression provable. Pinned to the measured-output line because that is the part that must not be paraphrased.",
+      },
+      {
+        path: "src/__tests__/services/nested-seed-without-phantom.test.ts",
+        context: "generate_audio: [\"BOOLEAN\", { default: true }],",
+        why: "The same third-party node's object_info spec, reproduced verbatim so the nested widget ORDER matches the reporter's. Order is the entire subject of #1334 — a shifted slot is the defect — so the fixture must carry their names in their positions, not stand-ins.",
+      },
+      {
+        path: "src/__tests__/services/nested-seed-without-phantom.test.ts",
+        context: "expect(inputs[\"model.generate_audio\"]).toBe(true);",
+        why: "The assertion on that same widget's converted value. It reads `model.generate_audio` because that is the dotted key the converter emits for the nested leaf; asserting on a renamed key would assert on something the reporter's workflow does not contain.",
+      },
+    ],
   },
   {
     name: "generate_video",


### PR DESCRIPTION
Closes #1334

The reporter diagnosed this precisely and had already patched their own checkout; this is that fix, with the guard applied at **both** call sites and the residual risk stated.

`specHasControlAfterGenerate` INFERS a phantom from "INT named seed/noise_seed/rand_seed". That is right for the frontend's auto-augmented top-level seeds and wrong for a V3 dynamic-combo **nested** `seed`, which need not have one. On `TongzeArkReferenceToVideo` (frontend 1.48.7) the converter skipped the real next value anyway and everything after it shifted by one:

| intended | produced |
|---|---|
| `watermark = false` | `watermark = true` |
| `generate_audio = true` | `generate_audio = "default"` |
| `priority = 0` | `priority = 172800` |

Silently wrong API output from a graph that is correct on disk *and* correct in the live panel.

The phantom is a frontend-owned combo, so its serialized value is always one of `fixed` / `randomize` / `increment` / `decrement`. The slot's own content is therefore stronger evidence than the name-and-type inference, and checking it costs nothing when a phantom really is present.

**Residual risk, stated not hidden:** a genuine widget whose value is literally one of those four strings in exactly that position would still be eaten. That is far narrower than what it replaces — every nested seed without a phantom, always — and it fails the same way the old code did rather than a new way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)