### PR TITLE
feat(i18n): translate the CLI surface — help, banners, setup output

### DIFF
--- a/src/__tests__/i18n/cli-strings.test.ts
+++ b/src/__tests__/i18n/cli-strings.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Source-level guards for the translated CLI surface.
+ *
+ * These read the SOURCE rather than the rendered output on purpose. Both properties they
+ * check are invisible in a rendering: a key typo'd out of its namespace still renders
+ * perfect English (the fallback is right there at the call site), and translating a tool
+ * definition also renders perfectly — right up until a model stops routing on it. Neither
+ * failure has an observable symptom until a catalog exists, by which point the mistake is
+ * spread across twelve of them.
+ */
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** The files this unit translates. */
+const CLI_SURFACE = [
+  join(SRC, "transport", "cli.ts"),
+  join(SRC, "boot.ts"),
+  join(SRC, "services", "agent-setup.ts"),
+];
+
+/** `tr("key"` — the key is always the first argument and always a plain literal. */
+const KEY = /\btr\(\s*"([^"]+)"/g;
+
+/** `tr("key", "fallback"` / `tr("key", 'fallback'` — the fallback's first literal fragment. */
+const KEY_AND_FALLBACK =
+  /\btr\(\s*"([^"]+)"\s*,\s*(?:("(?:[^"\\]|\\.)*")|('(?:[^'\\]|\\.)*'))/g;
+
+function matchAll(re: RegExp, text: string): RegExpExecArray[] {
+  return [...text.matchAll(new RegExp(re.source, re.flags))];
+}
+
+describe("CLI translation call sites", () => {
+  it("namespaces every key under `cli.`", () => {
+    for (const file of CLI_SURFACE) {
+      const src = readFileSync(file, "utf8");
+      const keys = matchAll(KEY, src).map((m) => m[1]);
+      expect(keys.length, `${relative(SRC, file)} should have translated strings`).toBeGreaterThan(0);
+      for (const key of keys) {
+        expect(key, `${relative(SRC, file)}: key "${key}" must start with "cli."`).toMatch(/^cli\./);
+      }
+    }
+  });
+
+  it("gives one key exactly one English text", () => {
+    // A key is the identity of a string in twelve catalogs at once. Two call sites sharing
+    // a key with DIFFERENT English is the one mistake a translator cannot detect and cannot
+    // fix: whichever wording they are shown, the other call site silently renders it.
+    // Sharing a key for genuinely identical text is fine, and this allows it.
+    const byKey = new Map<string, Set<string>>();
+    for (const file of CLI_SURFACE) {
+      for (const m of matchAll(KEY_AND_FALLBACK, readFileSync(file, "utf8"))) {
+        const set = byKey.get(m[1]) ?? new Set<string>();
+        set.add(m[2] ?? m[3]);
+        byKey.set(m[1], set);
+      }
+    }
+    expect(byKey.size).toBeGreaterThan(0);
+    for (const [key, texts] of byKey) {
+      expect([...texts], `key "${key}" carries more than one English text`).toHaveLength(1);
+    }
+  });
+});
+
+/** Every .ts under `dir`, recursively. */
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) out.push(...walk(p));
+    else if (name.endsWith(".ts")) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * The files whose ENGLISH IS THE INTERFACE. Enumerated, not pattern-matched: an over-broad
+ * guard here would block the units that legitimately DO translate parts of the orchestrator
+ * (the ready banner, the start-failure notice, the `say` frames), and a guard that blocks
+ * the fix is worse than the one it replaced.
+ */
+function agentFacingFiles(): string[] {
+  return [
+    ...walk(join(SRC, "tools")),
+    // The per-backend system prompts: the wording each harness's model is steered by.
+    ...readdirSync(join(SRC, "orchestrator"))
+      .filter((n) => n.endsWith("-backend.ts"))
+      .map((n) => join(SRC, "orchestrator", n)),
+    join(SRC, "orchestrator", "panel-tools.ts"),
+    join(SRC, "orchestrator", "fence-refusal.ts"),
+    join(SRC, "orchestrator", "call-tool-admission.ts"),
+    join(SRC, "orchestrator", "cli-remedy.ts"),
+  ];
+}
+
+describe("the agent-facing surface is NOT translated", () => {
+  it("keeps the translation runtime out of the files a model routes on", () => {
+    // The boundary from src/i18n/index.ts, enforced instead of only documented. Everything
+    // below is prompt engineering — its exact English wording is what the model selects on,
+    // `check:vocabulary` gates it in CI, and translating it degrades behaviour with nothing
+    // in this repo failing. A reviewer looking at a diff full of plausible `tr()` calls has
+    // no way to see which side of the line each one is on; this does.
+    //
+    // Both the import AND the call are checked. Matching only the import would miss
+    // `const { tr } = await import("../i18n/index.js")`, which is the form boot.ts already
+    // uses elsewhere in this very change; matching only the call would miss a re-export.
+    const IMPORTS_I18N = /(?:from|import\()\s*["'][^"']*i18n\/index\.js["']/;
+    // `(?:For)?`, not `For?` — the latter reads as "trFo" + optional "r" and matches neither
+    // `tr(` nor anything else that exists. It looked right and passed, which is exactly why
+    // this guard was mutation-tested against a call it was supposed to catch.
+    const CALLS_TR = /\btr(?:For)?\(/;
+    for (const file of agentFacingFiles()) {
+      let src: string;
+      try {
+        src = readFileSync(file, "utf8");
+      } catch {
+        continue; // a module that has since been renamed is not this test's business
+      }
+      const where = relative(SRC, file);
+      expect(src, `${where} must not import the i18n runtime`).not.toMatch(IMPORTS_I18N);
+      expect(src, `${where} must not call tr()/trFor()`).not.toMatch(CALLS_TR);
+    }
+  });
+
+  it("keeps PANEL_SYSTEM_APPEND untranslated without freezing the file around it", () => {
+    // src/orchestrator/index.ts cannot go in the list above: the panel persona lives there,
+    // but so do human-facing startup banners that ARE in scope for translation. So the guard
+    // is drawn around the symbol rather than the file.
+    const src = readFileSync(join(SRC, "orchestrator", "index.ts"), "utf8");
+    const start = src.indexOf("const PANEL_SYSTEM_APPEND");
+    expect(start, "PANEL_SYSTEM_APPEND was renamed — re-aim this guard").toBeGreaterThan(-1);
+    const persona = src.slice(start, src.indexOf("`;", start));
+    // A rename or a refactor that shrank the literal to nothing would make this vacuous.
+    expect(persona.length).toBeGreaterThan(500);
+    expect(persona, "the panel persona must not be translated").not.toMatch(/\btr(?:For)?\(/);
+  });
+});

--- a/src/__tests__/i18n/terminal-layout.test.ts
+++ b/src/__tests__/i18n/terminal-layout.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import {
+  displayWidth,
+  padTo,
+  widestLine,
+  banner,
+  labelRows,
+  numberedSteps,
+  RULE_MIN,
+  RULE_MAX,
+} from "../../i18n/terminal-layout.js";
+
+describe("displayWidth", () => {
+  it("counts ASCII one cell per character", () => {
+    expect(displayWidth("comfyui-mcp")).toBe(11);
+    expect(displayWidth("")).toBe(0);
+  });
+
+  it("counts CJK and Hangul as TWO cells — the failure this module exists for", () => {
+    // Korean, Japanese and Chinese are the three of our twelve locales where a
+    // character-counting pad is silently half as wide as it needs to be.
+    expect(displayWidth("한국어")).toBe(6);
+    expect(displayWidth("日本語")).toBe(6);
+    expect(displayWidth("中文")).toBe(4);
+    expect("한국어".length).toBe(3); // ...which is what the naive version would have used.
+  });
+
+  it("counts combining marks as ZERO — Arabic and Persian pad the other way", () => {
+    // U+0651 SHADDA renders into the preceding cell rather than taking one of its own.
+    expect(displayWidth("مَ")).toBe(1);
+    expect(displayWidth("é")).toBe(1);
+  });
+
+  it("treats the characters the banners are DRAWN from as one cell each", () => {
+    // If `═`, `—` or `•` were ever counted as wide, every rule in the CLI would double.
+    expect(displayWidth("═".repeat(68))).toBe(68);
+    expect(displayWidth("—")).toBe(1);
+    expect(displayWidth("•")).toBe(1);
+    expect(displayWidth("✓")).toBe(1);
+  });
+
+  it("counts an astral character once, not once per surrogate half", () => {
+    expect("🎨".length).toBe(2);
+    expect(displayWidth("🎨")).toBe(2); // wide, but for the right reason
+    expect(displayWidth("𠀀")).toBe(2); // CJK Extension B
+  });
+
+  it("counts emoji by presentation, not by which block they happen to sit in", () => {
+    // The emoji blocks are interleaved with narrow symbols, so any hand-picked range gets
+    // some of these wrong: 🚀 sits above the Emoticons block and ✅ is not in an emoji block
+    // at all, while ✓ and ✔ are text-presentation symbols one cell wide.
+    for (const wide of ["🚀", "✅", "🎨", "📦", "🧪", "⏰"]) {
+      expect(displayWidth(wide), `${wide} should be two cells`).toBe(2);
+    }
+    for (const narrow of ["✓", "✔", "→", "…", "±"]) {
+      expect(displayWidth(narrow), `${narrow} should be one cell`).toBe(1);
+    }
+  });
+});
+
+describe("padTo", () => {
+  it("pads to a cell column and never closer than the minimum separator", () => {
+    expect(padTo("abc", 10).length).toBe(10);
+    expect(displayWidth(padTo("한국어", 10))).toBe(10);
+    // Over-long input still gets its separator rather than colliding with the next column.
+    expect(padTo("a".repeat(20), 10, 3)).toBe(`${"a".repeat(20)}   `);
+  });
+});
+
+describe("widestLine", () => {
+  it("measures in cells and splits embedded newlines", () => {
+    expect(widestLine(["ab", "abcd"])).toBe(4);
+    expect(widestLine(["ab\nabcdef"])).toBe(6);
+    expect(widestLine(["한국어"])).toBe(6);
+  });
+});
+
+describe("labelRows", () => {
+  it("reproduces the hand-typed English alignment exactly", () => {
+    expect(
+      labelRows(" ", [
+        ["Agent bridge", "ws://127.0.0.1:9180"],
+        ["Driving", "https://example.com"],
+        ["Secure", "yes"],
+      ]),
+    ).toEqual([
+      " Agent bridge : ws://127.0.0.1:9180",
+      " Driving      : https://example.com",
+      " Secure       : yes",
+    ]);
+  });
+
+  it("aligns colons by CELLS, not characters", () => {
+    // The discriminating case: a `.length`-based implementation passes the English test
+    // above and fails this one, because here the two prefixes are the same number of cells
+    // and a DIFFERENT number of characters.
+    const rows = labelRows(" ", [
+      ["에이전트 브리지", "ws://127.0.0.1:9180"],
+      ["Driving", "https://example.com"],
+    ]);
+    const prefixes = rows.map((r) => r.slice(0, r.indexOf(": ")));
+    expect(new Set(prefixes.map(displayWidth)).size).toBe(1);
+    expect(new Set(prefixes.map((p) => p.length)).size).toBe(2);
+  });
+
+  it("returns nothing for no rows instead of throwing", () => {
+    // Callers assemble these lists conditionally, so an empty one is reachable — and the
+    // naive implementation throws RangeError from `" ".repeat(-Infinity)` on the startup
+    // path, where a layout helper crashing is far worse than a section rendering empty.
+    expect(labelRows(" ", [])).toEqual([]);
+  });
+
+  it("hangs a multi-line value under the value column, not under the label", () => {
+    const rows = labelRows(" ", [
+      ["Secure", "first line\nsecond line"],
+      ["Agent bridge", "x"],
+    ]);
+    expect(rows).toEqual([
+      " Secure       : first line",
+      "                second line",
+      " Agent bridge : x",
+    ]);
+    // The hanging indent is derived from the translated label's CELL width, so the
+    // continuation still starts in the value column when the label is not English.
+    const ko = labelRows(" ", [["보안", "one\ntwo"]]);
+    const cellColumnOf = (line: string, text: string) =>
+      displayWidth(line.slice(0, line.indexOf(text)));
+    expect(cellColumnOf(ko[1], "two")).toBe(cellColumnOf(ko[0], "one"));
+  });
+});
+
+describe("numberedSteps", () => {
+  it("numbers from 1 and hangs continuations under the text", () => {
+    expect(numberedSteps(["do a thing", "do another\non two lines"])).toEqual([
+      "   1. do a thing",
+      "   2. do another",
+      "      on two lines",
+    ]);
+  });
+});
+
+describe("banner", () => {
+  const ruleOf = (b: string) => b.split("\n")[1];
+
+  it("keeps the legacy rule width for content that fits inside it", () => {
+    expect(ruleOf(banner("title", [" short"]))).toBe("═".repeat(RULE_MIN));
+  });
+
+  it("widens the rule to its widest line rather than letting content overhang", () => {
+    // The connect banner has always had a 71-cell line inside a 68-cell rule.
+    expect(ruleOf(banner("t", [` ${"x".repeat(70)}`])).length).toBe(71);
+  });
+
+  it("measures that width in CELLS, so a CJK box is not drawn half-size", () => {
+    // 35 ideographs = 35 characters but 70 cells. A `.length` rule would stay at the 68-cell
+    // floor and the text would run past the end of its own box.
+    expect(ruleOf(banner("t", [` ${"字".repeat(35)}`])).length).toBe(71);
+  });
+
+  it("caps the rule at a width every terminal has, so it can never wrap", () => {
+    // A wrapped rule is not a wider box, it is two ragged lines and no box.
+    expect(RULE_MAX).toBeLessThanOrEqual(80);
+    expect(ruleOf(banner("t", [` ${"x".repeat(400)}`])).length).toBe(RULE_MAX);
+  });
+
+  it("drops null rows and fences the body between two identical rules", () => {
+    const lines = banner("t", [" a", null, " b"]).split("\n");
+    expect(lines[0]).toBe("");
+    expect(lines[2]).toBe(" t");
+    expect(lines.slice(4, -2)).toEqual([" a", " b"]);
+    expect(lines[1]).toBe(lines[3]);
+    expect(lines[1]).toBe(lines[lines.length - 2]);
+    expect(lines[lines.length - 1]).toBe("");
+  });
+});

--- a/src/__tests__/transport/cli.test.ts
+++ b/src/__tests__/transport/cli.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   exportExplicitToolMode,
+  helpRow,
   parseCliArgs,
   renderCliHelp,
   validateConnectUrl,
 } from "../../transport/cli.js";
+import { displayWidth } from "../../i18n/terminal-layout.js";
+import { __resetI18nForTest } from "../../i18n/index.js";
 
 const base = ["node", "comfyui-mcp"];
 
@@ -238,7 +241,34 @@ describe("validateConnectUrl", () => {
   });
 });
 
+/**
+ * Pin the CLI's language for a block of assertions.
+ *
+ * Not optional hygiene: `renderCliHelp()` now runs every string through `tr()`, and `tr()`
+ * resolves its locale from COMFYUI_MCP_LANG / LC_ALL / LC_MESSAGES / LANG. A contributor
+ * whose shell is `LANG=ko_KR.UTF-8` — the entire audience this feature is for — would
+ * otherwise get a red suite on an unmodified tree, and the `(active: …)` row makes that true
+ * TODAY, before any catalog exists. COMFYUI_MCP_LANG is set rather than the others because
+ * it wins the precedence chain outright, so one variable is enough to pin the answer.
+ */
+function pinLocale(locale: string): () => void {
+  const prev = process.env.COMFYUI_MCP_LANG;
+  process.env.COMFYUI_MCP_LANG = locale;
+  __resetI18nForTest();
+  return () => {
+    if (prev === undefined) delete process.env.COMFYUI_MCP_LANG;
+    else process.env.COMFYUI_MCP_LANG = prev;
+    __resetI18nForTest();
+  };
+}
+
 describe("--help (#860)", () => {
+  let restore = () => {};
+  beforeEach(() => {
+    restore = pinLocale("en");
+  });
+  afterEach(() => restore());
+
   it("sets help for both --help and -h, and does not disturb other options", () => {
     for (const flag of ["--help", "-h"]) {
       const cli = parseCliArgs([...base, flag], {});
@@ -294,5 +324,69 @@ describe("--help (#860)", () => {
     ]) {
       expect(help, `${flag} must appear in --help`).toContain(flag);
     }
+  });
+
+  it("consumes --lang's value so it cannot be read as an operand", () => {
+    // The parser stores nothing for `--lang` — processLocale() reads it off argv directly,
+    // because the locale has to be resolved before this parser runs. But the VALUE still has
+    // to be eaten: `connect` and `setup` both take their operand from the next bare token,
+    // so a loose locale code sitting in argv is one keystroke away from being read as one.
+    for (const argv of [
+      [...base, "--lang", "ko", "setup", "hermes"],
+      [...base, "--lang=ko", "setup", "hermes"],
+    ]) {
+      expect(parseCliArgs(argv, {}).setupAgent, argv.join(" ")).toBe("hermes");
+    }
+    // ...and the flag itself must not be mistaken for an operand either.
+    expect(parseCliArgs([...base, "setup", "--lang", "ko"], {}).setupAgent).toBe("");
+    expect(parseCliArgs([...base, "connect", "--lang", "ko"], {}).comfyuiUrl).toBeUndefined();
+    expect(parseCliArgs([...base, "connect", "http://x:8188", "--lang", "ko"], {}).comfyuiUrl).toBe(
+      "http://x:8188",
+    );
+  });
+
+  it("documents --lang, the one flag parseCliArgs never sees", () => {
+    // `--lang` is read straight out of argv by processLocale(), so the "every flag the
+    // parser accepts" test above structurally cannot cover it — and a language switch
+    // nobody can find is the same undiscoverability #860 was about.
+    const help = renderCliHelp();
+    expect(help).toContain("--lang <code>");
+    expect(help).toContain("env: COMFYUI_MCP_LANG");
+  });
+});
+
+describe("--help is translated, and degrades to English", () => {
+  let restore = () => {};
+  afterEach(() => restore());
+
+  it("renders English for a locale with no catalog on disk", () => {
+    // The shipping state today: `tr()` carries its English at the call site, so a user with
+    // LANG=ko_KR.UTF-8 gets a complete English screen rather than a screen of raw keys. This
+    // is the behaviour that has to hold for every release BETWEEN this change and the first
+    // catalog, which is most of them.
+    restore = pinLocale("en");
+    const english = renderCliHelp();
+    restore();
+    restore = pinLocale("ko");
+    const korean = renderCliHelp();
+    // The `--lang` row reports the ACTIVE locale, so it is the one line that is supposed to
+    // move. Everything else is prose, and prose with no catalog behind it stays English.
+    expect(korean).toContain("env: COMFYUI_MCP_LANG   (active: ko)");
+    expect(korean.replace("(active: ko)", "(active: en)")).toBe(english);
+    expect(korean).not.toMatch(/\bcli\.[a-z_]+\b/);
+  });
+
+  it("lays the two columns out in terminal CELLS, not characters", () => {
+    // The mutation this catches: `padTo(...)` swapped for `String.prototype.padEnd`. Every
+    // string on the screen is ASCII until a catalog lands, so the assembled output is
+    // IDENTICAL under both — the row helper is the only place the difference is observable
+    // before the bug ships to twelve languages at once.
+    const ascii = helpRow("--host <host>", "HTTP bind host", "env: MCP_HOST");
+    const korean = helpRow("--host <host>", "호스트", "env: MCP_HOST");
+    expect(displayWidth(ascii.slice(0, ascii.indexOf("env:")))).toBe(
+      displayWidth(korean.slice(0, korean.indexOf("env:"))),
+    );
+    // ...and prove the naive version would have disagreed here.
+    expect(korean.indexOf("env:")).not.toBe(ascii.indexOf("env:"));
   });
 });

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -17,6 +17,8 @@ import { startHttpServer } from "./transport/http.js";
 import { isLocalMode } from "./config.js";
 import { ensurePanelInstalled } from "./services/panel-installer.js";
 import { checkAndSelfUpdate } from "./services/self-update.js";
+import { tr } from "./i18n/index.js";
+import { banner, labelRows, numberedSteps } from "./i18n/terminal-layout.js";
 
 /**
  * Fire-and-forget: ensure the ComfyUI sidebar panel is installed (install-if-
@@ -246,26 +248,35 @@ async function openTunnelAndAnnounce(
   // Single multi-line block to stderr so it survives MCP stdio framing and is
   // easy to copy from the terminal.
   process.stderr.write(
-    [
+    banner(`ComfyUI MCP — ${tr("cli.tunnel_title", "Remote / Hosted Connector is LIVE")}`, [
+      ...labelRows(" ", [
+        [tr("cli.tunnel_label_public_url", "Public MCP URL"), mcpUrl],
+        [tr("cli.tunnel_label_token", "Auth token"), token],
+      ]),
       "",
-      "════════════════════════════════════════════════════════════════════",
-      " ComfyUI MCP — Remote / Hosted Connector is LIVE",
-      "════════════════════════════════════════════════════════════════════",
-      ` Public MCP URL : ${mcpUrl}`,
-      ` Auth token     : ${token}`,
+      // Names CLAUDE DESKTOP's own menu path, which is localised by Claude Desktop's
+      // language setting and not by ours. The English fallback must keep matching that app's
+      // English UI exactly; a catalog should only translate it to the wording Claude Desktop
+      // itself uses in that language, never to a literal translation of these words.
+      ` ${tr("cli.tunnel_desktop_connector_path", "Claude Desktop → Settings → Connectors → Add custom connector:")}`,
+      // The header NAMES are wire protocol, not prose — only the row labels translate.
+      ...labelRows("   • ", [
+        [tr("cli.tunnel_field_name", "Name"), "ComfyUI"],
+        [tr("cli.tunnel_field_url", "URL"), mcpUrl],
+        [
+          tr("cli.tunnel_field_header", "Header"),
+          // The alternative is one phrase, not the word "or" plus a header name: a lone
+          // conjunction is untranslatable without the sentence it sits in, and both header
+          // spellings have to survive into every language byte-for-byte anyway.
+          `X-API-Key: ${token}   ${tr("cli.tunnel_header_alt", "(or Authorization: Bearer {token})", { token })}`,
+        ],
+      ]),
       "",
-      " Claude Desktop → Settings → Connectors → Add custom connector:",
-      `   • Name : ComfyUI`,
-      `   • URL  : ${mcpUrl}`,
-      `   • Header: X-API-Key: ${token}   (or Authorization: Bearer ${token})`,
-      "",
-      " Headless / programmatic config snippet:",
+      ` ${tr("cli.tunnel_headless_snippet", "Headless / programmatic config snippet:")}`,
       snippet,
       "",
-      " Keep this terminal open — the tunnel closes when the process exits.",
-      "════════════════════════════════════════════════════════════════════",
-      "",
-    ].join("\n"),
+      ` ${tr("cli.tunnel_keep_open", "Keep this terminal open — the tunnel closes when the process exits.")}`,
+    ]),
   );
 }
 
@@ -308,10 +319,17 @@ async function main() {
     const { setupAgent, AGENT_NAMES } = await import("./services/agent-setup.js");
     const agent = cli.setupAgent as (typeof AGENT_NAMES)[number];
     if (!AGENT_NAMES.includes(agent)) {
+      // Only the prose translates. The command itself is passed in as a variable rather than
+      // spliced around a translated "Usage" label, so what the user has to type back stays
+      // verbatim in every language — including the agent names, which are the literal values
+      // the parser matches on.
+      const usage = `comfyui-mcp setup <${AGENT_NAMES.join("|")}> [--compact|--full] [--comfyui-url <url>] [--dry-run]`;
       process.stderr.write(
-        `\nUsage: comfyui-mcp setup <${AGENT_NAMES.join("|")}> [--compact|--full] [--comfyui-url <url>] [--dry-run]\n` +
-          (cli.setupAgent ? `\nUnknown agent "${cli.setupAgent}".\n` : "") +
-          `\nWrites the comfyui MCP server entry into the agent's own config file.\n`,
+        `\n${tr("cli.setup_usage", "Usage: {command}", { command: usage })}\n` +
+          (cli.setupAgent
+            ? `\n${tr("cli.setup_unknown_agent", 'Unknown agent "{agent}".', { agent: cli.setupAgent })}\n`
+            : "") +
+          `\n${tr("cli.setup_what_it_does", "Writes the comfyui MCP server entry into the agent's own config file.")}\n`,
       );
       process.exit(1);
     }
@@ -325,11 +343,15 @@ async function main() {
       const lines = [
         "",
         result.wrote
-          ? `✓ Added the "comfyui" MCP server to ${result.configPath}`
-          : `— dry run: would write ${result.configPath} as —`,
+          ? tr("cli.setup_wrote", '✓ Added the "comfyui" MCP server to {path}', {
+              path: result.configPath,
+            })
+          : tr("cli.setup_dry_run", "— dry run: would write {path} as —", {
+              path: result.configPath,
+            }),
         ...(result.wrote ? [] : ["", result.content.trimEnd()]),
         "",
-        "Next steps:",
+        tr("cli.setup_next_steps", "Next steps:"),
         ...result.nextSteps.map((s) => `  • ${s}`),
         "",
       ];
@@ -337,7 +359,9 @@ async function main() {
       process.exit(0);
     } catch (err) {
       process.stderr.write(
-        `\ncomfyui-mcp setup failed: ${err instanceof Error ? err.message : err}\n`,
+        `\n${tr("cli.setup_failed", "comfyui-mcp setup failed: {error}", {
+          error: err instanceof Error ? err.message : String(err),
+        })}\n`,
       );
       process.exit(1);
     }
@@ -363,7 +387,9 @@ async function main() {
       // local ComfyUI (which would make the banner below lie about what it drives).
       const urlError = validateConnectUrl(cli.comfyuiUrl);
       if (urlError) {
-        process.stderr.write(`\nComfyUI MCP — cannot start: ${urlError}\n\n`);
+        process.stderr.write(
+          `\n${tr("cli.cannot_start", "ComfyUI MCP — cannot start: {error}", { error: urlError })}\n\n`,
+        );
         process.exit(1);
       }
       process.env.COMFYUI_URL = cli.comfyuiUrl;
@@ -373,35 +399,58 @@ async function main() {
       // Remote https pod → secure wss:// tunnel (auto); local/http or
       // --insecure-bridge → plain loopback ws://. Informational only here.
       const secureBridge = !cli.insecureBridge && isRemoteHttpsPod(cli.comfyuiUrl);
-      const bridgeLine = secureBridge
-        ? " Agent bridge : wss:// secure Cloudflare tunnel (auto — nothing to copy)"
-        : ` Agent bridge : ws://127.0.0.1:${bridgePort}`;
+      const bridgeValue = secureBridge
+        ? tr("cli.connect_bridge_secure", "wss:// secure Cloudflare tunnel (auto — nothing to copy)")
+        : `ws://127.0.0.1:${bridgePort}`;
+      // Every string below that NAMES A PANEL CONTROL keeps its English fallback exactly as
+      // the panel renders it in English today, and says so in its key. The panel's own labels
+      // are being translated separately; until a catalog carries both, an English fallback is
+      // the only wording that still matches the button the user has to find. A catalog entry
+      // for one of these keys is only correct if it uses the panel's translation of that
+      // control, not a fresh translation of the sentence.
+      const steps = [
+        tr("cli.connect_step_open_comfyui", "Open that ComfyUI in your browser: {url}", {
+          url: cli.comfyuiUrl,
+        }),
+        tr(
+          "cli.connect_step_enable_external_orchestrator",
+          "In the Agent panel's Settings → General, turn ON\n'Use external/local orchestrator (advanced)'.",
+        ),
+        tr(
+          "cli.connect_step_click_connect",
+          "Click Connect in the panel (the Agent panel's Connect dropdown).",
+        ),
+      ];
       process.stderr.write(
-        [
+        banner(`ComfyUI MCP — ${tr("cli.connect_title", "local agent bridge is starting")}`, [
+          ...labelRows(" ", [
+            [tr("cli.connect_label_bridge", "Agent bridge"), bridgeValue],
+            [tr("cli.connect_label_driving", "Driving"), cli.comfyuiUrl],
+            ...(secureBridge
+              ? ([
+                  [
+                    tr("cli.connect_label_secure", "Secure"),
+                    tr(
+                      "cli.connect_secure_note",
+                      "the pod's HTTPS panel connects automatically over an\nencrypted tunnel — no URL to paste, works in any browser.",
+                    ),
+                  ],
+                ] as const)
+              : []),
+          ]),
           "",
-          "════════════════════════════════════════════════════════════════════",
-          " ComfyUI MCP — local agent bridge is starting",
-          "════════════════════════════════════════════════════════════════════",
-          bridgeLine,
-          ` Driving      : ${cli.comfyuiUrl}`,
-          secureBridge
-            ? " Secure       : the pod's HTTPS panel connects automatically over an\n                encrypted tunnel — no URL to paste, works in any browser."
-            : null,
+          ` ${tr("cli.connect_next_steps", "Next steps:")}`,
+          ...numberedSteps(steps),
           "",
-          " Next steps:",
-          `   1. Open that ComfyUI in your browser: ${cli.comfyuiUrl}`,
-          "   2. In the Agent panel's Settings → General, turn ON",
-          "      'Use external/local orchestrator (advanced)'.",
-          "   3. Click Connect in the panel (the Agent panel's Connect dropdown).",
-          "",
-          " Until you click Connect this window stays quiet — that's expected, not",
-          " a hang. The agent runs HERE on your Claude/Codex login; nothing is",
-          " installed on the ComfyUI box. Keep this terminal open.",
-          "════════════════════════════════════════════════════════════════════",
-          "",
-        ]
-          .filter((l): l is string => l !== null)
-          .join("\n"),
+          ...tr(
+            "cli.connect_quiet_note",
+            "Until you click Connect this window stays quiet — that's expected, not\n" +
+              "a hang. The agent runs HERE on your Claude/Codex login; nothing is\n" +
+              "installed on the ComfyUI box. Keep this terminal open.",
+          )
+            .split("\n")
+            .map((l) => ` ${l}`),
+        ]),
       );
     }
     const { runPanelOrchestrator } = await import("./orchestrator/index.js");

--- a/src/i18n/terminal-layout.ts
+++ b/src/i18n/terminal-layout.ts
@@ -1,0 +1,167 @@
+/**
+ * Laying out terminal text whose width you no longer control.
+ *
+ * THE PROBLEM. Every aligned thing this process prints was padded with `String.length`: the two-column
+ * `--help` screen, the colon-aligned label blocks in the connect and tunnel banners, the
+ * `════` rules that fence them. That was correct for exactly as long as every string was
+ * ASCII, because for ASCII the two numbers are equal.
+ *
+ * They stop being equal the moment the same line is Korean, Japanese or Chinese. Those
+ * characters are East Asian Wide: one code unit, TWO cells. Padding a 6-character Korean
+ * label to column 15 with `15 - s.length` therefore leaves it 6 cells too wide, and every
+ * line under it steps to the right — the exact "the box visibly broke" failure, and one
+ * that is invisible on a developer machine reading English.
+ *
+ * Combining marks go the other way. Arabic and Persian diacritics render INTO the preceding
+ * cell and occupy none of their own, so counting them pads too little.
+ *
+ * This is a deliberately narrow subset of UAX #11 — the Wide/Fullwidth blocks that can
+ * actually appear in the twelve locales we ship, plus zero for the marks and format
+ * characters. It is not a general `wcwidth` and does not need to be. Ambiguous-width
+ * characters (`—`, `•`, and the `═` box rule itself) are treated as ONE cell, which is what
+ * every terminal outside a CJK legacy locale does — and what the current banners already
+ * assume, since they draw their rules by repeating `═` a fixed number of times.
+ */
+
+/**
+ * East Asian Wide + Fullwidth. Ranges, not a property escape: ECMAScript exposes
+ * `\p{Script=Hangul}` but NOT `\p{East_Asian_Width=Wide}`, so there is nothing to ask.
+ */
+const WIDE: ReadonlyArray<readonly [number, number]> = [
+  [0x1100, 0x115f], // Hangul Jamo (initial consonants)
+  [0x2e80, 0x303e], // CJK Radicals … CJK Symbols. Stops before U+303F, which is narrow.
+  [0x3041, 0x33ff], // Hiragana, Katakana, Bopomofo, Hangul Compat Jamo, CJK compat
+  [0x3400, 0x4dbf], // CJK Unified Ideographs Extension A
+  [0x4e00, 0x9fff], // CJK Unified Ideographs
+  [0xa000, 0xa4cf], // Yi
+  [0xa960, 0xa97f], // Hangul Jamo Extended-A
+  [0xac00, 0xd7a3], // Hangul Syllables — the bulk of Korean text
+  [0xf900, 0xfaff], // CJK Compatibility Ideographs
+  [0xfe10, 0xfe19], // Vertical forms
+  [0xfe30, 0xfe6f], // CJK Compatibility Forms, small form variants
+  [0xff00, 0xff60], // Fullwidth ASCII forms
+  [0xffe0, 0xffe6], // Fullwidth signs
+  [0x20000, 0x3fffd], // CJK Extension B and beyond
+];
+
+/** Marks that render into the previous cell, plus format characters (ZWJ, bidi marks). */
+const ZERO_WIDTH = /^[\p{Mn}\p{Me}\p{Cf}]$/u;
+
+/**
+ * Emoji that default to the two-cell colour form, asked as a PROPERTY rather than as ranges.
+ *
+ * Ranges are the wrong tool here and were wrong when first written: the emoji blocks are
+ * interleaved with narrow symbols, so a hand-picked span like `1F300–1F64F` silently makes
+ * 🚀 (U+1F680) one cell and ✅ (U+2705, which is not in any emoji block at all) one cell,
+ * while the property gets both right. It also draws the line in exactly the place the
+ * banners need it: `✓`, `—`, `•` and `═` are text-presentation symbols, stay one cell, and
+ * so keep drawing the rules at the width this module promises.
+ */
+const EMOJI_WIDE = /^\p{Emoji_Presentation}$/u;
+
+/** Terminal cells a string occupies. */
+export function displayWidth(text: string): number {
+  let width = 0;
+  // Iterating the string (not indexing it) yields whole code points, so an astral
+  // character counts once rather than twice for its surrogate halves.
+  for (const ch of text) {
+    const cp = ch.codePointAt(0);
+    if (cp === undefined) continue;
+    if (ZERO_WIDTH.test(ch)) continue;
+    let wide = EMOJI_WIDE.test(ch);
+    if (!wide) {
+      for (const [lo, hi] of WIDE) {
+        if (cp >= lo && cp <= hi) {
+          wide = true;
+          break;
+        }
+      }
+    }
+    width += wide ? 2 : 1;
+  }
+  return width;
+}
+
+/**
+ * Pad `text` so the next column starts at `width` cells, never closer than `min`.
+ *
+ * `min` is what keeps an over-long entry readable instead of glued to its neighbour, and it
+ * is the reason this reproduces the hand-written help layout byte for byte: the existing
+ * screen already leaves three spaces after a description that overruns its column.
+ */
+export function padTo(text: string, width: number, min = 1): string {
+  return text + " ".repeat(Math.max(min, width - displayWidth(text)));
+}
+
+/** Widest line in a block, measured in cells. Embedded newlines are split first. */
+export function widestLine(lines: readonly string[]): number {
+  let widest = 0;
+  for (const line of lines) {
+    for (const part of line.split("\n")) widest = Math.max(widest, displayWidth(part));
+  }
+  return widest;
+}
+
+/**
+ * The `════` boxes the CLI prints, drawn from their CONTENT rather than from a rule length
+ * typed in once and hoped to still fit.
+ *
+ * These blocks used to be literal arrays with a 68-character rule above and below. That was
+ * a guess even in English — the connect banner's longest line is 71 cells, so its rule has
+ * been three short of its own content for as long as it has existed — and a guess is not
+ * something translation survives: the same sentence in Japanese is a different number of
+ * cells, in either direction. Deriving the rule from the widest line means the box fits
+ * whatever language is inside it.
+ *
+ * The floor keeps every box at least as wide as it renders today, so no box gets NARROWER
+ * because a language is terser.
+ *
+ * The ceiling is 80 because that is the width a terminal box can actually assume, and the
+ * two failure modes are not symmetric. A line that overhangs its rule looks untidy; a RULE
+ * that overhangs the terminal wraps onto a second line and stops being a frame at all. The
+ * tunnel banner is the case that settles it: one of its lines is a URL plus a 48-character
+ * token plus the same token again, which no rule was ever going to contain.
+ */
+export const RULE_MIN = 68;
+export const RULE_MAX = 80;
+
+export function banner(title: string, body: ReadonlyArray<string | null>): string {
+  const lines = body.filter((l): l is string => l !== null);
+  const width = Math.min(RULE_MAX, Math.max(RULE_MIN, widestLine([` ${title}`, ...lines])));
+  const rule = "═".repeat(width);
+  return ["", rule, ` ${title}`, rule, ...lines, rule, ""].join("\n");
+}
+
+/**
+ * A colon-aligned label block (` Driving      : http://…`).
+ *
+ * The column comes from the widest label PRESENT, in cells, so a translated label lands
+ * where its own text ends rather than where the English text used to. A value may contain
+ * newlines; continuation lines are indented to the value column by this helper, because
+ * that indent is a function of the translated label width and therefore cannot be baked
+ * into the string a translator writes.
+ */
+export function labelRows(
+  indent: string,
+  rows: ReadonlyArray<readonly [string, string]>,
+): string[] {
+  // Callers build these lists conditionally (the connect banner's `Secure` row is only there
+  // for a remote pod), so an empty list is reachable. `Math.max()` of nothing is -Infinity
+  // and `" ".repeat(-Infinity)` throws — which would turn an empty section into a crash on
+  // the startup path, in the one module that must never be able to add a failure.
+  if (rows.length === 0) return [];
+  const column = Math.max(...rows.map(([label]) => displayWidth(label))) + 1;
+  const hanging = " ".repeat(displayWidth(indent) + column + 2);
+  return rows.flatMap(([label, value]) => {
+    const [first, ...rest] = value.split("\n");
+    return [`${indent}${padTo(label, column, 1)}: ${first}`, ...rest.map((r) => hanging + r)];
+  });
+}
+
+/** `   1. …` steps. Continuation lines hang under the text, not under the number. */
+export function numberedSteps(steps: readonly string[]): string[] {
+  return steps.flatMap((step, i) => {
+    const [first, ...rest] = step.split("\n");
+    return [`   ${i + 1}. ${first}`, ...rest.map((r) => `      ${r}`)];
+  });
+}

--- a/src/services/agent-setup.ts
+++ b/src/services/agent-setup.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { parseDocument, Document } from "yaml";
+import { tr } from "../i18n/index.js";
 
 /**
  * First-class setup for non-Claude MCP harnesses (issue #97):
@@ -122,27 +123,51 @@ function mergeJson(existing: string, entry: Record<string, unknown>, file: strin
   return `${JSON.stringify(root, null, 2)}\n`;
 }
 
+/**
+ * Post-install instructions, printed to the terminal by `comfyui-mcp setup <agent>`.
+ *
+ * Translated (unlike almost everything else this package emits) because a person reads these
+ * and then does them by hand — see the scope note in src/i18n/index.ts. What stays verbatim
+ * in every language is everything the user has to TYPE or will SEE spelled that way in
+ * another program: the `/reload-mcp` and `/mcp show` slash commands, the `mcp_comfyui_*`
+ * tool names, the `--full` / `--compact` flags, and the model names.
+ */
 function nextSteps(agent: AgentName, compact: boolean): string[] {
   const compactNote = compact
-    ? "Compact tool mode is ON: the model gets list_tools/describe_tool/call_tool instead of ~200 schemas (rerun with --full for the complete surface)."
-    : "Full tool mode: ~200 tool schemas — right for frontier models (rerun with --compact for small/local models).";
+    ? tr(
+        "cli.setup_note_compact",
+        "Compact tool mode is ON: the model gets list_tools/describe_tool/call_tool instead of ~200 schemas (rerun with --full for the complete surface).",
+      )
+    : tr(
+        "cli.setup_note_full",
+        "Full tool mode: ~200 tool schemas — right for frontier models (rerun with --compact for small/local models).",
+      );
+  // One key, three call sites: both local-model harnesses print the same sentence, and a
+  // translator seeing it twice would be asked the same question twice.
+  const localModelsNote = tr(
+    "cli.setup_note_local_models",
+    "Local models: gemma4 (e4b or larger), qwen3, llama3.1+ have native tool calling; gemma3 does not.",
+  );
   switch (agent) {
     case "hermes":
       return [
-        "In a running Hermes session type /reload-mcp (or restart Hermes).",
-        "Tools appear as mcp_comfyui_list_tools / _describe_tool / _call_tool.",
-        "Local models: gemma4 (e4b or larger), qwen3, llama3.1+ have native tool calling; gemma3 does not.",
+        tr("cli.setup_hermes_reload", "In a running Hermes session type /reload-mcp (or restart Hermes)."),
+        tr(
+          "cli.setup_hermes_tool_names",
+          "Tools appear as mcp_comfyui_list_tools / _describe_tool / _call_tool.",
+        ),
+        localModelsNote,
         compactNote,
       ];
     case "openclaw":
       return [
-        "Restart the OpenClaw gateway to pick up the new server.",
-        "Local models: gemma4 (e4b or larger), qwen3, llama3.1+ have native tool calling; gemma3 does not.",
+        tr("cli.setup_openclaw_restart", "Restart the OpenClaw gateway to pick up the new server."),
+        localModelsNote,
         compactNote,
       ];
     case "copilot":
       return [
-        "Run `copilot` and check the server with /mcp show.",
+        tr("cli.setup_copilot_check", "Run `copilot` and check the server with /mcp show."),
         compactNote,
       ];
   }

--- a/src/transport/cli.ts
+++ b/src/transport/cli.ts
@@ -1,4 +1,6 @@
 import { parseComfyUIUrl } from "./comfyui-url.js";
+import { tr, processLocale } from "../i18n/index.js";
+import { padTo } from "../i18n/terminal-layout.js";
 
 export type TransportMode = "stdio" | "http";
 export type ToolMode = "full" | "compact";
@@ -179,6 +181,15 @@ export function parseCliArgs(
       } else {
         setupAgent = ""; // present but missing the agent → index.ts prints usage
       }
+    } else if (a === "--lang" || a.startsWith("--lang=")) {
+      // Recognised here ONLY so its value token cannot be mistaken for a positional. The
+      // value itself is read by processLocale() straight off argv, because the locale has to
+      // be known before this parser runs — `--help` is rendered in it, and so is the error
+      // this parser's own callers print. Skipping the case entirely (which is what happened
+      // when `--lang` was introduced) leaves a bare locale code loose in argv, in the same
+      // stream where `connect` and `setup` read their operands off the next token.
+      const [, ni] = valueOf(a, "--lang", i);
+      i = ni;
     } else if (a === "--dry-run") {
       setupDryRun = true;
     } else if (a === "--comfyui-url" || a.startsWith("--comfyui-url=")) {
@@ -257,11 +268,43 @@ export function validateConnectUrl(url: string): string | null {
     return null;
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
-    return (
-      `Invalid ComfyUI URL passed to \`connect\`: "${url}" (${reason}). ` +
-      `Pass a full http(s) URL, e.g. https://abcd-8188.proxy.runpod.net or http://127.0.0.1:8188.`
+    // Translated because this string IS the body of the fatal "cannot start" line the user
+    // reads in their terminal; translating the frame and leaving the reason English would
+    // produce a half-English sentence at the one moment the tool is refusing to run. The
+    // example URLs stay verbatim — they are things to copy, not things to read.
+    return tr(
+      "cli.connect_url_invalid",
+      'Invalid ComfyUI URL passed to `connect`: "{url}" ({reason}). ' +
+        "Pass a full http(s) URL, e.g. https://abcd-8188.proxy.runpod.net or http://127.0.0.1:8188.",
+      { url, reason },
     );
   }
+}
+
+/** Cell column where `--help` descriptions start, and where the trailing `env:` notes start. */
+const DESC_COL = 45;
+const ENV_COL = 65;
+
+/**
+ * One `--help` row: `left` is the flag/subcommand (never translated), `desc` the prose,
+ * `tail` an optional `env: …` note that keeps its own column.
+ *
+ * The gap used to be typed into the string literal, which is a layout that survives exactly
+ * as long as every description is English. This computes it from the DISPLAY WIDTH of
+ * whatever actually lands in the column, so a Korean description — two terminal cells per
+ * character — does not shove the `env:` notes off their column.
+ *
+ * The `3` minimum separator is not decoration: it is what keeps an entry whose description
+ * overruns its column readable, and it is what reproduces the previous hand-typed layout
+ * exactly (`--token` and `--tunnel` already sat three spaces from their `env:` note).
+ *
+ * Exported only so a test can hand it a Korean description. The whole screen renders English
+ * until a catalog exists, so nothing about the ASSEMBLED output can show whether the columns
+ * are computed in cells or in characters — the two agree for every string that exists today.
+ */
+export function helpRow(left: string, desc: string, tail?: string): string {
+  const body = tail ? padTo(desc, ENV_COL - DESC_COL, 3) + tail : desc;
+  return `  ${padTo(left, DESC_COL - 2)}${body}`.trimEnd();
 }
 
 /**
@@ -278,46 +321,98 @@ export function validateConnectUrl(url: string): string | null {
  * Deliberately carries NO tool COUNT. RFC #726 consolidates the surface to ~30
  * tools, so any number written here expires; the text describes the shapes
  * instead ("three meta-tools" is a property of the facade, not a census).
+ *
+ * TRANSLATED, PROSE ONLY. The left-hand column is flags and subcommands — what the user has
+ * to type, identical in every language — so only the descriptions go through `tr()`, and
+ * `helpRow` above owns the alignment that used to live in the string literals.
  */
 export function renderCliHelp(): string {
   const d = parseCliArgs([], {});
-  const def = (v: string | number | boolean) => `(default: ${String(v)})`;
+  // The whole parenthetical is one key, not the word "default" glued to a value. A lone
+  // adjective is the classic untranslatable unit — several of our languages inflect it by
+  // what follows — and the value itself is a machine token that must not be touched.
+  const def = (v: string | number | boolean) =>
+    tr("cli.help_default", "(default: {value})", { value: String(v) });
 
   return [
     "",
-    "comfyui-mcp — drive ComfyUI from an AI agent",
+    `comfyui-mcp — ${tr("cli.help_tagline", "drive ComfyUI from an AI agent")}`,
     "",
-    "USAGE",
-    "  comfyui-mcp [options]                      start the MCP server",
-    "  comfyui-mcp connect [<comfyui-url>]        run the panel orchestrator against a (possibly remote) ComfyUI",
-    "  comfyui-mcp setup <hermes|openclaw|copilot> [--compact|--full] [--comfyui-url <url>] [--dry-run]",
-    "                                             write the comfyui entry into that harness's config, then exit",
+    tr("cli.help_section_usage", "USAGE"),
+    helpRow("comfyui-mcp [options]", tr("cli.help_usage_server", "start the MCP server")),
+    helpRow(
+      "comfyui-mcp connect [<comfyui-url>]",
+      tr("cli.help_usage_connect", "run the panel orchestrator against a (possibly remote) ComfyUI"),
+    ),
+    helpRow("comfyui-mcp setup <hermes|openclaw|copilot> [--compact|--full] [--comfyui-url <url>] [--dry-run]", ""),
+    helpRow("", tr("cli.help_usage_setup", "write the comfyui entry into that harness's config, then exit")),
     "",
-    "TOOL SURFACE",
-    `  --compact                                  register only the three meta-tools ${def(d.toolMode === "compact")}`,
-    "                                             (list_tools / describe_tool / call_tool)",
-    "  --full                                     register the full direct tool surface",
-    "  --tool-mode <compact|full>                 same, as a value",
-    `                                             env: COMFYUI_MCP_TOOL_MODE      ${def(d.toolMode)}`,
+    tr("cli.help_section_tool_surface", "TOOL SURFACE"),
+    helpRow(
+      "--compact",
+      `${tr("cli.help_compact", "register only the three meta-tools")} ${def(d.toolMode === "compact")}`,
+    ),
+    // Not translated: three tool NAMES the user will type or read in a client.
+    helpRow("", "(list_tools / describe_tool / call_tool)"),
+    helpRow("--full", tr("cli.help_full", "register the full direct tool surface")),
+    helpRow("--tool-mode <compact|full>", tr("cli.help_same_as_value", "same, as a value")),
+    helpRow("", `env: COMFYUI_MCP_TOOL_MODE      ${def(d.toolMode)}`),
     "",
-    "TRANSPORT",
-    `  --stdio                                    stdio transport ${def(d.transport === "stdio")}`,
-    "  --http                                     streamable-HTTP transport",
-    "  --transport <stdio|http>                   same, as a value    env: MCP_TRANSPORT",
-    `  --host <host>                              HTTP bind host      env: MCP_HOST   ${def(d.host)}`,
-    `  --port <port>                              HTTP bind port      env: MCP_PORT   ${def(d.port)}`,
-    "  --token <token>                            require this shared secret on /mcp   env: COMFYUI_MCP_HTTP_TOKEN",
-    "  --tunnel                                   open a cloudflared quick tunnel (implies --http)   env: MCP_TUNNEL",
-    "  --allow-unauthenticated-non-loopback       allow an OPEN /mcp on a non-loopback host",
+    tr("cli.help_section_transport", "TRANSPORT"),
+    helpRow(
+      "--stdio",
+      `${tr("cli.help_stdio", "stdio transport")} ${def(d.transport === "stdio")}`,
+    ),
+    helpRow("--http", tr("cli.help_http", "streamable-HTTP transport")),
+    helpRow("--transport <stdio|http>", tr("cli.help_same_as_value", "same, as a value"), "env: MCP_TRANSPORT"),
+    helpRow("--host <host>", tr("cli.help_host", "HTTP bind host"), `env: MCP_HOST   ${def(d.host)}`),
+    helpRow("--port <port>", tr("cli.help_port", "HTTP bind port"), `env: MCP_PORT   ${def(d.port)}`),
+    helpRow(
+      "--token <token>",
+      tr("cli.help_token", "require this shared secret on /mcp"),
+      "env: COMFYUI_MCP_HTTP_TOKEN",
+    ),
+    helpRow(
+      "--tunnel",
+      tr("cli.help_tunnel", "open a cloudflared quick tunnel (implies --http)"),
+      "env: MCP_TUNNEL",
+    ),
+    helpRow(
+      "--allow-unauthenticated-non-loopback",
+      tr("cli.help_allow_unauth", "allow an OPEN /mcp on a non-loopback host"),
+    ),
     "",
-    "PANEL / COMFYUI",
-    "  --panel-orchestrator                       run the background orchestrator that drives the panel",
-    "  --comfyui-url <url>                        target a specific (incl. remote) ComfyUI   env: COMFYUI_URL",
-    "  --insecure-bridge                          allow an unauthenticated panel bridge",
+    tr("cli.help_section_panel", "PANEL / COMFYUI"),
+    helpRow(
+      "--panel-orchestrator",
+      tr("cli.help_panel_orchestrator", "run the background orchestrator that drives the panel"),
+    ),
+    helpRow(
+      "--comfyui-url <url>",
+      tr("cli.help_comfyui_url", "target a specific (incl. remote) ComfyUI"),
+      "env: COMFYUI_URL",
+    ),
+    helpRow("--insecure-bridge", tr("cli.help_insecure_bridge", "allow an unauthenticated panel bridge")),
     "",
-    "  -h, --help                                 show this and exit",
+    // `--lang` is parsed straight out of argv by processLocale(), not by parseCliArgs, so it
+    // is the one flag that would otherwise be undiscoverable from the tool it controls.
+    //
+    // ACTIVE, not "default", and that word is load-bearing. Every other value on this screen
+    // comes from `parseCliArgs([], {})` — a built-in default, deliberately blind to the
+    // environment. The language is the opposite: it is resolved FROM the environment through
+    // four variables and a fallback chain, so the only answer worth printing is the one the
+    // user is actually getting. Calling that a "default" would be false the moment they pass
+    // the flag this very row documents.
+    helpRow(
+      "--lang <code>",
+      tr("cli.help_lang", "language for this CLI's own output"),
+      `env: COMFYUI_MCP_LANG   ${tr("cli.help_active", "(active: {locale})", { locale: processLocale() })}`,
+    ),
+    helpRow("-h, --help", tr("cli.help_help", "show this and exit")),
     "",
-    "Full reference: https://github.com/artokun/comfyui-mcp#readme",
+    tr("cli.help_full_reference", "Full reference: {url}", {
+      url: "https://github.com/artokun/comfyui-mcp#readme",
+    }),
     "",
   ].join("\n");
 }


### PR DESCRIPTION
Unit 13 of the i18n effort: the **CLI surface** — the ~80 strings a person reads in their terminal. Based on `feat/mcp-i18n-foundation`, not `main`.

Every string keeps its English text at the call site as the `tr()` fallback, so a missing translation degrades to correct English rather than a raw key. **No file under `locales/` was created** — catalogs come later.

## What is translated

| Where | What |
|---|---|
| `src/transport/cli.ts` | the whole `--help` screen, and `validateConnectUrl`'s message (it *is* the body of the fatal line below) |
| `src/boot.ts` | the connect banner, the tunnel "Connector is LIVE" box, the `setup <agent>` usage + result, the fatal `cannot start` line |
| `src/services/agent-setup.ts` | `nextSteps()` — the per-harness post-install instructions |

## The boundary held — and is now enforced

Nothing under `src/tools/**`, no panel tool definition, no `.describe()`, no per-backend system prompt, and not `PANEL_SYSTEM_APPEND` was touched.

`src/__tests__/i18n/cli-strings.test.ts` asserts it: those files may neither import the i18n runtime (static **or** dynamic form) nor call `tr()`/`trFor()`. `PANEL_SYSTEM_APPEND` is guarded around the **symbol**, not the file, because `src/orchestrator/index.ts` also holds banners that *are* in scope for a later unit — a file-level guard there would block the fix.

The guard was mutation-tested against a call it was supposed to catch. That is how `/\btrFor?\(/` was found to match `trFo(` and never `tr(` — it read fine and passed.

## CJK width — how the alignment was handled

**This is the part the brief asked about.** Every aligned thing here was hand-padded with `String.length`, which is correct for exactly as long as every string is ASCII. Korean, Japanese and Chinese are East Asian Wide: one character, **two** terminal cells. A `.length` pad is then half the width it needs, and every line under it steps right. Arabic and Persian combining marks go the other way and take none.

`src/i18n/terminal-layout.ts` measures **cells**, and everything derives from it:

- the `--help` two-column layout (`helpRow`) — flags on the left are never translated, so only the description column moves;
- the colon-aligned banner labels (`labelRows`) — the column comes from the widest label *present*, and multi-line values get their **hanging indent computed**, because that indent is a function of the translated label width and cannot be baked into a string a translator writes;
- the `════` rules.

Emoji are asked for by `\p{Emoji_Presentation}` rather than by ranges: the emoji blocks interleave with narrow symbols, so a hand-picked span made 🚀 one cell and ✅ one cell, while `✓`, `—`, `•` and `═` correctly stay one — which is what keeps the rules the width this module promises.

## The box rules now fit their content, clamped to [68, 80]

68 was a guess that was **already wrong in English**: the connect banner's longest line is 71 cells and has overhung its own box since it was written. 80 is the ceiling because the two failure modes are not symmetric — an overhanging line is untidy, an overhanging *rule* wraps and stops being a frame at all. (The tunnel banner settles it: one line is a URL plus a 48-character token plus the same token again.)

English output is otherwise **byte-identical**, verified by rendering the help screen and both banners before and after. The only other change is the tunnel banner's three bullet rows, now aligned as a group so a translated label cannot break them:

```
   • Name   : ComfyUI          (was "• Name : " / "• URL  : " / "• Header: ")
   • URL    : https://…
   • Header : X-API-Key: …
```

## `--lang` is now documented, and parsed

Nothing advertised the flag that controls this feature. It is now on the help screen, and `parseCliArgs` has a case for it. The case **stores nothing** — `processLocale()` reads it straight off argv, because the locale has to resolve before the parser runs — but the *value* has to be consumed: `connect` and `setup` take their operand from the next bare token, and a loose locale code sitting in argv is one keystroke from being read as one.

Its row prints `(active: ko)`, not `(default: …)`. Every other value on that screen comes from `parseCliArgs([], {})`, a built-in default deliberately blind to the environment; the language is the opposite, resolved *from* the environment through four variables, so "default" would be false the moment the user passes the flag that row documents.

## Panel-control coupling

Strings that name a panel control keep their English fallback exactly as the panel renders it today, and say so in the key — e.g. `cli.connect_step_enable_external_orchestrator` for *"Settings → General, turn ON 'Use external/local orchestrator (advanced)'"*. A catalog entry for one of those keys is only correct if it uses the **panel's** translation of that control, not a fresh translation of the sentence. Same for the Claude Desktop menu path, which that app localises on its own setting rather than ours.

## Deliberately out of scope

`logger.*` calls, including the cloudflared-missing remediation block. That is a separate audience and a much larger surface; translating one line of it would produce a lopsided mix rather than fix one. The `agent-setup.ts` config-parse throws are also left English — they quote a YAML/JSON parser's own English message, which would dominate any wrapper.

## Verification

- `npm run lint` clean; `npm test` **442 files / 8535 tests green**.
- 29 tests added. Every guard mutation-tested: swap `padTo` for `padEnd` and the cell-alignment tests fail; add `tr(` to a tools file or to the panel persona and the boundary tests fail.
- Ran the built CLI: `--help` (and under `COMFYUI_MCP_LANG=ko` / `--lang ja` / `LANG=ko_KR.UTF-8` — identical English, the correct fallback with no catalog), `setup bogus`, `setup` with no agent, `setup hermes --dry-run`, `connect not-a-url`, `connect <http url>`, `connect <https pod>` (secure variant), and `--tunnel` against a real short-lived quick tunnel.
- The tests pin the locale, because a contributor whose shell is `LANG=ko_KR.UTF-8` — the audience this feature is for — would otherwise get a red suite on an unmodified tree.

## Note for the coordinator

`package.json` on the foundation branch declares `"i18n:check": "node scripts/i18n-check.mjs"`, but that script does not exist yet. Not this unit's file; flagging it so it does not get missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
