### PR TITLE
fix(#1341): accept a Desktop bundle whose binary is branded differently

### DIFF
--- a/src/__tests__/services/restart-relaunch-lifecycle.test.ts
+++ b/src/__tests__/services/restart-relaunch-lifecycle.test.ts
@@ -1035,6 +1035,107 @@ describe("restart_comfyui — a Desktop reboot needs a supervisor that is actual
     expect(fetchSpy).toHaveBeenCalled();
   });
 
+  it("#1341: a bundle whose BINARY is branded differently is still the supervisor", async () => {
+    // The reporter's live mac: backend PID parented by a healthy
+    // `/Applications/ComfyUI.app/Contents/MacOS/Comfy Desktop` (ComfyUI Desktop
+    // 1.0.38). The matcher tied the two names together with a backreference, on the
+    // convention that a bundle's binary is named after the bundle — which current
+    // packaging does not follow. So a real supervisor was rejected, the ancestry walk
+    // ran to PID 1, and the tool refused a safe restart with "no Desktop app is still
+    // supervising it — its parent process is gone."
+    //
+    // This is the COMMAND-LINE branch, which is the one macOS actually takes: `ps` has
+    // no authenticated-executable column, so a Desktop-managed mac never reaches the
+    // executablePath check. Fixing only that one would have left this untouched.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        return {
+          commandLine: "/Applications/ComfyUI.app/Contents/MacOS/Comfy Desktop",
+          startedAt: "2000",
+          parentPid: 1,
+        };
+      }
+      return undefined;
+    });
+    __processControlTestHooks.setParentPidResolver((pid) => {
+      if (pid === 4321) return 300;
+      if (pid === 300) return 1;
+      return undefined;
+    });
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    // Recognised as supervised: the restart proceeds rather than refusing.
+    expect(result.message).not.toMatch(/its parent process is gone/i);
+    expect(result.message).not.toMatch(/no Desktop app is still supervising/i);
+  });
+
+  it("#1341: the same, on the AUTHENTICATED executable path", async () => {
+    // The other half of the change. Both matchers carried the identical backreference.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        return {
+          commandLine: "(unreadable)",
+          executablePath: "/Applications/ComfyUI.app/Contents/MacOS/Comfy Desktop",
+          startedAt: "2000",
+          parentPid: 1,
+        };
+      }
+      return undefined;
+    });
+    __processControlTestHooks.setParentPidResolver((pid) => {
+      if (pid === 4321) return 300;
+      if (pid === 300) return 1;
+      return undefined;
+    });
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/its parent process is gone/i);
+  });
+
+  it("#1341: relaxing the NAME PAIR did not relax the name SET", async () => {
+    // The direction that would matter. Both halves are still drawn from the two
+    // trusted product names — dropping the requirement that they MATCH must not
+    // become "any bundle, any binary". A bundle that is not ours stays rejected even
+    // when its binary is branded like ours.
+    desktopServer();
+    __processControlTestHooks.setProcessIdentityResolver((pid) => {
+      if (pid === 4321) return { startedAt: "5000", parentPid: 300 };
+      if (pid === 300) {
+        return {
+          commandLine: "/Applications/Malware.app/Contents/MacOS/Comfy Desktop",
+          startedAt: "2000",
+          parentPid: 1,
+        };
+      }
+      return undefined;
+    });
+    __processControlTestHooks.setParentPidResolver((pid) => {
+      if (pid === 4321) return 300;
+      if (pid === 300) return 1;
+      return undefined;
+    });
+    __processControlTestHooks.setProcessExistsProbe(() => true);
+    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(killWasIssued()).toBe(false);
+  });
+
   it("a shim living INSIDE the bundle is not the bundle's shell", async () => {
     // The accidental sibling of the two forgeries the gate already caught. Accepting
     // any binary under `Contents/MacOS/` meant a launcher script or venv python that

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -524,15 +524,28 @@ function isDesktopSupervisorProcess(identity: ProcessIdentity): boolean {
     const base = norm.split("/").pop() ?? "";
     // Current and legacy Windows branding, including the electron-era install dir.
     if (base === "comfy desktop.exe" || base === "comfyui.exe") return true;
-    // macOS: the bundle's MAIN binary, which by convention is named after the bundle
-    // (`Comfy Desktop.app/Contents/MacOS/Comfy Desktop`). Accepting ANY binary under
-    // `Contents/MacOS/` was too loose: a venv shim or launcher script living inside
-    // the bundle would pass, and a shim re-execs nothing (coordinator gate). The
-    // backreference ties the two halves together so the binary must belong to the
-    // bundle naming it. Electron HELPERS are excluded structurally — they live in
-    // `Contents/Frameworks/<Helper>.app/Contents/MacOS/…`, so the first bundle in the
-    // path is not followed by `Contents/MacOS/`.
-    return /\/(comfy desktop|comfyui)\.app\/contents\/macos\/\1$/.test(norm);
+    // macOS: the bundle's MAIN binary. Accepting ANY binary under `Contents/MacOS/`
+    // would be too loose — a venv shim or launcher script living inside the bundle
+    // would pass, and a shim re-execs nothing (coordinator gate) — so BOTH halves are
+    // pinned to the trusted product names. Electron HELPERS are excluded structurally:
+    // they live in `Contents/Frameworks/<Helper>.app/Contents/MacOS/…`, so the first
+    // bundle in the path is not followed by `Contents/MacOS/`.
+    //
+    // #1341 — the two names are matched INDEPENDENTLY, not tied by a backreference.
+    // The convention that a bundle's binary is named after the bundle does not hold
+    // for current Desktop packaging: ComfyUI Desktop 1.0.38 ships bundle `ComfyUI.app`
+    // with main executable `Comfy Desktop`. The backreference rejected that real
+    // supervisor, the ancestry walk ran to PID 1, and a reporter with a healthy
+    // Desktop parent was told "no Desktop app is still supervising it — its parent
+    // process is gone" and refused a safe restart.
+    //
+    // This does NOT loosen the asymmetry documented above. Both halves are still
+    // drawn from the same two-name set, so nothing new becomes a supervisor; only the
+    // requirement that they be the SAME name is dropped, and that requirement was
+    // about Apple's naming convention rather than about trust.
+    return /\/(?:comfy desktop|comfyui)\.app\/contents\/macos\/(?:comfy desktop|comfyui)$/.test(
+      norm,
+    );
   };
 
   // THE KERNEL'S ANSWER FIRST, and ALONE when it exists (codex gate round 3).
@@ -564,11 +577,16 @@ function isDesktopSupervisorProcess(identity: ProcessIdentity): boolean {
   //
   // The BINARY NAME is required here too, for the same reason as above: a launcher
   // script or venv shim inside the bundle would otherwise be read as the shell
-  // (coordinator gate). `\2` ties it to the bundle that names it, and the match must
-  // end at whitespace or end-of-line so the binary is the whole argv[0] rather than a
-  // prefix of some longer name.
+  // (coordinator gate). The match must end at whitespace or end-of-line so the binary
+  // is the whole argv[0] rather than a prefix of some longer name.
+  //
+  // #1341 — and the two names are independent here as well. This fallback carried the
+  // identical backreference, so fixing only the executable-path matcher above would
+  // have left macOS installs failing on exactly the path macOS actually takes: `ps`
+  // has no authenticated-executable column, so this IS the branch a Desktop-managed
+  // mac reaches.
   const line = (identity.commandLine ?? "").trim().replace(/\\/g, "/").toLowerCase();
-  return /^"?(\/[^\s"]*\/)?(comfy desktop|comfyui)\.app\/contents\/macos\/\2(\s|"|$)/.test(
+  return /^"?(\/[^\s"]*\/)?(?:comfy desktop|comfyui)\.app\/contents\/macos\/(?:comfy desktop|comfyui)(\s|"|$)/.test(
     line,
   );
 }


### PR DESCRIPTION
Closes #1341

`panel_restart_comfyui` refuses a safe Desktop-managed restart on macOS and claims the parent is gone, while `ps` shows the backend PID parented by a **live** `/Applications/ComfyUI.app/Contents/MacOS/Comfy Desktop`.

The matcher ties the bundle and binary names together with a backreference:

```js
/\/(comfy desktop|comfyui)\.app\/contents\/macos\/\1$/
```

Current Desktop packaging ships bundle `ComfyUI.app` with main executable `Comfy Desktop` — two different trusted names — so the supervisor is rejected, the ancestry walk runs to PID 1, and the result is `abandoned`.

**The safety property is not being relaxed.** The comment above that matcher states the asymmetry deliberately: missing a real supervisor costs a refused restart, while accepting a NON-supervisor licenses a stop nothing undoes. Both halves stay pinned to the two trusted product names — a venv shim or launcher script inside the bundle still fails, and Electron helpers are still excluded structurally by living under `Contents/Frameworks/`. What changes is only that the two names no longer have to be *the same* one.

Same change in the flattened-command-line fallback, which carries the identical backreference.

Tests will pin the platform explicitly — process-control assertions that do not are the ones that pass on Windows and fail on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)