### PR TITLE
fix(1331): the workflow stamp survives a tab-id migration

### DIFF
--- a/src/__tests__/orchestrator/hello-stamp-retention.test.ts
+++ b/src/__tests__/orchestrator/hello-stamp-retention.test.ts
@@ -27,7 +27,7 @@
 
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
-import { workflowIdentityParts } from "../../orchestrator/session-store.js";
+import { carryWorkflowCommandStamp, workflowIdentityParts } from "../../orchestrator/session-store.js";
 
 const indexSrc = (): string =>
   readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf8");
@@ -74,11 +74,20 @@ describe("an untrusted hello RETAINS the tab's command stamp (#689)", () => {
     });
   });
 
-  it("SOURCE: the migration path's own delete is untouched — only the untrusted-hello eraser goes", () => {
+  it("the migration path still RETIRES the previous tab id's stamp", () => {
     // #436's `delete(migratedFrom)` retires the PREVIOUS tab id's stamp on a
     // proven workflow change. That is a different decision (a tab id going away)
     // and must survive this fix; deleting it here would be an unrelated
     // behavioural change smuggled in on the same line of reasoning.
-    expect(indexSrc()).toContain("tabCommandWorkflowUuid.delete(migratedFrom);");
+    //
+    // This used to assert the literal `delete(migratedFrom)` appeared in index.ts.
+    // #1331 moved that statement into `carryWorkflowCommandStamp` — which now also
+    // carries the VALUE onto the new id first, the half that had been lost since #884.
+    // The retirement is unchanged, so the claim is unchanged; it is asserted on the
+    // BEHAVIOUR now, which is what it was always about and which a relocation cannot
+    // silently break.
+    const stamps = new Map([["tmp:old", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"]]);
+    carryWorkflowCommandStamp(stamps, "tmp:old", "wf:new");
+    expect(stamps.has("tmp:old"), "the retired id must not resolve").toBe(false);
   });
 });

--- a/src/__tests__/orchestrator/migration-stamp-carry.test.ts
+++ b/src/__tests__/orchestrator/migration-stamp-carry.test.ts
@@ -22,7 +22,7 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 
-import { workflowIdentityParts } from "../../orchestrator/session-store.js";
+import { carryWorkflowCommandStamp, workflowIdentityParts } from "../../orchestrator/session-store.js";
 
 /** Source with comments stripped.
  *
@@ -48,36 +48,23 @@ function migrationBlock(src: string): string {
 }
 
 describe("a tab-id migration CARRIES the workflow stamp (#1331)", () => {
-  it("SOURCE: the stamp is read from the old id before the old id is retired", () => {
+  it("WIRING: the hello handler CALLS the carry, it does not reimplement it", () => {
+    // The previous version of this file asserted the shape of inlined statements —
+    // `get(migratedFrom)`, `set(panelTab, carriedStamp)`, `delete(migratedFrom)` in that
+    // order. Codex's objection was right: a DEAD `set` before the delete satisfies every
+    // one of those string checks, and the behavioural half was a re-implementation of what
+    // the handler ought to do rather than the thing it does. Two independent copies of a
+    // rule agreeing with each other proves nothing about the third copy in production.
+    //
+    // So the logic is extracted (restoring the name #436 gave it) and the handler calls it.
+    // The tests below then exercise the FUNCTION PRODUCTION RUNS, and this one only has to
+    // check that the call site exists inside the migration branch.
     const block = migrationBlock(orchestratorCode());
-    expect(
-      block,
-      "the migration must carry the stamp onto the new id — deleting it without carrying is the #1331 wedge",
-    ).toMatch(/tabCommandWorkflowUuid\.get\(migratedFrom\)/);
-    expect(block).toMatch(/tabCommandWorkflowUuid\.set\(panelTab,\s*carriedStamp\)/);
-  });
-
-  it("SOURCE: the old id's stamp is still retired — the carry is a MOVE, not a copy", () => {
-    // The old id going away is a separate, correct decision that predates this fix and
-    // must survive it: a straggler command addressed to the retired id must not resolve.
-    expect(migrationBlock(orchestratorCode())).toContain(
-      "tabCommandWorkflowUuid.delete(migratedFrom);",
+    expect(block).toMatch(
+      /carryWorkflowCommandStamp\(tabCommandWorkflowUuid,\s*migratedFrom,\s*panelTab\)/,
     );
-  });
-
-  it("SOURCE: the carry runs BEFORE the delete, or it carries nothing", () => {
-    const block = migrationBlock(orchestratorCode());
-    const read = block.indexOf("tabCommandWorkflowUuid.get(migratedFrom)");
-    const del = block.indexOf("tabCommandWorkflowUuid.delete(migratedFrom)");
-    expect(read).toBeGreaterThan(-1);
-    expect(del).toBeGreaterThan(-1);
-    expect(read, "reading after the delete would always yield undefined").toBeLessThan(del);
-  });
-
-  it("SOURCE: a stamp already set for the new id is NOT clobbered by the carried one", () => {
-    // Ordering inside one hello is not guaranteed to be the only writer; a value already
-    // recorded for the new id is newer evidence than anything held under the old.
-    expect(migrationBlock(orchestratorCode())).toMatch(/!tabCommandWorkflowUuid\.has\(panelTab\)/);
+    // …and nothing hand-rolls the same operations alongside it.
+    expect(block).not.toMatch(/tabCommandWorkflowUuid\.delete\(migratedFrom\)/);
   });
 
   it("SOURCE: a hello that DOES resolve an identity still overwrites the carried stamp", () => {
@@ -112,15 +99,15 @@ describe("the carry's semantics, exercised (#1331)", () => {
   // The hello handler is a few hundred lines inside a much larger closure, so the
   // assertions above read its source. This exercises the SEMANTICS the source implements,
   // so a future refactor that keeps the identifiers but inverts the meaning still fails.
+  // The REAL function the handler calls — not a local restatement of it. The `newIdentity`
+  // overwrite stays here because it lives in the handler, one branch later.
   function migrate(
     stamps: Map<string, string>,
     migratedFrom: string,
     panelTab: string,
     newIdentityUuid?: string,
   ): void {
-    const carried = stamps.get(migratedFrom);
-    if (carried !== undefined && !stamps.has(panelTab)) stamps.set(panelTab, carried);
-    stamps.delete(migratedFrom);
+    carryWorkflowCommandStamp(stamps, migratedFrom, panelTab);
     if (newIdentityUuid) stamps.set(panelTab, newIdentityUuid);
   }
 

--- a/src/__tests__/orchestrator/migration-stamp-carry.test.ts
+++ b/src/__tests__/orchestrator/migration-stamp-carry.test.ts
@@ -1,0 +1,174 @@
+// #1331 — after a reconnect, every mutating panel_* call is refused with "this workflow
+// has no trusted identity", while reads keep working. The reporter's recovery took four
+// calls to reach a state the panel already believed it was in.
+//
+// THIS IS THE MIGRATION TWIN OF #689, which hello-stamp-retention.test.ts already defends
+// for the same-id path. Same asymmetry, one branch over:
+//
+//   • a CARRIED-but-stale stamp authorizes nothing a correct one would not — the panel
+//     authorizes iff stamp === the live active workflow uuid, so a stale value simply
+//     mismatches and is refused;
+//   • an ABSENT stamp makes UiBridge send frames with no `workflow_uuid`, which the panel
+//     also counts as a mismatch (#718, fail-closed). So erasing does not relax the fence,
+//     it refuses HARDER — across everything the fence covers — and the panel's
+//     re-advertise repair is capped at MISMATCH_REHELLO_MAX_PER_IDENTITY (3), after which
+//     nothing retries and the tab is wedged for the session.
+//
+// And it is a REGRESSION with a name. #436 added `carryWorkflowCommandStamp` for exactly
+// this, recording that deleting the stamp "flapped sessions". The #884 orchestrator-scoped
+// -sessions refactor rewrote the migration block and left a bare delete behind. The
+// argument survived in the comments; the code implementing it did not.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+import { workflowIdentityParts } from "../../orchestrator/session-store.js";
+
+/** Source with comments stripped.
+ *
+ *  Two tests in #873 passed because the paragraph I wrote ABOVE a fix contained the
+ *  strings the test grepped for — deleting the code left them green. Every source
+ *  assertion below reads code only, and the header of this file names the very
+ *  identifiers it asserts on, so without this the tests would be a spell-check. */
+function orchestratorCode(): string {
+  return readFileSync(new URL("../../orchestrator/index.ts", import.meta.url), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*/g, "");
+}
+
+/** The `migratedFrom` block, isolated so an unrelated `tabCommandWorkflowUuid` site
+ *  elsewhere in this very large file cannot satisfy the assertions. */
+function migrationBlock(src: string): string {
+  const anchor = src.indexOf("if (migratedFrom && migratedFrom !== panelTab) {");
+  expect(anchor, "the same-socket migration block must still exist").toBeGreaterThan(-1);
+  const rest = src.slice(anchor);
+  const end = rest.indexOf("if (newIdentity) {");
+  expect(end, "the identity block must still follow the migration block").toBeGreaterThan(-1);
+  return rest.slice(0, end);
+}
+
+describe("a tab-id migration CARRIES the workflow stamp (#1331)", () => {
+  it("SOURCE: the stamp is read from the old id before the old id is retired", () => {
+    const block = migrationBlock(orchestratorCode());
+    expect(
+      block,
+      "the migration must carry the stamp onto the new id — deleting it without carrying is the #1331 wedge",
+    ).toMatch(/tabCommandWorkflowUuid\.get\(migratedFrom\)/);
+    expect(block).toMatch(/tabCommandWorkflowUuid\.set\(panelTab,\s*carriedStamp\)/);
+  });
+
+  it("SOURCE: the old id's stamp is still retired — the carry is a MOVE, not a copy", () => {
+    // The old id going away is a separate, correct decision that predates this fix and
+    // must survive it: a straggler command addressed to the retired id must not resolve.
+    expect(migrationBlock(orchestratorCode())).toContain(
+      "tabCommandWorkflowUuid.delete(migratedFrom);",
+    );
+  });
+
+  it("SOURCE: the carry runs BEFORE the delete, or it carries nothing", () => {
+    const block = migrationBlock(orchestratorCode());
+    const read = block.indexOf("tabCommandWorkflowUuid.get(migratedFrom)");
+    const del = block.indexOf("tabCommandWorkflowUuid.delete(migratedFrom)");
+    expect(read).toBeGreaterThan(-1);
+    expect(del).toBeGreaterThan(-1);
+    expect(read, "reading after the delete would always yield undefined").toBeLessThan(del);
+  });
+
+  it("SOURCE: a stamp already set for the new id is NOT clobbered by the carried one", () => {
+    // Ordering inside one hello is not guaranteed to be the only writer; a value already
+    // recorded for the new id is newer evidence than anything held under the old.
+    expect(migrationBlock(orchestratorCode())).toMatch(/!tabCommandWorkflowUuid\.has\(panelTab\)/);
+  });
+
+  it("SOURCE: a hello that DOES resolve an identity still overwrites the carried stamp", () => {
+    // The carry is a floor, never a ceiling. If this hello proves an identity, that wins.
+    const src = orchestratorCode();
+    const at = src.indexOf("if (newIdentity) {");
+    expect(at).toBeGreaterThan(-1);
+    expect(src.slice(at, at + 200)).toContain(
+      "tabCommandWorkflowUuid.set(panelTab, newIdentity.uuid);",
+    );
+  });
+});
+
+describe("the inputs that trigger the wedge are what a real reconnect produces (#1331)", () => {
+  it("a hello that lands before the canvas identity is readable yields NO identity", () => {
+    // Not a hypothetical branch. These are the exact shapes a reconnect emits, and each
+    // one leaves `newIdentity` undefined — which, before this fix, meant the deleted
+    // stamp was never restored.
+    const origin = "http://127.0.0.1:8188";
+    expect(workflowIdentityParts({ workflowUuid: undefined, origin })).toBeUndefined();
+    expect(workflowIdentityParts({ workflowUuid: "", origin })).toBeUndefined();
+    // …and an unresolvable server origin is untrusted too.
+    const uuid = "44444444-4444-4444-8444-444444444444";
+    expect(workflowIdentityParts({ workflowUuid: uuid, origin: undefined })).toBeUndefined();
+    // A fully-formed hello IS trusted, or the branch above would be the only one ever
+    // taken and none of this would prove anything about untrusted input.
+    expect(workflowIdentityParts({ workflowUuid: uuid, origin })).toEqual({ origin, uuid });
+  });
+});
+
+describe("the carry's semantics, exercised (#1331)", () => {
+  // The hello handler is a few hundred lines inside a much larger closure, so the
+  // assertions above read its source. This exercises the SEMANTICS the source implements,
+  // so a future refactor that keeps the identifiers but inverts the meaning still fails.
+  function migrate(
+    stamps: Map<string, string>,
+    migratedFrom: string,
+    panelTab: string,
+    newIdentityUuid?: string,
+  ): void {
+    const carried = stamps.get(migratedFrom);
+    if (carried !== undefined && !stamps.has(panelTab)) stamps.set(panelTab, carried);
+    stamps.delete(migratedFrom);
+    if (newIdentityUuid) stamps.set(panelTab, newIdentityUuid);
+  }
+
+  const WF = "11111111-1111-4111-8111-111111111111";
+
+  it("THE REPORTED CASE: save/rename migrates the id, hello carries no uuid — the stamp survives", () => {
+    // panel_new_workflow → build → panel_rename_workflow → panel_save_workflow mints a new
+    // tab id (tmp: → wf:). Before this fix the stamp was deleted here and, with no uuid in
+    // the hello, never restored: every mutating panel_* call refused for the session.
+    const stamps = new Map([["tmp:abc", WF]]);
+    migrate(stamps, "tmp:abc", "wf:abc", undefined);
+    expect(stamps.get("wf:abc"), "the new id must keep the identity we already proved").toBe(WF);
+    expect(stamps.has("tmp:abc"), "the retired id must not resolve").toBe(false);
+  });
+
+  it("new evidence beats carried evidence", () => {
+    const other = "22222222-2222-4222-8222-222222222222";
+    const stamps = new Map([["tmp:abc", WF]]);
+    migrate(stamps, "tmp:abc", "wf:abc", other);
+    expect(stamps.get("wf:abc")).toBe(other);
+  });
+
+  it("a stamp already recorded for the new id is not overwritten by the older carried one", () => {
+    const newer = "22222222-2222-4222-8222-222222222222";
+    const stamps = new Map([
+      ["tmp:abc", WF],
+      ["wf:abc", newer],
+    ]);
+    migrate(stamps, "tmp:abc", "wf:abc", undefined);
+    expect(stamps.get("wf:abc")).toBe(newer);
+  });
+
+  it("nothing to carry stays nothing — a migration does not invent a stamp", () => {
+    const stamps = new Map<string, string>();
+    migrate(stamps, "tmp:abc", "wf:abc", undefined);
+    expect(stamps.has("wf:abc")).toBe(false);
+  });
+
+  it("carrying cannot widen authorization: the fence still decides on EQUALITY", () => {
+    // The load-bearing safety claim. A carried stamp naming workflow A, on a canvas now
+    // showing workflow B, is refused exactly as an absent one would be — so carrying
+    // permits no write that a correct stamp would not.
+    const other = "22222222-2222-4222-8222-222222222222";
+    const stamps = new Map([["tmp:abc", WF]]);
+    migrate(stamps, "tmp:abc", "wf:abc", undefined);
+    const authorized = (liveWorkflowUuid: string): boolean =>
+      stamps.get("wf:abc") === liveWorkflowUuid;
+    expect(authorized(WF)).toBe(true);
+    expect(authorized(other)).toBe(false);
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -43,7 +43,7 @@ import { isPanelAutoInstallDisabled } from "../services/panel-installer.js";
 import { SelfRestarter, canSelfRestart } from "../services/self-restart.js";
 import { pairUrlDurability } from "./pair-durability.js";
 import { loadOrCreatePairToken } from "./pair-token-store.js";
-import { SessionStore, workflowIdentityParts } from "./session-store.js";
+import { SessionStore, workflowIdentityParts, carryWorkflowCommandStamp } from "./session-store.js";
 import { unreachableReason, noPanelTabReason, identityReason } from "./fence-refusal.js";
 import {
   SHARED_SESSION_SCOPE,
@@ -3539,19 +3539,18 @@ export async function runPanelOrchestrator(): Promise<void> {
         // stale stamp permits nothing a correct one would not; it simply mismatches
         // and is refused, exactly as before. An ABSENT stamp is the asymmetric
         // case: UiBridge then sends frames with no `workflow_uuid`, which the panel
-        // also counts as a mismatch, so every fenced command — including reads like
-        // `workflow_list` — is refused, and the panel's re-advertise repair is
+        // also counts as a mismatch, so every fenced command is refused. NOT
+        // `workflow_list`, which the panel deliberately exempts as its recovery probe
+        // (commandIsCanvasTargetless) — I claimed otherwise in the first version of this
+        // comment, an hour after reading the #1337 code that says so. The panel's
+        // re-advertise repair is
         // capped at MISMATCH_REHELLO_MAX_PER_IDENTITY (3). Once those are spent the
         // tab is wedged for the session, which is what cost the reporter four calls
         // to recover a state the panel already believed it was in.
         //
         // If THIS hello does resolve an identity, the `set` below overwrites what
         // we carried — new evidence always wins over old.
-        const carriedStamp = tabCommandWorkflowUuid.get(migratedFrom);
-        if (carriedStamp !== undefined && !tabCommandWorkflowUuid.has(panelTab)) {
-          tabCommandWorkflowUuid.set(panelTab, carriedStamp);
-        }
-        tabCommandWorkflowUuid.delete(migratedFrom);
+        carryWorkflowCommandStamp(tabCommandWorkflowUuid, migratedFrom, panelTab);
         logger.info(
           `[panel-orchestrator] same-socket re-hello ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} — routing state carried; the shared session continues (#884)`,
         );

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3518,10 +3518,39 @@ export async function runPanelOrchestrator(): Promise<void> {
         AskAnswers.moveKey(migratedFrom, panelTab);
         flushRunCompletions(panelTab);
         flushAskAnswers(panelTab);
-        // The OLD id's command stamp dies with it: a straggler command issued
-        // for the old workflow must keep failing the panel's fence rather than
-        // mutate the newly-shown one. The new id is stamped from THIS hello
-        // just below.
+        // The stamp MOVES to the new id, like every other piece of routing state
+        // above it (#1331). It used to be deleted here, and the justification —
+        // "a straggler command issued for the old workflow must keep failing the
+        // panel's fence" — is satisfied either way, because the OLD id ceases to
+        // resolve at all once the socket re-helloes under the new one.
+        //
+        // A REGRESSION, and one this file already knew about. #436 added
+        // `carryWorkflowCommandStamp` for exactly this, recording that deleting it
+        // "flapped sessions"; the #884 refactor rewrote this block and left a bare
+        // delete in its place. Thirty lines below, the surviving comment still
+        // argues the case and even names the scenario: "A reconnect hello that
+        // lands before the canvas identity is readable carries no uuid, which is
+        // enough to erase the stamp and wedge the tab for the rest of the session."
+        // That is #1331 verbatim — reported after a save/rename, which is one of
+        // the three events that mints a new tab id.
+        //
+        // Carrying cannot widen authorization. The panel authorizes a fenced
+        // command IFF stamp === the LIVE active workflow uuid, so a carried-but-
+        // stale stamp permits nothing a correct one would not; it simply mismatches
+        // and is refused, exactly as before. An ABSENT stamp is the asymmetric
+        // case: UiBridge then sends frames with no `workflow_uuid`, which the panel
+        // also counts as a mismatch, so every fenced command — including reads like
+        // `workflow_list` — is refused, and the panel's re-advertise repair is
+        // capped at MISMATCH_REHELLO_MAX_PER_IDENTITY (3). Once those are spent the
+        // tab is wedged for the session, which is what cost the reporter four calls
+        // to recover a state the panel already believed it was in.
+        //
+        // If THIS hello does resolve an identity, the `set` below overwrites what
+        // we carried — new evidence always wins over old.
+        const carriedStamp = tabCommandWorkflowUuid.get(migratedFrom);
+        if (carriedStamp !== undefined && !tabCommandWorkflowUuid.has(panelTab)) {
+          tabCommandWorkflowUuid.set(panelTab, carriedStamp);
+        }
         tabCommandWorkflowUuid.delete(migratedFrom);
         logger.info(
           `[panel-orchestrator] same-socket re-hello ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} — routing state carried; the shared session continues (#884)`,

--- a/src/orchestrator/session-store.ts
+++ b/src/orchestrator/session-store.ts
@@ -505,3 +505,41 @@ export class SessionStore {
     return this.flush();
   }
 }
+
+/**
+ * Move a tab's trusted workflow command stamp onto the id that replaced it (#1331).
+ *
+ * RESTORES A FUNCTION THIS REPO ALREADY HAD. #436 shipped `carryWorkflowCommandStamp` for
+ * exactly this, with a note that deleting the stamp "flapped sessions"; the #884
+ * orchestrator-scoped-sessions refactor rewrote the migration block and left a bare
+ * `delete` behind. The argument survived in the comments around it — including a paragraph
+ * naming this precise scenario — while the code implementing it did not.
+ *
+ * A same-socket re-hello mints a new tab id on a workflow switch, a save/rename
+ * (tmp: → wf:), or an id-scheme change. Deleting the stamp there and re-setting it only
+ * when THIS hello resolves an identity means a reconnect hello that lands before the canvas
+ * identity is readable leaves the tab with no stamp at all, and every fenced command is
+ * refused for the rest of the session.
+ *
+ * CARRYING CANNOT WIDEN AUTHORIZATION: the panel authorizes a fenced command iff the stamp
+ * equals the live active workflow uuid, so a carried-but-stale stamp naming workflow A on a
+ * canvas showing B is refused exactly as an absent one would be. What it avoids is the
+ * unrecoverable half — an absent stamp makes the bridge send frames with no workflow_uuid,
+ * which the panel also counts as a mismatch, and the panel's re-advertise repair is capped
+ * at 3 attempts per identity.
+ *
+ * Extracted and CALLED by the hello handler rather than inlined, so the tests exercise the
+ * function production runs instead of a re-implementation of what it ought to do.
+ */
+export function carryWorkflowCommandStamp(
+  stamps: Map<string, string>,
+  migratedFrom: string,
+  panelTab: string,
+): void {
+  const carried = stamps.get(migratedFrom);
+  // An entry already recorded for the new id is NEWER evidence than anything held under
+  // the old one, so it wins.
+  if (carried !== undefined && !stamps.has(panelTab)) stamps.set(panelTab, carried);
+  // The old id is still retired: a straggler command addressed to it must not resolve.
+  stamps.delete(migratedFrom);
+}


### PR DESCRIPTION
Draft — claiming Bug 1 of #1331: after a ComfyUI reconnect, every mutating `panel_*` call is refused with *"this workflow has no trusted identity for the panel to fence the command against"*, while reads keep working. Recovery cost the reporter four calls to get back to a state the panel already believed it was in.

**Root cause, and it is already argued against in the file's own comment.**

`src/orchestrator/index.ts` — a same-socket re-hello that changes the tab id runs:

```ts
tabCommandWorkflowUuid.delete(migratedFrom);
...
if (newIdentity) tabCommandWorkflowUuid.set(panelTab, newIdentity.uuid);
```

So when a reconnect hello arrives **before the canvas identity is readable**, `newIdentity` is undefined, the stamp is deleted and never restored. `resolveTabWorkflowUuid` then returns nothing, and `requiresWorkflowStampEnforcement` refuses every mutation.

Thirty lines below that delete, the file already explains why deleting is the wrong choice:

> Untrusted identity therefore means "no NEW evidence", not "the previous evidence is now false". Keep what we last proved and let the fence judge it on equality, which is the only test that decides authorization.

…and even names this exact scenario:

> A reconnect hello that lands before the canvas identity is readable carries no uuid, which is enough to erase the stamp and wedge the tab for the rest of the session.

That reasoning was applied to the same-id path (which retains by simply not overwriting) and not to the migration path, which deletes unconditionally first. The neighbouring routing state — `RunCompletions`, `AskAnswers` — is *moved* to the new id rather than dropped.

Plan: move the stamp with the rest of the routing state. A moved-but-stale stamp authorizes nothing a correct one would not, because the panel authorizes iff `stamp === the live active workflow uuid`; an absent stamp, by contrast, is unrecoverable once the panel's re-advertise repair budget is spent.

The reporter's other two observations (the false-alarm `workflow_open` mismatch, and the remedy the refusal suggests not being one that restores identity) are triaged in the thread.

Refs #1331
