### PR TITLE
chore(release): 0.50.105

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.105] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- say WHICH host the node definitions came from when a remote strip fails (#1362)
+
+
 ## [0.50.104] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.104",
+  "version": "0.50.105",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.104",
+      "version": "0.50.105",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.104",
+  "version": "0.50.105",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.105` tag (the tag publishes).

### Fixed
- **#1359** — `panel_strip_workflow` captures the graph from the connected panel but fetches `/object_info` over `COMFYUI_URL`. For a remote panel those are two hosts, and the failure was a bare `ECONNREFUSED 127.0.0.1:8188` that never mentioned the canvas host — the reporter had to read `dist/` to work it out. The failure now names both hosts, says which came from where, and gives the workaround. It claims "two different hosts" only when they actually differ, and a pack/path/inline source is not told about the panel at all.

The **cause** — the panel serving its own `/object_info` so a remote canvas can be converted — is deliberately not half-fixed here; it is artokun/comfyui-mcp-panel#1006, with the reasoning for why the orchestrator-side shortcut is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)