### PR TITLE
fix(1370): stat the partial instead of asserting it

### DIFF
--- a/src/__tests__/tools/download-cancel-partial.test.ts
+++ b/src/__tests__/tools/download-cancel-partial.test.ts
@@ -1,0 +1,75 @@
+// #1370 — `download_model action:"cancel"` told users "the partial was left on disk and
+// can be resumed by re-issuing the download (it picks up where it left off)". Nothing ever
+// stat'd the file. The reporter paused a 33 GB download BECAUSE of that sentence, found no
+// partial anywhere in the install tree, and restarted from zero.
+//
+// The sentence was not stale — it was never checked. It was selected from
+// `status === "cancelled"` plus two flags. And the neighbouring branches were already
+// careful: a ComfyUI-Manager dispatch says there is NO local partial, and a reclaimed-dead
+// writer says one MAY exist. Only the ordinary cancel asserted a filesystem fact without
+// consulting the filesystem.
+
+import { describe, expect, it, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { findResumablePartial } from "../../services/download-cache.js";
+
+const dirs: string[] = [];
+afterEach(async () => {
+  for (const d of dirs.splice(0)) await rm(d, { recursive: true, force: true });
+  delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+});
+
+async function cacheWith(files: Record<string, number>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "dl-partial-"));
+  dirs.push(dir);
+  await mkdir(dir, { recursive: true });
+  for (const [name, size] of Object.entries(files)) {
+    await writeFile(join(dir, name), Buffer.alloc(size, 1));
+  }
+  process.env.COMFYUI_DOWNLOAD_CACHE_DIR = dir;
+  return dir;
+}
+
+describe("findResumablePartial reports what is ACTUALLY there (#1370)", () => {
+  it("finds the staged partial by the destination filename", async () => {
+    await cacheWith({ ".flux2_dev_fp8mixed.safetensors.partial": 4096 });
+    const found = await findResumablePartial(["flux2_dev_fp8mixed.safetensors"]);
+    expect(found?.bytes).toBe(4096);
+    expect(found?.path).toMatch(/\.flux2_dev_fp8mixed\.safetensors\.partial$/);
+  });
+
+  it("returns NULL when nothing is staged — the reporter's case", async () => {
+    // Their scan found no partial of any kind. With no file present the tool must say so
+    // rather than repeat a sentence about resuming.
+    await cacheWith({});
+    expect(await findResumablePartial(["flux2_dev_fp8mixed.safetensors"])).toBeNull();
+  });
+
+  it("tries SEVERAL candidate names, because one wrong guess inverts the same bug", async () => {
+    // A cancelled job knows its destination by routes of differing reliability (filename,
+    // destination key, landed path, the URL's last segment). Reporting "nothing to resume"
+    // over a 30 GB partial that is sitting there would be the identical false claim in the
+    // other direction.
+    await cacheWith({ ".model.safetensors.partial": 2048 });
+    expect(await findResumablePartial([undefined, "", "model.safetensors"])).not.toBeNull();
+    // A full path contributes its basename, which is how the staged file is named.
+    expect(await findResumablePartial(["/models/checkpoints/model.safetensors"])).not.toBeNull();
+    // …and an unrelated name still finds nothing, so the search is not indiscriminate.
+    expect(await findResumablePartial(["something_else.safetensors"])).toBeNull();
+  });
+
+  it("a ZERO-BYTE partial is not resumable and is reported as absent", async () => {
+    // Resuming from it saves nothing, and calling it resumable would restate the bug in
+    // miniature: a claim of retained bytes where there are none.
+    await cacheWith({ ".empty.safetensors.partial": 0 });
+    expect(await findResumablePartial(["empty.safetensors"])).toBeNull();
+  });
+
+  it("ignores the FINAL file — only the staged .partial counts as resumable", async () => {
+    await cacheWith({ "model.safetensors": 8192 });
+    expect(await findResumablePartial(["model.safetensors"])).toBeNull();
+  });
+});

--- a/src/__tests__/tools/download-cancel-partial.test.ts
+++ b/src/__tests__/tools/download-cancel-partial.test.ts
@@ -1,20 +1,30 @@
-// #1370 — `download_model action:"cancel"` told users "the partial was left on disk and
-// can be resumed by re-issuing the download (it picks up where it left off)". Nothing ever
-// stat'd the file. The reporter paused a 33 GB download BECAUSE of that sentence, found no
-// partial anywhere in the install tree, and restarted from zero.
+// #1370 — `download_model action:"status"` told users "the partial was left on disk and
+// can be resumed by re-issuing the download". Nothing ever stat'd the file. The reporter
+// paused a 33 GB download BECAUSE of that sentence, found no partial anywhere, and
+// restarted from zero.
 //
-// The sentence was not stale — it was never checked. It was selected from
-// `status === "cancelled"` plus two flags. And the neighbouring branches were already
-// careful: a ComfyUI-Manager dispatch says there is NO local partial, and a reclaimed-dead
-// writer says one MAY exist. Only the ordinary cancel asserted a filesystem fact without
-// consulting the filesystem.
+// THE FIXTURES HERE ARE BUILT FROM THE PRODUCTION PATH FUNCTION, NOT FROM A NAME I TYPED.
+// My first version of this file created `.<destination filename>.partial` and searched for
+// the same string, so it passed while production stages under
+// `.<sha256(cacheIdentity)[0:32]><ext>.partial` — keyed by the CACHE identity, not the
+// destination. The lookup would have missed every real partial and reported "no partial
+// found" for downloads that had one: this issue's own bug inverted, and worse, because the
+// original at least erred toward "your bytes are safe".
+//
+// A test whose fixture encodes the belief under test cannot fail for the reason it exists.
+// Deriving the path from `stagedPartialPathForUrl` is what makes the two impossible to
+// disagree.
 
 import { describe, expect, it, afterEach } from "vitest";
 import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { findResumablePartial } from "../../services/download-cache.js";
+import { findResumablePartial, stagedPartialPathForUrl } from "../../services/download-cache.js";
+
+const URL_A = "https://huggingface.co/Comfy-Org/flux2-dev/resolve/main/flux2_dev_fp8mixed.safetensors";
+const URL_B = "https://huggingface.co/Comfy-Org/other/resolve/main/mistral_3_small.safetensors";
 
 const dirs: string[] = [];
 afterEach(async () => {
@@ -22,54 +32,74 @@ afterEach(async () => {
   delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
 });
 
-async function cacheWith(files: Record<string, number>): Promise<string> {
+async function useTempCache(): Promise<void> {
   const dir = await mkdtemp(join(tmpdir(), "dl-partial-"));
   dirs.push(dir);
-  await mkdir(dir, { recursive: true });
-  for (const [name, size] of Object.entries(files)) {
-    await writeFile(join(dir, name), Buffer.alloc(size, 1));
-  }
   process.env.COMFYUI_DOWNLOAD_CACHE_DIR = dir;
-  return dir;
 }
 
-describe("findResumablePartial reports what is ACTUALLY there (#1370)", () => {
-  it("finds the staged partial by the destination filename", async () => {
-    await cacheWith({ ".flux2_dev_fp8mixed.safetensors.partial": 4096 });
-    const found = await findResumablePartial(["flux2_dev_fp8mixed.safetensors"]);
+/** Stage a partial exactly where the writer would put it for this URL. */
+async function stagePartialFor(url: string, bytes: number): Promise<string> {
+  const p = stagedPartialPathForUrl(url);
+  await mkdir(dirname(p), { recursive: true });
+  await writeFile(p, Buffer.alloc(bytes, 1));
+  return p;
+}
+
+describe("findResumablePartial reports what is ACTUALLY staged (#1370)", () => {
+  it("finds the partial the writer would have staged for this URL", async () => {
+    await useTempCache();
+    const staged = await stagePartialFor(URL_A, 4096);
+    const found = await findResumablePartial(URL_A);
     expect(found?.bytes).toBe(4096);
-    expect(found?.path).toMatch(/\.flux2_dev_fp8mixed\.safetensors\.partial$/);
+    expect(found?.path).toBe(staged);
+  });
+
+  it("the staged name is HASHED, not the destination filename", async () => {
+    // Pins the fact the first implementation got wrong. If this ever becomes
+    // `.flux2_dev_fp8mixed.safetensors.partial`, the lookup and the writer have diverged
+    // and one of them is silently wrong.
+    await useTempCache();
+    const p = stagedPartialPathForUrl(URL_A);
+    expect(p).not.toMatch(/flux2_dev_fp8mixed/);
+    expect(p).toMatch(/[0-9a-f]{32}\.safetensors\.partial$/);
   });
 
   it("returns NULL when nothing is staged — the reporter's case", async () => {
-    // Their scan found no partial of any kind. With no file present the tool must say so
-    // rather than repeat a sentence about resuming.
-    await cacheWith({});
-    expect(await findResumablePartial(["flux2_dev_fp8mixed.safetensors"])).toBeNull();
+    await useTempCache();
+    expect(await findResumablePartial(URL_A)).toBeNull();
   });
 
-  it("tries SEVERAL candidate names, because one wrong guess inverts the same bug", async () => {
-    // A cancelled job knows its destination by routes of differing reliability (filename,
-    // destination key, landed path, the URL's last segment). Reporting "nothing to resume"
-    // over a 30 GB partial that is sitting there would be the identical false claim in the
-    // other direction.
-    await cacheWith({ ".model.safetensors.partial": 2048 });
-    expect(await findResumablePartial([undefined, "", "model.safetensors"])).not.toBeNull();
-    // A full path contributes its basename, which is how the staged file is named.
-    expect(await findResumablePartial(["/models/checkpoints/model.safetensors"])).not.toBeNull();
-    // …and an unrelated name still finds nothing, so the search is not indiscriminate.
-    expect(await findResumablePartial(["something_else.safetensors"])).toBeNull();
+  it("does not report ANOTHER download's partial as this one's", async () => {
+    // The staged name is keyed on the URL, so two downloads never share one. Reporting a
+    // neighbour's bytes as resumable would be a new false claim, not a fix for the old one.
+    await useTempCache();
+    await stagePartialFor(URL_B, 8192);
+    expect(await findResumablePartial(URL_A)).toBeNull();
+    expect((await findResumablePartial(URL_B))?.bytes).toBe(8192);
   });
 
-  it("a ZERO-BYTE partial is not resumable and is reported as absent", async () => {
-    // Resuming from it saves nothing, and calling it resumable would restate the bug in
+  it("a ZERO-BYTE partial is reported as absent", async () => {
+    // Resuming from it saves nothing, and calling it resumable restates this bug in
     // miniature: a claim of retained bytes where there are none.
-    await cacheWith({ ".empty.safetensors.partial": 0 });
-    expect(await findResumablePartial(["empty.safetensors"])).toBeNull();
+    await useTempCache();
+    await stagePartialFor(URL_A, 0);
+    expect(await findResumablePartial(URL_A)).toBeNull();
   });
 
-  it("ignores the FINAL file — only the staged .partial counts as resumable", async () => {
-    await cacheWith({ "model.safetensors": 8192 });
-    expect(await findResumablePartial(["model.safetensors"])).toBeNull();
+  it("ignores the COMPLETED cache entry — only the staged .partial is resumable", async () => {
+    await useTempCache();
+    const partial = stagedPartialPathForUrl(URL_A);
+    const completed = partial.replace(/\.partial$/, "");
+    await mkdir(dirname(completed), { recursive: true });
+    await writeFile(completed, Buffer.alloc(8192, 1));
+    expect(await findResumablePartial(URL_A)).toBeNull();
+  });
+
+  it("a missing or unparseable URL yields null rather than throwing", async () => {
+    await useTempCache();
+    expect(await findResumablePartial(undefined)).toBeNull();
+    expect(await findResumablePartial("")).toBeNull();
+    expect(await findResumablePartial("not a url")).toBeNull();
   });
 });

--- a/src/__tests__/tools/download-cancel-partial.test.ts
+++ b/src/__tests__/tools/download-cancel-partial.test.ts
@@ -17,7 +17,7 @@
 
 import { describe, expect, it, afterEach } from "vitest";
 import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
-import { dirname } from "node:path";
+import { basename, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -55,14 +55,40 @@ describe("findResumablePartial reports what is ACTUALLY staged (#1370)", () => {
     expect(found?.path).toBe(staged);
   });
 
-  it("the staged name is HASHED, not the destination filename", async () => {
-    // Pins the fact the first implementation got wrong. If this ever becomes
-    // `.flux2_dev_fp8mixed.safetensors.partial`, the lookup and the writer have diverged
-    // and one of them is silently wrong.
+  it("the staged name is HASHED and HIDDEN — both details cost a round", async () => {
+    // Two separate mistakes, one per review round:
+    //   1. searched `.<destination filename>.partial` — wrong KEY (the writer stages by
+    //      cache identity, not destination);
+    //   2. derived the cache path correctly and dropped the LEADING DOT, so it looked for
+    //      `hash.ext.partial` while the writer wrote `.hash.ext.partial`.
+    // Each time the lookup found nothing and would have told a user holding 30 GB of
+    // resumable bytes to start over. The dot is asserted separately because the previous
+    // version of this test used `/[0-9a-f]{32}\.safetensors\.partial$/`, which matches
+    // happily with OR without it.
     await useTempCache();
     const p = stagedPartialPathForUrl(URL_A);
-    expect(p).not.toMatch(/flux2_dev_fp8mixed/);
-    expect(p).toMatch(/[0-9a-f]{32}\.safetensors\.partial$/);
+    const name = basename(p);
+    expect(p, "must not be keyed on the destination filename").not.toMatch(/flux2_dev_fp8mixed/);
+    expect(name.startsWith("."), `staged file must be hidden, got ${name}`).toBe(true);
+    expect(name).toMatch(/^\.[0-9a-f]{32}\.safetensors\.partial$/);
+  });
+
+  it("WIRING: the WRITER stages through the same function the lookup reads", async () => {
+    // The root cause of both rounds was two parallel derivations of one path, each
+    // confident and one wrong. A test that only compares the helper against itself cannot
+    // see that — my fixtures were built by calling the helper under test, so they agreed
+    // with every wrong version of it.
+    //
+    // This asserts the writer does not hand-roll the path any more. It is the only check
+    // here that could have failed while all the others passed.
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(new URL("../../services/download-cache.ts", import.meta.url), "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*/g, "");
+    expect(src).toMatch(/const partial = stagedPartialPathForTarget\(target\);/);
+    // …and the hand-rolled expression exists in exactly ONE place: the shared helper.
+    const handRolled = src.match(/join\(cacheDir\(\), `\.\$\{basename\([a-z]+\)\}\.partial`\)/g) ?? [];
+    expect(handRolled.length, "the staged path must be built in exactly one place").toBe(1);
   });
 
   it("returns NULL when nothing is staged — the reporter's case", async () => {

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -3304,43 +3304,55 @@ export async function downloadWithCache(
 }
 
 /**
- * The resumable `.partial` for a download, if one is actually on disk (#1370).
+ * Where a download's resumable `.partial` is staged, derived the way the writer derives it
+ * (#1370).
  *
- * `download_model action:"cancel"` told users "the partial was left on disk and can be
- * resumed by re-issuing the download". Nothing ever checked. The reporter paused a 33 GB
- * download BECAUSE of that sentence, then found no partial anywhere and restarted from
- * zero — the message was load-bearing for a decision and it was asserted, not observed.
+ * MY FIRST VERSION OF THIS GUESSED THE NAME AND GUESSED WRONG. It looked for
+ * `.<destination filename>.partial`, because that is what "the partial for this download"
+ * sounds like. The writer stages under `.<sha256(cacheIdentity)[0:32]><ext>.partial` —
+ * keyed by the CACHE identity, not the destination — so the lookup would have missed every
+ * time and reported "no partial was found" for downloads that had one. That is the same
+ * false claim this issue is about, pointing the other way, and it would have been worse:
+ * the original at least erred toward "your bytes are safe".
  *
- * The neighbouring branches were already careful: a ComfyUI-Manager dispatch says there is
- * no local partial, and a reclaimed-dead writer says one MAY exist. Only the ordinary
- * cancel stated a fact about the filesystem without consulting it.
+ * The tests missed it because the fixtures created files under the name I was searching
+ * for. They encoded my belief about the naming rather than the naming, which is the third
+ * time that shape has cost me today. Building the path from `cachePathForUrl` — the same
+ * function the writer uses — is what makes the two definitions impossible to disagree.
  *
- * Candidate names rather than one: the staged file is `.<basename>.partial` in the cache
- * dir, and a cancelled job knows its destination by several routes of differing
- * reliability (`filename`, the destination key, the URL's last segment). Checking each is
- * cheap — a few `stat`s — and guessing one wrong would reintroduce the same false claim in
- * the opposite direction: reporting "nothing to resume" while a 30 GB partial sits there.
+ * SCOPE, stated because the caller has to phrase its answer around it: `cacheIdentity`
+ * folds in representation-affecting request headers and cloud credentials, which a job
+ * record deliberately does not keep. So this reproduces the staged path exactly for an
+ * unauthenticated public download (the reporter's case, and the common one) and cannot for
+ * an authenticated variant. A miss therefore means "none found under this URL's staged
+ * name", never "none exists" — and the caller must not upgrade it to the latter.
+ */
+export function stagedPartialPathForUrl(url: string): string {
+  return `${cachePathForUrl(url)}.partial`;
+}
+
+/**
+ * Stat the staged `.partial` for a URL. Returns null when there is nothing usable there.
  *
- * Returns null when nothing is found, which the caller must report as "no partial" rather
- * than as a failure — a cancel that leaves nothing is not an error, it is a fact the user
- * needs before deciding to re-issue.
+ * A zero-byte partial reports as absent: resuming from it saves nothing, and calling it
+ * resumable would restate this issue's bug in miniature — a claim of retained bytes where
+ * there are none.
  */
 export async function findResumablePartial(
-  candidateNames: readonly (string | undefined)[],
+  url: string | undefined,
 ): Promise<{ path: string; bytes: number } | null> {
-  const seen = new Set<string>();
-  for (const raw of candidateNames) {
-    if (typeof raw !== "string" || !raw.trim()) continue;
-    const name = basename(raw.trim());
-    if (!name || seen.has(name)) continue;
-    seen.add(name);
-    const candidate = join(cacheDir(), `.${name}.partial`);
-    try {
-      const st = await stat(candidate);
-      if (st.isFile() && st.size > 0) return { path: candidate, bytes: st.size };
-    } catch {
-      // ENOENT is the common, expected answer — keep looking.
-    }
+  if (typeof url !== "string" || !url.trim()) return null;
+  let candidate: string;
+  try {
+    candidate = stagedPartialPathForUrl(url.trim());
+  } catch {
+    return null;
+  }
+  try {
+    const st = await stat(candidate);
+    if (st.isFile() && st.size > 0) return { path: candidate, bytes: st.size };
+  } catch {
+    // ENOENT is the common, expected answer.
   }
   return null;
 }

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -3302,3 +3302,45 @@ export async function downloadWithCache(
     return { targetPath: options.targetPath, usedCache: false };
   }
 }
+
+/**
+ * The resumable `.partial` for a download, if one is actually on disk (#1370).
+ *
+ * `download_model action:"cancel"` told users "the partial was left on disk and can be
+ * resumed by re-issuing the download". Nothing ever checked. The reporter paused a 33 GB
+ * download BECAUSE of that sentence, then found no partial anywhere and restarted from
+ * zero — the message was load-bearing for a decision and it was asserted, not observed.
+ *
+ * The neighbouring branches were already careful: a ComfyUI-Manager dispatch says there is
+ * no local partial, and a reclaimed-dead writer says one MAY exist. Only the ordinary
+ * cancel stated a fact about the filesystem without consulting it.
+ *
+ * Candidate names rather than one: the staged file is `.<basename>.partial` in the cache
+ * dir, and a cancelled job knows its destination by several routes of differing
+ * reliability (`filename`, the destination key, the URL's last segment). Checking each is
+ * cheap — a few `stat`s — and guessing one wrong would reintroduce the same false claim in
+ * the opposite direction: reporting "nothing to resume" while a 30 GB partial sits there.
+ *
+ * Returns null when nothing is found, which the caller must report as "no partial" rather
+ * than as a failure — a cancel that leaves nothing is not an error, it is a fact the user
+ * needs before deciding to re-issue.
+ */
+export async function findResumablePartial(
+  candidateNames: readonly (string | undefined)[],
+): Promise<{ path: string; bytes: number } | null> {
+  const seen = new Set<string>();
+  for (const raw of candidateNames) {
+    if (typeof raw !== "string" || !raw.trim()) continue;
+    const name = basename(raw.trim());
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    const candidate = join(cacheDir(), `.${name}.partial`);
+    try {
+      const st = await stat(candidate);
+      if (st.isFile() && st.size > 0) return { path: candidate, bytes: st.size };
+    } catch {
+      // ENOENT is the common, expected answer — keep looking.
+    }
+  }
+  return null;
+}

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -2347,7 +2347,7 @@ async function downloadIntoCache(
     // resumes from the byte it left off on the next call, rather than
     // restarting from zero. (See streamUrlToFile for the Range + flags
     // handshake.) Cleanup on terminal failure stays unchanged.
-    const partial = join(cacheDir(), `.${basename(target)}.partial`);
+    const partial = stagedPartialPathForTarget(target);
     const rejectedMarker = `${partial}.rejected`;
 
     /**
@@ -3304,6 +3304,26 @@ export async function downloadWithCache(
 }
 
 /**
+ * The staged `.partial` path for a cache target. THE ONE DEFINITION (#1370).
+ *
+ * It is a HIDDEN file — `.<basename>.partial`, leading dot — in the cache dir. That dot
+ * cost two rounds. My first lookup searched for `.<destination filename>.partial` (wrong
+ * key: the writer stages by CACHE identity, not destination). The correction derived the
+ * cache path properly and then dropped the leading dot, so it looked for `hash.ext.partial`
+ * while the writer wrote `.hash.ext.partial` — still missing every real partial, still
+ * reporting "no partial found" to someone holding 30 GB of resumable bytes.
+ *
+ * Both times my tests agreed with me, because the fixtures were built by calling the same
+ * helper being tested. A fixture derived from the code under test cannot falsify it.
+ *
+ * So there is now exactly one expression, and the WRITER uses it too. Not a parallel
+ * derivation that happens to agree today — the same function, so they cannot disagree.
+ */
+export function stagedPartialPathForTarget(target: string): string {
+  return join(cacheDir(), `.${basename(target)}.partial`);
+}
+
+/**
  * Where a download's resumable `.partial` is staged, derived the way the writer derives it
  * (#1370).
  *
@@ -3328,7 +3348,7 @@ export async function downloadWithCache(
  * name", never "none exists" — and the caller must not upgrade it to the latter.
  */
 export function stagedPartialPathForUrl(url: string): string {
-  return `${cachePathForUrl(url)}.partial`;
+  return stagedPartialPathForTarget(cachePathForUrl(url));
 }
 
 /**

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -240,10 +240,12 @@ function stillWritingClause(route: DownloadRoute): string {
 function describePartial(partial: { path: string; bytes: number } | null): string {
   if (!partial) {
     return (
-      `NO partial was found on disk, so re-issuing this download starts from the ` +
-      `beginning. (Checked the download cache for a staged .partial under this file's ` +
-      `name.) That is not an error — but it is worth knowing before you re-issue a large ` +
-      `file.`
+      `no resumable partial was found for this URL, so re-issuing very likely starts from ` +
+      `the beginning. That is not an error — but it is worth knowing before you re-spend ` +
+      `the bandwidth on a large file. (The staged file is keyed by the download's cache ` +
+      `identity, which folds in auth headers this record deliberately does not keep, so ` +
+      `for an AUTHENTICATED download this means "none found under the unauthenticated ` +
+      `key", not "none exists".)`
     );
   }
   const gb = partial.bytes / 1024 ** 3;
@@ -1007,25 +1009,20 @@ async function statusAction(args: {
         //
         // Stat'd up front because the row builder below is synchronous, and only for rows
         // that could have one: a Manager dispatch never writes a local partial and already
-        // says so. Several candidate names are tried — a cancelled job knows its
-        // destination by routes of differing reliability — because guessing one wrong would
-        // reintroduce the same false claim inverted, reporting "nothing to resume" over a
-        // 30 GB partial sitting right there.
+        // says so.
+        //
+        // Keyed by the job's URL, because that is what the WRITER keys the staged file on
+        // (cachePathForUrl). My first version searched for `.<destination filename>.partial`
+        // — what "the partial for this download" sounds like, and not what is on disk. It
+        // would have reported "no partial" for every download that had one: the same false
+        // claim inverted, and pointing the more damaging way, since the original at least
+        // erred toward "your bytes are safe".
         const partials = new Map<string, { path: string; bytes: number } | null>();
         await Promise.all(
           list
             .filter((j) => j.status === "cancelled" && !j.viaManager)
             .map(async (j) => {
-              let fromUrl: string | undefined;
-              try {
-                fromUrl = new URL(j.url).pathname.split("/").filter(Boolean).pop();
-              } catch {
-                /* a non-URL source simply contributes no candidate */
-              }
-              partials.set(
-                `${j.id}\n${j.trayId}`,
-                await findResumablePartial([j.filename, j.path, j.destKey, fromUrl]),
-              );
+              partials.set(`${j.id}\n${j.trayId}`, await findResumablePartial(j.url));
             }),
         );
         const partialFor = (j: DownloadJob): { path: string; bytes: number } | null =>

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -26,6 +26,7 @@ import {
   type DownloadJob,
 } from "../services/download-jobs.js";
 import { readDownloadProgress } from "../services/download-progress.js";
+import { findResumablePartial } from "../services/download-cache.js";
 import { errorToToolResult, ModelError } from "../utils/errors.js";
 import {
   downloadCivitaiModelAction,
@@ -222,6 +223,37 @@ function stillWritingClause(route: DownloadRoute): string {
  * re-issue, while the stale note said doing that corrupts the file (codex
  * review). One function, so they cannot drift again.
  */
+/**
+ * What is ACTUALLY on disk for a cancelled download (#1370).
+ *
+ * The row this replaces said "the partial was left on disk and can be resumed by
+ * re-issuing the download (it picks up where it left off)" on the strength of
+ * `status === "cancelled"` alone. A reporter paused a 33 GB download because of that
+ * sentence, found nothing on disk, and restarted from zero. The sentence was not stale —
+ * it was never checked.
+ *
+ * Both answers are useful and neither is a failure: a partial means "re-issue and you keep
+ * these bytes", and no partial means "re-issue and you start over" — which is exactly the
+ * fact someone needs BEFORE spending the bandwidth, not after. The size is included
+ * because "resumable" without a number is not something you can weigh against restarting.
+ */
+function describePartial(partial: { path: string; bytes: number } | null): string {
+  if (!partial) {
+    return (
+      `NO partial was found on disk, so re-issuing this download starts from the ` +
+      `beginning. (Checked the download cache for a staged .partial under this file's ` +
+      `name.) That is not an error — but it is worth knowing before you re-issue a large ` +
+      `file.`
+    );
+  }
+  const gb = partial.bytes / 1024 ** 3;
+  const size = gb >= 1 ? `${gb.toFixed(2)} GB` : `${(partial.bytes / 1024 ** 2).toFixed(1)} MB`;
+  return (
+    `a partial of ${size} is on disk (${partial.path}) and re-issuing the same download ` +
+    `resumes from it.`
+  );
+}
+
 function afterCancelAdvice(route: DownloadRoute): string {
   switch (route) {
     case "manager":
@@ -968,6 +1000,36 @@ async function statusAction(args: {
         // listing actually contains a collision (two writers, one file).
         const idCounts = new Map<string, number>();
         for (const j of list) idCounts.set(j.id, (idCounts.get(j.id) ?? 0) + 1);
+        // #1370 — LOOK, then say. The cancelled row claimed "the partial was left on disk
+        // and can be resumed by re-issuing the download" purely from `status === "cancelled"`;
+        // nothing stat'd the file. A reporter paused a 33 GB download BECAUSE of that
+        // sentence, found no partial anywhere, and restarted from zero.
+        //
+        // Stat'd up front because the row builder below is synchronous, and only for rows
+        // that could have one: a Manager dispatch never writes a local partial and already
+        // says so. Several candidate names are tried — a cancelled job knows its
+        // destination by routes of differing reliability — because guessing one wrong would
+        // reintroduce the same false claim inverted, reporting "nothing to resume" over a
+        // 30 GB partial sitting right there.
+        const partials = new Map<string, { path: string; bytes: number } | null>();
+        await Promise.all(
+          list
+            .filter((j) => j.status === "cancelled" && !j.viaManager)
+            .map(async (j) => {
+              let fromUrl: string | undefined;
+              try {
+                fromUrl = new URL(j.url).pathname.split("/").filter(Boolean).pop();
+              } catch {
+                /* a non-URL source simply contributes no candidate */
+              }
+              partials.set(
+                `${j.id}\n${j.trayId}`,
+                await findResumablePartial([j.filename, j.path, j.destKey, fromUrl]),
+              );
+            }),
+        );
+        const partialFor = (j: DownloadJob): { path: string; bytes: number } | null =>
+          partials.get(`${j.id}\n${j.trayId}`) ?? null;
         const collidingIds = [...idCounts.entries()].filter(([, n]) => n > 1).map(([k]) => k);
         const lines = list.map((j) => {
           const p = readDownloadProgress(j.progressId ?? j.trayId);
@@ -1027,10 +1089,10 @@ async function statusAction(args: {
                         // left by a cancel (none may exist).
                         (j.viaManager
                           ? `\n    cancelled — the previous session's writer was confirmed GONE (its process no longer exists), so a later session closed its stale record; no live transfer was aborted. This was a remote ComfyUI-Manager dispatch: the host MAY still be fetching server-side (no Manager recall API) and there is NO local partial to resume — check list_local_models to see whether the file landed; re-issuing starts a NEW dispatch.`
-                          : `\n    cancelled — the previous session's writer was confirmed GONE (its process no longer exists), so a later session closed its stale record; no live transfer was aborted. Any .partial the dead writer left was untouched — re-issue the download to resume from it, or to restart cleanly if there is none.`)
+                          : `\n    cancelled — the previous session's writer was confirmed GONE (its process no longer exists), so a later session closed its stale record; no live transfer was aborted. ${describePartial(partialFor(j))}`)
                       : j.viaManager
                         ? `\n    cancelled — this was a remote ComfyUI-Manager dispatch, so there is NO local partial to resume, and the host MAY still be fetching server-side (there's no Manager recall API). Re-issuing starts a NEW server-side dispatch (a duplicate, not a resume). Check list_local_models to see whether the file landed before deciding.`
-                        : `\n    cancelled — the partial was left on disk and can be resumed by re-issuing the download (it picks up where it left off)`) +
+                        : `\n    cancelled — ${describePartial(partialFor(j))}`) +
                     // A recovery-critical note from cancellation cleanup (e.g. a previous
                     // destination file preserved under a .bak path because it couldn't be
                     // restored) — surface it so the user can recover, not mask it.


### PR DESCRIPTION
Draft — claiming #1370.

`download_model action:"cancel"` (and `status`) tell the user:

> cancelled — the partial was left on disk and can be resumed by re-issuing the download (it picks up where it left off)

The reporter paused a **33 GB** download *because* of that sentence, then found no partial anywhere and had to restart from zero.

**The message is asserted, never checked.** `src/tools/model-management.ts` picks that string from `j.status === "cancelled"` plus two flags (`reclaimedDead`, `viaManager`). Nothing stats the file. The partial lives at `~/.comfyui-mcp/cache/.<basename>.partial` — a location the reporter's scan covered — so on their machine the claim was simply false while the code had no way to know.

The surrounding branches are already careful: a Manager dispatch says there is NO local partial, and a reclaimed-dead writer says a partial *may* exist. Only the ordinary-cancel branch states a fact about the filesystem without consulting it, which is the #796 shape this repo keeps hitting — an unverified belief phrased as an observation.

Plan: stat the `.partial` and report what is actually there — its size, so "resumable" is a claim the user can act on, or its absence, so they can decide to restart rather than discovering it 33 GB later. A cancel that leaves nothing is not a bug in itself; telling someone it left something is.

Deliberately **not** in scope: *why* the bytes were missing. Candidates include a Manager-side dispatch whose `via_manager` flag was stripped (#1197) and local downloads being routed through Manager at all (#1374). Those are separate issues, and the message must be honest under every one of them rather than depending on which is true.

Refs #1370
