### PR TITLE
chore(release): 0.50.114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and the format follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## 0.50.114
+
+### Fixed
+
+- **A failed local download now says what made ComfyUI-Manager necessary (#1374).** A LOCAL
+  Windows-portable install could not download anything: every attempt died on "ComfyUI-
+  Manager's queue API is not reachable", for a capability that needs no Manager at all. The
+  reporter downloaded ~45 GB with `curl` instead.
+
+  That error is raised in generic Manager code which cannot know it is serving a download,
+  so it named the thing that BROKE and not the decision that made Manager necessary — this
+  MCP could not resolve where the connected server keeps its models. Only the second has a
+  remedy you can apply, and nothing distinguished it from "your ComfyUI is remote, this is
+  normal".
+
+  The failure now explains the route, per case, with the `argv[0]` and `cwd` that identify
+  which one you hit. It is appended ONLY when the Manager API call itself failed — a bad
+  source URL or an auth refusal keeps its own error untouched.
+
+  **The routing is deliberately unchanged.** The reporter's decision could not be
+  reproduced here: a live ComfyUI on this machine reports a relative `main.py` and no `cwd`
+  — the shape that looked like the culprit — and still resolves, because the process-table
+  probe anchors it. Guessing at which of six conditions fires for them, and "fixing" that,
+  is how a routing change breaks installs that work today. What ships is the answer being
+  visible in the next report.
+
 ## 0.50.113
 
 ### Fixed
@@ -170,6 +196,14 @@ All notable changes to this project are documented here. This project adheres to
   ComfyUI you did not mean to touch, not merely find nothing there (#1233, panel#851)
 
 ## Unreleased
+
+## [0.50.114] - 2026-08-11
+
+### MCP
+
+#### Fixed
+- a local download should not need ComfyUI-Manager (#1393)
+
 
 ## [0.50.113] - 2026-08-11
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.113",
+  "version": "0.50.114",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.113",
+      "version": "0.50.114",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.113",
+  "version": "0.50.114",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles 0.50.114 into protected main. Tag `v0.50.114` is pushed and publishes.

**#1374** — a failed local download now says what made ComfyUI-Manager necessary, instead of naming only the thing that broke.

The routing is deliberately unchanged: the reporter's decision could not be reproduced here (a live ComfyUI on this machine reports a relative `main.py` and no `cwd` — the shape that looked like the culprit — and still resolves via the process-table probe). Guessing at which of six conditions fires for them is how a routing change breaks installs that work today.

Five review rounds, each finding the same fault: a diagnostic narrating the routing *decision* while reading state that might not be what that decision saw. The claim is what changed in the end — it reports current state and says so.