### PR TITLE
chore(release): 0.50.115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.50.115] - 2026-08-11
+
+### MCP
+
+#### Fixed
+- warn before a credential save orphans in-flight downloads (#1406)
+- the smoke mock advertises a panel version, and a ratchet keeps it current (#1410)
+- a completed job no longer matches its own re-entry guard (#1407)
+- verify a .json attachment by parsing it, not by its content-type (#1405)
+- prove the configured base before writing a model into it (#1403)
+
+
 ## [0.50.114] - 2026-08-11
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.114",
+  "version": "0.50.115",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.114",
+      "version": "0.50.115",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.114",
+  "version": "0.50.115",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump for the v0.50.115 tag (already published from the tag).

Five fixes:
- **#1371** a symlinked model *directory* counts, the corroboration scan is bounded, and a scan that gives up early says so rather than reading as "this base holds nothing" — which silently permitted the misplaced write the check exists to stop.
- **#1373** a `.json` attachment is verified by parsing it; refusals distinguish *the server has no such file* (check the filename) from *a body arrived and is not the attachment* (the name was right).
- **#1378** a credential save or **revoke** warns about the in-flight downloads its respawn is about to orphan, including from the Settings endpoint. The snapshot lives inside the emit, so emitting without capturing and warning without emitting are both unreachable.
- **#1384** the knowledge-parity smoke's mock panel stops lying to the agent driving it (version, workflow identity, Origin, and the stamp it claims to enforce), with a ratchet that fails when a product fence rises.
- **#1385** the progress monitor no longer exits 1 on a clean run, no longer hangs when post-processing wedges, and no longer reports a cancelled job as a success.

Also filed: #1411 (a panel message sent during the orchestrator's startup window is silently dropped), found while fixing #1384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)