### PR TITLE
fix(417): a progress line is not a failure reason

### DIFF
--- a/src/__tests__/services/comfy-cli-progress-only-failure.test.ts
+++ b/src/__tests__/services/comfy-cli-progress-only-failure.test.ts
@@ -30,7 +30,7 @@ describe("failureReasonFrom keeps anything it does not RECOGNISE as progress (#4
   it("the reporter's exact line carries no reason", () => {
     expect(
       failureReasonFrom(
-        "Start downloading URL https://huggingface.co/x/y.safetensors into E:\\ComfyUI_windows_portable\\ComfyUI\\models\\text_encoders\\y.safetensors",
+        "Start downloading URL: https://huggingface.co/x/y.safetensors into E:\\ComfyUI_windows_portable\\ComfyUI\\models\\text_encoders\\y.safetensors",
       ),
     ).toBeNull();
   });
@@ -62,11 +62,69 @@ describe("failureReasonFrom keeps anything it does not RECOGNISE as progress (#4
   it("a real error mixed INTO progress output is extracted, not lost", () => {
     // The common real-world shape: progress, then the thing that actually went wrong.
     const captured = [
-      "Start downloading URL https://example.invalid/m.safetensors into C:\\models\\m.safetensors",
+      "Start downloading URL: https://example.invalid/m.safetensors into C:\\models\\m.safetensors",
       " 12%|█         | 300M/2.5G [00:10<01:20, 30.0MB/s]",
       "OSError: [Errno 28] No space left on device",
     ].join("\n");
     expect(failureReasonFrom(captured)).toBe("OSError: [Errno 28] No space left on device");
+  });
+
+
+  it("the REAL emitted line carries a colon — fixtures must match the emitter, not my memory", () => {
+    // comfy_cli/command/models/models.py:
+    //   print(f"Start downloading URL: {url} into {local_filepath}")
+    // Every fixture in my first version dropped that colon. Both spellings happened to
+    // match the shipped pattern, so nothing failed — but a test written against a string
+    // the tool never emits cannot catch a tightening that breaks on the real one. It is
+    // the same "the double certifies my belief" shape this file exists to punish.
+    expect(
+      failureReasonFrom("Start downloading URL: https://x/y.safetensors into /models/y.safetensors"),
+    ).toBeNull();
+    // …and the colon-less spelling still matches, so older comfy-cli builds are covered.
+    expect(failureReasonFrom("Start downloading URL https://x/y into /models/y")).toBeNull();
+  });
+
+  it("huggingface_hub's DESC-PREFIXED tqdm is progress — the only tqdm this tool emits", () => {
+    // comfy-cli's own downloader is rich.progress (which writes nothing to a pipe), so the
+    // bars that actually reach us come from huggingface_hub, and hf_hub_download ALWAYS
+    // passes a desc. Every pattern I wrote first was anchored `^\s*\d`, so a desc-prefixed
+    // bar matched none of them and #417 was still live on the gated-HF path — the exact
+    // path the new hint tells the user to suspect.
+    expect(
+      failureReasonFrom("y.safetensors: 45%|████▌     | 1.20G/2.70G [00:30<00:40, 40.0MB/s]"),
+    ).toBeNull();
+    expect(failureReasonFrom("model.bin:  4%|▍         | 100M/2.50G")).toBeNull();
+    // The desc may not contain a '%', so a real sentence that merely precedes a percentage
+    // is NOT eaten — the over-strip direction stays closed.
+    expect(
+      failureReasonFrom("Download aborted at 45% — checksum mismatch: 12%|"),
+    ).toBe("Download aborted at 45% — checksum mismatch: 12%|");
+  });
+
+  it("real comfy-cli 1.12.0 error strings all survive", () => {
+    // Taken from the shipped sdist rather than invented.
+    for (const line of [
+      "Failed to download file.",
+      "Forbidden url (403), please check the url and try again.",
+      "Unauthorized download (401), please check your credentials.",
+      "File not found on server (404)",
+      "Unknown error occurred (status code: 500)",
+      "Download error (attempt 1/3): the server returned HTTP 503",
+      "aria2 download was removed before completion",
+      "Lost connection to aria2 RPC server: connection refused",
+    ]) {
+      expect(failureReasonFrom(line), line).toBe(line);
+    }
+  });
+
+  it("a pathological single line does not hang the event loop", () => {
+    // The size quantifiers in the tqdm pattern were unbounded and ambiguous: measured
+    // 13.3s on a 200 KB line, which on a 16 MB capture (execFile's maxBuffer) is hours of
+    // blocked event loop. Bounding them is a one-character-class fix; this pins it.
+    const evil = " 45%|x| " + "1".repeat(200_000);
+    const started = performance.now();
+    failureReasonFrom(evil);
+    expect(performance.now() - started).toBeLessThan(1000);
   });
 
   it("splits on carriage returns, so a bar that ENDS in an error still yields the error", () => {
@@ -81,7 +139,7 @@ describe("failureReasonFrom keeps anything it does not RECOGNISE as progress (#4
 describe("the envelope says which of the three states it is in (#417)", () => {
   it("progress-only output is reported as NO reason available, and says what to check", () => {
     const env = failedWith(
-      "Start downloading URL https://huggingface.co/x/y.safetensors into E:\\ComfyUI\\models\\text_encoders\\y.safetensors",
+      "Start downloading URL: https://huggingface.co/x/y.safetensors into E:\\ComfyUI\\models\\text_encoders\\y.safetensors",
     );
     expect(env.ok).toBe(false);
     expect(env.error?.code).toBe("legacy_command_failed");
@@ -95,6 +153,33 @@ describe("the envelope says which of the three states it is in (#417)", () => {
     // drop it — the next reporter may recognise something in it that we do not.
     expect(env.error?.details).toMatchObject({ exit_code: 1 });
     expect(JSON.stringify(env.error?.details)).toMatch(/Start downloading URL/);
+  });
+
+  it("a NON-download command is not handed a fabricated download diagnosis", () => {
+    // normalizeComfyCliResult normalizes the ENTIRE comfy-cli surface — stop, launch, run,
+    // node install/update, models list/remove, skills_*, env — and the first version
+    // asserted "its output was download progress only" and offered disk-space and
+    // gated-Hugging-Face-auth advice for all of them. A failing `comfy node install` would
+    // have been told a story about a download it never performed.
+    //
+    // Which is this issue's own defect wearing better prose: #417 is about stating a cause
+    // that was never established.
+    const env = normalizeComfyCliResult(
+      ["node", "install", "comfyui-impact-pack"],
+      OPTS,
+      { stdout: "", stderr: "", exitCode: 1 },
+      "1.12.0",
+    );
+    expect(env.error?.message).toMatch(/exited with code 1/);
+    expect(env.error?.message).not.toMatch(/download progress/i);
+    expect(env.error?.hint).not.toMatch(/disk space|Hugging Face|401\/403/i);
+    // …it still says something useful, just nothing it cannot support.
+    expect(env.error?.hint).toMatch(/cannot infer|directly in a terminal/i);
+
+    // …while a real download still gets the download-specific advice.
+    const dl = failedWith("Start downloading URL: https://x/y into /models/y");
+    expect(dl.error?.message).toMatch(/download progress only/);
+    expect(dl.error?.hint).toMatch(/disk space/i);
   });
 
   it("a real stderr is passed through UNCHANGED, with no hint bolted on", () => {
@@ -121,7 +206,7 @@ describe("the envelope says which of the three states it is in (#417)", () => {
     const env = normalizeComfyCliResult(
       ARGS,
       OPTS,
-      { stdout: "Start downloading URL https://x/y into /z", stderr: "", exitCode: 0 },
+      { stdout: "Start downloading URL: https://x/y into /z", stderr: "", exitCode: 0 },
       "1.12.0",
     );
     expect(env.ok).toBe(true);

--- a/src/__tests__/services/comfy-cli-progress-only-failure.test.ts
+++ b/src/__tests__/services/comfy-cli-progress-only-failure.test.ts
@@ -1,0 +1,130 @@
+// #417 — a progress line is not a failure reason.
+//
+// The reporter's download died and the error they were handed was
+// `Start downloading URL ... into ...`: comfy-cli's own pre-download announcement,
+// promoted into the message field because it was the only thing on stderr. It reads like
+// a diagnosis, names no cause, and cost them a debugging session on a URL and a directory
+// that were both fine.
+//
+// The half of this issue about the 60s kill shipped in v0.48.12 (idle/liveness timeout).
+// This is the other half: distinguishing "the reason is X" from "there is no reason in
+// the output", instead of dressing the second up as the first (#796).
+//
+// THE TEST THAT MATTERS IS THE NEGATIVE ONE. A filter that strips too much replaces a real
+// error message with "no reason available" — strictly worse than the bug, and invisible,
+// because both the buggy and the over-eager version produce a confident-looking envelope.
+// So most of what follows checks that real messages SURVIVE.
+
+import { describe, expect, it } from "vitest";
+
+import { failureReasonFrom, normalizeComfyCliResult } from "../../services/comfy-cli.js";
+
+const OPTS = { where: "local" as const };
+const ARGS = ["model", "download", "--url", "https://example.invalid/m.safetensors"];
+
+function failedWith(stderr: string, stdout = "") {
+  return normalizeComfyCliResult(ARGS, OPTS, { stdout, stderr, exitCode: 1 }, "1.12.0");
+}
+
+describe("failureReasonFrom keeps anything it does not RECOGNISE as progress (#417)", () => {
+  it("the reporter's exact line carries no reason", () => {
+    expect(
+      failureReasonFrom(
+        "Start downloading URL https://huggingface.co/x/y.safetensors into E:\\ComfyUI_windows_portable\\ComfyUI\\models\\text_encoders\\y.safetensors",
+      ),
+    ).toBeNull();
+  });
+
+  it("tqdm progress, drawn or not, carries no reason", () => {
+    expect(failureReasonFrom(" 45%|█████     | 1.2G/2.7G [00:30<00:40, 40.0MB/s]")).toBeNull();
+    expect(failureReasonFrom(" 45%|          | 1.2G/2.7G")).toBeNull();
+    expect(failureReasonFrom("Downloading: 45%")).toBeNull();
+    expect(failureReasonFrom("[####------] ")).toBeNull();
+    expect(failureReasonFrom("   \n\n  ")).toBeNull();
+  });
+
+  it("a REAL error survives, including ones that mention downloading or a percentage", () => {
+    // The over-strip direction. Every string here would be eaten by the obvious
+    // implementation — a keyword test on "download", or "contains %".
+    const real = [
+      "HTTP 403 while downloading https://huggingface.co/gated/model.safetensors",
+      "OSError: [Errno 28] No space left on device",
+      "requests.exceptions.ConnectionError: Max retries exceeded",
+      "Error: downloading failed after 3 attempts",
+      "Download aborted at 45% — checksum mismatch",
+      "RepositoryNotFoundError: 401 Client Error",
+    ];
+    for (const line of real) {
+      expect(failureReasonFrom(line), line).toBe(line);
+    }
+  });
+
+  it("a real error mixed INTO progress output is extracted, not lost", () => {
+    // The common real-world shape: progress, then the thing that actually went wrong.
+    const captured = [
+      "Start downloading URL https://example.invalid/m.safetensors into C:\\models\\m.safetensors",
+      " 12%|█         | 300M/2.5G [00:10<01:20, 30.0MB/s]",
+      "OSError: [Errno 28] No space left on device",
+    ].join("\n");
+    expect(failureReasonFrom(captured)).toBe("OSError: [Errno 28] No space left on device");
+  });
+
+  it("splits on carriage returns, so a bar that ENDS in an error still yields the error", () => {
+    // A progress bar redraws with \r. Split only on \n and the bar plus its trailing error
+    // are one line, which matches no progress pattern — so the whole bar would be handed
+    // back as the "reason", burying the one useful sentence in redraw noise.
+    const bar = " 10%|# |\r 20%|## |\r 30%|### |\rConnectionResetError: peer closed";
+    expect(failureReasonFrom(bar)).toBe("ConnectionResetError: peer closed");
+  });
+});
+
+describe("the envelope says which of the three states it is in (#417)", () => {
+  it("progress-only output is reported as NO reason available, and says what to check", () => {
+    const env = failedWith(
+      "Start downloading URL https://huggingface.co/x/y.safetensors into E:\\ComfyUI\\models\\text_encoders\\y.safetensors",
+    );
+    expect(env.ok).toBe(false);
+    expect(env.error?.code).toBe("legacy_command_failed");
+    // The message must NOT be the progress line dressed as a cause.
+    expect(env.error?.message).not.toMatch(/Start downloading URL/);
+    expect(env.error?.message).toMatch(/printed no error/);
+    expect(env.error?.message).toMatch(/exited with code 1/);
+    expect(env.error?.hint).toMatch(/disk space/i);
+    expect(env.error?.hint).toMatch(/auth|401|403/i);
+    // …and the raw output is still there. Judging it uninformative is not licence to
+    // drop it — the next reporter may recognise something in it that we do not.
+    expect(env.error?.details).toMatchObject({ exit_code: 1 });
+    expect(JSON.stringify(env.error?.details)).toMatch(/Start downloading URL/);
+  });
+
+  it("a real stderr is passed through UNCHANGED, with no hint bolted on", () => {
+    const env = failedWith("OSError: [Errno 28] No space left on device");
+    expect(env.error?.message).toBe("OSError: [Errno 28] No space left on device");
+    // A hint here would be noise at best and misdirection at worst — the message already
+    // says exactly what happened.
+    expect(env.error?.hint).toBeUndefined();
+  });
+
+  it("falls back to stdout when stderr is progress-only but stdout has the reason", () => {
+    const env = failedWith(" 45%|#####     | 1.2G/2.7G", "fatal: destination path is not writable");
+    expect(env.error?.message).toBe("fatal: destination path is not writable");
+    expect(env.error?.hint).toBeUndefined();
+  });
+
+  it("an empty capture is still the no-reason case, not an empty message", () => {
+    const env = failedWith("", "");
+    expect(env.error?.message).toMatch(/exited with code 1/);
+    expect(env.error?.message).not.toBe("");
+  });
+
+  it("a SUCCESSFUL command is untouched — this only ever runs on a non-zero exit", () => {
+    const env = normalizeComfyCliResult(
+      ARGS,
+      OPTS,
+      { stdout: "Start downloading URL https://x/y into /z", stderr: "", exitCode: 0 },
+      "1.12.0",
+    );
+    expect(env.ok).toBe(true);
+    expect(env.error).toBeNull();
+  });
+});

--- a/src/services/comfy-cli.ts
+++ b/src/services/comfy-cli.ts
@@ -244,10 +244,23 @@ function hasJsonRecord(stdout: string): boolean {
  * much is recoverable; being wrong the other way hides the only evidence they had.
  */
 const PROGRESS_ONLY_LINE_PATTERNS: readonly RegExp[] = [
-  // comfy-cli's own pre-download announcement — the exact line from the report.
-  /^start downloading url\b.*\binto\b/i,
-  // tqdm: " 45%|█████     | 1.2G/2.7G [00:30<00:40, 40.0MB/s]"
-  /^\s*\d{1,3}%\|[^|]*\|\s*[\d.]+\s*\S*\/[\d.]+\s*\S*/i,
+  // comfy-cli's own pre-download announcement — the line from the report. The real
+  // emitter is `print(f"Start downloading URL: {url} into {local_filepath}")`
+  // (comfy_cli/command/models/models.py) — WITH a colon, which my first fixtures omitted.
+  /^start downloading url:?\s.*\binto\b/i,
+  // huggingface_hub's tqdm, which ALWAYS carries a desc:
+  //   "y.safetensors: 45%|████▌     | 1.20G/2.70G [00:30<00:40, 40.0MB/s]"
+  // Every earlier pattern was anchored `^\s*\d`, so a desc-prefixed bar — the only tqdm
+  // this tool actually produces — matched none of them. #417 was therefore still live on
+  // the gated-Hugging-Face path, which is the path the new hint tells the user to suspect.
+  // The desc is bounded and may not contain a `%`, so it cannot swallow a sentence that
+  // merely happens to precede a percentage.
+  /^[^%]{0,120}:\s*\d{1,3}%\|/,
+  // Bare tqdm: " 45%|█████| 1.2G/2.7G [00:30<00:40, 40.0MB/s]". The size quantifiers are
+  // BOUNDED: `[\d.]+\s*\S*\/` is ambiguous, and on a pathological single line it
+  // backtracks quadratically — measured 13.3s at 200 KB, which on a 16 MB capture
+  // (execFile's maxBuffer) would block the event loop for hours.
+  /^\s*\d{1,3}%\|[^|]{0,200}\|\s*[\d.]{1,20}\s*\S{0,10}\/[\d.]{1,20}\s*\S{0,10}/i,
   // tqdm with no bar drawn (non-tty): " 45%| | 1.2G/2.7G"
   /^\s*\d{1,3}%\|/,
   // A bare percentage or a "Downloading: 45%" heartbeat.
@@ -318,6 +331,9 @@ export function normalizeComfyCliResult<T = unknown>(
     // less satisfying and far more useful, because it redirects the search instead of
     // misdirecting it. The raw output stays in `details` either way; nothing is dropped.
     const reason = failureReasonFrom(details.stderr) ?? failureReasonFrom(details.stdout);
+    // Only a DOWNLOAD may be described as having produced download progress. Read from the
+    // argv this call actually ran, not from the tool that happened to call us.
+    const isDownload = args.includes("download") || args.includes("--url");
     return {
       schema: "envelope/1",
       type: "envelope",
@@ -330,17 +346,31 @@ export function normalizeComfyCliResult<T = unknown>(
         code: "legacy_command_failed",
         message:
           reason ??
-          `comfy-cli exited with code ${result.exitCode} and printed no error — its output was download progress only, so the cause is not visible from here.`,
+          `comfy-cli exited with code ${result.exitCode} and printed no error, so the cause is ` +
+            `not visible from here${isDownload ? " — the output was download progress only" : ""}.`,
         ...(reason
           ? {}
           : {
-              hint:
-                "Nothing in the command's output says why it stopped. Check, in this order: " +
-                "free disk space on the destination drive; whether the source needs auth (a gated " +
-                "Hugging Face repo returns 401/403 and some downloaders exit without printing it); " +
-                "and whether an antivirus or the OS killed the process. Re-running with the same " +
-                "arguments will show the same message — the missing information is on comfy-cli's " +
-                "side, not this tool's.",
+              // THE DIAGNOSIS IS SCOPED TO THE COMMAND THAT EARNED IT. This function
+              // normalizes the ENTIRE comfy-cli surface — stop, launch, run, node
+              // install/update, models list/search/remove, skills_*, env — and the first
+              // version asserted "its output was download progress only" and offered
+              // disk-space-and-gated-HF-auth advice for every one of them. A failing
+              // `comfy node install` would have been handed a fabricated download story.
+              //
+              // Which is this issue's own defect, inverted: #417 is about stating a cause
+              // that was never established. Replacing a progress line with a confident
+              // guess about a different command is the same error with better prose.
+              hint: isDownload
+                ? "Nothing in the command's output says why it stopped. Check, in this order: " +
+                  "free disk space on the destination drive; whether the source needs auth (a " +
+                  "gated Hugging Face repo returns 401/403 and some downloaders exit without " +
+                  "printing it); and whether an antivirus or the OS killed the process. " +
+                  "Re-running with the same arguments will show the same message — the missing " +
+                  "information is on comfy-cli's side, not this tool's."
+                : "Nothing in the command's output says why it stopped, and this tool cannot " +
+                  "infer it. Re-run the same command directly in a terminal, where comfy-cli " +
+                  "may print more than it does when its output is captured.",
             }),
         details: { ...details, exit_code: result.exitCode },
       },

--- a/src/services/comfy-cli.ts
+++ b/src/services/comfy-cli.ts
@@ -228,6 +228,52 @@ function hasJsonRecord(stdout: string): boolean {
   });
 }
 
+/**
+ * Output lines that are PROGRESS, not diagnosis (#417).
+ *
+ * ENUMERATED ON PURPOSE, and this is the whole safety argument. The failure this guards
+ * against is a non-zero exit whose captured output says nothing about why — the reporter
+ * was handed `Start downloading URL ... into ...` in the place a reason belongs. But a
+ * filter that is too eager does something strictly worse: it discards a REAL error message
+ * and replaces it with "no reason available", un-shipping the fix while looking like it
+ * worked. A keyword test ("downloading", "%") would do exactly that to
+ * `HTTP 403 while downloading ...`.
+ *
+ * So each entry matches one KNOWN emitter, anchored, and anything unrecognised is treated
+ * as a real message and preserved. Being wrong in the direction of showing the user too
+ * much is recoverable; being wrong the other way hides the only evidence they had.
+ */
+const PROGRESS_ONLY_LINE_PATTERNS: readonly RegExp[] = [
+  // comfy-cli's own pre-download announcement — the exact line from the report.
+  /^start downloading url\b.*\binto\b/i,
+  // tqdm: " 45%|█████     | 1.2G/2.7G [00:30<00:40, 40.0MB/s]"
+  /^\s*\d{1,3}%\|[^|]*\|\s*[\d.]+\s*\S*\/[\d.]+\s*\S*/i,
+  // tqdm with no bar drawn (non-tty): " 45%| | 1.2G/2.7G"
+  /^\s*\d{1,3}%\|/,
+  // A bare percentage or a "Downloading: 45%" heartbeat.
+  /^\s*(downloading:?\s*)?\d{1,3}(\.\d+)?%\s*$/i,
+  // A drawn bar with no other text.
+  /^[\s█▉▊▋▌▍▎▏#=>.\-\[\]|]+$/,
+];
+
+/**
+ * Does this captured output contain anything that could explain a failure?
+ *
+ * Returns the surviving text, or null when every line was recognised progress. Null means
+ * "I could not determine the reason" — a distinct third state from "the reason is X", and
+ * it must never be reported as one (#796).
+ */
+export function failureReasonFrom(text: string): string | null {
+  const meaningful = text
+    // A progress bar redraws with \r; without splitting on it the whole bar is ONE line
+    // ending in a real error, or one line of pure progress, depending on the emitter.
+    .split(/\r\n|\r|\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => !PROGRESS_ONLY_LINE_PATTERNS.some((re) => re.test(line)));
+  return meaningful.length ? meaningful.join("\n") : null;
+}
+
 export function normalizeComfyCliResult<T = unknown>(
   args: readonly string[],
   options: ComfyCliRunOptions,
@@ -259,6 +305,19 @@ export function normalizeComfyCliResult<T = unknown>(
     };
   }
   if (result.exitCode !== 0) {
+    // #417 — A PROGRESS LINE IS NOT A FAILURE REASON.
+    //
+    // This used to report `stderr || stdout` verbatim. When comfy-cli dies mid-download
+    // its stderr often holds nothing but the progress it had printed so far, so the
+    // reporter's error message was `Start downloading URL ... into ...` — a sentence that
+    // reads like a diagnosis, names no cause, and sent them looking at their URL and
+    // destination directory (both fine) instead of at the download.
+    //
+    // The three states are: a reason, no reason, and — the one that caused this — no
+    // reason DRESSED AS one. Saying plainly that the command produced no error output is
+    // less satisfying and far more useful, because it redirects the search instead of
+    // misdirecting it. The raw output stays in `details` either way; nothing is dropped.
+    const reason = failureReasonFrom(details.stderr) ?? failureReasonFrom(details.stdout);
     return {
       schema: "envelope/1",
       type: "envelope",
@@ -269,7 +328,20 @@ export function normalizeComfyCliResult<T = unknown>(
       data: null,
       error: {
         code: "legacy_command_failed",
-        message: details.stderr || details.stdout || `comfy-cli exited with code ${result.exitCode}`,
+        message:
+          reason ??
+          `comfy-cli exited with code ${result.exitCode} and printed no error — its output was download progress only, so the cause is not visible from here.`,
+        ...(reason
+          ? {}
+          : {
+              hint:
+                "Nothing in the command's output says why it stopped. Check, in this order: " +
+                "free disk space on the destination drive; whether the source needs auth (a gated " +
+                "Hugging Face repo returns 401/403 and some downloaders exit without printing it); " +
+                "and whether an antivirus or the OS killed the process. Re-running with the same " +
+                "arguments will show the same message — the missing information is on comfy-cli's " +
+                "side, not this tool's.",
+            }),
         details: { ...details, exit_code: result.exitCode },
       },
     };


### PR DESCRIPTION
Draft — claiming the half of #417 that is still open.

The reporter asked for two things. **The first already shipped**: c39acc4 (v0.48.12) put model downloads on an idle/liveness timeout, so a still-progressing download is no longer killed at 60s. That is why this issue has been quiet.

The second is untouched, and it is the part that made the report hard to write:

> Preserve and return the underlying downloader exception/HTTP error.

`normalizeComfyCliResult` reports a non-zero exit as `message: details.stderr || details.stdout`. When comfy-cli's stderr holds **only** the progress line, that progress line becomes the failure message — the reporter was told `Start downloading URL ... into ...` as their error. It reads like a diagnosis and carries none: "I don't know why it failed" presented as "here is why it failed", which is the #796 shape.

Plan: when the captured output contains no failure information, say exactly that instead of echoing progress, and name what the caller can check. A wrong-looking reason is worse than an admitted unknown, because it sends someone to debug the URL when the cause was disk space.

Refs #417
