### PR TITLE
fix(1371): prove the configured base before writing a model into it

### DIFF
--- a/src/__tests__/services/output-dir-symlink-fs.test.ts
+++ b/src/__tests__/services/output-dir-symlink-fs.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, readdirSync, statSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * The PREMISE the #1371 symlink handling rests on, checked against a real filesystem.
+ *
+ * `isModelFileEntry` accepts symlinks and `entryIsDirectoryLike` follows them because
+ * `Dirent.isFile()` and `Dirent.isDirectory()` are both FALSE for a symbolic link —
+ * readdir reports the link itself, not its target. Every other test in this area runs
+ * against a mocked `node:fs` whose Dirents I wrote, so those tests agree with that belief
+ * by construction and cannot contradict it. If Node ever reported otherwise, the fix would
+ * be pointless and 92 mocked tests would still pass.
+ *
+ * This file therefore mocks nothing. It creates real links and asks the real API.
+ *
+ * Setup runs at MODULE scope rather than in beforeAll so `skipIf` can see the result:
+ * a test that returns early is a test that passed, and "skipped because this machine
+ * cannot make links" must not look like "the premise holds".
+ */
+const dir = mkdtempSync(join(tmpdir(), "cmcp-symlink-premise-"));
+mkdirSync(join(dir, "real"));
+writeFileSync(join(dir, "real", "model.safetensors"), "x");
+
+/** Separate guards, because the two link kinds have different privilege rules on Windows.
+ *  A shared try meant one EPERM skipped BOTH — and the directory case, the one the P1 fix
+ *  turns on, is exactly the one that does work unprivileged. */
+const made = (name: string, target: string, type: "junction" | "file"): boolean => {
+  try {
+    // "junction" is the one directory-link kind Windows allows without elevation or
+    // developer mode; the argument is ignored on POSIX. A FILE symlink is EPERM there
+    // unless developer mode is on, so that case really can be unavailable.
+    symlinkSync(target, join(dir, name), type);
+    return true;
+  } catch {
+    return false;
+  }
+};
+const dirLinkWorks = made("link-to-dir", join(dir, "real"), "junction");
+const fileLinkWorks = made(
+  "link-to-model.safetensors",
+  join(dir, "real", "model.safetensors"),
+  "file",
+);
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("#1371 — what Node actually reports for a symlink", () => {
+  it.skipIf(!dirLinkWorks)("a link to a DIRECTORY is not isDirectory(), and statSync sees through it", () => {
+    const entry = readdirSync(dir, { withFileTypes: true }).find((e) => e.name === "link-to-dir");
+    expect(entry, "the link should be listed").toBeDefined();
+    // The trap. Recursing on isDirectory() alone silently skips a shared model tree.
+    expect(entry!.isDirectory()).toBe(false);
+    expect(entry!.isSymbolicLink()).toBe(true);
+    // ...and the escape hatch the fix uses: stat follows the link.
+    expect(statSync(join(dir, "link-to-dir")).isDirectory()).toBe(true);
+  });
+
+  it.skipIf(!fileLinkWorks)("a link to a FILE is not isFile() either", () => {
+    const entry = readdirSync(dir, { withFileTypes: true }).find(
+      (e) => e.name === "link-to-model.safetensors",
+    );
+    expect(entry, "the link should be listed").toBeDefined();
+    expect(entry!.isFile()).toBe(false);
+    expect(entry!.isSymbolicLink()).toBe(true);
+  });
+
+  it("a real file and a real directory report themselves normally", () => {
+    // The control, and it runs everywhere. Without it, a readdir that returned nothing on
+    // some platform would leave the two assertions above skipped and unmissed.
+    const entries = readdirSync(dir, { withFileTypes: true });
+    expect(entries.find((e) => e.name === "real")?.isDirectory()).toBe(true);
+    const inner = readdirSync(join(dir, "real"), { withFileTypes: true });
+    expect(inner.find((e) => e.name === "model.safetensors")?.isFile()).toBe(true);
+  });
+});

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../../utils/logger.js";
 import { basename, isAbsolute, join, resolve } from "node:path";
 
 let remoteMode = false;
@@ -39,6 +40,8 @@ let baseDirEntries = new Set<string>();
 let baseSymlinkEntries = new Set<string>();
 /** How many readdirs one resolve did — the P2 bound is a number, so assert on the number. */
 let readdirCalls = 0;
+/** How many stats one resolve did — the symlink bound is a number too. */
+let statCalls = 0;
 const direntOf = (name: string) => ({
   name,
   isFile: () => !baseDirEntries.has(name) && !baseSymlinkEntries.has(name),
@@ -62,6 +65,7 @@ vi.mock("node:fs", () => ({
   realpathSync: (p: string) => (realpathFor ? realpathFor(String(p)) : String(p)),
   existsSync: (p: string) => (existsFor ? existsFor(String(p)) : liveRootExists),
   statSync: (p: string) => {
+    statCalls += 1;
     const path = String(p);
     if (/[\\/]models$/.test(path)) {
       if (modelsDirStat === "enoent" || modelsDirStat === "eacces") {
@@ -102,6 +106,10 @@ const statExceptFor = (
   err.code = "ENOENT";
   throw err;
 };
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
 
 const getSystemStats = vi.fn();
 /** The server's own model inventory: category → filenames it reports seeing. */
@@ -1393,8 +1401,9 @@ describe("#1371 — a configured base the server demonstrably does not read is r
 
   it("the scan is bounded — a huge category does not become thousands of readdirs (codex P2)", async () => {
     // Depth alone bounds nothing: 10k empty subdirectories is 10k synchronous readdirs on
-    // the download path. Exhausting the budget answers "no model found", which is the safe
-    // direction — no contradiction, so no refusal, just the pre-existing warning.
+    // the download path. The bound is generous (512) because a real diffusers layout
+    // answers from the first directory it reads — it exists for the pathological tree, not
+    // the ordinary one.
     config.comfyuiPath = "/huge";
     getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
     serverInventory = { clip_vision: ["lives-elsewhere.safetensors"] };
@@ -1405,13 +1414,96 @@ describe("#1371 — a configured base the server demonstrably does not read is r
     baseDirEntries = new Set(many);
     baseNestedEntries = [];
     readdirCalls = 0;
+    statCalls = 0;
 
     const { modelsDir } = await resolveModelsDirWithBases({ targetCategory: "clip_vision" });
     expect(modelsDir).toBe(resolve("/huge", "models"));
     // The bound, asserted as a number rather than a vibe. Without it this is 5001.
-    expect(readdirCalls).toBeLessThanOrEqual(80);
+    expect(readdirCalls).toBeLessThanOrEqual(520);
     // ...and it really did have thousands of chances to exceed it.
-    expect(readdirCalls).toBeGreaterThan(1);
+    expect(readdirCalls).toBeGreaterThan(100);
+  });
+
+  it("SYMLINK entries are bounded too — the stat is itself the work (codex P2)", async () => {
+    // Bounding readdirs left this shape exactly as unbounded as before: `.some()` resolves
+    // every link with statSync and only THEN lets the recursion decline for want of
+    // budget. Thousands of symlinks in one category is the tree the symlink fix newly made
+    // reachable, so it is the tree that had to be bounded with it.
+    //
+    // The links point at FILES, deliberately. A link to a DIRECTORY consumes the readdir
+    // budget, so that budget bounds the stats as a side effect and the stat cap could be
+    // deleted with every test still green — mutation testing caught exactly that. A link
+    // to a file consumes nothing, so this shape is bounded by the stat cap alone.
+    config.comfyuiPath = "/huge-links";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { clip_vision: ["lives-elsewhere.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+    // No model extension, so the entries are not counted as models on their names.
+    const many = Array.from({ length: 20000 }, (_, i) => `link-${i}`);
+    baseCategoryEntries = many;
+    baseSymlinkEntries = new Set(many);
+    baseNestedEntries = [];
+    statFor = statExceptFor((p) => /link-\d+$/.test(p), {
+      isDirectory: () => false,
+      isFile: () => true,
+    });
+    readdirCalls = 0;
+    statCalls = 0;
+
+    const { modelsDir } = await resolveModelsDirWithBases({ targetCategory: "clip_vision" });
+    expect(modelsDir).toBe(resolve("/huge-links", "models"));
+    // The cap is 4096; without it this is 20000.
+    expect(statCalls, "every link must not be resolved").toBeLessThanOrEqual(4200);
+    expect(statCalls, "...and it really had 20k chances to exceed it").toBeGreaterThan(1000);
+    // Nothing recursed, so the readdir budget never applied — the stat cap is the only
+    // thing standing between this tree and 20k syscalls.
+    expect(readdirCalls).toBeLessThanOrEqual(3);
+  });
+
+  it("a TRUNCATED scan is reported, not folded into an empty-base finding (codex P1)", async () => {
+    // The dangerous half. A stale base whose only model sits behind the 512th directory
+    // looks exactly like an empty one, so the refusal is skipped and the file lands in an
+    // install the connected server never reads — the silent misplaced write this entire
+    // check exists to stop, reintroduced by its own bound.
+    //
+    // Refusing on an inconclusive scan is worse (it blocks working installs, which was an
+    // earlier P0 here), so the download proceeds — but the user is told the check did not
+    // finish, which is the one thing they cannot otherwise know.
+    const warn = vi.mocked(logger.warn);
+    warn.mockClear();
+    config.comfyuiPath = "/truncated";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { clip_vision: ["lives-elsewhere.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+    const many = Array.from({ length: 5000 }, (_, i) => `dir-${i}`);
+    baseCategoryEntries = many;
+    baseDirEntries = new Set(many);
+    baseNestedEntries = [];
+
+    await resolveModelsDirWithBases({ targetCategory: "clip_vision" });
+    const said = warn.mock.calls.map((c) => String(c[0])).join(" ");
+    expect(said).toMatch(/did not finish/);
+    expect(said).toMatch(/NOT a finding that this/);
+  });
+
+  it("...and a scan that COMPLETES says nothing about truncation", async () => {
+    // The over-broad direction: warning on every ordinary resolve would train the user to
+    // ignore the one that matters.
+    const warn = vi.mocked(logger.warn);
+    warn.mockClear();
+    config.comfyuiPath = "/small";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { clip_vision: ["lives-elsewhere.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+    baseCategoryEntries = ["a", "b"];
+    baseDirEntries = new Set(["a", "b"]);
+    baseNestedEntries = [];
+
+    await resolveModelsDirWithBases({ targetCategory: "clip_vision" });
+    expect(warn.mock.calls.map((c) => String(c[0])).join(" ")).not.toMatch(/did not finish/);
   });
 
   it("…but an EMPTY subfolder is still not evidence", async () => {

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { isAbsolute, join, resolve } from "node:path";
+import { basename, isAbsolute, join, resolve } from "node:path";
 
 let remoteMode = false;
 vi.mock("../../config.js", () => ({
@@ -28,8 +28,22 @@ let realpathFor: ((p: string) => string) | undefined;
  *  to hold files of its own — an EMPTY category dir is an extra_model_paths root that
  *  simply has nothing here yet, which is a working setup and must not be refused. */
 let baseCategoryEntries: string[] = [];
+/** Names inside a SUBDIRECTORY of the category, for the diffusers-style layout (#1371). */
+let baseNestedEntries: string[] = [];
+/** Entries the readdir mock reports as directories rather than files. */
+let baseDirEntries = new Set<string>();
+const direntOf = (name: string) => ({
+  name,
+  isFile: () => !baseDirEntries.has(name),
+  isDirectory: () => baseDirEntries.has(name),
+});
 vi.mock("node:fs", () => ({
-  readdirSync: () => baseCategoryEntries,
+  readdirSync: (p: string) => {
+    // Explicit two-level dispatch: the LAST path segment decides. A path ending in a name
+    // we declared to be a directory is the nested read; anything else is the category dir.
+    const last = basename(String(p));
+    return (baseDirEntries.has(last) ? baseNestedEntries : baseCategoryEntries).map(direntOf);
+  },
   realpathSync: (p: string) => (realpathFor ? realpathFor(String(p)) : String(p)),
   existsSync: (p: string) => (existsFor ? existsFor(String(p)) : liveRootExists),
   statSync: (p: string) => {
@@ -162,6 +176,8 @@ beforeEach(() => {
   existsFor = undefined;
   modelsDirStat = "dir";
   baseCategoryEntries = [];
+  baseNestedEntries = [];
+  baseDirEntries = new Set();
   statFor = undefined;
   realpathFor = undefined;
   serverInventory = undefined;
@@ -1233,23 +1249,55 @@ describe("#1371 — a configured base the server demonstrably does not read is r
     expect(modelsDir).toBe(resolve("/second-root", "models"));
   });
 
-  it("a diffusers-style base (models in SUBFOLDERS) is not contradicted — the safe direction", async () => {
-    // A category whose models live in subdirectories reads as metadata-only to this check,
-    // so a stale base of that shape is NOT refused and the download proceeds with the
-    // existing unconfirmed-visibility note. Deliberate: that is the behaviour these users
-    // had before the gate existed. Treating any subdirectory as evidence would re-open the
-    // metadata hole with an empty folder, and a false contradiction costs every download on
-    // a working install while a missed one costs a single misplaced file plus a warning.
-    config.comfyuiPath = "/diffusers-style";
+  it("a diffusers-style base IS contradicted — a nested model counts (codex P1)", async () => {
+    // The first version treated "no model file at the top level" as "not populated", so a
+    // stale base whose weights live in per-model folders sailed through and the download
+    // went into the wrong install. One level down is enough for the real layout and stops
+    // short of walking a models tree that can hold tens of thousands of files.
+    config.comfyuiPath = "/stale-diffusers";
     getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
-    serverInventory = { clip_vision: ["elsewhere.safetensors"] };
+    serverInventory = { clip_vision: ["lives-elsewhere.safetensors"] };
     modelsDirStat = "dir";
     existsFor = (p) => p.endsWith("models");
-    baseCategoryEntries = ["some-model-dir"]; // a folder, no model file at this level
+    baseCategoryEntries = ["some-model-dir"];
+    baseDirEntries = new Set(["some-model-dir"]);
+    baseNestedEntries = ["model.safetensors"];
+
+    await expect(
+      resolveModelsDirWithBases({ targetCategory: "clip_vision" }),
+    ).rejects.toThrow(/Refusing to download into/);
+  });
+
+  it("…but an EMPTY subfolder is still not evidence", async () => {
+    // The metadata hole in another costume: a folder that holds nothing says nothing.
+    config.comfyuiPath = "/empty-subfolder";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { clip_vision: ["lives-elsewhere.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+    baseCategoryEntries = ["empty-dir"];
+    baseDirEntries = new Set(["empty-dir"]);
+    baseNestedEntries = [];
 
     const { modelsDir } = await resolveModelsDirWithBases({ targetCategory: "clip_vision" });
-    expect(modelsDir).toBe(resolve("/diffusers-style", "models"));
+    expect(modelsDir).toBe(resolve("/empty-subfolder", "models"));
   });
+
+  it("a DIRECTORY named *.safetensors is not a model (codex)", async () => {
+    // Counting it would refuse a working base on the strength of a folder name.
+    config.comfyuiPath = "/folder-named-like-a-model";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { vae: ["elsewhere.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+    baseCategoryEntries = ["looks_like.safetensors"];
+    baseDirEntries = new Set(["looks_like.safetensors"]);
+    baseNestedEntries = [];
+
+    const { modelsDir } = await resolveModelsDirWithBases({ targetCategory: "vae" });
+    expect(modelsDir).toBe(resolve("/folder-named-like-a-model", "models"));
+  });
+
 
   it("does NOT refuse a multi-root base that is simply EMPTY for this category", async () => {
     // THE P0 DIRECTION. An extra_model_paths layout can legitimately have this base as one

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -1217,6 +1217,22 @@ describe("#1371 — a configured base the server demonstrably does not read is r
     );
   });
 
+  it("does NOT refuse a multi-root base holding only METADATA (codex P0)", async () => {
+    // "Has files of its own" has to mean MODEL files. Counting any directory entry treats
+    // a .gitkeep or a desktop.ini as proof the base is a populated root, so an
+    // extra_model_paths root with nothing but housekeeping in this category would be
+    // refused — the working install this refinement exists to protect.
+    config.comfyuiPath = "/second-root";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { vae: ["lives-in-the-other-root.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+    baseCategoryEntries = [".gitkeep", "desktop.ini", "Thumbs.db"];
+
+    const { modelsDir } = await resolveModelsDirWithBases({ targetCategory: "vae" });
+    expect(modelsDir).toBe(resolve("/second-root", "models"));
+  });
+
   it("does NOT refuse a multi-root base that is simply EMPTY for this category", async () => {
     // THE P0 DIRECTION. An extra_model_paths layout can legitimately have this base as one
     // of the server's roots with nothing in this category yet — indistinguishable from a

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -1233,6 +1233,24 @@ describe("#1371 — a configured base the server demonstrably does not read is r
     expect(modelsDir).toBe(resolve("/second-root", "models"));
   });
 
+  it("a diffusers-style base (models in SUBFOLDERS) is not contradicted — the safe direction", async () => {
+    // A category whose models live in subdirectories reads as metadata-only to this check,
+    // so a stale base of that shape is NOT refused and the download proceeds with the
+    // existing unconfirmed-visibility note. Deliberate: that is the behaviour these users
+    // had before the gate existed. Treating any subdirectory as evidence would re-open the
+    // metadata hole with an empty folder, and a false contradiction costs every download on
+    // a working install while a missed one costs a single misplaced file plus a warning.
+    config.comfyuiPath = "/diffusers-style";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { clip_vision: ["elsewhere.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+    baseCategoryEntries = ["some-model-dir"]; // a folder, no model file at this level
+
+    const { modelsDir } = await resolveModelsDirWithBases({ targetCategory: "clip_vision" });
+    expect(modelsDir).toBe(resolve("/diffusers-style", "models"));
+  });
+
   it("does NOT refuse a multi-root base that is simply EMPTY for this category", async () => {
     // THE P0 DIRECTION. An extra_model_paths layout can legitimately have this base as one
     // of the server's roots with nothing in this category yet — indistinguishable from a

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -1181,3 +1181,64 @@ describe("#1052: I/O dirs follow the CONNECTED server, not a second install", ()
     expect(await resolveOutputDir()).toBe(resolve(DESKTOP, "output"));
   });
 });
+
+describe("#1371 — a configured base the server demonstrably does not read is refused", () => {
+  // The reporter ran TWO local ComfyUIs. Connected to the second, COMFYUI_PATH still
+  // pointed at the first, and a model landed in the install the running server never reads
+  // — while the tool said "destination came from local configuration rather than the
+  // running server; visibility to the connected ComfyUI is unconfirmed". It knew, and wrote
+  // anyway.
+  //
+  // The `else if (base)` fallback took COMFYUI_PATH/models with no corroboration, and it is
+  // reached whenever the live root cannot be derived for any reason other than the
+  // relative-main.py shape the branch above it handles.
+
+  it("REFUSES when the server lists models for the category and NONE are under the base", async () => {
+    config.comfyuiPath = "/stale-install";
+    // A live server we cannot pin to a root: argv names no resolvable entrypoint.
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    // …and it will say what it sees. None of it is in the stale base.
+    serverInventory = { vae: ["h3-only.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+
+    await expect(resolveModelsDirWithBases({ targetCategory: "vae" })).rejects.toThrow(
+      /Refusing to download into/,
+    );
+  });
+
+  it("still writes when the server lists NOTHING — absence of evidence is not evidence", async () => {
+    // THE OVER-BROAD DIRECTION, and the reason this gate is contradiction-only. A fresh
+    // install has an empty models dir, corroborates nothing, and must still take its FIRST
+    // download. Refusing here would break every new setup.
+    config.comfyuiPath = "/fresh-install";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { vae: [] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+
+    const { modelsDir, source } = await resolveModelsDirWithBases({ targetCategory: "vae" });
+    expect(modelsDir).toBe(resolve("/fresh-install", "models"));
+    expect(source).toBe("configured-base");
+  });
+
+  it("still writes when the server is UNREACHABLE — nothing was established either way", async () => {
+    config.comfyuiPath = "/offline-install";
+    getSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+    serverInventory = undefined;
+
+    const { modelsDir } = await resolveModelsDirWithBases({ targetCategory: "vae" });
+    expect(modelsDir).toBe(resolve("/offline-install", "models"));
+  });
+
+  it("still writes when NO category was named — the check cannot contradict what it never asked", async () => {
+    config.comfyuiPath = "/unknown-category";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { vae: ["something.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+
+    const { modelsDir } = await resolveModelsDirWithBases();
+    expect(modelsDir).toBe(resolve("/unknown-category", "models"));
+  });
+});

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -24,7 +24,12 @@ let modelsDirStat: "dir" | "file" | "enoent" | "eacces" = "dir";
 let statFor: ((p: string) => { isDirectory: () => boolean; isFile: () => boolean }) | undefined;
 /** Canonicalization, for the #851 physical-containment check. Identity by default. */
 let realpathFor: ((p: string) => string) | undefined;
+/** What the BASE's own category dir contains (#1371). A contradiction requires this base
+ *  to hold files of its own — an EMPTY category dir is an extra_model_paths root that
+ *  simply has nothing here yet, which is a working setup and must not be refused. */
+let baseCategoryEntries: string[] = [];
 vi.mock("node:fs", () => ({
+  readdirSync: () => baseCategoryEntries,
   realpathSync: (p: string) => (realpathFor ? realpathFor(String(p)) : String(p)),
   existsSync: (p: string) => (existsFor ? existsFor(String(p)) : liveRootExists),
   statSync: (p: string) => {
@@ -156,6 +161,7 @@ beforeEach(() => {
   hasEntrypointFor = undefined;
   existsFor = undefined;
   modelsDirStat = "dir";
+  baseCategoryEntries = [];
   statFor = undefined;
   realpathFor = undefined;
   serverInventory = undefined;
@@ -1201,10 +1207,30 @@ describe("#1371 — a configured base the server demonstrably does not read is r
     serverInventory = { vae: ["h3-only.safetensors"] };
     modelsDirStat = "dir";
     existsFor = (p) => p.endsWith("models");
+    // The stale base holds its OWN models for this category — a second full install. That
+    // is what makes "none of the server's files are here" diagnostic rather than merely
+    // uninformative.
+    baseCategoryEntries = ["something-else.safetensors"];
 
     await expect(resolveModelsDirWithBases({ targetCategory: "vae" })).rejects.toThrow(
       /Refusing to download into/,
     );
+  });
+
+  it("does NOT refuse a multi-root base that is simply EMPTY for this category", async () => {
+    // THE P0 DIRECTION. An extra_model_paths layout can legitimately have this base as one
+    // of the server's roots with nothing in this category yet — indistinguishable from a
+    // stale base by filename listing alone. Refusing it would block a working install,
+    // which is worse than the wrong-directory write this gate exists to stop.
+    config.comfyuiPath = "/second-root";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { vae: ["lives-in-the-other-root.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+    baseCategoryEntries = [];
+
+    const { modelsDir } = await resolveModelsDirWithBases({ targetCategory: "vae" });
+    expect(modelsDir).toBe(resolve("/second-root", "models"));
   });
 
   it("still writes when the server lists NOTHING — absence of evidence is not evidence", async () => {

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -30,18 +30,26 @@ let realpathFor: ((p: string) => string) | undefined;
 let baseCategoryEntries: string[] = [];
 /** Names inside a SUBDIRECTORY of the category, for the diffusers-style layout (#1371). */
 let baseNestedEntries: string[] = [];
+/** Names one level below a nested directory, for the depth-2 diffusers case (#1371). */
+let baseDeepEntries: string[] = [];
 /** Entries the readdir mock reports as directories rather than files. */
 let baseDirEntries = new Set<string>();
+/** Entries the readdir mock reports as SYMLINKS — `Dirent.isFile()` is false for those,
+ *  which is how counting only isFile() stopped seeing a symlinked model tree (#1371). */
+let baseSymlinkEntries = new Set<string>();
 const direntOf = (name: string) => ({
   name,
-  isFile: () => !baseDirEntries.has(name),
+  isFile: () => !baseDirEntries.has(name) && !baseSymlinkEntries.has(name),
   isDirectory: () => baseDirEntries.has(name),
+  isSymbolicLink: () => baseSymlinkEntries.has(name),
 });
 vi.mock("node:fs", () => ({
   readdirSync: (p: string) => {
     // Explicit two-level dispatch: the LAST path segment decides. A path ending in a name
     // we declared to be a directory is the nested read; anything else is the category dir.
     const last = basename(String(p));
+    // Three levels: category dir → a nested dir → one deeper (the diffusers shape).
+    if (last === "transformer") return baseDeepEntries.map(direntOf);
     return (baseDirEntries.has(last) ? baseNestedEntries : baseCategoryEntries).map(direntOf);
   },
   realpathSync: (p: string) => (realpathFor ? realpathFor(String(p)) : String(p)),
@@ -177,7 +185,9 @@ beforeEach(() => {
   modelsDirStat = "dir";
   baseCategoryEntries = [];
   baseNestedEntries = [];
+  baseDeepEntries = [];
   baseDirEntries = new Set();
+  baseSymlinkEntries = new Set();
   statFor = undefined;
   realpathFor = undefined;
   serverInventory = undefined;
@@ -1262,6 +1272,43 @@ describe("#1371 — a configured base the server demonstrably does not read is r
     baseCategoryEntries = ["some-model-dir"];
     baseDirEntries = new Set(["some-model-dir"]);
     baseNestedEntries = ["model.safetensors"];
+
+    await expect(
+      resolveModelsDirWithBases({ targetCategory: "clip_vision" }),
+    ).rejects.toThrow(/Refusing to download into/);
+  });
+
+  it("a SYMLINKED model file counts — Dirent.isFile() is false for links (codex P1)", async () => {
+    // Sharing one model tree between installs by symlinking is ordinary practice, and this
+    // file says so elsewhere. Requiring isFile() alone made a stale base whose models are
+    // links read as EMPTY — reintroducing the misplaced write for exactly the users most
+    // likely to be running two installs.
+    config.comfyuiPath = "/stale-symlinked";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { vae: ["elsewhere.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+    baseCategoryEntries = ["linked-model.safetensors"];
+    baseSymlinkEntries = new Set(["linked-model.safetensors"]);
+
+    await expect(resolveModelsDirWithBases({ targetCategory: "vae" })).rejects.toThrow(
+      /Refusing to download into/,
+    );
+  });
+
+  it("a DEEPER diffusers tree counts too — <repo>/transformer/model.safetensors (codex P1)", async () => {
+    // One level down finds nothing in a real HF repo checkout, and "found nothing" was
+    // read as "this base is empty", permitting the misplaced write.
+    config.comfyuiPath = "/stale-deep";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { clip_vision: ["elsewhere.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+    baseCategoryEntries = ["repo"];
+    baseDirEntries = new Set(["repo", "transformer"]);
+    baseNestedEntries = ["transformer"];
+    // `transformer` resolves through the same nested list; give it a model at depth 2.
+    baseDeepEntries = ["model.safetensors"];
 
     await expect(
       resolveModelsDirWithBases({ targetCategory: "clip_vision" }),

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -37,6 +37,8 @@ let baseDirEntries = new Set<string>();
 /** Entries the readdir mock reports as SYMLINKS — `Dirent.isFile()` is false for those,
  *  which is how counting only isFile() stopped seeing a symlinked model tree (#1371). */
 let baseSymlinkEntries = new Set<string>();
+/** How many readdirs one resolve did — the P2 bound is a number, so assert on the number. */
+let readdirCalls = 0;
 const direntOf = (name: string) => ({
   name,
   isFile: () => !baseDirEntries.has(name) && !baseSymlinkEntries.has(name),
@@ -45,12 +47,17 @@ const direntOf = (name: string) => ({
 });
 vi.mock("node:fs", () => ({
   readdirSync: (p: string) => {
+    readdirCalls += 1;
     // Explicit two-level dispatch: the LAST path segment decides. A path ending in a name
     // we declared to be a directory is the nested read; anything else is the category dir.
     const last = basename(String(p));
     // Three levels: category dir → a nested dir → one deeper (the diffusers shape).
     if (last === "transformer") return baseDeepEntries.map(direntOf);
-    return (baseDirEntries.has(last) ? baseNestedEntries : baseCategoryEntries).map(direntOf);
+    // A SYMLINKED directory reads through to the nested listing too — readdir follows the
+    // link. Dispatching on baseDirEntries alone made the link re-serve the category's own
+    // listing, which is not a filesystem that exists.
+    const nested = baseDirEntries.has(last) || baseSymlinkEntries.has(last);
+    return (nested ? baseNestedEntries : baseCategoryEntries).map(direntOf);
   },
   realpathSync: (p: string) => (realpathFor ? realpathFor(String(p)) : String(p)),
   existsSync: (p: string) => (existsFor ? existsFor(String(p)) : liveRootExists),
@@ -74,6 +81,27 @@ vi.mock("node:fs", () => ({
     return { isDirectory: () => false, isFile: () => true };
   },
 }));
+
+/** statSync is consulted on MANY paths during resolution, not just the one a test cares
+ *  about. A blanket stub answers the others wrongly — an `isFile: true` fallback made the
+ *  server's listed file look PRESENT, so nothing was missing and the check returned ok
+ *  before reaching the branch under test. Override one path; defer the rest to the mock's
+ *  own default (present per existsFor, ENOENT otherwise). */
+const statExceptFor = (
+  match: (p: string) => boolean,
+  answer: { isDirectory: () => boolean; isFile: () => boolean } | "enoent",
+) => (path: string) => {
+  if (match(path)) {
+    if (answer !== "enoent") return answer;
+    const err = new Error(`stat ${path}`) as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    throw err;
+  }
+  if (existsFor ? existsFor(path) : liveRootExists) return { isDirectory: () => false, isFile: () => true };
+  const err = new Error(`stat ${path}`) as NodeJS.ErrnoException;
+  err.code = "ENOENT";
+  throw err;
+};
 
 const getSystemStats = vi.fn();
 /** The server's own model inventory: category → filenames it reports seeing. */
@@ -1313,6 +1341,77 @@ describe("#1371 — a configured base the server demonstrably does not read is r
     await expect(
       resolveModelsDirWithBases({ targetCategory: "clip_vision" }),
     ).rejects.toThrow(/Refusing to download into/);
+  });
+
+  it("a SYMLINKED model DIRECTORY counts — isDirectory() is false for those too (codex P1)", async () => {
+    // The same trap as isFile(), and it caught the same users. `models/checkpoints/SDXL ->
+    // /mnt/shared/SDXL` is what sharing one model tree between installs looks like, so the
+    // population this gate protects read as empty and the misplaced write went ahead —
+    // the symlinked-FILE fix above did nothing for them.
+    config.comfyuiPath = "/stale-linked-dir";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { clip_vision: ["elsewhere.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+    baseCategoryEntries = ["linked-dir"];
+    // A link to a directory: isDirectory() FALSE, isSymbolicLink() TRUE — Node's real
+    // Dirent semantics, pinned against the live filesystem in output-dir-symlink-fs.test.ts.
+    baseSymlinkEntries = new Set(["linked-dir"]);
+    baseNestedEntries = ["model.safetensors"];
+    // Scoped to the link. statSync is consulted on other paths during resolution, and a
+    // blanket stub answers those wrongly — the test then fails for an unrelated reason.
+    statFor = statExceptFor((p) => p.endsWith("linked-dir"), {
+      isDirectory: () => true,
+      isFile: () => false,
+    });
+
+    await expect(
+      resolveModelsDirWithBases({ targetCategory: "clip_vision" }),
+    ).rejects.toThrow(/Refusing to download into/);
+  });
+
+  it("a BROKEN link does not abort the scan around it", async () => {
+    // statSync on a dangling link throws. Letting it escape does not crash — an outer
+    // catch swallows it — which is exactly why this needed a test that can fail: the
+    // throw ABORTS the scan, so a base holding a stray broken link AND real models is
+    // never contradicted, and the misplaced write proceeds.
+    //
+    // The link is listed FIRST on purpose. Behind it, a model that must still be found.
+    config.comfyuiPath = "/broken-link";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { clip_vision: ["lives-elsewhere.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+    baseCategoryEntries = ["dangling", "real-model.safetensors"];
+    baseSymlinkEntries = new Set(["dangling"]);
+    statFor = statExceptFor((p) => p.endsWith("dangling"), "enoent");
+
+    await expect(
+      resolveModelsDirWithBases({ targetCategory: "clip_vision" }),
+    ).rejects.toThrow(/Refusing to download into/);
+  });
+
+  it("the scan is bounded — a huge category does not become thousands of readdirs (codex P2)", async () => {
+    // Depth alone bounds nothing: 10k empty subdirectories is 10k synchronous readdirs on
+    // the download path. Exhausting the budget answers "no model found", which is the safe
+    // direction — no contradiction, so no refusal, just the pre-existing warning.
+    config.comfyuiPath = "/huge";
+    getSystemStats.mockResolvedValue({ system: { argv: ["python"] } });
+    serverInventory = { clip_vision: ["lives-elsewhere.safetensors"] };
+    modelsDirStat = "dir";
+    existsFor = (p) => p.endsWith("models");
+    const many = Array.from({ length: 5000 }, (_, i) => `dir-${i}`);
+    baseCategoryEntries = many;
+    baseDirEntries = new Set(many);
+    baseNestedEntries = [];
+    readdirCalls = 0;
+
+    const { modelsDir } = await resolveModelsDirWithBases({ targetCategory: "clip_vision" });
+    expect(modelsDir).toBe(resolve("/huge", "models"));
+    // The bound, asserted as a number rather than a vibe. Without it this is 5001.
+    expect(readdirCalls).toBeLessThanOrEqual(80);
+    // ...and it really did have thousands of chances to exceed it.
+    expect(readdirCalls).toBeGreaterThan(1);
   });
 
   it("…but an EMPTY subfolder is still not evidence", async () => {

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -479,14 +479,47 @@ const BASE_OWN_MODEL_EXTENSIONS = new Set([
  * covers the real layout without turning a corroboration check into a recursive walk of a
  * models tree that can hold tens of thousands of files.
  */
-function directoryHoldsAModel(dir: string): boolean {
+function isModelFileEntry(entry: { name: string; isFile(): boolean; isSymbolicLink(): boolean }): boolean {
+  // SYMLINKS COUNT (codex). `Dirent.isFile()` is FALSE for a symbolic link, and sharing one
+  // model tree between installs by symlinking is ordinary practice — this file says so
+  // elsewhere. Requiring isFile() alone made a stale base whose models are links read as
+  // empty, reintroducing the misplaced write for exactly the users most likely to have two
+  // installs.
+  if (!entry.isFile() && !entry.isSymbolicLink()) return false;
+  return BASE_OWN_MODEL_EXTENSIONS.has(extname(entry.name).toLowerCase());
+}
+
+/**
+ * Does this directory tree hold a model file, within a bounded depth? (#1371)
+ *
+ * TWO LEVELS, not one. A Diffusers/HF repo checkout is `<category>/<repo>/transformer/
+ * model.safetensors` — one level down finds nothing there, and "found nothing" is read as
+ * "this base is empty", which permits the misplaced write this gate exists to stop.
+ *
+ * Bounded on purpose: a models tree can hold tens of thousands of files, and this runs
+ * synchronously inside a corroboration check on the download path. Depth 2 covers the real
+ * layouts without turning that into a full walk. Deeper nesting than that is a false
+ * negative — it proceeds with the existing unconfirmed-visibility warning, which is where
+ * these users were before the gate existed.
+ */
+function directoryHoldsAModel(dir: string, depth = 2): boolean {
+  if (depth <= 0) return false;
+  let entries: { name: string; isFile(): boolean; isSymbolicLink(): boolean; isDirectory(): boolean }[];
   try {
-    return readdirSync(dir, { withFileTypes: true }).some(
-      (e) => e.isFile() && BASE_OWN_MODEL_EXTENSIONS.has(extname(e.name).toLowerCase()),
-    );
+    entries = readdirSync(dir, { withFileTypes: true });
   } catch {
+    // Permission-denied or absent: nothing established either way.
     return false;
   }
+  for (const entry of entries) {
+    if (isModelFileEntry(entry)) return true;
+  }
+  for (const entry of entries) {
+    // Symlinked DIRECTORIES are deliberately not followed: a link can point back up the
+    // tree, and this is a corroboration check, not a crawler.
+    if (entry.isDirectory() && directoryHoldsAModel(join(dir, entry.name), depth - 1)) return true;
+  }
+  return false;
 }
 
 async function corroborateBaseByModelInventory(
@@ -736,13 +769,11 @@ async function corroborateBaseByModelInventory(
           // A nested model directory (diffusers-style) still counts — see below.
           baseHasOwnModelsHere = readdirSync(categoryDir, { withFileTypes: true }).some(
             (entry) =>
-              entry.isFile()
-                ? BASE_OWN_MODEL_EXTENSIONS.has(extname(entry.name).toLowerCase())
-                : // A SUBDIRECTORY counts too, but only when it actually holds a model
-                  // file. An empty folder is not evidence the base is populated, which is
-                  // the metadata hole in another costume; a diffusers-style directory of
-                  // shards is exactly the stale base the first version let through.
-                  entry.isDirectory() && directoryHoldsAModel(join(categoryDir, entry.name)),
+              isModelFileEntry(entry) ||
+              // A SUBDIRECTORY counts too, but only when it actually holds a model file
+              // within a bounded depth. An empty folder is not evidence the base is
+              // populated — that is the metadata hole wearing a directory.
+              (entry.isDirectory() && directoryHoldsAModel(join(categoryDir, entry.name))),
           );
         } catch {
           // Absent or unreadable — nothing established either way.

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -490,6 +490,44 @@ function isModelFileEntry(entry: { name: string; isFile(): boolean; isSymbolicLi
 }
 
 /**
+ * Is this entry a directory, INCLUDING a symlink pointing at one? (#1371)
+ *
+ * `Dirent.isDirectory()` is false for a symlink to a directory — the same trap as
+ * `isFile()` above, and it bit the same users twice. `models/checkpoints/SDXL ->
+ * /mnt/shared/SDXL` is the layout of someone sharing one model tree between installs,
+ * which is precisely the population this gate exists to protect: their base read as empty,
+ * so no contradiction was found, so the misplaced write went ahead.
+ *
+ * Following the link is safe here because the recursion below is depth-bounded and
+ * budget-bounded — a link pointing back up its own tree costs at most a couple of extra
+ * readdirs, not a cycle. A broken link throws and is simply not a directory.
+ */
+function entryIsDirectoryLike(dir: string, entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean }): boolean {
+  if (entry.isDirectory()) return true;
+  if (!entry.isSymbolicLink()) return false;
+  try {
+    return statSync(join(dir, entry.name)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * How many directories one corroboration check may read before it gives up. (#1371, codex P2)
+ *
+ * Depth alone does not bound the work: a category holding 10k subdirectories is 10k
+ * synchronous readdirs at depth 2, on the download path. Exhausting the budget answers
+ * "no model found", which is the SAFE direction — no contradiction means no refusal, only
+ * the pre-existing unconfirmed-visibility warning. A populated base almost always answers
+ * true from a file in the first directory read.
+ */
+const MODEL_SCAN_DIR_BUDGET = 64;
+
+function newModelScanBudget(): { dirs: number } {
+  return { dirs: MODEL_SCAN_DIR_BUDGET };
+}
+
+/**
  * Does this directory tree hold a model file, within a bounded depth? (#1371)
  *
  * TWO LEVELS, not one. A Diffusers/HF repo checkout is `<category>/<repo>/transformer/
@@ -502,8 +540,9 @@ function isModelFileEntry(entry: { name: string; isFile(): boolean; isSymbolicLi
  * negative — it proceeds with the existing unconfirmed-visibility warning, which is where
  * these users were before the gate existed.
  */
-function directoryHoldsAModel(dir: string, depth = 2): boolean {
-  if (depth <= 0) return false;
+function directoryHoldsAModel(dir: string, depth = 2, budget = newModelScanBudget()): boolean {
+  if (depth <= 0 || budget.dirs <= 0) return false;
+  budget.dirs -= 1;
   let entries: { name: string; isFile(): boolean; isSymbolicLink(): boolean; isDirectory(): boolean }[];
   try {
     entries = readdirSync(dir, { withFileTypes: true });
@@ -515,9 +554,9 @@ function directoryHoldsAModel(dir: string, depth = 2): boolean {
     if (isModelFileEntry(entry)) return true;
   }
   for (const entry of entries) {
-    // Symlinked DIRECTORIES are deliberately not followed: a link can point back up the
-    // tree, and this is a corroboration check, not a crawler.
-    if (entry.isDirectory() && directoryHoldsAModel(join(dir, entry.name), depth - 1)) return true;
+    if (budget.dirs <= 0) return false;
+    if (entryIsDirectoryLike(dir, entry) && directoryHoldsAModel(join(dir, entry.name), depth - 1, budget))
+      return true;
   }
   return false;
 }
@@ -767,13 +806,19 @@ async function corroborateBaseByModelInventory(
           // withFileTypes, because a DIRECTORY named `foo.safetensors` is not a model
           // (codex): counting it would refuse a base on the strength of a folder name.
           // A nested model directory (diffusers-style) still counts — see below.
+          // ONE budget for the whole scan, not one per subdirectory: the point of the
+          // bound is to cap this entire check, and a fresh budget per entry would let a
+          // category with 10k subdirectories spend 10k of them.
+          const budget = newModelScanBudget();
           baseHasOwnModelsHere = readdirSync(categoryDir, { withFileTypes: true }).some(
             (entry) =>
               isModelFileEntry(entry) ||
-              // A SUBDIRECTORY counts too, but only when it actually holds a model file
-              // within a bounded depth. An empty folder is not evidence the base is
-              // populated — that is the metadata hole wearing a directory.
-              (entry.isDirectory() && directoryHoldsAModel(join(categoryDir, entry.name))),
+              // A SUBDIRECTORY counts too — symlinked ones included — but only when it
+              // actually holds a model file within a bounded depth. An empty folder is not
+              // evidence the base is populated: that is the metadata hole wearing a
+              // directory.
+              (entryIsDirectoryLike(categoryDir, entry) &&
+                directoryHoldsAModel(join(categoryDir, entry.name), 2, budget)),
           );
         } catch {
           // Absent or unreadable — nothing established either way.

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -690,6 +690,16 @@ async function corroborateBaseByModelInventory(
         // nothing but metadata for this category would be refused, which is the working
         // install this whole refinement exists to protect. Only a real model file is
         // evidence that this base is a place models live.
+        //
+        // KNOWN AND DELIBERATE GAP: a category whose models live in SUBFOLDERS
+        // (diffusers-style directories, `clip_vision/<dir>/model.bin`) reads as
+        // metadata-only here, so a stale base of that shape is NOT contradicted and the
+        // download proceeds with the existing unconfirmed-visibility note. That is the
+        // safe direction — it returns the behaviour to what it was before this gate rather
+        // than blocking anyone — and the alternative, treating any subdirectory as
+        // evidence, re-opens the metadata hole with an empty folder. A missed contradiction
+        // costs one misplaced file and a warning; a false one costs every download on a
+        // working install.
         let baseHasOwnModelsHere = false;
         try {
           baseHasOwnModelsHere = readdirSync(categoryDir).some((entry) =>

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -453,7 +453,19 @@ async function corroborateBaseByModelInventory(
       /** How many the server listed, so a PARTIAL match can be reported as one. */
       listed: number;
     }
-  | { ok: false; reason: string }
+  | {
+      ok: false;
+      reason: string;
+      /**
+       * The server listed files for this category and NONE of them are under the base
+       * (#1371). That is not "no evidence" — it is evidence AGAINST, and the two must not
+       * be answered the same way. A fresh install with an empty models dir corroborates
+       * nothing either, and refusing that would block the first download on every new
+       * setup; a base the server demonstrably does not read is where a model silently
+       * lands in the wrong install.
+       */
+      contradicted?: boolean;
+    }
 > {
   // The corroboration must be about the category this download is FOR. A complete match
   // on some OTHER category proves only that THAT folder is under this base — and a server
@@ -492,6 +504,8 @@ async function corroborateBaseByModelInventory(
   // this used to sweep for any category that happened to match.
   let unreadableCategories = 0;
   let lastReason: string | undefined;
+  /** Set when the server's own listing shows the base is NOT a root it reads (#1371). */
+  let contradictedBase = false;
   for (const category of [targetCategory]) {
     let files: string[];
     try {
@@ -639,6 +653,7 @@ async function corroborateBaseByModelInventory(
           : "");
     } else if (missing.length > 0) {
       const present = files.length - missing.length;
+      if (present === 0) contradictedBase = true;
       lastReason =
         present === 0
           ? `the server lists ${files.length} file(s) under "${category}" and NONE of them are under ` +
@@ -662,7 +677,7 @@ async function corroborateBaseByModelInventory(
         `"${categoryDir}" (e.g. "${escaping[0]}"), so they cannot corroborate this base`;
     }
   }
-  if (lastReason) return { ok: false, reason: lastReason };
+  if (lastReason) return { ok: false, reason: lastReason, contradicted: contradictedBase };
   // Nothing was COMPARED. Say which of the two reasons that was: the listing could not be
   // read, or it was empty. Reporting the first as the second would be the same fold this
   // whole change is about — and an EMPTY target category genuinely cannot corroborate
@@ -853,6 +868,42 @@ export async function resolveModelsDirWithBases(opts?: {
           "Fix by launching ComfyUI with an ABSOLUTE --base-directory, or set COMFYUI_PATH to the directory whose models/ the server actually reads.",
       );
     } else if (base) {
+      // #1371 — DO NOT WRITE INTO A BASE THE SERVER DEMONSTRABLY DOES NOT READ.
+      //
+      // This fallback took COMFYUI_PATH/models with no corroboration at all, and it is
+      // reached whenever the live root could not be derived for any reason OTHER than the
+      // relative-main.py shape the branch above handles. A reporter running two local
+      // ComfyUIs — connected to :8190, COMFYUI_PATH pointing at the other install — had a
+      // model written into the install the server never reads, while the tool told them
+      // "destination came from local configuration rather than the running server;
+      // visibility to the connected ComfyUI is unconfirmed". It knew, and wrote anyway. A
+      // warning beside a write is not a substitute for not writing.
+      //
+      // THE GATE IS EVIDENCE AGAINST, NOT ABSENCE OF EVIDENCE. Refusing whenever the base
+      // cannot be corroborated would break every correct setup whose server reports no
+      // resolvable root — per #1374 that includes the ordinary Windows-portable shape — and
+      // it would block the FIRST download on any fresh install, whose models dir is empty
+      // and therefore corroborates nothing. So this refuses only when the server's own
+      // listing shows the base is not a root it reads: files listed for this category, none
+      // of them here. Silence still writes, with the existing unconfirmed-visibility note.
+      if (snapshot.reachable && !isRemoteMode()) {
+        const verdict = await corroborateBaseByModelInventory(
+          base,
+          (opts?.targetCategory ?? "").trim(),
+        );
+        if (!verdict.ok && verdict.contradicted) {
+          throw new ValidationError(
+            `Refusing to download into "${resolve(base, "models")}": ${verdict.reason}.
+
+` +
+              `The graph you are downloading for is served by a DIFFERENT ComfyUI than this ` +
+              `configured base describes, so the file would land where that server never looks ` +
+              `and be reported as a success (#1371). Fix by pointing COMFYUI_PATH at the install ` +
+              `the connected server actually runs, or by launching that server with an absolute ` +
+              `--base-directory so its models directory can be read from it directly.`,
+          );
+        }
+      }
       modelsDir = resolve(base, "models");
       source = "configured-base";
     } else {

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, realpathSync, statSync } from "node:fs";
-import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { config, isRemoteMode } from "../config.js";
 import { getSystemStats, comfyApiFetch } from "../comfyui/client.js";
 import {
@@ -441,6 +441,25 @@ function probeEntry(p: string): { kind: "file" | "absent" | "not-a-file" | "inde
   }
 }
 
+/**
+ * Extensions that make a directory entry a MODEL rather than housekeeping (#1371).
+ *
+ * Used only to answer "does this base hold models of its own for this category?" — the
+ * question that separates a stale second install from an extra_model_paths root that is
+ * simply empty here. A `.gitkeep` or a `desktop.ini` answers neither.
+ */
+const BASE_OWN_MODEL_EXTENSIONS = new Set([
+  ".safetensors",
+  ".sft",
+  ".ckpt",
+  ".pt",
+  ".pt2",
+  ".pth",
+  ".bin",
+  ".gguf",
+  ".onnx",
+]);
+
 async function corroborateBaseByModelInventory(
   base: string,
   targetCategory: string,
@@ -665,13 +684,21 @@ async function corroborateBaseByModelInventory(
       // against. A base holding a different set of files for the same category is the case
       // that is actually diagnostic, and it is the reporter's: a second full install.
       if (present === 0) {
-        let baseHasOwnFilesHere = false;
+        // …and "has files of its own" must mean MODEL files (codex P0). Counting any
+        // directory entry treats a `.gitkeep`, a `desktop.ini` or a `Thumbs.db` as proof
+        // the base is a populated root — so a legitimate extra_model_paths root holding
+        // nothing but metadata for this category would be refused, which is the working
+        // install this whole refinement exists to protect. Only a real model file is
+        // evidence that this base is a place models live.
+        let baseHasOwnModelsHere = false;
         try {
-          baseHasOwnFilesHere = readdirSync(categoryDir).length > 0;
+          baseHasOwnModelsHere = readdirSync(categoryDir).some((entry) =>
+            BASE_OWN_MODEL_EXTENSIONS.has(extname(String(entry)).toLowerCase()),
+          );
         } catch {
           // Absent or unreadable — nothing established either way.
         }
-        contradictedBase = baseHasOwnFilesHere;
+        contradictedBase = baseHasOwnModelsHere;
       }
       lastReason =
         present === 0

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -502,9 +502,22 @@ function isModelFileEntry(entry: { name: string; isFile(): boolean; isSymbolicLi
  * budget-bounded — a link pointing back up its own tree costs at most a couple of extra
  * readdirs, not a cycle. A broken link throws and is simply not a directory.
  */
-function entryIsDirectoryLike(dir: string, entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean }): boolean {
+function entryIsDirectoryLike(
+  dir: string,
+  entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean },
+  budget: ModelScanBudget,
+): boolean {
   if (entry.isDirectory()) return true;
   if (!entry.isSymbolicLink()) return false;
+  // THE STAT IS ITSELF THE WORK (codex P2). A category holding thousands of directory
+  // symlinks reached this line once per entry, because the readdir budget is only consumed
+  // one level down — so bounding readdirs left the symlink-heavy tree exactly as
+  // unbounded as before, in the shape the symlink fix newly made reachable.
+  if (budget.stats <= 0) {
+    budget.truncated = true;
+    return false;
+  }
+  budget.stats -= 1;
   try {
     return statSync(join(dir, entry.name)).isDirectory();
   } catch {
@@ -521,10 +534,29 @@ function entryIsDirectoryLike(dir: string, entry: { name: string; isDirectory():
  * the pre-existing unconfirmed-visibility warning. A populated base almost always answers
  * true from a file in the first directory read.
  */
-const MODEL_SCAN_DIR_BUDGET = 64;
+const MODEL_SCAN_DIR_BUDGET = 512;
 
-function newModelScanBudget(): { dirs: number } {
-  return { dirs: MODEL_SCAN_DIR_BUDGET };
+/** Companion cap on link resolutions, for the same reason one level down. */
+const MODEL_SCAN_STAT_BUDGET = 4096;
+
+interface ModelScanBudget {
+  dirs: number;
+  stats: number;
+  /**
+   * The scan GAVE UP; it did not finish and find nothing.
+   *
+   * These are not the same answer and folding them together is the defect this repo has a
+   * gate for (#796). "No model here" contradicts the base and refuses the download; "I
+   * stopped looking" establishes nothing, and reporting it as the former would refuse a
+   * working install, while reporting it as a clean negative — which is what the first
+   * version of this bound did — silently returns the misplaced write the whole check
+   * exists to stop. The caller proceeds either way, but says which one happened.
+   */
+  truncated: boolean;
+}
+
+function newModelScanBudget(): ModelScanBudget {
+  return { dirs: MODEL_SCAN_DIR_BUDGET, stats: MODEL_SCAN_STAT_BUDGET, truncated: false };
 }
 
 /**
@@ -541,7 +573,11 @@ function newModelScanBudget(): { dirs: number } {
  * these users were before the gate existed.
  */
 function directoryHoldsAModel(dir: string, depth = 2, budget = newModelScanBudget()): boolean {
-  if (depth <= 0 || budget.dirs <= 0) return false;
+  if (depth <= 0) return false;
+  if (budget.dirs <= 0) {
+    budget.truncated = true;
+    return false;
+  }
   budget.dirs -= 1;
   let entries: { name: string; isFile(): boolean; isSymbolicLink(): boolean; isDirectory(): boolean }[];
   try {
@@ -554,8 +590,14 @@ function directoryHoldsAModel(dir: string, depth = 2, budget = newModelScanBudge
     if (isModelFileEntry(entry)) return true;
   }
   for (const entry of entries) {
-    if (budget.dirs <= 0) return false;
-    if (entryIsDirectoryLike(dir, entry) && directoryHoldsAModel(join(dir, entry.name), depth - 1, budget))
+    if (budget.dirs <= 0) {
+      budget.truncated = true;
+      return false;
+    }
+    if (
+      entryIsDirectoryLike(dir, entry, budget) &&
+      directoryHoldsAModel(join(dir, entry.name), depth - 1, budget)
+    )
       return true;
   }
   return false;
@@ -585,6 +627,9 @@ async function corroborateBaseByModelInventory(
        * lands in the wrong install.
        */
       contradicted?: boolean;
+      /** The local model scan gave up at its bound, so "not contradicted" is not a finding
+       *  that this base holds nothing of its own. */
+      scanTruncated?: boolean;
     }
 > {
   // The corroboration must be about the category this download is FOR. A complete match
@@ -626,6 +671,8 @@ async function corroborateBaseByModelInventory(
   let lastReason: string | undefined;
   /** Set when the server's own listing shows the base is NOT a root it reads (#1371). */
   let contradictedBase = false;
+  /** The local scan hit its bound before answering. See the assignment for why it matters. */
+  let scanTruncated = false;
   for (const category of [targetCategory]) {
     let files: string[];
     try {
@@ -802,6 +849,29 @@ async function corroborateBaseByModelInventory(
         // costs one misplaced file and a warning; a false one costs every download on a
         // working install.
         let baseHasOwnModelsHere = false;
+        const budget = newModelScanBudget();
+        // The budget is read BEFORE the link resolution, not after: `.some()` would
+        // otherwise stat every one of thousands of entries and only then let the recursion
+        // decline for want of budget (codex P2).
+        //
+        // Named rather than inlined because the guard must MARK the truncation on its way
+        // out. Written inline as `budget.dirs > 0 && …` it short-circuited silently, so the
+        // scan gave up and reported a clean negative — precisely the fold this budget was
+        // being taught to avoid, committed in the line that avoids it.
+        const subdirHoldsAModel = (entry: {
+          name: string;
+          isDirectory(): boolean;
+          isSymbolicLink(): boolean;
+        }): boolean => {
+          if (budget.dirs <= 0) {
+            budget.truncated = true;
+            return false;
+          }
+          return (
+            entryIsDirectoryLike(categoryDir, entry, budget) &&
+            directoryHoldsAModel(join(categoryDir, entry.name), 2, budget)
+          );
+        };
         try {
           // withFileTypes, because a DIRECTORY named `foo.safetensors` is not a model
           // (codex): counting it would refuse a base on the strength of a folder name.
@@ -809,7 +879,6 @@ async function corroborateBaseByModelInventory(
           // ONE budget for the whole scan, not one per subdirectory: the point of the
           // bound is to cap this entire check, and a fresh budget per entry would let a
           // category with 10k subdirectories spend 10k of them.
-          const budget = newModelScanBudget();
           baseHasOwnModelsHere = readdirSync(categoryDir, { withFileTypes: true }).some(
             (entry) =>
               isModelFileEntry(entry) ||
@@ -817,13 +886,22 @@ async function corroborateBaseByModelInventory(
               // actually holds a model file within a bounded depth. An empty folder is not
               // evidence the base is populated: that is the metadata hole wearing a
               // directory.
-              (entryIsDirectoryLike(categoryDir, entry) &&
-                directoryHoldsAModel(join(categoryDir, entry.name), 2, budget)),
+              subdirHoldsAModel(entry),
           );
         } catch {
           // Absent or unreadable — nothing established either way.
         }
         contradictedBase = baseHasOwnModelsHere;
+        // A TRUNCATED SCAN IS NOT A CLEAN NEGATIVE (codex P1, #796 discipline).
+        //
+        // Not finding a model means this base is a place models do not live, which
+        // contradicts nothing and lets the download proceed. Giving up after the bound
+        // means we do not know — and a stale base whose only model sits behind the 512th
+        // directory reads identically to an empty one, which is the silent misplaced write
+        // this whole check exists to stop. The download still proceeds (refusing on an
+        // inconclusive scan would block working installs, which is worse), but the fact
+        // that the check did not finish is stated rather than folded away.
+        scanTruncated = budget.truncated && !baseHasOwnModelsHere;
       }
       lastReason =
         present === 0
@@ -848,7 +926,8 @@ async function corroborateBaseByModelInventory(
         `"${categoryDir}" (e.g. "${escaping[0]}"), so they cannot corroborate this base`;
     }
   }
-  if (lastReason) return { ok: false, reason: lastReason, contradicted: contradictedBase };
+  if (lastReason)
+    return { ok: false, reason: lastReason, contradicted: contradictedBase, scanTruncated };
   // Nothing was COMPARED. Say which of the two reasons that was: the listing could not be
   // read, or it was empty. Reporting the first as the second would be the same fold this
   // whole change is about — and an EMPTY target category genuinely cannot corroborate
@@ -1072,6 +1151,19 @@ export async function resolveModelsDirWithBases(opts?: {
               `and be reported as a success (#1371). Fix by pointing COMFYUI_PATH at the install ` +
               `the connected server actually runs, or by launching that server with an absolute ` +
               `--base-directory so its models directory can be read from it directly.`,
+          );
+        }
+        if (!verdict.ok && verdict.scanTruncated) {
+          // Proceeding, but not silently (codex P1). The refusal above needs the base to
+          // be PROVEN stale, and a scan that stopped early proves nothing — so the
+          // download goes ahead exactly as it did before this gate existed, with the one
+          // thing the user cannot otherwise know: the check did not finish.
+          logger.warn(
+            `The local check of "${resolve(base, "models")}" did not finish — it stopped at its ` +
+              `directory bound before finding a model of its own. That is NOT a finding that this ` +
+              `base is empty, so the download proceeds; but if this install is stale, the file will ` +
+              `land where the connected server never looks (#1371). ${verdict.reason}.`,
+            { modelsDir: resolve(base, "models"), basis: "filename-inventory", truncated: true },
           );
         }
       }

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync, statSync } from "node:fs";
+import { existsSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { config, isRemoteMode } from "../config.js";
 import { getSystemStats, comfyApiFetch } from "../comfyui/client.js";
@@ -653,7 +653,26 @@ async function corroborateBaseByModelInventory(
           : "");
     } else if (missing.length > 0) {
       const present = files.length - missing.length;
-      if (present === 0) contradictedBase = true;
+      // CONTRADICTION REQUIRES THIS BASE TO HAVE SOMETHING OF ITS OWN.
+      //
+      // present === 0 means none of the server's files for this category are here. That is
+      // a stale base — or an extra_model_paths layout where this IS one of the server's
+      // roots and simply has nothing in this category yet. A filename listing cannot tell
+      // those apart, and refusing the second would block a working install, which is worse
+      // than the wrong-directory write this gate exists to stop.
+      //
+      // An EMPTY (or absent) category dir here is therefore no evidence, not evidence
+      // against. A base holding a different set of files for the same category is the case
+      // that is actually diagnostic, and it is the reporter's: a second full install.
+      if (present === 0) {
+        let baseHasOwnFilesHere = false;
+        try {
+          baseHasOwnFilesHere = readdirSync(categoryDir).length > 0;
+        } catch {
+          // Absent or unreadable — nothing established either way.
+        }
+        contradictedBase = baseHasOwnFilesHere;
+      }
       lastReason =
         present === 0
           ? `the server lists ${files.length} file(s) under "${category}" and NONE of them are under ` +

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -458,7 +458,36 @@ const BASE_OWN_MODEL_EXTENSIONS = new Set([
   ".bin",
   ".gguf",
   ".onnx",
+  // Formats a first pass missed (codex P1). Omitting one is not neutral: a stale base
+  // holding only `.engine` files reads as EMPTY, the contradiction never fires, and the
+  // download goes into the wrong install — the exact write this gate exists to stop.
+  ".pte",
+  ".engine",
+  ".trt",
+  ".plan",
+  ".npz",
+  ".msgpack",
+  ".pkl",
+  ".model",
 ]);
+
+/**
+ * Does this directory hold a model file, one level down? (#1371)
+ *
+ * Diffusers-style categories keep their weights in per-model folders, so "no model file at
+ * the top level" is not the same as "this base is empty". One level is deliberate: it
+ * covers the real layout without turning a corroboration check into a recursive walk of a
+ * models tree that can hold tens of thousands of files.
+ */
+function directoryHoldsAModel(dir: string): boolean {
+  try {
+    return readdirSync(dir, { withFileTypes: true }).some(
+      (e) => e.isFile() && BASE_OWN_MODEL_EXTENSIONS.has(extname(e.name).toLowerCase()),
+    );
+  } catch {
+    return false;
+  }
+}
 
 async function corroborateBaseByModelInventory(
   base: string,
@@ -702,8 +731,18 @@ async function corroborateBaseByModelInventory(
         // working install.
         let baseHasOwnModelsHere = false;
         try {
-          baseHasOwnModelsHere = readdirSync(categoryDir).some((entry) =>
-            BASE_OWN_MODEL_EXTENSIONS.has(extname(String(entry)).toLowerCase()),
+          // withFileTypes, because a DIRECTORY named `foo.safetensors` is not a model
+          // (codex): counting it would refuse a base on the strength of a folder name.
+          // A nested model directory (diffusers-style) still counts — see below.
+          baseHasOwnModelsHere = readdirSync(categoryDir, { withFileTypes: true }).some(
+            (entry) =>
+              entry.isFile()
+                ? BASE_OWN_MODEL_EXTENSIONS.has(extname(entry.name).toLowerCase())
+                : // A SUBDIRECTORY counts too, but only when it actually holds a model
+                  // file. An empty folder is not evidence the base is populated, which is
+                  // the metadata hole in another costume; a diffusers-style directory of
+                  // shards is exactly the stale base the first version let through.
+                  entry.isDirectory() && directoryHoldsAModel(join(categoryDir, entry.name)),
           );
         } catch {
           // Absent or unreadable — nothing established either way.


### PR DESCRIPTION
Draft — claiming #1371: `download_model` wrote a model into a **stale `COMFYUI_PATH`** belonging to a different local install than the one it was connected to (`:8190`). The file landed under `...\ComfyUI\models` while visibility was checked against `...\ComfyUI_H3`.

**The refusal for this already exists — it just does not guard every path.**

`resolveModelsDirWithBases` (`src/services/output-dir.ts`) ranks its answer by source: `argv-flag` and `base-anchored` come from the running server; `configured-base` is plain local config. When the live root resolves but the configured base does not corroborate it, the function refuses outright, and says why:

> Refusing to write to a guessed directory (that is how a model lands in a stale install and is reported as a success).

That is exactly this bug, already written down. But the branch below it —

```ts
} else if (base) {
  modelsDir = resolve(base, "models");
  source = "configured-base";
}
```

— takes plain `COMFYUI_PATH/models` with **no corroboration at all**, and it is reached whenever the live root could not be derived. A second local ComfyUI on another port is precisely the case where the reporter's `COMFYUI_PATH` points somewhere real, writable, and wrong.

The reporter even saw the tool say *"destination came from local configuration rather than the running server; visibility to the connected ComfyUI is unconfirmed"* — it knew, and wrote anyway.

Plan: make the fallback prove itself the way the sibling branch does. The inventory check ("ask the running server what models it can SEE") already exists and covers a Docker/data-dir base that has no `main.py`; the fallback should use it, and refuse when it cannot corroborate — instead of writing to a directory it has only assumed the server reads.

**The over-broad direction is the one to watch**, and I will measure it before shipping: refusing whenever the live root is underivable would break every correctly-configured install whose server does not report a resolvable root — which, per #1374, includes the common Windows-portable shape. The corroboration has to be the gate, not the derivability.

Refs #1371
