### PR TITLE
fix(1352): a human fetching a credential is not a stalled operation

### DIFF
--- a/src/__tests__/orchestrator/secret-card-timeout-truth.test.ts
+++ b/src/__tests__/orchestrator/secret-card-timeout-truth.test.ts
@@ -21,11 +21,12 @@
 // card so an internal MCP client does not kill the request first (#325); moving one
 // means moving the other, which is the design decision #1352 is really asking for.
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   buildPanelToolDefs,
   makePanelToolCtx,
+  __panelAskTestHooks,
   type PanelToolCtx,
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
@@ -40,10 +41,24 @@ const REPLY_TIMEOUT = () =>
       `may be backgrounded or frozen`,
   );
 
-function bridge(fail: Error) {
+/** What the tool actually put on the wire, so the ask_id can be asserted rather than
+ *  assumed — a double that ignores the command cannot tell whether one was sent. */
+const sentCommands: Record<string, unknown>[] = [];
+
+function bridge(fail: Error, lateAnswer?: { value: unknown }) {
   return {
-    send: async () => {
+    send: async (cmd: Record<string, unknown>) => {
+      sentCommands.push(cmd);
       throw fail;
+    },
+    // #1352 — the grace poll asks the bridge for a late answer keyed by ask id. Supplying
+    // one here is what distinguishes "nobody typed it" from "they typed it a moment late",
+    // which are the two outcomes this tool now has to tell apart.
+    takeLateAskReply: () => {
+      if (!lateAnswer) return undefined;
+      const v = lateAnswer.value;
+      lateAnswer.value = undefined; // claimed once, like the real buffer
+      return v;
     },
     push: () => 1,
     canReach: () => true,
@@ -55,8 +70,8 @@ function bridge(fail: Error) {
   } as unknown as PanelToolCtx["bridge"];
 }
 
-async function requestSecret(fail: Error): Promise<string> {
-  const ctx = makePanelToolCtx(bridge(fail), TAB, new WorkflowTargetStore());
+async function requestSecret(fail: Error, lateAnswer?: { value: unknown }): Promise<string> {
+  const ctx = makePanelToolCtx(bridge(fail, lateAnswer), TAB, new WorkflowTargetStore());
   const def = buildPanelToolDefs().find((d) => d.name === "panel_request_secret");
   if (!def) throw new Error("panel_request_secret is not registered");
   const res: ToolResult = await def.handler(
@@ -67,6 +82,18 @@ async function requestSecret(fail: Error): Promise<string> {
 }
 
 describe("a timed-out secret card is described honestly (#1352)", () => {
+  // #1352 gave this card the ask path's deadline + GRACE, and the grace is a real wait:
+  // on a genuine no-answer the handler now polls for it before reporting. At the shipped
+  // 240s + 45s that is far past any test budget, so drive it at millisecond scale — the
+  // behaviour under test is the ORDER of events, not the size of the numbers.
+  beforeEach(() => {
+    sentCommands.length = 0;
+    __panelAskTestHooks.setAskTiming({ deadlineMs: 5, graceMs: 20, pollMs: 2 });
+  });
+  afterEach(() => {
+    __panelAskTestHooks.setAskTiming(null);
+  });
+
   it("does not accuse the tab of being frozen, or the user of declining", async () => {
     const text = await requestSecret(REPLY_TIMEOUT());
 
@@ -83,14 +110,46 @@ describe("a timed-out secret card is described honestly (#1352)", () => {
     expect(text).toMatch(/no credential was read/);
   });
 
-  it("says a LATE value is discarded — measured, not hedged", async () => {
-    // The claim rests on this card having no ask_id, so the id-keyed late buffer cannot
-    // match it. Hedging here would leave the user waiting for a save that cannot happen.
+  it("says the DEADLINE AND THE GRACE both elapsed — the claim that is true now", async () => {
+    // This test used to assert that a late value is discarded, which was measured and
+    // correct: the card carried no ask_id, so the id-keyed buffer could not match it.
+    // #1352 gave it one and a grace poll, so reaching this message means BOTH windows
+    // closed. The old sentence would now send someone away from a save that works.
     const text = await requestSecret(REPLY_TIMEOUT());
 
-    expect(text).toMatch(/cannot reach this call/);
-    expect(text).toMatch(/discarded rather than saved/);
+    expect(text).toMatch(/deadline AND the/);
+    expect(text).toMatch(/grace/);
+    expect(text).toMatch(/no path back to this call/);
     expect(text).toMatch(/call panel_request_secret again/);
+    // …and it must not resurrect the retired claim.
+    expect(text).not.toMatch(/discarded rather than saved/);
+  });
+
+  it("APPLIES a value that arrives during the grace, and says it was late", async () => {
+    // The point of the change. The card deadline fires, the human is still typing, and the
+    // answer lands a moment later — it is applied rather than thrown away.
+    //
+    // The value is deliberately one the tool will refuse to persist (whitespace), so this
+    // test exercises the RECOVERY without writing a credential anywhere: what is asserted
+    // is that the late answer reached the handler at all, which "No token entered" proves
+    // and a timeout message would disprove.
+    const text = await requestSecret(REPLY_TIMEOUT(), { value: "   " });
+
+    expect(text).toMatch(/No token entered/);
+    expect(text).not.toMatch(/no path back to this call/);
+  });
+
+  it("SENDS an ask_id, which is the only thing that makes a late answer recoverable", async () => {
+    // The bridge buffers a late reply only for a command that carried an ask_id
+    // (ui-bridge.ts, the askRidToId registration). Without one the grace poll above can
+    // never find anything — and a test double that answers regardless would not notice,
+    // which is exactly what mutation testing caught here.
+    await requestSecret(REPLY_TIMEOUT());
+
+    expect(sentCommands).toHaveLength(1);
+    expect(sentCommands[0].cmd).toBe("request_secret");
+    expect(typeof sentCommands[0].ask_id).toBe("string");
+    expect(String(sentCommands[0].ask_id).length).toBeGreaterThan(8);
   });
 
   it("keeps the masked-input rule — never route a secret through the conversation", async () => {
@@ -107,6 +166,6 @@ describe("a timed-out secret card is described honestly (#1352)", () => {
 
     expect(text).toMatch(/Panel tab is not open/);
     expect(text).not.toMatch(/very likely just time/);
-    expect(text).not.toMatch(/discarded rather than saved/);
+    expect(text).not.toMatch(/no path back to this call/);
   });
 });

--- a/src/__tests__/orchestrator/secret-card-timeout-truth.test.ts
+++ b/src/__tests__/orchestrator/secret-card-timeout-truth.test.ts
@@ -152,6 +152,19 @@ describe("a timed-out secret card is described honestly (#1352)", () => {
     expect(String(sentCommands[0].ask_id).length).toBeGreaterThan(8);
   });
 
+  it("a LATE arrival is announced as an arrival, never as a save", async () => {
+    // The note prefixes EVERY outcome, failures included. A token that lands during the
+    // grace and then fails to persist would otherwise be announced as applied by the very
+    // message explaining that it was not — so the note states only WHEN it arrived and
+    // leaves what happened to the rest of the result.
+    const text = await requestSecret(REPLY_TIMEOUT(), { value: "   " });
+    expect(text).toMatch(/arrived AFTER the/);
+    expect(text).toMatch(/grace period/);
+    expect(text).not.toMatch(/was still applied/);
+    // …and this particular late value was NOT saved, which the result still says plainly.
+    expect(text).toMatch(/No token entered/);
+  });
+
   it("keeps the masked-input rule — never route a secret through the conversation", async () => {
     // #952's finding: suggesting the conversational route defeats the entire purpose of
     // this tool. A recovery path is exactly where that would slip back in.

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -40,6 +40,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { waitFor } from "../helpers/wait-for.js";
+import { logger } from "../../utils/logger.js";
 
 /**
  * A real on-disk panel pack under a resolved base. The skew resolver re-reads
@@ -4405,6 +4406,16 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
     });
     const journaled: unknown[] = [];
     bridge.setLateAskReplySink((askId, result) => journaled.push({ askId, result }));
+    // Capture every log level for the duration — verified against the real bridge with a
+    // canary token, which is how this assertion earned its place.
+    const logged: unknown[] = [];
+    const levels = ["debug", "info", "warn", "error"] as const;
+    const originals = levels.map((l) => [l, logger[l]] as const);
+    for (const l of levels) {
+      (logger as unknown as Record<string, unknown>)[l] = (...args: unknown[]) => {
+        logged.push(args);
+      };
+    }
     sock.on("message", (buf) => {
       const msg = JSON.parse(buf.toString());
       if (msg.rid && msg.cmd === "request_secret") {
@@ -4431,6 +4442,10 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
     // the id — a sink that recorded the value under a different key would still be a leak.
     expect(journaled).toEqual([]);
     expect(JSON.stringify(journaled)).not.toContain("sk-live-TOKEN");
+    // …and it reached no LOG LINE either, at any level. A journal is the obvious place a
+    // credential must not land; a debug line is the easy one to add later without noticing.
+    expect(JSON.stringify(logged)).not.toContain("sk-live-TOKEN");
+    for (const [l, fn] of originals) (logger as unknown as Record<string, unknown>)[l] = fn;
     bridge.setLateAskReplySink(() => {});
   });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -4393,6 +4393,47 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
     expect(bridge.takeLateAskReply("ask-xyz")).toBeUndefined(); // drained once
   });
 
+  // #1352 — the same recovery for a CREDENTIAL, minus the one property that makes it
+  // durable. A secret card's late answer must be claimable in memory, because a user who
+  // finishes typing a moment late should still have their token applied — and it must
+  // NEVER reach the journal, because `panel_request_secret` exists so the value lands
+  // nowhere it can be read back.
+  it("buffers a late request_secret answer but NEVER hands it to the durable sink", async () => {
+    const sock = await connectPanel("tab-secret", "wf");
+    await waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-secret")).toBe(true), {
+      timeout: 3000,
+    });
+    const journaled: unknown[] = [];
+    bridge.setLateAskReplySink((askId, result) => journaled.push({ askId, result }));
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "request_secret") {
+        setTimeout(() => {
+          sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: "sk-live-TOKEN" }));
+        }, 80);
+      }
+    });
+
+    await expect(
+      bridge.send(
+        { cmd: "request_secret", ask_id: "secret-1", label: "token" },
+        { tabId: "tab-secret", timeoutMs: 30 },
+      ),
+    ).rejects.toThrow(/did not reply/i);
+
+    // Recoverable in memory: this is what lets a late token still be applied.
+    await waitFor(() => expect(bridge.takeLateAskReply("secret-1")).toBe("sk-live-TOKEN"), {
+      timeout: 3000,
+    });
+    // …and drained on claim, so it does not linger.
+    expect(bridge.takeLateAskReply("secret-1")).toBeUndefined();
+    // THE POINT: the durable journal never saw it. Asserted on the whole payload, not just
+    // the id — a sink that recorded the value under a different key would still be a leak.
+    expect(journaled).toEqual([]);
+    expect(JSON.stringify(journaled)).not.toContain("sk-live-TOKEN");
+    bridge.setLateAskReplySink(() => {});
+  });
+
   // The buffer only helps a caller that is still alive to poll it, and #486 is
   // exactly the case where there is none — the tools/call that asked has been
   // abandoned. The SINK is what makes the answer durable: it fires at arrival,

--- a/src/orchestrator/ask-answer-journal.ts
+++ b/src/orchestrator/ask-answer-journal.ts
@@ -661,11 +661,17 @@ export class AskAnswerJournalImpl {
   }
 
   /** Does this journal know the ask id — i.e. is a late answer for it one of
-   *  OURS? The bridge's late-answer sink is fed by every `ask_user` card
-   *  (confirm/consent/secret gates included) and only `panel_ask` answers belong
-   *  here; those other cards have their own, deliberately non-recoverable paths
-   *  (a recovered "Yes, go ahead" must never authorise a different destructive
-   *  operation). */
+   *  OURS? The bridge's late-answer sink is fed by the ask cards, and only
+   *  `panel_ask` answers belong here; the others have their own, deliberately
+   *  non-recoverable paths (a recovered "Yes, go ahead" must never authorise a
+   *  different destructive operation).
+   *
+   *  SECRET CARDS NO LONGER REACH THE SINK AT ALL (#1352). They are recoverable
+   *  now — a credential typed a moment late is applied rather than dropped — but
+   *  only from the bridge's in-memory buffer, because journaling is durable by
+   *  design and that is the one property a credential must not have. This prefix
+   *  check would also decline them; the bridge declines first, deliberately, so
+   *  the guarantee does not rest on a policy that lives in another file. */
   tracks(askId: string): boolean {
     return askId.startsWith(PANEL_ASK_ID_PREFIX);
   }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -9384,9 +9384,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         /** A recovered answer must never read as an ordinary one (#486's rule, here). */
         const lateAware = (r: ToolResult): ToolResult => {
           if (!arrivedLate) return r;
+          // ARRIVAL ONLY — never "and was applied". This prefixes EVERY outcome, failures
+          // included: a token that lands during the grace and then fails to persist
+          // (`secretNotPersisted`, a damaged store, an unconfirmed write) would otherwise
+          // be announced as applied by the very message explaining that it was not. The
+          // rest of the result already says what happened; this says only WHEN it arrived.
           const note =
             `(This token arrived AFTER the ${Math.round(timing.deadlineMs / 1000)}s card ` +
-            `deadline, within the grace period, and was still applied.) `;
+            `deadline, within the grace period that follows it.) `;
           const [first, ...rest] = r.content;
           return first && first.type === "text"
             ? { ...r, content: [{ ...first, text: note + first.text }, ...rest] }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -9359,11 +9359,56 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         hint: z.string().optional().describe("Optional reassurance/help text shown under the input."),
       },
       async (args: A, ctx) => {
+        // #1352 — A HUMAN FETCHING A CREDENTIAL IS NOT A STALLED OPERATION, and a flat
+        // 300s treated it as one.
+        //
+        // Waiting longer is NOT available: the enclosing MCP `tools/call` is killed at
+        // ~300s (see ASK_TOTAL_BUDGET_CAP_MS), so this card already sat at the framework
+        // ceiling. A bigger number only moves the kill from our timer to theirs, where the
+        // answer is lost instead of handled — the #360 lesson the confirm cards learned and
+        // this one did not.
+        //
+        // So it gets the STRUCTURE the ask path has: a deadline clamped under the budget,
+        // then a bounded grace poll of the late-answer buffer. Someone who finishes typing
+        // a second after the deadline now has their token APPLIED rather than discarded.
+        const timing = getAskTiming();
+        const budgetEnd = Date.now() + timing.deadlineMs + timing.graceMs;
+        // The ask_id is what makes a late answer recoverable at all (#486) — the bridge
+        // only buffers a reply whose command carried one, and this card never sent one.
+        //
+        // The bridge treats a `request_secret` card as SENSITIVE from the command name: it
+        // buffers the late value in memory but never hands it to the DURABLE late-answer
+        // journal. A credential must not be written down, which is why this tool exists.
+        const askId = randomUUID();
+        let arrivedLate = false;
+        /** A recovered answer must never read as an ordinary one (#486's rule, here). */
+        const lateAware = (r: ToolResult): ToolResult => {
+          if (!arrivedLate) return r;
+          const note =
+            `(This token arrived AFTER the ${Math.round(timing.deadlineMs / 1000)}s card ` +
+            `deadline, within the grace period, and was still applied.) `;
+          const [first, ...rest] = r.content;
+          return first && first.type === "text"
+            ? { ...r, content: [{ ...first, text: note + first.text }, ...rest] }
+            : r;
+        };
+        const run = async (): Promise<ToolResult> => {
         try {
-          const secret = await ctx.bridge.send(
-            { cmd: "request_secret", label: args.label, hint: args.hint },
-            { tabId: ctx.tabId, timeoutMs: 300000 },
-          );
+          let secret: unknown;
+          try {
+            secret = await ctx.bridge.send(
+              { cmd: "request_secret", ask_id: askId, label: args.label, hint: args.hint },
+              { tabId: ctx.tabId, timeoutMs: timing.deadlineMs },
+            );
+          } catch (err) {
+            // ONLY a reply timeout is recoverable. Any other failure — no panel, transport
+            // down — is not "they are still typing" and must not be waited out.
+            if (!isReplyTimeoutError(err)) throw err;
+            const late = await pollLateAskReply(ctx.bridge, askId, timing, budgetEnd);
+            if (late === undefined) throw err;
+            secret = late;
+            arrivedLate = true;
+          }
           // A whitespace-only paste must be treated as "nothing entered": it
           // would write and read back cleanly (so the save would be CONFIRMED)
           // while every reader treats a blank as absent, leaving the credential
@@ -9483,28 +9528,35 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // sending someone to fix one is the #1332 defect in a new place.
           //
           // It also has to say what happens to a value entered LATE, because that is the
-          // question the caller will actually have. MEASURED: this card is sent as a raw
-          // `request_secret` command with NO ask_id, and the late-reply buffer
-          // (takeLateAskReply) is keyed BY ask id — so a value typed after the timeout
-          // has no path back to this call. It is discarded, and the tool must be called
-          // again. "It may still arrive" would be a guess, and an expensive one: the
-          // user would wait for a save that cannot happen.
+          // question the caller will actually have. That answer CHANGED in #1352, and this
+          // comment changes with it: the card now carries an ask_id and this handler polls
+          // the late-answer buffer for a bounded grace, so a value typed shortly after the
+          // deadline IS applied. Reaching this branch means the grace elapsed too, and only
+          // then is it true that nothing more can reach this call.
+          //
+          // The previous text asserted the discard as a MEASURED fact, correctly at the
+          // time. A message that outlives the behaviour it describes is worse than none —
+          // someone stops waiting for a save that now works.
           if (isReplyTimeoutError(err)) {
             return fail(
-              `The secret card was not answered within 300s, so NOTHING was saved and no ` +
-                `credential was read. That is very likely just time — the card asks for a ` +
+              `The secret card went unanswered — through its ` +
+                `${Math.round(timing.deadlineMs / 1000)}s deadline AND the ` +
+                `${Math.round(timing.graceMs / 1000)}s grace after it — so NOTHING was saved and ` +
+                `no credential was read. That is very likely just time: the card asks for a ` +
                 `token, and finding one in a password manager or a billing console can take ` +
                 `longer than that. It does NOT mean the tab is frozen, and it does NOT mean ` +
                 `the user declined.\n\n` +
-                `A value typed into that card NOW cannot reach this call: it carries no id ` +
-                `this reply could be matched to, so a late answer is discarded rather than ` +
-                `saved. Ask whether they still want to set it and call panel_request_secret ` +
+                `A value typed into that card DURING the grace WOULD have been applied — that is ` +
+                `what the grace is for. Past it there is no path back to this call, so ask ` +
+                `whether they still want to set it and call panel_request_secret ` +
                 `again when they are ready to paste — the value goes straight from the masked ` +
                 `field into storage, and must never be typed into the conversation.`,
             );
           }
           return fail(err);
         }
+        };
+        return lateAware(await run());
       },
     ),
     def(

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2386,6 +2386,12 @@ export class UiBridge {
               // the one property a secret must not have. So a secret card's late answer is
               // recoverable within this process and nowhere else — and if nothing claims
               // it, it expires unread rather than being written down.
+              //
+              // The journal ALSO declines it on its own (`AskAnswers.tracks` accepts only
+              // panel_ask-prefixed ids), so this is the second of two barriers rather than
+              // the only one. It is still worth having here: that prefix rule is the
+              // JOURNAL's policy, expressed in another file for its own reasons, and a
+              // guarantee about credentials should not depend on it staying that way.
               try {
                 if (!entry.sensitive) this.lateAskSink?.(entry.askId, msg.result, entry.tabId);
               } catch (err) {

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1522,7 +1522,21 @@ export class UiBridge {
    *  caller, instead of being discarded as a "late reply for a timed-out command"
    *  (#486). Timestamped so an abandoned mapping (timeout/disconnect/send-failure
    *  whose late reply never arrives) is TTL-pruned rather than kept forever. */
-  private askRidToId = new Map<string, { askId: string; ts: number; tabId: string }>();
+  private askRidToId = new Map<
+    string,
+    {
+      askId: string;
+      ts: number;
+      tabId: string;
+      /**
+       * This card's answer is a CREDENTIAL (#1352). It may be buffered in memory so a
+       * late-arriving value can still be applied, but it must never reach the durable
+       * late-answer journal: `panel_request_secret` exists precisely so the value lands
+       * nowhere it can be read back, and a journal is exactly such a place.
+       */
+      sensitive?: boolean;
+    }
+  >();
   /**
    * Notified the instant a LATE (post-reply-timeout) ask answer validates (#486).
    *
@@ -2366,8 +2380,14 @@ export class UiBridge {
               // by a live poller; this is what makes an answer given after the
               // tool call died survive at all. Never let a sink fault break the
               // message loop.
+              //
+              // EXCEPT FOR A CREDENTIAL (#1352). The in-memory buffer above is bounded by
+              // a TTL and cleared when claimed; the journal is durable BY DESIGN, which is
+              // the one property a secret must not have. So a secret card's late answer is
+              // recoverable within this process and nowhere else — and if nothing claims
+              // it, it expires unread rather than being written down.
               try {
-                this.lateAskSink?.(entry.askId, msg.result, entry.tabId);
+                if (!entry.sensitive) this.lateAskSink?.(entry.askId, msg.result, entry.tabId);
               } catch (err) {
                 logger.warn(
                   `[ui-bridge] late ask-answer sink threw (the answer is still buffered): ${err instanceof Error ? err.message : String(err)}`,
@@ -4043,10 +4063,19 @@ export class UiBridge {
     const askId = (cmd as { ask_id?: unknown }).ask_id;
     if (typeof askId === "string" && askId) {
       this.pruneLateAsk();
+      // INFERRED FROM THE COMMAND, never from a caller-supplied flag (#1352). A flag is
+      // one forgotten argument away from journaling a credential, and the set of
+      // secret-collecting commands is closed and known here.
+      const sensitive = cmd.cmd === "request_secret";
       // Carry the ROUTED tab id with the mapping: the late-reply branch runs in a
       // scope that only knows the socket, and the journal needs the tab the card
       // was rendered on to address the answer.
-      this.askRidToId.set(rid, { askId, ts: Date.now(), tabId: ctx.tabId });
+      this.askRidToId.set(rid, {
+        askId,
+        ts: Date.now(),
+        tabId: ctx.tabId,
+        ...(sensitive ? { sensitive: true } : {}),
+      });
     }
     // Rewrite an old-panel "Unknown command" rejection into an actionable
     // update-your-panel message (see makeUnknownCommandError). Applied to the


### PR DESCRIPTION
Claiming the part of #1352 that is still live. The **message** half shipped in #1364 (`1bf9afa`) — a timed-out secret card no longer reads as a frozen tab. Verified on main, two things remain:

```
panel-tools.ts:8623   { cmd: "request_secret", label, hint },
panel-tools.ts:8624   { tabId: ctx.tabId, timeoutMs: 300000 },
```

1. **The 300s deadline is still hard-coded** on the bridge send. Someone opening a password manager, a billing dashboard, or another machine is doing exactly what this tool is for, and 300s is a plausible amount of time for it.
2. **A late answer is dropped.** The late-reply buffer keys on `cmd.ask_id` (`ui-bridge.ts:3905`), and `request_secret` sends none — so an answer that validates after the deadline is discarded rather than buffered, unlike an `ask_user` card (#486).

**A constraint that shapes (2), stated up front:** the existing late-answer path hands the value to `lateAskSink`, which writes to a DURABLE JOURNAL. A secret must never go there. Whatever recovers a late secret has to be in-memory only, must never reach that sink, a transcript, or a log — so this cannot simply reuse the `ask_id` mechanism, and I will not wire it up that way.

Question 3 from the issue (what the caller is told) is already answered by #1364; this PR must not regress it — a recovered-late answer and an expired one are different outcomes and have to read differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)