### PR TITLE
fix(#1329): refresh the node schema and retry the add, once

### DIFF
--- a/src/__tests__/orchestrator/add-node-stale-schema-retry.test.ts
+++ b/src/__tests__/orchestrator/add-node-stale-schema-retry.test.ts
@@ -1,0 +1,154 @@
+// #1329 — the refusal already knew the answer, and billed the caller for it.
+//
+// The reporter uploaded two images and both `panel_add_node("LoadImage")` calls were
+// refused:
+//
+//   "LoadImage" required input "image" was added or retyped since this page loaded its
+//   node schema, so creating it now would build the OLD shape. Call panel_refresh_nodes
+//   and retry.
+//
+// They called panel_refresh_nodes and retried, and it worked — both times. That is an
+// agent-visible error plus two extra calls for something with exactly one correct
+// response and no decision in it.
+//
+// WHY AUTOMATING THIS IS SAFE, and why the same reasoning does NOT license retrying
+// mutations generally: the panel's guard throws BEFORE it creates anything ("Refuse
+// before creating anything" — comfyui-mcp-panel.js), so the retry cannot leave two
+// nodes on the canvas. A transport failure is the opposite case — the outcome is
+// unknown, which is exactly why those are never re-issued on our own initiative.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+
+const STALE = () =>
+  new Error(
+    `"LoadImage" required input "image" was added or retyped since this page loaded its node ` +
+      `schema, so creating it now would build the OLD shape. Call panel_refresh_nodes and retry.`,
+  );
+
+/**
+ * `addOutcomes` is consumed one per graph_add_node call: "stale" throws the refusal,
+ * "ok" succeeds. `refreshFails` makes refresh_nodes throw.
+ */
+function bridge(addOutcomes: Array<"stale" | "ok">, refreshFails = false) {
+  const calls: string[] = [];
+  let addIdx = 0;
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push(String(cmd.cmd));
+      if (cmd.cmd === "refresh_nodes") {
+        if (refreshFails) throw new Error("panel did not answer the refresh");
+        return { refreshed: true };
+      }
+      if (cmd.cmd === "graph_add_node") {
+        const outcome = addOutcomes[Math.min(addIdx, addOutcomes.length - 1)];
+        addIdx += 1;
+        if (outcome === "stale") throw STALE();
+        return { ok: true, node_id: 42 };
+      }
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, calls };
+}
+
+async function addNode(addOutcomes: Array<"stale" | "ok">, refreshFails = false) {
+  const { b, calls } = bridge(addOutcomes, refreshFails);
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_add_node");
+  if (!def) throw new Error("panel_add_node is not registered");
+  const res: ToolResult = await def.handler({ class_type: "LoadImage" } as never, ctx);
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    isError: res.isError === true,
+    calls,
+  };
+}
+
+describe("a stale node schema is refreshed and retried once (#1329)", () => {
+  it("the reporter's case: refuse → refresh → add, with no error surfaced", async () => {
+    const { text, isError, calls } = await addNode(["stale", "ok"]);
+
+    expect(isError).toBe(false);
+    expect(calls).toEqual(["graph_add_node", "refresh_nodes", "graph_add_node"]);
+    // The refusal never reaches the caller — it was actionable, and it was acted on.
+    expect(text).not.toMatch(/added or retyped since this page loaded/);
+  });
+
+  it("EXACTLY once — a still-stale schema is not retried forever", async () => {
+    const { isError, calls } = await addNode(["stale", "stale"]);
+
+    expect(isError).toBe(true);
+    expect(calls.filter((c) => c === "graph_add_node")).toHaveLength(2);
+    expect(calls.filter((c) => c === "refresh_nodes")).toHaveLength(1);
+  });
+
+  it("…and when it is still stale, says the prescribed remedy will not clear it", async () => {
+    // The caller must not follow the refusal's own advice into a loop we already ran.
+    const { text } = await addNode(["stale", "stale"]);
+
+    expect(text).toMatch(/already retried ONCE automatically/);
+    expect(text).toMatch(/repeating panel_refresh_nodes will not clear it/);
+    expect(text).toMatch(/Reload the ComfyUI browser tab/);
+  });
+
+  it("a FAILED refresh keeps the original refusal and discloses the attempt", async () => {
+    // The schema refusal is the better error — it names what is wrong and what fixes
+    // it. The refresh failure rides alongside so the caller is not left wondering
+    // whether the automatic attempt happened.
+    const { text, isError, calls } = await addNode(["stale", "ok"], true);
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/added or retyped since this page loaded/); // preserved verbatim
+    expect(text).toMatch(/panel_refresh_nodes was dispatched and FAILED/);
+    // The add is NOT retried after a failed refresh — the schema is unchanged.
+    expect(calls.filter((c) => c === "graph_add_node")).toHaveLength(1);
+  });
+
+  it("a healthy add is untouched — one call, no refresh", async () => {
+    const { isError, calls } = await addNode(["ok"]);
+
+    expect(isError).toBe(false);
+    expect(calls).toEqual(["graph_add_node"]);
+  });
+
+  it("an UNRELATED failure is never retried", async () => {
+    // The guard keys on the drift sentence, not on the word panel_refresh_nodes, which
+    // appears in several other remedies. Keying on the recommendation would make any of
+    // them trigger a second mutating add.
+    const { b, calls } = bridge(["ok"]);
+    const bridgeThatFails = {
+      ...(b as object),
+      send: async (cmd: Record<string, unknown>) => {
+        calls.push(String(cmd.cmd));
+        throw new Error(
+          "something else went wrong entirely. Call panel_refresh_nodes and retry.",
+        );
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridgeThatFails, TAB, new WorkflowTargetStore());
+    const def = buildPanelToolDefs().find((d) => d.name === "panel_add_node");
+    if (!def) throw new Error("panel_add_node is not registered");
+    const res = await def.handler({ class_type: "LoadImage" } as never, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(calls.filter((c) => c === "graph_add_node")).toHaveLength(1);
+    expect(calls).not.toContain("refresh_nodes");
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1720,6 +1720,29 @@ function toolResultText(res: ToolResult): string {
  *  else about it — including `isError` and any non-text content. Used where the
  *  original message must reach the caller VERBATIM and we are only adding what we
  *  additionally know, never restating (or re-classifying) what it already said. */
+/** All text in a tool result, joined — for quoting one result inside another. */
+function textOfToolResult(res: ToolResult): string {
+  return res.content.map((c) => (c as { text?: string }).text ?? "").join(" ").trim();
+}
+
+/**
+ * #1329 — the panel's STALE NODE SCHEMA refusal, which is worth acting on rather than
+ * relaying.
+ *
+ * It is the one refusal here whose prescribed remedy has no decision in it: the class
+ * this page registered has drifted from the server's, and `refresh_nodes` re-fetches
+ * /object_info and re-registers it in place. The reporter ran that by hand twice and it
+ * worked twice.
+ *
+ * Matched on the drift sentence rather than on "panel_refresh_nodes", which appears in
+ * several unrelated remedies — keying on the recommendation would make any of them
+ * trigger an add-retry.
+ */
+function isStaleNodeSchemaRefusal(res: ToolResult): boolean {
+  if (!res.isError) return false;
+  return /added or retyped since this page loaded its node schema/i.test(textOfToolResult(res));
+}
+
 function appendToolResultText(res: ToolResult, extra: string): ToolResult {
   const idx = res?.content?.findIndex((c) => c.type === "text") ?? -1;
   const block = idx >= 0 ? res.content[idx] : undefined;
@@ -7868,15 +7891,55 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .describe("Canvas [x, y] (two numbers). Auto-placed beside existing nodes when omitted."),
         title: z.string().optional().describe("Optional custom node title."),
       },
-      async (args: A, ctx) =>
+      async (args: A, ctx) => {
         // #599: the frontend gates the add on a FRESH /object_info (assertAddNode-
         // ResolvableRefreshing) so an uninstalled class can't be added as a
         // placeholder — that fetch can outlast the 6000 ms default on a large
         // install. Give it the bounded refresh ack budget.
-        ctx.call(
-          { cmd: "graph_add_node", class_type: args.class_type, pos: args.pos, title: args.title },
-          OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
-        ),
+        const add = (): Promise<ToolResult> =>
+          ctx.call(
+            { cmd: "graph_add_node", class_type: args.class_type, pos: args.pos, title: args.title },
+            OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+          );
+        const first = await add();
+        if (!isStaleNodeSchemaRefusal(first)) return first;
+
+        // #1329 — DO THE REFRESH THE REFUSAL ASKS FOR, instead of billing the caller.
+        //
+        // The reporter uploaded two images, and both LoadImage adds were refused with
+        // "call panel_refresh_nodes and retry". Doing exactly that worked, both times.
+        // That is a round trip and an agent-visible error for something with one
+        // correct response and no decision in it.
+        //
+        // Safe to automate for a checkable reason, not a hopeful one: the panel's guard
+        // throws BEFORE it creates anything ("Refuse before creating anything"), so the
+        // retry cannot leave two nodes behind. Mutations are otherwise never re-issued
+        // on our own initiative, and that rule is intact — this is not a transport
+        // failure with an unknown outcome, it is a refusal that states its own.
+        const refreshed = await ctx.call({ cmd: "refresh_nodes" }, OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS);
+        if (refreshed.isError) {
+          // The refusal is the better error: it names what is wrong with the SCHEMA and
+          // what clears it. Carry the refresh failure alongside so the caller knows the
+          // automatic attempt happened and why it did not help.
+          return appendToolResultText(
+            first,
+            `\n\n(Tried to clear this automatically: panel_refresh_nodes was dispatched and FAILED, ` +
+              `so the schema is unchanged and retrying the add will refuse again. ` +
+              `${textOfToolResult(refreshed)})`,
+          );
+        }
+        const second = await add();
+        if (!isStaleNodeSchemaRefusal(second)) return second;
+        // Still stale after a successful refresh: report THAT, because it means the
+        // remedy the refusal prescribes does not fix this instance and a caller
+        // following it by hand would loop.
+        return appendToolResultText(
+          second,
+          `\n\n(This was already retried ONCE automatically: panel_refresh_nodes reported success ` +
+            `and the add still refuses, so repeating panel_refresh_nodes will not clear it. ` +
+            `Reload the ComfyUI browser tab, which rebuilds the page's node registry from scratch.)`,
+        );
+      },
     ),
     def(
       "panel_remove_node",


### PR DESCRIPTION
Closes #1329

`panel_add_node` refuses when the tab's cached node schema is stale, and tells the caller to run `panel_refresh_nodes` and retry. The refusal is correct — creating the node then would build the OLD shape — but the caller pays an error plus two extra calls for something the orchestrator can do itself.

Safe to automate for a specific, checkable reason: the panel's guard throws **before creating anything** (`comfyui-mcp-panel.js`: *"Refuse before creating anything"*), so a retry after the refresh cannot produce two nodes. That is the same property that made #1330's retry advice safe, and it is why this is an auto-retry rather than better wording.

Scope: refresh + retry **exactly once**, and preserve the existing refusal verbatim if the refresh or the retry fails. The schema safety check itself does not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)