### PR TITLE
fix(#1352): say what a timed-out secret card actually means

### DIFF
--- a/src/__tests__/orchestrator/secret-card-timeout-truth.test.ts
+++ b/src/__tests__/orchestrator/secret-card-timeout-truth.test.ts
@@ -1,0 +1,112 @@
+// #1352 — a secret card that times out was reported as a possibly-frozen tab.
+//
+// `panel_request_secret` blocks up to 300s on a MASKED INPUT, and its catch relayed the
+// bridge's generic no-reply message:
+//
+//   Panel tab … did not reply to "request_secret" within 300000 ms — the ComfyUI tab
+//   may be backgrounded or frozen
+//
+// For every other command that is the right sentence. Here it accuses the tab of a
+// fault it almost certainly does not have: the likely cause is that a human is still
+// typing, having gone to a password manager or a billing console for the token. Same
+// defect as #1332 — a mechanical outcome narrated as somebody's decision or a fault.
+//
+// AND IT HAS TO SAY WHAT HAPPENS TO A LATE VALUE, because that is the question the
+// caller will have. MEASURED, not assumed: this card is sent as a raw `request_secret`
+// command with NO ask_id, and the late-reply buffer (takeLateAskReply) is keyed BY ask
+// id — so a value typed after the timeout has no route back to this call. Saying "it
+// may still arrive" would leave the user waiting for a save that cannot happen.
+//
+// THE 300s BUDGET IS NOT TOUCHED. PANEL_TOOL_MCP_TIMEOUT_MS (315s) is sized above this
+// card so an internal MCP client does not kill the request first (#325); moving one
+// means moving the other, which is the design decision #1352 is really asking for.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+
+const TAB = "wf:workflows/a.json";
+
+/** The bridge's real no-reply wording, which is what used to reach the caller. */
+const REPLY_TIMEOUT = () =>
+  new Error(
+    `Panel tab ${TAB} did not reply to "request_secret" within 300000 ms — the ComfyUI tab ` +
+      `may be backgrounded or frozen`,
+  );
+
+function bridge(fail: Error) {
+  return {
+    send: async () => {
+      throw fail;
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: TAB, title: "wf", connected_at: 0 }],
+    resolveActiveTabId: () => TAB,
+    tabCanMutateGraph: () => true,
+    tabGraphMutationCapability: () => ({ known: true, canMutate: true }),
+  } as unknown as PanelToolCtx["bridge"];
+}
+
+async function requestSecret(fail: Error): Promise<string> {
+  const ctx = makePanelToolCtx(bridge(fail), TAB, new WorkflowTargetStore());
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_request_secret");
+  if (!def) throw new Error("panel_request_secret is not registered");
+  const res: ToolResult = await def.handler(
+    { mcp_server: "comfyui", label: "CivitAI token", key: "CIVITAI_API_TOKEN" } as never,
+    ctx,
+  );
+  return res.content.map((c) => (c as { text?: string }).text ?? "").join(" ");
+}
+
+describe("a timed-out secret card is described honestly (#1352)", () => {
+  it("does not accuse the tab of being frozen, or the user of declining", async () => {
+    const text = await requestSecret(REPLY_TIMEOUT());
+
+    expect(text).not.toMatch(/backgrounded or frozen/);
+    expect(text).toMatch(/does NOT mean the tab is frozen/);
+    expect(text).toMatch(/does NOT mean the user declined/);
+    // The likely truth, stated as likely.
+    expect(text).toMatch(/very likely just time/);
+  });
+
+  it("states the outcome that matters: nothing was saved", async () => {
+    const text = await requestSecret(REPLY_TIMEOUT());
+    expect(text).toMatch(/NOTHING was saved/);
+    expect(text).toMatch(/no credential was read/);
+  });
+
+  it("says a LATE value is discarded — measured, not hedged", async () => {
+    // The claim rests on this card having no ask_id, so the id-keyed late buffer cannot
+    // match it. Hedging here would leave the user waiting for a save that cannot happen.
+    const text = await requestSecret(REPLY_TIMEOUT());
+
+    expect(text).toMatch(/cannot reach this call/);
+    expect(text).toMatch(/discarded rather than saved/);
+    expect(text).toMatch(/call panel_request_secret again/);
+  });
+
+  it("keeps the masked-input rule — never route a secret through the conversation", async () => {
+    // #952's finding: suggesting the conversational route defeats the entire purpose of
+    // this tool. A recovery path is exactly where that would slip back in.
+    const text = await requestSecret(REPLY_TIMEOUT());
+    expect(text).toMatch(/never be typed into the conversation/);
+  });
+
+  it("a NON-timeout failure keeps its own words", async () => {
+    // The scope of this rewrite is one cause. A transport drop or a refusal must not be
+    // narrated as "someone is still typing".
+    const text = await requestSecret(new Error("Panel tab is not open"));
+
+    expect(text).toMatch(/Panel tab is not open/);
+    expect(text).not.toMatch(/very likely just time/);
+    expect(text).not.toMatch(/discarded rather than saved/);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -9156,6 +9156,36 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             `🔒 Token saved to MCP server "${server}" (${args.target_kind} "${args.key}"). Call panel_reload to load it.`,
           );
         } catch (err) {
+          // #1352 — A TIMED-OUT SECRET CARD IS NOT A FROZEN TAB.
+          //
+          // The bridge's generic no-reply message ("the ComfyUI tab may be backgrounded
+          // or frozen") is right for every other command and wrong here. This card
+          // blocks up to 300s on a MASKED INPUT, and the overwhelmingly likely reason it
+          // went unanswered is that a human is still typing — off finding the key in a
+          // password manager or a billing console. Nothing is wrong with the tab, and
+          // sending someone to fix one is the #1332 defect in a new place.
+          //
+          // It also has to say what happens to a value entered LATE, because that is the
+          // question the caller will actually have. MEASURED: this card is sent as a raw
+          // `request_secret` command with NO ask_id, and the late-reply buffer
+          // (takeLateAskReply) is keyed BY ask id — so a value typed after the timeout
+          // has no path back to this call. It is discarded, and the tool must be called
+          // again. "It may still arrive" would be a guess, and an expensive one: the
+          // user would wait for a save that cannot happen.
+          if (isReplyTimeoutError(err)) {
+            return fail(
+              `The secret card was not answered within 300s, so NOTHING was saved and no ` +
+                `credential was read. That is very likely just time — the card asks for a ` +
+                `token, and finding one in a password manager or a billing console can take ` +
+                `longer than that. It does NOT mean the tab is frozen, and it does NOT mean ` +
+                `the user declined.\n\n` +
+                `A value typed into that card NOW cannot reach this call: it carries no id ` +
+                `this reply could be matched to, so a late answer is discarded rather than ` +
+                `saved. Ask whether they still want to set it and call panel_request_secret ` +
+                `again when they are ready to paste — the value goes straight from the masked ` +
+                `field into storage, and must never be typed into the conversation.`,
+            );
+          }
           return fail(err);
         }
       },


### PR DESCRIPTION
Refs #1352 — the **truthfulness** half only.

`panel_request_secret` blocks up to 300s on a masked input and its catch is a bare `return fail(err)`, so a reply timeout relays the generic bridge message:

> Panel tab … did not reply to "request_secret" within 300000 ms — the ComfyUI tab may be backgrounded or frozen

For every other command that wording is right. Here it is misleading in the #1332 way: the overwhelmingly likely cause is that a **human is still typing** — they went to a password manager or a billing dashboard — and nothing about the tab is wrong. It also never says whether a value entered after that point still lands.

**Deliberately NOT changing the budget.** `PANEL_TOOL_MCP_TIMEOUT_MS` (315s) is sized above the 300s secret card so an internal MCP client does not kill the request first (#325). Raising one means raising the other, and that is the design decision this issue actually needs an owner for — it is not something to slip in behind a wording fix.

What ships: the timeout says nothing was saved, that the card may still be on screen, whether a late value is captured, and how to recover — without accusing the tab of being frozen or the user of declining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)