### PR TITLE
fix(#1359): say WHICH host the node definitions came from when a remote strip fails

### DIFF
--- a/src/__tests__/orchestrator/strip-object-info-host.test.ts
+++ b/src/__tests__/orchestrator/strip-object-info-host.test.ts
@@ -1,0 +1,116 @@
+// #1359 — the graph and its node definitions come from different authorities, and the
+// failure never said so.
+//
+// `panel_strip_workflow` captures the live canvas through the connected panel, then
+// fetches /object_info through the GLOBAL headless client, which resolves COMFYUI_URL.
+// One machine for a local session; two for a connected REMOTE panel. When they differ
+// the reporter got:
+//
+//   fetch failed: connect ECONNREFUSED 127.0.0.1:8188 — while requesting
+//   http://127.0.0.1:8188/object_info
+//
+// Nothing there mentions that the workflow itself came from a ComfyUI on a different
+// host. They had to read dist/orchestrator/panel-tools.js to work it out.
+//
+// THIS DOES NOT FIX THE SPLIT AUTHORITY. Stripping the live canvas correctly needs the
+// definitions to come from the panel's own ComfyUI, which is a panel protocol change
+// and is tracked separately. What it fixes is that the failure was undiagnosable —
+// the same class of defect as #1300 (a status where a reason belonged).
+
+import { describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({ objectInfoFails: { value: true } }));
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: async () => {
+    if (hoisted.objectInfoFails.value) {
+      throw new Error(
+        "fetch failed: connect ECONNREFUSED 127.0.0.1:8188 — while requesting http://127.0.0.1:8188/object_info",
+      );
+    }
+    return {};
+  },
+  backfillObjectInfo: async (bulk: unknown) => bulk,
+  resetClient: () => {},
+  resetObjectInfoCache: () => {},
+}));
+
+const { buildPanelToolDefs, makePanelToolCtx } = await import("../../orchestrator/panel-tools.js");
+import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+const REMOTE = "https://abc123-8188.proxy.runpod.net:443";
+
+/** A panel that serves the live graph and reports a REMOTE ComfyUI origin. */
+function bridge(serverOrigin: string | null) {
+  return {
+    send: async (cmd: Record<string, unknown>) => {
+      if (cmd.cmd === "graph_serialize" || cmd.cmd === "graph_get_state") {
+        return { workflow: { nodes: [], links: [] }, nodes: [], links: [] };
+      }
+      return { ok: true, workflow: { nodes: [], links: [] } };
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabServerOrigin: () => serverOrigin,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+async function strip(args: object, serverOrigin: string | null = REMOTE): Promise<string> {
+  const ctx = makePanelToolCtx(bridge(serverOrigin), TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_strip_workflow");
+  if (!def) throw new Error("panel_strip_workflow is not registered");
+  const res: ToolResult = await def.handler(args as never, ctx);
+  return res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+}
+
+describe("an /object_info failure names which host it asked (#1359)", () => {
+  it("LIVE CANVAS: says the graph and the definitions came from different places", async () => {
+    const text = await strip({});
+
+    // The raw cause is preserved — it is still the evidence.
+    expect(text).toMatch(/ECONNREFUSED 127\.0\.0\.1:8188/);
+    // …and now it says what the reporter had to read dist/ to learn.
+    expect(text).toMatch(/DIFFERENT PLACES/);
+    expect(text).toContain(REMOTE); // where the graph came from
+    expect(text).toMatch(/node definitions are fetched over COMFYUI_URL/i);
+    // The workaround that works today, and honesty that this is a known split.
+    expect(text).toMatch(/WORKAROUND: point COMFYUI_URL at the same ComfyUI/);
+    expect(text).toMatch(/#1359/);
+  });
+
+  it("names the two hosts as DIFFERENT only when they are", async () => {
+    // The over-claiming direction. If the panel is on the same host, "two different
+    // hosts, which is why this could not work" would be a false explanation for a
+    // failure with some other cause — a plain unreachable ComfyUI, say.
+    const text = await strip({}, "http://127.0.0.1:8188");
+
+    expect(text).toMatch(/DIFFERENT PLACES/); // the authorities are still split…
+    expect(text).not.toMatch(/two different hosts/); // …but they resolve to one machine
+  });
+
+  it("an unreadable panel origin costs a detail, not a wrong claim", async () => {
+    const text = await strip({}, null);
+
+    expect(text).toMatch(/ECONNREFUSED/);
+    expect(text).not.toMatch(/two different hosts/);
+    // Still names the workaround it can support.
+    expect(text).toMatch(/WORKAROUND/);
+  });
+
+  it("a PACK/PATH/INLINE source is not told about the panel at all", async () => {
+    // Those sources are deliberately tied to COMFYUI_URL, so the bare failure is
+    // already about the host the caller asked for. Blaming a host mismatch there
+    // would send them to change a setting that is correct.
+    const text = await strip({ graph: { nodes: [], links: [] } });
+
+    expect(text).toMatch(/Node definitions are read from COMFYUI_URL/);
+    expect(text).not.toMatch(/DIFFERENT PLACES/);
+    expect(text).not.toContain(REMOTE);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1417,6 +1417,67 @@ export function restartTimeoutFallbackAdvice({
   );
 }
 
+/**
+ * #1359 — an /object_info failure that names WHICH host it asked, and why that host.
+ *
+ * `panel_strip_workflow` reads the graph from the connected panel and then fetches node
+ * definitions through the global headless client, which resolves COMFYUI_URL. For a
+ * local session those are one machine. For a connected REMOTE panel they are two, and
+ * the tool fails with a bare
+ *
+ *   fetch failed: connect ECONNREFUSED 127.0.0.1:8188 — while requesting
+ *   http://127.0.0.1:8188/object_info
+ *
+ * which says nothing about the canvas being on a different host. The reporter of #1359
+ * had to read the compiled orchestrator to find that out.
+ *
+ * This does NOT fix the split authority — that needs the panel to serve its own
+ * /object_info, a protocol change tracked separately. It makes the existing failure
+ * diagnosable, and names the workaround that works today.
+ *
+ * The panel's origin is the SERVER-OBSERVED handshake Origin where available: the
+ * browser sets it on the WS upgrade and page JS cannot forge it. It is only being
+ * PRINTED here, never fetched from, so an unreadable one costs a detail rather than a
+ * wrong conclusion.
+ */
+function objectInfoHostMismatchMessage(
+  ctx: PanelToolCtx,
+  err: unknown,
+  liveCanvasSource: boolean,
+): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  let panelOrigin: string | null = null;
+  try {
+    panelOrigin = ctx.bridge?.tabServerOrigin?.(ctx.tabId) ?? null;
+  } catch {
+    /* best effort — the message stands without it */
+  }
+  const configured = getComfyUIBaseUrl();
+  if (!liveCanvasSource) {
+    // pack / path / inline: COMFYUI_URL is the right authority, so the bare failure is
+    // already about the host the caller asked for. Say only what is true.
+    return `${raw}\n\nNode definitions are read from COMFYUI_URL (${configured}) for a pack/path/inline source. That host did not answer /object_info.`;
+  }
+  const differs =
+    panelOrigin != null && configured != null && !sameHttpBase(panelOrigin, configured);
+  return (
+    `${raw}\n\nTHE GRAPH AND ITS NODE DEFINITIONS CAME FROM DIFFERENT PLACES. The workflow was ` +
+    `captured from the connected panel` +
+    (panelOrigin ? ` (ComfyUI at ${panelOrigin})` : "") +
+    `, but node definitions are fetched over COMFYUI_URL (${configured}) — and that is the ` +
+    `request that failed` +
+    (differs
+      ? `. Those are two different hosts, which is why this could not work: the orchestrator ` +
+        `has no route to the panel's ComfyUI for /object_info.`
+      : `.`) +
+    `\n\nWORKAROUND: point COMFYUI_URL at the same ComfyUI the panel is connected to` +
+    (panelOrigin ? ` (${panelOrigin})` : "") +
+    ` and retry, or pass an explicit \`graph\`/\`pack\`/\`path\` source instead of the live ` +
+    `canvas. This is a known split of authority (#1359): stripping the LIVE canvas needs ` +
+    `the definitions to come from the panel's own ComfyUI, which needs a panel-side change.`
+  );
+}
+
 function captureRebootHealthBase(ctx: PanelToolCtx): string | null {
   if (isCloudMode() || isRemoteMode()) return null;
   const bootBase = getBootLocalComfyUIBaseUrl(); // server-authorized, hello-immutable
@@ -8078,7 +8139,25 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         const captureNotes: string[] = [];
         const raw = await resolveWorkflowInput(args, ctx, true, captureNotes);
         const ui = raw as unknown as UiWorkflow;
-        const bulk = await getObjectInfo();
+        // #1359 — the graph came from the PANEL; the node definitions come from
+        // COMFYUI_URL. Those are the same machine for a local session and different
+        // ones for a connected REMOTE panel, and when they differ this fails with a
+        // bare `ECONNREFUSED 127.0.0.1:8188` that never mentions the canvas host. The
+        // reporter had to read dist/ to discover that the two halves have different
+        // authorities.
+        //
+        // Only the live-canvas source is affected: a pack/path/inline graph is
+        // deliberately tied to COMFYUI_URL, so its definitions belong there.
+        const liveCanvasSource = args.pack == null && args.path == null && args.graph == null;
+        let bulk: Awaited<ReturnType<typeof getObjectInfo>>;
+        try {
+          bulk = await getObjectInfo();
+        } catch (err) {
+          // Returned as a tool ERROR rather than thrown: a throw here escapes the
+          // handler and reaches the caller as a transport-shaped failure, which is how
+          // the bare ECONNREFUSED got to the reporter in the first place.
+          return fail(objectInfoHostMismatchMessage(ctx, err, liveCanvasSource));
+        }
         const objectInfo = await backfillObjectInfo(bulk, collectNodeTypes(ui));
         const converted = convertUiToApi(ui, objectInfo);
         const workflow = converted.workflow;


### PR DESCRIPTION
Refs #1359

`panel_strip_workflow` captures the live canvas through the connected panel, then fetches `/object_info` through the **global** headless client — which resolves `COMFYUI_URL`, not the connected tab's ComfyUI. A remote panel therefore cannot strip its own canvas, and what the user sees is:

```
fetch failed: connect ECONNREFUSED 127.0.0.1:8188 — while requesting http://127.0.0.1:8188/object_info
```

Nothing in that says the graph came from one host and the node definitions were sought on another. The reporter had to read `dist/orchestrator/panel-tools.js` to work that out.

**Scope, stated up front.** The reporter's proposed fix — a panel bridge command that returns the frontend's own `/object_info` — is the right one, and they are also right that it needs coordinated orchestrator + panel protocol changes. I am not landing a half version of it here:

- fetching from the panel's origin orchestrator-side would work for a public proxy URL but **not** in tunnel/loopback-only topologies, where the browser is the only thing that can reach that ComfyUI. That would trade one silent failure for a narrower one;
- and it would introduce an outbound fetch to an origin chosen by the tab, which deserves its own review.

So this PR makes the existing failure **diagnosable**: name both hosts, say which came from where, and give the one-line workaround. The protocol fix is filed separately so it is not lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)