### PR TITLE
fix(848): name the Desktop launch arguments that did not take effect

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
@@ -9,6 +9,9 @@
 // ready AND from the old #509 false-timeout error.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const resetClient = vi.fn();
 const resetObjectInfoCache = vi.fn();
@@ -18,6 +21,18 @@ const resetObjectInfoCache = vi.fn();
 const getSystemStats = vi.fn(async () => {
   throw new Error("ECONNRESET");
 });
+/** #848: a temp HOME for the one test that needs Desktop's installations.json. PASS-THROUGH
+ *  by default — the real homedir until a test sets this — so nothing else in this harness
+ *  changes behaviour, and nothing ever writes into the user's real Desktop config. */
+const homeRef = vi.hoisted(() => ({ value: "" }));
+vi.mock("node:os", async (orig) => {
+  const real = await orig<typeof import("node:os")>();
+  // vi.mock is HOISTED above ordinary declarations, so the factory cannot close over a
+  // plain `let` — it reads it in the temporal dead zone and throws during module init.
+  const home = () => homeRef.value || real.homedir();
+  return { ...real, homedir: home, default: { ...real, homedir: home } };
+});
+
 vi.mock("../../comfyui/client.js", () => ({
   getObjectInfo: vi.fn(),
   backfillObjectInfo: vi.fn(),
@@ -30,6 +45,7 @@ const { buildPanelToolDefs, __panelToolsTestHooks } = await import(
   "../../orchestrator/panel-tools.js"
 );
 import {
+  config,
   getBootLocalComfyUIBaseUrl,
   getComfyUIBaseUrl,
   setComfyuiTarget,
@@ -185,6 +201,57 @@ describe("panel_restart_comfyui recovery after an ACCEPTED reboot (coordinator p
     expect(String(out.note)).not.toMatch(/this restart did not change/i);
     expect(String(out.note)).toContain("If you were expecting different arguments");
     expect(String(out.note)).toMatch(/fully quit the ComfyUI Desktop app/i);
+  });
+
+  it("NAMES the saved Desktop argument that is not in force, on the PANEL path too (#848)", async () => {
+    // The panel tool has its own restart path; the service has the Manager-reboot one.
+    // Fixing one and not the other makes the answer depend on which route the user took,
+    // which is the shape of half the bugs in this cluster — so both are driven for real.
+    // The source-text version of this check passed with the call site's Desktop gate
+    // replaced by `false`.
+    const desktopHome = mkdtempSync(join(tmpdir(), "cmcp-panel-desktop-"));
+    homeRef.value = desktopHome;
+    const root = join(desktopHome, "ComfyUI-Installs", "ComfyUI");
+    const cfgDir = join(desktopHome, "AppData", "Roaming", "Comfy Desktop");
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "installations.json"),
+      JSON.stringify([
+        {
+          id: "inst-1",
+          name: "My Desktop Install",
+          installPath: root,
+          sourceId: "standalone",
+          launchArgs: "--disable-dynamic-vram",
+        },
+      ]),
+      "utf8",
+    );
+    const savedPath = config.comfyuiPath;
+    config.comfyuiPath = join(root, "ComfyUI");
+    try {
+      const argv = ["main.py", "--listen", "127.0.0.1", "--port", "8188"];
+      __panelToolsTestHooks.setLocalRestartPreflight(async () => ({
+        ok: true,
+        observedArgv: argv,
+        isDesktopApp: true,
+      }));
+      getSystemStats.mockImplementation(async () => ({ system: { argv: [...argv] } }));
+      const seq: ProbeSeq = ["down", "healthy"];
+      let i = 0;
+      __panelToolsTestHooks.setHealthProbe(async () => seq[Math.min(i++, seq.length - 1)]);
+      const { ctx } = makeCtx({ reboot: { rebooting: true } });
+
+      const out = parse(await rebootHandler()({ force: false }, ctx));
+      expect(out.ready).toBe(true);
+      expect(String(out.note)).toContain("--disable-dynamic-vram");
+      expect(String(out.note)).toContain("do NOT contain");
+      expect(String(out.note)).toContain("My Desktop Install");
+    } finally {
+      config.comfyuiPath = savedPath;
+      rmSync(desktopHome, { recursive: true, force: true });
+      homeRef.value = "";
+    }
   });
 
   it("reports launch arguments CHANGED when the restart did apply them (#848)", async () => {

--- a/src/__tests__/services/desktop-launch-args.test.ts
+++ b/src/__tests__/services/desktop-launch-args.test.ts
@@ -127,6 +127,43 @@ describe("#848 — the saved launch arguments", () => {
     ]);
   });
 
+  it("folds CASE only where the filesystem does (codex P2)", () => {
+    // Folding everywhere is wrong on Linux, where `/home/u/ComfyUI` and `/home/u/comfyui`
+    // are two different installs — the sentence would then be attributed to the wrong one
+    // and name a flag the user never put there.
+    //
+    // The assertion is platform-conditional because the CORRECT ANSWER is: Windows
+    // matches, a case-sensitive filesystem declines. Asserting one of those everywhere
+    // would just encode the bug on the other platform.
+    const root = join(home, "ComfyUI-Installs", "ComfyUI");
+    writeInstallations([localEntry(root)]);
+    const differentCase = root.toUpperCase();
+
+    if (process.platform === "win32") {
+      expect(desktopSavedLaunchArgs(differentCase)?.args).toEqual([
+        "--enable-manager",
+        "--enable-cors-header",
+      ]);
+    } else {
+      expect(desktopSavedLaunchArgs(differentCase)).toBeUndefined();
+    }
+    // Exact case matches everywhere, which is the case that actually ships.
+    expect(desktopSavedLaunchArgs(root)?.args).toHaveLength(2);
+  });
+
+  it("ignores a file far too large to be Desktop's own (codex P3)", () => {
+    // This read happens while composing a restart report. A bound keeps a pathological
+    // file at that name from being slurped; the honest residual — that the read is still
+    // synchronous — is stated in the code.
+    const root = join(home, "ComfyUI-Installs", "ComfyUI");
+    const dir = join(home, "AppData", "Roaming", "Comfy Desktop");
+    mkdirSync(dir, { recursive: true });
+    const entries = JSON.stringify([localEntry(root)]);
+    const padding = " ".repeat(5 * 1024 * 1024);
+    writeFileSync(join(dir, "installations.json"), entries + padding, "utf8");
+    expect(desktopSavedLaunchArgs(root)).toBeUndefined();
+  });
+
   it("DECLINES when two entries claim the same install", () => {
     // They cannot both be the install whose settings the user edited, and picking one puts
     // a specific, checkable sentence in front of them that may be about the other.

--- a/src/__tests__/services/desktop-launch-args.test.ts
+++ b/src/__tests__/services/desktop-launch-args.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * #848 — reading what ComfyUI Desktop SAVED, so a restart can name what did not take.
+ *
+ * The fixtures are written as REAL FILES in a temp HOME rather than mocked, because the
+ * thing being tested is a file format someone else owns. A hand-built double agrees with
+ * whatever I believed the format was, and I believed two wrong things about it before
+ * checking: that `launchArgs` was an array (it is one space-separated string) and that
+ * `installPath` pointed at the directory holding main.py (it points at the install ROOT,
+ * one level up). Both were caught by reading an actual installations.json.
+ */
+let home = "";
+
+vi.mock("node:os", async (orig) => {
+  const real = await orig<typeof import("node:os")>();
+  return { ...real, homedir: () => home, default: { ...real, homedir: () => home } };
+});
+
+const { desktopSavedLaunchArgs, describeSavedLaunchArgDrift } = await import(
+  "../../services/desktop-launch-args.js"
+);
+
+/** Write an installations.json into the fake Windows-shaped Desktop config dir. */
+const writeInstallations = (entries: unknown): string => {
+  const dir = join(home, "AppData", "Roaming", "Comfy Desktop");
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, "installations.json");
+  writeFileSync(file, JSON.stringify(entries), "utf8");
+  return file;
+};
+
+const localEntry = (installPath: string, extra: Record<string, unknown> = {}) => ({
+  id: "inst-1",
+  name: "ComfyUI",
+  installPath,
+  sourceId: "standalone",
+  launchArgs: "--enable-manager --enable-cors-header",
+  ...extra,
+});
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "cmcp-desktop-home-"));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("#848 — the saved launch arguments", () => {
+  it("reads them for the install ROOT and for the directory holding main.py", () => {
+    // The shape that actually ships: Desktop records the install root, and its own
+    // installer puts ComfyUI one level down. Our resolved path is the main.py directory,
+    // so matching only the recorded string finds nothing on exactly the installs this
+    // exists for — and a silent no-match is indistinguishable from "no drift".
+    const root = join(home, "ComfyUI-Installs", "ComfyUI");
+    writeInstallations([localEntry(root)]);
+
+    expect(desktopSavedLaunchArgs(root)?.args).toEqual([
+      "--enable-manager",
+      "--enable-cors-header",
+    ]);
+    expect(desktopSavedLaunchArgs(join(root, "ComfyUI"))?.args).toEqual([
+      "--enable-manager",
+      "--enable-cors-header",
+    ]);
+    expect(desktopSavedLaunchArgs(root)?.name).toBe("ComfyUI");
+  });
+
+  it("returns UNDEFINED — not an empty list — when nothing was established", () => {
+    // Three states (#796). "Desktop saves no arguments for this install" is a claim, and a
+    // missing or unreadable file does not support it. Reporting an empty set here would
+    // let the caller say the settings and the server agree when neither was read.
+    const root = join(home, "ComfyUI-Installs", "ComfyUI");
+
+    // No file at all.
+    expect(desktopSavedLaunchArgs(root)).toBeUndefined();
+
+    // Unreadable/malformed.
+    const dir = join(home, "AppData", "Roaming", "Comfy Desktop");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "installations.json"), "{not json", "utf8");
+    expect(desktopSavedLaunchArgs(root)).toBeUndefined();
+
+    // Present, but no entry for this path.
+    writeInstallations([localEntry(join(home, "somewhere-else"))]);
+    expect(desktopSavedLaunchArgs(root)).toBeUndefined();
+
+    // An entry for this path that saves no launchArgs KEY at all.
+    writeInstallations([{ id: "x", name: "ComfyUI", installPath: root, sourceId: "standalone" }]);
+    expect(desktopSavedLaunchArgs(root)).toBeUndefined();
+
+    // No path to ask about.
+    expect(desktopSavedLaunchArgs(undefined)).toBeUndefined();
+    expect(desktopSavedLaunchArgs("   ")).toBeUndefined();
+  });
+
+  it("an explicitly EMPTY launchArgs is an answer, not an absence", () => {
+    // The one case that is genuinely "none": the user cleared the field. It reads as an
+    // empty list, and the drift sentence then has nothing to report — which is different
+    // from never having looked.
+    const root = join(home, "ComfyUI-Installs", "ComfyUI");
+    writeInstallations([localEntry(root, { launchArgs: "" })]);
+    expect(desktopSavedLaunchArgs(root)).toEqual({ name: "ComfyUI", args: [] });
+  });
+
+  it("ignores remote and cloud entries, whose saved arguments are about nothing local", () => {
+    // ONE AT A TIME. Written as two entries together, this passed with the filter
+    // DELETED — two matches decline as ambiguous, so the assertion was satisfied by a
+    // different rule than the one it names. Mutation testing caught it.
+    const root = join(home, "ComfyUI-Installs", "ComfyUI");
+    for (const sourceId of ["remote", "cloud"]) {
+      writeInstallations([{ ...localEntry(root), sourceId, launchArgs: "--not-local" }]);
+      expect(desktopSavedLaunchArgs(root), `${sourceId} must not answer`).toBeUndefined();
+    }
+    // …and the same file WITH a local entry answers from the local one alone.
+    writeInstallations([
+      { ...localEntry(root), sourceId: "remote", launchArgs: "--not-local" },
+      localEntry(root),
+    ]);
+    expect(desktopSavedLaunchArgs(root)?.args).toEqual([
+      "--enable-manager",
+      "--enable-cors-header",
+    ]);
+  });
+
+  it("DECLINES when two entries claim the same install", () => {
+    // They cannot both be the install whose settings the user edited, and picking one puts
+    // a specific, checkable sentence in front of them that may be about the other.
+    const root = join(home, "ComfyUI-Installs", "ComfyUI");
+    writeInstallations([
+      localEntry(root, { id: "a", launchArgs: "--one" }),
+      localEntry(root, { id: "b", launchArgs: "--two" }),
+    ]);
+    expect(desktopSavedLaunchArgs(root)).toBeUndefined();
+  });
+
+  it("accepts an ARRAY too, rather than assuming the format cannot change", () => {
+    const root = join(home, "ComfyUI-Installs", "ComfyUI");
+    writeInstallations([localEntry(root, { launchArgs: ["--a", "--b"] })]);
+    expect(desktopSavedLaunchArgs(root)?.args).toEqual(["--a", "--b"]);
+    // …but not a shape it cannot read. A number is not a quiet empty list.
+    writeInstallations([localEntry(root, { launchArgs: 42 })]);
+    expect(desktopSavedLaunchArgs(root)).toBeUndefined();
+  });
+});
+
+describe("#848 — the sentence", () => {
+  const saved = { name: "ComfyUI", args: ["--enable-manager", "--disable-dynamic-vram"] };
+
+  it("names the arguments the running server does not have", () => {
+    const said = describeSavedLaunchArgDrift(saved, ["main.py", "--enable-manager"]);
+    expect(said).toMatch(/--disable-dynamic-vram/);
+    // The saved argument that IS present must not be named as missing.
+    expect(said).not.toMatch(/--enable-manager,|include --enable-manager/);
+    // The remedy is the one thing that applies them, and it is not this tool.
+    expect(said).toMatch(/quit the ComfyUI Desktop app and relaunch/);
+  });
+
+  it("says NOTHING when there is nothing established", () => {
+    // Each of these would otherwise produce a confident sentence about a comparison that
+    // never happened — the exact failure #848 reported, pointed the other way.
+    expect(describeSavedLaunchArgDrift(undefined, ["main.py"])).toBe("");
+    expect(describeSavedLaunchArgDrift(saved, undefined)).toBe("");
+    expect(describeSavedLaunchArgDrift(saved, [])).toBe("");
+    expect(describeSavedLaunchArgDrift({ name: "x", args: [] }, ["main.py"])).toBe("");
+  });
+
+  it("says nothing when every saved argument is in force", () => {
+    expect(
+      describeSavedLaunchArgDrift(saved, ["main.py", "--enable-manager", "--disable-dynamic-vram"]),
+    ).toBe("");
+  });
+
+  it("does NOT report the reverse direction", () => {
+    // A running server carrying arguments the saved settings do not mention is ordinary —
+    // Desktop adds its own — so reporting that would fire on every healthy install.
+    expect(
+      describeSavedLaunchArgDrift({ name: "ComfyUI", args: ["--enable-manager"] }, [
+        "main.py",
+        "--enable-manager",
+        "--windows-standalone-build",
+        "--port",
+        "8000",
+      ]),
+    ).toBe("");
+  });
+});
+
+describe("#848 — the wiring", () => {
+  it("BOTH restart paths append the sentence, and only for Desktop", async () => {
+    // A helper nobody calls is worth nothing, and the two restart paths are reached by
+    // different callers — the panel tool has its own, the service has the Manager-reboot
+    // one. Fixing one and not the other makes the answer depend on which route the user
+    // happened to take, which is the shape of half the bugs in this cluster.
+    const { readFileSync } = await import("node:fs");
+    const code = (rel: string): string =>
+      readFileSync(new URL(rel, import.meta.url), "utf8")
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/\/\/.*/g, "");
+
+    for (const rel of ["../../services/process-control.ts", "../../orchestrator/panel-tools.ts"]) {
+      const src = code(rel);
+      expect(src, `${rel} must call it`).toMatch(/describeSavedLaunchArgDrift\(/);
+      // Gated on Desktop: a self-spawned Python install has no Desktop settings, and
+      // asking about them would attach a sentence about a file that governs nothing here.
+      // Anchored on the CALL — the first occurrence is the import — and read as a fixed
+      // WINDOW before it. Searching backwards for a literal "isDesktop" instead matched a
+      // lowercase occurrence 580 lines away, because the gate here is `preflightIsDesktop`
+      // with a capital I; the assertion then measured a distance that meant nothing.
+      const callAt = src.lastIndexOf("describeSavedLaunchArgDrift(");
+      expect(callAt, `${rel} must call it`).toBeGreaterThan(-1);
+      const window = src.slice(Math.max(0, callAt - 300), callAt);
+      expect(window, `${rel} must gate the call on Desktop`).toMatch(/[Ii]sDesktop/);
+    }
+  });
+});

--- a/src/__tests__/services/desktop-launch-args.test.ts
+++ b/src/__tests__/services/desktop-launch-args.test.ts
@@ -138,6 +138,22 @@ describe("#848 — the saved launch arguments", () => {
     expect(desktopSavedLaunchArgs(root)).toBeUndefined();
   });
 
+  it("splits the saved string the way a shell would, honouring quotes", () => {
+    // A path with a space splits into fragments that appear nowhere in argv, so a naive
+    // whitespace split reports a setting that IS in force as missing.
+    const root = join(home, "ComfyUI-Installs", "ComfyUI");
+    writeInstallations([
+      localEntry(root, {
+        launchArgs: String.raw`--extra-model-paths-config "C:\my path\extra.yaml" --listen`,
+      }),
+    ]);
+    expect(desktopSavedLaunchArgs(root)?.args).toEqual([
+      "--extra-model-paths-config",
+      String.raw`C:\my path\extra.yaml`,
+      "--listen",
+    ]);
+  });
+
   it("accepts an ARRAY too, rather than assuming the format cannot change", () => {
     const root = join(home, "ComfyUI-Installs", "ComfyUI");
     writeInstallations([localEntry(root, { launchArgs: ["--a", "--b"] })]);
@@ -158,6 +174,34 @@ describe("#848 — the sentence", () => {
     expect(said).not.toMatch(/--enable-manager,|include --enable-manager/);
     // The remedy is the one thing that applies them, and it is not this tool.
     expect(said).toMatch(/quit the ComfyUI Desktop app and relaunch/);
+  });
+
+  it("does NOT claim drift when the same instruction is spelled differently", () => {
+    // The mirror of this bug, pointed at the user. The saved settings are ONE STRING and
+    // argv is already split, so `--port 8000` / `--port=8000` and a quoted path against its
+    // unquoted argv form are the same instruction in different words — and token equality
+    // called every one of them "not in force", which is a confident, checkable, wrong
+    // sentence sending someone to restart Desktop for nothing.
+    expect(
+      describeSavedLaunchArgDrift({ name: "X", args: ["--port=8000"] }, ["main.py", "--port", "8000"]),
+    ).toBe("");
+    expect(
+      describeSavedLaunchArgDrift({ name: "X", args: ["--port", "8000"] }, ["main.py", "--port=8000"]),
+    ).toBe("");
+    // A bare value is an argument to a flag; its formatting varies and it says nothing on
+    // its own, so it is never reported.
+    expect(
+      describeSavedLaunchArgDrift({ name: "X", args: ["--listen", "0.0.0.0"] }, ["main.py", "--listen", "127.0.0.1"]),
+    ).toBe("");
+  });
+
+  it("still reports a whole flag that is absent — the reported case", () => {
+    const said = describeSavedLaunchArgDrift({ name: "X", args: ["--disable-dynamic-vram"] }, [
+      "main.py",
+      "--listen",
+      "127.0.0.1",
+    ]);
+    expect(said).toMatch(/--disable-dynamic-vram/);
   });
 
   it("says NOTHING when there is nothing established", () => {

--- a/src/__tests__/services/desktop-launch-args.test.ts
+++ b/src/__tests__/services/desktop-launch-args.test.ts
@@ -262,3 +262,30 @@ describe("#848 — the wiring", () => {
     }
   });
 });
+
+describe("#848 — the two halves compose into ONE remedy", () => {
+  it("the finding REPLACES the conditional, and survives without it", async () => {
+    // Printed together they read: "if you were expecting different arguments … your
+    // --disable-dynamic-vram is not in force", which hedges a fact just established and
+    // then gives the same remedy twice. Caught by rendering the real sentence rather than
+    // by any test — the tests were green on both halves separately.
+    const { describeArgvDrift } = await import("../../services/process-control.js");
+    const same = ["main.py", "--listen", "127.0.0.1"];
+    const finding = describeSavedLaunchArgDrift(
+      { name: "My Desktop Install", args: ["--disable-dynamic-vram"] },
+      same,
+    );
+
+    const answered = describeArgvDrift(same, same, true, finding);
+    expect(answered).toContain("--disable-dynamic-vram");
+    // The hedge is gone: we read the settings, so we are no longer guessing.
+    expect(answered).not.toContain("If you were expecting different arguments");
+    // …and the remedy appears once.
+    expect(answered.match(/fully quit the ComfyUI Desktop app/g)).toHaveLength(1);
+
+    // When the settings could NOT be read, the conditional is still the honest answer.
+    const unanswered = describeArgvDrift(same, same, true, "");
+    expect(unanswered).toContain("If you were expecting different arguments");
+    expect(unanswered).not.toContain("do NOT contain");
+  });
+});

--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -6,6 +6,9 @@
 // spawn; no real process/port/network is touched.
 
 import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join } from "node:path";
 
 const hoisted = vi.hoisted(() => ({
   remoteMode: { value: false },
@@ -24,16 +27,36 @@ const hoisted = vi.hoisted(() => ({
   getSystemStats: vi.fn(),
   execSync: vi.fn(() => ""),
   spawn: vi.fn(),
+  comfyuiPath: { value: "/fake/comfy" },
 }));
 
 vi.mock("../../config.js", () => ({
-  config: { resolvedPort: 8188, comfyuiPath: "/fake/comfy", comfyuiBasePath: "" },
+  config: {
+    resolvedPort: 8188,
+    // MUTABLE, so a test can point it at the Desktop layout it wrote (#848). A getter
+    // rather than a fixed string: the module is imported once and the value is read at
+    // call time.
+    get comfyuiPath() {
+      return hoisted.comfyuiPath.value;
+    },
+    comfyuiBasePath: "",
+  },
   getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
   // #848 instance fence: the argv comparison is only spent while the configured
   // target has not moved. Driven from the fixture so a retarget can be modelled.
   getComfyuiTargetGeneration: () => hoisted.targetGeneration.value,
   isRemoteMode: () => hoisted.remoteMode.value,
 }));
+
+/** A temp HOME holding a real Desktop installations.json for the #848 cases. Real files,
+ *  not a mocked reader: the format belongs to Comfy Desktop, and a hand-built double
+ *  agrees with whatever I believed it was — which was wrong twice. */
+let desktopHome = "";
+vi.mock("node:os", async (orig) => {
+  const real = await orig<typeof import("node:os")>();
+  const home = () => desktopHome || real.homedir();
+  return { ...real, homedir: home, default: { ...real, homedir: home } };
+});
 
 vi.mock("../../comfyui/fetch.js", () => ({
   comfyuiFetch: (url: string, init?: RequestInit) => hoisted.fetchMock(url, init),
@@ -97,6 +120,10 @@ const findCall = (pred: (path: string) => boolean): FetchCall | undefined =>
   (hoisted.fetchMock.mock.calls as FetchCall[]).find(([u]) => pred(pathOf(u)));
 
 beforeEach(() => {
+
+  desktopHome = mkdtempSync(join(tmpdir(), "cmcp-desktop-restart-"));
+
+  hoisted.comfyuiPath.value = "/fake/comfy";
   hoisted.remoteMode.value = false;
   hoisted.targetGeneration.value = 0;
   hoisted.fetchMock.mockReset();
@@ -158,6 +185,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+
+  if (desktopHome) rmSync(desktopHome, { recursive: true, force: true });
+
+  desktopHome = "";
   __portOwnerTestHooks.reset();
   __processControlTestHooks.reset();
 });
@@ -273,6 +304,100 @@ describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]",
     expect(res.message).not.toMatch(/re-exec/i);
     // And it never contradicts the restart that genuinely happened.
     expect(res.message).toContain("ComfyUI is healthy now");
+  });
+
+  it("NAMES the saved Desktop argument that is not in force (#848)", async () => {
+    // The behavioural half of the fix. The UNCHANGED sentence above has to hedge — "if you
+    // were expecting different arguments" — because nothing had opened the user's settings.
+    // #848 is exactly the case where they HAD changed them, so reading Desktop's saved
+    // launchArgs turns that hint into the answer they came for.
+    //
+    // Driven through the real restart rather than by calling the helper: a source-text
+    // wiring assertion passed with the call site's Desktop gate replaced by `false`, which
+    // is a test of spelling, not of reachability.
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 1000,
+      intervalMs: 5,
+    });
+    // Desktop's own file, in a temp HOME, recording a flag the running server lacks.
+    const root = join(desktopHome, "ComfyUI-Installs", "ComfyUI");
+    const cfgDir = join(desktopHome, "AppData", "Roaming", "Comfy Desktop");
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "installations.json"),
+      JSON.stringify([
+        {
+          id: "inst-1",
+          name: "My Desktop Install",
+          installPath: root,
+          sourceId: "standalone",
+          launchArgs: "--disable-dynamic-vram",
+        },
+      ]),
+      "utf8",
+    );
+    // …and the configured path is the main.py directory one level down, which is the
+    // layout Desktop's installer actually produces.
+    hoisted.comfyuiPath.value = join(root, "ComfyUI");
+
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = pathOf(url);
+      if (path === "/v2/manager/reboot") return new Response("", { status: 200 });
+      if (path === "/system_stats") return new Response(JSON.stringify({ system: {} }), { status: 200 });
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.ready).toBe(true);
+    expect(res.message).toContain("--disable-dynamic-vram");
+    expect(res.message).toContain("do NOT contain");
+    expect(res.message).toContain("My Desktop Install");
+    // The remedy is the only thing that applies it, and it is not this tool.
+    expect(res.message).toContain("quit the ComfyUI Desktop app and relaunch");
+  });
+
+  it("says nothing extra when the saved arguments ARE in force (#848)", async () => {
+    // The over-broad direction. A sentence on every healthy Desktop restart would train
+    // the user to skip the one that matters.
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 1000,
+      intervalMs: 5,
+    });
+    const root = join(desktopHome, "ComfyUI-Installs", "ComfyUI");
+    const cfgDir = join(desktopHome, "AppData", "Roaming", "Comfy Desktop");
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "installations.json"),
+      JSON.stringify([
+        {
+          id: "inst-1",
+          name: "My Desktop Install",
+          installPath: root,
+          // Every one of these is in the fixture argv.
+          launchArgs: "--listen --port",
+          sourceId: "standalone",
+        },
+      ]),
+      "utf8",
+    );
+    hoisted.comfyuiPath.value = join(root, "ComfyUI");
+
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = pathOf(url);
+      if (path === "/v2/manager/reboot") return new Response("", { status: 200 });
+      if (path === "/system_stats") return new Response(JSON.stringify({ system: {} }), { status: 200 });
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.ready).toBe(true);
+    expect(res.message).not.toContain("do NOT contain");
+    // …and the existing conditional remedy still stands on its own.
+    expect(res.message).toContain("launch arguments are UNCHANGED");
   });
 
   it("says the launch arguments CHANGED when they actually did (#848)", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -11829,17 +11829,20 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             getComfyuiTargetGeneration() === preflightArgvGeneration &&
             sameHttpBase(getComfyUIBaseUrl(), healthBase)
           ) {
-            argvNote =
-              describeArgvDrift(preflightArgv, afterArgv, preflightIsDesktop) +
+            argvNote = describeArgvDrift(
+              preflightArgv,
+              afterArgv,
+              preflightIsDesktop,
               // #848: BOTH restart paths, or the answer depends on which one the user
               // happened to take. This is the panel tool's own path; the service's
-              // Manager-reboot path carries the same pair of lines.
-              (preflightIsDesktop
+              // Manager-reboot path passes the same finding.
+              preflightIsDesktop
                 ? describeSavedLaunchArgDrift(
                     desktopSavedLaunchArgs(config.comfyuiPath ?? undefined),
                     afterArgv,
                   )
-                : "");
+                : "",
+            );
           }
         }
         return ok({

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -142,6 +142,11 @@ import {
 } from "../services/process-control.js";
 import { resetManagerApiCache } from "../services/manager-api-cache.js";
 import {
+  desktopSavedLaunchArgs,
+  describeSavedLaunchArgDrift,
+} from "../services/desktop-launch-args.js";
+import {
+  config,
   isRemoteMode,
   isCloudMode,
   getBootLocalComfyUIBaseUrl,
@@ -11824,7 +11829,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             getComfyuiTargetGeneration() === preflightArgvGeneration &&
             sameHttpBase(getComfyUIBaseUrl(), healthBase)
           ) {
-            argvNote = describeArgvDrift(preflightArgv, afterArgv, preflightIsDesktop);
+            argvNote =
+              describeArgvDrift(preflightArgv, afterArgv, preflightIsDesktop) +
+              // #848: BOTH restart paths, or the answer depends on which one the user
+              // happened to take. This is the panel tool's own path; the service's
+              // Manager-reboot path carries the same pair of lines.
+              (preflightIsDesktop
+                ? describeSavedLaunchArgDrift(
+                    desktopSavedLaunchArgs(config.comfyuiPath ?? undefined),
+                    afterArgv,
+                  )
+                : "");
           }
         }
         return ok({

--- a/src/services/desktop-launch-args.ts
+++ b/src/services/desktop-launch-args.ts
@@ -53,6 +53,24 @@ function samePath(a: string, b: string): boolean {
 }
 
 /**
+ * Split the saved string into tokens the way a shell would, honouring quotes.
+ *
+ * `--extra-model-paths-config "C:\my path\x.yaml"` splits on whitespace into three
+ * fragments, none of which appears in argv — so a naive split reports a change that IS in
+ * force as missing, which is this issue's own defect pointed at the user.
+ */
+function splitLaunchArgs(raw: string): string[] {
+  const out: string[] = [];
+  const re = /"([^"]*)"|'([^']*)'|(\S+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(raw)) !== null) {
+    const tok = m[1] ?? m[2] ?? m[3];
+    if (tok) out.push(tok);
+  }
+  return out;
+}
+
+/**
  * Does this Desktop record describe the install we are running?
  *
  * Desktop's `installPath` is the install ROOT, and for its own installer layout `main.py`
@@ -105,7 +123,7 @@ export function desktopSavedLaunchArgs(installPath: string | undefined): SavedLa
       const raw = rec.launchArgs;
       const args =
         typeof raw === "string"
-          ? raw.split(/\s+/).filter(Boolean)
+          ? splitLaunchArgs(raw)
           : Array.isArray(raw) && raw.every((t) => typeof t === "string")
             ? (raw as string[]).filter(Boolean)
             : undefined;
@@ -120,6 +138,12 @@ export function desktopSavedLaunchArgs(installPath: string | undefined): SavedLa
   // whose settings the user edited, and picking one would put a specific, checkable
   // sentence in front of them that may be about the other.
   return matches.length === 1 ? matches[0] : undefined;
+}
+
+/** The flag NAME of a token: `--port=8000` and `--port` are the same instruction, and a
+ *  value token has no flag name at all. */
+function flagName(token: string): string {
+  return token.startsWith("-") ? token.split("=")[0] : "";
 }
 
 /**
@@ -140,8 +164,19 @@ export function describeSavedLaunchArgDrift(
   runningArgv: string[] | undefined,
 ): string {
   if (!saved || !saved.args.length || !runningArgv?.length) return "";
-  const running = new Set(runningArgv);
-  const missing = saved.args.filter((tok) => !running.has(tok));
+  // COMPARE FLAGS, NOT TOKENS. The saved settings are one string and argv is already
+  // split, so the same instruction is spelled several ways: `--port 8000` against
+  // `--port=8000`, a quoted path against its unquoted argv form. Token equality called all
+  // of those "not in force" — a confident, checkable, WRONG sentence sending the user to
+  // restart Desktop for nothing, which is this issue's defect pointed back at them.
+  //
+  // Only FLAGS are reported, and only by name. A bare value is an argument to a flag: its
+  // formatting varies, and it says nothing on its own. The reported case is a whole flag
+  // that is absent, which is exactly what #848 was about.
+  const runningFlags = new Set(runningArgv.map(flagName).filter(Boolean));
+  const missing = saved.args
+    .filter((tok) => tok.startsWith("-"))
+    .filter((tok) => !runningFlags.has(flagName(tok)));
   if (!missing.length) return "";
   return (
     ` ComfyUI Desktop's saved launch settings for "${saved.name}" include ` +

--- a/src/services/desktop-launch-args.ts
+++ b/src/services/desktop-launch-args.ts
@@ -1,0 +1,152 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve, sep } from "node:path";
+
+/**
+ * What ComfyUI Desktop SAVED as an install's launch arguments (#848).
+ *
+ * #848 is a configuration change that appeared to succeed and silently did not take: a
+ * flag was added to Desktop's saved launch settings, `panel_restart_comfyui` reported the
+ * server healthy, and the flag was absent. #850 already made the restart report whether
+ * the running arguments changed — but that sentence has to be conditioned on the user's
+ * own expectation ("if you were expecting different arguments…"), because nothing ever
+ * opened the settings. It is a hint where an observation was available.
+ *
+ * This reads the saved arguments so the restart can say the specific thing: the settings
+ * ask for X, the running server does not have X. That is two readings compared, in the
+ * style of the rest of this cluster — never a claim about WHY they differ, and never a
+ * claim that the restart caused it.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO. It does not apply the arguments. A Desktop backend is
+ * Electron-supervised and is never killed here (#400: killing it does not reliably bring
+ * the listener back), and a Manager reboot re-execs the running process — so nothing in
+ * this process can inject new launch arguments. Only the Desktop app can, at its own
+ * launch. Pretending otherwise would be this issue's own defect pointed the other way.
+ */
+export interface SavedLaunchArgs {
+  /** The install's display name in Desktop, for a message the user can act on. */
+  name: string;
+  /** Tokens exactly as saved. Desktop stores ONE space-separated string, not an array. */
+  args: string[];
+}
+
+/** The Desktop config directories, in the same order `config.ts` reads them. */
+function desktopConfigDirs(): string[] {
+  const home = homedir();
+  return [
+    join(home, "AppData", "Roaming", "Comfy Desktop"), // Windows
+    join(home, "Library", "Application Support", "Comfy Desktop"), // macOS
+    join(home, ".config", "Comfy Desktop"), // Linux
+  ];
+}
+
+/** Case- and separator-insensitive path identity, since Desktop and our config can
+ *  disagree on trailing slashes and (on Windows) case. */
+function samePath(a: string, b: string): boolean {
+  const norm = (p: string) =>
+    resolve(p.trim()).replace(new RegExp(`\\${sep}+$`), "").toLowerCase();
+  try {
+    return norm(a) === norm(b);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Does this Desktop record describe the install we are running?
+ *
+ * Desktop's `installPath` is the install ROOT, and for its own installer layout `main.py`
+ * sits one level down at `<installPath>/ComfyUI` — the same wrapper shape `config.ts`
+ * heals when it detects installs. Our resolved path is the directory that HOLDS main.py,
+ * so the two legitimately differ by that one segment. Comparing them naively finds nothing
+ * on exactly the Desktop installs this feature exists for, and a silent no-match is
+ * indistinguishable here from "no drift" — the sentence would simply never appear.
+ */
+function identifiesInstall(recorded: string, ours: string): boolean {
+  return samePath(recorded, ours) || samePath(join(recorded, "ComfyUI"), ours);
+}
+
+/**
+ * The saved launch arguments for the install at `installPath`, or undefined when the
+ * question could not be answered.
+ *
+ * UNDEFINED IS "NOT ESTABLISHED", NOT "NONE" (#796). No file, unreadable file, no entry
+ * for this path, two entries claiming it, or an entry with no `launchArgs` key are all
+ * cases where the caller must stay quiet rather than report an empty set — "Desktop saves
+ * no arguments for this install" is a claim, and a missing file does not support it. An
+ * entry that explicitly saves an EMPTY string is different: that is a real answer, and it
+ * comes back as an empty array.
+ */
+export function desktopSavedLaunchArgs(installPath: string | undefined): SavedLaunchArgs | undefined {
+  if (!installPath?.trim()) return undefined;
+  const matches: SavedLaunchArgs[] = [];
+  for (const dir of desktopConfigDirs()) {
+    let parsed: unknown;
+    try {
+      const file = join(dir, "installations.json");
+      if (!existsSync(file)) continue;
+      parsed = JSON.parse(readFileSync(file, "utf-8"));
+    } catch {
+      // Unreadable or malformed: nothing established.
+      continue;
+    }
+    if (!Array.isArray(parsed)) continue;
+    for (const inst of parsed) {
+      if (!inst || typeof inst !== "object") continue;
+      const rec = inst as Record<string, unknown>;
+      // A remote entry describes a URL, not a local process — its saved arguments say
+      // nothing about the server running here.
+      if (rec.sourceId === "remote" || rec.sourceId === "cloud") continue;
+      if (typeof rec.installPath !== "string" || !identifiesInstall(rec.installPath, installPath))
+        continue;
+      // Desktop writes ONE STRING. An array is accepted too rather than assumed away:
+      // the shape is theirs to change, and a silent mis-read here would produce a
+      // confident sentence about arguments nobody saved.
+      const raw = rec.launchArgs;
+      const args =
+        typeof raw === "string"
+          ? raw.split(/\s+/).filter(Boolean)
+          : Array.isArray(raw) && raw.every((t) => typeof t === "string")
+            ? (raw as string[]).filter(Boolean)
+            : undefined;
+      if (args === undefined) continue;
+      matches.push({
+        name: typeof rec.name === "string" && rec.name.trim() ? rec.name : installPath,
+        args,
+      });
+    }
+  }
+  // AMBIGUITY DECLINES. Two entries claiming the same path cannot both be the install
+  // whose settings the user edited, and picking one would put a specific, checkable
+  // sentence in front of them that may be about the other.
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+/**
+ * The sentence naming saved arguments the running server does not have (#848).
+ *
+ * Returns "" when there is nothing established to say — no saved settings, no running
+ * argv, or nothing missing. Silence is the correct output for all three: the caller
+ * already prints the general "if you were expecting different arguments" remedy, and this
+ * only ever REPLACES a conditional with an observation when one is available.
+ *
+ * ONLY ABSENCE IS REPORTED, never the reverse. A running server carrying arguments the
+ * saved settings do not mention is ordinary — Desktop adds its own — so that direction is
+ * not a finding. And the sentence says the tokens are absent, not that the restart
+ * dropped them or that Desktop ignored them: neither is observed here.
+ */
+export function describeSavedLaunchArgDrift(
+  saved: SavedLaunchArgs | undefined,
+  runningArgv: string[] | undefined,
+): string {
+  if (!saved || !saved.args.length || !runningArgv?.length) return "";
+  const running = new Set(runningArgv);
+  const missing = saved.args.filter((tok) => !running.has(tok));
+  if (!missing.length) return "";
+  return (
+    ` ComfyUI Desktop's saved launch settings for "${saved.name}" include ` +
+    `${missing.join(" ")}, which the running server's arguments do NOT contain — so that ` +
+    `change is not in effect. It is applied when Desktop itself spawns the server: fully ` +
+    `quit the ComfyUI Desktop app and relaunch it.`
+  );
+}

--- a/src/services/desktop-launch-args.ts
+++ b/src/services/desktop-launch-args.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve, sep } from "node:path";
 
@@ -30,6 +30,9 @@ export interface SavedLaunchArgs {
   args: string[];
 }
 
+/** Desktop's own file is a few kilobytes; anything far larger is not it. */
+const MAX_INSTALLATIONS_BYTES = 4 * 1024 * 1024;
+
 /** The Desktop config directories, in the same order `config.ts` reads them. */
 function desktopConfigDirs(): string[] {
   const home = homedir();
@@ -40,11 +43,24 @@ function desktopConfigDirs(): string[] {
   ];
 }
 
-/** Case- and separator-insensitive path identity, since Desktop and our config can
- *  disagree on trailing slashes and (on Windows) case. */
+/**
+ * Path identity, tolerant of trailing separators — and of CASE only where the filesystem
+ * is (codex).
+ *
+ * Folding case everywhere is wrong on Linux, where `/home/u/ComfyUI` and `/home/u/comfyui`
+ * are two different installs: the drift sentence would be attributed to the wrong one and
+ * name a flag the user never put there. Windows is case-insensitive, and it is the
+ * platform whose config layout this file is mostly about, so the fold is scoped to it.
+ *
+ * macOS is usually — not always — case-insensitive, and guessing is not worth it: a
+ * mismatch there DECLINES, which costs a sentence rather than printing a wrong one.
+ */
 function samePath(a: string, b: string): boolean {
-  const norm = (p: string) =>
-    resolve(p.trim()).replace(new RegExp(`\\${sep}+$`), "").toLowerCase();
+  const fold = process.platform === "win32";
+  const norm = (p: string) => {
+    const resolved = resolve(p.trim()).replace(new RegExp(`\\${sep}+$`), "");
+    return fold ? resolved.toLowerCase() : resolved;
+  };
   try {
     return norm(a) === norm(b);
   } catch {
@@ -103,6 +119,13 @@ export function desktopSavedLaunchArgs(installPath: string | undefined): SavedLa
     try {
       const file = join(dir, "installations.json");
       if (!existsSync(file)) continue;
+      // A SIZE BOUND (codex P3). This runs while composing the restart REPORT, and the
+      // answer is worth one small local JSON read — not an unbounded slurp of whatever
+      // happens to sit at that name. It does not make the read non-blocking, which is the
+      // honest residual: a redirected roaming profile on a slow share can still cost this
+      // report a moment. The restart itself has already happened by then, and this path
+      // already makes synchronous process-table and network probes.
+      if (statSync(file).size > MAX_INSTALLATIONS_BYTES) continue;
       parsed = JSON.parse(readFileSync(file, "utf-8"));
     } catch {
       // Unreadable or malformed: nothing established.

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -34,6 +34,10 @@ import {
 } from "./instance-witness.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
+import {
+  desktopSavedLaunchArgs,
+  describeSavedLaunchArgDrift,
+} from "./desktop-launch-args.js";
 import { findComfyuiPython } from "./env-capabilities.js";
 import {
   readLiveProcessEnv,
@@ -3850,7 +3854,18 @@ async function restartViaManagerRebootDispatch(
   }
   const argvNote =
     targetStable && identityContinuous
-      ? describeArgvDrift(priorArgv, afterArgv, context.isDesktop === true)
+      ? describeArgvDrift(priorArgv, afterArgv, context.isDesktop === true) +
+        // #848: and where the SAVED settings can be read, replace the conditional
+        // remedy with the observation. "If you were expecting different arguments" is
+        // a hint the user has to evaluate; naming the flag they added and confirming
+        // it is not in force is the answer they came for. Silent whenever the settings
+        // could not be established — a missing file is not evidence of agreement.
+        (context.isDesktop === true
+          ? describeSavedLaunchArgDrift(
+              desktopSavedLaunchArgs(config.comfyuiPath ?? undefined),
+              afterArgv,
+            )
+          : "")
       : "";
 
   return {

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1096,6 +1096,14 @@ export function describeArgvDrift(
   before: string[] | undefined,
   after: string[] | undefined,
   isDesktop: boolean,
+  /**
+   * The saved-settings finding (#848), when one could be established. It ANSWERS the
+   * question the conditional remedy below can only ask, so it REPLACES that remedy rather
+   * than following it: printed together, the user reads "if you were expecting different
+   * arguments…" immediately before "your --disable-dynamic-vram is not in force", which
+   * hedges a fact we just established and then repeats the same remedy twice.
+   */
+  savedNote = "",
 ): string {
   if (!before?.length || !after?.length) return "";
   const unchanged =
@@ -1108,7 +1116,7 @@ export function describeArgvDrift(
     return (
       ` Its launch arguments CHANGED between the reading taken before this restart request and the one taken now: before ${before
         .map(quoteToken)
-        .join(" ")} / now ${after.map(quoteToken).join(" ")}.`
+        .join(" ")} / now ${after.map(quoteToken).join(" ")}.` + savedNote
     );
   }
   // WHAT EQUAL ARGV ESTABLISHES (codex gate, twice). Two readings matched. That is
@@ -1123,9 +1131,12 @@ export function describeArgvDrift(
   // What IS supportable is the present state — the arguments in force NOW are the
   // old ones — so the remedy hangs off that, conditioned on the user's own
   // expectation, which only they can check.
+  const observed = ` Its launch arguments are UNCHANGED (${after.map(quoteToken).join(" ")}) — the same arguments were observed before this restart request and again now.`;
+  // A read of the user's actual settings beats a guess about their expectations.
+  if (savedNote) return observed + savedNote;
   return (
-    ` Its launch arguments are UNCHANGED (${after.map(quoteToken).join(" ")}) — the same arguments were observed before this restart request and again now. ` +
-    "If you were expecting different arguments" +
+    observed +
+    " If you were expecting different arguments" +
     (isDesktop
       ? " (after editing ComfyUI Desktop's saved launch settings, say), they are not in effect here: fully quit the ComfyUI Desktop app and relaunch it so it spawns the server from those settings."
       : " (after editing the launch command on the host, say), they are not in effect here: stop ComfyUI and start it again from its own launcher so the new arguments are used.")
@@ -3854,18 +3865,22 @@ async function restartViaManagerRebootDispatch(
   }
   const argvNote =
     targetStable && identityContinuous
-      ? describeArgvDrift(priorArgv, afterArgv, context.isDesktop === true) +
-        // #848: and where the SAVED settings can be read, replace the conditional
-        // remedy with the observation. "If you were expecting different arguments" is
-        // a hint the user has to evaluate; naming the flag they added and confirming
-        // it is not in force is the answer they came for. Silent whenever the settings
-        // could not be established — a missing file is not evidence of agreement.
-        (context.isDesktop === true
-          ? describeSavedLaunchArgDrift(
-              desktopSavedLaunchArgs(config.comfyuiPath ?? undefined),
-              afterArgv,
-            )
-          : "")
+      ? describeArgvDrift(
+          priorArgv,
+          afterArgv,
+          context.isDesktop === true,
+          // #848: where the SAVED settings can be read, the finding REPLACES the
+          // conditional remedy inside that function — "if you were expecting different
+          // arguments" is a question, and this is the answer. Silent whenever the
+          // settings could not be established: a missing file is not evidence of
+          // agreement.
+          context.isDesktop === true
+            ? describeSavedLaunchArgDrift(
+                desktopSavedLaunchArgs(config.comfyuiPath ?? undefined),
+                afterArgv,
+              )
+            : "",
+        )
       : "";
 
   return {


### PR DESCRIPTION
Claiming #848.

**What already shipped.** The reporting half landed in v0.50.0 (#850): a restart now reports whether the server's launch arguments changed, and for a Desktop instance it says to fully quit and relaunch the app. The reporter was on 0.49.5 and never saw it.

**What is still missing.** That sentence is conditioned on the user's own expectation — *"if you were expecting different arguments"* — because the code never opens the saved settings. #848's actual complaint is that a configuration change "appears to succeed while silently not taking effect", and the user is left to notice that themselves.

Comfy Desktop records `launchArgs` per installation in `installations.json` (a space-separated string; verified against a real file on this machine). We already read that file for install paths. Reading the saved arguments for the install the running instance belongs to turns the conditional into an observation:

> Desktop's saved launch settings for this install include `--disable-dynamic-vram`, which the running server's arguments do not contain.

**What this will NOT do.** It will not apply the arguments. A Desktop backend is Electron-supervised and deliberately never killed (#400: killing it does not reliably bring the listener back), and a Manager reboot re-execs the running process, so nothing we control can inject new launch arguments — only the Desktop app can, at its own launch. Claiming otherwise would be the same false-success this issue is about, pointed the other way.

Three states throughout: saved settings unreadable or no unambiguous entry ⇒ say nothing new; saved arguments all present ⇒ nothing to report; a saved argument absent from the running argv ⇒ name it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)