### PR TITLE
chore(release): 0.51.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.51.4] - 2026-08-11
+
+### MCP
+
+#### Fixed
+- a retarget that lands mid-turn tells the agent its tools were stale (#1430)
+
+
 ## [0.51.3] - 2026-08-11
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.3",
+  "version": "0.51.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.51.3",
+      "version": "0.51.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.51.3",
+  "version": "0.51.4",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconciles the 0.51.4 tag into protected main.

**0.51.4 — #1429**: a ComfyUI retarget that lands while a tab is mid-turn now tells that tab's agent its comfyui tools spent the turn on the OLD address.

The respawn of a tab's comfyui MCP child is deferred while the tab is busy (an MCP server cannot be pulled out from under a running turn), so the rest of that turn is served by a child still addressing the previous target. If the old target is dead that is a confusing failure; if it is still alive the call quietly succeeds against the wrong machine — a render on the pod you just left, an upload into its input/ — with nothing in the transcript saying so.

Verified live end-to-end against a real orchestrator with a real agent mid-turn:
```
1 tab(s) mid-turn during the retarget — their comfyui tools stay on http://127.0.0.1:8188 until the turn ends (#1429)
tab orchestr restart applied (idle, reason=comfyui-mcp-env, 0 queued carried over + retry nudge)
```