### PR TITLE
i18n: translate the ready banners and the two console HTML pages

### DIFF
--- a/src/__tests__/orchestrator/panel-console-http.test.ts
+++ b/src/__tests__/orchestrator/panel-console-http.test.ts
@@ -92,6 +92,95 @@ describe("panel-console-http", () => {
     }
   });
 
+  // ── i18n of the two served pages ───────────────────────────────────────────
+  //
+  // No catalogs are installed in this repo, so every page here renders English no
+  // matter what the browser asks for. That is exactly the case these guard: the
+  // document must not CLAIM a language it did not render. Negotiation and RTL, which
+  // need a catalog to be observable at all, are covered in panel-console-i18n.test.ts.
+  describe("page language, with no catalogs installed", () => {
+    const serve = async () =>
+      startPanelConsoleHttpServer({
+        port: 0,
+        bridgePort: 9180,
+        comfyuiUrl: "http://127.0.0.1:9500",
+        token: "tok-123",
+      });
+
+    // Stamping lang="fa" dir="rtl" onto untranslated English is worse than saying
+    // nothing: it mirrors the whole layout and tells a screen reader to pronounce
+    // English as Persian. Before the pages were translatable, an Arabic-speaking
+    // reader got a correct LTR English page — that must not regress on the way in.
+    it("declares English, not the requested language, while the prose is English", async () => {
+      const srv = await serve();
+      try {
+        for (const lang of ["fa-IR,fa;q=0.9", "ar", "ja-JP", "ru"]) {
+          const html = await (await fetch(srv.url, { headers: { "accept-language": lang } })).text();
+          expect(html).toContain(`<html lang="en">`);
+          expect(html).not.toContain(`dir="rtl"`);
+          expect(html).toContain("Control plane for the panel orchestrator");
+        }
+        const creds = await (
+          await fetch(`${srv.url}/credentials?token=tok-123`, { headers: { "accept-language": "ar" } })
+        ).text();
+        expect(creds).toContain(`<html lang="en">`);
+        expect(creds).not.toContain(`dir="rtl"`);
+      } finally {
+        await srv.stop();
+      }
+    });
+
+    // The 401 is a bare fragment with no <html> to carry the language, so the <p> has to.
+    it("carries the language on the unauthorized fragment itself", async () => {
+      const srv = await serve();
+      try {
+        const res = await fetch(`${srv.url}/credentials?token=wrong`, {
+          headers: { "accept-language": "fa" },
+        });
+        expect(res.status).toBe(401);
+        expect(await res.text()).toBe(`<p lang="en">Unauthorized — reconnect the panel.</p>`);
+      } finally {
+        await srv.stop();
+      }
+    });
+
+    // Translated strings are now serialized INTO the inline scripts. A stray quote
+    // or a `</script>` would break the page silently — the server would still answer
+    // 200 and the page would still contain its prose. Compiling the script body is
+    // the only assertion that sees it. (The hostile-translation case, which is what
+    // makes this bite, lives in panel-console-i18n.test.ts.)
+    it("keeps both inline scripts parseable", async () => {
+      const srv = await serve();
+      try {
+        for (const path of ["/console", "/credentials?token=tok-123"]) {
+          const html = await (await fetch(`${srv.url}${path}`)).text();
+          const scripts = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+          expect(scripts.length).toBeGreaterThan(0);
+          // `new Function` COMPILES without running: a syntax error throws here, and
+          // nothing touches document/fetch.
+          for (const body of scripts) expect(() => new Function(body)).not.toThrow();
+        }
+      } finally {
+        await srv.stop();
+      }
+    });
+
+    it("escapes markup from the served ComfyUI URL rather than emitting it", async () => {
+      const srv = await startPanelConsoleHttpServer({
+        port: 0,
+        bridgePort: 9180,
+        comfyuiUrl: "http://127.0.0.1:9500/<script>alert(1)</script>",
+      });
+      try {
+        const html = await (await fetch(srv.url)).text();
+        expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+        expect(html).not.toContain("<script>alert(1)</script>");
+      } finally {
+        await srv.stop();
+      }
+    });
+  });
+
   it("sends CORS headers for the ComfyUI origin (and its localhost twin) only", async () => {
     const srv = await startPanelConsoleHttpServer({
       port: 0,

--- a/src/__tests__/orchestrator/panel-console-i18n.test.ts
+++ b/src/__tests__/orchestrator/panel-console-i18n.test.ts
@@ -1,0 +1,201 @@
+// The console pages under a catalog that actually answers.
+//
+// No `locales/` catalogs ship in this repo, so with the real i18n module every page
+// renders its English fallback — which means a suite that only fetches pages cannot
+// tell a working translation path from one where `trFor` was deleted outright
+// (measured: replacing `trFor(...)` with the bare fallback leaves the sibling suite
+// fully green). So `trFor` is mocked here and each test installs the answer it needs:
+// a marker to prove the catalog is consulted with the right locale and key, or a
+// hostile string to prove no translation can break the document that carries it.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return { ...actual, getInstanceSlug: () => "test-instance" };
+});
+
+/** Installed per test; returning undefined defers to the real (fallback) behaviour. */
+let translate: ((locale: string, key: string) => string | undefined) | null = null;
+
+vi.mock("../../i18n/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../i18n/index.js")>();
+  return {
+    ...actual,
+    trFor: (locale: string, key: string, fallback: unknown, vars?: unknown) => {
+      const hit = translate?.(locale, key);
+      return hit === undefined
+        ? (actual.trFor as (...a: unknown[]) => string)(locale, key, fallback, vars)
+        : hit;
+    },
+  };
+});
+
+import { startPanelConsoleHttpServer } from "../../orchestrator/panel-console-http.js";
+import { resetLoraCatalog } from "../../services/lora-catalog.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "panel-console-i18n-"));
+  process.env.COMFYUI_MCP_LORA_CATALOG = join(dir, "lora-catalog.json");
+  process.env.COMFYUI_MCP_LORA_PREVIEWS = join(dir, "previews");
+  // Never let a test reach the developer's real ~/.comfyui-mcp/.env.
+  process.env.COMFYUI_MCP_ENV_FILE = join(dir, ".env");
+  process.env.COMFYUI_MCP_PANEL_SECRETS = join(dir, "panel-secrets.json");
+  resetLoraCatalog();
+});
+
+afterEach(() => {
+  translate = null;
+  for (const k of [
+    "COMFYUI_MCP_LORA_CATALOG",
+    "COMFYUI_MCP_LORA_PREVIEWS",
+    "COMFYUI_MCP_ENV_FILE",
+    "COMFYUI_MCP_PANEL_SECRETS",
+    "COMFYUI_MCP_LANG",
+  ]) {
+    delete process.env[k];
+  }
+  resetLoraCatalog();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const serve = () =>
+  startPanelConsoleHttpServer({
+    port: 0,
+    bridgePort: 9180,
+    comfyuiUrl: "http://127.0.0.1:9500",
+    token: "tok-123",
+  });
+
+const get = async (srvUrl: string, path: string, lang?: string): Promise<string> => {
+  const res = await fetch(`${srvUrl}${path}`, lang ? { headers: { "accept-language": lang } } : undefined);
+  return await res.text();
+};
+
+/** Every inline script body in the document. */
+const scriptsOf = (html: string) => [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+describe("console pages with a catalog installed", () => {
+  it("renders each page from the catalog, keyed by the negotiated locale", async () => {
+    translate = (locale, key) => `«${locale}:${key}»`;
+    const srv = await serve();
+    try {
+      const landing = await get(srv.url, "/console", "ja-JP");
+      expect(landing).toContain("«ja:console.landing.title»");
+      expect(landing).toContain("«ja:console.landing.subtitle»");
+      expect(landing).toContain("«ja:console.landing.status.loading»");
+      expect(landing).toContain(`<html lang="ja">`);
+
+      const creds = await get(srv.url, "/credentials?token=tok-123", "ko");
+      expect(creds).toContain("«ko:console.credentials.title»");
+      expect(creds).toContain("«ko:console.credentials.privacy»");
+      expect(creds).toContain(`<html lang="ko">`);
+
+      const denied = await get(srv.url, "/credentials?token=wrong", "ru");
+      expect(denied).toBe(`<p lang="ru">«ru:console.unauthorized»</p>`);
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  it("mirrors the document for Arabic and Persian only", async () => {
+    translate = (locale, key) => `«${locale}:${key}»`;
+    const srv = await serve();
+    try {
+      expect(await get(srv.url, "/console", "ar")).toContain(`<html lang="ar" dir="rtl">`);
+      expect(await get(srv.url, "/credentials?token=tok-123", "fa-IR")).toContain(
+        `<html lang="fa" dir="rtl">`,
+      );
+      const tr = await get(srv.url, "/console", "tr");
+      expect(tr).toContain(`<html lang="tr">`);
+      expect(tr).not.toContain(`dir="rtl"`);
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  it("ranks Accept-Language by q-value and honours a q=0 rejection", async () => {
+    translate = (locale, key) => `«${locale}:${key}»`;
+    const srv = await serve();
+    try {
+      // Order says English first; the weights say Japanese. The weights win.
+      expect(await get(srv.url, "/console", "en;q=0.3,ja;q=0.9")).toContain(`<html lang="ja">`);
+      // `q=0` REJECTS Arabic — taking it because it came first would hand an RTL page
+      // to someone who explicitly asked for something else.
+      expect(await get(srv.url, "/console", "ar;q=0,ja")).toContain(`<html lang="ja">`);
+      // The parameter name is case-insensitive per RFC 9110.
+      expect(await get(srv.url, "/console", "ar;Q=0,ja")).toContain(`<html lang="ja">`);
+      // A malformed weight means "accept", not "reject" — proxies do emit these.
+      expect(await get(srv.url, "/console", "ja;q=oops")).toContain(`<html lang="ja">`);
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  it("falls back to the process locale when the browser asks for nothing we ship", async () => {
+    translate = (locale, key) => `«${locale}:${key}»`;
+    process.env.COMFYUI_MCP_LANG = "tr";
+    const srv = await serve();
+    try {
+      expect(await get(srv.url, "/console", "kl-GL")).toContain(`<html lang="tr">`);
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  // A catalog is DATA — a hostile or simply careless entry must not be able to close
+  // the <script>, escape an attribute, or inject an element. Without the `<` escape in
+  // scriptJson this fails on the credentials page (measured), and without escapeHtml
+  // it fails on the landing page.
+  it("cannot break out of the document, whatever the catalog says", async () => {
+    const hostile = `</script><img src=x onerror="alert(1)">'"\\`;
+    translate = () => hostile;
+    const srv = await serve();
+    try {
+      for (const path of ["/console", "/credentials?token=tok-123"]) {
+        const html = await get(srv.url, path);
+        const scripts = scriptsOf(html);
+        expect(scripts.length).toBeGreaterThan(0);
+        for (const body of scripts) expect(() => new Function(body)).not.toThrow();
+        expect(html).not.toContain("<img src=x");
+        // The credentials page interpolates prose into an attribute value too.
+        expect(html).not.toContain(`placeholder="</script>`);
+      }
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  // A `{slot}` carries a fact, not decoration. A translation that drops one must lose
+  // the SENTENCE (fall back to English), never the fact inside it.
+  it("keeps the ComfyUI URL when a translation drops its placeholder", async () => {
+    translate = (_locale, key) =>
+      key === "console.landing.connection.endpoints" ? "接続情報" : undefined;
+    const srv = await serve();
+    try {
+      const html = await get(srv.url, "/console", "ja");
+      expect(html).not.toContain("接続情報");
+      expect(html).toContain("http://127.0.0.1:9500");
+      expect(html).toContain("ws://127.0.0.1:9180");
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  it("keeps the masked-key placeholder when a translation drops it", async () => {
+    translate = (_locale, key) => (key === "console.credentials.badge_set" ? "設定済み" : undefined);
+    const srv = await serve();
+    try {
+      const html = await get(srv.url, "/credentials?token=tok-123", "ja");
+      expect(html).not.toContain("設定済み");
+      expect(html).toContain("{masked}");
+    } finally {
+      await srv.stop();
+    }
+  });
+});

--- a/src/__tests__/orchestrator/ready-banner-i18n.test.ts
+++ b/src/__tests__/orchestrator/ready-banner-i18n.test.ts
@@ -1,0 +1,96 @@
+// The ready banner is a `say` frame a PERSON reads, so it must render in the
+// destination panel's language — which means the locale the caller supplies has to
+// reach `trFor`, on BOTH paths (the per-backend switch and the openai-provider
+// registry's readyMessage). Asserting on the English text alone cannot see that:
+// with no catalogs on disk every locale renders the same fallback, so a dropped
+// `locale` argument would look perfectly healthy. Hence the i18n module is mocked
+// and the (locale, key) pairs are observed directly.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface TrCall {
+  locale: string;
+  key: string;
+  fallback: string;
+  vars?: Record<string, string | number>;
+}
+const calls: TrCall[] = [];
+
+vi.mock("../../i18n/index.js", () => ({
+  // A sentinel rather than a real locale: an implementation that quietly hardcoded
+  // "en" instead of consulting the process locale would still be caught.
+  processLocale: () => "process-fallback",
+  trFor: (locale: string, key: string, fallback: string, vars?: Record<string, string | number>) => {
+    calls.push({ locale, key, fallback, vars });
+    return `${locale}|${key}`;
+  },
+}));
+
+import { readyBannerText, bannerCorrection } from "../../orchestrator/ready-banner.js";
+import { OPENAI_KEY_PROVIDERS } from "../../services/openai-provider-registry.js";
+
+beforeEach(() => {
+  calls.length = 0;
+});
+
+describe("ready-banner i18n wiring", () => {
+  it("passes the caller's locale to trFor on the per-backend switch path", () => {
+    expect(readyBannerText("ollama", "llama3", "", "ko")).toBe("ko|banner.ready.ollama");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].locale).toBe("ko");
+    expect(calls[0].vars?.label).toBe("llama3");
+    // The English source text stays at the call site, so a missing catalog degrades
+    // to correct English rather than a raw key.
+    expect(calls[0].fallback).toContain("comfyui-mcp agent ready");
+    expect(calls[0].fallback).toContain("{label}");
+  });
+
+  it("passes the caller's locale through to a registry provider's readyMessage", () => {
+    expect(readyBannerText("glm", "glm-5.2", "", "ja")).toBe("ja|banner.ready.glm");
+    expect(calls[0].locale).toBe("ja");
+    expect(calls[0].vars?.label).toBe("glm-5.2");
+  });
+
+  it("falls back to the process locale when the caller supplies none", () => {
+    readyBannerText("codex", "gpt-5.5");
+    readyBannerText("minimax", "MiniMax-M3");
+    expect(calls.map((c) => c.locale)).toEqual(["process-fallback", "process-fallback"]);
+  });
+
+  // bannerCorrection re-renders the SAME banner for the same tab, so it must carry
+  // the same locale — a correction arriving in a different language than the greeting
+  // it replaces is the visible bug this guards.
+  it("bannerCorrection forwards the locale to the re-rendered banner", () => {
+    expect(
+      bannerCorrection({
+        backend: "claude",
+        advertisedLabel: "claude-opus-5",
+        resolvedModel: "claude-sonnet-4-5",
+        locale: "fr",
+      }),
+    ).toBe("fr|banner.ready.claude");
+    expect(calls[0].vars?.label).toBe("claude-sonnet-4-5");
+  });
+
+  it("the custom-endpoint banner still carries its base URL as a var", () => {
+    readyBannerText("custom", "my-model", "http://localhost:8000/v1", "es");
+    expect(calls[0].key).toBe("banner.ready.custom");
+    expect(calls[0].vars?.url).toBe("http://localhost:8000/v1");
+    expect(calls[0].fallback).toContain("{url}");
+  });
+
+  // Seventeen near-identical lines were keyed by hand; a copy-pasted key would make
+  // two backends share one translation and no other test would notice.
+  it("every backend renders under its own key", () => {
+    const backends = [
+      "codex", "chatgpt", "gemini", "antigravity", "pi", "grok", "ollama", "lmstudio",
+      "llamacpp", "custom", "openrouter", "copilot", "claude",
+      ...OPENAI_KEY_PROVIDERS.map((p) => p.id),
+    ];
+    for (const b of backends) readyBannerText(b, "label", "", "en");
+    const keys = calls.map((c) => c.key);
+    expect(keys).toHaveLength(backends.length);
+    expect(new Set(keys).size).toBe(backends.length);
+    expect(keys.every((k) => k.startsWith("banner.ready."))).toBe(true);
+  });
+});

--- a/src/orchestrator/panel-console-http.ts
+++ b/src/orchestrator/panel-console-http.ts
@@ -26,6 +26,7 @@ import {
   CREDENTIAL_SLOTS,
 } from "../services/panel-secrets.js";
 import { OPENAI_KEY_PROVIDER_IDS } from "../services/openai-provider-registry.js";
+import { processLocale, resolveLocale, trFor, type Locale } from "../i18n/index.js";
 import { logger } from "../utils/logger.js";
 
 // The simple api-key providers (glm/kimi/moonshot) are spliced in from the
@@ -76,6 +77,135 @@ function sendFramedHtml(res: ServerResponse, status: number, html: string): void
     "Content-Security-Policy": FRAME_ANCESTORS,
   });
   res.end(html);
+}
+
+// ─── i18n for the two served pages ────────────────────────────────────────────
+//
+// These documents are read in a BROWSER, and the reader's language is not this
+// process's: the panel's own language setting lives in ComfyUI's client settings and
+// never reaches the orchestrator. `Accept-Language` is the closest thing to that
+// reader's own choice that a request carries, so it decides; a browser that asks for
+// nothing we ship falls back to the process locale, which honours an explicit `--lang`.
+
+/** The language for a page served from here. */
+function pageLocale(req: IncomingMessage): Locale {
+  const header = String(req.headers["accept-language"] ?? "");
+  // Ranked by q-value rather than trusting header order: descending order is a browser
+  // convention, not a requirement, and `q=0` is an explicit REJECTION of a language —
+  // picking it because it appeared first would be exactly backwards. Sort is stable, so
+  // equal weights keep the order the browser sent.
+  const ranked = header
+    .split(",")
+    .map((part) => {
+      const [tag, ...params] = part.split(";");
+      // The parameter NAME is case-insensitive per RFC 9110, so `Q=0` is the same
+      // rejection as `q=0`; matching only lowercase would read it as top preference.
+      const q = params.map((p) => p.trim().toLowerCase()).find((p) => p.startsWith("q="));
+      const weight = q ? Number.parseFloat(q.slice(2)) : 1;
+      // An UNPARSEABLE weight defaults to 1 (accept), never 0: proxies and older clients
+      // do emit `q=` and `q=high`, and 0 is reserved for a language the reader explicitly
+      // rejected. Treating a typo as a rejection silently deletes their language.
+      return { tag: tag.trim(), weight: Number.isFinite(weight) ? weight : 1 };
+    })
+    .filter((r) => r.tag && r.tag !== "*" && r.weight > 0)
+    .sort((a, b) => b.weight - a.weight);
+  for (const { tag } of ranked) {
+    const hit = resolveLocale(tag);
+    if (hit) return hit;
+  }
+  return processLocale();
+}
+
+/** The right-to-left languages we ship — the same pair the panel mirrors its layout for.
+ *  Keep in step with `LOCALES` in src/i18n/index.ts when a language is added. */
+const RTL_LOCALES: ReadonlySet<string> = new Set(["ar", "fa"]);
+
+/**
+ * The language the page will ACTUALLY render in, which is not always the one negotiated.
+ *
+ * `lang`/`dir` describe the bytes on the page, not the reader's wishes. Until a catalog
+ * for the negotiated locale is installed, those bytes are English — and stamping
+ * `lang="fa" dir="rtl"` onto English prose is worse than saying nothing: it mirrors the
+ * entire layout and tells a screen reader to pronounce English as Persian. So probe one
+ * long sentence from the page: if the catalog answers with something other than the
+ * English source, the page is genuinely translated and gets its real language; if it
+ * hands the fallback straight back, the page is English and says so. The day a catalog
+ * lands this starts reporting the real locale with no second change.
+ */
+function renderedLocale(negotiated: Locale, probeKey: string, probeFallback: string): Locale {
+  if (negotiated === "en") return "en";
+  return trFor(negotiated, probeKey, probeFallback) === probeFallback ? "en" : negotiated;
+}
+
+/** `<html>` attributes: the real language, plus `dir="rtl"` for Arabic and Persian so the
+ *  browser mirrors the page instead of laying RTL text out left-to-right. */
+function htmlAttrs(locale: Locale): string {
+  return `lang="${locale}"${RTL_LOCALES.has(locale) ? ` dir="rtl"` : ""}`;
+}
+
+/**
+ * Resolve a translation, but REJECT one that dropped a `{slot}`.
+ *
+ * A placeholder is not decoration — it carries the ComfyUI URL, the `~/.claude.json`
+ * path, the masked key. A catalog entry written without one renders a page missing the
+ * very fact it exists to state, with a 200 and nothing in the log. Falling back to the
+ * English source is the honest failure: a sentence the reader may not speak still beats
+ * a sentence with the answer cut out of it.
+ */
+function trSlots(locale: Locale, key: string, fallback: string, slots: string[]): string {
+  const out = trFor(locale, key, fallback);
+  return slots.every((s) => out.includes(`{${s}}`)) ? out : fallback;
+}
+
+/**
+ * Translate one fragment of page prose into text that is SAFE to interpolate as markup.
+ *
+ * A catalog is data, not a template: whatever it returns is HTML-escaped before it
+ * reaches the document, so a stray `<` in a translation cannot open a tag. Inline markup
+ * therefore stays in the source here — the translatable text carries `{slot}`
+ * placeholders and `markup` maps each one to a literal element, substituted AFTER
+ * escaping so the tags stay byte-identical whatever the translation says (and so a
+ * translator is free to move them, which word order in other languages requires).
+ * Anything a caller interpolates INTO a `markup` value must be escaped by that caller.
+ */
+function trHtml(
+  locale: Locale,
+  key: string,
+  fallback: string,
+  markup: Record<string, string> = {},
+): string {
+  let out = escapeHtml(trSlots(locale, key, fallback, Object.keys(markup)));
+  for (const [slot, html] of Object.entries(markup)) out = out.split(`{${slot}}`).join(html);
+  return out;
+}
+
+/** A page builder's locale-bound translator, so neither document repeats the binding. */
+function pageT(locale: Locale) {
+  return (key: string, fallback: string, markup?: Record<string, string>) =>
+    trHtml(locale, key, fallback, markup);
+}
+
+/**
+ * A `<code>` element holding a left-to-right technical string (a URL, a path).
+ *
+ * On an RTL page the bidi algorithm reorders these against the surrounding text — two
+ * URLs in one sentence swap visually and the reader cannot tell which is which — so an
+ * RTL document pins them with `dir="ltr"`. LTR pages emit the bare tag they always did.
+ */
+function ltrCode(locale: Locale, inner: string): string {
+  return RTL_LOCALES.has(locale) ? `<code dir="ltr">${inner}</code>` : `<code>${inner}</code>`;
+}
+
+/**
+ * Serialize a value for embedding in an inline `<script>`.
+ *
+ * `JSON.stringify` does not escape `<`, so a value containing `</script>` would close the
+ * element early and the remainder would render as page text. The `<` escape is the
+ * same character to a JS parser and inert to the HTML one. Now that catalog strings flow
+ * into these blocks, that is the difference between a bad translation and a broken page.
+ */
+function scriptJson(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, "\\u003C");
 }
 
 function tokenOk(req: IncomingMessage, expected?: string): boolean {
@@ -160,18 +290,40 @@ function serveLoraPreview(req: IncomingMessage, res: ServerResponse): void {
   createReadStream(abs).pipe(res);
 }
 
+/** English source for the landing page's subtitle — also its "is this page translated?"
+ *  probe, so it is named once rather than repeated at two call sites that could drift. */
+const LANDING_SUBTITLE_EN =
+  "Control plane for the panel orchestrator — MCP servers, OAuth, and service settings. The ComfyUI sidebar panel stays focused on chat, providers, and the live canvas.";
+
 function consoleLandingHtml(opts: {
   bridgePort: number;
   consolePort: number;
   comfyuiUrl: string;
+  locale: Locale;
 }): string {
   const { bridgePort, consolePort, comfyuiUrl } = opts;
+  // The subtitle is the probe: the longest sentence on the page, so a translation of it
+  // is never accidentally identical to the English.
+  const locale = renderedLocale(opts.locale, "console.landing.subtitle", LANDING_SUBTITLE_EN);
+  const t = pageT(locale);
+  // The status line is written with innerHTML (it carries its own <span>), so these
+  // strings are HTML-escaped like the rest of the page BEFORE being serialized into the
+  // script — `t()` does that — and the object goes through scriptJson so no translation
+  // can close the <script> element either.
+  const T = scriptJson({
+    running: t("console.landing.status.running", "Orchestrator running"),
+    none: t("console.landing.status.none", "no backends"),
+    ready: t("console.landing.status.ready", "ready"),
+    signIn: t("console.landing.status.sign_in", "sign in"),
+    installCli: t("console.landing.status.install_cli", "install CLI"),
+    failed: t("console.landing.status.failed", "Could not load status"),
+  });
   return `<!DOCTYPE html>
-<html lang="en">
+<html ${htmlAttrs(locale)}>
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>ComfyUI MCP Console</title>
+  <title>${t("console.landing.title", "ComfyUI MCP Console")}</title>
   <style>
     :root { color-scheme: dark; font-family: system-ui, -apple-system, Segoe UI, sans-serif; }
     body { margin: 0; background: #0f1115; color: #e8eaed; line-height: 1.5; }
@@ -180,7 +332,9 @@ function consoleLandingHtml(opts: {
     .sub { color: #9aa0a6; font-size: 0.9rem; margin-bottom: 1.5rem; }
     section { background: #181b22; border: 1px solid #2a2f3a; border-radius: 10px; padding: 1rem 1.1rem; margin-bottom: 1rem; }
     h2 { font-size: 0.95rem; margin: 0 0 0.6rem; color: #c4c7ce; }
-    ul { margin: 0.4rem 0 0; padding-left: 1.2rem; }
+    /* padding-INLINE-start, not padding-left: identical in LTR, but on an RTL page the
+       physical property reserves the gutter on the wrong side and the bullets overhang. */
+    ul { margin: 0.4rem 0 0; padding-inline-start: 1.2rem; }
     li { margin: 0.25rem 0; }
     code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.82rem; }
     pre { background: #0b0d11; border: 1px solid #2a2f3a; border-radius: 8px; padding: 0.75rem; overflow-x: auto; }
@@ -192,76 +346,107 @@ function consoleLandingHtml(opts: {
 </head>
 <body>
   <main>
-    <h1>ComfyUI MCP Console</h1>
-    <p class="sub">Control plane for the panel orchestrator — MCP servers, OAuth, and service settings. The ComfyUI sidebar panel stays focused on chat, providers, and the live canvas.</p>
+    <h1>${t("console.landing.title", "ComfyUI MCP Console")}</h1>
+    <p class="sub">${t("console.landing.subtitle", LANDING_SUBTITLE_EN)}</p>
 
     <section>
-      <h2>Connection</h2>
-      <p>Bridge <code>ws://127.0.0.1:${bridgePort}</code> · ComfyUI <code>${escapeHtml(comfyuiUrl)}</code></p>
-      <p id="status">Loading provider readiness…</p>
+      <h2>${t("console.landing.connection.heading", "Connection")}</h2>
+      <p>${t("console.landing.connection.endpoints", "Bridge {bridge} · ComfyUI {comfyui}", {
+        bridge: ltrCode(locale, `ws://127.0.0.1:${bridgePort}`),
+        comfyui: ltrCode(locale, escapeHtml(comfyuiUrl)),
+      })}</p>
+      <p id="status">${t("console.landing.status.loading", "Loading provider readiness…")}</p>
     </section>
 
     <section>
-      <h2>Coming here (panel stays in ComfyUI)</h2>
+      <h2>${t("console.landing.here.heading", "Coming here (panel stays in ComfyUI)")}</h2>
       <ul>
-        <li>Start / stop / restart orchestrator</li>
-        <li>MCP server mappings &amp; inherited <code>~/.claude.json</code> tools</li>
-        <li>OAuth &amp; API provider sign-in</li>
-        <li>LoRA library, image collections, Photomap-style tooling</li>
-        <li>A2UI-rich tool surfaces</li>
+        <li>${t("console.landing.here.lifecycle", "Start / stop / restart orchestrator")}</li>
+        <li>${t("console.landing.here.mcp", "MCP server mappings & inherited {file} tools", {
+          file: ltrCode(locale, "~/.claude.json"),
+        })}</li>
+        <li>${t("console.landing.here.oauth", "OAuth & API provider sign-in")}</li>
+        <li>${t("console.landing.here.library", "LoRA library, image collections, Photomap-style tooling")}</li>
+        <li>${t("console.landing.here.a2ui", "A2UI-rich tool surfaces")}</li>
       </ul>
     </section>
 
     <section>
-      <h2>Stays in the ComfyUI panel</h2>
+      <h2>${t("console.landing.panel.heading", "Stays in the ComfyUI panel")}</h2>
       <ul>
-        <li>Provider / model / effort pickers &amp; context window meter</li>
-        <li>Video storyboards &amp; live graph edits</li>
-        <li>Connect / Disconnect to this bridge</li>
+        <li>${t("console.landing.panel.pickers", "Provider / model / effort pickers & context window meter")}</li>
+        <li>${t("console.landing.panel.storyboards", "Video storyboards & live graph edits")}</li>
+        <li>${t("console.landing.panel.connect", "Connect / Disconnect to this bridge")}</li>
       </ul>
     </section>
 
     <section>
-      <h2>API</h2>
+      <h2>${t("console.landing.api.heading", "API")}</h2>
       <pre>GET /api/status</pre>
     </section>
   </main>
   <script>
+    const T = ${T};
     fetch('/api/status').then(r => r.json()).then(d => {
       const el = document.getElementById('status');
       const rows = (d.backends || []).map(b =>
-        b.backend + ': ' + (b.ready ? 'ready' : (b.cli ? 'sign in' : 'install CLI'))
+        b.backend + ': ' + (b.ready ? T.ready : (b.cli ? T.signIn : T.installCli))
       ).join(' · ');
-      el.innerHTML = '<span class="ok">Orchestrator running</span> — ' + (rows || 'no backends');
+      el.innerHTML = '<span class="ok">' + T.running + '</span> — ' + (rows || T.none);
     }).catch(() => {
-      document.getElementById('status').innerHTML = '<span class="warn">Could not load status</span>';
+      document.getElementById('status').innerHTML = '<span class="warn">' + T.failed + '</span>';
     });
   </script>
 </body>
 </html>`;
 }
 
+/** English source for the API Keys footer — also that page's "is this translated?" probe. */
+const CREDENTIALS_PRIVACY_EN = "Stored locally, per instance. Values never leave this machine.";
+
+/** English source for the token-rejection fragment; it is its own translation probe. */
+const UNAUTHORIZED_EN = "Unauthorized — reconnect the panel.";
+
 function credentialsHtml(
   slots: { id: string; label: string; help?: string }[],
   consoleUrl: string,
   token: string,
+  negotiatedLocale: Locale,
 ): string {
+  // Probe on the footer sentence — the page's one piece of real prose; the rest is single
+  // words a catalog might legitimately leave as-is. See renderedLocale.
+  const locale = renderedLocale(negotiatedLocale, "console.credentials.privacy", CREDENTIALS_PRIVACY_EN);
+  const t = pageT(locale);
   const rows = slots
     .map(
       (s) => `      <div class="row" data-slot="${escapeHtml(s.id)}">
         <div class="meta"><span class="label">${escapeHtml(s.label)}</span>${s.help ? `<span class="help">${escapeHtml(s.help)}</span>` : ""}</div>
         <div class="state"><span class="badge" data-badge>—</span></div>
-        <div class="entry"><input type="password" placeholder="Paste key…" data-input autocomplete="off" spellcheck="false" /><button data-save>Save</button></div>
+        <div class="entry"><input type="password" placeholder="${t("console.credentials.paste_key", "Paste key…")}" data-input autocomplete="off" spellcheck="false" /><button data-save>${t("console.credentials.save", "Save")}</button></div>
       </div>`,
     )
     .join("\n");
-  const cfg = JSON.stringify({ consoleUrl, token });
+  const cfg = scriptJson({ consoleUrl, token });
+  // Unlike the landing page's status line, every string below is assigned to
+  // `textContent`, never innerHTML — so these are NOT HTML-escaped (`&` would show up as
+  // "&amp;" on screen); scriptJson alone keeps them from escaping the <script>.
+  const T = scriptJson({
+    loadFailed: trFor(locale, "console.credentials.load_failed", "Could not load status — reconnect the panel."),
+    // `{masked}` is the masked key itself — a translation that drops it turns the badge
+    // into a bare "set" and loses the confirmation the row exists to give.
+    set: trSlots(locale, "console.credentials.badge_set", "set · {masked}", ["masked"]),
+    notSet: trFor(locale, "console.credentials.badge_unset", "not set"),
+    saving: trFor(locale, "console.credentials.saving", "Saving…"),
+    saved: trFor(locale, "console.credentials.saved", "Saved ✓"),
+    save: trFor(locale, "console.credentials.save", "Save"),
+    saveFailed: trFor(locale, "console.credentials.save_failed", "save failed"),
+  });
   return `<!DOCTYPE html>
-<html lang="en">
+<html ${htmlAttrs(locale)}>
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>API Keys</title>
+  <title>${t("console.credentials.title", "API Keys")}</title>
   <style>
     :root { color-scheme: dark; font-family: system-ui, -apple-system, Segoe UI, sans-serif; }
     body { margin: 0; background: #0f1115; color: #e8eaed; }
@@ -288,18 +473,19 @@ function credentialsHtml(
 </head>
 <body>
   <main>
-    <header><h1>API Keys</h1><button class="close" data-close title="Close">✕</button></header>
+    <header><h1>${t("console.credentials.title", "API Keys")}</h1><button class="close" data-close title="${t("console.credentials.close", "Close")}">✕</button></header>
     <div id="rows">
 ${rows}
     </div>
     <p class="err" id="err"></p>
     <footer>
-      <span class="help">Stored locally, per instance. Values never leave this machine.</span>
-      <button class="advanced" data-advanced>Advanced ↗</button>
+      <span class="help">${t("console.credentials.privacy", CREDENTIALS_PRIVACY_EN)}</span>
+      <button class="advanced" data-advanced>${t("console.credentials.advanced", "Advanced ↗")}</button>
     </footer>
   </main>
   <script>
     const CFG = ${cfg};
+    const T = ${T};
     const q = (t) => "?token=" + encodeURIComponent(t);
     function postHeight() {
       try { parent.postMessage({ type: "resize", height: document.body.scrollHeight }, "*"); } catch {}
@@ -312,10 +498,10 @@ ${rows}
           const row = document.querySelector('.row[data-slot="' + s.id + '"]');
           if (!row) continue;
           const badge = row.querySelector("[data-badge]");
-          badge.textContent = s.set ? "set · " + s.masked : "not set";
+          badge.textContent = s.set ? T.set.replace("{masked}", () => s.masked) : T.notSet;
           badge.classList.toggle("set", !!s.set);
         }
-      } catch (e) { document.getElementById("err").textContent = "Could not load status — reconnect the panel."; }
+      } catch (e) { document.getElementById("err").textContent = T.loadFailed; }
       postHeight();
     }
     document.querySelectorAll(".row").forEach((row) => {
@@ -324,22 +510,22 @@ ${rows}
       btn.addEventListener("click", async () => {
         const value = input.value.trim();
         if (!value) return;
-        btn.disabled = true; btn.textContent = "Saving…";
+        btn.disabled = true; btn.textContent = T.saving;
         try {
           const r = await fetch("/api/secrets" + q(CFG.token), {
             method: "POST", headers: { "content-type": "application/json" },
             body: JSON.stringify({ slot: row.dataset.slot, value }),
           });
           const d = await r.json();
-          if (!r.ok || !d.ok) throw new Error(d.error || "save failed");
+          if (!r.ok || !d.ok) throw new Error(d.error || T.saveFailed);
           input.value = "";
           const badge = row.querySelector("[data-badge]");
-          badge.textContent = "set · " + d.masked; badge.classList.add("set");
-          btn.textContent = "Saved ✓"; btn.classList.add("ok");
-          setTimeout(() => { btn.textContent = "Save"; btn.classList.remove("ok"); btn.disabled = false; }, 1500);
+          badge.textContent = T.set.replace("{masked}", () => d.masked); badge.classList.add("set");
+          btn.textContent = T.saved; btn.classList.add("ok");
+          setTimeout(() => { btn.textContent = T.save; btn.classList.remove("ok"); btn.disabled = false; }, 1500);
         } catch (e) {
           document.getElementById("err").textContent = String(e.message || e);
-          btn.textContent = "Save"; btn.disabled = false;
+          btn.textContent = T.save; btn.disabled = false;
         }
       });
     });
@@ -675,10 +861,28 @@ export function startPanelConsoleHttpServer(opts: {
       return;
     }
     if (req.method === "GET" && path === "/credentials") {
-      if (!tokenOk(req, opts.token)) { sendHtml(res, 401, "<p>Unauthorized — reconnect the panel.</p>"); return; }
+      // The rejection is a page the same person reads, so it follows the same language as
+      // the page they were trying to open — not English-only because the token was wrong.
+      const locale = pageLocale(req);
+      if (!tokenOk(req, opts.token)) {
+        // A bare fragment has no <html> to carry the language, so the <p> carries it —
+        // otherwise an Arabic or Persian rejection lays out left-to-right. The fragment
+        // is a single sentence, so it is its own translated-or-not probe.
+        const shown = renderedLocale(locale, "console.unauthorized", UNAUTHORIZED_EN);
+        sendHtml(
+          res,
+          401,
+          `<p ${htmlAttrs(shown)}>${trHtml(shown, "console.unauthorized", UNAUTHORIZED_EN)}</p>`,
+        );
+        return;
+      }
       const bound = server.address();
       const boundPort = bound && typeof bound === "object" ? bound.port : opts.port;
-      sendFramedHtml(res, 200, credentialsHtml(CREDENTIAL_SLOTS, `http://${host}:${boundPort}`, opts.token ?? ""));
+      sendFramedHtml(
+        res,
+        200,
+        credentialsHtml(CREDENTIAL_SLOTS, `http://${host}:${boundPort}`, opts.token ?? "", locale),
+      );
       return;
     }
     if (req.method === "GET" && (path === "/" || path === "/console")) {
@@ -689,6 +893,7 @@ export function startPanelConsoleHttpServer(opts: {
           bridgePort: opts.bridgePort,
           consolePort: opts.port,
           comfyuiUrl: opts.comfyuiUrl,
+          locale: pageLocale(req),
         }),
       );
       return;

--- a/src/orchestrator/ready-banner.ts
+++ b/src/orchestrator/ready-banner.ts
@@ -10,6 +10,7 @@
 // real model is known.
 
 import { openAiKeyProvider } from "../services/openai-provider-registry.js";
+import { processLocale, trFor } from "../i18n/index.js";
 
 /**
  * The "🟢 comfyui-mcp agent ready — <label> …" greeting for a given backend, with
@@ -17,41 +18,66 @@ import { openAiKeyProvider } from "../services/openai-provider-registry.js";
  * the custom-endpoint backend. Mirrors the connect-handler's provider phrasing
  * exactly so an initial banner and a later correction are identical but for the
  * model name.
+ *
+ * LOCALE. This text is pushed as a `say` frame, so it lands in a chat bubble inside a
+ * specific panel tab and belongs in THAT reader's language — hence `trFor`, not `tr`.
+ * The panel's hello frame carries no language field yet, so `locale` is an explicit
+ * parameter the caller supplies: when it is omitted we fall back to the process locale
+ * (`--lang` / `COMFYUI_MCP_LANG` / `LANG`), which on a loopback install is the same
+ * person's own setting and is a far better guess than hard-coding English. Once the
+ * panel reports its language, threading it here is a one-argument change and every
+ * greeting below follows automatically.
+ *
+ * The 🟢/⚠️ markers are NOT translated. They are the status signal a reader scans for
+ * before reading a word, they mean the same thing in every language, and a catalog
+ * that drops or swaps one changes what the line asserts — so each fallback carries
+ * its marker and every translation is expected to reproduce it verbatim.
  */
-export function readyBannerText(backend: string, label: string, customBaseUrl = ""): string {
+export function readyBannerText(
+  backend: string,
+  label: string,
+  customBaseUrl = "",
+  locale?: string,
+): string {
+  // `||`, not `??`: an unset panel language serializes as "" far more often than as
+  // undefined, and an empty string is not a locale — it would resolve to English and
+  // quietly skip the `--lang` the user actually set.
+  const loc = locale || processLocale();
+  const t = (key: string, fallback: string) => trFor(loc, key, fallback, { label, url: customBaseUrl });
   const reg = openAiKeyProvider(backend);
-  if (reg) return reg.readyMessage(label);
+  if (reg) return reg.readyMessage(label, loc);
   switch (backend) {
     case "codex":
-      return `🟢 comfyui-mcp agent ready — ${label} on your Codex (ChatGPT) account. Ask away.`;
+      return t("banner.ready.codex", "🟢 comfyui-mcp agent ready — {label} on your Codex (ChatGPT) account. Ask away.");
     case "chatgpt":
-      return `🟢 comfyui-mcp agent ready — ${label} on your ChatGPT subscription (direct OAuth). Ask away.`;
+      return t("banner.ready.chatgpt", "🟢 comfyui-mcp agent ready — {label} on your ChatGPT subscription (direct OAuth). Ask away.");
     case "gemini":
-      return `🟢 comfyui-mcp agent ready — ${label} on your Google account (Gemini Code Assist). Ask away.`;
+      return t("banner.ready.gemini", "🟢 comfyui-mcp agent ready — {label} on your Google account (Gemini Code Assist). Ask away.");
     case "antigravity":
-      return `🟢 comfyui-mcp agent ready — ${label} on your Google AI subscription via Antigravity CLI. Note: agy turns show final answers only (no live tool progress). Ask away.`;
+      return t("banner.ready.antigravity", "🟢 comfyui-mcp agent ready — {label} on your Google AI subscription via Antigravity CLI. Note: agy turns show final answers only (no live tool progress). Ask away.");
     case "pi":
       // Deliberately hedged: readiness for pi is a DISK check (a well-formed,
       // present credential), never a proven-working one — a revoked key or a
       // spent quota only shows up on the first real turn, so don't promise more
-      // than "we found a credential" (#491).
-      return `🟢 comfyui-mcp agent ready — ${label} via the pi CLI on your own provider credential (found on this machine; pi checks it on your first message). Note: pi has no ComfyUI tools (no MCP) — it works with its own coding tools on the local workspace, not the panel canvas. Ask away.`;
+      // than "we found a credential" (#491). The hedge is the POINT of this
+      // string, so it has to survive translation — keep it in every catalog.
+      return t("banner.ready.pi", "🟢 comfyui-mcp agent ready — {label} via the pi CLI on your own provider credential (found on this machine; pi checks it on your first message). Note: pi has no ComfyUI tools (no MCP) — it works with its own coding tools on the local workspace, not the panel canvas. Ask away.");
     case "grok":
-      return `🟢 comfyui-mcp agent ready — ${label} on your Grok (xAI) account. Ask away.`;
+      return t("banner.ready.grok", "🟢 comfyui-mcp agent ready — {label} on your Grok (xAI) account. Ask away.");
     case "ollama":
-      return `🟢 comfyui-mcp agent ready — ${label} running locally via Ollama (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`;
+      return t("banner.ready.ollama", "🟢 comfyui-mcp agent ready — {label} running locally via Ollama (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.");
     case "lmstudio":
-      return `🟢 comfyui-mcp agent ready — ${label} running locally via LM Studio (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`;
+      return t("banner.ready.lmstudio", "🟢 comfyui-mcp agent ready — {label} running locally via LM Studio (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.");
     case "llamacpp":
-      return `🟢 comfyui-mcp agent ready — ${label} running locally via llama.cpp (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`;
+      return t("banner.ready.llamacpp", "🟢 comfyui-mcp agent ready — {label} running locally via llama.cpp (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.");
     case "custom":
-      return `🟢 comfyui-mcp agent ready — ${label} via your custom endpoint (${customBaseUrl}). Ask away.`;
+      return t("banner.ready.custom", "🟢 comfyui-mcp agent ready — {label} via your custom endpoint ({url}). Ask away.");
     case "openrouter":
-      return `🟢 comfyui-mcp agent ready — ${label} via OpenRouter (hosted API, your OPENROUTER_API_KEY). Ask away.`;
+      return t("banner.ready.openrouter", "🟢 comfyui-mcp agent ready — {label} via OpenRouter (hosted API, your OPENROUTER_API_KEY). Ask away.");
     case "copilot":
-      return `🟢 comfyui-mcp agent ready — ${label} on your GitHub Copilot subscription (⚠️ experimental, ToS risk — you opted in). Ask away.`;
+      return t("banner.ready.copilot", "🟢 comfyui-mcp agent ready — {label} on your GitHub Copilot subscription (⚠️ experimental, ToS risk — you opted in). Ask away.");
     default:
-      return `🟢 comfyui-mcp agent ready — ${label} on your Claude subscription. Ask away.`;
+      return t("banner.ready.claude", "🟢 comfyui-mcp agent ready — {label} on your Claude subscription. Ask away.");
   }
 }
 
@@ -70,10 +96,12 @@ export function bannerCorrection(opts: {
   advertisedLabel: string | undefined;
   resolvedModel: string | undefined;
   customBaseUrl?: string;
+  /** Language of the tab this correction is destined for — see readyBannerText. */
+  locale?: string;
 }): string | null {
-  const { backend, advertisedLabel, resolvedModel, customBaseUrl = "" } = opts;
+  const { backend, advertisedLabel, resolvedModel, customBaseUrl = "", locale } = opts;
   if (typeof advertisedLabel !== "string" || !advertisedLabel) return null;
   if (typeof resolvedModel !== "string" || !resolvedModel.trim()) return null;
   if (resolvedModel === advertisedLabel) return null;
-  return readyBannerText(backend, resolvedModel, customBaseUrl);
+  return readyBannerText(backend, resolvedModel, customBaseUrl, locale);
 }

--- a/src/services/openai-provider-registry.ts
+++ b/src/services/openai-provider-registry.ts
@@ -24,7 +24,10 @@
 // creating a cycle. Credential resolution lives in `services/code-provider-auth`
 // (which reads these env keys itself); backend construction lives in
 // `orchestrator/index.ts` (which owns OllamaBackend). This module carries only
-// the copy/identity that used to be duplicated.
+// the copy/identity that used to be duplicated. (`i18n` is itself a leaf — node
+// builtins only — so translating the ready lines below keeps that property.)
+
+import { processLocale, trFor } from "../i18n/index.js";
 
 /** The simple OpenAI-compatible API-key providers, by id. */
 export type OpenAiKeyProviderId = "glm" | "kimi" | "moonshot" | "minimax";
@@ -32,9 +35,20 @@ export type OpenAiKeyProviderId = "glm" | "kimi" | "moonshot" | "minimax";
 export interface OpenAiKeyProvider {
   /** Panel backend id (a member of orchestrator BackendId). */
   id: OpenAiKeyProviderId;
-  /** Credential-slot label shown in the panel's API Keys card. */
+  /**
+   * Credential-slot label shown in the panel's API Keys card. Deliberately NOT
+   * translated: every one of these is a product name ("GLM / Zhipu", "MiniMax"),
+   * and a user hunting for the slot that matches the key they just copied off a
+   * vendor's dashboard needs the vendor's own spelling.
+   */
   slotLabel: string;
-  /** Credential-slot help text shown in the panel's API Keys card. */
+  /**
+   * Credential-slot help text shown in the panel's API Keys card. Still English:
+   * it is baked into the module-level `CREDENTIAL_SLOTS` const in panel-secrets,
+   * evaluated once at import, so it has no reader to follow — translating the slot
+   * help means making that list a per-request accessor, which is a separate change
+   * from these banners.
+   */
   slotHelp: string;
   /**
    * The env var(s) that carry this provider's API key. `envKeys[0]` is the
@@ -53,8 +67,15 @@ export interface OpenAiKeyProvider {
   defaultModel: string;
   /** Label the connect-ack falls back to when the model probe returns no ids. */
   ackFallbackLabel: string;
-  /** Connect-ack "ready" line, given the resolved agent label. */
-  readyMessage: (agentLabel: string) => string;
+  /**
+   * Connect-ack "ready" line, given the resolved agent label.
+   *
+   * `locale` is the language of the panel tab the line is destined for — this is a
+   * `say` frame a PERSON reads, so it follows that reader, not this process. Omitting
+   * it (or passing "", which is how an unset panel language arrives) falls back to the
+   * process locale; `readyBannerText` always passes one through.
+   */
+  readyMessage: (agentLabel: string, locale?: string) => string;
   /** Connect-ack "degraded" line (model probe empty / construction failed). */
   degradedMessage: string;
   /**
@@ -80,8 +101,13 @@ export const OPENAI_KEY_PROVIDERS: OpenAiKeyProvider[] = [
     modelEnv: "COMFYUI_MCP_GLM_MODEL",
     defaultModel: process.env.COMFYUI_MCP_GLM_MODEL?.trim() || "glm-5.2",
     ackFallbackLabel: "GLM",
-    readyMessage: (agentLabel) =>
-      `🟢 comfyui-mcp agent ready — ${agentLabel} on your Z.AI GLM Coding Plan. Ask away.`,
+    readyMessage: (agentLabel, locale) =>
+      trFor(
+        locale || processLocale(),
+        "banner.ready.glm",
+        "🟢 comfyui-mcp agent ready — {label} on your Z.AI GLM Coding Plan. Ask away.",
+        { label: agentLabel },
+      ),
     degradedMessage:
       "⚠️ The background agent isn't responding — GLM Code API couldn't start. Set ZAI_API_KEY (Z.AI Coding Plan), then Disconnect → Connect to retry.",
     simpleKeyAuth: true,
@@ -94,8 +120,13 @@ export const OPENAI_KEY_PROVIDERS: OpenAiKeyProvider[] = [
     modelEnv: "COMFYUI_MCP_KIMI_MODEL",
     defaultModel: process.env.COMFYUI_MCP_KIMI_MODEL?.trim() || "kimi-for-coding",
     ackFallbackLabel: "Kimi",
-    readyMessage: (agentLabel) =>
-      `🟢 comfyui-mcp agent ready — ${agentLabel} on your Kimi Code subscription. Ask away.`,
+    readyMessage: (agentLabel, locale) =>
+      trFor(
+        locale || processLocale(),
+        "banner.ready.kimi",
+        "🟢 comfyui-mcp agent ready — {label} on your Kimi Code subscription. Ask away.",
+        { label: agentLabel },
+      ),
     degradedMessage:
       "⚠️ The background agent isn't responding — Kimi Code couldn't start. Run Kimi Code login (~/.kimi/credentials/kimi-code.json) or set KIMI_API_KEY, then Disconnect → Connect to retry.",
     // OAuth dual-auth — KimiBackend + resolveKimiCodeOAuth + bespoke readiness stay.
@@ -109,8 +140,13 @@ export const OPENAI_KEY_PROVIDERS: OpenAiKeyProvider[] = [
     modelEnv: "COMFYUI_MCP_MOONSHOT_MODEL",
     defaultModel: process.env.COMFYUI_MCP_MOONSHOT_MODEL?.trim() || "kimi-k3",
     ackFallbackLabel: "Kimi K3",
-    readyMessage: (agentLabel) =>
-      `🟢 comfyui-mcp agent ready — ${agentLabel} on your Moonshot platform (Kimi K3) API key. Ask away.`,
+    readyMessage: (agentLabel, locale) =>
+      trFor(
+        locale || processLocale(),
+        "banner.ready.moonshot",
+        "🟢 comfyui-mcp agent ready — {label} on your Moonshot platform (Kimi K3) API key. Ask away.",
+        { label: agentLabel },
+      ),
     degradedMessage:
       "⚠️ The background agent isn't responding — Moonshot (Kimi K3) couldn't start. Set MOONSHOT_API_KEY from platform.kimi.ai, then Disconnect → Connect to retry.",
     simpleKeyAuth: true,
@@ -123,8 +159,13 @@ export const OPENAI_KEY_PROVIDERS: OpenAiKeyProvider[] = [
     modelEnv: "COMFYUI_MCP_MINIMAX_MODEL",
     defaultModel: process.env.COMFYUI_MCP_MINIMAX_MODEL?.trim() || "MiniMax-M3",
     ackFallbackLabel: "MiniMax",
-    readyMessage: (agentLabel) =>
-      `🟢 comfyui-mcp agent ready — ${agentLabel} on your MiniMax platform API key. Ask away.`,
+    readyMessage: (agentLabel, locale) =>
+      trFor(
+        locale || processLocale(),
+        "banner.ready.minimax",
+        "🟢 comfyui-mcp agent ready — {label} on your MiniMax platform API key. Ask away.",
+        { label: agentLabel },
+      ),
     degradedMessage:
       "⚠️ The background agent isn't responding — MiniMax couldn't start. Set MINIMAX_API_KEY from platform.minimax.io, then Disconnect → Connect to retry.",
     simpleKeyAuth: true,


### PR DESCRIPTION
Unit 15 of the orchestrator i18n pass — "Banners & console HTML". Based on
`feat/mcp-i18n-foundation`, not `main`.

## What is translated

| File | Strings |
|---|---|
| `src/orchestrator/ready-banner.ts` | 13 per-backend greetings + `bannerCorrection`, keys `banner.ready.*` |
| `src/services/openai-provider-registry.ts` | the 4 `readyMessage()` lines (glm/kimi/moonshot/minimax), same key space |
| `src/orchestrator/panel-console-http.ts` | both HTML documents + the 401 fragment, keys `console.*` |

Every call site keeps its current English text as the `fallback`, so with no
catalogs installed the output is unchanged. Nothing under `locales/` is touched.

**Not translated, deliberately** — `slotLabel` (vendor product names: a user is
matching the slot against the dashboard they copied the key from), `slotHelp`
(baked into the module-level `CREDENTIAL_SLOTS` const in panel-secrets, evaluated
once at import, so it has no reader to follow — making that list a per-request
accessor is its own change), the 🟢/⚠️ markers, and everything agent-facing.

## Why the banners take a `locale` parameter

`readyBannerText` is invoked at two places in `orchestrator/index.ts` (the connect
handler at ~3851 and the `onSession` correction at ~2329), and both push the result
as a **`say` frame to a specific tab** — so per the i18n module's "two audiences,
two locales" rule this is `trFor`, not `tr`. **No tab locale exists yet**: the
panel's hello frame carries no language field and the bridge does not record one,
so no call site supplies a locale today and every banner resolves through the
process locale (`--lang` / `COMFYUI_MCP_LANG` / `LANG`) — the same person's own
setting on a loopback install, and a better guess than hard-coding English.
Threading a real per-tab locale (the WS upgrade request's `Accept-Language` is
right there in `services/ui-bridge.ts`) is then a one-argument change; that file is
cross-cutting enough that it did not belong in this unit.

`locale || processLocale()`, not `??`: an unset panel language serializes as `""`
far more often than as `undefined`, and `""` would silently resolve to English.

## How the pages choose a language

`Accept-Language`, ranked **by q-value** rather than header order (descending order
is a browser convention, not a requirement) — a `q=0` entry is an explicit
rejection and is never selected, the parameter name is matched case-insensitively
per RFC 9110, and an unparseable weight means *accept* (1), never *reject* (0).
Falls back to the process locale.

`lang`/`dir` describe **the bytes on the page, not the request**. Until a catalog
for the negotiated locale is installed those bytes are English, so the page
declares `lang="en"` — stamping `lang="fa" dir="rtl"` onto English prose is worse
than saying nothing: it mirrors the entire layout and tells a screen reader to
pronounce English as Persian. One probe key per page decides; the day a catalog
lands it starts reporting the real locale with no second change. RTL set is
`ar`/`fa`, mirroring the panel.

RTL also gets: `padding-inline-start` instead of `padding-left` on the landing
page's lists (identical in LTR), and `dir="ltr"` on the `<code>` elements holding
URLs and paths, which the bidi algorithm otherwise reorders so the reader cannot
tell which URL is the bridge and which is ComfyUI. Both are inert for LTR readers.

## Escaping (the HTML question)

A catalog is **data, not a template**, and is treated as untrusted throughout:

- **Page prose** — `trHtml()` HTML-escapes the resolved string before it reaches
  the document, so a stray `<` can never open a tag. Inline markup stays in the
  source: the translatable text carries `{slot}` placeholders and the literal
  elements are substituted **after** escaping, which keeps every tag byte-identical
  and still lets a translator move them where word order demands.
- **Dropped placeholders** — a translation missing a declared `{slot}` is rejected
  in favour of the English source. A lost placeholder then costs the sentence,
  never the fact inside it (the ComfyUI URL, `~/.claude.json`, the masked key).
- **Inline scripts** — serialized with `JSON.stringify` plus `<` escaped, so no
  translation can close the `<script>` element. The landing page's status strings
  are additionally HTML-escaped because that script writes them with `innerHTML`;
  the credentials page's are not, because that one writes `textContent` (escaping
  there would put a literal `&amp;` on screen).
- Nothing else changed: `escapeHtml` still guards the interpolated ComfyUI URL and
  slot labels, and the pre-existing `CFG` object now goes through the same
  serializer.

Markup, attributes, ids, classes and styles are otherwise unchanged — verified by
rendering both pages before and after and diffing (see below).

## Verification

- `npm run lint` (`tsc --noEmit`) clean; `npm test` — **442 files / 8526 tests
  green** (2 pre-existing skips).
- **English output diffed byte-for-byte** against the pre-change build by serving
  both pages from each version: the only differences are the intended ones (script
  prose moved into a `T` constant, `padding-inline-start`, `lang="en"` added to the
  401 fragment).
- **Mutation-tested** — each of these turns a test red: dropping the `<`-escape
  from the script serializer; replacing the pages' `trFor` with the bare fallback
  (i.e. deleting i18n from both documents); trusting the negotiated locale
  unconditionally; removing the dropped-slot guard; dropping the `locale`
  pass-through on either the registry path or `bannerCorrection`.
- New tests: `ready-banner-i18n.test.ts` and `panel-console-i18n.test.ts` mock the
  i18n module so a catalog actually answers — without that, no catalogs ship and a
  suite that only fetches pages cannot tell a working translation path from a
  deleted one. The catalog-free sibling suite asserts the opposite invariant: the
  document must never claim a language it did not render.
- No browser/Playwright run, per the unit brief.

## Notes for the coordinator

- `npm run i18n:check` (added by the foundation commit) points at
  `scripts/i18n-check.mjs`, which does not exist in the repo — that gate is the
  natural home for "every catalog reproduces the 🟢/⚠️ markers and every `{slot}`".
- `degradedMessage` on the same registry interface, and the connect-ack failure
  branch in `orchestrator/index.ts`, are still English — a session can therefore
  mix languages. They belong to the start-failure/connect-ack unit; flagging so
  they do not fall between units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
