### PR TITLE
fix(#1353): stop telling a code-mode agent its panel tools are absent

### DIFF
--- a/src/__tests__/tools/compact.test.ts
+++ b/src/__tests__/tools/compact.test.ts
@@ -270,6 +270,32 @@ describe("compact mode over a real MCP client/server pair", () => {
   // bundled debug-render / director skills name panel_* tools), and an outside MCP
   // client reading it holds none of them.
   describe("a panel_* name is answered as a wrong-surface fact, not as non-existence (#804)", () => {
+    it("#1353: a DEFERRED/code-mode client is told where to look before concluding absence", async () => {
+      // The reporter's Codex code-mode session declared the live-canvas tools missing,
+      // repeatedly, while the panel MCP endpoint was answering tools/list with 91 tools
+      // and HTTP 200. No transport error anywhere — the failure was this message.
+      //
+      // It said "if it offers nothing under `panel_`, there is no live-canvas route
+      // from here". On code-mode the panel tools are DEFERRED: they sit in the
+      // ALL_TOOLS catalog as `mcp__panel__panel_graph_outline`, so a scan of the direct
+      // declarations for a bare `panel_` prefix finds nothing and the sentence licenses
+      // exactly the wrong conclusion.
+      const client = await compactPair(fakeCatalog());
+      const res = (await client.callTool({
+        name: "call_tool",
+        arguments: { name: "panel_graph_outline" },
+      })) as { isError?: boolean };
+      const text = textOf(res as never);
+
+      // The prefixed name it must actually look for…
+      expect(text).toContain("mcp__panel__panel_graph_outline");
+      // …the catalog it lives in…
+      expect(text).toMatch(/ALL_TOOLS/);
+      expect(text).toMatch(/deferred/i);
+      // …and the absence test now requires BOTH to be empty before concluding.
+      expect(text).toMatch(/Only when BOTH the direct declarations and the deferred catalog/);
+    });
+
     it("names the panel surface, and gives a remedy for BOTH surfaces the caller might hold", async () => {
       const client = await compactPair(fakeCatalog());
       const res = (await client.callTool({

--- a/src/tools/compact.ts
+++ b/src/tools/compact.ts
@@ -392,7 +392,24 @@ function panelNamespaceMessage(catalog: ToolCatalog, name: string): string {
     "see what else your client holds, so check the tool list your client gave you. " +
     `If it offers ${name}, or a panel router such as panel_call_tool, go that way — call_tool ` +
     "dispatches only within this server's own catalog and can never reach the panel surface. " +
-    "If it offers nothing under `panel_`, there is no live-canvas route from here: read the " +
+    // #1353 — SEARCHING ONLY THE DIRECT DECLARATIONS PRODUCES A FALSE NEGATIVE.
+    //
+    // On a code-mode client (the Codex backend) the panel tools are DEFERRED: they
+    // live in the `ALL_TOOLS` catalog under an `mcp__panel__` prefix, so a scan for a
+    // bare `panel_` prefix among direct declarations finds nothing while the panel MCP
+    // endpoint is answering tools/list with 91 tools. A reporter followed the sentence
+    // below literally and declared the live-canvas tools missing, repeatedly, with no
+    // transport error anywhere — the failure was entirely this instruction.
+    //
+    // So the absence test has to name both the prefix and the deferred catalog before
+    // it is allowed to conclude anything.
+    "BEFORE concluding they are absent: a code-mode/deferred-tool client (e.g. the Codex " +
+    "backend) does NOT declare these directly — it lists them in its deferred catalog " +
+    "(`ALL_TOOLS`) under an MCP prefix, so the name to look for is " +
+    "`mcp__panel__panel_graph_outline`, not `panel_graph_outline`. Search that catalog too, " +
+    "and if it is there, call it through the nested tools namespace. Only when BOTH the " +
+    "direct declarations and the deferred catalog have nothing matching `panel_` is there " +
+    "no live-canvas route from here: read the " +
     "workflow from disk instead (get_workflow, whose list/get/analyze/query actions read saved files), " +
     "or ask the user to make the request from the Agent tab in the ComfyUI sidebar, on a backend " +
     "that has ComfyUI tools (the pi backend has no MCP client and so has none)."


### PR DESCRIPTION
Closes #1353

The unknown-tool message ends with a discovery instruction the agent cannot follow correctly on the Codex code-mode backend:

> check the tool list your client gave you. … If it offers nothing under `panel_`, there is no live-canvas route from here

On code-mode the panel tools are **deferred**: they appear in the `ALL_TOOLS` catalog as `mcp__panel__panel_graph_outline`, not as direct declarations named `panel_graph_outline`. Following the instruction literally, an agent scans its direct declarations, finds nothing matching `panel_`, and concludes the live-canvas tools are missing — while the panel MCP endpoint is answering `tools/list` with 91 tools and HTTP 200.

The reporter hit exactly that, repeatedly. No transport error; the failure is entirely instruction-vs-discovery mismatch — the same family as #971 / #1330 / #1331, where a remedy could not be acted on.

Plan: say that a deferred/code-mode client exposes these under an `mcp__…__` prefix and may not declare them directly, so "nothing under `panel_`" is not evidence of absence until the deferred catalog has been searched too. The rest of the message — which surface you reached, and that `call_tool` can never dispatch to the panel — is accurate and stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)