### PR TITLE
chore(release): 0.50.101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.101] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- refresh the node schema and retry the add, once (#1354)
+- consume a control_after_generate slot only when it holds a control mode (#1350)
+
+
 ## [0.50.100] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.100",
+  "version": "0.50.101",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.100",
+      "version": "0.50.101",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.100",
+  "version": "0.50.101",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.101` tag (the tag publishes).

### Fixed
- **#1334** — UI→API conversion consumed a `control_after_generate` slot on any INT named `seed`, including a V3 dynamic-combo **nested** seed that has no phantom. Every widget after it shifted by one, so `watermark=false` became `true` and a 172800-second expiry landed in `priority` — silently wrong output from a graph that was correct on disk *and* in the live panel. The slot is now consumed only when it actually holds a control mode. Reported and diagnosed precisely by the reporter, who had already patched their own checkout.
- **#1329** — `panel_add_node` refused on a stale node schema and told the caller to run `panel_refresh_nodes` and retry. The orchestrator now does it, exactly once, and preserves the refusal verbatim if the refresh or retry fails. Safe because the panel's guard throws *before* creating anything, so a retry cannot leave two nodes behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)