### PR TITLE
chore(release): 0.50.108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.87] - 2026-08-09
+
+### MCP
+
+#### Fixed
+- a proven-irrelevant stale copy no longer vetoes the download (#1298)
+- say why a CivitAI download failed, instead of a bare status (#1303)
+
+#### Changed
+- 0.50.86 (#1304)
+- 0.50.85 (#1302)
+
+
 ## [0.50.86] - 2026-08-09
 
 > Covers changes since 0.50.85.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.86",
+  "version": "0.50.87",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.86",
+      "version": "0.50.87",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.86",
+  "version": "0.50.87",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles protected `main` with the `v0.50.108` tag (the tag publishes).

### Added
- **#1375** — a user-hidden `agent_note` channel. The panel auto-sync failure (a paragraph about a stale lock file plus its recovery procedure) was pushed as a visible chat bubble; it now goes to the agent only, via the panel half in artokun/comfyui-mcp-panel#1032. **Falls back to a visible `say` whenever the panel does not advertise `accepts_agent_notes`** — an older panel drops an unknown frame silently, so switching unconditionally would trade a wall of text for nothing at all.

Codex review found a P1 that is fixed here: the capability was read with `conns.get()` while `push()` routes with `resolveTarget()`, so a tab that re-helloed under a new id was judged incapable and then delivered to a perfectly capable panel — the wall of text reappearing on exactly the build that can hide it.

Codex's second P1 (in-memory queue lost on panel reload) is deliberately not persisted: `performPanelSync` runs on every hello with no once-guard, so a reload re-runs it and re-emits. The information regenerates rather than being lost.

The sibling *non-failure* sync message (synced → restart, pinned → unpin) stays **visible** by design — "restart ComfyUI to load it" is genuinely for the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)