### PR TITLE
chore(release): 0.50.102

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.102] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- clear the fence on the verdict that PROVED identity (#1355)
+
+
 ## [0.50.101] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.101",
+  "version": "0.50.102",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.101",
+      "version": "0.50.102",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.101",
+  "version": "0.50.102",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.102` tag (the tag publishes).

### Fixed
- **#1337** — a session could be permanently wedged with `workflow instance mismatch` and **no in-band recovery**: `workflow_open` re-derives the fence only on its success branch, and the *"bound but graph differs"* verdict arrives as an error. That verdict explicitly asserts identity was proven; what it withholds is graph **content**. The fence is now re-derived on that verdict via the panel's own fence-exempt `workflow_list` read, so the browser tab does not need reloading and unsaved canvas work survives. The identity-**unproven** verdict still adopts nothing, and the open still fails with its content warning intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)