### PR TITLE
fix(1352): reserve time to actually save a recovered token

### DIFF
--- a/src/__tests__/orchestrator/secret-card-timeout-truth.test.ts
+++ b/src/__tests__/orchestrator/secret-card-timeout-truth.test.ts
@@ -165,6 +165,38 @@ describe("a timed-out secret card is described honestly (#1352)", () => {
     expect(text).toMatch(/No token entered/);
   });
 
+  it("stops polling early enough to still SAVE what it accepts (codex P1)", async () => {
+    // The card wait plus the grace fill the whole ask budget, and the enclosing tools/call
+    // is killed shortly after it — so a token accepted at the very END of the grace had
+    // only the leftover framework margin in which to be written and read back. A slow
+    // store would then lose a credential the user DID supply in time.
+    //
+    // The rule this encodes: an answer arriving too late to be persisted SAFELY is not
+    // accepted at all. Better to tell someone their token did not land than to take it and
+    // lose it — they believe they supplied it either way.
+    //
+    // Driven at millisecond scale, where the 10s reserve consumes the whole grace, so the
+    // poll gets a single attempt. An answer that only shows up after that is therefore NOT
+    // taken — and with the reserve removed it would be, which is what makes this a test of
+    // the reserve rather than of the recovery.
+    let calls = 0;
+    const slowBuffer = {
+      get value() {
+        // Absent for the first few polls, then present — a user still typing.
+        return ++calls > 3 ? "sk-late" : undefined;
+      },
+      set value(_v: unknown) {
+        /* claimed-once semantics are irrelevant here */
+      },
+    };
+    __panelAskTestHooks.setAskTiming({ deadlineMs: 5, graceMs: 200, pollMs: 2 });
+    const text = await requestSecret(REPLY_TIMEOUT(), slowBuffer as { value: unknown });
+
+    // Not recovered: the reserve ended the poll before that answer appeared.
+    expect(text).toMatch(/no path back to this call/);
+    expect(text).not.toMatch(/arrived AFTER the/);
+  });
+
   it("keeps the masked-input rule — never route a secret through the conversation", async () => {
     // #952's finding: suggesting the conversational route defeats the entire purpose of
     // this tool. A recovery path is exactly where that would slip back in.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -6874,6 +6874,18 @@ let askTimingOverride: AskTiming | null = null;
 const ASK_TOTAL_BUDGET_CAP_MS = 285_000;
 
 /**
+ * Headroom kept back from a SECRET card's grace so a recovered token can still be written,
+ * read back and reported before the enclosing tools/call is killed (#1352, codex P1).
+ *
+ * The write is a small local file plus a read-back — milliseconds when nothing is in the
+ * way. This is sized for when something IS: a locked store, antivirus inspecting the
+ * write, a slow rewrite. Accepting a credential and then losing it to the framework
+ * deadline is worse than declining it a few seconds earlier, because the user believes
+ * they supplied it.
+ */
+const SECRET_PERSIST_RESERVE_MS = 10_000;
+
+/**
  * The per-request timeout an INTERNAL MCP client must use when calling panel_*
  * tools (#325). Several panel tools are DESIGNED to block on a human well past
  * the MCP SDK's 60s default request timeout: panel_ask / the confirm / consent
@@ -9371,8 +9383,20 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // So it gets the STRUCTURE the ask path has: a deadline clamped under the budget,
         // then a bounded grace poll of the late-answer buffer. Someone who finishes typing
         // a second after the deadline now has their token APPLIED rather than discarded.
+        // RESERVE TIME TO ACTUALLY SAVE IT (codex P1). The card wait plus the grace fill
+        // the whole 285s ask budget, and the enclosing tools/call is killed at ~300s — so
+        // a token recovered at the very end of the grace had only the leftover framework
+        // margin in which to be written, read back, and reported. A slow store (a locked
+        // file, antivirus on the write, a config rewrite) could then lose a credential the
+        // user DID supply in time: precisely the loss this whole change exists to prevent,
+        // moved one step later.
+        //
+        // So the grace stops early enough that anything accepted has room to persist. The
+        // cost is a slightly shorter window to type in; the alternative is accepting a
+        // token and then dropping it, which is worse than never having taken it.
         const timing = getAskTiming();
         const budgetEnd = Date.now() + timing.deadlineMs + timing.graceMs;
+        const pollUntil = budgetEnd - SECRET_PERSIST_RESERVE_MS;
         // The ask_id is what makes a late answer recoverable at all (#486) — the bridge
         // only buffers a reply whose command carried one, and this card never sent one.
         //
@@ -9409,7 +9433,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // ONLY a reply timeout is recoverable. Any other failure — no panel, transport
             // down — is not "they are still typing" and must not be waited out.
             if (!isReplyTimeoutError(err)) throw err;
-            const late = await pollLateAskReply(ctx.bridge, askId, timing, budgetEnd);
+            const late = await pollLateAskReply(ctx.bridge, askId, timing, pollUntil);
             if (late === undefined) throw err;
             secret = late;
             arrivedLate = true;


### PR DESCRIPTION
Codex P1 on #1424 — the same loss, one step later.

`budgetEnd` covered only the card wait and the grace, which together fill the whole 285s ask budget. A token recovered at the very end of the grace then had only the leftover framework margin (~15s) in which to be written, read back and reported — so a locked store, antivirus on the write, or a slow config rewrite could lose a credential the user **did** supply in time. That is precisely the failure #1352 exists to prevent, moved past the point where the fix was looking.

The grace now stops `SECRET_PERSIST_RESERVE_MS` (10s) early. The rule it encodes: an answer arriving too late to be persisted safely is not accepted at all — better to say the token did not land than to take it and lose it, since the user believes they supplied it either way.

**My first test for this was worthless** and mutation testing said so: `pollLateAskReply` checks the buffer once before consulting its deadline, so removing the reserve changed nothing observable. It now drives a buffer that only answers after several polls — a window the reserve cannot reach — and deleting the reserve fails it.

Codex's second finding (the late prefix claiming a failed save "was still applied") was already fixed in `256185c`, which landed after the head it reviewed.

8783 tests green, gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)