### PR TITLE
fix(1374): a local download should not need ComfyUI-Manager

### DIFF
--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -16,6 +16,10 @@ vi.mock("../../config.js", () => {
     // downloadModel branches on this; these tests always run with comfyuiPath
     // set (local mode), so it returns false.
     isRemoteMode: () => !config.comfyuiPath,
+    // #1374 — the route decision stamps the target it was made against, so this mock
+    // has to provide it. Faked rather than spread from the real config: these suites
+    // control `config` themselves and a real base URL would not match what they set.
+    getComfyUIBaseUrl: () => `http://127.0.0.1:8188`,
   };
 });
 

--- a/src/__tests__/services/download-retry.test.ts
+++ b/src/__tests__/services/download-retry.test.ts
@@ -21,7 +21,12 @@ vi.mock("../../config.js", () => {
     huggingfaceToken: undefined as string | undefined,
     civitaiApiToken: undefined as string | undefined,
   };
-  return { config, isRemoteMode: () => !config.comfyuiPath };
+  // #1374 — the route decision stamps the target it was made against.
+  return {
+    config,
+    isRemoteMode: () => !config.comfyuiPath,
+    getComfyUIBaseUrl: () => `http://127.0.0.1:8188`,
+  };
 });
 
 /** Every progress row the download machinery publishes. Recorded through a module

--- a/src/__tests__/services/manager-download-route-explained.test.ts
+++ b/src/__tests__/services/manager-download-route-explained.test.ts
@@ -49,78 +49,27 @@ vi.mock("../../comfyui/client.js", async (orig) => ({
   },
 }));
 
-const { explainManagerDownloadRoute, shouldDispatchDownloadToManager, resetRouteObservationForTests } =
-  await import("../../services/model-resolver.js");
+const { explainManagerDownloadRoute } = await import("../../services/model-resolver.js");
 
 afterEach(() => {
   hoisted.remote.value = false;
   hoisted.stats.value = undefined;
-  // The observation is process-global, so a test that does not clear it inherits the
-  // previous test's decision — which is the same staleness the production comment calls out.
-  resetRouteObservationForTests();
-  hoisted.target.value = "http://127.0.0.1:8188";
   hoisted.base.value = undefined;
 });
 
 describe("the download route explains ITSELF when Manager is the reason (#1374)", () => {
   it("REMOTE mode is normal and says so — not a misconfiguration", async () => {
     hoisted.remote.value = true;
-    await shouldDispatchDownloadToManager();
-    const why = explainManagerDownloadRoute();
+    const why = await explainManagerDownloadRoute();
     expect(why).toMatch(/REMOTE mode/);
     expect(why).toMatch(/by design/);
     // Must NOT tell a remote user to set COMFYUI_PATH — there is no local dir to stream to.
     expect(why).not.toMatch(/set COMFYUI_PATH/);
   });
 
-  it("explains NOTHING when no route was decided — it does not take a fresh reading", () => {
-    // The round-1 defect: the explainer re-read /system_stats on the error path, so a server
-    // that restarted in between was described as "did not answer", a state that routes LOCAL
-    // and therefore cannot be why Manager was chosen. It narrated a decision that never
-    // happened. With no recorded decision there is nothing truthful to say.
-    expect(explainManagerDownloadRoute()).toBe("");
-  });
 
-  it("an UNREACHABLE server explains nothing, because that state routes LOCAL", async () => {
-    // Reaching the explainer with this observation would mean the record and the route
-    // disagree. Inventing a reason there is how a diagnostic starts lying.
-    hoisted.stats.value = undefined;
-    await shouldDispatchDownloadToManager();
-    expect(explainManagerDownloadRoute()).toBe("");
-  });
 
-  it("a record that would have routed LOCAL explains nothing (codex: the stale-record case)", async () => {
-    // A record that would have chosen LOCAL cannot be why Manager was chosen, so there is
-    // nothing truthful to say and silence beats a confident wrong story.
-    //
-    // I originally justified this by arguing the record could not go stale under
-    // concurrency, since every routing input looked process-wide. That was wrong —
-    // setComfyuiTarget() mutates them at runtime — and the target stamp below is what
-    // actually closes it. The guard still earns its place for the time-based case, but the
-    // reasoning it shipped with did not survive review, which is worth leaving on the
-    // record next to it.
-    hoisted.stats.value = {
-      // An ABSOLUTE models dir: this is a record that would have routed LOCAL.
-      system: { argv: ["main.py", "--models-directory", "/srv/comfy/models"], cwd: "/srv/comfy" },
-    };
-    await shouldDispatchDownloadToManager();
-    expect(explainManagerDownloadRoute()).toBe("");
-  });
 
-  it("a record made against a DIFFERENT target explains nothing (codex round 3)", async () => {
-    // I argued this could not happen: every routing input looked process-wide, so two
-    // concurrent downloads had to observe the same thing. Wrong on a checkable fact —
-    // setComfyuiTarget() mutates host, port, remoteUrlActive and config.comfyuiPath at
-    // runtime, and a desktop `hello` invokes it. So download A records a Manager route,
-    // the target is retargeted, download B overwrites the record, and A's failure would be
-    // explained with B's observation.
-    hoisted.stats.value = { system: { argv: ["main.py"], cwd: undefined } };
-    await shouldDispatchDownloadToManager();
-    expect(explainManagerDownloadRoute()).not.toBe("");
-    // …the target moves under us.
-    hoisted.target.value = "http://127.0.0.1:8190";
-    expect(explainManagerDownloadRoute()).toBe("");
-  });
 
   it("a configured base does NOT suppress the relative-flag case (codex round 3)", async () => {
     // The predicate checks hasUnresolvableRelativeModelDirFlag FIRST — it deliberately
@@ -135,9 +84,21 @@ describe("the download route explains ITSELF when Manager is the reason (#1374)"
     hoisted.stats.value = {
       system: { argv: ["main.py", "--base-directory", "./models"], cwd: undefined },
     };
-    await shouldDispatchDownloadToManager();
-    const why = explainManagerDownloadRoute();
+    const why = await explainManagerDownloadRoute();
     expect(why).toMatch(/RELATIVE --base-directory/);
+  });
+
+  it("says the state is CURRENT, so it never claims to describe the routing decision", async () => {
+    // The whole subject of four review rounds. Every earlier version asserted it was
+    // narrating the decision — via a second /system_stats read, then a process-global
+    // record, then a target-stamped one — and each was shown to be describable-stale by a
+    // route the previous fix had not considered. The claim is what changed: this reports
+    // what it can see now, and says so, which cannot be wrong about a decision it does not
+    // mention.
+    hoisted.stats.value = { system: { argv: ["main.py"], cwd: undefined } };
+    const why = await explainManagerDownloadRoute();
+    expect(why).toMatch(/Reading the connected server NOW/);
+    expect(why).toMatch(/may not be what the routing decision saw/);
   });
 
   it("names the ARGV AND CWD it actually saw, because that is what identifies the case", async () => {
@@ -146,8 +107,7 @@ describe("the download route explains ITSELF when Manager is the reason (#1374)"
     // The real shape a Windows ComfyUI reports: a RELATIVE main.py and no cwd at all.
     const argv0 = String.raw`ComfyUI\main.py`;
     hoisted.stats.value = { system: { argv: [argv0, "--listen"], cwd: undefined } };
-    await shouldDispatchDownloadToManager();
-    const why = explainManagerDownloadRoute();
+    const why = await explainManagerDownloadRoute();
     expect(why).toContain(argv0);
     expect(why).toMatch(/cwd=\(not reported\)/);
     expect(why).toMatch(/set COMFYUI_PATH/);
@@ -164,8 +124,7 @@ describe("the download route explains ITSELF when Manager is the reason (#1374)"
     hoisted.stats.value = {
       system: { argv: ["main.py", "--base-directory", "./models"], cwd: undefined },
     };
-    await shouldDispatchDownloadToManager();
-    const why = explainManagerDownloadRoute();
+    const why = await explainManagerDownloadRoute();
     expect(why).toMatch(/RELATIVE --base-directory/);
     expect(why).toMatch(/ABSOLUTE --base-directory/);
   });

--- a/src/__tests__/services/manager-download-route-explained.test.ts
+++ b/src/__tests__/services/manager-download-route-explained.test.ts
@@ -19,14 +19,12 @@ import { describe, expect, it, vi, afterEach } from "vitest";
 const hoisted = vi.hoisted(() => ({
   remote: { value: false },
   stats: { value: undefined as unknown },
-  target: { value: "http://127.0.0.1:8188" },
   base: { value: undefined as string | undefined },
 }));
 
 vi.mock("../../config.js", async (orig) => ({
   ...(await orig<Record<string, unknown>>()),
   isRemoteMode: () => hoisted.remote.value,
-  getComfyUIBaseUrl: () => hoisted.target.value,
   config: { get comfyuiPath() { return hoisted.base.value; } },
 }));
 
@@ -55,6 +53,25 @@ afterEach(() => {
   hoisted.remote.value = false;
   hoisted.stats.value = undefined;
   hoisted.base.value = undefined;
+});
+
+describe("the explanation is AWAITED before it reaches the message (#1374)", () => {
+  it("the dispatch site awaits it — an un-awaited call renders [object Promise]", async () => {
+    // Codex P1, and it would have shipped. The explainer became async while its single
+    // caller still treated it as a string, so every non-abort Manager failure would have
+    // appended "WHY THIS WENT THROUGH ComfyUI-Manager AT ALL: [object Promise]" — the
+    // message this whole issue is about, replaced by a worse one.
+    //
+    // My `await` edit was in a shell command that died with a syntax error, so it never
+    // applied, and nothing else in the suite renders the final string. This asserts on the
+    // SOURCE because the failure is at the call site, not in the function.
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(new URL("../../services/model-resolver.ts", import.meta.url), "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*/g, "");
+    expect(src).toMatch(/await explainManagerDownloadRoute\(\)/);
+    expect(src).not.toMatch(/[^t] explainManagerDownloadRoute\(\);/);
+  });
 });
 
 describe("the download route explains ITSELF when Manager is the reason (#1374)", () => {

--- a/src/__tests__/services/manager-download-route-explained.test.ts
+++ b/src/__tests__/services/manager-download-route-explained.test.ts
@@ -83,6 +83,22 @@ describe("the download route explains ITSELF when Manager is the reason (#1374)"
     expect(explainManagerDownloadRoute()).toBe("");
   });
 
+  it("a record that would have routed LOCAL explains nothing (codex: the stale-record case)", async () => {
+    // The record is process-global. Interleaving alone cannot make two downloads disagree —
+    // every routing input is process-wide or reads the one connected server — but a server
+    // restarting between two decisions can, and concurrency widens that window.
+    //
+    // So the failure is made unreachable rather than argued about: a record that would have
+    // chosen LOCAL cannot be why Manager was chosen, and silence beats a confident wrong
+    // story. That is this issue's own lesson applied to its own fix.
+    hoisted.stats.value = {
+      // An ABSOLUTE models dir: this is a record that would have routed LOCAL.
+      system: { argv: ["main.py", "--models-directory", "/srv/comfy/models"], cwd: "/srv/comfy" },
+    };
+    await shouldDispatchDownloadToManager();
+    expect(explainManagerDownloadRoute()).toBe("");
+  });
+
   it("names the ARGV AND CWD it actually saw, because that is what identifies the case", async () => {
     // The reporter's report had no argv, and without it neither they nor I can tell which
     // of the conditions fired. Putting the observation in the message is the whole point.

--- a/src/__tests__/services/manager-download-route-explained.test.ts
+++ b/src/__tests__/services/manager-download-route-explained.test.ts
@@ -45,30 +45,42 @@ vi.mock("../../comfyui/client.js", async (orig) => ({
   },
 }));
 
-const { explainManagerDownloadRoute } = await import("../../services/model-resolver.js");
+const { explainManagerDownloadRoute, shouldDispatchDownloadToManager, resetRouteObservationForTests } =
+  await import("../../services/model-resolver.js");
 
 afterEach(() => {
   hoisted.remote.value = false;
   hoisted.stats.value = undefined;
+  // The observation is process-global, so a test that does not clear it inherits the
+  // previous test's decision — which is the same staleness the production comment calls out.
+  resetRouteObservationForTests();
 });
 
 describe("the download route explains ITSELF when Manager is the reason (#1374)", () => {
-  it("REMOTE mode is normal and says so — not a misconfiguration", () => {
+  it("REMOTE mode is normal and says so — not a misconfiguration", async () => {
     hoisted.remote.value = true;
-    return explainManagerDownloadRoute().then((why) => {
-      expect(why).toMatch(/REMOTE mode/);
-      expect(why).toMatch(/by design/);
-      // Must NOT tell a remote user to set COMFYUI_PATH — there is no local dir to stream to.
-      expect(why).not.toMatch(/set COMFYUI_PATH/);
-    });
+    await shouldDispatchDownloadToManager();
+    const why = explainManagerDownloadRoute();
+    expect(why).toMatch(/REMOTE mode/);
+    expect(why).toMatch(/by design/);
+    // Must NOT tell a remote user to set COMFYUI_PATH — there is no local dir to stream to.
+    expect(why).not.toMatch(/set COMFYUI_PATH/);
   });
 
-  it("an unreachable server says the layout could not be read, and claims nothing more", async () => {
-    hoisted.stats.value = undefined; // getSystemStats throws
-    const why = await explainManagerDownloadRoute();
-    expect(why).toMatch(/did not answer \/system_stats/);
-    // No remedy is invented for a case where nothing was observed.
-    expect(why).not.toMatch(/FIX:/);
+  it("explains NOTHING when no route was decided — it does not take a fresh reading", () => {
+    // The round-1 defect: the explainer re-read /system_stats on the error path, so a server
+    // that restarted in between was described as "did not answer", a state that routes LOCAL
+    // and therefore cannot be why Manager was chosen. It narrated a decision that never
+    // happened. With no recorded decision there is nothing truthful to say.
+    expect(explainManagerDownloadRoute()).toBe("");
+  });
+
+  it("an UNREACHABLE server explains nothing, because that state routes LOCAL", async () => {
+    // Reaching the explainer with this observation would mean the record and the route
+    // disagree. Inventing a reason there is how a diagnostic starts lying.
+    hoisted.stats.value = undefined;
+    await shouldDispatchDownloadToManager();
+    expect(explainManagerDownloadRoute()).toBe("");
   });
 
   it("names the ARGV AND CWD it actually saw, because that is what identifies the case", async () => {
@@ -77,7 +89,8 @@ describe("the download route explains ITSELF when Manager is the reason (#1374)"
     // The real shape a Windows ComfyUI reports: a RELATIVE main.py and no cwd at all.
     const argv0 = String.raw`ComfyUI\main.py`;
     hoisted.stats.value = { system: { argv: [argv0, "--listen"], cwd: undefined } };
-    const why = await explainManagerDownloadRoute();
+    await shouldDispatchDownloadToManager();
+    const why = explainManagerDownloadRoute();
     expect(why).toContain(argv0);
     expect(why).toMatch(/cwd=\(not reported\)/);
     expect(why).toMatch(/set COMFYUI_PATH/);
@@ -90,7 +103,8 @@ describe("the download route explains ITSELF when Manager is the reason (#1374)"
     hoisted.stats.value = {
       system: { argv: ["main.py", "--base-directory", "./models"], cwd: undefined },
     };
-    const why = await explainManagerDownloadRoute();
+    await shouldDispatchDownloadToManager();
+    const why = explainManagerDownloadRoute();
     expect(why).toMatch(/RELATIVE --base-directory/);
     expect(why).toMatch(/ABSOLUTE --base-directory/);
   });

--- a/src/__tests__/services/manager-download-route-explained.test.ts
+++ b/src/__tests__/services/manager-download-route-explained.test.ts
@@ -1,0 +1,97 @@
+// #1374 — a LOCAL download hard-failed with "ComfyUI-Manager's queue API is not reachable",
+// blocking ~45 GB of weights on an install that needs no Manager at all. The reporter used
+// curl instead.
+//
+// The error is raised deep in generic Manager code that cannot know it is serving a
+// download, so it named the thing that BROKE (Manager) and not the decision that made
+// Manager necessary (this MCP could not resolve where the server keeps its models). Only
+// the second has a remedy the user can apply, and nothing in the reply distinguished it
+// from "your ComfyUI is remote, this is normal".
+//
+// THIS IS NOT A ROUTING CHANGE, and the tests say so. I could not reproduce the reporter's
+// decision here — a live ComfyUI on this machine reports a relative main.py and NO cwd and
+// still resolves, because the process-table probe anchors it. Guessing at which of six
+// conditions fires for them, and "fixing" that, is the unverified confidence this codebase
+// keeps paying for. What ships is the answer being visible in their next report.
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  remote: { value: false },
+  stats: { value: undefined as unknown },
+}));
+
+vi.mock("../../config.js", async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  isRemoteMode: () => hoisted.remote.value,
+}));
+
+// The live-probe gate (#1263) is right to demand this: `resolveLiveInterpreter` shells out
+// to find the python actually serving the port on THIS machine, so without the stub these
+// tests assert one thing where ComfyUI is running and another where it is not — and CI is
+// one of the machines where they pass. That is the exact defect class the gate exists for,
+// and it caught me one commit after I wrote a test asserting a message about process
+// resolution.
+vi.mock("../../services/live-interpreter.js", async () => ({
+  ...(await vi.importActual<Record<string, unknown>>("../../services/live-interpreter.js")),
+  resolveLiveInterpreter: () => undefined,
+}));
+
+vi.mock("../../comfyui/client.js", async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  getSystemStats: async () => {
+    if (hoisted.stats.value === undefined) throw new Error("unreachable");
+    return hoisted.stats.value;
+  },
+}));
+
+const { explainManagerDownloadRoute } = await import("../../services/model-resolver.js");
+
+afterEach(() => {
+  hoisted.remote.value = false;
+  hoisted.stats.value = undefined;
+});
+
+describe("the download route explains ITSELF when Manager is the reason (#1374)", () => {
+  it("REMOTE mode is normal and says so — not a misconfiguration", () => {
+    hoisted.remote.value = true;
+    return explainManagerDownloadRoute().then((why) => {
+      expect(why).toMatch(/REMOTE mode/);
+      expect(why).toMatch(/by design/);
+      // Must NOT tell a remote user to set COMFYUI_PATH — there is no local dir to stream to.
+      expect(why).not.toMatch(/set COMFYUI_PATH/);
+    });
+  });
+
+  it("an unreachable server says the layout could not be read, and claims nothing more", async () => {
+    hoisted.stats.value = undefined; // getSystemStats throws
+    const why = await explainManagerDownloadRoute();
+    expect(why).toMatch(/did not answer \/system_stats/);
+    // No remedy is invented for a case where nothing was observed.
+    expect(why).not.toMatch(/FIX:/);
+  });
+
+  it("names the ARGV AND CWD it actually saw, because that is what identifies the case", async () => {
+    // The reporter's report had no argv, and without it neither they nor I can tell which
+    // of the conditions fired. Putting the observation in the message is the whole point.
+    // The real shape a Windows ComfyUI reports: a RELATIVE main.py and no cwd at all.
+    const argv0 = String.raw`ComfyUI\main.py`;
+    hoisted.stats.value = { system: { argv: [argv0, "--listen"], cwd: undefined } };
+    const why = await explainManagerDownloadRoute();
+    expect(why).toContain(argv0);
+    expect(why).toMatch(/cwd=\(not reported\)/);
+    expect(why).toMatch(/set COMFYUI_PATH/);
+    expect(why).toMatch(/#1374/);
+  });
+
+  it("a RELATIVE --base-directory with no cwd is called out specifically", async () => {
+    // This one has a different remedy (an absolute --base-directory), and lumping it in
+    // with the generic case would send the user to a fix that does not apply.
+    hoisted.stats.value = {
+      system: { argv: ["main.py", "--base-directory", "./models"], cwd: undefined },
+    };
+    const why = await explainManagerDownloadRoute();
+    expect(why).toMatch(/RELATIVE --base-directory/);
+    expect(why).toMatch(/ABSOLUTE --base-directory/);
+  });
+});

--- a/src/__tests__/services/manager-download-route-explained.test.ts
+++ b/src/__tests__/services/manager-download-route-explained.test.ts
@@ -19,11 +19,15 @@ import { describe, expect, it, vi, afterEach } from "vitest";
 const hoisted = vi.hoisted(() => ({
   remote: { value: false },
   stats: { value: undefined as unknown },
+  target: { value: "http://127.0.0.1:8188" },
+  base: { value: undefined as string | undefined },
 }));
 
 vi.mock("../../config.js", async (orig) => ({
   ...(await orig<Record<string, unknown>>()),
   isRemoteMode: () => hoisted.remote.value,
+  getComfyUIBaseUrl: () => hoisted.target.value,
+  config: { get comfyuiPath() { return hoisted.base.value; } },
 }));
 
 // The live-probe gate (#1263) is right to demand this: `resolveLiveInterpreter` shells out
@@ -54,6 +58,8 @@ afterEach(() => {
   // The observation is process-global, so a test that does not clear it inherits the
   // previous test's decision — which is the same staleness the production comment calls out.
   resetRouteObservationForTests();
+  hoisted.target.value = "http://127.0.0.1:8188";
+  hoisted.base.value = undefined;
 });
 
 describe("the download route explains ITSELF when Manager is the reason (#1374)", () => {
@@ -84,19 +90,54 @@ describe("the download route explains ITSELF when Manager is the reason (#1374)"
   });
 
   it("a record that would have routed LOCAL explains nothing (codex: the stale-record case)", async () => {
-    // The record is process-global. Interleaving alone cannot make two downloads disagree —
-    // every routing input is process-wide or reads the one connected server — but a server
-    // restarting between two decisions can, and concurrency widens that window.
+    // A record that would have chosen LOCAL cannot be why Manager was chosen, so there is
+    // nothing truthful to say and silence beats a confident wrong story.
     //
-    // So the failure is made unreachable rather than argued about: a record that would have
-    // chosen LOCAL cannot be why Manager was chosen, and silence beats a confident wrong
-    // story. That is this issue's own lesson applied to its own fix.
+    // I originally justified this by arguing the record could not go stale under
+    // concurrency, since every routing input looked process-wide. That was wrong —
+    // setComfyuiTarget() mutates them at runtime — and the target stamp below is what
+    // actually closes it. The guard still earns its place for the time-based case, but the
+    // reasoning it shipped with did not survive review, which is worth leaving on the
+    // record next to it.
     hoisted.stats.value = {
       // An ABSOLUTE models dir: this is a record that would have routed LOCAL.
       system: { argv: ["main.py", "--models-directory", "/srv/comfy/models"], cwd: "/srv/comfy" },
     };
     await shouldDispatchDownloadToManager();
     expect(explainManagerDownloadRoute()).toBe("");
+  });
+
+  it("a record made against a DIFFERENT target explains nothing (codex round 3)", async () => {
+    // I argued this could not happen: every routing input looked process-wide, so two
+    // concurrent downloads had to observe the same thing. Wrong on a checkable fact —
+    // setComfyuiTarget() mutates host, port, remoteUrlActive and config.comfyuiPath at
+    // runtime, and a desktop `hello` invokes it. So download A records a Manager route,
+    // the target is retargeted, download B overwrites the record, and A's failure would be
+    // explained with B's observation.
+    hoisted.stats.value = { system: { argv: ["main.py"], cwd: undefined } };
+    await shouldDispatchDownloadToManager();
+    expect(explainManagerDownloadRoute()).not.toBe("");
+    // …the target moves under us.
+    hoisted.target.value = "http://127.0.0.1:8190";
+    expect(explainManagerDownloadRoute()).toBe("");
+  });
+
+  it("a configured base does NOT suppress the relative-flag case (codex round 3)", async () => {
+    // The predicate checks hasUnresolvableRelativeModelDirFlag FIRST — it deliberately
+    // wins over the configured-base short-circuit — so this combination legitimately
+    // routes to Manager. My consistency guard checked the base first and suppressed the
+    // explanation for exactly the case that most needs it: a false negative introduced by
+    // a check meant to prevent false positives.
+    // A CONFIGURED BASE IS PRESENT — without it this test cannot see the defect at all,
+    // because the guard it is about only fires when resolveEffectiveComfyUIBase() is
+    // truthy. Mutation testing caught that: reordering the guards left it green.
+    hoisted.base.value = "/some/configured/install";
+    hoisted.stats.value = {
+      system: { argv: ["main.py", "--base-directory", "./models"], cwd: undefined },
+    };
+    await shouldDispatchDownloadToManager();
+    const why = explainManagerDownloadRoute();
+    expect(why).toMatch(/RELATIVE --base-directory/);
   });
 
   it("names the ARGV AND CWD it actually saw, because that is what identifies the case", async () => {
@@ -116,6 +157,10 @@ describe("the download route explains ITSELF when Manager is the reason (#1374)"
   it("a RELATIVE --base-directory with no cwd is called out specifically", async () => {
     // This one has a different remedy (an absolute --base-directory), and lumping it in
     // with the generic case would send the user to a fix that does not apply.
+    // A CONFIGURED BASE IS PRESENT — without it this test cannot see the defect at all,
+    // because the guard it is about only fires when resolveEffectiveComfyUIBase() is
+    // truthy. Mutation testing caught that: reordering the guards left it green.
+    hoisted.base.value = "/some/configured/install";
     hoisted.stats.value = {
       system: { argv: ["main.py", "--base-directory", "./models"], cwd: undefined },
     };

--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -18,6 +18,10 @@ vi.mock("../../config.js", () => {
   return {
     config,
     isRemoteMode: () => remoteOverride.value ?? !config.comfyuiPath,
+    // #1374 — the route decision stamps the target it was made against, so this mock
+    // has to provide it. Faked rather than spread from the real config: these suites
+    // control `config` themselves and a real base URL would not match what they set.
+    getComfyUIBaseUrl: () => `http://127.0.0.1:8188`,
   };
 });
 /** Per-test override for isRemoteMode; null = derive from comfyuiPath (legacy). */

--- a/src/__tests__/tools/model-extras.test.ts
+++ b/src/__tests__/tools/model-extras.test.ts
@@ -12,6 +12,10 @@ vi.mock("../../config.js", () => {
     config,
     isLocalMode: () => Boolean(config.comfyuiPath),
     isRemoteMode: () => !config.comfyuiPath,
+    // #1374 — the route decision stamps the target it was made against, so this mock
+    // has to provide it. Faked rather than spread from the real config: these suites
+    // control `config` themselves and a real base URL would not match what they set.
+    getComfyUIBaseUrl: () => `http://127.0.0.1:8188`,
   };
 });
 

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -2803,10 +2803,11 @@ WHY THIS WENT THROUGH ComfyUI-Manager AT ALL: ${why}`, {
  * restarted between the two reads produced an explanation of a state that would have routed
  * LOCAL, i.e. an explanation for a decision that never happened.
  */
-type RouteObservation =
+type RouteObservation = { target: string } & (
   | { remote: true }
   | { remote: false; unreachable: true }
-  | { remote: false; argv?: string[]; cwd?: string };
+  | { remote: false; argv?: string[]; cwd?: string }
+);
 let lastRouteObservation: RouteObservation | undefined;
 
 /**
@@ -2851,6 +2852,18 @@ export function resetRouteObservationForTests(): void {
  */
 export function explainManagerDownloadRoute(): string {
   const obs = lastRouteObservation;
+  // THE RECORD MUST BELONG TO THE TARGET WE ARE TALKING ABOUT (codex round 3).
+  //
+  // I argued this could not go wrong: every routing input looked process-wide, so two
+  // concurrent downloads had to observe the same thing. That was wrong on a checkable
+  // fact. `setComfyuiTarget()` mutates host, port, remoteUrlActive and config.comfyuiPath
+  // at RUNTIME — a desktop `hello` invokes it — so download A can record a Manager route,
+  // the target can be retargeted, download B can overwrite the record, and A's failure
+  // then gets explained with B's observation.
+  //
+  // Stamping the target makes the mismatch detectable instead of arguable: a record from a
+  // different target explains nothing.
+  if (obs && obs.target !== getComfyUIBaseUrl()) return "";
   if (!obs) {
     // No recorded decision. Say that rather than taking a fresh reading and narrating it as
     // though it were the one that mattered.
@@ -2872,20 +2885,26 @@ export function explainManagerDownloadRoute(): string {
   const { argv, cwd } = obs;
   // THE RECORD MUST BE CONSISTENT WITH HAVING CHOSEN MANAGER, or say nothing.
   //
-  // Codex called the process-global record unsafe under concurrent downloads. Measured
-  // against the predicate's inputs, interleaving alone cannot produce a disagreement: the
-  // route is decided from isRemoteMode() (process-wide), one connected server's
-  // /system_stats, and process-wide config — so two downloads in one process observe the
-  // same thing. What CAN differ is time: a server restarting between two decisions, which
-  // concurrency widens the window for.
+  // The record can go stale in TIME (a server restarting between two decisions). I also
+  // argued it could not go stale under concurrency, because every routing input looked
+  // process-wide — that was wrong, setComfyuiTarget() mutates them at runtime, and the
+  // target stamp above is what closes that. This guard covers the remaining case.
   //
   // Rather than argue the odds, the failure is made unreachable. If the recorded
   // observation would have routed LOCAL, it cannot be why Manager was chosen, so there is
   // nothing truthful to say and this returns "". A stale record now costs a missing
   // explanation instead of a confident wrong one — which is the whole subject of this
   // issue, applied to my own diagnostic.
-  if (resolveEffectiveComfyUIBase()) return "";
-  if (parseModelsDirFromArgv(argv, cwd)) return "";
+  // ORDER MATTERS, and mine did not match the predicate's (codex round 3). The route is
+  // decided with `hasUnresolvableRelativeModelDirFlag` FIRST — it deliberately wins over
+  // the configured-base short-circuit — so a configured COMFYUI_PATH alongside an
+  // unresolvable relative model-dir flag legitimately routes to Manager. My guard checked
+  // the base first and suppressed the explanation for exactly that case: a false negative
+  // introduced by a consistency check.
+  if (!hasUnresolvableRelativeModelDirFlag(argv, cwd)) {
+    if (resolveEffectiveComfyUIBase()) return "";
+    if (parseModelsDirFromArgv(argv, cwd)) return "";
+  }
   const detail =
     `The server reported argv[0]=${argv?.[0] ?? "(none)"} and cwd=${cwd ?? "(not reported)"} ` +
     `when this route was chosen.`;
@@ -2920,7 +2939,7 @@ export function explainManagerDownloadRoute(): string {
 
 export async function shouldDispatchDownloadToManager(): Promise<boolean> {
   if (isRemoteMode()) {
-    lastRouteObservation = { remote: true };
+    lastRouteObservation = { target: getComfyUIBaseUrl(), remote: true };
     return true;
   }
   try {
@@ -2933,7 +2952,7 @@ export async function shouldDispatchDownloadToManager(): Promise<boolean> {
     // as "did not answer /system_stats", a state that would have routed LOCAL and so cannot
     // be why Manager was chosen. A diagnostic that narrates a decision must narrate the
     // decision that happened, not a fresh one.
-    lastRouteObservation = { remote: false, argv, cwd };
+    lastRouteObservation = { target: getComfyUIBaseUrl(), remote: false, argv, cwd };
     // Ask the LIVE server FIRST. A server launched with a RELATIVE
     // --base-directory/--models-directory that did NOT report its cwd has an UNKNOWN
     // real models dir: any local guess (COMFYUI_PATH or the main.py root) would be
@@ -2973,7 +2992,7 @@ export async function shouldDispatchDownloadToManager(): Promise<boolean> {
   } catch {
     // No reachable server → nothing to dispatch to. A configured local base still
     // streams local; otherwise let the local resolver surface its clear error.
-    lastRouteObservation = { remote: false, unreachable: true };
+    lastRouteObservation = { target: getComfyUIBaseUrl(), remote: false, unreachable: true };
     return false;
   }
 }

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -2775,6 +2775,86 @@ async function downloadModelViaManagerRemote(
  * no server is reachable, so the local resolver surfaces its clear, actionable error
  * rather than silently succeeding.
  */
+/**
+ * WHY a download was routed to ComfyUI-Manager (#1374).
+ *
+ * The reporter's LOCAL Windows-portable install could not download anything: every attempt
+ * died on "ComfyUI-Manager's queue API is not reachable", for a capability that needs no
+ * Manager at all. ~45 GB of weights, worked around with `curl`.
+ *
+ * The routing decision itself is a bare boolean produced by six conditions, and the error
+ * they saw is raised deep in generic Manager code that cannot know it is serving a
+ * download — so the message named the thing that failed (Manager) rather than the thing
+ * that made Manager necessary (an install root this MCP could not resolve). Nothing in the
+ * reply distinguished "your ComfyUI is remote" from "I could not work out where your local
+ * ComfyUI keeps its models", and only the second has a remedy the user can apply.
+ *
+ * This re-derives the decision for the ERROR PATH only, and reports which condition sent
+ * it to Manager. It is deliberately a separate read rather than a value threaded through
+ * the predicate: the predicate is on the hot path for every download and is already
+ * carefully single-evaluation for split-brain reasons (#420), and a diagnostic must not
+ * change what it returns.
+ *
+ * NOT a routing change. I could not reproduce the reporter's decision on this machine — a
+ * live ComfyUI here reports a relative `main.py` and NO cwd, and still resolves, because
+ * the process-table probe anchors it. So I do not yet know which of the six conditions
+ * fires for them, and guessing at the fix would be exactly the unverified confidence this
+ * codebase keeps paying for. This makes the answer visible in their next report.
+ */
+export async function explainManagerDownloadRoute(): Promise<string> {
+  if (isRemoteMode()) {
+    return (
+      "This MCP is in REMOTE mode (--comfyui-url), so a download is dispatched to the " +
+      "connected ComfyUI's Manager by design — there is no local models directory to " +
+      "stream into. Manager must be installed and enabled on that host."
+    );
+  }
+  let argv: string[] | undefined;
+  let cwd: string | undefined;
+  try {
+    const stats = await getSystemStats();
+    argv = (stats as { system?: { argv?: string[] } })?.system?.argv;
+    cwd = (stats as { system?: { cwd?: string } })?.system?.cwd;
+  } catch {
+    return (
+      "The connected ComfyUI did not answer /system_stats, so its install layout could " +
+      "not be read at all."
+    );
+  }
+  // Rendered RAW, not JSON.stringify'd: a Windows argv comes back as
+  // `"ComfyUI\main.py"` with doubled backslashes, which the reader then has to mentally
+  // un-escape in the one line that exists to be pasted into a bug report.
+  const detail =
+    `The server reports argv[0]=${argv?.[0] ?? "(none)"} and cwd=${cwd ?? "(not reported)"}.`;
+  if (hasUnresolvableRelativeModelDirFlag(argv, cwd)) {
+    return (
+      `Your ComfyUI was started with a RELATIVE --base-directory/--models-directory and did ` +
+      `not report its working directory, so this MCP cannot tell where its models actually ` +
+      `live — writing locally would put the file somewhere the server never reads. ${detail} ` +
+      `FIX: restart ComfyUI with an ABSOLUTE --base-directory, or set COMFYUI_PATH to the ` +
+      `install root, and a local download will stream directly with no Manager involved.`
+    );
+  }
+  const liveRoot = resolveLiveServerRoot(argv, cwd, { remote: false });
+  if (liveRoot.root && !existsSync(liveRoot.root)) {
+    return (
+      `The connected ComfyUI reports its install root as ${liveRoot.root}, which does not ` +
+      `exist on THIS machine — it is a container-side or remote path (a Docker/SSH-forwarded ` +
+      `loopback server looks local but is not). Writing there would create a bogus directory ` +
+      `instead of reaching the server, so the fetch is handed to its Manager. ${detail} ` +
+      `FIX: enable Manager on that host, or run this MCP where the models directory really is.`
+    );
+  }
+  return (
+    `This MCP could not resolve where the connected ComfyUI keeps its models, so it handed ` +
+    `the fetch to that server's Manager instead of streaming locally. ${detail} ` +
+    `FIX: set COMFYUI_PATH to the ComfyUI install root (the directory containing main.py) — ` +
+    `a local download then streams directly and needs no Manager. Please include this whole ` +
+    `paragraph if you report it (#1374): the argv/cwd above is what identifies which case ` +
+    `this is.`
+  );
+}
+
 export async function shouldDispatchDownloadToManager(): Promise<boolean> {
   if (isRemoteMode()) return true;
   try {
@@ -2886,7 +2966,33 @@ export async function downloadModel(
   if (routeToManager) {
     // Thread the PRE-rewrite HF identity so the flip probe's credential derivation keeps the
     // HF token flowing to an HF_ENDPOINT mirror (matches the local path below).
-    return downloadModelViaManagerRemote(url, targetSubfolder, filename, auth, signal, wasHfUrl);
+    try {
+      return await downloadModelViaManagerRemote(url, targetSubfolder, filename, auth, signal, wasHfUrl);
+    } catch (err) {
+      // #1374 — SAY WHAT MADE MANAGER NECESSARY, not just that Manager failed.
+      //
+      // The reporter's LOCAL install could not download at all: every attempt died on
+      // "ComfyUI-Manager's queue API is not reachable", raised deep in generic Manager code
+      // that cannot know it is serving a download. The message named the thing that broke
+      // and not the decision that put them there, so a local-only capability read as
+      // "install Manager" when the real answer was "this MCP could not find your models
+      // directory". They downloaded 45 GB with curl instead.
+      //
+      // A cancel is not a routing problem and must pass through untouched.
+      if (err instanceof DOMException && err.name === "AbortError") throw err;
+      // unknown-ok: this is a DIAGNOSTIC wrapped around a real error, and the empty
+      // string is consumed one line below as "append nothing", not as "there is no
+      // reason". If the explainer itself fails, the caller must still receive the
+      // original Manager failure verbatim — swallowing that to report a diagnostic's
+      // failure would replace the user's actual problem with mine. The raw error is
+      // never conditional on this succeeding.
+      const why = await explainManagerDownloadRoute().catch(() => "");
+      const raw = err instanceof Error ? err.message : String(err);
+      throw new ModelError(
+        why ? `${raw}\n\nWHY THIS WENT THROUGH ComfyUI-Manager AT ALL: ${why}` : raw,
+        { url },
+      );
+    }
   }
 
   // Root the destination at the LIVE server's models dir (its --base-directory),

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -2776,6 +2776,35 @@ async function downloadModelViaManagerRemote(
  * rather than silently succeeding.
  */
 /**
+ * What `shouldDispatchDownloadToManager()` actually saw when it last chose a route (#1374).
+ *
+ * Single-process, single-decision: the predicate is deliberately evaluated ONCE per
+ * download and threaded to the writer (#420), so the error path must describe THAT
+ * evaluation rather than take a second look. Re-reading was a real defect — a server that
+ * restarted between the two reads produced an explanation of a state that would have routed
+ * LOCAL, i.e. an explanation for a decision that never happened.
+ */
+type RouteObservation =
+  | { remote: true }
+  | { remote: false; unreachable: true }
+  | { remote: false; argv?: string[]; cwd?: string };
+let lastRouteObservation: RouteObservation | undefined;
+
+/**
+ * SCOPE, stated because a diagnostic that overstates its own reach is the thing this issue
+ * is about: the record is process-global and describes the MOST RECENT routing decision.
+ * `downloadModel` is usually handed a route decided earlier by `startDownloadJob` (#420
+ * threads it so the writer cannot diverge from the job key), so the observation belongs to
+ * that decision — correct for the common case, and capable of describing a previous
+ * download if the connected server restarted with different arguments in between. The text
+ * therefore says "when this route was chosen" rather than asserting a current state, and
+ * every branch that cannot support a claim returns "" instead of guessing.
+ */
+export function resetRouteObservationForTests(): void {
+  lastRouteObservation = undefined;
+}
+
+/**
  * WHY a download was routed to ComfyUI-Manager (#1374).
  *
  * The reporter's LOCAL Windows-portable install could not download anything: every attempt
@@ -2801,31 +2830,30 @@ async function downloadModelViaManagerRemote(
  * fires for them, and guessing at the fix would be exactly the unverified confidence this
  * codebase keeps paying for. This makes the answer visible in their next report.
  */
-export async function explainManagerDownloadRoute(): Promise<string> {
-  if (isRemoteMode()) {
+export function explainManagerDownloadRoute(): string {
+  const obs = lastRouteObservation;
+  if (!obs) {
+    // No recorded decision. Say that rather than taking a fresh reading and narrating it as
+    // though it were the one that mattered.
+    return "";
+  }
+  if (obs.remote) {
     return (
       "This MCP is in REMOTE mode (--comfyui-url), so a download is dispatched to the " +
       "connected ComfyUI's Manager by design — there is no local models directory to " +
       "stream into. Manager must be installed and enabled on that host."
     );
   }
-  let argv: string[] | undefined;
-  let cwd: string | undefined;
-  try {
-    const stats = await getSystemStats();
-    argv = (stats as { system?: { argv?: string[] } })?.system?.argv;
-    cwd = (stats as { system?: { cwd?: string } })?.system?.cwd;
-  } catch {
-    return (
-      "The connected ComfyUI did not answer /system_stats, so its install layout could " +
-      "not be read at all."
-    );
+  if ("unreachable" in obs) {
+    // This state routes LOCAL, so it can never be why Manager was chosen. Reaching here
+    // means the recorded observation and the route disagree, which is worth saying rather
+    // than inventing a reason.
+    return "";
   }
-  // Rendered RAW, not JSON.stringify'd: a Windows argv comes back as
-  // `"ComfyUI\main.py"` with doubled backslashes, which the reader then has to mentally
-  // un-escape in the one line that exists to be pasted into a bug report.
+  const { argv, cwd } = obs;
   const detail =
-    `The server reports argv[0]=${argv?.[0] ?? "(none)"} and cwd=${cwd ?? "(not reported)"}.`;
+    `The server reported argv[0]=${argv?.[0] ?? "(none)"} and cwd=${cwd ?? "(not reported)"} ` +
+    `when this route was chosen.`;
   if (hasUnresolvableRelativeModelDirFlag(argv, cwd)) {
     return (
       `Your ComfyUI was started with a RELATIVE --base-directory/--models-directory and did ` +
@@ -2856,11 +2884,21 @@ export async function explainManagerDownloadRoute(): Promise<string> {
 }
 
 export async function shouldDispatchDownloadToManager(): Promise<boolean> {
-  if (isRemoteMode()) return true;
+  if (isRemoteMode()) {
+    lastRouteObservation = { remote: true };
+    return true;
+  }
   try {
     const stats = await getSystemStats();
     const argv = (stats as { system?: { argv?: string[] } })?.system?.argv;
     const cwd = (stats as { system?: { cwd?: string } })?.system?.cwd;
+    // THE OBSERVATION THE DECISION WAS MADE FROM (#1374, codex round 1). The explainer used
+    // to re-read /system_stats on the error path, which can report a DIFFERENT state than
+    // the one that chose the route — a server that restarted in between would be described
+    // as "did not answer /system_stats", a state that would have routed LOCAL and so cannot
+    // be why Manager was chosen. A diagnostic that narrates a decision must narrate the
+    // decision that happened, not a fresh one.
+    lastRouteObservation = { remote: false, argv, cwd };
     // Ask the LIVE server FIRST. A server launched with a RELATIVE
     // --base-directory/--models-directory that did NOT report its cwd has an UNKNOWN
     // real models dir: any local guess (COMFYUI_PATH or the main.py root) would be
@@ -2900,6 +2938,7 @@ export async function shouldDispatchDownloadToManager(): Promise<boolean> {
   } catch {
     // No reachable server → nothing to dispatch to. A configured local base still
     // streams local; otherwise let the local resolver surface its clear error.
+    lastRouteObservation = { remote: false, unreachable: true };
     return false;
   }
 }
@@ -2969,27 +3008,29 @@ export async function downloadModel(
     try {
       return await downloadModelViaManagerRemote(url, targetSubfolder, filename, auth, signal, wasHfUrl);
     } catch (err) {
-      // #1374 — SAY WHAT MADE MANAGER NECESSARY, not just that Manager failed.
+      // #1374 — SAY WHAT MADE MANAGER NECESSARY, but ONLY when Manager was actually the
+      // thing that failed.
       //
-      // The reporter's LOCAL install could not download at all: every attempt died on
-      // "ComfyUI-Manager's queue API is not reachable", raised deep in generic Manager code
-      // that cannot know it is serving a download. The message named the thing that broke
-      // and not the decision that put them there, so a local-only capability read as
-      // "install Manager" when the real answer was "this MCP could not find your models
-      // directory". They downloaded 45 GB with curl instead.
+      // The first version wrapped every error out of this call, and the remote payload
+      // PREFLIGHT runs before any Manager request is made — so a DNS or HTTP failure
+      // fetching the model source got "WHY THIS WENT THROUGH ComfyUI-Manager AT ALL"
+      // appended to it, attributing a source-host problem to a dispatch that never
+      // happened. Building a diagnostic to fix a message that named the wrong cause, and
+      // having it name the wrong cause, is not a mistake worth repeating quietly.
       //
-      // A cancel is not a routing problem and must pass through untouched.
+      // A cancel is not a routing problem either and passes through untouched.
       if (err instanceof DOMException && err.name === "AbortError") throw err;
-      // unknown-ok: this is a DIAGNOSTIC wrapped around a real error, and the empty
-      // string is consumed one line below as "append nothing", not as "there is no
-      // reason". If the explainer itself fails, the caller must still receive the
-      // original Manager failure verbatim — swallowing that to report a diagnostic's
-      // failure would replace the user's actual problem with mine. The raw error is
-      // never conditional on this succeeding.
-      const why = await explainManagerDownloadRoute().catch(() => "");
       const raw = err instanceof Error ? err.message : String(err);
+      // Only a failure to REACH Manager's API earns the explanation. Anything else — a bad
+      // source URL, an auth refusal from the model host, a disk error server-side — is
+      // about the download, and the route is not the interesting fact.
+      const managerWasTheProblem = /ComfyUI-Manager|manager\/queue|\/v2\/manager/i.test(raw);
+      if (!managerWasTheProblem) throw err;
+      const why = explainManagerDownloadRoute();
       throw new ModelError(
-        why ? `${raw}\n\nWHY THIS WENT THROUGH ComfyUI-Manager AT ALL: ${why}` : raw,
+        why ? `${raw}
+
+WHY THIS WENT THROUGH ComfyUI-Manager AT ALL: ${why}` : raw,
         { url },
       );
     }

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -2795,124 +2795,56 @@ WHY THIS WENT THROUGH ComfyUI-Manager AT ALL: ${why}`, {
  * rather than silently succeeding.
  */
 /**
- * What `shouldDispatchDownloadToManager()` actually saw when it last chose a route (#1374).
+ * WHY a download went to ComfyUI-Manager, reported as CURRENT STATE (#1374).
  *
- * Single-process, single-decision: the predicate is deliberately evaluated ONCE per
- * download and threaded to the writer (#420), so the error path must describe THAT
- * evaluation rather than take a second look. Re-reading was a real defect — a server that
- * restarted between the two reads produced an explanation of a state that would have routed
- * LOCAL, i.e. an explanation for a decision that never happened.
+ * The reporter's LOCAL install could not download at all: every attempt died on
+ * "ComfyUI-Manager's queue API is not reachable", for a capability that needs no Manager.
+ * That error is raised in generic Manager code which cannot know it is serving a download,
+ * so it named the thing that BROKE and not the decision that made Manager necessary --
+ * this MCP could not work out where the connected server keeps its models. Only the second
+ * has a remedy the user can apply.
+ *
+ * FOUR REVIEW ROUNDS WENT INTO A MESSAGE, and every one found the same shape of fault: a
+ * diagnostic claiming to narrate the routing DECISION while reading state that might not
+ * be the state that decision was made from. A second /system_stats read could describe a
+ * different server. A process-global record of the first read could be overwritten by a
+ * concurrent download. Stamping the target closed the simple overwrite but not an
+ * A -> B -> A retarget.
+ *
+ * Each fix made the window smaller instead of closing it, so what changes here is the
+ * CLAIM. This reports the state as it is now and says so. It cannot be stale, because it
+ * no longer asserts it was ever anything else -- and the argv/cwd a reporter needs in
+ * order to say which case they hit is exactly as useful either way.
  */
-type RouteObservation = { target: string } & (
-  | { remote: true }
-  | { remote: false; unreachable: true }
-  | { remote: false; argv?: string[]; cwd?: string }
-);
-let lastRouteObservation: RouteObservation | undefined;
-
-/**
- * SCOPE, stated because a diagnostic that overstates its own reach is the thing this issue
- * is about: the record is process-global and describes the MOST RECENT routing decision.
- * `downloadModel` is usually handed a route decided earlier by `startDownloadJob` (#420
- * threads it so the writer cannot diverge from the job key), so the observation belongs to
- * that decision — correct for the common case, and capable of describing a previous
- * download if the connected server restarted with different arguments in between. The text
- * therefore says "when this route was chosen" rather than asserting a current state, and
- * every branch that cannot support a claim returns "" instead of guessing.
- */
-export function resetRouteObservationForTests(): void {
-  lastRouteObservation = undefined;
-}
-
-/**
- * WHY a download was routed to ComfyUI-Manager (#1374).
- *
- * The reporter's LOCAL Windows-portable install could not download anything: every attempt
- * died on "ComfyUI-Manager's queue API is not reachable", for a capability that needs no
- * Manager at all. ~45 GB of weights, worked around with `curl`.
- *
- * The routing decision itself is a bare boolean produced by six conditions, and the error
- * they saw is raised deep in generic Manager code that cannot know it is serving a
- * download — so the message named the thing that failed (Manager) rather than the thing
- * that made Manager necessary (an install root this MCP could not resolve). Nothing in the
- * reply distinguished "your ComfyUI is remote" from "I could not work out where your local
- * ComfyUI keeps its models", and only the second has a remedy the user can apply.
- *
- * This re-derives the decision for the ERROR PATH only, and reports which condition sent
- * it to Manager. It is deliberately a separate read rather than a value threaded through
- * the predicate: the predicate is on the hot path for every download and is already
- * carefully single-evaluation for split-brain reasons (#420), and a diagnostic must not
- * change what it returns.
- *
- * NOT a routing change. I could not reproduce the reporter's decision on this machine — a
- * live ComfyUI here reports a relative `main.py` and NO cwd, and still resolves, because
- * the process-table probe anchors it. So I do not yet know which of the six conditions
- * fires for them, and guessing at the fix would be exactly the unverified confidence this
- * codebase keeps paying for. This makes the answer visible in their next report.
- */
-export function explainManagerDownloadRoute(): string {
-  const obs = lastRouteObservation;
-  // THE RECORD MUST BELONG TO THE TARGET WE ARE TALKING ABOUT (codex round 3).
-  //
-  // I argued this could not go wrong: every routing input looked process-wide, so two
-  // concurrent downloads had to observe the same thing. That was wrong on a checkable
-  // fact. `setComfyuiTarget()` mutates host, port, remoteUrlActive and config.comfyuiPath
-  // at RUNTIME — a desktop `hello` invokes it — so download A can record a Manager route,
-  // the target can be retargeted, download B can overwrite the record, and A's failure
-  // then gets explained with B's observation.
-  //
-  // Stamping the target makes the mismatch detectable instead of arguable: a record from a
-  // different target explains nothing.
-  if (obs && obs.target !== getComfyUIBaseUrl()) return "";
-  if (!obs) {
-    // No recorded decision. Say that rather than taking a fresh reading and narrating it as
-    // though it were the one that mattered.
-    return "";
-  }
-  if (obs.remote) {
+export async function explainManagerDownloadRoute(): Promise<string> {
+  if (isRemoteMode()) {
     return (
       "This MCP is in REMOTE mode (--comfyui-url), so a download is dispatched to the " +
-      "connected ComfyUI's Manager by design — there is no local models directory to " +
+      "connected ComfyUI's Manager by design -- there is no local models directory to " +
       "stream into. Manager must be installed and enabled on that host."
     );
   }
-  if ("unreachable" in obs) {
-    // This state routes LOCAL, so it can never be why Manager was chosen. Reaching here
-    // means the recorded observation and the route disagree, which is worth saying rather
-    // than inventing a reason.
+  let argv: string[] | undefined;
+  let cwd: string | undefined;
+  try {
+    const stats = await getSystemStats();
+    argv = (stats as { system?: { argv?: string[] } })?.system?.argv;
+    cwd = (stats as { system?: { cwd?: string } })?.system?.cwd;
+  } catch {
+    // Nothing observed now. Say nothing rather than guess why the route was taken.
     return "";
   }
-  const { argv, cwd } = obs;
-  // THE RECORD MUST BE CONSISTENT WITH HAVING CHOSEN MANAGER, or say nothing.
-  //
-  // The record can go stale in TIME (a server restarting between two decisions). I also
-  // argued it could not go stale under concurrency, because every routing input looked
-  // process-wide — that was wrong, setComfyuiTarget() mutates them at runtime, and the
-  // target stamp above is what closes that. This guard covers the remaining case.
-  //
-  // Rather than argue the odds, the failure is made unreachable. If the recorded
-  // observation would have routed LOCAL, it cannot be why Manager was chosen, so there is
-  // nothing truthful to say and this returns "". A stale record now costs a missing
-  // explanation instead of a confident wrong one — which is the whole subject of this
-  // issue, applied to my own diagnostic.
-  // ORDER MATTERS, and mine did not match the predicate's (codex round 3). The route is
-  // decided with `hasUnresolvableRelativeModelDirFlag` FIRST — it deliberately wins over
-  // the configured-base short-circuit — so a configured COMFYUI_PATH alongside an
-  // unresolvable relative model-dir flag legitimately routes to Manager. My guard checked
-  // the base first and suppressed the explanation for exactly that case: a false negative
-  // introduced by a consistency check.
-  if (!hasUnresolvableRelativeModelDirFlag(argv, cwd)) {
-    if (resolveEffectiveComfyUIBase()) return "";
-    if (parseModelsDirFromArgv(argv, cwd)) return "";
-  }
+  // Rendered RAW rather than JSON.stringify'd: a Windows argv comes back with doubled
+  // backslashes, in the one line that exists to be pasted into a bug report.
   const detail =
-    `The server reported argv[0]=${argv?.[0] ?? "(none)"} and cwd=${cwd ?? "(not reported)"} ` +
-    `when this route was chosen.`;
+    `Reading the connected server NOW: argv[0]=${argv?.[0] ?? "(none)"} and ` +
+    `cwd=${cwd ?? "(not reported)"}. (Current state -- if the server was restarted or ` +
+    `retargeted since this download started, it may not be what the routing decision saw.)`;
   if (hasUnresolvableRelativeModelDirFlag(argv, cwd)) {
     return (
       `Your ComfyUI was started with a RELATIVE --base-directory/--models-directory and did ` +
       `not report its working directory, so this MCP cannot tell where its models actually ` +
-      `live — writing locally would put the file somewhere the server never reads. ${detail} ` +
+      `live -- writing locally would put the file somewhere the server never reads. ${detail} ` +
       `FIX: restart ComfyUI with an ABSOLUTE --base-directory, or set COMFYUI_PATH to the ` +
       `install root, and a local download will stream directly with no Manager involved.`
     );
@@ -2921,7 +2853,7 @@ export function explainManagerDownloadRoute(): string {
   if (liveRoot.root && !existsSync(liveRoot.root)) {
     return (
       `The connected ComfyUI reports its install root as ${liveRoot.root}, which does not ` +
-      `exist on THIS machine — it is a container-side or remote path (a Docker/SSH-forwarded ` +
+      `exist on THIS machine -- it is a container-side or remote path (a Docker/SSH-forwarded ` +
       `loopback server looks local but is not). Writing there would create a bogus directory ` +
       `instead of reaching the server, so the fetch is handed to its Manager. ${detail} ` +
       `FIX: enable Manager on that host, or run this MCP where the models directory really is.`
@@ -2930,7 +2862,7 @@ export function explainManagerDownloadRoute(): string {
   return (
     `This MCP could not resolve where the connected ComfyUI keeps its models, so it handed ` +
     `the fetch to that server's Manager instead of streaming locally. ${detail} ` +
-    `FIX: set COMFYUI_PATH to the ComfyUI install root (the directory containing main.py) — ` +
+    `FIX: set COMFYUI_PATH to the ComfyUI install root (the directory containing main.py) -- ` +
     `a local download then streams directly and needs no Manager. Please include this whole ` +
     `paragraph if you report it (#1374): the argv/cwd above is what identifies which case ` +
     `this is.`
@@ -2938,21 +2870,11 @@ export function explainManagerDownloadRoute(): string {
 }
 
 export async function shouldDispatchDownloadToManager(): Promise<boolean> {
-  if (isRemoteMode()) {
-    lastRouteObservation = { target: getComfyUIBaseUrl(), remote: true };
-    return true;
-  }
+  if (isRemoteMode()) return true;
   try {
     const stats = await getSystemStats();
     const argv = (stats as { system?: { argv?: string[] } })?.system?.argv;
     const cwd = (stats as { system?: { cwd?: string } })?.system?.cwd;
-    // THE OBSERVATION THE DECISION WAS MADE FROM (#1374, codex round 1). The explainer used
-    // to re-read /system_stats on the error path, which can report a DIFFERENT state than
-    // the one that chose the route — a server that restarted in between would be described
-    // as "did not answer /system_stats", a state that would have routed LOCAL and so cannot
-    // be why Manager was chosen. A diagnostic that narrates a decision must narrate the
-    // decision that happened, not a fresh one.
-    lastRouteObservation = { target: getComfyUIBaseUrl(), remote: false, argv, cwd };
     // Ask the LIVE server FIRST. A server launched with a RELATIVE
     // --base-directory/--models-directory that did NOT report its cwd has an UNKNOWN
     // real models dir: any local guess (COMFYUI_PATH or the main.py root) would be
@@ -2992,7 +2914,6 @@ export async function shouldDispatchDownloadToManager(): Promise<boolean> {
   } catch {
     // No reachable server → nothing to dispatch to. A configured local base still
     // streams local; otherwise let the local resolver surface its clear error.
-    lastRouteObservation = { target: getComfyUIBaseUrl(), remote: false, unreachable: true };
     return false;
   }
 }

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -2715,17 +2715,36 @@ async function downloadModelViaManagerRemote(
     filename: resolvedFilename,
   });
 
-  await installModelViaManager({
-    // Manager's do_install_model reads json_data['name'] (required, non-empty).
-    // We only have the filename to identify the model here, so use it.
-    name: resolvedFilename,
-    url: dispatchUrl,
-    filename: resolvedFilename,
-    type: managerType,
-    save_path: managerSavePath,
-    // Panel tray: watch OUR canonical category for the file to land (#143).
-    trayCategory: modelType,
-  });
+  try {
+    await installModelViaManager({
+      // Manager's do_install_model reads json_data['name'] (required, non-empty).
+      // We only have the filename to identify the model here, so use it.
+      name: resolvedFilename,
+      url: dispatchUrl,
+      filename: resolvedFilename,
+      type: managerType,
+      save_path: managerSavePath,
+      // Panel tray: watch OUR canonical category for the file to land (#143).
+      trayCategory: modelType,
+    });
+  } catch (err) {
+    // #1374 — the ONLY failure entitled to the route explanation: Manager was contacted
+    // and Manager is what failed. Scoped to this call rather than the whole function
+    // because everything above it — target resolution, the remote payload preflight — can
+    // fail for reasons unrelated to the route. The first version wrapped the lot and
+    // matched on error text; the preflight's own auth-gated refusal mentions
+    // ComfyUI-Manager, so it was misattributed anyway. A flag at the call site cannot be
+    // fooled by prose.
+    if (err instanceof DOMException && err.name === "AbortError") throw err;
+    const why = explainManagerDownloadRoute();
+    if (!why) throw err;
+    const raw = err instanceof Error ? err.message : String(err);
+    throw new ModelError(`${raw}
+
+WHY THIS WENT THROUGH ComfyUI-Manager AT ALL: ${why}`, {
+      url,
+    });
+  }
 
   // Cancelled while the dispatch was in flight (#515): the local job is cancelled.
   // We CAN'T recall a Manager queue task, so the host may keep fetching — but this
@@ -2851,6 +2870,22 @@ export function explainManagerDownloadRoute(): string {
     return "";
   }
   const { argv, cwd } = obs;
+  // THE RECORD MUST BE CONSISTENT WITH HAVING CHOSEN MANAGER, or say nothing.
+  //
+  // Codex called the process-global record unsafe under concurrent downloads. Measured
+  // against the predicate's inputs, interleaving alone cannot produce a disagreement: the
+  // route is decided from isRemoteMode() (process-wide), one connected server's
+  // /system_stats, and process-wide config — so two downloads in one process observe the
+  // same thing. What CAN differ is time: a server restarting between two decisions, which
+  // concurrency widens the window for.
+  //
+  // Rather than argue the odds, the failure is made unreachable. If the recorded
+  // observation would have routed LOCAL, it cannot be why Manager was chosen, so there is
+  // nothing truthful to say and this returns "". A stale record now costs a missing
+  // explanation instead of a confident wrong one — which is the whole subject of this
+  // issue, applied to my own diagnostic.
+  if (resolveEffectiveComfyUIBase()) return "";
+  if (parseModelsDirFromArgv(argv, cwd)) return "";
   const detail =
     `The server reported argv[0]=${argv?.[0] ?? "(none)"} and cwd=${cwd ?? "(not reported)"} ` +
     `when this route was chosen.`;
@@ -3005,35 +3040,11 @@ export async function downloadModel(
   if (routeToManager) {
     // Thread the PRE-rewrite HF identity so the flip probe's credential derivation keeps the
     // HF token flowing to an HF_ENDPOINT mirror (matches the local path below).
-    try {
-      return await downloadModelViaManagerRemote(url, targetSubfolder, filename, auth, signal, wasHfUrl);
-    } catch (err) {
-      // #1374 — SAY WHAT MADE MANAGER NECESSARY, but ONLY when Manager was actually the
-      // thing that failed.
-      //
-      // The first version wrapped every error out of this call, and the remote payload
-      // PREFLIGHT runs before any Manager request is made — so a DNS or HTTP failure
-      // fetching the model source got "WHY THIS WENT THROUGH ComfyUI-Manager AT ALL"
-      // appended to it, attributing a source-host problem to a dispatch that never
-      // happened. Building a diagnostic to fix a message that named the wrong cause, and
-      // having it name the wrong cause, is not a mistake worth repeating quietly.
-      //
-      // A cancel is not a routing problem either and passes through untouched.
-      if (err instanceof DOMException && err.name === "AbortError") throw err;
-      const raw = err instanceof Error ? err.message : String(err);
-      // Only a failure to REACH Manager's API earns the explanation. Anything else — a bad
-      // source URL, an auth refusal from the model host, a disk error server-side — is
-      // about the download, and the route is not the interesting fact.
-      const managerWasTheProblem = /ComfyUI-Manager|manager\/queue|\/v2\/manager/i.test(raw);
-      if (!managerWasTheProblem) throw err;
-      const why = explainManagerDownloadRoute();
-      throw new ModelError(
-        why ? `${raw}
-
-WHY THIS WENT THROUGH ComfyUI-Manager AT ALL: ${why}` : raw,
-        { url },
-      );
-    }
+    // The route explanation lives INSIDE the dispatch (see downloadModelViaManagerRemote),
+    // where a flag records whether Manager was actually contacted. Matching on error text
+    // from out here could not tell a Manager failure from a preflight refusal that happens
+    // to mention Manager.
+    return await downloadModelViaManagerRemote(url, targetSubfolder, filename, auth, signal, wasHfUrl);
   }
 
   // Root the destination at the LIVE server's models dir (its --base-directory),

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -2736,7 +2736,7 @@ async function downloadModelViaManagerRemote(
     // ComfyUI-Manager, so it was misattributed anyway. A flag at the call site cannot be
     // fooled by prose.
     if (err instanceof DOMException && err.name === "AbortError") throw err;
-    const why = explainManagerDownloadRoute();
+    const why = await explainManagerDownloadRoute();
     if (!why) throw err;
     const raw = err instanceof Error ? err.message : String(err);
     throw new ModelError(`${raw}
@@ -2819,9 +2819,11 @@ WHY THIS WENT THROUGH ComfyUI-Manager AT ALL: ${why}`, {
 export async function explainManagerDownloadRoute(): Promise<string> {
   if (isRemoteMode()) {
     return (
-      "This MCP is in REMOTE mode (--comfyui-url), so a download is dispatched to the " +
-      "connected ComfyUI's Manager by design -- there is no local models directory to " +
-      "stream into. Manager must be installed and enabled on that host."
+      "This MCP is in REMOTE mode (--comfyui-url) RIGHT NOW, so downloads are dispatched " +
+      "to the connected ComfyUI's Manager by design -- there is no local models directory " +
+      "to stream into. Manager must be installed and enabled on that host. (Current state: " +
+      "if the target was changed since this download started, it may not be why this one " +
+      "took that route.)"
     );
   }
   let argv: string[] | undefined;


### PR DESCRIPTION
Draft — claiming #1374: a LOCAL download hard-fails with a ComfyUI-Manager error, blocking ~45 GB of weights on an install that needs no Manager at all.

**Root cause, reproduced on this machine rather than inferred.** `shouldDispatchDownloadToManager()` ends with:

```ts
const liveRoot = resolveLiveServerRoot(argv, cwd, { remote: false }).root;
if (liveRoot && existsSync(liveRoot)) return false;
return true;   // ← Manager
```

A real ComfyUI 0.31.1 reports:

```
argv[0] : "ComfyUI\main.py"     ← RELATIVE
cwd     : undefined              ← not reported at all
```

A relative `main.py` with no `cwd` cannot be resolved to an install root, so the predicate falls through to `return true` and the download is dispatched to Manager. This rig only downloads because it happens to run `--enable-manager`; the reporter's ComfyUI does not serve Manager routes, so the same path becomes a hard failure.

That also matches their timeline. They upgraded across 0.49.0, where `hasUnresolvableRelativeModelDirFlag` landed, and 0.49.4, where the `existsSync(liveRoot)` gate did — the "0.50.x regression" is those, perceived at the upgrade that crossed them.

**What I am not going to do** is make the Manager failure fall back to local streaming unconditionally. The predicate returns `true` in cases where writing locally would land bytes in the *wrong place* — an unresolvable relative `--base-directory`, or a loopback ComfyUI inside Docker whose reported path is container-side — and the surrounding comments say so explicitly. A blanket fallback trades a loud failure for a silent wrong write, which is the trade this codebase keeps regretting.

Plan, in order of confidence:

1. **Derive the root from evidence already on hand.** The same `argv` carries absolute paths (`--extra-model-paths-config`, `--input-directory`, `--output-directory` on this machine) that identify the install without needing `cwd`. Using them turns the common Windows-portable/Desktop shape from "unresolvable" into "resolved", which is the actual defect.
2. **When Manager IS chosen and unreachable, say why local was not used** — naming the specific condition (no `COMFYUI_PATH`, relative `main.py`, no `cwd`) and the concrete remedy — instead of a Manager-centric error for a capability that does not need Manager.

Refs #1374, and likely the reason #1370's reporter had no local `.partial` to resume.
