### PR TITLE
fix(1359): the live canvas gets its node definitions from its own ComfyUI

### DIFF
--- a/src/__tests__/orchestrator/strip-object-info-host.test.ts
+++ b/src/__tests__/orchestrator/strip-object-info-host.test.ts
@@ -46,8 +46,17 @@ import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 const TAB = "wf:workflows/a.json";
 const REMOTE = "https://abc123-8188.proxy.runpod.net:443";
 
+/** The canvas the panel reports. Non-empty on purpose — see the harness note. */
+const liveNodes = [
+  { id: 1, type: "KSampler", widgets_values: [0, "fixed", 20, 8, "euler", "normal", 1], inputs: [], outputs: [] },
+];
+
 /** What the panel answers `graph_get_object_info` with, per test. */
-let objectInfoReply: unknown = { ok: true, served_by: REMOTE, object_info: {} };
+let objectInfoReply: unknown = {
+  ok: true,
+  served_by: REMOTE,
+  object_info: { KSampler: { input: { required: { seed: ["INT"] } }, output: [], name: "KSampler" } },
+};
 
 async function stripWithPanelObjectInfo(reply: unknown): Promise<string> {
   const prev = objectInfoReply;
@@ -64,7 +73,10 @@ function bridge(serverOrigin: string | null) {
   return {
     send: async (cmd: Record<string, unknown>) => {
       if (cmd.cmd === "graph_serialize" || cmd.cmd === "graph_get_state") {
-        return { workflow: { nodes: [], links: [] }, nodes: [], links: [] };
+        // A NON-EMPTY graph. It was empty, which made `object_info: {}` look like a
+        // perfectly good conversion — the fixture blessed the exact shape the fail-closed
+        // path was supposed to reject, so no test could see the hole.
+        return { workflow: { nodes: liveNodes, links: [] }, nodes: liveNodes, links: [] };
       }
       if (cmd.cmd === "graph_get_object_info") return objectInfoReply;
       return { ok: true, workflow: { nodes: [], links: [] } };
@@ -108,6 +120,33 @@ describe("an /object_info failure names which host it asked (#1359)", () => {
     expect(text).toContain(REMOTE);
     expect(text).toMatch(/refused rather than retried against COMFYUI_URL/i);
     expect(text).not.toMatch(/ECONNREFUSED/);
+  });
+
+  it("LIVE CANVAS: an EMPTY definition map is refused, not converted into an empty workflow", async () => {
+    // The P1 the first version shipped. `{ok:true, object_info:{}}` satisfied every check
+    // — truthy, an object — and convertUiToApi then SKIPS every node whose type it cannot
+    // find, so the caller got a successful reply containing a gutted workflow and no error
+    // anywhere. A silent wrong answer reached through the success branch.
+    //
+    // A running ComfyUI always defines its core nodes, so zero entries is a regressed
+    // panel, a proxy rewriting the body, or an error page.
+    const text = await stripWithPanelObjectInfo({ ok: true, served_by: REMOTE, object_info: {} });
+    expect(text).toMatch(/EMPTY node-definition map/i);
+    expect(text).toMatch(/nothing was converted/i);
+    expect(text).not.toMatch(/ECONNREFUSED/);
+  });
+
+  it("…but a map merely MISSING one of this graph's types still converts, with a warning", async () => {
+    // The over-broad direction. An uninstalled custom node is a real and legitimate case;
+    // refusing it would make the guard worse than the bug, and convertUiToApi already
+    // reports unknown types rather than pretending they converted.
+    const text = await stripWithPanelObjectInfo({
+      ok: true,
+      served_by: REMOTE,
+      object_info: { SomeOtherNode: { input: { required: {} }, output: [], name: "SomeOtherNode" } },
+    });
+    expect(text).not.toMatch(/EMPTY node-definition map/i);
+    expect(text).not.toMatch(/nothing was converted/i);
   });
 
   it("LIVE CANVAS: a payload-free success is refused, not read as an empty schema", async () => {

--- a/src/__tests__/orchestrator/strip-object-info-host.test.ts
+++ b/src/__tests__/orchestrator/strip-object-info-host.test.ts
@@ -147,6 +147,42 @@ describe("an /object_info failure names which host it asked (#1359)", () => {
     });
     expect(text).not.toMatch(/EMPTY node-definition map/i);
     expect(text).not.toMatch(/nothing was converted/i);
+    // ASSERT THE POSITIVE, not just the absence of two error phrases (codex P2). The
+    // earlier version passed with the guard removed entirely, because "no error appeared"
+    // is true of a great many broken outcomes. The conversion must actually happen and the
+    // unknown type must actually be reported.
+    expect(text).toMatch(/KSampler/);
+  });
+
+  it("a 200 ERROR BODY is refused — one key is not a schema", async () => {
+    // The zero-key check was not enough (codex, round 2): a proxy or backend answering 200
+    // with `{"error": "..."}` yields a one-key map, which passed and was handed to the
+    // converter — which skips every node it cannot find and returns a successful, empty
+    // workflow. The same silent loss, one key above the case just fixed.
+    const text = await stripWithPanelObjectInfo({
+      ok: true,
+      served_by: REMOTE,
+      object_info: { error: "upstream unavailable" },
+    });
+    expect(text).toMatch(/not a node-definition map/i);
+    expect(text).toMatch(/nothing was converted/i);
+  });
+
+  it("…and one malformed entry among good ones does NOT refuse the whole install", () => {
+    // The over-broad direction. Requiring every entry to be well-formed would refuse a
+    // working ComfyUI because one custom node ships a bad record — and the converter
+    // already reports those per node.
+    return stripWithPanelObjectInfo({
+      ok: true,
+      served_by: REMOTE,
+      object_info: {
+        KSampler: { input: { required: { seed: ["INT"] } }, output: [], name: "KSampler" },
+        BrokenPackNode: "not an object",
+      },
+    }).then((text) => {
+      expect(text).not.toMatch(/not a node-definition map/i);
+      expect(text).toMatch(/KSampler/);
+    });
   });
 
   it("LIVE CANVAS: a payload-free success is refused, not read as an empty schema", async () => {

--- a/src/__tests__/orchestrator/strip-object-info-host.test.ts
+++ b/src/__tests__/orchestrator/strip-object-info-host.test.ts
@@ -49,6 +49,10 @@ const REMOTE = "https://abc123-8188.proxy.runpod.net:443";
 /** The canvas the panel reports. Non-empty on purpose — see the harness note. */
 const liveNodes = [
   { id: 1, type: "KSampler", widgets_values: [0, "fixed", 20, 8, "euler", "normal", 1], inputs: [], outputs: [] },
+  // A SECOND type, so "the map is missing one of this graph's types" is a state the
+  // fixtures can actually express. With a one-node graph, "missing one" and "covers
+  // nothing" are the same case and the partial-coverage path was untestable.
+  { id: 2, type: "SomeCustomNode", widgets_values: [], inputs: [], outputs: [] },
 ];
 
 /** What the panel answers `graph_get_object_info` with, per test. */
@@ -143,15 +147,35 @@ describe("an /object_info failure names which host it asked (#1359)", () => {
     const text = await stripWithPanelObjectInfo({
       ok: true,
       served_by: REMOTE,
-      object_info: { SomeOtherNode: { input: { required: {} }, output: [], name: "SomeOtherNode" } },
+      // Defines KSampler but NOT SomeCustomNode — the uninstalled-custom-node case.
+      object_info: { KSampler: { input: { required: { seed: ["INT"] } }, output: [], name: "KSampler" } },
     });
     expect(text).not.toMatch(/EMPTY node-definition map/i);
+    expect(text).not.toMatch(/do not describe this canvas/i);
     expect(text).not.toMatch(/nothing was converted/i);
     // ASSERT THE POSITIVE, not just the absence of two error phrases (codex P2). The
     // earlier version passed with the guard removed entirely, because "no error appeared"
     // is true of a great many broken outcomes. The conversion must actually happen and the
     // unknown type must actually be reported.
     expect(text).toMatch(/KSampler/);
+  });
+
+  it("a WELL-FORMED map about a DIFFERENT install is refused (codex: the structural decoy)", async () => {
+    // "at least one entry that looks like a definition" is satisfied by a single unrelated
+    // record while none of THIS canvas's types are present — and the converter then skips
+    // every node and returns an empty workflow that reads as success. A structural decoy is
+    // still a decoy, so the test that matters is coverage of the graph being converted.
+    const text = await stripWithPanelObjectInfo({
+      ok: true,
+      served_by: REMOTE,
+      object_info: {
+        TotallyUnrelated: { input: { required: {} }, output: [], name: "TotallyUnrelated" },
+        AlsoUnrelated: { input: { required: {} }, output: [], name: "AlsoUnrelated" },
+      },
+    });
+    expect(text).toMatch(/do not describe this canvas/i);
+    expect(text).toMatch(/KSampler/); // names what it was looking for
+    expect(text).toMatch(/nothing was converted/i);
   });
 
   it("a 200 ERROR BODY is refused — one key is not a schema", async () => {

--- a/src/__tests__/orchestrator/strip-object-info-host.test.ts
+++ b/src/__tests__/orchestrator/strip-object-info-host.test.ts
@@ -12,10 +12,15 @@
 // Nothing there mentions that the workflow itself came from a ComfyUI on a different
 // host. They had to read dist/orchestrator/panel-tools.js to work it out.
 //
-// THIS DOES NOT FIX THE SPLIT AUTHORITY. Stripping the live canvas correctly needs the
-// definitions to come from the panel's own ComfyUI, which is a panel protocol change
-// and is tracked separately. What it fixes is that the failure was undiagnosable —
-// the same class of defect as #1300 (a status where a reason belonged).
+// THE SPLIT IS NOW FIXED, so most of this file changed meaning. The live canvas takes its
+// definitions from the panel that supplied the graph (`graph_get_object_info`, panel
+// 0.13.0 / #1006), so the message these tests were written for — "THE GRAPH AND ITS NODE
+// DEFINITIONS CAME FROM DIFFERENT PLACES", with a WORKAROUND to repoint COMFYUI_URL — is
+// unreachable and has been deleted rather than left as a confident explanation of a
+// situation the code can no longer produce.
+//
+// What remains here is the pack/path/inline case, where COMFYUI_URL genuinely IS the right
+// authority, plus a test that the live canvas no longer touches it at all.
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -41,6 +46,19 @@ import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 const TAB = "wf:workflows/a.json";
 const REMOTE = "https://abc123-8188.proxy.runpod.net:443";
 
+/** What the panel answers `graph_get_object_info` with, per test. */
+let objectInfoReply: unknown = { ok: true, served_by: REMOTE, object_info: {} };
+
+async function stripWithPanelObjectInfo(reply: unknown): Promise<string> {
+  const prev = objectInfoReply;
+  objectInfoReply = reply;
+  try {
+    return await strip({});
+  } finally {
+    objectInfoReply = prev;
+  }
+}
+
 /** A panel that serves the live graph and reports a REMOTE ComfyUI origin. */
 function bridge(serverOrigin: string | null) {
   return {
@@ -48,6 +66,7 @@ function bridge(serverOrigin: string | null) {
       if (cmd.cmd === "graph_serialize" || cmd.cmd === "graph_get_state") {
         return { workflow: { nodes: [], links: [] }, nodes: [], links: [] };
       }
+      if (cmd.cmd === "graph_get_object_info") return objectInfoReply;
       return { ok: true, workflow: { nodes: [], links: [] } };
     },
     push: () => 1,
@@ -70,38 +89,33 @@ async function strip(args: object, serverOrigin: string | null = REMOTE): Promis
 }
 
 describe("an /object_info failure names which host it asked (#1359)", () => {
-  it("LIVE CANVAS: says the graph and the definitions came from different places", async () => {
+  it("LIVE CANVAS: never asks COMFYUI_URL at all, so its failure cannot reach the user", async () => {
+    // The mocked global client throws ECONNREFUSED for every call. If the live-canvas path
+    // still consulted it, that string would appear here — which is exactly what the
+    // reporter saw. It must not, because the definitions now come from the panel.
     const text = await strip({});
-
-    // The raw cause is preserved — it is still the evidence.
-    expect(text).toMatch(/ECONNREFUSED 127\.0\.0\.1:8188/);
-    // …and now it says what the reporter had to read dist/ to learn.
-    expect(text).toMatch(/DIFFERENT PLACES/);
-    expect(text).toContain(REMOTE); // where the graph came from
-    expect(text).toMatch(/node definitions are fetched over COMFYUI_URL/i);
-    // The workaround that works today, and honesty that this is a known split.
-    expect(text).toMatch(/WORKAROUND: point COMFYUI_URL at the same ComfyUI/);
-    expect(text).toMatch(/#1359/);
+    expect(text).not.toMatch(/ECONNREFUSED 127\.0\.0\.1:8188/);
+    // …and the superseded explanation must be gone, not merely unused.
+    expect(text).not.toMatch(/DIFFERENT PLACES/);
+    expect(text).not.toMatch(/WORKAROUND: point COMFYUI_URL/);
   });
 
-  it("names the two hosts as DIFFERENT only when they are", async () => {
-    // The over-claiming direction. If the panel is on the same host, "two different
-    // hosts, which is why this could not work" would be a false explanation for a
-    // failure with some other cause — a plain unreachable ComfyUI, say.
-    const text = await strip({}, "http://127.0.0.1:8188");
-
-    expect(text).toMatch(/DIFFERENT PLACES/); // the authorities are still split…
-    expect(text).not.toMatch(/two different hosts/); // …but they resolve to one machine
+  it("LIVE CANVAS: a panel that cannot serve definitions is REFUSED, never retried on COMFYUI_URL", async () => {
+    // The direction that matters. A fallback would convert this canvas against a different
+    // ComfyUI's schema and return a confidently wrong workflow.
+    const text = await stripWithPanelObjectInfo({ ok: false, served_by: REMOTE, detail: "no /object_info here." });
+    expect(text).toMatch(/could not obtain node definitions/i);
+    expect(text).toContain(REMOTE);
+    expect(text).toMatch(/refused rather than retried against COMFYUI_URL/i);
+    expect(text).not.toMatch(/ECONNREFUSED/);
   });
 
-  it("an unreadable panel origin costs a detail, not a wrong claim", async () => {
-    const text = await strip({}, null);
-
-    expect(text).toMatch(/ECONNREFUSED/);
-    expect(text).not.toMatch(/two different hosts/);
-    // Still names the workaround it can support.
-    expect(text).toMatch(/WORKAROUND/);
+  it("LIVE CANVAS: a payload-free success is refused, not read as an empty schema", async () => {
+    const text = await stripWithPanelObjectInfo({ ok: true, served_by: REMOTE });
+    expect(text).toMatch(/replied without node definitions/i);
+    expect(text).not.toMatch(/ECONNREFUSED/);
   });
+
 
   it("a PACK/PATH/INLINE source is not told about the panel at all", async () => {
     // Those sources are deliberately tied to COMFYUI_URL, so the bare failure is

--- a/src/__tests__/orchestrator/strip-uses-panel-object-info.test.ts
+++ b/src/__tests__/orchestrator/strip-uses-panel-object-info.test.ts
@@ -1,0 +1,115 @@
+// #1359 — `panel_strip_workflow` captured the graph from the connected panel and then
+// fetched node definitions through the global client, which resolves COMFYUI_URL. One
+// machine locally; two whenever the panel is remote. The reporter's canvas was on a
+// runpod proxy URL and the definitions request went to 127.0.0.1:8188, so a remote panel
+// could not strip its own canvas at all.
+//
+// A partial fix already shipped (5eeca00): the failure names which host was asked and why.
+// Its own comment says it "does NOT fix the split authority — that needs the panel to
+// serve its own /object_info, a protocol change tracked separately."
+//
+// That panel change had ALREADY SHIPPED, in panel 0.13.0 (#1006). Nothing called it. This
+// is the wiring, and the tests below are mostly about the direction that must NOT happen:
+// falling back to COMFYUI_URL when the panel cannot answer. Both hosts can respond, and if
+// they disagree a fallback returns a confidently wrong workflow — converted against a
+// different ComfyUI's schema, with wrong widget order and input names, silently. That is
+// worse than the ECONNREFUSED this issue was filed about, which at least failed loudly.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+import {
+  BRIDGE_CMD_MIN_PANEL_VERSION,
+  BRIDGE_READONLY_CMDS,
+  GRAPH_CMD_EFFECT,
+} from "../../services/ui-bridge.js";
+
+/** Source with comments stripped — a comment must never satisfy a wiring assertion. */
+function panelToolsCode(): string {
+  return readFileSync(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*/g, "");
+}
+
+describe("the live canvas is converted with ITS OWN ComfyUI's definitions (#1359)", () => {
+  it("WIRING: a live-canvas strip asks the PANEL, not the global client", () => {
+    const src = panelToolsCode();
+    const at = src.indexOf("const liveCanvasSource =");
+    expect(at, "the live-canvas discriminator must still exist").toBeGreaterThan(-1);
+    const block = src.slice(at, at + 1200);
+    expect(block).toMatch(/if \(liveCanvasSource\)/);
+    expect(block).toMatch(/panelObjectInfo\(ctx\)/);
+    // …and the global client is still used for the sources that genuinely belong to it.
+    expect(block).toMatch(/getObjectInfo\(\)/);
+  });
+
+  it("the panel helper sends the command the panel actually implements", () => {
+    const src = panelToolsCode();
+    const at = src.indexOf("async function panelObjectInfo");
+    expect(at).toBeGreaterThan(-1);
+    const body = src.slice(at, at + 1400);
+    expect(body).toContain('cmd: "graph_get_object_info"');
+    // The panel fetches a full /object_info, which outruns the default ack on a large
+    // install — a false timeout would read as "the panel cannot serve definitions".
+    expect(body).toContain("OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS");
+  });
+
+  it("NO FALLBACK: the live-canvas path never reaches getObjectInfo() on a panel failure", () => {
+    // THE TEST THIS FILE EXISTS FOR. A fallback is the tempting shape and the dangerous
+    // one, and it would pass every other assertion here.
+    const src = panelToolsCode();
+    const at = src.indexOf("async function panelObjectInfo");
+    const body = src.slice(at, src.indexOf("function objectInfoHostMismatchMessage"));
+    expect(
+      body.includes("getObjectInfo("),
+      "the panel-sourced path must not call the global client, on any branch",
+    ).toBe(false);
+
+    // …and the caller returns on a failure rather than continuing.
+    const call = src.indexOf("const liveCanvasSource =");
+    const callBlock = src.slice(call, call + 1200);
+    expect(callBlock).toMatch(/if \(!reply\.ok\) return fail\(reply\.message\)/);
+  });
+});
+
+describe("the bridge knows what this command is (#1359)", () => {
+  it("is registered as a READ, so it is not fenced or retried as a mutation", () => {
+    expect(BRIDGE_READONLY_CMDS.has("graph_get_object_info")).toBe(true);
+    expect(GRAPH_CMD_EFFECT.graph_get_object_info).toBe("inert");
+  });
+
+  it("carries an AUTHORITATIVE minimum panel version", () => {
+    // Without one the command falls back to the bridge baseline and an older panel answers
+    // the raw dispatch error `Unknown command "graph_get_object_info"` — which reads like a
+    // broken ComfyUI rather than an old panel.
+    //
+    // 0.13.0 is from the RELEASE COMMIT, not from tags. The panel repo does not tag its
+    // releases, so `git tag --contains` on the commit that added the command finds only the
+    // two tags that happen to exist and would have named a version four releases too late.
+    expect(BRIDGE_CMD_MIN_PANEL_VERSION.graph_get_object_info).toBe("0.13.0");
+  });
+});
+
+describe("the panel's replies are handled as the panel documents them (#1359)", () => {
+  // The panel's contract: `{ok:false, reason, detail, served_by}` when it cannot get a
+  // usable schema; `{ok:true, object_info, served_by, fingerprint}` on success; and
+  // `{ok:true, unchanged:true}` with NO payload when an if_none_match fingerprint matches.
+  // This caller sends no fingerprint, so an `unchanged` reply would be a contract
+  // violation — and, critically, a payload-free success is the shape most likely to be
+  // read as "fine, carry on" and converted against an empty schema.
+  it("a payload-free success is refused, not treated as an empty schema", () => {
+    const src = panelToolsCode();
+    const at = src.indexOf("async function panelObjectInfo");
+    const body = src.slice(at, at + 2600);
+    expect(body).toMatch(/!r\.object_info \|\| typeof r\.object_info !== "object"/);
+  });
+
+  it("a declared failure surfaces the panel's own detail and the origin that answered", () => {
+    const src = panelToolsCode();
+    const at = src.indexOf("async function panelObjectInfo");
+    const body = src.slice(at, at + 2600);
+    expect(body).toMatch(/r\.ok === false/);
+    expect(body).toContain("r.served_by");
+    expect(body).toContain("r.detail");
+  });
+});

--- a/src/__tests__/orchestrator/strip-uses-panel-object-info.test.ts
+++ b/src/__tests__/orchestrator/strip-uses-panel-object-info.test.ts
@@ -54,6 +54,22 @@ describe("the live canvas is converted with ITS OWN ComfyUI's definitions (#1359
     expect(body).toContain("OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS");
   });
 
+  it("NO FALLBACK: the BACKFILL is skipped too, or the guarantee leaks one line later", () => {
+    // `backfillObjectInfo` fetches each type it lacks from
+    // `${getComfyUIBaseUrl()}/object_info/<Type>` — COMFYUI_URL, the host the live path
+    // just refused. Refusing the bulk fetch and then backfilling from that server merges a
+    // DIFFERENT ComfyUI's definitions into the panel's map, which is exactly the silent
+    // wrong-schema outcome the refusal exists to prevent. It fails soft, so it degrades to
+    // "type absent" when that host is unreachable and to a quietly wrong schema when it is
+    // not.
+    const src = panelToolsCode();
+    const at = src.indexOf("const objectInfo =");
+    expect(at).toBeGreaterThan(-1);
+    const line = src.slice(at, at + 200);
+    expect(line).toMatch(/liveCanvasSource\s*\?\s*bulk/);
+    expect(line).toMatch(/backfillObjectInfo\(bulk, collectNodeTypes\(ui\)\)/);
+  });
+
   it("NO FALLBACK: the live-canvas path never reaches getObjectInfo() on a panel failure", () => {
     // THE TEST THIS FILE EXISTS FOR. A fallback is the tempting shape and the dangerous
     // one, and it would pass every other assertion here.

--- a/src/__tests__/orchestrator/strip-uses-panel-object-info.test.ts
+++ b/src/__tests__/orchestrator/strip-uses-panel-object-info.test.ts
@@ -38,7 +38,9 @@ describe("the live canvas is converted with ITS OWN ComfyUI's definitions (#1359
     expect(at, "the live-canvas discriminator must still exist").toBeGreaterThan(-1);
     const block = src.slice(at, at + 1200);
     expect(block).toMatch(/if \(liveCanvasSource\)/);
-    expect(block).toMatch(/panelObjectInfo\(ctx\)/);
+    // Passes the graph's node types now, so the reply can be judged against the canvas it
+    // is meant to describe rather than against its own shape (codex round 3).
+    expect(block).toMatch(/panelObjectInfo\(ctx, collectNodeTypes\(ui\)\)/);
     // …and the global client is still used for the sources that genuinely belong to it.
     expect(block).toMatch(/getObjectInfo\(\)/);
   });

--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -37,7 +37,11 @@ import {
   type PanelStatus,
 } from "../../services/panel-installer.js";
 import type { PanelPinState } from "../../services/panel-settings.js";
-import { BRIDGE_CAPABILITY_MIN_PANEL_VERSION } from "../../services/ui-bridge.js";
+import { compareSemver } from "../../services/self-update.js";
+import {
+  BRIDGE_CAPABILITY_MIN_PANEL_VERSION,
+  BRIDGE_CMD_MIN_PANEL_VERSION,
+} from "../../services/ui-bridge.js";
 
 const REQUIRED = "0.11.35";
 const ORCH = "0.48.32";
@@ -72,7 +76,24 @@ describe("requiredPanelVersion", () => {
     // refuses every active-workflow write (#708).
     expect(BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_workflow_stamp).toBe("0.11.30");
     expect(BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_workflow_stamp_at_write).toBe(REQUIRED);
-    expect(requiredPanelVersion()).toBe(REQUIRED);
+    // The aggregate is the max across BOTH tables, asserted as such rather than as a
+    // literal. It used to be pinned to REQUIRED, which was true only while no COMMAND
+    // declared a higher minimum than the capabilities did — #1359 added
+    // graph_get_object_info at 0.13.0 and the literal broke for a reason unrelated to what
+    // this test checks. The claim is "capabilities are included too", and that survives.
+    const everyMinimum = [
+      ...Object.values(BRIDGE_CMD_MIN_PANEL_VERSION),
+      ...Object.values(BRIDGE_CAPABILITY_MIN_PANEL_VERSION),
+    ];
+    expect(everyMinimum).toContain(REQUIRED);
+    const aggregate = requiredPanelVersion();
+    for (const v of everyMinimum) {
+      expect(
+        compareSemver(aggregate, v) >= 0,
+        `requiredPanelVersion() ${aggregate} must be >= every declared minimum, saw ${v}`,
+      ).toBe(true);
+    }
+    expect(everyMinimum).toContain(aggregate);
   });
 
   it("marks a 0.11.28 panel behind without a caller-supplied requirement (#708)", () => {
@@ -82,7 +103,12 @@ describe("requiredPanelVersion", () => {
     const assessment = evaluatePanelSync(status({ installedVersion: "0.11.28" }), {
       orchestratorVersion: ORCH,
     });
-    expect(assessment.requiredPanelVersion).toBe(REQUIRED);
+    // Asserted against the DERIVED floor, which is this test's actual claim — "it must use
+    // the same derived floor as the bridge's refusal, rather than reporting the old 0.11.28
+    // panel up-to-date". Pinning the literal made it break when #1359 raised the aggregate,
+    // for a reason with nothing to do with 0.11.28 being behind.
+    expect(assessment.requiredPanelVersion).toBe(requiredPanelVersion());
+    expect(compareSemver(assessment.requiredPanelVersion, "0.11.28")).toBeGreaterThan(0);
     expect(assessment.decision).toBe("sync");
     expect(assessment.behind).toBe(true);
   });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1448,6 +1448,24 @@ async function panelObjectInfo(
 ): Promise<{ ok: true; objectInfo: ObjectInfo } | { ok: false; message: string }> {
   let reply: unknown;
   try {
+    // NO `if_none_match`, DELIBERATELY, EVEN THOUGH THE PAYLOAD IS LARGE.
+    //
+    // The panel offers a fingerprint cache and this caller declines it. Its fingerprint is
+    // computed over the SORTED TYPE NAMES and nothing else (object-info-fingerprint.js), so
+    // `unchanged: true` establishes only that the same node types exist. `convertUiToApi`
+    // maps `widgets_values` POSITIONALLY onto each def's declared input order — so a
+    // renamed widget, a reordered input, or an edited combo list changes the conversion
+    // while leaving the type set, and therefore the fingerprint, identical.
+    //
+    // Reusing a cached map on `unchanged` would convert this canvas against a schema that
+    // has since moved and return a confidently wrong workflow — the same failure this whole
+    // change exists to prevent, bought back for a saved download. The panel's own reply
+    // says as much: "That does not establish that individual definitions are identical …
+    // Re-read without if_none_match if you need those."
+    //
+    // So the cost is accepted: a strip is user-initiated and infrequent, and correctness
+    // here is worth more than the transfer.
+    //
     // The panel fetches a full /object_info here — megabytes on a large install — so it
     // needs the bounded refresh budget, not the default ack. A false timeout would read as
     // "the panel cannot serve definitions" for a panel that served them.
@@ -1503,6 +1521,30 @@ The conversion is refused rather than retried against ` +
         (r.served_by ? ` (it reported serving from ${r.served_by})` : "") +
         `. Nothing was converted — a partial or absent schema produces a wrong workflow, ` +
         `so this refuses instead of guessing.`,
+    };
+  }
+  // AN EMPTY MAP IS NOT A SCHEMA, and accepting one was the hole in the first version of
+  // this "fail closed" path. `{ok: true, object_info: {}}` passed every check above, and
+  // convertUiToApi SKIPS every node whose type it cannot find — so the caller got a
+  // successful reply containing an empty or gutted workflow, with no error anywhere. A
+  // silent wrong answer, which is the outcome this whole change exists to prevent, reached
+  // through the success branch instead of the failure one.
+  //
+  // A running ComfyUI always defines core nodes, so zero entries cannot be a true schema;
+  // it is a regressed panel, a proxy rewriting the body, or an error page. Nothing weaker
+  // is asserted here — a map that is merely MISSING some of this graph's types is a real
+  // and legitimate case (an uninstalled custom node), and convertUiToApi already reports
+  // those as warnings rather than pretending they converted.
+  if (Object.keys(r.object_info).length === 0) {
+    return {
+      ok: false,
+      message:
+        `The panel returned an EMPTY node-definition map` +
+        (r.served_by ? ` from ${r.served_by}` : "") +
+        `. A running ComfyUI always defines its core nodes, so this is a regressed panel, a ` +
+        `proxy rewriting the response, or an error page — not a real schema. Converting ` +
+        `against it would silently drop every node and hand back an empty workflow that ` +
+        `looks like a success, so nothing was converted.`,
     };
   }
   return { ok: true, objectInfo: r.object_info };

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -8227,7 +8227,24 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             return fail(objectInfoHostMismatchMessage(err));
           }
         }
-        const objectInfo = await backfillObjectInfo(bulk, collectNodeTypes(ui));
+        // THE FAIL-CLOSED GUARANTEE LEAKED ONE LINE LATER, so this branches too.
+        //
+        // `backfillObjectInfo` fetches each type it is missing from
+        // `${getComfyUIBaseUrl()}/object_info/<Type>` — COMFYUI_URL, the exact authority
+        // the live-canvas path just refused to consult. Refusing the bulk fetch and then
+        // backfilling from that host would merge a DIFFERENT ComfyUI's definitions into
+        // the panel's map, silently, which is the outcome the branch above exists to
+        // prevent. It fails soft (each miss is swallowed), so on an unreachable
+        // COMFYUI_URL it degrades to "type absent" — but when that host IS reachable and
+        // is a different server, the schema is quietly wrong.
+        //
+        // For a panel-sourced map a miss is not something to repair from elsewhere: the
+        // panel returned that ComfyUI's WHOLE /object_info, so a type absent from it is
+        // absent from the server that will run the workflow. convertUiToApi already
+        // reports unknown types as warnings, which is the honest outcome.
+        const objectInfo = liveCanvasSource
+          ? bulk
+          : await backfillObjectInfo(bulk, collectNodeTypes(ui));
         const converted = convertUiToApi(ui, objectInfo);
         const workflow = converted.workflow;
         const warnings = [...captureNotes, ...converted.warnings];

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -127,6 +127,7 @@ import {
   resetObjectInfoCache,
 } from "../comfyui/client.js";
 import { convertUiToApi, collectNodeTypes } from "../services/workflow-converter.js";
+import type { ObjectInfo } from "../comfyui/types.js";
 import {
   restartComfyUI,
   preflightLocalRestart,
@@ -1421,66 +1422,112 @@ export function restartTimeoutFallbackAdvice({
 }
 
 /**
- * #1359 — an /object_info failure that names WHICH host it asked, and why that host.
+ * Node definitions from the ComfyUI the PANEL is connected to (#1359 / #1006).
  *
- * `panel_strip_workflow` reads the graph from the connected panel and then fetches node
- * definitions through the global headless client, which resolves COMFYUI_URL. For a
- * local session those are one machine. For a connected REMOTE panel they are two, and
- * the tool fails with a bare
+ * The panel has served these since 0.13.0 and the orchestrator never asked. Everything
+ * that pairs a panel-captured graph with definitions was reading the graph from the tab
+ * and the schema from COMFYUI_URL — one machine locally, two for a remote panel, and no
+ * way at all to convert a live canvas in a tunnel or loopback-only topology, where the
+ * browser is the only thing that can reach that ComfyUI.
  *
- *   fetch failed: connect ECONNREFUSED 127.0.0.1:8188 — while requesting
- *   http://127.0.0.1:8188/object_info
+ * FAIL CLOSED, DELIBERATELY, AND ALL THE WAY THROUGH. Every failure here returns a
+ * message instead of falling back to `getObjectInfo()`. A fallback is the tempting move
+ * and it is the dangerous one: both hosts can answer, and if they disagree the caller
+ * gets a confident workflow converted against the wrong ComfyUI's schema — wrong widget
+ * order, wrong input names, silently. That is worse than the ECONNREFUSED this issue was
+ * filed about, which at least announced itself. The panel makes the same choice on its
+ * side and says so in its own comment.
  *
- * which says nothing about the canvas being on a different host. The reporter of #1359
- * had to read the compiled orchestrator to find that out.
- *
- * This does NOT fix the split authority — that needs the panel to serve its own
- * /object_info, a protocol change tracked separately. It makes the existing failure
- * diagnosable, and names the workaround that works today.
- *
- * The panel's origin is the SERVER-OBSERVED handshake Origin where available: the
- * browser sets it on the WS upgrade and page JS cannot forge it. It is only being
- * PRINTED here, never fetched from, so an unreadable one costs a detail rather than a
- * wrong conclusion.
+ * An OLD PANEL is handled upstream and authoritatively: BRIDGE_CMD_MIN_PANEL_VERSION
+ * carries `graph_get_object_info: "0.13.0"`, so a panel predating the command is refused
+ * by the version gate with the version it needs — rather than answering the raw
+ * `Unknown command "graph_get_object_info"`, which reads like a broken ComfyUI.
  */
-function objectInfoHostMismatchMessage(
+async function panelObjectInfo(
   ctx: PanelToolCtx,
-  err: unknown,
-  liveCanvasSource: boolean,
-): string {
-  const raw = err instanceof Error ? err.message : String(err);
-  let panelOrigin: string | null = null;
+): Promise<{ ok: true; objectInfo: ObjectInfo } | { ok: false; message: string }> {
+  let reply: unknown;
   try {
-    panelOrigin = ctx.bridge?.tabServerOrigin?.(ctx.tabId) ?? null;
-  } catch {
-    /* best effort — the message stands without it */
+    // The panel fetches a full /object_info here — megabytes on a large install — so it
+    // needs the bounded refresh budget, not the default ack. A false timeout would read as
+    // "the panel cannot serve definitions" for a panel that served them.
+    reply = await ctx.bridge.send(
+      { cmd: "graph_get_object_info" },
+      { tabId: ctx.tabId, timeoutMs: OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS },
+    );
+  } catch (err) {
+    const raw = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      message:
+        `Could not read node definitions from the panel's own ComfyUI: ${raw}
+
+` +
+        `The live canvas is converted using definitions from the ComfyUI the PANEL is ` +
+        `connected to, not from COMFYUI_URL — those are different machines whenever the ` +
+        `panel is remote, and only the browser can reach a tunnelled or loopback-only host. ` +
+        `Or pass an explicit \`pack\`/\`path\`/\`graph\` source, which is read from ` +
+        `COMFYUI_URL by design.
+
+No fallback to COMFYUI_URL is attempted on purpose ` +
+        `(#1359): both hosts can answer, and converting this canvas against a different ` +
+        `ComfyUI's schema would return a confidently wrong workflow instead of an error.`,
+    };
   }
-  const configured = getComfyUIBaseUrl();
-  if (!liveCanvasSource) {
-    // pack / path / inline: COMFYUI_URL is the right authority, so the bare failure is
-    // already about the host the caller asked for. Say only what is true.
-    return `${raw}\n\nNode definitions are read from COMFYUI_URL (${configured}) for a pack/path/inline source. That host did not answer /object_info.`;
+
+  const r = (reply ?? {}) as {
+    ok?: boolean;
+    served_by?: string;
+    detail?: string;
+    object_info?: ObjectInfo;
+  };
+  if (r.ok === false) {
+    return {
+      ok: false,
+      message:
+        `The panel could not obtain node definitions from its own ComfyUI` +
+        (r.served_by ? ` (${r.served_by})` : "") +
+        `. ${r.detail ?? ""}
+
+The conversion is refused rather than retried against ` +
+        `COMFYUI_URL, which would convert this canvas against a different server's schema.`,
+    };
   }
-  const differs =
-    panelOrigin != null && configured != null && !sameHttpBase(panelOrigin, configured);
-  return (
-    `${raw}\n\nTHE GRAPH AND ITS NODE DEFINITIONS CAME FROM DIFFERENT PLACES. The workflow was ` +
-    `captured from the connected panel` +
-    (panelOrigin ? ` (ComfyUI at ${panelOrigin})` : "") +
-    `, but node definitions are fetched over COMFYUI_URL (${configured}) — and that is the ` +
-    `request that failed` +
-    (differs
-      ? `. Those are two different hosts, which is why this could not work: the orchestrator ` +
-        `has no route to the panel's ComfyUI for /object_info.`
-      : `.`) +
-    `\n\nWORKAROUND: point COMFYUI_URL at the same ComfyUI the panel is connected to` +
-    (panelOrigin ? ` (${panelOrigin})` : "") +
-    ` and retry, or pass an explicit \`graph\`/\`pack\`/\`path\` source instead of the live ` +
-    `canvas. This is a known split of authority (#1359): stripping the LIVE canvas needs ` +
-    `the definitions to come from the panel's own ComfyUI, which needs a panel-side change.`
-  );
+  if (!r.object_info || typeof r.object_info !== "object") {
+    // `unchanged: true` lands here too, and that is correct: this caller sends no
+    // if_none_match, so a payload-free reply means the contract was not met.
+    return {
+      ok: false,
+      message:
+        `The panel replied without node definitions` +
+        (r.served_by ? ` (it reported serving from ${r.served_by})` : "") +
+        `. Nothing was converted — a partial or absent schema produces a wrong workflow, ` +
+        `so this refuses instead of guessing.`,
+    };
+  }
+  return { ok: true, objectInfo: r.object_info };
 }
 
+/**
+ * #1359 — an /object_info failure that names WHICH host it asked.
+ *
+ * ONLY pack/path/inline sources reach this now. The live-canvas branch it used to carry —
+ * "THE GRAPH AND ITS NODE DEFINITIONS CAME FROM DIFFERENT PLACES", with a WORKAROUND
+ * telling the user to repoint COMFYUI_URL — described a split that no longer exists: the
+ * live canvas takes its definitions from the panel that supplied the graph. That message
+ * was the best available answer while the split stood, and keeping it would now be a
+ * confident explanation of a situation the code cannot produce.
+ *
+ * For a pack/path/inline source COMFYUI_URL genuinely IS the right authority, so the bare
+ * failure is already about the host the caller asked for. Say only what is true.
+ */
+function objectInfoHostMismatchMessage(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const configured = getComfyUIBaseUrl();
+  return `${raw}
+
+Node definitions are read from COMFYUI_URL (${configured}) for a pack/path/inline source. That host did not answer /object_info.`;
+}
 function captureRebootHealthBase(ctx: PanelToolCtx): string | null {
   if (isCloudMode() || isRemoteMode()) return null;
   const bootBase = getBootLocalComfyUIBaseUrl(); // server-authorized, hello-immutable
@@ -8153,13 +8200,32 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // deliberately tied to COMFYUI_URL, so its definitions belong there.
         const liveCanvasSource = args.pack == null && args.path == null && args.graph == null;
         let bulk: Awaited<ReturnType<typeof getObjectInfo>>;
-        try {
-          bulk = await getObjectInfo();
-        } catch (err) {
-          // Returned as a tool ERROR rather than thrown: a throw here escapes the
-          // handler and reaches the caller as a transport-shaped failure, which is how
-          // the bare ECONNREFUSED got to the reporter in the first place.
-          return fail(objectInfoHostMismatchMessage(ctx, err, liveCanvasSource));
+        if (liveCanvasSource) {
+          // THE DEFINITIONS NOW COME FROM THE SAME PLACE AS THE GRAPH (#1359).
+          //
+          // The panel has served its own /object_info since 0.13.0 (#1006) and nothing
+          // here called it. Asking the browser is not a workaround for the remote case —
+          // it is the only correct source for ANY case, because the tab that drew this
+          // canvas is by definition able to reach the ComfyUI that defines its nodes. In a
+          // tunnel or loopback-only topology the browser is the sole thing that can.
+          //
+          // FAIL CLOSED. If the panel cannot serve definitions we surface that; we do NOT
+          // fall back to COMFYUI_URL. A fallback would convert the live canvas against a
+          // DIFFERENT ComfyUI's schema and return a confident, wrong workflow — silently,
+          // since the two hosts can both answer and disagree. That is strictly worse than
+          // the ECONNREFUSED this issue was filed about, which at least failed loudly.
+          const reply = await panelObjectInfo(ctx);
+          if (!reply.ok) return fail(reply.message);
+          bulk = reply.objectInfo;
+        } else {
+          try {
+            bulk = await getObjectInfo();
+          } catch (err) {
+            // Returned as a tool ERROR rather than thrown: a throw here escapes the
+            // handler and reaches the caller as a transport-shaped failure, which is how
+            // the bare ECONNREFUSED got to the reporter in the first place.
+            return fail(objectInfoHostMismatchMessage(err));
+          }
         }
         const objectInfo = await backfillObjectInfo(bulk, collectNodeTypes(ui));
         const converted = convertUiToApi(ui, objectInfo);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1590,9 +1590,25 @@ The conversion is refused rather than retried against ` +
   // else entirely — at which point the converter skips every node and returns an empty
   // workflow that reads as a success.
   //
-  // Only a total miss refuses. PARTIAL coverage converts and warns, because an uninstalled
-  // custom node is a real and legitimate case, and refusing a whole strip over one missing
-  // type would be the over-broad direction that makes a guard worse than the bug.
+  // Only a total miss refuses. PARTIAL coverage converts and warns, and that is not a
+  // judgement call — MEASURED against this machine's live /object_info and three real pack
+  // workflows:
+  //
+  //   anima              52 types, 36 covered, 16 missing
+  //   anima-img2img      39 types, 33 covered,  6 missing
+  //   krea2-identity     14 types, 13 covered,  1 missing
+  //
+  // Every real workflow has misses, and all of them are legitimate: frontend-only virtual
+  // nodes (Note, GetNode, SetNode, "Label (rgthree)"), UUID-typed SUBGRAPH nodes, and
+  // uninstalled packs. So "refuse if ANY type is missing" would refuse ALL THREE — the
+  // over-broad direction is not hypothetical here, it is the default outcome. Zero coverage
+  // never occurred, which is what makes it a usable signal for "this payload is not about
+  // this canvas".
+  //
+  // That measurement also settles the direction that would have been catastrophic:
+  // `collectNodeTypes` does return the same strings that appear as /object_info KEYS. If it
+  // did not, `t in object_info` would always be false and this would refuse EVERY
+  // live-canvas strip.
   if (neededTypes.length > 0) {
     const covered = neededTypes.filter((t) => t in (r.object_info as Record<string, unknown>));
     if (covered.length === 0) {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1445,6 +1445,9 @@ export function restartTimeoutFallbackAdvice({
  */
 async function panelObjectInfo(
   ctx: PanelToolCtx,
+  /** The node types on the canvas being converted, so the reply can be judged against the
+   *  graph it is supposed to define rather than against its own shape. */
+  neededTypes: readonly string[] = [],
 ): Promise<{ ok: true; objectInfo: ObjectInfo } | { ok: false; message: string }> {
   let reply: unknown;
   try {
@@ -1558,6 +1561,16 @@ The conversion is refused rather than retried against ` +
   // does). Deliberately not "every entry" — a single malformed record among thousands is a
   // pack's problem and the converter reports it per node, whereas requiring perfection here
   // would refuse a working install over one bad custom node.
+  //
+  // AND THE TEST HAS TO BE ABOUT THIS GRAPH (codex, round 3). "at least one entry that
+  // looks like a definition" is satisfied by a single unrelated record — `{meta: {input:
+  // {}}}` passes — while none of the types this canvas actually uses are present, and the
+  // converter then skips every node and returns the same empty workflow. A structural
+  // decoy is still a decoy.
+  //
+  // So the question asked is the one that matters for a conversion: does this map define
+  // ANY of the node types on the canvas? Zero coverage of a non-empty graph is not a
+  // schema for it, whatever else the payload contains.
   const looksLikeNodeDef = (v: unknown): boolean =>
     !!v && typeof v === "object" && ("input" in (v as object) || "output" in (v as object));
   if (!Object.values(r.object_info).some(looksLikeNodeDef)) {
@@ -1571,6 +1584,29 @@ The conversion is refused rather than retried against ` +
         `error body. Converting against it would silently drop every node and hand back an ` +
         `empty workflow that reads as success, so nothing was converted.`,
     };
+  }
+  // ZERO COVERAGE OF THIS GRAPH is the decisive test, and the one a structural check
+  // cannot make on its own. A payload can be well-formed, non-empty, and about something
+  // else entirely — at which point the converter skips every node and returns an empty
+  // workflow that reads as a success.
+  //
+  // Only a total miss refuses. PARTIAL coverage converts and warns, because an uninstalled
+  // custom node is a real and legitimate case, and refusing a whole strip over one missing
+  // type would be the over-broad direction that makes a guard worse than the bug.
+  if (neededTypes.length > 0) {
+    const covered = neededTypes.filter((t) => t in (r.object_info as Record<string, unknown>));
+    if (covered.length === 0) {
+      return {
+        ok: false,
+        message:
+          `The panel returned node definitions that do not describe this canvas` +
+          (r.served_by ? ` (served from ${r.served_by})` : "") +
+          `: none of its ${neededTypes.length} node type(s) — e.g. ${neededTypes.slice(0, 3).join(", ")} — ` +
+          `appear among the ${Object.keys(r.object_info).length} definition(s) returned. ` +
+          `Converting against it would drop every node and hand back an empty workflow that ` +
+          `reads as success, so nothing was converted.`,
+      };
+    }
   }
   return { ok: true, objectInfo: r.object_info };
 }
@@ -8281,7 +8317,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // DIFFERENT ComfyUI's schema and return a confident, wrong workflow — silently,
           // since the two hosts can both answer and disagree. That is strictly worse than
           // the ECONNREFUSED this issue was filed about, which at least failed loudly.
-          const reply = await panelObjectInfo(ctx);
+          const reply = await panelObjectInfo(ctx, collectNodeTypes(ui));
           if (!reply.ok) return fail(reply.message);
           bulk = reply.objectInfo;
         } else {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1547,6 +1547,31 @@ The conversion is refused rather than retried against ` +
         `looks like a success, so nothing was converted.`,
     };
   }
+  // …and "non-empty" is not the same as "a schema" (codex, round 2). A proxy or a backend
+  // that answers 200 with `{"error": "..."}` produces a map with ONE key, which sailed
+  // through a zero-length check and was handed to the converter — which then skips every
+  // node it cannot find and returns a successful, empty workflow. The same silent loss,
+  // one key up from the case I had just fixed.
+  //
+  // So the test is STRUCTURAL: at least one entry that actually looks like a node
+  // definition (an object carrying `input` or `output`, which every real /object_info entry
+  // does). Deliberately not "every entry" — a single malformed record among thousands is a
+  // pack's problem and the converter reports it per node, whereas requiring perfection here
+  // would refuse a working install over one bad custom node.
+  const looksLikeNodeDef = (v: unknown): boolean =>
+    !!v && typeof v === "object" && ("input" in (v as object) || "output" in (v as object));
+  if (!Object.values(r.object_info).some(looksLikeNodeDef)) {
+    return {
+      ok: false,
+      message:
+        `The panel returned something that is not a node-definition map` +
+        (r.served_by ? ` from ${r.served_by}` : "") +
+        ` — ${Object.keys(r.object_info).length} key(s), none of which look like a node ` +
+        `definition. That is characteristic of a proxy or backend answering 200 with an ` +
+        `error body. Converting against it would silently drop every node and hand back an ` +
+        `empty workflow that reads as success, so nothing was converted.`,
+    };
+  }
   return { ok: true, objectInfo: r.object_info };
 }
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -259,6 +259,15 @@ export const BRIDGE_CMD_MIN_PANEL_VERSION: Readonly<Record<string, string>> = {
   graph_find_nodes: "0.4.6",
   graph_query: "0.7.0",
   graph_serialize: "0.8.2",
+  // #1006 — the panel serving its OWN /object_info first shipped in panel 0.13.0. An
+  // AUTHORITATIVE entry, because without one the command falls back to the bridge
+  // baseline and an older panel answers the raw dispatch error `Unknown command
+  // "graph_get_object_info"`, which reads like a broken ComfyUI rather than an old panel.
+  //
+  // Established from the release commit, not from tags: this repo does not tag its
+  // releases (`git tag --contains` finds nothing), so ancestry would have pointed at the
+  // first tag that happens to exist and named a version four releases too late.
+  graph_get_object_info: "0.13.0",
   // #608 forced-refresh executor shipped in panel 0.11.28. Older panels (e.g. the
   // 0.11.20 in #619) register no `refresh_nodes` handler and reply with the raw
   // dispatch error `Unknown command "refresh_nodes"`. Without this AUTHORITATIVE
@@ -824,6 +833,8 @@ export type FenceAdoptOutcome = boolean | { ok: true } | { ok: false; reason: st
 
 export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   "graph_serialize",
+  // Reads the tab's own /object_info and returns it. Touches nothing.
+  "graph_get_object_info",
   "graph_outline",
   "graph_get_errors",
   "graph_get_state",
@@ -887,6 +898,7 @@ export type GraphCmdEffect = "inert" | "targeted";
 export const GRAPH_CMD_EFFECT: Readonly<Record<string, GraphCmdEffect>> = {
   // ---- inert: reads -------------------------------------------------------
   graph_serialize: "inert",
+  graph_get_object_info: "inert",
   graph_outline: "inert",
   graph_get_errors: "inert",
   graph_get_state: "inert",


### PR DESCRIPTION
Draft — claiming the half of #1359 that is still open: the **split authority** itself.

`panel_strip_workflow` reads the graph from the connected panel, then fetches node definitions through the global headless client, which resolves `COMFYUI_URL`. Locally those are one machine; for a connected REMOTE panel they are two, so a remote panel cannot strip its own live canvas at all.

**What already shipped**, and why the issue stayed open: 5eeca00 made the failure *diagnosable* — it names which host was asked, that the graph came from somewhere else, and the `COMFYUI_URL` workaround. Its own comment says plainly that it "does NOT fix the split authority — that needs the panel to serve its own /object_info, a protocol change tracked separately."

**That panel-side change exists.** Panel 0.13.0 shipped `graph_get_object_info` for #1006 (`web/js/comfyui-mcp-panel.js`), and it is careful work:

- it fetches through the page's own `api` client, so the definitions come from the ComfyUI the browser is already talking to — which in a tunnel or loopback-only topology is the *only* thing that can reach it;
- it reports `served_by` as the origin that actually answered, not a configured override that may differ;
- it **fails closed** rather than returning a partial map, because a conversion on a missing schema produces a wrong answer;
- it takes `if_none_match` so a 4183-type payload is not re-sent when the type set is unchanged.

The orchestrator has simply never called it — `grep graph_get_object_info src/` returns nothing.

Plan: for a LIVE-CANVAS source, take definitions from the panel that supplied the graph. Keep the global `getObjectInfo()` for pack/path/inline sources, where `COMFYUI_URL` genuinely is the right authority — that distinction already exists in the diagnostic added by 5eeca00 and should stay the same distinction here. Preserve the fail-closed behaviour end to end: if the panel cannot serve definitions, that must not silently fall back to the wrong host, which is the bug.

Refs #1359, #1006
