### PR TITLE
chore(release): 0.50.103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.103] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- accept a Desktop bundle whose binary is branded differently (#1358)
+
+
 ## [0.50.102] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.102",
+  "version": "0.50.103",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.102",
+      "version": "0.50.103",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.102",
+  "version": "0.50.103",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.103` tag (the tag publishes).

### Fixed
- **#1341** — `panel_restart_comfyui` refused a safe Desktop-managed restart on macOS, reporting the parent process gone while `ps` showed the backend parented by a healthy `/Applications/ComfyUI.app/Contents/MacOS/Comfy Desktop`. Both supervisor matchers tied the bundle and binary names together with a backreference; current Desktop packaging ships two different *trusted* names. Both halves stay pinned to the trusted set — a shim inside the bundle is still rejected, and `Malware.app/Contents/MacOS/Comfy Desktop` still is too — only the requirement that the two names be identical is dropped. Both matchers changed: macOS reaches the command-line fallback, so fixing only the executable-path one would have left that platform broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)