### PR TITLE
chore(release): 0.50.107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.107] - 2026-08-10
+
+### MCP
+
+#### Fixed
+- gate the instance-witness channel too, not just the process probe (#1367)
+
+
 ## [0.50.106] - 2026-08-10
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.106",
+  "version": "0.50.107",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.106",
+      "version": "0.50.107",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.106",
+  "version": "0.50.107",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.107` tag (the tag publishes).

### Fixed
- **#1263** — the host-reaching test gate covered one probe, hardcoded by name, so a second channel walked past it: `gatherProcessInfo` reaches `acquireInstanceWitness`, which opens a **real WebSocket** to `COMFYUI_URL`. That is why `restart-live-first.test.ts` passed on a dev rig and failed on all three CI runners. The gate is now a table of host-reaching primitives; adding the next channel is a three-line change.

Test-only — no runtime behaviour changes.

Also records why the *third* channel (the `fetch` health probe) is deliberately absent: its only exported caller is `buildPanelToolDefs()`, which every panel test names, so gating on it would flag the whole suite. What would have to change first is attributing reachability to a tool rather than to the single export registering all 91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)