### PR TITLE
fix(1373): verify a .json attachment by parsing it, not by its content-type

### DIFF
--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -708,6 +708,45 @@ describe("#1373 — a .json attachment is accepted by PARSING it, not by its con
     ).resolves.toBeDefined();
   });
 
+  it("REFUSES a 200 JSON ERROR ENVELOPE — valid JSON is not the file they asked for", async () => {
+    // ComfyUI answers 200 with a JSON error body in several cases, and {"error":"..."}
+    // parses perfectly. Saving it as my_workflow.json is this issue's own bug in a new
+    // costume: a failure written to disk under the name of the thing that failed.
+    fetchImageMock.mockResolvedValue(jsonBody('{"error":"not found"}'));
+    await expect(
+      getOutputImage("wf.json", "input", "", { allowMedia: true, allowJson: true }),
+    ).rejects.toThrow(/did not return an image/);
+  });
+
+  it("…but a workflow that merely CONTAINS the word error is still saved", async () => {
+    // The refusal is a top-level `error` KEY on an object, not a substring search. A node
+    // titled "error handler" or a widget value mentioning errors is an ordinary workflow.
+    fetchImageMock.mockResolvedValue(
+      jsonBody('{"nodes":[{"title":"error handler","widgets_values":["error"]}]}'),
+    );
+    await expect(
+      getOutputImage("wf.json", "input", "", { allowMedia: true, allowJson: true }),
+    ).resolves.toBeDefined();
+  });
+
+  it("REFUSES an implausibly large .json rather than parsing it unchecked", async () => {
+    // Parsing is the acceptance test, and parsing means decoding the whole body and
+    // building an object graph — paid twice in memory before anything could reject it. A
+    // workflow is kilobytes; 32 MB is far above any real one. Above the ceiling the answer
+    // is REFUSE, because accepting unverified is exactly what this guard exists to prevent.
+    // VALID JSON, deliberately — an invalid blob would be refused by the parse regardless,
+    // so the test would pass with the ceiling removed and prove nothing. Mutation testing
+    // caught exactly that: my first version used 45 MB of "A".
+    const huge = JSON.stringify({ pad: "A".repeat(40 * 1024 * 1024) });
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from(huge, "utf8").toString("base64"),
+      mimeType: "application/json",
+    });
+    await expect(
+      getOutputImage("huge.json", "input", "", { allowMedia: true, allowJson: true }),
+    ).rejects.toThrow(/did not return an image/);
+  });
+
   it("REFUSES an HTML error page served as .json — the rejection this check exists for", async () => {
     // ComfyUI answers 200 with an error body often enough that this is the whole point.
     // A permissive "it was requested as .json, save it" would hand back a login page as a

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -787,6 +787,37 @@ describe("#1373 — a .json attachment is accepted by PARSING it, not by its con
     }
   });
 
+  it("a content refusal carries its OWN error code, not IMAGE_NOT_FOUND (codex P2)", async () => {
+    // The prose named the real reason; the CODE still said the file was missing — and the
+    // code is the part automation reads. A caller branching on it retried, re-listed the
+    // directory, and asked the user to check a filename that was never wrong.
+    fetchImageMock.mockResolvedValue(jsonBody('{"error":"not found"}'));
+    const err = await getOutputImage("wf.json", "input", "", {
+      allowMedia: true,
+      allowJson: true,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(ComfyUIError);
+    expect(err.code).toBe("ATTACHMENT_CONTENT_REJECTED");
+    // The reason, structured, so a caller need not parse the sentence to act on it.
+    expect(err.details?.rejectedBecause).toMatch(/JSON ERROR body/);
+  });
+
+  it("…and a genuinely absent file still says IMAGE_NOT_FOUND", async () => {
+    // The over-broad direction of the same change, which the test above cannot see:
+    // relabelling every rejection would erase the missing-file signal that #385 added,
+    // and #385's own tests use .png paths that never reach the JSON branch at all.
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from("<html>404</html>", "utf8").toString("base64"),
+      mimeType: "text/html",
+    });
+    const err = await getOutputImage("gone.png", "output", "", {
+      allowMedia: true,
+      allowJson: true,
+    }).catch((e) => e);
+    expect(err.code).toBe("IMAGE_NOT_FOUND");
+    expect(err.details?.rejectedBecause).toBeUndefined();
+  });
+
   it("…and KEEPS a real workflow that carries its own top-level `error` field (codex)", async () => {
     // The other direction of the same miscalibration: rejecting a legitimate attachment
     // because a key name collided. A body with workflow markers is a workflow.

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -715,7 +715,7 @@ describe("#1373 — a .json attachment is accepted by PARSING it, not by its con
     fetchImageMock.mockResolvedValue(jsonBody('{"error":"not found"}'));
     await expect(
       getOutputImage("wf.json", "input", "", { allowMedia: true, allowJson: true }),
-    ).rejects.toThrow(/did not return an image/);
+    ).rejects.toThrow(/JSON ERROR body/);
   });
 
   it("…but a workflow that merely CONTAINS the word error is still saved", async () => {
@@ -742,9 +742,11 @@ describe("#1373 — a .json attachment is accepted by PARSING it, not by its con
       base64: Buffer.from(huge, "utf8").toString("base64"),
       mimeType: "application/json",
     });
+    // …and the message names the SIZE, not "the file may not exist" — the caller's
+    // filename is perfectly correct and sending them to re-check it wastes the trip.
     await expect(
       getOutputImage("huge.json", "input", "", { allowMedia: true, allowJson: true }),
-    ).rejects.toThrow(/did not return an image/);
+    ).rejects.toThrow(/over the 32 MB ceiling/);
   });
 
   it("REFUSES an HTML error page served as .json — the rejection this check exists for", async () => {
@@ -757,21 +759,43 @@ describe("#1373 — a .json attachment is accepted by PARSING it, not by its con
     });
     await expect(
       getOutputImage("missing.json", "input", "", { allowMedia: true, allowJson: true }),
-    ).rejects.toThrow(/did not return an image/);
+    ).rejects.toThrow(/not valid JSON/);
   });
 
   it("REFUSES truncated JSON", async () => {
     fetchImageMock.mockResolvedValue(jsonBody('{"nodes":[],"li'));
     await expect(
       getOutputImage("truncated.json", "input", "", { allowMedia: true, allowJson: true }),
-    ).rejects.toThrow(/did not return an image/);
+    ).rejects.toThrow(/not valid JSON/);
   });
 
   it("REFUSES an empty body even though '' is a .json request", async () => {
     fetchImageMock.mockResolvedValue({ base64: "", mimeType: "application/json" });
     await expect(
       getOutputImage("empty.json", "input", "", { allowMedia: true, allowJson: true }),
-    ).rejects.toThrow(/did not return an image/);
+    ).rejects.toThrow(/an empty response/);
+  });
+
+  it("catches the OTHER ComfyUI error shapes, not just a top-level `error` (codex)", async () => {
+    // A single-key heuristic was calibrated wrong in both directions. These are error
+    // bodies whatever they are called.
+    for (const body of ['{"node_errors":{}}', '{"detail":"Not Found"}']) {
+      fetchImageMock.mockResolvedValue(jsonBody(body));
+      await expect(
+        getOutputImage("wf.json", "input", "", { allowMedia: true, allowJson: true }),
+      ).rejects.toThrow(/JSON ERROR body/);
+    }
+  });
+
+  it("…and KEEPS a real workflow that carries its own top-level `error` field (codex)", async () => {
+    // The other direction of the same miscalibration: rejecting a legitimate attachment
+    // because a key name collided. A body with workflow markers is a workflow.
+    fetchImageMock.mockResolvedValue(
+      jsonBody('{"nodes":[],"links":[],"last_node_id":3,"error":"captured during the run"}'),
+    );
+    await expect(
+      getOutputImage("wf.json", "input", "", { allowMedia: true, allowJson: true }),
+    ).resolves.toBeDefined();
   });
 
   it("does NOT widen anything when allowJson is off", async () => {

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -671,3 +671,85 @@ describe("listOutputImages — remote mode keyed off isRemoteMode (issue #2 regr
     expect(results.map((r) => r.filename)).toEqual(["remote.png"]);
   });
 });
+
+describe("#1373 — a .json attachment is accepted by PARSING it, not by its content-type", () => {
+  // get_image refused a valid ComfyUI workflow attachment because the reporter's server
+  // labelled it `video/json` — neither image/* nor a sniffable media format. The input
+  // directory legitimately holds workflow .json files, so they could not be saved at all.
+  //
+  // I could not reproduce that header: a stock ComfyUI 0.31.1 on this machine returns
+  // `application/json` for the same request, and ComfyUI's own source has no `video/<ext>`
+  // branch. So the label is install-specific, which is exactly why the fix cannot key on
+  // it — the next install will invent a different one.
+  //
+  // The rule this follows is already in the file, one branch up: media payloads must SNIFF
+  // as media, because "the declared content-type alone is no proof". JSON can answer that
+  // question directly.
+
+  const jsonBody = (text: string) => ({
+    base64: Buffer.from(text, "utf8").toString("base64"),
+    mimeType: "video/json",
+  });
+
+  it("accepts valid JSON however the server labelled it", async () => {
+    fetchImageMock.mockResolvedValue(jsonBody('{"nodes":[],"links":[]}'));
+    await expect(
+      getOutputImage("08_SAM2_Rotoscope.json", "input", "", { allowMedia: true, allowJson: true }),
+    ).resolves.toMatchObject({ filename: "08_SAM2_Rotoscope.json" });
+  });
+
+  it("…including the application/json a stock server actually sends", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from('{"a":1}', "utf8").toString("base64"),
+      mimeType: "application/json",
+    });
+    await expect(
+      getOutputImage("wf.json", "input", "", { allowMedia: true, allowJson: true }),
+    ).resolves.toBeDefined();
+  });
+
+  it("REFUSES an HTML error page served as .json — the rejection this check exists for", async () => {
+    // ComfyUI answers 200 with an error body often enough that this is the whole point.
+    // A permissive "it was requested as .json, save it" would hand back a login page as a
+    // workflow.
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from("<html><body>404 Not Found</body></html>", "utf8").toString("base64"),
+      mimeType: "video/json",
+    });
+    await expect(
+      getOutputImage("missing.json", "input", "", { allowMedia: true, allowJson: true }),
+    ).rejects.toThrow(/did not return an image/);
+  });
+
+  it("REFUSES truncated JSON", async () => {
+    fetchImageMock.mockResolvedValue(jsonBody('{"nodes":[],"li'));
+    await expect(
+      getOutputImage("truncated.json", "input", "", { allowMedia: true, allowJson: true }),
+    ).rejects.toThrow(/did not return an image/);
+  });
+
+  it("REFUSES an empty body even though '' is a .json request", async () => {
+    fetchImageMock.mockResolvedValue({ base64: "", mimeType: "application/json" });
+    await expect(
+      getOutputImage("empty.json", "input", "", { allowMedia: true, allowJson: true }),
+    ).rejects.toThrow(/did not return an image/);
+  });
+
+  it("does NOT widen anything when allowJson is off", async () => {
+    // The default path must be unchanged: this is opt-in from get_image(action:"get").
+    fetchImageMock.mockResolvedValue(jsonBody('{"nodes":[]}'));
+    await expect(getOutputImage("wf.json", "input", "")).rejects.toThrow(/did not return an image/);
+  });
+
+  it("does NOT accept JSON bytes requested under an IMAGE extension", async () => {
+    // Gated on the requested extension, so a JSON body cannot arrive as a .png and be
+    // saved as a working image.
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from('{"nodes":[]}', "utf8").toString("base64"),
+      mimeType: "application/json",
+    });
+    await expect(
+      getOutputImage("actually.png", "input", "", { allowMedia: true, allowJson: true }),
+    ).rejects.toThrow(/did not return an image/);
+  });
+});

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -783,7 +783,9 @@ describe("#1373 — a .json attachment is accepted by PARSING it, not by its con
     expect(err.code).toBe("IMAGE_NOT_FOUND");
     // ...and it must say the file may not exist, which is the actionable part.
     expect(err.message).toMatch(/may not exist/);
-    expect(err.details?.rejectedBecause).toBeUndefined();
+    // The reason rides along on both kinds: a caller should not have to parse a sentence
+    // to learn whether the server sent an error envelope or nothing at all.
+    expect(err.details?.rejectedBecause).toBe("an empty response");
   });
 
   it("catches the OTHER ComfyUI error shapes, not just a top-level `error` (codex)", async () => {
@@ -801,7 +803,13 @@ describe("#1373 — a .json attachment is accepted by PARSING it, not by its con
     // The prose named the real reason; the CODE still said the file was missing — and the
     // code is the part automation reads. A caller branching on it retried, re-listed the
     // directory, and asked the user to check a filename that was never wrong.
-    fetchImageMock.mockResolvedValue(jsonBody('{"error":"not found"}'));
+    //
+    // An HTML page from a proxy is the clean example of this kind: the name was right and
+    // the payload was wrong, so checking the filename is useless.
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from("<html><body>login required</body></html>", "utf8").toString("base64"),
+      mimeType: "application/json",
+    });
     const err = await getOutputImage("wf.json", "input", "", {
       allowMedia: true,
       allowJson: true,
@@ -809,7 +817,26 @@ describe("#1373 — a .json attachment is accepted by PARSING it, not by its con
     expect(err).toBeInstanceOf(ComfyUIError);
     expect(err.code).toBe("ATTACHMENT_CONTENT_REJECTED");
     // The reason, structured, so a caller need not parse the sentence to act on it.
+    expect(err.details?.rejectedBecause).toMatch(/not valid JSON/);
+    // …and it must NOT send them off to re-check a filename that was never the problem.
+    expect(err.message).not.toMatch(/may not exist/);
+  });
+
+  it("a JSON ERROR ENVELOPE is the server saying the file is ABSENT (codex round 3)", async () => {
+    // Byte length was the first discriminator and it got this backwards. `/view` answering
+    // `{"error":"not found"}` for a file that is genuinely gone is the server REPORTING
+    // that — so the remedy is the filename, and calling it a content refusal sends the
+    // caller to inspect a payload instead.
+    fetchImageMock.mockResolvedValue(jsonBody('{"error":"not found"}'));
+    const err = await getOutputImage("wf.json", "input", "", {
+      allowMedia: true,
+      allowJson: true,
+    }).catch((e) => e);
+    expect(err.code).toBe("IMAGE_NOT_FOUND");
+    // Both halves: what came back, and the part the caller can act on.
     expect(err.details?.rejectedBecause).toMatch(/JSON ERROR body/);
+    expect(err.message).toMatch(/JSON ERROR body/);
+    expect(err.message).toMatch(/check the filename/);
   });
 
   it("…and a genuinely absent file still says IMAGE_NOT_FOUND", async () => {
@@ -826,7 +853,7 @@ describe("#1373 — a .json attachment is accepted by PARSING it, not by its con
       allowJson: true,
     }).catch((e) => e);
     expect(missingJson.code).toBe("IMAGE_NOT_FOUND");
-    expect(missingJson.details?.rejectedBecause).toBeUndefined();
+    expect(missingJson.details?.rejectedBecause).toBe("an empty response");
 
     // …and the non-JSON path, unchanged.
     fetchImageMock.mockResolvedValue({

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -769,11 +769,21 @@ describe("#1373 — a .json attachment is accepted by PARSING it, not by its con
     ).rejects.toThrow(/not valid JSON/);
   });
 
-  it("REFUSES an empty body even though '' is a .json request", async () => {
+  it("REFUSES an empty body — and it is still a MISSING FILE, not a content refusal", async () => {
+    // codex P2. An empty 200 is what an unresolved `input` reference looks like; that is
+    // why #385 made it a structured not-found. Giving it the content-refusal code takes
+    // the missing-file branch away from callers for `.json` alone — the same wrong-cause
+    // failure this issue is about, pointed the other way.
     fetchImageMock.mockResolvedValue({ base64: "", mimeType: "application/json" });
-    await expect(
-      getOutputImage("empty.json", "input", "", { allowMedia: true, allowJson: true }),
-    ).rejects.toThrow(/an empty response/);
+    const err = await getOutputImage("empty.json", "input", "", {
+      allowMedia: true,
+      allowJson: true,
+    }).catch((e) => e);
+    expect(err.message).toMatch(/an empty response/);
+    expect(err.code).toBe("IMAGE_NOT_FOUND");
+    // ...and it must say the file may not exist, which is the actionable part.
+    expect(err.message).toMatch(/may not exist/);
+    expect(err.details?.rejectedBecause).toBeUndefined();
   });
 
   it("catches the OTHER ComfyUI error shapes, not just a top-level `error` (codex)", async () => {
@@ -804,8 +814,21 @@ describe("#1373 — a .json attachment is accepted by PARSING it, not by its con
 
   it("…and a genuinely absent file still says IMAGE_NOT_FOUND", async () => {
     // The over-broad direction of the same change, which the test above cannot see:
-    // relabelling every rejection would erase the missing-file signal that #385 added,
-    // and #385's own tests use .png paths that never reach the JSON branch at all.
+    // relabelling every rejection would erase the missing-file signal that #385 added.
+    //
+    // The FIRST version of this test used `gone.png`, which never reaches the JSON gate at
+    // all — so it asserted a branch the change could not affect and would have shipped the
+    // P2 above unnoticed (codex). A `.json` request whose body never arrived is the case
+    // that actually distinguishes the two codes.
+    fetchImageMock.mockResolvedValue({ base64: "", mimeType: "application/json" });
+    const missingJson = await getOutputImage("gone.json", "output", "", {
+      allowMedia: true,
+      allowJson: true,
+    }).catch((e) => e);
+    expect(missingJson.code).toBe("IMAGE_NOT_FOUND");
+    expect(missingJson.details?.rejectedBecause).toBeUndefined();
+
+    // …and the non-JSON path, unchanged.
     fetchImageMock.mockResolvedValue({
       base64: Buffer.from("<html>404</html>", "utf8").toString("base64"),
       mimeType: "text/html",

--- a/src/__tests__/tools/get-image-binary-safe.test.ts
+++ b/src/__tests__/tools/get-image-binary-safe.test.ts
@@ -119,7 +119,7 @@ describe("get_image — video/audio save-to-disk (#663)", () => {
       "I2V_HD_FaceLock_00036-audio.mp4",
       "output",
       "Eros",
-      { allowMedia: true },
+      { allowMedia: true, allowJson: true },
     );
     // Saved under the original filename/extension in the requested save_dir. The dir is
     // resolved first, so on Windows a rootless "/tmp/x" becomes the drive-qualified path

--- a/src/__tests__/tools/image-assets.test.ts
+++ b/src/__tests__/tools/image-assets.test.ts
@@ -313,7 +313,11 @@ describe("get_image: each action reaches exactly one service", () => {
 
   it('action:"get" forwards filename/type/subfolder and the allowMedia flag unchanged', async () => {
     await getImage()({ action: "get", filename: "p.png", type: "temp", subfolder: "sub" });
-    expect(getOutputImageMock).toHaveBeenCalledWith("p.png", "temp", "sub", { allowMedia: true });
+    expect(getOutputImageMock).toHaveBeenCalledWith("p.png", "temp", "sub", {
+      allowMedia: true,
+      // #1373 — the input dir legitimately holds workflow .json files.
+      allowJson: true,
+    });
   });
 
   it('action:"get" still defaults type/subfolder in the handler, not the schema', async () => {
@@ -321,7 +325,10 @@ describe("get_image: each action reaches exactly one service", () => {
     // the OTHER actions that share them; the get branch supplies the same
     // defaults it always did.
     await getImage()({ action: "get", filename: "p.png" });
-    expect(getOutputImageMock).toHaveBeenCalledWith("p.png", "output", "", { allowMedia: true });
+    expect(getOutputImageMock).toHaveBeenCalledWith("p.png", "output", "", {
+      allowMedia: true,
+      allowJson: true,
+    });
   });
 
   it('action:"convert" forwards exactly the encoder options the retired converter took', async () => {
@@ -552,7 +559,10 @@ describe("guards test ABSENCE, never falsiness", () => {
   // A `!x` guard would swallow that path and substitute generic text.
   it('get_image action:"get" forwards an empty filename to the service', async () => {
     await getImage()({ action: "get", filename: "" });
-    expect(getOutputImageMock).toHaveBeenCalledWith("", "output", "", { allowMedia: true });
+    expect(getOutputImageMock).toHaveBeenCalledWith("", "output", "", {
+      allowMedia: true,
+      allowJson: true,
+    });
   });
 
   it('get_image action:"view"/"asset_metadata" forward an empty asset_id', async () => {

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -742,7 +742,26 @@ export async function getOutputImage(
   filename: string,
   type: "output" | "input" | "temp" = "output",
   subfolder = "",
-  { allowMedia = false }: { allowMedia?: boolean } = {},
+  {
+    allowMedia = false,
+    /**
+     * Accept a `.json` attachment whose bytes actually PARSE as JSON (#1373).
+     *
+     * A ComfyUI input directory legitimately holds workflow `.json` files, and `get_image`
+     * refused to save them: the reporter's server labelled one `video/json`, which is
+     * neither `image/*` nor a sniffable media format.
+     *
+     * NOT AN ADDITION TO THE ACCEPT LIST. I could not reproduce that header — a stock
+     * ComfyUI 0.31.1 here returns `application/json` for the same request, so `video/json`
+     * comes from something in their stack, and the next install will invent a different
+     * one. Accepting the specific string would fix one machine.
+     *
+     * The declared type is a claim about the payload; parsing is a fact about it. So this
+     * follows the rule the media branch above already applies — bytes must be what they
+     * are said to be — and simply asks the question JSON can answer directly.
+     */
+    allowJson = false,
+  }: { allowMedia?: boolean; allowJson?: boolean } = {},
 ): Promise<{ base64: string; mimeType: string; filename: string }> {
   assertSafeViewRef(filename, subfolder);
   const result = await fetchImage(filename, type, subfolder);
@@ -780,7 +799,25 @@ export async function getOutputImage(
     extOk &&
     (mime === "application/octet-stream" ||
       MEDIA_FORMAT_BY_MIME[mime] === sniffedFormat);
-  if ((!isImage && !isMedia) || result.base64.length === 0) {
+  // A `.json` request whose bytes parse as JSON is accepted whatever the server called
+  // them (#1373). Gated on the REQUESTED extension so this can never widen the image or
+  // media paths, and on a successful parse so the rejection this function exists for is
+  // untouched: an HTML error page, a login redirect or a truncated body does not parse and
+  // is still refused. ComfyUI answers 200 with an error body often enough that this check
+  // is the only thing standing between the caller and a corrupt "image".
+  const isJson =
+    allowJson &&
+    ext === ".json" &&
+    result.base64.length > 0 &&
+    (() => {
+      try {
+        JSON.parse(Buffer.from(result.base64, "base64").toString("utf8"));
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+  if ((!isImage && !isMedia && !isJson) || result.base64.length === 0) {
     const where = subfolder ? `${type}/${subfolder}` : type;
     throw new ComfyUIError(
       `ComfyUI /view did not return an image for "${filename}" (${where}); ` +

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -805,18 +805,7 @@ export async function getOutputImage(
   // untouched: an HTML error page, a login redirect or a truncated body does not parse and
   // is still refused. ComfyUI answers 200 with an error body often enough that this check
   // is the only thing standing between the caller and a corrupt "image".
-  const isJson =
-    allowJson &&
-    ext === ".json" &&
-    result.base64.length > 0 &&
-    (() => {
-      try {
-        JSON.parse(Buffer.from(result.base64, "base64").toString("utf8"));
-        return true;
-      } catch {
-        return false;
-      }
-    })();
+  const isJson = allowJson && ext === ".json" && looksLikeSavableJson(result.base64);
   if ((!isImage && !isMedia && !isJson) || result.base64.length === 0) {
     const where = subfolder ? `${type}/${subfolder}` : type;
     throw new ComfyUIError(
@@ -830,6 +819,52 @@ export async function getOutputImage(
   }
 
   return { ...result, filename };
+}
+
+/**
+ * Byte ceiling for the JSON validation (#1373).
+ *
+ * A workflow is tens to hundreds of kilobytes; ComfyUI's own saves are well under a
+ * megabyte. Parsing is the acceptance test, and parsing means decoding the whole payload
+ * into a string and building an object graph from it — so an enormous body would be paid
+ * for twice in memory before anything could reject it. 32 MB is far above any real
+ * workflow and far below a problem.
+ *
+ * Above the ceiling the answer is REFUSE, not accept-unchecked: a `.json` that large is
+ * not the workflow attachment this path exists to save, and accepting it unverified would
+ * hand back exactly the unvalidated payload the surrounding guard is for.
+ */
+const MAX_JSON_ATTACHMENT_BYTES = 32 * 1024 * 1024;
+
+/**
+ * Is this payload a JSON document worth saving as the requested attachment? (#1373)
+ *
+ * Parsing is the test, because the declared content-type is a claim and parsing is a fact
+ * — the reporter's server labelled a valid workflow `video/json`.
+ *
+ * BUT VALID JSON IS NOT THE SAME AS THE FILE THEY ASKED FOR (codex). ComfyUI answers 200
+ * with a JSON error envelope in several cases, and `{"error":"not found"}` parses
+ * perfectly. Saving that as `my_workflow.json` is the original bug in a new costume: a
+ * failure written to disk under the name of the thing that failed. So a top-level `error`
+ * key on an object body is refused — narrow on purpose, because every OTHER shape of valid
+ * JSON is legitimately savable and guessing further would start rejecting real files.
+ */
+function looksLikeSavableJson(base64: string): boolean {
+  if (base64.length === 0) return false;
+  // base64 is 4 chars per 3 bytes; compare before decoding so the ceiling is not paid to
+  // be enforced.
+  if (Math.floor((base64.length * 3) / 4) > MAX_JSON_ATTACHMENT_BYTES) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(base64, "base64").toString("utf8"));
+  } catch {
+    return false;
+  }
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    const rec = parsed as Record<string, unknown>;
+    if ("error" in rec) return false;
+  }
+  return true;
 }
 
 /**

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -821,8 +821,20 @@ export async function getOutputImage(
           `got ${result.base64.length === 0 ? "an empty response" : `content-type "${result.mimeType}"`}. ` +
           `The file may not exist in the ComfyUI ${type} directory — ` +
           `check the filename/subfolder (e.g. via get_image (action:"list_outputs") or get_history).`,
-      "IMAGE_NOT_FOUND",
-      { filename, type, subfolder, mimeType: result.mimeType },
+      // THE CODE HAS TO AGREE WITH THE MESSAGE (codex P2). The message names the real
+      // reason, but a caller that branches on the code — which is the whole point of
+      // having one — still read IMAGE_NOT_FOUND and went off to re-check a filename that
+      // was never wrong. That is the same wrong-cause failure as the prose, one layer
+      // down, and it is the layer that automation reads.
+      jsonRefusal ? "ATTACHMENT_CONTENT_REJECTED" : "IMAGE_NOT_FOUND",
+      {
+        filename,
+        type,
+        subfolder,
+        mimeType: result.mimeType,
+        // The reason, structured, so a caller does not have to parse the sentence.
+        ...(jsonRefusal ? { rejectedBecause: jsonRefusal } : {}),
+      },
     );
   }
 

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -807,16 +807,13 @@ export async function getOutputImage(
   // is the only thing standing between the caller and a corrupt "image".
   const jsonRefusal = allowJson && ext === ".json" ? jsonAttachmentRefusal(result.base64) : null;
   const isJson = allowJson && ext === ".json" && jsonRefusal === null;
-  // AN EMPTY BODY IS A MISSING FILE, NOT A CONTENT REFUSAL (codex P2).
-  //
-  // `jsonAttachmentRefusal` answers "not savable" for an empty payload too, but this file
-  // already establishes what a 200-with-empty-body means: it is what an unresolved `input`
-  // reference looks like, which is why #385 made it a structured not-found in the first
-  // place. Routing it through the new code would take the missing-file branch away from
-  // callers for `.json` alone — the same wrong-cause failure this issue is about, just
-  // pointed the other way. Bytes arrived and were judged: content refusal. No bytes
-  // arrived: nothing was judged.
-  const contentRejected = jsonRefusal !== null && result.base64.length > 0;
+  // WHICH REFUSAL THIS IS decides the code, the message and the remedy — see
+  // `jsonAttachmentRefusal`. Byte length was the first attempt at this discriminator and it
+  // got the error-envelope case backwards: a `/view` that answers `{"error":"not found"}`
+  // is the server reporting an ABSENT FILE, and calling that a content refusal sends the
+  // caller to inspect a payload when the filename is the thing to look at.
+  const contentRejected = jsonRefusal?.kind === "content";
+
   if ((!isImage && !isMedia && !isJson) || result.base64.length === 0) {
     const where = subfolder ? `${type}/${subfolder}` : type;
     throw new ComfyUIError(
@@ -825,9 +822,15 @@ export async function getOutputImage(
           // arrived and was rejected on its CONTENT sends the caller to re-check a
           // filename that is perfectly correct — the wrong-cause failure this issue is
           // about, reproduced by its own fix.
-          `ComfyUI /view returned ${jsonRefusal}, for "${filename}" (${where}). ` +
+          `ComfyUI /view returned ${jsonRefusal?.reason}, for "${filename}" (${where}). ` +
           `Nothing was saved.`
-        : `ComfyUI /view did not return an image for "${filename}" (${where}); ` +
+        : jsonRefusal
+          ? // A MISSING-kind JSON refusal: say what came back AND point at the name, which
+            // is the part the caller can act on.
+            `ComfyUI /view returned ${jsonRefusal.reason}, for "${filename}" (${where}). ` +
+            `Nothing was saved. The file may not exist in the ComfyUI ${type} directory — ` +
+            `check the filename/subfolder (e.g. via get_image (action:"list_outputs") or get_history).`
+          : `ComfyUI /view did not return an image for "${filename}" (${where}); ` +
           `got ${result.base64.length === 0 ? "an empty response" : `content-type "${result.mimeType}"`}. ` +
           `The file may not exist in the ComfyUI ${type} directory — ` +
           `check the filename/subfolder (e.g. via get_image (action:"list_outputs") or get_history).`,
@@ -843,7 +846,9 @@ export async function getOutputImage(
         subfolder,
         mimeType: result.mimeType,
         // The reason, structured, so a caller does not have to parse the sentence.
-        ...(contentRejected ? { rejectedBecause: jsonRefusal } : {}),
+        // The reason rides along on BOTH kinds — a caller should not have to parse a
+        // sentence to learn the server sent an error envelope rather than nothing at all.
+        ...(jsonRefusal ? { rejectedBecause: jsonRefusal.reason } : {}),
       },
     );
   }
@@ -866,6 +871,12 @@ export async function getOutputImage(
  */
 const MAX_JSON_ATTACHMENT_BYTES = 32 * 1024 * 1024;
 
+/** Why a `.json` payload is not savable, and which of the two remedies applies. */
+interface JsonRefusal {
+  kind: "missing" | "content";
+  reason: string;
+}
+
 /**
  * Why a `.json` payload is not savable, or null when it is (#1373).
  *
@@ -881,24 +892,40 @@ const MAX_JSON_ATTACHMENT_BYTES = 32 * 1024 * 1024;
  * has" — so an error body is caught whatever it is called, and a real workflow is kept even
  * if it has an `error` extension of its own.
  */
-function jsonAttachmentRefusal(base64: string): string | null {
-  if (base64.length === 0) return "an empty response";
+function jsonAttachmentRefusal(base64: string): JsonRefusal | null {
+  // WHY THE KIND EXISTS (codex round 3). "Nothing was saved" is one outcome with two
+  // different remedies, and the remedy is the whole value of the answer:
+  //
+  //   missing — the server says it has no such file (an error envelope, or nothing at
+  //             all). CHECK THE FILENAME. This is what IMAGE_NOT_FOUND means and what
+  //             #385 added it for.
+  //   content — a body arrived and it is not the attachment: an HTML login page from a
+  //             proxy, a truncated stream, something over the ceiling. Checking the
+  //             filename is useless here; the name was right and the payload was wrong.
+  //
+  // Deciding this on emptiness alone got the error-envelope case backwards: a `/view`
+  // answering `{"error":"not found"}` for a file that is genuinely absent is the server
+  // TELLING us it is absent, and routing that to "the payload was unusable" sends the
+  // caller to inspect content instead of the name.
+  if (base64.length === 0) return { kind: "missing", reason: "an empty response" };
   // Decoded size from the base64 LENGTH, minus padding, so the ceiling costs nothing to
   // enforce and does not overestimate a padded payload by a byte or two at the boundary.
   const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
   const approxBytes = Math.floor((base64.length * 3) / 4) - padding;
   if (approxBytes > MAX_JSON_ATTACHMENT_BYTES) {
-    return (
-      `a ${(approxBytes / 1024 ** 2).toFixed(1)} MB JSON body, over the ` +
-      `${MAX_JSON_ATTACHMENT_BYTES / 1024 ** 2} MB ceiling for a workflow attachment — ` +
-      `parsing it to check it would cost that much again in memory, so it was refused unread`
-    );
+    return {
+      kind: "content",
+      reason:
+        `a ${(approxBytes / 1024 ** 2).toFixed(1)} MB JSON body, over the ` +
+        `${MAX_JSON_ATTACHMENT_BYTES / 1024 ** 2} MB ceiling for a workflow attachment — ` +
+        `parsing it to check it would cost that much again in memory, so it was refused unread`,
+    };
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(Buffer.from(base64, "base64").toString("utf8"));
   } catch {
-    return "a body that is not valid JSON";
+    return { kind: "content", reason: "a body that is not valid JSON" };
   }
   if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
     const rec = parsed as Record<string, unknown>;
@@ -906,11 +933,15 @@ function jsonAttachmentRefusal(base64: string): string | null {
     const workflowMarkers = ["nodes", "links", "last_node_id", "extra", "prompt", "workflow"];
     const looksLikeAWorkflow = workflowMarkers.some((k) => k in rec);
     if (errorish.length > 0 && !looksLikeAWorkflow) {
-      return (
-        `a JSON ERROR body (it carries "${errorish[0]}" and none of the keys a workflow has), ` +
-        `not the attachment you asked for — saving it would write a failure to disk under ` +
-        `the name of the thing that failed`
-      );
+      return {
+        // MISSING, not content. The server answered the request by saying it could not
+        // serve it; the actionable fact is the name, not the bytes.
+        kind: "missing",
+        reason:
+          `a JSON ERROR body (it carries "${errorish[0]}" and none of the keys a workflow has), ` +
+          `not the attachment you asked for — saving it would write a failure to disk under ` +
+          `the name of the thing that failed`,
+      };
     }
   }
   return null;

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -805,14 +805,22 @@ export async function getOutputImage(
   // untouched: an HTML error page, a login redirect or a truncated body does not parse and
   // is still refused. ComfyUI answers 200 with an error body often enough that this check
   // is the only thing standing between the caller and a corrupt "image".
-  const isJson = allowJson && ext === ".json" && looksLikeSavableJson(result.base64);
+  const jsonRefusal = allowJson && ext === ".json" ? jsonAttachmentRefusal(result.base64) : null;
+  const isJson = allowJson && ext === ".json" && jsonRefusal === null;
   if ((!isImage && !isMedia && !isJson) || result.base64.length === 0) {
     const where = subfolder ? `${type}/${subfolder}` : type;
     throw new ComfyUIError(
-      `ComfyUI /view did not return an image for "${filename}" (${where}); ` +
-        `got ${result.base64.length === 0 ? "an empty response" : `content-type "${result.mimeType}"`}. ` +
-        `The file may not exist in the ComfyUI ${type} directory — ` +
-        `check the filename/subfolder (e.g. via get_image (action:"list_outputs") or get_history).`,
+      jsonRefusal
+        ? // NAME THE ACTUAL REASON (#1373). "The file may not exist" for a body that
+          // arrived and was rejected on its CONTENT sends the caller to re-check a
+          // filename that is perfectly correct — the wrong-cause failure this issue is
+          // about, reproduced by its own fix.
+          `ComfyUI /view returned ${jsonRefusal}, for "${filename}" (${where}). ` +
+          `Nothing was saved.`
+        : `ComfyUI /view did not return an image for "${filename}" (${where}); ` +
+          `got ${result.base64.length === 0 ? "an empty response" : `content-type "${result.mimeType}"`}. ` +
+          `The file may not exist in the ComfyUI ${type} directory — ` +
+          `check the filename/subfolder (e.g. via get_image (action:"list_outputs") or get_history).`,
       "IMAGE_NOT_FOUND",
       { filename, type, subfolder, mimeType: result.mimeType },
     );
@@ -837,34 +845,53 @@ export async function getOutputImage(
 const MAX_JSON_ATTACHMENT_BYTES = 32 * 1024 * 1024;
 
 /**
- * Is this payload a JSON document worth saving as the requested attachment? (#1373)
+ * Why a `.json` payload is not savable, or null when it is (#1373).
  *
- * Parsing is the test, because the declared content-type is a claim and parsing is a fact
- * — the reporter's server labelled a valid workflow `video/json`.
+ * Returns a REASON rather than a boolean so the refusal can say what was actually wrong.
+ * Collapsing "40 MB" and "this is an error envelope" into the generic "the file may not
+ * exist in the ComfyUI input directory" sends the caller to check a filename that is
+ * perfectly correct — which is the same wrong-cause failure this whole issue is about.
  *
- * BUT VALID JSON IS NOT THE SAME AS THE FILE THEY ASKED FOR (codex). ComfyUI answers 200
- * with a JSON error envelope in several cases, and `{"error":"not found"}` parses
- * perfectly. Saving that as `my_workflow.json` is the original bug in a new costume: a
- * failure written to disk under the name of the thing that failed. So a top-level `error`
- * key on an object body is refused — narrow on purpose, because every OTHER shape of valid
- * JSON is legitimately savable and guessing further would start rejecting real files.
+ * WHAT COUNTS AS AN ERROR ENVELOPE (codex). A top-level `error` key alone was calibrated
+ * wrong in both directions: it missed ComfyUI's other shapes (`node_errors`, `detail`) and
+ * it rejected a legitimate workflow that happens to carry a top-level `error` field. The
+ * test is now "carries an error-ish key AND carries none of the markers a workflow always
+ * has" — so an error body is caught whatever it is called, and a real workflow is kept even
+ * if it has an `error` extension of its own.
  */
-function looksLikeSavableJson(base64: string): boolean {
-  if (base64.length === 0) return false;
-  // base64 is 4 chars per 3 bytes; compare before decoding so the ceiling is not paid to
-  // be enforced.
-  if (Math.floor((base64.length * 3) / 4) > MAX_JSON_ATTACHMENT_BYTES) return false;
+function jsonAttachmentRefusal(base64: string): string | null {
+  if (base64.length === 0) return "an empty response";
+  // Decoded size from the base64 LENGTH, minus padding, so the ceiling costs nothing to
+  // enforce and does not overestimate a padded payload by a byte or two at the boundary.
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  const approxBytes = Math.floor((base64.length * 3) / 4) - padding;
+  if (approxBytes > MAX_JSON_ATTACHMENT_BYTES) {
+    return (
+      `a ${(approxBytes / 1024 ** 2).toFixed(1)} MB JSON body, over the ` +
+      `${MAX_JSON_ATTACHMENT_BYTES / 1024 ** 2} MB ceiling for a workflow attachment — ` +
+      `parsing it to check it would cost that much again in memory, so it was refused unread`
+    );
+  }
   let parsed: unknown;
   try {
     parsed = JSON.parse(Buffer.from(base64, "base64").toString("utf8"));
   } catch {
-    return false;
+    return "a body that is not valid JSON";
   }
   if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
     const rec = parsed as Record<string, unknown>;
-    if ("error" in rec) return false;
+    const errorish = ["error", "node_errors", "detail"].filter((k) => k in rec);
+    const workflowMarkers = ["nodes", "links", "last_node_id", "extra", "prompt", "workflow"];
+    const looksLikeAWorkflow = workflowMarkers.some((k) => k in rec);
+    if (errorish.length > 0 && !looksLikeAWorkflow) {
+      return (
+        `a JSON ERROR body (it carries "${errorish[0]}" and none of the keys a workflow has), ` +
+        `not the attachment you asked for — saving it would write a failure to disk under ` +
+        `the name of the thing that failed`
+      );
+    }
   }
-  return true;
+  return null;
 }
 
 /**

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -807,10 +807,20 @@ export async function getOutputImage(
   // is the only thing standing between the caller and a corrupt "image".
   const jsonRefusal = allowJson && ext === ".json" ? jsonAttachmentRefusal(result.base64) : null;
   const isJson = allowJson && ext === ".json" && jsonRefusal === null;
+  // AN EMPTY BODY IS A MISSING FILE, NOT A CONTENT REFUSAL (codex P2).
+  //
+  // `jsonAttachmentRefusal` answers "not savable" for an empty payload too, but this file
+  // already establishes what a 200-with-empty-body means: it is what an unresolved `input`
+  // reference looks like, which is why #385 made it a structured not-found in the first
+  // place. Routing it through the new code would take the missing-file branch away from
+  // callers for `.json` alone — the same wrong-cause failure this issue is about, just
+  // pointed the other way. Bytes arrived and were judged: content refusal. No bytes
+  // arrived: nothing was judged.
+  const contentRejected = jsonRefusal !== null && result.base64.length > 0;
   if ((!isImage && !isMedia && !isJson) || result.base64.length === 0) {
     const where = subfolder ? `${type}/${subfolder}` : type;
     throw new ComfyUIError(
-      jsonRefusal
+      contentRejected
         ? // NAME THE ACTUAL REASON (#1373). "The file may not exist" for a body that
           // arrived and was rejected on its CONTENT sends the caller to re-check a
           // filename that is perfectly correct — the wrong-cause failure this issue is
@@ -826,14 +836,14 @@ export async function getOutputImage(
       // having one — still read IMAGE_NOT_FOUND and went off to re-check a filename that
       // was never wrong. That is the same wrong-cause failure as the prose, one layer
       // down, and it is the layer that automation reads.
-      jsonRefusal ? "ATTACHMENT_CONTENT_REJECTED" : "IMAGE_NOT_FOUND",
+      contentRejected ? "ATTACHMENT_CONTENT_REJECTED" : "IMAGE_NOT_FOUND",
       {
         filename,
         type,
         subfolder,
         mimeType: result.mimeType,
         // The reason, structured, so a caller does not have to parse the sentence.
-        ...(jsonRefusal ? { rejectedBecause: jsonRefusal } : {}),
+        ...(contentRejected ? { rejectedBecause: jsonRefusal } : {}),
       },
     );
   }

--- a/src/tools/image-management.ts
+++ b/src/tools/image-management.ts
@@ -353,7 +353,8 @@ export function registerImageManagementTools(server: McpServer): void {
               filename,
               args.type ?? "output",
               args.subfolder ?? "",
-              { allowMedia: true },
+              // #1373 — the input dir legitimately holds workflow .json files.
+              { allowMedia: true, allowJson: true },
             );
 
             // The bytes are already in hand at this point. Saving them is a SEPARATE


### PR DESCRIPTION
Draft — claiming #1373: `get_image(action:"get")` refuses a valid `.json` workflow attachment because ComfyUI's `/view` labelled it `video/json`, so it cannot be saved for inspection.

**I could not reproduce the header, and that is the useful part.** On this machine — ComfyUI 0.31.1, same version the reporter runs — `/view` returns:

```
HTTP/1.1 200 OK
X-Content-Type-Options: nosniff
Content-Type: application/json
```

for exactly that request shape (`filename=*.json&type=input`). So `video/json` is **install-specific**: something in their stack (a custom node overriding `/view`, or a different serving path) is inventing a `video/<ext>` type. Stock ComfyUI's own source has no such branch; the only `video/{ext}` construction I found anywhere on this install is inside an unrelated custom node.

That is the argument for the reporter's own proposal, and against the narrower fix. Accepting `video/json` specifically would fix this one install and leave the next one — `application/octet-stream`, `text/plain`, whatever the next wrapper decides — broken in the same way. **The declared content-type is not evidence about the payload.**

Plan, following the reporter's design: for an explicitly `.json` request, decode the body and `JSON.parse` it, and accept it only if that succeeds — regardless of what the server called it. A parse is a fact about the bytes; the header is a claim about them.

That also keeps the rejection this check exists for. An HTML error page, a truncated body, or a login redirect does not parse as JSON and is still refused — which is the reason `get_image` validates at all, since ComfyUI answers 200 with an error body in several cases.

Refs #1373
