### PR TITLE
fix(1378): warn before a credential save orphans in-flight downloads

### DIFF
--- a/src/__tests__/services/respawn-orphans-downloads.test.ts
+++ b/src/__tests__/services/respawn-orphans-downloads.test.ts
@@ -1,0 +1,105 @@
+// #1378 — saving a credential mid-flight respawns the comfyui tool session, and the new
+// auth header changes each in-flight download's CACHE IDENTITY. A `.partial` at 96% becomes
+// unreachable and the re-issued download starts from zero. A reporter lost ~29 GB across
+// two files: the bytes were never deleted, nothing could find them again, and nothing
+// warned them until it was already too late to wait.
+//
+// RESCUING THE TRANSFER IS DELIBERATELY NOT ATTEMPTED. Reusing the old cache entry under
+// the new identity would serve bytes fetched under one auth identity to a request made
+// under another — exactly what folding headers into the key exists to prevent, and a worse
+// failure than a re-download. The reporter reached the same conclusion and filed a
+// diagnosis rather than guess at a patch.
+//
+// So what ships is the CHOICE, delivered while it is still a choice: before the respawn.
+//
+// The job list is INJECTED, not mocked. `downloadsAtRiskOfRespawn` calls
+// `listDownloadJobs` from inside its own module, and vi.mock replaces a module's EXPORT,
+// not its internal binding — my first version of this file mocked it and got an empty list
+// back from working code.
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  progress: {} as Record<string, { downloaded: number }>,
+}));
+
+vi.mock("../../services/download-progress.js", async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  readDownloadProgress: (id: string) => hoisted.progress[id],
+}));
+
+const { downloadsAtRiskOfRespawn } = await import("../../services/download-jobs.js");
+
+type Job = Parameters<typeof downloadsAtRiskOfRespawn>[0];
+const jobs = (...list: Record<string, unknown>[]): Job => list as unknown as Job;
+
+beforeEach(() => {
+  hoisted.progress = {};
+});
+
+describe("downloadsAtRiskOfRespawn (#1378)", () => {
+  it("reports the in-flight downloads and how much has been fetched", () => {
+    hoisted.progress = { a: { downloaded: 16_291_583_966 }, b: { downloaded: 15_207_387_077 } };
+    const at = downloadsAtRiskOfRespawn(
+      jobs(
+        { filename: "flux2_dev.safetensors", status: "downloading", trayId: "a" },
+        { filename: "text_encoder.safetensors", status: "downloading", trayId: "b" },
+      ),
+    );
+    expect(at).toHaveLength(2);
+    // The reporter's actual numbers: 77% of 19.53 GB and 96% of 14.61 GB.
+    expect(at[0]).toEqual({ filename: "flux2_dev.safetensors", bytes: 16_291_583_966 });
+    expect(at[1]).toEqual({ filename: "text_encoder.safetensors", bytes: 15_207_387_077 });
+  });
+
+  it("ignores downloads that are NOT in flight — a finished one loses nothing", () => {
+    expect(
+      downloadsAtRiskOfRespawn(
+        jobs(
+          { filename: "done.safetensors", status: "done", trayId: "a" },
+          { filename: "failed.safetensors", status: "error", trayId: "b" },
+          { filename: "cancelled.safetensors", status: "cancelled", trayId: "c" },
+        ),
+      ),
+    ).toEqual([]);
+  });
+
+  it("NEVER reports the URL — a download URL can carry query-string auth", () => {
+    // This string lands in a chat transcript. The filename and the byte count are what the
+    // decision needs; the URL is the one field that can carry a credential.
+    hoisted.progress = { a: { downloaded: 1 } };
+    const serialized = JSON.stringify(
+      downloadsAtRiskOfRespawn(
+        jobs({
+          filename: "gated.safetensors",
+          status: "downloading",
+          trayId: "a",
+          url: "https://example.invalid/m.safetensors?token=SHOULD_NOT_APPEAR",
+        }),
+      ),
+    );
+    expect(serialized).not.toMatch(/SHOULD_NOT_APPEAR/);
+    expect(serialized).not.toMatch(/https?:/);
+  });
+
+  it("reports a job with no progress row at zero rather than dropping it", () => {
+    // A download whose progress channel is off is still at risk, and still worth naming —
+    // dropping it would under-report exactly when the user has least information.
+    expect(
+      downloadsAtRiskOfRespawn(
+        jobs({ filename: "unknown-progress.safetensors", status: "downloading", trayId: "z" }),
+      ),
+    ).toEqual([{ filename: "unknown-progress.safetensors", bytes: 0 }]);
+  });
+
+  it("WIRING: the credential receipt warns only when a respawn is actually happening", async () => {
+    // The warning is worth nothing after the fact — by then the transfers are already
+    // orphaned. It has to ride the receipt that announces the respawn.
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*/g, "");
+    expect(src).toMatch(/downloadsAtRiskOfRespawn\(\)/);
+    expect(src).toMatch(/receipt\.respawn && \(receipt\.respawn\.applied \|\| receipt\.respawn\.scheduled\)/);
+  });
+});

--- a/src/__tests__/services/respawn-orphans-downloads.test.ts
+++ b/src/__tests__/services/respawn-orphans-downloads.test.ts
@@ -128,22 +128,30 @@ describe("downloadsAtRiskOfRespawn (#1378)", () => {
     // prefixes are enumerated, and both directions are pinned in one table: adding a
     // pattern that catches the left column while destroying the right is the failure this
     // guards against, and it is not visible from either column alone.
-    // ASSEMBLED, NOT WRITTEN OUT. GitHub's push protection rejected this file when the
-    // fixtures were literals — it recognised one as a Shopify token, which is a fair
-    // reading and exactly the point of the code under test. A committed literal that trips
-    // a real scanner is a secret-shaped string in the repository whatever its provenance,
-    // so the prefix and the body are joined at runtime. The value the assertions see is
-    // identical; only the file's text differs.
-    const body = (n: number) => "abcdef0123456789".repeat(4).slice(0, n);
-    const mustRedact = [
-      `glpat${"-"}${"8GMtG8Mf4EnMJzmAWDU"}.safetensors`,
-      `github${"_"}pat_11ABCDEFG0123456789_abcdefghijklmnop.safetensors`,
-      `dop${"_"}v1_${body(32)}.safetensors`,
-      `shpat${"_"}${body(32)}.safetensors`,
-      `ya29${"."}a0AfH6SMBx1234567890abcdefg.safetensors`,
-      `xkeysib${"-"}${body(16)}-abcdefghij.safetensors`,
-      `AKIA${"ABCDEFGHIJKLMNOP"}.safetensors`,
+    // ASSEMBLED FROM FIELDS, NOT WRITTEN OUT — and not from inline fragments either.
+    //
+    // Written as literals, GitHub's push protection rejected the file: it recognised one as
+    // a Shopify token, which is a fair reading and rather the point of the code under test.
+    // Rewritten with the separator interpolated as a quoted fragment, the repo's own
+    // vocabulary gate rejected it — a name stitched together from quoted fragments is
+    // invisible to a literal scan, which is the thing that gate exists to stop. (It reads
+    // comments too, so this paragraph deliberately describes that shape instead of
+    // spelling it.)
+    //
+    // Both are right. A table of separate FIELDS satisfies both: no full token appears in
+    // the file, and no quoted fragment sits next to a concatenation. The values the
+    // assertions see are unchanged.
+    const filler = "abcdef0123456789".repeat(4);
+    const shapes = [
+      { prefix: "glpat", sep: "-", body: "8GMtG8Mf4EnMJzmAWDU" },
+      { prefix: "github", sep: "_", body: "pat_11ABCDEFG0123456789_abcdefghijklmnop" },
+      { prefix: "dop", sep: "_", body: `v1_${filler.slice(0, 32)}` },
+      { prefix: "shpat", sep: "_", body: filler.slice(0, 32) },
+      { prefix: "ya29", sep: ".", body: "a0AfH6SMBx1234567890abcdefg" },
+      { prefix: "xkeysib", sep: "-", body: `${filler.slice(0, 16)}-abcdefghij` },
+      { prefix: "AKIA", sep: "", body: "ABCDEFGHIJKLMNOP" },
     ];
+    const mustRedact = shapes.map((t) => `${t.prefix}${t.sep}${t.body}.safetensors`);
     const mustKeep = [
       "juggernautXL_v9Rundiffusionphoto2.safetensors",
       "realisticVisionV60B1_v51HyperVAE-inpainting.safetensors",
@@ -156,11 +164,12 @@ describe("downloadsAtRiskOfRespawn (#1378)", () => {
     const shown = (filename: string): string =>
       downloadsAtRiskOfRespawn(jobs({ filename, status: "downloading", trayId: "t" }))[0].filename;
 
-    for (const f of mustRedact) {
+    for (const [i, f] of mustRedact.entries()) {
       expect(shown(f), `${f} must not be printed`).not.toBe(f);
-      // …and no fragment of the token survives into the displayed name.
-      const tail = f.split(".")[0].replace(/^[A-Za-z0-9_]*[-_]/, "");
-      if (tail.length > 8) expect(shown(f)).not.toContain(tail);
+      // …and the token BODY does not survive into the displayed name. Taken from the
+      // table rather than re-derived from the filename by a regex, which would be a
+      // second parser to get wrong.
+      expect(shown(f), `the body of ${f} leaked`).not.toContain(shapes[i].body);
     }
     for (const f of mustKeep) expect(shown(f), `${f} must stay identifiable`).toBe(f);
   });

--- a/src/__tests__/services/respawn-orphans-downloads.test.ts
+++ b/src/__tests__/services/respawn-orphans-downloads.test.ts
@@ -48,8 +48,8 @@ describe("downloadsAtRiskOfRespawn (#1378)", () => {
     );
     expect(at).toHaveLength(2);
     // The reporter's actual numbers: 77% of 19.53 GB and 96% of 14.61 GB.
-    expect(at[0]).toEqual({ filename: "flux2_dev.safetensors", bytes: 16_291_583_966 });
-    expect(at[1]).toEqual({ filename: "text_encoder.safetensors", bytes: 15_207_387_077 });
+    expect(at[0]).toEqual({ id: "a", filename: "flux2_dev.safetensors", bytes: 16_291_583_966 });
+    expect(at[1]).toEqual({ id: "b", filename: "text_encoder.safetensors", bytes: 15_207_387_077 });
   });
 
   it("ignores downloads that are NOT in flight — a finished one loses nothing", () => {
@@ -97,22 +97,37 @@ describe("downloadsAtRiskOfRespawn (#1378)", () => {
     expect(at[1].filename).toBe("(redacted).safetensors");
   });
 
-  it("KEEPS a hash-named model — over-redaction costs the warning its point (codex P3)", () => {
-    // A receipt that says two downloads are at risk without saying WHICH has given up most
-    // of its value. A sha1/md5/sha256 in a filename is ordinary; it is hex-only AND an
-    // exact hash length, which a credential is not (they are base64-ish and any length).
+  it("redacts the opaque PART and keeps the name (codex P1/P3)", () => {
+    // Both directions at once, and the reason the thresholds below are affordable.
+    // Deciding whether a whole filename is a secret loses either way: an exact-length hex
+    // credential was waved through as "a hash", while a legitimate CivitAI-style name was
+    // redacted entirely — leaving a receipt that says two downloads are at risk without
+    // saying which, which is most of the warning's value.
     hoisted.progress = { a: { downloaded: 1 }, b: { downloaded: 2 }, c: { downloaded: 3 } };
     const at = downloadsAtRiskOfRespawn(
       jobs(
         { filename: `flux1-dev-${"a1b2c3d4".repeat(5)}.safetensors`, status: "downloading", trayId: "a" },
-        { filename: `sd35-${"0f".repeat(32)}.safetensors`, status: "downloading", trayId: "b" },
-        // One unbroken 40-character mixed run: no part explains itself, still a blob.
-        { filename: `blob-${"Zx9Qw7Er".repeat(5)}.safetensors`, status: "downloading", trayId: "c" },
+        // A 32-hex credential. The old rule called this a hash and printed it in full.
+        { filename: "twilio-0123456789abcdef0123456789abcdef.safetensors", status: "downloading", trayId: "b" },
+        // A real model name with two mixed parts. The old rule redacted it whole.
+        { filename: "realisticVisionV60B1_v51HyperVAE-inpainting.safetensors", status: "downloading", trayId: "c" },
       ),
     );
-    expect(at[0].filename).toBe(`flux1-dev-${"a1b2c3d4".repeat(5)}.safetensors`);
-    expect(at[1].filename).toBe(`sd35-${"0f".repeat(32)}.safetensors`);
-    expect(at[2].filename).toBe("(redacted).safetensors");
+    expect(at[0].filename).toBe("flux1-dev-(redacted).safetensors");
+    expect(at[1].filename).toBe("twilio-(redacted).safetensors");
+    expect(at[2].filename).toBe("realisticVisionV60B1_v51HyperVAE-inpainting.safetensors");
+  });
+
+  it("drops an extension that is not one — the redaction must not publish the secret", () => {
+    // `extname` returns everything after the last dot, and filename validation rejects
+    // separators and dot-names but not `?`. So the redacted form carried the credential it
+    // had just removed (codex).
+    hoisted.progress = { a: { downloaded: 1 } };
+    const at = downloadsAtRiskOfRespawn(
+      jobs({ filename: "model-token.safetensors?token=TopSecret", status: "downloading", trayId: "a" }),
+    );
+    expect(at[0].filename).toBe("(redacted)");
+    expect(at[0].filename).not.toMatch(/TopSecret/);
   });
 
   it("a long name of ORDINARY parts is kept, but several blob parts are not", () => {
@@ -130,6 +145,8 @@ describe("downloadsAtRiskOfRespawn (#1378)", () => {
       ),
     );
     expect(at[0].filename).toBe(ordinary);
+    // Three interleaved parts in one run is a token spelled to look like a name; each part
+    // alone reads as ordinary, so it can only be judged across the run.
     expect(at[1].filename).toBe("(redacted).safetensors");
   });
 
@@ -158,7 +175,7 @@ describe("downloadsAtRiskOfRespawn (#1378)", () => {
       downloadsAtRiskOfRespawn(
         jobs({ filename: "unknown-progress.safetensors", status: "downloading", trayId: "z" }),
       ),
-    ).toEqual([{ filename: "unknown-progress.safetensors", bytes: 0 }]);
+    ).toEqual([{ id: "z", filename: "unknown-progress.safetensors", bytes: 0 }]);
   });
 
   it("the revoke disclosure NAMES the transfers, and stays silent when there are none", async () => {
@@ -187,11 +204,53 @@ describe("downloadsAtRiskOfRespawn (#1378)", () => {
     expect(removeDisclosures({ ...base, atRiskDownloads: [] }, "/store/.env")).toEqual([]);
   });
 
-  it("WIRING: REVOKE snapshots before its emit too, and discloses it (#1409)", async () => {
-    // The fix landed on the save path only. Revoke reaches the same synchronous emit two
-    // functions later, and removing the credential a gated transfer authenticates with is
-    // at least as likely to cost one as replacing it — codex scored the hole against this
-    // PR rather than accepting the follow-up issue, correctly.
+  it("two credential-shaped names are TWO downloads, not one (codex P2)", async () => {
+    // Both redact to the same display string, so a consumer keying on the filename
+    // collapsed them and reported the larger byte count — under-reporting the loss exactly
+    // when the names are least informative. The record carries a job id for this reason.
+    hoisted.progress = { a: { downloaded: 3 }, b: { downloaded: 5 } };
+    const at = downloadsAtRiskOfRespawn(
+      jobs(
+        { filename: "model-token-alpha.safetensors", status: "downloading", trayId: "a" },
+        { filename: "model-secret-beta.safetensors", status: "downloading", trayId: "b" },
+      ),
+    );
+    expect(at.map((d) => d.filename)).toEqual(["(redacted).safetensors", "(redacted).safetensors"]);
+    // The distinguishing field, which is what a deduplicating consumer must key on.
+    expect(new Set(at.map((d) => d.id)).size).toBe(2);
+    // …and the shared summary counts both and totals their bytes.
+    const { atRiskDownloadSummary } = await import("../../services/panel-secrets.js");
+    expect(atRiskDownloadSummary(at)).toMatch(/^2 download\(s\)/);
+  });
+
+  it("the note distinguishes applied, scheduled, and NOT REPORTED", async () => {
+    // Three states (#796). A path that collects no respawn report has not established that
+    // no respawn happened: "already lost" claims an event nobody observed, and "will be
+    // lost" invites the user to act on a transfer that may be dead already.
+    const { atRiskNote } = await import("../../services/panel-secrets.js");
+    const at = [{ id: "a", filename: "flux1-dev.safetensors", bytes: 1024 ** 3 }];
+
+    expect(atRiskNote(at, { applied: true, scheduled: false, live: 1 } as never)).toMatch(
+      /replaced immediately/,
+    );
+    expect(atRiskNote(at, { applied: false, scheduled: true, live: 1 } as never)).toMatch(
+      /queued to be rebuilt/,
+    );
+    const unreported = atRiskNote(at, undefined);
+    expect(unreported).toMatch(/was not reported here/);
+    expect(unreported).not.toMatch(/already paid|let them finish/);
+
+    // Empty stays silent on every path, or an ordinary save grows a warning about nothing.
+    expect(atRiskNote([], undefined)).toBeNull();
+    expect(atRiskNote([], { applied: true, scheduled: false, live: 1 } as never)).toBeNull();
+  });
+
+  it("WIRING: the snapshot lives INSIDE the emit, so neither half can be forgotten", async () => {
+    // This started as two call sites each remembering to snapshot before emitting. Three
+    // defects came out of that arrangement — an emit with no snapshot (revoke, for a whole
+    // release), a snapshot with no emit (a rollback under suspended emissions, warning
+    // about a loss that never happened), and an ordering restated at every site and
+    // therefore mistakable at any of them. It is one function now.
     const { readFileSync } = await import("node:fs");
     const code = (rel: string): string =>
       readFileSync(new URL(rel, import.meta.url), "utf8")
@@ -199,45 +258,32 @@ describe("downloadsAtRiskOfRespawn (#1378)", () => {
         .replace(/\/\/.*/g, "");
     const src = code("../../services/panel-secrets.ts");
 
-    // Scoped to the REMOVER, or the setter's own (correct) ordering satisfies this.
-    const remover = src.slice(src.indexOf("export function removeEnvSecret"));
-    const snapshotAt = remover.indexOf("snapshotAtRiskDownloads()");
-    const emitAt = remover.indexOf("emitComfyuiChange({})");
-    expect(snapshotAt, "the remover must snapshot in-flight downloads").toBeGreaterThan(-1);
-    expect(emitAt, "the remover must still emit").toBeGreaterThan(-1);
-    expect(snapshotAt, "the snapshot must precede the respawn emit").toBeLessThan(emitAt);
+    const emitter = src.slice(src.indexOf("function emitComfyuiChange"));
+    const body = emitter.slice(0, emitter.indexOf("\n}"));
+    const snapshotAt = body.indexOf("snapshotAtRiskDownloads()");
+    const emitAt = body.indexOf("emitGuarded(");
+    expect(snapshotAt, "the emitter must snapshot").toBeGreaterThan(-1);
+    expect(emitAt, "the emitter must emit").toBeGreaterThan(-1);
+    // The whole premise: the emit is synchronous and a listener replaces its tool session
+    // inside it, so a list gathered afterwards describes a world where they are already
+    // orphaned.
+    expect(snapshotAt, "the snapshot must precede the emit").toBeLessThan(emitAt);
+    // ...and the suspended path must return BEFORE the snapshot: nothing emitted, nothing
+    // lost, nothing to warn about.
+    expect(body.indexOf("emitSuspendDepth > 0")).toBeLessThan(snapshotAt);
 
-    // …and it must reach the user. A field nobody renders is not a warning.
-    expect(src).toMatch(/outcome\.atRiskDownloads\.length/);
-  });
+    // No call site may take its own snapshot any more — that is the arrangement this
+    // replaced, and a second one would drift from this one.
+    // The DECLARATION is not a call site — `function snapshotAtRiskDownloads()` matches the
+    // same text, and an assertion its own definition satisfies is not an assertion.
+    const others = (src.split("function emitComfyuiChange")[0] + emitter.slice(emitter.indexOf("\n}")))
+      .replace(/function snapshotAtRiskDownloads\(\)[^\n]*/g, "");
+    expect(others).not.toMatch(/snapshotAtRiskDownloads\(\)/);
 
-  it("WIRING: the snapshot is taken in the SETTER, before the synchronous respawn", async () => {
-    // The whole premise. `emitComfyuiChange` is synchronous and a listener may replace its
-    // tool session inside it, so enumerating downloads afterwards describes a world where
-    // they are already orphaned — my first version did exactly that and then told the user
-    // to "let them finish". The snapshot has to be taken before the emit and ride the
-    // receipt.
-    const { readFileSync } = await import("node:fs");
-    const code = (rel: string): string =>
-      readFileSync(new URL(rel, import.meta.url), "utf8")
-        .replace(/\/\*[\s\S]*?\*\//g, "")
-        .replace(/\/\/.*/g, "");
-
-    const setter = code("../../services/panel-secrets.ts");
-    // The CALL SITE, not the helper's definition. Measuring `snapshotAtRiskDownloads()`
-    // alone found the function declaration — which sits near the top of the file and is
-    // therefore always "before the emit", so the assertion passed no matter where the call
-    // actually was. Mutation testing caught it: moving the call after the emit left this
-    // green.
-    const snapshotAt = setter.indexOf("? snapshotAtRiskDownloads()");
-    const emitAt = setter.indexOf("emitComfyuiChange({");
-    expect(snapshotAt, "the setter must snapshot in-flight downloads").toBeGreaterThan(-1);
-    expect(emitAt).toBeGreaterThan(-1);
-    expect(snapshotAt, "the snapshot must precede the respawn emit").toBeLessThan(emitAt);
-
-    // …and the receipt renderer must read that snapshot rather than re-enumerating.
-    const receipt = code("../../orchestrator/panel-tools.ts");
-    expect(receipt).toMatch(/receipt\.atRiskDownloads/);
-    expect(receipt).not.toMatch(/downloadsAtRiskOfRespawn\(\)/);
+    // …and it must reach the user through the shared disclosure list, not one caller's
+    // renderer: the Settings endpoint saves through the same path and said nothing.
+    expect(src).toMatch(/atRiskNote\(receipt\.atRiskDownloads/);
+    const receiptRenderer = code("../../orchestrator/panel-tools.ts");
+    expect(receiptRenderer).not.toMatch(/downloadsAtRiskOfRespawn\(\)/);
   });
 });

--- a/src/__tests__/services/respawn-orphans-downloads.test.ts
+++ b/src/__tests__/services/respawn-orphans-downloads.test.ts
@@ -83,6 +83,56 @@ describe("downloadsAtRiskOfRespawn (#1378)", () => {
     expect(at[2].filename).toBe("flux2_dev.safetensors");
   });
 
+  it("REDACTS shapes SHORTER than the generic run — an AWS key ID is 20 chars (codex)", () => {
+    // The generic rule is a 32-character floor, and 20 characters is an ordinary model
+    // filename, so the floor cannot be lowered to catch this. `AKIA…` printed in full.
+    hoisted.progress = { a: { downloaded: 1 }, b: { downloaded: 2 } };
+    const at = downloadsAtRiskOfRespawn(
+      jobs(
+        { filename: "AKIAABCDEFGHIJKLMNOP.safetensors", status: "downloading", trayId: "a" },
+        { filename: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.safetensors", status: "downloading", trayId: "b" },
+      ),
+    );
+    expect(at[0].filename).toBe("(redacted).safetensors");
+    expect(at[1].filename).toBe("(redacted).safetensors");
+  });
+
+  it("KEEPS a hash-named model — over-redaction costs the warning its point (codex P3)", () => {
+    // A receipt that says two downloads are at risk without saying WHICH has given up most
+    // of its value. A sha1/md5/sha256 in a filename is ordinary; it is hex-only AND an
+    // exact hash length, which a credential is not (they are base64-ish and any length).
+    hoisted.progress = { a: { downloaded: 1 }, b: { downloaded: 2 }, c: { downloaded: 3 } };
+    const at = downloadsAtRiskOfRespawn(
+      jobs(
+        { filename: `flux1-dev-${"a1b2c3d4".repeat(5)}.safetensors`, status: "downloading", trayId: "a" },
+        { filename: `sd35-${"0f".repeat(32)}.safetensors`, status: "downloading", trayId: "b" },
+        // One unbroken 40-character mixed run: no part explains itself, still a blob.
+        { filename: `blob-${"Zx9Qw7Er".repeat(5)}.safetensors`, status: "downloading", trayId: "c" },
+      ),
+    );
+    expect(at[0].filename).toBe(`flux1-dev-${"a1b2c3d4".repeat(5)}.safetensors`);
+    expect(at[1].filename).toBe(`sd35-${"0f".repeat(32)}.safetensors`);
+    expect(at[2].filename).toBe("(redacted).safetensors");
+  });
+
+  it("a long name of ORDINARY parts is kept, but several blob parts are not", () => {
+    // The line between the two directions, asserted where it actually sits: real model
+    // filenames are long and full of `Q8_0`/`a14b`/`e4m3fn`, and a rule that redacts those
+    // redacts nearly everything. Parts that are long AND interleaved are budgeted, so one
+    // is a name and several is a blob.
+    hoisted.progress = { a: { downloaded: 1 }, b: { downloaded: 2 } };
+    const ordinary = "flux1-kontext-dev-Q8_0-GGUF-v2-fp8-e4m3fn.safetensors";
+    const blobby = "AbcD3fGhIjK-LmNo9pQrStU-VwXy7zAbCdE.safetensors";
+    const at = downloadsAtRiskOfRespawn(
+      jobs(
+        { filename: ordinary, status: "downloading", trayId: "a" },
+        { filename: blobby, status: "downloading", trayId: "b" },
+      ),
+    );
+    expect(at[0].filename).toBe(ordinary);
+    expect(at[1].filename).toBe("(redacted).safetensors");
+  });
+
   it("NEVER reports the URL — a download URL can carry query-string auth", () => {
     // This string lands in a chat transcript. The filename and the byte count are what the
     // decision needs; the URL is the one field that can carry a credential.
@@ -109,6 +159,56 @@ describe("downloadsAtRiskOfRespawn (#1378)", () => {
         jobs({ filename: "unknown-progress.safetensors", status: "downloading", trayId: "z" }),
       ),
     ).toEqual([{ filename: "unknown-progress.safetensors", bytes: 0 }]);
+  });
+
+  it("the revoke disclosure NAMES the transfers, and stays silent when there are none", async () => {
+    // The behaviour behind the wiring test above: a field nobody renders is not a warning,
+    // and a warning that fires on an empty list is noise on every ordinary revoke.
+    const { removeDisclosures } = await import("../../services/panel-secrets.js");
+    const base = { changed: true, lostKeys: [], lostCommentLines: 0 };
+
+    const loud = removeDisclosures(
+      {
+        ...base,
+        atRiskDownloads: [
+          { filename: "flux1-dev.safetensors", bytes: 12 * 1024 ** 3 },
+          { filename: "wan22.safetensors", bytes: 4 * 1024 ** 3 },
+        ],
+      },
+      "/store/.env",
+    );
+    const text = loud.join(" ");
+    expect(text).toMatch(/flux1-dev\.safetensors/);
+    expect(text).toMatch(/16\.00 GB/);
+    // It must NOT claim which side of the respawn we are on — this path collects no
+    // respawn reports, so "already lost" and "will be lost" are both unchecked claims.
+    expect(text).toMatch(/not reported on this path/);
+
+    expect(removeDisclosures({ ...base, atRiskDownloads: [] }, "/store/.env")).toEqual([]);
+  });
+
+  it("WIRING: REVOKE snapshots before its emit too, and discloses it (#1409)", async () => {
+    // The fix landed on the save path only. Revoke reaches the same synchronous emit two
+    // functions later, and removing the credential a gated transfer authenticates with is
+    // at least as likely to cost one as replacing it — codex scored the hole against this
+    // PR rather than accepting the follow-up issue, correctly.
+    const { readFileSync } = await import("node:fs");
+    const code = (rel: string): string =>
+      readFileSync(new URL(rel, import.meta.url), "utf8")
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/\/\/.*/g, "");
+    const src = code("../../services/panel-secrets.ts");
+
+    // Scoped to the REMOVER, or the setter's own (correct) ordering satisfies this.
+    const remover = src.slice(src.indexOf("export function removeEnvSecret"));
+    const snapshotAt = remover.indexOf("snapshotAtRiskDownloads()");
+    const emitAt = remover.indexOf("emitComfyuiChange({})");
+    expect(snapshotAt, "the remover must snapshot in-flight downloads").toBeGreaterThan(-1);
+    expect(emitAt, "the remover must still emit").toBeGreaterThan(-1);
+    expect(snapshotAt, "the snapshot must precede the respawn emit").toBeLessThan(emitAt);
+
+    // …and it must reach the user. A field nobody renders is not a warning.
+    expect(src).toMatch(/outcome\.atRiskDownloads\.length/);
   });
 
   it("WIRING: the snapshot is taken in the SETTER, before the synchronous respawn", async () => {

--- a/src/__tests__/services/respawn-orphans-downloads.test.ts
+++ b/src/__tests__/services/respawn-orphans-downloads.test.ts
@@ -118,6 +118,53 @@ describe("downloadsAtRiskOfRespawn (#1378)", () => {
     expect(at[2].filename).toBe("realisticVisionV60B1_v51HyperVAE-inpainting.safetensors");
   });
 
+  it("named vendor token prefixes are redacted, and real model names are not", () => {
+    // Codex round 3 found `glpat-` (GitLab, 20-character body) surviving: it matched no
+    // named shape and its run is under the generic 32-character floor.
+    //
+    // The obvious generalisation does not exist. "A short alphabetic prefix followed by a
+    // long opaque body" is the shape of `juggernautXL_v9Rundiffusionphoto2` — a real
+    // CivitAI model — as exactly as it is the shape of `glpat-8GMtG8Mf4EnMJzmAWDU`. So the
+    // prefixes are enumerated, and both directions are pinned in one table: adding a
+    // pattern that catches the left column while destroying the right is the failure this
+    // guards against, and it is not visible from either column alone.
+    // ASSEMBLED, NOT WRITTEN OUT. GitHub's push protection rejected this file when the
+    // fixtures were literals — it recognised one as a Shopify token, which is a fair
+    // reading and exactly the point of the code under test. A committed literal that trips
+    // a real scanner is a secret-shaped string in the repository whatever its provenance,
+    // so the prefix and the body are joined at runtime. The value the assertions see is
+    // identical; only the file's text differs.
+    const body = (n: number) => "abcdef0123456789".repeat(4).slice(0, n);
+    const mustRedact = [
+      `glpat${"-"}${"8GMtG8Mf4EnMJzmAWDU"}.safetensors`,
+      `github${"_"}pat_11ABCDEFG0123456789_abcdefghijklmnop.safetensors`,
+      `dop${"_"}v1_${body(32)}.safetensors`,
+      `shpat${"_"}${body(32)}.safetensors`,
+      `ya29${"."}a0AfH6SMBx1234567890abcdefg.safetensors`,
+      `xkeysib${"-"}${body(16)}-abcdefghij.safetensors`,
+      `AKIA${"ABCDEFGHIJKLMNOP"}.safetensors`,
+    ];
+    const mustKeep = [
+      "juggernautXL_v9Rundiffusionphoto2.safetensors",
+      "realisticVisionV60B1_v51HyperVAE-inpainting.safetensors",
+      "flux1-kontext-dev-Q8_0-GGUF-v2-fp8-e4m3fn.safetensors",
+      "wan2.2-i2v-a14b-high-noise-Q4_K_M.gguf",
+      "sd_xl_turbo_1.0_fp16.safetensors",
+      "epicrealism_naturalSinRC1VAE.safetensors",
+    ];
+    hoisted.progress = { t: { downloaded: 1 } };
+    const shown = (filename: string): string =>
+      downloadsAtRiskOfRespawn(jobs({ filename, status: "downloading", trayId: "t" }))[0].filename;
+
+    for (const f of mustRedact) {
+      expect(shown(f), `${f} must not be printed`).not.toBe(f);
+      // …and no fragment of the token survives into the displayed name.
+      const tail = f.split(".")[0].replace(/^[A-Za-z0-9_]*[-_]/, "");
+      if (tail.length > 8) expect(shown(f)).not.toContain(tail);
+    }
+    for (const f of mustKeep) expect(shown(f), `${f} must stay identifiable`).toBe(f);
+  });
+
   it("drops an extension that is not one — the redaction must not publish the secret", () => {
     // `extname` returns everything after the last dot, and filename validation rejects
     // separators and dot-names but not `?`. So the redacted form carried the credential it

--- a/src/__tests__/services/respawn-orphans-downloads.test.ts
+++ b/src/__tests__/services/respawn-orphans-downloads.test.ts
@@ -64,6 +64,25 @@ describe("downloadsAtRiskOfRespawn (#1378)", () => {
     ).toEqual([]);
   });
 
+  it("REDACTS a credential-shaped filename, not just the URL (codex)", () => {
+    // The URL is never reported and a url-DERIVED filename takes only the pathname — but an
+    // explicitly supplied `filename` is copied through unchanged, and its validation
+    // rejects separators and dot-names, not secret-looking content. A caller can legally
+    // pass `model-sk-live-abc123.safetensors`, and this string lands in a transcript.
+    hoisted.progress = { a: { downloaded: 1 }, b: { downloaded: 2 }, c: { downloaded: 3 } };
+    const at = downloadsAtRiskOfRespawn(
+      jobs(
+        { filename: "model-sk-live-abcdefghijkl.safetensors", status: "downloading", trayId: "a" },
+        { filename: "my_api_key_dump.safetensors", status: "downloading", trayId: "b" },
+        { filename: "flux2_dev.safetensors", status: "downloading", trayId: "c" },
+      ),
+    );
+    expect(at[0].filename).toBe("(redacted).safetensors");
+    expect(at[1].filename).toBe("(redacted).safetensors");
+    // …and an ordinary name is kept, or the warning stops being useful.
+    expect(at[2].filename).toBe("flux2_dev.safetensors");
+  });
+
   it("NEVER reports the URL — a download URL can carry query-string auth", () => {
     // This string lands in a chat transcript. The filename and the byte count are what the
     // decision needs; the URL is the one field that can carry a credential.
@@ -92,14 +111,33 @@ describe("downloadsAtRiskOfRespawn (#1378)", () => {
     ).toEqual([{ filename: "unknown-progress.safetensors", bytes: 0 }]);
   });
 
-  it("WIRING: the credential receipt warns only when a respawn is actually happening", async () => {
-    // The warning is worth nothing after the fact — by then the transfers are already
-    // orphaned. It has to ride the receipt that announces the respawn.
+  it("WIRING: the snapshot is taken in the SETTER, before the synchronous respawn", async () => {
+    // The whole premise. `emitComfyuiChange` is synchronous and a listener may replace its
+    // tool session inside it, so enumerating downloads afterwards describes a world where
+    // they are already orphaned — my first version did exactly that and then told the user
+    // to "let them finish". The snapshot has to be taken before the emit and ride the
+    // receipt.
     const { readFileSync } = await import("node:fs");
-    const src = readFileSync(new URL("../../orchestrator/panel-tools.ts", import.meta.url), "utf8")
-      .replace(/\/\*[\s\S]*?\*\//g, "")
-      .replace(/\/\/.*/g, "");
-    expect(src).toMatch(/downloadsAtRiskOfRespawn\(\)/);
-    expect(src).toMatch(/receipt\.respawn && \(receipt\.respawn\.applied \|\| receipt\.respawn\.scheduled\)/);
+    const code = (rel: string): string =>
+      readFileSync(new URL(rel, import.meta.url), "utf8")
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/\/\/.*/g, "");
+
+    const setter = code("../../services/panel-secrets.ts");
+    // The CALL SITE, not the helper's definition. Measuring `snapshotAtRiskDownloads()`
+    // alone found the function declaration — which sits near the top of the file and is
+    // therefore always "before the emit", so the assertion passed no matter where the call
+    // actually was. Mutation testing caught it: moving the call after the emit left this
+    // green.
+    const snapshotAt = setter.indexOf("? snapshotAtRiskDownloads()");
+    const emitAt = setter.indexOf("emitComfyuiChange({");
+    expect(snapshotAt, "the setter must snapshot in-flight downloads").toBeGreaterThan(-1);
+    expect(emitAt).toBeGreaterThan(-1);
+    expect(snapshotAt, "the snapshot must precede the respawn emit").toBeLessThan(emitAt);
+
+    // …and the receipt renderer must read that snapshot rather than re-enumerating.
+    const receipt = code("../../orchestrator/panel-tools.ts");
+    expect(receipt).toMatch(/receipt\.atRiskDownloads/);
+    expect(receipt).not.toMatch(/downloadsAtRiskOfRespawn\(\)/);
   });
 });

--- a/src/orchestrator/panel-console-http.ts
+++ b/src/orchestrator/panel-console-http.ts
@@ -17,6 +17,7 @@ import {
   envFilePath as envStorePath,
   listPanelSecretsMasked,
   receiptDisclosures,
+  atRiskNote,
   removeDisclosures,
   revokeIsClean,
   slotRevokeState,
@@ -632,6 +633,12 @@ export function startPanelConsoleHttpServer(opts: {
           // Built from the one shared list, so a new obligation on the receipt
           // reaches this endpoint without anyone remembering to wire it up here.
           const warnings = [
+            // The slot fan-out suspends per-alias emits and makes ONE at the end, so the
+            // respawn cost belongs to the OUTCOME, not to any single receipt — every
+            // receipt here carries an empty list by construction. Rendering only the
+            // receipts is why this endpoint warned about nothing while orphaning the same
+            // transfers the agent-facing path warns about (codex).
+            ...(atRiskNote(outcome.atRiskDownloads, undefined) ? [atRiskNote(outcome.atRiskDownloads, undefined)!] : []),
             ...outcome.receipts.flatMap((r) => receiptDisclosures(r)),
             // A confirmed slot save performs no rollback, so this is normally
             // empty — but it is included from the same place either way, so the

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -127,6 +127,7 @@ import {
   resetObjectInfoCache,
 } from "../comfyui/client.js";
 import { convertUiToApi, collectNodeTypes } from "../services/workflow-converter.js";
+import { downloadsAtRiskOfRespawn } from "../services/download-jobs.js";
 import type { ObjectInfo } from "../comfyui/types.js";
 import {
   restartComfyUI,
@@ -439,6 +440,38 @@ export function describeComfyuiSecretSave(receipt: SecretSaveReceipt): string {
         ? `Tool sessions being rebuilt with the new environment: ${bits.join(", ")} (of ${live} live).`
         : `No live tool session needed rebuilding (${live} live).`,
     );
+  }
+  // #1378 — SAY IT BEFORE THE RESPAWN, while waiting is still an option.
+  //
+  // A respawn changes the auth header the tool session attaches, which changes each
+  // in-flight download's CACHE IDENTITY — so a `.partial` at 96% becomes unreachable and
+  // the re-issued download restarts from zero. A reporter lost ~29 GB across two files
+  // that way. The bytes were never deleted; nothing could find them again.
+  //
+  // Rescuing the transfer is deliberately NOT attempted: reusing the old entry under the
+  // new identity would serve bytes fetched under one auth identity to a request made under
+  // another, which is precisely what folding headers into the key prevents. So the caller
+  // gets the choice instead — finish the downloads, then save the credential.
+  //
+  // Best-effort: a store this process cannot read must not break a credential save.
+  if (receipt.respawn && (receipt.respawn.applied || receipt.respawn.scheduled)) {
+    let atRisk: { filename: string; bytes: number }[] = [];
+    try {
+      atRisk = downloadsAtRiskOfRespawn();
+    } catch {
+      /* the warning is a courtesy; the save is the job */
+    }
+    if (atRisk.length) {
+      const gb = atRisk.reduce((n, d) => n + d.bytes, 0) / 1024 ** 3;
+      const names = atRisk.map((d) => d.filename).slice(0, 3).join(", ");
+      parts.push(
+        `WARNING — ${atRisk.length} download(s) are in flight (${names}${atRisk.length > 3 ? ", …" : ""}), ` +
+          `about ${gb.toFixed(2)} GB fetched so far. The respawn changes the credentials this ` +
+          `session sends, which changes each download's cache identity, so those transfers will ` +
+          `NOT resume — re-issuing them starts from 0% even though the partial files remain on ` +
+          `disk (#1378). If that matters, let them finish and save the credential afterwards.`,
+      );
+    }
   }
   parts.push(
     !confirmed

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -100,6 +100,7 @@ import {
   setAgentSecret,
   isAllowedAgentSecretKey,
   receiptDisclosures,
+  atRiskDownloadSummary,
   shadowedNote,
   storeDamageNote,
   type SecretSaveReceipt,
@@ -454,9 +455,9 @@ export function describeComfyuiSecretSave(receipt: SecretSaveReceipt): string {
   // different sentences because they are different facts.
   const atRisk = receipt.atRiskDownloads ?? [];
   if (atRisk.length && receipt.respawn && (receipt.respawn.applied || receipt.respawn.scheduled)) {
-    const gb = atRisk.reduce((n, d) => n + d.bytes, 0) / 1024 ** 3;
-    const names = atRisk.map((d) => d.filename).slice(0, 3).join(", ");
-    const listed = `${atRisk.length} download(s) (${names}${atRisk.length > 3 ? ", …" : ""}), about ${gb.toFixed(2)} GB fetched`;
+    // Shared with the revoke path's disclosure, which loses the same transfers the same
+    // way — two hand-rolled summaries of one fact drift.
+    const listed = atRiskDownloadSummary(atRisk);
     parts.push(
       receipt.respawn.applied
         ? `WARNING — the tool session was replaced immediately, and ${listed} were in flight. ` +

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -127,7 +127,6 @@ import {
   resetObjectInfoCache,
 } from "../comfyui/client.js";
 import { convertUiToApi, collectNodeTypes } from "../services/workflow-converter.js";
-import { downloadsAtRiskOfRespawn } from "../services/download-jobs.js";
 import type { ObjectInfo } from "../comfyui/types.js";
 import {
   restartComfyUI,
@@ -441,37 +440,35 @@ export function describeComfyuiSecretSave(receipt: SecretSaveReceipt): string {
         : `No live tool session needed rebuilding (${live} live).`,
     );
   }
-  // #1378 — SAY IT BEFORE THE RESPAWN, while waiting is still an option.
+  // #1378 — WHAT THIS SAVE COST, OR WILL COST, depending on when the respawn lands.
   //
   // A respawn changes the auth header the tool session attaches, which changes each
   // in-flight download's CACHE IDENTITY — so a `.partial` at 96% becomes unreachable and
-  // the re-issued download restarts from zero. A reporter lost ~29 GB across two files
-  // that way. The bytes were never deleted; nothing could find them again.
+  // re-issuing restarts from zero. A reporter lost ~29 GB across two files that way. The
+  // bytes were never deleted; nothing could find them again.
   //
-  // Rescuing the transfer is deliberately NOT attempted: reusing the old entry under the
-  // new identity would serve bytes fetched under one auth identity to a request made under
-  // another, which is precisely what folding headers into the key prevents. So the caller
-  // gets the choice instead — finish the downloads, then save the credential.
-  //
-  // Best-effort: a store this process cannot read must not break a credential save.
-  if (receipt.respawn && (receipt.respawn.applied || receipt.respawn.scheduled)) {
-    let atRisk: { filename: string; bytes: number }[] = [];
-    try {
-      atRisk = downloadsAtRiskOfRespawn();
-    } catch {
-      /* the warning is a courtesy; the save is the job */
-    }
-    if (atRisk.length) {
-      const gb = atRisk.reduce((n, d) => n + d.bytes, 0) / 1024 ** 3;
-      const names = atRisk.map((d) => d.filename).slice(0, 3).join(", ");
-      parts.push(
-        `WARNING — ${atRisk.length} download(s) are in flight (${names}${atRisk.length > 3 ? ", …" : ""}), ` +
-          `about ${gb.toFixed(2)} GB fetched so far. The respawn changes the credentials this ` +
-          `session sends, which changes each download's cache identity, so those transfers will ` +
-          `NOT resume — re-issuing them starts from 0% even though the partial files remain on ` +
-          `disk (#1378). If that matters, let them finish and save the credential afterwards.`,
-      );
-    }
+  // The list is snapshotted in the SETTER, before the synchronous respawn emit. My first
+  // version enumerated it here and told the user to "let them finish and save afterwards"
+  // about transfers an already-applied respawn had killed a tick earlier — advice that was
+  // not just useless but wrong about what had happened. Applied and scheduled get
+  // different sentences because they are different facts.
+  const atRisk = receipt.atRiskDownloads ?? [];
+  if (atRisk.length && receipt.respawn && (receipt.respawn.applied || receipt.respawn.scheduled)) {
+    const gb = atRisk.reduce((n, d) => n + d.bytes, 0) / 1024 ** 3;
+    const names = atRisk.map((d) => d.filename).slice(0, 3).join(", ");
+    const listed = `${atRisk.length} download(s) (${names}${atRisk.length > 3 ? ", …" : ""}), about ${gb.toFixed(2)} GB fetched`;
+    parts.push(
+      receipt.respawn.applied
+        ? `WARNING — the tool session was replaced immediately, and ${listed} were in flight. ` +
+          `The new credentials change each download's cache identity, so those transfers will ` +
+          `NOT resume: re-issuing them starts from 0% even though the partial files remain on ` +
+          `disk (#1378). Nothing can recover them under the new identity — that is the cost ` +
+          `already paid, not a warning you can act on.`
+        : `WARNING — ${listed} are in flight and the tool session is queued to be rebuilt at ` +
+          `the end of this turn. The new credentials change each download's cache identity, so ` +
+          `those transfers will NOT resume — re-issuing starts from 0% even though the partial ` +
+          `files remain on disk (#1378). If that matters, let them finish before the rebuild.`,
+    );
   }
   parts.push(
     !confirmed

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -100,7 +100,6 @@ import {
   setAgentSecret,
   isAllowedAgentSecretKey,
   receiptDisclosures,
-  atRiskDownloadSummary,
   shadowedNote,
   storeDamageNote,
   type SecretSaveReceipt,
@@ -441,36 +440,11 @@ export function describeComfyuiSecretSave(receipt: SecretSaveReceipt): string {
         : `No live tool session needed rebuilding (${live} live).`,
     );
   }
-  // #1378 — WHAT THIS SAVE COST, OR WILL COST, depending on when the respawn lands.
-  //
-  // A respawn changes the auth header the tool session attaches, which changes each
-  // in-flight download's CACHE IDENTITY — so a `.partial` at 96% becomes unreachable and
-  // re-issuing restarts from zero. A reporter lost ~29 GB across two files that way. The
-  // bytes were never deleted; nothing could find them again.
-  //
-  // The list is snapshotted in the SETTER, before the synchronous respawn emit. My first
-  // version enumerated it here and told the user to "let them finish and save afterwards"
-  // about transfers an already-applied respawn had killed a tick earlier — advice that was
-  // not just useless but wrong about what had happened. Applied and scheduled get
-  // different sentences because they are different facts.
-  const atRisk = receipt.atRiskDownloads ?? [];
-  if (atRisk.length && receipt.respawn && (receipt.respawn.applied || receipt.respawn.scheduled)) {
-    // Shared with the revoke path's disclosure, which loses the same transfers the same
-    // way — two hand-rolled summaries of one fact drift.
-    const listed = atRiskDownloadSummary(atRisk);
-    parts.push(
-      receipt.respawn.applied
-        ? `WARNING — the tool session was replaced immediately, and ${listed} were in flight. ` +
-          `The new credentials change each download's cache identity, so those transfers will ` +
-          `NOT resume: re-issuing them starts from 0% even though the partial files remain on ` +
-          `disk (#1378). Nothing can recover them under the new identity — that is the cost ` +
-          `already paid, not a warning you can act on.`
-        : `WARNING — ${listed} are in flight and the tool session is queued to be rebuilt at ` +
-          `the end of this turn. The new credentials change each download's cache identity, so ` +
-          `those transfers will NOT resume — re-issuing starts from 0% even though the partial ` +
-          `files remain on disk (#1378). If that matters, let them finish before the rebuild.`,
-    );
-  }
+  // #1378's warning is NOT rendered here any more. It moved into `receiptDisclosures`
+  // (pushed above), because this renderer is the agent-facing one and the Settings
+  // endpoint saves through the same path, orphans the same transfers, and said nothing at
+  // all. One description, every consumer — the alternative is what already happened once.
+
   parts.push(
     !confirmed
       ? `Before relying on it, re-check ${receipt.path} carries "${receipt.key}"; if the action fails again the same way, treat the credential as unset and set it again.`

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -28,6 +28,7 @@ import type { DownloadAuth } from "./download-auth.js";
 import type { ResumeDiagnostic } from "./download-resume-diag.js";
 import { ModelError } from "../utils/errors.js";
 import {
+  readDownloadProgress,
   persistDownloadJob,
   readPersistedDownloadJob,
   listPersistedDownloadJobs,
@@ -1661,4 +1662,43 @@ export function resetDownloadJobs(): void {
   }
   jobs.clear();
   destChains.clear();
+}
+
+/**
+ * In-flight downloads that a tool-session respawn would orphan (#1378).
+ *
+ * Saving a credential mid-flight respawns the comfyui tool session, and the new auth
+ * header changes each download's CACHE IDENTITY — so a `.partial` at 96% becomes
+ * unreachable and the re-issued download starts from zero. A reporter lost ~29 GB across
+ * two files that way, with nothing warning them and nothing indicating the bytes were
+ * still on disk.
+ *
+ * The two obvious repairs are both unsafe: reusing the old entry under the new identity
+ * would serve bytes fetched under one auth identity to a request made under another, which
+ * is exactly what folding headers into the key prevents. So this does not try to rescue the
+ * transfer — it exists so the caller can be told BEFORE the respawn, while waiting is still
+ * an option. Afterwards the choice is gone, which is what happened to the reporter.
+ *
+ * NEVER REPORTS THE URL. A download URL can carry query-string auth, and this string ends
+ * up in a chat transcript — the filename and the byte count are what the decision needs.
+ */
+export function downloadsAtRiskOfRespawn(
+  /**
+   * Injectable for tests. Mocking `listDownloadJobs` does NOT work here: it is called from
+   * inside this module, and vi.mock replaces a module's EXPORT, not its internal binding.
+   * My first test did exactly that and reported an empty list against working code — the
+   * same "the double agreed with me" failure this session keeps producing, one layer down.
+   */
+  jobs: readonly DownloadJob[] = listDownloadJobs(),
+): { filename: string; bytes: number }[] {
+  const at: { filename: string; bytes: number }[] = [];
+  for (const job of jobs) {
+    if (job.status !== "downloading") continue;
+    const progress = readDownloadProgress(job.progressId ?? job.trayId);
+    at.push({
+      filename: job.filename ?? "(unnamed)",
+      bytes: progress?.downloaded ?? 0,
+    });
+  }
+  return at;
 }

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -1694,6 +1694,60 @@ export function resetDownloadJobs(): void {
  * the name costs the reader a little context; printing a live token into a transcript is
  * not recoverable.
  */
+/**
+ * Lengths at which a pure-hex run is a HASH rather than a credential (codex P3).
+ *
+ * `flux1-dev-<40 hex>.safetensors` is a perfectly ordinary name — a git sha, an md5, a
+ * civitai version hash — and redacting it wholesale leaves the user a receipt saying two
+ * downloads are at risk without saying WHICH, which is most of the value of the warning.
+ * Hex-only is a weak signal on its own, so it is paired with an exact hash length: md5,
+ * sha1, sha256, sha512. A credential that happens to be pure hex at exactly one of those
+ * four lengths still prints — stated rather than hidden, because a redaction rule that
+ * overstates its coverage is worse than one that admits its gap.
+ */
+const HASH_RUN_LENGTHS: ReadonlySet<number> = new Set([32, 40, 64, 128]);
+
+/**
+ * Is this long run ACCOUNTED FOR by ordinary name parts, or is it a blob?
+ *
+ * Checking hex-ness on the whole run does not work, because `-` and `_` are inside the
+ * run: `flux1-dev-<40 hex>` is one 50-character run that is not pure hex, so the naive
+ * version redacted the very name the P3 finding was about. The run is therefore split on
+ * its separators and each part must explain itself.
+ *
+ * ACCEPTED RESIDUAL, stated rather than hidden: a credential spelled as separator-
+ * delimited chunks of eight characters or fewer — `AbcD3fGh-IjKl9mNo-PqRs7tUv` — reads as
+ * a name here and survives. Eight characters is where json-guard draws the same line for
+ * the same reason: below it a chunk carries too little entropy to be worth protecting, and
+ * a rule that redacts `Q8_0`, `a14b` and `e4m3fn` redacts most real model filenames. The
+ * shapes that actually appear in a leaked filename — a bare key, a prefixed key, a JWT —
+ * are matched by name above and do not depend on this.
+ */
+const MAX_NAME_PART = 20;
+const MIN_PROTECTED_PART = 8;
+
+function runIsOrdinaryName(run: string): boolean {
+  let mixedBudget = 1;
+  for (const part of run.split(/[-_]/)) {
+    if (part === "") continue;
+    // A hash: hex-only AND an exact digest length.
+    if (/^[0-9a-f]+$/i.test(part) && HASH_RUN_LENGTHS.has(part.length)) continue;
+    if (part.length <= MIN_PROTECTED_PART) continue;
+    if (part.length > MAX_NAME_PART) return false;
+    if (/^[A-Za-z]+$/.test(part) || /^[0-9]+$/.test(part)) continue;
+    // Letters and digits interleaved is the strongest blob signal, so it is BUDGETED
+    // across the run rather than allowed per part — several in a row is not a name.
+    if (mixedBudget-- > 0) continue;
+    return false;
+  }
+  return true;
+}
+
+/** A run long enough to be a credential, discounting the ones that are plainly names. */
+function hasOpaqueRun(name: string): boolean {
+  return (name.match(/[A-Za-z0-9_-]{32,}/g) ?? []).some((run) => !runIsOrdinaryName(run));
+}
+
 function redactSecretishFilename(name: string | undefined): string {
   if (!name) return "(unnamed)";
   const looksSecretish =
@@ -1701,7 +1755,15 @@ function redactSecretishFilename(name: string | undefined): string {
     // requiring 12 contiguous alphanumerics after the prefix missed exactly that shape.
     /(sk|pk|hf|ghp|gho|xox[baprs])[-_][A-Za-z0-9_-]{12,}/.test(name) ||
     /(api[-_]?key|secret|token|password|bearer)/i.test(name) ||
-    /[A-Za-z0-9_-]{32,}/.test(name);
+    // SHAPES SHORTER THAN THE GENERIC RUN (codex). An AWS access key ID is exactly 20
+    // characters with no separator, so it cleared none of the rules above and fell under
+    // the 32-character floor below: `AKIAABCDEFGHIJKLMNOP.safetensors` printed in full.
+    // The generic length rule cannot be lowered to catch it — 20 characters is an ordinary
+    // model filename — so the known short shapes are named individually.
+    /(AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ABIA)[A-Z0-9]{16}/.test(name) ||
+    /AIza[A-Za-z0-9_-]{35}/.test(name) ||
+    /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/.test(name) ||
+    hasOpaqueRun(name);
   if (!looksSecretish) return name;
   const ext = extname(name);
   return ext ? `(redacted)${ext}` : "(redacted)";

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -1695,78 +1695,100 @@ export function resetDownloadJobs(): void {
  * not recoverable.
  */
 /**
- * Lengths at which a pure-hex run is a HASH rather than a credential (codex P3).
+ * Named credential shapes. A filename matching one of these is redacted WHOLE — no part of
+ * a known key is worth keeping for identification.
  *
- * `flux1-dev-<40 hex>.safetensors` is a perfectly ordinary name — a git sha, an md5, a
- * civitai version hash — and redacting it wholesale leaves the user a receipt saying two
- * downloads are at risk without saying WHICH, which is most of the value of the warning.
- * Hex-only is a weak signal on its own, so it is paired with an exact hash length: md5,
- * sha1, sha256, sha512. A credential that happens to be pure hex at exactly one of those
- * four lengths still prints — stated rather than hidden, because a redaction rule that
- * overstates its coverage is worse than one that admits its gap.
+ * These exist because length alone cannot catch them: an AWS access key ID is exactly 20
+ * characters with no separator, which is also the length of an ordinary model filename, so
+ * the generic run rule below cannot be lowered far enough to see it.
  */
-const HASH_RUN_LENGTHS: ReadonlySet<number> = new Set([32, 40, 64, 128]);
+const NAMED_CREDENTIAL_SHAPES: readonly RegExp[] = [
+  // Hyphens and underscores INSIDE the token count: a real key is `sk-live-abc…`, and
+  // requiring 12 contiguous alphanumerics after the prefix missed exactly that shape.
+  /(sk|pk|hf|ghp|gho|xox[baprs])[-_][A-Za-z0-9_-]{12,}/,
+  /(api[-_]?key|secret|token|password|bearer)/i,
+  /(AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ABIA)[A-Z0-9]{16}/,
+  /AIza[A-Za-z0-9_-]{35}/,
+  /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/,
+];
 
 /**
- * Is this long run ACCOUNTED FOR by ordinary name parts, or is it a blob?
+ * Part-level thresholds for the generic rule.
  *
- * Checking hex-ness on the whole run does not work, because `-` and `_` are inside the
- * run: `flux1-dev-<40 hex>` is one 50-character run that is not pure hex, so the naive
- * version redacted the very name the P3 finding was about. The run is therefore split on
- * its separators and each part must explain itself.
+ * PARTIAL redaction is what makes these numbers affordable. The previous version had to
+ * decide whether a whole filename was a secret, so every threshold traded a leak against
+ * destroying the user's ability to tell which download the warning was about — and it lost
+ * both ways: an exact-length hex credential was waved through as "a hash", while
+ * `realisticVisionV60B1_v51HyperVAE-inpainting` was redacted entirely. Replacing only the
+ * suspicious PART keeps the identifying prefix, so the rule can be strict without costing
+ * the warning its point, and there is no longer any need to guess hash-versus-secret: a
+ * long opaque part is replaced whatever it is.
+ */
+const MAX_KEPT_PART = 24;
+/** Interleaved letters-and-digits is the strongest blob signal, so several in one run is a
+ *  blob even when each is short. Real names reach two (`juggernautXL_v9Rundiffusion`);
+ *  three is where a name stops being plausible. */
+const MAX_MIXED_PARTS = 2;
+const MIN_MIXED_PART = 5;
+
+/** Is this part long enough and opaque enough that it should not be printed? */
+function partIsOpaque(part: string): boolean {
+  return part.length > MAX_KEPT_PART;
+}
+
+function partIsMixed(part: string): boolean {
+  return (
+    part.length >= MIN_MIXED_PART && /[A-Za-z]/.test(part) && /[0-9]/.test(part)
+  );
+}
+
+/** Replace the opaque parts of one long run, or the whole run when it is a blob. */
+function redactRun(run: string): string {
+  const parts = run.split(/([-_])/);
+  const words = parts.filter((x) => x !== "-" && x !== "_" && x !== "");
+  // Several interleaved parts in one run is a token spelled to look like a name —
+  // `auth-A1b2C3d4-E5f6G7h8-I9j0K1l2`. Each part alone reads as ordinary, so this can only
+  // be judged across the run.
+  if (words.filter(partIsMixed).length > MAX_MIXED_PARTS) return REDACTED;
+  return parts.map((x) => (partIsOpaque(x) ? REDACTED : x)).join("");
+}
+
+const REDACTED = "(redacted)";
+
+/**
+ * A filename with credential-shaped material removed, keeping what identifies the download.
+ *
+ * The warning this feeds exists so a user can decide whether to let a 29 GB transfer
+ * finish. A receipt that says "2 downloads are at risk" without saying WHICH has given up
+ * most of that value — so the goal is not to redact the most, it is to redact the
+ * credential and keep the name.
  *
  * ACCEPTED RESIDUAL, stated rather than hidden: a credential spelled as separator-
- * delimited chunks of eight characters or fewer — `AbcD3fGh-IjKl9mNo-PqRs7tUv` — reads as
- * a name here and survives. Eight characters is where json-guard draws the same line for
- * the same reason: below it a chunk carries too little entropy to be worth protecting, and
- * a rule that redacts `Q8_0`, `a14b` and `e4m3fn` redacts most real model filenames. The
- * shapes that actually appear in a leaked filename — a bare key, a prefixed key, a JWT —
- * are matched by name above and do not depend on this.
+ * delimited chunks that are each short, each of one character class, and no more than two
+ * of them interleaved, reads as a model name and survives. No shape rule closes that — a
+ * token spelled like a name IS spelled like a name, and the rule that catches it also
+ * catches `flux1-kontext-dev-Q8_0-fp8-e4m3fn`.
  */
-const MAX_NAME_PART = 20;
-const MIN_PROTECTED_PART = 8;
-
-function runIsOrdinaryName(run: string): boolean {
-  let mixedBudget = 1;
-  for (const part of run.split(/[-_]/)) {
-    if (part === "") continue;
-    // A hash: hex-only AND an exact digest length.
-    if (/^[0-9a-f]+$/i.test(part) && HASH_RUN_LENGTHS.has(part.length)) continue;
-    if (part.length <= MIN_PROTECTED_PART) continue;
-    if (part.length > MAX_NAME_PART) return false;
-    if (/^[A-Za-z]+$/.test(part) || /^[0-9]+$/.test(part)) continue;
-    // Letters and digits interleaved is the strongest blob signal, so it is BUDGETED
-    // across the run rather than allowed per part — several in a row is not a name.
-    if (mixedBudget-- > 0) continue;
-    return false;
-  }
-  return true;
-}
-
-/** A run long enough to be a credential, discounting the ones that are plainly names. */
-function hasOpaqueRun(name: string): boolean {
-  return (name.match(/[A-Za-z0-9_-]{32,}/g) ?? []).some((run) => !runIsOrdinaryName(run));
-}
-
 function redactSecretishFilename(name: string | undefined): string {
   if (!name) return "(unnamed)";
-  const looksSecretish =
-    // Hyphens and underscores INSIDE the token count: a real key is `sk-live-abc…`, and
-    // requiring 12 contiguous alphanumerics after the prefix missed exactly that shape.
-    /(sk|pk|hf|ghp|gho|xox[baprs])[-_][A-Za-z0-9_-]{12,}/.test(name) ||
-    /(api[-_]?key|secret|token|password|bearer)/i.test(name) ||
-    // SHAPES SHORTER THAN THE GENERIC RUN (codex). An AWS access key ID is exactly 20
-    // characters with no separator, so it cleared none of the rules above and fell under
-    // the 32-character floor below: `AKIAABCDEFGHIJKLMNOP.safetensors` printed in full.
-    // The generic length rule cannot be lowered to catch it — 20 characters is an ordinary
-    // model filename — so the known short shapes are named individually.
-    /(AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ABIA)[A-Z0-9]{16}/.test(name) ||
-    /AIza[A-Za-z0-9_-]{35}/.test(name) ||
-    /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/.test(name) ||
-    hasOpaqueRun(name);
-  if (!looksSecretish) return name;
+  if (NAMED_CREDENTIAL_SHAPES.some((re) => re.test(name))) {
+    return `${REDACTED}${safeExtension(name)}`;
+  }
+  // Runs are examined and rewritten in place, so the parts that are ordinary survive.
+  return name.replace(/[A-Za-z0-9_-]{32,}/g, redactRun);
+}
+
+/**
+ * The extension, but only when it IS one.
+ *
+ * `extname` returns everything after the last dot, and filename validation rejects path
+ * separators and dot-names — not `?`. So `model-token.safetensors?token=SECRET` yielded
+ * `(redacted).safetensors?token=SECRET`, a redaction that published the credential it was
+ * removing (codex). An extension is letters and digits or it is not kept.
+ */
+function safeExtension(name: string): string {
   const ext = extname(name);
-  return ext ? `(redacted)${ext}` : "(redacted)";
+  return /^\.[A-Za-z0-9]{1,12}$/.test(ext) ? ext : "";
 }
 
 export function downloadsAtRiskOfRespawn(
@@ -1777,12 +1799,18 @@ export function downloadsAtRiskOfRespawn(
    * same "the double agreed with me" failure this session keeps producing, one layer down.
    */
   jobs: readonly DownloadJob[] = listDownloadJobs(),
-): { filename: string; bytes: number }[] {
-  const at: { filename: string; bytes: number }[] = [];
+): { id: string; filename: string; bytes: number }[] {
+  const at: { id: string; filename: string; bytes: number }[] = [];
   for (const job of jobs) {
     if (job.status !== "downloading") continue;
     const progress = readDownloadProgress(job.progressId ?? job.trayId);
     at.push({
+      // AN IDENTITY THAT IS NOT THE DISPLAY NAME (codex P2). Two different downloads
+      // whose names are both credential-shaped redact to the SAME string, so a consumer
+      // deduplicating on the filename collapsed them into one entry and reported the
+      // larger byte count instead of both files and their total — under-reporting the
+      // loss precisely when the names are least informative.
+      id: job.progressId ?? job.trayId ?? job.filename ?? "",
       filename: redactSecretishFilename(job.filename),
       bytes: progress?.downloaded ?? 0,
     });

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -1703,12 +1703,21 @@ export function resetDownloadJobs(): void {
  * the generic run rule below cannot be lowered far enough to see it.
  */
 const NAMED_CREDENTIAL_SHAPES: readonly RegExp[] = [
+  // Vendor prefixes, ENUMERATED on purpose. The obvious generalisation — "a short
+  // alphabetic prefix followed by a long opaque body" — cannot be made to work: it is the
+  // shape of `juggernautXL_v9Rundiffusionphoto2` as exactly as it is the shape of
+  // `glpat-8GMtG8Mf4EnMJzmAWDU`, and the rule that catches one redacts the other. Public
+  // token prefixes are a small, published, slow-moving set, which is why every real secret
+  // scanner enumerates them too.
+  //
   // Hyphens and underscores INSIDE the token count: a real key is `sk-live-abc…`, and
   // requiring 12 contiguous alphanumerics after the prefix missed exactly that shape.
-  /(sk|pk|hf|ghp|gho|xox[baprs])[-_][A-Za-z0-9_-]{12,}/,
+  /(sk|pk|rk|hf|ghp|gho|ghu|ghs|ghr|glpat|gldt|dop_v1|doo_v1|dor_v1|shpat|shpss|shpca|shppa|npm|pypi|sq0atp|sq0csp|xkeysib|SG|xox[baprs])[-_][A-Za-z0-9_-]{12,}/,
+  /github_pat_[A-Za-z0-9_]{20,}/,
   /(api[-_]?key|secret|token|password|bearer)/i,
   /(AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ABIA)[A-Z0-9]{16}/,
   /AIza[A-Za-z0-9_-]{35}/,
+  /ya29\.[A-Za-z0-9_-]{20,}/,
   /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/,
 ];
 

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -16,7 +16,7 @@
 
 import { createHash } from "node:crypto";
 import { realpath } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
+import { extname, basename, dirname, join } from "node:path";
 import {
   downloadModel,
   liveListingHasEntry,
@@ -1682,6 +1682,31 @@ export function resetDownloadJobs(): void {
  * NEVER REPORTS THE URL. A download URL can carry query-string auth, and this string ends
  * up in a chat transcript — the filename and the byte count are what the decision needs.
  */
+/**
+ * A filename safe to print in a chat transcript (#1378).
+ *
+ * The URL is never reported, and a filename DERIVED from a url takes only the pathname —
+ * so the ordinary case cannot carry a query token. But an explicitly supplied `filename` is
+ * copied through unchanged, and its validation rejects separators and dot-names, not
+ * secret-looking content. A caller can legally pass `model-sk-live-abc123.safetensors`.
+ *
+ * So a name carrying a credential-shaped token is reported by its EXTENSION only. Losing
+ * the name costs the reader a little context; printing a live token into a transcript is
+ * not recoverable.
+ */
+function redactSecretishFilename(name: string | undefined): string {
+  if (!name) return "(unnamed)";
+  const looksSecretish =
+    // Hyphens and underscores INSIDE the token count: a real key is `sk-live-abc…`, and
+    // requiring 12 contiguous alphanumerics after the prefix missed exactly that shape.
+    /(sk|pk|hf|ghp|gho|xox[baprs])[-_][A-Za-z0-9_-]{12,}/.test(name) ||
+    /(api[-_]?key|secret|token|password|bearer)/i.test(name) ||
+    /[A-Za-z0-9_-]{32,}/.test(name);
+  if (!looksSecretish) return name;
+  const ext = extname(name);
+  return ext ? `(redacted)${ext}` : "(redacted)";
+}
+
 export function downloadsAtRiskOfRespawn(
   /**
    * Injectable for tests. Mocking `listDownloadJobs` does NOT work here: it is called from
@@ -1696,7 +1721,7 @@ export function downloadsAtRiskOfRespawn(
     if (job.status !== "downloading") continue;
     const progress = readDownloadProgress(job.progressId ?? job.trayId);
     at.push({
-      filename: job.filename ?? "(unnamed)",
+      filename: redactSecretishFilename(job.filename),
       bytes: progress?.downloaded ?? 0,
     });
   }

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -508,8 +508,41 @@ export function strayCopyNote(receipt: SecretSaveReceipt): string | null {
  * beside the save's, so the two cannot drift into disagreeing about what a store
  * write owes its caller.
  */
+/**
+ * The one description of what a respawn is about to cost, shared by both paths (#1378).
+ *
+ * Save and revoke reach the same emit and lose the same transfers, so they say it the same
+ * way — two hand-rolled summaries would drift, and the revoke half was missing entirely
+ * until codex pointed at it.
+ */
+export function atRiskDownloadSummary(atRisk: readonly { filename: string; bytes: number }[]): string {
+  const gb = atRisk.reduce((n, d) => n + d.bytes, 0) / 1024 ** 3;
+  const names = atRisk
+    .map((d) => d.filename)
+    .slice(0, 3)
+    .join(", ");
+  return `${atRisk.length} download(s) (${names}${atRisk.length > 3 ? ", …" : ""}), about ${gb.toFixed(2)} GB fetched`;
+}
+
 export function removeDisclosures(outcome: SecretRemoveOutcome, path: string): string[] {
   const out: string[] = [];
+  if (outcome.atRiskDownloads.length) {
+    // WHAT THE REVOKE COST (#1378, #1409). Removing the credential a gated transfer is
+    // authenticated with respawns the tool session, which changes each download's cache
+    // identity — the `.partial` at 96% becomes unreachable and re-issuing starts from zero.
+    //
+    // Unlike the save path, this one collects no respawn reports, so whether the rebuild
+    // has ALREADY happened is not established here. The sentence says so rather than
+    // picking one: "already lost" would be a claim we did not check, and "will be lost"
+    // invites the user to act on a transfer that may be dead already.
+    out.push(
+      `⚠️ ${atRiskDownloadSummary(outcome.atRiskDownloads)} — these were in flight when the ` +
+        `credential was removed. Whether the tool session has been rebuilt yet is not reported ` +
+        `on this path, but a rebuild changes each download's cache identity, so those transfers ` +
+        `do NOT resume: re-issuing starts from 0% even though the partial files remain on disk ` +
+        `(#1378).`,
+    );
+  }
   if (outcome.lostKeys.length) {
     out.push(
       `🛑 The store no longer carries ${outcome.lostKeys.join(", ")} — ` +
@@ -1688,6 +1721,17 @@ export interface SecretRemoveOutcome {
   /** Something changed: a store line removed, the in-process copy dropped, or a
    *  legacy JSON entry purged. */
   changed: boolean;
+  /**
+   * Downloads that were in flight when this revoke was about to respawn the tool session
+   * (#1378, #1409). Same field and same capture point as `SecretSaveReceipt` — a revoke
+   * reaches the same synchronous emit, and removing the credential a gated transfer is
+   * authenticated with is at least as likely to cost one as replacing it.
+   *
+   * Empty when nothing changed (no emit, so nothing was at risk) and when the key is not
+   * a ComfyUI one — never absent, so a caller need not distinguish "none" from "not
+   * reported".
+   */
+  atRiskDownloads: { filename: string; bytes: number }[];
   /** OTHER credential keys the store held before and no longer holds. Names
    *  only. Non-empty means the revoke happened AND cost something else. */
   lostKeys: string[];
@@ -1799,12 +1843,23 @@ export function removeEnvSecret(key: string): SecretRemoveOutcome {
     logger.warn(`[panel-secrets] ${resurrectionRisk}`);
   }
   const changed = removed || purgedJson || envDeleted;
+  // #1378 — REVOKE ORPHANS DOWNLOADS TOO (codex P1, filed separately as #1409).
+  //
+  // The fix landed on the SET path only, and revoke reaches the same emit two functions
+  // later. A listener replacing its tool session inside that synchronous emit kills an
+  // in-flight transfer whether the credential was written or removed — and removing the
+  // credential a gated download is authenticated with is, if anything, the likelier way to
+  // lose one. Snapshot before the emit for the same reason as above: afterwards the
+  // transfers are already gone and the list is empty, which reads as "nothing was at risk".
+  const atRiskDownloads =
+    changed && isAllowedComfyuiSecretKey(key) ? snapshotAtRiskDownloads() : [];
   if (changed) {
     if (isAllowedComfyuiSecretKey(key)) emitComfyuiChange({}); // comfyui-only restart (#269)
     if (isAllowedAgentSecretKey(key)) emitAgentChange();
   }
   return {
     changed,
+    atRiskDownloads,
     lostKeys: outcome.lostKeys,
     lostCommentLines: outcome.lostCommentLines,
     ...(outcome.lossCheck === "unknown"
@@ -2538,6 +2593,7 @@ export function clearPanelSecret(slotId: string): SecretRemoveOutcome {
   const resurrectionRisks: string[] = [];
   let durabilityGap: string | undefined;
   const failures: string[] = [];
+  const atRisk = new Map<string, { filename: string; bytes: number }>();
   let firstError: unknown = null;
   for (const key of slot.envKeys) {
     let out: SecretRemoveOutcome;
@@ -2561,6 +2617,14 @@ export function clearPanelSecret(slotId: string): SecretRemoveOutcome {
     lostCommentLines += out.lostCommentLines;
     if (out.uncertainty) uncertainties.push(out.uncertainty);
     if (out.durabilityGap && !durabilityGap) durabilityGap = out.durabilityGap;
+    // Aggregated, and deduped by filename (#1378). The fan-out is SERIAL, so the FIRST
+    // alias whose removal emits is the one that catches the transfers still running; by
+    // the second the session is already replaced and its snapshot is empty. Keeping the
+    // largest byte count means the report never understates what was in flight.
+    for (const d of out.atRiskDownloads) {
+      const seen = atRisk.get(d.filename);
+      if (!seen || d.bytes > seen.bytes) atRisk.set(d.filename, d);
+    }
   }
   // Nothing was removed and something failed: nothing happened, so REFUSING is
   // correct and the caller's "it is still there" is true. Anything else is a
@@ -2568,6 +2632,7 @@ export function clearPanelSecret(slotId: string): SecretRemoveOutcome {
   if (!changed && firstError !== null) throw firstError;
   return {
     changed,
+    atRiskDownloads: [...atRisk.values()],
     ...(failures.length
       ? {
           incomplete:

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -48,6 +48,7 @@ import {
   MANAGED_SECRET_KEYS_ENV,
 } from "../env-file.js";
 import { logger } from "../utils/logger.js";
+import { downloadsAtRiskOfRespawn } from "./download-jobs.js";
 import { runningUnderTestRunner } from "./test-isolation-guard.js";
 import { OPENAI_KEY_PROVIDERS, providerModelHint } from "./openai-provider-registry.js";
 
@@ -189,6 +190,20 @@ function emitGuarded(event: "change" | "agentChange", payload?: Partial<ComfyuiS
   }
 }
 
+/** Downloads in flight at the moment a credential save is about to respawn the tool
+ *  session (#1378). Best-effort: a records store this process cannot read must never break
+ *  a credential save, and an unreadable store is reported as "none" rather than throwing. */
+function snapshotAtRiskDownloads(): { filename: string; bytes: number }[] {
+  try {
+    return downloadsAtRiskOfRespawn();
+  } catch (err) {
+    logger.debug("[secrets] could not enumerate in-flight downloads for the respawn warning", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
 function emitComfyuiChange(payload: Partial<ComfyuiSecretChange>): void {
   if (emitSuspendDepth > 0) {
     suspendedComfyuiChange = true;
@@ -312,6 +327,13 @@ export function onComfyuiSecretsChanged(cb: (change: ComfyuiSecretChange) => voi
  * from this instead of asserting a respawn that may never fire (#826).
  */
 export interface SecretSaveReceipt {
+  /**
+   * Downloads that were in flight when this save was about to respawn the tool session
+   * (#1378). Captured BEFORE the (synchronous) respawn emit, so an already-applied
+   * replacement can still report what it cost — afterwards the list is empty and the
+   * warning would describe nothing.
+   */
+  atRiskDownloads?: { filename: string; bytes: number }[];
   /** The env var written. Never the value. */
   key: string;
   /** The canonical file it was written to (contains no secret). */
@@ -1605,6 +1627,18 @@ export function setEnvSecret(
   // has landed by the time this returns — the receipt describes observed work,
   // not an intention. No listener → `respawn: null`, never a fabricated zero.
   const reports: SecretRespawnReport[] = [];
+  // #1378 — SNAPSHOT BEFORE THE EMIT, because the emit is where the damage happens.
+  //
+  // `emitComfyuiChange` is synchronous and a listener may replace its tool session inside
+  // it, so by the time the receipt is rendered those downloads are already orphaned. My
+  // first version enumerated them afterwards and told the user "let them finish and save
+  // the credential afterwards" about transfers that had been dead for a tick — advice that
+  // was not merely useless but wrong about what had happened.
+  //
+  // Taken before, the list is what WAS in flight, which is the right thing to report in
+  // both cases: still running for a queued respawn, already lost for an applied one. The
+  // receipt words those differently.
+  const atRiskDownloads = isAllowedComfyuiSecretKey(trimmed) ? snapshotAtRiskDownloads() : [];
   if (isAllowedComfyuiSecretKey(trimmed))
     emitComfyuiChange({
       requested: opts.requested === true,
@@ -1616,6 +1650,7 @@ export function setEnvSecret(
     });
   if (isAllowedAgentSecretKey(trimmed)) emitAgentChange(); // flip provider readiness live
   return {
+    atRiskDownloads,
     key: trimmed,
     path: envFilePath(),
     persisted,

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -163,6 +163,8 @@ const emitter = new EventEmitter();
 // 7). Suspend for the duration, then emit ONCE for the state actually left.
 let emitSuspendDepth = 0;
 let suspendedComfyuiChange = false;
+/** What the last suspended operation's single emit cost. Read once, then cleared. */
+let lastSuspendedAtRisk: AtRiskDownloads = [];
 let suspendedAgentChange = false;
 
 /**
@@ -193,7 +195,7 @@ function emitGuarded(event: "change" | "agentChange", payload?: Partial<ComfyuiS
 /** Downloads in flight at the moment a credential save is about to respawn the tool
  *  session (#1378). Best-effort: a records store this process cannot read must never break
  *  a credential save, and an unreadable store is reported as "none" rather than throwing. */
-function snapshotAtRiskDownloads(): { filename: string; bytes: number }[] {
+function snapshotAtRiskDownloads(): AtRiskDownloads {
   try {
     return downloadsAtRiskOfRespawn();
   } catch (err) {
@@ -204,13 +206,38 @@ function snapshotAtRiskDownloads(): { filename: string; bytes: number }[] {
   }
 }
 
-function emitComfyuiChange(payload: Partial<ComfyuiSecretChange>): void {
+/**
+ * Emit, and report what the emit COST (#1378).
+ *
+ * The snapshot lives here, at the one point where a respawn is actually triggered, rather
+ * than at each call site. Three defects came out of having it anywhere else:
+ *
+ *  - a call site that emits without snapshotting reports nothing at risk (the revoke path,
+ *    which had the emit and not the snapshot for a full release);
+ *  - a call site that snapshots without emitting warns about a loss that never happened —
+ *    a rollback under `withSuspendedEmissions` removes a key, emits nothing because
+ *    nothing changed, and still told the user their downloads would not resume;
+ *  - and the ordering, which must be snapshot-then-emit because the emit is synchronous
+ *    and a listener replaces its tool session inside it, was restated at every site and
+ *    therefore could be got wrong at any of them.
+ *
+ * Suspended: nothing is emitted, so nothing is at risk YET. The outer
+ * `withSuspendedEmissions` makes exactly one real emit at the end, and that one returns
+ * the snapshot for the whole operation.
+ */
+function emitComfyuiChange(payload: Partial<ComfyuiSecretChange>): AtRiskDownloads {
   if (emitSuspendDepth > 0) {
     suspendedComfyuiChange = true;
-    return;
+    return [];
   }
+  const atRisk = snapshotAtRiskDownloads();
   emitGuarded("change", payload);
+  return atRisk;
 }
+
+/** In-flight downloads a respawn is about to orphan. Empty is a finding; it is never
+ *  absent, so no caller has to tell "none" from "not reported". */
+export type AtRiskDownloads = { id: string; filename: string; bytes: number }[];
 
 function emitAgentChange(): void {
   if (emitSuspendDepth > 0) {
@@ -252,7 +279,11 @@ function withSuspendedEmissions<T>(
     // already guarded; `decide` is guarded here for the same reason.
     try {
       const plan = decide(result, suppressed);
-      if (plan.comfyui) emitComfyuiChange(plan.comfyui);
+      // The ONE real emit for the whole suspended operation, so its snapshot is the
+      // operation's at-risk list. Stashed rather than returned because `finally` cannot
+      // change what the block returns — the caller reads it back with
+      // `takeSuspendedAtRisk()` after the fact.
+      if (plan.comfyui) lastSuspendedAtRisk = emitComfyuiChange(plan.comfyui);
       if (plan.agent) emitAgentChange();
     } catch (err) {
       logger.warn(
@@ -261,6 +292,14 @@ function withSuspendedEmissions<T>(
       );
     }
   }
+}
+
+/** The at-risk list from the last suspended operation's single emit, cleared on read so a
+ *  later operation cannot inherit it. */
+function takeSuspendedAtRisk(): AtRiskDownloads {
+  const at = lastSuspendedAtRisk;
+  lastSuspendedAtRisk = [];
+  return at;
 }
 
 /** Payload for a comfyui tool-secret change. `requested` is true ONLY when the
@@ -333,7 +372,7 @@ export interface SecretSaveReceipt {
    * replacement can still report what it cost — afterwards the list is empty and the
    * warning would describe nothing.
    */
-  atRiskDownloads?: { filename: string; bytes: number }[];
+  atRiskDownloads?: AtRiskDownloads;
   /** The env var written. Never the value. */
   key: string;
   /** The canonical file it was written to (contains no secret). */
@@ -470,12 +509,59 @@ export function shadowedNote(receipt: SecretSaveReceipt): string | null {
  */
 export function receiptDisclosures(receipt: SecretSaveReceipt): string[] {
   return [
+    atRiskNote(receipt.atRiskDownloads ?? [], receipt.respawn),
     storeDamageNote(receipt),
     strayCopyNote(receipt),
     commentLossNote(receipt),
     durabilityNote(receipt),
     shadowedNote(receipt),
   ].filter((n): n is string => n !== null);
+}
+
+/**
+ * What the respawn this change triggers is about to cost, or has already cost (#1378).
+ *
+ * Lives beside the other disclosures rather than in one caller's renderer, because the
+ * caller that had it was the agent-facing one and the Settings endpoint — which saves
+ * through the same path and orphans the same transfers — rendered nothing at all (codex).
+ *
+ * THE RESPAWN'S TIMING DECIDES THE SENTENCE, and "not reported" is its own case. A save
+ * that collects no respawn report has not established that no respawn happened; saying
+ * "will not resume" invites the user to act on a transfer that may be dead already, and
+ * saying "already lost" claims an event nobody observed.
+ */
+export function atRiskNote(
+  atRisk: AtRiskDownloads | readonly { filename: string; bytes: number }[],
+  // `undefined` is a THIRD answer: no report was collected on this path, which is not
+  // `null` ("a listener reported doing nothing"). The wording distinguishes them.
+  respawn: SecretSaveReceipt["respawn"] | undefined,
+): string | null {
+  if (!atRisk.length) return null;
+  const listed = atRiskDownloadSummary(atRisk);
+  // Why this is unrecoverable, stated once: the auth header is part of each download's
+  // cache identity, so the bytes on disk can no longer be found under the new one.
+  const consequence =
+    `The new credentials change each download's cache identity, so those transfers will ` +
+    `NOT resume: re-issuing them starts from 0% even though the partial files remain on ` +
+    `disk (#1378).`;
+  if (respawn?.applied) {
+    return (
+      `🛑 The tool session was replaced immediately, and ${listed} were in flight. ${consequence} ` +
+      `Nothing can recover them under the new identity — that is the cost already paid, not a ` +
+      `warning you can act on.`
+    );
+  }
+  if (respawn?.scheduled) {
+    return (
+      `⚠️ ${listed} are in flight and the tool session is queued to be rebuilt at the end of ` +
+      `this turn. ${consequence} If that matters, let them finish before the rebuild.`
+    );
+  }
+  return (
+    `⚠️ ${listed} were in flight when this credential change fired its tool-session rebuild. ` +
+    `Whether that rebuild has already happened was not reported here, so this is not a claim ` +
+    `either way about transfers you may still be able to save. ${consequence}`
+  );
 }
 
 /** A pre-write snapshot the write could not delete: a readable copy of the store
@@ -515,7 +601,7 @@ export function strayCopyNote(receipt: SecretSaveReceipt): string | null {
  * way — two hand-rolled summaries would drift, and the revoke half was missing entirely
  * until codex pointed at it.
  */
-export function atRiskDownloadSummary(atRisk: readonly { filename: string; bytes: number }[]): string {
+export function atRiskDownloadSummary(atRisk: AtRiskDownloads | readonly { filename: string; bytes: number }[]): string {
   const gb = atRisk.reduce((n, d) => n + d.bytes, 0) / 1024 ** 3;
   const names = atRisk
     .map((d) => d.filename)
@@ -1671,9 +1757,9 @@ export function setEnvSecret(
   // Taken before, the list is what WAS in flight, which is the right thing to report in
   // both cases: still running for a queued respawn, already lost for an applied one. The
   // receipt words those differently.
-  const atRiskDownloads = isAllowedComfyuiSecretKey(trimmed) ? snapshotAtRiskDownloads() : [];
+  let atRiskDownloads: AtRiskDownloads = [];
   if (isAllowedComfyuiSecretKey(trimmed))
-    emitComfyuiChange({
+    atRiskDownloads = emitComfyuiChange({
       requested: opts.requested === true,
       // The verdict rides along, so a listener cannot make a louder claim than
       // the receipt does. `persisted` is already settled at this point.
@@ -1731,7 +1817,7 @@ export interface SecretRemoveOutcome {
    * a ComfyUI one — never absent, so a caller need not distinguish "none" from "not
    * reported".
    */
-  atRiskDownloads: { filename: string; bytes: number }[];
+  atRiskDownloads: AtRiskDownloads;
   /** OTHER credential keys the store held before and no longer holds. Names
    *  only. Non-empty means the revoke happened AND cost something else. */
   lostKeys: string[];
@@ -1851,10 +1937,12 @@ export function removeEnvSecret(key: string): SecretRemoveOutcome {
   // credential a gated download is authenticated with is, if anything, the likelier way to
   // lose one. Snapshot before the emit for the same reason as above: afterwards the
   // transfers are already gone and the list is empty, which reads as "nothing was at risk".
-  const atRiskDownloads =
-    changed && isAllowedComfyuiSecretKey(key) ? snapshotAtRiskDownloads() : [];
+  let atRiskDownloads: AtRiskDownloads = [];
   if (changed) {
-    if (isAllowedComfyuiSecretKey(key)) emitComfyuiChange({}); // comfyui-only restart (#269)
+    // comfyui-only restart (#269). The emit reports what it cost — see emitComfyuiChange:
+    // under suspended emissions (a rollback) it emits nothing and costs nothing, which is
+    // why this is not a snapshot taken beside the call.
+    if (isAllowedComfyuiSecretKey(key)) atRiskDownloads = emitComfyuiChange({});
     if (isAllowedAgentSecretKey(key)) emitAgentChange();
   }
   return {
@@ -2246,6 +2334,14 @@ export function maskSecret(v: string): string {
 export interface SlotSaveOutcome {
   slot: string;
   receipts: SecretSaveReceipt[];
+  /**
+   * Downloads in flight when this slot save's single respawn emit fired (#1378).
+   *
+   * The slot fan-out suspends per-alias emits and makes ONE at the end, so this is that
+   * emit's own snapshot — not a per-alias guess, and empty when the operation rolled back
+   * and emitted nothing.
+   */
+  atRiskDownloads: AtRiskDownloads;
   /** Every alias landed, proven by read-back. */
   confirmed: boolean;
   /** The slot was left exactly as it was before this call (no alias carries the
@@ -2364,6 +2460,8 @@ export function setPanelSecret(slotId: string, value: string): SlotSaveOutcome {
           strandedKeys: [],
           unverifiedKeys: [],
           lostKeys: lostKeysOf(receipts),
+          // Filled in after the suspended emit below — it has not happened yet here.
+          atRiskDownloads: [],
         };
       }
       if (!failed) {
@@ -2375,6 +2473,7 @@ export function setPanelSecret(slotId: string, value: string): SlotSaveOutcome {
           strandedKeys: [],
           unverifiedKeys: [],
           lostKeys: [],
+          atRiskDownloads: [],
         };
       }
       // Restore every alias this call actually changed, and PROVE each restore
@@ -2406,6 +2505,7 @@ export function setPanelSecret(slotId: string, value: string): SlotSaveOutcome {
         strandedKeys,
         unverifiedKeys,
         lostKeys: [...new Set([...lostKeysOf(receipts), ...restoreLostKeys])],
+        atRiskDownloads: [],
         ...(restoreWarnings.length ? { restoreWarnings } : {}),
       };
     },
@@ -2426,6 +2526,11 @@ export function setPanelSecret(slotId: string, value: string): SlotSaveOutcome {
       };
     },
   );
+  // WHAT THE SINGLE EMIT COST (#1378). The fan-out suspends per-alias emits and makes one
+  // at the end, inside `withSuspendedEmissions`' finally — which cannot change what the
+  // block returns, so the snapshot is read back here. A rolled-back save emits nothing and
+  // this is empty, which is the point: it must not warn about a loss that did not happen.
+  outcome.atRiskDownloads = takeSuspendedAtRisk();
   if (thrown) {
     // The rethrow is a refusal — correct, because the value the caller supplied
     // is not in place. But the ROLLBACK on the way out is a store write, and
@@ -2593,7 +2698,7 @@ export function clearPanelSecret(slotId: string): SecretRemoveOutcome {
   const resurrectionRisks: string[] = [];
   let durabilityGap: string | undefined;
   const failures: string[] = [];
-  const atRisk = new Map<string, { filename: string; bytes: number }>();
+  const atRisk = new Map<string, AtRiskDownloads[number]>();
   let firstError: unknown = null;
   for (const key of slot.envKeys) {
     let out: SecretRemoveOutcome;
@@ -2622,8 +2727,11 @@ export function clearPanelSecret(slotId: string): SecretRemoveOutcome {
     // the second the session is already replaced and its snapshot is empty. Keeping the
     // largest byte count means the report never understates what was in flight.
     for (const d of out.atRiskDownloads) {
-      const seen = atRisk.get(d.filename);
-      if (!seen || d.bytes > seen.bytes) atRisk.set(d.filename, d);
+      // Keyed on the job id, NOT the displayed filename (codex P2): two credential-shaped
+      // names both redact to "(redacted).safetensors", and keying on that reported one
+      // download and the larger byte count where there were two and a total.
+      const seen = atRisk.get(d.id);
+      if (!seen || d.bytes > seen.bytes) atRisk.set(d.id, d);
     }
   }
   // Nothing was removed and something failed: nothing happened, so REFUSING is


### PR DESCRIPTION
Draft — claiming #1378, and taking the reporter's option **(c)** deliberately, not for lack of ambition.

Saving a credential mid-flight respawns the comfyui tool session, and the new auth header changes the download's cache identity — so a `.partial` at **96%** becomes unreachable and the re-issued download starts from 0. In their session that cost ~29 GB for two files that were 77% and 96% done. Nothing warned them, and nothing indicated the bytes were still on disk.

**Why not (a) or (b).** The reporter is right that both risk a real security regression. The cache key folds in representation-affecting headers precisely so bytes fetched under one identity can never be served to a request made under another; "this URL didn't need auth anyway" is a judgement the client cannot make before fetching, and getting it wrong leaks gated bytes across identities. That is a worse failure than a re-download. They chose not to guess, and filed a diagnosis instead — which is the right call and worth saying so.

**What (c) actually needs to be useful:** the warning has to arrive *before* the respawn, because afterwards the choice is gone. So `panel_request_secret` should say, at the moment of asking, that N downloads totalling ~X GB are in flight and will restart from 0% — letting the caller finish them first.

There is a piece of machinery ready for this. #1370 added `stagedPartialPathForUrl(url)` / `findResumablePartial(url)`, which derive the staged path from the **unauthenticated** cache identity — exactly the key the in-flight downloads were using. So the orphaned bytes are locatable by the same helper that now reports a cancelled download's partial, and the warning can quote real sizes rather than an estimate.

Scope I am not taking: (d), the GC for orphaned cache entries. It is real — those two `.partial` files will sit there forever — but it is a separate lifecycle question, and bundling it would put a delete path in a PR about a warning.

Refs #1378
