### PR TITLE
fix(1429): a retarget that lands mid-turn tells the agent its tools were stale

### DIFF
--- a/src/__tests__/orchestrator/retarget-stale-nudge.test.ts
+++ b/src/__tests__/orchestrator/retarget-stale-nudge.test.ts
@@ -1,0 +1,235 @@
+// #1429 — a retarget that lands while a tab is MID-TURN cannot replace that tab's
+// comfyui MCP child, so the rest of that turn is served by a child still pointed
+// at the OLD target. These pin the two halves of telling the agent about it:
+//
+//   * a tab that DEFERRED gets the nudge (it really did spend a turn stale), and
+//   * a tab that was IDLE does NOT (its respawn beat any tool call, so the nudge
+//     would be a false alarm — and a nudge is a real agent TURN, not a log line,
+//     so a spurious one costs the user a response about nothing).
+//
+// The second is the direction that fails silently. `onlyWhenDeferred` could be
+// ignored entirely and every "does the busy tab get told?" assertion would still
+// pass, because the old code delivered the nudge to everyone.
+
+import { describe, expect, it, beforeAll } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+import {
+  retargetIsWorthNudging,
+  retargetRestartArgs,
+  staleTargetNudge,
+} from "../../orchestrator/retarget-nudge.js";
+
+let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
+
+beforeAll(async () => {
+  ({ PanelAgentManager } = await import("../../orchestrator/panel-agent.js"));
+});
+
+/** Same shape as restart-coalesce.test.ts's backend: records every run() and every
+ *  turn text, and can hold a turn open so a tab stays BUSY. */
+class RecordingBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  runCount = 0;
+  turnTexts: string[] = [];
+  autoComplete = true;
+  private releaseTurn: (() => void) | null = null;
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    this.runCount += 1;
+    yield { type: "session", sessionId: "sess-x" };
+    for await (const turn of opts.channel) {
+      this.turnTexts.push(turn.text);
+      if (!this.autoComplete) {
+        await new Promise<void>((resolve) => {
+          this.releaseTurn = resolve;
+        });
+        this.releaseTurn = null;
+      }
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+
+  release(): void {
+    const r = this.releaseTurn;
+    this.releaseTurn = null;
+    r?.();
+  }
+
+  async interrupt(): Promise<void> {
+    this.release();
+  }
+
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+function makeManager(backend: AgentBackend) {
+  return new PanelAgentManager({
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-test",
+    onSay: () => {},
+    onTurn: () => {},
+    makeBackend: () => backend,
+  } as never);
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+const NUDGE = staleTargetNudge("http://127.0.0.1:8188", "https://pod-8188.proxy.runpod.net");
+
+describe("#1429 retarget nudge reaches exactly the tabs that were stale", () => {
+  it("a MID-TURN tab is told, when its deferred respawn finally lands", async () => {
+    const backend = new RecordingBackend();
+    backend.autoComplete = false; // hold the first turn open → tab is BUSY
+    const manager = makeManager(backend);
+
+    manager.send("tab-busy", "render me something");
+    await waitFor(() => backend.turnTexts.length >= 1);
+
+    // The retarget arrives mid-turn: it can only be scheduled.
+    const tally = manager.restartAllForMcpEnv(NUDGE, { onlyWhenDeferred: true });
+    expect(tally).toEqual({ live: 1, applied: 0, scheduled: 1 });
+    // Nothing delivered YET — the turn is still running, and interrupting it to
+    // deliver news is not the trade this makes.
+    expect(backend.turnTexts).toHaveLength(1);
+
+    backend.autoComplete = true;
+    backend.release(); // turn-done → applyPendingRestarts fires the respawn + nudge
+
+    await waitFor(() => backend.turnTexts.includes(NUDGE));
+    expect(backend.turnTexts.filter((t) => t === NUDGE)).toHaveLength(1);
+  });
+
+  it("an IDLE tab is NOT told — its child was replaced before it could run anything", async () => {
+    const backend = new RecordingBackend();
+    backend.autoComplete = true; // turn completes at once → tab goes IDLE
+    const manager = makeManager(backend);
+
+    manager.send("tab-idle", "hello");
+    await waitFor(() => backend.turnTexts.length >= 1);
+    // Let the turn finish so the tab is genuinely idle, not merely un-started.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const before = backend.turnTexts.length;
+    const tally = manager.restartAllForMcpEnv(NUDGE, { onlyWhenDeferred: true });
+    // Applied on the spot — so there was never a stale window to report.
+    expect(tally.scheduled).toBe(0);
+    expect(tally.applied).toBe(1);
+
+    // Give a wrongly-delivered nudge every chance to show up.
+    await new Promise((r) => setTimeout(r, 150));
+    expect(backend.turnTexts.slice(before)).not.toContain(NUDGE);
+    expect(backend.turnTexts).not.toContain(NUDGE);
+  });
+
+  it("does NOT erase a per-request retry nudge already queued for that tab (#164)", async () => {
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+
+    manager.send("tab-both", "download that model");
+    await waitFor(() => backend.turnTexts.length >= 1);
+
+    // A per-request retry nudge is queued first (credentials arrived, #164) …
+    expect(manager.restartForMcpEnv("tab-both", "RETRY the download")).toBe("scheduled");
+    // … then a retarget lands on the same still-busy tab.
+    manager.restartAllForMcpEnv(NUDGE, { onlyWhenDeferred: true });
+
+    backend.autoComplete = true;
+    backend.release();
+
+    await waitFor(() => backend.turnTexts.includes("RETRY the download"));
+    // The more specific nudge survives; the retarget did not overwrite it, and
+    // the tab is not restarted twice to deliver both.
+    expect(backend.turnTexts.filter((t) => t === "RETRY the download")).toHaveLength(1);
+    expect(backend.turnTexts).not.toContain(NUDGE);
+  });
+
+  it("the plain (non-retarget) nudge still reaches an IDLE tab — #164 semantics unchanged", async () => {
+    const backend = new RecordingBackend();
+    backend.autoComplete = true;
+    const manager = makeManager(backend);
+
+    manager.send("tab-plain", "hello");
+    await waitFor(() => backend.turnTexts.length >= 1);
+
+    // No onlyWhenDeferred: this nudge means "the thing you just tried can be
+    // retried NOW", which is exactly right for an idle tab.
+    manager.restartAllForMcpEnv("RETRY");
+    await waitFor(() => backend.turnTexts.includes("RETRY"));
+  });
+});
+
+describe("#1429 nudge wording", () => {
+  it("names BOTH addresses — 'the target moved' alone cannot be acted on", () => {
+    const msg = staleTargetNudge("http://old:8188", "http://new:8188");
+    expect(msg).toContain("http://old:8188");
+    expect(msg).toContain("http://new:8188");
+  });
+
+  it("says the stale address is a likely cause of a failure in that turn", () => {
+    // The reported symptom (#1415-shaped) is a confusing connection failure; an
+    // agent that reads this must not conclude ComfyUI is down.
+    expect(staleTargetNudge("a", "b").toLowerCase()).toContain("retry");
+  });
+
+  it("a first-ever target is a startup seed, not a move — nothing to nudge about", () => {
+    expect(retargetIsWorthNudging(null, "http://127.0.0.1:8188")).toBe(false);
+    expect(retargetIsWorthNudging(undefined, "http://127.0.0.1:8188")).toBe(false);
+    expect(retargetIsWorthNudging("", "http://127.0.0.1:8188")).toBe(false);
+  });
+
+  it("a same-address reaffirmation is not a move either", () => {
+    expect(retargetIsWorthNudging("http://127.0.0.1:8188", "http://127.0.0.1:8188")).toBe(false);
+  });
+
+  it("an actual switch IS worth nudging about", () => {
+    expect(retargetIsWorthNudging("http://127.0.0.1:8188", "https://pod.proxy.net")).toBe(true);
+  });
+});
+
+// The call site is `manager.restartAllForMcpEnv(...retargetRestartArgs(prev, url))`,
+// so these ARE the wiring: a change that dropped the flag would have to change
+// this function, and these assertions, to get through.
+describe("#1429 the arguments the retarget actually passes", () => {
+  it("a real switch passes the nudge AND onlyWhenDeferred", () => {
+    const args = retargetRestartArgs("http://127.0.0.1:8188", "https://pod.proxy.net");
+    expect(args).toHaveLength(2);
+    expect(args[0]).toBe(staleTargetNudge("http://127.0.0.1:8188", "https://pod.proxy.net"));
+    // Without this flag every idle tab is nudged too — the exact false alarm the
+    // deferred-only path exists to prevent.
+    expect(args[1]).toEqual({ onlyWhenDeferred: true });
+  });
+
+  it("a startup seed passes NOTHING — the plain silent respawn", () => {
+    expect(retargetRestartArgs(null, "http://127.0.0.1:8188")).toEqual([]);
+  });
+
+  it("a same-address reaffirmation passes nothing either", () => {
+    expect(retargetRestartArgs("http://x:8188", "http://x:8188")).toEqual([]);
+  });
+
+  it("spreading the empty result is the no-nudge call — not an undefined nudge", () => {
+    // `restartAllForMcpEnv(...[])` must be indistinguishable from `…()`, or the
+    // #164 nudge-preserving branch (which keys on `nudge === undefined`) changes
+    // meaning for every retarget.
+    const [nudge, opts] = retargetRestartArgs(null, "http://127.0.0.1:8188");
+    expect(nudge).toBeUndefined();
+    expect(opts).toBeUndefined();
+  });
+});

--- a/src/__tests__/orchestrator/retarget-stale-nudge.test.ts
+++ b/src/__tests__/orchestrator/retarget-stale-nudge.test.ts
@@ -7,9 +7,14 @@
 //     would be a false alarm — and a nudge is a real agent TURN, not a log line,
 //     so a spurious one costs the user a response about nothing).
 //
-// The second is the direction that fails silently. `onlyWhenDeferred` could be
-// ignored entirely and every "does the busy tab get told?" assertion would still
-// pass, because the old code delivered the nudge to everyone.
+// The second is the direction that fails silently: a retargetAllForMcpEnv that
+// nudged unconditionally would still pass every "does the busy tab get told?"
+// assertion.
+//
+// The rest come from adversarial review of the first cut, and each one produced
+// something worse than silence: an A-to-B message delivered while the child is on
+// C, a per-request retry nudge erased one step removed, and a nudge fired for a
+// target that never actually moved.
 
 import { describe, expect, it, beforeAll } from "vitest";
 import type {
@@ -19,11 +24,7 @@ import type {
   ModelChoice,
 } from "../../orchestrator/agent-backend.js";
 import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
-import {
-  retargetIsWorthNudging,
-  retargetRestartArgs,
-  staleTargetNudge,
-} from "../../orchestrator/retarget-nudge.js";
+import { retargetIsWorthNudging, staleTargetNudge } from "../../orchestrator/retarget-nudge.js";
 
 let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
 
@@ -90,7 +91,9 @@ async function waitFor(cond: () => boolean, timeoutMs = 5000): Promise<void> {
   }
 }
 
-const NUDGE = staleTargetNudge("http://127.0.0.1:8188", "https://pod-8188.proxy.runpod.net");
+const OLD = "http://127.0.0.1:8188";
+const NEW = "https://pod-8188.proxy.runpod.net";
+const NUDGE = staleTargetNudge(OLD, NEW);
 
 describe("#1429 retarget nudge reaches exactly the tabs that were stale", () => {
   it("a MID-TURN tab is told, when its deferred respawn finally lands", async () => {
@@ -102,7 +105,7 @@ describe("#1429 retarget nudge reaches exactly the tabs that were stale", () => 
     await waitFor(() => backend.turnTexts.length >= 1);
 
     // The retarget arrives mid-turn: it can only be scheduled.
-    const tally = manager.restartAllForMcpEnv(NUDGE, { onlyWhenDeferred: true });
+    const tally = manager.retargetAllForMcpEnv(OLD, NEW);
     expect(tally).toEqual({ live: 1, applied: 0, scheduled: 1 });
     // Nothing delivered YET — the turn is still running, and interrupting it to
     // deliver news is not the trade this makes.
@@ -126,7 +129,7 @@ describe("#1429 retarget nudge reaches exactly the tabs that were stale", () => 
     await new Promise((r) => setTimeout(r, 50));
 
     const before = backend.turnTexts.length;
-    const tally = manager.restartAllForMcpEnv(NUDGE, { onlyWhenDeferred: true });
+    const tally = manager.retargetAllForMcpEnv(OLD, NEW);
     // Applied on the spot — so there was never a stale window to report.
     expect(tally.scheduled).toBe(0);
     expect(tally.applied).toBe(1);
@@ -148,7 +151,7 @@ describe("#1429 retarget nudge reaches exactly the tabs that were stale", () => 
     // A per-request retry nudge is queued first (credentials arrived, #164) …
     expect(manager.restartForMcpEnv("tab-both", "RETRY the download")).toBe("scheduled");
     // … then a retarget lands on the same still-busy tab.
-    manager.restartAllForMcpEnv(NUDGE, { onlyWhenDeferred: true });
+    manager.retargetAllForMcpEnv(OLD, NEW);
 
     backend.autoComplete = true;
     backend.release();
@@ -158,6 +161,77 @@ describe("#1429 retarget nudge reaches exactly the tabs that were stale", () => 
     // the tab is not restarted twice to deliver both.
     expect(backend.turnTexts.filter((t) => t === "RETRY the download")).toHaveLength(1);
     expect(backend.turnTexts).not.toContain(NUDGE);
+  });
+
+  it("two retargets in one turn report A-to-C — never the obsolete A-to-B", async () => {
+    // codex finding: keeping the FIRST retarget's message tells the agent it is
+    // on B while its respawned child is on C. Wrong information is worse than
+    // none — it invites the agent to reason about infrastructure that moved on.
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+    const A = "http://127.0.0.1:8188";
+    const B = "https://pod-b.proxy.runpod.net";
+    const C = "https://pod-c.proxy.runpod.net";
+
+    manager.send("tab-abc", "render");
+    await waitFor(() => backend.turnTexts.length >= 1);
+
+    manager.retargetAllForMcpEnv(A, B); // stranded on A
+    manager.retargetAllForMcpEnv(B, C); // still stranded on A — now heading to C
+
+    backend.autoComplete = true;
+    backend.release();
+
+    await waitFor(() => backend.turnTexts.length >= 2);
+    const delivered = backend.turnTexts[backend.turnTexts.length - 1];
+    // The ORIGIN is what the turn actually used, and C is where it is now.
+    expect(delivered).toBe(staleTargetNudge(A, C));
+    expect(backend.turnTexts).not.toContain(staleTargetNudge(A, B));
+    expect(delivered).not.toContain(B);
+  });
+
+  it("a per-request nudge queued AFTER a retarget survives the NEXT retarget", async () => {
+    // codex finding, one step removed from #164: the retarget marker has to be
+    // cleared when a per-request nudge overwrites the queued value, or the next
+    // retarget classifies that nudge as its own and takes it.
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+
+    manager.send("tab-order", "download that model");
+    await waitFor(() => backend.turnTexts.length >= 1);
+
+    manager.retargetAllForMcpEnv(OLD, NEW); // retarget nudge queued
+    expect(manager.restartForMcpEnv("tab-order", "RETRY the download")).toBe("scheduled");
+    manager.retargetAllForMcpEnv(NEW, "https://pod-z.proxy.runpod.net"); // must not steal it
+
+    backend.autoComplete = true;
+    backend.release();
+
+    await waitFor(() => backend.turnTexts.length >= 2);
+    expect(backend.turnTexts.filter((x) => x === "RETRY the download")).toHaveLength(1);
+  });
+
+  it("a same-target reaffirmation that only differs textually nudges NOBODY", async () => {
+    // codex finding: the previous target is the raw COMFYUI_URL, the event carries
+    // the canonical base URL, so a trailing slash reads as a move. A busy tab must
+    // not be charged a whole turn to hear about a target that did not change.
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+
+    manager.send("tab-canon", "render");
+    await waitFor(() => backend.turnTexts.length >= 1);
+
+    const tally = manager.retargetAllForMcpEnv("http://127.0.0.1:8188/", "http://127.0.0.1:8188");
+    expect(tally.scheduled).toBe(1); // the respawn still happens…
+
+    backend.autoComplete = true;
+    backend.release();
+    await new Promise((r) => setTimeout(r, 150));
+    // …but nothing is said about a target that did not move.
+    expect(backend.turnTexts.some((x) => x.includes("target changed"))).toBe(false);
   });
 
   it("the plain (non-retarget) nudge still reaches an IDLE tab — #164 semantics unchanged", async () => {
@@ -203,33 +277,29 @@ describe("#1429 nudge wording", () => {
   });
 });
 
-// The call site is `manager.restartAllForMcpEnv(...retargetRestartArgs(prev, url))`,
-// so these ARE the wiring: a change that dropped the flag would have to change
-// this function, and these assertions, to get through.
-describe("#1429 the arguments the retarget actually passes", () => {
-  it("a real switch passes the nudge AND onlyWhenDeferred", () => {
-    const args = retargetRestartArgs("http://127.0.0.1:8188", "https://pod.proxy.net");
-    expect(args).toHaveLength(2);
-    expect(args[0]).toBe(staleTargetNudge("http://127.0.0.1:8188", "https://pod.proxy.net"));
-    // Without this flag every idle tab is nudged too — the exact false alarm the
-    // deferred-only path exists to prevent.
-    expect(args[1]).toEqual({ onlyWhenDeferred: true });
+describe("#1429 same-target detection (the expensive direction is a FALSE move)", () => {
+  const moved = (a: string, b: string) => retargetIsWorthNudging(a, b);
+
+  it("trailing slash, case and default ports are not moves", () => {
+    expect(moved("http://127.0.0.1:8188/", "http://127.0.0.1:8188")).toBe(false);
+    expect(moved("http://LOCALHOST:8188", "http://localhost:8188")).toBe(false);
+    expect(moved("http://example.com:80", "http://example.com")).toBe(false);
+    expect(moved("https://example.com:443/", "https://example.com")).toBe(false);
   });
 
-  it("a startup seed passes NOTHING — the plain silent respawn", () => {
-    expect(retargetRestartArgs(null, "http://127.0.0.1:8188")).toEqual([]);
+  it("a real move is still a move", () => {
+    expect(moved("http://127.0.0.1:8188", "http://127.0.0.1:8189")).toBe(true);
+    expect(moved("http://127.0.0.1:8188", "https://127.0.0.1:8188")).toBe(true);
+    expect(moved("http://127.0.0.1:8188", "https://pod.proxy.net")).toBe(true);
   });
 
-  it("a same-address reaffirmation passes nothing either", () => {
-    expect(retargetRestartArgs("http://x:8188", "http://x:8188")).toEqual([]);
+  it("a base path is part of the target", () => {
+    expect(moved("http://h:8188/comfyapi", "http://h:8188")).toBe(true);
+    expect(moved("http://h:8188/comfyapi/", "http://h:8188/comfyapi")).toBe(false);
   });
 
-  it("spreading the empty result is the no-nudge call — not an undefined nudge", () => {
-    // `restartAllForMcpEnv(...[])` must be indistinguishable from `…()`, or the
-    // #164 nudge-preserving branch (which keys on `nudge === undefined`) changes
-    // meaning for every retarget.
-    const [nudge, opts] = retargetRestartArgs(null, "http://127.0.0.1:8188");
-    expect(nudge).toBeUndefined();
-    expect(opts).toBeUndefined();
+  it("unparseable input falls back to exact equality rather than guessing", () => {
+    expect(moved("not a url", "not a url")).toBe(false);
+    expect(moved("not a url", "http://127.0.0.1:8188")).toBe(true);
   });
 });

--- a/src/__tests__/orchestrator/retarget-stale-nudge.test.ts
+++ b/src/__tests__/orchestrator/retarget-stale-nudge.test.ts
@@ -234,6 +234,54 @@ describe("#1429 retarget nudge reaches exactly the tabs that were stale", () => 
     expect(backend.turnTexts.some((x) => x.includes("target changed"))).toBe(false);
   });
 
+  it("a BROADCAST per-request nudge is not stolen by the next retarget either", async () => {
+    // Round-2 self-review: restartForMcpEnv cleared the marker but its all-tabs
+    // sibling did not, so the same theft was still reachable one call over.
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+
+    manager.send("tab-broadcast", "download that model");
+    await waitFor(() => backend.turnTexts.length >= 1);
+
+    manager.retargetAllForMcpEnv(OLD, NEW); // retarget nudge queued
+    manager.restartAllForMcpEnv("RETRY the download"); // broadcast nudge replaces it
+    manager.retargetAllForMcpEnv(NEW, "https://pod-z.proxy.runpod.net"); // must not steal it
+
+    backend.autoComplete = true;
+    backend.release();
+
+    await waitFor(() => backend.turnTexts.length >= 2);
+    expect(backend.turnTexts.filter((x) => x === "RETRY the download")).toHaveLength(1);
+  });
+
+  it("a tab renamed mid-turn keeps its retarget classification", async () => {
+    // Round-2 self-review: rebindAgent migrated the queued nudge but not the
+    // marker that says what KIND it is, so after a rename the next retarget read
+    // it as a per-request nudge and preserved an obsolete target.
+    const backend = new RecordingBackend();
+    backend.autoComplete = false;
+    const manager = makeManager(backend);
+    const A = "http://127.0.0.1:8188";
+    const B = "https://pod-b.proxy.runpod.net";
+    const C = "https://pod-c.proxy.runpod.net";
+
+    manager.send("tab-before", "render");
+    await waitFor(() => backend.turnTexts.length >= 1);
+
+    manager.retargetAllForMcpEnv(A, B); // stranded on A, queued under the old key
+    expect(manager.rebindAgent("tab-before", "tab-after")).toBe(true);
+    manager.retargetAllForMcpEnv(B, C); // must still recompose to A->C
+
+    backend.autoComplete = true;
+    backend.release();
+
+    await waitFor(() => backend.turnTexts.length >= 2);
+    const delivered = backend.turnTexts[backend.turnTexts.length - 1];
+    expect(delivered).toBe(staleTargetNudge(A, C));
+    expect(backend.turnTexts).not.toContain(staleTargetNudge(A, B));
+  });
+
   it("the plain (non-retarget) nudge still reaches an IDLE tab — #164 semantics unchanged", async () => {
     const backend = new RecordingBackend();
     backend.autoComplete = true;

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -76,7 +76,6 @@ import {
 } from "./panel-agent.js";
 import { promptText } from "./error-text.js";
 import { callToolAdmission } from "./call-tool-admission.js";
-import { retargetRestartArgs } from "./retarget-nudge.js";
 import {
   createPanelMcpServer,
   makePanelToolCtx,
@@ -5864,7 +5863,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       // A tab that is mid-turn cannot have its comfyui MCP child replaced now, so
       // it keeps serving `previousUrl` until the turn ends (#1429). Tell those
       // tabs — and ONLY those; an idle tab respawns before it can run anything.
-      const tally = manager.restartAllForMcpEnv(...retargetRestartArgs(previousUrl, url));
+      const tally = manager.retargetAllForMcpEnv(previousUrl, url);
       if (tally.scheduled > 0) {
         logger.warn(
           `[panel-orchestrator] ${tally.scheduled} tab(s) mid-turn during the retarget — ` +

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -76,6 +76,7 @@ import {
 } from "./panel-agent.js";
 import { promptText } from "./error-text.js";
 import { callToolAdmission } from "./call-tool-admission.js";
+import { retargetRestartArgs } from "./retarget-nudge.js";
 import {
   createPanelMcpServer,
   makePanelToolCtx,
@@ -5842,6 +5843,9 @@ export async function runPanelOrchestrator(): Promise<void> {
     // siblings' pending promises intact (codex finding).
     if (!machineRetargetInFlight) { pendingPodConnects.clear(); persistPendingConnects(); }
     if (url !== lastRetargetUrl) {
+      // Captured BEFORE the reassignment: the address every mid-turn tab's
+      // comfyui child is still serving, which is what the #1429 nudge names.
+      const previousUrl = lastRetargetUrl;
       lastRetargetUrl = url;
       // Sync the shared target closures FIRST: retargets that did NOT come
       // through applyComfyuiUrl (runpod tools, watcher callbacks) leave them
@@ -5857,7 +5861,16 @@ export async function runPanelOrchestrator(): Promise<void> {
       QueueMonitor.start(url);
       manager.setMcpServers(buildMcpServers());
       manager.setComfyuiUrl(url);
-      manager.restartAllForMcpEnv();
+      // A tab that is mid-turn cannot have its comfyui MCP child replaced now, so
+      // it keeps serving `previousUrl` until the turn ends (#1429). Tell those
+      // tabs — and ONLY those; an idle tab respawns before it can run anything.
+      const tally = manager.restartAllForMcpEnv(...retargetRestartArgs(previousUrl, url));
+      if (tally.scheduled > 0) {
+        logger.warn(
+          `[panel-orchestrator] ${tally.scheduled} tab(s) mid-turn during the retarget — ` +
+            `their comfyui tools stay on ${previousUrl} until the turn ends (#1429)`,
+        );
+      }
       void refreshEnvCapabilities();
     }
     // The readvertise timer follows the target too (created only at startup

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -2177,25 +2177,53 @@ export class PanelAgentManager {
    *  next idle so the turn that SAVED the secret finishes first (we never
    *  interrupt a live reply). `nudge`, if given, is enqueued to each resumed
    *  agent so it auto-continues (e.g. retries the download the secret unblocked). */
-  restartAllForMcpEnv(nudge?: string): McpEnvRestartTally {
+  restartAllForMcpEnv(
+    nudge?: string,
+    opts?: {
+      /** #1429 — deliver `nudge` ONLY to tabs whose restart had to be DEFERRED.
+       *  A retarget nudge says "your tools spent that turn on the old address";
+       *  that is true exactly when the tab was mid-turn. An idle tab respawns
+       *  before it can run anything, so nudging it would be a false alarm — and
+       *  a nudge is a real agent turn (restartAgentResume delivers it as one),
+       *  not a log line, so a false one costs the user a spurious response.
+       *  The per-request retry nudge (#164) means something different — "the
+       *  thing you just tried can be retried now" — and is right to fire on an
+       *  idle tab, so it keeps the default. */
+      onlyWhenDeferred?: boolean;
+    },
+  ): McpEnvRestartTally {
     // Snapshot the key set: applyPendingRestarts REPLACES entries in this.agents
     // (spawn + retire) while we iterate, and mutating a Map during its own
     // iteration is how a tab silently gets skipped.
     const keys = [...this.agents.keys()];
     const tally: McpEnvRestartTally = { live: 0, applied: 0, scheduled: 0 };
+    const deferredOnly = opts?.onlyWhenDeferred === true;
     for (const tabId of keys) {
       // A SILENT env respawn (no nudge) must NOT downgrade a tab that already has
       // a retry nudge queued (#164): a concurrent env change on another tab, or a
       // retarget, would otherwise erase a still-pending per-request nudge before
       // its busy agent could apply it. Keep the existing nudge; still coalesce.
-      if (nudge === undefined && this.pendingMcpRestart.get(tabId)) {
+      //
+      // A deferred-only nudge is silent AT THIS POINT — whether it applies is not
+      // known until the outcome below — so it takes the same branch, and for the
+      // same reason: the queued per-request nudge is the more specific one.
+      if ((nudge === undefined || deferredOnly) && this.pendingMcpRestart.get(tabId)) {
         tallyRestart(tally, this.applyPendingRestarts(tabId));
         continue;
       }
-      this.pendingMcpRestart.set(tabId, nudge ?? null);
+      this.pendingMcpRestart.set(tabId, deferredOnly ? null : (nudge ?? null));
       // Apply immediately when the tab is already idle; otherwise it fires on the
       // next turn-done via applyPendingRestarts().
-      tallyRestart(tally, this.applyPendingRestarts(tabId));
+      const outcome = this.applyPendingRestarts(tabId);
+      // "scheduled" means the tab is mid-turn and its comfyui child goes on
+      // serving the OLD target until this restart lands (#1429). That is the one
+      // case the retarget nudge is about, and the entry is still pending here
+      // (applyPendingRestarts only clears it when it APPLIES), so upgrading the
+      // queued value now is what makes it ride along with the deferred respawn.
+      if (deferredOnly && nudge !== undefined && outcome === "scheduled") {
+        this.pendingMcpRestart.set(tabId, nudge);
+      }
+      tallyRestart(tally, outcome);
     }
     return tally;
   }

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -29,6 +29,7 @@ import type { AgentBackend, AgentEvent, NeutralTurn } from "./agent-backend.js";
 import { type AudioRef, dedupeAudioRefs, noAudioPartText } from "./audio-attachment.js";
 import { runErrorNotice } from "./cli-remedy.js";
 import { runCompletionDirective } from "./todo-state.js";
+import { retargetIsWorthNudging, staleTargetNudge } from "./retarget-nudge.js";
 import {
   ClaudeBackend,
   fetchSupportedModels,
@@ -2033,6 +2034,12 @@ export class PanelAgentManager {
    *  an optional nudge to enqueue after the resumed agent comes back (e.g. "retry
    *  the download"). Applied at the next idle so the saving turn finishes first. */
   private pendingMcpRestart = new Map<string, string | null>();
+  /** #1429 — tabs whose queued MCP-restart nudge is a RETARGET nudge, mapped to
+   *  the EARLIEST address they were stranded on. Two jobs: it tells a retarget
+   *  nudge apart from a per-request retry nudge (#164, which must never be
+   *  overwritten), and it makes A→B→C inside one turn report A→C rather than the
+   *  obsolete A→B. Cleared wherever pendingMcpRestart is. */
+  private pendingRetargetFrom = new Map<string, string>();
   /** Default model/effort for newly-spawned agents (the env/config defaults). */
   private model: string;
   private effort?: Effort;
@@ -2177,51 +2184,84 @@ export class PanelAgentManager {
    *  next idle so the turn that SAVED the secret finishes first (we never
    *  interrupt a live reply). `nudge`, if given, is enqueued to each resumed
    *  agent so it auto-continues (e.g. retries the download the secret unblocked). */
-  restartAllForMcpEnv(
-    nudge?: string,
-    opts?: {
-      /** #1429 — deliver `nudge` ONLY to tabs whose restart had to be DEFERRED.
-       *  A retarget nudge says "your tools spent that turn on the old address";
-       *  that is true exactly when the tab was mid-turn. An idle tab respawns
-       *  before it can run anything, so nudging it would be a false alarm — and
-       *  a nudge is a real agent turn (restartAgentResume delivers it as one),
-       *  not a log line, so a false one costs the user a spurious response.
-       *  The per-request retry nudge (#164) means something different — "the
-       *  thing you just tried can be retried now" — and is right to fire on an
-       *  idle tab, so it keeps the default. */
-      onlyWhenDeferred?: boolean;
-    },
-  ): McpEnvRestartTally {
+  restartAllForMcpEnv(nudge?: string): McpEnvRestartTally {
     // Snapshot the key set: applyPendingRestarts REPLACES entries in this.agents
     // (spawn + retire) while we iterate, and mutating a Map during its own
     // iteration is how a tab silently gets skipped.
     const keys = [...this.agents.keys()];
     const tally: McpEnvRestartTally = { live: 0, applied: 0, scheduled: 0 };
-    const deferredOnly = opts?.onlyWhenDeferred === true;
     for (const tabId of keys) {
       // A SILENT env respawn (no nudge) must NOT downgrade a tab that already has
       // a retry nudge queued (#164): a concurrent env change on another tab, or a
       // retarget, would otherwise erase a still-pending per-request nudge before
       // its busy agent could apply it. Keep the existing nudge; still coalesce.
-      //
-      // A deferred-only nudge is silent AT THIS POINT — whether it applies is not
-      // known until the outcome below — so it takes the same branch, and for the
-      // same reason: the queued per-request nudge is the more specific one.
-      if ((nudge === undefined || deferredOnly) && this.pendingMcpRestart.get(tabId)) {
+      if (nudge === undefined && this.pendingMcpRestart.get(tabId)) {
         tallyRestart(tally, this.applyPendingRestarts(tabId));
         continue;
       }
-      this.pendingMcpRestart.set(tabId, deferredOnly ? null : (nudge ?? null));
+      this.pendingMcpRestart.set(tabId, nudge ?? null);
       // Apply immediately when the tab is already idle; otherwise it fires on the
       // next turn-done via applyPendingRestarts().
+      tallyRestart(tally, this.applyPendingRestarts(tabId));
+    }
+    return tally;
+  }
+
+  /**
+   * #1429 — the ComfyUI target moved, so every tab's comfyui MCP child must be
+   * respawned to learn the new address. Identical to restartAllForMcpEnv() except
+   * for what a MID-TURN tab is told afterwards.
+   *
+   * A tab that is busy cannot have its child replaced now, so it goes on serving
+   * `from` for the rest of that turn. It gets a nudge naming both addresses. A
+   * tab that is IDLE respawns before it can run anything and gets NOTHING: a
+   * nudge is a real agent turn (restartAgentResume delivers it as one), not a log
+   * line, so a false one costs the user a response about nothing.
+   *
+   * Two orderings this has to get right, both found in adversarial review:
+   *
+   *   * A per-request retry nudge (#164, "the download you just tried can be
+   *     retried now") is MORE SPECIFIC than a retarget nudge and must never be
+   *     overwritten by one — hence pendingRetargetFrom, which is what tells the
+   *     two apart when a nudge is already queued.
+   *   * Two retargets inside one turn (A→B then B→C) must tell the agent A→C.
+   *     Keeping the first message would state a target the respawned child is
+   *     NOT on, which is worse than saying nothing — so the ORIGIN is what
+   *     persists, and the message is recomposed against the current target.
+   */
+  retargetAllForMcpEnv(from: string | null | undefined, to: string): McpEnvRestartTally {
+    // A startup seed (no previous target) or a same-address reaffirmation is not
+    // a move: nothing ever ran against a different address, so there is nothing
+    // to report and this degrades to the ordinary silent respawn.
+    if (!retargetIsWorthNudging(from, to)) return this.restartAllForMcpEnv();
+
+    const keys = [...this.agents.keys()];
+    const tally: McpEnvRestartTally = { live: 0, applied: 0, scheduled: 0 };
+    for (const tabId of keys) {
+      const queued = this.pendingMcpRestart.get(tabId);
+      const queuedIsRetarget = this.pendingRetargetFrom.has(tabId);
+      // #164: a queued PER-REQUEST nudge wins outright. (A queued `null` is a
+      // silent pending respawn — no payload to protect — so it falls through.)
+      if (queued && !queuedIsRetarget) {
+        tallyRestart(tally, this.applyPendingRestarts(tabId));
+        continue;
+      }
+      // The EARLIEST address this tab was stranded on is the true `from`.
+      const origin = this.pendingRetargetFrom.get(tabId) ?? (from as string);
+      // Recompose BEFORE applying, not after: if the tab went idle in between,
+      // applyPendingRestarts delivers whatever is queued right now, and a stale
+      // A→B message would go out while the child is being respawned onto C.
+      this.pendingMcpRestart.set(tabId, queuedIsRetarget ? staleTargetNudge(origin, to) : null);
       const outcome = this.applyPendingRestarts(tabId);
-      // "scheduled" means the tab is mid-turn and its comfyui child goes on
-      // serving the OLD target until this restart lands (#1429). That is the one
-      // case the retarget nudge is about, and the entry is still pending here
-      // (applyPendingRestarts only clears it when it APPLIES), so upgrading the
-      // queued value now is what makes it ride along with the deferred respawn.
-      if (deferredOnly && nudge !== undefined && outcome === "scheduled") {
-        this.pendingMcpRestart.set(tabId, nudge);
+      if (outcome === "scheduled") {
+        // Mid-turn: the tab is stranded on `origin` until the turn ends. Record
+        // the origin so a further retarget in the same turn keeps it, and queue
+        // the message the deferred respawn will carry.
+        this.pendingRetargetFrom.set(tabId, origin);
+        this.pendingMcpRestart.set(tabId, staleTargetNudge(origin, to));
+      } else {
+        // Applied (or no agent): nothing is stranded any more.
+        this.pendingRetargetFrom.delete(tabId);
       }
       tallyRestart(tally, outcome);
     }
@@ -2240,6 +2280,10 @@ export class PanelAgentManager {
       return this.applyPendingRestarts(key);
     }
     this.pendingMcpRestart.set(key, nudge ?? null);
+    // Whatever is queued now, it is no longer a retarget nudge (#1429). Leaving
+    // the marker set would make the NEXT retarget classify this per-request nudge
+    // as its own and overwrite it — the exact #164 erasure, one step removed.
+    this.pendingRetargetFrom.delete(key);
     return this.applyPendingRestarts(key);
   }
 
@@ -2275,6 +2319,7 @@ export class PanelAgentManager {
     if (!agent || agent.isStopped) {
       this.pendingEffortRestart.delete(tabId);
       this.pendingMcpRestart.delete(tabId);
+      this.pendingRetargetFrom.delete(tabId);
       return "no-agent";
     }
     // Still mid-work (a queued message will start the next turn) — wait for the
@@ -2284,6 +2329,7 @@ export class PanelAgentManager {
     const nudge = wantMcp ? (this.pendingMcpRestart.get(tabId) ?? undefined) : undefined;
     this.pendingEffortRestart.delete(tabId);
     this.pendingMcpRestart.delete(tabId);
+    this.pendingRetargetFrom.delete(tabId);
     const carried = this.restartAgentResume(tabId, agent, nudge);
     const reasons = [wantEffort ? "effort" : null, wantMcp ? "comfyui-mcp-env" : null]
       .filter(Boolean)

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -2200,6 +2200,9 @@ export class PanelAgentManager {
         continue;
       }
       this.pendingMcpRestart.set(tabId, nudge ?? null);
+      // Whatever is queued now is not a retarget nudge any more (#1429) — leaving
+      // the marker set lets the NEXT retarget claim this one as its own.
+      this.pendingRetargetFrom.delete(tabId);
       // Apply immediately when the tab is already idle; otherwise it fires on the
       // next turn-done via applyPendingRestarts().
       tallyRestart(tally, this.applyPendingRestarts(tabId));
@@ -2679,6 +2682,13 @@ export class PanelAgentManager {
       this.pendingMcpRestart.set(newKey, this.pendingMcpRestart.get(oldKey)!);
       this.pendingMcpRestart.delete(oldKey);
     }
+    // The marker classifies that value (#1429), so it has to travel with it: left
+    // behind, the renamed tab's queued retarget nudge reads as a per-request one
+    // and the next retarget preserves an obsolete target instead of recomposing.
+    if (this.pendingRetargetFrom.has(oldKey)) {
+      this.pendingRetargetFrom.set(newKey, this.pendingRetargetFrom.get(oldKey)!);
+      this.pendingRetargetFrom.delete(oldKey);
+    }
     if (this.modelByKey.has(oldKey)) {
       this.modelByKey.set(newKey, this.modelByKey.get(oldKey)!);
       this.modelByKey.delete(oldKey);
@@ -2936,6 +2946,7 @@ export class PanelAgentManager {
     const durableCleared = this.opts.sessionStore ? this.opts.sessionStore.clear(tabId) : true;
     this.pendingEffortRestart.delete(tabId); // a reset supersedes any deferred restart
     this.pendingMcpRestart.delete(tabId);
+    this.pendingRetargetFrom.delete(tabId); // #1429 — nothing queued, nothing to classify
     // Drop this key's picker override so a provider switch (which reset()s the old
     // key) can't carry the old provider's model/effort into the new backend's spawn.
     this.modelByKey.delete(tabId);

--- a/src/orchestrator/retarget-nudge.ts
+++ b/src/orchestrator/retarget-nudge.ts
@@ -38,21 +38,36 @@ export function staleTargetNudge(from: string, to: string): string {
  *  so a nudge would be a false alarm. Same-address is likewise not a move; the
  *  caller already skips those, and this keeps the helper honest on its own. */
 export function retargetIsWorthNudging(from: string | null | undefined, to: string): boolean {
-  return typeof from === "string" && from.length > 0 && from !== to;
+  if (typeof from !== "string" || from.length === 0) return false;
+  return sameTarget(from, to) === false;
 }
 
 /**
- * The exact argument list the retarget hands `restartAllForMcpEnv`, so the whole
- * decision — nudge or not, deferred-only or not — lives HERE and is unit-testable,
- * and the call site is a spread that cannot quietly lose the flag. A call site
- * that passed the nudge WITHOUT `onlyWhenDeferred` would still type-check and
- * still pass every manager-level test; it would just also nudge idle tabs, which
- * is the failure this whole module exists to avoid.
+ * Whether two target strings name the same ComfyUI, textual differences aside.
+ *
+ * The comparison CANNOT be `from !== to` (codex finding). The previous target is
+ * seeded from the raw `COMFYUI_URL` the user set, while every retarget event
+ * carries the canonical `getComfyUIBaseUrl()` — so booting with a trailing slash,
+ * an uppercase host, or an explicit `:80`/`:443` and then reaffirming that very
+ * same target reads as a MOVE, and a mid-turn tab gets told its ComfyUI changed
+ * when nothing changed. A false nudge costs a real agent turn, so the false
+ * direction here is the expensive one.
+ *
+ * Unparseable input falls back to exact string equality rather than guessing.
  */
-export function retargetRestartArgs(
-  from: string | null | undefined,
-  to: string,
-): [nudge?: string, opts?: { onlyWhenDeferred?: boolean }] {
-  if (!retargetIsWorthNudging(from, to)) return [];
-  return [staleTargetNudge(from as string, to), { onlyWhenDeferred: true }];
+function sameTarget(a: string, b: string): boolean {
+  if (a === b) return true;
+  let ua: URL, ub: URL;
+  try {
+    ua = new URL(a);
+    ub = new URL(b);
+  } catch {
+    return false;
+  }
+  const norm = (u: URL) => {
+    // URL already lowercases host+protocol and folds a default port to "".
+    const path = u.pathname.replace(/\/+$/, "");
+    return `${u.protocol}//${u.hostname}:${u.port}${path}`;
+  };
+  return norm(ua) === norm(ub);
 }

--- a/src/orchestrator/retarget-nudge.ts
+++ b/src/orchestrator/retarget-nudge.ts
@@ -1,0 +1,58 @@
+/**
+ * #1429 — what to tell an agent whose comfyui tools were stale for a whole turn.
+ *
+ * A ComfyUI retarget respawns every tab's comfyui MCP child, because `config` is
+ * a module-load snapshot (src/config.ts) and a running child has no channel to
+ * learn a new address. When the tab is mid-turn the respawn is DEFERRED to
+ * turn-done (panel-agent.ts, applyPendingRestarts → "scheduled") — correct, since
+ * an MCP server cannot be pulled out from under a running turn, but it means the
+ * rest of that turn was served by a child still addressing the OLD target.
+ *
+ * The failure that gets reported is the dead-old-target one (a confusing "fetch
+ * failed" naming an address the user believes they already left). The failure
+ * that does NOT get reported, and is worse, is the LIVE-old-target one: the call
+ * succeeds against the previous machine. A render lands on the pod the user just
+ * left; an upload writes into its input/. Nothing in the transcript says so.
+ *
+ * This is the after-the-fact half of the fix: the agent is told, at turn-done,
+ * which address its tools actually used. Preventing the wrong-machine call needs
+ * the child to learn a target without a respawn, which is a larger change.
+ */
+
+/** Wording for the retry nudge. Both addresses are named — "the target moved" on
+ *  its own leaves the agent unable to say WHICH of its calls went where, and the
+ *  whole point is that the transcript is otherwise silent about it. These are the
+ *  same base URLs the orchestrator already prints when it logs the retarget. */
+export function staleTargetNudge(from: string, to: string): string {
+  return (
+    `ComfyUI's target changed from ${from} to ${to} while your previous turn was still running. ` +
+    `Your comfyui tools were pointed at ${from} for that entire turn and switched to ${to} only just now. ` +
+    `Anything you queued, uploaded, downloaded or listed during that turn went to ${from}, not ${to} — ` +
+    `check whether it belonged on ${to} and re-run it there if so. ` +
+    `If a comfyui tool failed during that turn, the stale address is the likely reason; retry it before concluding ComfyUI is unreachable.`
+  );
+}
+
+/** True when a retarget is worth nudging about at all. A first-ever target (no
+ *  previous) is a startup seed, not a switch — nothing ran against anything else,
+ *  so a nudge would be a false alarm. Same-address is likewise not a move; the
+ *  caller already skips those, and this keeps the helper honest on its own. */
+export function retargetIsWorthNudging(from: string | null | undefined, to: string): boolean {
+  return typeof from === "string" && from.length > 0 && from !== to;
+}
+
+/**
+ * The exact argument list the retarget hands `restartAllForMcpEnv`, so the whole
+ * decision — nudge or not, deferred-only or not — lives HERE and is unit-testable,
+ * and the call site is a spread that cannot quietly lose the flag. A call site
+ * that passed the nudge WITHOUT `onlyWhenDeferred` would still type-check and
+ * still pass every manager-level test; it would just also nudge idle tabs, which
+ * is the failure this whole module exists to avoid.
+ */
+export function retargetRestartArgs(
+  from: string | null | undefined,
+  to: string,
+): [nudge?: string, opts?: { onlyWhenDeferred?: boolean }] {
+  if (!retargetIsWorthNudging(from, to)) return [];
+  return [staleTargetNudge(from as string, to), { onlyWhenDeferred: true }];
+}


### PR DESCRIPTION
Closes #1429.

A ComfyUI retarget respawns each tab's comfyui MCP child, but the respawn is deferred when the tab is mid-turn — so the rest of that turn's comfyui tool calls are served by a child still pointed at the previous server. If the old target is dead that is a confusing failure; if it is alive the call quietly succeeds **against the wrong machine**.

Attaching a retry nudge to exactly the tabs whose restart came back `scheduled`, so the agent is told at turn-done. Idle tabs must not get it — their respawn was immediate and nothing was stale.

Draft while I build it out.