### PR TITLE
fix(1385): a completed job no longer matches its own re-entry guard

### DIFF
--- a/plugin/scripts/monitor-progress.mjs
+++ b/plugin/scripts/monitor-progress.mjs
@@ -49,6 +49,10 @@ for (const id of promptIds) {
     startTime: Date.now(),
     lastActivity: Date.now(), // last WS event or status change
     stallWarned: false,
+    // #1385 — the terminal re-entry guard. A FLAG, not a status comparison: markDone
+    // assigns "success", which never matched a guard testing for "done", so one
+    // completion was counted twice and the monitor exited while another job ran.
+    finished: false,
   });
 }
 
@@ -145,7 +149,25 @@ async function checkServerHealth() {
 
 async function markDone(promptId, status) {
   const job = jobs.get(promptId);
-  if (!job || job.status === "done" || job.status === "error") return;
+  // RE-ENTRY GUARD, on a flag rather than the status string (#1385).
+  //
+  // This used to test `status === "done" || "error"` and then assign `status`, which the
+  // callers pass as "success" — so a successfully finished job never matched its own
+  // guard. Two callers reach here for one completion (the WS `execution_success` event and
+  // the history poller), and the second went straight through: `[DONE]` printed twice,
+  // `successCount` and `doneCount` incremented twice, and `checkAllDone` then saw two of
+  // two finished while the other job was still executing. The monitor exited 0 on a job
+  // that had not produced its file yet.
+  //
+  // SET BEFORE ANY await, which is the other half. `doneCount++` sits after a
+  // HISTORY_DELAY_MS sleep and a /history fetch, so even a correct status guard leaves a
+  // window where both callers are past the check before either increments. A flag written
+  // in the same tick as the check cannot be raced on a single-threaded event loop.
+  //
+  // It is also independent of the status vocabulary: adding a new terminal status can no
+  // longer silently reopen this.
+  if (!job || job.finished) return;
+  job.finished = true;
 
   job.status = status;
   const elapsed = ((Date.now() - job.startTime) / 1000).toFixed(1);
@@ -213,7 +235,9 @@ async function checkAlreadyDone() {
 
 function printProgress(promptId, step, max, node) {
   const job = jobs.get(promptId);
-  if (!job || job.status === "done" || job.status === "error") return;
+  // Same stale-status pattern as markDone (#1385): a finished job kept printing progress
+  // because its status reads "success", not "done".
+  if (!job || job.finished) return;
 
   job.step = step;
   job.maxSteps = max;
@@ -246,7 +270,7 @@ function printProgress(promptId, step, max, node) {
 function checkStalls() {
   const now = Date.now();
   for (const [promptId, job] of jobs) {
-    if (job.status === "done" || job.status === "error") continue;
+    if (job.finished) continue;
 
     const idleSec = ((now - job.lastActivity) / 1000).toFixed(0);
     const totalSec = ((now - job.startTime) / 1000).toFixed(0);
@@ -356,7 +380,7 @@ function startPolling() {
     }
 
     for (const [promptId, job] of jobs) {
-      if (job.status === "done" || job.status === "error") continue;
+      if (job.finished) continue;
 
       try {
         const history = await fetchJSON(`/history/${promptId}`);

--- a/plugin/scripts/monitor-progress.mjs
+++ b/plugin/scripts/monitor-progress.mjs
@@ -423,7 +423,12 @@ function startStallChecker() {
 setTimeout(() => {
   if (doneCount < jobs.size) {
     const remaining = [...jobs.entries()]
-      .filter(([, j]) => j.status !== "done" && j.status !== "error")
+      // The SAME stale vocabulary, in its inequality form (#1385, codex). A successful job
+      // carries status "success", so `!== "done" && !== "error"` calls it incomplete — and
+      // the window is real: `finished` is set before the history fetch but `doneCount++`
+      // comes after it, so a timeout landing in between reports a job that succeeded as
+      // still running, and exits 1. My first pass fixed only the equality comparisons.
+      .filter(([, j]) => !j.finished)
       .map(([id, j]) => {
         const elapsed = ((Date.now() - j.startTime) / 1000).toFixed(0);
         return `${short(id)} (${j.status}, ${elapsed}s)`;

--- a/plugin/scripts/monitor-progress.mjs
+++ b/plugin/scripts/monitor-progress.mjs
@@ -421,18 +421,27 @@ function startStallChecker() {
 // ── Timeout ─────────────────────────────────────────────────────────────
 
 setTimeout(() => {
-  if (doneCount < jobs.size) {
-    const remaining = [...jobs.entries()]
+  // GATE ON THE SAME FACT THE LIST REPORTS (#1385, codex round 2). This used to enter on
+  // `doneCount < jobs.size`, and `doneCount++` lands only AFTER the awaited history fetch —
+  // so a job that finished a moment before the timeout has `finished` true and is correctly
+  // absent from `remaining`, while `doneCount` has not caught up. The result was
+  // "[TIMEOUT] 0 job(s) still incomplete" followed by exit 1: a clean run reported as a
+  // failure, with an empty list as the evidence.
+  //
+  // One fact, read once. If nothing is unfinished there is nothing to time out.
+  const remaining = [...jobs.entries()]
       // The SAME stale vocabulary, in its inequality form (#1385, codex). A successful job
       // carries status "success", so `!== "done" && !== "error"` calls it incomplete — and
       // the window is real: `finished` is set before the history fetch but `doneCount++`
       // comes after it, so a timeout landing in between reports a job that succeeded as
       // still running, and exits 1. My first pass fixed only the equality comparisons.
-      .filter(([, j]) => !j.finished)
-      .map(([id, j]) => {
-        const elapsed = ((Date.now() - j.startTime) / 1000).toFixed(0);
-        return `${short(id)} (${j.status}, ${elapsed}s)`;
-      });
+    .filter(([, j]) => !j.finished)
+    .map(([id, j]) => {
+      const elapsed = ((Date.now() - j.startTime) / 1000).toFixed(0);
+      // `j.status` here is DISPLAY only — the decision above is the flag.
+      return `${short(id)} (${j.status}, ${elapsed}s)`;
+    });
+  if (remaining.length > 0) {
     console.log(
       `[TIMEOUT] ${remaining.length} job(s) still incomplete after 10 minutes: ${remaining.join(", ")}`,
     );

--- a/plugin/scripts/monitor-progress.mjs
+++ b/plugin/scripts/monitor-progress.mjs
@@ -13,6 +13,8 @@
  *      COMFYUI_SSL (default false — set "true" to use https:// + wss://)
  */
 
+import { timeoutVerdict, describeTimeout, classifyHistoryMessages } from "./monitor-timeout.mjs";
+
 const HOST = process.env.COMFYUI_HOST || process.env.COMFY_HOST || "127.0.0.1";
 const PORT = Number(process.env.COMFYUI_PORT || process.env.COMFY_PORT) || 8000;
 const SSL = process.env.COMFYUI_SSL === "true";
@@ -57,6 +59,11 @@ for (const id of promptIds) {
 }
 
 const short = (id) => id.slice(0, 8);
+/** How long the timeout waits for post-processing once every job has reported. Short: the
+ *  case it exists for is a fetch that already has its headers and needs a moment, not a
+ *  second monitoring window. */
+const POST_PROCESSING_GRACE_MS = 15_000;
+
 let doneCount = 0;
 let successCount = 0;
 let errorCount = 0;
@@ -222,8 +229,13 @@ async function checkAlreadyDone() {
       const entry = history[promptId];
       if (entry?.status?.completed) {
         const messages = entry.status.messages || [];
-        const hasError = messages.some((m) => m[0] === "execution_error");
-        await markDone(promptId, hasError ? "error" : "success");
+        // A CANCELLED RUN IS NOT A SUCCESSFUL ONE (codex, pre-existing). ComfyUI marks
+        // an interrupted prompt `completed` and reports `execution_interrupted`;
+        // testing only for `execution_error` counted it as a success and printed it
+        // as one. This repo's own history reader already treats that message as a
+        // non-success terminal state (src/services/job-history.ts) — this script was
+        // the odd one out, in two places with two copies of the same test.
+        await markDone(promptId, classifyHistoryMessages(messages));
       }
     } catch {
       // Not in history yet — still pending/running
@@ -388,8 +400,13 @@ function startPolling() {
         const entry = history[promptId];
         if (entry?.status?.completed) {
           const messages = entry.status.messages || [];
-          const hasError = messages.some((m) => m[0] === "execution_error");
-          await markDone(promptId, hasError ? "error" : "success");
+          // A CANCELLED RUN IS NOT A SUCCESSFUL ONE (codex, pre-existing). ComfyUI marks
+          // an interrupted prompt `completed` and reports `execution_interrupted`;
+          // testing only for `execution_error` counted it as a success and printed it
+          // as one. This repo's own history reader already treats that message as a
+          // non-success terminal state (src/services/job-history.ts) — this script was
+          // the odd one out, in two places with two copies of the same test.
+          await markDone(promptId, classifyHistoryMessages(messages));
         }
       } catch {
         consecutiveFailures++;
@@ -421,32 +438,32 @@ function startStallChecker() {
 // ── Timeout ─────────────────────────────────────────────────────────────
 
 setTimeout(() => {
-  // GATE ON THE SAME FACT THE LIST REPORTS (#1385, codex round 2). This used to enter on
-  // `doneCount < jobs.size`, and `doneCount++` lands only AFTER the awaited history fetch —
-  // so a job that finished a moment before the timeout has `finished` true and is correctly
-  // absent from `remaining`, while `doneCount` has not caught up. The result was
-  // "[TIMEOUT] 0 job(s) still incomplete" followed by exit 1: a clean run reported as a
-  // failure, with an empty list as the evidence.
-  //
-  // One fact, read once. If nothing is unfinished there is nothing to time out.
-  const remaining = [...jobs.entries()]
-      // The SAME stale vocabulary, in its inequality form (#1385, codex). A successful job
-      // carries status "success", so `!== "done" && !== "error"` calls it incomplete — and
-      // the window is real: `finished` is set before the history fetch but `doneCount++`
-      // comes after it, so a timeout landing in between reports a job that succeeded as
-      // still running, and exits 1. My first pass fixed only the equality comparisons.
-    .filter(([, j]) => !j.finished)
-    .map(([id, j]) => {
-      const elapsed = ((Date.now() - j.startTime) / 1000).toFixed(0);
-      // `j.status` here is DISPLAY only — the decision above is the flag.
-      return `${short(id)} (${j.status}, ${elapsed}s)`;
-    });
-  if (remaining.length > 0) {
+  // The decision lives in monitor-timeout.mjs so the tests can call the real one — see the
+  // comment there for why all three outcomes exist and which two used to be conflated.
+  const verdict = timeoutVerdict(jobs, { postProcessingDone: doneCount >= jobs.size });
+  const line = describeTimeout(verdict, {
+    jobCount: jobs.size,
+    graceSeconds: POST_PROCESSING_GRACE_MS / 1000,
+  });
+  if (line) console.log(line);
+  if (verdict.kind === "incomplete") process.exit(1);
+  if (verdict.kind === "clean") return; // the normal exit path is a moment away
+
+  // STALLED. Every job reported a terminal state, so the run is not waiting on ComfyUI; it
+  // is waiting on its own post-processing, and nothing bounds that — `fetchJSON` clears its
+  // abort timer once response HEADERS arrive, so a body that never finishes streaming keeps
+  // an open socket and the process alive forever (codex P1). Returning here is the hang the
+  // old unconditional exit(1) was accidentally preventing. A short grace first, because a
+  // job finishing a moment before the timeout is exactly the near-miss this whole fix is
+  // about, and it resolves in well under a second.
+  setTimeout(() => {
+    if (doneCount >= jobs.size) return; // it landed during the grace; let the normal exit run
     console.log(
-      `[TIMEOUT] ${remaining.length} job(s) still incomplete after 10 minutes: ${remaining.join(", ")}`,
+      `[TIMEOUT] giving up: ${jobs.size} job(s) finished but their history/outputs never ` +
+        `finished being read. The jobs themselves completed — check ComfyUI directly for results.`,
     );
     process.exit(1);
-  }
+  }, POST_PROCESSING_GRACE_MS);
 }, TIMEOUT_MS);
 
 // ── Main ────────────────────────────────────────────────────────────────

--- a/plugin/scripts/monitor-progress.mjs
+++ b/plugin/scripts/monitor-progress.mjs
@@ -67,6 +67,9 @@ const POST_PROCESSING_GRACE_MS = 15_000;
 let doneCount = 0;
 let successCount = 0;
 let errorCount = 0;
+/** Interrupted runs. Its own tally, because folding them into either of the other two says
+ *  something untrue: a cancelled job did not succeed, and nothing failed. */
+let cancelledCount = 0;
 
 console.log(
   `[MONITOR] Tracking ${jobs.size} job(s): ${[...promptIds].map(short).join(", ")}`,
@@ -190,6 +193,15 @@ async function markDone(promptId, status) {
     } else {
       console.log(`[ERROR] ${short(promptId)} | Failed after ${elapsed}s`);
     }
+  } else if (status === "cancelled") {
+    // A NEW TERMINAL STATUS NEEDS A HOME EVERYWHERE IT LANDS (codex round 3). Teaching the
+    // classifier to say "cancelled" while `markDone` still had two branches meant the new
+    // value fell into the `else` — so an interrupted run printed `| success |` and counted
+    // toward successCount, which is the very claim the classifier was added to stop making.
+    // Fixing the vocabulary in one place and not the other is worse than not fixing it: the
+    // code now looks like it handles interruption.
+    cancelledCount++;
+    console.log(`[CANCELLED] ${short(promptId)} | interrupted after ${elapsed}s | no outputs`);
   } else {
     successCount++;
     await new Promise((r) => setTimeout(r, HISTORY_DELAY_MS));
@@ -214,8 +226,12 @@ function checkAllDone() {
       1000
     ).toFixed(1);
     console.log(
-      `[COMPLETE] All ${jobs.size} jobs finished: ${successCount} success, ${errorCount} error (total: ${totalElapsed}s)`,
+      `[COMPLETE] All ${jobs.size} jobs finished: ${successCount} success, ${errorCount} error` +
+        `${cancelledCount > 0 ? `, ${cancelledCount} cancelled` : ""} (total: ${totalElapsed}s)`,
     );
+    // The exit code is unchanged for cancellations. A user who interrupts a job did not
+    // hit a failure, and the summary above names what happened; turning their own action
+    // into a non-zero exit would make every deliberate cancel look like a broken run.
     process.exit(0);
   }
 }

--- a/plugin/scripts/monitor-timeout.mjs
+++ b/plugin/scripts/monitor-timeout.mjs
@@ -1,0 +1,72 @@
+/**
+ * What the monitor's 10-minute timeout should DO. (#1385)
+ *
+ * Its own module so the tests can call the real thing. The previous test reimplemented
+ * this decision inline and asserted against its own copy, which is a test of the test: a
+ * regression that inverted the production condition would have left it green (codex P3).
+ * `monitor-progress.mjs` connects to ComfyUI at import, so the decision has to live
+ * somewhere importable on its own for that to be possible.
+ *
+ * THREE OUTCOMES, because there are three situations and the old code had one:
+ *
+ *  - "incomplete" — jobs are genuinely still running. The timeout's reason for existing.
+ *  - "stalled"    — every job reported a terminal state, but the run has not exited, so
+ *                   post-processing (the history/output fetch) is still in flight or wedged.
+ *                   Returning here hangs forever: the abort timer in `fetchJSON` is cleared
+ *                   once response HEADERS arrive, so a body that never finishes streaming
+ *                   is not bounded by anything, and the open socket keeps the process
+ *                   alive. The old unconditional `exit(1)` masked that.
+ *  - "clean"      — everything finished and the normal exit path is a moment away. This is
+ *                   the case the previous version got wrong: `doneCount++` lands after an
+ *                   awaited fetch, so a job that finished just before the timeout left an
+ *                   EMPTY list and still exited 1, reporting a clean run as a failure.
+ */
+export function timeoutVerdict(jobs, { now = Date.now(), postProcessingDone = false } = {}) {
+  const unfinished = [...jobs.entries()].filter(([, j]) => !j.finished);
+  if (unfinished.length > 0) {
+    return {
+      kind: "incomplete",
+      remaining: unfinished.map(([id, j]) => ({
+        id,
+        // DISPLAY only — the decision above is the flag, which is set synchronously before
+        // any await; `status` is a local observation that can lag the server.
+        status: j.status,
+        seconds: Math.round((now - j.startTime) / 1000),
+      })),
+    };
+  }
+  return { kind: postProcessingDone ? "clean" : "stalled", remaining: [] };
+}
+
+/** One line describing the verdict, or null when there is nothing to say. */
+export function describeTimeout(verdict, { jobCount, graceSeconds }) {
+  if (verdict.kind === "incomplete") {
+    const list = verdict.remaining.map((r) => `${r.id} (${r.status}, ${r.seconds}s)`).join(", ");
+    return `[TIMEOUT] ${verdict.remaining.length} job(s) still incomplete after 10 minutes: ${list}`;
+  }
+  if (verdict.kind === "stalled") {
+    // Named precisely, because "0 job(s) still incomplete" — the old message for this
+    // state — reads as a script that cannot count.
+    return (
+      `[TIMEOUT] all ${jobCount} job(s) reported a terminal state, but the run has not ` +
+      `finished fetching their history/outputs. Waiting ${graceSeconds}s more, then giving up.`
+    );
+  }
+  return null;
+}
+
+/**
+ * What a completed history entry's messages say the run actually DID. (#1385, codex)
+ *
+ * Shared, because the two places that asked — the startup catch-up scan and the poller —
+ * each had their own copy of `hasError ? "error" : "success"`, and both therefore reported
+ * a CANCELLED run as a success. ComfyUI marks an interrupted prompt `completed` and emits
+ * `execution_interrupted`; this repo's own history reader already treats that as a
+ * non-success terminal state (src/services/job-history.ts). Only this script disagreed.
+ */
+export function classifyHistoryMessages(messages) {
+  const has = (name) => (messages ?? []).some((m) => m?.[0] === name);
+  if (has("execution_error")) return "error";
+  if (has("execution_interrupted")) return "cancelled";
+  return "success";
+}

--- a/src/__tests__/scripts/monitor-progress-reentry.test.ts
+++ b/src/__tests__/scripts/monitor-progress-reentry.test.ts
@@ -99,6 +99,28 @@ describe("monitor-progress re-entry guard (#1385)", () => {
     expect(classifyHistoryMessages(undefined)).toBe("success");
   });
 
+  it("a cancelled run is not counted or printed as a success", () => {
+    // Codex round 3, and it is the half I left undone: teaching the classifier to say
+    // "cancelled" while markDone still had exactly two branches meant the new value fell
+    // into the `else` — printing `| success |` and incrementing successCount, which is the
+    // claim the classifier was added to stop making. A vocabulary fixed in one place and
+    // not the other is worse than none: the code then LOOKS like it handles interruption.
+    const s = code();
+    const body = s.slice(s.indexOf("async function markDone"), s.indexOf("function checkAllDone"));
+    expect(body).toMatch(/status === "cancelled"/);
+    // The branch must come BEFORE the catch-all, or it never runs.
+    expect(body.indexOf('status === "cancelled"')).toBeLessThan(body.indexOf("successCount++"));
+    // …and it must not reach the success tally.
+    const cancelledBranch = body.slice(
+      body.indexOf('status === "cancelled"'),
+      body.indexOf("} else {", body.indexOf('status === "cancelled"')),
+    );
+    expect(cancelledBranch).not.toMatch(/successCount/);
+    expect(cancelledBranch).toMatch(/cancelledCount\+\+/);
+    // The summary has to say it happened, or the count is invisible.
+    expect(s).toMatch(/cancelledCount > 0/);
+  });
+
   it("both classification sites use the shared rule", () => {
     // There were two copies, indented differently, and fixing the one I happened to read
     // would have left a cancelled job reported as a success on the other path.

--- a/src/__tests__/scripts/monitor-progress-reentry.test.ts
+++ b/src/__tests__/scripts/monitor-progress-reentry.test.ts
@@ -1,0 +1,79 @@
+// #1385 — `monitor-progress.mjs` printed `[DONE]` twice for one job and exited
+// `[COMPLETE] All 2 jobs finished` while the second job was still executing. Its mp4 did
+// not exist yet.
+//
+// TWO FAULTS, EITHER OF WHICH IS ENOUGH:
+//
+//   1. the re-entry guard tested `job.status === "done" || "error"` while the function
+//      assigned `status`, which callers pass as "success" — so a successful job never
+//      matched its own guard;
+//   2. `doneCount++` sits after an await (a HISTORY_DELAY_MS sleep plus a /history fetch),
+//      so even a correct status guard leaves a window where both callers are past the
+//      check before either increments.
+//
+// Two callers reach markDone for one completion: the WS `execution_success` event and the
+// history poller. Single-ID runs never showed it because exiting at the first completion is
+// correct anyway.
+//
+// This asserts on the SOURCE. The script is a standalone .mjs with top-level side effects
+// (it opens a WebSocket and calls process.exit), so importing it into a test would start a
+// monitor rather than test one — and the defect is structural: which expression the guard
+// reads, and whether the flag is set before the first await.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const src = (): string =>
+  readFileSync(new URL("../../../plugin/scripts/monitor-progress.mjs", import.meta.url), "utf8");
+
+/** Source with comments stripped — this file's own header names the strings it asserts. */
+const code = (): string => src().replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*/g, "");
+
+describe("monitor-progress re-entry guard (#1385)", () => {
+  it("guards on a FLAG, not on a status string it does not write", () => {
+    const s = code();
+    expect(s).toMatch(/if \(!job \|\| job\.finished\) return;/);
+    expect(s).toMatch(/job\.finished = true;/);
+  });
+
+  it("no guard compares against the status vocabulary any more", () => {
+    // All four sites had the same pattern; fixing only markDone would leave printProgress
+    // and the two sweep loops treating a finished job as live.
+    expect(code()).not.toMatch(/job\.status === "done"/);
+    expect(code()).not.toMatch(/job\.status === "error"/);
+  });
+
+  it("the flag is set BEFORE the first await in markDone", () => {
+    // The half a correct status guard would still not fix: both callers can be past the
+    // check while the first is suspended in the history fetch.
+    const s = code();
+    const fn = s.slice(s.indexOf("async function markDone"), s.indexOf("function checkAllDone"));
+    expect(fn).toContain("job.finished = true;");
+    expect(fn.indexOf("job.finished = true;")).toBeLessThan(fn.indexOf("await"));
+  });
+
+  it("the flag is initialised on every job, so the first guard read is defined", () => {
+    expect(code()).toMatch(/finished: false,/);
+  });
+
+  it("SEMANTICS: a second completion for the same job is a no-op", () => {
+    // The behaviour the source shape is for, exercised directly: two callers, one
+    // completion, one increment. Before the fix the second call passed the guard and
+    // doneCount reached 2 for a single finished job — which is exactly what let
+    // `doneCount >= jobs.size` fire while another job was still running.
+    const job = { finished: false, status: "running" };
+    let doneCount = 0;
+    const markDone = (j: { finished: boolean; status: string }, status: string): void => {
+      if (!j || j.finished) return;
+      j.finished = true;
+      j.status = status;
+      doneCount++;
+    };
+    markDone(job, "success");
+    markDone(job, "success");
+    expect(doneCount).toBe(1);
+    // …and the status it writes is still not one the old guard would have matched, which
+    // is why the flag rather than a vocabulary fix.
+    expect(job.status).toBe("success");
+  });
+});

--- a/src/__tests__/scripts/monitor-progress-reentry.test.ts
+++ b/src/__tests__/scripts/monitor-progress-reentry.test.ts
@@ -52,12 +52,38 @@ describe("monitor-progress re-entry guard (#1385)", () => {
     }
   });
 
-  it("the TIMEOUT path uses the flag — a finished job is never reported as incomplete", () => {
-    // `finished` is set before the history fetch and `doneCount++` comes after it, so a
-    // timeout landing in that window used to name a job that had already succeeded.
+  it("the TIMEOUT decides on the flag, and only reports when something is unfinished", () => {
+    // Two faults lived here. The filter used the stale vocabulary, and the ENTRY condition
+    // used `doneCount < jobs.size` — which lags, because `doneCount++` lands only after the
+    // awaited history fetch. A job finishing just before the timeout is correctly absent
+    // from the list while doneCount has not caught up, so the script printed
+    // "[TIMEOUT] 0 job(s) still incomplete" and exited 1: a clean run reported as failure,
+    // with an empty list as its own evidence.
+    //
+    // Asserted on BEHAVIOUR rather than source text (codex P3): the previous version
+    // matched an exact `.filter(([, j]) => !j.finished)` string, which a rename of `j` or a
+    // reformat would break while preserving semantics.
+    const decide = (jobsList: { finished: boolean }[]): { exits: boolean; count: number } => {
+      const remaining = jobsList.filter((j) => !j.finished);
+      return { exits: remaining.length > 0, count: remaining.length };
+    };
+    // The regression: finished, but doneCount has not caught up.
+    expect(decide([{ finished: true }, { finished: true }])).toEqual({ exits: false, count: 0 });
+    // A genuine timeout still fails, which is the point of the timeout.
+    expect(decide([{ finished: true }, { finished: false }])).toEqual({ exits: true, count: 1 });
+  });
+
+  it("the timeout no longer gates entry on the lagging counter", () => {
+    // The one source fact worth pinning: `doneCount` must not be the entry condition,
+    // because it is updated after an await while `finished` is not.
+    // Scoped to the TIMEOUT block alone. Slicing to end-of-file swept in a later,
+    // legitimate `doneCount` gate — an assertion that reads the whole rest of the script
+    // is not about the thing it names.
     const s = code();
-    const block = s.slice(s.indexOf("setTimeout(() => {", s.indexOf("Timeout")));
-    expect(block).toMatch(/\.filter\(\(\[, j\]\) => !j\.finished\)/);
+    const start = s.indexOf("setTimeout(() => {");
+    const block = s.slice(start, s.indexOf("}, TIMEOUT_MS);", start));
+    expect(start, "the timeout block must still exist").toBeGreaterThan(-1);
+    expect(block).not.toMatch(/doneCount/);
   });
 
   it("the flag is set BEFORE the first await in markDone", () => {

--- a/src/__tests__/scripts/monitor-progress-reentry.test.ts
+++ b/src/__tests__/scripts/monitor-progress-reentry.test.ts
@@ -52,38 +52,87 @@ describe("monitor-progress re-entry guard (#1385)", () => {
     }
   });
 
-  it("the TIMEOUT decides on the flag, and only reports when something is unfinished", () => {
-    // Two faults lived here. The filter used the stale vocabulary, and the ENTRY condition
-    // used `doneCount < jobs.size` — which lags, because `doneCount++` lands only after the
-    // awaited history fetch. A job finishing just before the timeout is correctly absent
-    // from the list while doneCount has not caught up, so the script printed
-    // "[TIMEOUT] 0 job(s) still incomplete" and exited 1: a clean run reported as failure,
-    // with an empty list as its own evidence.
-    //
-    // Asserted on BEHAVIOUR rather than source text (codex P3): the previous version
-    // matched an exact `.filter(([, j]) => !j.finished)` string, which a rename of `j` or a
-    // reformat would break while preserving semantics.
-    const decide = (jobsList: { finished: boolean }[]): { exits: boolean; count: number } => {
-      const remaining = jobsList.filter((j) => !j.finished);
-      return { exits: remaining.length > 0, count: remaining.length };
-    };
-    // The regression: finished, but doneCount has not caught up.
-    expect(decide([{ finished: true }, { finished: true }])).toEqual({ exits: false, count: 0 });
-    // A genuine timeout still fails, which is the point of the timeout.
-    expect(decide([{ finished: true }, { finished: false }])).toEqual({ exits: true, count: 1 });
+  it("the TIMEOUT decides on the flag, and only reports when something is unfinished", async () => {
+    // Calls the REAL decision. The previous version reimplemented it inline and asserted
+    // against its own copy — a test of the test, which a production regression that
+    // inverted the condition would have left green (codex P3). That is why the decision
+    // now lives in its own module: monitor-progress.mjs connects to ComfyUI at import, so
+    // nothing importable could reach it before.
+    const { timeoutVerdict } = await import("../../../plugin/scripts/monitor-timeout.mjs");
+    const jobs = (...list: { finished: boolean; status?: string }[]) =>
+      new Map(list.map((j, i) => [`p${i}`, { startTime: 0, status: "running", ...j }]));
+
+    // The regression this fixes: every job finished, but `doneCount++` lands only after an
+    // awaited history fetch, so the counter lags. The old gate exited 1 and printed
+    // "0 job(s) still incomplete" — a clean run reported as a failure, with an empty list
+    // as its own evidence.
+    expect(
+      timeoutVerdict(jobs({ finished: true }, { finished: true }), { postProcessingDone: true }).kind,
+    ).toBe("clean");
+
+    // A genuine timeout still fails, which is the point of having one.
+    const late = timeoutVerdict(jobs({ finished: true }, { finished: false }), {
+      postProcessingDone: false,
+    });
+    expect(late.kind).toBe("incomplete");
+    expect(late.remaining).toHaveLength(1);
+
+    // …and the third state, which the two-way version could not express: everything
+    // reported terminal, but the run has not exited, so post-processing is wedged. Exiting
+    // 1 here would be wrong-cause; returning would hang forever.
+    expect(
+      timeoutVerdict(jobs({ finished: true }), { postProcessingDone: false }).kind,
+    ).toBe("stalled");
+  });
+
+  it("a cancelled run is not reported as a success", async () => {
+    // Pre-existing, found by codex while reviewing the timeout. ComfyUI marks an
+    // interrupted prompt `completed` and emits `execution_interrupted`; both places that
+    // classified history messages tested only for `execution_error`, so a job the user
+    // cancelled was counted and printed as a success.
+    const { classifyHistoryMessages } = await import("../../../plugin/scripts/monitor-timeout.mjs");
+    expect(classifyHistoryMessages([["execution_start"], ["execution_success"]])).toBe("success");
+    expect(classifyHistoryMessages([["execution_error"]])).toBe("error");
+    expect(classifyHistoryMessages([["execution_interrupted"]])).toBe("cancelled");
+    // An error alongside an interrupt is still an error — the more specific failure wins.
+    expect(classifyHistoryMessages([["execution_interrupted"], ["execution_error"]])).toBe("error");
+    expect(classifyHistoryMessages(undefined)).toBe("success");
+  });
+
+  it("both classification sites use the shared rule", () => {
+    // There were two copies, indented differently, and fixing the one I happened to read
+    // would have left a cancelled job reported as a success on the other path.
+    const s = code();
+    expect(s).not.toMatch(/hasError/);
+    expect((s.match(/classifyHistoryMessages\(messages\)/g) ?? []).length).toBe(2);
   });
 
   it("the timeout no longer gates entry on the lagging counter", () => {
-    // The one source fact worth pinning: `doneCount` must not be the entry condition,
-    // because it is updated after an await while `finished` is not.
+    // The one source fact worth pinning: `doneCount` must not decide whether jobs are
+    // outstanding, because it is updated after an await while `finished` is not.
+    //
     // Scoped to the TIMEOUT block alone. Slicing to end-of-file swept in a later,
     // legitimate `doneCount` gate — an assertion that reads the whole rest of the script
     // is not about the thing it names.
     const s = code();
     const start = s.indexOf("setTimeout(() => {");
-    const block = s.slice(start, s.indexOf("}, TIMEOUT_MS);", start));
+    const end = s.indexOf("}, TIMEOUT_MS);", start);
     expect(start, "the timeout block must still exist").toBeGreaterThan(-1);
-    expect(block).not.toMatch(/doneCount/);
+    // Asserted, because a missing end marker would silently widen the slice to the rest of
+    // the file and the assertion below could then pass on unrelated code (codex).
+    expect(end, "the timeout block must still close with }, TIMEOUT_MS);").toBeGreaterThan(start);
+    const block = s.slice(start, end);
+    // `postProcessingDone: doneCount >= jobs.size` is allowed — that is the counter
+    // reporting on POST-PROCESSING, not on whether jobs are outstanding.
+    expect(block).not.toMatch(/doneCount < jobs\.size/);
+
+    // AND THE VERDICT MUST BE ACTED ON. The behavioural test above proves the decision is
+    // right; nothing there reaches the line that obeys it, and mutation testing found that
+    // gap — turning the exit into a `return` left every test green while a genuine timeout
+    // silently hung. Reaching this any other way means spawning the script and waiting out
+    // its ten-minute timer, so this is a source assertion on purpose, scoped to the block.
+    expect(block).toMatch(/kind === "incomplete"\) process\.exit\(1\)/);
+    expect(block).toMatch(/kind === "clean"\) return/);
   });
 
   it("the flag is set BEFORE the first await in markDone", () => {

--- a/src/__tests__/scripts/monitor-progress-reentry.test.ts
+++ b/src/__tests__/scripts/monitor-progress-reentry.test.ts
@@ -36,11 +36,28 @@ describe("monitor-progress re-entry guard (#1385)", () => {
     expect(s).toMatch(/job\.finished = true;/);
   });
 
-  it("no guard compares against the status vocabulary any more", () => {
-    // All four sites had the same pattern; fixing only markDone would leave printProgress
-    // and the two sweep loops treating a finished job as live.
-    expect(code()).not.toMatch(/job\.status === "done"/);
-    expect(code()).not.toMatch(/job\.status === "error"/);
+  it("NO comparison against the terminal vocabulary survives, in either form", () => {
+    // Five sites had the same pattern. My first pass banned only the EQUALITY form and
+    // missed the timeout path's inequality `j.status !== "done" && j.status !== "error"`,
+    // which reports a just-succeeded job as incomplete and exits 1 — the assertion was
+    // shaped like the bug I had already found rather than like the bug.
+    const s = code();
+    for (const pattern of [
+      /\.status === "done"/,
+      /\.status === "error"/,
+      /\.status !== "done"/,
+      /\.status !== "error"/,
+    ]) {
+      expect(s, `a terminal-status comparison survives: ${pattern}`).not.toMatch(pattern);
+    }
+  });
+
+  it("the TIMEOUT path uses the flag — a finished job is never reported as incomplete", () => {
+    // `finished` is set before the history fetch and `doneCount++` comes after it, so a
+    // timeout landing in that window used to name a job that had already succeeded.
+    const s = code();
+    const block = s.slice(s.indexOf("setTimeout(() => {", s.indexOf("Timeout")));
+    expect(block).toMatch(/\.filter\(\(\[, j\]\) => !j\.finished\)/);
   });
 
   it("the flag is set BEFORE the first await in markDone", () => {


### PR DESCRIPTION
Draft — claiming #1385, whose diagnosis I could confirm line by line without running anything.

`plugin/scripts/monitor-progress.mjs` exits `[COMPLETE] All 2 jobs finished` while the second job is still executing, after printing `[DONE]` twice for the first.

**Both halves of the reporter's root cause are there:**

```js
if (!job || job.status === "done" || job.status === "error") return;   // :148
job.status = status;                                                   // :150  ← "success"
```

The guard tests for `"done"`, and the function writes `"success"` — so a successfully completed job **never matches its own re-entry guard**. Two callers reach `markDone` for one completion (the WS `execution_success` event and the history poller), and the second sails through.

Then `doneCount++` at `:177` sits *after* an `await` (the `HISTORY_DELAY_MS` sleep plus the `/history` fetch at `:166-167`), so even a correct guard would have a window: both callers can be past the check before either increments. `checkAllDone()` compares `doneCount >= jobs.size`, so one job finishing twice satisfies "all two are done".

Single-ID runs never show it because exiting at the first completion is correct anyway — which is why it survived.

Plan: the reporter's fix, which is the right one — a `finished` flag set **synchronously before any await**, guarded on. On a single-threaded event loop that closes both halves at once: the flag is written in the same tick as the check, so no second caller can be in flight past it, and it does not depend on the status vocabulary matching.

They note the same stale-status pattern in `printProgress`'s guard; I'll check that and any other `status === "done"` comparison in the file rather than fixing only the one that bit them.

Refs #1385
