### PR TITLE
chore(release): 0.50.104

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.104] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- stop telling a code-mode agent its panel tools are absent (#1360)
+
+
 ## [0.50.103] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.103",
+  "version": "0.50.104",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.103",
+      "version": "0.50.104",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.103",
+  "version": "0.50.104",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.104` tag (the tag publishes).

### Fixed
- **#1353** — the unknown-tool message told a code-mode agent that finding nothing under `panel_` meant there was no live-canvas route. On the Codex backend those tools are **deferred**: they sit in `ALL_TOOLS` as `mcp__panel__panel_graph_outline`, so scanning direct declarations found nothing while the panel MCP endpoint was answering `tools/list` with 91 tools and HTTP 200. The absence test now requires both the direct declarations *and* the deferred catalog to be empty, and names the prefixed form to search for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)