### PR TITLE
feat(#873): restrict the tool surface — deny/allow lists and presets

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -274,6 +274,46 @@ available, HTTP polling otherwise).
   single step won't honor it immediately — this wait is what detects a true wedge.
 </ParamField>
 
+## Restricting the tool surface
+
+For a **hosted** deployment — a shared Open WebUI, a team frontend — the operator is not
+the person prompting. These variables withhold tools from the model entirely: a withheld
+tool is never registered, so it is absent from `tools/list`, absent from `call_tool`, and
+the model never learns it exists.
+
+<ParamField path="COMFYUI_MCP_TOOL_PRESET" type="string">
+  `safe` — everything except tools that change the machine or the model library.
+  Rendering still works; installing, deleting and restarting do not.
+  `readonly` — inspection only: no renders queued, nothing written, nothing spent.
+  Both also withhold the whole `panel_*` surface, which drives a live shared canvas.
+</ParamField>
+<ParamField path="COMFYUI_MCP_TOOL_DENY" type="string">
+  Comma-separated tool names to withhold, e.g. `restart_comfyui,download_model`. A
+  trailing `*` matches a family: `train_*`. Applied on top of any preset **and** on top
+  of an allow list.
+</ParamField>
+<ParamField path="COMFYUI_MCP_TOOL_ALLOW" type="string">
+  Comma-separated allow list. When set, the surface is **exactly** these tools — anything
+  not named is withheld even if no deny rule mentions it. Use it to opt individual tools
+  back in past a preset: `COMFYUI_MCP_TOOL_PRESET=safe` plus
+  `COMFYUI_MCP_TOOL_ALLOW=panel_graph_outline,panel_query_graph`.
+</ParamField>
+
+```bash A hosted deployment that cannot install or restart anything
+COMFYUI_MCP_TOOL_PRESET=safe npx comfyui-mcp@latest --http --host 0.0.0.0 --port 9100
+```
+
+<Warning>
+  This is a boundary against the **model** and the people prompting it — not against
+  whoever sets the environment, who can simply unset it, and not a substitute for keeping
+  an untrusted party off the ComfyUI host.
+
+  A misconfiguration **refuses to start** rather than starting unrestricted: an unknown
+  preset name, or a variable that is set but empty (an unexpanded `${VAR}` in a compose
+  file), aborts with the reason. Coming up with a full tool surface while you believe it
+  is restricted is worse than having no filter at all.
+</Warning>
+
 ## Transport
 
 The server speaks **stdio** by default (what Claude Code expects). It can also serve the

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -283,7 +283,10 @@ the model never learns it exists.
 
 <ParamField path="COMFYUI_MCP_TOOL_PRESET" type="string">
   `safe` — everything except tools that change the machine or the model library.
-  Rendering still works; installing, deleting and restarting do not.
+  Installing, deleting and restarting are withheld. **Rendering still works, and so do
+  the things that come with it**: queueing generations, `list_api_nodes` (hosted partner
+  nodes that spend PAID credits), and `report_issue` (files a public GitHub issue). Use
+  `readonly` if a shared frontend's users must not be able to spend or publish.
   `readonly` — inspection only: no renders queued, nothing written, nothing spent.
   Both also withhold the whole `panel_*` surface, which drives a live shared canvas.
 </ParamField>
@@ -297,6 +300,11 @@ the model never learns it exists.
   not named is withheld even if no deny rule mentions it. Use it to opt individual tools
   back in past a preset: `COMFYUI_MCP_TOOL_PRESET=safe` plus
   `COMFYUI_MCP_TOOL_ALLOW=panel_graph_outline,panel_query_graph`.
+
+  Only an **exact name** opts a tool back in past a preset. A glob (`list_*`) narrows the
+  surface like any other entry but cannot re-open what a preset closed — otherwise
+  `ALLOW=list_*` would re-admit `list_packs`, whose `install_deps` action installs and
+  runs third-party code, and `ALLOW=*` would make every preset inert.
 </ParamField>
 
 ```bash A hosted deployment that cannot install or restart anything

--- a/src/__tests__/orchestrator/panel-tools-strict-schema.test.ts
+++ b/src/__tests__/orchestrator/panel-tools-strict-schema.test.ts
@@ -124,7 +124,11 @@ describe("panel-tools #754: strict schemas reject unknown argument keys", () => 
     // registerPanelTools (MCP SDK / Codex HTTP transport).
     const registerIdx = src.indexOf("export function registerPanelTools(");
     expect(registerIdx).toBeGreaterThan(0);
-    const registerBlock = src.slice(registerIdx, registerIdx + 1200);
+    // Widened from 1200: #873 added the tool-surface policy check at the top of this
+    // function, pushing the schema line past the old window. The assertion is about
+    // WHICH schema builder the call site uses, not about how near the top it appears —
+    // a fixed byte window turns any insertion above it into a false failure.
+    const registerBlock = src.slice(registerIdx, registerIdx + 2200);
     expect(registerBlock).toMatch(/inputSchema:\s*strictPanelSchema\(d\.schema\)/);
     expect(registerBlock).not.toMatch(/inputSchema:\s*d\.schema[,\s]/);
 

--- a/src/__tests__/orchestrator/panel-tools-strict-schema.test.ts
+++ b/src/__tests__/orchestrator/panel-tools-strict-schema.test.ts
@@ -121,21 +121,28 @@ describe("panel-tools #754: strict schemas reject unknown argument keys", () => 
     const here = dirname(fileURLToPath(import.meta.url));
     const src = readFileSync(join(here, "../../orchestrator/panel-tools.ts"), "utf8");
 
+    // Slice each function to the START OF THE NEXT top-level declaration rather than a
+    // fixed byte count. #873 inserted a policy check at the top of BOTH functions and
+    // pushed the schema line past a 1200- and then an 1800-byte window; each time the
+    // test failed for a reason that had nothing to do with what it asserts. The claim is
+    // WHICH schema builder each call site uses — a window that depends on how much
+    // unrelated code sits above it measures the wrong thing, and the natural repair
+    // (widen it again) leaves the same trap armed for the next edit.
+    const functionBody = (marker: string): string => {
+      const start = src.indexOf(marker);
+      expect(start, `${marker} not found`).toBeGreaterThan(0);
+      const rest = src.slice(start + marker.length);
+      const end = rest.search(/\nexport (async )?function |\nexport const /);
+      return rest.slice(0, end === -1 ? undefined : end);
+    };
+
     // registerPanelTools (MCP SDK / Codex HTTP transport).
-    const registerIdx = src.indexOf("export function registerPanelTools(");
-    expect(registerIdx).toBeGreaterThan(0);
-    // Widened from 1200: #873 added the tool-surface policy check at the top of this
-    // function, pushing the schema line past the old window. The assertion is about
-    // WHICH schema builder the call site uses, not about how near the top it appears —
-    // a fixed byte window turns any insertion above it into a false failure.
-    const registerBlock = src.slice(registerIdx, registerIdx + 2200);
+    const registerBlock = functionBody("export function registerPanelTools(");
     expect(registerBlock).toMatch(/inputSchema:\s*strictPanelSchema\(d\.schema\)/);
     expect(registerBlock).not.toMatch(/inputSchema:\s*d\.schema[,\s]/);
 
     // createPanelMcpServer (Anthropic Agent SDK / Claude in-process transport).
-    const createIdx = src.indexOf("export function createPanelMcpServer(");
-    expect(createIdx).toBeGreaterThan(0);
-    const createBlock = src.slice(createIdx, createIdx + 1800);
+    const createBlock = functionBody("export function createPanelMcpServer(");
     expect(createBlock).toMatch(/strictPanelSchema\(d\.schema\)/);
   });
 });

--- a/src/__tests__/tools/tool-surface-filter.test.ts
+++ b/src/__tests__/tools/tool-surface-filter.test.ts
@@ -21,6 +21,10 @@ import {
   toolMatches,
   TOOL_PRESETS,
   MUTATING_ACTION_NAMES,
+  EXECUTION_ACTION_NAMES,
+  MUTATING_TOOLS,
+  EXECUTION_TOOLS,
+  READONLY_TOOLS,
   declaredActions,
   withToolSurfaceFilter,
 } from "../../tools/tool-surface-filter.js";
@@ -50,7 +54,10 @@ describe("the operator's policy is read from the environment (#873)", () => {
     expect(resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_ALLOW: "x" }).allow).toEqual(["x"]);
     const preset = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "safe" });
     expect(preset.preset).toBe("safe");
-    expect(preset.deny).toContain("restart_comfyui");
+    // The preset's patterns live in presetDeny, kept apart from an explicit DENY because
+    // an allow list is entitled to refine a preset but not to overrule an explicit deny.
+    expect(preset.presetDeny).toContain("restart_comfyui");
+    expect(preset.deny).toEqual([]);
   });
 
   it("an UNKNOWN preset REFUSES TO START rather than failing open (codex P0)", () => {
@@ -88,6 +95,43 @@ describe("allow wins, and is absolute (#873)", () => {
     const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_DENY: "restart_comfyui" });
     expect(toolAllowed("restart_comfyui", p)).toBe(false);
     expect(toolAllowed("generate_image", p)).toBe(true);
+  });
+
+  it("an EXPLICIT deny still applies on top of an allow list", () => {
+    // The first version returned early on the allow match, so naming a tool in BOTH
+    // allowed it — `ALLOW=list_local_models,get_history` + `DENY=list_local_models` left
+    // a tool whose action:"remove" deletes a model file reachable. Both variables are the
+    // operator saying something; the intersection is the only reading that discards
+    // neither, and it errs toward the smaller surface.
+    const p = resolveToolSurfacePolicy({
+      COMFYUI_MCP_TOOL_ALLOW: "list_local_models,get_history",
+      COMFYUI_MCP_TOOL_DENY: "list_local_models",
+    });
+    expect(toolAllowed("list_local_models", p)).toBe(false);
+    expect(toolAllowed("get_history", p)).toBe(true);
+  });
+
+  it("…but an allow list DOES refine a preset, or the documented opt-in would be a lie", () => {
+    // A preset is a broad default. `PRESET=safe` denies panel_* wholesale, and naming two
+    // of them in ALLOW is exactly how the docs say to get them back.
+    const p = resolveToolSurfacePolicy({
+      COMFYUI_MCP_TOOL_PRESET: "safe",
+      COMFYUI_MCP_TOOL_ALLOW: "panel_graph_outline",
+    });
+    expect(toolAllowed("panel_graph_outline", p)).toBe(true);
+    expect(toolAllowed("panel_run", p)).toBe(false);
+    expect(toolAllowed("restart_comfyui", p)).toBe(false);
+  });
+
+  it("a variable SET BUT EMPTY refuses to start — the fail-open by another route", () => {
+    // `COMFYUI_MCP_TOOL_ALLOW=${ALLOWED_TOOLS}` in a compose file with ALLOWED_TOOLS
+    // unset expands to "". Reading that as "no rules configured" produces the full
+    // surface with no log — the identical failure the unknown-preset throw exists to
+    // prevent, reached from a different direction.
+    for (const v of ["COMFYUI_MCP_TOOL_ALLOW", "COMFYUI_MCP_TOOL_DENY", "COMFYUI_MCP_TOOL_PRESET"]) {
+      expect(() => resolveToolSurfacePolicy({ [v]: "" }), v).toThrow(/set but empty/);
+      expect(() => resolveToolSurfacePolicy({ [v]: "  ,  " }), v).toThrow(/Refusing to start|set but empty/);
+    }
   });
 
   it("a prefix glob groups a family, and does not match more than it reads like", () => {
@@ -166,32 +210,112 @@ describe("a denied tool is ABSENT, not refusing (#873)", () => {
 describe("the presets cover what a NAME no longer reveals (codex P1)", () => {
   it("withholds tools whose destructive action hides behind an inspection-sounding name", () => {
     // The 0.50.0 consolidation folded deletion into `list_local_models` (action:"remove"
-    // deletes a model file), installation into `search_custom_nodes`, config writes into
-    // `get_defaults`, and queue destruction into `queue`. My first preset list was
-    // written from the names and missed every one.
+    // deletes a model file), config writes into `get_defaults`, queue destruction into
+    // `queue`, and pack INSTALLATION into `list_packs` (action:"install_deps" downloads
+    // and RUNS third-party code on the ComfyUI host). My first preset list was written
+    // from the names and missed every one.
     const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "safe" });
-    for (const name of ["list_local_models", "search_custom_nodes", "get_defaults", "queue"]) {
+    for (const name of ["list_local_models", "list_packs", "get_defaults", "queue", "apps"]) {
       expect(toolAllowed(name, p), `${name} can mutate and must be withheld by "safe"`).toBe(false);
     }
   });
 
-  it("STAYS complete: every live tool advertising a mutating action is denied by safe", async () => {
-    // The hand list is auditable, which is why it stays hand-written — but it must not
-    // silently ROT. This scans the REAL catalog and fails when a tool advertising a
-    // destructive action is missing, so the next consolidation that hides
-    // action:"delete" behind a read-sounding name breaks a test instead of quietly
-    // widening every deployment's surface.
+  it("does NOT withhold search_custom_nodes — it only searches", () => {
+    // It was on the deny list, and the justification was that action:"install" installs a
+    // pack. It has exactly two actions, `search` and `details`, and is read-only; the
+    // installing tool is `install_custom_node`. The false claim came from its description
+    // MENTIONING `install_custom_node (action:"install")` — the same cross-reference
+    // confusion `declaredActions` strips, made by me while reading. The net effect was an
+    // inversion: `safe` withheld a registry search while allowing `list_packs`, which
+    // genuinely installs.
+    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "safe" });
+    expect(toolAllowed("search_custom_nodes", p)).toBe(true);
+  });
+
+  it("STAYS complete: EVERY live tool is classified, and the ledger names only live tools", async () => {
+    // THE GUARANTEE, and the reason it is a ledger rather than a pattern.
+    //
+    // The previous version scanned descriptions for a mutating verb and passed 17/17
+    // while `list_packs` — which installs and runs third-party code — was allowed by both
+    // presets, because its verb is `install_deps` and the pattern was anchored `^install$`.
+    // A pattern can only catch what someone already thought of; being read as coverage is
+    // what made it worse than nothing.
+    //
+    // Exhaustive partition instead: a NEW tool belongs to no list, so it fails here as
+    // "unclassified" and someone has to decide. The failure mode is a stopped build, not
+    // an assumption that it is harmless.
     const { collectToolCatalog } = await import("../../tools/index.js");
     const catalog = await collectToolCatalog();
-    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "safe" });
+    const live = [...catalog.tools.keys()].sort();
+    const ledger = [...MUTATING_TOOLS, ...EXECUTION_TOOLS, ...READONLY_TOOLS].sort();
 
-    const leaked: string[] = [];
-    for (const [name, tool] of catalog.tools) {
-      const actions = declaredActions(tool.description ?? "");
-      const mutating = actions.filter((a) => MUTATING_ACTION_NAMES.test(a));
-      if (mutating.length && toolAllowed(name, p)) leaked.push(`${name} (${mutating.join(",")})`);
+    const unclassified = live.filter((n) => !ledger.includes(n));
+    expect(
+      unclassified,
+      `live tools in NO list — classify each as mutating / execution / readonly: ${unclassified.join(", ")}`,
+    ).toEqual([]);
+
+    const phantom = ledger.filter((n) => !live.includes(n));
+    expect(phantom, `ledger entries that match no live tool: ${phantom.join(", ")}`).toEqual([]);
+
+    // …and no tool in two lists, or the presets would disagree with themselves.
+    const dupes = ledger.filter((n, i) => ledger.indexOf(n) !== i);
+    expect([...new Set(dupes)], `tools classified twice: ${dupes.join(", ")}`).toEqual([]);
+  });
+
+  it("CROSS-CHECK: nothing classified read-only advertises a mutating action", async () => {
+    // Secondary to the ledger above, and worth exactly what it is: the ledger catches a
+    // MISSING classification, this catches a WRONG one. It is why `list_packs` moved —
+    // once the pattern was widened to match a verb PREFIX (`install_deps`, `add_path`,
+    // `generate_skill`) rather than a whole word, it stopped being blind to the family of
+    // names the consolidation actually produced.
+    const { collectToolCatalog } = await import("../../tools/index.js");
+    const catalog = await collectToolCatalog();
+
+    const misclassified: string[] = [];
+    for (const name of READONLY_TOOLS) {
+      const actions = declaredActions(catalog.tools.get(name)?.description ?? "", {
+        selfName: name,
+        knownTools: new Set(catalog.tools.keys()),
+      });
+      const mutating = actions.filter(
+        (a) => MUTATING_ACTION_NAMES.test(a) && !EXECUTION_ACTION_NAMES.test(a),
+      );
+      if (mutating.length) misclassified.push(`${name} (${mutating.join(",")})`);
     }
-    expect(leaked, `tools with a mutating action that "safe" still allows: ${leaked.join("; ")}`).toEqual([]);
+    expect(
+      misclassified,
+      `tools classified READONLY that advertise a mutating action: ${misclassified.join("; ")}`,
+    ).toEqual([]);
+  });
+
+  it("declaredActions strips a CROSS-reference but never a SELF-declaration", () => {
+    // The over-stripping direction is the one that matters: a tool whose own declaration
+    // got eaten looks action-free, so the cross-check sees nothing and reports no hole —
+    // a silent false negative in a guard, which is worse than no guard.
+    const known = new Set(["get_defaults", "download_model", "model_metadata"]);
+
+    // Both spellings of a cross-reference go, parenthesised or not.
+    expect(
+      declaredActions('- action:"generate" — uses get_defaults (action:"set") and download_model action:"download_civitai".', {
+        selfName: "generate_image",
+        knownTools: known,
+      }),
+    ).toEqual(["generate"]);
+
+    // A tool naming ITSELF keeps the action…
+    expect(
+      declaredActions('model_metadata action:"read" — reads embedded metadata.', {
+        selfName: "model_metadata",
+        knownTools: known,
+      }),
+    ).toEqual(["read"]);
+
+    // …and so does a reference to a name that is not a known tool, because an unrecognised
+    // word is not evidence that the action belongs to someone else.
+    expect(
+      declaredActions('somethingelse action:"delete"', { selfName: "x", knownTools: known }),
+    ).toEqual(["delete"]);
   });
 
   it("the PANEL surface is withheld wholesale by both presets (codex P0)", () => {
@@ -225,6 +349,54 @@ describe("WIRING: the filter covers the call_tool route, not just registration (
     const body = src.slice(at, at + 1400);
     expect(body).toContain("resolveToolSurfacePolicy()");
     expect(body).toContain("toolAllowed(d.name, policy)");
+  });
+
+  it("is applied to the OTHER panel registration path as well — createPanelMcpServer", async () => {
+    // There are TWO. registerPanelTools serves the MCP SDK; createPanelMcpServer serves
+    // the Anthropic Agent SDK (Claude backend, in-process transport). They build from the
+    // same buildPanelToolDefs(), so fixing one left `panel_run` queueing renders under
+    // PRESET=readonly for every Claude-backend tab — the same hole, reported closed.
+    //
+    // The previous version of this test grepped only registerPanelTools and passed while
+    // that was true, which is why this one names the second function explicitly rather
+    // than searching the file as a whole.
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf-8");
+    const at = src.indexOf("export function createPanelMcpServer");
+    expect(at).toBeGreaterThan(-1);
+    const body = src.slice(at, at + 1800);
+    expect(body).toContain("resolveToolSurfacePolicy()");
+    expect(body).toContain("toolAllowed(d.name, policy)");
+  });
+
+  it("the policy reaches the SPAWNED comfyui child, which builds its env explicitly", async () => {
+    // comfyuiBaseEnv() constructs the child's environment rather than inheriting it (on
+    // purpose — a spread cannot REMOVE a revoked credential), and the MCP SDK spawns
+    // stdio children with a PATH/HOME-class default env. So an unforwarded variable does
+    // not exist over there: panel tools withheld and logged as withheld, while the
+    // agent's own comfyui child still offers download_model and restart_comfyui.
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(new URL("../../orchestrator/index.ts", import.meta.url), "utf-8");
+    const at = src.indexOf("const comfyuiBaseEnv");
+    expect(at).toBeGreaterThan(-1);
+    const body = src.slice(at, at + 2600);
+    for (const v of ["COMFYUI_MCP_TOOL_PRESET", "COMFYUI_MCP_TOOL_ALLOW", "COMFYUI_MCP_TOOL_DENY"]) {
+      expect(body, `${v} must be forwarded to the child`).toContain(v);
+    }
+  });
+
+  it("the policy is validated at BOOT, so 'Refusing to start' is true on http too", async () => {
+    // The throw is only a refusal-to-start if something calls it before the transport
+    // comes up. --transport http builds the server LAZILY inside the request handler, so
+    // the socket bound, "server running on http://…" printed, and every initialize came
+    // back 500 with the real reason buried in a log line. Fail-closed, so not a hole —
+    // but the message promised something that transport did not do.
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(new URL("../../boot.ts", import.meta.url), "utf-8");
+    const call = src.indexOf("resolveToolSurfacePolicy();");
+    expect(call).toBeGreaterThan(-1);
+    // …and BEFORE the http branch, or it has not bought anything.
+    expect(call).toBeLessThan(src.indexOf('if (cli.transport === "http")'));
   });
 
   it("is applied inside collectToolCatalog, which call_tool dispatches through", async () => {

--- a/src/__tests__/tools/tool-surface-filter.test.ts
+++ b/src/__tests__/tools/tool-surface-filter.test.ts
@@ -20,6 +20,8 @@ import {
   toolAllowed,
   toolMatches,
   TOOL_PRESETS,
+  MUTATING_ACTION_NAMES,
+  declaredActions,
   withToolSurfaceFilter,
 } from "../../tools/tool-surface-filter.js";
 
@@ -51,14 +53,22 @@ describe("the operator's policy is read from the environment (#873)", () => {
     expect(preset.deny).toContain("restart_comfyui");
   });
 
-  it("an UNKNOWN preset name does not silently become 'no policy'", () => {
-    // Failing open on a typo is the dangerous direction: the operator believes the
-    // surface is restricted and it is not. A bare unknown preset yields no deny rules,
-    // so `active` must stay false and the LOG must be the thing that tells them —
-    // rather than a half-applied policy that looks like it worked.
-    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "saef" });
-    expect(p.deny).toEqual([]);
-    expect(p.active).toBe(false);
+  it("an UNKNOWN preset REFUSES TO START rather than failing open (codex P0)", () => {
+    // I got this wrong first time and wrote a test asserting the broken behaviour.
+    // `saef` resolved to no rules → `active` false → the decorator returned the
+    // registrar unwrapped AND the "surface restricted" log, gated on the same flag,
+    // never fired. The server came up with its FULL surface, silently, while the
+    // operator believed it was locked down. My justification at the time — "the log
+    // tells them" — was false about my own code.
+    //
+    // For a control whose entire purpose is a guarantee, silence on misconfiguration is
+    // the one unacceptable outcome.
+    expect(() => resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "saef" })).toThrow(
+      /is not a known preset/,
+    );
+    expect(() => resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "saef" })).toThrow(
+      /Refusing to start/,
+    );
   });
 });
 
@@ -122,8 +132,12 @@ describe("a denied tool is ABSENT, not refusing (#873)", () => {
     expect(toolAllowed("enqueue_workflow", p)).toBe(false);
     expect(toolAllowed("restart_comfyui", p)).toBe(false);
     // …but inspection still works, or the preset would be useless.
+    //
+    // This used to assert `list_local_models` was allowed — a tool whose action:"remove"
+    // DELETES a model file. The assertion was wrong before the preset was, and it read
+    // as reassurance. Use tools that genuinely only read.
     expect(toolAllowed("get_history", p)).toBe(true);
-    expect(toolAllowed("list_local_models", p)).toBe(true);
+    expect(toolAllowed("get_system_stats", p)).toBe(true);
   });
 
   it("safe keeps rendering while withholding machine changes", () => {
@@ -140,12 +154,79 @@ describe("a denied tool is ABSENT, not refusing (#873)", () => {
     const { collectToolCatalog } = await import("../../tools/index.js");
     const catalog = await collectToolCatalog();
     const live = new Set([...catalog.tools.keys()]);
-    const unknown = [...new Set(Object.values(TOOL_PRESETS).flat())].filter((n) => !live.has(n));
+    // Globs are patterns, not names — `panel_*` deliberately matches a surface that is
+    // registered on a different server and is not in this catalog at all.
+    const unknown = [...new Set(Object.values(TOOL_PRESETS).flat())]
+      .filter((n) => !n.endsWith("*"))
+      .filter((n) => !live.has(n));
     expect(unknown, `preset entries that match no live tool: ${unknown.join(", ")}`).toEqual([]);
   });
 });
 
+describe("the presets cover what a NAME no longer reveals (codex P1)", () => {
+  it("withholds tools whose destructive action hides behind an inspection-sounding name", () => {
+    // The 0.50.0 consolidation folded deletion into `list_local_models` (action:"remove"
+    // deletes a model file), installation into `search_custom_nodes`, config writes into
+    // `get_defaults`, and queue destruction into `queue`. My first preset list was
+    // written from the names and missed every one.
+    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "safe" });
+    for (const name of ["list_local_models", "search_custom_nodes", "get_defaults", "queue"]) {
+      expect(toolAllowed(name, p), `${name} can mutate and must be withheld by "safe"`).toBe(false);
+    }
+  });
+
+  it("STAYS complete: every live tool advertising a mutating action is denied by safe", async () => {
+    // The hand list is auditable, which is why it stays hand-written — but it must not
+    // silently ROT. This scans the REAL catalog and fails when a tool advertising a
+    // destructive action is missing, so the next consolidation that hides
+    // action:"delete" behind a read-sounding name breaks a test instead of quietly
+    // widening every deployment's surface.
+    const { collectToolCatalog } = await import("../../tools/index.js");
+    const catalog = await collectToolCatalog();
+    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "safe" });
+
+    const leaked: string[] = [];
+    for (const [name, tool] of catalog.tools) {
+      const actions = declaredActions(tool.description ?? "");
+      const mutating = actions.filter((a) => MUTATING_ACTION_NAMES.test(a));
+      if (mutating.length && toolAllowed(name, p)) leaked.push(`${name} (${mutating.join(",")})`);
+    }
+    expect(leaked, `tools with a mutating action that "safe" still allows: ${leaked.join("; ")}`).toEqual([]);
+  });
+
+  it("the PANEL surface is withheld wholesale by both presets (codex P0)", () => {
+    // 91 panel_* tools register through a different method on a separate server and
+    // bypassed the filter entirely — `panel_run` still queued renders under `readonly`.
+    // Denied as a family because classifying 91 by name got several wrong in both
+    // directions, and the list grows every release.
+    for (const preset of ["safe", "readonly"]) {
+      const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: preset });
+      for (const name of ["panel_run", "panel_add_node", "panel_graph_outline", "panel_set_property"]) {
+        expect(toolAllowed(name, p), `${name} under ${preset}`).toBe(false);
+      }
+    }
+  });
+
+  it("…and can be opted back in explicitly", () => {
+    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_ALLOW: "panel_graph_outline,panel_query_graph" });
+    expect(toolAllowed("panel_graph_outline", p)).toBe(true);
+    expect(toolAllowed("panel_run", p)).toBe(false);
+  });
+});
+
 describe("WIRING: the filter covers the call_tool route, not just registration (#873)", () => {
+  it("is applied to the PANEL registration path too (codex P0)", async () => {
+    // That path uses `registerTool` on a separate server, so the headless decorator —
+    // which proxies `.tool` — could never have caught it.
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf-8");
+    const at = src.indexOf("export function registerPanelTools");
+    expect(at).toBeGreaterThan(-1);
+    const body = src.slice(at, at + 1400);
+    expect(body).toContain("resolveToolSurfacePolicy()");
+    expect(body).toContain("toolAllowed(d.name, policy)");
+  });
+
   it("is applied inside collectToolCatalog, which call_tool dispatches through", async () => {
     // The bypass this feature exists to close. Asserted on the source because the
     // catalog is built once per process and the policy is read from the environment at

--- a/src/__tests__/tools/tool-surface-filter.test.ts
+++ b/src/__tests__/tools/tool-surface-filter.test.ts
@@ -1,0 +1,166 @@
+// #873 — an operator needs to guarantee the model cannot reach install/delete/restart
+// tools, whatever a user types.
+//
+// Reported from a Docker Compose + Open WebUI deployment behind llama-swap, where the
+// operator is NOT the person prompting. That is a different trust model from the local
+// one this codebase otherwise assumes, and it is why the request is worth building: with
+// one machine and one person a tool filter is theatre; with a shared frontend it is the
+// difference between shipping and not.
+//
+// THE BYPASS IS THE POINT. Compact mode narrows discovery but is explicitly not a
+// boundary — `call_tool` dispatches by name. A filter applied only to the registered list
+// would leave the facade wide open, and the report says so directly. Both paths run the
+// same registrar decorator, and the tests below check BOTH, because "I filtered the
+// registration" is exactly the fix that looks complete and is not.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveToolSurfacePolicy,
+  toolAllowed,
+  toolMatches,
+  TOOL_PRESETS,
+  withToolSurfaceFilter,
+} from "../../tools/tool-surface-filter.js";
+
+/** A minimal stand-in for the SDK registrar: records what actually got registered. */
+function recordingRegistrar() {
+  const registered: string[] = [];
+  return {
+    registrar: { tool: (name: string) => registered.push(name) },
+    registered,
+  };
+}
+
+describe("the operator's policy is read from the environment (#873)", () => {
+  it("is INACTIVE by default — a local install is unchanged", () => {
+    const p = resolveToolSurfacePolicy({});
+    expect(p.active).toBe(false);
+    // And an inactive policy must not wrap: every tool registers.
+    const { registrar, registered } = recordingRegistrar();
+    const wrapped = withToolSurfaceFilter(registrar, p);
+    wrapped.tool("restart_comfyui");
+    expect(registered).toEqual(["restart_comfyui"]);
+  });
+
+  it("reads deny, allow and a preset", () => {
+    expect(resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_DENY: "a, b ,c" }).deny).toEqual(["a", "b", "c"]);
+    expect(resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_ALLOW: "x" }).allow).toEqual(["x"]);
+    const preset = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "safe" });
+    expect(preset.preset).toBe("safe");
+    expect(preset.deny).toContain("restart_comfyui");
+  });
+
+  it("an UNKNOWN preset name does not silently become 'no policy'", () => {
+    // Failing open on a typo is the dangerous direction: the operator believes the
+    // surface is restricted and it is not. A bare unknown preset yields no deny rules,
+    // so `active` must stay false and the LOG must be the thing that tells them —
+    // rather than a half-applied policy that looks like it worked.
+    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "saef" });
+    expect(p.deny).toEqual([]);
+    expect(p.active).toBe(false);
+  });
+});
+
+describe("allow wins, and is absolute (#873)", () => {
+  it("an allow list makes the surface EXACTLY those tools", () => {
+    // The alternative reading — allow as a mere exemption from deny — turns an
+    // incomplete list into a wide-open surface, which nobody notices until it matters.
+    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_ALLOW: "generate_image,queue" });
+    expect(toolAllowed("generate_image", p)).toBe(true);
+    expect(toolAllowed("queue", p)).toBe(true);
+    // Never mentioned by any rule — still denied.
+    expect(toolAllowed("restart_comfyui", p)).toBe(false);
+    expect(toolAllowed("download_model", p)).toBe(false);
+  });
+
+  it("deny works on its own", () => {
+    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_DENY: "restart_comfyui" });
+    expect(toolAllowed("restart_comfyui", p)).toBe(false);
+    expect(toolAllowed("generate_image", p)).toBe(true);
+  });
+
+  it("a prefix glob groups a family, and does not match more than it reads like", () => {
+    expect(toolMatches("train_start", "train_*")).toBe(true);
+    expect(toolMatches("train_doctor", "train_*")).toBe(true);
+    expect(toolMatches("generate_image", "train_*")).toBe(false);
+    // Not a full glob — a mid-string wildcard is NOT silently honoured, because a rule
+    // that matches more than it reads like is worse than one that matches nothing.
+    expect(toolMatches("generate_image", "gen*image")).toBe(false);
+  });
+});
+
+describe("a denied tool is ABSENT, not refusing (#873)", () => {
+  it("never registers, so the model never learns it exists", () => {
+    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "safe" });
+    const { registrar, registered } = recordingRegistrar();
+    const wrapped = withToolSurfaceFilter(registrar, p);
+
+    wrapped.tool("generate_image");
+    wrapped.tool("restart_comfyui");
+    wrapped.tool("download_model");
+
+    expect(registered).toEqual(["generate_image"]);
+  });
+
+  it("the FACADE is never filtered — restricting must not mean breaking", () => {
+    // Removing call_tool from a compact surface leaves a client unable to reach ANY
+    // tool. The facade only routes; what it can route to is governed by the same policy
+    // through the shared catalog, so exempting it grants nothing.
+    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_ALLOW: "nothing_matches" });
+    const { registrar, registered } = recordingRegistrar();
+    const wrapped = withToolSurfaceFilter(registrar, p);
+
+    for (const n of ["list_tools", "describe_tool", "call_tool", "generate_image"]) wrapped.tool(n);
+
+    expect(registered).toEqual(["list_tools", "describe_tool", "call_tool"]);
+  });
+
+  it("readonly withholds execution as well as mutation", () => {
+    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "readonly" });
+    expect(toolAllowed("generate_image", p)).toBe(false);
+    expect(toolAllowed("enqueue_workflow", p)).toBe(false);
+    expect(toolAllowed("restart_comfyui", p)).toBe(false);
+    // …but inspection still works, or the preset would be useless.
+    expect(toolAllowed("get_history", p)).toBe(true);
+    expect(toolAllowed("list_local_models", p)).toBe(true);
+  });
+
+  it("safe keeps rendering while withholding machine changes", () => {
+    const p = resolveToolSurfacePolicy({ COMFYUI_MCP_TOOL_PRESET: "safe" });
+    expect(toolAllowed("generate_image", p)).toBe(true);
+    expect(toolAllowed("restart_comfyui", p)).toBe(false);
+    expect(toolAllowed("install_custom_node", p)).toBe(false);
+  });
+
+  it("the presets name only tools that exist", async () => {
+    // A preset naming a renamed tool protects nothing while reading as though it does —
+    // the 0.50.0 consolidation renamed a great many, and this is the check that keeps a
+    // hardcoded list honest against the live surface.
+    const { collectToolCatalog } = await import("../../tools/index.js");
+    const catalog = await collectToolCatalog();
+    const live = new Set([...catalog.tools.keys()]);
+    const unknown = [...new Set(Object.values(TOOL_PRESETS).flat())].filter((n) => !live.has(n));
+    expect(unknown, `preset entries that match no live tool: ${unknown.join(", ")}`).toEqual([]);
+  });
+});
+
+describe("WIRING: the filter covers the call_tool route, not just registration (#873)", () => {
+  it("is applied inside collectToolCatalog, which call_tool dispatches through", async () => {
+    // The bypass this feature exists to close. Asserted on the source because the
+    // catalog is built once per process and the policy is read from the environment at
+    // that moment; a runtime assertion here would test my mock, not the wiring.
+    const { readFile } = await import("node:fs/promises");
+    const src = await readFile(new URL("../../tools/index.ts", import.meta.url), "utf-8");
+
+    const at = src.indexOf("export async function collectToolCatalog");
+    expect(at).toBeGreaterThan(-1);
+    const body = src.slice(at, at + 1200);
+    expect(body).toContain("withToolSurfaceFilter(");
+    expect(body).toContain("resolveToolSurfacePolicy()");
+
+    // …and on the direct registration path too.
+    const reg = src.slice(src.indexOf("export async function registerAllTools"), at);
+    expect(reg).toContain("withToolSurfaceFilter(");
+  });
+});

--- a/src/__tests__/tools/tool-surface-filter.test.ts
+++ b/src/__tests__/tools/tool-surface-filter.test.ts
@@ -29,6 +29,20 @@ import {
   withToolSurfaceFilter,
 } from "../../tools/tool-surface-filter.js";
 
+/**
+ * Source with comments removed.
+ *
+ * Every source-grepping test below needs this, and finding out why was worth more than the
+ * tests. Two of them asserted `src.includes("COMFYUI_MCP_TOOL_PRESET")` and
+ * `src.indexOf("resolveToolSurfacePolicy();")` — and I had written a PARAGRAPH of comment
+ * above each fix explaining what it does, naming those exact strings. Deleting the code
+ * outright left both tests green, because the comment satisfied them. A wiring test that a
+ * comment can satisfy is not a wiring test; it is a spell-check on my own prose.
+ */
+function codeOnly(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*/g, "");
+}
+
 /** A minimal stand-in for the SDK registrar: records what actually got registered. */
 function recordingRegistrar() {
   const registered: string[] = [];
@@ -121,6 +135,42 @@ describe("allow wins, and is absolute (#873)", () => {
     expect(toolAllowed("panel_graph_outline", p)).toBe(true);
     expect(toolAllowed("panel_run", p)).toBe(false);
     expect(toolAllowed("restart_comfyui", p)).toBe(false);
+  });
+
+  it("a GLOB in allow narrows, but cannot re-open what a preset closed", () => {
+    // Measured on the first version, which let any allow match override the preset:
+    // ALLOW=list_* re-admitted list_packs — the install-and-execute tool that was the
+    // headline finding of the round which added these presets — and ALLOW=* made every
+    // preset inert while still reporting itself active.
+    //
+    // Naming `panel_graph_outline` is a decision about one tool. Writing `list_*` is a
+    // decision about a shape, and it sweeps in whatever the next release names that way.
+    const glob = resolveToolSurfacePolicy({
+      COMFYUI_MCP_TOOL_PRESET: "safe",
+      COMFYUI_MCP_TOOL_ALLOW: "list_*",
+    });
+    expect(toolAllowed("list_packs", glob)).toBe(false);
+    expect(toolAllowed("list_api_nodes", glob)).toBe(true); // allowed by safe anyway
+    expect(toolAllowed("restart_comfyui", glob)).toBe(false); // outside the allow bound
+
+    const star = resolveToolSurfacePolicy({
+      COMFYUI_MCP_TOOL_PRESET: "safe",
+      COMFYUI_MCP_TOOL_ALLOW: "*",
+    });
+    expect(toolAllowed("restart_comfyui", star), "ALLOW=* must not void a preset").toBe(false);
+
+    const readonlyGlob = resolveToolSurfacePolicy({
+      COMFYUI_MCP_TOOL_PRESET: "readonly",
+      COMFYUI_MCP_TOOL_ALLOW: "panel_*",
+    });
+    expect(toolAllowed("panel_run", readonlyGlob)).toBe(false);
+
+    // …while the EXACT name still refines, which is the documented opt-in.
+    const exact = resolveToolSurfacePolicy({
+      COMFYUI_MCP_TOOL_PRESET: "readonly",
+      COMFYUI_MCP_TOOL_ALLOW: "panel_run",
+    });
+    expect(toolAllowed("panel_run", exact)).toBe(true);
   });
 
   it("a variable SET BUT EMPTY refuses to start — the fail-open by another route", () => {
@@ -379,7 +429,7 @@ describe("WIRING: the filter covers the call_tool route, not just registration (
     // That path uses `registerTool` on a separate server, so the headless decorator —
     // which proxies `.tool` — could never have caught it.
     const { readFile } = await import("node:fs/promises");
-    const src = await readFile(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf-8");
+    const src = codeOnly(await readFile(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf-8"));
     const at = src.indexOf("export function registerPanelTools");
     expect(at).toBeGreaterThan(-1);
     const body = src.slice(at, at + 1400);
@@ -397,7 +447,7 @@ describe("WIRING: the filter covers the call_tool route, not just registration (
     // that was true, which is why this one names the second function explicitly rather
     // than searching the file as a whole.
     const { readFile } = await import("node:fs/promises");
-    const src = await readFile(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf-8");
+    const src = codeOnly(await readFile(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf-8"));
     const at = src.indexOf("export function createPanelMcpServer");
     expect(at).toBeGreaterThan(-1);
     const body = src.slice(at, at + 1800);
@@ -405,20 +455,33 @@ describe("WIRING: the filter covers the call_tool route, not just registration (
     expect(body).toContain("toolAllowed(d.name, policy)");
   });
 
-  it("the policy reaches the SPAWNED comfyui child, which builds its env explicitly", async () => {
-    // comfyuiBaseEnv() constructs the child's environment rather than inheriting it (on
-    // purpose — a spread cannot REMOVE a revoked credential), and the MCP SDK spawns
-    // stdio children with a PATH/HOME-class default env. So an unforwarded variable does
-    // not exist over there: panel tools withheld and logged as withheld, while the
-    // agent's own comfyui child still offers download_model and restart_comfyui.
+  it("the policy reaches the SPAWNED comfyui child through the env builder BOTH lanes share", async () => {
+    // There are two comfyui spawn lanes. I put this forwarding in comfyuiBaseEnv(), which
+    // only the Codex/Gemini lane spreads; the DEFAULT Claude lane builds its own literal
+    // and calls buildComfyuiMcpEnv directly, so it kept spawning a child with all 37
+    // tools while the panel surface was withheld and logged as withheld.
+    //
+    // That is the same defect as the two panel registration paths — fix one, test the one
+    // you fixed — committed again in the same change, one file over. So this asserts on
+    // the CHOKE POINT both lanes pass through, not on either call site.
     const { readFile } = await import("node:fs/promises");
-    const src = await readFile(new URL("../../orchestrator/index.ts", import.meta.url), "utf-8");
-    const at = src.indexOf("const comfyuiBaseEnv");
+    const src = codeOnly(await readFile(new URL("../../services/panel-secrets.ts", import.meta.url), "utf-8"));
+    const at = src.indexOf("export function buildComfyuiMcpEnv");
     expect(at).toBeGreaterThan(-1);
-    const body = src.slice(at, at + 2600);
+    const body = src.slice(at, at + 3200);
     for (const v of ["COMFYUI_MCP_TOOL_PRESET", "COMFYUI_MCP_TOOL_ALLOW", "COMFYUI_MCP_TOOL_DENY"]) {
-      expect(body, `${v} must be forwarded to the child`).toContain(v);
+      // Assert the ASSIGNMENT, not that the name appears somewhere. Checking only for the
+      // name passed with the forwarding deleted, because the `process.env.X ?` guard on
+      // the line above still mentions X — the test matched the condition and called it
+      // the effect.
+      expect(body, `${v} must be ASSIGNED into the child env, not merely mentioned`).toContain(
+        `${v}: process.env.${v}`,
+      );
     }
+
+    // …and both lanes really do route through it, or the choke point is not one.
+    const orch = codeOnly(await readFile(new URL("../../orchestrator/index.ts", import.meta.url), "utf-8"));
+    expect(orch.match(/buildComfyuiMcpEnv\(/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
   });
 
   it("the policy is validated at BOOT, so 'Refusing to start' is true on http too", async () => {
@@ -428,10 +491,14 @@ describe("WIRING: the filter covers the call_tool route, not just registration (
     // back 500 with the real reason buried in a log line. Fail-closed, so not a hole —
     // but the message promised something that transport did not do.
     const { readFile } = await import("node:fs/promises");
-    const src = await readFile(new URL("../../boot.ts", import.meta.url), "utf-8");
+    const src = codeOnly(await readFile(new URL("../../boot.ts", import.meta.url), "utf-8"));
     const call = src.indexOf("resolveToolSurfacePolicy();");
     expect(call).toBeGreaterThan(-1);
-    // …and BEFORE the http branch, or it has not bought anything.
+    // Above EVERY branch that starts something. Asserting only against the http branch
+    // missed --panel-orchestrator, which returns above it and never comes back: a typo'd
+    // preset there bound the bridge, the loopback MCP and the console, printed the ready
+    // banner, and only threw later at first use, inside a request handler.
+    expect(call).toBeLessThan(src.indexOf("if (cli.panelOrchestrator)"));
     expect(call).toBeLessThan(src.indexOf('if (cli.transport === "http")'));
   });
 
@@ -440,7 +507,7 @@ describe("WIRING: the filter covers the call_tool route, not just registration (
     // catalog is built once per process and the policy is read from the environment at
     // that moment; a runtime assertion here would test my mock, not the wiring.
     const { readFile } = await import("node:fs/promises");
-    const src = await readFile(new URL("../../tools/index.ts", import.meta.url), "utf-8");
+    const src = codeOnly(await readFile(new URL("../../tools/index.ts", import.meta.url), "utf-8"));
 
     const at = src.indexOf("export async function collectToolCatalog");
     expect(at).toBeGreaterThan(-1);

--- a/src/__tests__/tools/tool-surface-filter.test.ts
+++ b/src/__tests__/tools/tool-surface-filter.test.ts
@@ -318,6 +318,42 @@ describe("the presets cover what a NAME no longer reveals (codex P1)", () => {
     ).toEqual(["delete"]);
   });
 
+  it("declaredActions never strips a tool's OWN action, measured on all 37 live descriptions", async () => {
+    // The hand-written case above proves the rule; this proves it against the real text,
+    // which is where it can actually fail. `queue` and `batch` are tool names AND ordinary
+    // English words, so a sentence ending "...drains the queue." immediately before a
+    // bulleted `action:"clear"` would capture `queue` as a cross-reference and delete a
+    // self-declaration — leaving the tool looking action-free and the cross-check
+    // reporting no hole.
+    //
+    // GROUND TRUTH: a tool's own actions are introduced as a BULLET (`- action:"x" — …`);
+    // a cross-reference never is. My first attempt at this check read the zod action enum
+    // off the catalog entry, resolved it for 0 of 37 tools, and printed a confident pass —
+    // so the count is asserted below to keep this from going quietly vacuous the same way.
+    const { collectToolCatalog } = await import("../../tools/index.js");
+    const catalog = await collectToolCatalog();
+    const known = new Set(catalog.tools.keys());
+
+    const selfStripped: string[] = [];
+    let measured = 0;
+    for (const [name, tool] of catalog.tools) {
+      const description = tool.description ?? "";
+      const own = [
+        ...new Set(
+          [...description.matchAll(/(?:^|\n)\s*[-*]\s*action:"([a-z_0-9]+)"/g)].map((m) => m[1]),
+        ),
+      ];
+      if (!own.length) continue;
+      measured++;
+      const kept = declaredActions(description, { selfName: name, knownTools: known });
+      const lost = own.filter((a) => !kept.includes(a));
+      if (lost.length) selfStripped.push(`${name} lost ${lost.join(",")}`);
+    }
+
+    expect(measured, "no descriptions had bullet-declared actions — this check read nothing").toBeGreaterThan(25);
+    expect(selfStripped, `tools whose OWN action was stripped: ${selfStripped.join("; ")}`).toEqual([]);
+  });
+
   it("the PANEL surface is withheld wholesale by both presets (codex P0)", () => {
     // 91 panel_* tools register through a different method on a separate server and
     // bypassed the filter entirely — `panel_run` still queued renders under `readonly`.

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -344,6 +344,25 @@ async function main() {
     }
   }
 
+  // #873 — VALIDATE THE OPERATOR'S TOOL POLICY BEFORE ANY SERVER STARTS, of any kind.
+  //
+  // resolveToolSurfacePolicy() throws on a misconfiguration (an unknown preset, a variable
+  // set but empty) with a message that says "Refusing to start". Making that true took two
+  // corrections, both the same mistake:
+  //
+  //   - On --transport http the server is built LAZILY inside the request handler, so the
+  //     socket bound, "running on http://…" printed, and every initialize came back 500
+  //     with the reason buried in a log line.
+  //   - Moving the call above the http branch left --panel-orchestrator, which returns
+  //     BELOW me and never came back. A typo'd preset there started the bridge, the
+  //     loopback panel MCP and the console, printed the ready banner, and only threw later
+  //     at first use — inside a request handler, per session.
+  //
+  // Both times the fix was placed at the first spot that satisfied the case in front of me
+  // rather than at the point every path passes through. This is that point: above every
+  // branch that starts anything.
+  resolveToolSurfacePolicy();
+
   // Standalone background orchestrator: owns the UI bridge and drives the panel
   // with autonomous Agent SDK sessions. Not an MCP server — it never returns.
   if (cli.panelOrchestrator) {
@@ -409,21 +428,6 @@ async function main() {
     await runPanelOrchestrator();
     return;
   }
-
-  // #873 — VALIDATE THE OPERATOR'S TOOL POLICY BEFORE ANY TRANSPORT STARTS.
-  //
-  // resolveToolSurfacePolicy() throws on a misconfiguration (an unknown preset, a variable
-  // set but empty) with a message that says "Refusing to start". On stdio that was true,
-  // because the first call happens while building the server. On HTTP it was NOT: that
-  // transport calls createServer() lazily inside the request handler, so the socket bound,
-  // the "server running on http://…" line printed, and every `initialize` came back as a
-  // bare 500 with the real reason buried in a request-error log. Fail-closed, so no hole —
-  // but the message promised something the HTTP path did not do, and a message that lies
-  // about its own behaviour is how an operator ends up debugging the wrong thing.
-  //
-  // Calling it here makes the promise true on every transport. The result is discarded;
-  // each registration site resolves its own (the env cannot change under us mid-process).
-  resolveToolSurfacePolicy();
 
   await JobWatcher.cleanupOldFiles();
 

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -14,6 +14,7 @@ import { logger } from "./utils/logger.js";
 import { JobWatcher } from "./services/job-watcher.js";
 import { parseCliArgs, validateConnectUrl, exportExplicitToolMode, type ToolMode } from "./transport/cli.js";
 import { startHttpServer } from "./transport/http.js";
+import { resolveToolSurfacePolicy } from "./tools/tool-surface-filter.js";
 import { isLocalMode } from "./config.js";
 import { ensurePanelInstalled } from "./services/panel-installer.js";
 import { checkAndSelfUpdate } from "./services/self-update.js";
@@ -408,6 +409,21 @@ async function main() {
     await runPanelOrchestrator();
     return;
   }
+
+  // #873 — VALIDATE THE OPERATOR'S TOOL POLICY BEFORE ANY TRANSPORT STARTS.
+  //
+  // resolveToolSurfacePolicy() throws on a misconfiguration (an unknown preset, a variable
+  // set but empty) with a message that says "Refusing to start". On stdio that was true,
+  // because the first call happens while building the server. On HTTP it was NOT: that
+  // transport calls createServer() lazily inside the request handler, so the socket bound,
+  // the "server running on http://…" line printed, and every `initialize` came back as a
+  // bare 500 with the real reason buried in a request-error log. Fail-closed, so no hole —
+  // but the message promised something the HTTP path did not do, and a message that lies
+  // about its own behaviour is how an operator ends up debugging the wrong thing.
+  //
+  // Calling it here makes the promise true on every transport. The result is discarded;
+  // each registration site resolves its own (the env cannot change under us mid-process).
+  resolveToolSurfacePolicy();
 
   await JobWatcher.cleanupOldFiles();
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1876,6 +1876,22 @@ export async function runPanelOrchestrator(): Promise<void> {
     // it as a real env override — a revoke that did not revoke.
     // Test-only tool-call trace (knowledge-parity smoke). No-op unless set.
     ...(process.env.COMFYUI_MCP_TOOL_TRACE ? { COMFYUI_MCP_TOOL_TRACE: process.env.COMFYUI_MCP_TOOL_TRACE } : {}),
+    // #873 — the operator's tool-surface policy MUST reach the spawned child. This env is
+    // CONSTRUCTED, not inherited (deliberately — see the credentials note above), and the
+    // MCP SDK spawns stdio children with a PATH/HOME-class default environment, so an
+    // unforwarded variable simply does not exist over there. Without this the panel tools
+    // are withheld and LOGGED as withheld while the agent's own comfyui child still
+    // offers download_model, install_custom_node, restart_comfyui and comfy_cli — a
+    // filter that reports success and restricts the wrong half of the surface.
+    ...(process.env.COMFYUI_MCP_TOOL_PRESET
+      ? { COMFYUI_MCP_TOOL_PRESET: process.env.COMFYUI_MCP_TOOL_PRESET }
+      : {}),
+    ...(process.env.COMFYUI_MCP_TOOL_ALLOW
+      ? { COMFYUI_MCP_TOOL_ALLOW: process.env.COMFYUI_MCP_TOOL_ALLOW }
+      : {}),
+    ...(process.env.COMFYUI_MCP_TOOL_DENY
+      ? { COMFYUI_MCP_TOOL_DENY: process.env.COMFYUI_MCP_TOOL_DENY }
+      : {}),
   });
 
   // The orchestrator-hosted loopback HTTP MCP for panel_* tools. Started for the

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1876,22 +1876,9 @@ export async function runPanelOrchestrator(): Promise<void> {
     // it as a real env override — a revoke that did not revoke.
     // Test-only tool-call trace (knowledge-parity smoke). No-op unless set.
     ...(process.env.COMFYUI_MCP_TOOL_TRACE ? { COMFYUI_MCP_TOOL_TRACE: process.env.COMFYUI_MCP_TOOL_TRACE } : {}),
-    // #873 — the operator's tool-surface policy MUST reach the spawned child. This env is
-    // CONSTRUCTED, not inherited (deliberately — see the credentials note above), and the
-    // MCP SDK spawns stdio children with a PATH/HOME-class default environment, so an
-    // unforwarded variable simply does not exist over there. Without this the panel tools
-    // are withheld and LOGGED as withheld while the agent's own comfyui child still
-    // offers download_model, install_custom_node, restart_comfyui and comfy_cli — a
-    // filter that reports success and restricts the wrong half of the surface.
-    ...(process.env.COMFYUI_MCP_TOOL_PRESET
-      ? { COMFYUI_MCP_TOOL_PRESET: process.env.COMFYUI_MCP_TOOL_PRESET }
-      : {}),
-    ...(process.env.COMFYUI_MCP_TOOL_ALLOW
-      ? { COMFYUI_MCP_TOOL_ALLOW: process.env.COMFYUI_MCP_TOOL_ALLOW }
-      : {}),
-    ...(process.env.COMFYUI_MCP_TOOL_DENY
-      ? { COMFYUI_MCP_TOOL_DENY: process.env.COMFYUI_MCP_TOOL_DENY }
-      : {}),
+    // #873 — the tool-surface policy is forwarded in buildComfyuiMcpEnv(), which BOTH
+    // comfyui spawn lanes share. It was here first, and here is only the Codex/Gemini
+    // lane: the default Claude lane calls buildComfyuiMcpEnv directly and got nothing.
   });
 
   // The orchestrator-hosted loopback HTTP MCP for panel_* tools. Started for the

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -11976,7 +11976,29 @@ export function createPanelMcpServer(
   workflowTargets?: WorkflowTargetStore,
 ): McpSdkServerConfigWithInstance {
   const ctx = makePanelToolCtx(bridge, tabId, workflowTargets);
-  const defs = buildPanelToolDefs();
+  // #873 — THE SECOND PANEL REGISTRATION PATH. This one serves the Anthropic Agent SDK
+  // (Claude backend, in-process transport); registerPanelTools serves the MCP SDK. They
+  // build from the SAME buildPanelToolDefs(), so filtering only the other one left
+  // `panel_run` queueing renders under PRESET=readonly for every Claude-backend tab — the
+  // exact hole the previous round closed on the sibling path and, by fixing only one of
+  // two, left open. Filtering at the shared def list would be tidier and is deliberately
+  // not done here: both call sites are then trivially greppable, and the wiring tests
+  // assert on each by name.
+  const policy = resolveToolSurfacePolicy();
+  const withheldSdk: string[] = [];
+  const defs = buildPanelToolDefs().filter((d) => {
+    if (policy.active && !toolAllowed(d.name, policy)) {
+      withheldSdk.push(d.name);
+      return false;
+    }
+    return true;
+  });
+  if (withheldSdk.length) {
+    toolPolicyLogger.info(
+      `[panel-tools] surface restricted by policy${policy.preset ? ` (preset "${policy.preset}")` : ""} — ` +
+        `${withheldSdk.length} panel tool(s) withheld from the in-process server`,
+    );
+  }
   // The Anthropic SDK's tool() accepts (name, description, zodRawShape, cb). The
   // shared handler is transport-agnostic — bind it to this tab's ctx. Each def's
   // schema is a distinct zod shape, so the produced tool generics differ; widen

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -25,6 +25,9 @@
 
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
+// #873 — the operator's tool-surface policy also governs the panel surface.
+import { resolveToolSurfacePolicy, toolAllowed } from "../tools/tool-surface-filter.js";
+import { logger as toolPolicyLogger } from "../utils/logger.js";
 import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import type { Stats } from "node:fs";
 import {
@@ -12017,7 +12020,18 @@ export function createPanelMcpServer(
  * tools forward to the bridge for THAT tab — same surface as the Claude path.
  */
 export function registerPanelTools(server: McpServer, ctx: PanelToolCtx): void {
+  // #873 — the operator's policy applies HERE too. This path registers through
+  // `registerTool` on a separate MCP server, so it bypassed the headless filter
+  // entirely: with COMFYUI_MCP_TOOL_PRESET=readonly set, `panel_run` still queued
+  // renders. A filter with a hole is worse than no filter, because the operator has been
+  // told the surface is restricted.
+  const policy = resolveToolSurfacePolicy();
+  const withheld: string[] = [];
   for (const d of buildPanelToolDefs()) {
+    if (policy.active && !toolAllowed(d.name, policy)) {
+      withheld.push(d.name);
+      continue;
+    }
     server.registerTool(
       d.name,
       {
@@ -12034,6 +12048,15 @@ export function registerPanelTools(server: McpServer, ctx: PanelToolCtx): void {
         // ToolResult is already the MCP CallToolResult shape (content[] + isError).
         return res as never;
       }) as never,
+    );
+  }
+  if (withheld.length) {
+    // Logged for the OPERATOR, never surfaced to the model — the point is that it does
+    // not learn these exist. Silence here is how a policy that withholds the whole panel
+    // becomes an afternoon of "why can't it see my canvas".
+    toolPolicyLogger.info(
+      `[panel-tools] surface restricted by policy${policy.preset ? ` (preset "${policy.preset}")` : ""} — ` +
+        `${withheld.length} panel tool(s) withheld`,
     );
   }
 }

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -2036,6 +2036,31 @@ export function buildComfyuiMcpEnv(base: Record<string, string>): Record<string,
     ...(process.env.COMFYUI_MCP_ENV_FILE
       ? { COMFYUI_MCP_ENV_FILE: process.env.COMFYUI_MCP_ENV_FILE }
       : {}),
+    // #873 — THE OPERATOR'S TOOL-SURFACE POLICY, forwarded HERE because this is the one
+    // function BOTH comfyui spawn lanes share.
+    //
+    // I first put this in comfyuiBaseEnv(), which only the Codex/Gemini lane spreads. The
+    // Claude lane — the DEFAULT backend — builds its own literal and calls this function
+    // directly, so it kept spawning a child with all 37 tools while the panel surface was
+    // correctly withheld and logged as withheld. An operator setting PRESET=readonly got
+    // a server that reported itself restricted and still offered restart_comfyui,
+    // install_custom_node and download_model.
+    //
+    // That is the same defect I had just written a commit message about — fixing one of
+    // two registration paths and testing only the one I fixed — committed again, in the
+    // same change, one file over. Two call sites is the bug; the choke point is the fix.
+    // The child's env is CONSTRUCTED rather than inherited (a spread cannot remove a
+    // revoked credential, see below), so an unforwarded variable simply does not exist
+    // over there.
+    ...(process.env.COMFYUI_MCP_TOOL_PRESET
+      ? { COMFYUI_MCP_TOOL_PRESET: process.env.COMFYUI_MCP_TOOL_PRESET }
+      : {}),
+    ...(process.env.COMFYUI_MCP_TOOL_ALLOW
+      ? { COMFYUI_MCP_TOOL_ALLOW: process.env.COMFYUI_MCP_TOOL_ALLOW }
+      : {}),
+    ...(process.env.COMFYUI_MCP_TOOL_DENY
+      ? { COMFYUI_MCP_TOOL_DENY: process.env.COMFYUI_MCP_TOOL_DENY }
+      : {}),
     // KEY NAMES only — never values.
     ...(managed.length ? { [MANAGED_SECRET_KEYS_ENV]: managed.join(",") } : {}),
     ...secrets,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -39,6 +39,7 @@ import { DefaultsManager } from "../services/defaults-manager.js";
 import { ToolCatalog } from "./catalog.js";
 import { registerCompactTools } from "./compact.js";
 import { logger } from "../utils/logger.js";
+import { resolveToolSurfacePolicy, withToolSurfaceFilter } from "./tool-surface-filter.js";
 
 /**
  * Every static tool group, in registration order (order is observable in
@@ -161,9 +162,24 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   // Hydrate persisted defaults before any tool registration so subsequent
   // tools can consult DefaultsManager.apply() against a fully-resolved view.
   await DefaultsManager.load();
-  const gated = withBlindImageGate(server);
+  // #873 — the operator's tool-surface policy, applied in the SAME position as the
+  // blind-image gate. collectToolCatalog() applies it too, which is what stops the
+  // compact `call_tool` facade being a way around it.
+  const policy = resolveToolSurfacePolicy();
+  const filtered: string[] = [];
+  const gated = withToolSurfaceFilter(withBlindImageGate(server), policy, (n) => filtered.push(n));
   for (const [, register] of TOOL_GROUPS) register(gated);
   await registerAutoloadedWorkflows(gated);
+  if (policy.active) {
+    // Logged, never pushed to the model: the point is that it does not learn these
+    // exist. The OPERATOR needs to see it, and a silent filter is how a misconfigured
+    // allow list becomes an afternoon of "why can't it render".
+    logger.info(
+      `[tools] surface restricted by policy${policy.preset ? ` (preset "${policy.preset}")` : ""} — ` +
+        `${filtered.length} tool(s) withheld` +
+        (filtered.length ? `: ${filtered.slice(0, 12).join(", ")}${filtered.length > 12 ? ", …" : ""}` : ""),
+    );
+  }
 }
 
 /**
@@ -237,7 +253,15 @@ export async function registerFullTools(
 export async function collectToolCatalog(): Promise<ToolCatalog> {
   await DefaultsManager.load();
   const catalog = new ToolCatalog();
-  const registrar = withBlindImageGate(catalog.asRegistrar());
+  // #873 — THE LOAD-BEARING HALF. `call_tool` dispatches through this catalog and
+  // `list_tools` is built from it, so filtering here is what makes the policy a boundary
+  // rather than a suggestion: a denied tool is neither listed nor reachable by name.
+  // Filtering only the direct registration above would leave the facade as a clean
+  // bypass, which is precisely what the report calls out.
+  const registrar = withToolSurfaceFilter(
+    withBlindImageGate(catalog.asRegistrar()),
+    resolveToolSurfacePolicy(),
+  );
   for (const [category, register] of TOOL_GROUPS) {
     catalog.setCategory(category);
     register(registrar);

--- a/src/tools/tool-surface-filter.ts
+++ b/src/tools/tool-surface-filter.ts
@@ -21,7 +21,28 @@
  * by remembering to cover them.
  */
 
-/** Tools that change the machine, the model library, or the running server. */
+/**
+ * Tools that change the machine, the model library, or the running server.
+ *
+ * A NAME NO LONGER TELLS YOU WHAT A TOOL CAN DO (codex, P1). The 0.50.0 consolidation
+ * folded destructive actions into tools that read as inspection:
+ *
+ *   list_local_models   action:"remove" deletes a model file; add_path/remove_path
+ *                       rewrite extra_model_paths.yaml
+ *   search_custom_nodes action:"install" installs a node pack
+ *   get_defaults        action:"set" writes persistent config
+ *   queue               action:"clear"/"cancel" destroys work — someone else's, in the
+ *                       shared deployment this feature exists for
+ *
+ * My first list was written from the names and missed every one of those. Since the
+ * filter is per-TOOL and cannot see actions, the rule is: deny the whole tool when ANY of
+ * its actions violates the preset. That costs `safe` some genuinely useful reads, and
+ * that is the correct trade — an operator who thinks deletion is impossible and is wrong
+ * is worse off than one who has to allow a tool back explicitly.
+ *
+ * Per-action policy is the real answer and is deliberately not attempted here; it needs a
+ * vocabulary these tools do not yet expose uniformly.
+ */
 const MUTATING_TOOLS = [
   "install_comfyui",
   "install_custom_node",
@@ -42,6 +63,11 @@ const MUTATING_TOOLS = [
   "create_workflow",
   "upload_image",
   "bisect",
+  // …the consolidated ones a name-based list misses:
+  "list_local_models",
+  "search_custom_nodes",
+  "get_defaults",
+  "queue",
 ];
 
 /** …plus everything that queues work or spends money. */
@@ -49,10 +75,43 @@ const EXECUTION_TOOLS = [
   "generate_image",
   "enqueue_workflow",
   "batch",
-  "queue",
   "apps",
   "list_api_nodes",
 ];
+
+/**
+ * Action names that mean a tool can change something. Used ONLY by the completeness test,
+ * which scans the live catalog and fails when a tool advertising one of these is missing
+ * from the `safe` deny list.
+ *
+ * The hand-written list above stays hand-written — it is auditable, and an operator can
+ * read it. What this adds is that it cannot silently ROT: the next consolidation that
+ * hides `action:"delete"` behind an inspection-sounding name fails a test instead of
+ * quietly widening every deployment's surface.
+ */
+export const MUTATING_ACTION_NAMES =
+  /^(remove|delete|clear|cancel|uninstall|install|reset|kill|stop|restart|purge|prune|apply|create|upload|train|add_path|remove_path|set|save|write|switch|update|fix|disable|enable)$/i;
+
+/**
+ * Verbs that mean "queue work / spend", which `safe` deliberately ALLOWS — rendering is
+ * the point of the product — and only `readonly` withholds. Kept separate so the
+ * completeness check does not flag `enqueue_workflow` as a hole in `safe`.
+ */
+export const EXECUTION_ACTION_NAMES = /^(enqueue|start|submit|run)$/i;
+
+/**
+ * Extract the actions a tool declares for ITSELF, from its description.
+ *
+ * Cross-references are excluded, and that is not a detail: `generate_image`'s description
+ * mentions `get_defaults (action:"set")` while explaining where defaults come from. A
+ * naive scan reads that as generate_image having a `set` action and reports a hole that
+ * does not exist. A completeness check that cries wolf gets muted, and then it is not a
+ * check.
+ */
+export function declaredActions(description: string): string[] {
+  const withoutCrossRefs = description.replace(/\b[a-z_0-9]+\s*\(action:"[a-z_0-9]+"\)/gi, "");
+  return [...new Set([...withoutCrossRefs.matchAll(/action:"([a-z_0-9]+)"/g)].map((m) => m[1]))];
+}
 
 /**
  * Named presets, so an operator is not hand-maintaining a list against a surface that
@@ -62,9 +121,29 @@ const EXECUTION_TOOLS = [
  *              Rendering still works; installing, deleting and restarting do not.
  * `readonly` — inspection only. No renders queued, nothing written, nothing spent.
  */
+/**
+ * THE PANEL SURFACE IS DENIED WHOLESALE BY BOTH PRESETS (codex, P0).
+ *
+ * `registerPanelTools` registers 91 `panel_*` tools through a different method
+ * (`registerTool`) on a separate server, so they bypassed the filter entirely: under
+ * `readonly`, `panel_run` still queued renders. That is the "a filter with a hole is
+ * worse than none" case — the operator is told the surface is restricted and it is not.
+ *
+ * Denied as a FAMILY rather than tool-by-tool, deliberately. I classified those 91 by
+ * name first and got several wrong in both directions (`panel_set_property`,
+ * `panel_move_node`, `panel_add_subgraph` and `panel_update_node` all mutate and none
+ * match an obvious write-ish pattern). A hand list over a surface that grows every
+ * release is the rot this feature already tripped over once. `panel_*` is also exactly
+ * what a hosted operator would withhold: it drives a live canvas their users share.
+ *
+ * Opt back in explicitly — `COMFYUI_MCP_TOOL_ALLOW=panel_graph_outline,panel_query_graph`
+ * — which is the direction that fails safe when someone forgets one.
+ */
+const PANEL_SURFACE = ["panel_*"];
+
 export const TOOL_PRESETS: Record<string, string[]> = {
-  safe: MUTATING_TOOLS,
-  readonly: [...MUTATING_TOOLS, ...EXECUTION_TOOLS],
+  safe: [...MUTATING_TOOLS, ...PANEL_SURFACE],
+  readonly: [...MUTATING_TOOLS, ...EXECUTION_TOOLS, ...PANEL_SURFACE],
 };
 
 export interface ToolSurfacePolicy {
@@ -100,11 +179,34 @@ export function toolMatches(name: string, pattern: string): boolean {
   return false;
 }
 
-/** Read the policy from the environment. */
+/**
+ * Read the policy from the environment.
+ *
+ * AN UNKNOWN PRESET THROWS (codex, P0). The first version resolved a typo — `saef` for
+ * `safe` — to no rules at all, which made `active` false, which meant the decorator
+ * returned the registrar unwrapped AND the "surface restricted" log never fired. The
+ * server came up with its complete tool surface and said nothing, while the operator
+ * believed they had locked it down. Worse, I had written a test asserting exactly that
+ * and called it correct, on the reasoning that "the log will tell them" — the log is
+ * gated on the same flag.
+ *
+ * For a control whose whole purpose is a guarantee, silence on a misconfiguration is the
+ * one unacceptable outcome. Refusing to start is loud, immediate, and cannot be mistaken
+ * for success.
+ */
 export function resolveToolSurfacePolicy(env: NodeJS.ProcessEnv = process.env): ToolSurfacePolicy {
   const allow = splitList(env.COMFYUI_MCP_TOOL_ALLOW);
   const denyRaw = splitList(env.COMFYUI_MCP_TOOL_DENY);
   const presetName = (env.COMFYUI_MCP_TOOL_PRESET ?? "").trim();
+  if (presetName && !Object.prototype.hasOwnProperty.call(TOOL_PRESETS, presetName)) {
+    throw new Error(
+      `COMFYUI_MCP_TOOL_PRESET="${presetName}" is not a known preset. ` +
+        `Valid presets: ${Object.keys(TOOL_PRESETS).join(", ")}. ` +
+        `Refusing to start: continuing would expose the FULL tool surface while you believe ` +
+        `it is restricted, which is worse than no filter at all. Fix the value, or drop the ` +
+        `variable and use COMFYUI_MCP_TOOL_DENY / COMFYUI_MCP_TOOL_ALLOW directly.`,
+    );
+  }
   const preset = presetName ? TOOL_PRESETS[presetName] : undefined;
   const deny = [...(preset ?? []), ...denyRaw];
   return {

--- a/src/tools/tool-surface-filter.ts
+++ b/src/tools/tool-surface-filter.ts
@@ -94,9 +94,16 @@ export const EXECUTION_TOOLS = [
   "get_image",
   // Runs hosted partner nodes that spend PAID credits.
   "list_api_nodes",
-  // Files a PUBLIC GitHub issue under the operator's token. Nothing on the machine
-  // changes, so `safe` permits it; `readonly` promises "nothing written" and a public
-  // issue written by whoever is prompting a shared frontend is squarely a write.
+  // Files a PUBLIC GitHub issue. Nothing on the machine changes, so `safe` permits it;
+  // `readonly` promises "nothing written", and a public issue written by whoever is
+  // prompting a shared frontend is squarely a write.
+  //
+  // My first note here said "under the operator's token", which is wrong: the GitHub
+  // token is server-side in the intake Worker and the client key is a soft anti-spam gate
+  // (report-issue.ts:18-23). The classification is unaffected — the issue is still public
+  // and still attributable to this deployment — but a wrong premise in this ledger is
+  // exactly what produced the `search_custom_nodes` inversion one round ago, so it gets
+  // corrected rather than left as harmless-sounding filler.
   "report_issue",
 ];
 
@@ -164,7 +171,13 @@ export const EXECUTION_ACTION_NAMES = /^(enqueue|start|submit|run)$/i;
  */
 export function declaredActions(
   description: string,
-  opts: { selfName?: string; knownTools?: ReadonlySet<string> } = {},
+  // REQUIRED, and both fields with it. They read like optional refinements and are the
+  // only thing standing between this function and the over-stripping its own comment
+  // calls the dangerous direction: with the guards defaulted off, every `name action:"x"`
+  // is deleted, so `install_comfyui` loses its own pin/unpin/unlock and
+  // `list_local_models` loses `download`. A caller that forgets them gets a silently
+  // blinded result and a check that reports no holes. Make it impossible to forget.
+  opts: { selfName: string; knownTools: ReadonlySet<string> },
 ): string[] {
   const { selfName, knownTools } = opts;
   // Both spellings occur in the real descriptions: `get_defaults (action:"set")` and
@@ -348,10 +361,22 @@ export function toolAllowed(name: string, policy: ToolSurfacePolicy): boolean {
   // An EXPLICIT deny beats an allow list — both are the operator speaking, and the
   // smaller surface wins the tie.
   if (policy.deny.some((p) => toolMatches(name, p))) return false;
-  // A PRESET is a broad default, so naming a tool in the allow list is how you refine it
+  // A PRESET is a broad default, so NAMING a tool in the allow list is how you refine it
   // (`PRESET=safe` + `ALLOW=panel_graph_outline,panel_query_graph`). Without this, the
   // documented opt-back-in would silently do nothing.
-  if (policy.allow.length > 0) return true;
+  //
+  // AN EXACT NAME REFINES A PRESET; A GLOB DOES NOT. Measured on the first version, which
+  // let any allow match override: `PRESET=safe` + `ALLOW=list_*` re-admitted `list_packs`
+  // — the tool whose action:"install_deps" downloads and runs third-party code, and the
+  // headline finding of the round that added the preset. `ALLOW=*` made every preset
+  // entirely inert while reporting itself active.
+  //
+  // The difference is what the operator actually asserted. Writing `panel_graph_outline`
+  // is a decision about one tool, made with it in mind. Writing `list_*` is a decision
+  // about a shape, and it sweeps in whatever the next release happens to name that way —
+  // which is precisely what a preset exists to protect against. So a glob narrows the
+  // surface like any allow entry, and cannot re-open what the preset closed.
+  if (policy.allow.includes(name)) return true;
   return !policy.presetDeny.some((p) => toolMatches(name, p));
 }
 

--- a/src/tools/tool-surface-filter.ts
+++ b/src/tools/tool-surface-filter.ts
@@ -1,0 +1,173 @@
+/**
+ * #873 — OPERATOR-LEVEL RESTRICTION OF THE TOOL SURFACE.
+ *
+ * Reported from a Docker Compose + Open WebUI deployment behind llama-swap, where the
+ * operator is NOT the person prompting. That is a different trust model from the one the
+ * rest of this codebase assumes: locally, operator and prompter are the same person and a
+ * tool filter would be theatre. In a shared frontend the operator needs to guarantee the
+ * model cannot reach install/delete/restart tools whatever a user types.
+ *
+ * WHAT THIS IS AND IS NOT. It is a boundary against the MODEL and the people prompting
+ * it. It is not a boundary against whoever sets the environment — they can unset it — and
+ * it is not a substitute for not handing an untrusted party the ComfyUI host. Saying that
+ * plainly matters, because an operator who believes this is more than it is will deploy
+ * something they should not.
+ *
+ * Compact mode narrows DISCOVERY and is explicitly not a boundary: `call_tool` dispatches
+ * by name, so a filter applied only to the registered list leaves the facade as a bypass.
+ * This is applied as a registrar decorator, in the same position as the blind-image gate,
+ * which both `registerAllTools` and `collectToolCatalog` already run — and `call_tool`
+ * dispatches through that catalog. So both routes are covered by construction rather than
+ * by remembering to cover them.
+ */
+
+/** Tools that change the machine, the model library, or the running server. */
+const MUTATING_TOOLS = [
+  "install_comfyui",
+  "install_custom_node",
+  "download_model",
+  "node_pack",
+  "node_snapshot",
+  "restart_comfyui",
+  "clear_vram",
+  "apply_manifest",
+  "comfy_cli",
+  "runpod",
+  "runpod_watch",
+  "train_start",
+  "train_prepare_dataset",
+  "train_doctor",
+  "workspace",
+  "save_workflow",
+  "create_workflow",
+  "upload_image",
+  "bisect",
+];
+
+/** …plus everything that queues work or spends money. */
+const EXECUTION_TOOLS = [
+  "generate_image",
+  "enqueue_workflow",
+  "batch",
+  "queue",
+  "apps",
+  "list_api_nodes",
+];
+
+/**
+ * Named presets, so an operator is not hand-maintaining a list against a surface that
+ * grows every release — the reason a hand-written denylist rots.
+ *
+ * `safe`     — everything except tools that change the machine or the model library.
+ *              Rendering still works; installing, deleting and restarting do not.
+ * `readonly` — inspection only. No renders queued, nothing written, nothing spent.
+ */
+export const TOOL_PRESETS: Record<string, string[]> = {
+  safe: MUTATING_TOOLS,
+  readonly: [...MUTATING_TOOLS, ...EXECUTION_TOOLS],
+};
+
+export interface ToolSurfacePolicy {
+  /** Explicit allow list. When non-empty, ONLY these may register. */
+  allow: string[];
+  /** Deny list, including any preset expansion. */
+  deny: string[];
+  /** True when the operator configured anything at all. */
+  active: boolean;
+  /** The preset name, when one was named — for disclosure in logs. */
+  preset?: string;
+}
+
+function splitList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Does `name` match `pattern`? Exact, or a trailing `*` glob (`train_*`).
+ *
+ * Deliberately not a full glob: an operator writing a denylist is naming tools, and a
+ * richer syntax buys expressiveness at the cost of a rule that quietly matches more than
+ * it reads like. Prefix globs cover the real grouping in this surface (`train_*`,
+ * `runpod*`) and cannot surprise anyone.
+ */
+export function toolMatches(name: string, pattern: string): boolean {
+  if (pattern === name) return true;
+  if (pattern.endsWith("*")) return name.startsWith(pattern.slice(0, -1));
+  return false;
+}
+
+/** Read the policy from the environment. */
+export function resolveToolSurfacePolicy(env: NodeJS.ProcessEnv = process.env): ToolSurfacePolicy {
+  const allow = splitList(env.COMFYUI_MCP_TOOL_ALLOW);
+  const denyRaw = splitList(env.COMFYUI_MCP_TOOL_DENY);
+  const presetName = (env.COMFYUI_MCP_TOOL_PRESET ?? "").trim();
+  const preset = presetName ? TOOL_PRESETS[presetName] : undefined;
+  const deny = [...(preset ?? []), ...denyRaw];
+  return {
+    allow,
+    deny,
+    active: allow.length > 0 || deny.length > 0,
+    ...(preset ? { preset: presetName } : {}),
+  };
+}
+
+/**
+ * Is this tool permitted?
+ *
+ * ALLOW WINS, and is absolute when present: naming an allow list is a statement that the
+ * surface is exactly those tools, so a name absent from it is denied even if no deny rule
+ * mentions it. That is the safer reading of an operator's intent — the alternative (allow
+ * as a mere exemption from deny) turns an incomplete list into a wide-open surface, which
+ * is the failure mode nobody notices until it matters.
+ */
+export function toolAllowed(name: string, policy: ToolSurfacePolicy): boolean {
+  if (policy.allow.length > 0) return policy.allow.some((p) => toolMatches(name, p));
+  return !policy.deny.some((p) => toolMatches(name, p));
+}
+
+/**
+ * The three facade tools are NEVER filtered.
+ *
+ * Removing `call_tool` from a compact-mode surface leaves a client with no way to reach
+ * ANY tool — the filter would read as "restrict the surface" and behave as "break the
+ * server". The facade is a router; what it can route to is already governed by the same
+ * policy through the shared catalog, so exempting it grants nothing.
+ */
+const FACADE_TOOLS = new Set(["list_tools", "describe_tool", "call_tool"]);
+
+/**
+ * Wrap a registrar so denied tools are never registered.
+ *
+ * Denied names are ABSENT rather than erroring on call: a tool that refuses is still a
+ * tool the model can see, reason about and keep retrying. Absent means it never learns
+ * the capability exists, which is what the reporter asked for and also the cheaper
+ * outcome in tokens.
+ */
+export function withToolSurfaceFilter<T extends object>(
+  server: T,
+  policy: ToolSurfacePolicy,
+  onFiltered?: (name: string) => void,
+): T {
+  if (!policy.active) return server;
+  const orig = (server as unknown as { tool: (...args: unknown[]) => unknown }).tool.bind(server);
+  const tool = (...args: unknown[]): unknown => {
+    const name = typeof args[0] === "string" ? args[0] : undefined;
+    if (name && !FACADE_TOOLS.has(name) && !toolAllowed(name, policy)) {
+      onFiltered?.(name);
+      // Registration is skipped entirely. The SDK's `tool()` returns a handle some
+      // callers chain on, so hand back something inert rather than undefined.
+      return { name, disabled: true } as unknown;
+    }
+    return orig(...args);
+  };
+  return new Proxy(server, {
+    get(target, prop, receiver) {
+      if (prop === "tool") return tool;
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as T;
+}

--- a/src/tools/tool-surface-filter.ts
+++ b/src/tools/tool-surface-filter.ts
@@ -43,54 +43,108 @@
  * Per-action policy is the real answer and is deliberately not attempted here; it needs a
  * vocabulary these tools do not yet expose uniformly.
  */
-const MUTATING_TOOLS = [
+export const MUTATING_TOOLS = [
+  "apply_manifest",
+  // action:"import" installs an app from the public registry and creates it locally.
+  "apps",
+  "bisect",
+  "clear_vram",
+  "comfy_cli",
+  "create_workflow",
+  "download_model",
+  // action:"set" writes persistent config.
+  "get_defaults",
   "install_comfyui",
   "install_custom_node",
-  "download_model",
+  // action:"remove" deletes a model FILE; add_path/remove_path rewrite
+  // extra_model_paths.yaml.
+  "list_local_models",
+  // action:"install_deps" resolves and INSTALLS custom-node packs through
+  // ComfyUI-Manager — it downloads and RUNS third-party code on the ComfyUI host.
+  // Missed by every earlier version of this list, including the pattern-matching
+  // completeness test, because the verb is `install_deps` and the pattern was `^install$`.
+  "list_packs",
   "node_pack",
   "node_snapshot",
+  // action:"clear"/"cancel" destroys work — someone ELSE's, in the shared deployment
+  // this feature exists for.
+  "queue",
   "restart_comfyui",
-  "clear_vram",
-  "apply_manifest",
-  "comfy_cli",
   "runpod",
   "runpod_watch",
-  "train_start",
-  "train_prepare_dataset",
-  "train_doctor",
-  "workspace",
   "save_workflow",
-  "create_workflow",
+  // Sets up the trainer itself: docker, GPU passthrough, venv.
+  "train_doctor",
+  "train_prepare_dataset",
+  "train_start",
   "upload_image",
-  "bisect",
-  // …the consolidated ones a name-based list misses:
-  "list_local_models",
-  "search_custom_nodes",
-  "get_defaults",
-  "queue",
-];
-
-/** …plus everything that queues work or spends money. */
-const EXECUTION_TOOLS = [
-  "generate_image",
-  "enqueue_workflow",
-  "batch",
-  "apps",
-  "list_api_nodes",
+  "workspace",
 ];
 
 /**
- * Action names that mean a tool can change something. Used ONLY by the completeness test,
- * which scans the live catalog and fails when a tool advertising one of these is missing
- * from the `safe` deny list.
+ * Queues work, spends money, writes a file, or publishes something. `safe` allows these
+ * — rendering is the point of the product — and only `readonly` withholds them.
+ */
+export const EXECUTION_TOOLS = [
+  "batch",
+  "enqueue_workflow",
+  "generate_image",
+  // action:"convert" writes a converted file, and video/audio outputs are SAVED to a
+  // model-chosen directory. Fetching is a read; this tool does not only fetch.
+  "get_image",
+  // Runs hosted partner nodes that spend PAID credits.
+  "list_api_nodes",
+  // Files a PUBLIC GitHub issue under the operator's token. Nothing on the machine
+  // changes, so `safe` permits it; `readonly` promises "nothing written" and a public
+  // issue written by whoever is prompting a shared frontend is squarely a write.
+  "report_issue",
+];
+
+/**
+ * Neither mutates nor spends. Allowed by every preset.
  *
- * The hand-written list above stays hand-written — it is auditable, and an operator can
- * read it. What this adds is that it cannot silently ROT: the next consolidation that
- * hides `action:"delete"` behind an inspection-sounding name fails a test instead of
- * quietly widening every deployment's surface.
+ * `search_custom_nodes` IS ON THIS LIST, AND USED TO BE ON THE MUTATING ONE. I denied it
+ * claiming `action:"install"` installs a node pack. It has exactly two actions, `search`
+ * and `details`, and is read-only and network-only; the installing tool is
+ * `install_custom_node`, already denied. The claim came from its description MENTIONING
+ * `install_custom_node (action:"install")` — the same cross-reference confusion that
+ * `declaredActions()` below exists to strip, made by me while reading rather than by the
+ * scanner. The net effect was an inversion worth stating plainly: `safe` withheld a pure
+ * registry read while allowing `list_packs`, which genuinely installs.
+ */
+export const READONLY_TOOLS = [
+  "calculate",
+  "get_history",
+  "get_system_stats",
+  "get_workflow",
+  // action:"propose" says so itself: "This does NOT write". Read + network only.
+  "model_metadata",
+  "search_custom_nodes",
+  "visualize_workflow",
+];
+
+/**
+ * Action names that mean a tool can change something. A SECONDARY cross-check, and it is
+ * important to be honest about how little it is worth on its own.
+ *
+ * The first version of this feature relied on a scan like this AS the completeness
+ * guarantee, with the pattern anchored to whole verbs — `^install$`. `list_packs` declares
+ * `action:"install_deps"`, so the scan did not match it, and `list_packs` INSTALLS AND RUNS
+ * third-party code on the ComfyUI host. The test passed 17/17 with that hole wide open,
+ * which is the worst possible outcome for a check whose entire job is to notice holes: it
+ * was read as coverage.
+ *
+ * A pattern over tool descriptions can only ever catch the cases someone already thought
+ * of. So the real guarantee is now the LEDGER — every live tool must appear in exactly one
+ * of MUTATING/EXECUTION/READONLY, and a new tool in none of them fails a test. That cannot
+ * silently rot, because the failure mode is "unclassified", not "assumed harmless".
+ *
+ * What this pattern is still good for: catching a tool someone classified READONLY that
+ * advertises a mutating action — a wrong hand-classification rather than a missing one.
+ * The prefix form (`install_deps`, `add_path`, `generate_skill`) is deliberate.
  */
 export const MUTATING_ACTION_NAMES =
-  /^(remove|delete|clear|cancel|uninstall|install|reset|kill|stop|restart|purge|prune|apply|create|upload|train|add_path|remove_path|set|save|write|switch|update|fix|disable|enable)$/i;
+  /^(remove|delete|clear|cancel|uninstall|install|reset|kill|stop|restart|purge|prune|apply|create|upload|train|add|set|save|write|switch|update|fix|disable|enable|import|convert|generate|prepare|download|move|rename)(_|$)/i;
 
 /**
  * Verbs that mean "queue work / spend", which `safe` deliberately ALLOWS — rendering is
@@ -108,8 +162,27 @@ export const EXECUTION_ACTION_NAMES = /^(enqueue|start|submit|run)$/i;
  * does not exist. A completeness check that cries wolf gets muted, and then it is not a
  * check.
  */
-export function declaredActions(description: string): string[] {
-  const withoutCrossRefs = description.replace(/\b[a-z_0-9]+\s*\(action:"[a-z_0-9]+"\)/gi, "");
+export function declaredActions(
+  description: string,
+  opts: { selfName?: string; knownTools?: ReadonlySet<string> } = {},
+): string[] {
+  const { selfName, knownTools } = opts;
+  // Both spellings occur in the real descriptions: `get_defaults (action:"set")` and
+  // `download_model action:"download_civitai"`. Only the first was stripped, so
+  // model_metadata — which is read-only and merely mentions where a sidecar comes from —
+  // was reported as advertising a download.
+  const withoutCrossRefs = description.replace(
+    /\b([a-z_0-9]+)\s*(?:\(\s*)?action:"[a-z_0-9]+"\s*\)?/gi,
+    (match, refName: string) => {
+      // OVER-STRIPPING IS THE DANGEROUS DIRECTION: a tool whose own declaration got eaten
+      // looks action-free, and a check that sees nothing reports no hole. So a reference
+      // is removed ONLY when it names a tool that is not this one — a self-reference
+      // ("model_metadata action:\"read\"") is kept, and so is a name nobody recognises.
+      if (selfName && refName === selfName) return match;
+      if (knownTools && !knownTools.has(refName)) return match;
+      return "";
+    },
+  );
   return [...new Set([...withoutCrossRefs.matchAll(/action:"([a-z_0-9]+)"/g)].map((m) => m[1]))];
 }
 
@@ -149,20 +222,47 @@ export const TOOL_PRESETS: Record<string, string[]> = {
 export interface ToolSurfacePolicy {
   /** Explicit allow list. When non-empty, ONLY these may register. */
   allow: string[];
-  /** Deny list, including any preset expansion. */
+  /**
+   * Explicit COMFYUI_MCP_TOOL_DENY entries. Kept SEPARATE from the preset's, because the
+   * two lose to an allow list differently: a preset is a broad default an allow list is
+   * entitled to refine (that is how you opt two `panel_*` tools back in), while an
+   * explicit deny is the operator naming a tool to withhold — as explicit as the allow
+   * list, and the tie goes to the smaller surface.
+   */
   deny: string[];
+  /** The preset's deny patterns, if a preset was named. */
+  presetDeny: string[];
   /** True when the operator configured anything at all. */
   active: boolean;
   /** The preset name, when one was named — for disclosure in logs. */
   preset?: string;
 }
 
-function splitList(raw: string | undefined): string[] {
-  if (!raw) return [];
-  return raw
+/**
+ * A variable that is SET BUT EMPTY throws, rather than silently meaning "no rules".
+ *
+ * `COMFYUI_MCP_TOOL_ALLOW=${ALLOWED_TOOLS}` in a docker-compose file with `ALLOWED_TOOLS`
+ * unset expands to an empty string. Treating that as "no rules configured" produces the
+ * full tool surface with no log — the identical fail-open the unknown-preset throw was
+ * added to eliminate, reached by a different route. Setting the variable is the operator
+ * stating an intent; an empty value cannot satisfy it either way, so neither answer is
+ * safe to assume.
+ */
+function splitList(raw: string | undefined, varName: string): string[] {
+  if (raw === undefined) return [];
+  const items = raw
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
+  if (items.length === 0) {
+    throw new Error(
+      `${varName} is set but empty. Refusing to start: this is usually an unexpanded ` +
+        `shell variable (e.g. \`${varName}=\${ALLOWED_TOOLS}\` with ALLOWED_TOOLS unset), and ` +
+        `treating it as "no rules" would expose the FULL tool surface while you believe it is ` +
+        `restricted. Give it a value, or remove the variable entirely.`,
+    );
+  }
+  return items;
 }
 
 /**
@@ -195,9 +295,17 @@ export function toolMatches(name: string, pattern: string): boolean {
  * for success.
  */
 export function resolveToolSurfacePolicy(env: NodeJS.ProcessEnv = process.env): ToolSurfacePolicy {
-  const allow = splitList(env.COMFYUI_MCP_TOOL_ALLOW);
-  const denyRaw = splitList(env.COMFYUI_MCP_TOOL_DENY);
+  const allow = splitList(env.COMFYUI_MCP_TOOL_ALLOW, "COMFYUI_MCP_TOOL_ALLOW");
+  const denyRaw = splitList(env.COMFYUI_MCP_TOOL_DENY, "COMFYUI_MCP_TOOL_DENY");
   const presetName = (env.COMFYUI_MCP_TOOL_PRESET ?? "").trim();
+  if (env.COMFYUI_MCP_TOOL_PRESET !== undefined && presetName === "") {
+    throw new Error(
+      `COMFYUI_MCP_TOOL_PRESET is set but empty. Refusing to start: this is usually an ` +
+        `unexpanded shell variable, and treating it as "no preset" would expose the FULL tool ` +
+        `surface while you believe it is restricted. Valid presets: ` +
+        `${Object.keys(TOOL_PRESETS).join(", ")}. Give it a value, or remove the variable.`,
+    );
+  }
   if (presetName && !Object.prototype.hasOwnProperty.call(TOOL_PRESETS, presetName)) {
     throw new Error(
       `COMFYUI_MCP_TOOL_PRESET="${presetName}" is not a known preset. ` +
@@ -208,11 +316,11 @@ export function resolveToolSurfacePolicy(env: NodeJS.ProcessEnv = process.env): 
     );
   }
   const preset = presetName ? TOOL_PRESETS[presetName] : undefined;
-  const deny = [...(preset ?? []), ...denyRaw];
   return {
     allow,
-    deny,
-    active: allow.length > 0 || deny.length > 0,
+    deny: denyRaw,
+    presetDeny: preset ?? [],
+    active: allow.length > 0 || denyRaw.length > 0 || preset !== undefined,
     ...(preset ? { preset: presetName } : {}),
   };
 }
@@ -220,15 +328,31 @@ export function resolveToolSurfacePolicy(env: NodeJS.ProcessEnv = process.env): 
 /**
  * Is this tool permitted?
  *
- * ALLOW WINS, and is absolute when present: naming an allow list is a statement that the
- * surface is exactly those tools, so a name absent from it is denied even if no deny rule
- * mentions it. That is the safer reading of an operator's intent — the alternative (allow
- * as a mere exemption from deny) turns an incomplete list into a wide-open surface, which
- * is the failure mode nobody notices until it matters.
+ * ALLOW BOUNDS THE SURFACE, and is absolute when present: naming an allow list is a
+ * statement that the surface is exactly those tools, so a name absent from it is denied
+ * even if no deny rule mentions it. That is the safer reading of an operator's intent —
+ * the alternative (allow as a mere exemption from deny) turns an incomplete list into a
+ * wide-open surface, which is the failure mode nobody notices until it matters.
+ *
+ * DENY THEN APPLIES ON TOP, rather than being switched off by the presence of an allow
+ * list. The first version returned early on the allow match, so
+ * `ALLOW=list_local_models,get_history` plus `DENY=list_local_models` allowed
+ * `list_local_models` — a tool whose `action:"remove"` deletes a model file — because the
+ * allow list won outright. Both variables are the operator saying "not this"; the
+ * intersection is the only reading where neither statement is silently discarded, and it
+ * is the one that errs toward a smaller surface.
  */
 export function toolAllowed(name: string, policy: ToolSurfacePolicy): boolean {
-  if (policy.allow.length > 0) return policy.allow.some((p) => toolMatches(name, p));
-  return !policy.deny.some((p) => toolMatches(name, p));
+  const allowed = policy.allow.length === 0 || policy.allow.some((p) => toolMatches(name, p));
+  if (!allowed) return false;
+  // An EXPLICIT deny beats an allow list — both are the operator speaking, and the
+  // smaller surface wins the tie.
+  if (policy.deny.some((p) => toolMatches(name, p))) return false;
+  // A PRESET is a broad default, so naming a tool in the allow list is how you refine it
+  // (`PRESET=safe` + `ALLOW=panel_graph_outline,panel_query_graph`). Without this, the
+  // documented opt-back-in would silently do nothing.
+  if (policy.allow.length > 0) return true;
+  return !policy.presetDeny.some((p) => toolMatches(name, p));
 }
 
 /**


### PR DESCRIPTION
Closes #873

Reported via Discord by **jnbackup**, wiring comfyui-mcp into Open WebUI behind llama-swap: *"missing a way to filter tools, aka a blacklist, this would make production setup possible."*

**The trust model here is genuinely different from the local one.** This codebase assumes one machine, one person — operator and prompter are the same, so a tool filter would be theatre. In a hosted/shared chat frontend the operator is **not** the person prompting, and they need to guarantee the model cannot reach install/delete/restart tools regardless of what a user types. That is a real boundary, and today the honest answer is that it does not exist.

**The load-bearing part is .** Compact mode narrows *discovery* but is explicitly not a boundary — `call_tool` dispatches by name, so filtering only the registered list would leave the facade as a bypass.

The architecture already has the right seam: `withBlindImageGate(registrar)` is a registrar decorator applied by **both** `registerAllTools` and `collectToolCatalog` — and `call_tool` dispatches through that same catalog. A filter in the same position covers both paths by construction rather than by remembering to.

Planned:
- `COMFYUI_MCP_TOOL_DENY` / `COMFYUI_MCP_TOOL_ALLOW` (comma lists, globs), allow wins.
- Presets so operators are not hand-maintaining lists.
- Denied names **absent** from `list_tools` rather than erroring on call, so the model never learns they exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)