### PR TITLE
feat(i18n): say bubbles render in the PANEL's language, not the server's

### DIFF
--- a/src/__tests__/services/ui-bridge-locale.test.ts
+++ b/src/__tests__/services/ui-bridge-locale.test.ts
@@ -14,7 +14,8 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createServer } from "node:net";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import WebSocket from "ws";
 import { UiBridge } from "../../services/ui-bridge.js";
@@ -22,7 +23,9 @@ import { trFor, __resetI18nForTest } from "../../i18n/index.js";
 import {
   buildStartFailureNotice,
   startFailureHint,
+  startFailureSay,
 } from "../../orchestrator/start-failure-notice.js";
+import { openAiKeyProvider } from "../../services/openai-provider-registry.js";
 
 let bridge: UiBridge;
 let port: number;
@@ -122,12 +125,30 @@ describe("tabLocale — where a say frame's language comes from", () => {
     sock.close();
   });
 
-  it("answers English for an unknown, ambiguous or disconnected tab instead of throwing", () => {
-    // resolveTarget THROWS for all three. Every caller here is mid-failure-report, so the
-    // lookup absorbs it: a frame in the wrong language is a blemish, an exception is a bug.
+  it("answers English for an unknown tab instead of throwing, even with others connected", async () => {
+    // With NOTHING connected this passes for an uninteresting reason, so a real tab is
+    // connected first: the question is whether an unknown id borrows a stranger's language.
+    // resolveTarget throws for it, and every caller here is mid-failure-report — so the
+    // lookup absorbs it. A frame in the wrong language is a blemish; an exception is a bug.
     expect(() => bridge.tabLocale("never-existed")).not.toThrow();
     expect(bridge.tabLocale("never-existed")).toBe("en");
-    expect(bridge.tabLocale("")).toBe("en");
+    const sock = await open();
+    await hello(sock, "tab-only", { locale: "ko" });
+    expect(() => bridge.tabLocale("never-existed")).not.toThrow();
+    expect(bridge.tabLocale("never-existed")).toBe("en");
+    sock.close();
+  });
+
+  it("answers ambiguous prefixes in English rather than picking one of the matches", async () => {
+    const a = await open();
+    const b = await open();
+    await hello(a, "tab-amb-1", { locale: "ko" });
+    await hello(b, "tab-amb-2", { locale: "fr" });
+    // "tab-amb" prefixes both, which resolveTarget refuses — a push would refuse too.
+    expect(() => bridge.tabLocale("tab-amb")).not.toThrow();
+    expect(bridge.tabLocale("tab-amb")).toBe("en");
+    a.close();
+    b.close();
   });
 
   it("keeps the language across a same-socket re-hello that omits it", async () => {
@@ -216,9 +237,11 @@ describe("say frames degrade to English rather than failing", () => {
   });
 
   it("renders intact text for a locale with no catalog, and never a key or an empty bubble", () => {
+    // Exercises `startFailureSay` — the function the orchestrator ACTUALLY calls per tab —
+    // rather than buildStartFailureNotice, which has no locale of its own precisely so that a
+    // test cannot pin a path production never takes.
     for (const locale of ["ko", "ar", "zh-TW", "kl-GL", "", "not-a-locale"]) {
-      const { frames } = buildStartFailureNotice("tab-1::openrouter", "401", "claude", locale);
-      const text = (frames[0] as { text: string }).text;
+      const text = startFailureSay("openrouter", "401", locale);
       expect(text).toContain("OPENROUTER_API_KEY");
       expect(text).not.toContain("say.");
       expect(text).not.toContain("{");
@@ -228,14 +251,23 @@ describe("say frames degrade to English rather than failing", () => {
   it("keeps the ⚠️ status marker outside the translatable span", () => {
     // The emoji is what the eye and the panel's bubble styling key on; it means the same
     // thing in every language and must survive a catalog that translates the prose.
-    const { frames } = buildStartFailureNotice("t::claude", "boom", "claude", "ja");
-    expect((frames[0] as { text: string }).text.startsWith("⚠️ ")).toBe(true);
+    expect(startFailureSay("claude", "boom", "ja").startsWith("⚠️ ")).toBe(true);
+  });
+
+  it("delivers the SAME sentence the frame builder holds, so the two cannot drift", () => {
+    // The orchestrator re-renders per recipient instead of pushing frames[0]. If those two
+    // ever stopped sharing one function, the tested text and the delivered text would differ
+    // with everything still green.
+    const { frames } = buildStartFailureNotice("t::custom", "ECONNREFUSED", "claude");
+    expect((frames[0] as { text: string }).text).toBe(
+      startFailureSay("custom", "ECONNREFUSED"),
+    );
   });
 
   it("leaves the ack and turn frames alone — they are machine state, not prose", () => {
     // `kind` is string-matched by the panel and these read as machine errors; translating
     // them would break the parse while looking like a courtesy.
-    const { frames } = buildStartFailureNotice("t::claude", "boom", "claude", "ko");
+    const { frames } = buildStartFailureNotice("t::claude", "boom", "claude");
     expect(frames[1]).toEqual({ type: "ack", ok: false, kind: "degraded" });
     expect(frames[2]).toEqual({ type: "turn", state: "done" });
   });
@@ -243,6 +275,18 @@ describe("say frames degrade to English rather than failing", () => {
   it("passes the provider label and env var through untranslated — they are typed, not read", () => {
     const hint = startFailureHint("moonshot", "ru");
     expect(hint).toContain("MOONSHOT_API_KEY");
+  });
+
+  it("keeps every registry degraded message shaped like the ones beside it", () => {
+    // The glm/kimi/moonshot/minimax bubbles live in a data table and carry their own leading
+    // ⚠️; the call site strips it so all 15 say.degraded.* fallbacks have one shape and a
+    // catalog never has to guess which include the marker. If the table stopped leading with
+    // ⚠️, that strip would silently become a no-op and the key would gain a second one.
+    for (const backend of ["glm", "kimi", "moonshot", "minimax"]) {
+      const reg = openAiKeyProvider(backend);
+      expect(reg, `${backend} is no longer a registered key provider`).toBeTruthy();
+      expect(reg!.degradedMessage.startsWith("⚠️ "), `${backend} degradedMessage`).toBe(true);
+    }
   });
 
   it("renders a counted string from a plain-string fallback, so English keeps its '(s)' hedge", () => {
@@ -265,21 +309,100 @@ describe("say frames degrade to English rather than failing", () => {
 });
 
 /**
- * The mechanism above is only worth having if the CALL SITES use it, and nothing else in the
- * suite would notice if one stopped: a deleted `trFor(` wrapper leaves correct English, a
- * passing type-check and a green run — the string is simply never translatable again. The
- * same hole swallows a NEW `say` site added later by someone who has not read this file.
+ * THE ROT GUARD. The mechanism above is only worth having if the CALL SITES use it, and
+ * nothing else in the suite would notice if one stopped: a deleted `trFor(` wrapper leaves
+ * correct English, a passing type-check and a green run — the string is simply never
+ * translatable again. The same hole swallows a NEW `say` site added later by someone who has
+ * not read this file.
  *
- * So this asserts on the SOURCE, with an ENUMERATED exemption list rather than a keyword
- * heuristic: a keyword ("text:", "message") would quietly excuse a genuinely untranslated
- * site, which is exactly the failure it exists to catch. Each exemption must still MATCH
- * something — a stale one that no longer corresponds to real code is itself a failure, or the
- * list would silently grant amnesty to whatever moved into its place.
+ * Two things make this guard honest rather than decorative, and both were added only after a
+ * mutation proved the earlier version wrong:
+ *
+ *   - It reads THE FRAME'S OWN `text:` VALUE, not a character window around the marker. Any
+ *     window wide enough to hold a multi-line frame also holds the NEXT frame's translator
+ *     call, and an untranslated `say` inserted just before a translated one sailed through.
+ *     The value is bounded by indentation: prettier puts every continuation line deeper than
+ *     the `text:` line, and the next thing at that indent or shallower ends the expression.
+ *   - Each exemption is bound to ONE SITE, by position, not to a neighbourhood. The collar
+ *     that let both `pushSayToConversation` fragments count as "used" was equally happy to
+ *     excuse an untranslated frame dropped between them.
+ *
+ * Exemptions are ENUMERATED rather than pattern-matched: a keyword rule ("text:", "message")
+ * would quietly excuse a genuinely untranslated site, which is the exact failure this exists
+ * to catch. Every entry must still MATCH live code, so a stale one is a failure rather than a
+ * standing amnesty for whatever moved into its place.
  */
-const srcOf = (rel: string): string =>
-  readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), "utf8");
+const SRC_ROOT = fileURLToPath(new URL("../../", import.meta.url));
+const srcOf = (rel: string): string => readFileSync(join(SRC_ROOT, rel), "utf8");
 
-/** `say` sites whose text is composed elsewhere, each with the reason it is not wrapped here. */
+/** Every non-test source file, so a new module that emits `say` frames cannot slip past an
+ *  allowlist — start-failure-notice.ts already emits one and an earlier allowlist missed it. */
+function sourceFiles(dir = SRC_ROOT, out: string[] = []): string[] {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name !== "__tests__" && e.name !== "node_modules") sourceFiles(full, out);
+    } else if (e.name.endsWith(".ts") && !e.name.endsWith(".test.ts")) {
+      out.push(relative(SRC_ROOT, full).split("\\").join("/"));
+    }
+  }
+  return out;
+}
+
+const SAY_MARKER = `type: "say"`;
+
+/** Byte offsets of every `say` frame in `src`. */
+function saySites(src: string): number[] {
+  const out: number[] = [];
+  for (
+    let at = src.indexOf(SAY_MARKER);
+    at !== -1;
+    at = src.indexOf(SAY_MARKER, at + SAY_MARKER.length)
+  ) {
+    out.push(at);
+  }
+  return out;
+}
+
+/**
+ * The `text:` value expression of the frame at `at` — nothing before it, and nothing from the
+ * frame after it.
+ *
+ * Bounded by INDENTATION rather than brace matching: braces appear inside these strings
+ * (`{count}`, `${trFor(`), so a depth counter would need a full string/template scanner to be
+ * trustworthy, whereas prettier's layout is already unambiguous. A one-line frame yields the
+ * rest of its line, which is exactly the right answer for `text: degradedText }, panelTab);`.
+ */
+function sayTextExpression(src: string, at: number): string {
+  const lines = src.split("\n");
+  const lineOf = (off: number) => src.slice(0, off).split("\n").length - 1;
+  const indentOf = (l: string) => l.length - l.trimStart().length;
+  const markerLine = lineOf(at);
+  // `text` may be on the marker's own line or a few lines below it (a comment can sit
+  // between). Stop at the first line that dedents out of the frame literal.
+  const frameIndent = indentOf(lines[markerLine]);
+  let textLine = -1;
+  let col = -1;
+  for (let i = markerLine; i < lines.length && i < markerLine + 12; i++) {
+    if (i > markerLine && lines[i].trim() && indentOf(lines[i]) < frameIndent) break;
+    const m = /\btext\b\s*[:,}]/.exec(lines[i]);
+    if (m && (i > markerLine || m.index > at - src.slice(0, at).lastIndexOf("\n") - 1)) {
+      textLine = i;
+      col = m.index;
+      break;
+    }
+  }
+  if (textLine === -1) return "";
+  const baseIndent = indentOf(lines[textLine]);
+  const parts = [lines[textLine].slice(col)];
+  for (let i = textLine + 1; i < lines.length; i++) {
+    if (lines[i].trim() && indentOf(lines[i]) <= baseIndent) break;
+    parts.push(lines[i]);
+  }
+  return parts.join("\n");
+}
+
+/** A `say` site whose text is composed elsewhere, with the reason it carries no `trFor`. */
 const SAY_EXEMPTIONS: Array<{ file: string; fragment: string; why: string }> = [
   {
     file: "orchestrator/index.ts",
@@ -294,79 +417,91 @@ const SAY_EXEMPTIONS: Array<{ file: string; fragment: string; why: string }> = [
   {
     file: "orchestrator/index.ts",
     fragment: `{ type: "say", text, id: meta?.id`,
-    why: "the AGENT's own reply text — a model wrote it, in whatever language it was asked in",
+    why: "the AGENT's own reply — a model wrote it, in whatever language it was asked in",
   },
   {
     file: "orchestrator/index.ts",
     fragment: `{ type: "say", text: corrected }`,
-    why: "bannerCorrection() in ready-banner.ts owns that string",
+    why: "TRANSLATED ELSEWHERE (pending): bannerCorrection() in ready-banner.ts owns it; that file has no i18n yet",
   },
   {
     file: "orchestrator/index.ts",
     fragment: `{ type: "say", text: parts.join(" ") }`,
-    why: "the parts are each trFor'd where they are built, a few lines above",
+    why: "each part is trFor'd a few lines above, where it is built",
   },
   {
     file: "orchestrator/index.ts",
     fragment: "${sync.message}",
-    why: "panel-sync owns that message; only the ⚠️ marker is added here",
+    why: "TRANSLATED ELSEWHERE (pending): panel-sync owns the message; only the ⚠️ marker is added here",
   },
   {
     file: "orchestrator/index.ts",
     fragment: "readyBannerText(backend, bannerLabel, customBaseUrl)",
-    why: "ready-banner.ts owns the greeting",
+    why: "TRANSLATED ELSEWHERE (pending): ready-banner.ts owns the greeting; that file has no i18n yet",
   },
   {
     file: "orchestrator/index.ts",
     fragment: `{ type: "say", text: degradedText }`,
-    why: "degradedText is assembled with trFor in the ternary chain just above",
+    why: "every branch of the ternary above goes through dtr() — including the registry one",
   },
   {
     file: "orchestrator/index.ts",
     fragment: `announce: (text) => void bridge.push({ type: "say", text })`,
-    why: "self-restarter owns the update announcement, and it broadcasts to every tab",
+    why: "TRANSLATED ELSEWHERE (pending): self-restarter owns it, and it broadcasts to every tab at once",
+  },
+  {
+    file: "orchestrator/start-failure-notice.ts",
+    fragment: "text: startFailureSay(backend, message) }",
+    why: "startFailureSay, defined just above in this same file, IS the trFor call",
   },
 ];
 
 describe("every say frame is wired to the per-tab translator", () => {
-  for (const file of ["orchestrator/index.ts", "services/ui-bridge.ts"]) {
+  const filesWithSay = sourceFiles().filter((f) => srcOf(f).includes(SAY_MARKER));
+
+  it("scans every source file that emits a say frame, not an allowlist", () => {
+    // An allowlist of two files missed start-failure-notice.ts, which emits one. A new module
+    // that composes frames would be invisible the same way.
+    expect(filesWithSay.length).toBeGreaterThanOrEqual(3);
+    for (const f of ["orchestrator/index.ts", "services/ui-bridge.ts", "orchestrator/start-failure-notice.ts"]) {
+      expect(filesWithSay, `${f} emits say frames and must be scanned`).toContain(f);
+    }
+  });
+
+  for (const file of filesWithSay) {
     it(`${file}: no untranslated say site`, () => {
       const src = srcOf(file);
+      const sites = saySites(src);
       const exemptions = SAY_EXEMPTIONS.filter((e) => e.file === file);
+
+      // Bind each exemption OCCURRENCE to exactly one site: the last marker at or before the
+      // fragment's end. A fragment that starts before its marker (`announce: (text) => …`) and
+      // one that trails it (`${sync.message}`) both land on their own frame, and neither can
+      // reach the frame next door.
+      const excused = new Map<number, string>();
       const unmatched = new Set(exemptions.map((e) => e.fragment));
-      const marker = `type: "say"`;
-      const sites: number[] = [];
-      for (let at = src.indexOf(marker); at !== -1; at = src.indexOf(marker, at + marker.length)) {
-        sites.push(at);
-      }
-      for (const [n, at] of sites.entries()) {
-        // Bounded by the NEXT say site, not by a fixed character budget. A fixed window let a
-        // neighbouring translated frame vouch for an untranslated one — verified by mutation:
-        // an untranslated say inserted immediately before a translated one passed. Ending the
-        // window where the next frame begins makes each site answer for itself.
-        const next = sites[n + 1] ?? src.length;
-        const body = src.slice(at, Math.min(next, at + 900));
-        // A tight collar for the exemptions: an exempt fragment can start just before the
-        // marker (`announce: (text) => …`) or land just after it (`${sync.message}`), but it
-        // must belong to THIS frame — a wide window would let one exemption excuse the frame
-        // next to it. Every exemption visible here counts as USED, not just the first: two
-        // say sites can sit three lines apart (pushSayToConversation's park and fan-out paths
-        // do), and claiming only one would report the other as stale forever.
-        const collar = src.slice(Math.max(0, at - 80), at + 120);
-        const matched = exemptions.filter((e) => collar.includes(e.fragment));
-        for (const e of matched) unmatched.delete(e.fragment);
-        if (matched.length === 0) {
-          expect(
-            body,
-            `an untranslated say frame at ${file}:${src.slice(0, at).split("\n").length} — ` +
-              "wrap it in trFor(bridge.tabLocale(<tab>), …), or add it to SAY_EXEMPTIONS with a reason",
-          ).toContain("trFor(");
+      for (const e of exemptions) {
+        for (let f = src.indexOf(e.fragment); f !== -1; f = src.indexOf(e.fragment, f + 1)) {
+          const end = f + e.fragment.length;
+          const site = [...sites].reverse().find((at) => at <= end && at >= f - 200);
+          if (site !== undefined) {
+            excused.set(site, e.why);
+            unmatched.delete(e.fragment);
+          }
         }
       }
-      expect(
-        sites.length,
-        `no say frames found in ${file} — the marker must have changed`,
-      ).toBeGreaterThan(0);
+
+      for (const at of sites) {
+        if (excused.has(at)) continue;
+        const line = src.slice(0, at).split("\n").length;
+        expect(
+          sayTextExpression(src, at),
+          `an untranslated say frame at ${file}:${line} — wrap it in ` +
+            "trFor(bridge.tabLocale(<tab>), …), or add it to SAY_EXEMPTIONS with a reason",
+        ).toContain("trFor(");
+      }
+
+      expect(sites.length, `no say frames in ${file} — the marker must have changed`).toBeGreaterThan(0);
       expect(
         [...unmatched],
         "stale SAY_EXEMPTIONS entries: they match no code, so they excuse whatever moved in",
@@ -374,16 +509,33 @@ describe("every say frame is wired to the per-tab translator", () => {
     });
   }
 
+  it("bounds a frame's text at its own expression, not at a character window", () => {
+    // The property this guard depends on, asserted directly rather than trusted: the extracted
+    // value must stop before the NEXT say frame's translator call, or a neighbour vouches for
+    // an untranslated site (which is exactly how the previous version passed a mutation).
+    const src = srcOf("orchestrator/index.ts");
+    const sites = saySites(src);
+    for (const [n, at] of sites.entries()) {
+      const next = sites[n + 1];
+      if (next === undefined) continue;
+      const expr = sayTextExpression(src, at);
+      expect(expr, `no text expression found for the say frame at index ${n}`).not.toBe("");
+      // Where the extracted expression actually ENDS in the file — not `at + length`, which
+      // would understate it, since the expression begins at `text:`, some way past the marker.
+      const end = src.indexOf(expr, at) + expr.length;
+      expect(
+        end,
+        `the text expression at index ${n} (line ${src.slice(0, at).split("\n").length}) ` +
+          "runs into the next say frame, so that frame's translator would vouch for this one",
+      ).toBeLessThanOrEqual(next);
+    }
+  });
+
   it("uses trFor (the destination tab's language), never tr (the terminal's)", () => {
     // `tr()` follows LANG/--lang on the machine running the orchestrator. A say frame naming
     // "Settings → OpenRouter" in the server operator's language points at a control the
     // panel's user cannot find — the whole reason those two calls are separate.
-    for (const file of [
-      "orchestrator/index.ts",
-      "services/ui-bridge.ts",
-      "orchestrator/start-failure-notice.ts",
-    ]) {
-      expect(srcOf(file), `${file} must import trFor`).toMatch(/import \{[^}]*\btrFor\b/);
+    for (const file of filesWithSay) {
       expect(srcOf(file), `${file} must not use the process-locale tr()`).not.toMatch(
         /[^A-Za-z0-9_.$]tr\(/,
       );
@@ -405,7 +557,9 @@ describe("every say frame is wired to the per-tab translator", () => {
       srcOf("orchestrator/index.ts") +
       srcOf("services/ui-bridge.ts") +
       srcOf("orchestrator/start-failure-notice.ts");
-    const keys = [...src.matchAll(/trFor\([\s\S]{0,80}?"([a-z][\w.]*)"/g)].map((m) => m[1]);
+    // Backtick keys count too: `say.degraded.${backend}` builds 15 keys from one call site,
+    // and a quote-only regex would leave all 15 unguarded.
+    const keys = [...src.matchAll(/trFor\([\s\S]{0,80}?["`]([a-z][\w.]*)/g)].map((m) => m[1]);
     expect(keys.length, "no trFor keys found — the say frames lost their wrappers").toBeGreaterThan(20);
     for (const k of keys) {
       expect(k, `${k} is not under the say. prefix this unit owns`).toMatch(/^say\./);

--- a/src/__tests__/services/ui-bridge-locale.test.ts
+++ b/src/__tests__/services/ui-bridge-locale.test.ts
@@ -1,0 +1,416 @@
+/**
+ * PER-TAB panel language for the bridge's HUMAN-facing `say` frames.
+ *
+ * A `say` renders as a chat bubble inside ONE panel tab, and those strings name panel
+ * controls ("Settings → OpenRouter → 'Set API key…'"). Rendered in the process locale — the
+ * language of whoever launched the orchestrator — the instruction would point at a label the
+ * user cannot find on their own screen. So the language has to come from the destination tab,
+ * which is what `hello.locale` + `tabLocale()` provide.
+ *
+ * The behaviour actually worth guarding is what happens when it CANNOT work. These frames are
+ * emitted while reporting OTHER failures — an agent that would not start, render results that
+ * were lost, a panel sync that did not happen — so a locale lookup that threw would turn one
+ * failure report into two. Every unknown here must produce English, never an exception.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "node:net";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import WebSocket from "ws";
+import { UiBridge } from "../../services/ui-bridge.js";
+import { trFor, __resetI18nForTest } from "../../i18n/index.js";
+import {
+  buildStartFailureNotice,
+  startFailureHint,
+} from "../../orchestrator/start-failure-notice.js";
+
+let bridge: UiBridge;
+let port: number;
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      const p = addr && typeof addr === "object" ? addr.port : 0;
+      srv.close((err) => (err ? reject(err) : resolve(p)));
+    });
+  });
+}
+
+/** Open a socket without registering, so a test can drive the hello frames itself. */
+function open(): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    sock.on("open", () => resolve(sock));
+    sock.on("error", reject);
+  });
+}
+
+/** Register `tabId` on `sock`, resolving once the bridge has processed the hello. */
+async function hello(
+  sock: WebSocket,
+  tabId: string,
+  extra: Record<string, unknown> = {},
+): Promise<void> {
+  const before = bridge.tabConnectionGeneration(tabId);
+  sock.send(JSON.stringify({ type: "hello", tab_id: tabId, title: "wf", ...extra }));
+  // Every hello bumps the tab's generation, so this waits for THIS hello rather than for a
+  // fixed sleep — a re-hello that changes nothing observable would otherwise race.
+  for (let i = 0; i < 100; i++) {
+    if (bridge.tabConnectionGeneration(tabId) !== before) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error(`hello for ${tabId} was never processed`);
+}
+
+beforeEach(async () => {
+  port = await freePort();
+  bridge = new UiBridge(port);
+  bridge.start();
+  expect(await bridge.whenReady()).toBe(true);
+});
+
+afterEach(async () => {
+  await bridge.stop();
+  __resetI18nForTest();
+});
+
+describe("tabLocale — where a say frame's language comes from", () => {
+  it("takes the language the panel advertised in its hello", async () => {
+    const sock = await open();
+    await hello(sock, "tab-ko", { locale: "ko" });
+    expect(bridge.tabLocale("tab-ko")).toBe("ko");
+    sock.close();
+  });
+
+  it("normalises what the panel actually sends (regional + script variants)", async () => {
+    // ComfyUI's own language list is the source, so the panel can hand us pt-PT or zh-HK;
+    // both must land on a locale we ship rather than silently degrading to English.
+    const a = await open();
+    await hello(a, "tab-pt", { locale: "pt-PT" });
+    expect(bridge.tabLocale("tab-pt")).toBe("pt-BR");
+    const b = await open();
+    await hello(b, "tab-hk", { locale: "zh-HK" });
+    expect(bridge.tabLocale("tab-hk")).toBe("zh-TW");
+    a.close();
+    b.close();
+  });
+
+  it("falls back to English for a tab that never advertised a language", async () => {
+    // The panel builds that predate `hello.locale` are the common case, not an error.
+    const sock = await open();
+    await hello(sock, "tab-old");
+    expect(bridge.tabLocale("tab-old")).toBe("en");
+    sock.close();
+  });
+
+  it("falls back to English for a language we do not ship, rather than guessing a neighbour", async () => {
+    const sock = await open();
+    await hello(sock, "tab-kl", { locale: "kl-GL" });
+    expect(bridge.tabLocale("tab-kl")).toBe("en");
+    sock.close();
+  });
+
+  it("falls back to English for junk instead of throwing", async () => {
+    // Not a security boundary — the panel is trusted — but this value is read while
+    // REPORTING a failure, so a bad one must not be able to add a second failure.
+    const sock = await open();
+    await hello(sock, "tab-junk", { locale: { nope: true } });
+    expect(bridge.tabLocale("tab-junk")).toBe("en");
+    sock.close();
+  });
+
+  it("answers English for an unknown, ambiguous or disconnected tab instead of throwing", () => {
+    // resolveTarget THROWS for all three. Every caller here is mid-failure-report, so the
+    // lookup absorbs it: a frame in the wrong language is a blemish, an exception is a bug.
+    expect(() => bridge.tabLocale("never-existed")).not.toThrow();
+    expect(bridge.tabLocale("never-existed")).toBe("en");
+    expect(bridge.tabLocale("")).toBe("en");
+  });
+
+  it("keeps the language across a same-socket re-hello that omits it", async () => {
+    // The workflow-switch re-hello does not restate every field; the panel's language did
+    // not change just because this frame was shorter.
+    const sock = await open();
+    await hello(sock, "tab-keep", { locale: "ja" });
+    expect(bridge.tabLocale("tab-keep")).toBe("ja");
+    await hello(sock, "tab-keep");
+    expect(bridge.tabLocale("tab-keep")).toBe("ja");
+    sock.close();
+  });
+
+  it("lets a same-socket re-hello CHANGE the language", async () => {
+    const sock = await open();
+    await hello(sock, "tab-switch", { locale: "ja" });
+    await hello(sock, "tab-switch", { locale: "fr" });
+    expect(bridge.tabLocale("tab-switch")).toBe("fr");
+    sock.close();
+  });
+
+  it("resets to English when a re-hello asks for a language we do not ship", async () => {
+    // PRESENCE is authoritative, not resolvability. Someone who just switched the panel to
+    // German needs English here — keeping their previous Japanese would name controls in a
+    // language that is no longer anywhere on their screen, which is worse than not trying.
+    const sock = await open();
+    await hello(sock, "tab-de", { locale: "ja" });
+    await hello(sock, "tab-de", { locale: "de" });
+    expect(bridge.tabLocale("tab-de")).toBe("en");
+    // …and the same for a value that is not even a string.
+    await hello(sock, "tab-de", { locale: "ja" });
+    await hello(sock, "tab-de", { locale: 42 });
+    expect(bridge.tabLocale("tab-de")).toBe("en");
+    sock.close();
+  });
+
+  it("carries the language across a workflow switch, which re-hellos under a NEW tab id", async () => {
+    // The per-workflow re-hello is a same-SOCKET, different-ID event, so plain same-socket
+    // inheritance cannot see the retiring conn — it has already been deleted and re-keyed.
+    // Switching workflows must not silently drop a user back into English mid-session.
+    const sock = await open();
+    await hello(sock, "wf:route1:/a.json", { locale: "ko" });
+    expect(bridge.tabLocale("wf:route1:/a.json")).toBe("ko");
+    await hello(sock, "wf:route1:/b.json");
+    expect(bridge.tabLocale("wf:route1:/b.json")).toBe("ko");
+    sock.close();
+  });
+
+  it("does not let a DIFFERENT socket TAKING OVER a live tab id inherit the old one's language", async () => {
+    // `wf:` tab ids recur, and a second browser tab can take over a live one. The takeover
+    // is a different browser tab whose language we have not been told — English, not the
+    // previous tenant's. The first socket stays OPEN on purpose: only then is the outgoing
+    // conn still in `conns` and the inherit-vs-discard branch actually reached (with it
+    // closed the record is already gone and the test would pass without proving anything).
+    const first = await open();
+    await hello(first, "wf:recycled", { locale: "ru" });
+    expect(bridge.tabLocale("wf:recycled")).toBe("ru");
+    const second = await open();
+    await hello(second, "wf:recycled");
+    expect(bridge.tabLocale("wf:recycled")).toBe("en");
+    first.close();
+    second.close();
+  });
+
+  it("resolves through the same prefix path a push takes, so the language matches the recipient", async () => {
+    // Frames route by exact id OR unambiguous prefix; the locale must follow the SAME
+    // resolution or a bubble can arrive in a language its tab never asked for.
+    const sock = await open();
+    await hello(sock, "tab-prefix-9999", { locale: "es" });
+    expect(bridge.tabLocale("tab-prefix")).toBe("es");
+    sock.close();
+  });
+});
+
+describe("say frames degrade to English rather than failing", () => {
+  it("renders the start-failure notice in English when the tab's language is unknown", () => {
+    // No catalogs are installed in this repo, so every locale renders its English fallback —
+    // the assertion that matters is that the TEXT IS INTACT, never a raw key.
+    const { frames } = buildStartFailureNotice("tab-1::custom", "ECONNREFUSED", "claude");
+    const say = frames[0] as { type: string; text: string };
+    expect(say.type).toBe("say");
+    expect(say.text).toBe(
+      "⚠️ The custom agent could not start: ECONNREFUSED — " +
+        "Check the base URL and API key in Settings → Custom endpoint, then Disconnect → Connect to retry.",
+    );
+  });
+
+  it("renders intact text for a locale with no catalog, and never a key or an empty bubble", () => {
+    for (const locale of ["ko", "ar", "zh-TW", "kl-GL", "", "not-a-locale"]) {
+      const { frames } = buildStartFailureNotice("tab-1::openrouter", "401", "claude", locale);
+      const text = (frames[0] as { text: string }).text;
+      expect(text).toContain("OPENROUTER_API_KEY");
+      expect(text).not.toContain("say.");
+      expect(text).not.toContain("{");
+    }
+  });
+
+  it("keeps the ⚠️ status marker outside the translatable span", () => {
+    // The emoji is what the eye and the panel's bubble styling key on; it means the same
+    // thing in every language and must survive a catalog that translates the prose.
+    const { frames } = buildStartFailureNotice("t::claude", "boom", "claude", "ja");
+    expect((frames[0] as { text: string }).text.startsWith("⚠️ ")).toBe(true);
+  });
+
+  it("leaves the ack and turn frames alone — they are machine state, not prose", () => {
+    // `kind` is string-matched by the panel and these read as machine errors; translating
+    // them would break the parse while looking like a courtesy.
+    const { frames } = buildStartFailureNotice("t::claude", "boom", "claude", "ko");
+    expect(frames[1]).toEqual({ type: "ack", ok: false, kind: "degraded" });
+    expect(frames[2]).toEqual({ type: "turn", state: "done" });
+  });
+
+  it("passes the provider label and env var through untranslated — they are typed, not read", () => {
+    const hint = startFailureHint("moonshot", "ru");
+    expect(hint).toContain("MOONSHOT_API_KEY");
+  });
+
+  it("renders a counted string from a plain-string fallback, so English keeps its '(s)' hedge", () => {
+    // The lost-completion notice passes `{ count }` with a STRING fallback: a catalog may
+    // still supply `_one`/`_few`/`_other` forms, while English stays byte-identical to what
+    // it said before this unit. If the count path ever stopped falling back to a plain
+    // string, that notice would render empty — in the middle of reporting a data loss.
+    expect(
+      trFor("ru", "say.restart_lost.withheld", "{count} further answer(s) on this tab", {
+        count: 3,
+      }),
+    ).toBe("3 further answer(s) on this tab");
+    expect(
+      trFor("ko", "say.restart_lost.runs", "{count} result(s) ({runs})", {
+        count: 1,
+        runs: "a; b",
+      }),
+    ).toBe("1 result(s) (a; b)");
+  });
+});
+
+/**
+ * The mechanism above is only worth having if the CALL SITES use it, and nothing else in the
+ * suite would notice if one stopped: a deleted `trFor(` wrapper leaves correct English, a
+ * passing type-check and a green run — the string is simply never translatable again. The
+ * same hole swallows a NEW `say` site added later by someone who has not read this file.
+ *
+ * So this asserts on the SOURCE, with an ENUMERATED exemption list rather than a keyword
+ * heuristic: a keyword ("text:", "message") would quietly excuse a genuinely untranslated
+ * site, which is exactly the failure it exists to catch. Each exemption must still MATCH
+ * something — a stale one that no longer corresponds to real code is itself a failure, or the
+ * list would silently grant amnesty to whatever moved into its place.
+ */
+const srcOf = (rel: string): string =>
+  readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), "utf8");
+
+/** `say` sites whose text is composed elsewhere, each with the reason it is not wrapped here. */
+const SAY_EXEMPTIONS: Array<{ file: string; fragment: string; why: string }> = [
+  {
+    file: "orchestrator/index.ts",
+    fragment: `{ type: "say", text: build("en") }`,
+    why: "pushSayToConversation's own park path — `build` IS the translator",
+  },
+  {
+    file: "orchestrator/index.ts",
+    fragment: `{ type: "say", text: build(bridge.tabLocale(t)) }`,
+    why: "pushSayToConversation's own fan-out — `build` IS the translator",
+  },
+  {
+    file: "orchestrator/index.ts",
+    fragment: `{ type: "say", text, id: meta?.id`,
+    why: "the AGENT's own reply text — a model wrote it, in whatever language it was asked in",
+  },
+  {
+    file: "orchestrator/index.ts",
+    fragment: `{ type: "say", text: corrected }`,
+    why: "bannerCorrection() in ready-banner.ts owns that string",
+  },
+  {
+    file: "orchestrator/index.ts",
+    fragment: `{ type: "say", text: parts.join(" ") }`,
+    why: "the parts are each trFor'd where they are built, a few lines above",
+  },
+  {
+    file: "orchestrator/index.ts",
+    fragment: "${sync.message}",
+    why: "panel-sync owns that message; only the ⚠️ marker is added here",
+  },
+  {
+    file: "orchestrator/index.ts",
+    fragment: "readyBannerText(backend, bannerLabel, customBaseUrl)",
+    why: "ready-banner.ts owns the greeting",
+  },
+  {
+    file: "orchestrator/index.ts",
+    fragment: `{ type: "say", text: degradedText }`,
+    why: "degradedText is assembled with trFor in the ternary chain just above",
+  },
+  {
+    file: "orchestrator/index.ts",
+    fragment: `announce: (text) => void bridge.push({ type: "say", text })`,
+    why: "self-restarter owns the update announcement, and it broadcasts to every tab",
+  },
+];
+
+describe("every say frame is wired to the per-tab translator", () => {
+  for (const file of ["orchestrator/index.ts", "services/ui-bridge.ts"]) {
+    it(`${file}: no untranslated say site`, () => {
+      const src = srcOf(file);
+      const exemptions = SAY_EXEMPTIONS.filter((e) => e.file === file);
+      const unmatched = new Set(exemptions.map((e) => e.fragment));
+      const marker = `type: "say"`;
+      const sites: number[] = [];
+      for (let at = src.indexOf(marker); at !== -1; at = src.indexOf(marker, at + marker.length)) {
+        sites.push(at);
+      }
+      for (const [n, at] of sites.entries()) {
+        // Bounded by the NEXT say site, not by a fixed character budget. A fixed window let a
+        // neighbouring translated frame vouch for an untranslated one — verified by mutation:
+        // an untranslated say inserted immediately before a translated one passed. Ending the
+        // window where the next frame begins makes each site answer for itself.
+        const next = sites[n + 1] ?? src.length;
+        const body = src.slice(at, Math.min(next, at + 900));
+        // A tight collar for the exemptions: an exempt fragment can start just before the
+        // marker (`announce: (text) => …`) or land just after it (`${sync.message}`), but it
+        // must belong to THIS frame — a wide window would let one exemption excuse the frame
+        // next to it. Every exemption visible here counts as USED, not just the first: two
+        // say sites can sit three lines apart (pushSayToConversation's park and fan-out paths
+        // do), and claiming only one would report the other as stale forever.
+        const collar = src.slice(Math.max(0, at - 80), at + 120);
+        const matched = exemptions.filter((e) => collar.includes(e.fragment));
+        for (const e of matched) unmatched.delete(e.fragment);
+        if (matched.length === 0) {
+          expect(
+            body,
+            `an untranslated say frame at ${file}:${src.slice(0, at).split("\n").length} — ` +
+              "wrap it in trFor(bridge.tabLocale(<tab>), …), or add it to SAY_EXEMPTIONS with a reason",
+          ).toContain("trFor(");
+        }
+      }
+      expect(
+        sites.length,
+        `no say frames found in ${file} — the marker must have changed`,
+      ).toBeGreaterThan(0);
+      expect(
+        [...unmatched],
+        "stale SAY_EXEMPTIONS entries: they match no code, so they excuse whatever moved in",
+      ).toEqual([]);
+    });
+  }
+
+  it("uses trFor (the destination tab's language), never tr (the terminal's)", () => {
+    // `tr()` follows LANG/--lang on the machine running the orchestrator. A say frame naming
+    // "Settings → OpenRouter" in the server operator's language points at a control the
+    // panel's user cannot find — the whole reason those two calls are separate.
+    for (const file of [
+      "orchestrator/index.ts",
+      "services/ui-bridge.ts",
+      "orchestrator/start-failure-notice.ts",
+    ]) {
+      expect(srcOf(file), `${file} must import trFor`).toMatch(/import \{[^}]*\btrFor\b/);
+      expect(srcOf(file), `${file} must not use the process-locale tr()`).not.toMatch(
+        /[^A-Za-z0-9_.$]tr\(/,
+      );
+    }
+  });
+
+  it("fans the start-failure say out PER TAB instead of pre-rendering one language", () => {
+    // #884's conversation spans every tab on the failed backend, and the composite key is
+    // usually the SCOPE address `orchestrator::<backend>` — so there is no single "owning
+    // tab" whose locale would be right. Deleting this one line leaves the notice correct in
+    // English, the type-check clean and the suite green; nothing else would notice.
+    expect(srcOf("orchestrator/index.ts")).toMatch(
+      /pushSayToConversation\(key, \(locale\) => startFailureSay\(/,
+    );
+  });
+
+  it("keys every say string under the say. prefix, once", () => {
+    const src =
+      srcOf("orchestrator/index.ts") +
+      srcOf("services/ui-bridge.ts") +
+      srcOf("orchestrator/start-failure-notice.ts");
+    const keys = [...src.matchAll(/trFor\([\s\S]{0,80}?"([a-z][\w.]*)"/g)].map((m) => m[1]);
+    expect(keys.length, "no trFor keys found — the say frames lost their wrappers").toBeGreaterThan(20);
+    for (const k of keys) {
+      expect(k, `${k} is not under the say. prefix this unit owns`).toMatch(/^say\./);
+    }
+    // Two sentences sharing one key would give them one translation and lose a meaning.
+    expect(new Set(keys).size, `duplicate say keys: ${keys.join(", ")}`).toBe(keys.length);
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3467,8 +3467,8 @@ export async function runPanelOrchestrator(): Promise<void> {
                   {
                     type: "say",
                     // `detail` is the underlying failure's own text (untranslated, from
-                    // whatever threw) and is substituted last so nothing inside it is
-                    // mistaken for a placeholder.
+                    // whatever threw). trFor substitutes in ONE pass, so a brace sequence
+                    // inside it is never mistaken for a placeholder.
                     text: `⚠️ ${trFor(
                       syncLocale,
                       "say.panel_sync_failed",
@@ -3963,13 +3963,20 @@ export async function runPanelOrchestrator(): Promise<void> {
             // Studio → Developer → Start Server", "Settings → Custom endpoint"), so it
             // renders in THIS tab's panel language. CLI invocations, env-var names, URLs and
             // model ids are interpolated or quoted literally and never translated — they are
-            // typed, not read. `reg.degradedMessage` comes from the key-provider registry and
-            // is still English (that table is not part of this unit).
+            // typed, not read.
             const dLocale = bridge.tabLocale(panelTab);
             const dtr = (key: string, en: string, vars?: Record<string, string | number>): string =>
               `⚠️ ${trFor(dLocale, `say.degraded.${key}`, en, vars)}`;
             const degradedText = reg
-              ? reg.degradedMessage
+              ? // The key-provider registry (glm / kimi / moonshot / minimax) keeps its sentence
+                // in a data table. Keyed by BACKEND with the table's English as the fallback,
+                // rather than left as the one branch of this chain that can never be
+                // translated: otherwise a Korean panel on GLM gets the start-failure notice in
+                // Korean and the degraded notice for the same class of failure in English.
+                // The table's copy carries its own leading ⚠️ (asserted in the say-frame
+                // tests); stripping it keeps all 15 say.degraded.* fallbacks the same shape, so
+                // a catalog never has to guess which ones include the marker.
+                dtr(backend, reg.degradedMessage.replace(/^⚠️\s*/u, ""))
               : isCx
               ? dtr("codex", "The background agent isn't responding — the Codex app-server couldn't start. Make sure Codex is installed and signed in (run `codex login`), then Disconnect → Connect to retry.")
               : isCg
@@ -4493,8 +4500,8 @@ export async function runPanelOrchestrator(): Promise<void> {
           onAuthChanged: () => pushReadiness(tabId),
           onBackgroundError: (providerId, message) => {
             const label = OAUTH_PROVIDERS[providerId]?.label ?? providerId;
-            // `message` is the provider's own failure text — untranslated, and substituted
-            // after {provider} so nothing inside it is read as a placeholder.
+            // `message` is the provider's own failure text — untranslated, and safe to embed:
+            // trFor interpolates in one pass, so braces inside it stay literal.
             bridge.push(
               {
                 type: "say",

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -128,7 +128,12 @@ import { SYSTEM as MODEL_CARD_SYSTEM } from "./ai-proposer.js";
 import { resolvePrompt, registerPrompt, onPromptsChanged } from "../services/prompt-overrides.js";
 import { allBackendReadiness, piCredentialPresent } from "./backend-readiness.js";
 import { handleOAuthBegin, handleOAuthStatus, handleOAuthSignout } from "./oauth-bridge.js";
-import { buildStartFailureNotice } from "./start-failure-notice.js";
+// HUMAN-facing `say` bubbles only — `trFor`, never `tr`: each frame renders inside one
+// specific panel tab, in THAT user's language (bridge.tabLocale), not the language of
+// whoever launched this process. Everything else this file emits — tool text, system
+// prompts, ack `message` fields, log lines — is read by a machine and stays English.
+import { trFor } from "../i18n/index.js";
+import { buildStartFailureNotice, startFailureSay } from "./start-failure-notice.js";
 import { readyBannerText, bannerCorrection } from "./ready-banner.js";
 import { OAUTH_PROVIDERS } from "../services/oauth-flow.js";
 import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "./panel-mcp-http.js";
@@ -1701,6 +1706,25 @@ export async function runPanelOrchestrator(): Promise<void> {
     }
     parkedConversationFrames.set(key, q);
   };
+  /**
+   * A HUMAN-facing `say` fanned out to a conversation's tabs, rendered PER TAB.
+   *
+   * pushToConversation cannot serve this: one conversation can span tabs whose panels are in
+   * DIFFERENT languages, and a single pre-rendered string would then be wrong on all but one
+   * of them. `build` is called once per recipient with that tab's own locale.
+   *
+   * With no tab connected the frame parks like any other (replayed on the next hello),
+   * rendered in English: the tab that will eventually receive it has not told us its language
+   * yet, and English is the honest default rather than a guess.
+   */
+  const pushSayToConversation = (key: string, build: (locale: string) => string): void => {
+    const tabs = conversationDeliveryTabs(key, "say");
+    if (!tabs.length) {
+      pushToConversation(key, { type: "say", text: build("en") });
+      return;
+    }
+    for (const t of tabs) bridge.push({ type: "say", text: build(bridge.tabLocale(t)) }, t);
+  };
   // The REAL tab ids participating in the conversation that `originTab` belongs
   // to — used when a conversation BOUNDARY (New chat / resume switch / rewind)
   // must close every participating tab's journaled tickets, not just the
@@ -2387,7 +2411,20 @@ export async function runPanelOrchestrator(): Promise<void> {
       // start-failure-notice.ts so it is unit-testable (issue #255). #884: the
       // frames fan out to every tab on the failed backend's conversation.
       const { backend, frames } = buildStartFailureNotice(key, message, defaultBackend);
-      for (const frame of frames) pushToConversation(key, frame);
+      for (const frame of frames) {
+        // The say is the only HUMAN-facing frame of the three, and #884's conversation
+        // spans every tab on this backend — which can be several panels in DIFFERENT
+        // languages. So it is rendered per recipient rather than pushing one pre-rendered
+        // copy; deriving a single locale from the key cannot work either, since the key is
+        // usually the SCOPE address `orchestrator::<backend>` and resolves to whichever tab
+        // happens to be pinned or last-active. The ack + turn are machine state and fan out
+        // unchanged. Push order (say → ack → turn) is preserved.
+        if (frame.type === "say") {
+          pushSayToConversation(key, (locale) => startFailureSay(backend, message, locale));
+        } else {
+          pushToConversation(key, frame);
+        }
+      }
       logger.warn(
         `[panel-orchestrator] ${backend} agent failed to start — degraded THIS backend's conversation only, other providers unaffected (${message})`,
       );
@@ -2635,21 +2672,40 @@ export async function runPanelOrchestrator(): Promise<void> {
     }
     try {
       for (const [panelTab, { runs, answers, withheld }] of byTab) {
+        // Per TAB, so each person reads this in their own panel's language. `{ count }` is
+        // passed even though the English fallback hedges with "(s)": it lets a catalog
+        // supply real plural forms (`_one`/`_few`/`_other` via Intl.PluralRules, which
+        // knows Korean has one form and Russian four) without touching the English here.
+        const locale = bridge.tabLocale(panelTab);
         // Two different losses, two different remedies — never merged.
-        const parts: string[] = ["⚠️ The agent backend is being restarted."];
+        const parts: string[] = [
+          `⚠️ ${trFor(locale, "say.restart_lost.header", "The agent backend is being restarted.")}`,
+        ];
         if (runs.length) {
+          // `get_history (action:"list")` is a TOOL CALL the user relays to the agent, so it
+          // stays spelled exactly as typed in every language.
           parts.push(
-            `${runs.length} finished render result(s) could not be delivered (${runs.join("; ")}). ` +
-              `Their outcome is UNDETERMINED from the agent's point of view — ask it to check \`get_history (action:"list")\` ` +
-              `for those runs once it reconnects rather than assuming it saw them.`,
+            trFor(
+              locale,
+              "say.restart_lost.runs",
+              `{count} finished render result(s) could not be delivered ({runs}). ` +
+                `Their outcome is UNDETERMINED from the agent's point of view — ask it to check \`get_history (action:"list")\` ` +
+                `for those runs once it reconnects rather than assuming it saw them.`,
+              { count: runs.length, runs: runs.join("; ") },
+            ),
           );
         }
         if (answers.length) {
           parts.push(
-            `${answers.length} answer(s) you gave on a question card never reached the agent: ${answers.join("; ")}. ` +
-              `An answer is not a render — there is NO history to look it up in, and the agent has no way to ` +
-              `recover it once this restart completes. Please tell it your choice again (or paste the text above) ` +
-              `when it comes back.`,
+            trFor(
+              locale,
+              "say.restart_lost.answers",
+              `{count} answer(s) you gave on a question card never reached the agent: {answers}. ` +
+                `An answer is not a render — there is NO history to look it up in, and the agent has no way to ` +
+                `recover it once this restart completes. Please tell it your choice again (or paste the text above) ` +
+                `when it comes back.`,
+              { count: answers.length, answers: answers.join("; ") },
+            ),
           );
         }
         if (withheld > 0) {
@@ -2657,9 +2713,14 @@ export async function runPanelOrchestrator(): Promise<void> {
           // replaced (a new chat, a rewind, a provider switch, another tab taking
           // this workflow). Their text is in the log, not on this screen.
           parts.push(
-            `${withheld} further answer(s) on this tab belong to an earlier conversation that has ` +
-              `since been replaced; they were never delivered either, but they are not shown here ` +
-              `because they were not given to the conversation you are in now.`,
+            trFor(
+              locale,
+              "say.restart_lost.withheld",
+              `{count} further answer(s) on this tab belong to an earlier conversation that has ` +
+                `since been replaced; they were never delivered either, but they are not shown here ` +
+                `because they were not given to the conversation you are in now.`,
+              { count: withheld },
+            ),
           );
         }
         bridge.push({ type: "say", text: parts.join(" ") }, panelTab);
@@ -2914,10 +2975,16 @@ export async function runPanelOrchestrator(): Promise<void> {
           // #884 — keys are shared (`orchestrator::<backend>`); the notices fan
           // out to that backend's conversation like any other agent output.
           if (msgs.length > 0) {
-            pushToConversation(key, {
-              type: "say",
-              text: "✅ Render finished — the local agent is back. Answering your queued message now.",
-            });
+            // Per tab: this conversation's members may be in different panel languages.
+            pushSayToConversation(
+              key,
+              (locale) =>
+                `✅ ${trFor(
+                  locale,
+                  "say.local_agent_resumed",
+                  "Render finished — the local agent is back. Answering your queued message now.",
+                )}`,
+            );
           }
           for (const m of msgs) {
             pushToConversation(key, { type: "turn", state: "working" });
@@ -3380,19 +3447,34 @@ export async function runPanelOrchestrator(): Promise<void> {
                   );
                   return;
                 }
+                const syncLocale = bridge.tabLocale(panelTab);
+                // #784 — this is pushed to the embedded panel chat, whose
+                // tool set does not include install_comfyui(action:'panel'). Name it only where
+                // it can be invoked. The tool call itself is a literal the user types or
+                // relays; it is inside the sentence and must survive translation verbatim.
+                const advice = panelRecoveryContext().installPanelUsable
+                  ? trFor(
+                      syncLocale,
+                      "say.panel_sync_failed.inspect_here",
+                      "Run install_comfyui(action:'panel', panel_action:'status') to inspect it, then retry install_comfyui(action:'panel', panel_action:'sync') if appropriate.",
+                    )
+                  : trFor(
+                      syncLocale,
+                      "say.panel_sync_failed.inspect_on_host",
+                      "Inspect and update the panel pack on the ComfyUI host itself — no tool in this session can do it.",
+                    );
                 bridge.push(
                   {
                     type: "say",
-                    text:
-                      `⚠️ Could not automatically sync the ComfyUI-MCP panel; no update was claimed. ` +
-                      // #784 — this is pushed to the embedded panel chat, whose
-                      // tool set does not include install_comfyui(action:'panel'). Name it only where
-                      // it can be invoked.
-                      `${
-                        panelRecoveryContext().installPanelUsable
-                          ? "Run install_comfyui(action:'panel', panel_action:'status') to inspect it, then retry install_comfyui(action:'panel', panel_action:'sync') if appropriate."
-                          : "Inspect and update the panel pack on the ComfyUI host itself — no tool in this session can do it."
-                      } (${detail})`,
+                    // `detail` is the underlying failure's own text (untranslated, from
+                    // whatever threw) and is substituted last so nothing inside it is
+                    // mistaken for a placeholder.
+                    text: `⚠️ ${trFor(
+                      syncLocale,
+                      "say.panel_sync_failed",
+                      "Could not automatically sync the ComfyUI-MCP panel; no update was claimed. {advice} ({detail})",
+                      { advice, detail },
+                    )}`,
                   },
                   panelTab,
                 );
@@ -3721,10 +3803,17 @@ export async function runPanelOrchestrator(): Promise<void> {
         bridge.push(
           {
             type: "say",
-            text:
-              "⚠️ OpenRouter has no API key — the connection would fail on your first message. " +
-              "Set it in Settings → OpenRouter → “Set API key…” (masked, stored by the orchestrator — takes effect immediately, no reconnect needed), " +
-              "or set the OPENROUTER_API_KEY environment variable and restart the orchestrator. Keys: https://openrouter.ai/keys",
+            // Translated in the TAB's language, not the process's: "Settings → OpenRouter →
+            // 'Set API key…'" names controls the user has to find on their own screen, and
+            // a panel in Korean has no menu item spelled "Settings". Env-var names and URLs
+            // are typed literally and stay as they are.
+            text: `⚠️ ${trFor(
+              bridge.tabLocale(panelTab),
+              "say.openrouter_no_key",
+              "OpenRouter has no API key — the connection would fail on your first message. " +
+                "Set it in Settings → OpenRouter → “Set API key…” (masked, stored by the orchestrator — takes effect immediately, no reconnect needed), " +
+                "or set the OPENROUTER_API_KEY environment variable and restart the orchestrator. Keys: https://openrouter.ai/keys",
+            )}`,
           },
           panelTab,
         );
@@ -3741,12 +3830,15 @@ export async function runPanelOrchestrator(): Promise<void> {
         bridge.push(
           {
             type: "say",
-            text:
-              "⚠️ pi has no usable provider credential — the connection would greet ready and then fail on your first message. " +
-              "Configure a provider: set a provider API key (e.g. ANTHROPIC_API_KEY / OPENAI_API_KEY / CEREBRAS_API_KEY) and restart the orchestrator, " +
-              "or run `pi` once and `/login` (stored in ~/.pi/agent/auth.json), then Disconnect → Connect. " +
-              "If you already did one of those, check the entry is complete — an ~/.pi/agent/auth.json record with no `key`, " +
-              "a models.json provider with no `apiKey`, or GOOGLE_APPLICATION_CREDENTIALS pointing at a missing file cannot authenticate. https://pi.dev",
+            text: `⚠️ ${trFor(
+              bridge.tabLocale(panelTab),
+              "say.pi_no_credential",
+              "pi has no usable provider credential — the connection would greet ready and then fail on your first message. " +
+                "Configure a provider: set a provider API key (e.g. ANTHROPIC_API_KEY / OPENAI_API_KEY / CEREBRAS_API_KEY) and restart the orchestrator, " +
+                "or run `pi` once and `/login` (stored in ~/.pi/agent/auth.json), then Disconnect → Connect. " +
+                "If you already did one of those, check the entry is complete — an ~/.pi/agent/auth.json record with no `key`, " +
+                "a models.json provider with no `apiKey`, or GOOGLE_APPLICATION_CREDENTIALS pointing at a missing file cannot authenticate. https://pi.dev",
+            )}`,
           },
           panelTab,
         );
@@ -3760,9 +3852,12 @@ export async function runPanelOrchestrator(): Promise<void> {
         bridge.push(
           {
             type: "say",
-            text:
-              "⚠️ No endpoint configured — set the base URL in Settings → Custom endpoint (include the /v1, e.g. http://192.168.1.20:8000/v1 for vLLM, or a hosted provider's OpenAI-compatible URL), " +
-              "plus “Set API key…” if the server needs one. Both apply immediately — then Connect again.",
+            text: `⚠️ ${trFor(
+              bridge.tabLocale(panelTab),
+              "say.custom_no_base_url",
+              "No endpoint configured — set the base URL in Settings → Custom endpoint (include the /v1, e.g. http://192.168.1.20:8000/v1 for vLLM, or a hosted provider's OpenAI-compatible URL), " +
+                "plus “Set API key…” if the server needs one. Both apply immediately — then Connect again.",
+            )}`,
           },
           panelTab,
         );
@@ -3819,9 +3914,13 @@ export async function runPanelOrchestrator(): Promise<void> {
                   bridge.push(
                     {
                       type: "say",
-                      text:
-                        "⚠️ Your llama-server is running WITHOUT `--jinja`, so tool calling is disabled — every agent action would fail. " +
-                        "Restart it with tool support: `llama-server -m <model>.gguf --jinja -c 16384` (current builds enable jinja by default; older ones need the flag), then Disconnect → Connect.",
+                      // Shell command lines stay verbatim — they are pasted, not read.
+                      text: `⚠️ ${trFor(
+                        bridge.tabLocale(panelTab),
+                        "say.llamacpp_no_jinja",
+                        "Your llama-server is running WITHOUT `--jinja`, so tool calling is disabled — every agent action would fail. " +
+                          "Restart it with tool support: `llama-server -m <model>.gguf --jinja -c 16384` (current builds enable jinja by default; older ones need the flag), then Disconnect → Connect.",
+                      )}`,
                     },
                     panelTab,
                   );
@@ -3829,7 +3928,12 @@ export async function runPanelOrchestrator(): Promise<void> {
                   bridge.push(
                     {
                       type: "say",
-                      text: `ℹ️ Your llama-server context is ${props.nCtx} tokens (launch flag -c). The agent's tool payload wants ≥16384 — below that, long turns silently truncate. Consider restarting with \`-c 16384\` or higher.`,
+                      text: `ℹ️ ${trFor(
+                        bridge.tabLocale(panelTab),
+                        "say.llamacpp_small_context",
+                        "Your llama-server context is {tokens} tokens (launch flag -c). The agent's tool payload wants ≥16384 — below that, long turns silently truncate. Consider restarting with `-c 16384` or higher.",
+                        { tokens: props.nCtx },
+                      )}`,
                     },
                     panelTab,
                   );
@@ -3855,31 +3959,40 @@ export async function runPanelOrchestrator(): Promise<void> {
             bridge.push({ type: "ack", ok: true, kind: "ready", agent: agentLabel, backend }, panelTab);
             logger.debug(`[panel-orchestrator] tab ${panelTab.slice(0, 8)} connected (${backend}) — agent healthy, ready ack`);
           } else {
+            // Each variant names a per-provider remedy the user performs by hand ("Open LM
+            // Studio → Developer → Start Server", "Settings → Custom endpoint"), so it
+            // renders in THIS tab's panel language. CLI invocations, env-var names, URLs and
+            // model ids are interpolated or quoted literally and never translated — they are
+            // typed, not read. `reg.degradedMessage` comes from the key-provider registry and
+            // is still English (that table is not part of this unit).
+            const dLocale = bridge.tabLocale(panelTab);
+            const dtr = (key: string, en: string, vars?: Record<string, string | number>): string =>
+              `⚠️ ${trFor(dLocale, `say.degraded.${key}`, en, vars)}`;
             const degradedText = reg
               ? reg.degradedMessage
               : isCx
-              ? "⚠️ The background agent isn't responding — the Codex app-server couldn't start. Make sure Codex is installed and signed in (run `codex login`), then Disconnect → Connect to retry."
+              ? dtr("codex", "The background agent isn't responding — the Codex app-server couldn't start. Make sure Codex is installed and signed in (run `codex login`), then Disconnect → Connect to retry.")
               : isCg
-                ? "⚠️ The background agent isn't responding — ChatGPT direct OAuth couldn't start. Make sure ~/.codex/auth.json exists (run `codex login`), then Disconnect → Connect to retry."
+                ? dtr("chatgpt", "The background agent isn't responding — ChatGPT direct OAuth couldn't start. Make sure ~/.codex/auth.json exists (run `codex login`), then Disconnect → Connect to retry.")
               : isGm
-                ? "⚠️ The background agent isn't responding — the Gemini CLI couldn't start. Make sure the Gemini CLI is installed and signed in (run `gemini` once and complete the Google sign-in), then Disconnect → Connect to retry."
+                ? dtr("gemini", "The background agent isn't responding — the Gemini CLI couldn't start. Make sure the Gemini CLI is installed and signed in (run `gemini` once and complete the Google sign-in), then Disconnect → Connect to retry.")
                 : isAg
-                  ? "⚠️ The background agent isn't responding — the Antigravity CLI couldn't answer `agy models`. Install it from https://antigravity.google, run `agy` once and complete the Google Sign-In, then Disconnect → Connect to retry."
+                  ? dtr("antigravity", "The background agent isn't responding — the Antigravity CLI couldn't answer `agy models`. Install it from https://antigravity.google, run `agy` once and complete the Google Sign-In, then Disconnect → Connect to retry.")
                 : isPi
-                  ? "⚠️ The background agent isn't responding — the pi CLI couldn't run `pi --list-models`. Install it from https://pi.dev (`curl -fsSL https://pi.dev/install.sh | sh`), configure a provider (set a provider API key or run `pi` once and `/login`), then Disconnect → Connect to retry."
+                  ? dtr("pi", "The background agent isn't responding — the pi CLI couldn't run `pi --list-models`. Install it from https://pi.dev (`curl -fsSL https://pi.dev/install.sh | sh`), configure a provider (set a provider API key or run `pi` once and `/login`), then Disconnect → Connect to retry.")
                 : isGk
-                  ? "⚠️ The background agent isn't responding — the Grok CLI couldn't start. Make sure Grok is installed and signed in (run `grok` once and complete the xAI sign-in), then Disconnect → Connect to retry."
+                  ? dtr("grok", "The background agent isn't responding — the Grok CLI couldn't start. Make sure Grok is installed and signed in (run `grok` once and complete the xAI sign-in), then Disconnect → Connect to retry.")
                 : isOl
-                  ? "⚠️ The background agent isn't responding — Ollama isn't reachable. Start it with `ollama serve` and pull our fine-tuned model (`ollama pull artokun/gemma4-comfyui-mcp:e4b` — gemma4 trained on the comfyui-mcp tool suite — arena-best local model; `:12b` for ~8 GB VRAM), then Disconnect → Connect to retry."
+                  ? dtr("ollama", "The background agent isn't responding — Ollama isn't reachable. Start it with `ollama serve` and pull our fine-tuned model (`ollama pull artokun/gemma4-comfyui-mcp:e4b` — gemma4 trained on the comfyui-mcp tool suite — arena-best local model; `:12b` for ~8 GB VRAM), then Disconnect → Connect to retry.")
                   : isLs
-                    ? `⚠️ The background agent isn't responding — LM Studio isn't reachable at ${LMSTUDIO_BASE_URL}. Open LM Studio → Developer → Start Server and load a tool-calling model (our gemma4-comfyui-mcp GGUFs from Hugging Face work great), or set COMFYUI_MCP_LMSTUDIO_HOST if it serves elsewhere — then Disconnect → Connect to retry.`
+                    ? dtr("lmstudio", "The background agent isn't responding — LM Studio isn't reachable at {url}. Open LM Studio → Developer → Start Server and load a tool-calling model (our gemma4-comfyui-mcp GGUFs from Hugging Face work great), or set COMFYUI_MCP_LMSTUDIO_HOST if it serves elsewhere — then Disconnect → Connect to retry.", { url: LMSTUDIO_BASE_URL })
                     : isLc
-                      ? `⚠️ The background agent isn't responding — llama-server isn't reachable at ${LLAMACPP_BASE_URL}. Start it with \`llama-server -m <model>.gguf -c 16384\` (our gemma4-comfyui-mcp GGUFs work great; add --jinja on older builds — required there for tool calling), or set COMFYUI_MCP_LLAMACPP_HOST — then Disconnect → Connect to retry.`
+                      ? dtr("llamacpp", "The background agent isn't responding — llama-server isn't reachable at {url}. Start it with `llama-server -m <model>.gguf -c 16384` (our gemma4-comfyui-mcp GGUFs work great; add --jinja on older builds — required there for tool calling), or set COMFYUI_MCP_LLAMACPP_HOST — then Disconnect → Connect to retry.", { url: LLAMACPP_BASE_URL })
                       : isCu
-                        ? `⚠️ The background agent isn't responding — your custom endpoint isn't answering at ${customBaseUrl}. Check the base URL in Settings → Custom endpoint (it must be OpenAI-compatible and include the /v1) and the API key if the server requires one — then Connect to retry.`
+                        ? dtr("custom", "The background agent isn't responding — your custom endpoint isn't answering at {url}. Check the base URL in Settings → Custom endpoint (it must be OpenAI-compatible and include the /v1) and the API key if the server requires one — then Connect to retry.", { url: customBaseUrl })
                         : isCp
-                          ? "⚠️ The background agent isn't responding — GitHub Copilot (experimental) couldn't start. Sign in from the panel's experimental row, then Disconnect → Connect to retry."
-                        : "⚠️ The background agent isn't responding — the Claude Agent SDK couldn't start. Make sure you're signed in (run `claude` once), then Disconnect → Connect to retry.";
+                          ? dtr("copilot", "The background agent isn't responding — GitHub Copilot (experimental) couldn't start. Sign in from the panel's experimental row, then Disconnect → Connect to retry.")
+                        : dtr("claude", "The background agent isn't responding — the Claude Agent SDK couldn't start. Make sure you're signed in (run `claude` once), then Disconnect → Connect to retry.");
             bridge.push({ type: "say", text: degradedText }, panelTab);
             bridge.push({ type: "ack", ok: false, kind: "degraded" }, panelTab);
             logger.warn(`[panel-orchestrator] tab ${panelTab.slice(0, 8)} connected (${backend}) but model probe empty — degraded ack`);
@@ -4380,7 +4493,20 @@ export async function runPanelOrchestrator(): Promise<void> {
           onAuthChanged: () => pushReadiness(tabId),
           onBackgroundError: (providerId, message) => {
             const label = OAUTH_PROVIDERS[providerId]?.label ?? providerId;
-            bridge.push({ type: "say", text: `⚠️ ${label} sign-in failed: ${message}` }, tabId);
+            // `message` is the provider's own failure text — untranslated, and substituted
+            // after {provider} so nothing inside it is read as a placeholder.
+            bridge.push(
+              {
+                type: "say",
+                text: `⚠️ ${trFor(
+                  bridge.tabLocale(tabId),
+                  "say.oauth_signin_failed",
+                  "{provider} sign-in failed: {message}",
+                  { provider: label, message },
+                )}`,
+              },
+              tabId,
+            );
           },
         },
       )
@@ -4462,9 +4588,19 @@ export async function runPanelOrchestrator(): Promise<void> {
         bridge.push(
           {
             type: "say",
+            // 🕶️/👁️ carry the ON/OFF distinction at a glance and are the same in every
+            // language, so they stay outside the translated span.
             text: nextBlind
-              ? "🕶️ Blind mode ON — the agent's image tools now withhold pixels (applies after the current turn; the session resumes automatically)."
-              : "👁️ Blind mode OFF — the agent's image tools deliver pixels again (applies after the current turn).",
+              ? `🕶️ ${trFor(
+                  bridge.tabLocale(tabId),
+                  "say.blind_on",
+                  "Blind mode ON — the agent's image tools now withhold pixels (applies after the current turn; the session resumes automatically).",
+                )}`
+              : `👁️ ${trFor(
+                  bridge.tabLocale(tabId),
+                  "say.blind_off",
+                  "Blind mode OFF — the agent's image tools deliver pixels again (applies after the current turn).",
+                )}`,
           },
           tabId,
         );
@@ -4508,7 +4644,18 @@ export async function runPanelOrchestrator(): Promise<void> {
         // Legacy contract: old clients only understand the say. A rid-stamped
         // request ALSO gets an ok:false options ack so the correlating client
         // resolves the exact failed attempt instead of waiting out a timeout.
-        bridge.push({ type: "say", text: `⚠️ Could not change model/effort: ${message}` }, tabId);
+        bridge.push(
+          {
+            type: "say",
+            text: `⚠️ ${trFor(
+              bridge.tabLocale(tabId),
+              "say.options_change_failed",
+              "Could not change model/effort: {message}",
+              { message },
+            )}`,
+          },
+          tabId,
+        );
         const errorAck = optionsErrorAckFrame(message, meta);
         if (errorAck) bridge.push(errorAck, tabId);
       });
@@ -4672,11 +4819,14 @@ export async function runPanelOrchestrator(): Promise<void> {
         bridge.push(
           {
             type: "say",
-            text:
-              "⚠️ New chat started, but the previous conversation's stored session could not be " +
-              "removed from disk (the write failed — a full or locked filesystem?). If the " +
-              "orchestrator restarts before this conversation's first exchange completes, the " +
-              "OLD conversation may resume; start a New chat again if that happens.",
+            text: `⚠️ ${trFor(
+              bridge.tabLocale(tabId),
+              "say.new_chat_durable_clear_failed",
+              "New chat started, but the previous conversation's stored session could not be " +
+                "removed from disk (the write failed — a full or locked filesystem?). If the " +
+                "orchestrator restarts before this conversation's first exchange completes, the " +
+                "OLD conversation may resume; start a New chat again if that happens.",
+            )}`,
           },
           tabId,
         );
@@ -5042,7 +5192,11 @@ export async function runPanelOrchestrator(): Promise<void> {
       bridge.push(
         {
           type: "say",
-          text: "⏸ A render is running, so I've queued your message to keep the GPU free for it. I'll answer the moment it finishes.",
+          text: `⏸ ${trFor(
+            bridge.tabLocale(event.tab_id),
+            "say.message_queued_during_render",
+            "A render is running, so I've queued your message to keep the GPU free for it. I'll answer the moment it finishes.",
+          )}`,
         },
         event.tab_id,
       );

--- a/src/orchestrator/start-failure-notice.ts
+++ b/src/orchestrator/start-failure-notice.ts
@@ -95,13 +95,13 @@ export interface StartFailureNotice {
  * Exported separately from the notice below because the conversation this is announced to
  * can span several tabs whose panels are in DIFFERENT languages: the orchestrator renders
  * this once per recipient, while the `ack`/`turn` frames beside it are machine state and fan
- * out unchanged. Keeping the sentence in one function is what stops those two paths from
- * drifting into two slightly different messages.
+ * out unchanged. This IS the sentence — `buildStartFailureNotice` calls it too rather than
+ * holding a second copy, so the delivered text and the tested text cannot drift apart.
  */
 export function startFailureSay(backend: string, message: string, locale = "en"): string {
-  // ⚠️ outside the translated span — a status marker, not prose. `message` is the provider's
-  // own error text and is passed through verbatim in every language; it is substituted LAST
-  // so a `{hint}`-looking sequence inside it stays literal.
+  // ⚠️ outside the translated span — a status marker, not prose, and the same in every
+  // language. `message` is the provider's own error text and is passed through verbatim;
+  // trFor interpolates in ONE pass, so a `{hint}`-looking sequence inside it stays literal.
   return `⚠️ ${trFor(
     locale,
     "say.start_failure.notice",
@@ -110,20 +110,26 @@ export function startFailureSay(backend: string, message: string, locale = "en")
   )}`;
 }
 
-/** Build the per-tab degradation frames for a start failure on `key`, with the `say`
- *  rendered in `locale` (the destination tab's panel language; English when unknown). */
+/**
+ * Build the per-tab degradation frames for a start failure on `key`.
+ *
+ * The `say` here is ENGLISH, deliberately and always. The orchestrator does not deliver this
+ * copy of it — it re-renders the sentence per recipient through `startFailureSay`, because one
+ * conversation can span panels in different languages. A `locale` parameter on this function
+ * would therefore be exercised only by its own tests, pinning a path production never takes;
+ * the two could then drift apart with everything still green.
+ */
 export function buildStartFailureNotice(
   key: string,
   message: string,
   defaultBackend: string,
-  locale = "en",
 ): StartFailureNotice {
   const backend = backendOfKey(key, defaultBackend);
   return {
     panelTab: panelTabOfKey(key),
     backend,
     frames: [
-      { type: "say", text: startFailureSay(backend, message, locale) },
+      { type: "say", text: startFailureSay(backend, message) },
       { type: "ack", ok: false, kind: "degraded" },
       { type: "turn", state: "done" },
     ],

--- a/src/orchestrator/start-failure-notice.ts
+++ b/src/orchestrator/start-failure-notice.ts
@@ -18,7 +18,18 @@
  * (`panelTabId::backend`); frames must go to the PANEL tab, so the composite
  * key is split here on its LAST separator (a panel tab id never contains "::";
  * backend names never do).
+ *
+ * The `say` is HUMAN-facing and names panel controls ("Settings → Custom
+ * endpoint", "the API Keys card"), so it renders in the DESTINATION TAB's panel
+ * language rather than the process's. There is usually more than one destination
+ * — #884's conversation spans every tab on the failed backend, and those panels
+ * can be in different languages — so the sentence also lives on its own in
+ * `startFailureSay()`, which the orchestrator calls once per recipient. `locale`
+ * defaults to English throughout, so every existing caller and test keeps its
+ * exact current output. The `ack` and `turn` frames beside it are machine state
+ * and stay untranslated.
  */
+import { trFor } from "../i18n/index.js";
 import { openAiKeyProvider } from "../services/openai-provider-registry.js";
 
 export const AGENT_KEY_SEP = "::";
@@ -35,19 +46,38 @@ export function backendOfKey(key: string, fallback: string): string {
   return i >= 0 ? key.slice(i + AGENT_KEY_SEP.length) : fallback;
 }
 
-/** Check-your-credentials guidance for a backend that failed to start. */
-export function startFailureHint(backend: string): string {
+/** Check-your-credentials guidance for a backend that failed to start, in `locale`.
+ *  The provider label and env-var name are interpolated, never translated: they are the
+ *  literal strings the user has to find in the API Keys card and in their shell. */
+export function startFailureHint(backend: string, locale = "en"): string {
   const reg = openAiKeyProvider(backend);
   if (reg) {
-    return `Check your ${reg.slotLabel} API key in the API Keys card (${reg.envKeys[0]}), then Disconnect → Connect to retry.`;
+    return trFor(
+      locale,
+      "say.start_failure.hint.key_provider",
+      "Check your {provider} API key in the API Keys card ({env}), then Disconnect → Connect to retry.",
+      { provider: reg.slotLabel, env: reg.envKeys[0] },
+    );
   }
   if (backend === "openrouter") {
-    return "Check your OpenRouter API key in the API Keys card (OPENROUTER_API_KEY), then Disconnect → Connect to retry.";
+    return trFor(
+      locale,
+      "say.start_failure.hint.openrouter",
+      "Check your OpenRouter API key in the API Keys card (OPENROUTER_API_KEY), then Disconnect → Connect to retry.",
+    );
   }
   if (backend === "custom") {
-    return "Check the base URL and API key in Settings → Custom endpoint, then Disconnect → Connect to retry.";
+    return trFor(
+      locale,
+      "say.start_failure.hint.custom",
+      "Check the base URL and API key in Settings → Custom endpoint, then Disconnect → Connect to retry.",
+    );
   }
-  return "Check the provider's credentials/login, then Disconnect → Connect to retry.";
+  return trFor(
+    locale,
+    "say.start_failure.hint.generic",
+    "Check the provider's credentials/login, then Disconnect → Connect to retry.",
+  );
 }
 
 export interface StartFailureNotice {
@@ -59,20 +89,41 @@ export interface StartFailureNotice {
   frames: Array<Record<string, unknown>>;
 }
 
-/** Build the per-tab degradation frames for a start failure on `key`. */
+/**
+ * The HUMAN-facing bubble for a start failure, in `locale`.
+ *
+ * Exported separately from the notice below because the conversation this is announced to
+ * can span several tabs whose panels are in DIFFERENT languages: the orchestrator renders
+ * this once per recipient, while the `ack`/`turn` frames beside it are machine state and fan
+ * out unchanged. Keeping the sentence in one function is what stops those two paths from
+ * drifting into two slightly different messages.
+ */
+export function startFailureSay(backend: string, message: string, locale = "en"): string {
+  // ⚠️ outside the translated span — a status marker, not prose. `message` is the provider's
+  // own error text and is passed through verbatim in every language; it is substituted LAST
+  // so a `{hint}`-looking sequence inside it stays literal.
+  return `⚠️ ${trFor(
+    locale,
+    "say.start_failure.notice",
+    "The {backend} agent could not start: {message} — {hint}",
+    { backend, hint: startFailureHint(backend, locale), message },
+  )}`;
+}
+
+/** Build the per-tab degradation frames for a start failure on `key`, with the `say`
+ *  rendered in `locale` (the destination tab's panel language; English when unknown). */
 export function buildStartFailureNotice(
   key: string,
   message: string,
   defaultBackend: string,
+  locale = "en",
 ): StartFailureNotice {
   const backend = backendOfKey(key, defaultBackend);
-  const panelTab = panelTabOfKey(key);
-  const hint = startFailureHint(backend);
   return {
-    panelTab,
+    panelTab: panelTabOfKey(key),
     backend,
     frames: [
-      { type: "say", text: `⚠️ The ${backend} agent could not start: ${message} — ${hint}` },
+      { type: "say", text: startFailureSay(backend, message, locale) },
       { type: "ack", ok: false, kind: "degraded" },
       { type: "turn", state: "done" },
     ],

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -17,6 +17,7 @@
 
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import { WebSocketServer, WebSocket } from "ws";
+import { resolveLocale, trFor, type Locale } from "../i18n/index.js";
 import { logger } from "../utils/logger.js";
 import { midCommandDisconnectMessage } from "./mid-command-remedy.js";
 import {
@@ -232,6 +233,16 @@ interface Conn {
    *  connections, whose advertised loopback origin is NOT the orchestrator's host
    *  and must not be directly health-probed (#509). */
   local: boolean;
+  /** The panel language THIS tab resolved for itself (`locale` in its `hello`), already
+   *  narrowed to a locale we ship. Undefined when the panel sent none (an older build) or
+   *  sent one we do not ship — both mean UNKNOWN, and unknown renders English.
+   *
+   *  Why per TAB and not per process: a `say` frame is a chat bubble inside one specific
+   *  panel tab, and those strings NAME PANEL CONTROLS ("Settings → OpenRouter → 'Set API
+   *  key…'"). Rendered in the process locale — the language of whoever launched the server —
+   *  the instruction would point at a label that user cannot find on their own screen. So the
+   *  language must come from the destination tab. See {@link tabLocale}. */
+  locale?: Locale;
 }
 
 /** Panel build that first implements the full graph_* / ui_* bridge command set.
@@ -1921,6 +1932,12 @@ export class UiBridge {
     // deleted during migration below; without carrying this, a graph-edit-triggered
     // migration + undercutting-version hello would reintroduce the false "too old" gate.
     let migratedProvenSupported: Set<string> | undefined;
+    // Same idea for the panel language: a WORKFLOW SWITCH re-hellos on this socket under a
+    // NEW tab id, so the retiring conn is not `existing` and same-socket inheritance cannot
+    // see it. Without this carry-over a panel that omitted `locale` on the switch hello would
+    // drop back to English mid-session — which is exactly the case the field's doc claims is
+    // preserved. Consumed once, with migratedProvenSupported.
+    let migratedLocale: Locale | undefined;
 
     sock.on("message", (buf: unknown) => {
       const raw = String(buf);
@@ -1963,6 +1980,9 @@ export class UiBridge {
           // Carry the retiring conn's proven-supported veto to the migrated id (#422)
           // — same socket/panel, so demonstrated capability must not be lost.
           migratedProvenSupported = this.conns.get(tabId)?.provenSupportedCmds;
+          // …and the panel language, for the same reason: same socket, same browser tab, same
+          // person reading the bubbles.
+          migratedLocale = this.conns.get(tabId)?.locale;
           this.conns.delete(tabId);
           // Move mirror subscribers to the migrated tab id so viewers keep this
           // tab's live feed across a same-socket re-hello. #570 P0a — this is OPTIMISTIC
@@ -2160,6 +2180,27 @@ export class UiBridge {
           serverOrigin: existing?.sock === sock ? (serverOrigin ?? existing?.serverOrigin) : serverOrigin,
           // Server-trusted provenance of THIS socket (not client-controlled).
           local,
+          // The panel's own resolved UI language, so `say` bubbles land in the language of
+          // the controls they name. Narrowed here rather than at the read sites: an unshipped
+          // or garbage value becomes undefined once, at the boundary, instead of every caller
+          // having to defend against it.
+          //
+          // PRESENCE decides inheritance, not resolvability. A hello that CARRIES the field is
+          // authoritative even when we cannot ship what it asked for: a user who just switched
+          // the panel to German must get English, not the Japanese they had a moment ago —
+          // otherwise every bubble names controls in a language no longer on their screen.
+          //
+          // Only an ABSENT field inherits, and only from this same socket (the `originUrl`
+          // rule above, same reason: wf: ids recur, so a DIFFERENT socket reusing this id is a
+          // different browser tab whose language we have not been told) — or from the conn
+          // this socket is migrating away from, since a workflow switch re-hellos under a NEW
+          // tab id. Cosmetic either way; nothing gates on it.
+          locale:
+            "locale" in msg
+              ? typeof msg.locale === "string"
+                ? (resolveLocale(msg.locale) ?? undefined)
+                : undefined
+              : ((existing?.sock === sock ? existing?.locale : undefined) ?? migratedLocale),
         });
         // CONSUME the migration carry-over exactly once: it belongs to THIS hello's
         // conn only. Leaving it set would let a LATER same-socket re-hello rebuild the
@@ -2167,6 +2208,7 @@ export class UiBridge {
         // Unknown-command reply cleared it — re-bypassing the undercut-version gate
         // (codex round-8 P1).
         migratedProvenSupported = undefined;
+        migratedLocale = undefined;
         if (incomingHeadless) {
           this.headlessSeen.add(tabId);
         } else {
@@ -2825,6 +2867,28 @@ export class UiBridge {
     }
   }
 
+  /**
+   * The panel language to render a HUMAN-facing frame in for `tabId` — English when the
+   * tab never advertised one, advertised one we do not ship, or is not connected.
+   *
+   * Resolved through the SAME path as `push` (exact id → prefix → same-socket migration
+   * alias → scope address), so the language is the language of the tab that will actually
+   * RECEIVE the frame, not of whatever id the caller happened to hold. A `say` naming
+   * "Settings → OpenRouter" is useless in a language the panel around it is not in.
+   *
+   * NEVER THROWS, and that is the load-bearing part: these strings are emitted while
+   * reporting OTHER failures — a start failure, a lost render completion, a panel sync that
+   * did not happen — so a locale lookup that could throw would turn a report of one failure
+   * into two. English is always an acceptable answer; an exception never is.
+   */
+  tabLocale(tabId: string): Locale {
+    try {
+      return this.resolveTarget(tabId).locale ?? "en";
+    } catch {
+      return "en";
+    }
+  }
+
   /** #952 — the DISTINCT ComfyUI origins the connected tabs actually front, for
    *  the headless-fetch drift comparison (see comfyui/fetch.ts). Trusted
    *  handshake Origins only, so a tab that supplied none is simply absent rather
@@ -3099,10 +3163,16 @@ export class UiBridge {
           this.push(
             {
               type: "say",
-              text:
-                `⚠️ Too many question cards are open at once in this tab, so the oldest ones can no ` +
-                `longer accept an answer — clicking them will do nothing. Answer the most recent card, ` +
-                `or just type your choice in the chat and the agent will pick it up.`,
+              // The ⚠️ stays outside the translated span: it is the status marker the panel's
+              // own bubble styling and a skimming eye both key on, and it means the same thing
+              // in every language.
+              text: `⚠️ ${trFor(
+                this.tabLocale(tabId),
+                "say.too_many_question_cards",
+                "Too many question cards are open at once in this tab, so the oldest ones can no " +
+                  "longer accept an answer — clicking them will do nothing. Answer the most recent card, " +
+                  "or just type your choice in the chat and the agent will pick it up.",
+              )}`,
             },
             tabId,
           );


### PR DESCRIPTION
## What

The 21 `say` bridge frames — the orchestrator's only chat bubbles, the ones a **person** reads — now render in the **destination panel tab's** language.

Base: `feat/mcp-i18n-foundation` (the i18n runtime). Merge that first.

## Why `trFor`, not `tr`

These strings name panel controls: *"Settings → OpenRouter → 'Set API key…'"*, *"Open LM Studio → Developer → Start Server"*, *"the API Keys card"*. `tr()` follows `--lang`/`LANG` on the machine running the orchestrator — the language of whoever launched the server, which on a RunPod box or a shared workstation is nobody in particular. A bubble in that language points the user at a label that is not on their screen. That is worse than English, because it looks like it should work.

So the language has to come from the destination tab.

## The mechanism (the design decision this PR asks you to review)

The panel did not report its language over the bridge. **Smallest sound mechanism:** an optional `locale` field on the **existing `hello`** frame.

| | |
|---|---|
| Wire | `hello.locale` — one optional string, no new frame type, no round trip |
| Narrowing | `resolveLocale()` once at the boundary, so an unshipped/garbage value becomes `undefined` in one place instead of at every read site |
| Storage | `Conn.locale` (`ui-bridge.ts`), beside `panelVersion` / `originUrl` |
| Read | `bridge.tabLocale(tabId)` → `Locale`, **English when unknown** |
| Panel change needed to ship this | **None.** A panel that sends nothing gets English — byte-identical to today. |

`tabLocale` resolves through the **same path `push` does** (exact id → prefix → same-socket migration alias → scope address), so the language is the language of the tab that will actually *receive* the frame, not of whatever id the caller happened to be holding.

**`tabLocale` never throws**, and that is load-bearing rather than defensive habit. Every one of these strings is emitted while reporting some *other* failure — an agent that would not start, render results that were lost, a panel sync that did not happen. A lookup that could throw would turn one failure report into two, in the moment the user is already dealing with a problem. There is a test for each unknown (absent / unshipped / non-string / unknown tab while another is connected / ambiguous prefix).

### Panel side (follow-up, not blocking)

`comfyui-mcp-panel` needs one line in `buildHelloPayload()` (`web/js/lib/session-rebind.js`) — that function is already the single place every hello is built, and the panel's i18n branch already has `currentLocale()`. **Until that lands, every `tabLocale()` returns `"en"` and this unit is inert**; it only makes the strings translatable.

## Things that were wrong first

Two adversarial review rounds. Round 1 found four runtime defects; round 2 found no runtime regression but four defects *in the guard whose entire job is to stop this from rotting*. Every one has a mutation-verified test.

**Round 1 — runtime**

1. **PRESENCE decides inheritance, not resolvability.** A hello carrying `locale: "de"` is authoritative even though we do not ship German. Someone who *just switched the panel to German* needs English — keeping their previous Japanese means every bubble names controls in a language no longer anywhere on their screen.
2. **A workflow switch re-hellos on the same socket under a NEW tab id**, so plain same-socket inheritance cannot see the retiring conn (already deleted and re-keyed). Carried over explicitly, next to the #422 `provenSupportedCmds` veto that needed the identical treatment.
3. **The start-failure notice fans out to a CONVERSATION** (#884) — every tab on that backend, which can be several panels in different languages. It renders **per recipient** via a new `pushSayToConversation`. Deriving one locale from the agent key cannot work: the key is usually the scope address `orchestrator::<backend>`, which resolves to whichever tab happens to be pinned or last-active.
4. The source guard's fixed-width window let a neighbouring translated frame vouch for an untranslated one.

**Round 2 — the guard was vouching for what it was meant to catch**

5. Bounding the window at the *next* `say` site fixed only the trailing direction. The translator calls that build the next frame's text sit **between** the two markers — so an untranslated `say` inserted *before* the panel-sync frame passed, with `advice`'s two `trFor` calls standing in for it. The guard now reads the frame's **own `text:` value**, bounded by indentation (brace matching would need a full string/template scanner here — `{count}`, `${trFor(` — while prettier's layout is already unambiguous). A test asserts the extraction stops before the next frame, so the property the guard rests on is measured rather than believed.
6. **Exemptions were a neighbourhood, so they excused the neighbours.** The ±80/120 collar existed so both `pushSayToConversation` fragments would count as used; that same width happily excused an untranslated frame dropped between them. Each occurrence now binds to exactly **one site**.
7. **It scanned an allowlist of two files and missed one that emits a frame** — `start-failure-notice.ts`. It now walks every non-test source file. Verified by planting an untranslated frame in `ready-banner.ts`, which no allowlist ever named.
8. **It certified four bubbles that were permanently English.** The `degradedText` exemption said "assembled with trFor in the ternary chain just above" — true of eleven branches, false of the twelfth: `reg.degradedMessage` is a hardcoded sentence in the key-provider registry.

## Scope

**Translated (~35 strings, key prefix `say.`)**

- `src/orchestrator/index.ts` — connect-time guards (OpenRouter keyless, pi credential-less, custom no base URL), all **15** per-backend "background agent isn't responding" variants, llama.cpp `--jinja` / small-context probes, blind mode on/off, options-change failure, OAuth sign-in failure, New-chat durable-clear failure, the local-VRAM queue notice, the render-finished resume notice, the lost-completion restart disclosure, the panel auto-sync failure
- `src/services/ui-bridge.ts` — the too-many-question-cards notice
- `src/orchestrator/start-failure-notice.ts` — `startFailureHint()` (4 variants) + the notice sentence, extracted to `startFailureSay()` so one sentence serves both the frame builder and the per-tab fan-out

English fallbacks are **byte-identical** to what shipped, `(s)` plural hedge included — `{ count }` rides along so a catalog can supply real plural forms (`_one`/`_few`/`_other` via `Intl.PluralRules`) without anyone editing English. Emoji (⚠️ ✅ ⏸ 🕶️ 👁️ ℹ️) stay **outside** the translated span: they carry status independent of language. Tool calls, shell commands, env-var names, URLs and provider labels are interpolated or quoted literally — they are typed, not read.

**AMBIGUOUS — deliberately left English**

- **`ack` frame `message:` fields.** As instructed, and I agree: they read as machine errors, `kind` is string-matched by the panel, and they double as agent-visible text. They are the one surface here where a translation could break a parse rather than just read oddly. If we ever want them localized it should be a separate `message_key` alongside the English `message`, not a swap.
- **`error-text.ts`** — untouched. Its sentinels (`"[object Object]"`, `"unknown error"`, `"[unserializable message payload]"`) are matched by code.
- **`readyBannerText`/`bannerCorrection`** (ready-banner.ts), the **panel-sync** message, and the **self-restarter's** announcement — each has its own owning module and belongs to whichever unit covers it. Those files have no i18n yet, so the exemptions naming them say **TRANSLATED ELSEWHERE (pending)** rather than the misleading "X owns that string".
- **`reg.degradedMessage`** (`openai-provider-registry.ts`) is **no longer** on this list — see round-2 finding 8. Now keyed `say.degraded.<backend>` with the table's own English as the fallback, its leading ⚠️ stripped so all fifteen `say.degraded.*` fallbacks have one shape (a catalog should never have to guess which include the marker). A test pins that assumption about the table.
- **Mirror viewers (phone).** An attached viewer receives `say` frames through the mirror fan-out of the desktop tab it drives, so it gets **that tab's** language, not its own. Correct-ish (it is mirroring that tab) but worth naming.
- **Parked frames.** When no tab is connected, a conversation `say` parks in English and is replayed on the next hello — the tab that will receive it has not told us its language yet. English is the honest default rather than a guess.

**NOT translated, by design** — `panel-tools.ts`, `src/tools/**`, `PANEL_SYSTEM_APPEND`, the per-backend system prompts, the refusal modules, `plugin/**`, every `.describe()`. That is prompt engineering the model routes on; translating it degrades behaviour silently and no test here would catch it.

## Tests — 29 new, and why a source-level guard

Nothing in a normal suite would notice a deleted `trFor(` wrapper: the English stays correct, the types stay clean, the run stays green, and the string is quietly untranslatable forever. The same hole swallows a new `say` site added by someone who has not read this file.

So `ui-bridge-locale.test.ts` walks **every non-test source file**, extracts each `say` frame's own `text:` expression, and requires a `trFor` in it. Exemptions are an **enumerated list**, each naming the module that owns its text, each bound to exactly one site, and each required to still match live code so a stale entry cannot silently grant amnesty to whatever moved into its place.

Verified by mutation in both directions — each of these was confirmed to fail the suite, then reverted:

| Mutation | Caught by |
|---|---|
| `locale` never stored | 6 tests |
| inherit across *any* socket (not just same-socket) | takeover test |
| `tabLocale` bypasses `resolveTarget` | prefix-routing test |
| `tabLocale` loses its try/catch | never-throws test |
| workflow-switch carry-over dropped | migration test |
| inheritance keyed on resolvability instead of presence | German-switch test |
| a call site's `trFor` wrapper removed | source guard, with the exact line number |
| an untranslated `say` inserted **before** a translated one, translator calls in between | source guard (round-2 fix) |
| an untranslated `say` dropped **beside an exempt fragment** | source guard (round-2 fix) |
| an untranslated `say` planted in a file no allowlist named (`ready-banner.ts`) | source guard (round-2 fix) |

`npm run lint` clean. `npm test`: **8538 passed, 0 failed**.

**Pre-existing flake, not from this branch:** `src/__tests__/services/ui-bridge.test.ts` intermittently fails one test in the mirror / scope-routing describes — always a `vi.waitFor(() => bridge.tabs()…)` on tab registration, a different test each run. Reproduced on the **untouched base** by stashing this branch's changes (2 failures in one run there). Worth a separate look; the file takes ~62s and these look like they sit on a timeout boundary.

**Base merged.** `origin/feat/mcp-i18n-foundation` advanced during review (`df07a4d`: single-pass interpolation + the missing `scripts/i18n-check.mjs`). Merged in — which also made three of my own comments stale, since they explained placeholder safety by *variable order* and interpolation is now one regex pass where order is irrelevant. Reworded rather than left for a later reader to "restore".
