### PR TITLE
fix(#1337): clear the fence on the verdict that PROVED identity

### DIFF
--- a/src/__tests__/orchestrator/open-clears-fence-on-drift.test.ts
+++ b/src/__tests__/orchestrator/open-clears-fence-on-drift.test.ts
@@ -1,0 +1,161 @@
+// #1337 — the fence-EXEMPT escape hatch could not clear the fence, and the session lost
+// the canvas for the rest of the task.
+//
+// Every panel_* graph call refused with `workflow instance mismatch`. The documented
+// recovery contract is that `workflow_open` is the one command the panel exempts, so it
+// "re-derives this session's fence from its own reply". But it only does that on the
+// SUCCESS branch, and the panel answered with this verdict, delivered as an error:
+//
+//   workflow_open RAN and the canvas IS bound to X — that much was proven — but the
+//   graph on it does not match the state that was loaded … You are NOT on the wrong
+//   workflow: X IS the active one.
+//
+// So control took the error branch, the fence was never re-derived, and the loop
+// (mismatch → open → mismatch) ran three full cycles across two session resumes without
+// ever self-clearing. The only remaining move was a browser reload, which destroys
+// unsaved canvas work.
+//
+// TWO LEVELS WERE BEING CONFLATED. The verdict asserts IDENTITY was proven; what it
+// withholds is CONTENT — the panel cannot tell frontend normalisation from a partial
+// load. Content-level uncertainty was gating an identity-level fence.
+//
+// MEASURED, since the comment defending the old behaviour claims otherwise: the panel
+// really does publish no workflow_uuid on this reply, so there is nothing to adopt from
+// the reply — but `workflow_list` IS fence-exempt (commandIsCanvasTargetless), and the
+// panel's own text names panel_list_workflows as the exempt recovery that "republishes
+// the active identity". The fence could always be re-derived here; nothing tried.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+const PATH = "workflows/a.json";
+const LIVE = "77777777-7777-4777-8777-777777777777";
+
+/** The reporter's verdict: identity PROVEN, content unknown, no fence refresh. */
+const IDENTITY_PROVEN_DRIFT =
+  `workflow_open RAN and the canvas IS bound to ${PATH} — that much was proven — but the graph ` +
+  `on it does not match the state that was loaded, and the panel cannot tell whether the ComfyUI ` +
+  `frontend merely normalized it (node sizes, widget values) or the load only partly applied. ` +
+  `Treat the canvas as UNKNOWN and re-read it (panel_graph_outline) before editing. You are NOT ` +
+  `on the wrong workflow: ${PATH} IS the active one. This reply carries NO fence refresh.`;
+
+/** The other verdict class: identity itself unproven. Must NOT adopt. */
+const IDENTITY_UNPROVEN =
+  `workflow_open RAN but could not prove that the active canvas was rebound to ${PATH}, so treat ` +
+  `the canvas as unknown rather than unchanged. The panel could not confirm which workflow is ` +
+  `active, so the open may have left a different one active.`;
+
+/** `listUuid: null` → the exempt workflow_list read establishes nothing.
+ *  `"throw"` → it fails outright. */
+function bridge(openVerdict: string, listUuid: string | null | "throw") {
+  const calls: string[] = [];
+  let stamp: string | undefined;
+  const b = {
+    send: async (cmd: Record<string, unknown>) => {
+      calls.push(String(cmd.cmd));
+      if (cmd.cmd === "workflow_list") {
+        if (listUuid === "throw") throw new Error("panel did not answer");
+        const active = {
+          path: PATH,
+          routing_key: TAB,
+          ...(listUuid ? { workflow_uuid: listUuid } : {}),
+        };
+        return { active, workflows: [{ ...active, active: true }], active_confirmed: true };
+      }
+      if (cmd.cmd === "workflow_open") throw new Error(openVerdict);
+      return { ok: true };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    refreshWorkflowUuid: (_t: string, uuid: string) => {
+      calls.push(`adopt:${uuid}`);
+      stamp = uuid;
+      return true;
+    },
+    workflowUuidFor: () => ({ known: Boolean(stamp), uuid: stamp }),
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+  return { b, calls };
+}
+
+async function openWorkflow(openVerdict: string, listUuid: string | null | "throw") {
+  const { b, calls } = bridge(openVerdict, listUuid);
+  const ctx = makePanelToolCtx(b, TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_open_workflow");
+  if (!def) throw new Error("panel_open_workflow is not registered");
+  const res: ToolResult = await def.handler({ path: PATH } as never, ctx);
+  return {
+    text: res.content.map((c) => (c as { text?: string }).text ?? "").join(" "),
+    isError: res.isError === true,
+    calls,
+  };
+}
+
+describe("workflow_open clears the fence on the identity-PROVEN verdict (#1337)", () => {
+  it("the reporter's wedge: the fence is re-derived via the exempt read", async () => {
+    const { text, calls } = await openWorkflow(IDENTITY_PROVEN_DRIFT, LIVE);
+
+    // The exempt read actually happened — the whole fix is that round trip.
+    expect(calls).toContain("workflow_list");
+    expect(text).toMatch(/FENCE: CLEARED/);
+    expect(text).toContain(LIVE);
+    // The thing that ends the wedge: no reload, so unsaved work survives.
+    expect(text).toMatch(/do NOT need to reload the browser tab/i);
+    expect(text).toMatch(/no unsaved canvas work is at risk/i);
+  });
+
+  it("the CONTENT warning is preserved verbatim — the open still fails", async () => {
+    // Clearing the fence does not make the graph known. "Re-read before editing" is
+    // still the right instruction, and the call is still an error.
+    const { text, isError } = await openWorkflow(IDENTITY_PROVEN_DRIFT, LIVE);
+
+    expect(isError).toBe(true);
+    expect(text).toMatch(/Treat the canvas as UNKNOWN and re-read it/);
+    expect(text).toMatch(/content warning above still stands/i);
+  });
+
+  it("the UNPROVEN verdict adopts NOTHING — identity itself is in doubt", async () => {
+    // The direction that would be dangerous. Re-deriving a fence onto a canvas the
+    // panel cannot identify is how an edit lands on the wrong graph, which is the
+    // entire reason the fence exists.
+    const { text, calls } = await openWorkflow(IDENTITY_UNPROVEN, LIVE);
+
+    expect(text).not.toMatch(/FENCE: CLEARED/);
+    expect(text).not.toMatch(/FENCE:/);
+    // ADOPTION is the thing that must not happen. A workflow_list read still occurs on
+    // this path — `observeActiveAfterOpen` performs one to check for drift, and that
+    // predates this change — so asserting the read never happens would pin the wrong
+    // property and pass for the wrong reason.
+    expect(calls.some((c) => c.startsWith("adopt:"))).toBe(false);
+  });
+
+  it("an exempt read that establishes nothing says the fence is NOT cleared", async () => {
+    // No identity on the active record — promising a cleared fence here would send the
+    // caller straight back into the loop this issue is about.
+    const { text } = await openWorkflow(IDENTITY_PROVEN_DRIFT, null);
+
+    expect(text).toMatch(/FENCE: NOT cleared/);
+    expect(text).toMatch(/Graph commands stay refused/);
+    expect(text).not.toMatch(/FENCE: CLEARED/);
+  });
+
+  it("a THROWN exempt read reports the fence state as unknown, not cleared", async () => {
+    const { text } = await openWorkflow(IDENTITY_PROVEN_DRIFT, "throw");
+
+    expect(text).toMatch(/FENCE: NOT cleared/);
+    expect(text).toMatch(/UNKNOWN/);
+    expect(text).not.toMatch(/FENCE: CLEARED/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2935,6 +2935,70 @@ export function readOpenActiveAgainstTarget(
  * all. Requiring corroboration there is what kept the reporter's own case
  * unexamined.
  */
+/**
+ * #1337 — CLEAR THE FENCE ON THE VERDICT THAT PROVED IDENTITY.
+ *
+ * A reporter's session lost the canvas permanently: every graph call refused with
+ * `workflow instance mismatch`, and the one fence-EXEMPT recovery could not clear it.
+ *
+ * `workflow_open` re-derives the fence only on its success branch. The verdict
+ *
+ *   "workflow_open RAN and the canvas IS bound to X — that much was proven — but the
+ *    graph on it does not match the state that was loaded … You are NOT on the wrong
+ *    workflow: X IS the active one."
+ *
+ * is delivered as an ERROR, so control never reaches the re-derivation. That mismatches
+ * two different levels: the verdict asserts IDENTITY was proven, and what it withholds
+ * is CONTENT (frontend normalisation vs a partial load). Applying content-level
+ * uncertainty to an identity-level fence is what leaves the session with no in-band
+ * recovery — the only remaining move is a browser reload, which destroys unsaved work.
+ *
+ * MEASURED, because the comment that justified the old behaviour asserts otherwise:
+ *   • the panel really does publish NO workflow_uuid on this reply (its own
+ *     FENCE_NOT_REFRESHED text), so there is nothing to adopt FROM THE REPLY — true;
+ *   • but `workflow_list` IS fence-exempt (commandIsCanvasTargetless in the panel's
+ *     workflow-chat-identity.js), and the panel's own recovery text names
+ *     panel_list_workflows as "exempt from the fence" and says it "republishes the
+ *     active identity". So the fence CAN be re-derived here; nothing tried.
+ *
+ * This runs that exempt re-derivation and reports what it achieved. The open still
+ * FAILS — the content warning is preserved verbatim, because "re-read before editing"
+ * is still the right instruction — and nothing is adopted on the UNPROVEN verdict,
+ * where identity itself is in doubt.
+ */
+async function clearFenceOnIdentityProvenOpen(
+  ctx: PanelToolCtx,
+  res: ToolResult,
+): Promise<ToolResult> {
+  const text = toolResultText(res);
+  // ONLY the class that states identity was proven. The UNPROVEN verdict ("could not
+  // prove that the active canvas was rebound") must keep failing closed: re-deriving a
+  // fence onto a canvas we cannot identify is how an edit lands on the wrong graph.
+  if (!/the canvas IS bound to/i.test(text)) return res;
+
+  let note: string;
+  try {
+    const rebind = await rebindWorkflowFence(ctx);
+    note =
+      rebind.status === "refreshed" || rebind.status === "already_current"
+        ? `\n\nFENCE: CLEARED. This reply published no workflow_uuid, so the fence was re-derived ` +
+          `from the panel's own fence-EXEMPT workflow_list read instead — the active identity is ` +
+          `${rebind.uuid}, and graph commands from this session are stamped with it again. You do ` +
+          `NOT need to reload the browser tab, and no unsaved canvas work is at risk. The content ` +
+          `warning above still stands: re-read the graph before editing.`
+        : `\n\nFENCE: NOT cleared (${rebind.status}). The re-derivation was attempted — the panel ` +
+          `publishes no workflow_uuid on this verdict, so the fence-exempt workflow_list read is ` +
+          `the only way to refresh it — and it did not establish an identity. Graph commands stay ` +
+          `refused. Try panel_list_workflows directly; if that also fails, the panel tab is the ` +
+          `thing to fix.`;
+  } catch (err) {
+    note =
+      `\n\nFENCE: NOT cleared — the re-derivation threw, so the fence state is UNKNOWN and graph ` +
+      `commands may still be refused. (${err instanceof Error ? err.message : String(err)})`;
+  }
+  return appendToolResultText(res, note);
+}
+
 async function observeActiveAfterOpen(
   ctx: PanelToolCtx,
   requestedPath: string,
@@ -4258,7 +4322,7 @@ async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<
       // which is exactly the class that can assert a false active workflow.
       if (!/workflow_open RAN/i.test(toolResultText(res))) return res;
       const drift = await observeActiveAfterOpen(ctx, path);
-      if (!drift) return res;
+      if (!drift) return await clearFenceOnIdentityProvenOpen(ctx, res);
       return fail(
         `${toolResultText(res)}\n\nAND — checked after that failure — ${drift.activeLabel} is the ` +
           `ACTIVE workflow now, not ${path}. Whatever that message says about ${path} being active, ` +


### PR DESCRIPTION
Closes #1337

The reporter's session lost the canvas permanently: every graph call refused with `workflow instance mismatch`, and the one fence-EXEMPT recovery could not clear it.

Their diagnosis is correct and names the path. `workflow_open` re-derives the fence only on the success branch; the *"RAN and the canvas IS bound to X — that much was proven — but the graph does not match"* verdict is delivered as `isError`, so control takes the error branch and `refreshOpenWorkflowUuid` is never reached.

The mismatch of levels is the defect: that verdict **explicitly asserts identity was proven** (*"X IS the active one"*). What is unproven is graph CONTENT — normalisation vs partial load. Content-level uncertainty is being applied to an identity-level fence.

**Measured while scoping this**, because the code comment justifying the current behaviour asserts the opposite:

- the panel publishes **no** `workflow_uuid` on this reply (`FENCE_NOT_REFRESHED`), so there is nothing to adopt from the reply itself — that half of the comment holds;
- but `workflow_list` **is fence-exempt** (`commandIsCanvasTargetless` in `workflow-chat-identity.js` returns true for it), and the panel's own text names `panel_list_workflows` as the recovery *"exempt from the fence"* that *"republishes the active identity"*. So the fence CAN be re-derived here — the orchestrator simply never tries.

Plan: on the identity-proven verdict class only, perform that exempt re-derivation and report whether the fence is usable again, keeping the content warning verbatim. The UNPROVEN class must not adopt anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)