### PR TITLE
fix(1372): a frontend-only node is not an unknown runtime

### DIFF
--- a/src/__tests__/services/runtime-virtual-nodes.test.ts
+++ b/src/__tests__/services/runtime-virtual-nodes.test.ts
@@ -59,6 +59,31 @@ describe("a frontend-only node is not an unknown runtime (#1372)", () => {
     }
   });
 
+  it("a REGISTERED node that collides with a virtual name is still classified (codex P1)", async () => {
+    // THE SAFETY HOLE. The skip used to run before the /object_info lookup, so a
+    // third-party backend node legitimately named "Note" — registered, executable, and
+    // api_node:true — was skipped unexamined and the workflow reported "local /
+    // usesApiNodes:false". That tells the agent the run is confirmed FREE and skips the
+    // credit confirmation, which is the one outcome this classifier exists to prevent.
+    //
+    // Absence from the registry is not a heuristic for "virtual", it is the definition.
+    const r = await checkWorkflowRuntime(
+      graphOf("KSampler", "Note"),
+      depsWith({ KSampler: KSAMPLER, Note: { ...API_NODE, name: "Note" } }),
+    );
+    expect(r.runtime, "a registered api_node must never be skipped as virtual").toBe("mixed");
+    expect(r.usesApiNodes).toBe(true);
+  });
+
+  it("…and a registered LOCAL node of the same name is classified local, not skipped", async () => {
+    const r = await checkWorkflowRuntime(
+      graphOf("Note"),
+      depsWith({ Note: { input: { required: {} }, output: [], name: "Note" } }),
+    );
+    expect(r.runtime).toBe("local");
+    expect(r.usesApiNodes).toBe(false);
+  });
+
   it("a GENUINELY unrecognised node still collapses the verdict — the doubt is preserved", async () => {
     // The over-broad direction. If this stopped refusing, the safety flow would claim
     // "free" for a workflow that might contain a paid partner node.

--- a/src/__tests__/services/runtime-virtual-nodes.test.ts
+++ b/src/__tests__/services/runtime-virtual-nodes.test.ts
@@ -1,0 +1,99 @@
+// #1372 — `list_packs(action:"check_runtime")` returned runtime:"unknown" because
+// MarkdownNote was in unknownNodes, which stops the paid-API safety flow to ask a question
+// that already has an answer.
+//
+// The "unknown" verdict expresses a specific and correct doubt: this class_type is absent
+// from the server's registry, so it COULD be a paid partner node the server does not
+// expose, and claiming "local/free" would be a guess with someone's money on it.
+//
+// It just cannot apply to a node that does not execute. MarkdownNote, Note, Reroute and
+// PrimitiveNode are LiteGraph-native — the frontend registers them, /object_info never
+// lists them, and they are stripped before a prompt is queued. A virtual node can no more
+// be a paid API node than it can be a checkpoint loader.
+//
+// MEASURED, not assumed: across four real pack workflows checked against this machine's
+// live /object_info, every class_type that landed in unknownNodes was frontend-only —
+// GetNode, SetNode, Note, "Label (rgthree)", "Fast Groups Bypasser (rgthree)", "Fast Groups
+// Muter (rgthree)". None of them executes anywhere, let alone on a paid API.
+
+import { describe, expect, it } from "vitest";
+
+import { checkWorkflowRuntime } from "../../services/api-nodes.js";
+import { NON_EXECUTING_NODE_TYPES } from "../../services/workflow-converter.js";
+
+const KSAMPLER = { input: { required: { seed: ["INT"] } }, output: ["LATENT"], name: "KSampler" };
+/** An API node as the classifier recognises one. */
+const API_NODE = {
+  input: { required: {} },
+  output: ["IMAGE"],
+  name: "FluxProImageNode",
+  api_node: true,
+};
+
+function graphOf(...types: string[]): unknown {
+  return {
+    nodes: types.map((type, i) => ({ id: i + 1, type, widgets_values: [] })),
+    links: [],
+  };
+}
+
+function depsWith(objectInfo: Record<string, unknown>) {
+  return { getObjectInfo: async () => objectInfo } as never;
+}
+
+describe("a frontend-only node is not an unknown runtime (#1372)", () => {
+  it("THE REPORTED CASE: a local workflow with MarkdownNote is local, not unknown", async () => {
+    const r = await checkWorkflowRuntime(graphOf("KSampler", "MarkdownNote"), depsWith({ KSampler: KSAMPLER }));
+    expect(r.runtime).toBe("local");
+    expect(r.usesApiNodes).toBe(false);
+    expect(r.unknownNodes).toEqual([]);
+  });
+
+  it("every type in the shared set is treated the same way", async () => {
+    // Imported from the converter, so this cannot drift from the list that decides what
+    // gets stripped before queueing.
+    for (const t of NON_EXECUTING_NODE_TYPES) {
+      const r = await checkWorkflowRuntime(graphOf("KSampler", t), depsWith({ KSampler: KSAMPLER }));
+      expect(r.runtime, `${t} must not make the runtime unknown`).toBe("local");
+      expect(r.unknownNodes, `${t} must not be reported as unknown`).toEqual([]);
+    }
+  });
+
+  it("a GENUINELY unrecognised node still collapses the verdict — the doubt is preserved", async () => {
+    // The over-broad direction. If this stopped refusing, the safety flow would claim
+    // "free" for a workflow that might contain a paid partner node.
+    const r = await checkWorkflowRuntime(
+      graphOf("KSampler", "SomeUninstalledPackNode"),
+      depsWith({ KSampler: KSAMPLER }),
+    );
+    expect(r.runtime).toBe("unknown");
+    expect(r.usesApiNodes).toBeNull();
+    expect(r.unknownNodes).toEqual(["SomeUninstalledPackNode"]);
+  });
+
+  it("virtual nodes leave the DENOMINATOR too, or an all-local graph reads as mixed", async () => {
+    // One API node plus three Notes was 1-of-4 classifiable → "mixed". The notes are not
+    // evidence of anything, in either direction.
+    const r = await checkWorkflowRuntime(
+      graphOf("FluxProImageNode", "Note", "Note", "MarkdownNote"),
+      depsWith({ FluxProImageNode: API_NODE }),
+    );
+    expect(r.runtime).toBe("api");
+    expect(r.usesApiNodes).toBe(true);
+  });
+
+  it("a workflow of ONLY virtual nodes is local, not unknown and not a division by zero", async () => {
+    const r = await checkWorkflowRuntime(graphOf("Note", "MarkdownNote"), depsWith({}));
+    expect(r.runtime).toBe("local");
+    expect(r.usesApiNodes).toBe(false);
+  });
+
+  it("an API node is still detected when a virtual node sits beside it", async () => {
+    const r = await checkWorkflowRuntime(
+      graphOf("KSampler", "FluxProImageNode", "MarkdownNote"),
+      depsWith({ KSampler: KSAMPLER, FluxProImageNode: API_NODE }),
+    );
+    expect(r.runtime).toBe("mixed");
+    expect(r.usesApiNodes).toBe(true);
+  });
+});

--- a/src/services/api-nodes.ts
+++ b/src/services/api-nodes.ts
@@ -4,6 +4,7 @@ import type {
   NodeInputSpec,
   WorkflowJSON,
 } from "../comfyui/types.js";
+import { NON_EXECUTING_NODE_TYPES } from "./workflow-converter.js";
 import { getObjectInfo } from "../comfyui/client.js";
 import { enqueueWorkflow } from "./workflow-executor.js";
 import { config } from "../config.js";
@@ -221,6 +222,22 @@ export async function checkWorkflowRuntime(
   const apiNodes: string[] = [];
   const unknownNodes: string[] = [];
   for (const ct of classTypes) {
+    // A FRONTEND-ONLY NODE IS NOT AN UNKNOWN ONE (#1372). MarkdownNote, Note, Reroute and
+    // PrimitiveNode are LiteGraph-native: the frontend registers them, /object_info never
+    // lists them, and they are stripped before a prompt is queued.
+    //
+    // The "unknown" verdict exists to express a specific doubt — this class_type is absent
+    // from the server's registry, so it COULD be a paid partner node the server does not
+    // expose, and claiming "local/free" would be a guess with someone's money on it. That
+    // caution is right and stays. It just cannot apply to a node that does not execute at
+    // all: a virtual node can no more be a paid API node than it can be a checkpoint
+    // loader, so it earns none of the doubt while collapsing the whole verdict to
+    // "unknown" and stopping the safety flow to ask an unanswerable question.
+    //
+    // The set is IMPORTED from the converter rather than restated here. It already had to
+    // know which types never reach the backend, and a second copy drifting from the first
+    // is exactly how this bug happened.
+    if (NON_EXECUTING_NODE_TYPES.has(ct)) continue;
     const def = objectInfo[ct];
     if (!def) {
       unknownNodes.push(ct);
@@ -230,7 +247,11 @@ export async function checkWorkflowRuntime(
   }
   const hasApiNodes = apiNodes.length > 0;
   // "api" only if EVERY classifiable node is an API node; "mixed" if some are.
-  const classifiable = classTypes.length - unknownNodes.length;
+  // Virtual nodes are not classifiable EITHER WAY, so they leave the denominator too —
+  // otherwise a workflow of one KSampler plus three Notes reads as 1-of-4 API and reports
+  // "mixed" when it is entirely local.
+  const virtualCount = classTypes.filter((ct) => NON_EXECUTING_NODE_TYPES.has(ct)).length;
+  const classifiable = classTypes.length - unknownNodes.length - virtualCount;
   let runtime: "local" | "api" | "mixed" | "unknown";
   let usesApiNodes: boolean | null;
   if (hasApiNodes) {

--- a/src/services/api-nodes.ts
+++ b/src/services/api-nodes.ts
@@ -237,8 +237,19 @@ export async function checkWorkflowRuntime(
     // The set is IMPORTED from the converter rather than restated here. It already had to
     // know which types never reach the backend, and a second copy drifting from the first
     // is exactly how this bug happened.
-    if (NON_EXECUTING_NODE_TYPES.has(ct)) continue;
     const def = objectInfo[ct];
+    // …but ONLY when the server does not register it (codex P1). The skip used to run
+    // BEFORE this lookup, which meant a third-party backend node legitimately named `Note`
+    // or `PrimitiveNode` — and registered with api_node:true — was skipped unexamined and
+    // the workflow reported "local / usesApiNodes:false". That tells the agent the run is
+    // confirmed free and skips the credit confirmation, which is the one outcome this
+    // classifier exists to prevent. A safety check that can be bypassed by a name
+    // collision is worse than the false "unknown" it was fixing.
+    //
+    // Absence from /object_info is not a heuristic for "virtual", it is the definition:
+    // the frontend registers these, the backend does not. So a REGISTERED node of the same
+    // name is a real node and is classified as one.
+    if (!def && NON_EXECUTING_NODE_TYPES.has(ct)) continue;
     if (!def) {
       unknownNodes.push(ct);
       continue;
@@ -250,7 +261,9 @@ export async function checkWorkflowRuntime(
   // Virtual nodes are not classifiable EITHER WAY, so they leave the denominator too —
   // otherwise a workflow of one KSampler plus three Notes reads as 1-of-4 API and reports
   // "mixed" when it is entirely local.
-  const virtualCount = classTypes.filter((ct) => NON_EXECUTING_NODE_TYPES.has(ct)).length;
+  const virtualCount = classTypes.filter(
+    (ct) => !objectInfo[ct] && NON_EXECUTING_NODE_TYPES.has(ct),
+  ).length;
   const classifiable = classTypes.length - unknownNodes.length - virtualCount;
   let runtime: "local" | "api" | "mixed" | "unknown";
   let usesApiNodes: boolean | null;

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -2254,6 +2254,25 @@ export function convertApiToUi(
 }
 
 /**
+ * Frontend-only node types that never reach the backend (#1372).
+ *
+ * LiteGraph-native: the ComfyUI frontend registers them, the server's node registry does
+ * not, and they are stripped before a prompt is queued. `panel_add_node`'s own description
+ * says the same — they "legitimately bypass the backend class_type check".
+ *
+ * EXPORTED because a second copy is how two lists drift, and #1372 is what that cost: the
+ * converter knew MarkdownNote does not execute while the runtime classifier called it an
+ * unknown node and refused to say the workflow was free — stopping the paid-API safety
+ * flow to ask a question that already had an answer.
+ */
+export const NON_EXECUTING_NODE_TYPES: ReadonlySet<string> = new Set([
+  "Reroute",
+  "Note",
+  "MarkdownNote",
+  "PrimitiveNode",
+]);
+
+/**
  * Convert a ComfyUI UI-format workflow to API format.
  * Requires objectInfo from /object_info to map widgets_values to named inputs.
  */
@@ -2294,7 +2313,7 @@ export function convertUiToApi(
   }
 
   // Node types that are purely visual/internal and have no API equivalent
-  const SKIP_TYPES = new Set(["Reroute", "Note", "PrimitiveNode", "MarkdownNote"]);
+  const SKIP_TYPES = NON_EXECUTING_NODE_TYPES;
 
   // Get/Set node types that need special handling (not in object_info)
   const GET_SET_TYPES = new Set([


### PR DESCRIPTION
Draft — claiming #1372: `list_packs(action:"check_runtime")` returns `runtime:"unknown"` because `MarkdownNote` is in `unknownNodes`, which stops the paid-API safety flow to ask a question that has an answer.

**Why the classifier is right to be cautious, and wrong here.** `checkWorkflowRuntime` (`src/services/api-nodes.ts:222-243`) treats any class_type absent from `/object_info` as unclassifiable, and refuses to claim "local/free" while one exists — because an unknown node *could* be a paid partner node the server doesn't expose. That caution is correct and worth keeping.

But `MarkdownNote` is not an unclassifiable node. It is a **frontend-only virtual type**: LiteGraph-native, never in the backend registry, and it does not execute. It cannot be a paid API node, so it cannot justify the doubt the "unknown" verdict exists to express.

**The repo already knows this**, in two places:

- `src/services/workflow-converter.ts:2261` — `SKIP_TYPES = new Set(["Reroute", "Note", "PrimitiveNode", "MarkdownNote"])`, the converter's list of things that never reach the backend.
- `panel_add_node`'s own description: *"Frontend-only virtual types are addable too: 'Note' and 'MarkdownNote' … plus 'Reroute' and 'PrimitiveNode'. These are LiteGraph-native and never appear in the backend node registry."*

I measured the same thing yesterday from the other direction while working on #1359: across three real pack workflows checked against this machine's live `/object_info`, every one had misses, and they were `Note`, `GetNode`, `SetNode`, `Label (rgthree)`, and UUID-typed subgraph nodes — never anything that executes on a paid API.

Plan: have the classifier consult the converter's existing set rather than a second copy of it. A second list is how the two drift, and this issue is what that costs. I'll check whether `GetNode`/`SetNode`/subgraph-UUID types belong in the same bucket, since they hit the same path and have the same property, rather than fixing only the type named in the report.

Refs #1372, #741
