### PR TITLE
chore(release): 0.51.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.2] - 2026-08-11
+
+### MCP
+
+#### Fixed
+- ui-bridge.test.ts flakes in isolation, not just under load (#1419)
+
+
 ## [0.51.1] - 2026-08-11
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.1",
+      "version": "0.51.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump for the v0.51.2 tag (published from the tag). **Test-only — no product code changed.**

**#1325** — a starved test runner no longer decides these tests.

`vi.waitFor`'s default timeout is **one second**, and `testTimeout` does not govern it: waitFor rejects on its own deadline carrying the last assertion from its callback, so CPU starvation reported *"expected false to be true"* instead of a timeout. That disguise is why this was never connected to #852, which raised `testTimeout` to 30s for the same starvation, noting *"nothing about the code under test is racy; the measurement apparatus was"*.

290 waits across 14 files inherited that 1s; `ui-bridge.test.ts` holds 193 of them, which is why it is the file that visibly flaked across six different tests.

They now route through one helper that supplies a 15s default and changes **nothing else** — an explicit timeout passes through untouched (two of them are genuine bounded-time assertions that the first version silently rewrote), and the polling interval stays vitest's own.

**Verified under the condition that reproduced it:** with 14 CPU-burning processes alongside — confirmed still running afterwards, since an earlier A/B of mine was invalidated by the load window expiring — unfixed main failed 2 of 6 runs, and this fixes 0 of 8.

**Stated limit:** 15s is not proven sufficient under heavier load. #1325 stays open until the suite has run clean for a while.

🤖 Generated with [Claude Code](https://claude.com/claude-code)