### PR TITLE
chore(release): 0.50.100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.100] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- stop reporting a lost transport as "the user cancelled" (#1348)
+
+
 ## [0.50.99] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.99",
+  "version": "0.50.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.99",
+      "version": "0.50.100",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.99",
+  "version": "0.50.100",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.100` tag (the tag publishes).

### Fixed
- **#1332** — `panel_restart_comfyui` answered *"Cancelled — ComfyUI was not restarted"* about a ComfyUI that had just restarted. One `catch` mapped every non-timeout confirm failure onto `"no"`, so a dropped socket became a user declining — and a restart is precisely the event that drops the socket its own confirmation card must answer on. A fourth `ConfirmOutcome`, `unreachable`, separates them. The destructive operation is still skipped by construction (both callers branch `!== "yes"`, and a test asserts `graph_clear` is never dispatched); only the claim changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)