### PR TITLE
chore(release): 0.50.106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.106] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- say what a timed-out secret card actually means (#1364)
+
+
 ## [0.50.105] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.105",
+  "version": "0.50.106",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.105",
+      "version": "0.50.106",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.105",
+  "version": "0.50.106",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.106` tag (the tag publishes).

### Fixed
- **#1352** (truthfulness half) — `panel_request_secret` relayed the bridge's generic *"the ComfyUI tab may be backgrounded or frozen"* when its 300s masked-input card went unanswered. The likely cause is a human still fetching the token from a password manager, so that accused the tab of a fault it does not have. It now says nothing was saved, that this is very likely just time, and — measured, because the card carries no `ask_id` and the late-reply buffer is keyed by one — that a value typed after the timeout is discarded rather than saved.

The **budget** is deliberately unchanged: `PANEL_TOOL_MCP_TIMEOUT_MS` (315s) is sized above the 300s card so an internal MCP client does not kill the request first (#325). Moving one means moving the other; #1352 stays open for that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)