### PR TITLE
chore(release): 0.51.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.1] - 2026-08-11
+
+### MCP
+
+#### Fixed
+- name the Desktop launch arguments that did not take effect (#1414)
+- the smoke mock implements what it advertises (#1412)
+
+
 ## [0.50.115] - 2026-08-11
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.50.115",
+  "version": "0.51.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.50.115",
+      "version": "0.51.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump for the v0.51.1 tag (published from the tag).

- **#848** a Desktop restart now NAMES the saved launch argument that is not in force, instead of asking whether you were expecting a different one. It does not apply it, and says so — an Electron-supervised backend is never killed here (#400) and a Manager reboot re-execs the running process, so only Desktop can apply its own settings.
- **#1384** the knowledge-parity smoke's mock panel stops lying to the agent driving it: it answers in the product's reply shapes, refuses a workflow it cannot load instead of reporting a load of nothing, and its verdict requires that the pack was applied AND the canvas changed.

Verified on main: full suite 459 files / 8771 tests green; the #848 reader checked against this machine's real `installations.json`; a live parity-smoke run exercised the `graph_load` path and correctly credited the canvas with zero `graph_add_node` calls — the false-FAIL that review caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)