### PR TITLE
chore(release): 0.51.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.3] - 2026-08-11
+
+### MCP
+
+#### Fixed
+- reserve time to actually SAVE a recovered token (#1426)
+- a human fetching a credential is not a stalled operation (#1424)
+
+
 ## [0.51.2] - 2026-08-11
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.2",
+  "version": "0.51.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.2",
+      "version": "0.51.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.2",
+  "version": "0.51.3",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Ships #1352.

`panel_request_secret` had a flat 300s deadline and no recovery. **Waiting longer was never available** — the enclosing MCP `tools/call` is killed at ~300s (that is why `ASK_TOTAL_BUDGET_CAP_MS` exists), so the card already sat at the framework ceiling and a bigger number would only move the kill somewhere the answer is lost.

It now has the structure the ask cards got in #360: a deadline clamped under the budget, then a bounded grace poll. A token typed a second after the deadline is **applied** rather than dropped. The grace stops 10s early so anything accepted has room to actually be written and read back — an answer arriving too late to persist safely is declined rather than taken and lost.

**The credential is never journaled.** The late-answer path exists to make answers *durable*, which is the one property a secret must not have. The bridge marks a `request_secret` card sensitive from the command name (not a caller-supplied flag), buffers it in memory only, and skips the durable sink. Verified by driving a canary token through the real bridge over a real socket: recoverable in memory, absent from the journal, absent from every log level, drained on claim.

Codex reviewed and found two: the unbounded persistence window (fixed in #1426) and a prefix that claimed a failed save "was still applied" (already fixed in `256185c`). Mutation testing caught three of my own tests being toothless along the way, including the first version of the reserve test, which passed with the reserve removed.

8783 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)