### PR TITLE
feat(agent-notes): send operational status to the agent, not to the user

### DIFF
--- a/src/__tests__/services/agent-note-channel.test.ts
+++ b/src/__tests__/services/agent-note-channel.test.ts
@@ -79,6 +79,49 @@ describe("operational status reaches the agent without reaching the user", () =>
     expect(sent[0]?.type).toBe("say");
   });
 
+  it("a MIGRATED tab is judged by the connection that will RECEIVE it (codex P1)", () => {
+    // The capability was read with conns.get() while push() routes with
+    // resolveTarget(), which follows alias/migration mappings. A tab that re-helloed
+    // under a new id was therefore judged incapable and then delivered to a perfectly
+    // capable panel — the wall of text reappearing on exactly the build that can hide
+    // it. Both now go through resolveTarget.
+    const bridge = new UiBridge(0);
+    const sent: Frame[] = [];
+    (bridge as unknown as { push: (f: Frame, t?: string) => number }).push = (f) => {
+      sent.push(f);
+      return 1;
+    };
+    // The capable connection lives under its NEW id; the caller still holds the old one.
+    (bridge as unknown as { conns: Map<string, unknown> }).conns.set("tab-new", {
+      acceptsAgentNotes: true,
+    });
+    (bridge as unknown as { resolveTarget: (t: string) => unknown }).resolveTarget = (t) => {
+      if (t === "tab-old" || t === "tab-new") return { acceptsAgentNotes: true };
+      throw new Error("no such tab");
+    };
+
+    expect(bridge.pushAgentNote(NOTE, "tab-old")).toBe("agent_note");
+    expect(sent[0]?.type).toBe("agent_note");
+  });
+
+  it("an UNROUTABLE tab still falls back — the buffered frame must be the safe one", () => {
+    // push() buffers for replay on the next hello when the tab is not routable. We
+    // cannot know what will pick that frame up, so the one we hand it must be the
+    // visible `say`.
+    const bridge = new UiBridge(0);
+    const sent: Frame[] = [];
+    (bridge as unknown as { push: (f: Frame, t?: string) => number }).push = (f) => {
+      sent.push(f);
+      return 1;
+    };
+    (bridge as unknown as { resolveTarget: (t: string) => unknown }).resolveTarget = () => {
+      throw new Error("tab not connected");
+    };
+
+    expect(bridge.pushAgentNote(NOTE, "gone")).toBe("say");
+    expect(sent[0]?.type).toBe("say");
+  });
+
   it("a MISSING capability field is treated as absent, not as truthy", () => {
     const bridge = new UiBridge(0);
     const sent: Frame[] = [];

--- a/src/__tests__/services/agent-note-channel.test.ts
+++ b/src/__tests__/services/agent-note-channel.test.ts
@@ -1,0 +1,110 @@
+// A user-hidden channel for operational status, so the walls of text stop landing in
+// somebody's image conversation.
+//
+// The panel auto-sync failure is the motivating one. It is true, it is necessary, and it
+// is addressed to the wrong reader:
+//
+//   ⚠️ Could not automatically sync the ComfyUI-MCP panel; no update was claimed. Run
+//   install_comfyui(action:'panel', panel_action:'status') … (Timed out after 60000ms
+//   waiting for the panel operation lock. The lock at …\panel-op.lock was taken 73 hours
+//   ago by pid 4544 … To recover a proven abandoned lock, run install_comfyui(…
+//
+// The agent has to know that. The person who asked for a clothes swap does not, and
+// printing it mid-conversation reads like the assistant lost its place.
+//
+// WHY THIS IS CAPABILITY-GATED RATHER THAN A STRAIGHT SWITCH. An older panel silently
+// DROPS a frame type it does not recognise. Sending `agent_note` unconditionally would
+// therefore turn "too loud" into "gone" for everyone who has not updated — and a notice
+// nobody sees is worse than an ugly one. That fallback is the property most worth pinning
+// here, because it is the one a future refactor would quietly delete.
+
+import { describe, expect, it } from "vitest";
+
+import { UiBridge } from "../../services/ui-bridge.js";
+
+type Frame = { type?: string; text?: string };
+
+/** A bridge with one connection whose hello did or did not advertise the capability. */
+function bridgeWithConn(accepts: boolean): { bridge: UiBridge; sent: Frame[] } {
+  const bridge = new UiBridge(0);
+  const sent: Frame[] = [];
+  // Reach past the socket: `push` serialises to a live WebSocket, and this test is about
+  // WHICH FRAME is chosen, not about transport.
+  (bridge as unknown as { push: (f: Frame, tabId?: string) => number }).push = (f) => {
+    sent.push(f);
+    return 1;
+  };
+  (bridge as unknown as { conns: Map<string, unknown> }).conns.set("tab-a", {
+    acceptsAgentNotes: accepts,
+  });
+  return { bridge, sent };
+}
+
+const NOTE = "⚠️ Could not automatically sync the ComfyUI-MCP panel; no update was claimed.";
+
+describe("operational status reaches the agent without reaching the user", () => {
+  it("a CAPABLE panel gets the hidden frame", () => {
+    const { bridge, sent } = bridgeWithConn(true);
+
+    const used = bridge.pushAgentNote(NOTE, "tab-a");
+
+    expect(used).toBe("agent_note");
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.type).toBe("agent_note");
+    // The text is carried verbatim — hiding it must not also trim it, since the agent
+    // needs the lock path and the recovery command.
+    expect(sent[0]?.text).toBe(NOTE);
+  });
+
+  it("an OLDER panel still gets a VISIBLE say — the notice is never lost", () => {
+    // The direction that matters. An un-updated panel drops an unknown frame silently,
+    // so falling back is what keeps this from being a regression dressed as a fix.
+    const { bridge, sent } = bridgeWithConn(false);
+
+    const used = bridge.pushAgentNote(NOTE, "tab-a");
+
+    expect(used).toBe("say");
+    expect(sent[0]?.type).toBe("say");
+    expect(sent[0]?.text).toBe(NOTE);
+  });
+
+  it("an UNKNOWN tab falls back too, rather than assuming support", () => {
+    // No connection to read the capability from. Fail toward the visible channel: a
+    // notice shown unnecessarily is recoverable, one silently dropped is not.
+    const { bridge, sent } = bridgeWithConn(true);
+
+    const used = bridge.pushAgentNote(NOTE, "tab-does-not-exist");
+
+    expect(used).toBe("say");
+    expect(sent[0]?.type).toBe("say");
+  });
+
+  it("a MISSING capability field is treated as absent, not as truthy", () => {
+    const bridge = new UiBridge(0);
+    const sent: Frame[] = [];
+    (bridge as unknown as { push: (f: Frame) => number }).push = (f) => {
+      sent.push(f);
+      return 1;
+    };
+    // A hello from a build predating the flag: the key simply is not there.
+    (bridge as unknown as { conns: Map<string, unknown> }).conns.set("tab-a", {});
+
+    expect(bridge.pushAgentNote(NOTE, "tab-a")).toBe("say");
+  });
+});
+
+describe("WIRING: the panel-sync failure uses the hidden channel (#panel-noise)", () => {
+  it("is sent with pushAgentNote, not a bare say", async () => {
+    // Asserted on the source because reaching that emit needs a failed Manager sync
+    // inside a hello handler. If someone reverts it to `bridge.push({type:"say"})` the
+    // wall of text comes back and no unit test would otherwise notice.
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(new URL("../../orchestrator/index.ts", import.meta.url), "utf-8");
+
+    const at = src.indexOf("Could not automatically sync the ComfyUI-MCP panel");
+    expect(at).toBeGreaterThan(-1);
+    const before = src.slice(Math.max(0, at - 600), at);
+    expect(before).toContain("bridge.pushAgentNote(");
+    expect(before).not.toMatch(/bridge\.push\(\s*\{\s*type:\s*"say"/);
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3380,10 +3380,13 @@ export async function runPanelOrchestrator(): Promise<void> {
                   );
                   return;
                 }
-                bridge.push(
-                  {
-                    type: "say",
-                    text:
+                // AGENT-ONLY. This is operational status with a lock-recovery procedure
+                // attached — necessary, and addressed to the wrong reader. Printed in the
+                // chat it lands mid-conversation as a wall of text about a subsystem the
+                // user did not ask about. pushAgentNote falls back to a visible `say` on
+                // a panel too old to understand the hidden frame, so nothing is lost.
+                bridge.pushAgentNote(
+                  (
                       `⚠️ Could not automatically sync the ComfyUI-MCP panel; no update was claimed. ` +
                       // #784 — this is pushed to the embedded panel chat, whose
                       // tool set does not include install_comfyui(action:'panel'). Name it only where
@@ -3392,8 +3395,8 @@ export async function runPanelOrchestrator(): Promise<void> {
                         panelRecoveryContext().installPanelUsable
                           ? "Run install_comfyui(action:'panel', panel_action:'status') to inspect it, then retry install_comfyui(action:'panel', panel_action:'sync') if appropriate."
                           : "Inspect and update the panel pack on the ComfyUI host itself — no tool in this session can do it."
-                      } (${detail})`,
-                  },
+                      } (${detail})`
+                  ),
                   panelTab,
                 );
               })

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2589,7 +2589,23 @@ export class UiBridge {
    * assume.
    */
   pushAgentNote(text: string, tabId?: string): "agent_note" | "say" {
-    const conn = tabId ? this.conns.get(tabId) : undefined;
+    // Resolve through resolveTarget — the SAME lookup push() will use (codex, P1).
+    // A direct conns.get() misses alias/migration mappings that resolveTarget follows,
+    // so a tab that re-helloed under a new id mid-operation would be judged incapable
+    // here and then delivered to perfectly capable panel: the wall of text reappears on
+    // exactly the build that can hide it. Reading it the same way removes the
+    // disagreement, and there is no await between this and the push, so run-to-
+    // completion guarantees the two see the same connection.
+    let conn: Conn | undefined;
+    if (tabId) {
+      try {
+        conn = this.resolveTarget(tabId);
+      } catch {
+        // Not routable. push() will buffer for replay on the next hello; the frame it
+        // buffers must be the SAFE one, because we cannot know what will pick it up.
+        conn = undefined;
+      }
+    }
     const hidden = conn?.acceptsAgentNotes === true;
     this.push({ type: hidden ? "agent_note" : "say", text }, tabId);
     return hidden ? "agent_note" : "say";

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -187,6 +187,14 @@ interface Conn {
    * its required fresh-backend query yields to the browser, allowing a workflow
    * switch before it writes. Re-read per hello and fail closed if absent. */
   enforcesWorkflowStampAtWrite: boolean;
+  /** True when THIS hello advertises that the panel understands `agent_note` — a frame
+   *  delivered to the AGENT ONLY and never rendered as a chat bubble.
+   *
+   *  Capability-gated on purpose. An older panel silently DROPS an unknown frame type, so
+   *  switching unconditionally would make these notices vanish for anyone who has not
+   *  updated — a wall of text traded for nothing at all, which is the worse failure. When
+   *  this is false the caller falls back to a visible `say`. */
+  acceptsAgentNotes: boolean;
   /** Commands THIS connection has already proven it doesn't support, via a real
    *  "Unknown command" reply earlier in the session (#236). Once a cmd lands
    *  here, every later call is gated proactively — rejected before it ever
@@ -2130,6 +2138,9 @@ export class UiBridge {
             (msg as { enforces_workflow_stamp?: unknown }).enforces_workflow_stamp === true,
           enforcesWorkflowStampAtWrite:
             (msg as { enforces_workflow_stamp_at_write?: unknown }).enforces_workflow_stamp_at_write === true,
+          // Re-read per hello like the stamps above: a reconnect can be a different build.
+          acceptsAgentNotes:
+            (msg as { accepts_agent_notes?: unknown }).accepts_agent_notes === true,
           // Fresh per hello — see the field's doc comment (#236).
           unsupportedCmds: new Set<string>(),
           // INHERITED across a reconnect (the panel code did not get older) so a command
@@ -2561,6 +2572,29 @@ export class UiBridge {
    * like the send gate, it intentionally describes the local panel protocol
    * needed to avoid an unfenced wrong-workflow write.
    */
+  /**
+   * Send operational status to the AGENT ONLY — never rendered in the user's chat.
+   *
+   * For the walls of text that are true, necessary and addressed to the wrong reader: a
+   * failed panel auto-sync and its lock-recovery procedure, for instance. The agent has
+   * to know; the person asking for an image does not, and printing one mid-conversation
+   * reads like the assistant lost its place.
+   *
+   * FALLS BACK TO A VISIBLE `say` when the panel does not advertise `accepts_agent_notes`.
+   * An older panel drops an unknown frame silently, so sending unconditionally would turn
+   * "too loud" into "gone" — and a notice nobody sees is worse than an ugly one. The
+   * fallback is the current behaviour exactly, so an un-updated panel is unaffected.
+   *
+   * Returns which channel was used, so a caller can log the difference rather than
+   * assume.
+   */
+  pushAgentNote(text: string, tabId?: string): "agent_note" | "say" {
+    const conn = tabId ? this.conns.get(tabId) : undefined;
+    const hidden = conn?.acceptsAgentNotes === true;
+    this.push({ type: hidden ? "agent_note" : "say", text }, tabId);
+    return hidden ? "agent_note" : "say";
+  }
+
   tabCanMutateGraph(tabId: string): boolean {
     // FAIL-CLOSED convenience for the readiness callers: an unreadable probe is
     // treated as "not ready", which is the right default when the question is


### PR DESCRIPTION
Pairs with artokun/comfyui-mcp-panel#1032.

The panel auto-sync failure is pushed as `say` — a visible chat bubble. What lands is a paragraph about a lock file taken 73 hours ago by a dead pid, why it is never auto-reclaimed, and a two-branch recovery procedure, dropped into the middle of a conversation about an image.

Every word is true and the agent needs it. The user does not.

`pushAgentNote` sends it on the panel's `agent_note` channel, which is delivered into the agent's next turn and never rendered.

**It falls back to a visible `say` whenever the panel does not advertise `accepts_agent_notes`** — and that is the part worth keeping. An older panel drops an unknown frame *silently*, so switching unconditionally would turn "too loud" into "gone" for everyone who has not updated, and a notice nobody sees is worse than an ugly one. An unknown tab falls back too: a notice shown unnecessarily is recoverable, one silently dropped is not.

The fallback is what the tests pin hardest — mutating the gate to always-hidden kills 3 of 5. A source-level test pins that the sync failure itself uses `pushAgentNote`, because reaching that emit requires a failed Manager sync inside a hello handler and a revert would otherwise restore the wall of text unnoticed.

Full suite: 440 files, 8502 passed. `tsc`, lint, vocabulary and unknown-collapse gates all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)